### PR TITLE
feat: hybrid search -- FTS + vector with RRF fusion

### DIFF
--- a/.rsync-exclude
+++ b/.rsync-exclude
@@ -1,0 +1,7 @@
+node_modules
+.git
+*.test.ts
+__tests__
+.env
+.env.*
+.DS_Store

--- a/src/db/migrations/005_fts_hybrid.sql
+++ b/src/db/migrations/005_fts_hybrid.sql
@@ -1,0 +1,56 @@
+-- Add full-text search columns + GIN indexes for hybrid search (vector + FTS + RRF)
+-- tsvector columns are GENERATED ALWAYS -- auto-update on row changes, zero maintenance
+--
+-- LOCKING WARNING: Each `ALTER TABLE ADD COLUMN ... GENERATED ALWAYS ... STORED` takes an
+-- ACCESS EXCLUSIVE lock and rewrites every row to populate the generated column. On tables
+-- with significant data this will block all reads and writes for the duration. Options:
+--   1. Run during a scheduled low-traffic maintenance window.
+--   2. Add the column as plain tsvector (no GENERATED), backfill in batches, then add the
+--      GENERATED definition in a follow-up migration once the table is fully populated.
+--   3. Use `CREATE INDEX CONCURRENTLY` for the GIN indexes (already IF NOT EXISTS here, but
+--      CONCURRENTLY avoids the share lock if you need to add them post-migration online).
+
+-- thoughts: index content
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (to_tsvector('english', COALESCE(content, ''))) STORED;
+CREATE INDEX IF NOT EXISTS idx_thoughts_fts
+  ON thoughts USING GIN(search_vector) WHERE archived_at IS NULL;
+
+-- decisions: index title + rationale + context
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (to_tsvector('english',
+    COALESCE(title, '') || ' ' || COALESCE(rationale, '') || ' ' || COALESCE(context, '')
+  )) STORED;
+CREATE INDEX IF NOT EXISTS idx_decisions_fts
+  ON decisions USING GIN(search_vector) WHERE archived_at IS NULL;
+
+-- relationships: index person_name + context
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (to_tsvector('english',
+    COALESCE(person_name, '') || ' ' || COALESCE(context, '')
+  )) STORED;
+CREATE INDEX IF NOT EXISTS idx_relationships_fts
+  ON relationships USING GIN(search_vector) WHERE archived_at IS NULL;
+
+-- projects: index name + description
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (to_tsvector('english',
+    COALESCE(name, '') || ' ' || COALESCE(description, '')
+  )) STORED;
+CREATE INDEX IF NOT EXISTS idx_projects_fts
+  ON projects USING GIN(search_vector) WHERE archived_at IS NULL;
+
+-- sessions: index summary + next_steps + key_decisions
+-- array_to_string is STABLE not IMMUTABLE, so GENERATED columns need an IMMUTABLE wrapper
+CREATE OR REPLACE FUNCTION immutable_array_to_string(arr text[], sep text)
+RETURNS text LANGUAGE sql IMMUTABLE STRICT
+AS $$ SELECT array_to_string(arr, sep) $$;
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS search_vector tsvector
+  GENERATED ALWAYS AS (to_tsvector('english',
+    COALESCE(summary, '') || ' ' ||
+    COALESCE(immutable_array_to_string(next_steps, ' '), '') || ' ' ||
+    COALESCE(immutable_array_to_string(key_decisions, ' '), '')
+  )) STORED;
+CREATE INDEX IF NOT EXISTS idx_sessions_fts
+  ON sessions USING GIN(search_vector) WHERE archived_at IS NULL;

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -549,7 +549,7 @@ describe("search_all", () => {
       try {
         const result = await client.callTool({
           name: "search_all",
-          arguments: { query: "max limit", limit: 50 },
+          arguments: { query: "max limit", limit: 50, search_mode: "vector" },
         });
         expect(result.isError).toBeFalsy();
         // Verify limit passed to SQL
@@ -691,15 +691,15 @@ describe("search_all", () => {
       try {
         const r1 = await client.callTool({
           name: "search_all",
-          arguments: { query: "rapid 1" },
+          arguments: { query: "rapid 1", search_mode: "vector" },
         });
         const r2 = await client.callTool({
           name: "search_all",
-          arguments: { query: "rapid 2" },
+          arguments: { query: "rapid 2", search_mode: "vector" },
         });
         const r3 = await client.callTool({
           name: "search_all",
-          arguments: { query: "rapid 3" },
+          arguments: { query: "rapid 3", search_mode: "vector" },
         });
 
         const p1 = parseResult(r1);
@@ -749,7 +749,7 @@ describe("search_all", () => {
       try {
         const result = await client.callTool({
           name: "search_all",
-          arguments: { query: "embed fail" },
+          arguments: { query: "embed fail", search_mode: "vector" },
         });
         expect(result.isError).toBeFalsy();
         const parsed = parseResult(result);
@@ -1129,7 +1129,11 @@ describe("search_all", () => {
       try {
         await client.callTool({
           name: "search_all",
-          arguments: { query: "tracking test", sources: "brain" },
+          arguments: {
+            query: "tracking test",
+            sources: "brain",
+            search_mode: "vector",
+          },
         });
 
         // Wait for fire-and-forget tracking
@@ -1166,7 +1170,7 @@ describe("search_all", () => {
       try {
         await client.callTool({
           name: "search_all",
-          arguments: { query: "default limit" },
+          arguments: { query: "default limit", search_mode: "vector" },
         });
         const [, params] = queryCalls[0];
         expect(params).toContain(10);

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -303,7 +303,7 @@ describe("search_brain", () => {
       try {
         const result = await client.callTool({
           name: "search_brain",
-          arguments: { query: "embed failure" },
+          arguments: { query: "embed failure", search_mode: "vector" },
         });
 
         expect(result.isError).toBe(true);
@@ -364,7 +364,7 @@ describe("search_brain", () => {
       try {
         await client.callTool({
           name: "search_brain",
-          arguments: { query: "default limit" },
+          arguments: { query: "default limit", search_mode: "vector" },
         });
 
         // The limit parameter ($2) should be 10
@@ -394,7 +394,11 @@ describe("search_brain", () => {
       try {
         await client.callTool({
           name: "search_brain",
-          arguments: { query: "custom limit", limit: 25 },
+          arguments: {
+            query: "custom limit",
+            limit: 25,
+            search_mode: "vector",
+          },
         });
 
         const [, params] = queryCalls[0];
@@ -549,7 +553,7 @@ describe("search_brain", () => {
       try {
         await client.callTool({
           name: "search_brain",
-          arguments: { query: "track this" },
+          arguments: { query: "track this", search_mode: "vector" },
         });
 
         // Wait for fire-and-forget promises to settle
@@ -592,7 +596,7 @@ describe("search_brain", () => {
       try {
         await client.callTool({
           name: "search_brain",
-          arguments: { query: "empty results" },
+          arguments: { query: "empty results", search_mode: "vector" },
         });
 
         // Wait for any fire-and-forget promises
@@ -624,7 +628,7 @@ describe("search_brain", () => {
       try {
         await client.callTool({
           name: "search_brain",
-          arguments: { query: "embed fail" },
+          arguments: { query: "embed fail", search_mode: "vector" },
         });
 
         await new Promise((r) => setTimeout(r, 50));

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { toSql } from "pgvector/pg";
 import { canRead } from "../permissions.ts";
-import type { AuthInfo, Table } from "../types.ts";
+import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
-import { ALL_TABLES, buildTableCTE } from "./search-brain.ts";
+import {
+  ALL_TABLES,
+  executeSearch,
+  trackUsage,
+  type SearchMode,
+  type SearchRow,
+} from "./search-brain.ts";
 
 interface UnifiedResult {
   source: "brain" | "qmd";
@@ -95,6 +100,12 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
           .enum(["all", "brain", "qmd"])
           .optional()
           .describe("Which sources to search (default: all)"),
+        search_mode: z
+          .enum(["hybrid", "vector", "keyword"])
+          .optional()
+          .describe(
+            "Brain search mode: hybrid (default) = vector + keyword with RRF, vector = semantic only, keyword = full-text only",
+          ),
       },
       annotations: {
         title: "Search All",
@@ -119,16 +130,14 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
 
       const limit = args.limit ?? 10;
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
+      const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const searchBrain = sources === "all" || sources === "brain";
       const searchQmdSource = sources === "all" || sources === "qmd";
 
-      // Generate embedding for OB search (needed even if qmd-only, but skip if not)
-      const embedding = searchBrain ? await deps.embedFn(args.query) : null;
-
       // Launch both searches in parallel
       const [brainResults, qmdResults] = await Promise.all([
-        searchBrain && embedding
-          ? searchOB(deps, auth, embedding, limit)
+        searchBrain
+          ? searchOB(deps, auth, args.query, limit, mode)
           : Promise.resolve([]),
         searchQmdSource ? searchQmd(args.query, limit) : Promise.resolve([]),
       ]);
@@ -169,68 +178,31 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
 async function searchOB(
   deps: ToolDeps,
   auth: AuthInfo,
-  embedding: number[],
+  query: string,
   limit: number,
+  mode: SearchMode = "hybrid",
 ): Promise<UnifiedResult[]> {
   const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
   if (accessibleTables.length === 0) return [];
 
-  const ctes = accessibleTables.map(buildTableCTE);
-  const cteNames = accessibleTables.map((t) => `${t}_results`);
-  const unionAll = cteNames
-    .map((name) => `SELECT * FROM ${name}`)
-    .join("\nUNION ALL\n");
-
-  const sql = `WITH query_embedding AS (
-  SELECT $1::halfvec(768) AS emb
-),
-${ctes.join(",\n")}
-SELECT * FROM (
-${unionAll}
-) AS combined
-ORDER BY (distance * 0.8 + (1.0 - COALESCE(usefulness, 0.5)) * 0.2) ASC
-LIMIT $2`;
-
-  const { rows } = await deps.pool.query(sql, [toSql(embedding), limit]);
-
-  // Fire-and-forget usage tracking
-  if (rows.length > 0) {
-    const byTable = new Map<Table, string[]>();
-    for (const row of rows) {
-      const table = tableFromLabel(row.source_type as string);
-      if (!table) continue;
-      const ids = byTable.get(table) ?? [];
-      ids.push(row.id as string);
-      byTable.set(table, ids);
-    }
-    for (const [table, ids] of byTable) {
-      deps.pool
-        .query(
-          `UPDATE ${table} SET access_count = access_count + 1, last_accessed_at = NOW() WHERE id = ANY($1)`,
-          [ids],
-        )
-        .catch(() => {});
-    }
+  let rows: SearchRow[];
+  try {
+    rows = await executeSearch(deps, accessibleTables, query, limit, mode);
+  } catch (err) {
+    logger.warn("searchOB_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
   }
+
+  trackUsage(deps, rows);
 
   return rows.map((row) => ({
     source: "brain" as const,
-    type: row.source_type as string,
-    content: (row.content_preview as string).slice(0, 300),
-    score: 1 - (row.distance as number), // invert distance to score (higher = better)
-    id: row.id as string,
-    tags: row.tags as string[],
+    type: row.source_type,
+    content: row.content_preview.slice(0, 300),
+    score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
+    id: row.id,
+    tags: row.tags ?? undefined,
   }));
-}
-
-const LABEL_TO_TABLE: Record<string, Table> = {
-  thought: "thoughts",
-  decision: "decisions",
-  relationship: "relationships",
-  project: "projects",
-  session: "sessions",
-};
-
-function tableFromLabel(label: string): Table | undefined {
-  return LABEL_TO_TABLE[label];
 }

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -37,7 +37,7 @@ const LABEL_TO_TABLE: Record<string, Table> = Object.fromEntries(
  */
 const CONTENT_PREVIEW: Record<Table, string> = {
   thoughts: "t.content",
-  decisions: "d.title || ': ' || d.rationale",
+  decisions: "d.title || ': ' || COALESCE(d.rationale, '')",
   relationships: "r.person_name || ': ' || COALESCE(r.context, '')",
   projects: "p.name || ': ' || COALESCE(p.description, '')",
   sessions: "COALESCE(s.project || ': ', '') || LEFT(s.summary, 200)",
@@ -51,6 +51,25 @@ const TABLE_ALIAS: Record<Table, string> = {
   projects: "p",
   sessions: "s",
 };
+
+export type SearchMode = "hybrid" | "vector" | "keyword";
+
+/** RRF constant -- standard value from Cormack et al. 2009 */
+const RRF_K = 60;
+
+/** Over-fetch multiplier for hybrid mode (fetch N*3 from each path, merge to N) */
+const HYBRID_FETCH_MULTIPLIER = 3;
+
+export interface SearchRow {
+  source_type: string;
+  id: string;
+  content_preview: string;
+  tags: string[] | null;
+  created_at: string;
+  usefulness: number;
+  distance?: number;
+  fts_rank?: number;
+}
 
 export function buildTableCTE(table: Table): string {
   const alias = TABLE_ALIAS[table];
@@ -72,11 +91,191 @@ export function buildTableCTE(table: Table): string {
 )`;
 }
 
+function buildFtsCTE(table: Table): string {
+  const alias = TABLE_ALIAS[table];
+  const label = SOURCE_LABELS[table];
+  const preview = CONTENT_PREVIEW[table];
+  const cteName = `${table}_fts`;
+
+  return `${cteName} AS (
+  SELECT
+    '${label}' AS source_type,
+    ${alias}.id,
+    ${preview} AS content_preview,
+    ${alias}.tags,
+    ${alias}.created_at,
+    ts_rank_cd(${alias}.search_vector, plainto_tsquery('english', (SELECT q FROM fts_query))) AS fts_rank,
+    COALESCE(${alias}.usefulness_score, 0.5) AS usefulness
+  FROM ${table} ${alias}
+  WHERE ${alias}.search_vector @@ plainto_tsquery('english', (SELECT q FROM fts_query))
+    AND ${alias}.archived_at IS NULL
+)`;
+}
+
+async function vectorSearch(
+  deps: ToolDeps,
+  accessibleTables: Table[],
+  embedding: number[],
+  fetchLimit: number,
+): Promise<SearchRow[]> {
+  const ctes = accessibleTables.map(buildTableCTE);
+  const cteNames = accessibleTables.map((t) => `${t}_results`);
+  const unionAll = cteNames
+    .map((name) => `SELECT * FROM ${name}`)
+    .join("\nUNION ALL\n");
+
+  const sql = `WITH query_embedding AS (
+  SELECT $1::halfvec(768) AS emb
+),
+${ctes.join(",\n")}
+SELECT * FROM (
+${unionAll}
+) AS combined
+ORDER BY (distance * 0.8 + (1.0 - COALESCE(usefulness, 0.5)) * 0.2) ASC
+LIMIT $2`;
+
+  const { rows } = await deps.pool.query(sql, [toSql(embedding), fetchLimit]);
+  return rows as SearchRow[];
+}
+
+async function ftsSearch(
+  deps: ToolDeps,
+  accessibleTables: Table[],
+  query: string,
+  fetchLimit: number,
+): Promise<SearchRow[]> {
+  const ctes = accessibleTables.map(buildFtsCTE);
+  const cteNames = accessibleTables.map((t) => `${t}_fts`);
+  const unionAll = cteNames
+    .map((name) => `SELECT * FROM ${name}`)
+    .join("\nUNION ALL\n");
+
+  const sql = `WITH fts_query AS (
+  SELECT $1::text AS q
+),
+${ctes.join(",\n")}
+SELECT * FROM (
+${unionAll}
+) AS combined
+ORDER BY fts_rank DESC
+LIMIT $2`;
+
+  const { rows } = await deps.pool.query(sql, [query, fetchLimit]);
+  return rows as SearchRow[];
+}
+
+/**
+ * Reciprocal Rank Fusion: merge ranked lists from different scoring systems.
+ * Items appearing in both lists get summed RRF scores (boosted).
+ * Items in only one list get a single RRF score.
+ */
+function rrfMerge(
+  vectorRows: SearchRow[],
+  ftsRows: SearchRow[],
+  limit: number,
+): SearchRow[] {
+  const scoreMap = new Map<string, { row: SearchRow; rrf: number }>();
+
+  for (let i = 0; i < vectorRows.length; i++) {
+    const row = vectorRows[i]!;
+    const key = `${row.source_type}:${row.id}`;
+    scoreMap.set(key, { row, rrf: 1 / (RRF_K + i + 1) });
+  }
+
+  for (let i = 0; i < ftsRows.length; i++) {
+    const row = ftsRows[i]!;
+    const key = `${row.source_type}:${row.id}`;
+    const existing = scoreMap.get(key);
+    if (existing) {
+      existing.rrf += 1 / (RRF_K + i + 1);
+    } else {
+      scoreMap.set(key, { row, rrf: 1 / (RRF_K + i + 1) });
+    }
+  }
+
+  return Array.from(scoreMap.values())
+    .sort((a, b) => b.rrf - a.rrf)
+    .slice(0, limit)
+    .map(({ row }) => row);
+}
+
+export function trackUsage(deps: ToolDeps, rows: SearchRow[]): void {
+  if (rows.length === 0) return;
+
+  const byTable = new Map<Table, string[]>();
+  for (const row of rows) {
+    const table = LABEL_TO_TABLE[row.source_type];
+    if (!table) continue;
+    const ids = byTable.get(table) ?? [];
+    ids.push(row.id);
+    byTable.set(table, ids);
+  }
+
+  const trackingPromises: Promise<unknown>[] = [];
+  for (const [table, ids] of byTable) {
+    trackingPromises.push(
+      deps.pool
+        .query(
+          `UPDATE ${table} SET access_count = access_count + 1, last_accessed_at = NOW() WHERE id = ANY($1)`,
+          [ids],
+        )
+        .catch((err: unknown) => {
+          logger.warn("search_tracking_error", {
+            table,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }),
+    );
+  }
+
+  void Promise.allSettled(trackingPromises).catch(() => {});
+}
+
+export async function executeSearch(
+  deps: ToolDeps,
+  accessibleTables: Table[],
+  query: string,
+  limit: number,
+  mode: SearchMode = "hybrid",
+): Promise<SearchRow[]> {
+  if (mode === "keyword") {
+    return ftsSearch(deps, accessibleTables, query, limit);
+  }
+
+  // Vector and hybrid both need an embedding
+  const embedding = await deps.embedFn(query);
+  if (!embedding) {
+    // Fall back to keyword-only if embedding fails in hybrid mode
+    if (mode === "hybrid") {
+      logger.warn("embedding_failed_fallback_fts", {
+        query: query.slice(0, 50),
+      });
+      return ftsSearch(deps, accessibleTables, query, limit);
+    }
+    // In vector mode, null embedding is a hard failure -- signal via thrown error
+    throw new Error("Failed to generate query embedding");
+  }
+
+  if (mode === "vector") {
+    return vectorSearch(deps, accessibleTables, embedding, limit);
+  }
+
+  // Hybrid: run both in parallel, merge with RRF
+  const fetchLimit = limit * HYBRID_FETCH_MULTIPLIER;
+  const [vectorRows, ftsRows] = await Promise.all([
+    vectorSearch(deps, accessibleTables, embedding, fetchLimit),
+    ftsSearch(deps, accessibleTables, query, fetchLimit),
+  ]);
+
+  return rrfMerge(vectorRows, ftsRows, limit);
+}
+
 export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
     "search_brain",
     {
-      description: "Search across all brain tables using semantic similarity",
+      description:
+        "Search across all brain tables. Supports hybrid (vector + keyword), pure vector, or keyword-only modes.",
       inputSchema: {
         query: z.string().min(1).describe("Natural language search query"),
         table: z
@@ -96,6 +295,12 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           .max(50)
           .optional()
           .describe("Maximum results to return (default 10)"),
+        search_mode: z
+          .enum(["hybrid", "vector", "keyword"])
+          .optional()
+          .describe(
+            "Search mode: hybrid (default) = vector + keyword with RRF fusion, vector = semantic only, keyword = full-text only",
+          ),
       },
       annotations: {
         title: "Search Brain",
@@ -118,12 +323,10 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      // Determine which tables the caller can read
       const tableFilter = args.table as Table | undefined;
       let accessibleTables: Table[];
 
       if (tableFilter) {
-        // Specific table requested -- check read permission
         if (!canRead(auth.role, tableFilter)) {
           return {
             content: [
@@ -137,7 +340,6 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         }
         accessibleTables = [tableFilter];
       } else {
-        // No filter -- include all readable tables
         accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
       }
 
@@ -153,72 +355,27 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      // Generate query embedding -- required for search
-      const embedding = await deps.embedFn(args.query);
-      if (!embedding) {
+      const limit = args.limit ?? 10;
+      const mode = (args.search_mode as SearchMode) ?? "hybrid";
+
+      let rows;
+      try {
+        rows = await executeSearch(
+          deps,
+          accessibleTables,
+          args.query,
+          limit,
+          mode,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: "Failed to generate query embedding",
-            },
-          ],
+          content: [{ type: "text" as const, text: message }],
           isError: true,
         };
       }
 
-      const limit = args.limit ?? 10;
-
-      // Build dynamic CTE SQL based on accessible tables
-      const ctes = accessibleTables.map(buildTableCTE);
-      const cteNames = accessibleTables.map((t) => `${t}_results`);
-
-      const unionAll = cteNames
-        .map((name) => `SELECT * FROM ${name}`)
-        .join("\nUNION ALL\n");
-
-      const sql = `WITH query_embedding AS (
-  SELECT $1::halfvec(768) AS emb
-),
-${ctes.join(",\n")}
-SELECT * FROM (
-${unionAll}
-) AS combined
-ORDER BY (distance * 0.8 + (1.0 - COALESCE(usefulness, 0.5)) * 0.2) ASC
-LIMIT $2`;
-
-      const { rows } = await deps.pool.query(sql, [toSql(embedding), limit]);
-
-      // Fire-and-forget usage tracking: increment access_count for returned rows
-      if (rows.length > 0) {
-        const byTable = new Map<Table, string[]>();
-        for (const row of rows) {
-          const table = LABEL_TO_TABLE[row.source_type as string];
-          if (!table) continue;
-          const ids = byTable.get(table) ?? [];
-          ids.push(row.id as string);
-          byTable.set(table, ids);
-        }
-
-        const trackingPromises: Promise<unknown>[] = [];
-        for (const [table, ids] of byTable) {
-          trackingPromises.push(
-            deps.pool
-              .query(
-                `UPDATE ${table} SET access_count = access_count + 1, last_accessed_at = NOW() WHERE id = ANY($1)`,
-                [ids],
-              )
-              .catch((err: unknown) => {
-                logger.warn("search_tracking_error", {
-                  table,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-              }),
-          );
-        }
-
-        void Promise.allSettled(trackingPromises).catch(() => {});
-      }
+      trackUsage(deps, rows);
 
       return {
         content: [


### PR DESCRIPTION
## Summary
- Adds PostgreSQL full-text search (tsvector + GIN) alongside existing pgvector HNSW
- Three search modes: `hybrid` (default), `vector`, `keyword` -- selectable via `search_mode` param
- Hybrid over-fetches 3x from both vector and FTS paths, merges via Reciprocal Rank Fusion (RRF)
- Items appearing in both result sets get boosted RRF scores
- Graceful fallback: if embedding fails in hybrid mode, falls back to keyword-only
- 32 previously unsearchable (unembedded) entries now findable via keyword mode
- Shared `executeSearch` abstraction eliminates code duplication between `search_brain` and `search_all`

## Changes
- `src/db/migrations/005_fts_hybrid.sql` -- tsvector GENERATED columns + GIN indexes on all 5 domain tables
- `src/tools/search-brain.ts` -- refactored with `executeSearch`, `vectorSearch`, `ftsSearch`, `rrfMerge`
- `src/tools/search-all.ts` -- delegates to shared `executeSearch`, adds `search_mode` passthrough
- Tests updated for new search_mode param (312 pass, 0 fail)
- `.rsync-exclude` added to prevent overwriting server `.env` on deploy

## Deployment
- Migration already applied to production DB (10.71.20.49)
- Code already deployed to OB LXC (10.71.20.15) and verified with 20 edge case tests
- mcp2cli skills regenerated locally

## Swarm Review
Full 4-agent review completed (security, code quality, architecture, consistency):
- 34 findings (0 critical, 8 high, 9 medium, 17 low)
- All HIGH findings fixed: NULL concat, RRF key collision, migration locking warning, double tracking
- Report: `.reports/open-brain/skippy-review/findings-2026-03-22-164900.md`

## Test plan
- [x] 312 unit tests pass, 0 type errors
- [x] 20 edge case integration tests via mcp2cli (stop words, special chars, limits, table filters, mode comparison, unembedded rows, unicode)
- [x] All 3 modes return different result sets confirming hybrid merges correctly
- [ ] Verify on air/CC/OC instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)