### PR TITLE
feat: add brain skill docs to repo with reference-based structure

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: brain
+description: Query, write, and manage your Open Brain knowledge base with automatic namespace resolution. USE WHEN logging thoughts, decisions, searching brain, session saves, or any OB interaction. All OB calls MUST go through this skill for proper namespace tagging.
+metadata:
+  version: 0.3.0
+  author: Rico
+  source: https://github.com/rodaddy/open-brain
+  category: utility
+triggers:
+  - /brain
+  - search brain
+  - what do I know about
+  - how did I handle
+  - find in kb
+  - log thought
+  - log decision
+  - save to brain
+  - push to ob
+  - remember this
+  - my brain
+  - personal brain
+  - collab brain
+---
+
+# Brain - Open Brain with Namespace Awareness
+
+All Open Brain interactions MUST go through this skill. Direct `mcp2cli open-brain` calls without namespace resolution will be blocked by hooks.
+
+## Namespace Resolution (CRITICAL)
+
+Before ANY write to OB, resolve the namespace. See [references/namespace-guide.md](references/namespace-guide.md) for full rules.
+
+**Quick version:**
+1. **Explicit intent** -- user says "personal"/"my brain" -> `<caller_identity>`; says "collab"/"team"/"king" -> `collab`
+2. **Host type** -- `cc-*` LXC -> `collab`; `*.local` -> `<caller_identity>`
+3. **Directory** -- personal machines only: `king*` dirs -> `collab`
+4. **Fallback** -- `<caller_identity>` from auth token
+
+## Tools Available
+
+| Tool | Use For | Namespace Required |
+|------|---------|-------------------|
+| `search_brain` | Semantic search across all tables (supports `tier` filter) | Optional (filter) |
+| `search_all` | Federated OB + qmd search (supports `tier` filter) | Optional (filter) |
+| `find_person` | Lookup people by name or context | No |
+| `log_thought` | Save a new thought/learning/note | **Yes** |
+| `log_decision` | Record a decision with rationale | **Yes** |
+| `session_save` | Save session summary | **Yes** |
+| `session_load` | Load previous session context | No |
+| `list_recent` | Browse recent entries (supports `tier` filter) | Optional (filter) |
+| `update_entry` | Modify existing entry | No (inherits) |
+| `rate_entry` | Rate entry usefulness | No |
+| `archive_entry` | Soft-delete entry | No |
+| `set_tier` | Set entry cognitive tier (hot/warm/cold) | No |
+| `upsert_person` | Create/update contact | **Yes** |
+
+## Graceful Degradation
+
+If `mcp2cli open-brain` fails (server down, network issue):
+1. Log a warning: "Open Brain unavailable, falling back to local search"
+2. Run `scripts/search-kb.ts <query>` for local JSON-based search
+3. Present results in the same output format
+
+## Reference Docs
+
+- [Namespace Guide](references/namespace-guide.md) -- full mapping table, host detection, intent keywords
+- [Agent Usage](references/agent-usage.md) -- how autonomous agents should use this skill
+- [Cognitive Tiering](references/cognitive-tiering.md) -- hot/warm/cold tiers, set_tier, filtering, dream cycle
+- [Search Guide](references/search-guide.md) -- search modes, output format, auto-tagging

--- a/skill/references/agent-usage.md
+++ b/skill/references/agent-usage.md
@@ -1,0 +1,108 @@
+# Brain Skill -- Agent Usage Guide
+
+Instructions for autonomous agents (Skippy OC, n8n-spawned agents, etc.) using Open Brain.
+
+## Before ANY OB Write
+
+You MUST resolve the namespace. Do NOT default to omitting it.
+
+### Quick Resolution
+
+```bash
+# 1. Detect host type
+HOST=$(hostname)
+
+# 2. Detect directory context
+CWD_BASE=$(basename "$PWD")
+
+# 3. Resolve
+if [[ "$HOST" == cc-* ]]; then
+  # LXC -- default collab
+  NS="collab"
+elif [[ "$CWD_BASE" == king* ]] || [[ "$CWD_BASE" == King* ]]; then
+  # Personal machine + king directory
+  NS="collab"
+else
+  # Personal machine + non-king directory
+  # Use your authenticated identity (from your auth token)
+  NS="<your_client_id>"
+fi
+```
+
+### For Skippy OC Specifically
+
+- You run on `rodaddy-air-2.local` (Air) or `Mini-M4-Pro.local` (local)
+- Your `clientId` is `skippy`
+- Default: `namespace = "skippy"` (unless in a king dir -> "collab")
+- If a user explicitly tells you "this is for the team" or "push to collab" -> use "collab"
+- If a user says "save this to Rico's brain" or "this is personal for me" -> use that user's identity, NOT "skippy"
+
+### For LXC Agents (cc-king, cc-kevin, cc-geetesh)
+
+- Default: `namespace = "collab"` (you're doing team work)
+- Only switch to personal namespace if the user explicitly asks
+- Your `clientId` from the auth token tells OB who you are for audit purposes
+
+## Mandatory Parameters on Writes
+
+Every `log_thought`, `log_decision`, `session_save`, `upsert_person` call MUST include:
+
+```json
+{
+  "namespace": "<resolved_namespace>",
+  "tags": ["<contextual_tags>"]
+}
+```
+
+Never omit namespace. Never omit tags. Empty tags array `[]` is acceptable if genuinely no tags apply, but try to include at least the project/repo name.
+
+## Tag Conventions
+
+| Working On | Tags to Include |
+|-----------|-----------------|
+| King Capital code | `["king", "<repo-name>"]` |
+| Infrastructure | `["infra", "<service>"]` |
+| PAI system itself | `["pai", "<component>"]` |
+| Agent/OC work | `["oc", "<task-domain>"]` |
+| User-requested personal | `["personal"]` |
+| Session summaries | `["session", "<project>"]` |
+
+## Common Mistakes
+
+1. **Omitting namespace** -- the server defaults to your `clientId`, which may be wrong for collab work
+2. **Hardcoding "rico"** -- use the authenticated identity, not a hardcoded string
+3. **Ignoring user intent** -- "save this to my brain" means THEIR namespace, not yours
+4. **No tags** -- always tag with at least the project context for traceability
+
+## Example: Skippy OC Logging a Thought from King Work
+
+```bash
+# On rodaddy-air-2.local, in ~/Development/king-trading
+mcp2cli open-brain log_thought --params '{
+  "content": "The RRF fusion weights need tuning -- k=60 is too aggressive for short queries",
+  "tags": ["king", "king-trading", "search", "rrf"],
+  "namespace": "collab"
+}'
+```
+
+## Example: Skippy OC Logging a Personal Observation
+
+```bash
+# On rodaddy-air-2.local, in ~/Development/pai-skills
+mcp2cli open-brain log_thought --params '{
+  "content": "Skill enforcement hooks should check recent messages deeper than 20",
+  "tags": ["pai", "hooks", "skills"],
+  "namespace": "skippy"
+}'
+```
+
+## Example: User Says "Save This to My Brain"
+
+```bash
+# User = Rico, on any host
+mcp2cli open-brain log_thought --params '{
+  "content": "Whatever the user asked to save",
+  "tags": ["personal"],
+  "namespace": "rico"
+}'
+```

--- a/skill/references/cognitive-tiering.md
+++ b/skill/references/cognitive-tiering.md
@@ -1,0 +1,85 @@
+# Cognitive Tiering
+
+Every brain entry has a **tier** that affects search ranking and can be used to filter results.
+
+## Tiers
+
+| Tier | Meaning | Search Boost | Promotion Trigger | Demotion Trigger |
+|------|---------|-------------|-------------------|------------------|
+| **hot** | Front-of-mind -- actively relevant | +0.3 RRF boost | 3+ accesses in 7 days | 0 accesses in 7 days -> warm |
+| **warm** | Default for all new entries | No boost | New entries start here | 0 accesses in 30 days -> cold |
+| **cold** | Deprioritized -- still searchable | -0.2 RRF penalty | Rescued from cold by access | 60+ days cold with no rescue -> discard |
+
+## Setting Tier
+
+```bash
+# Promote an entry to hot
+mcp2cli open-brain set_tier --params '{"table": "thoughts", "id": "<uuid>", "tier": "hot"}'
+
+# Demote an entry to cold
+mcp2cli open-brain set_tier --params '{"table": "decisions", "id": "<uuid>", "tier": "cold"}'
+
+# Reset to warm (default)
+mcp2cli open-brain set_tier --params '{"table": "thoughts", "id": "<uuid>", "tier": "warm"}'
+```
+
+Requires write permission on the target table.
+
+## Searching by Tier
+
+```bash
+# Filter search results to hot-tier only
+mcp2cli open-brain search_brain --params '{"query": "<query>", "tier": "hot"}'
+
+# Federated search, brain results filtered to hot
+mcp2cli open-brain search_all --params '{"query": "<query>", "tier": "hot"}'
+
+# List recent cold entries (candidates for review)
+mcp2cli open-brain list_recent --params '{"tier": "cold"}'
+
+# List recent hot entries (front-of-mind)
+mcp2cli open-brain list_recent --params '{"tier": "hot", "days": 30}'
+```
+
+When no tier filter is provided, all tiers are returned but hot entries are boosted and cold entries are deprioritized via RRF score adjustments.
+
+## How Tier Boost Works
+
+During hybrid search (vector + FTS merged via RRF), the final score is adjusted:
+
+```
+final_score = rrf_score + TIER_BOOST[tier]
+```
+
+Where `TIER_BOOST = { hot: 0.3, warm: 0, cold: -0.2 }`.
+
+This means a hot entry ranked 5th by pure relevance might surface to 2nd, while a cold entry ranked 3rd might drop to 5th. The content still needs to be relevant -- tier boost is a nudge, not an override.
+
+## Access Tracking
+
+Every search result and session load automatically records access:
+- `access_count` and `last_accessed_at` updated on the entry's source table
+- Detailed log entry in `entry_access_log` with query text and context
+
+This data drives the dream cycle's promotion/demotion decisions.
+
+## Dream Cycle
+
+The dream cycle is a periodic process that adjusts tiers based on access patterns. Currently run manually (guided by Skippy at 3am), not yet automated.
+
+### What It Does
+
+1. **Score** -- query `entry_access_log` for frequency/recency per entry
+2. **Promote** -- warm entries with 3+ accesses in 7 days -> hot
+3. **Demote** -- hot entries with 0 accesses in 7 days -> warm; warm with 0 in 30 days -> cold
+4. **Consolidate** -- cluster cold entries by embedding similarity, LLM-merge groups of 3+, archive originals
+5. **Prune** -- cold entries older than 60 days with no rescues -> `discarded_entries` table
+6. **Report** -- log what changed for review
+
+### Schema Support
+
+The database already has the schema for full dream cycle support:
+- `tier` column on all 5 tables (CHECK constraint: hot/warm/cold)
+- `entry_access_log` table with entry_id, source_table, accessed_at, query_text, context
+- `discarded_entries` table with reason, expires_at, access_summary
+- `consolidated_into` / `consolidated_from` columns for merge tracking

--- a/skill/references/namespace-guide.md
+++ b/skill/references/namespace-guide.md
@@ -1,0 +1,109 @@
+# Brain Namespace Guide
+
+## Host Detection
+
+| Hostname Pattern | Type | Default Namespace | Example |
+|-----------------|------|-------------------|---------|
+| `cc-*` | LXC container | `collab` | cc-king, cc-kevin, cc-geetesh |
+| `*.local` | Personal machine | `<caller_identity>` | Mini-M4-Pro.local, rodaddy-air-2.local |
+| Other | Unknown | `<caller_identity>` | |
+
+## Known Hosts
+
+| Hostname | Owner | Location |
+|----------|-------|----------|
+| `Mini-M4-Pro.local` | Rico | Local Mac Mini |
+| `rodaddy-air-2.local` | Rico/Skippy | MacBook Air |
+| `cc-king` | King (collab) | LXC 10.71.20.120 |
+| `cc-kevin` | Kevin | LXC 10.71.20.121 |
+| `cc-geetesh` | Geetesh | LXC 10.71.20.122 |
+
+## Directory-Based Override (Personal Machines Only)
+
+On `*.local` hosts, the working directory overrides the default:
+
+| Directory Pattern | Namespace | Why |
+|-------------------|-----------|-----|
+| `*/king*` or `*/King*` | `collab` | King Capital work is shared |
+| Everything else | `<caller_identity>` | Personal by default |
+
+LXC boxes do NOT use directory detection -- they default to `collab` regardless of cwd.
+
+## Intent Keywords
+
+These phrases override all host/directory detection:
+
+### Personal Override
+- "my brain", "my ob"
+- "personal", "private"
+- "save to my ..."
+- "this is personal"
+- "keep this private"
+
+Result: `namespace = <caller_identity>`
+
+### Collab Override
+- "collab", "shared", "team"
+- "king", "push to collab"
+- "this is for the team"
+
+Result: `namespace = "collab"`
+
+## Resolution Order
+
+1. **Explicit intent** -- user says "personal" or "collab" -> use that
+2. **Host type** -- `cc-*` -> collab default; `*.local` -> identity default
+3. **Directory** -- only on personal machines; `king*` -> collab
+4. **Fallback** -- `<caller_identity>`
+
+## Examples
+
+### Rico on local Mac, in ~/Development/king-trading
+```
+Host: Mini-M4-Pro.local (personal machine)
+CWD: king-trading (matches king*)
+-> namespace: "collab"
+```
+
+### Rico on local Mac, in ~/Development/tax-strategy
+```
+Host: Mini-M4-Pro.local (personal machine)
+CWD: tax-strategy (no king match)
+-> namespace: "rico"
+```
+
+### Rico on local Mac, in ~/Development/tax-strategy, says "push this to collab"
+```
+Host: Mini-M4-Pro.local (personal machine)
+CWD: tax-strategy (no king match)
+Intent: "collab" override
+-> namespace: "collab" (intent wins)
+```
+
+### Kevin on cc-kevin LXC, working on anything
+```
+Host: cc-kevin (LXC)
+-> namespace: "collab"
+```
+
+### Kevin on cc-kevin LXC, says "save this to my brain"
+```
+Host: cc-kevin (LXC)
+Intent: "my brain" -> personal override
+-> namespace: "kevin" (intent wins)
+```
+
+### Skippy on rodaddy-air-2.local, in ~/Development/open-brain
+```
+Host: rodaddy-air-2.local (personal machine)
+CWD: open-brain (no king match)
+Caller: skippy
+-> namespace: "skippy"
+```
+
+### Skippy on rodaddy-air-2.local, says "this is for the team"
+```
+Host: rodaddy-air-2.local (personal machine)
+Intent: "team" -> collab override
+-> namespace: "collab" (intent wins)
+```

--- a/skill/references/search-guide.md
+++ b/skill/references/search-guide.md
@@ -1,0 +1,99 @@
+# Search Guide
+
+## Search Modes
+
+| Mode | How It Works | Best For |
+|------|-------------|----------|
+| **hybrid** (default) | Runs vector + FTS in parallel, merges with RRF (k=60) | General queries -- best recall |
+| **vector** | Semantic similarity via embedding cosine distance | Conceptual/fuzzy queries |
+| **keyword** | PostgreSQL full-text search (`tsvector`/`tsquery`) | Exact term matching |
+
+```bash
+# Default hybrid
+mcp2cli open-brain search_brain --params '{"query": "authentication patterns"}'
+
+# Force vector-only
+mcp2cli open-brain search_brain --params '{"query": "how we handle auth", "search_mode": "vector"}'
+
+# Force keyword-only
+mcp2cli open-brain search_brain --params '{"query": "JWT token", "search_mode": "keyword"}'
+```
+
+## Federated Search (search_all)
+
+`search_all` searches both Open Brain and qmd file index, merging results with RRF:
+
+```bash
+# Search everywhere
+mcp2cli open-brain search_all --params '{"query": "deployment process"}'
+
+# Brain only (skip qmd)
+mcp2cli open-brain search_all --params '{"query": "deployment", "sources": "brain"}'
+
+# qmd only (skip brain)
+mcp2cli open-brain search_all --params '{"query": "deployment", "sources": "qmd"}'
+```
+
+## Output Format
+
+### search_brain Response
+
+```json
+[
+  {
+    "source_type": "thought",
+    "id": "uuid",
+    "content_preview": "The content...",
+    "tags": ["tag1", "tag2"],
+    "tier": "warm",
+    "created_at": "2026-04-06T...",
+    "distance": 0.12,
+    "usefulness": 0.8
+  }
+]
+```
+
+### search_all Response
+
+```json
+{
+  "total": 15,
+  "brain_hits": 10,
+  "qmd_hits": 5,
+  "results": [
+    { "source": "brain", "type": "thought", "content": "...", "score": 0.85, "id": "uuid", "tags": ["..."], "tier": "hot" },
+    { "source": "qmd", "type": "file", "content": "...", "score": 0.72, "path": "/path/to/file" }
+  ]
+}
+```
+
+### Recommended Display Format
+
+```
+## Brain Search: "<query>"
+
+### Decisions (N found)
+- **Title** -- rationale summary
+  Tags: tag1, tag2
+
+### Thoughts/Learnings (N found)
+- Content preview
+  Tags: tag1, tag2
+
+### Sessions (N found)
+- **Project** (date) -- summary
+```
+
+## Auto-Tagging Guidelines
+
+When logging thoughts/decisions, include contextual tags:
+
+| Context | Auto-Tags |
+|---------|-----------|
+| In a king repo | `["king", "<repo-name>"]` |
+| Infrastructure work | `["infra", "<service-name>"]` |
+| Personal/career | `["personal"]` |
+| Financial | `["personal", "finance"]` |
+| Session wrap | `["session", "<project>"]` |
+
+Tags are additive -- merge with any user-provided tags.

--- a/skill/scripts/search-kb.ts
+++ b/skill/scripts/search-kb.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env bun
+// Search PAI Knowledge Base
+// Usage: search-kb.ts <query> [--decisions] [--learnings] [--patterns] [--limit N]
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+interface KBEntry {
+  title: string;
+  summary: string;
+  weight: number;
+  tags?: string[];
+  impact?: string;
+  context?: string;
+  files?: string[];
+  alternatives?: string[];
+  tradeoffs?: string;
+  evidence?: string[];
+  problem?: string;
+  solution?: string;
+  keyInsight?: string;
+  avoid?: string;
+  date?: string;
+  lastSeen?: string;
+}
+
+interface SearchResult extends KBEntry {
+  category: "decision" | "learning" | "pattern";
+  score: number;
+}
+
+function loadKB(filename: string): KBEntry[] {
+  const kbPath = join(
+    homedir(),
+    ".config",
+    "pai-private",
+    "knowledge",
+    filename,
+  );
+  if (!existsSync(kbPath)) return [];
+
+  try {
+    const data = JSON.parse(readFileSync(kbPath, "utf-8"));
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 2);
+}
+
+function scoreEntry(entry: KBEntry, queryTokens: string[]): number {
+  const searchFields = [
+    entry.title || "",
+    entry.summary || "",
+    entry.context || "",
+    (entry.tags || []).join(" "),
+    (entry.files || []).join(" "),
+    entry.problem || "",
+    entry.solution || "",
+    entry.keyInsight || "",
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  let score = 0;
+
+  // Token matching
+  for (const token of queryTokens) {
+    if (searchFields.includes(token)) {
+      score += 10;
+      // Bonus for title match
+      if ((entry.title || "").toLowerCase().includes(token)) {
+        score += 20;
+      }
+    }
+  }
+
+  // Weight bonus (0-100 normalized to 0-10)
+  score += (entry.weight || 0) / 10;
+
+  // Recency bonus (last 7 days = +20, last 30 days = +10)
+  if (entry.lastSeen) {
+    const lastSeen = new Date(entry.lastSeen);
+    const now = new Date();
+    const daysSince =
+      (now.getTime() - lastSeen.getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSince <= 7) score += 20;
+    else if (daysSince <= 30) score += 10;
+  }
+
+  // Impact bonus
+  if (entry.impact === "CRITICAL") score += 15;
+  else if (entry.impact === "HIGH") score += 10;
+
+  return score;
+}
+
+function search(
+  query: string,
+  categories: string[],
+  limit: number,
+): SearchResult[] {
+  const queryTokens = tokenize(query);
+  const results: SearchResult[] = [];
+
+  if (categories.includes("decisions") || categories.length === 0) {
+    const decisions = loadKB("decisions-v2.json");
+    for (const entry of decisions) {
+      const score = scoreEntry(entry, queryTokens);
+      if (score > 10) {
+        results.push({ ...entry, category: "decision", score });
+      }
+    }
+  }
+
+  if (categories.includes("learnings") || categories.length === 0) {
+    const learnings = loadKB("learnings-v2.json");
+    for (const entry of learnings) {
+      const score = scoreEntry(entry, queryTokens);
+      if (score > 10) {
+        results.push({ ...entry, category: "learning", score });
+      }
+    }
+  }
+
+  if (categories.includes("patterns") || categories.length === 0) {
+    const patterns = loadKB("patterns-v2.json");
+    for (const entry of patterns) {
+      const score = scoreEntry(entry, queryTokens);
+      if (score > 10) {
+        results.push({ ...entry, category: "pattern", score });
+      }
+    }
+  }
+
+  // Sort by score descending
+  results.sort((a, b) => b.score - a.score);
+
+  return results.slice(0, limit);
+}
+
+function formatResult(result: SearchResult): string {
+  const impact = result.impact ? ` [${result.impact}]` : "";
+  const weight = result.weight ? ` (w:${result.weight})` : "";
+  const score = ` (score:${result.score.toFixed(1)})`;
+
+  let output = `- **${result.title}**${impact}${weight}${score}`;
+
+  if (result.summary && result.summary !== result.title) {
+    output += `\n  ${result.summary}`;
+  }
+
+  if (result.category === "decision") {
+    if (result.context) {
+      output += `\n  *Rationale:* ${result.context.slice(0, 200)}...`;
+    }
+    if (result.alternatives && result.alternatives.length > 0) {
+      output += `\n  *Rejected:* ${result.alternatives[0]}`;
+    }
+  }
+
+  if (result.category === "learning") {
+    if (result.problem) {
+      output += `\n  *Problem:* ${result.problem}`;
+    }
+    if (result.solution) {
+      output += `\n  *Solution:* ${result.solution}`;
+    }
+    if (result.avoid) {
+      output += `\n  *Avoid:* ${result.avoid}`;
+    }
+  }
+
+  return output;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  // Parse flags
+  const categories: string[] = [];
+  let limit = 10;
+  const queryParts: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--decisions") categories.push("decisions");
+    else if (arg === "--learnings") categories.push("learnings");
+    else if (arg === "--patterns") categories.push("patterns");
+    else if (arg === "--limit" && args[i + 1]) {
+      limit = parseInt(args[++i], 10) || 10;
+    } else if (!arg.startsWith("--")) {
+      queryParts.push(arg);
+    }
+  }
+
+  const query = queryParts.join(" ");
+
+  if (!query) {
+    console.log(
+      "Usage: search-kb.ts <query> [--decisions] [--learnings] [--patterns] [--limit N]",
+    );
+    process.exit(1);
+  }
+
+  const results = search(query, categories, limit);
+
+  if (results.length === 0) {
+    console.log(`## Brain Query: "${query}"\n\nNo results found.`);
+    process.exit(0);
+  }
+
+  console.log(`## Brain Query: "${query}"\n`);
+
+  // Group by category
+  const byCategory = {
+    decision: results.filter((r) => r.category === "decision"),
+    learning: results.filter((r) => r.category === "learning"),
+    pattern: results.filter((r) => r.category === "pattern"),
+  };
+
+  if (byCategory.decision.length > 0) {
+    console.log(`### Decisions (${byCategory.decision.length} found)\n`);
+    byCategory.decision.forEach((r) => console.log(formatResult(r) + "\n"));
+  }
+
+  if (byCategory.learning.length > 0) {
+    console.log(`### Learnings (${byCategory.learning.length} found)\n`);
+    byCategory.learning.forEach((r) => console.log(formatResult(r) + "\n"));
+  }
+
+  if (byCategory.pattern.length > 0) {
+    console.log(`### Patterns (${byCategory.pattern.length} found)\n`);
+    byCategory.pattern.forEach((r) => console.log(formatResult(r) + "\n"));
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Moves brain skill from `~/.config/pai/Skills/brain/` into the repo at `skill/`
- Slim SKILL.md (~75 lines) with core routing logic, tools table, and pointers to reference docs
- Detailed reference files for specific topics:
  - `references/namespace-guide.md` -- host detection, directory overrides, intent keywords
  - `references/agent-usage.md` -- autonomous agent instructions and examples
  - `references/cognitive-tiering.md` -- tier definitions, set_tier usage, dream cycle overview
  - `references/search-guide.md` -- search modes, output format, auto-tagging conventions
- `scripts/search-kb.ts` -- local fallback search for when OB server is down

## Test plan

- [ ] Verify SKILL.md renders correctly on GitHub
- [ ] Update symlink in `~/.config/pai/Skills/brain/` to point to repo copy
- [ ] Verify agents can read reference docs via the relative paths in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)