### PR TITLE
fix: prevent session leak exhausting MAX_SESSIONS

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,4 +33,6 @@ export const logger = {
     log("warn", message, extra),
   error: (message: string, extra?: Record<string, unknown>) =>
     log("error", message, extra),
+  debug: (message: string, extra?: Record<string, unknown>) =>
+    log("debug", message, extra),
 };

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -57,7 +57,8 @@ function removeSession(sessionId: string): void {
 }
 
 // Safety-net sweeper: force-clean sessions that survived past 2x TTL
-setInterval(() => {
+// unref() so the timer doesn't prevent clean process exit
+const sweepTimer = setInterval(() => {
   const now = Date.now();
   let swept = 0;
   for (const [id, entry] of sessions) {
@@ -71,6 +72,7 @@ setInterval(() => {
     swept,
   });
 }, SWEEP_INTERVAL_MS);
+sweepTimer.unref();
 
 export function getSessionAuth(sessionId: string): AuthInfo | undefined {
   return sessions.get(sessionId)?.auth;
@@ -200,8 +202,7 @@ export function createTransportHandlers(
           return;
         }
 
-        await entry.transport.close();
-        removeSession(sessionId);
+        await expireSession(sessionId, "client-delete");
         res.status(200).json({ status: "session closed" });
         return;
       }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -7,24 +7,44 @@ import type { AuthInfo } from "./types.ts";
 import { logger } from "./logger.ts";
 
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_SESSIONS = 100;
 
 interface SessionEntry {
   transport: StreamableHTTPServerTransport;
   auth: AuthInfo;
   timer: ReturnType<typeof setTimeout>;
+  lastActivity: number;
 }
 
 const sessions: Map<string, SessionEntry> = new Map();
+
+async function expireSession(
+  sessionId: string,
+  reason: string,
+): Promise<void> {
+  const entry = sessions.get(sessionId);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  sessions.delete(sessionId); // delete BEFORE close — can't leak
+  try {
+    await entry.transport.close();
+  } catch (err) {
+    logger.warn("Error closing transport during session expiry", {
+      sessionId,
+      reason,
+      error: String(err),
+    });
+  }
+}
 
 function resetTimer(sessionId: string): void {
   const entry = sessions.get(sessionId);
   if (!entry) return;
   clearTimeout(entry.timer);
+  entry.lastActivity = Date.now();
   entry.timer = setTimeout(() => {
-    logger.info("Session expired due to inactivity", { sessionId });
-    entry.transport.close();
-    sessions.delete(sessionId);
+    expireSession(sessionId, "inactivity");
   }, SESSION_TTL_MS);
 }
 
@@ -35,6 +55,22 @@ function removeSession(sessionId: string): void {
     sessions.delete(sessionId);
   }
 }
+
+// Safety-net sweeper: force-clean sessions that survived past 2x TTL
+setInterval(() => {
+  const now = Date.now();
+  let swept = 0;
+  for (const [id, entry] of sessions) {
+    if (now - entry.lastActivity > SESSION_TTL_MS * 2) {
+      expireSession(id, "sweeper");
+      swept++;
+    }
+  }
+  logger.debug("Session sweeper tick", {
+    active: sessions.size,
+    swept,
+  });
+}, SWEEP_INTERVAL_MS);
 
 export function getSessionAuth(sessionId: string): AuthInfo | undefined {
   return sessions.get(sessionId)?.auth;
@@ -92,14 +128,15 @@ export function createTransportHandlers(
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (id: string) => {
             const timer = setTimeout(() => {
-              logger.info("Session expired due to inactivity", {
-                sessionId: id,
-              });
-              transport.close();
-              sessions.delete(id);
+              expireSession(id, "inactivity");
             }, SESSION_TTL_MS);
 
-            sessions.set(id, { transport, auth: reqAuth, timer });
+            sessions.set(id, {
+              transport,
+              auth: reqAuth,
+              timer,
+              lastActivity: Date.now(),
+            });
           },
         });
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -8,7 +8,9 @@ import { logger } from "./logger.ts";
 
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const CLOSE_TIMEOUT_MS = 5_000; // 5 seconds max for transport.close()
 const MAX_SESSIONS = 100;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface SessionEntry {
   transport: StreamableHTTPServerTransport;
@@ -28,7 +30,12 @@ async function expireSession(
   clearTimeout(entry.timer);
   sessions.delete(sessionId); // delete BEFORE close — can't leak
   try {
-    await entry.transport.close();
+    await Promise.race([
+      entry.transport.close(),
+      new Promise<void>((_, reject) =>
+        setTimeout(() => reject(new Error("close timed out")), CLOSE_TIMEOUT_MS),
+      ),
+    ]);
   } catch (err) {
     logger.warn("Error closing transport during session expiry", {
       sessionId,
@@ -46,14 +53,6 @@ function resetTimer(sessionId: string): void {
   entry.timer = setTimeout(() => {
     expireSession(sessionId, "inactivity");
   }, SESSION_TTL_MS);
-}
-
-function removeSession(sessionId: string): void {
-  const entry = sessions.get(sessionId);
-  if (entry) {
-    clearTimeout(entry.timer);
-    sessions.delete(sessionId);
-  }
 }
 
 // Safety-net sweeper: force-clean sessions that survived past 2x TTL
@@ -93,7 +92,9 @@ export function createTransportHandlers(
 ): TransportHandlers {
   return {
     async handlePost(req: Request, res: Response): Promise<void> {
-      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      const rawId = req.headers["mcp-session-id"];
+      const sessionId =
+        typeof rawId === "string" && UUID_RE.test(rawId) ? rawId : undefined;
       const reqAuth = (req as any).auth as AuthInfo | undefined;
 
       if (sessionId && sessions.has(sessionId)) {
@@ -129,6 +130,12 @@ export function createTransportHandlers(
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (id: string) => {
+            // Re-check cap atomically at registration time
+            if (sessions.size >= MAX_SESSIONS) {
+              logger.warn("Session cap exceeded at registration", { id });
+              return; // timer never set — sweeper will not find it either
+            }
+
             const timer = setTimeout(() => {
               expireSession(id, "inactivity");
             }, SESSION_TTL_MS);
@@ -142,16 +149,28 @@ export function createTransportHandlers(
           },
         });
 
+        // Inline cleanup — transport is already closing, so do NOT call close() again
         transport.onclose = () => {
           const id = transport.sessionId;
           if (id) {
-            removeSession(id);
+            const e = sessions.get(id);
+            if (e) {
+              clearTimeout(e.timer);
+              sessions.delete(id);
+            }
           }
         };
 
         const server = serverFactory();
         await server.connect(transport);
-        await transport.handleRequest(req, res, req.body);
+        try {
+          await transport.handleRequest(req, res, req.body);
+        } catch (err) {
+          // If handleRequest fails after session was registered, clean up
+          const id = transport.sessionId;
+          if (id) expireSession(id, "init-error");
+          throw err;
+        }
         return;
       }
 
@@ -161,7 +180,9 @@ export function createTransportHandlers(
     },
 
     async handleGet(req: Request, res: Response): Promise<void> {
-      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      const rawId = req.headers["mcp-session-id"];
+      const sessionId =
+        typeof rawId === "string" && UUID_RE.test(rawId) ? rawId : undefined;
 
       if (sessionId && sessions.has(sessionId)) {
         const entry = sessions.get(sessionId)!;
@@ -186,7 +207,9 @@ export function createTransportHandlers(
     },
 
     async handleDelete(req: Request, res: Response): Promise<void> {
-      const sessionId = req.headers["mcp-session-id"] as string | undefined;
+      const rawId = req.headers["mcp-session-id"];
+      const sessionId =
+        typeof rawId === "string" && UUID_RE.test(rawId) ? rawId : undefined;
 
       if (sessionId && sessions.has(sessionId)) {
         const entry = sessions.get(sessionId)!;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -133,7 +133,8 @@ export function createTransportHandlers(
             // Re-check cap atomically at registration time
             if (sessions.size >= MAX_SESSIONS) {
               logger.warn("Session cap exceeded at registration", { id });
-              return; // timer never set — sweeper will not find it either
+              void transport.close().catch(() => {}); // clean up untracked transport
+              return;
             }
 
             const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- **Delete-first pattern**: `expireSession()` removes the session from the map *before* calling `transport.close()`, so a rejected close can never leave a leaked entry
- **`lastActivity` timestamp**: Tracks last activity on each session to enable the sweeper
- **Safety-net sweeper**: Runs every 5 minutes, force-cleans any session that survived past 2x TTL (60 min) — catches anything the timer missed

## Root cause
Timer callbacks called `transport.close()` without `await` or `try/catch`. If `close()` rejected (e.g., transport already dead from a dropped SSE connection), `sessions.delete()` never executed and the session leaked permanently. Leaked sessions accumulated until hitting `MAX_SESSIONS` (100), returning 503 to all clients.

## Test plan
- [x] `bun test` passes (324 pass, 0 fail)
- [ ] Deploy and confirm `search_all` works for all token types
- [ ] Monitor logs for sweeper activity over 24h — should see `Session sweeper tick` with `swept: 0`

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)