### PR TITLE
feat: OB1-inspired extraction, federated search, bulk import

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -12,6 +12,9 @@ DB_PASSWORD=@secret(exec(./fetch-secrets.sh DB_PASSWORD))
 LITELLM_URL=http://10.71.1.33:4000
 LITELLM_API_KEY=@secret(exec(./fetch-secrets.sh LITELLM_API_KEY))
 
+# Extraction (auto-metadata on writes)
+EXTRACTION_MODEL=@optional
+
 # Server
 PORT=3100
 

--- a/hooks/open-brain-session-capture.ts
+++ b/hooks/open-brain-session-capture.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 // SessionEnd hook: captures session knowledge to Open Brain
+// Uses mcp2cli for transport/auth -- no raw HTTP
 // Fires on: session end
 // Silent on all errors -- never blocks session end
 
@@ -9,10 +10,6 @@ try {
   const input = await Bun.stdin.json();
   const { cwd } = input;
   const project = cwd.split("/").pop() || "unknown";
-
-  const OPEN_BRAIN_URL = "http://10.71.20.15:3100/mcp";
-  const TOKEN = Bun.env.OPEN_BRAIN_AGENT_TOKEN;
-  if (!TOKEN) process.exit(0);
 
   // Get recent git log (last 10 commits)
   let commits: string[] = [];
@@ -31,10 +28,20 @@ try {
   // Get git diff --stat for changed files
   let diffStat = "";
   try {
-    const diffResult = Bun.spawnSync(
-      ["git", "diff", "--stat", "HEAD~1", "HEAD"],
-      { cwd, timeout: 3000 },
-    );
+    // Check commit count first -- HEAD~1 fails on single-commit repos
+    const countResult = Bun.spawnSync(["git", "rev-list", "--count", "HEAD"], {
+      cwd,
+      timeout: 2000,
+    });
+    const commitCount =
+      countResult.exitCode === 0
+        ? parseInt(countResult.stdout.toString().trim(), 10)
+        : 0;
+    const diffArgs =
+      commitCount <= 1
+        ? ["git", "show", "--stat", "--format=", "HEAD"]
+        : ["git", "diff", "--stat", "HEAD~1", "HEAD"];
+    const diffResult = Bun.spawnSync(diffArgs, { cwd, timeout: 3000 });
     if (diffResult.exitCode === 0) {
       diffStat = diffResult.stdout.toString().trim();
     }
@@ -85,75 +92,23 @@ try {
     }
   }
 
-  // Parse SSE or JSON response
-  const parseMcpResponse = async (resp: Response) => {
-    const text = await resp.text();
-    for (const line of text.split("\n")) {
-      if (line.startsWith("data: ")) {
-        try {
-          return JSON.parse(line.slice(6));
-        } catch {
-          /* skip */
-        }
-      }
+  // Helper to call mcp2cli
+  const callOB = (tool: string, params: Record<string, unknown>): boolean => {
+    const result = Bun.spawnSync(
+      ["mcp2cli", "open-brain", tool, "--params", JSON.stringify(params)],
+      { timeout: 12000 },
+    );
+    if (result.exitCode !== 0) {
+      console.error(
+        `open-brain ${tool} failed: ${result.stderr.toString().trim()}`,
+      );
+      return false;
     }
-    try {
-      return JSON.parse(text);
-    } catch {
-      return null;
-    }
-  };
-
-  // Init MCP session
-  const initResp = await fetch(OPEN_BRAIN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      Authorization: `Bearer ${TOKEN}`,
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientInfo: { name: "claude-code-hook", version: "2.0.0" },
-      },
-    }),
-  });
-
-  const mcpSessionId = initResp.headers.get("mcp-session-id");
-  if (!mcpSessionId) process.exit(0);
-
-  const headers = {
-    "Content-Type": "application/json",
-    Accept: "application/json, text/event-stream",
-    Authorization: `Bearer ${TOKEN}`,
-    "mcp-session-id": mcpSessionId,
-  };
-
-  const callTool = async (
-    id: number,
-    name: string,
-    args: Record<string, unknown>,
-  ) => {
-    const resp = await fetch(OPEN_BRAIN_URL, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id,
-        method: "tools/call",
-        params: { name, arguments: args },
-      }),
-    });
-    return parseMcpResponse(resp);
+    return true;
   };
 
   // Save session
-  await callTool(2, "session_save", {
+  callOB("session_save", {
     summary,
     project,
     tags,
@@ -162,10 +117,9 @@ try {
   });
 
   // Log each decision commit
-  let toolId = 3;
   for (const commit of decisionCommits) {
     const title = commit.replace(/^[a-f0-9]+ /, "");
-    await callTool(toolId++, "log_decision", {
+    callOB("log_decision", {
       title,
       rationale: "Decided during session",
       tags: [project, ...tags],
@@ -174,12 +128,13 @@ try {
 
   // Log a thought summarizing the diff if we have one
   if (diffStat) {
-    await callTool(toolId++, "log_thought", {
+    callOB("log_thought", {
       content: `Files changed in ${project} session:\n\n${diffStat}`,
       tags: [project, "git-diff", "session-end"],
     });
   }
-} catch {
-  // Silent failure -- never block session end
+} catch (err) {
+  // Log but never block session end
+  console.error(`open-brain session-capture hook error: ${err}`);
   process.exit(0);
 }

--- a/hooks/open-brain-session-load.ts
+++ b/hooks/open-brain-session-load.ts
@@ -1,24 +1,16 @@
 #!/usr/bin/env bun
 // SessionStart hook: loads knowledge + session context from Open Brain
-// Replaces: inject-brain-context.ts + query-knowledge.ts + original session-load
+// Uses mcp2cli for transport/auth -- no raw HTTP
 // Fires on: * (all session starts)
 // Silent on all errors -- never blocks session start
 
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
-interface McpResponse {
-  result?: { content?: Array<{ text?: string }> };
-}
-
 try {
   const input = await Bun.stdin.json();
   const { cwd } = input;
   const project = cwd.split("/").pop() || "unknown";
-
-  const OPEN_BRAIN_URL = "http://10.71.20.15:3100/mcp";
-  const TOKEN = Bun.env.OPEN_BRAIN_AGENT_TOKEN;
-  if (!TOKEN) process.exit(0);
 
   // Detect project tags from package.json dependencies
   const tags: string[] = [];
@@ -48,8 +40,6 @@ try {
       };
       for (const dep of Object.keys(deps)) {
         if (knownTags[dep]) tags.push(knownTags[dep]);
-        // Also add @types/* packages as tags
-        else if (dep.startsWith("@types/")) tags.push(`types-${dep.slice(7)}`);
       }
     } catch {
       /* ignore parse errors */
@@ -58,159 +48,174 @@ try {
 
   const searchQuery = [project, ...tags.slice(0, 5)].join(" ");
 
-  // Init MCP session
-  const initResp = await fetch(OPEN_BRAIN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      Authorization: `Bearer ${TOKEN}`,
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientInfo: { name: "claude-code-hook", version: "2.0.0" },
-      },
-    }),
-  });
-
-  const mcpSessionId = initResp.headers.get("mcp-session-id");
-  if (!mcpSessionId) process.exit(0);
-
-  // Parse SSE or JSON response from MCP server
-  const parseMcpResponse = async (
-    resp: Response,
-  ): Promise<McpResponse | null> => {
-    const text = await resp.text();
-    // SSE format: "event: message\ndata: {...}\n\n"
-    for (const line of text.split("\n")) {
-      if (line.startsWith("data: ")) {
-        return JSON.parse(line.slice(6));
-      }
-    }
-    // Fallback: try plain JSON
+  // Helper to call mcp2cli and parse JSON result
+  const callMcp = (
+    service: string,
+    tool: string,
+    params: Record<string, unknown>,
+  ): unknown | null => {
+    const result = Bun.spawnSync(
+      ["mcp2cli", service, tool, "--params", JSON.stringify(params)],
+      { timeout: 8000 },
+    );
+    if (result.exitCode !== 0) return null;
     try {
-      return JSON.parse(text);
+      const output = JSON.parse(result.stdout.toString().trim());
+      if (output?.result !== undefined) {
+        const inner = output.result;
+        if (typeof inner === "string") {
+          try {
+            return JSON.parse(inner);
+          } catch {
+            return inner;
+          }
+        }
+        return inner;
+      }
+      return output;
     } catch {
       return null;
     }
   };
 
-  // Helper to call an MCP tool
-  const callTool = async (
-    id: number,
-    name: string,
-    args: Record<string, unknown>,
-  ): Promise<string | null> => {
-    const resp = await fetch(OPEN_BRAIN_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        Authorization: `Bearer ${TOKEN}`,
-        "mcp-session-id": mcpSessionId,
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id,
-        method: "tools/call",
-        params: { name, arguments: args },
-      }),
-    });
-    const result = await parseMcpResponse(resp);
-    return result?.result?.content?.[0]?.text ?? null;
-  };
+  // Client-side federation: OB search_brain + qmd BM25 search + session_load in parallel
+  // All three are sync calls but run sequentially (Bun.spawnSync)
+  const obResult = callMcp("open-brain", "search_brain", {
+    query: searchQuery,
+    limit: 7,
+  });
+  const qmdResult = callMcp("qmd", "search", { query: searchQuery, limit: 5 });
+  const sessionResult = callMcp("open-brain", "session_load", { project });
 
-  // Call search_brain + session_load in parallel
-  const [searchText, sessionText] = await Promise.all([
-    callTool(2, "search_brain", { query: searchQuery, limit: 7 }),
-    callTool(3, "session_load", { project }),
-  ]);
+  // Normalize OB results (distance 0-1 lower=better -> score 0-1 higher=better)
+  const brainResults: Array<Record<string, unknown>> = [];
+  if (Array.isArray(obResult)) {
+    for (const r of obResult as Array<Record<string, unknown>>) {
+      brainResults.push({
+        source: "brain",
+        type: r.source_type,
+        content: r.content_preview,
+        score: 1 - (Number(r.distance) || 0.5),
+        tags: r.tags,
+      });
+    }
+  }
+
+  // Normalize qmd results (score 0-1 higher=better, nested in .results)
+  const qmdResults: Array<Record<string, unknown>> = [];
+  const qmdInner =
+    qmdResult && typeof qmdResult === "object" && !Array.isArray(qmdResult)
+      ? ((qmdResult as Record<string, unknown>).results as
+          | Array<Record<string, unknown>>
+          | undefined)
+      : null;
+  if (Array.isArray(qmdInner)) {
+    for (const r of qmdInner) {
+      qmdResults.push({
+        source: "qmd",
+        type: "file",
+        content: String(r.snippet ?? r.content ?? "").slice(0, 300),
+        score: Number(r.score) || 0.5,
+        path: r.file || r.path,
+        collection: r.collection,
+      });
+    }
+  }
+
+  // Merge and sort by score descending
+  const results = [...brainResults, ...qmdResults]
+    .sort((a, b) => Number(b.score) - Number(a.score))
+    .slice(0, 10);
 
   const lines: string[] = [];
 
-  // Knowledge context section
-  if (searchText) {
-    try {
-      const results = JSON.parse(searchText);
-      if (Array.isArray(results) && results.length > 0) {
-        lines.push(`<!-- PAI Brain Context for ${project} -->`);
+  if (results.length > 0) {
+    lines.push(`<!-- PAI Brain Context for ${project} -->`);
+    lines.push(`<!-- Detected tags: ${tags.map((t) => "#" + t).join(" ")} -->`);
+    lines.push("");
+    lines.push("## Relevant Past Learnings");
+    lines.push("");
+    for (const r of results as Array<Record<string, unknown>>) {
+      const isBrain = r.source === "brain";
+      const typeLabel = isBrain
+        ? r.type === "decision"
+          ? "DECISION"
+          : r.type === "thought"
+            ? "TECHNIQUE"
+            : String(r.type ?? "ENTRY").toUpperCase()
+        : "FILE";
+      const firstLine = isBrain
+        ? String(r.content ?? "").split("\n")[0] || "Untitled"
+        : r.path
+          ? `${r.path}`
+          : String(r.content ?? "").split("\n")[0] || "Untitled";
+      lines.push(`## [${typeLabel}] ${firstLine}`);
+      if (Array.isArray(r.tags) && r.tags.length) {
         lines.push(
-          `<!-- Detected tags: ${tags.map((t) => "#" + t).join(" ")} -->`,
+          `**Tags:** ${(r.tags as string[]).map((t: string) => "#" + t).join(" ")}`,
         );
-        lines.push("");
-        lines.push("## Relevant Past Learnings");
-        lines.push("");
-        for (const r of results) {
-          const typeLabel =
-            r.source_type === "decision"
-              ? "DECISION"
-              : r.source_type === "thought"
-                ? "TECHNIQUE"
-                : r.source_type?.toUpperCase() || "ENTRY";
-          const firstLine = r.content_preview?.split("\n")[0] || "Untitled";
-          lines.push(`## [${typeLabel}] ${firstLine}`);
-          if (r.tags?.length) {
-            lines.push(
-              `**Tags:** ${r.tags.map((t: string) => "#" + t).join(" ")}`,
-            );
-          }
-          if (r.content_preview) {
-            const preview =
-              r.content_preview.length > 500
-                ? r.content_preview.slice(0, 500) + "..."
-                : r.content_preview;
-            lines.push(preview);
-          }
-          lines.push("");
-          lines.push("---");
-          lines.push("");
-        }
       }
-    } catch {
-      /* not JSON or empty */
+      if (r.collection) lines.push(`**Collection:** ${r.collection}`);
+      const content = String(r.content ?? "");
+      if (content) {
+        lines.push(
+          content.length > 500 ? content.slice(0, 500) + "..." : content,
+        );
+      }
+      lines.push("");
+      lines.push("---");
+      lines.push("");
     }
   }
 
   // Session context section
-  if (sessionText && !sessionText.startsWith("No sessions")) {
-    try {
-      const session = JSON.parse(sessionText);
-      if (!lines.length) {
-        lines.push(`<!-- PAI Brain Context for ${project} -->`);
-      }
-      lines.push("## Previous Session");
-      lines.push(
-        `**Project:** ${session.project || "global"} | **Saved:** ${session.created_at}`,
-      );
-      if (session.summary) lines.push(`\n${session.summary}`);
-      if (session.key_decisions?.length) {
-        lines.push("\n### Key Decisions");
-        for (const d of session.key_decisions) lines.push(`- ${d}`);
-      }
-      if (session.blockers?.length) {
-        lines.push("\n### Blockers");
-        for (const b of session.blockers) lines.push(`- ${b}`);
-      }
-      if (session.next_steps?.length) {
-        lines.push("\n### Next Steps");
-        for (const s of session.next_steps) lines.push(`- ${s}`);
-      }
-      lines.push("");
-    } catch {
-      /* not JSON */
+  if (
+    sessionResult &&
+    typeof sessionResult === "object" &&
+    !(
+      "text" in (sessionResult as Record<string, unknown>) &&
+      String((sessionResult as Record<string, unknown>).text).startsWith(
+        "No sessions",
+      )
+    )
+  ) {
+    const session = sessionResult as Record<string, unknown>;
+    if (!lines.length) {
+      lines.push(`<!-- PAI Brain Context for ${project} -->`);
     }
+    lines.push("## Previous Session");
+    lines.push(
+      `**Project:** ${session.project || "global"} | **Saved:** ${session.created_at}`,
+    );
+    if (session.summary) lines.push(`\n${session.summary}`);
+    if (Array.isArray(session.key_decisions) && session.key_decisions.length) {
+      lines.push("\n### Key Decisions");
+      for (const d of session.key_decisions) lines.push(`- ${d}`);
+    }
+    if (Array.isArray(session.blockers) && session.blockers.length) {
+      lines.push("\n### Blockers");
+      for (const b of session.blockers) lines.push(`- ${b}`);
+    }
+    if (Array.isArray(session.next_steps) && session.next_steps.length) {
+      lines.push("\n### Next Steps");
+      for (const s of session.next_steps) lines.push(`- ${s}`);
+    }
+    lines.push("");
   }
 
   if (lines.length > 0) {
     lines.push("<!-- End PAI Brain Context -->");
-    console.log(lines.join("\n"));
+    let output = lines.join("\n");
+    if (output.length > 3000) {
+      const omitted = output.length - 3000;
+      output =
+        output.slice(0, 3000) +
+        `\n<!-- Truncated: ${omitted} chars omitted -->`;
+    }
+    console.log(output);
   }
-} catch {
-  // Silent failure -- don't block session start
+} catch (err) {
+  // Log but never block session start
+  console.error(`open-brain session-load hook error: ${err}`);
   process.exit(0);
 }

--- a/hooks/open-brain-session-load.ts
+++ b/hooks/open-brain-session-load.ts
@@ -48,19 +48,26 @@ try {
 
   const searchQuery = [project, ...tags.slice(0, 5)].join(" ");
 
-  // Helper to call mcp2cli and parse JSON result
-  const callMcp = (
+  // Async helper: call mcp2cli and parse JSON result
+  const callMcp = async (
     service: string,
     tool: string,
     params: Record<string, unknown>,
-  ): unknown | null => {
-    const result = Bun.spawnSync(
-      ["mcp2cli", service, tool, "--params", JSON.stringify(params)],
-      { timeout: 8000 },
-    );
-    if (result.exitCode !== 0) return null;
+  ): Promise<unknown | null> => {
     try {
-      const output = JSON.parse(result.stdout.toString().trim());
+      const proc = Bun.spawn(
+        ["mcp2cli", service, tool, "--params", JSON.stringify(params)],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const stdout = await Promise.race([
+        new Response(proc.stdout).text(),
+        new Promise<string>((_, reject) =>
+          setTimeout(() => reject(new Error("timeout")), 8000),
+        ),
+      ]);
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) return null;
+      const output = JSON.parse(stdout.trim());
       if (output?.result !== undefined) {
         const inner = output.result;
         if (typeof inner === "string") {
@@ -78,14 +85,12 @@ try {
     }
   };
 
-  // Client-side federation: OB search_brain + qmd BM25 search + session_load in parallel
-  // All three are sync calls but run sequentially (Bun.spawnSync)
-  const obResult = callMcp("open-brain", "search_brain", {
-    query: searchQuery,
-    limit: 7,
-  });
-  const qmdResult = callMcp("qmd", "search", { query: searchQuery, limit: 5 });
-  const sessionResult = callMcp("open-brain", "session_load", { project });
+  // Client-side federation: all three calls in parallel
+  const [obResult, qmdResult, sessionResult] = await Promise.all([
+    callMcp("open-brain", "search_brain", { query: searchQuery, limit: 7 }),
+    callMcp("qmd", "search", { query: searchQuery, limit: 5 }),
+    callMcp("open-brain", "session_load", { project }),
+  ]);
 
   // Normalize OB results (distance 0-1 lower=better -> score 0-1 higher=better)
   const brainResults: Array<Record<string, unknown>> = [];

--- a/hooks/open-brain-session-save.ts
+++ b/hooks/open-brain-session-save.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 // PreCompact hook: saves session state to Open Brain before context compaction
-// Enhanced: extracts git context for key_decisions and branch info
+// Uses mcp2cli for transport/auth -- no raw HTTP
 // Fires on: manual | auto compaction
 // Silent on all errors -- never blocks compaction
 
@@ -10,10 +10,6 @@ try {
   const input = await Bun.stdin.json();
   const { cwd, trigger, custom_instructions } = input;
   const project = cwd.split("/").pop() || "unknown";
-
-  const OPEN_BRAIN_URL = "http://10.71.20.15:3100/mcp";
-  const TOKEN = Bun.env.OPEN_BRAIN_AGENT_TOKEN;
-  if (!TOKEN) process.exit(0);
 
   // Extract recent git commits as key decisions
   const key_decisions: string[] = [];
@@ -63,55 +59,26 @@ try {
       tags.push(branchType);
   }
 
-  // Init MCP session
-  const initResp = await fetch(OPEN_BRAIN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      Authorization: `Bearer ${TOKEN}`,
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientInfo: { name: "claude-code-hook", version: "2.0.0" },
-      },
-    }),
+  // Save via mcp2cli
+  const params = JSON.stringify({
+    summary,
+    project,
+    tags,
+    next_steps: [],
+    key_decisions,
   });
 
-  const mcpSessionId = initResp.headers.get("mcp-session-id");
-  if (!mcpSessionId) process.exit(0);
+  const result = Bun.spawnSync(
+    ["mcp2cli", "open-brain", "session_save", "--params", params],
+    { timeout: 12000 },
+  );
 
-  // Call session_save
-  await fetch(OPEN_BRAIN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      Authorization: `Bearer ${TOKEN}`,
-      "mcp-session-id": mcpSessionId,
-    },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: 2,
-      method: "tools/call",
-      params: {
-        name: "session_save",
-        arguments: {
-          summary,
-          project,
-          tags,
-          next_steps: [],
-          key_decisions,
-        },
-      },
-    }),
-  });
-} catch {
-  // Silent failure -- never block compaction
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString().trim();
+    console.error(`open-brain session_save failed: ${stderr}`);
+  }
+} catch (err) {
+  // Log but never block compaction
+  console.error(`open-brain pre-compact hook error: ${err}`);
   process.exit(0);
 }

--- a/scripts/__tests__/bulk-import.test.ts
+++ b/scripts/__tests__/bulk-import.test.ts
@@ -1,0 +1,1041 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import type pg from "pg";
+
+// ---------------------------------------------------------------------------
+// Mocks -- must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const logCalls: {
+  info: Array<[string, Record<string, unknown>?]>;
+  warn: Array<[string, Record<string, unknown>?]>;
+  error: Array<[string, Record<string, unknown>?]>;
+} = { info: [], warn: [], error: [] };
+
+mock.module("../../src/logger.ts", () => ({
+  logger: {
+    info: (msg: string, extra?: Record<string, unknown>) => {
+      logCalls.info.push([msg, extra]);
+    },
+    warn: (msg: string, extra?: Record<string, unknown>) => {
+      logCalls.warn.push([msg, extra]);
+    },
+    error: (msg: string, extra?: Record<string, unknown>) => {
+      logCalls.error.push([msg, extra]);
+    },
+  },
+}));
+
+mock.module("../../src/embedding.ts", () => ({
+  contentHash: (text: string) => {
+    // Deterministic hash for testing -- just use a simple string hash
+    const { createHash } = require("node:crypto");
+    const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
+    return createHash("sha256").update(normalized).digest("hex");
+  },
+  generateEmbedding: mock(async () => null),
+}));
+
+// No mock needed for extraction.ts -- tests use extract:false (default).
+// Mocking it would leak into other test files via bun's global mock.module.
+
+mock.module("../../src/db/pool.ts", () => ({
+  createPool: () => {
+    throw new Error("createPool should not be called in tests");
+  },
+}));
+
+mock.module("pgvector/pg", () => ({
+  toSql: (arr: number[]) => `[${arr.join(",")}]`,
+}));
+
+// Import after mocks
+const {
+  parseFrontmatter,
+  readFiles,
+  importThought,
+  importDecision,
+  importSession,
+  parseArgs,
+} = await import("../bulk-import.ts");
+const { contentHash } = await import("../../src/embedding.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function createMockPool(
+  queryImpl?: (
+    ...args: unknown[]
+  ) => Promise<{ rows: unknown[]; rowCount: number }>,
+) {
+  const defaultImpl = async () => ({ rows: [], rowCount: 1 });
+  const mockQuery = mock(queryImpl ?? defaultImpl);
+  const mockEnd = mock(async () => {});
+  return {
+    pool: { query: mockQuery, end: mockEnd } as unknown as pg.Pool,
+    mockQuery,
+    mockEnd,
+  };
+}
+
+const defaultOpts = {
+  extraTags: [] as string[],
+  sourceLabel: "bulk-import",
+  embed: false,
+  extract: false,
+};
+
+function makeFile(
+  body: string,
+  frontmatter: Record<string, unknown> = {},
+  filePath = "/test/file.md",
+): {
+  filePath: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  return { filePath, frontmatter, body };
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "ob-bulk-test-"));
+  logCalls.info.length = 0;
+  logCalls.warn.length = 0;
+  logCalls.error.length = 0;
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// FRONTMATTER PARSING
+// ===========================================================================
+
+describe("parseFrontmatter", () => {
+  it("parses valid YAML frontmatter with title and tags", () => {
+    const raw = `---
+title: My Note
+tags: [ai, memory]
+project: open-brain
+---
+
+This is the body content.`;
+    const result = parseFrontmatter(raw);
+
+    expect(result.frontmatter.title).toBe("My Note");
+    expect(result.frontmatter.tags).toEqual(["ai", "memory"]);
+    expect(result.frontmatter.project).toBe("open-brain");
+    expect(result.body).toBe("This is the body content.");
+  });
+
+  it("returns empty frontmatter when no YAML delimiters present", () => {
+    const raw = "Just plain markdown content with no frontmatter.";
+    const result = parseFrontmatter(raw);
+
+    expect(result.frontmatter).toEqual({});
+    expect(result.body).toBe(
+      "Just plain markdown content with no frontmatter.",
+    );
+  });
+
+  it("handles frontmatter with quoted string values", () => {
+    const raw = `---
+title: "A Quoted Title"
+author: 'Single Quoted'
+---
+
+Body here.`;
+    const result = parseFrontmatter(raw);
+
+    expect(result.frontmatter.title).toBe("A Quoted Title");
+    expect(result.frontmatter.author).toBe("Single Quoted");
+  });
+
+  it("handles frontmatter with tags containing quoted items", () => {
+    const raw = `---
+tags: ["tag one", 'tag two', plain]
+---
+
+Some body text for the test file.`;
+    const result = parseFrontmatter(raw);
+
+    expect(result.frontmatter.tags).toEqual(["tag one", "tag two", "plain"]);
+  });
+
+  it("handles malformed frontmatter (missing closing delimiter)", () => {
+    const raw = `---
+title: Broken
+This never closes the frontmatter section.`;
+    const result = parseFrontmatter(raw);
+
+    // No match, so treated as plain body
+    expect(result.frontmatter).toEqual({});
+    expect(result.body).toContain("title: Broken");
+  });
+
+  it("handles frontmatter with lines that have no colon", () => {
+    const raw = `---
+title: Valid Key
+no-colon-line
+tags: [test]
+---
+
+Body text with enough content to pass.`;
+    const result = parseFrontmatter(raw);
+
+    expect(result.frontmatter.title).toBe("Valid Key");
+    expect(result.frontmatter.tags).toEqual(["test"]);
+    // The line without colon is silently skipped
+  });
+
+  it("handles empty frontmatter block (regex requires content between delimiters)", () => {
+    // The regex requires at least one line between --- delimiters,
+    // so an empty frontmatter block is treated as no frontmatter
+    const raw = `---
+---
+
+Body after empty frontmatter section.`;
+    const result = parseFrontmatter(raw);
+
+    // No match on the regex, so entire content is treated as body
+    expect(result.frontmatter).toEqual({});
+    expect(result.body).toContain("Body after empty frontmatter section.");
+  });
+
+  it("trims whitespace from body", () => {
+    const raw = `---
+title: Test
+---
+
+   Body with leading whitespace.   `;
+    const result = parseFrontmatter(raw);
+
+    expect(result.body).toBe("Body with leading whitespace.");
+  });
+});
+
+// ===========================================================================
+// FILE READING (readFiles)
+// ===========================================================================
+
+describe("readFiles", () => {
+  it("reads a single markdown file from a directory", async () => {
+    await Bun.write(
+      join(tmpDir, "note.md"),
+      `---\ntitle: Test Note\n---\n\nThis is a test note with enough content to pass the minimum length check.`,
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+
+    expect(files).toHaveLength(1);
+    expect(files[0]!.frontmatter.title).toBe("Test Note");
+    expect(files[0]!.body).toContain("This is a test note");
+  });
+
+  it("skips files with body shorter than 10 characters", async () => {
+    await Bun.write(join(tmpDir, "short.md"), "tiny");
+    await Bun.write(
+      join(tmpDir, "long.md"),
+      "This file has enough content to be included in the import.",
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+
+    expect(files).toHaveLength(1);
+    expect(files[0]!.body).toContain("enough content");
+  });
+
+  it("skips files with only frontmatter and no body", async () => {
+    await Bun.write(
+      join(tmpDir, "fm-only.md"),
+      `---\ntitle: Only FM\ntags: [a]\n---\n`,
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("reads files from nested directories with glob pattern", async () => {
+    const nestedDir = join(tmpDir, "sub", "deep");
+    await Bun.write(
+      join(nestedDir, "nested.md"),
+      "This is a nested file with plenty of body content for the import.",
+    );
+    await Bun.write(
+      join(tmpDir, "top.md"),
+      "This is a top-level file with enough body content to pass.",
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+
+    expect(files).toHaveLength(2);
+    const paths = files.map((f) => f.filePath);
+    expect(paths.some((p) => p.includes("nested.md"))).toBe(true);
+    expect(paths.some((p) => p.includes("top.md"))).toBe(true);
+  });
+
+  it("respects custom glob pattern", async () => {
+    await Bun.write(
+      join(tmpDir, "note.md"),
+      "Markdown file with enough content for the import test.",
+    );
+    await Bun.write(
+      join(tmpDir, "note.txt"),
+      "Text file with enough content for the import test.",
+    );
+
+    const mdFiles = await readFiles(tmpDir, "*.md");
+    expect(mdFiles).toHaveLength(1);
+
+    const txtFiles = await readFiles(tmpDir, "*.txt");
+    expect(txtFiles).toHaveLength(1);
+  });
+
+  it("handles empty directory", async () => {
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0);
+  });
+
+  it("handles binary-like content that passes length check", async () => {
+    // Binary files won't have frontmatter, body is the raw content
+    const binaryContent = Buffer.alloc(100, 0xff).toString();
+    await Bun.write(join(tmpDir, "binary.md"), binaryContent);
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    // It may or may not pass the length check depending on encoding,
+    // but it should not throw
+    expect(files.length).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ===========================================================================
+// SMALL: Single file import, verify SQL params
+// ===========================================================================
+
+describe("small: single file import", () => {
+  it("imports one thought with correct SQL params", async () => {
+    const file = makeFile(
+      "This is my thought content for testing the import function.",
+      { tags: ["ai", "test"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    const result = await importThought(pool, file, defaultOpts);
+
+    expect(result).toBe("imported");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO thoughts");
+    expect(sql).toContain("content_hash");
+    expect(sql).toContain("WHERE NOT EXISTS");
+    // params: content, tags, source, created_by, embedding, hash, embedded_at, model, extracted
+    expect(params![0]).toBe(
+      "This is my thought content for testing the import function.",
+    );
+    expect(params![1]).toEqual(["ai", "test"]);
+    expect(params![2]).toBe("bulk-import"); // sourceLabel
+    expect(params![3]).toBe("bulk-import"); // created_by
+    expect(params![4]).toBeNull(); // embedding (embed=false)
+    expect(typeof params![5]).toBe("string"); // hash
+    expect(params![6]).toBeNull(); // embedded_at
+    expect(params![7]).toBeNull(); // embedding_model
+    expect(params![8]).toBeNull(); // extracted_metadata
+  });
+
+  it("returns 'duplicate' when rowCount is 0", async () => {
+    const file = makeFile(
+      "Duplicate content that already exists in the database.",
+    );
+    const { pool } = createMockPool(async () => ({ rows: [], rowCount: 0 }));
+
+    const result = await importThought(pool, file, defaultOpts);
+    expect(result).toBe("duplicate");
+  });
+
+  it("returns 'error' when query throws", async () => {
+    const file = makeFile(
+      "Content that will cause a database error during insert.",
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("connection refused");
+    });
+
+    const result = await importThought(pool, file, defaultOpts);
+    expect(result).toBe("error");
+  });
+});
+
+// ===========================================================================
+// MEDIUM: 10 files, dedup verification
+// ===========================================================================
+
+describe("medium: 10-file import with dedup", () => {
+  it("imports 10 unique files and all succeed", async () => {
+    const { pool, mockQuery } = createMockPool();
+    const results: string[] = [];
+
+    for (let i = 0; i < 10; i++) {
+      const file = makeFile(
+        `Unique thought content number ${i} with enough text for testing.`,
+        { tags: ["batch"] },
+        `/test/file-${i}.md`,
+      );
+      const result = await importThought(pool, file, defaultOpts);
+      results.push(result);
+    }
+
+    expect(results.filter((r) => r === "imported")).toHaveLength(10);
+    expect(mockQuery).toHaveBeenCalledTimes(10);
+  });
+
+  it("detects duplicates when same content hash is already in DB", async () => {
+    // First call succeeds (rowCount=1), subsequent calls with same hash return rowCount=0
+    const seenHashes = new Set<string>();
+    const { pool } = createMockPool(async (_sql: unknown, params: unknown) => {
+      const hash = (params as unknown[])[5] as string;
+      if (seenHashes.has(hash)) {
+        return { rows: [], rowCount: 0 };
+      }
+      seenHashes.add(hash);
+      return { rows: [], rowCount: 1 };
+    });
+
+    const results: string[] = [];
+    // Import same content twice
+    for (let i = 0; i < 2; i++) {
+      const file = makeFile(
+        "Identical content that should be detected as a duplicate on second import.",
+      );
+      const result = await importThought(pool, file, defaultOpts);
+      results.push(result);
+    }
+
+    expect(results[0]).toBe("imported");
+    expect(results[1]).toBe("duplicate");
+  });
+
+  it("imports 10 files and verifies progress stats", async () => {
+    const { pool } = createMockPool();
+    let imported = 0;
+    let duplicates = 0;
+    let errors = 0;
+
+    for (let i = 0; i < 10; i++) {
+      const file = makeFile(
+        `Thought file ${i} has enough content for testing the import process.`,
+      );
+      const result = await importThought(pool, file, defaultOpts);
+      if (result === "imported") imported++;
+      else if (result === "duplicate") duplicates++;
+      else errors++;
+    }
+
+    expect(imported).toBe(10);
+    expect(duplicates).toBe(0);
+    expect(errors).toBe(0);
+  });
+});
+
+// ===========================================================================
+// LARGE: 100 files, programmatic generation
+// ===========================================================================
+
+describe("large: 100-file import", () => {
+  it("reads 100 programmatically generated files", async () => {
+    for (let i = 0; i < 100; i++) {
+      await Bun.write(
+        join(tmpDir, `file-${i}.md`),
+        `---\ntitle: Test ${i}\ntags: [test, batch]\n---\n\nThis is test file number ${i} with enough content to pass the minimum length check.`,
+      );
+    }
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(100);
+  });
+
+  it("imports all 100 files as thoughts", async () => {
+    const { pool } = createMockPool();
+    let imported = 0;
+
+    for (let i = 0; i < 100; i++) {
+      const file = makeFile(
+        `This is test file number ${i} with enough content to pass the minimum length check.`,
+        { tags: ["test", "batch"] },
+        join(tmpDir, `file-${i}.md`),
+      );
+      const result = await importThought(pool, file, defaultOpts);
+      if (result === "imported") imported++;
+    }
+
+    expect(imported).toBe(100);
+  });
+
+  it("100 files with mix of unique and duplicate content", async () => {
+    const seenHashes = new Set<string>();
+    const { pool } = createMockPool(async (_sql: unknown, params: unknown) => {
+      const hash = (params as unknown[])[5] as string;
+      if (seenHashes.has(hash)) {
+        return { rows: [], rowCount: 0 };
+      }
+      seenHashes.add(hash);
+      return { rows: [], rowCount: 1 };
+    });
+
+    let imported = 0;
+    let duplicates = 0;
+
+    for (let i = 0; i < 100; i++) {
+      // Every 10th file is a duplicate of file 0's content
+      const content =
+        i % 10 === 0 && i > 0
+          ? "This is test file number 0 with enough content to pass the minimum length check."
+          : `This is test file number ${i} with enough content to pass the minimum length check.`;
+      const file = makeFile(content, { tags: ["test"] }, `/test/file-${i}.md`);
+      const result = await importThought(pool, file, defaultOpts);
+      if (result === "imported") imported++;
+      else if (result === "duplicate") duplicates++;
+    }
+
+    // file 0 imports, files 10,20,30,40,50,60,70,80,90 are dupes of file 0
+    expect(duplicates).toBe(9);
+    expect(imported).toBe(91);
+  });
+});
+
+// ===========================================================================
+// TABLE ROUTING: thoughts vs decisions vs sessions
+// ===========================================================================
+
+describe("table routing", () => {
+  it("importThought uses INSERT INTO thoughts", async () => {
+    const file = makeFile(
+      "A thought about testing table routing in the bulk import script.",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, defaultOpts);
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO thoughts");
+    expect(sql).not.toContain("INSERT INTO decisions");
+    expect(sql).not.toContain("INSERT INTO sessions");
+  });
+
+  it("importDecision uses INSERT INTO decisions with title and rationale", async () => {
+    const file = makeFile(
+      "We decided to use Bun because it is faster than Node for our workload.",
+      { title: "Use Bun Runtime", tags: ["infrastructure"] },
+      "/test/decision.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO decisions");
+    expect(sql).toContain("title");
+    expect(sql).toContain("rationale");
+    expect(sql).toContain("context");
+    expect(params![0]).toBe("Use Bun Runtime"); // title from frontmatter
+    expect(params![1]).toBe(
+      "We decided to use Bun because it is faster than Node for our workload.",
+    ); // rationale = body
+    expect(params![3]).toContain("Imported from:"); // context
+  });
+
+  it("importDecision falls back to first line of body for title when no frontmatter title", async () => {
+    const file = makeFile(
+      "# Switch to PostgreSQL\n\nBecause it has better vector support than SQLite.",
+      {},
+      "/test/decision-no-title.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    // Title is derived from first line with leading # stripped
+    expect(params![0]).toBe("Switch to PostgreSQL");
+  });
+
+  it("importDecision uses frontmatter.name as fallback title", async () => {
+    const file = makeFile(
+      "This decision has a name field instead of a title field in frontmatter.",
+      { name: "Named Decision" },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![0]).toBe("Named Decision");
+  });
+
+  it("importSession uses INSERT INTO sessions with project and summary", async () => {
+    const file = makeFile(
+      "We worked on the bulk import feature and added comprehensive test coverage.",
+      { project: "open-brain", tags: ["session"] },
+      "/test/session.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO sessions");
+    expect(sql).toContain("project");
+    expect(sql).toContain("summary");
+    expect(params![0]).toBe("open-brain"); // project from frontmatter
+    expect(params![1]).toBe(
+      "We worked on the bulk import feature and added comprehensive test coverage.",
+    ); // summary = body
+    expect(params![2]).toEqual(["session"]); // tags
+    expect(params![3]).toBe("bulk-import"); // created_by
+  });
+
+  it("importSession sets project to null when not in frontmatter", async () => {
+    const file = makeFile(
+      "Session without a project field in the frontmatter metadata.",
+      {},
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![0]).toBeNull(); // project
+  });
+
+  it("importSession uses VALUES (not WHERE NOT EXISTS) since sessions allow duplicates", async () => {
+    const file = makeFile(
+      "Session content that can appear multiple times in the database.",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("VALUES");
+    expect(sql).not.toContain("WHERE NOT EXISTS");
+  });
+});
+
+// ===========================================================================
+// TAG HANDLING: --tags flag merges with frontmatter tags
+// ===========================================================================
+
+describe("tag handling", () => {
+  it("merges extraTags with frontmatter tags for thoughts", async () => {
+    const file = makeFile(
+      "Content with both frontmatter and CLI tags for testing merge behavior.",
+      { tags: ["fm-tag-1", "fm-tag-2"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      extraTags: ["cli-tag-1", "cli-tag-2"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![1]).toEqual([
+      "fm-tag-1",
+      "fm-tag-2",
+      "cli-tag-1",
+      "cli-tag-2",
+    ]);
+  });
+
+  it("uses only extraTags when frontmatter has no tags", async () => {
+    const file = makeFile(
+      "Content without frontmatter tags but with CLI-provided tags.",
+      {},
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      extraTags: ["added-tag"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![1]).toEqual(["added-tag"]);
+  });
+
+  it("uses only frontmatter tags when no extraTags", async () => {
+    const file = makeFile(
+      "Content with frontmatter tags and no extra CLI tags provided.",
+      { tags: ["only-fm"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![1]).toEqual(["only-fm"]);
+  });
+
+  it("handles non-array frontmatter tags gracefully", async () => {
+    const file = makeFile(
+      "Content where frontmatter tags is a string instead of an array.",
+      { tags: "not-an-array" },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      extraTags: ["extra"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    // Non-array tags should be treated as empty, only extraTags used
+    expect(params![1]).toEqual(["extra"]);
+  });
+
+  it("merges tags for decisions the same way", async () => {
+    const file = makeFile(
+      "Decision content for testing tag merge behavior in the decisions table.",
+      { title: "Tag Test", tags: ["decision-tag"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, {
+      ...defaultOpts,
+      extraTags: ["cli-tag"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![2]).toEqual(["decision-tag", "cli-tag"]); // tags is param index 2 for decisions
+  });
+
+  it("merges tags for sessions the same way", async () => {
+    const file = makeFile(
+      "Session content for testing tag merge behavior in the sessions table.",
+      { tags: ["session-tag"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: ["cli-tag"],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![2]).toEqual(["session-tag", "cli-tag"]); // tags is param index 2 for sessions
+  });
+});
+
+// ===========================================================================
+// DRY RUN: no DB calls
+// ===========================================================================
+
+describe("dry run", () => {
+  it("readFiles works but no DB calls are needed in dry-run mode", async () => {
+    // Simulate what the main function does in dry-run: read files, print them, exit
+    for (let i = 0; i < 5; i++) {
+      await Bun.write(
+        join(tmpDir, `note-${i}.md`),
+        `---\ntitle: Note ${i}\n---\n\nThis is note ${i} with enough content to pass the minimum length check.`,
+      );
+    }
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(5);
+
+    // In dry-run mode, the script just prints files and exits without calling pool.query
+    const { pool, mockQuery } = createMockPool();
+
+    // Dry-run: iterate and collect output but do NOT call any import function
+    const dryRunOutput: string[] = [];
+    for (const f of files) {
+      const title =
+        (f.frontmatter.title as string) ||
+        (f.body.split("\n")[0] ?? "").slice(0, 80);
+      dryRunOutput.push(`${f.filePath} -> ${title}`);
+    }
+
+    expect(dryRunOutput).toHaveLength(5);
+    expect(dryRunOutput[0]).toContain("->");
+    // Verify NO database calls were made
+    expect(mockQuery).not.toHaveBeenCalled();
+    // Pool.end should not be called in dry-run either (pool is never created)
+  });
+});
+
+// ===========================================================================
+// PARSE ARGS
+// ===========================================================================
+
+describe("parseArgs", () => {
+  it("parses source directory as positional argument", () => {
+    const result = parseArgs(["bun", "script.ts", "/some/dir"]);
+    expect(result.sourceDir).toBe("/some/dir");
+    expect(result.table).toBe("thoughts"); // default
+    expect(result.dryRun).toBe(false);
+    expect(result.pattern).toBe("**/*.md");
+  });
+
+  it("parses --table flag", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/dir",
+      "--table",
+      "decisions",
+    ]);
+    expect(result.table).toBe("decisions");
+  });
+
+  it("parses --tags flag with comma-separated values", () => {
+    const result = parseArgs(["bun", "script.ts", "/dir", "--tags", "a,b,c"]);
+    expect(result.extraTags).toEqual(["a", "b", "c"]);
+  });
+
+  it("parses --source flag", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/dir",
+      "--source",
+      "my-source",
+    ]);
+    expect(result.sourceLabel).toBe("my-source");
+  });
+
+  it("parses --pattern flag", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/dir",
+      "--pattern",
+      "*.txt",
+    ]);
+    expect(result.pattern).toBe("*.txt");
+  });
+
+  it("parses boolean flags: --embed, --extract, --dry-run", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/dir",
+      "--embed",
+      "--extract",
+      "--dry-run",
+    ]);
+    expect(result.embed).toBe(true);
+    expect(result.extract).toBe(true);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("parses all options together", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/my/dir",
+      "--table",
+      "sessions",
+      "--tags",
+      "x,y",
+      "--source",
+      "custom",
+      "--pattern",
+      "notes/*.md",
+      "--embed",
+      "--dry-run",
+    ]);
+    expect(result.sourceDir).toBe("/my/dir");
+    expect(result.table).toBe("sessions");
+    expect(result.extraTags).toEqual(["x", "y"]);
+    expect(result.sourceLabel).toBe("custom");
+    expect(result.pattern).toBe("notes/*.md");
+    expect(result.embed).toBe(true);
+    expect(result.extract).toBe(false);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("trims whitespace from tag values", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/dir",
+      "--tags",
+      " a , b , c ",
+    ]);
+    expect(result.extraTags).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ===========================================================================
+// EDGE CASES
+// ===========================================================================
+
+describe("edge cases", () => {
+  it("skips empty files (< 10 chars body)", async () => {
+    await Bun.write(join(tmpDir, "empty.md"), "");
+    await Bun.write(join(tmpDir, "short.md"), "hi");
+    await Bun.write(join(tmpDir, "nine.md"), "123456789"); // exactly 9 chars
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0);
+  });
+
+  it("includes files with exactly 10 chars body", async () => {
+    await Bun.write(join(tmpDir, "ten.md"), "1234567890"); // exactly 10 chars
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(1);
+  });
+
+  it("handles files with frontmatter but empty body", async () => {
+    await Bun.write(
+      join(tmpDir, "fm-only.md"),
+      `---\ntitle: All Frontmatter\ntags: [a, b]\n---\n`,
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0);
+  });
+
+  it("handles files with frontmatter and very short body", async () => {
+    await Bun.write(
+      join(tmpDir, "fm-short.md"),
+      `---\ntitle: Short Body\n---\n\nHi`,
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0); // "Hi" is < 10 chars
+  });
+
+  it("handles nested directories with glob pattern", async () => {
+    await Bun.write(
+      join(tmpDir, "a", "b", "c", "deep.md"),
+      "Deeply nested file content with enough text for the import.",
+    );
+    await Bun.write(
+      join(tmpDir, "a", "sibling.md"),
+      "Sibling file content with enough text for the import test.",
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(2);
+  });
+
+  it("custom source label propagates to SQL params for thoughts", async () => {
+    const file = makeFile(
+      "Content with a custom source label for testing propagation.",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      sourceLabel: "my-custom-source",
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![2]).toBe("my-custom-source");
+  });
+
+  it("decision context includes file path", async () => {
+    const file = makeFile(
+      "Decision body with enough content for the minimum length check.",
+      { title: "Test Decision" },
+      "/my/notes/decision-001.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params![3]).toBe("Imported from: /my/notes/decision-001.md");
+  });
+
+  it("importThought logs warning on query error", async () => {
+    const file = makeFile(
+      "Content that triggers a database error for testing error handling.",
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("test-db-error");
+    });
+
+    const result = await importThought(pool, file, defaultOpts);
+
+    expect(result).toBe("error");
+    const warnCall = logCalls.warn.find(([msg]) => msg === "Import error");
+    expect(warnCall).toBeTruthy();
+    expect(warnCall![1]!.error).toBe("test-db-error");
+  });
+
+  it("importDecision logs warning on query error", async () => {
+    const file = makeFile(
+      "Decision content that triggers a database error for testing.",
+      { title: "Error Decision" },
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("decision-db-error");
+    });
+
+    const result = await importDecision(pool, file, defaultOpts);
+
+    expect(result).toBe("error");
+    const warnCall = logCalls.warn.find(
+      ([, extra]) => extra?.error === "decision-db-error",
+    );
+    expect(warnCall).toBeTruthy();
+  });
+
+  it("importSession logs warning on query error", async () => {
+    const file = makeFile(
+      "Session content that triggers a database error for testing.",
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("session-db-error");
+    });
+
+    const result = await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "test",
+      embed: false,
+    });
+
+    expect(result).toBe("error");
+  });
+
+  it("content hash is deterministic for identical content", () => {
+    const hash1 = contentHash("Hello world test content");
+    const hash2 = contentHash("Hello world test content");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("content hash differs for different content", () => {
+    const hash1 = contentHash("Content version A for hash testing");
+    const hash2 = contentHash("Content version B for hash testing");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("content hash normalizes whitespace", () => {
+    const hash1 = contentHash("hello  world");
+    const hash2 = contentHash("hello world");
+    expect(hash1).toBe(hash2);
+  });
+});

--- a/scripts/bulk-import.ts
+++ b/scripts/bulk-import.ts
@@ -1,0 +1,431 @@
+#!/usr/bin/env bun
+/**
+ * Bulk import markdown files into Open Brain.
+ *
+ * Usage:
+ *   bun run scripts/bulk-import.ts <source-dir> [options]
+ *
+ * Options:
+ *   --table <name>      Target: thoughts (default) | decisions | sessions
+ *   --tags <t1,t2>      Additional tags for all imports
+ *   --source <label>    Source label (default: "bulk-import")
+ *   --embed             Generate embeddings inline (default: skip, use backfill)
+ *   --extract           Run auto-metadata extraction (default: skip)
+ *   --dry-run           Show what would be imported
+ *   --pattern <glob>    File glob (default: "**\/*.md")
+ */
+import { Glob } from "bun";
+import type pg from "pg";
+import { toSql } from "pgvector/pg";
+import { createPool } from "../src/db/pool.ts";
+import { contentHash, generateEmbedding } from "../src/embedding.ts";
+import { extractMetadata, mergeTags } from "../src/extraction.ts";
+import { logger } from "../src/logger.ts";
+
+const DELAY_MS = 200;
+const EMBEDDING_MODEL = "gemini-embedding-001";
+
+type ImportTable = "thoughts" | "decisions" | "sessions";
+
+interface ParsedFile {
+  filePath: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+interface ImportStats {
+  imported: number;
+  skipped: number;
+  duplicates: number;
+  errors: number;
+}
+
+function parseFrontmatter(raw: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: raw.trim() };
+
+  const fm: Record<string, unknown> = {};
+  for (const line of match[1]!.split("\n")) {
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    let val: unknown = line.slice(colon + 1).trim();
+    // Handle simple YAML arrays like [a, b] or quoted strings
+    if (typeof val === "string" && val.startsWith("[") && val.endsWith("]")) {
+      val = val
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim().replace(/^["']|["']$/g, ""));
+    } else if (
+      typeof val === "string" &&
+      (val.startsWith('"') || val.startsWith("'"))
+    ) {
+      val = val.replace(/^["']|["']$/g, "");
+    }
+    fm[key] = val;
+  }
+
+  return { frontmatter: fm, body: match[2]!.trim() };
+}
+
+async function readFiles(
+  sourceDir: string,
+  pattern: string,
+): Promise<ParsedFile[]> {
+  const glob = new Glob(pattern);
+  const files: ParsedFile[] = [];
+
+  for await (const path of glob.scan({ cwd: sourceDir, absolute: true })) {
+    const raw = await Bun.file(path).text();
+    const { frontmatter, body } = parseFrontmatter(raw);
+    if (!body || body.length < 10) continue;
+    files.push({ filePath: path, frontmatter, body });
+  }
+
+  return files;
+}
+
+async function importThought(
+  pool: pg.Pool,
+  file: ParsedFile,
+  opts: {
+    extraTags: string[];
+    sourceLabel: string;
+    embed: boolean;
+    extract: boolean;
+  },
+): Promise<"imported" | "duplicate" | "error"> {
+  const content = file.body;
+  const hash = contentHash(content);
+
+  const fmTags = Array.isArray(file.frontmatter.tags)
+    ? (file.frontmatter.tags as string[])
+    : [];
+  let tags = [...fmTags, ...opts.extraTags];
+
+  let embedding: number[] | null = null;
+  let extracted: Awaited<ReturnType<typeof extractMetadata>> = null;
+
+  if (opts.embed || opts.extract) {
+    const promises: [
+      Promise<number[] | null>,
+      Promise<Awaited<ReturnType<typeof extractMetadata>>>,
+    ] = [
+      opts.embed ? generateEmbedding(content) : Promise.resolve(null),
+      opts.extract ? extractMetadata(content) : Promise.resolve(null),
+    ];
+    [embedding, extracted] = await Promise.all(promises);
+    tags = mergeTags(tags, extracted);
+    await new Promise((r) => setTimeout(r, DELAY_MS));
+  }
+
+  try {
+    const { rowCount } = await pool.query(
+      `INSERT INTO thoughts (content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model, extracted_metadata)
+       SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+       WHERE NOT EXISTS (SELECT 1 FROM thoughts WHERE content_hash = $6)`,
+      [
+        content,
+        tags,
+        opts.sourceLabel,
+        "bulk-import",
+        embedding ? toSql(embedding) : null,
+        hash,
+        embedding ? new Date().toISOString() : null,
+        embedding ? EMBEDDING_MODEL : null,
+        extracted ? JSON.stringify(extracted) : null,
+      ],
+    );
+    return rowCount && rowCount > 0 ? "imported" : "duplicate";
+  } catch (err) {
+    logger.warn("Import error", {
+      file: file.filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return "error";
+  }
+}
+
+async function importDecision(
+  pool: pg.Pool,
+  file: ParsedFile,
+  opts: {
+    extraTags: string[];
+    sourceLabel: string;
+    embed: boolean;
+    extract: boolean;
+  },
+): Promise<"imported" | "duplicate" | "error"> {
+  const title =
+    (file.frontmatter.title as string) ||
+    (file.frontmatter.name as string) ||
+    (file.body.split("\n")[0] ?? "").replace(/^#+\s*/, "").slice(0, 200);
+  const rationale = file.body;
+  const textToEmbed = `${title}\n${rationale}`;
+  const hash = contentHash(textToEmbed);
+
+  const fmTags = Array.isArray(file.frontmatter.tags)
+    ? (file.frontmatter.tags as string[])
+    : [];
+  let tags = [...fmTags, ...opts.extraTags];
+
+  let embedding: number[] | null = null;
+  let extracted: Awaited<ReturnType<typeof extractMetadata>> = null;
+
+  if (opts.embed || opts.extract) {
+    const promises: [
+      Promise<number[] | null>,
+      Promise<Awaited<ReturnType<typeof extractMetadata>>>,
+    ] = [
+      opts.embed ? generateEmbedding(textToEmbed) : Promise.resolve(null),
+      opts.extract ? extractMetadata(textToEmbed) : Promise.resolve(null),
+    ];
+    [embedding, extracted] = await Promise.all(promises);
+    tags = mergeTags(tags, extracted);
+    await new Promise((r) => setTimeout(r, DELAY_MS));
+  }
+
+  try {
+    const { rowCount } = await pool.query(
+      `INSERT INTO decisions (title, rationale, tags, context, created_by, embedding, content_hash, embedded_at, embedding_model, extracted_metadata)
+       SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+       WHERE NOT EXISTS (SELECT 1 FROM decisions WHERE content_hash = $7)`,
+      [
+        title,
+        rationale,
+        tags,
+        `Imported from: ${file.filePath}`,
+        "bulk-import",
+        embedding ? toSql(embedding) : null,
+        hash,
+        embedding ? new Date().toISOString() : null,
+        embedding ? EMBEDDING_MODEL : null,
+        extracted ? JSON.stringify(extracted) : null,
+      ],
+    );
+    return rowCount && rowCount > 0 ? "imported" : "duplicate";
+  } catch (err) {
+    logger.warn("Import error", {
+      file: file.filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return "error";
+  }
+}
+
+async function importSession(
+  pool: pg.Pool,
+  file: ParsedFile,
+  opts: {
+    extraTags: string[];
+    sourceLabel: string;
+    embed: boolean;
+  },
+): Promise<"imported" | "duplicate" | "error"> {
+  const summary = file.body;
+  const project = (file.frontmatter.project as string) || null;
+  // Sessions use timestamp in hash to allow multiple saves
+  const hash = contentHash(summary + "|" + new Date().toISOString());
+
+  const fmTags = Array.isArray(file.frontmatter.tags)
+    ? (file.frontmatter.tags as string[])
+    : [];
+  const tags = [...fmTags, ...opts.extraTags];
+
+  let embedding: number[] | null = null;
+  if (opts.embed) {
+    embedding = await generateEmbedding(summary);
+    await new Promise((r) => setTimeout(r, DELAY_MS));
+  }
+
+  try {
+    const { rowCount } = await pool.query(
+      `INSERT INTO sessions (project, summary, tags, created_by, embedding, content_hash, embedded_at, embedding_model)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        project,
+        summary,
+        tags,
+        "bulk-import",
+        embedding ? toSql(embedding) : null,
+        hash,
+        embedding ? new Date().toISOString() : null,
+        embedding ? EMBEDDING_MODEL : null,
+      ],
+    );
+    return rowCount && rowCount > 0 ? "imported" : "duplicate";
+  } catch (err) {
+    logger.warn("Import error", {
+      file: file.filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return "error";
+  }
+}
+
+function parseArgs(argv: string[]): {
+  sourceDir: string;
+  table: ImportTable;
+  extraTags: string[];
+  sourceLabel: string;
+  embed: boolean;
+  extract: boolean;
+  dryRun: boolean;
+  pattern: string;
+} {
+  const args = argv.slice(2);
+  let sourceDir = "";
+  let table = "thoughts";
+  let extraTags: string[] = [];
+  let sourceLabel = "bulk-import";
+  let embed = false;
+  let extract = false;
+  let dryRun = false;
+  let pattern = "**/*.md";
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    switch (arg) {
+      case "--table":
+        table = args[++i]!;
+        break;
+      case "--tags":
+        extraTags = args[++i]!.split(",").map((t) => t.trim());
+        break;
+      case "--source":
+        sourceLabel = args[++i]!;
+        break;
+      case "--pattern":
+        pattern = args[++i]!;
+        break;
+      case "--embed":
+        embed = true;
+        break;
+      case "--extract":
+        extract = true;
+        break;
+      case "--dry-run":
+        dryRun = true;
+        break;
+      default:
+        if (!arg.startsWith("--") && !sourceDir) sourceDir = arg;
+    }
+  }
+
+  if (!sourceDir) {
+    console.error(
+      "Usage: bun run scripts/bulk-import.ts <source-dir> [--table thoughts|decisions|sessions] [--tags t1,t2] [--embed] [--extract] [--dry-run]",
+    );
+    process.exit(1);
+  }
+
+  const validTables = new Set(["thoughts", "decisions", "sessions"] as const);
+  if (!validTables.has(table as ImportTable)) {
+    console.error(
+      `Invalid table: ${table}. Must be thoughts, decisions, or sessions.`,
+    );
+    process.exit(1);
+  }
+
+  return {
+    sourceDir,
+    table: table as ImportTable,
+    extraTags,
+    sourceLabel,
+    embed,
+    extract,
+    dryRun,
+    pattern,
+  };
+}
+
+if (import.meta.main) {
+  const opts = parseArgs(process.argv);
+  const files = await readFiles(opts.sourceDir, opts.pattern);
+
+  logger.info("Bulk import starting", {
+    sourceDir: opts.sourceDir,
+    table: opts.table,
+    fileCount: files.length,
+    embed: opts.embed,
+    extract: opts.extract,
+    dryRun: opts.dryRun,
+  });
+
+  if (opts.dryRun) {
+    for (const f of files) {
+      const title =
+        (f.frontmatter.title as string) ||
+        (f.frontmatter.name as string) ||
+        (f.body.split("\n")[0] ?? "").slice(0, 80);
+      console.log(`  ${f.filePath} -> ${title}`);
+    }
+    console.log(`\n${files.length} files would be imported into ${opts.table}`);
+    process.exit(0);
+  }
+
+  const pool = createPool();
+  const stats: ImportStats = {
+    imported: 0,
+    skipped: 0,
+    duplicates: 0,
+    errors: 0,
+  };
+
+  try {
+    const importers: Record<
+      ImportTable,
+      (
+        p: pg.Pool,
+        f: ParsedFile,
+        o: typeof opts,
+      ) => Promise<"imported" | "duplicate" | "error">
+    > = {
+      thoughts: importThought,
+      decisions: importDecision,
+      sessions: importSession,
+    };
+    const importer = importers[opts.table];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]!;
+      const result = await importer(pool, file, opts);
+
+      switch (result) {
+        case "imported":
+          stats.imported++;
+          break;
+        case "duplicate":
+          stats.duplicates++;
+          break;
+        case "error":
+          stats.errors++;
+          break;
+      }
+
+      if ((i + 1) % 10 === 0 || i === files.length - 1) {
+        console.log(
+          `  [${i + 1}/${files.length}] imported=${stats.imported} dupes=${stats.duplicates} errors=${stats.errors}`,
+        );
+      }
+    }
+
+    const suffix = opts.embed
+      ? ""
+      : " -- run 'bun run backfill' for embeddings";
+    logger.info(
+      `Import complete${suffix}`,
+      stats as unknown as Record<string, unknown>,
+    );
+  } catch (err) {
+    logger.error("Import failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}

--- a/scripts/bulk-import.ts
+++ b/scripts/bulk-import.ts
@@ -25,22 +25,22 @@ import { logger } from "../src/logger.ts";
 const DELAY_MS = 200;
 const EMBEDDING_MODEL = "gemini-embedding-001";
 
-type ImportTable = "thoughts" | "decisions" | "sessions";
+export type ImportTable = "thoughts" | "decisions" | "sessions";
 
-interface ParsedFile {
+export interface ParsedFile {
   filePath: string;
   frontmatter: Record<string, unknown>;
   body: string;
 }
 
-interface ImportStats {
+export interface ImportStats {
   imported: number;
   skipped: number;
   duplicates: number;
   errors: number;
 }
 
-function parseFrontmatter(raw: string): {
+export function parseFrontmatter(raw: string): {
   frontmatter: Record<string, unknown>;
   body: string;
 } {
@@ -71,7 +71,7 @@ function parseFrontmatter(raw: string): {
   return { frontmatter: fm, body: match[2]!.trim() };
 }
 
-async function readFiles(
+export async function readFiles(
   sourceDir: string,
   pattern: string,
 ): Promise<ParsedFile[]> {
@@ -88,7 +88,7 @@ async function readFiles(
   return files;
 }
 
-async function importThought(
+export async function importThought(
   pool: pg.Pool,
   file: ParsedFile,
   opts: {
@@ -149,7 +149,7 @@ async function importThought(
   }
 }
 
-async function importDecision(
+export async function importDecision(
   pool: pg.Pool,
   file: ParsedFile,
   opts: {
@@ -216,7 +216,7 @@ async function importDecision(
   }
 }
 
-async function importSession(
+export async function importSession(
   pool: pg.Pool,
   file: ParsedFile,
   opts: {
@@ -266,7 +266,7 @@ async function importSession(
   }
 }
 
-function parseArgs(argv: string[]): {
+export function parseArgs(argv: string[]): {
   sourceDir: string;
   table: ImportTable;
   extraTags: string[];

--- a/src/__tests__/extraction.test.ts
+++ b/src/__tests__/extraction.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, afterEach, beforeEach } from "bun:test";
+import { extractMetadata, mergeTags } from "../extraction.ts";
+import type { ExtractedMetadata } from "../extraction.ts";
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  // Restore env vars that tests may have modified
+  process.env.LITELLM_URL = originalEnv.LITELLM_URL;
+  process.env.LITELLM_API_KEY = originalEnv.LITELLM_API_KEY;
+  process.env.EXTRACTION_MODEL = originalEnv.EXTRACTION_MODEL;
+});
+
+/** Helper: build a mock fetch that returns a successful LiteLLM chat completion */
+function mockFetchOk(metadata: ExtractedMetadata): typeof fetch {
+  return (async () => ({
+    ok: true,
+    json: async () => ({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify(metadata),
+          },
+        },
+      ],
+    }),
+  })) as unknown as typeof fetch;
+}
+
+describe("extractMetadata", () => {
+  beforeEach(() => {
+    // Clear env so tests control it explicitly
+    delete process.env.LITELLM_URL;
+    delete process.env.LITELLM_API_KEY;
+    delete process.env.EXTRACTION_MODEL;
+  });
+
+  describe("returns null for empty/short text", () => {
+    it("returns null for empty string", async () => {
+      const result = await extractMetadata("");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for text shorter than 10 chars", async () => {
+      const result = await extractMetadata("too short");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for undefined-ish text", async () => {
+      const result = await extractMetadata(undefined as unknown as string);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("returns null when no LITELLM_URL is configured", () => {
+    it("returns null when neither param nor env var is set", async () => {
+      delete process.env.LITELLM_URL;
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("returns null on HTTP error", () => {
+    it("returns null when server responds with non-ok status", async () => {
+      globalThis.fetch = (async () => ({
+        ok: false,
+        status: 500,
+      })) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("returns null on invalid JSON response", () => {
+    it("returns null when LLM returns unparseable content", async () => {
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: "not valid json {{{",
+              },
+            },
+          ],
+        }),
+      })) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when choices array is empty", async () => {
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => ({ choices: [] }),
+      })) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when message content is missing", async () => {
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: {} }],
+        }),
+      })) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("parses valid response correctly", () => {
+    it("extracts all fields from well-formed response", async () => {
+      const expected: ExtractedMetadata = {
+        topics: ["TypeScript", "testing"],
+        people: ["Alice", "Bob"],
+        action_items: ["Write tests"],
+        dates: ["2026-03-17"],
+      };
+
+      globalThis.fetch = mockFetchOk(expected);
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it("defaults missing arrays to empty", async () => {
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ topics: ["only-topics"] }),
+              },
+            },
+          ],
+        }),
+      })) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+
+      expect(result).toEqual({
+        topics: ["only-topics"],
+        people: [],
+        action_items: [],
+        dates: [],
+      });
+    });
+
+    it("uses litellmUrl param over env var", async () => {
+      process.env.LITELLM_URL = "http://env-url:4000";
+      let calledUrl = "";
+
+      globalThis.fetch = (async (url: string) => {
+        calledUrl = url;
+        return {
+          ok: true,
+          json: async () => ({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    topics: [],
+                    people: [],
+                    action_items: [],
+                    dates: [],
+                  }),
+                },
+              },
+            ],
+          }),
+        };
+      }) as unknown as typeof fetch;
+
+      await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://param-url:4000",
+      );
+
+      expect(calledUrl).toBe("http://param-url:4000/chat/completions");
+    });
+
+    it("falls back to LITELLM_URL env var when param is omitted", async () => {
+      process.env.LITELLM_URL = "http://env-url:4000";
+      let calledUrl = "";
+
+      globalThis.fetch = (async (url: string) => {
+        calledUrl = url;
+        return {
+          ok: true,
+          json: async () => ({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    topics: [],
+                    people: [],
+                    action_items: [],
+                    dates: [],
+                  }),
+                },
+              },
+            ],
+          }),
+        };
+      }) as unknown as typeof fetch;
+
+      await extractMetadata("This is a sufficiently long text for extraction");
+
+      expect(calledUrl).toBe("http://env-url:4000/chat/completions");
+    });
+  });
+
+  describe("handles timeout gracefully", () => {
+    it("returns null when fetch is aborted", async () => {
+      globalThis.fetch = (async (
+        _url: string,
+        opts: { signal?: AbortSignal },
+      ) => {
+        // Simulate an abort by checking signal and throwing
+        if (opts.signal) {
+          // Immediately abort to simulate timeout
+          opts.signal.throwIfAborted?.();
+        }
+        return new Promise((_resolve, reject) => {
+          const abortHandler = () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          };
+          if (opts.signal?.aborted) {
+            abortHandler();
+          } else {
+            opts.signal?.addEventListener("abort", abortHandler);
+          }
+        });
+      }) as unknown as typeof fetch;
+
+      // Use a direct abort approach: the real code uses setTimeout with 8000ms,
+      // but we can test the abort path by using a fetch that never resolves
+      // and manually triggering the abort. Instead, let's just throw AbortError.
+      globalThis.fetch = (async () => {
+        throw new DOMException("The operation was aborted", "AbortError");
+      }) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null on generic network error", async () => {
+      globalThis.fetch = (async () => {
+        throw new Error("ECONNREFUSED");
+      }) as unknown as typeof fetch;
+
+      const result = await extractMetadata(
+        "This is a sufficiently long text for extraction",
+        "http://localhost:4000",
+      );
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("mergeTags", () => {
+  describe("deduplicates case-insensitively", () => {
+    it("does not add a topic that already exists in different case", () => {
+      const existing = ["TypeScript"];
+      const extracted: ExtractedMetadata = {
+        topics: ["typescript", "TYPESCRIPT", "Testing"],
+        people: [],
+        action_items: [],
+        dates: [],
+      };
+
+      const result = mergeTags(existing, extracted);
+      expect(result).toEqual(["TypeScript", "Testing"]);
+    });
+  });
+
+  describe("prefixes people with person:", () => {
+    it("adds person: prefix to each person entry", () => {
+      const existing: string[] = [];
+      const extracted: ExtractedMetadata = {
+        topics: [],
+        people: ["Alice", "Bob"],
+        action_items: [],
+        dates: [],
+      };
+
+      const result = mergeTags(existing, extracted);
+      expect(result).toEqual(["person:Alice", "person:Bob"]);
+    });
+
+    it("deduplicates people against existing person: tags", () => {
+      const existing = ["person:Alice"];
+      const extracted: ExtractedMetadata = {
+        topics: [],
+        people: ["Alice", "Charlie"],
+        action_items: [],
+        dates: [],
+      };
+
+      const result = mergeTags(existing, extracted);
+      expect(result).toEqual(["person:Alice", "person:Charlie"]);
+    });
+  });
+
+  describe("preserves existing tags", () => {
+    it("returns all existing tags plus new ones", () => {
+      const existing = ["existing-tag", "another-tag"];
+      const extracted: ExtractedMetadata = {
+        topics: ["new-topic"],
+        people: ["NewPerson"],
+        action_items: [],
+        dates: [],
+      };
+
+      const result = mergeTags(existing, extracted);
+      expect(result).toEqual([
+        "existing-tag",
+        "another-tag",
+        "new-topic",
+        "person:NewPerson",
+      ]);
+    });
+
+    it("does not modify the original array", () => {
+      const existing = ["original"];
+      const extracted: ExtractedMetadata = {
+        topics: ["added"],
+        people: [],
+        action_items: [],
+        dates: [],
+      };
+
+      const result = mergeTags(existing, extracted);
+      expect(existing).toEqual(["original"]); // unchanged
+      expect(result).toEqual(["original", "added"]);
+    });
+  });
+
+  describe("handles null extracted metadata", () => {
+    it("returns existing tags unchanged when extracted is null", () => {
+      const existing = ["keep-me", "also-keep"];
+      const result = mergeTags(existing, null);
+      expect(result).toEqual(["keep-me", "also-keep"]);
+    });
+
+    it("returns empty array when both existing is empty and extracted is null", () => {
+      const result = mergeTags([], null);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/db/migrations/003_extraction_metadata.sql
+++ b/src/db/migrations/003_extraction_metadata.sql
@@ -1,0 +1,27 @@
+-- Add extracted_metadata JSONB to thoughts and decisions
+-- Rehash existing content with lowercase normalization
+
+-- New columns for LLM-extracted metadata
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS extracted_metadata JSONB;
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS extracted_metadata JSONB;
+
+-- Rehash existing rows: old hash was trim+collapse-whitespace, new adds lowercase
+-- Using convert_to() for proper text-to-bytea conversion
+
+-- thoughts: hash input is content
+UPDATE thoughts
+SET content_hash = encode(sha256(convert_to(regexp_replace(trim(lower(content)), '\s+', ' ', 'g'), 'UTF8')), 'hex')
+WHERE content_hash IS NOT NULL;
+
+-- decisions: hash input is title || '\n' || rationale
+UPDATE decisions
+SET content_hash = encode(sha256(convert_to(regexp_replace(trim(lower(title || E'\n' || rationale)), '\s+', ' ', 'g'), 'UTF8')), 'hex')
+WHERE content_hash IS NOT NULL;
+
+-- sessions: hash includes timestamp (summary + '|' + ISO timestamp), cannot rehash
+-- relationships: rehash based on person_name + context
+UPDATE relationships
+SET content_hash = encode(sha256(convert_to(regexp_replace(trim(lower(
+  person_name || COALESCE(E'\n' || context, '') || COALESCE(E'\n' || notes, '')
+)), '\s+', ' ', 'g'), 'UTF8')), 'hex')
+WHERE content_hash IS NOT NULL;

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -74,6 +74,6 @@ export async function generateEmbedding(
 }
 
 export function contentHash(text: string): string {
-  const normalized = text.trim().replace(/\s+/g, " ");
+  const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
   return createHash("sha256").update(normalized).digest("hex");
 }

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -1,6 +1,7 @@
 import { logger } from "./logger.ts";
 
 const EXTRACTION_TIMEOUT_MS = 8000;
+const RETRY_DELAYS_MS = [0, 2000, 5000]; // immediate, 2s, 5s
 
 export interface ExtractedMetadata {
   topics: string[];

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -1,0 +1,125 @@
+import { logger } from "./logger.ts";
+
+const EXTRACTION_TIMEOUT_MS = 8000;
+
+export interface ExtractedMetadata {
+  topics: string[];
+  people: string[];
+  action_items: string[];
+  dates: string[];
+}
+
+const SYSTEM_PROMPT = `Extract metadata from the text. Return JSON only, no markdown fences.
+{"topics":["1-5 key topics"],"people":["mentioned names"],"action_items":["tasks if any"],"dates":["YYYY-MM-DD if any"]}
+Return empty arrays for categories with no matches. Be concise.`;
+
+export async function extractMetadata(
+  text: string,
+  litellmUrl?: string,
+): Promise<ExtractedMetadata | null> {
+  if (!text || text.length < 10) return null;
+
+  const baseUrl = litellmUrl ?? process.env.LITELLM_URL;
+  const model = process.env.EXTRACTION_MODEL ?? "flash";
+  if (!baseUrl) {
+    logger.warn("No LiteLLM URL configured for extraction");
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), EXTRACTION_TIMEOUT_MS);
+
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const apiKey = process.env.LITELLM_API_KEY;
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: text.slice(0, 4000) },
+        ],
+        response_format: { type: "json_object" },
+        max_tokens: 1024,
+        temperature: 0,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      logger.warn("Extraction request failed", { status: response.status });
+      return null;
+    }
+
+    const json = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const raw = json.choices?.[0]?.message?.content;
+    if (!raw) {
+      logger.warn("Extraction returned empty content");
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      topics: Array.isArray(parsed.topics) ? (parsed.topics as string[]) : [],
+      people: Array.isArray(parsed.people) ? (parsed.people as string[]) : [],
+      action_items: Array.isArray(parsed.action_items)
+        ? (parsed.action_items as string[])
+        : [],
+      dates: Array.isArray(parsed.dates) ? (parsed.dates as string[]) : [],
+    };
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      logger.warn("Extraction returned invalid JSON");
+    } else {
+      logger.warn("Extraction error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Merge extracted topics and people into existing tags array.
+ * People are prefixed with "person:" for filtering.
+ * Deduplicates against existing tags (case-insensitive).
+ */
+export function mergeTags(
+  existingTags: string[],
+  extracted: ExtractedMetadata | null,
+): string[] {
+  if (!extracted) return existingTags;
+
+  const seen = new Set(existingTags.map((t) => t.toLowerCase()));
+  const merged = [...existingTags];
+
+  for (const topic of extracted.topics) {
+    const key = topic.toLowerCase();
+    if (!seen.has(key)) {
+      merged.push(topic);
+      seen.add(key);
+    }
+  }
+
+  for (const person of extracted.people) {
+    const tagged = `person:${person}`;
+    const key = tagged.toLowerCase();
+    if (!seen.has(key)) {
+      merged.push(tagged);
+      seen.add(key);
+    }
+  }
+
+  return merged;
+}

--- a/src/tools/__tests__/log-decision.test.ts
+++ b/src/tools/__tests__/log-decision.test.ts
@@ -80,19 +80,16 @@ describe("log_decision", () => {
         expect(queryCalls.length).toBe(1);
         const [sql, params] = queryCalls[0];
         expect(sql).toContain("INSERT INTO decisions");
-        expect(sql).toContain("extracted_metadata");
         expect(params[0]).toBe("Use Bun"); // title
         expect(params[1]).toBe("Faster than Node.js for our use case"); // rationale
         // alternatives should be JSON-serialized
         const alts = params[2];
         expect(typeof alts).toBe("string");
         expect(JSON.parse(alts)).toEqual(["Node.js", "Deno"]);
-        // Tags may be enriched by extraction -- verify originals are included
-        expect(params[3]).toEqual(expect.arrayContaining(["runtime"]));
+        expect(params[3]).toEqual(["runtime"]); // tags (original -- extraction is fire-and-forget)
         expect(params[4]).toBe("Server runtime selection"); // context
         expect(params[5]).toBe("admin-client"); // created_by
-        // params[10] = extracted_metadata (JSON string or null)
-        expect(params.length).toBe(11);
+        expect(params.length).toBe(10);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/log-decision.test.ts
+++ b/src/tools/__tests__/log-decision.test.ts
@@ -80,15 +80,19 @@ describe("log_decision", () => {
         expect(queryCalls.length).toBe(1);
         const [sql, params] = queryCalls[0];
         expect(sql).toContain("INSERT INTO decisions");
+        expect(sql).toContain("extracted_metadata");
         expect(params[0]).toBe("Use Bun"); // title
         expect(params[1]).toBe("Faster than Node.js for our use case"); // rationale
         // alternatives should be JSON-serialized
         const alts = params[2];
         expect(typeof alts).toBe("string");
         expect(JSON.parse(alts)).toEqual(["Node.js", "Deno"]);
-        expect(params[3]).toEqual(["runtime"]); // tags
+        // Tags may be enriched by extraction -- verify originals are included
+        expect(params[3]).toEqual(expect.arrayContaining(["runtime"]));
         expect(params[4]).toBe("Server runtime selection"); // context
         expect(params[5]).toBe("admin-client"); // created_by
+        // params[10] = extracted_metadata (JSON string or null)
+        expect(params.length).toBe(11);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/log-thought.test.ts
+++ b/src/tools/__tests__/log-thought.test.ts
@@ -89,14 +89,18 @@ describe("log_thought", () => {
         const [sql, params] = queryCalls[0];
         expect(sql).toContain("INSERT INTO thoughts");
         expect(sql).toContain("ON CONFLICT (content_hash)");
+        expect(sql).toContain("extracted_metadata");
         expect(params[0]).toBe("A test thought"); // content
-        expect(params[1]).toEqual(["test", "unit"]); // tags
+        // Tags may be enriched by extraction -- verify originals are included
+        expect(params[1]).toEqual(expect.arrayContaining(["test", "unit"]));
         expect(params[2]).toBe("test-client"); // created_by
         // params[3] = embedding (toSql result)
         expect(params[3]).toBeTruthy(); // embedding should be non-null
         // params[4] = content_hash
         expect(typeof params[4]).toBe("string");
         expect(params[4].length).toBeGreaterThan(0);
+        // params[7] = extracted_metadata (JSON string or null)
+        expect(params.length).toBe(8);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/log-thought.test.ts
+++ b/src/tools/__tests__/log-thought.test.ts
@@ -89,18 +89,15 @@ describe("log_thought", () => {
         const [sql, params] = queryCalls[0];
         expect(sql).toContain("INSERT INTO thoughts");
         expect(sql).toContain("ON CONFLICT (content_hash)");
-        expect(sql).toContain("extracted_metadata");
         expect(params[0]).toBe("A test thought"); // content
-        // Tags may be enriched by extraction -- verify originals are included
-        expect(params[1]).toEqual(expect.arrayContaining(["test", "unit"]));
+        expect(params[1]).toEqual(["test", "unit"]); // tags (original, not enriched -- extraction is fire-and-forget)
         expect(params[2]).toBe("test-client"); // created_by
         // params[3] = embedding (toSql result)
         expect(params[3]).toBeTruthy(); // embedding should be non-null
         // params[4] = content_hash
         expect(typeof params[4]).toBe("string");
         expect(params[4].length).toBeGreaterThan(0);
-        // params[7] = extracted_metadata (JSON string or null)
-        expect(params.length).toBe(8);
+        expect(params.length).toBe(7);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -1,0 +1,1216 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerSearchAll } from "../search-all.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+/** Build mock OB rows with sensible defaults. */
+function makeMockRows(
+  count: number,
+  overrides: Partial<{
+    source_type: string;
+    distance: number;
+    usefulness: number;
+  }> = {},
+) {
+  return Array.from({ length: count }, (_, i) => ({
+    source_type: overrides.source_type ?? "thought",
+    id: `uuid-${i}`,
+    content_preview: `Content preview ${i}`,
+    distance: overrides.distance ?? 0.1 + i * 0.05,
+    tags: ["tag-a"],
+    created_at: "2026-01-01T00:00:00Z",
+    usefulness: overrides.usefulness ?? 0.5,
+  }));
+}
+
+/** Rows spanning all 5 tables. */
+function makeMultiTableRows(perTable: number = 1) {
+  const types = ["thought", "decision", "relationship", "project", "session"];
+  return types.flatMap((t, ti) =>
+    Array.from({ length: perTable }, (_, i) => ({
+      source_type: t,
+      id: `${t}-uuid-${i}`,
+      content_preview: `${t} content ${i}`,
+      distance: 0.05 + ti * 0.02 + i * 0.01,
+      tags: [`${t}-tag`],
+      created_at: "2026-01-01T00:00:00Z",
+      usefulness: 0.6,
+    })),
+  );
+}
+
+async function setupClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  mockEmbed: ReturnType<typeof createMockEmbed>,
+  auth: AuthInfo | null,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: mockEmbed };
+  registerSearchAll(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  if (auth) {
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) => {
+      return originalSend(message, { ...options, authInfo: auth });
+    };
+  }
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+/** Parse the JSON payload returned by search_all. */
+function parseResult(result: any) {
+  const text = (result.content as any)[0].text;
+  return JSON.parse(text) as {
+    total: number;
+    brain_hits: number;
+    qmd_hits: number;
+    results: any[];
+  };
+}
+
+// We need to intercept Bun.spawn for qmd tests. Store the original and
+// restore after each test.
+const originalSpawn = Bun.spawn;
+
+function mockBunSpawn(exitCode: number, stdout: string, stderr: string = "") {
+  (Bun as any).spawn = (_cmd: any, _opts: any) => {
+    const encoder = new TextEncoder();
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(stdout));
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(stderr));
+          controller.close();
+        },
+      }),
+      exited: Promise.resolve(exitCode),
+    };
+  };
+}
+
+function restoreBunSpawn() {
+  (Bun as any).spawn = originalSpawn;
+}
+
+/** Build a valid mcp2cli qmd response wrapper. */
+function qmdWrapper(docs: any[]) {
+  return JSON.stringify({
+    success: true,
+    result: {
+      content: [{ type: "text", text: JSON.stringify(docs) }],
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("search_all", () => {
+  afterEach(() => {
+    restoreBunSpawn();
+  });
+
+  // -----------------------------------------------------------------------
+  // SMALL
+  // -----------------------------------------------------------------------
+  describe("Small -- basic behaviour", () => {
+    it("returns permission denied when auth is missing", async () => {
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        null,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "test" },
+        });
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text;
+        expect(text).toContain("Permission denied");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("returns brain-only results when sources='brain'", async () => {
+      // qmd should NOT be called; mock spawn to fail so we'd notice
+      mockBunSpawn(1, "", "should not be called");
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(2) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "brain only", sources: "brain" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.brain_hits).toBe(2);
+        expect(parsed.qmd_hits).toBe(0);
+        expect(parsed.results.every((r: any) => r.source === "brain")).toBe(
+          true,
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("returns qmd-only results when sources='qmd'", async () => {
+      const qmdDocs = [
+        { path: "/a.md", content: "hello", score: 0.9 },
+        { path: "/b.md", content: "world", score: 0.8 },
+      ];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+
+      // Pool should NOT be queried for brain search
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "qmd only", sources: "qmd" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.brain_hits).toBe(0);
+        expect(parsed.qmd_hits).toBe(2);
+        expect(parsed.results.every((r: any) => r.source === "qmd")).toBe(true);
+        // OB pool should not have been queried (no search SELECT)
+        expect(queryCalls.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("returns empty results when both sources return nothing", async () => {
+      mockBunSpawn(0, qmdWrapper([]));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "nothing here" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.total).toBe(0);
+        expect(parsed.brain_hits).toBe(0);
+        expect(parsed.qmd_hits).toBe(0);
+        expect(parsed.results).toEqual([]);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("returns single table OB result correctly", async () => {
+      mockBunSpawn(1, ""); // qmd fails gracefully
+      const mockPool = {
+        query: async () => ({
+          rows: [
+            {
+              source_type: "decision",
+              id: "dec-1",
+              content_preview: "Use Bun over Node",
+              distance: 0.08,
+              tags: ["runtime"],
+              created_at: "2026-01-10",
+              usefulness: 0.7,
+            },
+          ],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "bun vs node" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.brain_hits).toBe(1);
+        expect(parsed.results[0].source).toBe("brain");
+        expect(parsed.results[0].type).toBe("decision");
+        expect(parsed.results[0].id).toBe("dec-1");
+        expect(parsed.results[0].tags).toEqual(["runtime"]);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // MEDIUM
+  // -----------------------------------------------------------------------
+  describe("Medium -- merging and scoring", () => {
+    it("merges OB and qmd results, sorted by score descending", async () => {
+      // qmd returns one high-score result
+      const qmdDocs = [
+        { path: "/top.md", content: "top qmd hit", score: 0.95 },
+      ];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+
+      // OB returns two results: distance 0.1 => score 0.9, distance 0.3 => score 0.7
+      const mockPool = {
+        query: async () => ({
+          rows: [
+            {
+              source_type: "thought",
+              id: "t1",
+              content_preview: "brain hit 1",
+              distance: 0.1,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+            {
+              source_type: "thought",
+              id: "t2",
+              content_preview: "brain hit 2",
+              distance: 0.3,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+          ],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "merge test", limit: 10 },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.total).toBe(3);
+        expect(parsed.brain_hits).toBe(2);
+        expect(parsed.qmd_hits).toBe(1);
+
+        // Scores: qmd=0.95, brain1=0.9 (1-0.1), brain2=0.7 (1-0.3)
+        expect(parsed.results[0].source).toBe("qmd");
+        expect(parsed.results[0].score).toBe(0.95);
+        expect(parsed.results[1].source).toBe("brain");
+        expect(parsed.results[1].score).toBeCloseTo(0.9);
+        expect(parsed.results[2].source).toBe("brain");
+        expect(parsed.results[2].score).toBeCloseTo(0.7);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("normalizes OB distance to score via 1-distance inversion", async () => {
+      mockBunSpawn(1, ""); // no qmd
+      const mockPool = {
+        query: async () => ({
+          rows: [
+            {
+              source_type: "thought",
+              id: "t1",
+              content_preview: "close match",
+              distance: 0.05,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+            {
+              source_type: "thought",
+              id: "t2",
+              content_preview: "far match",
+              distance: 0.85,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+          ],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "distance check", sources: "brain" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].score).toBeCloseTo(0.95); // 1 - 0.05
+        expect(parsed.results[1].score).toBeCloseTo(0.15); // 1 - 0.85
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("enforces limit by slicing merged results", async () => {
+      // 3 from qmd + 3 from OB = 6 total, limit 4
+      const qmdDocs = [
+        { path: "/a.md", content: "a", score: 0.9 },
+        { path: "/b.md", content: "b", score: 0.7 },
+        { path: "/c.md", content: "c", score: 0.5 },
+      ];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(3) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "limit test", limit: 4 },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.total).toBe(4);
+        expect(parsed.results.length).toBe(4);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("sources='brain' skips embedding when sources='qmd'", async () => {
+      // When sources=qmd, embedFn should NOT be called
+      let embedCalled = false;
+      const mockEmbed = async (_text: string) => {
+        embedCalled = true;
+        return Array(768).fill(0.1);
+      };
+      mockBunSpawn(
+        0,
+        qmdWrapper([{ path: "/x.md", content: "x", score: 0.5 }]),
+      );
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(mockPool, mockEmbed, auth);
+
+      try {
+        await client.callTool({
+          name: "search_all",
+          arguments: { query: "skip embed", sources: "qmd" },
+        });
+        expect(embedCalled).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("multiple OB tables merged with distinct source_type labels", async () => {
+      mockBunSpawn(1, ""); // no qmd
+      const mockPool = {
+        query: async () => ({
+          rows: [
+            {
+              source_type: "thought",
+              id: "t1",
+              content_preview: "thought content",
+              distance: 0.1,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+            {
+              source_type: "decision",
+              id: "d1",
+              content_preview: "decision content",
+              distance: 0.2,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+            {
+              source_type: "session",
+              id: "s1",
+              content_preview: "session content",
+              distance: 0.3,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+          ],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "multi table", sources: "brain" },
+        });
+        const parsed = parseResult(result);
+        const types = parsed.results.map((r: any) => r.type);
+        expect(types).toContain("thought");
+        expect(types).toContain("decision");
+        expect(types).toContain("session");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // LARGE
+  // -----------------------------------------------------------------------
+  describe("Large -- max limit, all 5 tables", () => {
+    it("accepts max limit of 50", async () => {
+      mockBunSpawn(1, "");
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "max limit", limit: 50 },
+        });
+        expect(result.isError).toBeFalsy();
+        // Verify limit passed to SQL
+        const [, params] = queryCalls[0];
+        expect(params).toContain(50);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("merges results from all 5 OB tables and qmd, ranked by score", async () => {
+      const qmdDocs = [
+        { path: "/doc1.md", content: "qmd doc 1", score: 0.88 },
+        { path: "/doc2.md", content: "qmd doc 2", score: 0.72 },
+      ];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+
+      const mockPool = {
+        query: async () => ({ rows: makeMultiTableRows(1) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "full merge", limit: 20 },
+        });
+        const parsed = parseResult(result);
+        // 5 OB rows + 2 qmd rows = 7 total
+        expect(parsed.brain_hits).toBe(5);
+        expect(parsed.qmd_hits).toBe(2);
+        expect(parsed.total).toBe(7);
+
+        // Verify both sources present
+        const sources = new Set(parsed.results.map((r: any) => r.source));
+        expect(sources.has("brain")).toBe(true);
+        expect(sources.has("qmd")).toBe(true);
+
+        // Verify sorted descending by score
+        for (let i = 1; i < parsed.results.length; i++) {
+          expect(parsed.results[i - 1].score).toBeGreaterThanOrEqual(
+            parsed.results[i].score,
+          );
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("SQL includes CTEs for all 5 tables for admin role", async () => {
+      mockBunSpawn(1, "");
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "search_all",
+          arguments: { query: "all tables" },
+        });
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("thoughts_results");
+        expect(sql).toContain("decisions_results");
+        expect(sql).toContain("relationships_results");
+        expect(sql).toContain("projects_results");
+        expect(sql).toContain("sessions_results");
+        expect(sql).toContain("UNION ALL");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // RAPID -- multiple sequential calls
+  // -----------------------------------------------------------------------
+  describe("Rapid -- sequential calls return independently", () => {
+    it("three sequential calls each return their own results", async () => {
+      let callIndex = 0;
+      const mockPool = {
+        query: async () => {
+          callIndex++;
+          return {
+            rows: makeMockRows(callIndex, { source_type: `type-${callIndex}` }),
+          };
+        },
+      };
+      // qmd returns different things per invocation
+      let spawnCount = 0;
+      (Bun as any).spawn = () => {
+        spawnCount++;
+        const docs = [
+          {
+            path: `/rapid-${spawnCount}.md`,
+            content: `rapid ${spawnCount}`,
+            score: 0.5,
+          },
+        ];
+        const stdout = qmdWrapper(docs);
+        const encoder = new TextEncoder();
+        return {
+          stdout: new ReadableStream({
+            start(c) {
+              c.enqueue(encoder.encode(stdout));
+              c.close();
+            },
+          }),
+          stderr: new ReadableStream({
+            start(c) {
+              c.close();
+            },
+          }),
+          exited: Promise.resolve(0),
+        };
+      };
+
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const r1 = await client.callTool({
+          name: "search_all",
+          arguments: { query: "rapid 1" },
+        });
+        const r2 = await client.callTool({
+          name: "search_all",
+          arguments: { query: "rapid 2" },
+        });
+        const r3 = await client.callTool({
+          name: "search_all",
+          arguments: { query: "rapid 3" },
+        });
+
+        const p1 = parseResult(r1);
+        const p2 = parseResult(r2);
+        const p3 = parseResult(r3);
+
+        // Each call got a different brain_hits count (1, 2, 3)
+        expect(p1.brain_hits).toBe(1);
+        expect(p2.brain_hits).toBe(2);
+        expect(p3.brain_hits).toBe(3);
+
+        // Each call got qmd results
+        expect(p1.qmd_hits).toBe(1);
+        expect(p2.qmd_hits).toBe(1);
+        expect(p3.qmd_hits).toBe(1);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // EDGE CASES
+  // -----------------------------------------------------------------------
+  describe("Edge cases", () => {
+    it("returns OB-only results when embedFn returns null (brain skipped)", async () => {
+      // When embedding fails, brain search is skipped entirely
+      const qmdDocs = [
+        { path: "/fallback.md", content: "qmd only", score: 0.7 },
+      ];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(2) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(null),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "embed fail" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        // Brain search should be skipped (embedding is null)
+        expect(parsed.brain_hits).toBe(0);
+        expect(parsed.qmd_hits).toBe(1);
+        // Pool should not have been queried for search
+        expect(queryCalls.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("gracefully returns brain-only results when qmd spawn exits non-zero", async () => {
+      mockBunSpawn(1, "", "qmd process crashed");
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(2) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "qmd fail" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.brain_hits).toBe(2);
+        expect(parsed.qmd_hits).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("gracefully handles qmd returning malformed JSON", async () => {
+      mockBunSpawn(0, "this is not json at all {{{");
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(1) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "bad json" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.brain_hits).toBe(1);
+        expect(parsed.qmd_hits).toBe(0); // qmd parse failure => 0 results
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("handles qmd returning valid wrapper but no text content", async () => {
+      const emptyWrapper = JSON.stringify({
+        success: true,
+        result: { content: [] },
+      });
+      mockBunSpawn(0, emptyWrapper);
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(1) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "empty qmd wrapper" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.qmd_hits).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("handles qmd returning non-array docs inside text", async () => {
+      const nonArrayWrapper = JSON.stringify({
+        success: true,
+        result: {
+          content: [{ type: "text", text: '{"not":"an array"}' }],
+        },
+      });
+      mockBunSpawn(0, nonArrayWrapper);
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(1) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "non-array qmd" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.qmd_hits).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("discord role gets no brain results (no readable tables) but still gets qmd", async () => {
+      const qmdDocs = [{ path: "/pub.md", content: "public info", score: 0.6 }];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "discord", clientId: "discord-bot" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "discord search" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        // discord has WO on thoughts, no read on anything
+        expect(parsed.brain_hits).toBe(0);
+        expect(parsed.qmd_hits).toBe(1);
+        // pool should NOT have been queried (no accessible tables => skip)
+        expect(queryCalls.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("content_preview is truncated to 300 chars for brain results", async () => {
+      mockBunSpawn(1, "");
+      const longContent = "x".repeat(500);
+      const mockPool = {
+        query: async () => ({
+          rows: [
+            {
+              source_type: "thought",
+              id: "long-1",
+              content_preview: longContent,
+              distance: 0.1,
+              tags: [],
+              created_at: "2026-01-01",
+              usefulness: 0.5,
+            },
+          ],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "long content", sources: "brain" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].content.length).toBe(300);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("qmd doc content is truncated to 300 chars", async () => {
+      const longContent = "y".repeat(500);
+      const qmdDocs = [{ path: "/long.md", content: longContent, score: 0.5 }];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "long qmd", sources: "qmd" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].content.length).toBe(300);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("qmd doc uses 'text' field when 'content' is absent", async () => {
+      const qmdDocs = [{ path: "/t.md", text: "from text field", score: 0.6 }];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "text fallback", sources: "qmd" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].content).toBe("from text field");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("qmd doc uses 'preview' field when content and text are absent", async () => {
+      const qmdDocs = [{ path: "/p.md", preview: "from preview", score: 0.6 }];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "preview fallback", sources: "qmd" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].content).toBe("from preview");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("qmd doc uses 'similarity' field when 'score' is absent", async () => {
+      const qmdDocs = [{ path: "/s.md", content: "sim", similarity: 0.77 }];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "similarity field", sources: "qmd" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].score).toBe(0.77);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("qmd doc defaults score to 0.5 when neither score nor similarity is present", async () => {
+      const qmdDocs = [{ path: "/d.md", content: "no score" }];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "default score", sources: "qmd" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].score).toBe(0.5);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("qmd doc maps 'file' field to 'path' when 'path' is absent", async () => {
+      const qmdDocs = [
+        { file: "/via-file.md", content: "file field", score: 0.5 },
+      ];
+      mockBunSpawn(0, qmdWrapper(qmdDocs));
+      const mockPool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "file field", sources: "qmd" },
+        });
+        const parsed = parseResult(result);
+        expect(parsed.results[0].path).toBe("/via-file.md");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("fires usage tracking UPDATEs for brain results", async () => {
+      mockBunSpawn(1, "");
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return {
+            rows: [
+              {
+                source_type: "thought",
+                id: "track-1",
+                content_preview: "tracked",
+                distance: 0.1,
+                tags: [],
+                created_at: "2026-01-01",
+                usefulness: 0.5,
+              },
+              {
+                source_type: "decision",
+                id: "track-2",
+                content_preview: "also tracked",
+                distance: 0.2,
+                tags: [],
+                created_at: "2026-01-01",
+                usefulness: 0.5,
+              },
+            ],
+          };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "search_all",
+          arguments: { query: "tracking test", sources: "brain" },
+        });
+
+        // Wait for fire-and-forget tracking
+        await new Promise((r) => setTimeout(r, 50));
+
+        // First call is the search SELECT, rest are tracking UPDATEs
+        expect(queryCalls.length).toBeGreaterThan(1);
+        const trackingCalls = queryCalls.slice(1);
+        for (const call of trackingCalls) {
+          expect(call[0]).toContain("access_count");
+          expect(call[0]).toContain("last_accessed_at");
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("default limit is 10 when not specified", async () => {
+      mockBunSpawn(1, "");
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "search_all",
+          arguments: { query: "default limit" },
+        });
+        const [, params] = queryCalls[0];
+        expect(params).toContain(10);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("readonly role can search brain (has read on all tables)", async () => {
+      mockBunSpawn(1, "");
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "readonly", clientId: "ro" };
+      const { client, cleanup } = await setupClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: { query: "readonly search", sources: "brain" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseResult(result);
+        expect(parsed.brain_hits).toBe(1);
+        // Verify all 5 table CTEs in SQL
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("thoughts_results");
+        expect(sql).toContain("decisions_results");
+        expect(sql).toContain("relationships_results");
+        expect(sql).toContain("projects_results");
+        expect(sql).toContain("sessions_results");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerArchiveEntry } from "./archive-entry.ts";
 import { registerListRecent } from "./list-recent.ts";
 import { registerUpdateEntry } from "./update-entry.ts";
 import { registerRateEntry } from "./rate-entry.ts";
+import { registerSearchAll } from "./search-all.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -28,4 +29,5 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerListRecent(server, deps);
   registerUpdateEntry(server, deps);
   registerRateEntry(server, deps);
+  registerSearchAll(server, deps);
 }

--- a/src/tools/log-decision.ts
+++ b/src/tools/log-decision.ts
@@ -47,35 +47,28 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
 
       const textToEmbed = `${args.title}\n${args.rationale}`;
       const hash = contentHash(textToEmbed);
-      const [embedding, extracted] = await Promise.all([
-        deps.embedFn(textToEmbed),
-        extractMetadata(textToEmbed),
-      ]);
+      const embedding = await deps.embedFn(textToEmbed);
       logger.info("tool_embedding", {
         tool: "log_decision",
         embedded: !!embedding,
-        extracted: !!extracted,
       });
 
-      const enrichedTags = mergeTags(args.tags ?? [], extracted);
-
       const { rows } = await deps.pool.query(
-        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, embedding, content_hash, embedded_at, embedding_model, extracted_metadata)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, embedding, content_hash, embedded_at, embedding_model)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
          ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL DO NOTHING
          RETURNING id`,
         [
           args.title,
           args.rationale,
           JSON.stringify(args.alternatives ?? []),
-          enrichedTags,
+          args.tags ?? [],
           args.context ?? null,
           auth.clientId,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
           embedding ? "gemini-embedding-001" : null,
-          extracted ? JSON.stringify(extracted) : null,
         ],
       );
 
@@ -90,12 +83,33 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
         };
       }
 
+      const insertedId = rows[0].id as string;
+
+      // Fire-and-forget: extract metadata and enrich in background
+      extractMetadata(textToEmbed)
+        .then((extracted) => {
+          if (!extracted) return;
+          const enrichedTags = mergeTags(args.tags ?? [], extracted);
+          deps.pool
+            .query(
+              `UPDATE decisions SET tags = $1, extracted_metadata = $2 WHERE id = $3`,
+              [enrichedTags, JSON.stringify(extracted), insertedId],
+            )
+            .catch((err: unknown) => {
+              logger.warn("extraction_update_error", {
+                id: insertedId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+        })
+        .catch(() => {});
+
       return {
         content: [
           {
             type: "text" as const,
             text: JSON.stringify({
-              id: rows[0].id,
+              id: insertedId,
               embedded: !!embedding,
             }),
           },

--- a/src/tools/log-decision.ts
+++ b/src/tools/log-decision.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
 import { contentHash } from "../embedding.ts";
+import { extractMetadata, mergeTags } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -46,28 +47,35 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
 
       const textToEmbed = `${args.title}\n${args.rationale}`;
       const hash = contentHash(textToEmbed);
-      const embedding = await deps.embedFn(textToEmbed);
+      const [embedding, extracted] = await Promise.all([
+        deps.embedFn(textToEmbed),
+        extractMetadata(textToEmbed),
+      ]);
       logger.info("tool_embedding", {
         tool: "log_decision",
         embedded: !!embedding,
+        extracted: !!extracted,
       });
 
+      const enrichedTags = mergeTags(args.tags ?? [], extracted);
+
       const { rows } = await deps.pool.query(
-        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, embedding, content_hash, embedded_at, embedding_model, extracted_metadata)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
          ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL DO NOTHING
          RETURNING id`,
         [
           args.title,
           args.rationale,
           JSON.stringify(args.alternatives ?? []),
-          args.tags ?? [],
+          enrichedTags,
           args.context ?? null,
           auth.clientId,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
           embedding ? "gemini-embedding-001" : null,
+          extracted ? JSON.stringify(extracted) : null,
         ],
       );
 

--- a/src/tools/log-thought.ts
+++ b/src/tools/log-thought.ts
@@ -39,32 +39,25 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
       }
 
       const hash = contentHash(args.content);
-      const [embedding, extracted] = await Promise.all([
-        deps.embedFn(args.content),
-        extractMetadata(args.content),
-      ]);
+      const embedding = await deps.embedFn(args.content);
       logger.info("tool_embedding", {
         tool: "log_thought",
         embedded: !!embedding,
-        extracted: !!extracted,
       });
 
-      const enrichedTags = mergeTags(args.tags ?? [], extracted);
-
       const { rows } = await deps.pool.query(
-        `INSERT INTO thoughts (content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model, extracted_metadata)
-         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7, $8)
+        `INSERT INTO thoughts (content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model)
+         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7)
          ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL DO NOTHING
          RETURNING id`,
         [
           args.content,
-          enrichedTags,
+          args.tags ?? [],
           auth.clientId,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
           embedding ? "gemini-embedding-001" : null,
-          extracted ? JSON.stringify(extracted) : null,
         ],
       );
 
@@ -79,12 +72,33 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
         };
       }
 
+      const insertedId = rows[0].id as string;
+
+      // Fire-and-forget: extract metadata and enrich in background
+      extractMetadata(args.content)
+        .then((extracted) => {
+          if (!extracted) return;
+          const enrichedTags = mergeTags(args.tags ?? [], extracted);
+          deps.pool
+            .query(
+              `UPDATE thoughts SET tags = $1, extracted_metadata = $2 WHERE id = $3`,
+              [enrichedTags, JSON.stringify(extracted), insertedId],
+            )
+            .catch((err: unknown) => {
+              logger.warn("extraction_update_error", {
+                id: insertedId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+        })
+        .catch(() => {});
+
       return {
         content: [
           {
             type: "text" as const,
             text: JSON.stringify({
-              id: rows[0].id,
+              id: insertedId,
               embedded: !!embedding,
             }),
           },

--- a/src/tools/log-thought.ts
+++ b/src/tools/log-thought.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
 import { contentHash } from "../embedding.ts";
+import { extractMetadata, mergeTags } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -38,25 +39,32 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
       }
 
       const hash = contentHash(args.content);
-      const embedding = await deps.embedFn(args.content);
+      const [embedding, extracted] = await Promise.all([
+        deps.embedFn(args.content),
+        extractMetadata(args.content),
+      ]);
       logger.info("tool_embedding", {
         tool: "log_thought",
         embedded: !!embedding,
+        extracted: !!extracted,
       });
 
+      const enrichedTags = mergeTags(args.tags ?? [], extracted);
+
       const { rows } = await deps.pool.query(
-        `INSERT INTO thoughts (content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7)
+        `INSERT INTO thoughts (content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model, extracted_metadata)
+         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7, $8)
          ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL DO NOTHING
          RETURNING id`,
         [
           args.content,
-          args.tags ?? [],
+          enrichedTags,
           auth.clientId,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
           embedding ? "gemini-embedding-001" : null,
+          extracted ? JSON.stringify(extracted) : null,
         ],
       );
 

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -1,0 +1,229 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toSql } from "pgvector/pg";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES, buildTableCTE } from "./search-brain.ts";
+
+interface UnifiedResult {
+  source: "brain" | "qmd";
+  type: string;
+  content: string;
+  score: number;
+  id?: string;
+  path?: string;
+  tags?: string[];
+  collection?: string;
+}
+
+interface QmdDocument {
+  id?: string;
+  path?: string;
+  file?: string;
+  content?: string;
+  text?: string;
+  preview?: string;
+  score?: number;
+  similarity?: number;
+  collection?: string;
+}
+
+async function searchQmd(
+  query: string,
+  limit: number,
+): Promise<UnifiedResult[]> {
+  try {
+    const params = JSON.stringify({ query, limit });
+    // Use BM25 search (0.07s) not vsearch (3-6s). OB handles semantic; qmd adds keyword coverage.
+    const proc = Bun.spawn(["mcp2cli", "qmd", "search", "--params", params], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      logger.warn("qmd vsearch failed", { exitCode });
+      return [];
+    }
+
+    // mcp2cli wraps results: {"success": true, "result": {"content": [{"type":"text","text":"..."}]}}
+    const wrapper = JSON.parse(stdout) as {
+      success?: boolean;
+      result?: {
+        content?: Array<{ text?: string }>;
+      };
+    };
+
+    const textContent = wrapper.result?.content?.[0]?.text;
+    if (!textContent) return [];
+
+    const docs: QmdDocument[] = JSON.parse(textContent);
+    if (!Array.isArray(docs)) return [];
+
+    return docs.map((doc) => ({
+      source: "qmd" as const,
+      type: "file",
+      content: (doc.content || doc.text || doc.preview || "").slice(0, 300),
+      score: doc.score ?? doc.similarity ?? 0.5,
+      path: doc.path || doc.file,
+      collection: doc.collection,
+    }));
+  } catch (err) {
+    logger.warn("qmd search error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "search_all",
+    {
+      description:
+        "Federated search across Open Brain knowledge AND qmd file index. Returns merged, ranked results from both sources.",
+      inputSchema: {
+        query: z.string().min(1).describe("Natural language search query"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe("Max results per source (default 10)"),
+        sources: z
+          .enum(["all", "brain", "qmd"])
+          .optional()
+          .describe("Which sources to search (default: all)"),
+      },
+      annotations: {
+        title: "Search All",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const limit = args.limit ?? 10;
+      const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
+      const searchBrain = sources === "all" || sources === "brain";
+      const searchQmdSource = sources === "all" || sources === "qmd";
+
+      // Generate embedding for OB search (needed even if qmd-only, but skip if not)
+      const embedding = searchBrain ? await deps.embedFn(args.query) : null;
+
+      // Launch both searches in parallel
+      const [brainResults, qmdResults] = await Promise.all([
+        searchBrain && embedding
+          ? searchOB(deps, auth, embedding, limit)
+          : Promise.resolve([]),
+        searchQmdSource ? searchQmd(args.query, limit) : Promise.resolve([]),
+      ]);
+
+      // Merge and sort by normalized score (descending)
+      const merged = [...brainResults, ...qmdResults]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              total: merged.length,
+              brain_hits: brainResults.length,
+              qmd_hits: qmdResults.length,
+              results: merged,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}
+
+async function searchOB(
+  deps: ToolDeps,
+  auth: AuthInfo,
+  embedding: number[],
+  limit: number,
+): Promise<UnifiedResult[]> {
+  const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+  if (accessibleTables.length === 0) return [];
+
+  const ctes = accessibleTables.map(buildTableCTE);
+  const cteNames = accessibleTables.map((t) => `${t}_results`);
+  const unionAll = cteNames
+    .map((name) => `SELECT * FROM ${name}`)
+    .join("\nUNION ALL\n");
+
+  const sql = `WITH query_embedding AS (
+  SELECT $1::halfvec(768) AS emb
+),
+${ctes.join(",\n")}
+SELECT * FROM (
+${unionAll}
+) AS combined
+ORDER BY (distance * 0.8 + (1.0 - COALESCE(usefulness, 0.5)) * 0.2) ASC
+LIMIT $2`;
+
+  const { rows } = await deps.pool.query(sql, [toSql(embedding), limit]);
+
+  // Fire-and-forget usage tracking
+  if (rows.length > 0) {
+    const byTable = new Map<Table, string[]>();
+    for (const row of rows) {
+      const table = tableFromLabel(row.source_type as string);
+      if (!table) continue;
+      const ids = byTable.get(table) ?? [];
+      ids.push(row.id as string);
+      byTable.set(table, ids);
+    }
+    for (const [table, ids] of byTable) {
+      deps.pool
+        .query(
+          `UPDATE ${table} SET access_count = access_count + 1, last_accessed_at = NOW() WHERE id = ANY($1)`,
+          [ids],
+        )
+        .catch(() => {});
+    }
+  }
+
+  return rows.map((row) => ({
+    source: "brain" as const,
+    type: row.source_type as string,
+    content: (row.content_preview as string).slice(0, 300),
+    score: 1 - (row.distance as number), // invert distance to score (higher = better)
+    id: row.id as string,
+    tags: row.tags as string[],
+  }));
+}
+
+const LABEL_TO_TABLE: Record<string, Table> = {
+  thought: "thoughts",
+  decision: "decisions",
+  relationship: "relationships",
+  project: "projects",
+  session: "sessions",
+};
+
+function tableFromLabel(label: string): Table | undefined {
+  return LABEL_TO_TABLE[label];
+}

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -6,7 +6,7 @@ import type { AuthInfo, Table } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
 
-const ALL_TABLES: Table[] = [
+export const ALL_TABLES: Table[] = [
   "thoughts",
   "decisions",
   "relationships",
@@ -52,7 +52,7 @@ const TABLE_ALIAS: Record<Table, string> = {
   sessions: "s",
 };
 
-function buildTableCTE(table: Table): string {
+export function buildTableCTE(table: Table): string {
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];

--- a/src/tools/session-save.ts
+++ b/src/tools/session-save.ts
@@ -51,7 +51,8 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      const hash = contentHash(args.summary);
+      // Include ISO timestamp in hash so identical summaries on different saves don't collide
+      const hash = contentHash(args.summary + "|" + new Date().toISOString());
       const embedding = await deps.embedFn(args.summary);
       logger.info("tool_embedding", {
         tool: "session_save",


### PR DESCRIPTION
## Summary

Inspired by [NateBJones/OB1](https://github.com/NateBJones-Projects/OB1), adds three major features adapted to PAI's architecture:

- **Auto metadata extraction**: `log_thought`/`log_decision` fire-and-forget LLM extraction of topics, people, action_items, dates. Tags auto-enrich (e.g. `person:Nate Jones`). Writes stay at 0.6s -- extraction runs in background with 3-retry backoff.
- **Federated search (`search_all`)**: New MCP tool queries OB tables + qmd file index in parallel. Session-load hook does client-side federation (OB search_brain + qmd BM25 via Promise.all).
- **Bulk import CLI**: `scripts/bulk-import.ts` imports markdown files with frontmatter parsing, table routing (thoughts/decisions/sessions), optional embedding/extraction, dedup via content_hash. Successfully imported 3,770 entries from session history, knowledge files, and planning docs across 12 projects.

Additional changes:
- Lowercase content hash normalization for case-insensitive dedup
- Migration 003: `extracted_metadata` JSONB column + hash rehashing
- Session-load hook parallelized (was sequential spawnSync, now async Promise.all)
- Extraction retry loop (3 attempts with 0s/2s/5s backoff)
- LAW 10 updated from "qmd First" to "Search First" across PAI config (external to this repo)

## Test plan

- [x] 304 tests pass, 0 fail (was 206)
- [x] 21 extraction tests (mock fetch, retry, mergeTags, edge cases)
- [x] 30 search_all tests (small/medium/large/rapid/edge cases, 100% line coverage)
- [x] 59 bulk-import tests (frontmatter/routing/tags/stress/100-file batch)
- [x] Typecheck clean
- [x] Live verification: search_all returns results, extraction enriches tags in background, session-load hook federates OB + qmd
- [x] Deployed to production (10.71.20.15), health check passing
- [x] Migration 003 applied successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)