### PR TITLE
feat: add total_count to list_recent, raise limit to 500

### DIFF
--- a/src/tools/__tests__/list-recent.test.ts
+++ b/src/tools/__tests__/list-recent.test.ts
@@ -72,7 +72,7 @@ describe("list_recent", () => {
         expect(result.isError).toBeFalsy();
 
         // Verify SQL shape
-        expect(queryCalls.length).toBe(1);
+        expect(queryCalls.length).toBe(2); // data query + count query
         const [sql, params] = queryCalls[0];
 
         // Should query all 5 tables (admin has read on all)
@@ -93,8 +93,11 @@ describe("list_recent", () => {
 
         // Verify result format
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(Array.isArray(parsed)).toBe(true);
-        expect(parsed.length).toBe(3);
+        expect(parsed.entries).toBeDefined();
+        expect(Array.isArray(parsed.entries)).toBe(true);
+        expect(typeof parsed.total_count).toBe("number");
+        expect(typeof parsed.has_more).toBe("boolean");
+        expect(parsed.entries.length).toBe(3);
       } finally {
         await cleanup();
       }
@@ -233,7 +236,10 @@ describe("list_recent", () => {
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed.entries).toBeDefined();
+        expect(Array.isArray(parsed.entries)).toBe(true);
+        expect(typeof parsed.total_count).toBe("number");
+        expect(typeof parsed.has_more).toBe("boolean");
       } finally {
         await cleanup();
       }
@@ -361,8 +367,11 @@ describe("list_recent", () => {
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(Array.isArray(parsed)).toBe(true);
-        expect(parsed.length).toBe(0);
+        expect(parsed.entries).toBeDefined();
+        expect(Array.isArray(parsed.entries)).toBe(true);
+        expect(typeof parsed.total_count).toBe("number");
+        expect(typeof parsed.has_more).toBe("boolean");
+        expect(parsed.entries.length).toBe(0);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/list-recent.test.ts
+++ b/src/tools/__tests__/list-recent.test.ts
@@ -56,6 +56,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 3 }] };
+          }
           return { rows: makeMockRows(3) };
         },
       };
@@ -95,8 +99,8 @@ describe("list_recent", () => {
         const parsed = JSON.parse((result.content as any)[0].text);
         expect(parsed.entries).toBeDefined();
         expect(Array.isArray(parsed.entries)).toBe(true);
-        expect(typeof parsed.total_count).toBe("number");
-        expect(typeof parsed.has_more).toBe("boolean");
+        expect(parsed.total_count).toBe(3);
+        expect(parsed.has_more).toBe(false);
         expect(parsed.entries.length).toBe(3);
       } finally {
         await cleanup();
@@ -110,6 +114,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 1 }] };
+          }
           return { rows: makeMockRows(1) };
         },
       };
@@ -141,6 +149,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 2 }] };
+          }
           return { rows: makeMockRows(2) };
         },
       };
@@ -169,6 +181,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 0 }] };
+          }
           return { rows: [] };
         },
       };
@@ -196,6 +212,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 5 }] };
+          }
           return { rows: makeMockRows(5) };
         },
       };
@@ -222,7 +242,13 @@ describe("list_recent", () => {
   describe("readonly role -- has read permission", () => {
     it("succeeds because readonly can read all tables", async () => {
       const mockPool = {
-        query: async () => ({ rows: makeMockRows(1) }),
+        query: async (...args: any[]) => {
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 1 }] };
+          }
+          return { rows: makeMockRows(1) };
+        },
       };
       const auth: AuthInfo = { role: "readonly", clientId: "ro-client" };
 
@@ -238,8 +264,8 @@ describe("list_recent", () => {
         const parsed = JSON.parse((result.content as any)[0].text);
         expect(parsed.entries).toBeDefined();
         expect(Array.isArray(parsed.entries)).toBe(true);
-        expect(typeof parsed.total_count).toBe("number");
-        expect(typeof parsed.has_more).toBe("boolean");
+        expect(parsed.total_count).toBe(1);
+        expect(parsed.has_more).toBe(false);
       } finally {
         await cleanup();
       }
@@ -277,6 +303,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 1 }] };
+          }
           return { rows: makeMockRows(1) };
         },
       };
@@ -304,6 +334,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 1 }] };
+          }
           return { rows: makeMockRows(1) };
         },
       };
@@ -329,6 +363,10 @@ describe("list_recent", () => {
       const mockPool = {
         query: async (...args: any[]) => {
           queryCalls.push(args);
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 1 }] };
+          }
           return { rows: makeMockRows(1) };
         },
       };
@@ -353,7 +391,13 @@ describe("list_recent", () => {
   describe("empty results", () => {
     it("returns empty array, no isError", async () => {
       const mockPool = {
-        query: async () => ({ rows: [] }),
+        query: async (...args: any[]) => {
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 0 }] };
+          }
+          return { rows: [] };
+        },
       };
       const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
 
@@ -369,9 +413,73 @@ describe("list_recent", () => {
         const parsed = JSON.parse((result.content as any)[0].text);
         expect(parsed.entries).toBeDefined();
         expect(Array.isArray(parsed.entries)).toBe(true);
-        expect(typeof parsed.total_count).toBe("number");
-        expect(typeof parsed.has_more).toBe("boolean");
+        expect(parsed.total_count).toBe(0);
+        expect(parsed.has_more).toBe(false);
         expect(parsed.entries.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("has_more pagination", () => {
+    it("returns has_more=true when total_count exceeds returned rows", async () => {
+      const mockPool = {
+        query: async (...args: any[]) => {
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            return { rows: [{ total_count: 10 }] };
+          }
+          return { rows: makeMockRows(2) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_recent",
+          arguments: { limit: 2, offset: 0 },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.entries.length).toBe(2);
+        expect(parsed.total_count).toBe(10);
+        expect(parsed.has_more).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("count query failure", () => {
+    it("returns data with total_count=null and has_more=false when count query fails", async () => {
+      const mockPool = {
+        query: async (...args: any[]) => {
+          const [sql] = args;
+          if (sql.includes("SUM(cnt)")) {
+            throw new Error("connection timeout");
+          }
+          return { rows: makeMockRows(3) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_recent",
+          arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.entries.length).toBe(3);
+        expect(parsed.total_count).toBeNull();
+        expect(parsed.has_more).toBe(false);
       } finally {
         await cleanup();
       }

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -13,6 +13,18 @@ import {
   VALID_TIERS,
 } from "./table-constants.ts";
 
+function buildWhereClause(
+  alias: string,
+  includeArchived: boolean,
+  tier?: Tier,
+): string {
+  const archiveFilter = includeArchived
+    ? ""
+    : ` AND ${alias}.archived_at IS NULL`;
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  return `WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
+}
+
 function buildTableSelect(
   table: Table,
   includeArchived: boolean,
@@ -22,11 +34,7 @@ function buildTableSelect(
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
-
-  const archiveFilter = includeArchived
-    ? ""
-    : ` AND ${alias}.archived_at IS NULL`;
-  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  const where = buildWhereClause(alias, includeArchived, tier);
 
   return `SELECT
     '${label}' AS source_type,
@@ -36,7 +44,7 @@ function buildTableSelect(
     ${alias}.tier,
     ${alias}.created_at
   FROM ${table} ${alias}
-  WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
+  ${where}`;
 }
 
 function buildCountSelect(
@@ -46,15 +54,11 @@ function buildCountSelect(
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
-
-  const archiveFilter = includeArchived
-    ? ""
-    : ` AND ${alias}.archived_at IS NULL`;
-  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  const where = buildWhereClause(alias, includeArchived, tier);
 
   return `SELECT COUNT(*) AS cnt
   FROM ${table} ${alias}
-  WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
+  ${where}`;
 }
 
 export function registerListRecent(server: McpServer, deps: ToolDeps): void {
@@ -187,11 +191,14 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
 
       const [dataResult, countResult] = await Promise.all([
         deps.pool.query(sql, [days, limit, offset]),
-        deps.pool.query(countSql, [days]),
+        deps.pool.query(countSql, [days]).catch(() => null),
       ]);
 
-      const totalCount = countResult.rows[0]?.total_count ?? 0;
-      const hasMore = offset + dataResult.rows.length < totalCount;
+      const totalCount = countResult?.rows[0]?.total_count ?? null;
+      const hasMore =
+        totalCount !== null
+          ? offset + dataResult.rows.length < totalCount
+          : false;
 
       return {
         content: [

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -5,46 +5,20 @@ import type { AuthInfo, Table, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 
-const ALL_TABLES: Table[] = [
-  "thoughts",
-  "decisions",
-  "relationships",
-  "projects",
-  "sessions",
-];
-
-/** Singular labels for list results */
-const SOURCE_LABELS: Record<Table, string> = {
-  thoughts: "thought",
-  decisions: "decision",
-  relationships: "relationship",
-  projects: "project",
-  sessions: "session",
-};
-
-/** Content preview SQL expression per table */
-const CONTENT_PREVIEW: Record<Table, string> = {
-  thoughts: "t.content",
-  decisions: "d.title || ': ' || d.rationale",
-  relationships: "r.person_name || ': ' || COALESCE(r.context, '')",
-  projects: "p.name || ': ' || COALESCE(p.description, '')",
-  sessions: "COALESCE(s.project || ': ', '') || LEFT(s.summary, 200)",
-};
-
-/** Table alias used in SELECTs */
-const TABLE_ALIAS: Record<Table, string> = {
-  thoughts: "t",
-  decisions: "d",
-  relationships: "r",
-  projects: "p",
-  sessions: "s",
-};
+import {
+  ALL_TABLES,
+  SOURCE_LABELS,
+  CONTENT_PREVIEW,
+  TABLE_ALIAS,
+  VALID_TIERS,
+} from "./table-constants.ts";
 
 function buildTableSelect(
   table: Table,
   includeArchived: boolean,
   tier?: Tier,
 ): string {
+  if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -70,6 +44,7 @@ function buildCountSelect(
   includeArchived: boolean,
   tier?: Tier,
 ): string {
+  if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
 
   const archiveFilter = includeArchived

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -4,20 +4,47 @@ import { canRead } from "../permissions.ts";
 import type { AuthInfo, Table, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
-import {
-  ALL_TABLES,
-  SOURCE_LABELS,
-  CONTENT_PREVIEW,
-  TABLE_ALIAS,
-  VALID_TIERS,
-} from "./table-constants.ts";
+
+const ALL_TABLES: Table[] = [
+  "thoughts",
+  "decisions",
+  "relationships",
+  "projects",
+  "sessions",
+];
+
+/** Singular labels for list results */
+const SOURCE_LABELS: Record<Table, string> = {
+  thoughts: "thought",
+  decisions: "decision",
+  relationships: "relationship",
+  projects: "project",
+  sessions: "session",
+};
+
+/** Content preview SQL expression per table */
+const CONTENT_PREVIEW: Record<Table, string> = {
+  thoughts: "t.content",
+  decisions: "d.title || ': ' || d.rationale",
+  relationships: "r.person_name || ': ' || COALESCE(r.context, '')",
+  projects: "p.name || ': ' || COALESCE(p.description, '')",
+  sessions: "COALESCE(s.project || ': ', '') || LEFT(s.summary, 200)",
+};
+
+/** Table alias used in SELECTs */
+const TABLE_ALIAS: Record<Table, string> = {
+  thoughts: "t",
+  decisions: "d",
+  relationships: "r",
+  projects: "p",
+  sessions: "s",
+};
 
 function buildTableSelect(
   table: Table,
   includeArchived: boolean,
   tier?: Tier,
 ): string {
-  if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -38,12 +65,29 @@ function buildTableSelect(
   WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
 }
 
+function buildCountSelect(
+  table: Table,
+  includeArchived: boolean,
+  tier?: Tier,
+): string {
+  const alias = TABLE_ALIAS[table];
+
+  const archiveFilter = includeArchived
+    ? ""
+    : ` AND ${alias}.archived_at IS NULL`;
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+
+  return `SELECT COUNT(*) AS cnt
+  FROM ${table} ${alias}
+  WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
+}
+
 export function registerListRecent(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
     "list_recent",
     {
       description:
-        "List recent brain entries chronologically. Supports table filter, date range, and archived toggle.",
+        "List recent brain entries chronologically. Supports table filter, date range, tier filter, and pagination with total_count.",
       inputSchema: {
         table: z
           .enum([
@@ -66,9 +110,9 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
           .number()
           .int()
           .min(1)
-          .max(250)
+          .max(500)
           .optional()
-          .describe("Maximum entries to return (default 20)"),
+          .describe("Maximum entries to return (default 20, max 500)"),
         offset: z
           .number()
           .int()
@@ -152,6 +196,12 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       const unionSql = selects.join("\nUNION ALL\n");
       const sql = `${unionSql}\nORDER BY created_at DESC\nLIMIT $2 OFFSET $3`;
 
+      // Build total count query
+      const countSelects = accessibleTables.map((t) =>
+        buildCountSelect(t, includeArchived, tier),
+      );
+      const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
+
       logger.info("list_recent_query", {
         tables: accessibleTables,
         days,
@@ -160,13 +210,25 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
         includeArchived,
       });
 
-      const { rows } = await deps.pool.query(sql, [days, limit, offset]);
+      const [dataResult, countResult] = await Promise.all([
+        deps.pool.query(sql, [days, limit, offset]),
+        deps.pool.query(countSql, [days]),
+      ]);
+
+      const totalCount = countResult.rows[0]?.total_count ?? 0;
+      const hasMore = offset + dataResult.rows.length < totalCount;
 
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(rows),
+            text: JSON.stringify({
+              entries: dataResult.rows,
+              total_count: totalCount,
+              offset,
+              limit,
+              has_more: hasMore,
+            }),
           },
         ],
       };


### PR DESCRIPTION
Closes #24

## Changes
- Response now returns `{entries, total_count, offset, limit, has_more}` instead of raw array
- `total_count` tells callers exactly how many matching entries exist for pagination
- `has_more` boolean for easy "load more" logic
- Limit raised from 250 to 500
- Count query runs in parallel with data query via `Promise.all` (no perf impact)
- 11 tests updated and passing

## Before
```json
[{...}, {...}, ...]  // raw array, no idea how many more exist
```

## After
```json
{
  "entries": [{...}, {...}, ...],
  "total_count": 427,
  "offset": 0,
  "limit": 20,
  "has_more": true
}
```

**Breaking change:** callers that `JSON.parse` the response and expect an array need to access `.entries` instead.