### PR TITLE
perf: HNSW index activation, unused index cleanup, pg_stat_statements

### DIFF
--- a/scripts/ob-backfill.ts
+++ b/scripts/ob-backfill.ts
@@ -511,7 +511,11 @@ async function processSession(
   );
   if (!extract || !extract.summary) {
     console.log(`  Skipped: extraction returned empty`);
-    await appendToFailedQueue(jsonlPath, project, "extraction returned empty or LLM unavailable");
+    await appendToFailedQueue(
+      jsonlPath,
+      project,
+      "extraction returned empty or LLM unavailable",
+    );
     return false;
   }
 
@@ -536,6 +540,7 @@ async function main() {
       "dry-run": { type: "boolean", default: false },
       retry: { type: "boolean", default: false },
       limit: { type: "string", default: "10" },
+      concurrency: { type: "string", default: "1" },
     },
   });
 
@@ -544,6 +549,7 @@ async function main() {
   const dryRun = values["dry-run"]!;
   const retryMode = values.retry!;
   const limit = parseInt(values.limit!, 10);
+  const concurrency = parseInt(values.concurrency!, 10);
 
   // Retry mode: re-process only previously failed sessions
   if (retryMode) {
@@ -557,7 +563,9 @@ async function main() {
     let retryPushed = 0;
     for (const entry of queue) {
       if (!existsSync(entry.path)) {
-        console.log(`  ${basename(entry.path)} -- file no longer exists, removing from queue`);
+        console.log(
+          `  ${basename(entry.path)} -- file no longer exists, removing from queue`,
+        );
         await removeFromFailedQueue(entry.path);
         continue;
       }
@@ -587,17 +595,24 @@ async function main() {
 
   console.log(`ob-backfill: scanning ${projectsDir}`);
   if (dryRun) console.log("  MODE: dry-run (no OB writes)");
-  console.log(`  LIMIT: ${limit} sessions per project\n`);
+  console.log(`  LIMIT: ${limit} sessions per project`);
+  console.log(`  CONCURRENCY: ${concurrency} parallel workers\n`);
 
   // Load history index for date resolution
   console.log("Loading history index...");
   const historyIndex = await loadHistoryIndex();
   console.log(`  ${historyIndex.size} sessions indexed from history.jsonl\n`);
 
+  // Collect all work items first
+  interface WorkItem {
+    filePath: string;
+    sessionDir: string | null;
+    project: string;
+    historyInfo: { date: string; firstPrompt: string } | undefined;
+  }
+
+  const workItems: WorkItem[] = [];
   const projectDirs = await readdir(projectsDir);
-  let totalProcessed = 0;
-  let totalPushed = 0;
-  let totalSkipped = 0;
 
   for (const dirName of projectDirs.sort()) {
     const project = parseProjectName(dirName);
@@ -613,12 +628,9 @@ async function main() {
       .slice(0, limit);
     if (jsonlFiles.length === 0) continue;
 
-    // Check for session directories (contain subagents/)
     const sessionDirs = new Set(
       entries.filter((f) => !f.endsWith(".jsonl") && !f.startsWith(".")),
     );
-
-    console.log(`=== ${project} (${jsonlFiles.length} sessions) ===`);
 
     for (const file of jsonlFiles) {
       const filePath = join(dirPath, file);
@@ -627,17 +639,51 @@ async function main() {
         ? join(dirPath, sessionUuid)
         : null;
       const historyInfo = historyIndex.get(sessionUuid);
+      workItems.push({ filePath, sessionDir, project, historyInfo });
+    }
+  }
 
+  console.log(`Total sessions to process: ${workItems.length}\n`);
+
+  let totalProcessed = 0;
+  let totalPushed = 0;
+  let totalSkipped = 0;
+  let currentProject = "";
+
+  // Process in batches of `concurrency`
+  for (let i = 0; i < workItems.length; i += concurrency) {
+    const batch = workItems.slice(i, i + concurrency);
+
+    // Print project headers for new projects in this batch
+    for (const item of batch) {
+      if (item.project !== currentProject) {
+        currentProject = item.project;
+        const count = workItems.filter(
+          (w) => w.project === item.project,
+        ).length;
+        console.log(`\n=== ${item.project} (${count} sessions) ===`);
+      }
+    }
+
+    const results = await Promise.allSettled(
+      batch.map((item) =>
+        processSession(
+          item.filePath,
+          item.sessionDir,
+          item.project,
+          item.historyInfo,
+          dryRun,
+        ),
+      ),
+    );
+
+    for (const result of results) {
       totalProcessed++;
-      const success = await processSession(
-        filePath,
-        sessionDir,
-        project,
-        historyInfo,
-        dryRun,
-      );
-      if (success) totalPushed++;
-      else totalSkipped++;
+      if (result.status === "fulfilled" && result.value) {
+        totalPushed++;
+      } else {
+        totalSkipped++;
+      }
     }
   }
 
@@ -649,12 +695,17 @@ async function main() {
   console.log(`Pushed to OB: ${totalPushed}`);
   console.log(`Skipped (too short or extraction failed): ${totalSkipped}`);
   if (failedQueue.length > 0) {
-    console.log(`\n⚠️  ${failedQueue.length} session(s) in failed queue (${FAILED_QUEUE_PATH})`);
+    console.log(
+      `\n⚠️  ${failedQueue.length} session(s) in failed queue (${FAILED_QUEUE_PATH})`,
+    );
     console.log(`   Run with --retry to re-process them.`);
     for (const entry of failedQueue.slice(0, 5)) {
-      console.log(`   - ${basename(entry.path)} (${entry.project}): ${entry.reason}`);
+      console.log(
+        `   - ${basename(entry.path)} (${entry.project}): ${entry.reason}`,
+      );
     }
-    if (failedQueue.length > 5) console.log(`   ... and ${failedQueue.length - 5} more`);
+    if (failedQueue.length > 5)
+      console.log(`   ... and ${failedQueue.length - 5} more`);
   }
   if (dryRun) console.log("(dry-run mode — nothing was written)");
 }

--- a/src/db/migrations/008_index_cleanup.sql
+++ b/src/db/migrations/008_index_cleanup.sql
@@ -1,0 +1,28 @@
+-- 008: Drop unused indexes and install pg_stat_statements
+-- Audit on 2026-04-20 found 14 unused non-PK indexes.
+-- Dropping the ones with measurable write overhead or storage cost.
+
+-- entry_access_log: write-only table, all 3 non-PK indexes have 0 scans
+DROP INDEX IF EXISTS idx_access_log_entry;
+DROP INDEX IF EXISTS idx_access_log_source;
+DROP INDEX IF EXISTS idx_access_log_time;
+
+-- extracted_metadata GIN indexes: feature not yet queried (0 scans each)
+DROP INDEX IF EXISTS idx_decisions_extracted_meta;
+DROP INDEX IF EXISTS idx_thoughts_extracted_meta;
+
+-- pg_stat_statements: essential for query performance monitoring
+-- NOTE: requires shared_preload_libraries = 'pg_stat_statements' in postgresql.conf
+-- and a server restart. The CREATE EXTENSION will fail if not preloaded.
+-- Run manually: ALTER SYSTEM SET shared_preload_libraries = 'pg_stat_statements';
+-- Then restart PostgreSQL and re-run this migration.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+    BEGIN
+      CREATE EXTENSION pg_stat_statements;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'pg_stat_statements not available -- add to shared_preload_libraries and restart PostgreSQL';
+    END;
+  END IF;
+END $$;

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -109,7 +109,11 @@ export interface SearchRow {
 
 const HAS_EXTRACTED_METADATA: Set<Table> = new Set(["thoughts", "decisions"]);
 
-export function buildTableCTE(table: Table, tier?: Tier): string {
+export function buildTableCTE(
+  table: Table,
+  perTableLimit: number,
+  tier?: Tier,
+): string {
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -133,10 +137,12 @@ export function buildTableCTE(table: Table, tier?: Tier): string {
     ${metaCol}
   FROM ${table} ${alias}
   WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL${tierFilter}
+  ORDER BY ${alias}.embedding <=> (SELECT emb FROM query_embedding) ASC
+  LIMIT ${perTableLimit}
 )`;
 }
 
-function buildFtsCTE(table: Table, tier?: Tier): string {
+function buildFtsCTE(table: Table, perTableLimit: number, tier?: Tier): string {
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -162,6 +168,8 @@ function buildFtsCTE(table: Table, tier?: Tier): string {
   FROM ${table} ${alias}
   WHERE ${alias}.search_vector @@ plainto_tsquery('english', (SELECT q FROM fts_query))
     AND ${alias}.archived_at IS NULL${tierFilter}
+  ORDER BY fts_rank DESC
+  LIMIT ${perTableLimit}
 )`;
 }
 
@@ -173,7 +181,10 @@ async function vectorSearch(
   tier?: Tier,
   offset = 0,
 ): Promise<SearchRow[]> {
-  const ctes = accessibleTables.map((t) => buildTableCTE(t, tier));
+  const perTableLimit = fetchLimit;
+  const ctes = accessibleTables.map((t) =>
+    buildTableCTE(t, perTableLimit, tier),
+  );
   const cteNames = accessibleTables.map((t) => `${t}_results`);
   const unionAll = cteNames
     .map((name) => `SELECT * FROM ${name}`)
@@ -205,7 +216,8 @@ async function ftsSearch(
   tier?: Tier,
   offset = 0,
 ): Promise<SearchRow[]> {
-  const ctes = accessibleTables.map((t) => buildFtsCTE(t, tier));
+  const perTableLimit = fetchLimit;
+  const ctes = accessibleTables.map((t) => buildFtsCTE(t, perTableLimit, tier));
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
   const unionAll = cteNames
     .map((name) => `SELECT * FROM ${name}`)


### PR DESCRIPTION
## Summary
- **Fixed vector search CTEs** to add inner `ORDER BY distance LIMIT` per table — enables HNSW index scans instead of full table seq scans (42 MB of indexes were being ignored due to query structure)
- **Fixed FTS CTEs** with inner `ORDER BY fts_rank LIMIT` for same benefit on GIN indexes
- **Dropped 5 unused indexes** via migration 008: 3 on entry_access_log (0 scans, write-only table) + 2 extracted_metadata GIN indexes (0 scans, feature not yet queried)
- **Installed pg_stat_statements** on PG server (shared_preload_libraries + extension) for query performance monitoring
- **Ran VACUUM ANALYZE** on relationships (91% dead tuples → 0%) and sessions (9.6% dead tuples)

## Context
Database audit found the DB is healthy (147 MB, 97.25% cache hit ratio) but HNSW vector indexes consuming 29% of storage were never being used. Root cause: search CTEs computed distance for ALL rows with LIMIT only on the outer UNION ALL — pgvector needs `ORDER BY <distance_op> LIMIT N` inside the scan to use the HNSW index. At current scale (10K rows) this is fine, but would become a bottleneck at 100K+.

## Test plan
- [x] All 324 tests pass, 0 failures
- [x] TypeScript typecheck clean
- [x] Migration 008 applied and registered on live DB
- [x] Verified dropped indexes are gone
- [x] Verified VACUUM cleaned up dead tuples
- [x] pg_stat_statements installed and accessible to open_brain user

🤖 Generated with [Claude Code](https://claude.com/claude-code)