### PR TITLE
chore: ignore reports/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Private development artifacts (contain infrastructure-specific details)
 .planning/
 .reports/
+reports/
 .claude/
 .env.dev


### PR DESCRIPTION
## Summary
- Add `reports/` to `.gitignore` alongside existing `.reports/` entry
- Prevents private session/briefing files from showing in public repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)