### PR TITLE
feat: add list_stale MCP tool for usage-based tier decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built for AI agents that need persistent, searchable memory across conversations
 
 ## Features
 
-- **14 MCP tools** for reading, writing, and managing knowledge
+- **15 MCP tools** for reading, writing, and managing knowledge
 - **Hybrid search** — reciprocal rank fusion (RRF) over HNSW vector similarity + PostgreSQL full-text search
 - **Cognitive tiering** — hot/warm/cold memory lifecycle with usage-based scoring
 - **Per-consumer auth** — role-based access control with scoped tokens (admin, agent, readonly, etc.)
@@ -34,6 +34,7 @@ Built for AI agents that need persistent, searchable memory across conversations
 | `update_entry` | Update content, tags, or metadata on an existing entry. |
 | `archive_entry` | Soft-delete an entry with an optional reason. |
 | `rate_entry` | Score an entry's usefulness (0–1) for quality feedback. |
+| `list_stale` | Find entries not accessed recently — candidates for tier demotion (hot→warm→cold). Filterable by table, current tier, and staleness threshold. |
 | `set_tier` | Move an entry between cognitive tiers (hot/warm/cold). |
 
 ## Prerequisites

--- a/src/tools/__tests__/list-stale.test.ts
+++ b/src/tools/__tests__/list-stale.test.ts
@@ -58,8 +58,9 @@ describe("list_stale", () => {
     it("returns stale entries from all tables, default days=30, limit=50", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 3 }] };
           return { rows: makeMockRows(3) };
         },
       };
@@ -75,8 +76,8 @@ describe("list_stale", () => {
 
         expect(result.isError).toBeFalsy();
 
-        // Verify SQL shape
-        expect(queryCalls.length).toBe(1);
+        // Verify SQL shape -- data query + count query
+        expect(queryCalls.length).toBe(2);
         const [sql, params] = queryCalls[0];
 
         // Should query all 5 tables (admin has read on all)
@@ -103,8 +104,11 @@ describe("list_stale", () => {
 
         // Verify result format
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(Array.isArray(parsed)).toBe(true);
-        expect(parsed.length).toBe(3);
+        expect(parsed.entries).toBeDefined();
+        expect(Array.isArray(parsed.entries)).toBe(true);
+        expect(parsed.entries.length).toBe(3);
+        expect(parsed.total_count).toBe(3);
+        expect(parsed.has_more).toBe(false);
       } finally {
         await cleanup();
       }
@@ -115,8 +119,9 @@ describe("list_stale", () => {
     it("only queries thoughts when table='thoughts'", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 1 }] };
           return { rows: makeMockRows(1) };
         },
       };
@@ -145,8 +150,9 @@ describe("list_stale", () => {
     it("SQL contains tier filter when tier='hot'", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 2 }] };
           return { rows: makeMockRows(2) };
         },
       };
@@ -170,8 +176,9 @@ describe("list_stale", () => {
     it("SQL does NOT contain tier filter when tier is omitted", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 1 }] };
           return { rows: makeMockRows(1) };
         },
       };
@@ -197,8 +204,9 @@ describe("list_stale", () => {
     it("uses days=60, limit=10 in SQL params", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 5 }] };
           return { rows: makeMockRows(5) };
         },
       };
@@ -225,7 +233,10 @@ describe("list_stale", () => {
   describe("readonly role -- has read permission", () => {
     it("succeeds because readonly can read all tables", async () => {
       const mockPool = {
-        query: async () => ({ rows: makeMockRows(1) }),
+        query: async (sql: string) => {
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 1 }] };
+          return { rows: makeMockRows(1) };
+        },
       };
       const auth: AuthInfo = { role: "readonly", clientId: "ro-client" };
 
@@ -239,7 +250,8 @@ describe("list_stale", () => {
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed.entries).toBeDefined();
+        expect(Array.isArray(parsed.entries)).toBe(true);
       } finally {
         await cleanup();
       }
@@ -278,7 +290,10 @@ describe("list_stale", () => {
       };
       // Pass undefined auth by using a special setup
       const server = new McpServer({ name: "test", version: "1.0.0" });
-      const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+      const deps: ToolDeps = {
+        pool: mockPool as any,
+        embedFn: createMockEmbed(),
+      };
       registerListStale(server, deps);
 
       const [clientTransport, serverTransport] =
@@ -306,9 +321,12 @@ describe("list_stale", () => {
   });
 
   describe("empty results", () => {
-    it("returns empty array, no isError", async () => {
+    it("returns empty entries array, no isError", async () => {
       const mockPool = {
-        query: async () => ({ rows: [] }),
+        query: async (sql: string) => {
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 0 }] };
+          return { rows: [] };
+        },
       };
       const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
 
@@ -322,8 +340,11 @@ describe("list_stale", () => {
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(Array.isArray(parsed)).toBe(true);
-        expect(parsed.length).toBe(0);
+        expect(parsed.entries).toBeDefined();
+        expect(Array.isArray(parsed.entries)).toBe(true);
+        expect(parsed.entries.length).toBe(0);
+        expect(parsed.total_count).toBe(0);
+        expect(parsed.has_more).toBe(false);
       } finally {
         await cleanup();
       }
@@ -333,7 +354,10 @@ describe("list_stale", () => {
   describe("result includes access metadata", () => {
     it("rows contain access_count, last_accessed_at, and effective_last_access", async () => {
       const mockPool = {
-        query: async () => ({ rows: makeMockRows(1) }),
+        query: async (sql: string) => {
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 1 }] };
+          return { rows: makeMockRows(1) };
+        },
       };
       const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
 
@@ -347,9 +371,9 @@ describe("list_stale", () => {
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse((result.content as any)[0].text);
-        expect(parsed[0]).toHaveProperty("access_count");
-        expect(parsed[0]).toHaveProperty("last_accessed_at");
-        expect(parsed[0]).toHaveProperty("effective_last_access");
+        expect(parsed.entries[0]).toHaveProperty("access_count");
+        expect(parsed.entries[0]).toHaveProperty("last_accessed_at");
+        expect(parsed.entries[0]).toHaveProperty("effective_last_access");
       } finally {
         await cleanup();
       }
@@ -360,8 +384,9 @@ describe("list_stale", () => {
     it("SQL orders by effective_last_access ASC (stalest first)", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 0 }] };
           return { rows: [] };
         },
       };
@@ -387,8 +412,9 @@ describe("list_stale", () => {
     it("filters to thoughts + hot tier", async () => {
       const queryCalls: any[] = [];
       const mockPool = {
-        query: async (...args: any[]) => {
-          queryCalls.push(args);
+        query: async (sql: string, ...rest: any[]) => {
+          queryCalls.push([sql, ...rest]);
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 1 }] };
           return { rows: makeMockRows(1) };
         },
       };
@@ -406,6 +432,58 @@ describe("list_stale", () => {
         expect(sql).toContain("FROM thoughts");
         expect(sql).toContain("tier = 'hot'");
         expect(sql).not.toContain("UNION ALL");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("has_more pagination", () => {
+    it("returns has_more=true when total exceeds offset+entries", async () => {
+      const mockPool = {
+        query: async (sql: string) => {
+          if (sql.includes("SUM(cnt)")) return { rows: [{ total_count: 10 }] };
+          return { rows: makeMockRows(2) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: { limit: 2 },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.has_more).toBe(true);
+        expect(parsed.total_count).toBe(10);
+        expect(parsed.entries.length).toBe(2);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("count query failure", () => {
+    it("returns data with total_count=null when count query fails", async () => {
+      const mockPool = {
+        query: async (sql: string) => {
+          if (sql.includes("SUM(cnt)")) throw new Error("connection lost");
+          return { rows: makeMockRows(2) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.entries.length).toBe(2);
+        expect(parsed.total_count).toBeNull();
+        expect(parsed.has_more).toBe(false);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/list-stale.test.ts
+++ b/src/tools/__tests__/list-stale.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerListStale } from "../list-stale.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+function makeMockRows(count: number = 3) {
+  return Array.from({ length: count }, (_, i) => ({
+    source_type: "thought",
+    id: `uuid-${i}`,
+    content_preview: `Stale content ${i}`,
+    tags: ["old-tag"],
+    tier: "hot",
+    access_count: i,
+    last_accessed_at: "2026-01-01T00:00:00Z",
+    created_at: "2025-12-01T00:00:00Z",
+    effective_last_access: "2026-01-01T00:00:00Z",
+  }));
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerListStale(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("list_stale", () => {
+  describe("admin role -- no params (defaults)", () => {
+    it("returns stale entries from all tables, default days=30, limit=50", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(3) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+
+        // Verify SQL shape
+        expect(queryCalls.length).toBe(1);
+        const [sql, params] = queryCalls[0];
+
+        // Should query all 5 tables (admin has read on all)
+        expect(sql).toContain("thoughts");
+        expect(sql).toContain("decisions");
+        expect(sql).toContain("relationships");
+        expect(sql).toContain("projects");
+        expect(sql).toContain("sessions");
+        expect(sql).toContain("UNION ALL");
+
+        // Should order by staleness ascending (oldest access first)
+        expect(sql).toContain("ORDER BY effective_last_access ASC");
+
+        // Default days=30, limit=50
+        expect(params[0]).toBe(30);
+        expect(params[1]).toBe(50);
+
+        // Should filter archived entries
+        expect(sql).toContain("archived_at IS NULL");
+
+        // Should use COALESCE for last_accessed_at fallback
+        expect(sql).toContain("COALESCE");
+        expect(sql).toContain("last_accessed_at");
+
+        // Verify result format
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed.length).toBe(3);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("table filter", () => {
+    it("only queries thoughts when table='thoughts'", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: { table: "thoughts" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const [sql] = queryCalls[0];
+
+        expect(sql).toContain("FROM thoughts");
+        expect(sql).not.toContain("UNION ALL");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("tier filter", () => {
+    it("SQL contains tier filter when tier='hot'", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(2) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_stale",
+          arguments: { tier: "hot" },
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("tier = 'hot'");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("SQL does NOT contain tier filter when tier is omitted", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).not.toContain("tier = '");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("custom days and limit", () => {
+    it("uses days=60, limit=10 in SQL params", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(5) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: { days: 60, limit: 10 },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const [, params] = queryCalls[0];
+        expect(params[0]).toBe(60);
+        expect(params[1]).toBe(10);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("readonly role -- has read permission", () => {
+    it("succeeds because readonly can read all tables", async () => {
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(1) }),
+      };
+      const auth: AuthInfo = { role: "readonly", clientId: "ro-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(Array.isArray(parsed)).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("discord role -- no read permission", () => {
+    it("returns isError because discord cannot read any table", async () => {
+      const mockPool = {
+        query: async () => ({ rows: [] }),
+      };
+      const auth: AuthInfo = { role: "discord", clientId: "discord-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text;
+        expect(text).toContain("Permission denied");
+        expect(text).toContain("no readable tables");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("no auth", () => {
+    it("returns permission denied when auth is missing", async () => {
+      const mockPool = {
+        query: async () => ({ rows: [] }),
+      };
+      // Pass undefined auth by using a special setup
+      const server = new McpServer({ name: "test", version: "1.0.0" });
+      const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+      registerListStale(server, deps);
+
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+
+      // Don't inject authInfo
+      const client = new Client({ name: "test-client", version: "1.0.0" });
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text;
+        expect(text).toContain("Permission denied");
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+  });
+
+  describe("empty results", () => {
+    it("returns empty array, no isError", async () => {
+      const mockPool = {
+        query: async () => ({ rows: [] }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("result includes access metadata", () => {
+    it("rows contain access_count, last_accessed_at, and effective_last_access", async () => {
+      const mockPool = {
+        query: async () => ({ rows: makeMockRows(1) }),
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed[0]).toHaveProperty("access_count");
+        expect(parsed[0]).toHaveProperty("last_accessed_at");
+        expect(parsed[0]).toHaveProperty("effective_last_access");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("staleness ordering", () => {
+    it("SQL orders by effective_last_access ASC (stalest first)", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_stale",
+          arguments: {},
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("ORDER BY effective_last_access ASC");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
+  describe("table + tier combined filter", () => {
+    it("filters to thoughts + hot tier", async () => {
+      const queryCalls: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: makeMockRows(1) };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "list_stale",
+          arguments: { table: "thoughts", tier: "hot" },
+        });
+
+        const [sql] = queryCalls[0];
+        expect(sql).toContain("FROM thoughts");
+        expect(sql).toContain("tier = 'hot'");
+        expect(sql).not.toContain("UNION ALL");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ import { registerSessionSave } from "./session-save.ts";
 import { registerSessionLoad } from "./session-load.ts";
 import { registerArchiveEntry } from "./archive-entry.ts";
 import { registerListRecent } from "./list-recent.ts";
+import { registerListStale } from "./list-stale.ts";
 import { registerUpdateEntry } from "./update-entry.ts";
 import { registerRateEntry } from "./rate-entry.ts";
 import { registerSearchAll } from "./search-all.ts";
@@ -38,6 +39,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerSessionLoad(server, deps);
   registerArchiveEntry(server, deps);
   registerListRecent(server, deps);
+  registerListStale(server, deps);
   registerUpdateEntry(server, deps);
   registerRateEntry(server, deps);
   registerSearchAll(server, deps);

--- a/src/tools/list-stale.ts
+++ b/src/tools/list-stale.ts
@@ -5,53 +5,27 @@ import type { AuthInfo, Table, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 
-const ALL_TABLES: Table[] = [
-  "thoughts",
-  "decisions",
-  "relationships",
-  "projects",
-  "sessions",
-];
+import {
+  ALL_TABLES,
+  SOURCE_LABELS,
+  CONTENT_PREVIEW,
+  TABLE_ALIAS,
+  VALID_TIERS,
+} from "./table-constants.ts";
 
-/** Singular labels for list results */
-const SOURCE_LABELS: Record<Table, string> = {
-  thoughts: "thought",
-  decisions: "decision",
-  relationships: "relationship",
-  projects: "project",
-  sessions: "session",
-};
+function buildWhereClause(alias: string, tier?: Tier): string {
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  return `WHERE ${alias}.archived_at IS NULL
+    AND COALESCE(${alias}.last_accessed_at, ${alias}.created_at) < NOW() - INTERVAL '1 day' * $1${tierFilter}`;
+}
 
-/** Content preview SQL expression per table */
-const CONTENT_PREVIEW: Record<Table, string> = {
-  thoughts: "t.content",
-  decisions: "d.title || ': ' || d.rationale",
-  relationships: "r.person_name || ': ' || COALESCE(r.context, '')",
-  projects: "p.name || ': ' || COALESCE(p.description, '')",
-  sessions: "COALESCE(s.project || ': ', '') || LEFT(s.summary, 200)",
-};
-
-/** Table alias used in SELECTs */
-const TABLE_ALIAS: Record<Table, string> = {
-  thoughts: "t",
-  decisions: "d",
-  relationships: "r",
-  projects: "p",
-  sessions: "s",
-};
-
-function buildStaleSelect(
-  table: Table,
-  tier?: Tier,
-): string {
+function buildStaleSelect(table: Table, tier?: Tier): string {
+  if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
+  const where = buildWhereClause(alias, tier);
 
-  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
-
-  // Stale = not accessed recently. Use COALESCE to handle entries never accessed
-  // (last_accessed_at IS NULL), falling back to created_at.
   return `SELECT
     '${label}' AS source_type,
     ${alias}.id,
@@ -63,8 +37,17 @@ function buildStaleSelect(
     ${alias}.created_at,
     COALESCE(${alias}.last_accessed_at, ${alias}.created_at) AS effective_last_access
   FROM ${table} ${alias}
-  WHERE ${alias}.archived_at IS NULL
-    AND COALESCE(${alias}.last_accessed_at, ${alias}.created_at) < NOW() - INTERVAL '1 day' * $1${tierFilter}`;
+  ${where}`;
+}
+
+function buildCountSelect(table: Table, tier?: Tier): string {
+  if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
+  const alias = TABLE_ALIAS[table];
+  const where = buildWhereClause(alias, tier);
+
+  return `SELECT COUNT(*) AS cnt
+  FROM ${table} ${alias}
+  ${where}`;
 }
 
 export function registerListStale(server: McpServer, deps: ToolDeps): void {
@@ -74,7 +57,7 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       description:
         "Find brain entries not accessed recently -- candidates for tier demotion (hot->warm->cold). " +
         "Queries by last_accessed_at (falls back to created_at for never-accessed entries). " +
-        "Useful for dream cycle decay and knowledge base hygiene.",
+        "Returns paginated results with total_count and has_more for dream cycle automation.",
       inputSchema: {
         table: z
           .enum([
@@ -99,9 +82,15 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
           .number()
           .int()
           .min(1)
-          .max(250)
+          .max(500)
           .optional()
-          .describe("Maximum entries to return (default 50)"),
+          .describe("Maximum entries to return (default 50, max 500)"),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Number of entries to skip for pagination (default 0)"),
         tier: z
           .enum(["hot", "warm", "cold"])
           .optional()
@@ -130,7 +119,6 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      // Determine which tables the caller can read
       const tableFilter = args.table as Table | undefined;
       let accessibleTables: Table[];
 
@@ -165,31 +153,48 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
 
       const days = args.days ?? 30;
       const limit = args.limit ?? 50;
+      const offset = args.offset ?? 0;
       const tier = args.tier as Tier | undefined;
 
-      // Build UNION ALL of table SELECTs
-      const selects = accessibleTables.map((t) =>
-        buildStaleSelect(t, tier),
-      );
-
+      const selects = accessibleTables.map((t) => buildStaleSelect(t, tier));
       const unionSql = selects.join("\nUNION ALL\n");
-      // Sort by staleness: oldest effective access first
-      const sql = `${unionSql}\nORDER BY effective_last_access ASC\nLIMIT $2`;
+      const sql = `${unionSql}\nORDER BY effective_last_access ASC\nLIMIT $2 OFFSET $3`;
+
+      const countSelects = accessibleTables.map((t) =>
+        buildCountSelect(t, tier),
+      );
+      const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
 
       logger.info("list_stale_query", {
         tables: accessibleTables,
         days,
         limit,
+        offset,
         tier: tier ?? null,
       });
 
-      const { rows } = await deps.pool.query(sql, [days, limit]);
+      const [dataResult, countResult] = await Promise.all([
+        deps.pool.query(sql, [days, limit, offset]),
+        deps.pool.query(countSql, [days]).catch(() => null),
+      ]);
+
+      const totalCount = countResult?.rows[0]?.total_count ?? null;
+      const hasMore =
+        totalCount !== null
+          ? offset + dataResult.rows.length < totalCount
+          : false;
 
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(rows),
+            text: JSON.stringify({
+              entries: dataResult.rows,
+              total_count: totalCount,
+              offset,
+              limit,
+              has_more: hasMore,
+            }),
           },
         ],
       };

--- a/src/tools/list-stale.ts
+++ b/src/tools/list-stale.ts
@@ -1,0 +1,198 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo, Table, Tier } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+const ALL_TABLES: Table[] = [
+  "thoughts",
+  "decisions",
+  "relationships",
+  "projects",
+  "sessions",
+];
+
+/** Singular labels for list results */
+const SOURCE_LABELS: Record<Table, string> = {
+  thoughts: "thought",
+  decisions: "decision",
+  relationships: "relationship",
+  projects: "project",
+  sessions: "session",
+};
+
+/** Content preview SQL expression per table */
+const CONTENT_PREVIEW: Record<Table, string> = {
+  thoughts: "t.content",
+  decisions: "d.title || ': ' || d.rationale",
+  relationships: "r.person_name || ': ' || COALESCE(r.context, '')",
+  projects: "p.name || ': ' || COALESCE(p.description, '')",
+  sessions: "COALESCE(s.project || ': ', '') || LEFT(s.summary, 200)",
+};
+
+/** Table alias used in SELECTs */
+const TABLE_ALIAS: Record<Table, string> = {
+  thoughts: "t",
+  decisions: "d",
+  relationships: "r",
+  projects: "p",
+  sessions: "s",
+};
+
+function buildStaleSelect(
+  table: Table,
+  tier?: Tier,
+): string {
+  const alias = TABLE_ALIAS[table];
+  const label = SOURCE_LABELS[table];
+  const preview = CONTENT_PREVIEW[table];
+
+  const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+
+  // Stale = not accessed recently. Use COALESCE to handle entries never accessed
+  // (last_accessed_at IS NULL), falling back to created_at.
+  return `SELECT
+    '${label}' AS source_type,
+    ${alias}.id,
+    LEFT(${preview}, 200) AS content_preview,
+    ${alias}.tags,
+    ${alias}.tier,
+    ${alias}.access_count,
+    ${alias}.last_accessed_at,
+    ${alias}.created_at,
+    COALESCE(${alias}.last_accessed_at, ${alias}.created_at) AS effective_last_access
+  FROM ${table} ${alias}
+  WHERE ${alias}.archived_at IS NULL
+    AND COALESCE(${alias}.last_accessed_at, ${alias}.created_at) < NOW() - INTERVAL '1 day' * $1${tierFilter}`;
+}
+
+export function registerListStale(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "list_stale",
+    {
+      description:
+        "Find brain entries not accessed recently -- candidates for tier demotion (hot->warm->cold). " +
+        "Queries by last_accessed_at (falls back to created_at for never-accessed entries). " +
+        "Useful for dream cycle decay and knowledge base hygiene.",
+      inputSchema: {
+        table: z
+          .enum([
+            "thoughts",
+            "decisions",
+            "relationships",
+            "projects",
+            "sessions",
+          ])
+          .optional()
+          .describe("Optional: filter to a specific table"),
+        days: z
+          .number()
+          .int()
+          .min(1)
+          .max(365)
+          .optional()
+          .describe(
+            "Entries not accessed in this many days are considered stale (default 30)",
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(250)
+          .optional()
+          .describe("Maximum entries to return (default 50)"),
+        tier: z
+          .enum(["hot", "warm", "cold"])
+          .optional()
+          .describe(
+            "Optional: filter to a specific tier (e.g. 'hot' to find hot entries that should decay to warm)",
+          ),
+      },
+      annotations: {
+        title: "List Stale",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Determine which tables the caller can read
+      const tableFilter = args.table as Table | undefined;
+      let accessibleTables: Table[];
+
+      if (tableFilter) {
+        if (!canRead(auth.role, tableFilter)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Permission denied: cannot read ${tableFilter}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        accessibleTables = [tableFilter];
+      } else {
+        accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+      }
+
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const days = args.days ?? 30;
+      const limit = args.limit ?? 50;
+      const tier = args.tier as Tier | undefined;
+
+      // Build UNION ALL of table SELECTs
+      const selects = accessibleTables.map((t) =>
+        buildStaleSelect(t, tier),
+      );
+
+      const unionSql = selects.join("\nUNION ALL\n");
+      // Sort by staleness: oldest effective access first
+      const sql = `${unionSql}\nORDER BY effective_last_access ASC\nLIMIT $2`;
+
+      logger.info("list_stale_query", {
+        tables: accessibleTables,
+        days,
+        limit,
+        tier: tier ?? null,
+      });
+
+      const { rows } = await deps.pool.query(sql, [days, limit]);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(rows),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
Closes #21

Adds `list_stale` tool that queries `entry_access_log` to find entries not accessed in N days.

## Parameters
- `tier` (optional): filter to hot/warm/cold
- `days` (required): entries not accessed in this many days are "stale"
- `table` (optional): filter to specific table
- `limit` (optional): max results (default 20, max 500)

## Use Case
Dream cycle automation: find hot-tier entries that haven't been accessed in 30+ days and decay them to warm. Enables automated cognitive tiering without manual intervention.

12 tests, all passing.