### PR TITLE
feat: entity graph tools, qmd timeout fix, OB memory contract (#39, #40)

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -1,0 +1,72 @@
+# Open Brain Operational Memory Contract
+
+## What Open Brain Is
+
+Open Brain is the **durable operational memory** for PAI agents. It stores:
+- **Session lanes**: persistent threads of work tied to agent + platform + context
+- **Session events**: append-only facts, decisions, blockers, artifacts during active work
+- **Sessions**: checkpointed summaries of completed work phases
+- **Thoughts**: learnings, observations, insights
+- **Decisions**: choices made with rationale
+- **Relationships**: people and contacts
+- **Projects**: project metadata
+- **Entities & Links**: explicit knowledge graph adjacency
+
+## What Open Brain Is NOT
+
+- **Not a behavior layer.** Rules, routing, and personality live in CLAUDE.md / skill files.
+- **Not raw recall.** Session transcripts and logs are separate from OB entries.
+- **Not Honcho.** OB is the authoritative source for operational state. Honcho/session vibes are not canonical.
+
+## Memory Tiers
+
+| Tier | Meaning | Access Pattern |
+|------|---------|---------------|
+| **Hot** | Front of mind — actively used | Direct lane/event lookup |
+| **Warm** | Accessible — searchable, not preloaded | Semantic search via search_brain |
+| **Cold** | Deep storage — rarely accessed | Explicit query with tier filter |
+
+## Agent Workflow
+
+### Starting Work
+1. Call `session_start` with your session_key → get lane + recent events
+2. Lane persists across compactions. Wrap is a checkpoint, not an ending.
+
+### During Work
+1. Log events via `append_session_event` (facts, decisions, blockers, artifacts)
+2. Update lane context via `lane_upsert` when the working state changes
+3. Link related entities via `link_entities`
+
+### At Compaction
+1. Call `session_context` to gather current state
+2. Distill summary locally via LLM
+3. Call `session_wrap` to checkpoint the summary to durable storage
+4. Context compacts. Lane persists.
+
+### Resuming After Compaction
+1. Call `session_start` → lane + events are immediately available
+2. Search OB for related past work if needed
+
+## Namespace Convention
+
+- Namespace defaults to `auth.clientId` (agent identity)
+- Cross-namespace access is allowed for coordination (not a security boundary)
+- `collab` namespace for shared/cross-agent knowledge
+
+## Tool Reference
+
+| Tool | Purpose | Auth |
+|------|---------|------|
+| session_start | Find/create lane, return context | write |
+| session_context | Read lane + events | read |
+| session_wrap | Checkpoint summary to durable storage | write |
+| append_session_event | Log event to lane | write |
+| lane_upsert | Update lane metadata/context | write |
+| lane_load | Query lanes by filters | read |
+| upsert_entity | Create/update graph entity | write |
+| link_entities | Create relationship between entries | write |
+| adjacent_context | Traverse link graph from a node | read |
+| search_brain | Semantic search across all tables | read |
+| search_all | Federated search (OB + qmd) | read |
+| log_thought | Record a learning/insight | write |
+| log_decision | Record a decision with rationale | write |

--- a/src/tools/__tests__/adjacent-context.test.ts
+++ b/src/tools/__tests__/adjacent-context.test.ts
@@ -1,0 +1,499 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerAdjacentContext } from "../adjacent-context.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerAdjacentContext(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const SOURCE_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const LINKED_ID_1 = "11111111-2222-4333-9444-555555555555";
+const LINKED_ID_2 = "66666666-7777-4888-9999-aaaaaaaaaaaa";
+
+const MOCK_OUTGOING_LINKS = [
+  {
+    id: "link-1",
+    from_type: "entity",
+    from_id: SOURCE_ID,
+    to_type: "thought",
+    to_id: LINKED_ID_1,
+    relation: "mentions",
+    weight: 2.0,
+    metadata: {},
+    created_at: "2026-06-08T10:00:00Z",
+  },
+  {
+    id: "link-2",
+    from_type: "entity",
+    from_id: SOURCE_ID,
+    to_type: "decision",
+    to_id: LINKED_ID_2,
+    relation: "decided_by",
+    weight: 1.0,
+    metadata: { context: "review" },
+    created_at: "2026-06-08T09:00:00Z",
+  },
+];
+
+const MOCK_INCOMING_LINKS = [
+  {
+    id: "link-3",
+    from_type: "session",
+    from_id: LINKED_ID_1,
+    to_type: "entity",
+    to_id: SOURCE_ID,
+    relation: "artifact",
+    weight: 1.5,
+    metadata: {},
+    created_at: "2026-06-08T08:00:00Z",
+  },
+];
+
+describe("adjacent_context", () => {
+  // ── AUTH PATHS ──
+
+  it("denies read when auth is missing entirely", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: mockPool as any,
+      embedFn: createMockEmbed(),
+    };
+    registerAdjacentContext(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies read for discord role", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = { role: "discord", clientId: "random-user" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows readonly role (read tool)", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── OUTGOING LINKS ──
+
+  it("returns outgoing links", async () => {
+    let capturedSql = "";
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        capturedSql = sql;
+        return { rows: MOCK_OUTGOING_LINKS };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+          direction: "outgoing",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.count).toBe(2);
+      expect(parsed.links[0].direction).toBe("outgoing");
+      expect(parsed.links[0].linked_type).toBe("thought");
+      expect(parsed.links[0].linked_id).toBe(LINKED_ID_1);
+      expect(parsed.links[0].relation).toBe("mentions");
+      expect(parsed.links[1].linked_type).toBe("decision");
+
+      // SQL should have from_type/from_id only
+      expect(capturedSql).toContain("from_type = $1 AND from_id = $2");
+      expect(capturedSql).not.toContain("to_type = $1");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── INCOMING LINKS ──
+
+  it("returns incoming links", async () => {
+    let capturedSql = "";
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        capturedSql = sql;
+        return { rows: MOCK_INCOMING_LINKS };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+          direction: "incoming",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.count).toBe(1);
+      expect(parsed.links[0].direction).toBe("incoming");
+      expect(parsed.links[0].linked_type).toBe("session");
+      expect(parsed.links[0].linked_id).toBe(LINKED_ID_1);
+      expect(parsed.links[0].relation).toBe("artifact");
+
+      // SQL should have to_type/to_id only
+      expect(capturedSql).toContain("to_type = $1 AND to_id = $2");
+      expect(capturedSql).not.toContain("from_type = $1 AND from_id = $2");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── BOTH DIRECTIONS ──
+
+  it("returns both directions (default)", async () => {
+    let capturedSql = "";
+    const allLinks = [...MOCK_OUTGOING_LINKS, ...MOCK_INCOMING_LINKS];
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        capturedSql = sql;
+        return { rows: allLinks };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.count).toBe(3);
+
+      // Should have both outgoing and incoming
+      const directions = parsed.links.map((l: any) => l.direction);
+      expect(directions).toContain("outgoing");
+      expect(directions).toContain("incoming");
+
+      // SQL should have OR clause
+      expect(capturedSql).toContain("from_type = $1 AND from_id = $2");
+      expect(capturedSql).toContain("OR");
+      expect(capturedSql).toContain("to_type = $1 AND to_id = $2");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── RELATION FILTER ──
+
+  it("filters by relation type", async () => {
+    let capturedSql = "";
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        capturedSql = sql;
+        capturedParams = params;
+        return { rows: [MOCK_OUTGOING_LINKS[0]] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+          relation: "mentions",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedSql).toContain("relation =");
+      expect(capturedParams!).toContain("mentions");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── NAMESPACE FILTER ──
+
+  it("applies namespace filter", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+          namespace: "collab",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(capturedParams!).toContain("collab");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("defaults namespace to auth.clientId", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+
+      expect(capturedParams!).toContain("nagatha");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── EMPTY RESULTS ──
+
+  it("returns empty links array when no links found", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.links).toEqual([]);
+      expect(parsed.count).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── LIMIT ──
+
+  it("respects limit parameter", async () => {
+    let capturedSql = "";
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        capturedSql = sql;
+        capturedParams = params;
+        return { rows: [MOCK_OUTGOING_LINKS[0]] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+          limit: 5,
+        },
+      });
+
+      // Limit should be the last param
+      expect(capturedParams![capturedParams!.length - 1]).toBe(5);
+      expect(capturedSql).toContain("LIMIT");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("defaults limit to 50", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+
+      expect(capturedParams![capturedParams!.length - 1]).toBe(50);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── AGENT / N8N ROLES ──
+
+  it("allows agent role", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DATABASE ERROR ──
+
+  it("returns isError=true with message when DB query throws", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection timeout");
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("connection timeout");
+      expect((result.content as any)[0].text).toContain("Database error");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/link-entities.test.ts
+++ b/src/tools/__tests__/link-entities.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerLinkEntities } from "../link-entities.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerLinkEntities(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const FROM_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const TO_ID = "11111111-2222-4333-9444-555555555555";
+
+function createLinkPool(
+  id = "link-uuid-1",
+  isNew = true,
+  relation = "depends_on",
+  weight = 1.0,
+  createdAt = "2026-06-08T10:00:00Z",
+) {
+  return {
+    query: async (_sql: string, _params?: any[]) => {
+      return {
+        rows: [{ id, is_new: isNew, relation, weight, created_at: createdAt }],
+      };
+    },
+  };
+}
+
+describe("link_entities", () => {
+  // ── AUTH PATHS ──
+
+  it("denies write when auth is missing entirely", async () => {
+    const mockPool = createLinkPool();
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: mockPool as any,
+      embedFn: createMockEmbed(),
+    };
+    registerLinkEntities(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "depends_on",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies write for discord role", async () => {
+    const mockPool = createLinkPool();
+    const auth: AuthInfo = { role: "discord", clientId: "random-user" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "depends_on",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies write for readonly role", async () => {
+    const mockPool = createLinkPool();
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "depends_on",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── HAPPY PATH ──
+
+  it("admin can create link (is_new: true)", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "link-uuid-1",
+              is_new: true,
+              relation: "depends_on",
+              weight: 1.0,
+              created_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "thought",
+          from_id: FROM_ID,
+          to_type: "decision",
+          to_id: TO_ID,
+          relation: "depends_on",
+          namespace: "collab",
+          weight: 2.5,
+          metadata: { reason: "causal" },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.id).toBe("link-uuid-1");
+      expect(parsed.from_type).toBe("thought");
+      expect(parsed.from_id).toBe(FROM_ID);
+      expect(parsed.to_type).toBe("decision");
+      expect(parsed.to_id).toBe(TO_ID);
+      expect(parsed.relation).toBe("depends_on");
+      expect(parsed.is_new).toBe(true);
+
+      // Verify SQL params
+      expect(capturedParams![0]).toBe("thought"); // from_type
+      expect(capturedParams![1]).toBe(FROM_ID); // from_id
+      expect(capturedParams![2]).toBe("decision"); // to_type
+      expect(capturedParams![3]).toBe(TO_ID); // to_id
+      expect(capturedParams![4]).toBe("depends_on"); // relation
+      expect(capturedParams![5]).toBe(2.5); // weight
+      expect(capturedParams![6]).toBe("collab"); // namespace
+      expect(JSON.parse(capturedParams![7] as string)).toEqual({
+        reason: "causal",
+      }); // metadata
+      expect(capturedParams![8]).toBe("skippy"); // created_by
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── SELF-LINK PREVENTION ──
+
+  it("rejects self-link (same type and id)", async () => {
+    const mockPool = createLinkPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: FROM_ID,
+          relation: "relates_to",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain(
+        "cannot link a node to itself",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows same id with different types (not a self-link)", async () => {
+    const mockPool = createLinkPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "thought",
+          from_id: FROM_ID,
+          to_type: "decision",
+          to_id: FROM_ID,
+          relation: "caused_by",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── UPSERT EXISTING LINK ──
+
+  it("upsert existing link updates weight (is_new: false)", async () => {
+    const mockPool = createLinkPool("link-uuid-1", false, "depends_on", 5.0);
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "depends_on",
+          weight: 5.0,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.is_new).toBe(false);
+      expect(parsed.weight).toBe(5.0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── ALL 13 RELATION TYPES ──
+
+  const allRelations = [
+    "artifact",
+    "depends_on",
+    "supersedes",
+    "caused_by",
+    "same_lane",
+    "adjacent",
+    "mentions",
+    "implemented_by",
+    "blocked_by",
+    "decided_by",
+    "relates_to",
+    "contradicts",
+    "duplicates",
+  ] as const;
+
+  for (const relation of allRelations) {
+    it(`accepts relation="${relation}"`, async () => {
+      const mockPool = createLinkPool("link-uuid-1", true, relation);
+      const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "link_entities",
+          arguments: {
+            from_type: "entity",
+            from_id: FROM_ID,
+            to_type: "entity",
+            to_id: TO_ID,
+            relation,
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.relation).toBe(relation);
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  // ── NAMESPACE DEFAULTING ──
+
+  it("defaults namespace to auth.clientId when not provided", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "link-uuid-1",
+              is_new: true,
+              relation: "mentions",
+              weight: 1.0,
+              created_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "bilby-agent" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "thought",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "mentions",
+        },
+      });
+
+      expect(capturedParams![6]).toBe("bilby-agent"); // namespace
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── WEIGHT DEFAULTING ──
+
+  it("defaults weight to 1.0 when not provided", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "link-uuid-1",
+              is_new: true,
+              relation: "relates_to",
+              weight: 1.0,
+              created_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "relates_to",
+        },
+      });
+
+      expect(capturedParams![5]).toBe(1.0); // weight
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── AGENT / N8N ROLES ──
+
+  it("allows agent role", async () => {
+    const mockPool = createLinkPool();
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "adjacent",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DATABASE ERROR ──
+
+  it("returns isError=true with message when DB query throws", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection refused");
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "link_entities",
+        arguments: {
+          from_type: "entity",
+          from_id: FROM_ID,
+          to_type: "entity",
+          to_id: TO_ID,
+          relation: "depends_on",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("connection refused");
+      expect((result.content as any)[0].text).toContain("Database error");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/upsert-entity.test.ts
+++ b/src/tools/__tests__/upsert-entity.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerUpsertEntity } from "../upsert-entity.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+function createThrowingEmbed(error: Error) {
+  return async (_text: string): Promise<number[] | null> => {
+    throw error;
+  };
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+  embedFn?: (text: string) => Promise<number[] | null>,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = {
+    pool: mockPool as any,
+    embedFn: embedFn ?? createMockEmbed(),
+  };
+  registerUpsertEntity(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+function createUpsertPool(
+  id = "entity-uuid-1",
+  isNew = true,
+  entityType = "host",
+  name = "ct235",
+  namespace = "skippy",
+  createdAt = "2026-06-08T10:00:00Z",
+  updatedAt = "2026-06-08T10:00:00Z",
+) {
+  return {
+    query: async (_sql: string, _params?: any[]) => {
+      return {
+        rows: [
+          {
+            id,
+            is_new: isNew,
+            entity_type: entityType,
+            name,
+            namespace,
+            created_at: createdAt,
+            updated_at: updatedAt,
+          },
+        ],
+      };
+    },
+  };
+}
+
+describe("upsert_entity", () => {
+  // ── AUTH PATHS ──
+
+  it("denies write when auth is missing entirely", async () => {
+    const mockPool = createUpsertPool();
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: mockPool as any,
+      embedFn: createMockEmbed(),
+    };
+    registerUpsertEntity(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct235",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies write for discord role", async () => {
+    const mockPool = createUpsertPool();
+    const auth: AuthInfo = { role: "discord", clientId: "random-user" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct235",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies write for readonly role", async () => {
+    const mockPool = createUpsertPool();
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct235",
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── HAPPY PATH ──
+
+  it("admin can upsert entity (new entity, is_new: true)", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "entity-uuid-1",
+              is_new: true,
+              entity_type: "host",
+              name: "ct235",
+              namespace: "collab",
+              created_at: "2026-06-08T10:00:00Z",
+              updated_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct235",
+          namespace: "collab",
+          canonical_id: "host:ct235",
+          metadata: { ip: "10.71.20.35" },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.id).toBe("entity-uuid-1");
+      expect(parsed.entity_type).toBe("host");
+      expect(parsed.name).toBe("ct235");
+      expect(parsed.namespace).toBe("collab");
+      expect(parsed.is_new).toBe(true);
+      expect(parsed.created_at).toBe("2026-06-08T10:00:00Z");
+
+      // Verify params
+      expect(capturedParams![0]).toBe("host"); // entity_type
+      expect(capturedParams![1]).toBe("ct235"); // name
+      expect(capturedParams![2]).toBe("host:ct235"); // canonical_id
+      expect(capturedParams![3]).toBe("collab"); // namespace
+      expect(JSON.parse(capturedParams![4] as string)).toEqual({
+        ip: "10.71.20.35",
+      }); // metadata
+      expect(capturedParams![6]).toBe("skippy"); // created_by
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("upsert existing entity updates metadata (is_new: false)", async () => {
+    const mockPool = createUpsertPool(
+      "entity-uuid-1",
+      false,
+      "service",
+      "open-brain",
+      "collab",
+      "2026-06-01T10:00:00Z",
+      "2026-06-08T12:00:00Z",
+    );
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "service",
+          name: "open-brain",
+          namespace: "collab",
+          metadata: { version: "2.0" },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.is_new).toBe(false);
+      expect(parsed.updated_at).toBe("2026-06-08T12:00:00Z");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── NAMESPACE DEFAULTING ──
+
+  it("defaults namespace to auth.clientId when not provided", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "entity-uuid-1",
+              is_new: true,
+              entity_type: "workflow",
+              name: "deploy-pipeline",
+              namespace: "bilby-agent",
+              created_at: "2026-06-08T10:00:00Z",
+              updated_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "bilby-agent" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "workflow",
+          name: "deploy-pipeline",
+        },
+      });
+
+      expect(capturedParams![3]).toBe("bilby-agent"); // namespace
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── EMBEDDING PATHS ──
+
+  it("embedding failure is non-fatal — entity still inserted", async () => {
+    const mockPool = createUpsertPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(
+      mockPool,
+      auth,
+      createThrowingEmbed(new Error("LiteLLM timeout")),
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct235",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.id).toBe("entity-uuid-1");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("null embedding passed when embed returns null", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "entity-uuid-1",
+              is_new: true,
+              entity_type: "agent",
+              name: "skippy",
+              namespace: "skippy",
+              created_at: "2026-06-08T10:00:00Z",
+              updated_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(
+      mockPool,
+      auth,
+      createMockEmbed(null),
+    );
+
+    try {
+      await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "agent",
+          name: "skippy",
+        },
+      });
+
+      expect(capturedParams![5]).toBeNull(); // embedding
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── AGENT / N8N ROLES ──
+
+  it("allows agent role", async () => {
+    const mockPool = createUpsertPool();
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "project",
+          name: "test-project",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows n8n role", async () => {
+    const mockPool = createUpsertPool();
+    const auth: AuthInfo = { role: "n8n", clientId: "n8n-worker" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "workflow",
+          name: "daily-backup",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DATABASE ERROR ──
+
+  it("returns isError=true with message when DB query throws", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection refused");
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct999",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("connection refused");
+      expect((result.content as any)[0].text).toContain("Database error");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── OPTIONAL FIELDS ──
+
+  it("passes null for optional canonical_id when omitted", async () => {
+    let capturedParams: any[] | undefined;
+    const mockPool = {
+      query: async (_sql: string, params?: any[]) => {
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "entity-uuid-1",
+              is_new: true,
+              entity_type: "host",
+              name: "ct235",
+              namespace: "skippy",
+              created_at: "2026-06-08T10:00:00Z",
+              updated_at: "2026-06-08T10:00:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      await client.callTool({
+        name: "upsert_entity",
+        arguments: {
+          entity_type: "host",
+          name: "ct235",
+        },
+      });
+
+      expect(capturedParams![2]).toBeNull(); // canonical_id
+      expect(JSON.parse(capturedParams![4] as string)).toEqual({}); // metadata
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/adjacent-context.ts
+++ b/src/tools/adjacent-context.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { LINK_RELATIONS } from "./table-constants.ts";
+
+const DIRECTIONS = ["outgoing", "incoming", "both"] as const;
+
+export function registerAdjacentContext(
+  server: McpServer,
+  deps: ToolDeps,
+): void {
+  server.registerTool(
+    "adjacent_context",
+    {
+      description:
+        "Find entities and entries linked to a given node. " +
+        "Traverses the knowledge graph from a source node in one or both directions.",
+      inputSchema: {
+        type: z.string().min(1).max(200).describe("Type of the source node"),
+        id: z.string().uuid().describe("UUID of the source node"),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        relation: z
+          .enum(LINK_RELATIONS)
+          .optional()
+          .describe("Filter by relation type"),
+        direction: z
+          .enum(DIRECTIONS)
+          .optional()
+          .describe(
+            'Traversal direction: "outgoing", "incoming", or "both" (default)',
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe("Maximum links to return (default 50)"),
+      },
+      annotations: {
+        title: "Adjacent Context",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+
+      // Auth gate
+      if (!auth || !canRead(auth.role, "sessions")) {
+        logger.warn("adjacent_context_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot read link graph",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const direction = args.direction ?? "both";
+      const limit = args.limit ?? 50;
+
+      logger.debug("adjacent_context_start", {
+        type: args.type,
+        id: args.id,
+        namespace: ns,
+        direction,
+        relation: args.relation ?? null,
+        limit,
+        clientId: auth.clientId,
+      });
+
+      try {
+        // Build WHERE clause based on direction
+        const conditions: string[] = [];
+        const params: unknown[] = [args.type, args.id];
+        let paramIdx = 3;
+
+        if (direction === "outgoing") {
+          conditions.push("from_type = $1 AND from_id = $2");
+        } else if (direction === "incoming") {
+          conditions.push("to_type = $1 AND to_id = $2");
+        } else {
+          // "both"
+          conditions.push(
+            "(from_type = $1 AND from_id = $2) OR (to_type = $1 AND to_id = $2)",
+          );
+        }
+
+        // Optional namespace filter
+        const nsCondition = `namespace = $${paramIdx++}`;
+        params.push(ns);
+
+        // Optional relation filter
+        let relationCondition = "";
+        if (args.relation) {
+          relationCondition = ` AND relation = $${paramIdx++}`;
+          params.push(args.relation);
+        }
+
+        params.push(limit);
+
+        const sql = `SELECT id, from_type, from_id, to_type, to_id, relation, weight, metadata, created_at
+FROM ob_links
+WHERE (${conditions.join("")}) AND ${nsCondition}${relationCondition}
+ORDER BY weight DESC, created_at DESC
+LIMIT $${paramIdx}`;
+
+        const { rows } = await deps.pool.query(sql, params);
+
+        // Map results to include direction and linked node info relative to source
+        const links = rows.map((row: any) => {
+          const isOutgoing =
+            row.from_type === args.type && row.from_id === args.id;
+          return {
+            id: row.id,
+            direction: isOutgoing ? "outgoing" : "incoming",
+            relation: row.relation,
+            weight: row.weight,
+            linked_type: isOutgoing ? row.to_type : row.from_type,
+            linked_id: isOutgoing ? row.to_id : row.from_id,
+            metadata: row.metadata ?? {},
+            created_at: row.created_at,
+          };
+        });
+
+        const result = {
+          links,
+          count: links.length,
+        };
+
+        logger.info("adjacent_context_ok", {
+          type: args.type,
+          id: args.id,
+          namespace: ns,
+          direction,
+          count: result.count,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("adjacent_context_db_error", {
+          type: args.type,
+          id: args.id,
+          namespace: ns,
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Database error during adjacency lookup: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -30,6 +30,9 @@ import { registerAppendSessionEvent } from "./append-session-event.ts";
 import { registerSessionContext } from "./session-context.ts";
 import { registerSessionStart } from "./session-start.ts";
 import { registerSessionWrap } from "./session-wrap.ts";
+import { registerUpsertEntity } from "./upsert-entity.ts";
+import { registerLinkEntities } from "./link-entities.ts";
+import { registerAdjacentContext } from "./adjacent-context.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -66,4 +69,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerSessionContext(server, deps);
   registerSessionStart(server, deps);
   registerSessionWrap(server, deps);
+  registerUpsertEntity(server, deps);
+  registerLinkEntities(server, deps);
+  registerAdjacentContext(server, deps);
 }

--- a/src/tools/link-entities.ts
+++ b/src/tools/link-entities.ts
@@ -1,0 +1,184 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canWrite } from "../permissions.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { LINK_RELATIONS } from "./table-constants.ts";
+
+export function registerLinkEntities(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "link_entities",
+    {
+      description:
+        "Create a link between two entities or entries in the knowledge graph. " +
+        "Idempotent by namespace + from_type + from_id + to_type + to_id + relation.",
+      inputSchema: {
+        from_type: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe(
+            'Source node type, e.g. "thought", "decision", "entity", "session"',
+          ),
+        from_id: z.string().uuid().describe("Source node UUID"),
+        to_type: z.string().min(1).max(200).describe("Target node type"),
+        to_id: z.string().uuid().describe("Target node UUID"),
+        relation: z
+          .enum(LINK_RELATIONS)
+          .describe("Relationship type between the two nodes"),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        weight: z
+          .number()
+          .min(0)
+          .max(100)
+          .optional()
+          .describe("Relationship weight (default 1.0)"),
+        metadata: z
+          .record(z.string().max(100), z.unknown())
+          .optional()
+          .refine(
+            (v) =>
+              !v ||
+              (Object.keys(v).length <= 50 &&
+                JSON.stringify(v).length <= 100_000),
+            { message: "metadata: max 50 keys, max 100KB total" },
+          )
+          .describe("Arbitrary JSON metadata; max 50 keys, max 100KB total"),
+      },
+      annotations: {
+        title: "Link Entities",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+
+      // Auth gate
+      if (!auth || !canWrite(auth.role, "sessions")) {
+        logger.warn("link_entities_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot write links",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Self-link prevention (app-layer; DB CHECK also covers this)
+      if (args.from_type === args.to_type && args.from_id === args.to_id) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Invalid link: cannot link a node to itself",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const weight = args.weight ?? 1.0;
+
+      logger.debug("link_entities_start", {
+        from_type: args.from_type,
+        from_id: args.from_id,
+        to_type: args.to_type,
+        to_id: args.to_id,
+        relation: args.relation,
+        namespace: ns,
+        weight,
+        clientId: auth.clientId,
+      });
+
+      try {
+        const metadataJson = JSON.stringify(args.metadata ?? {});
+
+        const { rows } = await deps.pool.query(
+          `INSERT INTO ob_links
+             (from_type, from_id, to_type, to_id, relation, weight, namespace, metadata, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+           ON CONFLICT (namespace, from_type, from_id, to_type, to_id, relation)
+           DO UPDATE SET
+             weight = EXCLUDED.weight,
+             metadata = ob_links.metadata || EXCLUDED.metadata,
+             updated_at = NOW()
+           RETURNING id, (xmax = 0) AS is_new, relation, weight, created_at`,
+          [
+            args.from_type,
+            args.from_id,
+            args.to_type,
+            args.to_id,
+            args.relation,
+            weight,
+            ns,
+            metadataJson,
+            auth.clientId,
+          ],
+        );
+
+        const row = rows[0];
+        const result = {
+          id: row.id,
+          from_type: args.from_type,
+          from_id: args.from_id,
+          to_type: args.to_type,
+          to_id: args.to_id,
+          relation: row.relation,
+          weight: row.weight,
+          is_new: row.is_new,
+          created_at: row.created_at,
+        };
+
+        logger.info("link_entities_ok", {
+          id: result.id,
+          from_type: result.from_type,
+          to_type: result.to_type,
+          relation: result.relation,
+          is_new: result.is_new,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("link_entities_db_error", {
+          from_type: args.from_type,
+          from_id: args.from_id,
+          to_type: args.to_type,
+          to_id: args.to_id,
+          namespace: ns,
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Database error during link upsert: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -40,6 +40,8 @@ interface QmdDocument {
 
 const QMD_PATH = process.env.QMD_PATH ?? "/opt/qmd/src/qmd.ts";
 
+const QMD_TIMEOUT_MS = 10_000;
+
 async function searchQmd(
   query: string,
   limit: number,
@@ -49,18 +51,33 @@ async function searchQmd(
       ["bun", QMD_PATH, "search", query, "--json", "-n", String(limit)],
       { stdout: "pipe", stderr: "pipe" },
     );
-    const killTimeout = setTimeout(() => proc.kill(), 10_000);
 
-    const stdout = await new Response(proc.stdout).text();
-    const exitCode = await proc.exited;
-    clearTimeout(killTimeout);
+    const result = await Promise.race([
+      (async () => {
+        const stdout = await new Response(proc.stdout).text();
+        const exitCode = await proc.exited;
+        return { stdout, exitCode, timedOut: false };
+      })(),
+      new Promise<{ stdout: string; exitCode: number; timedOut: boolean }>(
+        (resolve) =>
+          setTimeout(() => {
+            proc.kill();
+            resolve({ stdout: "", exitCode: -1, timedOut: true });
+          }, QMD_TIMEOUT_MS),
+      ),
+    ]);
 
-    if (exitCode !== 0) {
-      logger.warn("qmd search failed", { exitCode });
+    if (result.timedOut) {
+      logger.warn("qmd search timed out", { timeoutMs: QMD_TIMEOUT_MS });
       return [];
     }
 
-    const docs: QmdDocument[] = JSON.parse(stdout);
+    if (result.exitCode !== 0) {
+      logger.warn("qmd search failed", { exitCode: result.exitCode });
+      return [];
+    }
+
+    const docs: QmdDocument[] = JSON.parse(result.stdout);
     if (!Array.isArray(docs)) return [];
 
     return docs.map((doc) => ({

--- a/src/tools/table-constants.ts
+++ b/src/tools/table-constants.ts
@@ -66,3 +66,24 @@ export const TABLE_ALIAS: Record<Table, string> = {
   projects: "p",
   sessions: "s",
 };
+
+/**
+ * All valid link relation types for the entity graph.
+ * Keep in sync with CHECK (relation IN (...)) in 010_entity_links.sql
+ * and LinkRelation type in ../types.ts.
+ */
+export const LINK_RELATIONS = [
+  "artifact",
+  "depends_on",
+  "supersedes",
+  "caused_by",
+  "same_lane",
+  "adjacent",
+  "mentions",
+  "implemented_by",
+  "blocked_by",
+  "decided_by",
+  "relates_to",
+  "contradicts",
+  "duplicates",
+] as const;

--- a/src/tools/upsert-entity.ts
+++ b/src/tools/upsert-entity.ts
@@ -1,0 +1,171 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toSql } from "pgvector/pg";
+import { canWrite } from "../permissions.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerUpsertEntity(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "upsert_entity",
+    {
+      description:
+        "Create or update an entity in the knowledge graph. " +
+        "Idempotent by namespace + entity_type + name (case-insensitive).",
+      inputSchema: {
+        entity_type: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe(
+            'Entity type, e.g. "host", "workflow", "service", "agent", "project"',
+          ),
+        name: z.string().min(1).max(500).describe("Entity name"),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        canonical_id: z
+          .string()
+          .max(500)
+          .optional()
+          .describe('Optional canonical identifier, e.g. "host:ct235"'),
+        metadata: z
+          .record(z.string().max(100), z.unknown())
+          .optional()
+          .refine(
+            (v) =>
+              !v ||
+              (Object.keys(v).length <= 50 &&
+                JSON.stringify(v).length <= 100_000),
+            { message: "metadata: max 50 keys, max 100KB total" },
+          )
+          .describe("Arbitrary JSON metadata; max 50 keys, max 100KB total"),
+      },
+      annotations: {
+        title: "Upsert Entity",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+
+      // Auth gate
+      if (!auth || !canWrite(auth.role, "sessions")) {
+        logger.warn("upsert_entity_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+          entity_type: args.entity_type,
+          name: args.name,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot write entities",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+
+      logger.debug("upsert_entity_start", {
+        entity_type: args.entity_type,
+        name: args.name,
+        namespace: ns,
+        clientId: auth.clientId,
+      });
+
+      try {
+        // Generate embedding (non-fatal)
+        const embeddingText = `${args.entity_type}: ${args.name}`;
+        let embedding: number[] | null = null;
+        try {
+          embedding = await deps.embedFn(embeddingText);
+        } catch (err) {
+          logger.warn("upsert_entity_embed_error", {
+            entity_type: args.entity_type,
+            name: args.name,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        const embeddingVal = embedding ? toSql(embedding) : null;
+        const metadataJson = JSON.stringify(args.metadata ?? {});
+
+        const { rows } = await deps.pool.query(
+          `INSERT INTO ob_entities
+             (entity_type, name, canonical_id, namespace, metadata, embedding, created_by)
+           VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
+           ON CONFLICT (namespace, entity_type, lower(name))
+           DO UPDATE SET
+             canonical_id = COALESCE(EXCLUDED.canonical_id, ob_entities.canonical_id),
+             metadata = ob_entities.metadata || EXCLUDED.metadata,
+             embedding = COALESCE(EXCLUDED.embedding, ob_entities.embedding),
+             updated_at = NOW()
+           RETURNING id, (xmax = 0) AS is_new, entity_type, name, namespace, created_at, updated_at`,
+          [
+            args.entity_type,
+            args.name,
+            args.canonical_id ?? null,
+            ns,
+            metadataJson,
+            embeddingVal,
+            auth.clientId,
+          ],
+        );
+
+        const row = rows[0];
+        const result = {
+          id: row.id,
+          entity_type: row.entity_type,
+          name: row.name,
+          namespace: row.namespace,
+          is_new: row.is_new,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+        };
+
+        logger.info("upsert_entity_ok", {
+          id: result.id,
+          entity_type: result.entity_type,
+          name: result.name,
+          namespace: result.namespace,
+          is_new: result.is_new,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("upsert_entity_db_error", {
+          entity_type: args.entity_type,
+          name: args.name,
+          namespace: ns,
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Database error during entity upsert: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Completes the remaining open issues for OB v2.

### Entity Graph Tools (#39)
- **`upsert_entity`**: Idempotent entity creation/update with embedding, metadata merge on conflict
- **`link_entities`**: Create/update links between any two nodes (13 relation types), self-link prevention, weight + metadata upsert
- **`adjacent_context`**: Traverse link graph from a source node — outgoing/incoming/both, relation + namespace filtering

### QMD Timeout Fix
- Replace racy `clearTimeout` pattern with `Promise.race` in `searchQmd`

### OB Operational Memory Contract (#40)
- `docs/memory-contract.md`: Defines what OB is/isn't, memory tiers (hot/warm/cold), agent workflow (start → events → checkpoint → resume), namespace conventions, full tool reference

### Shared Constants
- `LINK_RELATIONS` added to `table-constants.ts` (13 values matching `LinkRelation` type + DB CHECK)

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] 520 tests pass (50 new)
- [x] Auth gates verified on all 3 tools
- [x] Self-link prevention tested
- [x] All 13 relation types tested
- [x] Embedding failure non-fatal

Closes #39, closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)