### PR TITLE
feat: add AgentMemory facade

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -5,6 +5,31 @@ Python client package for talking to a remote Open Brain service.
 This package is installed on agent hosts. The Open Brain service remains remote
 and exposes HTTP endpoints such as `/health` and `/mcp`.
 
+## Quickstart
+
+```python
+from openbrain_memory import AgentMemory, OpenBrainClient
+
+client = OpenBrainClient(
+    "https://brain.example",
+    token="...",
+    namespace="bilby",
+    agent_id="bilby",
+    role="agent",
+)
+memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+memory.start_session("project/session", topic="client facade")
+context = memory.recall("OpenBrainClient call shape", limit=5)
+memory.append_event("assistant", "Implemented the facade.", event_type="action")
+memory.remember_fact("AgentMemory delegates protocol work to OpenBrainClient.")
+memory.remember_decision("Keep runtime adapter names out of openbrain-memory.")
+memory.checkpoint("Facade implemented and tested.")
+memory.wrap_session("Ready for PR review.")
+
+prompt_context = context.as_prompt_text()
+```
+
 ## Test
 
 ```bash

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -1,3 +1,11 @@
+from .agent import (
+    AgentMemory,
+    MemoryClient,
+    MemoryContext,
+    MemoryItem,
+    MemoryPolicy,
+    MemorySpool,
+)
 from .client import (
     OpenBrainClient,
     OpenBrainError,
@@ -7,6 +15,12 @@ from .client import (
 )
 
 __all__ = [
+    "AgentMemory",
+    "MemoryClient",
+    "MemoryContext",
+    "MemoryItem",
+    "MemoryPolicy",
+    "MemorySpool",
     "OpenBrainClient",
     "OpenBrainError",
     "OpenBrainHTTPError",

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+from .client import JSON
+
+
+EVENT_TYPES = {
+    "fact",
+    "decision",
+    "blocker",
+    "action",
+    "artifact",
+    "receipt",
+    "question",
+    "correction",
+    "handoff",
+}
+PROTECTED_KEYS = {
+    "agent",
+    "project",
+    "session_key",
+    "namespace",
+    "role",
+    "source",
+    "event_type",
+    "content",
+    "kind",
+    "title",
+    "rationale",
+    "summary",
+}
+SESSION_START_KEYS = {"channel_id", "thread_id", "topic"}
+SESSION_WRAP_KEYS = {"key_decisions", "next_steps"}
+DECISION_KEYS = {"alternatives", "tags", "context", "namespace"}
+THOUGHT_KEYS = {"tags", "namespace"}
+
+
+class MemoryClient(Protocol):
+    def session_start(self, **arguments: Any) -> JSON:
+        ...
+
+    def append_session_event(self, **arguments: Any) -> JSON:
+        ...
+
+    def search_all(self, **arguments: Any) -> JSON:
+        ...
+
+    def log_thought(self, **arguments: Any) -> JSON:
+        ...
+
+    def log_decision(self, **arguments: Any) -> JSON:
+        ...
+
+    def session_wrap(self, **arguments: Any) -> JSON:
+        ...
+
+
+class MemorySpool(Protocol):
+    def append(self, operation: str, payload: Mapping[str, Any]) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class MemoryPolicy:
+    max_items: int = 8
+    max_chars: int = 4000
+    max_item_chars: int = 800
+
+    def __post_init__(self) -> None:
+        if self.max_items < 1:
+            raise ValueError("MemoryPolicy.max_items must be >= 1")
+        if self.max_chars < 1:
+            raise ValueError("MemoryPolicy.max_chars must be >= 1")
+        if self.max_item_chars < 1:
+            raise ValueError("MemoryPolicy.max_item_chars must be >= 1")
+
+
+@dataclass(frozen=True)
+class MemoryItem:
+    text: str
+    source: str | None = None
+    kind: str | None = None
+    score: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MemoryContext:
+    query: str
+    items: tuple[MemoryItem, ...]
+    text: str
+    raw: Mapping[str, Any]
+
+    def as_prompt_text(self) -> str:
+        return self.text
+
+
+class AgentMemory:
+    def __init__(
+        self,
+        client: MemoryClient,
+        agent: str,
+        project: str | None = None,
+        policy: MemoryPolicy | Mapping[str, Any] | None = None,
+        spool: MemorySpool | None = None,
+    ) -> None:
+        self.client: MemoryClient = client
+        self.agent = agent
+        self.project = project
+        self.policy = _coerce_policy(policy)
+        self.spool = spool
+        self.conversation_key: str | None = None
+
+    def start_session(self, conversation_key: str, **metadata: Any) -> JSON:
+        self._reject_reserved_metadata(metadata)
+        self._reject_unknown_metadata(metadata, SESSION_START_KEYS)
+        payload = dict(metadata)
+        payload["session_key"] = conversation_key
+        payload["agent"] = self.agent
+        if self.project is not None:
+            payload["project"] = self.project
+        result = self.client.session_start(**payload)
+        self.conversation_key = conversation_key
+        return result
+
+    def recall(
+        self,
+        query: str,
+        *,
+        limit: int | None = None,
+        include_decisions: bool = True,
+        include_facts: bool = True,
+        include_raw: bool = False,
+    ) -> MemoryContext:
+        effective_limit = self._effective_limit(limit)
+        sources = _sources(include_decisions, include_facts)
+        payload = {
+            "query": query,
+            "limit": effective_limit,
+        }
+        if sources:
+            payload["sources"] = sources
+
+        raw = self.client.search_all(**payload)
+        raw_mapping = raw if isinstance(raw, Mapping) else {}
+        items = _bounded_items(raw_mapping, self.policy, effective_limit)
+        return MemoryContext(
+            query=query,
+            items=items,
+            text=_prompt_text(items, self.policy),
+            raw=raw_mapping if include_raw else {},
+        )
+
+    def append_event(self, role: str, content: str, **metadata: Any) -> JSON:
+        self._require_session("append_event")
+        event_type = str(metadata.pop("event_type", "fact"))
+        if event_type not in EVENT_TYPES:
+            raise ValueError(f"Unsupported event_type: {event_type}")
+        self._reject_reserved_metadata(metadata)
+        return self.client.append_session_event(
+            **self._session_payload(
+                {
+                    "event_type": event_type,
+                    "content": content,
+                    "source": role,
+                    "metadata": dict(metadata),
+                }
+            )
+        )
+
+    def remember_fact(self, text: str, **metadata: Any) -> JSON:
+        self._reject_reserved_metadata(metadata)
+        self._reject_unknown_metadata(metadata, THOUGHT_KEYS)
+        tags = _tags("fact", metadata.pop("tags", None))
+        payload: dict[str, Any] = {"content": text, "tags": tags}
+        if "namespace" in metadata:
+            payload["namespace"] = metadata["namespace"]
+        return self.client.log_thought(**payload)
+
+    def remember_decision(self, text: str, **metadata: Any) -> JSON:
+        self._reject_reserved_metadata(metadata)
+        self._reject_unknown_metadata(metadata, DECISION_KEYS)
+        payload: dict[str, Any] = {
+            "title": _title_from_text(text),
+            "rationale": text,
+        }
+        for key in DECISION_KEYS:
+            if key in metadata:
+                payload[key] = metadata[key]
+        return self.client.log_decision(**payload)
+
+    def checkpoint(self, summary: str, **metadata: Any) -> JSON:
+        self._require_session("checkpoint")
+        if not summary:
+            raise ValueError("checkpoint summary must not be empty")
+        self._reject_reserved_metadata(metadata)
+        self._reject_unknown_metadata(metadata, SESSION_WRAP_KEYS)
+        return self.client.session_wrap(
+            **self._session_payload({"summary": summary, **metadata})
+        )
+
+    def wrap_session(self, summary: str | None = None, **metadata: Any) -> JSON:
+        self._require_session("wrap_session")
+        if not summary:
+            raise ValueError("wrap_session summary must not be empty")
+        self._reject_reserved_metadata(metadata)
+        self._reject_unknown_metadata(metadata, SESSION_WRAP_KEYS)
+        payload = dict(metadata)
+        payload["summary"] = summary
+        return self.client.session_wrap(**self._session_payload(payload))
+
+    def _session_payload(self, metadata: Mapping[str, Any]) -> dict[str, Any]:
+        payload = dict(metadata)
+        if self.project is not None:
+            payload["project"] = self.project
+        if self.conversation_key is not None:
+            payload["session_key"] = self.conversation_key
+        return payload
+
+    def _require_session(self, method_name: str) -> None:
+        if not self.conversation_key:
+            raise RuntimeError(f"{method_name} requires start_session() first")
+
+    def _reject_reserved_metadata(self, metadata: Mapping[str, Any]) -> None:
+        collisions = PROTECTED_KEYS.intersection(metadata)
+        if collisions:
+            names = ", ".join(sorted(collisions))
+            raise ValueError(f"metadata contains reserved keys: {names}")
+
+    def _reject_unknown_metadata(
+        self,
+        metadata: Mapping[str, Any],
+        allowed_keys: set[str],
+    ) -> None:
+        unknown = set(metadata).difference(allowed_keys)
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise ValueError(f"metadata contains unsupported keys: {names}")
+
+    def _effective_limit(self, limit: int | None) -> int:
+        if limit is None:
+            return self.policy.max_items
+        if limit < 1:
+            raise ValueError("recall limit must be >= 1")
+        return min(limit, self.policy.max_items)
+
+
+def _coerce_policy(policy: MemoryPolicy | Mapping[str, Any] | None) -> MemoryPolicy:
+    if policy is None:
+        return MemoryPolicy()
+    if isinstance(policy, MemoryPolicy):
+        return policy
+    return MemoryPolicy(**dict(policy))
+
+
+def _bounded_items(
+    raw: Mapping[str, Any],
+    policy: MemoryPolicy,
+    limit: int,
+) -> tuple[MemoryItem, ...]:
+    results = raw.get("results", [])
+    if not isinstance(results, list):
+        return ()
+
+    items: list[MemoryItem] = []
+    used_chars = 0
+    for result in results:
+        if not isinstance(result, Mapping):
+            continue
+        text = _result_text(result)
+        if not text:
+            continue
+        text = _trim(text, policy.max_item_chars)
+        if used_chars + len(text) > policy.max_chars and items:
+            break
+        items.append(
+            MemoryItem(
+                text=text,
+                source=_optional_str(result.get("source")),
+                kind=_optional_str(result.get("kind") or result.get("type")),
+                score=_optional_float(result.get("score")),
+                metadata=_bounded_metadata(result),
+            )
+        )
+        used_chars += len(text)
+        if len(items) >= limit:
+            break
+    return tuple(items)
+
+
+def _prompt_text(items: tuple[MemoryItem, ...], policy: MemoryPolicy) -> str:
+    lines = []
+    used_chars = 0
+    for item in items:
+        prefix_parts = [part for part in (item.kind, item.source) if part]
+        prefix = f"[{'/'.join(prefix_parts)}] " if prefix_parts else ""
+        prefix = f"- {prefix}"
+        remaining = policy.max_chars - used_chars - len(prefix)
+        if remaining <= 0:
+            break
+        line = prefix + _trim(item.text, remaining)
+        lines.append(line)
+        used_chars += len(line)
+    return "\n".join(lines)
+
+
+def _result_text(result: Mapping[str, Any]) -> str:
+    for key in ("text", "content", "summary", "memory"):
+        value = result.get(key)
+        if isinstance(value, str):
+            return value.strip()
+    return ""
+
+
+def _trim(text: str, max_chars: int) -> str:
+    if max_chars < 1:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return "." * max_chars
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _title_from_text(text: str) -> str:
+    title = text.strip().splitlines()[0] if text.strip() else "Decision"
+    return _trim(title, 120)
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _optional_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _sources(include_decisions: bool, include_facts: bool) -> str | None:
+    if include_decisions or include_facts:
+        return "brain"
+    return "qmd"
+
+
+def _tags(required: str, value: Any) -> list[str]:
+    tags = [required]
+    if isinstance(value, list):
+        tags.extend(str(item) for item in value if item != required)
+    return tags
+
+
+def _bounded_metadata(result: Mapping[str, Any]) -> dict[str, Any]:
+    allowed = ("id", "path", "collection", "tags", "tier")
+    return {key: result[key] for key in allowed if key in result}

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import pytest
+
+from openbrain_memory import (
+    AgentMemory,
+    MemoryClient,
+    MemoryContext,
+    MemoryItem,
+    MemoryPolicy,
+    MemorySpool,
+    OpenBrainClient,
+)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls = []
+        self.search_payload = {
+            "results": [
+                {
+                    "text": "First useful fact about the project.",
+                    "source": "brain",
+                    "kind": "fact",
+                    "score": 0.9,
+                },
+                {
+                    "content": "Decision context that should be included.",
+                    "source": "brain",
+                    "kind": "decision",
+                    "score": 0.8,
+                },
+                {"text": "This item exceeds the item count bound."},
+            ]
+        }
+
+    def _record(self, name, arguments):
+        self.calls.append((name, arguments))
+        return {"tool": name, "arguments": arguments}
+
+    def session_start(self, **arguments):
+        return self._record("session_start", arguments)
+
+    def append_session_event(self, **arguments):
+        return self._record("append_session_event", arguments)
+
+    def search_all(self, **arguments):
+        self.calls.append(("search_all", arguments))
+        return self.search_payload
+
+    def log_thought(self, **arguments):
+        return self._record("log_thought", arguments)
+
+    def log_decision(self, **arguments):
+        return self._record("log_decision", arguments)
+
+    def session_wrap(self, **arguments):
+        return self._record("session_wrap", arguments)
+
+
+def test_start_session_records_runtime_agnostic_conversation_key():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    result = memory.start_session("project/session", topic="client facade")
+
+    assert result["tool"] == "session_start"
+    assert client.calls == [
+        (
+            "session_start",
+            {
+                "topic": "client facade",
+                "agent": "bilby",
+                "project": "open-brain",
+                "session_key": "project/session",
+            },
+        )
+    ]
+
+
+def test_append_event_routes_to_session_event_wrapper():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+    memory.start_session("conversation")
+
+    memory.append_event("assistant", "Here is the update.", event_type="action", turn=3)
+
+    assert client.calls[-1] == (
+        "append_session_event",
+        {
+            "event_type": "action",
+            "content": "Here is the update.",
+            "source": "assistant",
+            "metadata": {"turn": 3},
+            "session_key": "conversation",
+        },
+    )
+
+
+def test_remember_fact_routes_to_thought_memory_write_semantics():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+    memory.start_session("conversation")
+
+    memory.remember_fact("The client uses MCP-over-HTTP.", tags=["client"])
+
+    assert client.calls[-1] == (
+        "log_thought",
+        {
+            "content": "The client uses MCP-over-HTTP.",
+            "tags": ["fact", "client"],
+        },
+    )
+
+
+def test_remember_decision_routes_to_decision_logging_semantics():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    memory.remember_decision("Use OpenBrainClient wrappers, not raw protocol calls.")
+
+    assert client.calls == [
+        (
+            "log_decision",
+            {
+                "title": "Use OpenBrainClient wrappers, not raw protocol calls.",
+                "rationale": "Use OpenBrainClient wrappers, not raw protocol calls.",
+            },
+        )
+    ]
+
+
+def test_recall_assembles_bounded_prompt_context():
+    client = FakeClient()
+    memory = AgentMemory(
+        client,
+        agent="bilby",
+        project="open-brain",
+        policy=MemoryPolicy(max_items=2, max_chars=200, max_item_chars=80),
+    )
+    memory.start_session("conversation")
+
+    context = memory.recall("client facade", limit=10)
+
+    assert client.calls[-1] == (
+        "search_all",
+            {
+                "query": "client facade",
+                "limit": 2,
+                "sources": "brain",
+            },
+        )
+    assert len(context.items) == 2
+    assert context.items[0].text == "First useful fact about the project."
+    assert context.items[1].text == "Decision context that should be included."
+    assert context.as_prompt_text() == (
+        "- [fact/brain] First useful fact about the project.\n"
+        "- [decision/brain] Decision context that should be included."
+    )
+    assert context.raw == {}
+
+
+def test_recall_can_exclude_fact_and_decision_classes():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    memory.recall("narrow", include_decisions=False, include_facts=False)
+
+    assert client.calls[-1] == (
+        "search_all",
+        {
+            "query": "narrow",
+            "limit": 8,
+            "sources": "qmd",
+        },
+    )
+
+
+def test_checkpoint_and_wrap_use_session_tools():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+    memory.start_session("conversation")
+
+    memory.checkpoint("Mid-run checkpoint.", key_decisions=["Use wrapper facade"])
+    memory.wrap_session("Done.", next_steps=["Open PR"])
+
+    assert client.calls[-2:] == [
+        (
+            "session_wrap",
+            {
+                "summary": "Mid-run checkpoint.",
+                "key_decisions": ["Use wrapper facade"],
+                "session_key": "conversation",
+            },
+        ),
+        (
+            "session_wrap",
+            {
+                "next_steps": ["Open PR"],
+                "summary": "Done.",
+                "session_key": "conversation",
+            },
+        ),
+    ]
+
+
+def test_public_facade_exports_quickstart_types():
+    assert AgentMemory
+    assert MemoryClient
+    assert MemoryContext
+    assert MemoryItem
+    assert MemoryPolicy
+    assert MemorySpool
+    assert OpenBrainClient
+
+
+def test_reserved_metadata_cannot_spoof_identity_or_semantics():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    with pytest.raises(ValueError, match="reserved keys"):
+        memory.start_session("real", session_key="spoofed")
+
+    memory.start_session("real")
+    with pytest.raises(ValueError, match="reserved keys"):
+        memory.remember_fact("fact", agent="spoofed")
+    with pytest.raises(ValueError, match="reserved keys"):
+        memory.append_event("assistant", "event", session_key="spoofed")
+    with pytest.raises(ValueError, match="reserved keys"):
+        memory.checkpoint("summary", session_key="spoofed")
+
+
+def test_unsupported_metadata_is_rejected_before_tool_calls():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+    memory.start_session("real")
+
+    with pytest.raises(ValueError, match="unsupported keys"):
+        memory.remember_fact("fact", confidence="high")
+    with pytest.raises(ValueError, match="unsupported keys"):
+        memory.remember_decision("decision", extra="nope")
+    with pytest.raises(ValueError, match="unsupported keys"):
+        memory.checkpoint("summary", status="green")
+    with pytest.raises(ValueError, match="unsupported keys"):
+        memory.wrap_session("summary", outcome="merged")
+
+
+def test_session_methods_require_started_session():
+    memory = AgentMemory(FakeClient(), agent="bilby")
+
+    with pytest.raises(RuntimeError, match="start_session"):
+        memory.append_event("assistant", "event")
+    with pytest.raises(RuntimeError, match="start_session"):
+        memory.checkpoint("summary")
+    with pytest.raises(RuntimeError, match="start_session"):
+        memory.wrap_session("summary")
+
+
+def test_policy_and_limit_bounds_are_validated():
+    with pytest.raises(ValueError, match="max_items"):
+        MemoryPolicy(max_items=0)
+    with pytest.raises(ValueError, match="max_chars"):
+        MemoryPolicy(max_chars=0)
+    with pytest.raises(ValueError, match="max_item_chars"):
+        MemoryPolicy(max_item_chars=0)
+
+    memory = AgentMemory(FakeClient(), agent="bilby")
+    with pytest.raises(ValueError, match="limit"):
+        memory.recall("bad", limit=0)
+
+
+def test_prompt_context_respects_total_char_budget_for_first_item():
+    client = FakeClient()
+    client.search_payload = {"results": [{"text": "x" * 100, "kind": "fact"}]}
+    memory = AgentMemory(
+        client,
+        agent="bilby",
+        policy=MemoryPolicy(max_items=3, max_chars=24, max_item_chars=100),
+    )
+
+    context = memory.recall("budget")
+
+    assert len(context.as_prompt_text()) <= 24
+    assert context.as_prompt_text().endswith("...")
+
+
+def test_recall_raw_response_is_opt_in_and_bad_shapes_are_empty():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    assert memory.recall("default raw").raw == {}
+    assert memory.recall("debug raw", include_raw=True).raw is client.search_payload
+
+    client.search_payload = None
+    context = memory.recall("bad shape")
+    assert context.items == ()
+    assert context.as_prompt_text() == ""


### PR DESCRIPTION
Closes #68

## Summary
- Add AgentMemory facade over OpenBrainClient wrappers.
- Add bounded MemoryContext/MemoryItem/MemoryPolicy types plus MemoryClient and MemorySpool protocols.
- Route session lifecycle, recall, facts, decisions, checkpoint, and wrap calls through schema-valid client wrapper calls.
- Update README quickstart for the public facade.

## Acceptance criteria
- Public API matches the issue: AgentMemory(client, agent, project=None, policy=None, spool=None), start_session, recall, append_event, remember_fact, remember_decision, checkpoint, wrap_session.
- Fake-client tests verify wrapper routing without network.
- Fact writes route through log_thought; decision writes route through log_decision.
- Recall returns bounded context and raw search output is opt-in.
- Checkpoint and wrap route to session_wrap with valid schema fields.
- No Hermes adapter code is included.

## Verification
- uv run pytest in python/openbrain-memory: 33 passed, 1 skipped.
- bun test at repo root: 579 passed, 16 skipped.
- git diff --cached --check: passed.

## Notes
Unsupported kwargs are rejected instead of forwarded to MCP tools, so the facade stays aligned with the live Open Brain tool schemas.