### PR TITLE
fix: add response_format backwards compat for list_recent/list_stale

### DIFF
--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -106,6 +106,12 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
           .enum(["hot", "warm", "cold"])
           .optional()
           .describe("Optional: filter to a specific cognitive tier"),
+        response_format: z
+          .enum(["envelope", "array"])
+          .optional()
+          .describe(
+            "Response format: 'envelope' (default) returns {entries, total_count, has_more}; 'array' returns raw array for backwards compatibility",
+          ),
       },
       annotations: {
         title: "List Recent",
@@ -166,6 +172,7 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       const offset = args.offset ?? 0;
       const includeArchived = args.include_archived ?? false;
       const tier = args.tier as Tier | undefined;
+      const useArray = args.response_format === "array";
 
       // Build UNION ALL of table SELECTs
       const selects = accessibleTables.map((t) =>
@@ -200,17 +207,21 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
           ? offset + dataResult.rows.length < totalCount
           : false;
 
+      const responseBody = useArray
+        ? dataResult.rows
+        : {
+            entries: dataResult.rows,
+            total_count: totalCount,
+            offset,
+            limit,
+            has_more: hasMore,
+          };
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({
-              entries: dataResult.rows,
-              total_count: totalCount,
-              offset,
-              limit,
-              has_more: hasMore,
-            }),
+            text: JSON.stringify(responseBody),
           },
         ],
       };

--- a/src/tools/list-stale.ts
+++ b/src/tools/list-stale.ts
@@ -97,6 +97,12 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Optional: filter to a specific tier (e.g. 'hot' to find hot entries that should decay to warm)",
           ),
+        response_format: z
+          .enum(["envelope", "array"])
+          .optional()
+          .describe(
+            "Response format: 'envelope' (default) returns {entries, total_count, has_more}; 'array' returns raw array for backwards compatibility",
+          ),
       },
       annotations: {
         title: "List Stale",
@@ -155,6 +161,7 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       const limit = args.limit ?? 50;
       const offset = args.offset ?? 0;
       const tier = args.tier as Tier | undefined;
+      const useArray = args.response_format === "array";
 
       const selects = accessibleTables.map((t) => buildStaleSelect(t, tier));
       const unionSql = selects.join("\nUNION ALL\n");
@@ -184,17 +191,21 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
           ? offset + dataResult.rows.length < totalCount
           : false;
 
+      const responseBody = useArray
+        ? dataResult.rows
+        : {
+            entries: dataResult.rows,
+            total_count: totalCount,
+            offset,
+            limit,
+            has_more: hasMore,
+          };
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({
-              entries: dataResult.rows,
-              total_count: totalCount,
-              offset,
-              limit,
-              has_more: hasMore,
-            }),
+            text: JSON.stringify(responseBody),
           },
         ],
       };


### PR DESCRIPTION
## Summary
Adds `response_format` parameter to `list_recent` and `list_stale` tools.

- `"envelope"` (default): `{entries, total_count, offset, limit, has_more}`
- `"array"`: raw array, matching the old format

Existing callers (brain skill, n8n workflows) can pass `response_format: "array"` to avoid breakage, then migrate to the envelope format at their own pace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)