### PR TITLE
feat: OB v2 -- 8 new MCP tools, namespace filter, agent attribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .planning/
 .reports/
 .claude/
+.env.dev

--- a/src/db/migrations/009_agent_attribution.sql
+++ b/src/db/migrations/009_agent_attribution.sql
@@ -1,0 +1,14 @@
+-- Migration 009: Agent attribution + access log index restoration
+-- Adds accessed_by column to entry_access_log for per-agent analytics.
+-- Re-adds indexes on entry_access_log that were prematurely dropped in migration 008.
+
+-- 1. Add accessed_by column for agent attribution
+ALTER TABLE entry_access_log ADD COLUMN IF NOT EXISTS accessed_by TEXT;
+
+-- 2. Re-add indexes dropped in migration 008
+CREATE INDEX IF NOT EXISTS idx_access_log_entry ON entry_access_log(entry_id);
+CREATE INDEX IF NOT EXISTS idx_access_log_time ON entry_access_log(accessed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_access_log_agent ON entry_access_log(accessed_by);
+
+-- 3. Composite index for agent-specific analytics
+CREATE INDEX IF NOT EXISTS idx_access_log_entry_agent ON entry_access_log(entry_id, accessed_by);

--- a/src/tools/__tests__/access-report.test.ts
+++ b/src/tools/__tests__/access-report.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerAccessReport } from "../access-report.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerAccessReport(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("access_report", () => {
+  it("returns access report for a valid entry", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("COUNT(*) AS total")) {
+          return { rows: [{ total: "25" }] };
+        }
+        if (sql.includes("DISTINCT query_text")) {
+          return { rows: [{ unique_queries: "8" }] };
+        }
+        if (sql.includes("DISTINCT accessed_by")) {
+          return { rows: [{ unique_agents: "3" }] };
+        }
+        if (sql.includes("recent_7d")) {
+          return { rows: [{ recent_7d: "10", previous_7d: "5" }] };
+        }
+        if (sql.includes("MAX(accessed_at)")) {
+          return { rows: [{ last_accessed: new Date().toISOString() }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "access_report",
+        arguments: {
+          entry_id: "550e8400-e29b-41d4-a716-446655440000",
+          days: 30,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.entry_id).toBe("550e8400-e29b-41d4-a716-446655440000");
+      expect(parsed.total_accesses).toBe(25);
+      expect(parsed.unique_queries).toBe(8);
+      expect(parsed.unique_agents).toBe(3);
+      expect(parsed.trend).toBe("rising");
+      expect(parsed.last_accessed).toBeDefined();
+      expect(parsed.days_since_last_access).toBeDefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns stable trend when recent equals previous", async () => {
+    const mockPool = {
+      query: async (sql: string) => {
+        if (sql.includes("COUNT(*) AS total")) return { rows: [{ total: "10" }] };
+        if (sql.includes("DISTINCT query_text")) return { rows: [{ unique_queries: "5" }] };
+        if (sql.includes("DISTINCT accessed_by")) return { rows: [{ unique_agents: "2" }] };
+        if (sql.includes("recent_7d")) return { rows: [{ recent_7d: "5", previous_7d: "5" }] };
+        if (sql.includes("MAX(accessed_at)")) return { rows: [{ last_accessed: null }] };
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "access_report",
+        arguments: { entry_id: "550e8400-e29b-41d4-a716-446655440001" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.trend).toBe("stable");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unauthenticated requests", async () => {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+    registerAccessReport(server, deps);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "access_report",
+        arguments: { entry_id: "550e8400-e29b-41d4-a716-446655440002" },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/src/tools/__tests__/bulk-archive.test.ts
+++ b/src/tools/__tests__/bulk-archive.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerBulkArchive } from "../bulk-archive.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: any,
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerBulkArchive(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("bulk_archive", () => {
+  it("archives multiple entries in a transaction", async () => {
+    const queryCalls: string[] = [];
+    const mockClient = {
+      query: async (sql: string) => {
+        queryCalls.push(sql);
+        if (sql.includes("UPDATE")) return { rowCount: 1 };
+        return { rows: [] };
+      },
+      release: () => {},
+    };
+    const mockPool = {
+      connect: async () => mockClient,
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "bulk_archive",
+        arguments: {
+          entries: [
+            { id: "550e8400-e29b-41d4-a716-446655440000", table: "thoughts" },
+            { id: "550e8400-e29b-41d4-a716-446655440001", table: "decisions" },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.requested).toBe(2);
+      expect(parsed.archived).toBe(2);
+      expect(queryCalls).toContain("BEGIN");
+      expect(queryCalls).toContain("COMMIT");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies agent role (no delete permission)", async () => {
+    const mockPool = {
+      connect: async () => ({ query: async () => ({ rows: [] }), release: () => {} }),
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "agent-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "bulk_archive",
+        arguments: {
+          entries: [
+            { id: "550e8400-e29b-41d4-a716-446655440000", table: "thoughts" },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rolls back on error", async () => {
+    const queryCalls: string[] = [];
+    const mockClient = {
+      query: async (sql: string) => {
+        queryCalls.push(sql);
+        if (sql.includes("UPDATE")) throw new Error("DB boom");
+        return { rows: [] };
+      },
+      release: () => {},
+    };
+    const mockPool = {
+      connect: async () => mockClient,
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "bulk_archive",
+        arguments: {
+          entries: [
+            { id: "550e8400-e29b-41d4-a716-446655440000", table: "thoughts" },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Transaction failed");
+      expect(queryCalls).toContain("ROLLBACK");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/bulk-set-tier.test.ts
+++ b/src/tools/__tests__/bulk-set-tier.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerBulkSetTier } from "../bulk-set-tier.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: any,
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerBulkSetTier(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("bulk_set_tier", () => {
+  it("updates multiple entries in a transaction", async () => {
+    const queryCalls: string[] = [];
+    const mockClient = {
+      query: async (sql: string, _params?: any[]) => {
+        queryCalls.push(sql);
+        if (sql.includes("UPDATE")) return { rowCount: 1 };
+        return { rows: [] };
+      },
+      release: () => {},
+    };
+    const mockPool = {
+      connect: async () => mockClient,
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "bulk_set_tier",
+        arguments: {
+          entries: [
+            { id: "550e8400-e29b-41d4-a716-446655440000", table: "thoughts", tier: "hot" },
+            { id: "550e8400-e29b-41d4-a716-446655440001", table: "decisions", tier: "cold" },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.requested).toBe(2);
+      expect(parsed.updated).toBe(2);
+      expect(queryCalls).toContain("BEGIN");
+      expect(queryCalls).toContain("COMMIT");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies readonly role", async () => {
+    const mockPool = {
+      connect: async () => ({ query: async () => ({ rows: [] }), release: () => {} }),
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "readonly", clientId: "ro-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "bulk_set_tier",
+        arguments: {
+          entries: [
+            { id: "550e8400-e29b-41d4-a716-446655440000", table: "thoughts", tier: "hot" },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rolls back on error", async () => {
+    const queryCalls: string[] = [];
+    const mockClient = {
+      query: async (sql: string) => {
+        queryCalls.push(sql);
+        if (sql.includes("UPDATE")) throw new Error("DB error");
+        return { rows: [] };
+      },
+      release: () => {},
+    };
+    const mockPool = {
+      connect: async () => mockClient,
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "bulk_set_tier",
+        arguments: {
+          entries: [
+            { id: "550e8400-e29b-41d4-a716-446655440000", table: "thoughts", tier: "hot" },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Transaction failed");
+      expect(queryCalls).toContain("ROLLBACK");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/curate-entries.test.ts
+++ b/src/tools/__tests__/curate-entries.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerCurateEntries } from "../curate-entries.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerCurateEntries(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("curate_entries", () => {
+  it("finds stale entries in dry_run mode", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("access_count") && sql.includes("INTERVAL")) {
+          return {
+            rows: [
+              { id: "stale-uuid-1", content_preview: "Old unused thought" },
+              { id: "stale-uuid-2", content_preview: "Another stale entry" },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "curate_entries",
+        arguments: { mode: "stale", dry_run: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.dry_run).toBe(true);
+      expect(parsed.summary.stale_found).toBeGreaterThan(0);
+      expect(parsed.stale[0].action).toBe("would_flag");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies agent role for dry_run=false", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "agent-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "curate_entries",
+        arguments: { mode: "all", dry_run: false },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("admin permission required");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows agent role for dry_run=true", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "agent-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "curate_entries",
+        arguments: { mode: "vague", dry_run: true },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.dry_run).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("finds duplicates", async () => {
+    const mockPool = {
+      query: async (sql: string) => {
+        if (sql.includes("embedding <=> b.embedding")) {
+          return {
+            rows: [{ id_a: "dup-a", id_b: "dup-b", distance: 0.04 }],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "curate_entries",
+        arguments: { mode: "duplicates", table: "thoughts" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.summary.duplicates_found).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/find-duplicates.test.ts
+++ b/src/tools/__tests__/find-duplicates.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerFindDuplicates } from "../find-duplicates.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerFindDuplicates(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("find_duplicates", () => {
+  it("returns duplicate pairs", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("embedding <=> b.embedding")) {
+          return {
+            rows: [
+              {
+                id_a: "uuid-1",
+                preview_a: "First entry content",
+                id_b: "uuid-2",
+                preview_b: "Almost identical content",
+                distance: 0.03,
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "find_duplicates",
+        arguments: { table: "thoughts", threshold: 0.08 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.duplicates_found).toBe(1);
+      expect(parsed.duplicates[0].entry_a.id).toBe("uuid-1");
+      expect(parsed.duplicates[0].entry_b.id).toBe("uuid-2");
+      expect(parsed.duplicates[0].distance).toBe(0.03);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns empty when no duplicates found", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "find_duplicates",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.duplicates_found).toBe(0);
+      expect(parsed.duplicates).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies discord role (no read access)", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "discord", clientId: "discord-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "find_duplicates",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/get-stats.test.ts
+++ b/src/tools/__tests__/get-stats.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerGetStats } from "../get-stats.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerGetStats(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("get_stats", () => {
+  it("returns aggregate stats for admin role", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("COUNT(*) FILTER")) {
+          return { rows: [{ table_name: "thoughts", active: "10", archived: "2" }] };
+        }
+        if (sql.includes("GROUP BY tier")) {
+          return { rows: [{ table_name: "thoughts", tier: "warm", count: "8" }] };
+        }
+        if (sql.includes("GROUP BY namespace")) {
+          return { rows: [{ table_name: "thoughts", namespace: "collab", count: "10" }] };
+        }
+        if (sql.includes("total_log_entries")) {
+          return { rows: [{ total_log_entries: "50", unique_entries_accessed: "20" }] };
+        }
+        if (sql.includes("AVG")) {
+          return { rows: [{ avg_access: "3.5" }] };
+        }
+        if (sql.includes("access_count, 0) = 0")) {
+          return { rows: [{ table_name: "thoughts", count: "4" }] };
+        }
+        if (sql.includes("ORDER BY access_count DESC")) {
+          return { rows: [{ id: "uuid-1", table_name: "thoughts", content_preview: "test content", access_count: "15" }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "get_stats",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.entry_counts).toBeDefined();
+      expect(parsed.tier_distribution).toBeDefined();
+      expect(parsed.access_stats).toBeDefined();
+      expect(parsed.top_accessed).toBeDefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies readonly with no tables", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "discord", clientId: "discord-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "get_stats",
+        arguments: {},
+      });
+
+      // discord role can only write thoughts, not read
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/list-namespaces.test.ts
+++ b/src/tools/__tests__/list-namespaces.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerListNamespaces } from "../list-namespaces.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerListNamespaces(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("list_namespaces", () => {
+  it("returns namespaces with counts", async () => {
+    const mockPool = {
+      query: async (sql: string) => {
+        if (sql.includes("GROUP BY namespace")) {
+          return {
+            rows: [
+              { table_name: "thoughts", namespace: "collab", count: "15" },
+              { table_name: "thoughts", namespace: "skippy", count: "5" },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "list_namespaces",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.namespace_count).toBeGreaterThan(0);
+      expect(parsed.namespaces[0].namespace).toBeDefined();
+      expect(parsed.namespaces[0].total).toBeGreaterThan(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies discord role", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "discord", clientId: "discord-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "list_namespaces",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/tier-recommendations.test.ts
+++ b/src/tools/__tests__/tier-recommendations.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerTierRecommendations } from "../tier-recommendations.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerTierRecommendations(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("tier_recommendations", () => {
+  it("returns demote candidates", async () => {
+    const mockPool = {
+      query: async (sql: string) => {
+        if (sql.includes("tier") && sql.includes("warm") && sql.includes("access_count")) {
+          return {
+            rows: [
+              {
+                id: "demote-uuid",
+                content_preview: "Rarely used thought",
+                tier: "warm",
+                access_count: "0",
+                last_accessed_at: null,
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "tier_recommendations",
+        arguments: { action: "demote", threshold_days: 30 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.action).toBe("demote");
+      expect(parsed.candidates_found).toBeGreaterThan(0);
+      expect(parsed.candidates[0].suggested_tier).toBe("cold");
+      expect(parsed.candidates[0].reasoning).toContain("Warm entry");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns promote candidates", async () => {
+    const mockPool = {
+      query: async (sql: string) => {
+        if (sql.includes("recent_accesses")) {
+          return {
+            rows: [
+              {
+                id: "promote-uuid",
+                content_preview: "Frequently accessed decision",
+                tier: "warm",
+                access_count: "20",
+                last_accessed_at: new Date().toISOString(),
+                recent_accesses: "12",
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "tier_recommendations",
+        arguments: { action: "promote", threshold_days: 7 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.action).toBe("promote");
+      expect(parsed.candidates[0].suggested_tier).toBe("hot");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unauthenticated requests", async () => {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+    registerTierRecommendations(server, deps);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "tier_recommendations",
+        arguments: { action: "demote" },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text;
+      expect(text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/src/tools/access-report.ts
+++ b/src/tools/access-report.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "access_report",
+    {
+      description:
+        "Returns a detailed access report for a specific entry: total accesses, unique queries, unique agents, access trend, and recency.",
+      inputSchema: {
+        entry_id: z.string().uuid().describe("UUID of the entry to report on"),
+        days: z
+          .number()
+          .int()
+          .min(1)
+          .max(365)
+          .optional()
+          .describe("Number of days to look back (default 30)"),
+      },
+      annotations: {
+        title: "Access Report",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Check if user can read at least one table
+      const { ALL_TABLES } = await import("./table-constants.ts");
+      const hasReadAccess = ALL_TABLES.some((t) => canRead(auth.role, t));
+      if (!hasReadAccess) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const entryId = args.entry_id;
+      const days = args.days ?? 30;
+
+      // Total accesses in period
+      const totalResult = await deps.pool.query(
+        `SELECT COUNT(*) AS total
+         FROM entry_access_log
+         WHERE entry_id = $1
+           AND accessed_at >= NOW() - INTERVAL '1 day' * $2`,
+        [entryId, days],
+      );
+
+      // Unique queries
+      const uniqueQueriesResult = await deps.pool.query(
+        `SELECT COUNT(DISTINCT query_text) AS unique_queries
+         FROM entry_access_log
+         WHERE entry_id = $1
+           AND accessed_at >= NOW() - INTERVAL '1 day' * $2
+           AND query_text IS NOT NULL`,
+        [entryId, days],
+      );
+
+      // Unique agents
+      const uniqueAgentsResult = await deps.pool.query(
+        `SELECT COUNT(DISTINCT accessed_by) AS unique_agents
+         FROM entry_access_log
+         WHERE entry_id = $1
+           AND accessed_at >= NOW() - INTERVAL '1 day' * $2
+           AND accessed_by IS NOT NULL`,
+        [entryId, days],
+      );
+
+      // Access trend: last 7 days vs previous 7 days
+      const trendResult = await deps.pool.query(
+        `SELECT
+           COUNT(*) FILTER (WHERE accessed_at >= NOW() - INTERVAL '7 days') AS recent_7d,
+           COUNT(*) FILTER (WHERE accessed_at >= NOW() - INTERVAL '14 days' AND accessed_at < NOW() - INTERVAL '7 days') AS previous_7d
+         FROM entry_access_log
+         WHERE entry_id = $1`,
+        [entryId],
+      );
+
+      // Last accessed
+      const lastAccessResult = await deps.pool.query(
+        `SELECT MAX(accessed_at) AS last_accessed
+         FROM entry_access_log
+         WHERE entry_id = $1`,
+        [entryId],
+      );
+
+      const recent7d = Number(trendResult.rows[0]?.recent_7d ?? 0);
+      const previous7d = Number(trendResult.rows[0]?.previous_7d ?? 0);
+      let trend: string;
+      if (recent7d > previous7d * 1.2) {
+        trend = "rising";
+      } else if (recent7d < previous7d * 0.8) {
+        trend = "declining";
+      } else {
+        trend = "stable";
+      }
+
+      const lastAccessed = lastAccessResult.rows[0]?.last_accessed ?? null;
+      let daysSinceLastAccess: number | null = null;
+      if (lastAccessed) {
+        daysSinceLastAccess = Math.floor(
+          (Date.now() - new Date(lastAccessed).getTime()) / (1000 * 60 * 60 * 24),
+        );
+      }
+
+      const report = {
+        entry_id: entryId,
+        period_days: days,
+        total_accesses: Number(totalResult.rows[0]?.total ?? 0),
+        unique_queries: Number(uniqueQueriesResult.rows[0]?.unique_queries ?? 0),
+        unique_agents: Number(uniqueAgentsResult.rows[0]?.unique_agents ?? 0),
+        trend,
+        trend_detail: { recent_7d: recent7d, previous_7d: previous7d },
+        last_accessed: lastAccessed,
+        days_since_last_access: daysSinceLastAccess,
+      };
+
+      logger.info("access_report_success", { entry_id: entryId });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(report),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/bulk-archive.ts
+++ b/src/tools/bulk-archive.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canDelete } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerBulkArchive(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "bulk_archive",
+    {
+      description:
+        "Soft-delete multiple entries in a single transaction. Max 100 entries per call.",
+      inputSchema: {
+        entries: z
+          .array(
+            z.object({
+              id: z.string().uuid().describe("UUID of the entry to archive"),
+              table: z
+                .enum([
+                  "thoughts",
+                  "decisions",
+                  "relationships",
+                  "projects",
+                  "sessions",
+                ])
+                .describe("Table containing the entry"),
+            }),
+          )
+          .min(1)
+          .max(100)
+          .describe("Array of entries to archive (max 100)"),
+      },
+      annotations: {
+        title: "Bulk Archive",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const entries = args.entries as Array<{ id: string; table: Table }>;
+
+      // Check delete permission for all referenced tables
+      const uniqueTables = new Set(entries.map((e) => e.table));
+      for (const table of uniqueTables) {
+        if (!canDelete(auth.role, table)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Permission denied: cannot delete from ${table}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      const client = await deps.pool.connect();
+      let archived = 0;
+
+      try {
+        await client.query("BEGIN");
+
+        for (const entry of entries) {
+          // Table name is validated by Zod enum -- safe for interpolation
+          const { rowCount } = await client.query(
+            `UPDATE ${entry.table} SET archived_at = NOW() WHERE id = $1 AND archived_at IS NULL`,
+            [entry.id],
+          );
+          archived += rowCount ?? 0;
+        }
+
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error("bulk_archive_error", { error: message });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Transaction failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      } finally {
+        client.release();
+      }
+
+      logger.info("bulk_archive_success", {
+        requested: entries.length,
+        archived,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              requested: entries.length,
+              archived,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/bulk-set-tier.ts
+++ b/src/tools/bulk-set-tier.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canWrite } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerBulkSetTier(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "bulk_set_tier",
+    {
+      description:
+        "Set cognitive tiers for multiple entries in a single transaction. Max 100 entries per call.",
+      inputSchema: {
+        entries: z
+          .array(
+            z.object({
+              id: z.string().uuid().describe("UUID of the entry"),
+              table: z
+                .enum([
+                  "thoughts",
+                  "decisions",
+                  "relationships",
+                  "projects",
+                  "sessions",
+                ])
+                .describe("Table containing the entry"),
+              tier: z
+                .enum(["hot", "warm", "cold"])
+                .describe("Target cognitive tier"),
+            }),
+          )
+          .min(1)
+          .max(100)
+          .describe("Array of entries to update (max 100)"),
+      },
+      annotations: {
+        title: "Bulk Set Tier",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const entries = args.entries as Array<{
+        id: string;
+        table: Table;
+        tier: string;
+      }>;
+
+      // Check write permission for all referenced tables
+      const uniqueTables = new Set(entries.map((e) => e.table));
+      for (const table of uniqueTables) {
+        if (!canWrite(auth.role, table)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Permission denied: cannot write to ${table}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      const client = await deps.pool.connect();
+      let updated = 0;
+
+      try {
+        await client.query("BEGIN");
+
+        for (const entry of entries) {
+          // Table name is validated by Zod enum -- safe for interpolation
+          const { rowCount } = await client.query(
+            `UPDATE ${entry.table} SET tier = $1 WHERE id = $2 AND archived_at IS NULL`,
+            [entry.tier, entry.id],
+          );
+          updated += rowCount ?? 0;
+        }
+
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error("bulk_set_tier_error", { error: message });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Transaction failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      } finally {
+        client.release();
+      }
+
+      logger.info("bulk_set_tier_success", {
+        requested: entries.length,
+        updated,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              requested: entries.length,
+              updated,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/curate-entries.ts
+++ b/src/tools/curate-entries.ts
@@ -1,0 +1,270 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead, canDelete } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES } from "./table-constants.ts";
+
+/** Content preview SQL per table (matches curate.ts) */
+const CONTENT_PREVIEW: Record<Table, string> = {
+  thoughts: "content",
+  decisions: "title || ': ' || rationale",
+  relationships: "person_name || ': ' || COALESCE(context, '')",
+  projects: "name || ': ' || COALESCE(description, '')",
+  sessions: "COALESCE(project || ': ', '') || LEFT(summary, 200)",
+};
+
+const DUPLICATE_THRESHOLD = 0.08;
+const STALE_DAYS = 90;
+
+interface CurateResult {
+  mode: string;
+  dry_run: boolean;
+  tables_processed: string[];
+  duplicates: Array<{
+    table: string;
+    entry_a: string;
+    entry_b: string;
+    distance: number;
+    action: string;
+  }>;
+  stale: Array<{
+    table: string;
+    id: string;
+    preview: string;
+    action: string;
+  }>;
+  vague: Array<{
+    table: string;
+    id: string;
+    preview: string;
+    action: string;
+  }>;
+  summary: {
+    duplicates_found: number;
+    stale_found: number;
+    vague_found: number;
+    archived: number;
+  };
+}
+
+export function registerCurateEntries(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "curate_entries",
+    {
+      description:
+        "Run curation analysis on brain entries. Detects duplicates, stale entries, and vague content. SAFE BY DEFAULT (dry_run=true).",
+      inputSchema: {
+        mode: z
+          .enum(["duplicates", "stale", "vague", "all"])
+          .describe("Curation mode: which checks to run"),
+        dry_run: z
+          .boolean()
+          .optional()
+          .describe("If true (default), only report findings without modifying data"),
+        table: z
+          .enum([
+            "thoughts",
+            "decisions",
+            "relationships",
+            "projects",
+            "sessions",
+          ])
+          .optional()
+          .describe("Optional: limit to a specific table"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max entries to process per table (default 20)"),
+      },
+      annotations: {
+        title: "Curate Entries",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const dryRun = args.dry_run !== false; // default true
+      const mode = args.mode as string;
+      const limit = args.limit ?? 20;
+      const tableFilter = args.table as Table | undefined;
+
+      // For dry_run=false, require admin/delete permission
+      if (!dryRun) {
+        const hasAdmin = auth.role === "admin" || auth.role === "n8n";
+        if (!hasAdmin) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Permission denied: admin permission required for dry_run=false",
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      const tablesToScan = tableFilter ? [tableFilter] : ALL_TABLES;
+      const accessibleTables = tablesToScan.filter((t) => canRead(auth.role, t));
+
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const result: CurateResult = {
+        mode,
+        dry_run: dryRun,
+        tables_processed: accessibleTables,
+        duplicates: [],
+        stale: [],
+        vague: [],
+        summary: {
+          duplicates_found: 0,
+          stale_found: 0,
+          vague_found: 0,
+          archived: 0,
+        },
+      };
+
+      for (const table of accessibleTables) {
+        const preview = CONTENT_PREVIEW[table];
+
+        // Duplicates
+        if (mode === "duplicates" || mode === "all") {
+          const { rows } = await deps.pool.query(
+            `SELECT
+              a.id AS id_a,
+              b.id AS id_b,
+              a.embedding <=> b.embedding AS distance
+            FROM ${table} a
+            JOIN ${table} b ON a.id < b.id
+              AND b.archived_at IS NULL AND b.embedding IS NOT NULL
+            WHERE a.archived_at IS NULL AND a.embedding IS NOT NULL
+              AND a.embedding <=> b.embedding < $1
+            ORDER BY distance ASC
+            LIMIT $2`,
+            [DUPLICATE_THRESHOLD, limit],
+          );
+
+          for (const row of rows) {
+            let action = "would_archive_older";
+            if (!dryRun) {
+              // Archive the first entry (a < b by ID, but we archive a)
+              await deps.pool.query(
+                `UPDATE ${table} SET archived_at = NOW() WHERE id = $1 AND archived_at IS NULL`,
+                [row.id_a],
+              );
+              action = "archived";
+              result.summary.archived++;
+            }
+            result.duplicates.push({
+              table,
+              entry_a: row.id_a,
+              entry_b: row.id_b,
+              distance: Number(row.distance),
+              action,
+            });
+          }
+          result.summary.duplicates_found += rows.length;
+        }
+
+        // Stale
+        if (mode === "stale" || mode === "all") {
+          const { rows } = await deps.pool.query(
+            `SELECT id, ${preview} AS content_preview
+             FROM ${table}
+             WHERE archived_at IS NULL
+               AND created_at < NOW() - INTERVAL '1 day' * $1
+               AND COALESCE(access_count, 0) = 0
+             LIMIT $2`,
+            [STALE_DAYS, limit],
+          );
+
+          for (const row of rows) {
+            let action = "would_flag";
+            if (!dryRun) {
+              await deps.pool.query(
+                `UPDATE ${table} SET archived_at = NOW() WHERE id = $1 AND archived_at IS NULL`,
+                [row.id],
+              );
+              action = "archived";
+              result.summary.archived++;
+            }
+            result.stale.push({
+              table,
+              id: row.id,
+              preview: (row.content_preview ?? "").slice(0, 200),
+              action,
+            });
+          }
+          result.summary.stale_found += rows.length;
+        }
+
+        // Vague
+        if (mode === "vague" || mode === "all") {
+          const { rows } = await deps.pool.query(
+            `SELECT id, ${preview} AS content_preview
+             FROM ${table}
+             WHERE archived_at IS NULL
+               AND (usefulness_score IS NULL OR usefulness_score < 0.3)
+               AND (tags IS NULL OR array_length(tags, 1) IS NULL)
+             LIMIT $1`,
+            [limit],
+          );
+
+          for (const row of rows) {
+            result.vague.push({
+              table,
+              id: row.id,
+              preview: (row.content_preview ?? "").slice(0, 200),
+              action: "flagged_for_review",
+            });
+          }
+          result.summary.vague_found += rows.length;
+        }
+      }
+
+      logger.info("curate_entries_success", {
+        mode,
+        dry_run: dryRun,
+        ...result.summary,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/find-duplicates.ts
+++ b/src/tools/find-duplicates.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES } from "./table-constants.ts";
+
+/** Simple content preview per table using a given alias */
+function contentPreviewForAlias(table: Table, alias: string): string {
+  switch (table) {
+    case "thoughts":
+      return `${alias}.content`;
+    case "decisions":
+      return `${alias}.title || ': ' || COALESCE(${alias}.rationale, '')`;
+    case "relationships":
+      return `${alias}.person_name || ': ' || COALESCE(${alias}.context, '')`;
+    case "projects":
+      return `${alias}.name || ': ' || COALESCE(${alias}.description, '')`;
+    case "sessions":
+      return `COALESCE(${alias}.project || ': ', '') || LEFT(${alias}.summary, 200)`;
+  }
+}
+
+export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "find_duplicates",
+    {
+      description:
+        "Discover potential duplicate entries using vector similarity. Read-only -- does NOT archive anything.",
+      inputSchema: {
+        table: z
+          .enum([
+            "thoughts",
+            "decisions",
+            "relationships",
+            "projects",
+            "sessions",
+          ])
+          .optional()
+          .describe("Optional: limit to a specific table (default: all)"),
+        threshold: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe("Cosine distance threshold for duplicates (default 0.08, lower = stricter)"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max duplicate pairs to return (default 20)"),
+      },
+      annotations: {
+        title: "Find Duplicates",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const threshold = args.threshold ?? 0.08;
+      const limit = args.limit ?? 20;
+      const tableFilter = args.table as Table | undefined;
+
+      const tablesToScan = tableFilter ? [tableFilter] : ALL_TABLES;
+      const accessibleTables = tablesToScan.filter((t) => canRead(auth.role, t));
+
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const duplicates: Array<{
+        entry_a: { id: string; preview: string };
+        entry_b: { id: string; preview: string };
+        table: string;
+        distance: number;
+      }> = [];
+
+      for (const table of accessibleTables) {
+        if (duplicates.length >= limit) break;
+
+        const remaining = limit - duplicates.length;
+        const previewA = contentPreviewForAlias(table, "a");
+        const previewB = contentPreviewForAlias(table, "b");
+
+        // Table name is validated by Zod enum -- safe for interpolation
+        const { rows } = await deps.pool.query(
+          `SELECT
+            a.id AS id_a,
+            LEFT(${previewA}, 200) AS preview_a,
+            b.id AS id_b,
+            LEFT(${previewB}, 200) AS preview_b,
+            a.embedding <=> b.embedding AS distance
+          FROM ${table} a
+          JOIN ${table} b ON a.id < b.id
+            AND b.archived_at IS NULL
+            AND b.embedding IS NOT NULL
+          WHERE a.archived_at IS NULL
+            AND a.embedding IS NOT NULL
+            AND a.embedding <=> b.embedding < $1
+          ORDER BY distance ASC
+          LIMIT $2`,
+          [threshold, remaining],
+        );
+
+        for (const row of rows) {
+          duplicates.push({
+            entry_a: { id: row.id_a, preview: row.preview_a },
+            entry_b: { id: row.id_b, preview: row.preview_b },
+            table,
+            distance: Number(row.distance),
+          });
+        }
+      }
+
+      logger.info("find_duplicates_success", {
+        tables_scanned: accessibleTables.length,
+        duplicates_found: duplicates.length,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              threshold,
+              duplicates_found: duplicates.length,
+              duplicates,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/get-stats.ts
+++ b/src/tools/get-stats.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES, CONTENT_PREVIEW, TABLE_ALIAS } from "./table-constants.ts";
+
+export function registerGetStats(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "get_stats",
+    {
+      description:
+        "Returns aggregate statistics about the Open Brain knowledge base: entry counts, tier distribution, namespace breakdown, and access analytics.",
+      inputSchema: {},
+      annotations: {
+        title: "Get Stats",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (_args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // 1. Entry counts per table (active vs archived)
+      const countQueries = accessibleTables.map((table) =>
+        deps.pool.query(
+          `SELECT
+            '${table}' AS table_name,
+            COUNT(*) FILTER (WHERE archived_at IS NULL) AS active,
+            COUNT(*) FILTER (WHERE archived_at IS NOT NULL) AS archived
+          FROM ${table}`,
+        ),
+      );
+
+      // 2. Tier distribution per table
+      const tierQueries = accessibleTables.map((table) =>
+        deps.pool.query(
+          `SELECT
+            '${table}' AS table_name,
+            COALESCE(tier, 'warm') AS tier,
+            COUNT(*) AS count
+          FROM ${table}
+          WHERE archived_at IS NULL
+          GROUP BY tier`,
+        ),
+      );
+
+      // 3. Namespace breakdown (top 10)
+      const nsQueries = accessibleTables.map((table) =>
+        deps.pool.query(
+          `SELECT
+            '${table}' AS table_name,
+            namespace,
+            COUNT(*) AS count
+          FROM ${table}
+          WHERE archived_at IS NULL
+          GROUP BY namespace
+          ORDER BY count DESC
+          LIMIT 10`,
+        ),
+      );
+
+      // 4. Access stats
+      const accessStatsQuery = deps.pool.query(
+        `SELECT
+          COUNT(*) AS total_log_entries,
+          COUNT(DISTINCT entry_id) AS unique_entries_accessed
+        FROM entry_access_log`,
+      );
+
+      // 5. Average access_count across all tables
+      const avgAccessQueries = accessibleTables.map((table) =>
+        deps.pool.query(
+          `SELECT AVG(COALESCE(access_count, 0)) AS avg_access FROM ${table} WHERE archived_at IS NULL`,
+        ),
+      );
+
+      // 6. Zero-access entries per table
+      const zeroAccessQueries = accessibleTables.map((table) =>
+        deps.pool.query(
+          `SELECT '${table}' AS table_name, COUNT(*) AS count
+          FROM ${table}
+          WHERE archived_at IS NULL AND COALESCE(access_count, 0) = 0`,
+        ),
+      );
+
+      // 7. Top 10 most accessed entries
+      const topAccessedParts = accessibleTables.map((table) => {
+        const alias = TABLE_ALIAS[table];
+        const preview = CONTENT_PREVIEW[table];
+        return `SELECT ${alias}.id, '${table}' AS table_name, ${preview} AS content_preview, COALESCE(${alias}.access_count, 0) AS access_count FROM ${table} ${alias} WHERE ${alias}.archived_at IS NULL`;
+      });
+      const topAccessedSql = `SELECT id, table_name, LEFT(content_preview, 200) AS content_preview, access_count FROM (${topAccessedParts.join(" UNION ALL ")}) AS combined ORDER BY access_count DESC LIMIT 10`;
+
+      const [
+        countResults,
+        tierResults,
+        nsResults,
+        accessStats,
+        avgAccessResults,
+        zeroAccessResults,
+        topAccessed,
+      ] = await Promise.all([
+        Promise.all(countQueries),
+        Promise.all(tierQueries),
+        Promise.all(nsQueries),
+        accessStatsQuery,
+        Promise.all(avgAccessQueries),
+        Promise.all(zeroAccessQueries),
+        deps.pool.query(topAccessedSql),
+      ]);
+
+      // Build entry counts
+      const entryCounts: Record<string, { active: number; archived: number }> = {};
+      for (const result of countResults) {
+        const row = result.rows[0];
+        entryCounts[row.table_name] = {
+          active: Number(row.active),
+          archived: Number(row.archived),
+        };
+      }
+
+      // Build tier distribution
+      const tierDistribution: Record<string, Record<string, number>> = {};
+      for (const result of tierResults) {
+        for (const row of result.rows) {
+          const td = tierDistribution[row.table_name] ?? {}; tierDistribution[row.table_name] = td;
+          td[row.tier] = Number(row.count);
+        }
+      }
+
+      // Build namespace breakdown
+      const namespaces: Array<{ table: string; namespace: string; count: number }> = [];
+      for (const result of nsResults) {
+        for (const row of result.rows) {
+          namespaces.push({
+            table: row.table_name,
+            namespace: row.namespace,
+            count: Number(row.count),
+          });
+        }
+      }
+
+      // Compute average access count across tables
+      let totalAvg = 0;
+      let avgCount = 0;
+      for (const result of avgAccessResults) {
+        const val = Number(result.rows[0]?.avg_access ?? 0);
+        totalAvg += val;
+        avgCount++;
+      }
+
+      // Build zero-access
+      const zeroAccess: Record<string, number> = {};
+      for (const result of zeroAccessResults) {
+        const row = result.rows[0];
+        zeroAccess[row.table_name] = Number(row.count);
+      }
+
+      const stats = {
+        entry_counts: entryCounts,
+        tier_distribution: tierDistribution,
+        namespaces: namespaces.slice(0, 10),
+        access_stats: {
+          total_log_entries: Number(accessStats.rows[0]?.total_log_entries ?? 0),
+          unique_entries_accessed: Number(accessStats.rows[0]?.unique_entries_accessed ?? 0),
+          avg_access_count: avgCount > 0 ? Math.round((totalAvg / avgCount) * 100) / 100 : 0,
+        },
+        zero_access_entries: zeroAccess,
+        top_accessed: topAccessed.rows.map((r: any) => ({
+          id: r.id,
+          table: r.table_name,
+          content_preview: r.content_preview,
+          access_count: Number(r.access_count),
+        })),
+      };
+
+      logger.info("get_stats_success", { tables: accessibleTables.length });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(stats),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,14 @@ import { registerSearchAll } from "./search-all.ts";
 import { registerUpsertPerson } from "./upsert-person.ts";
 import { registerSetTier } from "./set-tier.ts";
 import { registerGetEntry } from "./get-entry.ts";
+import { registerGetStats } from "./get-stats.ts";
+import { registerAccessReport } from "./access-report.ts";
+import { registerBulkSetTier } from "./bulk-set-tier.ts";
+import { registerFindDuplicates } from "./find-duplicates.ts";
+import { registerCurateEntries } from "./curate-entries.ts";
+import { registerBulkArchive } from "./bulk-archive.ts";
+import { registerListNamespaces } from "./list-namespaces.ts";
+import { registerTierRecommendations } from "./tier-recommendations.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -36,4 +44,12 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerUpsertPerson(server, deps);
   registerSetTier(server, deps);
   registerGetEntry(server, deps);
+  registerGetStats(server, deps);
+  registerAccessReport(server, deps);
+  registerBulkSetTier(server, deps);
+  registerFindDuplicates(server, deps);
+  registerCurateEntries(server, deps);
+  registerBulkArchive(server, deps);
+  registerListNamespaces(server, deps);
+  registerTierRecommendations(server, deps);
 }

--- a/src/tools/list-namespaces.ts
+++ b/src/tools/list-namespaces.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES } from "./table-constants.ts";
+
+export function registerListNamespaces(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "list_namespaces",
+    {
+      description:
+        "List all namespaces with entry counts per table. Useful for understanding data distribution across agents/users.",
+      inputSchema: {},
+      annotations: {
+        title: "List Namespaces",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (_args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Query each table for namespace counts
+      const queries = accessibleTables.map((table) =>
+        deps.pool.query(
+          `SELECT
+            '${table}' AS table_name,
+            namespace,
+            COUNT(*) AS count
+          FROM ${table}
+          WHERE archived_at IS NULL
+          GROUP BY namespace
+          ORDER BY count DESC`,
+        ),
+      );
+
+      const results = await Promise.all(queries);
+
+      // Aggregate by namespace
+      const nsMap = new Map<
+        string,
+        { total: number; per_table: Record<string, number> }
+      >();
+
+      for (const result of results) {
+        for (const row of result.rows) {
+          const ns = row.namespace as string;
+          const existing = nsMap.get(ns) ?? { total: 0, per_table: {} };
+          const count = Number(row.count);
+          existing.total += count;
+          existing.per_table[row.table_name] = count;
+          nsMap.set(ns, existing);
+        }
+      }
+
+      // Sort by total count descending
+      const namespaces = Array.from(nsMap.entries())
+        .map(([namespace, data]) => ({
+          namespace,
+          total: data.total,
+          per_table: data.per_table,
+        }))
+        .sort((a, b) => b.total - a.total);
+
+      logger.info("list_namespaces_success", {
+        namespace_count: namespaces.length,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              namespace_count: namespaces.length,
+              namespaces,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -86,6 +86,10 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
         "Federated search across Open Brain knowledge AND qmd file index. Returns merged, ranked results from both sources.",
       inputSchema: {
         query: z.string().min(1).describe("Natural language search query"),
+        namespace: z
+          .string()
+          .optional()
+          .describe("Optional: filter brain results to a specific namespace (e.g. clientId or 'collab')"),
         limit: z
           .number()
           .int()
@@ -142,6 +146,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
+      const namespace = args.namespace as string | undefined;
       const searchBrain = sources === "all" || sources === "brain";
       const searchQmdSource = sources === "all" || sources === "qmd";
 
@@ -151,7 +156,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       // Launch both searches in parallel
       const [brainResults, qmdResults] = await Promise.all([
         searchBrain
-          ? searchOB(deps, auth, args.query, totalNeeded, mode, tier)
+          ? searchOB(deps, auth, args.query, totalNeeded, mode, tier, namespace)
           : Promise.resolve([]),
         searchQmdSource
           ? searchQmd(args.query, totalNeeded)
@@ -204,6 +209,7 @@ async function searchOB(
   limit: number,
   mode: SearchMode = "hybrid",
   tier?: Tier,
+  namespace?: string,
 ): Promise<UnifiedResult[]> {
   const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
   if (accessibleTables.length === 0) return [];
@@ -217,6 +223,8 @@ async function searchOB(
       limit,
       mode,
       tier,
+      0,
+      namespace,
     );
   } catch (err) {
     logger.warn("searchOB_failed", {
@@ -225,7 +233,7 @@ async function searchOB(
     return [];
   }
 
-  trackUsage(deps, rows, query);
+  trackUsage(deps, rows, query, "search", auth.clientId);
 
   return rows.map((row) => ({
     source: "brain" as const,

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -85,6 +85,7 @@ export function buildTableCTE(
   table: Table,
   perTableLimit: number,
   tier?: Tier,
+  namespace?: string,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
@@ -92,6 +93,7 @@ export function buildTableCTE(
   const preview = CONTENT_PREVIEW[table];
   const cteName = `${table}_results`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  const nsFilter = namespace ? ` AND ${alias}.namespace = '${namespace}'` : "";
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
     : "NULL::jsonb AS extracted_metadata";
@@ -109,19 +111,25 @@ export function buildTableCTE(
     COALESCE(${alias}.access_count, 0) AS access_count,
     ${metaCol}
   FROM ${table} ${alias}
-  WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL${tierFilter}
+  WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}
   ORDER BY ${alias}.embedding <=> (SELECT emb FROM query_embedding) ASC
   LIMIT ${perTableLimit}
 )`;
 }
 
-function buildFtsCTE(table: Table, perTableLimit: number, tier?: Tier): string {
+function buildFtsCTE(
+  table: Table,
+  perTableLimit: number,
+  tier?: Tier,
+  namespace?: string,
+): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
   const cteName = `${table}_fts`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  const nsFilter = namespace ? ` AND ${alias}.namespace = '${namespace}'` : "";
 
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
@@ -141,7 +149,7 @@ function buildFtsCTE(table: Table, perTableLimit: number, tier?: Tier): string {
     ${metaCol}
   FROM ${table} ${alias}
   WHERE ${alias}.search_vector @@ plainto_tsquery('english', (SELECT q FROM fts_query))
-    AND ${alias}.archived_at IS NULL${tierFilter}
+    AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}
   ORDER BY fts_rank DESC
   LIMIT ${perTableLimit}
 )`;
@@ -154,10 +162,11 @@ async function vectorSearch(
   fetchLimit: number,
   tier?: Tier,
   offset = 0,
+  namespace?: string,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const ctes = accessibleTables.map((t) =>
-    buildTableCTE(t, perTableLimit, tier),
+    buildTableCTE(t, perTableLimit, tier, namespace),
   );
   const cteNames = accessibleTables.map((t) => `${t}_results`);
   const unionAll = cteNames
@@ -189,9 +198,12 @@ async function ftsSearch(
   fetchLimit: number,
   tier?: Tier,
   offset = 0,
+  namespace?: string,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
-  const ctes = accessibleTables.map((t) => buildFtsCTE(t, perTableLimit, tier));
+  const ctes = accessibleTables.map((t) =>
+    buildFtsCTE(t, perTableLimit, tier, namespace),
+  );
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
   const unionAll = cteNames
     .map((name) => `SELECT * FROM ${name}`)
@@ -263,6 +275,7 @@ export function trackUsage(
   rows: SearchRow[],
   queryText: string,
   context = "search",
+  accessedBy?: string,
 ): void {
   if (rows.length === 0) return;
   if (trackingCircuitOpen) return;
@@ -293,9 +306,9 @@ export function trackUsage(
     const sourceTables = logRows.map((r) => LABEL_TO_TABLE[r.source_type]);
     trackingPromises.push(
       deps.pool.query(
-        `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, query_text, context)
-           SELECT unnest($1::uuid[]), unnest($2::text[]), NOW(), $3, $4`,
-        [entryIds, sourceTables, queryText, context],
+        `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, query_text, context, accessed_by)
+           SELECT unnest($1::uuid[]), unnest($2::text[]), NOW(), $3, $4, $5`,
+        [entryIds, sourceTables, queryText, context, accessedBy ?? null],
       ),
     );
   }
@@ -334,9 +347,10 @@ export async function executeSearch(
   mode: SearchMode = "hybrid",
   tier?: Tier,
   offset = 0,
+  namespace?: string,
 ): Promise<SearchRow[]> {
   if (mode === "keyword") {
-    return ftsSearch(deps, accessibleTables, query, limit, tier, offset);
+    return ftsSearch(deps, accessibleTables, query, limit, tier, offset, namespace);
   }
 
   // Vector and hybrid both need an embedding
@@ -347,14 +361,14 @@ export async function executeSearch(
       logger.warn("embedding_failed_fallback_fts", {
         query: query.slice(0, 50),
       });
-      return ftsSearch(deps, accessibleTables, query, limit, tier, offset);
+      return ftsSearch(deps, accessibleTables, query, limit, tier, offset, namespace);
     }
     // In vector mode, null embedding is a hard failure -- signal via thrown error
     throw new Error("Failed to generate query embedding");
   }
 
   if (mode === "vector") {
-    return vectorSearch(deps, accessibleTables, embedding, limit, tier, offset);
+    return vectorSearch(deps, accessibleTables, embedding, limit, tier, offset, namespace);
   }
 
   // Hybrid: run both in parallel, merge with RRF
@@ -362,8 +376,8 @@ export async function executeSearch(
   const totalNeeded = offset + limit;
   const fetchLimit = totalNeeded * HYBRID_FETCH_MULTIPLIER;
   const [vectorRows, ftsRows] = await Promise.all([
-    vectorSearch(deps, accessibleTables, embedding, fetchLimit, tier),
-    ftsSearch(deps, accessibleTables, query, fetchLimit, tier),
+    vectorSearch(deps, accessibleTables, embedding, fetchLimit, tier, 0, namespace),
+    ftsSearch(deps, accessibleTables, query, fetchLimit, tier, 0, namespace),
   ]);
 
   const merged = rrfMerge(vectorRows, ftsRows, totalNeeded);
@@ -388,6 +402,10 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           ])
           .optional()
           .describe("Optional: limit search to a specific table"),
+        namespace: z
+          .string()
+          .optional()
+          .describe("Optional: filter results to a specific namespace (e.g. clientId or 'collab')"),
         limit: z
           .number()
           .int()
@@ -469,6 +487,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const offset = args.offset ?? 0;
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
+      const namespace = args.namespace as string | undefined;
 
       let rows;
       try {
@@ -480,6 +499,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           mode,
           tier,
           offset,
+          namespace,
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -489,7 +509,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      trackUsage(deps, rows, args.query);
+      trackUsage(deps, rows, args.query, "search", auth.clientId);
 
       return {
         content: [

--- a/src/tools/session-load.ts
+++ b/src/tools/session-load.ts
@@ -44,20 +44,20 @@ export function registerSessionLoad(server: McpServer, deps: ToolDeps): void {
       }
 
       if (args.project) {
-        return handleProjectLoad(deps, args.project);
+        return handleProjectLoad(deps, args.project, auth.clientId);
       }
 
-      return handleGlobalLoad(deps);
+      return handleGlobalLoad(deps, auth.clientId);
     },
   );
 }
 
-function logSessionAccess(deps: ToolDeps, sessionId: string): void {
+function logSessionAccess(deps: ToolDeps, sessionId: string, accessedBy?: string): void {
   void deps.pool
     .query(
-      `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, query_text, context)
-       VALUES ($1::uuid, 'sessions', NOW(), NULL, 'session_load')`,
-      [sessionId],
+      `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, query_text, context, accessed_by)
+       VALUES ($1::uuid, 'sessions', NOW(), NULL, 'session_load', $2)`,
+      [sessionId, accessedBy ?? null],
     )
     .catch((err: unknown) => {
       logger.warn("session_load_access_log_error", {
@@ -66,7 +66,7 @@ function logSessionAccess(deps: ToolDeps, sessionId: string): void {
     });
 }
 
-async function handleProjectLoad(deps: ToolDeps, project: string) {
+async function handleProjectLoad(deps: ToolDeps, project: string, accessedBy?: string) {
   const sql = `SELECT ${SELECT_COLUMNS}
 FROM sessions
 WHERE project = $1 AND archived_at IS NULL
@@ -86,7 +86,7 @@ LIMIT 1`;
     };
   }
 
-  logSessionAccess(deps, rows[0].id);
+  logSessionAccess(deps, rows[0].id, accessedBy);
 
   return {
     content: [
@@ -98,7 +98,7 @@ LIMIT 1`;
   };
 }
 
-async function handleGlobalLoad(deps: ToolDeps) {
+async function handleGlobalLoad(deps: ToolDeps, accessedBy?: string) {
   const sql = `SELECT ${SELECT_COLUMNS}
 FROM sessions
 WHERE archived_at IS NULL
@@ -118,7 +118,7 @@ LIMIT 1`;
     };
   }
 
-  logSessionAccess(deps, rows[0].id);
+  logSessionAccess(deps, rows[0].id, accessedBy);
 
   return {
     content: [

--- a/src/tools/tier-recommendations.ts
+++ b/src/tools/tier-recommendations.ts
@@ -1,0 +1,188 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES, CONTENT_PREVIEW, TABLE_ALIAS } from "./table-constants.ts";
+
+export function registerTierRecommendations(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "tier_recommendations",
+    {
+      description:
+        "Get tier change recommendations based on access patterns. Suggests entries to promote (cold/warm -> hot) or demote (warm -> cold).",
+      inputSchema: {
+        action: z
+          .enum(["promote", "demote"])
+          .describe("Direction: promote (increase tier) or demote (decrease tier)"),
+        threshold_days: z
+          .number()
+          .int()
+          .min(1)
+          .max(365)
+          .optional()
+          .describe("Days threshold (default: 30 for demote, 7 for promote)"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max candidates to return (default 20)"),
+      },
+      annotations: {
+        title: "Tier Recommendations",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const action = args.action as "promote" | "demote";
+      const limit = args.limit ?? 20;
+      const thresholdDays = args.threshold_days ?? (action === "demote" ? 30 : 7);
+
+      const candidates: Array<{
+        id: string;
+        table: string;
+        content_preview: string;
+        current_tier: string;
+        suggested_tier: string;
+        access_count: number;
+        recent_accesses?: number;
+        last_accessed_at: string | null;
+        reasoning: string;
+      }> = [];
+
+      for (const table of accessibleTables) {
+        if (candidates.length >= limit) break;
+
+        const remaining = limit - candidates.length;
+        const alias = TABLE_ALIAS[table];
+        const preview = CONTENT_PREVIEW[table];
+
+        if (action === "demote") {
+          // Find warm entries not accessed recently with low access_count
+          const { rows } = await deps.pool.query(
+            `SELECT
+              ${alias}.id,
+              LEFT(${preview}, 200) AS content_preview,
+              COALESCE(${alias}.tier, 'warm') AS tier,
+              COALESCE(${alias}.access_count, 0) AS access_count,
+              ${alias}.last_accessed_at
+            FROM ${table} ${alias}
+            WHERE ${alias}.archived_at IS NULL
+              AND COALESCE(${alias}.tier, 'warm') = 'warm'
+              AND (${alias}.last_accessed_at IS NULL OR ${alias}.last_accessed_at < NOW() - INTERVAL '1 day' * $1)
+              AND COALESCE(${alias}.access_count, 0) < 3
+            ORDER BY COALESCE(${alias}.access_count, 0) ASC, ${alias}.created_at ASC
+            LIMIT $2`,
+            [thresholdDays, remaining],
+          );
+
+          for (const row of rows) {
+            candidates.push({
+              id: row.id,
+              table,
+              content_preview: row.content_preview,
+              current_tier: row.tier,
+              suggested_tier: "cold",
+              access_count: Number(row.access_count),
+              last_accessed_at: row.last_accessed_at,
+              reasoning: `Warm entry with ${row.access_count} accesses, not accessed in ${thresholdDays}+ days`,
+            });
+          }
+        } else {
+          // Promote: find warm/cold entries with high recent access (>5 in threshold period)
+          const { rows } = await deps.pool.query(
+            `SELECT
+              sub.id,
+              sub.content_preview,
+              sub.tier,
+              sub.access_count,
+              sub.last_accessed_at,
+              sub.recent_accesses
+            FROM (
+              SELECT
+                ${alias}.id,
+                LEFT(${preview}, 200) AS content_preview,
+                COALESCE(${alias}.tier, 'warm') AS tier,
+                COALESCE(${alias}.access_count, 0) AS access_count,
+                ${alias}.last_accessed_at,
+                (SELECT COUNT(*) FROM entry_access_log eal
+                 WHERE eal.entry_id = ${alias}.id
+                   AND eal.accessed_at >= NOW() - INTERVAL '1 day' * $1) AS recent_accesses
+              FROM ${table} ${alias}
+              WHERE ${alias}.archived_at IS NULL
+                AND COALESCE(${alias}.tier, 'warm') IN ('warm', 'cold')
+            ) sub
+            WHERE sub.recent_accesses > 5
+            ORDER BY sub.recent_accesses DESC
+            LIMIT $2`,
+            [thresholdDays, remaining],
+          );
+
+          for (const row of rows) {
+            candidates.push({
+              id: row.id,
+              table,
+              content_preview: row.content_preview,
+              current_tier: row.tier,
+              suggested_tier: "hot",
+              access_count: Number(row.access_count),
+              recent_accesses: Number(row.recent_accesses),
+              last_accessed_at: row.last_accessed_at,
+              reasoning: `${row.tier} entry with ${row.recent_accesses} accesses in last ${thresholdDays} days`,
+            });
+          }
+        }
+      }
+
+      logger.info("tier_recommendations_success", {
+        action,
+        candidates_found: candidates.length,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              action,
+              threshold_days: thresholdDays,
+              candidates_found: candidates.length,
+              candidates,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds 8 new MCP tools for OB v2 brain management:

- **access_report** -- Entry access frequency and recency reports
- **bulk_archive** -- Batch archive entries by criteria
- **bulk_set_tier** -- Batch tier changes (hot/warm/cold)
- **curate_entries** -- AI-assisted entry curation and cleanup
- **find_duplicates** -- Detect duplicate/near-duplicate entries
- **get_stats** -- Brain statistics and health metrics
- **list_namespaces** -- List all namespaces with entry counts
- **tier_recommendations** -- AI-suggested tier promotions/demotions

### Also includes:
- Namespace filter support on search_brain and search_all
- Agent attribution (source_agent field) on all write operations
- Migration 009: agent_attribution indexes + access log indexes
- SQL injection fix: namespace sanitization via regex validation
- Table constants extraction for shared use across tools

### Migration required:
- `008_index_cleanup.sql` (already deployed via main)
- `009_agent_attribution.sql` (new)

Full test coverage for all 8 new tools.