### PR TITLE
feat: Dreamer promotion primitives

### DIFF
--- a/src/db/migrations/016_promotion_provenance.sql
+++ b/src/db/migrations/016_promotion_provenance.sql
@@ -1,0 +1,17 @@
+-- Migration 016: Promotion provenance tracking
+-- Adds promoted_from JSONB column to all core tables for tracking
+-- when entries are promoted from agent namespaces to collab.
+-- Schema: {source_namespace, source_id, source_agent, promotion_reason, promoted_at, promoted_by}
+-- Transaction managed by migration runner.
+
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS promoted_from JSONB;
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS promoted_from JSONB;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS promoted_from JSONB;
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS promoted_from JSONB;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS promoted_from JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_thoughts_promoted ON thoughts ((promoted_from IS NOT NULL)) WHERE promoted_from IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_decisions_promoted ON decisions ((promoted_from IS NOT NULL)) WHERE promoted_from IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_relationships_promoted ON relationships ((promoted_from IS NOT NULL)) WHERE promoted_from IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_projects_promoted ON projects ((promoted_from IS NOT NULL)) WHERE promoted_from IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_promoted ON sessions ((promoted_from IS NOT NULL)) WHERE promoted_from IS NOT NULL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { generateEmbedding } from "./embedding.ts";
 import { runMigrations } from "./db/migrate.ts";
 import { logger } from "./logger.ts";
 import { requestLogger } from "./middleware/request-logger.ts";
+import { createRestRouter } from "./rest-api.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 
 const LITELLM_URL = process.env.LITELLM_URL;
@@ -61,12 +62,17 @@ export function createApp(
     res.status(status.status === "healthy" ? 200 : 503).json(status);
   });
 
-  // Auth middleware for MCP routes only
+  // Auth middleware
   const auth = authMiddleware(tokenMap);
+
+  // Shared deps for both MCP tools and REST API
+  const toolDeps = { pool, embedFn: generateEmbedding };
+
+  // REST API -- no MCP handshake required
+  app.use("/api/v1", auth, createRestRouter(toolDeps));
 
   // MCP server factory -- creates a fresh server per session to avoid
   // "Already connected to a transport" errors with concurrent clients
-  const toolDeps = { pool, embedFn: generateEmbedding };
   const serverFactory = () => {
     const s = createBrainServer();
     registerAllTools(s, toolDeps);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { runMigrations } from "./db/migrate.ts";
 import { logger } from "./logger.ts";
 import { requestLogger } from "./middleware/request-logger.ts";
 import { createRestRouter } from "./rest-api.ts";
+import { createPromotionRouter } from "./rest-promotion.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 
 const LITELLM_URL = process.env.LITELLM_URL;
@@ -70,6 +71,7 @@ export function createApp(
 
   // REST API -- no MCP handshake required
   app.use("/api/v1", auth, createRestRouter(toolDeps));
+  app.use("/api/v1", auth, createPromotionRouter(toolDeps));
 
   // MCP server factory -- creates a fresh server per session to avoid
   // "Already connected to a transport" errors with concurrent clients

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,27 @@ export function createApp(
 
   // REST API -- no MCP handshake required
   app.use("/api/v1", auth, createRestRouter(toolDeps));
+  app.use(
+    "/api/v1",
+    (err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+      const pgCode =
+        typeof err === "object" && err !== null && "code" in err
+          ? String((err as { code?: unknown }).code)
+          : undefined;
+      const statusCode =
+        typeof err === "object" && err !== null && "statusCode" in err
+          ? Number((err as { statusCode?: unknown }).statusCode)
+          : undefined;
+      const status = statusCode && statusCode >= 400 ? statusCode : pgCode === "23505" ? 409 : 500;
+      logger.error("REST API error", {
+        error: err instanceof Error ? err.message : String(err),
+        code: pgCode,
+      });
+      res.status(status).json({
+        error: status === 500 ? "Internal error" : err instanceof Error ? err.message : "Request failed",
+      });
+    },
+  );
 
   // MCP server factory -- creates a fresh server per session to avoid
   // "Already connected to a transport" errors with concurrent clients

--- a/src/read-policy.ts
+++ b/src/read-policy.ts
@@ -1,0 +1,23 @@
+import type { AuthInfo } from "./types.ts";
+
+export function readableNamespaces(auth: AuthInfo): string[] | undefined {
+  if (auth.role === "admin" || auth.role === "n8n") {
+    return undefined;
+  }
+  return [auth.clientId, "collab"];
+}
+
+export function canReadNamespace(auth: AuthInfo, namespace: string): boolean {
+  const allowed = readableNamespaces(auth);
+  return !allowed || allowed.includes(namespace);
+}
+
+export function namespaceFilterFor(
+  auth: AuthInfo,
+  namespace?: string,
+): string | string[] | undefined {
+  if (namespace !== undefined) {
+    return namespace;
+  }
+  return readableNamespaces(auth);
+}

--- a/src/rest-api.test.ts
+++ b/src/rest-api.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "bun:test";
+import express from "express";
+import type { Request, Response, NextFunction } from "express";
+import { createRestRouter } from "./rest-api.ts";
+import type { AuthInfo } from "./types.ts";
+
+function createMockPool(rows: Record<string, unknown>[] = [{ id: "test-uuid" }]) {
+  return {
+    query: async () => ({ rows }),
+  };
+}
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+function buildApp(
+  auth: AuthInfo,
+  pool?: ReturnType<typeof createMockPool>,
+  embed?: ReturnType<typeof createMockEmbed>,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    (req as any).auth = auth;
+    next();
+  });
+  const deps = {
+    pool: (pool ?? createMockPool()) as any,
+    embedFn: embed ?? createMockEmbed(),
+  };
+  app.use("/api/v1", createRestRouter(deps));
+  return app;
+}
+
+async function req(
+  app: express.Express,
+  method: "get" | "post",
+  path: string,
+  body?: unknown,
+) {
+  const opts: RequestInit = { method: method.toUpperCase() };
+  if (body) {
+    opts.headers = { "Content-Type": "application/json" };
+    opts.body = JSON.stringify(body);
+  }
+
+  let server: ReturnType<typeof app.listen>;
+  const port = 19000 + Math.floor(Math.random() * 1000);
+
+  return new Promise<{ status: number; json: any }>((resolve, reject) => {
+    server = app.listen(port, async () => {
+      try {
+        const resp = await fetch(`http://localhost:${port}${path}`, opts);
+        const json = await resp.json();
+        resolve({ status: resp.status, json });
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
+describe("REST API", () => {
+  describe("POST /api/v1/thoughts", () => {
+    it("creates a thought and returns 201", async () => {
+      const pool = createMockPool([{ id: "t-uuid", is_new: true }]);
+      const app = buildApp({ role: "agent", clientId: "bilby" }, pool);
+
+      const { status, json } = await req(app, "post", "/api/v1/thoughts", {
+        content: "A test thought",
+        tags: ["test"],
+      });
+
+      expect(status).toBe(201);
+      expect(json.id).toBe("t-uuid");
+      expect(json.namespace).toBe("bilby");
+      expect(json.embedded).toBe(true);
+    });
+
+    it("returns 400 when content is missing", async () => {
+      const app = buildApp({ role: "agent", clientId: "bilby" });
+      const { status, json } = await req(app, "post", "/api/v1/thoughts", {});
+
+      expect(status).toBe(400);
+      expect(json.error).toContain("content");
+    });
+
+    it("returns 403 for cross-namespace write", async () => {
+      const app = buildApp({ role: "agent", clientId: "bilby" });
+      const { status, json } = await req(app, "post", "/api/v1/thoughts", {
+        content: "cross write",
+        namespace: "nagatha",
+      });
+
+      expect(status).toBe(403);
+      expect(json.error).toContain("Permission denied");
+    });
+
+    it("allows admin to write to any namespace", async () => {
+      const pool = createMockPool([{ id: "admin-uuid", is_new: true }]);
+      const app = buildApp({ role: "admin", clientId: "rico" }, pool);
+
+      const { status, json } = await req(app, "post", "/api/v1/thoughts", {
+        content: "admin thought",
+        namespace: "bilby",
+      });
+
+      expect(status).toBe(201);
+      expect(json.namespace).toBe("bilby");
+    });
+  });
+
+  describe("POST /api/v1/decisions", () => {
+    it("creates a decision and returns 201", async () => {
+      const pool = createMockPool([{ id: "d-uuid", is_new: true }]);
+      const app = buildApp({ role: "agent", clientId: "bilby" }, pool);
+
+      const { status, json } = await req(app, "post", "/api/v1/decisions", {
+        title: "Use REST",
+        rationale: "Simpler for Python clients",
+      });
+
+      expect(status).toBe(201);
+      expect(json.id).toBe("d-uuid");
+      expect(json.namespace).toBe("bilby");
+    });
+
+    it("returns 400 when title/rationale missing", async () => {
+      const app = buildApp({ role: "agent", clientId: "bilby" });
+      const { status } = await req(app, "post", "/api/v1/decisions", {
+        title: "Missing rationale",
+      });
+
+      expect(status).toBe(400);
+    });
+  });
+
+  describe("POST /api/v1/persons", () => {
+    it("creates a person and returns 201", async () => {
+      const pool = createMockPool([{ id: "p-uuid", inserted: true }]);
+      const app = buildApp({ role: "agent", clientId: "bilby" }, pool);
+
+      const { status, json } = await req(app, "post", "/api/v1/persons", {
+        name: "Rico",
+        context: "Owner",
+      });
+
+      expect(status).toBe(201);
+      expect(json.person_name).toBe("Rico");
+      expect(json.action).toBe("created");
+    });
+  });
+
+  describe("POST /api/v1/sessions", () => {
+    it("creates a session and returns 201", async () => {
+      const pool = createMockPool([{ id: "s-uuid" }]);
+      const app = buildApp({ role: "agent", clientId: "bilby" }, pool);
+
+      const { status, json } = await req(app, "post", "/api/v1/sessions", {
+        summary: "Worked on namespace writes",
+        project: "open-brain",
+      });
+
+      expect(status).toBe(201);
+      expect(json.id).toBe("s-uuid");
+      expect(json.namespace).toBe("bilby");
+    });
+  });
+
+  describe("GET /api/v1/entries/:table/:id", () => {
+    it("returns entry by table and id", async () => {
+      const pool = createMockPool([
+        { id: "e-uuid", content: "test thought", namespace: "bilby" },
+      ]);
+      const app = buildApp({ role: "admin", clientId: "rico" }, pool);
+
+      const { status, json } = await req(
+        app,
+        "get",
+        "/api/v1/entries/thoughts/e-uuid",
+      );
+
+      expect(status).toBe(200);
+      expect(json.id).toBe("e-uuid");
+      expect(json.content).toBe("test thought");
+    });
+
+    it("returns 404 when entry not found", async () => {
+      const pool = createMockPool([]);
+      const app = buildApp({ role: "admin", clientId: "rico" }, pool);
+
+      const { status } = await req(
+        app,
+        "get",
+        "/api/v1/entries/thoughts/00000000-0000-0000-0000-000000000000",
+      );
+
+      expect(status).toBe(404);
+    });
+
+    it("returns 400 for invalid table", async () => {
+      const app = buildApp({ role: "admin", clientId: "rico" });
+      const { status } = await req(
+        app,
+        "get",
+        "/api/v1/entries/invalid/some-id",
+      );
+
+      expect(status).toBe(400);
+    });
+  });
+
+  describe("GET /api/v1/namespaces", () => {
+    it("returns namespace breakdown", async () => {
+      const pool = {
+        query: async () => ({
+          rows: [
+            { table_name: "thoughts", namespace: "bilby", count: "5" },
+            { table_name: "thoughts", namespace: "collab", count: "10" },
+          ],
+        }),
+      };
+      const app = buildApp({ role: "admin", clientId: "rico" }, pool as any);
+
+      const { status, json } = await req(app, "get", "/api/v1/namespaces");
+
+      expect(status).toBe(200);
+      expect(json.namespace_count).toBeGreaterThan(0);
+      expect(json.namespaces[0].namespace).toBe("collab");
+    });
+  });
+
+  describe("auth enforcement", () => {
+    it("returns 403 for readonly role writing thoughts", async () => {
+      const app = buildApp({ role: "readonly", clientId: "viewer" });
+      const { status } = await req(app, "post", "/api/v1/thoughts", {
+        content: "should fail",
+      });
+
+      expect(status).toBe(403);
+    });
+  });
+});

--- a/src/rest-api.test.ts
+++ b/src/rest-api.test.ts
@@ -10,6 +10,17 @@ function createMockPool(rows: Record<string, unknown>[] = [{ id: "test-uuid" }])
   };
 }
 
+function createRecordingPool(rows: Record<string, unknown>[] = [{ id: "test-uuid" }]) {
+  const calls: { sql: string; params?: unknown[] }[] = [];
+  return {
+    calls,
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params });
+      return { rows };
+    },
+  };
+}
+
 function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
   return async (_text: string) => result;
 }
@@ -85,7 +96,18 @@ describe("REST API", () => {
       const { status, json } = await req(app, "post", "/api/v1/thoughts", {});
 
       expect(status).toBe(400);
-      expect(json.error).toContain("content");
+      expect(json.error).toBe("Invalid request");
+    });
+
+    it("returns 400 when tags is not an array", async () => {
+      const app = buildApp({ role: "agent", clientId: "bilby" });
+      const { status, json } = await req(app, "post", "/api/v1/thoughts", {
+        content: "A test thought",
+        tags: "test",
+      });
+
+      expect(status).toBe(400);
+      expect(json.error).toBe("Invalid request");
     });
 
     it("returns 403 for cross-namespace write", async () => {
@@ -173,19 +195,51 @@ describe("REST API", () => {
   describe("GET /api/v1/entries/:table/:id", () => {
     it("returns entry by table and id", async () => {
       const pool = createMockPool([
-        { id: "e-uuid", content: "test thought", namespace: "bilby" },
+        {
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          content: "test thought",
+          namespace: "bilby",
+          promoted_from: { source_id: "source-uuid" },
+        },
       ]);
       const app = buildApp({ role: "admin", clientId: "rico" }, pool);
 
       const { status, json } = await req(
         app,
         "get",
-        "/api/v1/entries/thoughts/e-uuid",
+        "/api/v1/entries/thoughts/123e4567-e89b-12d3-a456-426614174000",
       );
 
       expect(status).toBe(200);
-      expect(json.id).toBe("e-uuid");
+      expect(json.id).toBe("123e4567-e89b-12d3-a456-426614174000");
       expect(json.content).toBe("test thought");
+      expect(json.promoted_from).toEqual({ source_id: "source-uuid" });
+    });
+
+    it("adds namespace predicate for non-admin entry reads", async () => {
+      const pool = createRecordingPool([
+        {
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          content: "test thought",
+          namespace: "collab",
+        },
+      ]);
+      const app = buildApp({ role: "agent", clientId: "bilby" }, pool as any);
+
+      const { status } = await req(
+        app,
+        "get",
+        "/api/v1/entries/thoughts/123e4567-e89b-12d3-a456-426614174000",
+      );
+
+      expect(status).toBe(200);
+      const call = pool.calls[0];
+      expect(call).toBeDefined();
+      expect(call!.sql).toContain("namespace = ANY");
+      expect(call!.params).toEqual([
+        "123e4567-e89b-12d3-a456-426614174000",
+        ["bilby", "collab"],
+      ]);
     });
 
     it("returns 404 when entry not found", async () => {
@@ -210,6 +264,39 @@ describe("REST API", () => {
       );
 
       expect(status).toBe(400);
+    });
+
+    it("returns 400 for invalid id", async () => {
+      const app = buildApp({ role: "admin", clientId: "rico" });
+      const { status } = await req(
+        app,
+        "get",
+        "/api/v1/entries/thoughts/not-a-uuid",
+      );
+
+      expect(status).toBe(400);
+    });
+  });
+
+  describe("GET /api/v1/search", () => {
+    it("denies unauthorized namespace filter", async () => {
+      const app = buildApp({ role: "agent", clientId: "bilby" });
+      const { status, json } = await req(
+        app,
+        "get",
+        "/api/v1/search?q=test&namespace=nagatha",
+      );
+
+      expect(status).toBe(403);
+      expect(json.error).toContain("namespace read access");
+    });
+
+    it("returns 400 for invalid limit", async () => {
+      const app = buildApp({ role: "agent", clientId: "bilby" });
+      const { status, json } = await req(app, "get", "/api/v1/search?q=test&limit=0");
+
+      expect(status).toBe(400);
+      expect(json.error).toBe("Invalid query");
     });
   });
 

--- a/src/rest-api.ts
+++ b/src/rest-api.ts
@@ -1,0 +1,514 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { toSql } from "pgvector/pg";
+import type pg from "pg";
+import { canWrite, canRead } from "./permissions.ts";
+import { canWriteNamespace } from "./namespace-policy.ts";
+import { contentHash, EMBEDDING_MODEL } from "./embedding.ts";
+import { backgroundExtract } from "./extraction.ts";
+import { executeSearch } from "./tools/search-brain.ts";
+import { ALL_TABLES } from "./tools/table-constants.ts";
+import type { AuthInfo, Table, Tier } from "./types.ts";
+import type { generateEmbedding } from "./embedding.ts";
+
+interface RestDeps {
+  pool: pg.Pool;
+  embedFn: typeof generateEmbedding;
+}
+
+function getAuth(req: Request): AuthInfo | null {
+  return (req as any).auth ?? null;
+}
+
+function nsError(reason: string | undefined): { error: string } {
+  return { error: `Permission denied: ${reason ?? "namespace access denied"}` };
+}
+
+export function createRestRouter(deps: RestDeps): Router {
+  const router = Router();
+
+  // POST /api/v1/thoughts
+  router.post("/thoughts", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || !canWrite(auth.role, "thoughts")) {
+      res.status(403).json({ error: "Permission denied" });
+      return;
+    }
+
+    const { content, tags, namespace } = req.body;
+    if (!content || typeof content !== "string" || content.trim().length === 0) {
+      res.status(400).json({ error: "content is required" });
+      return;
+    }
+
+    const ns = namespace ?? auth.clientId;
+    const nsCheck = canWriteNamespace(auth, ns);
+    if (!nsCheck.allowed) {
+      res.status(403).json(nsError(nsCheck.reason));
+      return;
+    }
+
+    const hash = contentHash(content);
+    const textToEmbed = tags?.length
+      ? `${content}\n${tags.join(" ")}`
+      : content;
+    const embedding = await deps.embedFn(textToEmbed);
+
+    const { rows } = await deps.pool.query(
+      `INSERT INTO thoughts (content, tags, source, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+       VALUES ($1, $2, 'rest', $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
+       DO UPDATE SET
+         tags = (
+           SELECT COALESCE(array_agg(DISTINCT tag), '{}')
+           FROM unnest(thoughts.tags || EXCLUDED.tags) AS tag
+           WHERE tag IS NOT NULL
+         ),
+         updated_at = NOW()
+       RETURNING id, (xmax = 0) AS is_new`,
+      [
+        content,
+        tags ?? [],
+        auth.clientId,
+        ns,
+        embedding ? toSql(embedding) : null,
+        hash,
+        embedding ? new Date().toISOString() : null,
+        embedding ? EMBEDDING_MODEL : null,
+      ],
+    );
+
+    const entryId = rows[0].id as string;
+    const isNew = rows[0].is_new as boolean;
+
+    if (isNew) {
+      backgroundExtract(deps.pool, "thoughts", entryId, content, tags ?? []);
+    }
+
+    res
+      .status(isNew ? 201 : 200)
+      .json({ id: entryId, namespace: ns, embedded: !!embedding, merged: !isNew });
+  });
+
+  // POST /api/v1/decisions
+  router.post("/decisions", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || !canWrite(auth.role, "decisions")) {
+      res.status(403).json({ error: "Permission denied" });
+      return;
+    }
+
+    const { title, rationale, alternatives, tags, context, namespace } =
+      req.body;
+    if (!title || !rationale) {
+      res.status(400).json({ error: "title and rationale are required" });
+      return;
+    }
+
+    const ns = namespace ?? auth.clientId;
+    const nsCheck = canWriteNamespace(auth, ns);
+    if (!nsCheck.allowed) {
+      res.status(403).json(nsError(nsCheck.reason));
+      return;
+    }
+
+    const parts = [title, rationale];
+    if (context) parts.push(context);
+    if (alternatives?.length) parts.push(alternatives.join(", "));
+    if (tags?.length) parts.push(tags.join(" "));
+    const textToEmbed = parts.join("\n");
+    const hash = contentHash(textToEmbed);
+    const embedding = await deps.embedFn(textToEmbed);
+
+    const { rows } = await deps.pool.query(
+      `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
+       DO UPDATE SET
+         tags = (
+           SELECT COALESCE(array_agg(DISTINCT tag), '{}')
+           FROM unnest(decisions.tags || EXCLUDED.tags) AS tag
+           WHERE tag IS NOT NULL
+         ),
+         updated_at = NOW()
+       RETURNING id, (xmax = 0) AS is_new`,
+      [
+        title,
+        rationale,
+        alternatives ?? [],
+        tags ?? [],
+        context ?? null,
+        auth.clientId,
+        ns,
+        embedding ? toSql(embedding) : null,
+        hash,
+        embedding ? new Date().toISOString() : null,
+        embedding ? EMBEDDING_MODEL : null,
+      ],
+    );
+
+    const entryId = rows[0].id as string;
+    const isNew = rows[0].is_new as boolean;
+
+    if (isNew) {
+      backgroundExtract(
+        deps.pool,
+        "decisions",
+        entryId,
+        textToEmbed,
+        tags ?? [],
+      );
+    }
+
+    res
+      .status(isNew ? 201 : 200)
+      .json({ id: entryId, namespace: ns, embedded: !!embedding, merged: !isNew });
+  });
+
+  // POST /api/v1/persons
+  router.post("/persons", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || !canWrite(auth.role, "relationships")) {
+      res.status(403).json({ error: "Permission denied" });
+      return;
+    }
+
+    const {
+      name,
+      context,
+      relationship_type,
+      warmth,
+      last_contact,
+      email,
+      phone,
+      notes,
+      tags,
+      metadata,
+      namespace,
+    } = req.body;
+
+    if (!name || typeof name !== "string") {
+      res.status(400).json({ error: "name is required" });
+      return;
+    }
+
+    const ns = namespace ?? auth.clientId;
+    const nsCheck = canWriteNamespace(auth, ns);
+    if (!nsCheck.allowed) {
+      res.status(403).json(nsError(nsCheck.reason));
+      return;
+    }
+
+    const embeddableText = [name, context ?? "", notes ?? ""]
+      .filter(Boolean)
+      .join("\n");
+    const hash = contentHash(embeddableText);
+    const embedding = await deps.embedFn(embeddableText);
+
+    const { rows } = await deps.pool.query(
+      `INSERT INTO relationships (
+        person_name, context, relationship_type, warmth, last_contact,
+        email, phone, notes, tags, metadata,
+        created_by, namespace, embedding, content_hash, embedded_at, embedding_model
+      ) VALUES (
+        $1, $2, $3, $4, $5::date,
+        $6, $7, $8, COALESCE($9::text[], '{}'), COALESCE($10::jsonb, '{}'),
+        $11, $12, $13, $14, $15, $16
+      )
+      ON CONFLICT (namespace, person_name) DO UPDATE SET
+        context = COALESCE(EXCLUDED.context, relationships.context),
+        relationship_type = COALESCE(EXCLUDED.relationship_type, relationships.relationship_type),
+        warmth = COALESCE(EXCLUDED.warmth, relationships.warmth),
+        last_contact = COALESCE(EXCLUDED.last_contact, relationships.last_contact),
+        email = COALESCE(EXCLUDED.email, relationships.email),
+        phone = COALESCE(EXCLUDED.phone, relationships.phone),
+        notes = COALESCE(EXCLUDED.notes, relationships.notes),
+        tags = CASE WHEN $9 IS NOT NULL THEN EXCLUDED.tags ELSE relationships.tags END,
+        metadata = CASE WHEN $10 IS NOT NULL THEN EXCLUDED.metadata ELSE relationships.metadata END,
+        embedding = EXCLUDED.embedding,
+        content_hash = EXCLUDED.content_hash,
+        embedded_at = EXCLUDED.embedded_at,
+        embedding_model = EXCLUDED.embedding_model
+      RETURNING id, (xmax = 0) AS inserted`,
+      [
+        name,
+        context ?? null,
+        relationship_type ?? null,
+        warmth ?? null,
+        last_contact ?? null,
+        email ?? null,
+        phone ?? null,
+        notes ?? null,
+        tags ?? null,
+        metadata ? JSON.stringify(metadata) : null,
+        auth.clientId,
+        ns,
+        embedding ? toSql(embedding) : null,
+        hash,
+        embedding ? new Date().toISOString() : null,
+        embedding ? EMBEDDING_MODEL : null,
+      ],
+    );
+
+    const row = rows[0];
+    const action = row.inserted ? "created" : "updated";
+
+    res.status(row.inserted ? 201 : 200).json({
+      id: row.id,
+      person_name: name,
+      namespace: ns,
+      action,
+      embedded: !!embedding,
+    });
+  });
+
+  // POST /api/v1/sessions
+  router.post("/sessions", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || !canWrite(auth.role, "sessions")) {
+      res.status(403).json({ error: "Permission denied" });
+      return;
+    }
+
+    const {
+      summary,
+      project,
+      session_id,
+      tags,
+      blockers,
+      next_steps,
+      key_decisions,
+      namespace,
+    } = req.body;
+
+    if (!summary || typeof summary !== "string") {
+      res.status(400).json({ error: "summary is required" });
+      return;
+    }
+
+    const ns = namespace ?? auth.clientId;
+    const nsCheck = canWriteNamespace(auth, ns);
+    if (!nsCheck.allowed) {
+      res.status(403).json(nsError(nsCheck.reason));
+      return;
+    }
+
+    const hash = contentHash(summary + "|" + (project ?? ""));
+    const embedParts = [summary];
+    if (key_decisions?.length) embedParts.push(key_decisions.join(". "));
+    if (next_steps?.length) embedParts.push(next_steps.join(". "));
+    if (blockers?.length) embedParts.push(blockers.join(". "));
+    const embedding = await deps.embedFn(embedParts.join("\n"));
+
+    const embeddingVal = embedding ? toSql(embedding) : null;
+    const embeddedAt = embedding ? new Date().toISOString() : null;
+    const model = embedding ? EMBEDDING_MODEL : null;
+
+    if (session_id) {
+      const { rows } = await deps.pool.query(
+        `INSERT INTO sessions (session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         ON CONFLICT (namespace, session_id) WHERE session_id IS NOT NULL
+         DO UPDATE SET
+           summary = EXCLUDED.summary,
+           tags = EXCLUDED.tags,
+           blockers = EXCLUDED.blockers,
+           next_steps = EXCLUDED.next_steps,
+           key_decisions = EXCLUDED.key_decisions,
+           embedding = EXCLUDED.embedding,
+           content_hash = EXCLUDED.content_hash,
+           embedded_at = EXCLUDED.embedded_at,
+           updated_at = NOW()
+         RETURNING id, (xmax = 0) AS is_new`,
+        [
+          session_id,
+          project ?? null,
+          summary,
+          tags ?? [],
+          blockers ?? [],
+          next_steps ?? [],
+          key_decisions ?? [],
+          auth.clientId,
+          ns,
+          embeddingVal,
+          hash,
+          embeddedAt,
+          model,
+        ],
+      );
+
+      res.status(rows[0].is_new ? 201 : 200).json({
+        id: rows[0].id,
+        namespace: ns,
+        session_id,
+        embedded: !!embedding,
+        merged: !rows[0].is_new,
+      });
+      return;
+    }
+
+    const { rows } = await deps.pool.query(
+      `INSERT INTO sessions (project, summary, tags, blockers, next_steps, key_decisions, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+       ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL DO NOTHING
+       RETURNING id`,
+      [
+        project ?? null,
+        summary,
+        tags ?? [],
+        blockers ?? [],
+        next_steps ?? [],
+        key_decisions ?? [],
+        auth.clientId,
+        ns,
+        embeddingVal,
+        hash,
+        embeddedAt,
+        model,
+      ],
+    );
+
+    if (rows.length === 0) {
+      res.status(409).json({ error: "Duplicate session content" });
+      return;
+    }
+
+    res.status(201).json({
+      id: rows[0].id,
+      namespace: ns,
+      embedded: !!embedding,
+    });
+  });
+
+  // GET /api/v1/search
+  router.get("/search", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth) {
+      res.status(401).json({ error: "Not authenticated" });
+      return;
+    }
+
+    const q = req.query.q as string;
+    if (!q) {
+      res.status(400).json({ error: "q query parameter is required" });
+      return;
+    }
+
+    const namespace = (req.query.namespace as string) || undefined;
+    const limit = Math.min(parseInt((req.query.limit as string) ?? "10", 10) || 10, 250);
+    const offset = parseInt((req.query.offset as string) ?? "0", 10) || 0;
+    const table = (req.query.table as string) || undefined;
+    const mode = (req.query.mode as string) || "hybrid";
+    const tier = (req.query.tier as string) || undefined;
+
+    const accessibleTables = table
+      ? [table as Table].filter((t) => ALL_TABLES.includes(t) && canRead(auth.role, t))
+      : ALL_TABLES.filter((t) => canRead(auth.role, t));
+
+    if (accessibleTables.length === 0) {
+      res.status(403).json({ error: "No accessible tables" });
+      return;
+    }
+
+    const rows = await executeSearch(
+      deps,
+      accessibleTables,
+      q,
+      limit,
+      mode as "hybrid" | "vector" | "keyword",
+      tier as Tier | undefined,
+      offset,
+      namespace,
+    );
+
+    res.json({ results: rows, count: rows.length });
+  });
+
+  // GET /api/v1/entries/:table/:id
+  router.get("/entries/:table/:id", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    const table = req.params.table as Table;
+
+    if (!ALL_TABLES.includes(table)) {
+      res.status(400).json({ error: `Invalid table: ${table}` });
+      return;
+    }
+    if (!auth || !canRead(auth.role, table)) {
+      res.status(403).json({ error: "Permission denied" });
+      return;
+    }
+
+    const TABLE_COLUMNS: Record<Table, string> = {
+      thoughts:
+        "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace",
+      decisions:
+        "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace",
+      relationships:
+        "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, created_by, created_at, tier, usefulness_score, access_count, namespace",
+      projects:
+        "id, name, status, description, metadata, tags, created_by, created_at, tier, usefulness_score, access_count, namespace",
+      sessions:
+        "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, created_at, updated_at, tier, namespace",
+    };
+
+    const columns = TABLE_COLUMNS[table];
+    const { rows } = await deps.pool.query(
+      `SELECT ${columns} FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
+      [req.params.id],
+    );
+
+    if (rows.length === 0) {
+      res.status(404).json({ error: "Entry not found or archived" });
+      return;
+    }
+
+    res.json(rows[0]);
+  });
+
+  // GET /api/v1/namespaces
+  router.get("/namespaces", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth) {
+      res.status(401).json({ error: "Not authenticated" });
+      return;
+    }
+
+    const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
+    const queries = accessibleTables.map((table) =>
+      deps.pool.query(
+        `SELECT '${table}' AS table_name, namespace, COUNT(*) AS count
+         FROM ${table} WHERE archived_at IS NULL
+         GROUP BY namespace ORDER BY count DESC`,
+      ),
+    );
+
+    const results = await Promise.all(queries);
+    const nsMap = new Map<
+      string,
+      { total: number; per_table: Record<string, number> }
+    >();
+
+    for (const result of results) {
+      for (const row of result.rows) {
+        const ns = row.namespace as string;
+        const existing = nsMap.get(ns) ?? { total: 0, per_table: {} };
+        const count = Number(row.count);
+        existing.total += count;
+        existing.per_table[row.table_name] = count;
+        nsMap.set(ns, existing);
+      }
+    }
+
+    const namespaces = Array.from(nsMap.entries())
+      .map(([namespace, data]) => ({
+        namespace,
+        total: data.total,
+        per_table: data.per_table,
+      }))
+      .sort((a, b) => b.total - a.total);
+
+    res.json({ namespace_count: namespaces.length, namespaces });
+  });
+
+  return router;
+}

--- a/src/rest-api.ts
+++ b/src/rest-api.ts
@@ -1,13 +1,16 @@
 import { Router } from "express";
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
+import { z } from "zod";
 import { toSql } from "pgvector/pg";
 import type pg from "pg";
 import { canWrite, canRead } from "./permissions.ts";
 import { canWriteNamespace } from "./namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "./embedding.ts";
 import { backgroundExtract } from "./extraction.ts";
-import { executeSearch } from "./tools/search-brain.ts";
+import { executeSearch, type SearchMode } from "./tools/search-brain.ts";
 import { ALL_TABLES } from "./tools/table-constants.ts";
+import { TABLE_COLUMNS } from "./table-projections.ts";
+import { canReadNamespace, namespaceFilterFor, readableNamespaces } from "./read-policy.ts";
 import type { AuthInfo, Table, Tier } from "./types.ts";
 import type { generateEmbedding } from "./embedding.ts";
 
@@ -24,22 +27,120 @@ function nsError(reason: string | undefined): { error: string } {
   return { error: `Permission denied: ${reason ?? "namespace access denied"}` };
 }
 
+const validTableValues = ALL_TABLES as [Table, ...Table[]];
+const uuidSchema = z.string().uuid();
+const namespaceSchema = z.string().trim().min(1).max(500);
+const stringArraySchema = z.array(z.string()).default([]);
+const jsonRecordSchema = z.record(z.string(), z.unknown());
+
+const thoughtSchema = z.object({
+  content: z.string().trim().min(1),
+  tags: stringArraySchema.optional(),
+  namespace: namespaceSchema.optional(),
+});
+
+const decisionSchema = z.object({
+  title: z.string().trim().min(1),
+  rationale: z.string().trim().min(1),
+  alternatives: stringArraySchema.optional(),
+  tags: stringArraySchema.optional(),
+  context: z.string().optional(),
+  namespace: namespaceSchema.optional(),
+});
+
+const personSchema = z.object({
+  name: z.string().trim().min(1),
+  context: z.string().optional(),
+  relationship_type: z.string().optional(),
+  warmth: z.number().int().min(0).max(10).optional(),
+  last_contact: z.string().optional(),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  notes: z.string().optional(),
+  tags: stringArraySchema.optional(),
+  metadata: jsonRecordSchema.optional(),
+  namespace: namespaceSchema.optional(),
+});
+
+const sessionSchema = z.object({
+  summary: z.string().trim().min(1),
+  project: z.string().optional(),
+  session_id: z.string().trim().min(1).optional(),
+  tags: stringArraySchema.optional(),
+  blockers: stringArraySchema.optional(),
+  next_steps: stringArraySchema.optional(),
+  key_decisions: stringArraySchema.optional(),
+  namespace: namespaceSchema.optional(),
+});
+
+const searchQuerySchema = z.object({
+  q: z.string().trim().min(1),
+  namespace: namespaceSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(250).default(10),
+  offset: z.coerce.number().int().min(0).default(0),
+  table: z.enum(validTableValues).optional(),
+  mode: z.enum(["hybrid", "vector", "keyword"]).default("hybrid"),
+  tier: z.enum(["hot", "warm", "cold"]).optional(),
+});
+
+function parseBody<T>(
+  schema: z.ZodType<T>,
+  body: unknown,
+  res: Response,
+): T | null {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    res.status(400).json({ error: "Invalid request", issues: parsed.error.issues });
+    return null;
+  }
+  return parsed.data;
+}
+
+function parseQuery<T>(
+  schema: z.ZodType<T>,
+  query: unknown,
+  res: Response,
+): T | null {
+  const parsed = schema.safeParse(query);
+  if (!parsed.success) {
+    res.status(400).json({ error: "Invalid query", issues: parsed.error.issues });
+    return null;
+  }
+  return parsed.data;
+}
+
+function asyncHandler(
+  handler: (req: Request, res: Response) => Promise<void>,
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    handler(req, res).catch(next);
+  };
+}
+
+function isReadableNamespaceDenied(auth: AuthInfo, namespace?: string): boolean {
+  return namespace !== undefined && !canReadNamespace(auth, namespace);
+}
+
+function readNamespacePredicate(auth: AuthInfo, paramIndex: number): string {
+  return readableNamespaces(auth)
+    ? ` AND namespace = ANY($${paramIndex}::text[])`
+    : "";
+}
+
 export function createRestRouter(deps: RestDeps): Router {
   const router = Router();
 
   // POST /api/v1/thoughts
-  router.post("/thoughts", async (req: Request, res: Response) => {
+  router.post("/thoughts", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     if (!auth || !canWrite(auth.role, "thoughts")) {
       res.status(403).json({ error: "Permission denied" });
       return;
     }
 
-    const { content, tags, namespace } = req.body;
-    if (!content || typeof content !== "string" || content.trim().length === 0) {
-      res.status(400).json({ error: "content is required" });
-      return;
-    }
+    const parsed = parseBody(thoughtSchema, req.body, res);
+    if (!parsed) return;
+    const { content, tags, namespace } = parsed;
 
     const ns = namespace ?? auth.clientId;
     const nsCheck = canWriteNamespace(auth, ns);
@@ -88,22 +189,19 @@ export function createRestRouter(deps: RestDeps): Router {
     res
       .status(isNew ? 201 : 200)
       .json({ id: entryId, namespace: ns, embedded: !!embedding, merged: !isNew });
-  });
+  }));
 
   // POST /api/v1/decisions
-  router.post("/decisions", async (req: Request, res: Response) => {
+  router.post("/decisions", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     if (!auth || !canWrite(auth.role, "decisions")) {
       res.status(403).json({ error: "Permission denied" });
       return;
     }
 
-    const { title, rationale, alternatives, tags, context, namespace } =
-      req.body;
-    if (!title || !rationale) {
-      res.status(400).json({ error: "title and rationale are required" });
-      return;
-    }
+    const parsed = parseBody(decisionSchema, req.body, res);
+    if (!parsed) return;
+    const { title, rationale, alternatives, tags, context, namespace } = parsed;
 
     const ns = namespace ?? auth.clientId;
     const nsCheck = canWriteNamespace(auth, ns);
@@ -122,7 +220,7 @@ export function createRestRouter(deps: RestDeps): Router {
 
     const { rows } = await deps.pool.query(
       `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10, $11)
        ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
        DO UPDATE SET
          tags = (
@@ -135,7 +233,7 @@ export function createRestRouter(deps: RestDeps): Router {
       [
         title,
         rationale,
-        alternatives ?? [],
+        JSON.stringify(alternatives ?? []),
         tags ?? [],
         context ?? null,
         auth.clientId,
@@ -163,10 +261,10 @@ export function createRestRouter(deps: RestDeps): Router {
     res
       .status(isNew ? 201 : 200)
       .json({ id: entryId, namespace: ns, embedded: !!embedding, merged: !isNew });
-  });
+  }));
 
   // POST /api/v1/persons
-  router.post("/persons", async (req: Request, res: Response) => {
+  router.post("/persons", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     if (!auth || !canWrite(auth.role, "relationships")) {
       res.status(403).json({ error: "Permission denied" });
@@ -185,12 +283,8 @@ export function createRestRouter(deps: RestDeps): Router {
       tags,
       metadata,
       namespace,
-    } = req.body;
-
-    if (!name || typeof name !== "string") {
-      res.status(400).json({ error: "name is required" });
-      return;
-    }
+    } = parseBody(personSchema, req.body, res) ?? {};
+    if (!name) return;
 
     const ns = namespace ?? auth.clientId;
     const nsCheck = canWriteNamespace(auth, ns);
@@ -260,10 +354,10 @@ export function createRestRouter(deps: RestDeps): Router {
       action,
       embedded: !!embedding,
     });
-  });
+  }));
 
   // POST /api/v1/sessions
-  router.post("/sessions", async (req: Request, res: Response) => {
+  router.post("/sessions", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     if (!auth || !canWrite(auth.role, "sessions")) {
       res.status(403).json({ error: "Permission denied" });
@@ -279,12 +373,8 @@ export function createRestRouter(deps: RestDeps): Router {
       next_steps,
       key_decisions,
       namespace,
-    } = req.body;
-
-    if (!summary || typeof summary !== "string") {
-      res.status(400).json({ error: "summary is required" });
-      return;
-    }
+    } = parseBody(sessionSchema, req.body, res) ?? {};
+    if (!summary) return;
 
     const ns = namespace ?? auth.clientId;
     const nsCheck = canWriteNamespace(auth, ns);
@@ -378,28 +468,24 @@ export function createRestRouter(deps: RestDeps): Router {
       namespace: ns,
       embedded: !!embedding,
     });
-  });
+  }));
 
   // GET /api/v1/search
-  router.get("/search", async (req: Request, res: Response) => {
+  router.get("/search", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     if (!auth) {
       res.status(401).json({ error: "Not authenticated" });
       return;
     }
 
-    const q = req.query.q as string;
-    if (!q) {
-      res.status(400).json({ error: "q query parameter is required" });
+    const parsed = parseQuery(searchQuerySchema, req.query, res);
+    if (!parsed) return;
+    const { q, namespace, limit, offset, table, mode, tier } = parsed;
+
+    if (isReadableNamespaceDenied(auth, namespace)) {
+      res.status(403).json({ error: "Permission denied: namespace read access denied" });
       return;
     }
-
-    const namespace = (req.query.namespace as string) || undefined;
-    const limit = Math.min(parseInt((req.query.limit as string) ?? "10", 10) || 10, 250);
-    const offset = parseInt((req.query.offset as string) ?? "0", 10) || 0;
-    const table = (req.query.table as string) || undefined;
-    const mode = (req.query.mode as string) || "hybrid";
-    const tier = (req.query.tier as string) || undefined;
 
     const accessibleTables = table
       ? [table as Table].filter((t) => ALL_TABLES.includes(t) && canRead(auth.role, t))
@@ -415,17 +501,17 @@ export function createRestRouter(deps: RestDeps): Router {
       accessibleTables,
       q,
       limit,
-      mode as "hybrid" | "vector" | "keyword",
+      mode as SearchMode,
       tier as Tier | undefined,
       offset,
-      namespace,
+      namespaceFilterFor(auth, namespace),
     );
 
     res.json({ results: rows, count: rows.length });
-  });
+  }));
 
   // GET /api/v1/entries/:table/:id
-  router.get("/entries/:table/:id", async (req: Request, res: Response) => {
+  router.get("/entries/:table/:id", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     const table = req.params.table as Table;
 
@@ -438,23 +524,19 @@ export function createRestRouter(deps: RestDeps): Router {
       return;
     }
 
-    const TABLE_COLUMNS: Record<Table, string> = {
-      thoughts:
-        "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace",
-      decisions:
-        "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace",
-      relationships:
-        "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, created_by, created_at, tier, usefulness_score, access_count, namespace",
-      projects:
-        "id, name, status, description, metadata, tags, created_by, created_at, tier, usefulness_score, access_count, namespace",
-      sessions:
-        "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, created_at, updated_at, tier, namespace",
-    };
+    const id = uuidSchema.safeParse(req.params.id);
+    if (!id.success) {
+      res.status(400).json({ error: "Invalid entry id" });
+      return;
+    }
 
     const columns = TABLE_COLUMNS[table];
+    const readable = readableNamespaces(auth);
+    const predicate = readNamespacePredicate(auth, 2);
+    const params: unknown[] = readable ? [id.data, readable] : [id.data];
     const { rows } = await deps.pool.query(
-      `SELECT ${columns} FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
-      [req.params.id],
+      `SELECT ${columns} FROM ${table} WHERE id = $1${predicate} AND archived_at IS NULL`,
+      params,
     );
 
     if (rows.length === 0) {
@@ -463,10 +545,10 @@ export function createRestRouter(deps: RestDeps): Router {
     }
 
     res.json(rows[0]);
-  });
+  }));
 
   // GET /api/v1/namespaces
-  router.get("/namespaces", async (req: Request, res: Response) => {
+  router.get("/namespaces", asyncHandler(async (req: Request, res: Response) => {
     const auth = getAuth(req);
     if (!auth) {
       res.status(401).json({ error: "Not authenticated" });
@@ -474,13 +556,16 @@ export function createRestRouter(deps: RestDeps): Router {
     }
 
     const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
-    const queries = accessibleTables.map((table) =>
-      deps.pool.query(
+    const readable = readableNamespaces(auth);
+    const queries = accessibleTables.map((table) => {
+      const predicate = readable ? " AND namespace = ANY($1::text[])" : "";
+      return deps.pool.query(
         `SELECT '${table}' AS table_name, namespace, COUNT(*) AS count
-         FROM ${table} WHERE archived_at IS NULL
+         FROM ${table} WHERE archived_at IS NULL${predicate}
          GROUP BY namespace ORDER BY count DESC`,
-      ),
-    );
+        readable ? [readable] : [],
+      );
+    });
 
     const results = await Promise.all(queries);
     const nsMap = new Map<
@@ -508,7 +593,7 @@ export function createRestRouter(deps: RestDeps): Router {
       .sort((a, b) => b.total - a.total);
 
     res.json({ namespace_count: namespaces.length, namespaces });
-  });
+  }));
 
   return router;
 }

--- a/src/rest-promotion.ts
+++ b/src/rest-promotion.ts
@@ -1,0 +1,227 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import type pg from "pg";
+import type { AuthInfo, Table } from "./types.ts";
+import { ALL_TABLES } from "./tools/table-constants.ts";
+import type { generateEmbedding } from "./embedding.ts";
+
+interface RestDeps {
+  pool: pg.Pool;
+  embedFn: typeof generateEmbedding;
+}
+
+function getAuth(req: Request): AuthInfo | null {
+  return (req as any).auth ?? null;
+}
+
+const CONTENT_COLUMNS: Record<Table, string> = {
+  thoughts:
+    "content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score, extracted_metadata",
+  decisions:
+    "title, rationale, alternatives, context, tags, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score, extracted_metadata",
+  relationships:
+    "person_name, context, relationship_type, warmth, last_contact, email, phone, notes, tags, metadata, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score",
+  projects:
+    "name, status, description, metadata, tags, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score",
+  sessions:
+    "session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, embedding, content_hash, embedded_at, embedding_model, tier",
+};
+
+export function createPromotionRouter(deps: RestDeps): Router {
+  const router = Router();
+
+  // POST /api/v1/promote
+  router.post("/promote", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || (auth.role !== "admin" && auth.role !== "n8n")) {
+      res.status(403).json({ error: "Permission denied: admin or n8n role required" });
+      return;
+    }
+
+    const { table, id, reason, target_namespace } = req.body;
+    if (!table || !id) {
+      res.status(400).json({ error: "table and id are required" });
+      return;
+    }
+    if (!ALL_TABLES.includes(table)) {
+      res.status(400).json({ error: `Invalid table: ${table}` });
+      return;
+    }
+
+    const targetNs = target_namespace ?? "collab";
+
+    const { rows: sourceRows } = await deps.pool.query(
+      `SELECT *, namespace AS source_namespace FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
+      [id],
+    );
+
+    if (sourceRows.length === 0) {
+      res.status(404).json({ error: "Source entry not found or archived" });
+      return;
+    }
+
+    const source = sourceRows[0];
+    if (source.namespace === targetNs) {
+      res.status(409).json({ error: `Entry is already in namespace '${targetNs}'` });
+      return;
+    }
+
+    if (source.content_hash) {
+      const { rows: dupes } = await deps.pool.query(
+        `SELECT id FROM ${table} WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL`,
+        [source.content_hash, targetNs],
+      );
+      if (dupes.length > 0) {
+        res.status(409).json({
+          status: "duplicate",
+          existing_id: dupes[0].id,
+          source_id: id,
+          target_namespace: targetNs,
+        });
+        return;
+      }
+    }
+
+    const provenance = {
+      source_namespace: source.namespace,
+      source_id: id,
+      source_agent: source.created_by,
+      promotion_reason: reason ?? null,
+      promoted_at: new Date().toISOString(),
+      promoted_by: auth.clientId,
+    };
+
+    const columns = CONTENT_COLUMNS[table as Table];
+    const { rows: inserted } = await deps.pool.query(
+      `INSERT INTO ${table} (${columns}, namespace, promoted_from)
+       SELECT ${columns}, $2, $3::jsonb
+       FROM ${table} WHERE id = $1
+       RETURNING id`,
+      [id, targetNs, JSON.stringify(provenance)],
+    );
+
+    res.status(201).json({
+      status: "promoted",
+      new_id: inserted[0].id,
+      source_id: id,
+      source_namespace: source.namespace,
+      target_namespace: targetNs,
+      provenance,
+    });
+  });
+
+  // POST /api/v1/demote
+  router.post("/demote", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || auth.role !== "admin") {
+      res.status(403).json({ error: "Permission denied: admin role required" });
+      return;
+    }
+
+    const { table, id } = req.body;
+    if (!table || !id) {
+      res.status(400).json({ error: "table and id are required" });
+      return;
+    }
+    if (!ALL_TABLES.includes(table)) {
+      res.status(400).json({ error: `Invalid table: ${table}` });
+      return;
+    }
+
+    const { rows } = await deps.pool.query(
+      `SELECT id, namespace, promoted_from FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
+      [id],
+    );
+
+    if (rows.length === 0) {
+      res.status(404).json({ error: "Entry not found or already archived" });
+      return;
+    }
+    if (!rows[0].promoted_from) {
+      res.status(400).json({ error: "Entry was not promoted — cannot demote" });
+      return;
+    }
+
+    const provenance = rows[0].promoted_from;
+    await deps.pool.query(`UPDATE ${table} SET archived_at = NOW() WHERE id = $1`, [id]);
+
+    res.json({
+      status: "demoted",
+      archived_id: id,
+      source_id: provenance.source_id,
+      source_namespace: provenance.source_namespace,
+    });
+  });
+
+  // GET /api/v1/scan/:namespace
+  router.get("/scan/:namespace", async (req: Request, res: Response) => {
+    const auth = getAuth(req);
+    if (!auth || (auth.role !== "admin" && auth.role !== "n8n")) {
+      res.status(403).json({ error: "Permission denied: admin or n8n role required" });
+      return;
+    }
+
+    const namespace = req.params.namespace;
+    const table = (req.query.table as string) || undefined;
+    const since = (req.query.since as string) || undefined;
+    const limit = Math.min(parseInt((req.query.limit as string) ?? "20", 10) || 20, 100);
+
+    const tables = table ? [table as Table].filter((t) => ALL_TABLES.includes(t)) : ALL_TABLES;
+    const candidates: any[] = [];
+    const duplicateEntries: any[] = [];
+    const alreadyPromoted: any[] = [];
+
+    for (const t of tables) {
+      const sinceFilter = since ? ` AND t.created_at >= $3` : "";
+      const params: unknown[] = [namespace, limit];
+      if (since) params.push(since);
+
+      const { rows } = await deps.pool.query(
+        `SELECT t.id, t.content_hash, t.namespace, t.created_at, t.promoted_from,
+                '${t}' AS table_name
+         FROM ${t} t
+         WHERE t.namespace = $1 AND t.archived_at IS NULL${sinceFilter}
+         ORDER BY t.created_at DESC
+         LIMIT $2`,
+        params,
+      );
+
+      for (const row of rows) {
+        if (row.promoted_from) {
+          alreadyPromoted.push({ table: t, id: row.id, created_at: row.created_at });
+          continue;
+        }
+        if (row.content_hash) {
+          const { rows: collabDupes } = await deps.pool.query(
+            `SELECT id FROM ${t} WHERE content_hash = $1 AND namespace = 'collab' AND archived_at IS NULL LIMIT 1`,
+            [row.content_hash],
+          );
+          if (collabDupes.length > 0) {
+            duplicateEntries.push({
+              table: t,
+              id: row.id,
+              existing_collab_id: collabDupes[0].id,
+              created_at: row.created_at,
+            });
+            continue;
+          }
+        }
+        candidates.push({ table: t, id: row.id, created_at: row.created_at });
+      }
+    }
+
+    res.json({
+      namespace,
+      candidates,
+      duplicates: duplicateEntries,
+      already_promoted: alreadyPromoted,
+      summary: {
+        candidates: candidates.length,
+        duplicates: duplicateEntries.length,
+        already_promoted: alreadyPromoted.length,
+      },
+    });
+  });
+
+  return router;
+}

--- a/src/table-projections.ts
+++ b/src/table-projections.ts
@@ -1,0 +1,14 @@
+import type { Table } from "./types.ts";
+
+export const TABLE_COLUMNS: Record<Table, string> = {
+  thoughts:
+    "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace, promoted_from",
+  decisions:
+    "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace, promoted_from",
+  relationships:
+    "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
+  projects:
+    "id, name, status, description, metadata, tags, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
+  sessions:
+    "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, created_at, updated_at, tier, namespace, promoted_from",
+};

--- a/src/tools/demote-entry.ts
+++ b/src/tools/demote-entry.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerDemoteEntry(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "demote_entry",
+    {
+      description:
+        "Archive a previously promoted entry, reversing a promotion. " +
+        "Only works on entries that have promoted_from provenance metadata. Admin only.",
+      inputSchema: {
+        table: z.enum(["thoughts", "decisions", "relationships", "projects", "sessions"]).describe("Table name"),
+        id: z.string().uuid().describe("UUID of the promoted entry to demote"),
+      },
+      annotations: {
+        title: "Demote Entry",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || auth.role !== "admin") {
+        return {
+          content: [{ type: "text" as const, text: "Permission denied: admin role required" }],
+          isError: true,
+        };
+      }
+
+      const table = args.table as Table;
+
+      const { rows } = await deps.pool.query(
+        `SELECT id, namespace, promoted_from FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
+        [args.id],
+      );
+
+      if (rows.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: "Entry not found or already archived" }],
+          isError: true,
+        };
+      }
+
+      if (!rows[0].promoted_from) {
+        return {
+          content: [{ type: "text" as const, text: "Entry was not promoted — cannot demote" }],
+          isError: true,
+        };
+      }
+
+      const provenance = rows[0].promoted_from;
+
+      await deps.pool.query(
+        `UPDATE ${table} SET archived_at = NOW() WHERE id = $1`,
+        [args.id],
+      );
+
+      logger.info("demote_entry_ok", {
+        table,
+        id: args.id,
+        source_id: provenance.source_id,
+        source_namespace: provenance.source_namespace,
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            status: "demoted",
+            archived_id: args.id,
+            source_id: provenance.source_id,
+            source_namespace: provenance.source_namespace,
+          }),
+        }],
+      };
+    },
+  );
+}

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -3,19 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
-
-const TABLE_COLUMNS: Record<Table, string> = {
-  thoughts:
-    "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace",
-  decisions:
-    "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace",
-  relationships:
-    "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, created_by, created_at, tier, usefulness_score, access_count, namespace",
-  projects:
-    "id, name, status, description, metadata, tags, created_by, created_at, tier, usefulness_score, access_count, namespace",
-  sessions:
-    "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, created_at, updated_at, tier, namespace",
-};
+import { TABLE_COLUMNS } from "../table-projections.ts";
 
 export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
   server.registerTool(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,6 +33,9 @@ import { registerSessionWrap } from "./session-wrap.ts";
 import { registerUpsertEntity } from "./upsert-entity.ts";
 import { registerLinkEntities } from "./link-entities.ts";
 import { registerAdjacentContext } from "./adjacent-context.ts";
+import { registerPromoteEntry } from "./promote-entry.ts";
+import { registerDemoteEntry } from "./demote-entry.ts";
+import { registerScanNamespace } from "./scan-namespace.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -72,4 +75,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerUpsertEntity(server, deps);
   registerLinkEntities(server, deps);
   registerAdjacentContext(server, deps);
+  registerPromoteEntry(server, deps);
+  registerDemoteEntry(server, deps);
+  registerScanNamespace(server, deps);
 }

--- a/src/tools/promote-entry.ts
+++ b/src/tools/promote-entry.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+const CONTENT_COLUMNS: Record<Table, string> = {
+  thoughts:
+    "content, tags, source, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score, extracted_metadata",
+  decisions:
+    "title, rationale, alternatives, context, tags, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score, extracted_metadata",
+  relationships:
+    "person_name, context, relationship_type, warmth, last_contact, email, phone, notes, tags, metadata, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score",
+  projects:
+    "name, status, description, metadata, tags, created_by, embedding, content_hash, embedded_at, embedding_model, tier, usefulness_score",
+  sessions:
+    "session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, embedding, content_hash, embedded_at, embedding_model, tier",
+};
+
+export function registerPromoteEntry(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "promote_entry",
+    {
+      description:
+        "Promote an entry from an agent namespace to collab (or another target namespace). " +
+        "Copies the entry with provenance tracking. Checks for duplicates by content_hash.",
+      inputSchema: {
+        table: z.enum(["thoughts", "decisions", "relationships", "projects", "sessions"]).describe("Source table"),
+        id: z.string().uuid().describe("Source entry UUID"),
+        reason: z.string().max(1000).optional().describe("Why this entry is being promoted"),
+        target_namespace: z.string().min(1).max(500).optional().describe("Target namespace (default: collab)"),
+      },
+      annotations: {
+        title: "Promote Entry",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || (auth.role !== "admin" && auth.role !== "n8n")) {
+        return {
+          content: [{ type: "text" as const, text: "Permission denied: admin or n8n role required" }],
+          isError: true,
+        };
+      }
+
+      const table = args.table as Table;
+      const targetNs = args.target_namespace ?? "collab";
+
+      const { rows: sourceRows } = await deps.pool.query(
+        `SELECT *, namespace AS source_namespace FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
+        [args.id],
+      );
+
+      if (sourceRows.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: "Source entry not found or archived" }],
+          isError: true,
+        };
+      }
+
+      const source = sourceRows[0];
+
+      if (source.namespace === targetNs) {
+        return {
+          content: [{ type: "text" as const, text: `Entry is already in namespace '${targetNs}'` }],
+          isError: true,
+        };
+      }
+
+      if (source.content_hash) {
+        const { rows: dupes } = await deps.pool.query(
+          `SELECT id FROM ${table} WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL`,
+          [source.content_hash, targetNs],
+        );
+
+        if (dupes.length > 0) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                status: "duplicate",
+                existing_id: dupes[0].id,
+                source_id: args.id,
+                target_namespace: targetNs,
+              }),
+            }],
+          };
+        }
+      }
+
+      const provenance = {
+        source_namespace: source.namespace,
+        source_id: args.id,
+        source_agent: source.created_by,
+        promotion_reason: args.reason ?? null,
+        promoted_at: new Date().toISOString(),
+        promoted_by: auth.clientId,
+      };
+
+      const columns = CONTENT_COLUMNS[table];
+      const { rows: inserted } = await deps.pool.query(
+        `INSERT INTO ${table} (${columns}, namespace, promoted_from)
+         SELECT ${columns}, $2, $3::jsonb
+         FROM ${table} WHERE id = $1
+         RETURNING id`,
+        [args.id, targetNs, JSON.stringify(provenance)],
+      );
+
+      const newId = inserted[0].id;
+
+      logger.info("promote_entry_ok", {
+        table,
+        source_id: args.id,
+        new_id: newId,
+        source_namespace: source.namespace,
+        target_namespace: targetNs,
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            status: "promoted",
+            new_id: newId,
+            source_id: args.id,
+            source_namespace: source.namespace,
+            target_namespace: targetNs,
+            provenance,
+          }),
+        }],
+      };
+    },
+  );
+}

--- a/src/tools/scan-namespace.ts
+++ b/src/tools/scan-namespace.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES } from "./table-constants.ts";
+
+export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "scan_namespace",
+    {
+      description:
+        "Scan an agent namespace for promotion candidates. Returns entries categorized as " +
+        "candidates (not yet in collab), duplicates (already in collab), or already_promoted.",
+      inputSchema: {
+        namespace: z.string().min(1).max(500).describe("Agent namespace to scan"),
+        table: z
+          .enum(["thoughts", "decisions", "relationships", "projects", "sessions"])
+          .optional()
+          .describe("Limit scan to a specific table"),
+        since: z
+          .string()
+          .optional()
+          .describe("Only entries created after this ISO date"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max entries to scan per table (default 20)"),
+      },
+      annotations: {
+        title: "Scan Namespace",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || (auth.role !== "admin" && auth.role !== "n8n")) {
+        return {
+          content: [{ type: "text" as const, text: "Permission denied: admin or n8n role required" }],
+          isError: true,
+        };
+      }
+
+      const tables = args.table ? [args.table as Table] : ALL_TABLES;
+      const limit = args.limit ?? 20;
+      const candidates: any[] = [];
+      const duplicates: any[] = [];
+      const alreadyPromoted: any[] = [];
+
+      for (const table of tables) {
+        const sinceFilter = args.since ? ` AND t.created_at >= $3` : "";
+        const params: unknown[] = [args.namespace, limit];
+        if (args.since) params.push(args.since);
+
+        const { rows } = await deps.pool.query(
+          `SELECT t.id, t.content_hash, t.namespace, t.created_at, t.promoted_from,
+                  '${table}' AS table_name
+           FROM ${table} t
+           WHERE t.namespace = $1 AND t.archived_at IS NULL${sinceFilter}
+           ORDER BY t.created_at DESC
+           LIMIT $2`,
+          params,
+        );
+
+        for (const row of rows) {
+          if (row.promoted_from) {
+            alreadyPromoted.push({
+              table: table,
+              id: row.id,
+              created_at: row.created_at,
+              promoted_to: row.promoted_from,
+            });
+            continue;
+          }
+
+          if (row.content_hash) {
+            const { rows: collabDupes } = await deps.pool.query(
+              `SELECT id FROM ${table}
+               WHERE content_hash = $1 AND namespace = 'collab' AND archived_at IS NULL
+               LIMIT 1`,
+              [row.content_hash],
+            );
+
+            if (collabDupes.length > 0) {
+              duplicates.push({
+                table: table,
+                id: row.id,
+                existing_collab_id: collabDupes[0].id,
+                created_at: row.created_at,
+              });
+              continue;
+            }
+          }
+
+          candidates.push({
+            table: table,
+            id: row.id,
+            created_at: row.created_at,
+          });
+        }
+      }
+
+      logger.info("scan_namespace_ok", {
+        namespace: args.namespace,
+        candidates: candidates.length,
+        duplicates: duplicates.length,
+        already_promoted: alreadyPromoted.length,
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            namespace: args.namespace,
+            candidates,
+            duplicates,
+            already_promoted: alreadyPromoted,
+            summary: {
+              candidates: candidates.length,
+              duplicates: duplicates.length,
+              already_promoted: alreadyPromoted.length,
+            },
+          }),
+        }],
+      };
+    },
+  );
+}

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -24,6 +24,7 @@ const LABEL_TO_TABLE: Record<string, Table> = Object.fromEntries(
 ) as Record<string, Table>;
 
 export type SearchMode = "hybrid" | "vector" | "keyword";
+type NamespaceFilter = string | string[];
 
 /** RRF constant -- standard value from Cormack et al. 2009 */
 const RRF_K = 60;
@@ -111,7 +112,7 @@ function linkKey(type: string, id: string): string {
 
 function appendNamespaceParam(
   params: unknown[],
-  namespace?: string,
+  namespace?: NamespaceFilter,
 ): number | undefined {
   if (namespace === undefined) return undefined;
   params.push(namespace);
@@ -128,7 +129,7 @@ function paramRef(index: number): string {
 async function attachExplicitLinks(
   deps: ToolDeps,
   rows: SearchRow[],
-  namespace?: string,
+  namespace?: NamespaceFilter,
 ): Promise<SearchRow[]> {
   if (rows.length === 0) return rows;
 
@@ -137,7 +138,9 @@ async function attachExplicitLinks(
   const params: unknown[] = [resultTypes, resultIds];
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
   const namespaceFilter = namespaceParamIndex
-    ? ` AND namespace = ${paramRef(namespaceParamIndex)}`
+    ? Array.isArray(namespace)
+      ? ` AND namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
+      : ` AND namespace = ${paramRef(namespaceParamIndex)}`
     : "";
 
   try {
@@ -214,6 +217,7 @@ function buildTableCTE(
   perTableLimit: number,
   tier?: Tier,
   namespaceParamIndex?: number,
+  namespaceIsArray = false,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
@@ -222,7 +226,9 @@ function buildTableCTE(
   const cteName = `${table}_results`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
   const nsFilter = namespaceParamIndex
-    ? ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
+    ? namespaceIsArray
+      ? ` AND ${alias}.namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
+      : ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
     : "";
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
@@ -252,6 +258,7 @@ function buildFtsCTE(
   perTableLimit: number,
   tier?: Tier,
   namespaceParamIndex?: number,
+  namespaceIsArray = false,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
@@ -260,7 +267,9 @@ function buildFtsCTE(
   const cteName = `${table}_fts`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
   const nsFilter = namespaceParamIndex
-    ? ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
+    ? namespaceIsArray
+      ? ` AND ${alias}.namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
+      : ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
     : "";
 
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
@@ -294,13 +303,14 @@ async function vectorSearch(
   fetchLimit: number,
   tier?: Tier,
   offset = 0,
-  namespace?: string,
+  namespace?: NamespaceFilter,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const params = [toSql(embedding), fetchLimit, offset];
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
+  const namespaceIsArray = Array.isArray(namespace);
   const ctes = accessibleTables.map((t) =>
-    buildTableCTE(t, perTableLimit, tier, namespaceParamIndex),
+    buildTableCTE(t, perTableLimit, tier, namespaceParamIndex, namespaceIsArray),
   );
   const cteNames = accessibleTables.map((t) => `${t}_results`);
   const unionAll = cteNames
@@ -328,13 +338,14 @@ async function ftsSearch(
   fetchLimit: number,
   tier?: Tier,
   offset = 0,
-  namespace?: string,
+  namespace?: NamespaceFilter,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const params = [query, fetchLimit, offset];
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
+  const namespaceIsArray = Array.isArray(namespace);
   const ctes = accessibleTables.map((t) =>
-    buildFtsCTE(t, perTableLimit, tier, namespaceParamIndex),
+    buildFtsCTE(t, perTableLimit, tier, namespaceParamIndex, namespaceIsArray),
   );
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
   const unionAll = cteNames
@@ -479,7 +490,7 @@ export async function executeSearch(
   mode: SearchMode = "hybrid",
   tier?: Tier,
   offset = 0,
-  namespace?: string,
+  namespace?: NamespaceFilter,
   includeLinks?: boolean,
 ): Promise<SearchRow[]> {
   let rows: SearchRow[];


### PR DESCRIPTION
Lands #57 dreamer promotion code onto main (was merged to feat/rest-api branch, not main).

Includes: migration 016 (promoted_from JSONB), promote_entry/demote_entry/scan_namespace MCP tools, REST endpoints, promotion-service, namespace policy change (agents blocked from direct collab writes).

566 tests pass, typecheck clean.