### PR TITLE
fix: resilient parsing for old/new OB compat + skill doc updates

### DIFF
--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -66,7 +66,9 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
     "list_recent",
     {
       description:
-        "List recent brain entries chronologically. Supports table filter, date range, tier filter, and pagination with total_count.",
+        "List recent brain entries chronologically. Returns {entries, total_count, has_more} envelope by default, " +
+        "or raw array with response_format='array'. " +
+        "Resilient parsing: const entries = Array.isArray(result) ? result : result.entries ?? [];",
       inputSchema: {
         table: z
           .enum([

--- a/src/tools/list-stale.ts
+++ b/src/tools/list-stale.ts
@@ -57,7 +57,8 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       description:
         "Find brain entries not accessed recently -- candidates for tier demotion (hot->warm->cold). " +
         "Queries by last_accessed_at (falls back to created_at for never-accessed entries). " +
-        "Returns paginated results with total_count and has_more for dream cycle automation.",
+        "Returns {entries, total_count, has_more} envelope by default, or raw array with response_format='array'. " +
+        "Resilient parsing: const entries = Array.isArray(result) ? result : result.entries ?? [];",
       inputSchema: {
         table: z
           .enum([


### PR DESCRIPTION
## Summary
Makes callers resilient to both old (array) and new (envelope) response formats.

### OB Server
- Tool descriptions for `list_recent` and `list_stale` now include the resilient parsing pattern:
  `const entries = Array.isArray(result) ? result : result.entries ?? [];`

### Brain Skill Docs (separate repo, included here for reference)
- Updated tool table with all new session/entity/lane tools
- Updated pagination docs: max 500, `has_more` envelope, resilient parsing
- Updated cognitive-tiering: `list_stale` for decay, `has_more` pagination
- Updated search-guide: corrected max limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)