### PR TITLE
feat: cognitive tiering tools -- set_tier, tier filtering, list_recent awareness

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,66 @@
+q# Glossary
+
+Project-specific terminology for Open Brain. All agents and contributors use these definitions.
+
+## Domain Terms
+
+| Term | Definition | NOT This |
+|------|-----------|----------|
+| **Brain** | The collective knowledge store -- all five domain tables (thoughts, decisions, relationships, projects, sessions) accessed as a unified system. | A single table or the database host. |
+| **Curation** | The automated process of detecting and handling duplicates, stale entries, and vague content via LLM-as-judge; runs via `scripts/curate.ts`. | Manual review or deletion of records. |
+| **Decision** | A recorded choice with a required `title` and `rationale`, plus optional `alternatives` and `context`; stored in the `decisions` table. | Any loosely noted choice; decisions must capture why and what alternatives were considered. |
+| **Entry** | Any single row in any of the five brain tables; the generic term used in tools like `archive_entry`, `update_entry`, and `rate_entry`. | A specific table record; use the table name when precision matters. |
+| **Person** | A contact record in the `relationships` table, keyed on `person_name` (case-insensitive unique). | A system user or auth role. |
+| **Project** | A named entity in the `projects` table that groups related work; a secondary store alongside `.planning/`. | A filesystem directory or GitHub repository. |
+| **Relationship** | A row in the `relationships` table representing a person, their `warmth`, and how the owner knows them. | A database foreign key or join. |
+| **Session** | A saved AI session summary in the `sessions` table, capturing `summary`, `blockers`, `next_steps`, and `key_decisions` for continuity across context compactions. | An HTTP/MCP transport session or a user login session. |
+| **Soft-delete / Archive** | Setting `archived_at = NOW()` on a row rather than deleting it; archived rows are excluded from all searches and listings by default. | Hard deletion from the database. |
+| **Stale entry** | A row untouched (`access_count = 0`) for more than 90 days; a candidate for LLM-judge review during curation. | Any old row; staleness requires zero accesses, not just age. |
+| **Thought** | A freeform idea, observation, or note stored in the `thoughts` table; the most general entry type. | A structured record with required fields; thoughts have only `content` and optional `tags`. |
+| **Cognitive Tiering** | The system of classifying brain entries as hot, warm, or cold based on relevance; affects search ranking via RRF score boosts and enables filtering. | A caching layer or performance optimization; tiering is about knowledge relevance, not system performance. |
+| **Dream Cycle** | A periodic process that evaluates entry access patterns and adjusts tiers (promote warm→hot for frequently accessed, demote warm→cold for stale entries, consolidate related cold entries). Currently manual, not scripted. | A cron job or sleep/wake scheduler; the dream cycle is specifically about tier lifecycle management. |
+| **Front of Mind** | Entries in the hot tier -- actively relevant knowledge that gets boosted in search results (+0.3 RRF). | A UI concept or notification system; "front of mind" means higher search ranking. |
+| **Tier** | One of three cognitive priority levels (`hot`/`warm`/`cold`) assigned to every brain entry; stored as a TEXT column with CHECK constraint; defaults to `warm`. | A pricing tier or access level; tiers are about knowledge priority, not user permissions. |
+| **Tier Boost** | The RRF score adjustment applied during search based on an entry's tier: hot=+0.3, warm=0, cold=-0.2; defined in `TIER_BOOST` constant in search-brain.ts. | A generic ranking signal; tier boost is the specific numeric adjustment in Reciprocal Rank Fusion. |
+| **Usefulness score** | A 0.0-1.0 float on every entry reflecting perceived value; affects vector search ranking and curation decisions (default 0.5 when null). | A search relevance score or distance metric. |
+| **Warmth** | An integer 1-5 on a `relationships` row indicating closeness (1 = distant, 5 = very close); used for sorting in `find_person`. | A temperature, sentiment score, or generic rating. |
+
+## Technical Terms
+
+| Term | Definition | NOT This |
+|------|-----------|----------|
+| **Access tracking** | Fire-and-forget `UPDATE` that increments `access_count` and sets `last_accessed_at`, plus `INSERT` into `entry_access_log`, whenever search results are returned; drives stale detection and tier promotion. | Real-time analytics or audit logging. |
+| **Backfill** | The `scripts/backfill.ts` process that generates embeddings for rows where `embedding IS NULL`; run after bulk imports. | Any migration or data fix; backfill is specifically for embedding generation. |
+| **content_hash** | SHA-256 of normalized (lowercase, trimmed, whitespace-collapsed) embeddable text; used as a partial unique index to prevent exact duplicate inserts. | A row ID or version fingerprint. |
+| **CTE** | Common Table Expression in PostgreSQL; used extensively in `search-brain.ts` to build per-table vector and FTS queries before unioning results. | A cached query result or materialized view. |
+| **Distance** | Cosine distance (`<=>`) between two `halfvec(768)` vectors; lower = more similar; 0.0 is identical, 2.0 is maximally dissimilar. | Euclidean distance or similarity score (which is inverted). |
+| **Duplicate threshold** | The cosine distance cutoff (`0.08`) below which two entries are considered semantically identical and the older is archived by curation. | A fuzzy-match string threshold. |
+| **Extracted metadata** | Structured JSON (`topics`, `people`, `action_items`, `dates`) produced by a fast LLM call after every `log_thought` / `log_decision`; stored in `extracted_metadata` and merged back into `tags`. | The raw content or user-supplied tags. |
+| **Fire-and-forget** | An async operation (metadata extraction, access tracking) launched without awaiting the result so it does not block the MCP response. | A queued job or background worker. |
+| **FTS / Full-text search** | PostgreSQL `tsvector`-based keyword search using `plainto_tsquery`; the keyword path in hybrid search, scored with `ts_rank_cd`. | Vector/semantic search. |
+| **GIN index** | Generalized Inverted Index on `search_vector` columns; enables fast full-text search in the hybrid mode. | The HNSW index used for vector search. |
+| **halfvec(768)** | PostgreSQL `pgvector` type storing a 768-dimension embedding as 16-bit half-precision floats; all five tables use this type. | `vector(768)` (full 32-bit); this project specifically uses halfvec for storage efficiency. |
+| **HNSW** | Hierarchical Navigable Small World index (`m=16, ef_construction=200`) on every embedding column; enables approximate nearest-neighbor search. | A brute-force scan; HNSW trades recall for speed. |
+| **Hybrid search** | The default `search_mode`: runs vector and FTS in parallel, then merges with RRF; falls back to FTS-only if embedding generation fails. | A multi-table scan; hybrid refers to the two retrieval methods, not multiple tables. |
+| **LiteLLM** | The gateway service used for both embedding generation (`/embeddings`) and LLM-as-judge calls (`/chat/completions`); configured via `LITELLM_URL` env var. | OpenAI directly; all model calls go through LiteLLM. |
+| **LLM-as-judge** | Using a fast LLM (`CURATE_MODEL`, default `gpt-4o-mini`) to classify stale entries as KEEP / ARCHIVE / DOWNGRADE or to score vague content quality. | Human review or rule-based classification. |
+| **person: tag prefix** | The naming convention `person:<Name>` applied when `extractMetadata` finds a person mention; enables tag-based filtering on person references. | A relationship table entry; a `person:` tag is a tag on another entry, not the person record itself. |
+| **RRF / Reciprocal Rank Fusion** | Merge algorithm that combines ranked result lists using `1 / (k + rank)` scores (k=60); items appearing in both lists get boosted; used in both within-brain hybrid search and `search_all` across brain + qmd. | A weighted average or score normalization. |
+| **Role** | One of five auth identities (`admin`, `agent`, `discord`, `n8n`, `readonly`) mapped to Bearer tokens; determines per-table read/write/delete permissions. | A user account or database role. |
+| **search_vector** | A `tsvector GENERATED ALWAYS AS ... STORED` column on each table; auto-maintained by PostgreSQL on every row update; used for FTS. | The embedding column; `search_vector` is for keyword search, `embedding` is for semantic search. |
+| **Semantic fields** | The subset of a table's columns that feed into embedding generation (e.g., `content` for thoughts, `title + rationale` for decisions); changing these triggers re-embedding. | All columns; non-semantic fields like `tags` do not affect the embedding. |
+| **Stateless mode** | MCP request handling without a persistent session; the server creates an ephemeral transport, injects a synthetic initialize handshake, processes the request, then tears down. Used by mcp2cli, curl, and n8n. | Stateful session mode where the client sends `mcp-session-id`. |
+
+## Abbreviations
+
+| Abbrev | Expansion |
+|--------|-----------|
+| **CTE** | Common Table Expression (PostgreSQL) |
+| **FTS** | Full-Text Search |
+| **GIN** | Generalized Inverted Index (PostgreSQL index type for tsvector) |
+| **HNSW** | Hierarchical Navigable Small World (approximate nearest-neighbor index algorithm) |
+| **KB** | Knowledge Base (legacy term; the pre-Open Brain JSON files in `pai-private/knowledge/`) |
+| **MCP** | Model Context Protocol (the transport/tool protocol this server implements) |
+| **OB** | Open Brain (this project; used in code comments and `searchOB` function) |
+| **RRF** | Reciprocal Rank Fusion |
+| **TTL** | Time To Live (30-minute MCP session expiry in `transport.ts`) |

--- a/src/direct-handler.ts
+++ b/src/direct-handler.ts
@@ -1,0 +1,345 @@
+/**
+ * Direct JSON-RPC handler for stateless MCP clients.
+ *
+ * Bypasses the MCP SDK's StreamableHTTPServerTransport entirely.
+ * Plain JSON in, plain JSON out -- no SSE, no sessions, no initialization.
+ *
+ * Supports: tools/list, tools/call
+ * Clients: mcp2cli, curl, n8n webhooks, any HTTP client
+ */
+
+import type pg from "pg";
+import type { generateEmbedding } from "./embedding.ts";
+import { canRead } from "./permissions.ts";
+import {
+  ALL_TABLES,
+  executeSearch,
+  trackUsage,
+  type SearchMode,
+} from "./tools/search-brain.ts";
+import type { AuthInfo, Table, Tier } from "./types.ts";
+import { logger } from "./logger.ts";
+
+interface JsonRpcRequest {
+  jsonrpc: string;
+  method: string;
+  params?: any;
+  id?: string | number | null;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: string;
+  result?: any;
+  error?: { code: number; message: string; data?: any };
+  id: string | number | null;
+}
+
+export interface ToolDeps {
+  pool: pg.Pool;
+  embedFn: typeof generateEmbedding;
+}
+
+/** Tool registry -- maps tool names to handler functions */
+type ToolHandler = (
+  args: Record<string, any>,
+  auth: AuthInfo,
+  deps: ToolDeps,
+) => Promise<any>;
+
+const TOOL_SCHEMAS: Record<string, { description: string; inputSchema: any }> =
+  {
+    search_brain: {
+      description:
+        "Search across all brain tables. Supports hybrid (vector + keyword), pure vector, or keyword-only modes.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Natural language search query",
+          },
+          table: {
+            type: "string",
+            enum: [
+              "thoughts",
+              "decisions",
+              "relationships",
+              "projects",
+              "sessions",
+            ],
+            description: "Optional: limit search to a specific table",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum results to return (default 10)",
+          },
+          search_mode: {
+            type: "string",
+            enum: ["hybrid", "vector", "keyword"],
+            description: "Search mode (default: hybrid)",
+          },
+          namespace: {
+            type: "string",
+            description:
+              "Override namespace filter. Default: caller's own namespace + collab. Admins see all.",
+          },
+          tier: {
+            type: "string",
+            enum: ["hot", "warm", "cold"],
+            description:
+              "Optional: filter results to a specific cognitive tier",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    search_all: {
+      description:
+        "Federated search across Open Brain knowledge AND qmd file index.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Natural language search query",
+          },
+          limit: {
+            type: "number",
+            description: "Max results per source (default 10)",
+          },
+          sources: {
+            type: "string",
+            enum: ["all", "brain", "qmd"],
+            description: "Which sources to search (default: all)",
+          },
+          search_mode: {
+            type: "string",
+            enum: ["hybrid", "vector", "keyword"],
+            description: "Brain search mode (default: hybrid)",
+          },
+          namespace: {
+            type: "string",
+            description:
+              "Override namespace filter. Default: caller's own namespace + collab. Admins see all.",
+          },
+          tier: {
+            type: "string",
+            enum: ["hot", "warm", "cold"],
+            description:
+              "Optional: filter brain results to a specific cognitive tier",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  };
+
+const toolHandlers: Record<string, ToolHandler> = {
+  async search_brain(args, auth, deps) {
+    const query = args.query as string;
+    if (!query || query.length < 1) throw new Error("query is required");
+
+    const tableFilter = args.table as Table | undefined;
+    let accessibleTables: Table[];
+
+    if (tableFilter) {
+      if (!canRead(auth.role, tableFilter)) {
+        throw new Error(`Permission denied: cannot read ${tableFilter}`);
+      }
+      accessibleTables = [tableFilter];
+    } else {
+      accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+    }
+
+    if (accessibleTables.length === 0) {
+      throw new Error("Permission denied: no readable tables");
+    }
+
+    const limit = Math.min(Math.max(args.limit ?? 10, 1), 50);
+    const mode = (args.search_mode as SearchMode) ?? "hybrid";
+    const tier = args.tier as Tier | undefined;
+
+    const rows = await executeSearch(
+      deps,
+      accessibleTables,
+      query,
+      limit,
+      mode,
+      tier,
+    );
+    trackUsage(deps, rows, query);
+    return rows;
+  },
+
+  async search_all(args, auth, deps) {
+    const query = args.query as string;
+    if (!query || query.length < 1) throw new Error("query is required");
+
+    const limit = Math.min(Math.max(args.limit ?? 10, 1), 50);
+    const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
+    const mode = (args.search_mode as SearchMode) ?? "hybrid";
+    const searchBrain = sources === "all" || sources === "brain";
+    const searchQmd = sources === "all" || sources === "qmd";
+
+    const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+    const tier = args.tier as Tier | undefined;
+
+    const [brainResults, qmdResults] = await Promise.all([
+      searchBrain && accessibleTables.length > 0
+        ? executeSearch(deps, accessibleTables, query, limit, mode, tier).catch(
+            (err) => {
+              logger.warn("brain search failed in direct handler", {
+                error: err instanceof Error ? err.message : String(err),
+              });
+              return [];
+            },
+          )
+        : Promise.resolve([]),
+      searchQmd ? searchQmdCli(query, limit) : Promise.resolve([]),
+    ]);
+
+    // RRF merge
+    const RRF_K = 60;
+    const withRrf: Array<any & { rrf: number }> = [];
+    for (let i = 0; i < brainResults.length; i++) {
+      withRrf.push({
+        source: "brain",
+        type: brainResults[i]!.source_type,
+        content: brainResults[i]!.content_preview.slice(0, 300),
+        score:
+          brainResults[i]!.distance != null
+            ? 1 - brainResults[i]!.distance!
+            : (brainResults[i]!.fts_rank ?? 0.5),
+        id: brainResults[i]!.id,
+        tags: brainResults[i]!.tags ?? undefined,
+        rrf: 1 / (RRF_K + i + 1),
+      });
+    }
+    for (let i = 0; i < qmdResults.length; i++) {
+      withRrf.push({ ...qmdResults[i]!, rrf: 1 / (RRF_K + i + 1) });
+    }
+    const merged = withRrf
+      .sort((a, b) => b.rrf - a.rrf)
+      .slice(0, limit)
+      .map(({ rrf, ...rest }) => ({ ...rest, score: rrf }));
+
+    if (brainResults.length > 0) {
+      trackUsage(deps, brainResults, query);
+    }
+
+    return {
+      total: merged.length,
+      brain_hits: brainResults.length,
+      qmd_hits: qmdResults.length,
+      results: merged,
+    };
+  },
+};
+
+/** qmd CLI search -- same as search-all.ts */
+async function searchQmdCli(query: string, limit: number): Promise<any[]> {
+  try {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "/opt/qmd/src/qmd.ts",
+        "search",
+        query,
+        "--json",
+        "-n",
+        String(limit),
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return [];
+    const docs = JSON.parse(stdout);
+    if (!Array.isArray(docs)) return [];
+    return docs.map((doc: any) => ({
+      source: "qmd",
+      type: "file",
+      content: (doc.content || doc.text || doc.preview || "").slice(0, 300),
+      score: doc.score ?? doc.similarity ?? 0.5,
+      path: doc.path || doc.file,
+      collection: doc.collection,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export function createDirectHandler(
+  deps: ToolDeps,
+): (
+  body: JsonRpcRequest,
+  auth: AuthInfo | undefined,
+) => Promise<JsonRpcResponse> {
+  return async (body, auth) => {
+    const id = body.id ?? null;
+
+    if (!auth) {
+      return {
+        jsonrpc: "2.0",
+        error: { code: -32600, message: "Not authenticated" },
+        id,
+      };
+    }
+
+    // Handle tools/list
+    if (body.method === "tools/list") {
+      const tools = Object.entries(TOOL_SCHEMAS).map(([name, schema]) => ({
+        name,
+        ...schema,
+      }));
+      return { jsonrpc: "2.0", result: { tools }, id };
+    }
+
+    // Handle tools/call
+    if (body.method === "tools/call") {
+      const toolName = body.params?.name as string;
+      const toolArgs = body.params?.arguments ?? {};
+
+      const handler = toolHandlers[toolName];
+      if (!handler) {
+        return {
+          jsonrpc: "2.0",
+          error: { code: -32601, message: `Unknown tool: ${toolName}` },
+          id,
+        };
+      }
+
+      try {
+        const result = await handler(toolArgs, auth, deps);
+        return {
+          jsonrpc: "2.0",
+          result: {
+            content: [{ type: "text", text: JSON.stringify(result) }],
+          },
+          id,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          jsonrpc: "2.0",
+          result: {
+            content: [{ type: "text", text: message }],
+            isError: true,
+          },
+          id,
+        };
+      }
+    }
+
+    // Handle notifications (fire and forget)
+    if (body.method?.startsWith("notifications/")) {
+      return { jsonrpc: "2.0", result: {}, id };
+    }
+
+    return {
+      jsonrpc: "2.0",
+      error: { code: -32601, message: `Method not found: ${body.method}` },
+      id,
+    };
+  };
+}

--- a/src/tools/__tests__/list-recent.test.ts
+++ b/src/tools/__tests__/list-recent.test.ts
@@ -265,6 +265,85 @@ describe("list_recent", () => {
     });
   });
 
+  describe("tier in SELECT columns", () => {
+    it("SQL SELECT includes tier column", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_recent",
+          arguments: {},
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain(".tier");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("tier filter", () => {
+    it("SQL contains tier filter when tier param is provided", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_recent",
+          arguments: { tier: "hot" },
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("tier = 'hot'");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("SQL does NOT contain tier filter when tier is omitted", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_recent",
+          arguments: {},
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).not.toContain("tier = '");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
   describe("empty results", () => {
     it("returns empty array, no isError", async () => {
       const mockPool = {

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -1142,10 +1142,8 @@ describe("search_all", () => {
         // First call is the search SELECT, rest are tracking UPDATEs
         expect(queryCalls.length).toBeGreaterThan(1);
         const trackingCalls = queryCalls.slice(1);
-        for (const call of trackingCalls) {
-          expect(call[0]).toContain("access_count");
-          expect(call[0]).toContain("last_accessed_at");
-        }
+        const allSql = trackingCalls.map((c: any) => c[0]).join(" ");
+        expect(allSql).toContain("entry_access_log");
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -566,12 +566,9 @@ describe("search_brain", () => {
         const trackingCalls = queryCalls.slice(1);
         expect(trackingCalls.length).toBeGreaterThan(0);
 
-        // Each tracking UPDATE should contain access_count and last_accessed_at
-        for (const call of trackingCalls) {
-          const sql = call[0];
-          expect(sql).toContain("access_count");
-          expect(sql).toContain("last_accessed_at");
-        }
+        // Tracking calls should include entry_access_log INSERTs
+        const allSql = trackingCalls.map((c: any) => c[0]).join(" ");
+        expect(allSql).toContain("entry_access_log");
       } finally {
         await cleanup();
       }
@@ -635,6 +632,100 @@ describe("search_brain", () => {
 
         // No pool.query calls at all when embedding fails
         expect(queryCalls.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("tier filtering", () => {
+    it("SQL contains tier filter when tier param is provided", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+
+      const { client, cleanup } = await setupSearchClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "search_brain",
+          arguments: { query: "tier filter test", tier: "hot" },
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("tier = 'hot'");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("SQL does NOT contain tier filter when tier is omitted", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+
+      const { client, cleanup } = await setupSearchClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "search_brain",
+          arguments: { query: "no tier filter" },
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).not.toContain("tier = '");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("tier filter flows into FTS CTE in keyword mode", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+
+      const { client, cleanup } = await setupSearchClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "keyword tier test",
+            search_mode: "keyword",
+            tier: "cold",
+          },
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("tier = 'cold'");
+        expect(sql).toContain("search_vector");
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/set-tier.test.ts
+++ b/src/tools/__tests__/set-tier.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerSetTier } from "../set-tier.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerSetTier(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("set_tier", () => {
+  describe("admin role -- set tier to hot", () => {
+    it("updates tier and returns result", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [{ id: "test-uuid", tier: "hot" }] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "set_tier",
+          arguments: {
+            table: "thoughts",
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            tier: "hot",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.id).toBe("test-uuid");
+        expect(parsed.table).toBe("thoughts");
+        expect(parsed.tier).toBe("hot");
+
+        // Verify SQL shape
+        expect(queryCalls.length).toBe(1);
+        const [sql, params] = queryCalls[0];
+        expect(sql).toContain("UPDATE");
+        expect(sql).toContain("tier");
+        expect(sql).toContain("archived_at IS NULL");
+        expect(sql).toContain("RETURNING");
+        expect(params[0]).toBe("hot");
+        expect(params[1]).toBe("550e8400-e29b-41d4-a716-446655440000");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("admin role -- set tier to cold", () => {
+    it("sets tier to cold", async () => {
+      const mockPool = {
+        query: async () => ({
+          rows: [{ id: "cold-uuid", tier: "cold" }],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "set_tier",
+          arguments: {
+            table: "decisions",
+            id: "550e8400-e29b-41d4-a716-446655440001",
+            tier: "cold",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.tier).toBe("cold");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("admin role -- reset tier to warm", () => {
+    it("sets tier back to warm (default)", async () => {
+      const mockPool = {
+        query: async () => ({
+          rows: [{ id: "warm-uuid", tier: "warm" }],
+        }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "set_tier",
+          arguments: {
+            table: "sessions",
+            id: "550e8400-e29b-41d4-a716-446655440002",
+            tier: "warm",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.tier).toBe("warm");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("agent role -- has write permission", () => {
+    it("succeeds because agent can write to thoughts", async () => {
+      const mockPool = {
+        query: async () => ({
+          rows: [{ id: "agent-uuid", tier: "hot" }],
+        }),
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "agent-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "set_tier",
+          arguments: {
+            table: "thoughts",
+            id: "550e8400-e29b-41d4-a716-446655440003",
+            tier: "hot",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.tier).toBe("hot");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("readonly role -- permission denied", () => {
+    it("returns isError because readonly cannot write", async () => {
+      const mockPool = {
+        query: async () => ({ rows: [] }),
+      };
+      const auth: AuthInfo = { role: "readonly", clientId: "ro-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "set_tier",
+          arguments: {
+            table: "thoughts",
+            id: "550e8400-e29b-41d4-a716-446655440004",
+            tier: "hot",
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text;
+        expect(text).toContain("Permission denied");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("not found or archived -- 0 rows affected", () => {
+    it("returns 'Entry not found or archived' when UPDATE returns 0 rows", async () => {
+      const mockPool = {
+        query: async () => ({ rows: [] }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "set_tier",
+          arguments: {
+            table: "thoughts",
+            id: "550e8400-e29b-41d4-a716-446655440005",
+            tier: "cold",
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text;
+        expect(text).toContain("Entry not found or archived");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import { registerUpdateEntry } from "./update-entry.ts";
 import { registerRateEntry } from "./rate-entry.ts";
 import { registerSearchAll } from "./search-all.ts";
 import { registerUpsertPerson } from "./upsert-person.ts";
+import { registerSetTier } from "./set-tier.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -32,4 +33,5 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerRateEntry(server, deps);
   registerSearchAll(server, deps);
   registerUpsertPerson(server, deps);
+  registerSetTier(server, deps);
 }

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
-import type { AuthInfo, Table } from "../types.ts";
+import type { AuthInfo, Table, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 
@@ -40,7 +40,11 @@ const TABLE_ALIAS: Record<Table, string> = {
   sessions: "s",
 };
 
-function buildTableSelect(table: Table, includeArchived: boolean): string {
+function buildTableSelect(
+  table: Table,
+  includeArchived: boolean,
+  tier?: Tier,
+): string {
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -48,15 +52,17 @@ function buildTableSelect(table: Table, includeArchived: boolean): string {
   const archiveFilter = includeArchived
     ? ""
     : ` AND ${alias}.archived_at IS NULL`;
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
 
   return `SELECT
     '${label}' AS source_type,
     ${alias}.id,
     ${preview} AS content_preview,
     ${alias}.tags,
+    ${alias}.tier,
     ${alias}.created_at
   FROM ${table} ${alias}
-  WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}`;
+  WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
 }
 
 export function registerListRecent(server: McpServer, deps: ToolDeps): void {
@@ -94,6 +100,10 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
           .boolean()
           .optional()
           .describe("Include archived entries (default false)"),
+        tier: z
+          .enum(["hot", "warm", "cold"])
+          .optional()
+          .describe("Optional: filter to a specific cognitive tier"),
       },
       annotations: {
         title: "List Recent",
@@ -152,10 +162,11 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       const days = args.days ?? 7;
       const limit = args.limit ?? 20;
       const includeArchived = args.include_archived ?? false;
+      const tier = args.tier as Tier | undefined;
 
       // Build UNION ALL of table SELECTs
       const selects = accessibleTables.map((t) =>
-        buildTableSelect(t, includeArchived),
+        buildTableSelect(t, includeArchived, tier),
       );
 
       const unionSql = selects.join("\nUNION ALL\n");

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
-import type { AuthInfo } from "../types.ts";
+import type { AuthInfo, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 import {
@@ -12,8 +12,6 @@ import {
   type SearchMode,
   type SearchRow,
 } from "./search-brain.ts";
-
-
 
 interface UnifiedResult {
   source: "brain" | "qmd";
@@ -110,6 +108,12 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Brain search mode: hybrid (default) = vector + keyword with RRF, vector = semantic only, keyword = full-text only",
           ),
+        tier: z
+          .enum(["hot", "warm", "cold"])
+          .optional()
+          .describe(
+            "Optional: filter brain results to a specific cognitive tier",
+          ),
       },
       annotations: {
         title: "Search All",
@@ -135,13 +139,14 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const limit = args.limit ?? 10;
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
+      const tier = args.tier as Tier | undefined;
       const searchBrain = sources === "all" || sources === "brain";
       const searchQmdSource = sources === "all" || sources === "qmd";
 
       // Launch both searches in parallel
       const [brainResults, qmdResults] = await Promise.all([
         searchBrain
-          ? searchOB(deps, auth, args.query, limit, mode)
+          ? searchOB(deps, auth, args.query, limit, mode, tier)
           : Promise.resolve([]),
         searchQmdSource ? searchQmd(args.query, limit) : Promise.resolve([]),
       ]);
@@ -154,7 +159,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const withRrf: Array<UnifiedResult & { rrf: number }> = [];
       for (let i = 0; i < brainResults.length; i++) {
         const result = brainResults[i]!;
-        const boost = TIER_BOOST[result.tier ?? ""] ?? 0;
+        const boost = TIER_BOOST[(result.tier ?? "warm") as Tier];
         withRrf.push({ ...result, rrf: 1 / (RRF_K + i + 1) + boost });
       }
       for (let i = 0; i < qmdResults.length; i++) {
@@ -188,13 +193,21 @@ async function searchOB(
   query: string,
   limit: number,
   mode: SearchMode = "hybrid",
+  tier?: Tier,
 ): Promise<UnifiedResult[]> {
   const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
   if (accessibleTables.length === 0) return [];
 
   let rows: SearchRow[];
   try {
-    rows = await executeSearch(deps, accessibleTables, query, limit, mode);
+    rows = await executeSearch(
+      deps,
+      accessibleTables,
+      query,
+      limit,
+      mode,
+      tier,
+    );
   } catch (err) {
     logger.warn("searchOB_failed", {
       error: err instanceof Error ? err.message : String(err),

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canRead } from "../permissions.ts";
-import type { AuthInfo, Table } from "../types.ts";
+import type { AuthInfo, Table, Tier } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
 
@@ -61,7 +61,11 @@ const RRF_K = 60;
 const HYBRID_FETCH_MULTIPLIER = 3;
 
 /** Tier-based RRF score adjustments for cognitive tiering */
-export const TIER_BOOST: Record<string, number> = { hot: 0.3, cold: -0.2 };
+export const TIER_BOOST: Record<Tier, number> = {
+  hot: 0.3,
+  warm: 0,
+  cold: -0.2,
+};
 
 export interface SearchRow {
   source_type: string;
@@ -75,11 +79,12 @@ export interface SearchRow {
   fts_rank?: number;
 }
 
-export function buildTableCTE(table: Table): string {
+export function buildTableCTE(table: Table, tier?: Tier): string {
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
   const cteName = `${table}_results`;
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
 
   return `${cteName} AS (
   SELECT
@@ -92,15 +97,16 @@ export function buildTableCTE(table: Table): string {
     ${alias}.embedding <=> (SELECT emb FROM query_embedding) AS distance,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness
   FROM ${table} ${alias}
-  WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL
+  WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL${tierFilter}
 )`;
 }
 
-function buildFtsCTE(table: Table): string {
+function buildFtsCTE(table: Table, tier?: Tier): string {
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
   const cteName = `${table}_fts`;
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
 
   return `${cteName} AS (
   SELECT
@@ -114,7 +120,7 @@ function buildFtsCTE(table: Table): string {
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness
   FROM ${table} ${alias}
   WHERE ${alias}.search_vector @@ plainto_tsquery('english', (SELECT q FROM fts_query))
-    AND ${alias}.archived_at IS NULL
+    AND ${alias}.archived_at IS NULL${tierFilter}
 )`;
 }
 
@@ -123,8 +129,9 @@ async function vectorSearch(
   accessibleTables: Table[],
   embedding: number[],
   fetchLimit: number,
+  tier?: Tier,
 ): Promise<SearchRow[]> {
-  const ctes = accessibleTables.map(buildTableCTE);
+  const ctes = accessibleTables.map((t) => buildTableCTE(t, tier));
   const cteNames = accessibleTables.map((t) => `${t}_results`);
   const unionAll = cteNames
     .map((name) => `SELECT * FROM ${name}`)
@@ -149,8 +156,9 @@ async function ftsSearch(
   accessibleTables: Table[],
   query: string,
   fetchLimit: number,
+  tier?: Tier,
 ): Promise<SearchRow[]> {
-  const ctes = accessibleTables.map(buildFtsCTE);
+  const ctes = accessibleTables.map((t) => buildFtsCTE(t, tier));
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
   const unionAll = cteNames
     .map((name) => `SELECT * FROM ${name}`)
@@ -203,7 +211,7 @@ function rrfMerge(
   return Array.from(scoreMap.values())
     .map(({ row, rrf }) => ({
       row,
-      rrf: rrf + (TIER_BOOST[row.tier ?? ""] ?? 0),
+      rrf: rrf + TIER_BOOST[(row.tier ?? "warm") as Tier],
     }))
     .sort((a, b) => b.rrf - a.rrf)
     .slice(0, limit)
@@ -273,9 +281,10 @@ export async function executeSearch(
   query: string,
   limit: number,
   mode: SearchMode = "hybrid",
+  tier?: Tier,
 ): Promise<SearchRow[]> {
   if (mode === "keyword") {
-    return ftsSearch(deps, accessibleTables, query, limit);
+    return ftsSearch(deps, accessibleTables, query, limit, tier);
   }
 
   // Vector and hybrid both need an embedding
@@ -286,21 +295,21 @@ export async function executeSearch(
       logger.warn("embedding_failed_fallback_fts", {
         query: query.slice(0, 50),
       });
-      return ftsSearch(deps, accessibleTables, query, limit);
+      return ftsSearch(deps, accessibleTables, query, limit, tier);
     }
     // In vector mode, null embedding is a hard failure -- signal via thrown error
     throw new Error("Failed to generate query embedding");
   }
 
   if (mode === "vector") {
-    return vectorSearch(deps, accessibleTables, embedding, limit);
+    return vectorSearch(deps, accessibleTables, embedding, limit, tier);
   }
 
   // Hybrid: run both in parallel, merge with RRF
   const fetchLimit = limit * HYBRID_FETCH_MULTIPLIER;
   const [vectorRows, ftsRows] = await Promise.all([
-    vectorSearch(deps, accessibleTables, embedding, fetchLimit),
-    ftsSearch(deps, accessibleTables, query, fetchLimit),
+    vectorSearch(deps, accessibleTables, embedding, fetchLimit, tier),
+    ftsSearch(deps, accessibleTables, query, fetchLimit, tier),
   ]);
 
   return rrfMerge(vectorRows, ftsRows, limit);
@@ -337,6 +346,10 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Search mode: hybrid (default) = vector + keyword with RRF fusion, vector = semantic only, keyword = full-text only",
           ),
+        tier: z
+          .enum(["hot", "warm", "cold"])
+          .optional()
+          .describe("Optional: filter results to a specific cognitive tier"),
       },
       annotations: {
         title: "Search Brain",
@@ -393,6 +406,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
 
       const limit = args.limit ?? 10;
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
+      const tier = args.tier as Tier | undefined;
 
       let rows;
       try {
@@ -402,6 +416,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           args.query,
           limit,
           mode,
+          tier,
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -429,8 +444,13 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
  * Inlines namespace values as a SQL array literal (safe for known internal values).
  * If namespaces is null (admin/no filter), returns empty string.
  */
-export function buildNsClause(alias: string, namespaces: string[] | null): string {
+export function buildNsClause(
+  alias: string,
+  namespaces: string[] | null,
+): string {
   if (!namespaces || namespaces.length === 0) return "";
-  const escaped = namespaces.map(ns => "'" + ns.replace(/'/g, "''") + "'").join(",");
+  const escaped = namespaces
+    .map((ns) => "'" + ns.replace(/'/g, "''") + "'")
+    .join(",");
   return ` AND ${alias}.namespace IN (${escaped})`;
 }

--- a/src/tools/set-tier.ts
+++ b/src/tools/set-tier.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canWrite } from "../permissions.ts";
+import type { AuthInfo, Table, Tier } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerSetTier(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "set_tier",
+    {
+      description:
+        "Set the cognitive tier (hot/warm/cold) for a brain entry. Hot entries are boosted in search, cold entries are deprioritized. Requires write permission.",
+      inputSchema: {
+        table: z
+          .enum([
+            "thoughts",
+            "decisions",
+            "relationships",
+            "projects",
+            "sessions",
+          ])
+          .describe("Table containing the entry"),
+        id: z.string().uuid().describe("UUID of the entry to update"),
+        tier: z
+          .enum(["hot", "warm", "cold"])
+          .describe(
+            "Cognitive tier: hot (front-of-mind, boosted), warm (default), cold (deprioritized)",
+          ),
+      },
+      annotations: {
+        title: "Set Tier",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      const table = args.table as Table;
+
+      if (!auth || !canWrite(auth.role, table)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot write to " + table,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Table name is validated by Zod enum -- safe for interpolation
+      const { rows } = await deps.pool.query(
+        `UPDATE ${table} SET tier = $1 WHERE id = $2 AND archived_at IS NULL RETURNING id, tier`,
+        [args.tier, args.id],
+      );
+
+      if (rows.length === 0) {
+        logger.info("set_tier_noop", { table, id: args.id });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Entry not found or archived",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      logger.info("set_tier_success", {
+        table,
+        id: rows[0].id,
+        tier: rows[0].tier,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              id: rows[0].id,
+              table,
+              tier: rows[0].tier,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Table =
   | "relationships"
   | "projects"
   | "sessions";
+export type Tier = "hot" | "warm" | "cold";
 export type Permission = "read" | "write" | "delete";
 
 export interface AuthInfo {


### PR DESCRIPTION
## Summary

Completes the cognitive tiering API surface on top of Skippy's schema + search boost work (PRs #11-14).

- **New `set_tier` tool** -- manual tier mutation (hot/warm/cold) following rate_entry pattern
- **Tier filtering** -- optional `tier` param on `search_brain`, `search_all`, `list_recent`
- **`list_recent` tier awareness** -- tier column in SELECT output
- **Direct handler sync** -- tier support in stateless JSON-RPC path
- **Type safety** -- `Tier` type, typed `TIER_BOOST` as `Record<Tier, number>`
- **Bug fixes** -- fixed pre-existing `trackUsage` bug in direct-handler (missing queryText), fixed 2 stale tracking tests
- **Docs** -- GLOSSARY.md tiering terms, brain SKILL.md updated with tiering section + set_tier tool

## Test plan

- [x] `bun run typecheck` -- zero errors
- [x] `bun test` -- 324 pass, 0 fail (was 2 fail on main, now fixed)
- [ ] Smoke test: `set_tier` a thought to hot, verify search boost
- [ ] Smoke test: `search_brain` with `tier: "hot"` filters correctly
- [ ] Smoke test: `list_recent` with `tier: "cold"` filters correctly
- [ ] Deploy to prod (.15) and restart service

🤖 Generated with [Claude Code](https://claude.com/claude-code)