### PR TITLE
feat: Cognitive Tiering (OB Dreaming) -- tier boost, access logging, session tracking

### DIFF
--- a/src/db/migrations/006_cognitive_tiering.sql
+++ b/src/db/migrations/006_cognitive_tiering.sql
@@ -1,0 +1,69 @@
+-- Migration: Cognitive Tiering (OB Dreaming)
+-- Adds tier system, consolidation tracking, access log, and discard staging
+-- Issue: https://github.com/rodaddy/open-brain/issues/12
+
+BEGIN;
+
+-- 1. Add tier column to all searchable tables
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS tier TEXT DEFAULT 'warm' CHECK (tier IN ('hot','warm','cold'));
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS tier TEXT DEFAULT 'warm' CHECK (tier IN ('hot','warm','cold'));
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS tier TEXT DEFAULT 'warm' CHECK (tier IN ('hot','warm','cold'));
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS tier TEXT DEFAULT 'warm' CHECK (tier IN ('hot','warm','cold'));
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tier TEXT DEFAULT 'warm' CHECK (tier IN ('hot','warm','cold'));
+
+-- 2. Add consolidation tracking columns
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS consolidated_into UUID REFERENCES thoughts(id);
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS consolidated_from UUID[];
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS consolidated_into UUID REFERENCES decisions(id);
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS consolidated_from UUID[];
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS consolidated_into UUID REFERENCES relationships(id);
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS consolidated_from UUID[];
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS consolidated_into UUID REFERENCES projects(id);
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS consolidated_from UUID[];
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS consolidated_into UUID REFERENCES sessions(id);
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS consolidated_from UUID[];
+
+-- 3. Indexes for tier-based queries
+CREATE INDEX IF NOT EXISTS idx_thoughts_tier ON thoughts(tier) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_decisions_tier ON decisions(tier) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_relationships_tier ON relationships(tier) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_projects_tier ON projects(tier) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_tier ON sessions(tier) WHERE archived_at IS NULL;
+
+-- 4. Access tracking log table
+CREATE TABLE IF NOT EXISTS entry_access_log (
+    id BIGSERIAL PRIMARY KEY,
+    entry_id UUID NOT NULL,
+    source_table TEXT NOT NULL CHECK (source_table IN ('thoughts','decisions','relationships','projects','sessions')),
+    accessed_at TIMESTAMPTZ DEFAULT now(),
+    query_text TEXT,
+    context TEXT DEFAULT 'search' CHECK (context IN ('search','session_load','direct'))
+);
+CREATE INDEX IF NOT EXISTS idx_access_log_entry ON entry_access_log(entry_id, accessed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_access_log_time ON entry_access_log(accessed_at);
+CREATE INDEX IF NOT EXISTS idx_access_log_source ON entry_access_log(source_table, entry_id);
+
+-- 5. Discard staging table
+CREATE TABLE IF NOT EXISTS discarded_entries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    original_id UUID NOT NULL,
+    source_table TEXT NOT NULL CHECK (source_table IN ('thoughts','decisions','relationships','projects','sessions')),
+    original_content TEXT NOT NULL,
+    tags TEXT[],
+    namespace TEXT,
+    tier_at_discard TEXT,
+    access_summary JSONB,
+    discarded_at TIMESTAMPTZ DEFAULT now(),
+    reason TEXT CHECK (reason IN ('decay','consolidated','manual')),
+    expires_at TIMESTAMPTZ,
+    consolidated_into UUID
+);
+CREATE INDEX IF NOT EXISTS idx_discarded_expires ON discarded_entries(expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_discarded_original ON discarded_entries(original_id);
+
+-- 6. Record this migration
+INSERT INTO _migrations (name, applied_at) 
+VALUES ('006_cognitive_tiering', now())
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/src/db/migrations/006_cognitive_tiering.sql
+++ b/src/db/migrations/006_cognitive_tiering.sql
@@ -62,8 +62,8 @@ CREATE INDEX IF NOT EXISTS idx_discarded_expires ON discarded_entries(expires_at
 CREATE INDEX IF NOT EXISTS idx_discarded_original ON discarded_entries(original_id);
 
 -- 6. Record this migration
-INSERT INTO _migrations (name, applied_at) 
-VALUES ('006_cognitive_tiering', now())
+INSERT INTO _migrations (filename, applied_at) 
+VALUES ('006_cognitive_tiering.sql', now())
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -12,6 +12,9 @@ import {
   type SearchRow,
 } from "./search-brain.ts";
 
+/** Tier-based RRF score adjustments for cognitive tiering */
+const TIER_BOOST: Record<string, number> = { hot: 0.3, cold: -0.2 };
+
 interface UnifiedResult {
   source: "brain" | "qmd";
   type: string;
@@ -21,6 +24,7 @@ interface UnifiedResult {
   path?: string;
   tags?: string[];
   collection?: string;
+  tier?: string;
 }
 
 interface QmdDocument {
@@ -145,10 +149,13 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       // Reciprocal Rank Fusion: merge results from different scoring systems
       // using position-based scoring: rrf = 1/(k + rank). k=60 is standard.
       // This ensures both sources get fair representation regardless of raw score scales.
+      // Brain entries also receive a tier boost: hot=+0.3, cold=-0.2, warm=0.
       const RRF_K = 60;
       const withRrf: Array<UnifiedResult & { rrf: number }> = [];
       for (let i = 0; i < brainResults.length; i++) {
-        withRrf.push({ ...brainResults[i]!, rrf: 1 / (RRF_K + i + 1) });
+        const result = brainResults[i]!;
+        const boost = TIER_BOOST[result.tier ?? ""] ?? 0;
+        withRrf.push({ ...result, rrf: 1 / (RRF_K + i + 1) + boost });
       }
       for (let i = 0; i < qmdResults.length; i++) {
         withRrf.push({ ...qmdResults[i]!, rrf: 1 / (RRF_K + i + 1) });
@@ -195,7 +202,7 @@ async function searchOB(
     return [];
   }
 
-  trackUsage(deps, rows);
+  trackUsage(deps, rows, query);
 
   return rows.map((row) => ({
     source: "brain" as const,
@@ -204,5 +211,6 @@ async function searchOB(
     score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
     id: row.id,
     tags: row.tags ?? undefined,
+    tier: row.tier,
   }));
 }

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -60,6 +60,9 @@ const RRF_K = 60;
 /** Over-fetch multiplier for hybrid mode (fetch N*3 from each path, merge to N) */
 const HYBRID_FETCH_MULTIPLIER = 3;
 
+/** Tier-based RRF score adjustments for cognitive tiering */
+const TIER_BOOST: Record<string, number> = { hot: 0.3, cold: -0.2 };
+
 export interface SearchRow {
   source_type: string;
   id: string;
@@ -67,6 +70,7 @@ export interface SearchRow {
   tags: string[] | null;
   created_at: string;
   usefulness: number;
+  tier?: string;
   distance?: number;
   fts_rank?: number;
 }
@@ -84,6 +88,7 @@ export function buildTableCTE(table: Table): string {
     ${preview} AS content_preview,
     ${alias}.tags,
     ${alias}.created_at,
+    ${alias}.tier,
     ${alias}.embedding <=> (SELECT emb FROM query_embedding) AS distance,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness
   FROM ${table} ${alias}
@@ -104,6 +109,7 @@ function buildFtsCTE(table: Table): string {
     ${preview} AS content_preview,
     ${alias}.tags,
     ${alias}.created_at,
+    ${alias}.tier,
     ts_rank_cd(${alias}.search_vector, plainto_tsquery('english', (SELECT q FROM fts_query))) AS fts_rank,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness
   FROM ${table} ${alias}
@@ -168,6 +174,7 @@ LIMIT $2`;
  * Reciprocal Rank Fusion: merge ranked lists from different scoring systems.
  * Items appearing in both lists get summed RRF scores (boosted).
  * Items in only one list get a single RRF score.
+ * Hot entries get +0.3 boost, cold entries get -0.2, warm is unchanged.
  */
 function rrfMerge(
   vectorRows: SearchRow[],
@@ -194,12 +201,21 @@ function rrfMerge(
   }
 
   return Array.from(scoreMap.values())
+    .map(({ row, rrf }) => ({
+      row,
+      rrf: rrf + (TIER_BOOST[row.tier ?? ""] ?? 0),
+    }))
     .sort((a, b) => b.rrf - a.rrf)
     .slice(0, limit)
     .map(({ row }) => row);
 }
 
-export function trackUsage(deps: ToolDeps, rows: SearchRow[]): void {
+export function trackUsage(
+  deps: ToolDeps,
+  rows: SearchRow[],
+  queryText: string,
+  context = "search",
+): void {
   if (rows.length === 0) return;
 
   const byTable = new Map<Table, string[]>();
@@ -222,6 +238,26 @@ export function trackUsage(deps: ToolDeps, rows: SearchRow[]): void {
         .catch((err: unknown) => {
           logger.warn("search_tracking_error", {
             table,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }),
+    );
+  }
+
+  // Bulk-insert into entry_access_log for all returned entries
+  const logRows = rows.filter((r) => LABEL_TO_TABLE[r.source_type]);
+  if (logRows.length > 0) {
+    const entryIds = logRows.map((r) => r.id);
+    const sourceTables = logRows.map((r) => LABEL_TO_TABLE[r.source_type]);
+    trackingPromises.push(
+      deps.pool
+        .query(
+          `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, query_text, context)
+           SELECT unnest($1::uuid[]), unnest($2::text[]), NOW(), $3, $4`,
+          [entryIds, sourceTables, queryText, context],
+        )
+        .catch((err: unknown) => {
+          logger.warn("access_log_error", {
             error: err instanceof Error ? err.message : String(err),
           });
         }),
@@ -375,7 +411,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      trackUsage(deps, rows);
+      trackUsage(deps, rows, args.query);
 
       return {
         content: [

--- a/src/tools/session-load.ts
+++ b/src/tools/session-load.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
 import type { AuthInfo } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
+import { logger } from "../logger.ts";
 
 const SELECT_COLUMNS =
   "id, project, summary, tags, blockers, next_steps, key_decisions, created_by, created_at";
@@ -51,6 +52,20 @@ export function registerSessionLoad(server: McpServer, deps: ToolDeps): void {
   );
 }
 
+function logSessionAccess(deps: ToolDeps, sessionId: string): void {
+  void deps.pool
+    .query(
+      `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, query_text, context)
+       VALUES ($1::uuid, 'sessions', NOW(), NULL, 'session_load')`,
+      [sessionId],
+    )
+    .catch((err: unknown) => {
+      logger.warn("session_load_access_log_error", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
 async function handleProjectLoad(deps: ToolDeps, project: string) {
   const sql = `SELECT ${SELECT_COLUMNS}
 FROM sessions
@@ -70,6 +85,8 @@ LIMIT 1`;
       ],
     };
   }
+
+  logSessionAccess(deps, rows[0].id);
 
   return {
     content: [
@@ -100,6 +117,8 @@ LIMIT 1`;
       ],
     };
   }
+
+  logSessionAccess(deps, rows[0].id);
 
   return {
     content: [


### PR DESCRIPTION
Implements the code side of cognitive tiering (issue #12).

**Schema migration** (006, already applied to prod):
- `tier` column on all 5 tables (hot/warm/cold)
- `consolidated_into`/`consolidated_from` columns
- `entry_access_log` table for detailed access tracking
- `discarded_entries` staging table

**Search changes** (search-brain.ts, search-all.ts):
- Tier included in CTE SELECT + search results
- RRF score boost: hot +0.3, cold -0.2, warm unchanged
- Access log: every search result logged to `entry_access_log` with query text

**Session tracking** (session-load.ts):
- Session loads logged to `entry_access_log` with context=session_load

Type check clean. Closes #12.