### PR TITLE
feat: add session event journal + context tools (#35, #36)

### DIFF
--- a/src/db/migrations/013_session_events.sql
+++ b/src/db/migrations/013_session_events.sql
@@ -1,0 +1,40 @@
+-- Migration 013: Session event journal (Issues #35 + #36)
+-- Append-only event stream for session lanes. Each event captures a discrete
+-- fact, decision, blocker, action, etc. within a lane's lifecycle.
+
+CREATE TABLE IF NOT EXISTS ob_session_events (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  lane_id         UUID NOT NULL REFERENCES ob_session_lanes(id) ON DELETE CASCADE,
+  event_type      TEXT NOT NULL,
+  content         TEXT NOT NULL,
+  source          TEXT,
+  artifact_path   TEXT,
+  importance      TEXT NOT NULL DEFAULT 'warm',
+  metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  embedding       halfvec(768),
+  content_hash    TEXT,
+  embedded_at     TIMESTAMPTZ,
+  embedding_model TEXT,
+  created_by      TEXT NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (btrim(content) <> ''),
+  CHECK (event_type IN (
+    'fact', 'decision', 'blocker', 'action',
+    'artifact', 'receipt', 'question', 'correction', 'handoff'
+  )),
+  CHECK (importance IN ('hot', 'warm', 'cold'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_lane
+  ON ob_session_events (lane_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_type
+  ON ob_session_events (lane_id, event_type);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_importance
+  ON ob_session_events (lane_id, importance)
+  WHERE importance = 'hot';
+
+CREATE INDEX IF NOT EXISTS idx_session_events_embedding
+  ON ob_session_events USING hnsw (embedding halfvec_cosine_ops)
+  WITH (m = 16, ef_construction = 200);

--- a/src/db/migrations/013_session_events.sql
+++ b/src/db/migrations/013_session_events.sql
@@ -35,6 +35,10 @@ CREATE INDEX IF NOT EXISTS idx_session_events_importance
   ON ob_session_events (lane_id, importance)
   WHERE importance = 'hot';
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_events_content_hash
+  ON ob_session_events (lane_id, content_hash)
+  WHERE content_hash IS NOT NULL;
+
 CREATE INDEX IF NOT EXISTS idx_session_events_embedding
   ON ob_session_events USING hnsw (embedding halfvec_cosine_ops)
   WITH (m = 16, ef_construction = 200);

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerAppendSessionEvent } from "../append-session-event.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+function createThrowingEmbed(error: Error) {
+  return async (_text: string): Promise<number[] | null> => {
+    throw error;
+  };
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+  embedFn?: (text: string) => Promise<number[] | null>,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = {
+    pool: mockPool as any,
+    embedFn: embedFn ?? createMockEmbed(),
+  };
+  registerAppendSessionEvent(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+/** Mock pool that returns a lane for the lookup query, then returns event data for the insert. */
+function createLaneFoundPool(
+  laneId = "lane-uuid-1",
+  eventId = "event-uuid-1",
+  createdAt = "2026-06-08T10:00:00Z",
+) {
+  return {
+    query: async (sql: string, _params?: any[]) => {
+      if (sql.includes("ob_session_lanes")) {
+        return { rows: [{ id: laneId }] };
+      }
+      // INSERT into ob_session_events
+      return { rows: [{ id: eventId, created_at: createdAt }] };
+    },
+  };
+}
+
+/** Mock pool that returns no lanes (lane not found). */
+function createLaneNotFoundPool() {
+  return {
+    query: async (sql: string, _params?: any[]) => {
+      if (sql.includes("ob_session_lanes")) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+describe("append_session_event", () => {
+  // ── AUTH PATHS ──
+
+  it("denies write when auth is missing entirely", async () => {
+    const mockPool = createLaneFoundPool();
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: mockPool as any,
+      embedFn: createMockEmbed(),
+    };
+    registerAppendSessionEvent(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "test content",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies write for discord role", async () => {
+    const mockPool = createLaneFoundPool();
+    const auth: AuthInfo = { role: "discord", clientId: "random-user" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "test content",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies write for readonly role", async () => {
+    const mockPool = createLaneFoundPool();
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "test content",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── HAPPY PATH ──
+
+  it("admin can append event — full field propagation", async () => {
+    let capturedQueries: { sql: string; params: any[] }[] = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        capturedQueries.push({ sql, params: params ?? [] });
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1" }] };
+        }
+        return {
+          rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "ob-v2-dev",
+          namespace: "collab",
+          event_type: "decision",
+          content: "Decided to use append-only event journal",
+          source: "skippy",
+          artifact_path: "/src/tools/append-session-event.ts",
+          importance: "hot",
+          metadata: { pr: 42 },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.event_id).toBe("event-uuid-1");
+      expect(parsed.lane_id).toBe("lane-uuid-1");
+      expect(parsed.event_type).toBe("decision");
+      expect(parsed.importance).toBe("hot");
+      expect(parsed.created_at).toBe("2026-06-08T10:00:00Z");
+
+      // Verify lane lookup used correct namespace + session_key
+      const laneLookup = capturedQueries.find((q) =>
+        q.sql.includes("ob_session_lanes"),
+      );
+      expect(laneLookup!.params[0]).toBe("collab");
+      expect(laneLookup!.params[1]).toBe("ob-v2-dev");
+
+      // Verify insert params
+      const insert = capturedQueries.find((q) =>
+        q.sql.includes("ob_session_events"),
+      );
+      expect(insert!.params[0]).toBe("lane-uuid-1"); // lane_id
+      expect(insert!.params[1]).toBe("decision"); // event_type
+      expect(insert!.params[2]).toBe(
+        "Decided to use append-only event journal",
+      ); // content
+      expect(insert!.params[3]).toBe("skippy"); // source
+      expect(insert!.params[4]).toBe("/src/tools/append-session-event.ts"); // artifact_path
+      expect(insert!.params[5]).toBe("hot"); // importance
+      expect(JSON.parse(insert!.params[6] as string)).toEqual({ pr: 42 }); // metadata
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows agent role", async () => {
+    const mockPool = createLaneFoundPool();
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Agent recorded a fact",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows n8n role", async () => {
+    const mockPool = createLaneFoundPool();
+    const auth: AuthInfo = { role: "n8n", clientId: "n8n-worker" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "receipt",
+          content: "Workflow completed",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── LANE NOT FOUND ──
+
+  it("returns error when lane not found", async () => {
+    const mockPool = createLaneNotFoundPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "nonexistent",
+          event_type: "fact",
+          content: "This lane does not exist",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Lane not found");
+      expect((result.content as any)[0].text).toContain("nonexistent");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── NAMESPACE DEFAULTING ──
+
+  it("defaults namespace to auth.clientId when not provided", async () => {
+    let capturedLaneParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          capturedLaneParams = params;
+          return { rows: [{ id: "lane-uuid-1" }] };
+        }
+        return {
+          rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "bilby-agent" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "my-lane",
+          event_type: "fact",
+          content: "Something happened",
+        },
+      });
+
+      expect(capturedLaneParams![0]).toBe("bilby-agent");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── IMPORTANCE DEFAULTING ──
+
+  it("defaults importance to 'warm' when not provided", async () => {
+    const mockPool = createLaneFoundPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Default importance test",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.importance).toBe("warm");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── EMBEDDING PATHS ──
+
+  it("embedding failure is non-fatal — event still inserted", async () => {
+    const mockPool = createLaneFoundPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(
+      mockPool,
+      auth,
+      createThrowingEmbed(new Error("LiteLLM timeout")),
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "blocker",
+          content: "Something is blocking progress",
+        },
+      });
+
+      // Should succeed despite embedding failure
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.event_id).toBe("event-uuid-1");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── CONTENT HASH ──
+
+  it("content hash is generated and passed to insert", async () => {
+    let capturedInsertParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1" }] };
+        }
+        capturedInsertParams = params;
+        return {
+          rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Hash test content",
+        },
+      });
+
+      // content_hash is param index 8 (0-based)
+      const hash = capturedInsertParams![8];
+      expect(typeof hash).toBe("string");
+      expect(hash.length).toBe(64); // SHA-256 hex
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── ALL EVENT TYPES ──
+
+  const allEventTypes = [
+    "fact",
+    "decision",
+    "blocker",
+    "action",
+    "artifact",
+    "receipt",
+    "question",
+    "correction",
+    "handoff",
+  ] as const;
+
+  for (const eventType of allEventTypes) {
+    it(`accepts event_type="${eventType}"`, async () => {
+      const mockPool = createLaneFoundPool();
+      const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "append_session_event",
+          arguments: {
+            session_key: "test",
+            event_type: eventType,
+            content: `Testing ${eventType} event type`,
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.event_type).toBe(eventType);
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  // ── OPTIONAL FIELDS DEFAULT TO NULL ──
+
+  it("passes null for optional source and artifact_path when omitted", async () => {
+    let capturedInsertParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1" }] };
+        }
+        capturedInsertParams = params;
+        return {
+          rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Minimal event",
+        },
+      });
+
+      expect(capturedInsertParams![3]).toBeNull(); // source
+      expect(capturedInsertParams![4]).toBeNull(); // artifact_path
+      expect(JSON.parse(capturedInsertParams![6] as string)).toEqual({}); // metadata
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DATABASE ERROR ──
+
+  it("returns isError=true with message when DB query throws", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection refused");
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "DB will crash",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("connection refused");
+      expect((result.content as any)[0].text).toContain("Database error");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -54,11 +54,12 @@ function createLaneFoundPool(
   laneId = "lane-uuid-1",
   eventId = "event-uuid-1",
   createdAt = "2026-06-08T10:00:00Z",
+  status = "active",
 ) {
   return {
     query: async (sql: string, _params?: any[]) => {
       if (sql.includes("ob_session_lanes")) {
-        return { rows: [{ id: laneId }] };
+        return { rows: [{ id: laneId, status }] };
       }
       // INSERT into ob_session_events
       return { rows: [{ id: eventId, created_at: createdAt }] };
@@ -163,7 +164,7 @@ describe("append_session_event", () => {
       query: async (sql: string, params?: any[]) => {
         capturedQueries.push({ sql, params: params ?? [] });
         if (sql.includes("ob_session_lanes")) {
-          return { rows: [{ id: "lane-uuid-1" }] };
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
         }
         return {
           rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
@@ -285,6 +286,94 @@ describe("append_session_event", () => {
     }
   });
 
+  // ── ARCHIVED LANE ──
+
+  it("rejects append to archived lane", async () => {
+    const mockPool = createLaneFoundPool(
+      "lane-uuid-1",
+      "event-uuid-1",
+      "2026-06-08T10:00:00Z",
+      "archived",
+    );
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "old-lane",
+          event_type: "fact",
+          content: "Should not be appended",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("archived");
+      expect((result.content as any)[0].text).toContain("reactivate");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows append to wrapped lane", async () => {
+    const mockPool = createLaneFoundPool(
+      "lane-uuid-1",
+      "event-uuid-1",
+      "2026-06-08T10:00:00Z",
+      "wrapped",
+    );
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "wrapped-lane",
+          event_type: "handoff",
+          content: "Late event during wrap",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DUPLICATE DETECTION ──
+
+  it("returns duplicate response when content_hash conflicts", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
+        }
+        // INSERT returns no rows due to ON CONFLICT DO NOTHING
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Already exists",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.duplicate).toBe(true);
+      expect(parsed.message).toContain("identical content");
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── NAMESPACE DEFAULTING ──
 
   it("defaults namespace to auth.clientId when not provided", async () => {
@@ -293,7 +382,7 @@ describe("append_session_event", () => {
       query: async (sql: string, params?: any[]) => {
         if (sql.includes("ob_session_lanes")) {
           capturedLaneParams = params;
-          return { rows: [{ id: "lane-uuid-1" }] };
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
         }
         return {
           rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
@@ -381,7 +470,7 @@ describe("append_session_event", () => {
     const mockPool = {
       query: async (sql: string, params?: any[]) => {
         if (sql.includes("ob_session_lanes")) {
-          return { rows: [{ id: "lane-uuid-1" }] };
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
         }
         capturedInsertParams = params;
         return {
@@ -457,7 +546,7 @@ describe("append_session_event", () => {
     const mockPool = {
       query: async (sql: string, params?: any[]) => {
         if (sql.includes("ob_session_lanes")) {
-          return { rows: [{ id: "lane-uuid-1" }] };
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
         }
         capturedInsertParams = params;
         return {

--- a/src/tools/__tests__/session-context.test.ts
+++ b/src/tools/__tests__/session-context.test.ts
@@ -231,6 +231,28 @@ describe("session_context", () => {
     }
   });
 
+  // ── MISSING LANE IDENTIFIER ──
+
+  it("requires at least one of session_key or channel_id", async () => {
+    const mockPool = createFullContextPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain(
+        "At least one of session_key or channel_id is required",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── CHANNEL LOOKUP ──
 
   it("looks up lane by channel_id", async () => {

--- a/src/tools/__tests__/session-context.test.ts
+++ b/src/tools/__tests__/session-context.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerSessionContext } from "../session-context.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerSessionContext(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const MOCK_LANE = {
+  id: "lane-uuid-1",
+  session_key: "ob-v2-dev",
+  namespace: "skippy",
+  status: "active",
+  agent: "skippy",
+  project: "open-brain",
+  topic: "OB v2 development",
+  current_context_md: "## Active work\nSession events feature.",
+  metadata: {},
+  created_at: "2026-06-08T08:00:00Z",
+  updated_at: "2026-06-08T10:00:00Z",
+};
+
+const MOCK_EVENTS = [
+  {
+    id: "event-1",
+    event_type: "decision",
+    content: "Using append-only journal",
+    source: "skippy",
+    artifact_path: null,
+    importance: "hot",
+    metadata: {},
+    created_at: "2026-06-08T10:00:00Z",
+    created_by: "skippy",
+  },
+  {
+    id: "event-2",
+    event_type: "fact",
+    content: "Migration 013 created",
+    source: null,
+    artifact_path: "/src/db/migrations/013_session_events.sql",
+    importance: "warm",
+    metadata: {},
+    created_at: "2026-06-08T09:30:00Z",
+    created_by: "skippy",
+  },
+  {
+    id: "event-3",
+    event_type: "blocker",
+    content: "Need embedding model config",
+    source: null,
+    artifact_path: null,
+    importance: "cold",
+    metadata: {},
+    created_at: "2026-06-08T09:00:00Z",
+    created_by: "skippy",
+  },
+];
+
+/** Mock pool that returns lane + events, differentiating by SQL content. */
+function createFullContextPool(lane = MOCK_LANE, events = MOCK_EVENTS) {
+  return {
+    query: async (sql: string, _params?: any[]) => {
+      if (sql.includes("ob_session_lanes")) {
+        return { rows: [lane] };
+      }
+      if (sql.includes("ob_session_events")) {
+        return { rows: events };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+describe("session_context", () => {
+  // ── AUTH PATHS ──
+
+  it("denies read when auth is missing entirely", async () => {
+    const mockPool = createFullContextPool();
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: mockPool as any,
+      embedFn: createMockEmbed(),
+    };
+    registerSessionContext(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "test" },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies read for discord role", async () => {
+    const mockPool = createFullContextPool();
+    const auth: AuthInfo = { role: "discord", clientId: "random-user" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "test" },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows readonly role", async () => {
+    const mockPool = createFullContextPool();
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "ob-v2-dev" },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── HAPPY PATH ──
+
+  it("admin can load context with events", async () => {
+    const mockPool = createFullContextPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "ob-v2-dev" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+
+      // Lane fields
+      expect(parsed.lane.id).toBe("lane-uuid-1");
+      expect(parsed.lane.session_key).toBe("ob-v2-dev");
+      expect(parsed.lane.project).toBe("open-brain");
+      expect(parsed.lane.current_context_md).toContain("Session events");
+
+      // Events
+      expect(parsed.events).toHaveLength(3);
+      expect(parsed.events[0].event_type).toBe("decision");
+      expect(parsed.events[1].event_type).toBe("fact");
+      expect(parsed.events[2].event_type).toBe("blocker");
+      expect(parsed.event_count).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── LANE NOT FOUND ──
+
+  it("returns null lane when not found", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "nonexistent" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.lane).toBeNull();
+      expect(parsed.events).toEqual([]);
+      expect(parsed.event_count).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── CHANNEL LOOKUP ──
+
+  it("looks up lane by channel_id", async () => {
+    let capturedLaneSql = "";
+    let capturedLaneParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          capturedLaneSql = sql;
+          capturedLaneParams = params;
+          return { rows: [MOCK_LANE] };
+        }
+        return { rows: MOCK_EVENTS };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { channel_id: "discord-123" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedLaneSql).toContain("channel_id =");
+      expect(capturedLaneParams!).toContain("discord-123");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("looks up lane by channel_id + thread_id", async () => {
+    let capturedLaneSql = "";
+    let capturedLaneParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          capturedLaneSql = sql;
+          capturedLaneParams = params;
+          return { rows: [MOCK_LANE] };
+        }
+        return { rows: MOCK_EVENTS };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "session_context",
+        arguments: { channel_id: "discord-123", thread_id: "thread-456" },
+      });
+
+      expect(capturedLaneSql).toContain("channel_id =");
+      expect(capturedLaneSql).toContain("thread_id =");
+      expect(capturedLaneParams!).toContain("discord-123");
+      expect(capturedLaneParams!).toContain("thread-456");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── EVENT TYPE FILTER ──
+
+  it("filters events by event_types", async () => {
+    let capturedEventSql = "";
+    let capturedEventParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [MOCK_LANE] };
+        }
+        if (sql.includes("ob_session_events")) {
+          capturedEventSql = sql;
+          capturedEventParams = params;
+          return { rows: [MOCK_EVENTS[0]] }; // just the decision
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: {
+          session_key: "ob-v2-dev",
+          event_types: ["decision", "blocker"],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedEventSql).toContain("event_type = ANY");
+      expect(capturedEventParams!).toContainEqual(["decision", "blocker"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── IMPORTANCE FILTER ──
+
+  it("filters events by importance", async () => {
+    let capturedEventSql = "";
+    let capturedEventParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [MOCK_LANE] };
+        }
+        if (sql.includes("ob_session_events")) {
+          capturedEventSql = sql;
+          capturedEventParams = params;
+          return { rows: [MOCK_EVENTS[0]] }; // hot event only
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: {
+          session_key: "ob-v2-dev",
+          importance: "hot",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedEventSql).toContain("importance =");
+      expect(capturedEventParams!).toContain("hot");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── INCLUDE_EVENTS=FALSE ──
+
+  it("skips event query when include_events is false", async () => {
+    let eventQueryCalled = false;
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [MOCK_LANE] };
+        }
+        if (sql.includes("ob_session_events")) {
+          eventQueryCalled = true;
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: {
+          session_key: "ob-v2-dev",
+          include_events: false,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(eventQueryCalled).toBe(false);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.lane.id).toBe("lane-uuid-1");
+      expect(parsed.events).toEqual([]);
+      expect(parsed.event_count).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── NAMESPACE DEFAULTING ──
+
+  it("defaults namespace to auth.clientId when not provided", async () => {
+    let capturedLaneParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          capturedLaneParams = params;
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "test" },
+      });
+
+      expect(capturedLaneParams![0]).toBe("nagatha");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── EVENT LIMIT ──
+
+  it("respects event_limit parameter", async () => {
+    let capturedEventParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [MOCK_LANE] };
+        }
+        if (sql.includes("ob_session_events")) {
+          capturedEventParams = params;
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "session_context",
+        arguments: {
+          session_key: "ob-v2-dev",
+          event_limit: 5,
+        },
+      });
+
+      // Limit should be the last param
+      expect(capturedEventParams![capturedEventParams!.length - 1]).toBe(5);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("defaults event_limit to 50", async () => {
+    let capturedEventParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [MOCK_LANE] };
+        }
+        if (sql.includes("ob_session_events")) {
+          capturedEventParams = params;
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "ob-v2-dev" },
+      });
+
+      expect(capturedEventParams![capturedEventParams!.length - 1]).toBe(50);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DATABASE ERROR ──
+
+  it("returns isError=true with message when DB query throws", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection timeout");
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "crash" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("connection timeout");
+      expect((result.content as any)[0].text).toContain("Database error");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -1,0 +1,228 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toSql } from "pgvector/pg";
+import { canWrite } from "../permissions.ts";
+import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+const EVENT_TYPES = [
+  "fact",
+  "decision",
+  "blocker",
+  "action",
+  "artifact",
+  "receipt",
+  "question",
+  "correction",
+  "handoff",
+] as const;
+
+const IMPORTANCE_LEVELS = ["hot", "warm", "cold"] as const;
+
+export function registerAppendSessionEvent(
+  server: McpServer,
+  deps: ToolDeps,
+): void {
+  server.registerTool(
+    "append_session_event",
+    {
+      description:
+        "Append an event to a session lane's journal. Events are append-only " +
+        "and capture discrete facts, decisions, blockers, actions, etc.",
+      inputSchema: {
+        session_key: z
+          .string()
+          .min(1)
+          .max(500)
+          .describe(
+            "Session key identifying the lane to append to (looked up by namespace + session_key)",
+          ),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        event_type: z
+          .enum(EVENT_TYPES)
+          .describe(
+            "Type of event: fact, decision, blocker, action, artifact, receipt, question, correction, handoff",
+          ),
+        content: z
+          .string()
+          .min(1)
+          .max(50_000)
+          .describe("Event content — what happened"),
+        source: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Source of the event (agent name, tool, user, etc.)"),
+        artifact_path: z
+          .string()
+          .max(2000)
+          .optional()
+          .describe("Path to related artifact (file, URL, etc.)"),
+        importance: z
+          .enum(IMPORTANCE_LEVELS)
+          .optional()
+          .describe("Event importance: hot, warm (default), cold"),
+        metadata: z
+          .record(z.string().max(100), z.unknown())
+          .optional()
+          .refine(
+            (v) =>
+              !v ||
+              (Object.keys(v).length <= 50 &&
+                JSON.stringify(v).length <= 100_000),
+            { message: "metadata: max 50 keys, max 100KB total" },
+          )
+          .describe("Arbitrary JSON metadata; max 50 keys, max 100KB total"),
+      },
+      annotations: {
+        title: "Append Session Event",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+
+      // Auth gate
+      if (!auth || !canWrite(auth.role, "sessions")) {
+        logger.warn("append_session_event_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+          session_key: args.session_key,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot write to session events",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const importance = args.importance ?? "warm";
+
+      logger.debug("append_session_event_start", {
+        session_key: args.session_key,
+        namespace: ns,
+        event_type: args.event_type,
+        importance,
+        clientId: auth.clientId,
+        content_length: args.content.length,
+      });
+
+      try {
+        // Look up the lane
+        const { rows: laneRows } = await deps.pool.query(
+          `SELECT id FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
+          [ns, args.session_key],
+        );
+
+        if (laneRows.length === 0) {
+          logger.info("append_session_event_lane_not_found", {
+            session_key: args.session_key,
+            namespace: ns,
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Lane not found for session_key "${args.session_key}" in namespace "${ns}"`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const laneId = laneRows[0].id;
+
+        // Generate embedding (non-fatal)
+        let embedding: number[] | null = null;
+        try {
+          embedding = await deps.embedFn(args.content);
+        } catch (err) {
+          logger.warn("append_session_event_embed_error", {
+            session_key: args.session_key,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        const hash = contentHash(args.content);
+        const embeddingVal = embedding ? toSql(embedding) : null;
+        const embeddedAt = embedding ? new Date().toISOString() : null;
+        const model = embedding ? EMBEDDING_MODEL : null;
+
+        const { rows } = await deps.pool.query(
+          `INSERT INTO ob_session_events
+             (lane_id, event_type, content, source, artifact_path, importance,
+              metadata, embedding, content_hash, embedded_at, embedding_model, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+           RETURNING id, created_at`,
+          [
+            laneId,
+            args.event_type,
+            args.content,
+            args.source ?? null,
+            args.artifact_path ?? null,
+            importance,
+            JSON.stringify(args.metadata ?? {}),
+            embeddingVal,
+            hash,
+            embeddedAt,
+            model,
+            auth.clientId,
+          ],
+        );
+
+        const result = {
+          event_id: rows[0].id,
+          lane_id: laneId,
+          event_type: args.event_type,
+          importance,
+          created_at: rows[0].created_at,
+        };
+
+        logger.info("append_session_event_ok", {
+          event_id: result.event_id,
+          lane_id: result.lane_id,
+          event_type: result.event_type,
+          importance: result.importance,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("append_session_event_db_error", {
+          session_key: args.session_key,
+          namespace: ns,
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Database error during event append: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -6,20 +6,7 @@ import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
-
-const EVENT_TYPES = [
-  "fact",
-  "decision",
-  "blocker",
-  "action",
-  "artifact",
-  "receipt",
-  "question",
-  "correction",
-  "handoff",
-] as const;
-
-const IMPORTANCE_LEVELS = ["hot", "warm", "cold"] as const;
+import { EVENT_TYPES, IMPORTANCE_LEVELS } from "./table-constants.ts";
 
 export function registerAppendSessionEvent(
   server: McpServer,
@@ -84,7 +71,7 @@ export function registerAppendSessionEvent(
         title: "Append Session Event",
         readOnlyHint: false,
         destructiveHint: false,
-        idempotentHint: false,
+        idempotentHint: true,
       },
     },
     async (args, extra) => {
@@ -123,7 +110,7 @@ export function registerAppendSessionEvent(
       try {
         // Look up the lane
         const { rows: laneRows } = await deps.pool.query(
-          `SELECT id FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
+          `SELECT id, status FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
           [ns, args.session_key],
         );
 
@@ -137,6 +124,18 @@ export function registerAppendSessionEvent(
               {
                 type: "text" as const,
                 text: `Lane not found for session_key "${args.session_key}" in namespace "${ns}"`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (laneRows[0].status === "archived") {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Lane "${args.session_key}" is archived; reactivate before appending events`,
               },
             ],
             isError: true,
@@ -166,6 +165,7 @@ export function registerAppendSessionEvent(
              (lane_id, event_type, content, source, artifact_path, importance,
               metadata, embedding, content_hash, embedded_at, embedding_model, created_by)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+           ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL DO NOTHING
            RETURNING id, created_at`,
           [
             laneId,
@@ -182,6 +182,21 @@ export function registerAppendSessionEvent(
             auth.clientId,
           ],
         );
+
+        if (rows.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  duplicate: true,
+                  message:
+                    "Event with identical content already exists in this lane",
+                }),
+              },
+            ],
+          };
+        }
 
         const result = {
           event_id: rows[0].id,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -26,6 +26,8 @@ import { registerListNamespaces } from "./list-namespaces.ts";
 import { registerTierRecommendations } from "./tier-recommendations.ts";
 import { registerLaneUpsert } from "./lane-upsert.ts";
 import { registerLaneLoad } from "./lane-load.ts";
+import { registerAppendSessionEvent } from "./append-session-event.ts";
+import { registerSessionContext } from "./session-context.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -58,4 +60,6 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerTierRecommendations(server, deps);
   registerLaneUpsert(server, deps);
   registerLaneLoad(server, deps);
+  registerAppendSessionEvent(server, deps);
+  registerSessionContext(server, deps);
 }

--- a/src/tools/session-context.ts
+++ b/src/tools/session-context.ts
@@ -1,0 +1,237 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo } from "../types.ts";
+import type { ToolDeps } from "./index.ts";
+import { logger } from "../logger.ts";
+
+const EVENT_TYPES = [
+  "fact",
+  "decision",
+  "blocker",
+  "action",
+  "artifact",
+  "receipt",
+  "question",
+  "correction",
+  "handoff",
+] as const;
+
+const IMPORTANCE_LEVELS = ["hot", "warm", "cold"] as const;
+
+const LANE_COLUMNS = `id, session_key, namespace, status, agent, project, topic,
+  current_context_md, metadata, created_at, updated_at`;
+
+export function registerSessionContext(
+  server: McpServer,
+  deps: ToolDeps,
+): void {
+  server.registerTool(
+    "session_context",
+    {
+      description:
+        "Load lane state and recent events for a session. " +
+        "Provides the full context needed to resume work on a lane.",
+      inputSchema: {
+        session_key: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Session key to look up the lane"),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        channel_id: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Look up lane by channel_id instead of session_key"),
+        thread_id: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Further narrow channel_id lookup by thread_id"),
+        include_events: z
+          .boolean()
+          .optional()
+          .describe("Whether to include events (default: true)"),
+        event_limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe("Max events to return (default: 50)"),
+        event_types: z
+          .array(z.enum(EVENT_TYPES))
+          .optional()
+          .describe("Filter events by type(s)"),
+        importance: z
+          .enum(IMPORTANCE_LEVELS)
+          .optional()
+          .describe("Filter events by importance level"),
+      },
+      annotations: {
+        title: "Session Context",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+
+      // Auth gate
+      if (!auth || !canRead(auth.role, "sessions")) {
+        logger.warn("session_context_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot read session context",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const includeEvents = args.include_events !== false;
+      const eventLimit = args.event_limit ?? 50;
+
+      logger.debug("session_context_start", {
+        session_key: args.session_key ?? null,
+        namespace: ns,
+        channel_id: args.channel_id ?? null,
+        thread_id: args.thread_id ?? null,
+        include_events: includeEvents,
+        event_limit: eventLimit,
+        clientId: auth.clientId,
+      });
+
+      try {
+        // Build lane lookup query
+        const laneConditions: string[] = [`namespace = $1`];
+        const laneParams: unknown[] = [ns];
+        let paramIdx = 2;
+
+        if (args.session_key) {
+          laneConditions.push(`session_key = $${paramIdx++}`);
+          laneParams.push(args.session_key);
+        } else if (args.channel_id) {
+          laneConditions.push(`channel_id = $${paramIdx++}`);
+          laneParams.push(args.channel_id);
+          if (args.thread_id) {
+            laneConditions.push(`thread_id = $${paramIdx++}`);
+            laneParams.push(args.thread_id);
+          }
+        }
+
+        const laneSql = `SELECT ${LANE_COLUMNS}
+FROM ob_session_lanes
+WHERE ${laneConditions.join(" AND ")}
+ORDER BY updated_at DESC
+LIMIT 1`;
+
+        const { rows: laneRows } = await deps.pool.query(laneSql, laneParams);
+
+        if (laneRows.length === 0) {
+          logger.info("session_context_lane_not_found", {
+            session_key: args.session_key ?? null,
+            namespace: ns,
+            channel_id: args.channel_id ?? null,
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  lane: null,
+                  events: [],
+                  event_count: 0,
+                }),
+              },
+            ],
+          };
+        }
+
+        const lane = laneRows[0];
+        let events: unknown[] = [];
+
+        if (includeEvents) {
+          const eventConditions: string[] = [`lane_id = $1`];
+          const eventParams: unknown[] = [lane.id];
+          let evParamIdx = 2;
+
+          if (args.event_types && args.event_types.length > 0) {
+            eventConditions.push(`event_type = ANY($${evParamIdx++})`);
+            eventParams.push(args.event_types);
+          }
+
+          if (args.importance) {
+            eventConditions.push(`importance = $${evParamIdx++}`);
+            eventParams.push(args.importance);
+          }
+
+          eventParams.push(eventLimit);
+
+          const eventSql = `SELECT id, event_type, content, source, artifact_path,
+  importance, metadata, created_at, created_by
+FROM ob_session_events
+WHERE ${eventConditions.join(" AND ")}
+ORDER BY created_at DESC
+LIMIT $${evParamIdx}`;
+
+          const { rows: eventRows } = await deps.pool.query(
+            eventSql,
+            eventParams,
+          );
+          events = eventRows;
+        }
+
+        const result = {
+          lane,
+          events,
+          event_count: events.length,
+        };
+
+        logger.info("session_context_ok", {
+          lane_id: lane.id,
+          session_key: lane.session_key,
+          namespace: ns,
+          event_count: events.length,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("session_context_db_error", {
+          session_key: args.session_key ?? null,
+          namespace: ns,
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Database error during session context load: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/session-context.ts
+++ b/src/tools/session-context.ts
@@ -4,22 +4,9 @@ import { canRead } from "../permissions.ts";
 import type { AuthInfo } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
+import { EVENT_TYPES, IMPORTANCE_LEVELS } from "./table-constants.ts";
 
-const EVENT_TYPES = [
-  "fact",
-  "decision",
-  "blocker",
-  "action",
-  "artifact",
-  "receipt",
-  "question",
-  "correction",
-  "handoff",
-] as const;
-
-const IMPORTANCE_LEVELS = ["hot", "warm", "cold"] as const;
-
-const LANE_COLUMNS = `id, session_key, namespace, status, agent, project, topic,
+const CONTEXT_LANE_COLUMNS = `id, session_key, namespace, status, agent, project, topic,
   current_context_md, metadata, created_at, updated_at`;
 
 export function registerSessionContext(
@@ -31,7 +18,8 @@ export function registerSessionContext(
     {
       description:
         "Load lane state and recent events for a session. " +
-        "Provides the full context needed to resume work on a lane.",
+        "Provides the full context needed to resume work on a lane. " +
+        "When both session_key and channel_id are provided, session_key takes precedence.",
       inputSchema: {
         session_key: z
           .string()
@@ -100,6 +88,18 @@ export function registerSessionContext(
         };
       }
 
+      if (!args.session_key && !args.channel_id) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "At least one of session_key or channel_id is required",
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const ns = args.namespace ?? auth.clientId;
       const includeEvents = args.include_events !== false;
       const eventLimit = args.event_limit ?? 50;
@@ -132,7 +132,7 @@ export function registerSessionContext(
           }
         }
 
-        const laneSql = `SELECT ${LANE_COLUMNS}
+        const laneSql = `SELECT ${CONTEXT_LANE_COLUMNS}
 FROM ob_session_lanes
 WHERE ${laneConditions.join(" AND ")}
 ORDER BY updated_at DESC

--- a/src/tools/table-constants.ts
+++ b/src/tools/table-constants.ts
@@ -42,6 +42,22 @@ export const CONTENT_PREVIEW: Record<Table, string> = {
     " THEN E'\\nNext: ' || immutable_array_to_string(s.next_steps, '; ') ELSE '' END",
 };
 
+/** Valid session event types */
+export const EVENT_TYPES = [
+  "fact",
+  "decision",
+  "blocker",
+  "action",
+  "artifact",
+  "receipt",
+  "question",
+  "correction",
+  "handoff",
+] as const;
+
+/** Valid event importance levels */
+export const IMPORTANCE_LEVELS = ["hot", "warm", "cold"] as const;
+
 /** Table alias used in CTE/SELECT queries */
 export const TABLE_ALIAS: Record<Table, string> = {
   thoughts: "t",


### PR DESCRIPTION
## Summary
- **Migration 013**: `ob_session_events` table — append-only event stream for session lanes
- **`append_session_event` tool**: Write facts, decisions, blockers, artifacts, receipts, corrections, and more to a lane
- **`session_context` tool**: Load lane state + recent events by session_key or channel_id, with type/importance filters
- 36 tests, full auth coverage, embedding resilience

## Event Types
`fact`, `decision`, `blocker`, `action`, `artifact`, `receipt`, `question`, `correction`, `handoff`

## Importance Levels
`hot`, `warm` (default), `cold`

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] 437 tests pass (36 new)
- [x] Auth gates verified (admin/agent/n8n allowed, discord/readonly/no-auth denied for writes, readonly allowed for reads)
- [x] Embedding failure is non-fatal
- [x] Lane-not-found returns clean error

Closes #35, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)