### PR TITLE
fix: honor delegated namespace headers

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -108,6 +108,7 @@ describe("authMiddleware", () => {
   const tokenMap = new Map<string, AuthInfo>([
     ["valid-admin-token", { role: "admin", clientId: "admin" }],
     ["valid-agent-token", { role: "agent", clientId: "agent" }],
+    ["valid-readonly-token", { role: "readonly", clientId: "readonly" }],
   ]);
 
   const middleware = authMiddleware(tokenMap);
@@ -161,7 +162,6 @@ describe("authMiddleware", () => {
       tokenClientId: "admin",
       agentId: undefined,
       namespaceSource: "token",
-      headerRole: undefined,
     });
     expect(next).toHaveBeenCalledTimes(1);
   });
@@ -179,7 +179,6 @@ describe("authMiddleware", () => {
       tokenClientId: "agent",
       agentId: undefined,
       namespaceSource: "token",
-      headerRole: undefined,
     });
     expect(next).toHaveBeenCalledTimes(1);
   });
@@ -202,9 +201,23 @@ describe("authMiddleware", () => {
       tokenClientId: "agent",
       agentId: "bilby",
       namespaceSource: "header",
-      headerRole: "agent",
     });
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 403 when readonly token sends X-Namespace", () => {
+    const req = mockReq({
+      authorization: "Bearer valid-readonly-token",
+      "x-namespace": "bilby",
+    });
+    const res = mockRes();
+    const next = mock(() => {});
+
+    middleware(req as any, res as any, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Role not permitted to delegate namespace" });
+    expect(next).not.toHaveBeenCalled();
   });
 
   test("rejects invalid delegated namespace header", () => {

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -155,7 +155,14 @@ describe("authMiddleware", () => {
 
     middleware(req as any, res as any, next);
 
-    expect((req as any).auth).toEqual({ role: "admin", clientId: "admin" });
+    expect((req as any).auth).toEqual({
+      role: "admin",
+      clientId: "admin",
+      tokenClientId: "admin",
+      agentId: undefined,
+      namespaceSource: "token",
+      headerRole: undefined,
+    });
     expect(next).toHaveBeenCalledTimes(1);
   });
 
@@ -166,8 +173,53 @@ describe("authMiddleware", () => {
 
     middleware(req as any, res as any, next);
 
-    expect((req as any).auth).toEqual({ role: "agent", clientId: "agent" });
+    expect((req as any).auth).toEqual({
+      role: "agent",
+      clientId: "agent",
+      tokenClientId: "agent",
+      agentId: undefined,
+      namespaceSource: "token",
+      headerRole: undefined,
+    });
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses X-Namespace as effective clientId and keeps token identity", () => {
+    const req = mockReq({
+      authorization: "Bearer valid-agent-token",
+      "x-namespace": "bilby",
+      "x-agent-id": "bilby",
+      "x-role": "agent",
+    });
+    const res = mockRes();
+    const next = mock(() => {});
+
+    middleware(req as any, res as any, next);
+
+    expect((req as any).auth).toEqual({
+      role: "agent",
+      clientId: "bilby",
+      tokenClientId: "agent",
+      agentId: "bilby",
+      namespaceSource: "header",
+      headerRole: "agent",
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects invalid delegated namespace header", () => {
+    const req = mockReq({
+      authorization: "Bearer valid-agent-token",
+      "x-namespace": "../bilby",
+    });
+    const res = mockRes();
+    const next = mock(() => {});
+
+    middleware(req as any, res as any, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid X-Namespace header" });
+    expect(next).not.toHaveBeenCalled();
   });
 
   test("handles empty token map gracefully", () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,6 +19,8 @@ const ROLE_ENV_KEYS: Array<{ envKey: string; role: Role }> = [
   { envKey: "AUTH_TOKEN_READONLY", role: "readonly" },
 ];
 
+const DELEGATED_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
 export function buildTokenMap(
   env: Record<string, string | undefined>,
 ): Map<string, AuthInfo> {
@@ -96,11 +98,36 @@ export function authMiddleware(
     }
 
     if (matched) {
-      (req as any).auth = matched;
+      const namespace = headerValue(req.headers["x-namespace"]);
+      const agentId = headerValue(req.headers["x-agent-id"]);
+      const headerRole = headerValue(req.headers["x-role"]);
+
+      if (namespace && !DELEGATED_ID_RE.test(namespace)) {
+        res.status(400).json({ error: "Invalid X-Namespace header" });
+        return;
+      }
+      if (agentId && !DELEGATED_ID_RE.test(agentId)) {
+        res.status(400).json({ error: "Invalid X-Agent-Id header" });
+        return;
+      }
+
+      (req as any).auth = {
+        ...matched,
+        clientId: namespace ?? matched.clientId,
+        tokenClientId: matched.clientId,
+        agentId,
+        namespaceSource: namespace ? "header" : "token",
+        headerRole,
+      } satisfies AuthInfo;
       next();
       return;
     }
 
     res.status(401).json({ error: "Invalid token" });
   };
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]?.trim() || undefined;
+  return value?.trim() || undefined;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -99,9 +99,11 @@ export function authMiddleware(
 
     if (matched) {
       const namespace = headerValue(req.headers["x-namespace"]);
+      if (namespace && matched.role !== "admin" && matched.role !== "n8n" && matched.role !== "agent") {
+        res.status(403).json({ error: "Role not permitted to delegate namespace" });
+        return;
+      }
       const agentId = headerValue(req.headers["x-agent-id"]);
-      const headerRole = headerValue(req.headers["x-role"]);
-
       if (namespace && !DELEGATED_ID_RE.test(namespace)) {
         res.status(400).json({ error: "Invalid X-Namespace header" });
         return;
@@ -117,7 +119,6 @@ export function authMiddleware(
         tokenClientId: matched.clientId,
         agentId,
         namespaceSource: namespace ? "header" : "token",
-        headerRole,
       } satisfies AuthInfo;
       next();
       return;

--- a/src/middleware/request-logger.test.ts
+++ b/src/middleware/request-logger.test.ts
@@ -86,6 +86,31 @@ describe("requestLogger middleware", () => {
 
     const [, data] = lastInfoCall();
     expect(data).toHaveProperty("consumerId", "admin");
+    expect(data).toHaveProperty("effectiveNamespace", "admin");
+    expect(data).toHaveProperty("namespaceSource", "token");
+  });
+
+  test("delegated namespace is logged separately from token consumer", () => {
+    const req = mockReq({
+      auth: {
+        role: "agent",
+        clientId: "bilby",
+        tokenClientId: "agent",
+        agentId: "bilby",
+        namespaceSource: "header",
+      },
+    });
+    const res = mockRes();
+    const next = mock(() => {});
+
+    requestLogger(req, res, next as NextFunction);
+    (res as any)._emit("finish");
+
+    const [, data] = lastInfoCall();
+    expect(data).toHaveProperty("consumerId", "agent");
+    expect(data).toHaveProperty("effectiveNamespace", "bilby");
+    expect(data).toHaveProperty("namespaceSource", "X-Namespace header");
+    expect(data).toHaveProperty("agentId", "bilby");
   });
 
   test("consumerId is 'anonymous' when req.auth is undefined", () => {

--- a/src/middleware/request-logger.ts
+++ b/src/middleware/request-logger.ts
@@ -18,7 +18,18 @@ export function requestLogger(
       path: req.path,
       status: res.statusCode,
       durationMs,
-      consumerId: (req as any).auth?.clientId ?? "anonymous",
+      consumerId:
+        (req as any).auth?.tokenClientId ??
+        (req as any).auth?.clientId ??
+        "anonymous",
+      effectiveNamespace: (req as any).auth?.clientId,
+      namespaceSource:
+        (req as any).auth?.namespaceSource === "header"
+          ? "X-Namespace header"
+          : (req as any).auth
+            ? "token"
+            : undefined,
+      agentId: (req as any).auth?.agentId,
     });
   });
 

--- a/src/namespace-policy.test.ts
+++ b/src/namespace-policy.test.ts
@@ -17,6 +17,19 @@ describe("canWriteNamespace", () => {
     expect(canWriteNamespace(auth, "bilby").allowed).toBe(true);
   });
 
+  it("header namespace locks admin writes to delegated namespace", () => {
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "bilby",
+      tokenClientId: "admin",
+      namespaceSource: "header",
+    };
+    expect(canWriteNamespace(auth, "bilby").allowed).toBe(true);
+    const result = canWriteNamespace(auth, "skippy");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("X-Namespace");
+  });
+
   it("agent can write to own namespace", () => {
     const auth: AuthInfo = { role: "agent", clientId: "bilby" };
     expect(canWriteNamespace(auth, "bilby").allowed).toBe(true);

--- a/src/namespace-policy.ts
+++ b/src/namespace-policy.ts
@@ -9,6 +9,13 @@ export function canWriteNamespace(
   auth: AuthInfo,
   targetNamespace: string,
 ): NamespaceCheck {
+  if (auth.namespaceSource === "header" && targetNamespace !== auth.clientId) {
+    return {
+      allowed: false,
+      reason: `X-Namespace header requires writes to namespace '${auth.clientId}'`,
+    };
+  }
+
   if (auth.role === "admin" || auth.role === "n8n") {
     return { allowed: true };
   }

--- a/src/read-policy.test.ts
+++ b/src/read-policy.test.ts
@@ -15,10 +15,10 @@ describe("read-policy", () => {
       namespaceSource: "header",
     };
 
-    expect(readableNamespaces(auth)).toEqual(["bilby"]);
+    expect(readableNamespaces(auth)).toEqual(["bilby", "collab"]);
     expect(canReadNamespace(auth, "bilby")).toBe(true);
-    expect(canReadNamespace(auth, "collab")).toBe(false);
-    expect(namespaceFilterFor(auth)).toEqual(["bilby"]);
+    expect(canReadNamespace(auth, "collab")).toBe(true);
+    expect(namespaceFilterFor(auth)).toEqual(["bilby", "collab"]);
   });
 
   it("allows delegated admin to request namespace all", () => {
@@ -29,7 +29,7 @@ describe("read-policy", () => {
       namespaceSource: "header",
     };
 
-    expect(readableNamespaces(auth)).toEqual(["bilby"]);
+    expect(readableNamespaces(auth)).toEqual(["bilby", "collab"]);
     expect(canReadNamespace(auth, "all")).toBe(true);
     expect(namespaceFilterFor(auth, "all")).toBeUndefined();
   });

--- a/src/read-policy.test.ts
+++ b/src/read-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthInfo } from "./types.ts";
+import {
+  canReadNamespace,
+  namespaceFilterFor,
+  readableNamespaces,
+} from "./read-policy.ts";
+
+describe("read-policy", () => {
+  it("scopes delegated header callers to the header namespace", () => {
+    const auth: AuthInfo = {
+      role: "agent",
+      clientId: "bilby",
+      tokenClientId: "agent",
+      namespaceSource: "header",
+    };
+
+    expect(readableNamespaces(auth)).toEqual(["bilby"]);
+    expect(canReadNamespace(auth, "bilby")).toBe(true);
+    expect(canReadNamespace(auth, "collab")).toBe(false);
+    expect(namespaceFilterFor(auth)).toEqual(["bilby"]);
+  });
+
+  it("allows delegated admin to request namespace all", () => {
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "bilby",
+      tokenClientId: "admin",
+      namespaceSource: "header",
+    };
+
+    expect(readableNamespaces(auth)).toEqual(["bilby"]);
+    expect(canReadNamespace(auth, "all")).toBe(true);
+    expect(namespaceFilterFor(auth, "all")).toBeUndefined();
+  });
+});

--- a/src/read-policy.test.ts
+++ b/src/read-policy.test.ts
@@ -21,7 +21,7 @@ describe("read-policy", () => {
     expect(namespaceFilterFor(auth)).toEqual(["bilby", "collab"]);
   });
 
-  it("allows delegated admin to request namespace all", () => {
+  it("keeps delegated admin scoped when requesting namespace all", () => {
     const auth: AuthInfo = {
       role: "admin",
       clientId: "bilby",
@@ -30,6 +30,18 @@ describe("read-policy", () => {
     };
 
     expect(readableNamespaces(auth)).toEqual(["bilby", "collab"]);
+    expect(canReadNamespace(auth, "all")).toBe(false);
+  });
+
+  it("allows token-sourced admin to request namespace all", () => {
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "admin",
+      tokenClientId: "admin",
+      namespaceSource: "token",
+    };
+
+    expect(readableNamespaces(auth)).toBeUndefined();
     expect(canReadNamespace(auth, "all")).toBe(true);
     expect(namespaceFilterFor(auth, "all")).toBeUndefined();
   });

--- a/src/read-policy.ts
+++ b/src/read-policy.ts
@@ -1,6 +1,9 @@
 import type { AuthInfo } from "./types.ts";
 
 export function readableNamespaces(auth: AuthInfo): string[] | undefined {
+  if (auth.namespaceSource === "header") {
+    return [auth.clientId];
+  }
   if (auth.role === "admin" || auth.role === "n8n") {
     return undefined;
   }
@@ -8,6 +11,13 @@ export function readableNamespaces(auth: AuthInfo): string[] | undefined {
 }
 
 export function canReadNamespace(auth: AuthInfo, namespace: string): boolean {
+  if (
+    namespace === "all" &&
+    auth.namespaceSource === "header" &&
+    (auth.role === "admin" || auth.role === "n8n")
+  ) {
+    return true;
+  }
   const allowed = readableNamespaces(auth);
   return !allowed || allowed.includes(namespace);
 }
@@ -16,6 +26,13 @@ export function namespaceFilterFor(
   auth: AuthInfo,
   namespace?: string,
 ): string | string[] | undefined {
+  if (
+    namespace === "all" &&
+    auth.namespaceSource === "header" &&
+    (auth.role === "admin" || auth.role === "n8n")
+  ) {
+    return undefined;
+  }
   if (namespace !== undefined) {
     return namespace;
   }

--- a/src/read-policy.ts
+++ b/src/read-policy.ts
@@ -2,7 +2,7 @@ import type { AuthInfo } from "./types.ts";
 
 export function readableNamespaces(auth: AuthInfo): string[] | undefined {
   if (auth.namespaceSource === "header") {
-    return [auth.clientId];
+    return [auth.clientId, "collab"];
   }
   if (auth.role === "admin" || auth.role === "n8n") {
     return undefined;

--- a/src/read-policy.ts
+++ b/src/read-policy.ts
@@ -13,7 +13,7 @@ export function readableNamespaces(auth: AuthInfo): string[] | undefined {
 export function canReadNamespace(auth: AuthInfo, namespace: string): boolean {
   if (
     namespace === "all" &&
-    auth.namespaceSource === "header" &&
+    auth.namespaceSource !== "header" &&
     (auth.role === "admin" || auth.role === "n8n")
   ) {
     return true;
@@ -28,7 +28,7 @@ export function namespaceFilterFor(
 ): string | string[] | undefined {
   if (
     namespace === "all" &&
-    auth.namespaceSource === "header" &&
+    auth.namespaceSource !== "header" &&
     (auth.role === "admin" || auth.role === "n8n")
   ) {
     return undefined;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -29,6 +29,7 @@ const mockPool = {
 // -- Token map ----------------------------------------------------------------
 const testTokenMap = new Map<string, AuthInfo>([
   ["test-token-123", { role: "admin" as const, clientId: "test" }],
+  ["agent-token-123", { role: "agent" as const, clientId: "agent" }],
 ]);
 
 // -- Server lifecycle ---------------------------------------------------------
@@ -182,5 +183,54 @@ describe("POST /mcp", () => {
     const sessionId = res.headers.get("mcp-session-id");
     expect(sessionId).toBeTruthy();
     expect(typeof sessionId).toBe("string");
+  });
+
+  it("allows same token session reuse with a different delegated namespace", async () => {
+    const initRequest = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0.0" },
+      },
+    };
+
+    const init = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer agent-token-123",
+        Accept: "application/json, text/event-stream",
+        "X-Namespace": "bilby",
+        "X-Agent-Id": "bilby",
+        "X-Role": "agent",
+      },
+      body: JSON.stringify(initRequest),
+    });
+
+    expect(init.status).toBe(200);
+    const sessionId = init.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    const initialized = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer agent-token-123",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": sessionId!,
+        "X-Namespace": "skippy",
+        "X-Agent-Id": "skippy",
+        "X-Role": "agent",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+    });
+
+    expect(initialized.status).not.toBe(403);
   });
 });

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { registerGetEntry } from "../get-entry.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  getErrorText,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+describe("get_entry", () => {
+  it("filters scoped callers to readable namespaces", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        return { rows: [{ id: params?.[0], namespace: "bilby", content: "ok" }] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440000",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result).namespace).toBe("bilby");
+      expect(queries[0]?.sql).toContain("namespace = ANY($2::text[])");
+      expect(queries[0]?.params).toEqual([
+        "550e8400-e29b-41d4-a716-446655440000",
+        ["bilby", "collab"],
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns not found when scoped namespace filter excludes the row", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "bilby",
+      tokenClientId: "admin",
+      namespaceSource: "header",
+    };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440001",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("Entry not found");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/scan-namespace.test.ts
+++ b/src/tools/__tests__/scan-namespace.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { registerScanNamespace } from "../scan-namespace.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  getErrorText,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+describe("scan_namespace", () => {
+  it("denies delegated admin scanning outside the delegated namespace", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "bilby",
+      tokenClientId: "admin",
+      namespaceSource: "header",
+    };
+    const { client, cleanup } = await setupMcpClient(
+      registerScanNamespace,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "scan_namespace",
+        arguments: { namespace: "skippy" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("namespace read access denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows delegated admin scanning the delegated namespace", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "bilby",
+      tokenClientId: "admin",
+      namespaceSource: "header",
+    };
+    const { client, cleanup } = await setupMcpClient(
+      registerScanNamespace,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "scan_namespace",
+        arguments: { namespace: "bilby", table: "thoughts" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result).namespace).toBe("bilby");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { readableNamespaces } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { TABLE_COLUMNS } from "../table-projections.ts";
@@ -49,9 +50,13 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
       }
 
       const columns = TABLE_COLUMNS[table];
+      const readable = readableNamespaces(auth);
+      const namespacePredicate = readable
+        ? " AND namespace = ANY($2::text[])"
+        : "";
       const { rows } = await deps.pool.query(
-        `SELECT ${columns} FROM ${table} WHERE id = $1 AND archived_at IS NULL`,
-        [args.id],
+        `SELECT ${columns} FROM ${table} WHERE id = $1 AND archived_at IS NULL${namespacePredicate}`,
+        readable ? [args.id, readable] : [args.id],
       );
 
       if (rows.length === 0) {

--- a/src/tools/list-namespaces.ts
+++ b/src/tools/list-namespaces.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { readableNamespaces } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -48,18 +49,23 @@ export function registerListNamespaces(server: McpServer, deps: ToolDeps): void 
       }
 
       // Query each table for namespace counts
-      const queries = accessibleTables.map((table) =>
-        deps.pool.query(
+      const readable = readableNamespaces(auth);
+      const queries = accessibleTables.map((table) => {
+        const namespacePredicate = readable
+          ? " AND namespace = ANY($1::text[])"
+          : "";
+        return deps.pool.query(
           `SELECT
             '${table}' AS table_name,
             namespace,
             COUNT(*) AS count
           FROM ${table}
-          WHERE archived_at IS NULL
+          WHERE archived_at IS NULL${namespacePredicate}
           GROUP BY namespace
           ORDER BY count DESC`,
-        ),
-      );
+          readable ? [readable] : [],
+        );
+      });
 
       const results = await Promise.all(queries);
 

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { readableNamespaces } from "../read-policy.ts";
 import type { AuthInfo, Table, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -17,24 +18,29 @@ function buildWhereClause(
   alias: string,
   includeArchived: boolean,
   tier?: Tier,
+  namespaceParamIndex?: number,
 ): string {
   const archiveFilter = includeArchived
     ? ""
     : ` AND ${alias}.archived_at IS NULL`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
-  return `WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}`;
+  const namespaceFilter = namespaceParamIndex
+    ? ` AND ${alias}.namespace = ANY($${namespaceParamIndex}::text[])`
+    : "";
+  return `WHERE ${alias}.created_at >= NOW() - INTERVAL '1 day' * $1${archiveFilter}${tierFilter}${namespaceFilter}`;
 }
 
 function buildTableSelect(
   table: Table,
   includeArchived: boolean,
   tier?: Tier,
+  namespaceParamIndex?: number,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
-  const where = buildWhereClause(alias, includeArchived, tier);
+  const where = buildWhereClause(alias, includeArchived, tier, namespaceParamIndex);
 
   return `SELECT
     '${label}' AS source_type,
@@ -51,10 +57,11 @@ function buildCountSelect(
   table: Table,
   includeArchived: boolean,
   tier?: Tier,
+  namespaceParamIndex?: number,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
-  const where = buildWhereClause(alias, includeArchived, tier);
+  const where = buildWhereClause(alias, includeArchived, tier, namespaceParamIndex);
 
   return `SELECT COUNT(*) AS cnt
   FROM ${table} ${alias}
@@ -175,10 +182,12 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       const includeArchived = args.include_archived ?? false;
       const tier = args.tier as Tier | undefined;
       const useArray = args.response_format === "array";
+      const readable = readableNamespaces(auth);
+      const namespaceParamIndex = readable ? 4 : undefined;
 
       // Build UNION ALL of table SELECTs
       const selects = accessibleTables.map((t) =>
-        buildTableSelect(t, includeArchived, tier),
+        buildTableSelect(t, includeArchived, tier, namespaceParamIndex),
       );
 
       const unionSql = selects.join("\nUNION ALL\n");
@@ -186,7 +195,7 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
 
       // Build total count query
       const countSelects = accessibleTables.map((t) =>
-        buildCountSelect(t, includeArchived, tier),
+        buildCountSelect(t, includeArchived, tier, namespaceParamIndex),
       );
       const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
 
@@ -199,8 +208,8 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       });
 
       const [dataResult, countResult] = await Promise.all([
-        deps.pool.query(sql, [days, limit, offset]),
-        deps.pool.query(countSql, [days]).catch(() => null),
+        deps.pool.query(sql, readable ? [days, limit, offset, readable] : [days, limit, offset]),
+        deps.pool.query(countSql, readable ? [days, undefined, undefined, readable] : [days]).catch(() => null),
       ]);
 
       const totalCount = countResult?.rows[0]?.total_count ?? null;

--- a/src/tools/list-recent.ts
+++ b/src/tools/list-recent.ts
@@ -184,6 +184,7 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
       const useArray = args.response_format === "array";
       const readable = readableNamespaces(auth);
       const namespaceParamIndex = readable ? 4 : undefined;
+      const countNamespaceParamIndex = readable ? 2 : undefined;
 
       // Build UNION ALL of table SELECTs
       const selects = accessibleTables.map((t) =>
@@ -195,7 +196,7 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
 
       // Build total count query
       const countSelects = accessibleTables.map((t) =>
-        buildCountSelect(t, includeArchived, tier, namespaceParamIndex),
+        buildCountSelect(t, includeArchived, tier, countNamespaceParamIndex),
       );
       const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
 
@@ -209,7 +210,7 @@ export function registerListRecent(server: McpServer, deps: ToolDeps): void {
 
       const [dataResult, countResult] = await Promise.all([
         deps.pool.query(sql, readable ? [days, limit, offset, readable] : [days, limit, offset]),
-        deps.pool.query(countSql, readable ? [days, undefined, undefined, readable] : [days]).catch(() => null),
+        deps.pool.query(countSql, readable ? [days, readable] : [days]).catch(() => null),
       ]);
 
       const totalCount = countResult?.rows[0]?.total_count ?? null;

--- a/src/tools/list-stale.ts
+++ b/src/tools/list-stale.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { readableNamespaces } from "../read-policy.ts";
 import type { AuthInfo, Table, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -13,18 +14,29 @@ import {
   VALID_TIERS,
 } from "./table-constants.ts";
 
-function buildWhereClause(alias: string, tier?: Tier): string {
+function buildWhereClause(
+  alias: string,
+  tier?: Tier,
+  namespaceParamIndex?: number,
+): string {
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
+  const namespaceFilter = namespaceParamIndex
+    ? ` AND ${alias}.namespace = ANY($${namespaceParamIndex}::text[])`
+    : "";
   return `WHERE ${alias}.archived_at IS NULL
-    AND COALESCE(${alias}.last_accessed_at, ${alias}.created_at) < NOW() - INTERVAL '1 day' * $1${tierFilter}`;
+    AND COALESCE(${alias}.last_accessed_at, ${alias}.created_at) < NOW() - INTERVAL '1 day' * $1${tierFilter}${namespaceFilter}`;
 }
 
-function buildStaleSelect(table: Table, tier?: Tier): string {
+function buildStaleSelect(
+  table: Table,
+  tier?: Tier,
+  namespaceParamIndex?: number,
+): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
-  const where = buildWhereClause(alias, tier);
+  const where = buildWhereClause(alias, tier, namespaceParamIndex);
 
   return `SELECT
     '${label}' AS source_type,
@@ -40,10 +52,14 @@ function buildStaleSelect(table: Table, tier?: Tier): string {
   ${where}`;
 }
 
-function buildCountSelect(table: Table, tier?: Tier): string {
+function buildCountSelect(
+  table: Table,
+  tier?: Tier,
+  namespaceParamIndex?: number,
+): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   const alias = TABLE_ALIAS[table];
-  const where = buildWhereClause(alias, tier);
+  const where = buildWhereClause(alias, tier, namespaceParamIndex);
 
   return `SELECT COUNT(*) AS cnt
   FROM ${table} ${alias}
@@ -163,13 +179,17 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       const offset = args.offset ?? 0;
       const tier = args.tier as Tier | undefined;
       const useArray = args.response_format === "array";
+      const readable = readableNamespaces(auth);
+      const namespaceParamIndex = readable ? 4 : undefined;
 
-      const selects = accessibleTables.map((t) => buildStaleSelect(t, tier));
+      const selects = accessibleTables.map((t) =>
+        buildStaleSelect(t, tier, namespaceParamIndex),
+      );
       const unionSql = selects.join("\nUNION ALL\n");
       const sql = `${unionSql}\nORDER BY effective_last_access ASC\nLIMIT $2 OFFSET $3`;
 
       const countSelects = accessibleTables.map((t) =>
-        buildCountSelect(t, tier),
+        buildCountSelect(t, tier, namespaceParamIndex),
       );
       const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
 
@@ -182,8 +202,8 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       });
 
       const [dataResult, countResult] = await Promise.all([
-        deps.pool.query(sql, [days, limit, offset]),
-        deps.pool.query(countSql, [days]).catch(() => null),
+        deps.pool.query(sql, readable ? [days, limit, offset, readable] : [days, limit, offset]),
+        deps.pool.query(countSql, readable ? [days, undefined, undefined, readable] : [days]).catch(() => null),
       ]);
 
       const totalCount = countResult?.rows[0]?.total_count ?? null;

--- a/src/tools/list-stale.ts
+++ b/src/tools/list-stale.ts
@@ -181,6 +181,7 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       const useArray = args.response_format === "array";
       const readable = readableNamespaces(auth);
       const namespaceParamIndex = readable ? 4 : undefined;
+      const countNamespaceParamIndex = readable ? 2 : undefined;
 
       const selects = accessibleTables.map((t) =>
         buildStaleSelect(t, tier, namespaceParamIndex),
@@ -189,7 +190,7 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
       const sql = `${unionSql}\nORDER BY effective_last_access ASC\nLIMIT $2 OFFSET $3`;
 
       const countSelects = accessibleTables.map((t) =>
-        buildCountSelect(t, tier, namespaceParamIndex),
+        buildCountSelect(t, tier, countNamespaceParamIndex),
       );
       const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
 
@@ -203,7 +204,7 @@ export function registerListStale(server: McpServer, deps: ToolDeps): void {
 
       const [dataResult, countResult] = await Promise.all([
         deps.pool.query(sql, readable ? [days, limit, offset, readable] : [days, limit, offset]),
-        deps.pool.query(countSql, readable ? [days, undefined, undefined, readable] : [days]).catch(() => null),
+        deps.pool.query(countSql, readable ? [days, readable] : [days]).catch(() => null),
       ]);
 
       const totalCount = countResult?.rows[0]?.total_count ?? null;

--- a/src/tools/scan-namespace.ts
+++ b/src/tools/scan-namespace.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canReadNamespace } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -42,6 +43,12 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
       if (!auth || (auth.role !== "admin" && auth.role !== "n8n")) {
         return {
           content: [{ type: "text" as const, text: "Permission denied: admin or n8n role required" }],
+          isError: true,
+        };
+      }
+      if (!canReadNamespace(auth, args.namespace)) {
+        return {
+          content: [{ type: "text" as const, text: "Permission denied: namespace read access denied" }],
           isError: true,
         };
       }

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { canReadNamespace, namespaceFilterFor } from "../read-policy.ts";
 import type { AuthInfo, Tier } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -12,6 +13,8 @@ import {
   type SearchMode,
   type SearchRow,
 } from "./search-brain.ts";
+
+type NamespaceFilter = string | string[];
 
 interface UnifiedResult {
   source: "brain" | "qmd";
@@ -166,7 +169,19 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
-      const namespace = args.namespace as string | undefined;
+      const requestedNamespace = args.namespace as string | undefined;
+      if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: namespace read access denied",
+            },
+          ],
+          isError: true,
+        };
+      }
+      const namespace = namespaceFilterFor(auth, requestedNamespace);
       const searchBrain = sources === "all" || sources === "brain";
       const searchQmdSource = sources === "all" || sources === "qmd";
 
@@ -229,7 +244,7 @@ async function searchOB(
   limit: number,
   mode: SearchMode = "hybrid",
   tier?: Tier,
-  namespace?: string,
+  namespace?: NamespaceFilter,
 ): Promise<UnifiedResult[]> {
   const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
   if (accessibleTables.length === 0) return [];

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canRead } from "../permissions.ts";
+import { canReadNamespace, namespaceFilterFor } from "../read-policy.ts";
 import type { AuthInfo, LinkRelation, Table, Tier } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
@@ -685,7 +686,19 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const offset = args.offset ?? 0;
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
-      const namespace = args.namespace as string | undefined;
+      const requestedNamespace = args.namespace as string | undefined;
+      if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: namespace read access denied",
+            },
+          ],
+          isError: true,
+        };
+      }
+      const namespace = namespaceFilterFor(auth, requestedNamespace);
 
       let rows;
       try {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -78,6 +78,20 @@ function getSessionAuth(sessionId: string): AuthInfo | undefined {
   return sessions.get(sessionId)?.auth;
 }
 
+function tokenClientId(auth: AuthInfo | undefined): string | undefined {
+  return auth?.tokenClientId ?? auth?.clientId;
+}
+
+function sameTokenIdentity(
+  requestAuth: AuthInfo | undefined,
+  sessionAuth: AuthInfo,
+): boolean {
+  return (
+    tokenClientId(requestAuth) === tokenClientId(sessionAuth) &&
+    requestAuth?.role === sessionAuth.role
+  );
+}
+
 export function getSessionCount(): number {
   return sessions.size;
 }
@@ -102,10 +116,7 @@ export function createTransportHandlers(
         const entry = sessions.get(sessionId)!;
 
         // Verify the bearer token matches the session's original auth
-        if (
-          reqAuth?.clientId !== entry.auth.clientId ||
-          reqAuth?.role !== entry.auth.role
-        ) {
+        if (!sameTokenIdentity(reqAuth, entry.auth)) {
           res
             .status(403)
             .json({ error: "Token does not match session identity" });
@@ -199,10 +210,7 @@ export function createTransportHandlers(
         const entry = sessions.get(sessionId)!;
         const reqAuth = (req as any).auth as AuthInfo | undefined;
 
-        if (
-          reqAuth?.clientId !== entry.auth.clientId ||
-          reqAuth?.role !== entry.auth.role
-        ) {
+        if (!sameTokenIdentity(reqAuth, entry.auth)) {
           res
             .status(403)
             .json({ error: "Token does not match session identity" });
@@ -226,10 +234,7 @@ export function createTransportHandlers(
         const entry = sessions.get(sessionId)!;
         const reqAuth = (req as any).auth as AuthInfo | undefined;
 
-        if (
-          reqAuth?.clientId !== entry.auth.clientId ||
-          reqAuth?.role !== entry.auth.role
-        ) {
+        if (!sameTokenIdentity(reqAuth, entry.auth)) {
           res
             .status(403)
             .json({ error: "Token does not match session identity" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,10 @@ export type Permission = "read" | "write" | "delete";
 export interface AuthInfo {
   role: Role;
   clientId: string;
+  tokenClientId?: string;
+  agentId?: string;
+  namespaceSource?: "token" | "header";
+  headerRole?: string;
 }
 
 export interface PoolHealth {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface AuthInfo {
   tokenClientId?: string;
   agentId?: string;
   namespaceSource?: "token" | "header";
-  headerRole?: string;
 }
 
 export interface PoolHealth {


### PR DESCRIPTION
## Summary
- Honor trusted mcp2cli delegated identity headers by using X-Namespace as the effective namespace while preserving the bearer-token profile for session identity checks.
- Scope read paths by effective namespace across search, search_all, list_recent, list_stale, and list_namespaces.
- Add request log audit fields for consumerId, effectiveNamespace, namespaceSource, and agentId.
- Lock writes to the delegated namespace when X-Namespace is present.

Closes #64

## Swarm Review Findings

5-agent parallel review (correctness, adversarial, quality, security, domain specialist).

### Fixed in this PR

| ID | Severity | Finding | Fix |
|---|---|---|---|
| H-1 | HIGH | Any role (including readonly) could set X-Namespace and read another namespace's data | Gate delegation to admin/n8n/agent roles; readonly/discord get 403 |
| H-2 | HIGH | `headerRole` (X-Role) stored unvalidated, never consumed — latent priv-esc risk | Removed `headerRole` from AuthInfo entirely |
| H-3 | HIGH | Delegated callers lost access to "collab" namespace (behavioral regression) | Delegated callers now get `[clientId, "collab"]` matching non-delegated behavior |
| M-1 | MEDIUM | Count queries passed `undefined` for unused SQL params $2/$3 | Separate `countNamespaceParamIndex` with `[days, readable]` params |

### Deferred (follow-up scope, pre-existing gaps)

| ID | Severity | Description |
|---|---|---|
| H-4 | HIGH | 8 read tools (get-entry, session-load, find-person, access-report, find-duplicates, tier-recommendations, curate-entries, scan-namespace) lack namespace scoping for delegated callers |
| H-5 | HIGH | `created_by`/`accessed_by` columns record delegated namespace instead of token identity, corrupting audit trail |
| M-2 | MEDIUM | Duplicated `namespace === "all"` logic in `canReadNamespace` and `namespaceFilterFor` |
| M-3 | MEDIUM | No tests for namespace filtering in list-stale, list-recent, list-namespaces, search-brain, search-all, or transport identity |

### Security Checklist
- [x] Secrets scan (ggshield): PASS
- [x] Input validation: DELEGATED_ID_RE on X-Namespace, X-Agent-Id
- [x] SQL injection: parameterized queries throughout
- [x] Session integrity: `sameTokenIdentity` uses tokenClientId
- [x] Role gating: delegation restricted to admin/n8n/agent
- [x] Write lock: header-delegated writes locked to delegated namespace
- [x] Audit logging: consumerId, effectiveNamespace, namespaceSource, agentId

## Verification
- bun test (574 pass, 0 fail)
- bun run typecheck (clean)