### PR TITLE
feat: pagination offset + 250 limit on all read tools

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -2,7 +2,7 @@
 name: brain
 description: Query, write, and manage your Open Brain knowledge base with automatic namespace resolution. USE WHEN logging thoughts, decisions, searching brain, session saves, or any OB interaction. All OB calls MUST go through this skill for proper namespace tagging.
 metadata:
-  version: 0.3.0
+  version: 0.4.0
   author: Rico
   source: https://github.com/rodaddy/open-brain
   category: utility
@@ -40,19 +40,36 @@ Before ANY write to OB, resolve the namespace. See [references/namespace-guide.m
 
 | Tool | Use For | Namespace Required |
 |------|---------|-------------------|
-| `search_brain` | Semantic search across all tables (supports `tier` filter) | Optional (filter) |
-| `search_all` | Federated OB + qmd search (supports `tier` filter) | Optional (filter) |
-| `find_person` | Lookup people by name or context | No |
+| `search_brain` | Semantic search across all tables (supports `tier`, `offset`) | Optional (filter) |
+| `search_all` | Federated OB + qmd search (supports `tier`, `offset`) | Optional (filter) |
+| `find_person` | Lookup people by name or context (supports `offset`) | No |
 | `log_thought` | Save a new thought/learning/note | **Yes** |
 | `log_decision` | Record a decision with rationale | **Yes** |
 | `session_save` | Save session summary | **Yes** |
 | `session_load` | Load previous session context | No |
-| `list_recent` | Browse recent entries (supports `tier` filter) | Optional (filter) |
+| `list_recent` | Browse recent entries (supports `tier`, `offset`) | Optional (filter) |
 | `update_entry` | Modify existing entry | No (inherits) |
 | `rate_entry` | Rate entry usefulness | No |
 | `archive_entry` | Soft-delete entry | No |
 | `set_tier` | Set entry cognitive tier (hot/warm/cold) | No |
 | `upsert_person` | Create/update contact | **Yes** |
+
+## Pagination
+
+All read tools support `offset` (skip N entries) and `limit` (max 250 per page, default varies by tool). Use these together to page through large result sets:
+
+```bash
+# Page 1: first 100 entries
+mcp2cli open-brain list_recent --params '{"limit": 100, "days": 30}'
+
+# Page 2: next 100
+mcp2cli open-brain list_recent --params '{"limit": 100, "offset": 100, "days": 30}'
+
+# Page 3: next 100
+mcp2cli open-brain list_recent --params '{"limit": 100, "offset": 200, "days": 30}'
+```
+
+This applies to `list_recent`, `search_brain`, `search_all`, and `find_person`.
 
 ## Graceful Degradation
 

--- a/skill/references/cognitive-tiering.md
+++ b/skill/references/cognitive-tiering.md
@@ -76,6 +76,25 @@ The dream cycle is a periodic process that adjusts tiers based on access pattern
 5. **Prune** -- cold entries older than 60 days with no rescues -> `discarded_entries` table
 6. **Report** -- log what changed for review
 
+### Scanning All Entries
+
+Use `list_recent` with `offset` pagination to scan the full inventory (max 250 per page):
+
+```bash
+# Scan all entries from last 30 days, page by page
+mcp2cli open-brain list_recent --params '{"limit": 250, "days": 30}'
+mcp2cli open-brain list_recent --params '{"limit": 250, "offset": 250, "days": 30}'
+mcp2cli open-brain list_recent --params '{"limit": 250, "offset": 500, "days": 30}'
+# Continue until empty response
+```
+
+Filter by tier to focus on specific maintenance tasks:
+
+```bash
+# Find all cold entries for consolidation review
+mcp2cli open-brain list_recent --params '{"limit": 250, "tier": "cold", "days": 60}'
+```
+
 ### Schema Support
 
 The database already has the schema for full dream cycle support:

--- a/skill/references/search-guide.md
+++ b/skill/references/search-guide.md
@@ -19,6 +19,24 @@ mcp2cli open-brain search_brain --params '{"query": "how we handle auth", "searc
 mcp2cli open-brain search_brain --params '{"query": "JWT token", "search_mode": "keyword"}'
 ```
 
+## Pagination
+
+All search/list tools support `offset` + `limit` (max 250 per page):
+
+```bash
+# Page through search results
+mcp2cli open-brain search_brain --params '{"query": "auth", "limit": 50}'
+mcp2cli open-brain search_brain --params '{"query": "auth", "limit": 50, "offset": 50}'
+
+# Page through list_recent (essential for bulk scans like dream cycle)
+mcp2cli open-brain list_recent --params '{"limit": 250, "days": 30}'
+mcp2cli open-brain list_recent --params '{"limit": 250, "offset": 250, "days": 30}'
+mcp2cli open-brain list_recent --params '{"limit": 250, "offset": 500, "days": 30}'
+
+# Federated search with pagination
+mcp2cli open-brain search_all --params '{"query": "deploy", "limit": 50, "offset": 50}'
+```
+
 ## Federated Search (search_all)
 
 `search_all` searches both Open Brain and qmd file index, merging results with RRF:

--- a/src/tools/find-person.ts
+++ b/src/tools/find-person.ts
@@ -29,9 +29,15 @@ export function registerFindPerson(server: McpServer, deps: ToolDeps): void {
           .number()
           .int()
           .min(1)
-          .max(20)
+          .max(250)
           .optional()
           .describe("Maximum results to return (default 5)"),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Number of results to skip for pagination (default 0)"),
       },
       annotations: {
         title: "Find Person",
@@ -56,17 +62,23 @@ export function registerFindPerson(server: McpServer, deps: ToolDeps): void {
 
       const mode = args.mode ?? "name";
       const limit = args.limit ?? 5;
+      const offset = args.offset ?? 0;
 
       if (mode === "semantic") {
-        return handleSemanticSearch(deps, args.query, limit);
+        return handleSemanticSearch(deps, args.query, limit, offset);
       }
 
-      return handleNameSearch(deps, args.query, limit);
+      return handleNameSearch(deps, args.query, limit, offset);
     },
   );
 }
 
-async function handleNameSearch(deps: ToolDeps, query: string, limit: number) {
+async function handleNameSearch(
+  deps: ToolDeps,
+  query: string,
+  limit: number,
+  offset: number,
+) {
   // Escape ILIKE special characters before wrapping with %
   const escaped = query.replace(/%/g, "\\%").replace(/_/g, "\\_");
 
@@ -74,9 +86,9 @@ async function handleNameSearch(deps: ToolDeps, query: string, limit: number) {
 FROM relationships
 WHERE person_name ILIKE $1 AND archived_at IS NULL
 ORDER BY warmth DESC NULLS LAST, last_contact DESC NULLS LAST
-LIMIT $2`;
+LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [`%${escaped}%`, limit]);
+  const { rows } = await deps.pool.query(sql, [`%${escaped}%`, limit, offset]);
 
   if (rows.length === 0) {
     return {
@@ -103,6 +115,7 @@ async function handleSemanticSearch(
   deps: ToolDeps,
   query: string,
   limit: number,
+  offset: number,
 ) {
   const embedding = await deps.embedFn(query);
   if (!embedding) {
@@ -122,9 +135,13 @@ async function handleSemanticSearch(
 FROM relationships
 WHERE embedding IS NOT NULL AND archived_at IS NULL
 ORDER BY distance ASC
-LIMIT $2`;
+LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [toSql(embedding), limit]);
+  const { rows } = await deps.pool.query(sql, [
+    toSql(embedding),
+    limit,
+    offset,
+  ]);
 
   if (rows.length === 0) {
     return {

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -93,9 +93,15 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
           .number()
           .int()
           .min(1)
-          .max(100)
+          .max(250)
           .optional()
           .describe("Maximum entries to return (default 20)"),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Number of entries to skip for pagination (default 0)"),
         include_archived: z
           .boolean()
           .optional()
@@ -161,6 +167,7 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
 
       const days = args.days ?? 7;
       const limit = args.limit ?? 20;
+      const offset = args.offset ?? 0;
       const includeArchived = args.include_archived ?? false;
       const tier = args.tier as Tier | undefined;
 
@@ -170,16 +177,17 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       );
 
       const unionSql = selects.join("\nUNION ALL\n");
-      const sql = `${unionSql}\nORDER BY created_at DESC\nLIMIT $2`;
+      const sql = `${unionSql}\nORDER BY created_at DESC\nLIMIT $2 OFFSET $3`;
 
       logger.info("list_recent_query", {
         tables: accessibleTables,
         days,
         limit,
+        offset,
         includeArchived,
       });
 
-      const { rows } = await deps.pool.query(sql, [days, limit]);
+      const { rows } = await deps.pool.query(sql, [days, limit, offset]);
 
       return {
         content: [

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -95,9 +95,15 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
           .number()
           .int()
           .min(1)
-          .max(50)
+          .max(250)
           .optional()
           .describe("Max results per source (default 10)"),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Number of results to skip for pagination (default 0)"),
         sources: z
           .enum(["all", "brain", "qmd"])
           .optional()
@@ -137,18 +143,24 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       }
 
       const limit = args.limit ?? 10;
+      const offset = args.offset ?? 0;
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
       const searchBrain = sources === "all" || sources === "brain";
       const searchQmdSource = sources === "all" || sources === "qmd";
 
+      // Over-fetch to cover offset + limit, then slice after merge
+      const totalNeeded = offset + limit;
+
       // Launch both searches in parallel
       const [brainResults, qmdResults] = await Promise.all([
         searchBrain
-          ? searchOB(deps, auth, args.query, limit, mode, tier)
+          ? searchOB(deps, auth, args.query, totalNeeded, mode, tier)
           : Promise.resolve([]),
-        searchQmdSource ? searchQmd(args.query, limit) : Promise.resolve([]),
+        searchQmdSource
+          ? searchQmd(args.query, totalNeeded)
+          : Promise.resolve([]),
       ]);
 
       // Reciprocal Rank Fusion: merge results from different scoring systems
@@ -167,7 +179,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       }
       const merged = withRrf
         .sort((a, b) => b.rrf - a.rrf)
-        .slice(0, limit)
+        .slice(offset, offset + limit)
         .map(({ rrf, ...rest }) => ({ ...rest, score: rrf }));
 
       return {

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -130,6 +130,7 @@ async function vectorSearch(
   embedding: number[],
   fetchLimit: number,
   tier?: Tier,
+  offset = 0,
 ): Promise<SearchRow[]> {
   const ctes = accessibleTables.map((t) => buildTableCTE(t, tier));
   const cteNames = accessibleTables.map((t) => `${t}_results`);
@@ -145,9 +146,13 @@ SELECT * FROM (
 ${unionAll}
 ) AS combined
 ORDER BY (distance * 0.8 + (1.0 - COALESCE(usefulness, 0.5)) * 0.2) ASC
-LIMIT $2`;
+LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [toSql(embedding), fetchLimit]);
+  const { rows } = await deps.pool.query(sql, [
+    toSql(embedding),
+    fetchLimit,
+    offset,
+  ]);
   return rows as SearchRow[];
 }
 
@@ -157,6 +162,7 @@ async function ftsSearch(
   query: string,
   fetchLimit: number,
   tier?: Tier,
+  offset = 0,
 ): Promise<SearchRow[]> {
   const ctes = accessibleTables.map((t) => buildFtsCTE(t, tier));
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
@@ -172,9 +178,9 @@ SELECT * FROM (
 ${unionAll}
 ) AS combined
 ORDER BY fts_rank DESC
-LIMIT $2`;
+LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [query, fetchLimit]);
+  const { rows } = await deps.pool.query(sql, [query, fetchLimit, offset]);
   return rows as SearchRow[];
 }
 
@@ -282,9 +288,10 @@ export async function executeSearch(
   limit: number,
   mode: SearchMode = "hybrid",
   tier?: Tier,
+  offset = 0,
 ): Promise<SearchRow[]> {
   if (mode === "keyword") {
-    return ftsSearch(deps, accessibleTables, query, limit, tier);
+    return ftsSearch(deps, accessibleTables, query, limit, tier, offset);
   }
 
   // Vector and hybrid both need an embedding
@@ -295,24 +302,27 @@ export async function executeSearch(
       logger.warn("embedding_failed_fallback_fts", {
         query: query.slice(0, 50),
       });
-      return ftsSearch(deps, accessibleTables, query, limit, tier);
+      return ftsSearch(deps, accessibleTables, query, limit, tier, offset);
     }
     // In vector mode, null embedding is a hard failure -- signal via thrown error
     throw new Error("Failed to generate query embedding");
   }
 
   if (mode === "vector") {
-    return vectorSearch(deps, accessibleTables, embedding, limit, tier);
+    return vectorSearch(deps, accessibleTables, embedding, limit, tier, offset);
   }
 
   // Hybrid: run both in parallel, merge with RRF
-  const fetchLimit = limit * HYBRID_FETCH_MULTIPLIER;
+  // Over-fetch to cover offset + limit, then slice after merge
+  const totalNeeded = offset + limit;
+  const fetchLimit = totalNeeded * HYBRID_FETCH_MULTIPLIER;
   const [vectorRows, ftsRows] = await Promise.all([
     vectorSearch(deps, accessibleTables, embedding, fetchLimit, tier),
     ftsSearch(deps, accessibleTables, query, fetchLimit, tier),
   ]);
 
-  return rrfMerge(vectorRows, ftsRows, limit);
+  const merged = rrfMerge(vectorRows, ftsRows, totalNeeded);
+  return merged.slice(offset);
 }
 
 export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
@@ -337,9 +347,15 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           .number()
           .int()
           .min(1)
-          .max(50)
+          .max(250)
           .optional()
           .describe("Maximum results to return (default 10)"),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Number of results to skip for pagination (default 0)"),
         search_mode: z
           .enum(["hybrid", "vector", "keyword"])
           .optional()
@@ -405,6 +421,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       }
 
       const limit = args.limit ?? 10;
+      const offset = args.offset ?? 0;
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
 
@@ -417,6 +434,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           limit,
           mode,
           tier,
+          offset,
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Added `offset` pagination parameter to `list_recent`, `search_brain`, `search_all`, and `find_person`
- Raised max `limit` from 50-100 to 250 across all read tools
- Hybrid search handles offset via over-fetch + post-merge slice for correct RRF ranking
- Skill docs updated to v0.4.0 with pagination section and examples

## Why
Skippy's dream cycle could only see the top 100 entries per table -- couldn't page through the 5000+ entries in OB. This unblocks bulk scanning for tier maintenance.

## Test plan
- [x] `bun run typecheck` clean
- [x] 324 tests pass, 0 failures
- [ ] Deploy and verify `list_recent` with offset returns different pages
- [ ] Verify Skippy can page through full OB inventory via mcp2cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)