### PR TITLE
feat: add OpenBrain Python client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .eslintcache
 .cache
 *.tsbuildinfo
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
 
 # IntelliJ based IDEs
 .idea

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -1,0 +1,29 @@
+# openbrain-memory
+
+Python client package for talking to a remote Open Brain service.
+
+This package is installed on agent hosts. The Open Brain service remains remote
+and exposes HTTP endpoints such as `/health` and `/mcp`.
+
+## Test
+
+```bash
+uv run pytest
+```
+
+## Optional Live Canary
+
+Default tests use fake transports and do not require credentials. A live canary
+can be enabled explicitly with environment variables:
+
+```bash
+OPENBRAIN_LIVE_CANARY=1 \
+OPENBRAIN_BASE_URL=http://127.0.0.1:3100 \
+OPENBRAIN_TOKEN=... \
+OPENBRAIN_NAMESPACE=bilby \
+uv run pytest tests/test_live_canary.py
+```
+
+Non-local `http://` endpoints are rejected by default because MCP requests carry
+bearer tokens. For trusted lab-only HTTP endpoints, set
+`OPENBRAIN_ALLOW_INSECURE_HTTP=1` explicitly.

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "openbrain-memory"
+version = "0.1.0"
+description = "Python client for remote Open Brain memory service"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -1,0 +1,15 @@
+from .client import (
+    OpenBrainClient,
+    OpenBrainError,
+    OpenBrainHTTPError,
+    OpenBrainProtocolError,
+    OpenBrainToolError,
+)
+
+__all__ = [
+    "OpenBrainClient",
+    "OpenBrainError",
+    "OpenBrainHTTPError",
+    "OpenBrainProtocolError",
+    "OpenBrainToolError",
+]

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -1,0 +1,594 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from itertools import count
+import re
+from typing import Any, Mapping, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+JSON = dict[str, Any]
+MCP_PROTOCOL_VERSION = "2025-03-26"
+
+
+@dataclass(frozen=True)
+class TransportResponse:
+    status_code: int
+    headers: Mapping[str, str]
+    text: str
+
+    def json(self) -> Any:
+        if not self.text:
+            return None
+        return json.loads(self.text)
+
+
+class Transport(Protocol):
+    def get(self, url: str, *, headers: Mapping[str, str], timeout: float) -> TransportResponse:
+        ...
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json_body: JSON,
+        timeout: float,
+    ) -> TransportResponse:
+        ...
+
+
+class UrllibTransport:
+    def __init__(self) -> None:
+        self._opener = build_opener(_NoRedirectHandler)
+
+    def get(self, url: str, *, headers: Mapping[str, str], timeout: float) -> TransportResponse:
+        request = Request(url, headers=dict(headers), method="GET")
+        return self._send(request, timeout)
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json_body: JSON,
+        timeout: float,
+    ) -> TransportResponse:
+        data = json.dumps(json_body).encode("utf-8")
+        request = Request(url, data=data, headers=dict(headers), method="POST")
+        return self._send(request, timeout)
+
+    def _send(self, request: Request, timeout: float) -> TransportResponse:
+        try:
+            with self._opener.open(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+                return TransportResponse(
+                    status_code=response.status,
+                    headers={k.lower(): v for k, v in response.headers.items()},
+                    text=body,
+                )
+        except HTTPError as exc:
+            try:
+                body = exc.read().decode("utf-8", errors="replace")
+            except OSError:
+                body = ""
+            return TransportResponse(
+                status_code=exc.code,
+                headers={k.lower(): v for k, v in exc.headers.items()},
+                text=body,
+            )
+        except URLError as exc:
+            raise OpenBrainHTTPError(
+                f"Open Brain request failed: {exc.reason}",
+                context="transport",
+            ) from exc
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+class OpenBrainError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        context: str | None = None,
+        body: str | None = None,
+        token: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.context = context
+        self.body = _redact(body or "", token=token, session_id=session_id)
+        parts = [message]
+        if status_code is not None:
+            parts.append(f"status={status_code}")
+        if context:
+            parts.append(f"context={context}")
+        if self.body:
+            parts.append(f"body={self.body}")
+        super().__init__(" ".join(parts))
+
+
+class OpenBrainHTTPError(OpenBrainError):
+    pass
+
+
+class OpenBrainProtocolError(OpenBrainError):
+    pass
+
+
+class OpenBrainToolError(OpenBrainError):
+    pass
+
+
+class OpenBrainClient:
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        namespace: str,
+        agent_id: str | None = None,
+        role: str | None = None,
+        timeout: float = 30.0,
+        transport: Transport | None = None,
+        allow_insecure_http: bool = False,
+    ) -> None:
+        _validate_base_url(base_url, allow_insecure_http=allow_insecure_http)
+        self.base_url = base_url.rstrip("/") + "/"
+        self.token = token
+        self.namespace = namespace
+        self.agent_id = agent_id
+        self.role = role
+        self.timeout = timeout
+        self.transport = transport or UrllibTransport()
+        self._session_id: str | None = None
+        self._protocol_version = MCP_PROTOCOL_VERSION
+        self._ids = count(1)
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    def health(self) -> JSON:
+        response = self.transport.get(
+            self._url("health"),
+            headers={"Accept": "application/json"},
+            timeout=self.timeout,
+        )
+        self._raise_for_status(response, context="health")
+        payload = self._decode_json_response(response, context="health")
+        if not isinstance(payload, dict):
+            raise OpenBrainProtocolError("Health response was not a JSON object", context="health")
+        return payload
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any] | None = None) -> JSON:
+        self._ensure_session()
+        request_id = next(self._ids)
+        payload: JSON = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": dict(arguments or {})},
+        }
+        response = self.transport.post(
+            self._url("mcp"),
+            headers=self._mcp_headers(include_session=True),
+            json_body=payload,
+            timeout=self.timeout,
+        )
+        self._raise_for_status(response, context=f"call_tool:{name}")
+        message = self._decode_jsonrpc_response(
+            response,
+            expected_id=request_id,
+            context=f"call_tool:{name}",
+        )
+        result = message.get("result")
+        if not isinstance(result, dict):
+            raise OpenBrainProtocolError("MCP tool result was not a JSON object", context=f"call_tool:{name}")
+        if result.get("isError"):
+            raise OpenBrainToolError(
+                "Open Brain tool returned an error",
+                context=f"call_tool:{name}",
+                body=_tool_text(result),
+                token=self.token,
+                session_id=self._session_id,
+            )
+        return _decode_tool_payload(result)
+
+    def access_report(self, **arguments: Any) -> JSON:
+        return self.call_tool("access_report", arguments)
+
+    def adjacent_context(self, **arguments: Any) -> JSON:
+        return self.call_tool("adjacent_context", arguments)
+
+    def session_start(self, **arguments: Any) -> JSON:
+        return self.call_tool("session_start", arguments)
+
+    def session_context(self, **arguments: Any) -> JSON:
+        return self.call_tool("session_context", arguments)
+
+    def append_session_event(self, **arguments: Any) -> JSON:
+        return self.call_tool("append_session_event", arguments)
+
+    def archive_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("archive_entry", arguments)
+
+    def bulk_archive(self, **arguments: Any) -> JSON:
+        return self.call_tool("bulk_archive", arguments)
+
+    def bulk_set_tier(self, **arguments: Any) -> JSON:
+        return self.call_tool("bulk_set_tier", arguments)
+
+    def curate_entries(self, **arguments: Any) -> JSON:
+        return self.call_tool("curate_entries", arguments)
+
+    def demote_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("demote_entry", arguments)
+
+    def find_duplicates(self, **arguments: Any) -> JSON:
+        return self.call_tool("find_duplicates", arguments)
+
+    def find_person(self, **arguments: Any) -> JSON:
+        return self.call_tool("find_person", arguments)
+
+    def get_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("get_entry", arguments)
+
+    def get_stats(self, **arguments: Any) -> JSON:
+        return self.call_tool("get_stats", arguments)
+
+    def lane_load(self, **arguments: Any) -> JSON:
+        return self.call_tool("lane_load", arguments)
+
+    def lane_upsert(self, **arguments: Any) -> JSON:
+        return self.call_tool("lane_upsert", arguments)
+
+    def link_entities(self, **arguments: Any) -> JSON:
+        return self.call_tool("link_entities", arguments)
+
+    def list_namespaces(self, **arguments: Any) -> JSON:
+        return self.call_tool("list_namespaces", arguments)
+
+    def list_recent(self, **arguments: Any) -> JSON:
+        return self.call_tool("list_recent", arguments)
+
+    def list_stale(self, **arguments: Any) -> JSON:
+        return self.call_tool("list_stale", arguments)
+
+    def session_wrap(self, **arguments: Any) -> JSON:
+        return self.call_tool("session_wrap", arguments)
+
+    def log_thought(self, **arguments: Any) -> JSON:
+        return self.call_tool("log_thought", arguments)
+
+    def log_decision(self, **arguments: Any) -> JSON:
+        return self.call_tool("log_decision", arguments)
+
+    def promote_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("promote_entry", arguments)
+
+    def rate_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("rate_entry", arguments)
+
+    def scan_namespace(self, **arguments: Any) -> JSON:
+        return self.call_tool("scan_namespace", arguments)
+
+    def search_all(self, **arguments: Any) -> JSON:
+        return self.call_tool("search_all", arguments)
+
+    def search_brain(self, **arguments: Any) -> JSON:
+        return self.call_tool("search_brain", arguments)
+
+    def session_load(self, **arguments: Any) -> JSON:
+        return self.call_tool("session_load", arguments)
+
+    def session_save(self, **arguments: Any) -> JSON:
+        return self.call_tool("session_save", arguments)
+
+    def set_tier(self, **arguments: Any) -> JSON:
+        return self.call_tool("set_tier", arguments)
+
+    def tier_recommendations(self, **arguments: Any) -> JSON:
+        return self.call_tool("tier_recommendations", arguments)
+
+    def update_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("update_entry", arguments)
+
+    def upsert_entity(self, **arguments: Any) -> JSON:
+        return self.call_tool("upsert_entity", arguments)
+
+    def upsert_person(self, **arguments: Any) -> JSON:
+        return self.call_tool("upsert_person", arguments)
+
+    def _ensure_session(self) -> None:
+        if self._session_id:
+            return
+        request_id = next(self._ids)
+        payload: JSON = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "openbrain-memory", "version": "0.1.0"},
+            },
+        }
+        response = self.transport.post(
+            self._url("mcp"),
+            headers=self._mcp_headers(include_session=False),
+            json_body=payload,
+            timeout=self.timeout,
+        )
+        self._raise_for_status(response, context="initialize")
+        pending_session_id = _header(response.headers, "mcp-session-id")
+        if not pending_session_id:
+            raise OpenBrainProtocolError("Initialize response missing mcp-session-id", context="initialize")
+        message = self._decode_jsonrpc_response(
+            response,
+            expected_id=request_id,
+            context="initialize",
+        )
+        result = message.get("result")
+        if not isinstance(result, dict):
+            raise OpenBrainProtocolError(
+                "Initialize response missing result object",
+                context="initialize",
+                body=json.dumps(message, sort_keys=True),
+                token=self.token,
+            )
+        protocol_version = result.get("protocolVersion")
+        if not isinstance(protocol_version, str):
+            raise OpenBrainProtocolError(
+                "Initialize response missing protocolVersion",
+                context="initialize",
+                body=json.dumps(result, sort_keys=True),
+                token=self.token,
+            )
+        self._protocol_version = protocol_version
+        self._send_initialized_notification(pending_session_id)
+        self._session_id = pending_session_id
+
+    def _send_initialized_notification(self, session_id: str) -> None:
+        payload: JSON = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        response = self.transport.post(
+            self._url("mcp"),
+            headers=self._mcp_headers(include_session=True, session_id=session_id),
+            json_body=payload,
+            timeout=self.timeout,
+        )
+        self._raise_for_status(response, context="initialized")
+
+    def _url(self, path: str) -> str:
+        return urljoin(self.base_url, path)
+
+    def _mcp_headers(
+        self,
+        *,
+        include_session: bool,
+        session_id: str | None = None,
+    ) -> dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "X-Namespace": self.namespace,
+        }
+        if self.agent_id:
+            headers["X-Agent-Id"] = self.agent_id
+        if self.role:
+            headers["X-Role"] = self.role
+        if include_session:
+            active_session_id = session_id or self._session_id
+            if not active_session_id:
+                raise OpenBrainProtocolError("MCP session has not been initialized", context="headers")
+            headers["Mcp-Session-Id"] = active_session_id
+            headers["MCP-Protocol-Version"] = self._protocol_version
+        return headers
+
+    def _raise_for_status(self, response: TransportResponse, *, context: str) -> None:
+        if 200 <= response.status_code < 300:
+            return
+        raise OpenBrainHTTPError(
+            "Open Brain HTTP error",
+            status_code=response.status_code,
+            context=context,
+            body=response.text,
+            token=self.token,
+            session_id=self._session_id,
+        )
+
+    def _decode_json_response(self, response: TransportResponse, *, context: str) -> Any:
+        try:
+            return response.json()
+        except json.JSONDecodeError as exc:
+            raise OpenBrainProtocolError(
+                "Open Brain response was not valid JSON",
+                status_code=response.status_code,
+                context=context,
+                body=response.text,
+                token=self.token,
+                session_id=self._session_id,
+            ) from exc
+
+    def _decode_mcp_response(self, response: TransportResponse, *, context: str) -> Any:
+        text = response.text.strip()
+        if not text:
+            return None
+        content_type = _header(response.headers, "content-type") or ""
+        if "text/event-stream" in content_type or text.startswith("event:") or text.startswith("data:"):
+            text = _last_sse_data(text)
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise OpenBrainProtocolError(
+                "MCP response was not valid JSON",
+                status_code=response.status_code,
+                context=context,
+                body=text,
+                token=self.token,
+                session_id=self._session_id,
+            ) from exc
+
+    def _decode_jsonrpc_response(
+        self,
+        response: TransportResponse,
+        *,
+        expected_id: int,
+        context: str,
+    ) -> JSON:
+        message = self._decode_mcp_response(response, context=context)
+        if not isinstance(message, dict):
+            raise OpenBrainProtocolError("MCP response was not a JSON object", context=context)
+        if message.get("jsonrpc") != "2.0":
+            raise OpenBrainProtocolError(
+                "MCP response missing jsonrpc=2.0",
+                context=context,
+                body=json.dumps(message, sort_keys=True),
+                token=self.token,
+                session_id=self._session_id,
+            )
+        if message.get("id") != expected_id:
+            raise OpenBrainProtocolError(
+                "MCP response id did not match request",
+                context=context,
+                body=json.dumps(message, sort_keys=True),
+                token=self.token,
+                session_id=self._session_id,
+            )
+        if "error" in message:
+            raise OpenBrainProtocolError(
+                "MCP JSON-RPC error",
+                context=context,
+                body=json.dumps(message["error"], sort_keys=True),
+                token=self.token,
+                session_id=self._session_id,
+            )
+        return message
+
+
+def _header(headers: Mapping[str, str], name: str) -> str | None:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value
+    return None
+
+
+def _last_sse_data(text: str) -> str:
+    data_blocks: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if not line:
+            if current:
+                data_blocks.append("\n".join(current))
+                current = []
+            continue
+        if line.startswith("data:"):
+            current.append(line.removeprefix("data:").strip())
+    if current:
+        data_blocks.append("\n".join(current))
+    if not data_blocks:
+        raise OpenBrainProtocolError("MCP SSE response did not contain data")
+    return data_blocks[-1]
+
+
+def _tool_text(result: Mapping[str, Any]) -> str:
+    content = result.get("content")
+    if not isinstance(content, list):
+        return json.dumps(result, sort_keys=True)
+    parts = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            parts.append(str(item.get("text", "")))
+    return "\n".join(parts)
+
+
+def _decode_tool_payload(result: Mapping[str, Any]) -> JSON:
+    content = result.get("content")
+    if not isinstance(content, list) or len(content) != 1:
+        return dict(result)
+    item = content[0]
+    if not isinstance(item, dict) or item.get("type") != "text":
+        return dict(result)
+    text = item.get("text")
+    if not isinstance(text, str):
+        return dict(result)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return dict(result)
+    return parsed if isinstance(parsed, dict) else dict(result)
+
+
+def _validate_base_url(base_url: str, *, allow_insecure_http: bool) -> None:
+    parsed = urlparse(base_url)
+    if parsed.scheme == "https":
+        return
+    if parsed.scheme == "http":
+        host = (parsed.hostname or "").lower()
+        if allow_insecure_http or host in {"localhost", "127.0.0.1", "::1"}:
+            return
+    raise ValueError(
+        "OpenBrainClient base_url must use https, localhost http, "
+        "or allow_insecure_http=True"
+    )
+
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)authorization\s*[:=]\s*bearer\s+[^\s,;]+"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+"),
+    re.compile(r'(?i)"?(api[_-]?key|github[_-]?token|token|password|secret)"?\s*:\s*"[^"]+"'),
+    re.compile(r"(?i)(api[_-]?key|github[_-]?token|token|password|secret)\s*[:=]\s*[^\s,;]+"),
+]
+SENSITIVE_KEY_PATTERN = re.compile(
+    r"(?i)(token|secret|password|api[_-]?key|credential|authorization|session[_-]?id)"
+)
+
+
+def _redact_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if SENSITIVE_KEY_PATTERN.search(str(key)):
+                redacted[str(key)] = "[REDACTED]"
+            else:
+                redacted[str(key)] = _redact_json_value(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_json_value(item) for item in value]
+    return value
+
+
+def _redact_json_text(text: str) -> str | None:
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return json.dumps(_redact_json_value(parsed), sort_keys=True)
+
+
+def _redact(
+    text: str,
+    *,
+    token: str | None = None,
+    session_id: str | None = None,
+    max_length: int = 1000,
+) -> str:
+    redacted = _redact_json_text(text) or text
+    for secret in (token, session_id):
+        if secret:
+            redacted = redacted.replace(secret, "[REDACTED]")
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    if len(redacted) > max_length:
+        redacted = redacted[:max_length] + "...[truncated]"
+    return redacted

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+
+import pytest
+
+from openbrain_memory import (
+    OpenBrainClient,
+    OpenBrainHTTPError,
+    OpenBrainProtocolError,
+    OpenBrainToolError,
+)
+from openbrain_memory.client import TransportResponse, UrllibTransport
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.requests = []
+        self.health_payload = {"status": "healthy", "database": {"connected": True}}
+        self.tool_results = {}
+        self.next_status = 200
+        self.next_text = ""
+
+    def get(self, url, *, headers, timeout):
+        self.requests.append(
+            {"method": "GET", "url": url, "headers": dict(headers), "timeout": timeout}
+        )
+        return TransportResponse(
+            status_code=self.next_status,
+            headers={"content-type": "application/json"},
+            text=json.dumps(self.health_payload) if not self.next_text else self.next_text,
+        )
+
+    def post(self, url, *, headers, json_body, timeout):
+        self.requests.append(
+            {
+                "method": "POST",
+                "url": url,
+                "headers": dict(headers),
+                "json": json_body,
+                "timeout": timeout,
+            }
+        )
+        if self.next_status >= 400:
+            return TransportResponse(
+                status_code=self.next_status,
+                headers={"content-type": "application/json"},
+                text=self.next_text,
+            )
+        method = json_body.get("method")
+        if method == "initialize":
+            return TransportResponse(
+                status_code=200,
+                headers={
+                    "content-type": "application/json",
+                    "mcp-session-id": "session-123",
+                },
+                text=json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": json_body["id"],
+                        "result": {"protocolVersion": "2025-03-26"},
+                    }
+                ),
+            )
+        if method == "notifications/initialized":
+            return TransportResponse(status_code=202, headers={}, text="")
+        if method == "tools/call":
+            name = json_body["params"]["name"]
+            result = self.tool_results.get(
+                name,
+                {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "tool": name,
+                                    "ok": True,
+                                    "total": 0,
+                                    "brain_hits": 0,
+                                    "qmd_hits": 0,
+                                    "results": [],
+                                }
+                            ),
+                        }
+                    ]
+                },
+            )
+            return TransportResponse(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                text=json.dumps(
+                    {"jsonrpc": "2.0", "id": json_body["id"], "result": result}
+                ),
+            )
+        raise AssertionError(f"Unexpected JSON-RPC method: {method}")
+
+
+def make_client(transport: FakeTransport) -> OpenBrainClient:
+    return OpenBrainClient(
+        "https://brain.example",
+        "secret-token",
+        "bilby",
+        agent_id="bilby-agent",
+        role="agent",
+        timeout=12.5,
+        transport=transport,
+    )
+
+
+def post_requests(transport: FakeTransport):
+    return [request for request in transport.requests if request["method"] == "POST"]
+
+
+def tool_requests(transport: FakeTransport):
+    return [
+        request
+        for request in post_requests(transport)
+        if request["json"].get("method") == "tools/call"
+    ]
+
+
+def test_health_check_uses_public_health_endpoint_without_credentials():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    assert client.health()["status"] == "healthy"
+
+    request = transport.requests[0]
+    assert request["method"] == "GET"
+    assert request["url"] == "https://brain.example/health"
+    assert request["headers"] == {"Accept": "application/json"}
+
+
+def test_initialize_sends_auth_namespace_and_stores_session_id():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    client.call_tool("search_all", {"query": "namespace routing"})
+
+    initialize = post_requests(transport)[0]
+    headers = initialize["headers"]
+    assert headers["Authorization"] == "Bearer secret-token"
+    assert headers["Accept"] == "application/json, text/event-stream"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["X-Namespace"] == "bilby"
+    assert headers["X-Agent-Id"] == "bilby-agent"
+    assert headers["X-Role"] == "agent"
+    assert "Mcp-Session-Id" not in headers
+    assert initialize["json"]["method"] == "initialize"
+    assert client.session_id == "session-123"
+
+
+def test_initialized_notification_and_tool_calls_reuse_session_header():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    client.call_tool("search_all", {"query": "policy"})
+
+    initialized = post_requests(transport)[1]
+    call = post_requests(transport)[2]
+    assert initialized["json"]["method"] == "notifications/initialized"
+    assert initialized["headers"]["Mcp-Session-Id"] == "session-123"
+    assert initialized["headers"]["MCP-Protocol-Version"] == "2025-03-26"
+    assert call["headers"]["Mcp-Session-Id"] == "session-123"
+    assert call["headers"]["MCP-Protocol-Version"] == "2025-03-26"
+
+
+def test_generic_call_tool_emits_json_rpc_tools_call_shape():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    result = client.call_tool("search_all", {"query": "policy", "limit": 3})
+
+    call = tool_requests(transport)[0]
+    assert call["json"]["jsonrpc"] == "2.0"
+    assert call["json"]["method"] == "tools/call"
+    assert call["json"]["params"] == {
+        "name": "search_all",
+        "arguments": {"query": "policy", "limit": 3},
+    }
+    assert result["tool"] == "search_all"
+    assert result["results"] == []
+
+
+def test_representative_wrappers_use_generic_call_tool_shape():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    client.session_start(session_key="chan/thread", agent="bilby")
+    client.append_session_event(
+        session_key="chan/thread",
+        event_type="fact",
+        content="The client works.",
+    )
+    client.search_all(query="client works")
+
+    calls = tool_requests(transport)
+    assert [call["json"]["params"]["name"] for call in calls] == [
+        "session_start",
+        "append_session_event",
+        "search_all",
+    ]
+    assert calls[0]["json"]["params"]["arguments"]["session_key"] == "chan/thread"
+    assert calls[1]["json"]["params"]["arguments"]["event_type"] == "fact"
+    assert calls[2]["json"]["params"]["arguments"]["query"] == "client works"
+
+
+def test_thin_wrappers_cover_current_issue_scope():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    client.session_context(session_key="s")
+    client.session_wrap(session_key="s", summary="done")
+    client.log_thought(content="fact")
+    client.log_decision(title="decision", rationale="because")
+    client.search_brain(query="decision")
+
+    assert [call["json"]["params"]["name"] for call in tool_requests(transport)] == [
+        "session_context",
+        "session_wrap",
+        "log_thought",
+        "log_decision",
+        "search_brain",
+    ]
+
+
+def test_all_registered_tool_wrappers_call_matching_tool_names():
+    transport = FakeTransport()
+    client = make_client(transport)
+    wrapper_names = [
+        "access_report",
+        "adjacent_context",
+        "append_session_event",
+        "archive_entry",
+        "bulk_archive",
+        "bulk_set_tier",
+        "curate_entries",
+        "demote_entry",
+        "find_duplicates",
+        "find_person",
+        "get_entry",
+        "get_stats",
+        "lane_load",
+        "lane_upsert",
+        "link_entities",
+        "list_namespaces",
+        "list_recent",
+        "list_stale",
+        "log_decision",
+        "log_thought",
+        "promote_entry",
+        "rate_entry",
+        "scan_namespace",
+        "search_all",
+        "search_brain",
+        "session_context",
+        "session_load",
+        "session_save",
+        "session_start",
+        "session_wrap",
+        "set_tier",
+        "tier_recommendations",
+        "update_entry",
+        "upsert_entity",
+        "upsert_person",
+    ]
+
+    for name in wrapper_names:
+        getattr(client, name)(probe=True)
+
+    assert [call["json"]["params"]["name"] for call in tool_requests(transport)] == wrapper_names
+
+
+def test_http_errors_include_context_status_and_redact_token():
+    transport = FakeTransport()
+    transport.next_status = 401
+    transport.next_text = "authorization: bearer secret-token session Mcp-Session-Id=session-123"
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError) as exc_info:
+        client.call_tool("search_all", {"query": "x"})
+
+    message = str(exc_info.value)
+    assert "status=401" in message
+    assert "context=initialize" in message
+    assert "secret-token" not in message
+    assert "[REDACTED]" in message
+    assert "authorization" not in message.lower()
+    assert "session-123" not in message
+
+
+def test_tool_errors_include_tool_context_and_redact_token():
+    transport = FakeTransport()
+    transport.tool_results["search_all"] = {
+        "isError": True,
+        "content": [
+            {
+                "type": "text",
+                "text": "tool failed with secret-token in body",
+            }
+        ],
+    }
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainToolError) as exc_info:
+        client.search_all(query="x")
+
+    message = str(exc_info.value)
+    assert "context=call_tool:search_all" in message
+    assert "secret-token" not in message
+    assert "[REDACTED]" in message
+
+
+def test_error_body_redaction_caps_and_scrubs_secret_patterns():
+    transport = FakeTransport()
+    transport.tool_results["search_all"] = {
+        "isError": True,
+        "content": [
+            {
+                "type": "text",
+                "text": "api_key=abc123456789 password=hunter2 "
+                + ("x" * 1200),
+            }
+        ],
+    }
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainToolError) as exc_info:
+        client.search_all(query="x")
+
+    message = str(exc_info.value)
+    assert "abc123456789" not in message
+    assert "hunter2" not in message
+    assert "[truncated]" in message
+
+
+def test_error_body_redaction_scrubs_json_secret_fields():
+    transport = FakeTransport()
+    transport.next_status = 500
+    transport.next_text = json.dumps(
+        {
+            "api_key": "abc123456789",
+            "password": "hunter2",
+            "token": "othersecret123",
+            "access_token": "access-secret-123",
+            "refresh_token": "refresh-secret-123",
+            "nested": {"client_secret": "client-secret-123"},
+            "credential": "credential-secret-123",
+            "message": "failed",
+        }
+    )
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError) as exc_info:
+        client.search_all(query="x")
+
+    message = str(exc_info.value)
+    assert "abc123456789" not in message
+    assert "hunter2" not in message
+    assert "othersecret123" not in message
+    assert "access-secret-123" not in message
+    assert "refresh-secret-123" not in message
+    assert "client-secret-123" not in message
+    assert "credential-secret-123" not in message
+    assert "failed" in message
+
+
+def test_missing_session_id_is_protocol_error():
+    class MissingSessionTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            response = super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+            if json_body.get("method") == "initialize":
+                return TransportResponse(
+                    status_code=200,
+                    headers={"content-type": "application/json"},
+                    text=response.text,
+                )
+            return response
+
+    client = make_client(MissingSessionTransport())
+
+    with pytest.raises(OpenBrainProtocolError, match="mcp-session-id"):
+        client.search_all(query="x")
+
+
+def test_initialized_failure_does_not_commit_session_and_retry_reinitializes():
+    class FailingInitializedTransport(FakeTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_initialized = True
+
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "notifications/initialized" and self.fail_initialized:
+                self.fail_initialized = False
+                return TransportResponse(
+                    status_code=500,
+                    headers={"content-type": "application/json"},
+                    text='{"error":"init failed"}',
+                )
+            return super().post(url, headers=headers, json_body=json_body, timeout=timeout)
+
+    transport = FailingInitializedTransport()
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError, match="context=initialized"):
+        client.search_all(query="x")
+
+    assert client.session_id is None
+    client.search_all(query="x")
+    assert [
+        request["json"]["method"]
+        for request in post_requests(transport)
+        if request["json"].get("method") == "initialize"
+    ] == ["initialize", "initialize"]
+
+
+def test_jsonrpc_response_id_must_match_request():
+    class WrongIdTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            response = super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+            if json_body.get("method") == "tools/call":
+                payload = response.json()
+                payload["id"] = 999
+                return TransportResponse(
+                    status_code=200,
+                    headers=response.headers,
+                    text=json.dumps(payload),
+                )
+            return response
+
+    client = make_client(WrongIdTransport())
+
+    with pytest.raises(OpenBrainProtocolError, match="id did not match"):
+        client.search_all(query="x")
+
+
+def test_jsonrpc_response_requires_version():
+    class MissingVersionTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            response = super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+            if json_body.get("method") == "tools/call":
+                payload = response.json()
+                payload.pop("jsonrpc", None)
+                return TransportResponse(
+                    status_code=200,
+                    headers=response.headers,
+                    text=json.dumps(payload),
+                )
+            return response
+
+    client = make_client(MissingVersionTransport())
+
+    with pytest.raises(OpenBrainProtocolError, match="jsonrpc=2.0"):
+        client.search_all(query="x")
+
+
+def test_initialize_error_does_not_establish_session():
+    class InitializeErrorTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "initialize":
+                return TransportResponse(
+                    status_code=200,
+                    headers={
+                        "content-type": "application/json",
+                        "mcp-session-id": "session-123",
+                    },
+                    text=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": json_body["id"],
+                            "error": {"message": "bad init"},
+                        }
+                    ),
+                )
+            return super().post(url, headers=headers, json_body=json_body, timeout=timeout)
+
+    client = make_client(InitializeErrorTransport())
+
+    with pytest.raises(OpenBrainProtocolError, match="JSON-RPC error"):
+        client.search_all(query="x")
+    assert client.session_id is None
+
+
+def test_sse_mcp_responses_are_decoded():
+    class SseTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            response = super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+            if json_body.get("method") == "tools/call":
+                return TransportResponse(
+                    status_code=200,
+                    headers={"content-type": "text/event-stream"},
+                    text="event: message\n"
+                    f"data: {response.text}\n\n",
+                )
+            return response
+
+    client = make_client(SseTransport())
+
+    assert client.search_all(query="x")["tool"] == "search_all"
+
+
+def test_remote_http_requires_explicit_opt_in_but_loopback_is_allowed():
+    with pytest.raises(ValueError, match="https"):
+        OpenBrainClient("http://brain.example", "token", "bilby")
+
+    OpenBrainClient("http://127.0.0.1:3100", "token", "bilby")
+    OpenBrainClient(
+        "http://brain.example",
+        "token",
+        "bilby",
+        allow_insecure_http=True,
+    )
+
+
+def test_urllib_transport_does_not_follow_redirects_with_auth_headers():
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(302)
+            self.send_header("Location", "https://evil.example/mcp")
+            self.end_headers()
+
+        def log_message(self, _format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), RedirectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        response = UrllibTransport().post(
+            f"http://127.0.0.1:{server.server_port}/mcp",
+            headers={"Authorization": "Bearer secret-token"},
+            json_body={"jsonrpc": "2.0"},
+            timeout=2,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert response.status_code == 302

--- a/python/openbrain-memory/tests/test_live_canary.py
+++ b/python/openbrain-memory/tests/test_live_canary.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+import json
+
+import pytest
+
+from openbrain_memory import OpenBrainClient
+
+
+@pytest.mark.skipif(
+    os.environ.get("OPENBRAIN_LIVE_CANARY") != "1",
+    reason="live canary requires OPENBRAIN_LIVE_CANARY=1 and credentials",
+)
+def test_live_health_and_search_all_canary():
+    base_url = os.environ["OPENBRAIN_BASE_URL"]
+    token = os.environ["OPENBRAIN_TOKEN"]
+    namespace = os.environ["OPENBRAIN_NAMESPACE"]
+    client = OpenBrainClient(
+        base_url,
+        token,
+        namespace,
+        agent_id=os.environ.get("OPENBRAIN_AGENT_ID"),
+        role=os.environ.get("OPENBRAIN_ROLE"),
+        timeout=float(os.environ.get("OPENBRAIN_TIMEOUT", "10")),
+        allow_insecure_http=os.environ.get("OPENBRAIN_ALLOW_INSECURE_HTTP") == "1",
+    )
+
+    health = client.health()
+    assert "status" in health
+    result = client.search_all(query="live canary", limit=1, sources="brain")
+    assert result.get("isError") is not True
+    if "content" in result:
+        content = result["content"]
+        assert isinstance(content, list) and content
+        text = content[0].get("text")
+        assert isinstance(text, str)
+        result = json.loads(text)
+    assert {"total", "brain_hits", "qmd_hits", "results"} <= set(result)
+    assert isinstance(result["results"], list)
+    for item in result["results"]:
+        assert item.get("source") == "brain"

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "openbrain-memory"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]


### PR DESCRIPTION
Closes #67

## Summary
- Add python/openbrain-memory with a synchronous OpenBrainClient and injectable transport.
- Implement health(), MCP initialize/initialized session setup, generic call_tool(), and thin wrappers for registered Open Brain tools.
- Add fake-transport tests plus an env-gated live canary.

## Acceptance criteria
- Health check uses GET /health without credentials.
- Auth sends Authorization: Bearer <token>.
- Namespace sends X-Namespace plus optional X-Agent-Id and X-Role.
- MCP initialize stores mcp-session-id and protocol version, then sends notifications/initialized.
- call_tool() emits JSON-RPC tools/call and validates response version/id/errors.
- session_start, append_session_event, and search_all wrappers are covered through the generic call shape.
- No live Open Brain server or credentials are required by default.

## Verification
- uv run pytest: 19 passed, 1 skipped.
- bun test: 579 passed, 16 skipped.
- git diff --cached --check: passed.

## Live canary
Disabled by default. Enable with OPENBRAIN_LIVE_CANARY=1 plus OPENBRAIN_BASE_URL, OPENBRAIN_TOKEN, and OPENBRAIN_NAMESPACE. Non-local HTTP requires OPENBRAIN_ALLOW_INSECURE_HTTP=1.