### PR TITLE
feat: explicit namespace param on core write tools

### DIFF
--- a/src/db/migrations/014_namespace_scoped_uniqueness.sql
+++ b/src/db/migrations/014_namespace_scoped_uniqueness.sql
@@ -2,8 +2,7 @@
 -- Changes content_hash and person_name uniqueness from global to per-namespace.
 -- Allows the same content to exist in different namespaces (required for promotion).
 -- Safe for existing data: all rows currently have namespace = 'collab'.
-
-BEGIN;
+-- Transaction managed by migration runner -- do not wrap in BEGIN/COMMIT.
 
 -- thoughts: content_hash unique per namespace
 DROP INDEX IF EXISTS idx_thoughts_content_hash;
@@ -37,5 +36,3 @@ CREATE UNIQUE INDEX idx_projects_content_hash ON projects (content_hash, namespa
 DROP INDEX IF EXISTS idx_sessions_content_hash;
 CREATE UNIQUE INDEX idx_sessions_content_hash ON sessions (content_hash, namespace)
   WHERE content_hash IS NOT NULL;
-
-COMMIT;

--- a/src/db/migrations/014_namespace_scoped_uniqueness.sql
+++ b/src/db/migrations/014_namespace_scoped_uniqueness.sql
@@ -1,0 +1,41 @@
+-- Migration 014: Namespace-scoped unique indexes
+-- Changes content_hash and person_name uniqueness from global to per-namespace.
+-- Allows the same content to exist in different namespaces (required for promotion).
+-- Safe for existing data: all rows currently have namespace = 'collab'.
+
+BEGIN;
+
+-- thoughts: content_hash unique per namespace
+DROP INDEX IF EXISTS idx_thoughts_content_hash;
+CREATE UNIQUE INDEX idx_thoughts_content_hash ON thoughts (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;
+
+-- decisions: content_hash unique per namespace
+DROP INDEX IF EXISTS idx_decisions_content_hash;
+CREATE UNIQUE INDEX idx_decisions_content_hash ON decisions (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;
+
+-- relationships: person_name unique per namespace
+DROP INDEX IF EXISTS idx_relationships_person;
+CREATE UNIQUE INDEX idx_relationships_person ON relationships (namespace, person_name);
+
+-- relationships: content_hash unique per namespace
+DROP INDEX IF EXISTS idx_relationships_content_hash;
+CREATE UNIQUE INDEX idx_relationships_content_hash ON relationships (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;
+
+-- projects: name unique per namespace
+DROP INDEX IF EXISTS idx_projects_name;
+CREATE UNIQUE INDEX idx_projects_name ON projects (namespace, name);
+
+-- projects: content_hash unique per namespace
+DROP INDEX IF EXISTS idx_projects_content_hash;
+CREATE UNIQUE INDEX idx_projects_content_hash ON projects (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;
+
+-- sessions: content_hash unique per namespace
+DROP INDEX IF EXISTS idx_sessions_content_hash;
+CREATE UNIQUE INDEX idx_sessions_content_hash ON sessions (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;
+
+COMMIT;

--- a/src/db/migrations/015_session_id_namespace_scoped.sql
+++ b/src/db/migrations/015_session_id_namespace_scoped.sql
@@ -1,0 +1,8 @@
+-- Migration 015: Namespace-scoped session_id uniqueness
+-- Makes session_id unique per namespace instead of globally unique.
+-- Prevents cross-namespace collisions when agents use the same session_id.
+-- Transaction managed by migration runner.
+
+DROP INDEX IF EXISTS idx_sessions_session_id;
+CREATE UNIQUE INDEX idx_sessions_session_id ON sessions (namespace, session_id)
+  WHERE session_id IS NOT NULL;

--- a/src/namespace-policy.test.ts
+++ b/src/namespace-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "bun:test";
+import { canWriteNamespace } from "./namespace-policy.ts";
+import type { AuthInfo } from "./types.ts";
+
+describe("canWriteNamespace", () => {
+  it("admin can write to any namespace", () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    expect(canWriteNamespace(auth, "rico").allowed).toBe(true);
+    expect(canWriteNamespace(auth, "collab").allowed).toBe(true);
+    expect(canWriteNamespace(auth, "bilby").allowed).toBe(true);
+    expect(canWriteNamespace(auth, "nagatha").allowed).toBe(true);
+  });
+
+  it("n8n can write to any namespace", () => {
+    const auth: AuthInfo = { role: "n8n", clientId: "n8n" };
+    expect(canWriteNamespace(auth, "collab").allowed).toBe(true);
+    expect(canWriteNamespace(auth, "bilby").allowed).toBe(true);
+  });
+
+  it("agent can write to own namespace", () => {
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    expect(canWriteNamespace(auth, "bilby").allowed).toBe(true);
+  });
+
+  it("agent can write to collab", () => {
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    expect(canWriteNamespace(auth, "collab").allowed).toBe(true);
+  });
+
+  it("agent cannot write to another agent's namespace", () => {
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const result = canWriteNamespace(auth, "nagatha");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("nagatha");
+  });
+
+  it("discord can write to own namespace", () => {
+    const auth: AuthInfo = { role: "discord", clientId: "discord-bot" };
+    expect(canWriteNamespace(auth, "discord-bot").allowed).toBe(true);
+  });
+
+  it("discord cannot write to collab", () => {
+    const auth: AuthInfo = { role: "discord", clientId: "discord-bot" };
+    const result = canWriteNamespace(auth, "collab");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("discord");
+  });
+
+  it("readonly cannot write to any namespace", () => {
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const result = canWriteNamespace(auth, "viewer");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("readonly");
+  });
+});

--- a/src/namespace-policy.ts
+++ b/src/namespace-policy.ts
@@ -1,0 +1,39 @@
+import type { AuthInfo } from "./types.ts";
+
+export interface NamespaceCheck {
+  allowed: boolean;
+  reason?: string;
+}
+
+export function canWriteNamespace(
+  auth: AuthInfo,
+  targetNamespace: string,
+): NamespaceCheck {
+  if (auth.role === "admin" || auth.role === "n8n") {
+    return { allowed: true };
+  }
+
+  if (auth.role === "readonly") {
+    return { allowed: false, reason: "readonly role cannot write" };
+  }
+
+  if (targetNamespace === auth.clientId) {
+    return { allowed: true };
+  }
+
+  if (targetNamespace === "collab" && auth.role === "agent") {
+    return { allowed: true };
+  }
+
+  if (auth.role === "discord") {
+    return {
+      allowed: false,
+      reason: `discord role can only write to own namespace (${auth.clientId})`,
+    };
+  }
+
+  return {
+    allowed: false,
+    reason: `${auth.role} role cannot write to namespace '${targetNamespace}'`,
+  };
+}

--- a/src/tools/__tests__/log-thought.test.ts
+++ b/src/tools/__tests__/log-thought.test.ts
@@ -135,6 +135,122 @@ describe("log_thought", () => {
     });
   });
 
+  describe("namespace support", () => {
+    it("defaults namespace to clientId when omitted", async () => {
+      let capturedParams: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          capturedParams = args;
+          return { rows: [{ id: "ns-uuid", is_new: true }] };
+        },
+      };
+      const mockEmbed = createMockEmbed();
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        mockEmbed,
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_thought",
+          arguments: { content: "Bilby's thought" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.namespace).toBe("bilby");
+        expect(capturedParams[1]).toContain("bilby");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("uses explicit namespace when provided", async () => {
+      let capturedParams: any[] = [];
+      const mockPool = {
+        query: async (...args: any[]) => {
+          capturedParams = args;
+          return { rows: [{ id: "collab-uuid", is_new: true }] };
+        },
+      };
+      const mockEmbed = createMockEmbed();
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        mockEmbed,
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_thought",
+          arguments: { content: "Shared thought", namespace: "collab" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.namespace).toBe("collab");
+        expect(capturedParams[1]).toContain("collab");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("denies agent writing to another agent's namespace", async () => {
+      const mockPool = createMockPool();
+      const mockEmbed = createMockEmbed();
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        mockEmbed,
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_thought",
+          arguments: { content: "Cross-write", namespace: "nagatha" },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text;
+        expect(text).toContain("Permission denied");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("allows admin to write to any namespace", async () => {
+      const mockPool = createMockPool([{ id: "admin-uuid", is_new: true }]);
+      const mockEmbed = createMockEmbed();
+      const auth: AuthInfo = { role: "admin", clientId: "rico" };
+
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        mockEmbed,
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_thought",
+          arguments: { content: "Admin write", namespace: "bilby" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.namespace).toBe("bilby");
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
   describe("permission denied", () => {
     it("returns isError: true when role cannot write thoughts", async () => {
       const mockPool = createMockPool();

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -24,8 +24,145 @@ const searchPool = (rows: any[]) => ({
   },
 });
 
+function expectNamespaceParameterized(
+  sql: unknown,
+  params: unknown,
+  namespace: string,
+): void {
+  expect(Array.isArray(params)).toBe(true);
+  const namespaceParamIndex = (params as unknown[]).indexOf(namespace) + 1;
+  expect(namespaceParamIndex).toBeGreaterThan(0);
+  expect(String(sql)).toContain(`namespace = $${namespaceParamIndex}`);
+  expect(String(sql)).not.toContain(namespace);
+}
+
 describe("search_brain", () => {
   describe("admin role -- all tables accessible", () => {
+    it("parameterizes namespace in vector SQL", async () => {
+      const maliciousNamespace = "' OR 1=1 --";
+      const queryCalls: any[] = [];
+      const pool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          const [sql] = args;
+          if (String(sql).includes("FROM ob_links")) return { rows: [] };
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "namespace injection",
+            namespace: maliciousNamespace,
+            search_mode: "vector",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const [sql, params] = queryCalls[0];
+        expectNamespaceParameterized(sql, params, maliciousNamespace);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("parameterizes namespace in keyword SQL", async () => {
+      const maliciousNamespace = "' OR 1=1 --";
+      const queryCalls: any[] = [];
+      const pool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          const [sql] = args;
+          if (String(sql).includes("FROM ob_links")) return { rows: [] };
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "namespace injection",
+            namespace: maliciousNamespace,
+            search_mode: "keyword",
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const [sql, params] = queryCalls[0];
+        expectNamespaceParameterized(sql, params, maliciousNamespace);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("parameterizes namespace in default hybrid SQL", async () => {
+      const maliciousNamespace = "' OR 1=1 --";
+      const searchCalls: any[] = [];
+      const pool = {
+        query: async (...args: any[]) => {
+          const [sql] = args;
+          if (String(sql).includes("FROM ob_links")) return { rows: [] };
+          searchCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "namespace injection",
+            namespace: maliciousNamespace,
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(searchCalls.length).toBe(2);
+        for (const [sql, params] of searchCalls) {
+          expectNamespaceParameterized(sql, params, maliciousNamespace);
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("rejects blank namespace instead of running an unscoped search", async () => {
+      const queryCalls: any[] = [];
+      const pool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "namespace injection",
+            namespace: "   ",
+            search_mode: "keyword",
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(queryCalls.length).toBe(0);
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("returns ranked results with expected shape", async () => {
       const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
       const { client, cleanup } = await setup(

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
@@ -96,6 +97,18 @@ export function registerAppendSessionEvent(
       }
 
       const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const importance = args.importance ?? "warm";
 
       logger.debug("append_session_event_start", {

--- a/src/tools/lane-upsert.ts
+++ b/src/tools/lane-upsert.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
@@ -110,6 +111,18 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
       }
 
       const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const status = args.status ?? null;
 
       logger.debug("lane_upsert_start", {

--- a/src/tools/link-entities.ts
+++ b/src/tools/link-entities.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -91,6 +92,18 @@ export function registerLinkEntities(server: McpServer, deps: ToolDeps): void {
       }
 
       const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const weight = args.weight ?? 1.0;
 
       logger.debug("link_entities_start", {

--- a/src/tools/log-decision.ts
+++ b/src/tools/log-decision.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import { backgroundExtract } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
@@ -23,6 +24,10 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
           .describe("Alternatives that were considered"),
         tags: z.array(z.string()).optional().describe("Optional tags"),
         context: z.string().optional().describe("Additional context"),
+        namespace: z
+          .string()
+          .optional()
+          .describe("Namespace to store in (defaults to caller's clientId)"),
       },
       annotations: {
         title: "Log Decision",
@@ -45,6 +50,20 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
         };
       }
 
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const parts = [args.title, args.rationale];
       if (args.context) parts.push(args.context);
       if (args.alternatives?.length) parts.push(args.alternatives.join(", "));
@@ -58,9 +77,9 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
       });
 
       const { rows } = await deps.pool.query(
-        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-         ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL
+        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+         ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
          DO UPDATE SET
            tags = (
              SELECT COALESCE(array_agg(DISTINCT tag), '{}')
@@ -76,6 +95,7 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
           args.tags ?? [],
           args.context ?? null,
           auth.clientId,
+          ns,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
@@ -102,6 +122,7 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
             type: "text" as const,
             text: JSON.stringify({
               id: entryId,
+              namespace: ns,
               embedded: !!embedding,
               merged: !isNew,
             }),

--- a/src/tools/log-decision.ts
+++ b/src/tools/log-decision.ts
@@ -26,6 +26,8 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
         context: z.string().optional().describe("Additional context"),
         namespace: z
           .string()
+          .min(1)
+          .max(500)
           .optional()
           .describe("Namespace to store in (defaults to caller's clientId)"),
       },

--- a/src/tools/log-thought.ts
+++ b/src/tools/log-thought.ts
@@ -19,6 +19,8 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
         tags: z.array(z.string()).optional().describe("Optional tags"),
         namespace: z
           .string()
+          .min(1)
+          .max(500)
           .optional()
           .describe("Namespace to store in (defaults to caller's clientId)"),
       },

--- a/src/tools/log-thought.ts
+++ b/src/tools/log-thought.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import { backgroundExtract } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
@@ -16,6 +17,10 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
       inputSchema: {
         content: z.string().min(1).describe("The thought content"),
         tags: z.array(z.string()).optional().describe("Optional tags"),
+        namespace: z
+          .string()
+          .optional()
+          .describe("Namespace to store in (defaults to caller's clientId)"),
       },
       annotations: {
         title: "Log Thought",
@@ -38,6 +43,20 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
         };
       }
 
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const hash = contentHash(args.content);
       const textToEmbed = args.tags?.length
         ? `${args.content}\n${args.tags.join(" ")}`
@@ -49,9 +68,9 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
       });
 
       const { rows } = await deps.pool.query(
-        `INSERT INTO thoughts (content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7)
-         ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL
+        `INSERT INTO thoughts (content, tags, source, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
          DO UPDATE SET
            tags = (
              SELECT COALESCE(array_agg(DISTINCT tag), '{}')
@@ -64,6 +83,7 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
           args.content,
           args.tags ?? [],
           auth.clientId,
+          ns,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
@@ -90,6 +110,7 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
             type: "text" as const,
             text: JSON.stringify({
               id: entryId,
+              namespace: ns,
               embedded: !!embedding,
               merged: !isNew,
             }),

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -109,6 +109,22 @@ function linkKey(type: string, id: string): string {
   return `${type}:${id}`;
 }
 
+function appendNamespaceParam(
+  params: unknown[],
+  namespace?: string,
+): number | undefined {
+  if (namespace === undefined) return undefined;
+  params.push(namespace);
+  return params.length;
+}
+
+function paramRef(index: number): string {
+  if (!Number.isInteger(index) || index < 1) {
+    throw new Error(`Invalid SQL parameter index: ${index}`);
+  }
+  return `$${index}`;
+}
+
 async function attachExplicitLinks(
   deps: ToolDeps,
   rows: SearchRow[],
@@ -119,8 +135,10 @@ async function attachExplicitLinks(
   const resultTypes = rows.map((row) => row.source_type);
   const resultIds = rows.map((row) => row.id);
   const params: unknown[] = [resultTypes, resultIds];
-  const namespaceFilter = namespace ? " AND namespace = $3" : "";
-  if (namespace) params.push(namespace);
+  const namespaceParamIndex = appendNamespaceParam(params, namespace);
+  const namespaceFilter = namespaceParamIndex
+    ? ` AND namespace = ${paramRef(namespaceParamIndex)}`
+    : "";
 
   try {
     const { rows: linkRows } = await deps.pool.query<LinkRow>(
@@ -191,11 +209,11 @@ async function attachExplicitLinks(
   }
 }
 
-export function buildTableCTE(
+function buildTableCTE(
   table: Table,
   perTableLimit: number,
   tier?: Tier,
-  namespace?: string,
+  namespaceParamIndex?: number,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
@@ -203,7 +221,9 @@ export function buildTableCTE(
   const preview = CONTENT_PREVIEW[table];
   const cteName = `${table}_results`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
-  const nsFilter = namespace ? ` AND ${alias}.namespace = '${namespace}'` : "";
+  const nsFilter = namespaceParamIndex
+    ? ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
+    : "";
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
     : "NULL::jsonb AS extracted_metadata";
@@ -231,7 +251,7 @@ function buildFtsCTE(
   table: Table,
   perTableLimit: number,
   tier?: Tier,
-  namespace?: string,
+  namespaceParamIndex?: number,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
@@ -239,7 +259,9 @@ function buildFtsCTE(
   const preview = CONTENT_PREVIEW[table];
   const cteName = `${table}_fts`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
-  const nsFilter = namespace ? ` AND ${alias}.namespace = '${namespace}'` : "";
+  const nsFilter = namespaceParamIndex
+    ? ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
+    : "";
 
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
@@ -275,8 +297,10 @@ async function vectorSearch(
   namespace?: string,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
+  const params = [toSql(embedding), fetchLimit, offset];
+  const namespaceParamIndex = appendNamespaceParam(params, namespace);
   const ctes = accessibleTables.map((t) =>
-    buildTableCTE(t, perTableLimit, tier, namespace),
+    buildTableCTE(t, perTableLimit, tier, namespaceParamIndex),
   );
   const cteNames = accessibleTables.map((t) => `${t}_results`);
   const unionAll = cteNames
@@ -293,11 +317,7 @@ ${unionAll}
 ORDER BY (distance * ${VECTOR_WEIGHT} + (1.0 - COALESCE(usefulness, 0.5)) * ${USEFULNESS_WEIGHT} + EXTRACT(EPOCH FROM (NOW() - created_at)) / 86400.0 * ${AGE_WEIGHT}) ASC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [
-    toSql(embedding),
-    fetchLimit,
-    offset,
-  ]);
+  const { rows } = await deps.pool.query(sql, params);
   return rows as SearchRow[];
 }
 
@@ -311,8 +331,10 @@ async function ftsSearch(
   namespace?: string,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
+  const params = [query, fetchLimit, offset];
+  const namespaceParamIndex = appendNamespaceParam(params, namespace);
   const ctes = accessibleTables.map((t) =>
-    buildFtsCTE(t, perTableLimit, tier, namespace),
+    buildFtsCTE(t, perTableLimit, tier, namespaceParamIndex),
   );
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
   const unionAll = cteNames
@@ -329,7 +351,7 @@ ${unionAll}
 ORDER BY fts_rank DESC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [query, fetchLimit, offset]);
+  const { rows } = await deps.pool.query(sql, params);
   return rows as SearchRow[];
 }
 
@@ -564,6 +586,9 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           .describe("Optional: limit search to a specific table"),
         namespace: z
           .string()
+          .trim()
+          .min(1)
+          .max(500)
           .optional()
           .describe(
             "Optional: filter results to a specific namespace (e.g. clientId or 'collab')",

--- a/src/tools/session-save.ts
+++ b/src/tools/session-save.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
@@ -35,6 +36,10 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
           .array(z.string())
           .optional()
           .describe("Key decisions made during this session"),
+        namespace: z
+          .string()
+          .optional()
+          .describe("Namespace to store in (defaults to caller's clientId)"),
       },
       annotations: {
         title: "Save Session",
@@ -51,6 +56,20 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
             {
               type: "text" as const,
               text: "Permission denied: cannot write to sessions",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
             },
           ],
           isError: true,
@@ -76,8 +95,8 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
       // If session_id provided, upsert: re-push updates the existing entry
       if (args.session_id) {
         const { rows } = await deps.pool.query(
-          `INSERT INTO sessions (session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, embedding, content_hash, embedded_at, embedding_model)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+          `INSERT INTO sessions (session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
            ON CONFLICT (session_id) WHERE session_id IS NOT NULL
            DO UPDATE SET
              summary = EXCLUDED.summary,
@@ -99,6 +118,7 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
             args.next_steps ?? [],
             args.key_decisions ?? [],
             auth.clientId,
+            ns,
             embeddingVal,
             hash,
             embeddedAt,
@@ -112,6 +132,7 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
               type: "text" as const,
               text: JSON.stringify({
                 id: rows[0].id,
+                namespace: ns,
                 session_id: args.session_id,
                 embedded: !!embedding,
                 merged: !rows[0].is_new,
@@ -123,9 +144,9 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
 
       // Legacy path: content_hash dedup (no session_id)
       const { rows } = await deps.pool.query(
-        `INSERT INTO sessions (project, summary, tags, blockers, next_steps, key_decisions, created_by, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-         ON CONFLICT (content_hash) WHERE content_hash IS NOT NULL DO NOTHING
+        `INSERT INTO sessions (project, summary, tags, blockers, next_steps, key_decisions, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+         ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL DO NOTHING
          RETURNING id`,
         [
           args.project ?? null,
@@ -135,6 +156,7 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
           args.next_steps ?? [],
           args.key_decisions ?? [],
           auth.clientId,
+          ns,
           embeddingVal,
           hash,
           embeddedAt,
@@ -159,6 +181,7 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
             type: "text" as const,
             text: JSON.stringify({
               id: rows[0].id,
+              namespace: ns,
               embedded: !!embedding,
             }),
           },

--- a/src/tools/session-save.ts
+++ b/src/tools/session-save.ts
@@ -38,6 +38,8 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
           .describe("Key decisions made during this session"),
         namespace: z
           .string()
+          .min(1)
+          .max(500)
           .optional()
           .describe("Namespace to store in (defaults to caller's clientId)"),
       },
@@ -97,7 +99,7 @@ export function registerSessionSave(server: McpServer, deps: ToolDeps): void {
         const { rows } = await deps.pool.query(
           `INSERT INTO sessions (session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-           ON CONFLICT (session_id) WHERE session_id IS NOT NULL
+           ON CONFLICT (namespace, session_id) WHERE session_id IS NOT NULL
            DO UPDATE SET
              summary = EXCLUDED.summary,
              tags = EXCLUDED.tags,

--- a/src/tools/session-start.ts
+++ b/src/tools/session-start.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -85,6 +86,18 @@ export function registerSessionStart(server: McpServer, deps: ToolDeps): void {
       }
 
       const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
 
       logger.debug("session_start_begin", {
         session_key: args.session_key,

--- a/src/tools/session-wrap.ts
+++ b/src/tools/session-wrap.ts
@@ -156,7 +156,7 @@ WHERE namespace = $1 AND session_key = $2`,
           `INSERT INTO sessions
   (summary, key_decisions, next_steps, project, namespace, embedding, content_hash, embedded_at, embedding_model, created_by)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-ON CONFLICT (content_hash) DO NOTHING
+ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL DO NOTHING
 RETURNING id, created_at`,
           [
             args.summary,

--- a/src/tools/session-wrap.ts
+++ b/src/tools/session-wrap.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
@@ -75,6 +76,18 @@ export function registerSessionWrap(server: McpServer, deps: ToolDeps): void {
       }
 
       const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
 
       logger.debug("session_wrap_begin", {
         session_key: args.session_key,

--- a/src/tools/upsert-entity.ts
+++ b/src/tools/upsert-entity.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -74,6 +75,18 @@ export function registerUpsertEntity(server: McpServer, deps: ToolDeps): void {
       }
 
       const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
 
       logger.debug("upsert_entity_start", {
         entity_type: args.entity_type,

--- a/src/tools/upsert-person.ts
+++ b/src/tools/upsert-person.ts
@@ -58,6 +58,8 @@ export function registerUpsertPerson(server: McpServer, deps: ToolDeps): void {
           ),
         namespace: z
           .string()
+          .min(1)
+          .max(500)
           .optional()
           .describe("Namespace to store in (defaults to caller's clientId)"),
       },

--- a/src/tools/upsert-person.ts
+++ b/src/tools/upsert-person.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
@@ -55,6 +56,10 @@ export function registerUpsertPerson(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Additional structured data (e.g. apple_id, imessage, social handles)",
           ),
+        namespace: z
+          .string()
+          .optional()
+          .describe("Namespace to store in (defaults to caller's clientId)"),
       },
       annotations: {
         title: "Upsert Person",
@@ -77,6 +82,20 @@ export function registerUpsertPerson(server: McpServer, deps: ToolDeps): void {
         };
       }
 
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       // Build embeddable text: name + context + notes
       const embeddableText = [args.name, args.context ?? "", args.notes ?? ""]
         .filter(Boolean)
@@ -93,13 +112,13 @@ export function registerUpsertPerson(server: McpServer, deps: ToolDeps): void {
         `INSERT INTO relationships (
           person_name, context, relationship_type, warmth, last_contact,
           email, phone, notes, tags, metadata,
-          created_by, embedding, content_hash, embedded_at, embedding_model
+          created_by, namespace, embedding, content_hash, embedded_at, embedding_model
         ) VALUES (
           $1, $2, $3, $4, $5::date,
           $6, $7, $8, COALESCE($9::text[], '{}'), COALESCE($10::jsonb, '{}'),
-          $11, $12, $13, $14, $15
+          $11, $12, $13, $14, $15, $16
         )
-        ON CONFLICT (person_name) DO UPDATE SET
+        ON CONFLICT (namespace, person_name) DO UPDATE SET
           context = COALESCE(EXCLUDED.context, relationships.context),
           relationship_type = COALESCE(EXCLUDED.relationship_type, relationships.relationship_type),
           warmth = COALESCE(EXCLUDED.warmth, relationships.warmth),
@@ -126,6 +145,7 @@ export function registerUpsertPerson(server: McpServer, deps: ToolDeps): void {
           args.tags ?? null,
           args.metadata ? JSON.stringify(args.metadata) : null,
           auth.clientId,
+          ns,
           embedding ? toSql(embedding) : null,
           hash,
           embedding ? new Date().toISOString() : null,
@@ -149,6 +169,7 @@ export function registerUpsertPerson(server: McpServer, deps: ToolDeps): void {
             text: JSON.stringify({
               id: row.id,
               person_name: args.name,
+              namespace: ns,
               action,
               embedded: !!embedding,
             }),


### PR DESCRIPTION
Closes #54

## Summary
- New `namespace-policy.ts` module — `canWriteNamespace(auth, ns)` enforcing: admin/n8n → any namespace, agent → own + collab, discord → own only
- Added `namespace` param to `log_thought`, `log_decision`, `upsert_person`, `session_save` — defaults to `auth.clientId` when omitted
- Added namespace policy enforcement to `session_start`, `session_wrap`, `lane_upsert`, `upsert_entity`, `append_session_event` (had namespace param but no policy check)
- Migration 014: namespace-scoped unique indexes (content_hash, person_name) — allows same content in different namespaces for promotion
- Response JSON now includes `namespace` field

## Test plan
- [x] 528 tests pass, 0 fail
- [x] Typecheck clean
- [x] New namespace policy tests (8 cases covering all roles)
- [x] New log_thought namespace tests (4 cases: default, explicit, cross-namespace deny, admin override)
- [ ] Smoke test: Bilby `log_thought` with `namespace=bilby`, search confirms isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)