### PR TITLE
feat: add memory safety layer

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -13,6 +13,8 @@ from .client import (
     OpenBrainProtocolError,
     OpenBrainToolError,
 )
+from .policy import RetryExhaustedError, RetryPolicy, redact_text, redact_value
+from .spool import JsonlSpool, SpoolRecord, replay_records
 
 __all__ = [
     "AgentMemory",
@@ -26,4 +28,11 @@ __all__ = [
     "OpenBrainHTTPError",
     "OpenBrainProtocolError",
     "OpenBrainToolError",
+    "JsonlSpool",
+    "RetryExhaustedError",
+    "RetryPolicy",
+    "SpoolRecord",
+    "redact_text",
+    "redact_value",
+    "replay_records",
 ]

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping, Protocol
 
 from .client import JSON
+from .policy import RetryPolicy, idempotency_key, redact_value, with_retry
 
 
 EVENT_TYPES = {
@@ -21,7 +22,6 @@ PROTECTED_KEYS = {
     "agent",
     "project",
     "session_key",
-    "namespace",
     "role",
     "source",
     "event_type",
@@ -58,7 +58,13 @@ class MemoryClient(Protocol):
 
 
 class MemorySpool(Protocol):
-    def append(self, operation: str, payload: Mapping[str, Any]) -> None:
+    def append(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+        *,
+        key: str | None = None,
+    ) -> str:
         ...
 
 
@@ -105,12 +111,14 @@ class AgentMemory:
         project: str | None = None,
         policy: MemoryPolicy | Mapping[str, Any] | None = None,
         spool: MemorySpool | None = None,
+        retry_policy: RetryPolicy | Mapping[str, Any] | None = None,
     ) -> None:
         self.client: MemoryClient = client
         self.agent = agent
         self.project = project
         self.policy = _coerce_policy(policy)
         self.spool = spool
+        self.retry_policy = _coerce_retry_policy(retry_policy)
         self.conversation_key: str | None = None
 
     def start_session(self, conversation_key: str, **metadata: Any) -> JSON:
@@ -121,7 +129,7 @@ class AgentMemory:
         payload["agent"] = self.agent
         if self.project is not None:
             payload["project"] = self.project
-        result = self.client.session_start(**payload)
+        result = self._call_write("session_start", payload, self.client.session_start)
         self.conversation_key = conversation_key
         return result
 
@@ -159,37 +167,48 @@ class AgentMemory:
         if event_type not in EVENT_TYPES:
             raise ValueError(f"Unsupported event_type: {event_type}")
         self._reject_reserved_metadata(metadata)
-        return self.client.append_session_event(
-            **self._session_payload(
-                {
-                    "event_type": event_type,
-                    "content": content,
-                    "source": role,
-                    "metadata": dict(metadata),
-                }
-            )
+        key = idempotency_key()
+        payload = self._session_payload(
+            {
+                "event_type": event_type,
+                "content": content,
+                "source": role,
+                "metadata": {**dict(metadata), "idempotency_key": key},
+            }
+        )
+        return self._call_write(
+            "append_session_event",
+            payload,
+            self.client.append_session_event,
+            key=key,
         )
 
     def remember_fact(self, text: str, **metadata: Any) -> JSON:
         self._reject_reserved_metadata(metadata)
         self._reject_unknown_metadata(metadata, THOUGHT_KEYS)
+        key = idempotency_key()
         tags = _tags("fact", metadata.pop("tags", None))
+        tags.append(f"idempotency:{key}")
         payload: dict[str, Any] = {"content": text, "tags": tags}
         if "namespace" in metadata:
             payload["namespace"] = metadata["namespace"]
-        return self.client.log_thought(**payload)
+        return self._call_write("log_thought", payload, self.client.log_thought, key=key)
 
     def remember_decision(self, text: str, **metadata: Any) -> JSON:
         self._reject_reserved_metadata(metadata)
         self._reject_unknown_metadata(metadata, DECISION_KEYS)
+        idem = idempotency_key()
         payload: dict[str, Any] = {
             "title": _title_from_text(text),
             "rationale": text,
+            "tags": [f"idempotency:{idem}"],
         }
         for key in DECISION_KEYS:
             if key in metadata:
                 payload[key] = metadata[key]
-        return self.client.log_decision(**payload)
+        if "tags" in metadata:
+            payload["tags"] = _tags(f"idempotency:{idem}", metadata["tags"])
+        return self._call_write("log_decision", payload, self.client.log_decision, key=idem)
 
     def checkpoint(self, summary: str, **metadata: Any) -> JSON:
         self._require_session("checkpoint")
@@ -197,8 +216,13 @@ class AgentMemory:
             raise ValueError("checkpoint summary must not be empty")
         self._reject_reserved_metadata(metadata)
         self._reject_unknown_metadata(metadata, SESSION_WRAP_KEYS)
-        return self.client.session_wrap(
-            **self._session_payload({"summary": summary, **metadata})
+        key = idempotency_key()
+        payload = self._session_payload({"summary": summary, **metadata})
+        return self._call_write(
+            "session_wrap",
+            payload,
+            self.client.session_wrap,
+            key=key,
         )
 
     def wrap_session(self, summary: str | None = None, **metadata: Any) -> JSON:
@@ -209,7 +233,13 @@ class AgentMemory:
         self._reject_unknown_metadata(metadata, SESSION_WRAP_KEYS)
         payload = dict(metadata)
         payload["summary"] = summary
-        return self.client.session_wrap(**self._session_payload(payload))
+        key = idempotency_key()
+        return self._call_write(
+            "session_wrap",
+            self._session_payload(payload),
+            self.client.session_wrap,
+            key=key,
+        )
 
     def _session_payload(self, metadata: Mapping[str, Any]) -> dict[str, Any]:
         payload = dict(metadata)
@@ -246,6 +276,27 @@ class AgentMemory:
             raise ValueError("recall limit must be >= 1")
         return min(limit, self.policy.max_items)
 
+    def _call_write(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+        call: Any,
+        *,
+        key: str | None = None,
+    ) -> JSON:
+        safe_payload = redact_value(dict(payload))
+        try:
+            if operation == "session_start":
+                return with_retry(
+                    lambda: call(**safe_payload),
+                    retry_policy=self.retry_policy,
+                )
+            return call(**safe_payload)
+        except Exception:
+            if self.spool is not None:
+                self.spool.append(operation, safe_payload, key=key)
+            raise
+
 
 def _coerce_policy(policy: MemoryPolicy | Mapping[str, Any] | None) -> MemoryPolicy:
     if policy is None:
@@ -253,6 +304,14 @@ def _coerce_policy(policy: MemoryPolicy | Mapping[str, Any] | None) -> MemoryPol
     if isinstance(policy, MemoryPolicy):
         return policy
     return MemoryPolicy(**dict(policy))
+
+
+def _coerce_retry_policy(policy: RetryPolicy | Mapping[str, Any] | None) -> RetryPolicy:
+    if policy is None:
+        return RetryPolicy()
+    if isinstance(policy, RetryPolicy):
+        return policy
+    return RetryPolicy(**dict(policy))
 
 
 def _bounded_items(

--- a/python/openbrain-memory/src/openbrain_memory/policy.py
+++ b/python/openbrain-memory/src/openbrain_memory/policy.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import time
+from typing import Any, Callable, TypeVar
+from uuid import uuid4
+
+
+SK_PREFIX = "sk" + "-"
+GITHUB_PREFIX_RE = "gh" + r"[pousr]_"
+GITHUB_PAT_PREFIX = "github" + r"_pat_"
+PRIVATE_KEY_BLOCK_RE = (
+    "-----BEGIN [A-Z ]*PRIVATE "
+    "KEY-----.*?-----END [A-Z ]*PRIVATE "
+    "KEY-----"
+)
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)authorization\s*[:=]\s*bearer\s+[^\s,;]+"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(rf"\b{SK_PREFIX}[A-Za-z0-9_-]{{10,}}\b"),
+    re.compile(rf"(?i){GITHUB_PAT_PREFIX}[A-Za-z0-9_]+"),
+    re.compile(rf"(?i){GITHUB_PREFIX_RE}[A-Za-z0-9_]{{20,}}"),
+    re.compile(r"(?i)(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+"),
+    re.compile(r'(?i)"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"'),
+    re.compile(PRIVATE_KEY_BLOCK_RE, re.S),
+]
+SENSITIVE_KEY_RE = re.compile(r"(?i)(token|secret|password|api[_-]?key|credential|authorization)")
+
+
+class RetryExhaustedError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    attempts: int = 2
+    backoff_seconds: float = 0.05
+
+    def __post_init__(self) -> None:
+        if self.attempts < 1:
+            raise ValueError("RetryPolicy.attempts must be >= 1")
+        if self.backoff_seconds < 0:
+            raise ValueError("RetryPolicy.backoff_seconds must be >= 0")
+
+
+T = TypeVar("T")
+
+
+def idempotency_key() -> str:
+    return f"obmem-{uuid4().hex}"
+
+
+def redact_text(text: str) -> str:
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+def redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            redacted[key_text] = "[REDACTED]" if SENSITIVE_KEY_RE.search(key_text) else redact_value(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    return value
+
+
+def with_retry(
+    operation: Callable[[], T],
+    *,
+    retry_policy: RetryPolicy,
+    retryable: Callable[[BaseException], bool] | None = None,
+) -> T:
+    retryable = retryable or _default_retryable
+    last_error: BaseException | None = None
+    for attempt in range(1, retry_policy.attempts + 1):
+        try:
+            return operation()
+        except BaseException as exc:
+            last_error = exc
+            if attempt >= retry_policy.attempts or not retryable(exc):
+                raise
+            time.sleep(retry_policy.backoff_seconds * attempt)
+    raise RetryExhaustedError("retry attempts exhausted") from last_error
+
+
+def _default_retryable(exc: BaseException) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code == 429 or 500 <= status_code <= 599
+    return isinstance(exc, (ConnectionError, TimeoutError, OSError))

--- a/python/openbrain-memory/src/openbrain_memory/spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/spool.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import stat
+import tempfile
+import time
+from typing import Any, Callable, Iterable, Mapping
+import fcntl
+
+from .client import JSON
+from .policy import idempotency_key, redact_value
+
+
+@dataclass(frozen=True)
+class SpoolRecord:
+    idempotency_key: str
+    operation: str
+    payload: Mapping[str, Any]
+    created_at: float
+
+
+class JsonlSpool:
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        max_lines: int = 1000,
+        max_bytes: int = 1_000_000,
+    ) -> None:
+        if max_lines < 1:
+            raise ValueError("max_lines must be >= 1")
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+        self.path = Path(path)
+        self.lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        self.max_lines = max_lines
+        self.max_bytes = max_bytes
+
+    def append(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+        *,
+        key: str | None = None,
+    ) -> str:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._reject_symlink(self.path)
+        safe_key = key or idempotency_key()
+        record = {
+            "idempotency_key": safe_key,
+            "operation": operation,
+            "payload": redact_value(dict(payload)),
+            "created_at": time.time(),
+        }
+        line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+        lock_fd = self._lock()
+        try:
+            flags = os.O_CREAT | os.O_APPEND | os.O_WRONLY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            fd = os.open(self.path, flags, 0o600)
+            try:
+                self._validate_fd(fd, self.path)
+                os.fchmod(fd, 0o600)
+                os.write(fd, line.encode("utf-8"))
+            finally:
+                os.close(fd)
+            self._trim_locked()
+        finally:
+            self._unlock(lock_fd)
+        return safe_key
+
+    def records(self) -> list[SpoolRecord]:
+        if not self.path.exists():
+            return []
+        self._reject_symlink(self.path)
+        records: list[SpoolRecord] = []
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                payload = json.loads(line)
+                records.append(
+                    SpoolRecord(
+                        idempotency_key=str(payload["idempotency_key"]),
+                        operation=str(payload["operation"]),
+                        payload=payload.get("payload", {}),
+                        created_at=float(payload.get("created_at", 0)),
+                    )
+                )
+        return records
+
+    def replay(self, dispatcher: Callable[[SpoolRecord], JSON]) -> list[JSON]:
+        results = []
+        remaining = []
+        lock_fd = self._lock()
+        try:
+            for record in self.records():
+                try:
+                    results.append(dispatcher(record))
+                except Exception:
+                    remaining.append(record)
+            self._rewrite_records(remaining)
+        finally:
+            self._unlock(lock_fd)
+        return results
+
+    def _trim_locked(self) -> None:
+        if not self.path.exists():
+            return
+        lines = self.path.read_text(encoding="utf-8").splitlines(keepends=True)
+        sizes = [len(line.encode("utf-8")) for line in lines]
+        total = sum(sizes)
+        while len(lines) > self.max_lines or total > self.max_bytes:
+            lines.pop(0)
+            total -= sizes.pop(0)
+        self._write_lines(lines)
+
+    def _rewrite_records(self, records: list[SpoolRecord]) -> None:
+        lines = [
+            json.dumps(
+                {
+                    "idempotency_key": record.idempotency_key,
+                    "operation": record.operation,
+                    "payload": redact_value(dict(record.payload)),
+                    "created_at": record.created_at,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+            for record in records
+        ]
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._reject_symlink(self.path)
+        self._write_lines(lines)
+
+    def _write_lines(self, lines: list[str]) -> None:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            suffix=".tmp",
+            dir=self.path.parent,
+        )
+        try:
+            os.fchmod(fd, 0o600)
+            os.write(fd, "".join(lines).encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(tmp_name, self.path)
+        os.chmod(self.path, 0o600)
+
+    def _reject_symlink(self, path: Path) -> None:
+        try:
+            mode = os.lstat(path).st_mode
+        except FileNotFoundError:
+            return
+        if stat.S_ISLNK(mode):
+            raise OSError(f"Refusing to use symlink spool path: {path}")
+
+    def _validate_fd(self, fd: int, path: Path) -> None:
+        mode = os.fstat(fd).st_mode
+        if not stat.S_ISREG(mode):
+            raise OSError(f"Spool path is not a regular file: {path}")
+
+    def _lock(self) -> int:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._reject_symlink(self.lock_path)
+        flags = os.O_CREAT | os.O_RDWR
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(self.lock_path, flags, 0o600)
+        try:
+            self._validate_fd(fd, self.lock_path)
+            os.fchmod(fd, 0o600)
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except Exception:
+            os.close(fd)
+            raise
+        return fd
+
+    def _unlock(self, fd: int) -> None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def replay_records(
+    records: Iterable[SpoolRecord],
+    dispatcher: Callable[[SpoolRecord], JSON],
+) -> list[JSON]:
+    return [dispatcher(record) for record in records]

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -85,16 +85,14 @@ def test_append_event_routes_to_session_event_wrapper():
 
     memory.append_event("assistant", "Here is the update.", event_type="action", turn=3)
 
-    assert client.calls[-1] == (
-        "append_session_event",
-        {
-            "event_type": "action",
-            "content": "Here is the update.",
-            "source": "assistant",
-            "metadata": {"turn": 3},
-            "session_key": "conversation",
-        },
-    )
+    name, payload = client.calls[-1]
+    assert name == "append_session_event"
+    assert payload["event_type"] == "action"
+    assert payload["content"] == "Here is the update."
+    assert payload["source"] == "assistant"
+    assert payload["metadata"]["turn"] == 3
+    assert payload["metadata"]["idempotency_key"].startswith("obmem-")
+    assert payload["session_key"] == "conversation"
 
 
 def test_remember_fact_routes_to_thought_memory_write_semantics():
@@ -104,13 +102,11 @@ def test_remember_fact_routes_to_thought_memory_write_semantics():
 
     memory.remember_fact("The client uses MCP-over-HTTP.", tags=["client"])
 
-    assert client.calls[-1] == (
-        "log_thought",
-        {
-            "content": "The client uses MCP-over-HTTP.",
-            "tags": ["fact", "client"],
-        },
-    )
+    name, payload = client.calls[-1]
+    assert name == "log_thought"
+    assert payload["content"] == "The client uses MCP-over-HTTP."
+    assert payload["tags"][:2] == ["fact", "client"]
+    assert payload["tags"][2].startswith("idempotency:obmem-")
 
 
 def test_remember_decision_routes_to_decision_logging_semantics():
@@ -119,15 +115,10 @@ def test_remember_decision_routes_to_decision_logging_semantics():
 
     memory.remember_decision("Use OpenBrainClient wrappers, not raw protocol calls.")
 
-    assert client.calls == [
-        (
-            "log_decision",
-            {
-                "title": "Use OpenBrainClient wrappers, not raw protocol calls.",
-                "rationale": "Use OpenBrainClient wrappers, not raw protocol calls.",
-            },
-        )
-    ]
+    assert client.calls[0][0] == "log_decision"
+    assert client.calls[0][1]["title"] == "Use OpenBrainClient wrappers, not raw protocol calls."
+    assert client.calls[0][1]["rationale"] == "Use OpenBrainClient wrappers, not raw protocol calls."
+    assert client.calls[0][1]["tags"][0].startswith("idempotency:obmem-")
 
 
 def test_recall_assembles_bounded_prompt_context():

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from openbrain_memory import (
+    AgentMemory,
+    JsonlSpool,
+    RetryExhaustedError,
+    RetryPolicy,
+    SpoolRecord,
+    redact_text,
+    redact_value,
+    replay_records,
+)
+
+
+def token_sample(*parts: str) -> str:
+    return "".join(parts)
+
+
+class FlakyClient:
+    def __init__(self, failures: int = 0) -> None:
+        self.failures = failures
+        self.calls = []
+
+    def session_start(self, **arguments):
+        self.calls.append(("session_start", arguments))
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("temporary")
+        return {"ok": True}
+
+    def append_session_event(self, **arguments):
+        self.calls.append(("append_session_event", arguments))
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("temporary")
+        return {"ok": True}
+
+    def search_all(self, **arguments):
+        self.calls.append(("search_all", arguments))
+        return {"results": [{"content": "x" * 100, "type": "thought", "source": "brain"}]}
+
+    def log_thought(self, **arguments):
+        self.calls.append(("log_thought", arguments))
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("temporary")
+        return {"ok": True}
+
+    def log_decision(self, **arguments):
+        self.calls.append(("log_decision", arguments))
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("temporary")
+        return {"ok": True}
+
+    def session_wrap(self, **arguments):
+        self.calls.append(("session_wrap", arguments))
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("temporary")
+        return {"ok": True}
+
+
+def test_redaction_scrubs_common_secret_shapes():
+    text = "\n".join(
+        [
+            "Authorization: Bearer " + token_sample("abcdefgh", "ijklmnop"),
+            token_sample("OPENAI_", "API_", "KEY=") + token_sample("sk", "-secret"),
+            "password: " + token_sample("hunt", "er2"),
+            '"api_key": "json-secret"',
+            "token: " + token_sample("sk", "-abcdefghijklmnopqrstuvwxyz"),
+            token_sample("GITHUB_", "TOKEN=") + token_sample("ghp", "_abcdefghijklmnopqrstuvwxyz"),
+            token_sample("-----BEGIN ", "PRIVATE ", "KEY-----\nabc\n-----END ", "PRIVATE ", "KEY-----"),
+        ]
+    )
+
+    redacted = redact_text(text)
+
+    assert "abcdefghijklmnop" not in redacted
+    assert token_sample("sk", "-secret") not in redacted
+    assert token_sample("hunt", "er2") not in redacted
+    assert "json-secret" not in redacted
+    assert token_sample("sk", "-abcdefghijklmnopqrstuvwxyz") not in redacted
+    assert token_sample("ghp", "_") not in redacted
+    assert token_sample("PRIVATE ", "KEY") not in redacted
+    assert redacted.count("[REDACTED]") >= 4
+
+
+def test_redact_value_recurses_sensitive_keys():
+    value = {"nested": {"access_token": "secret-token"}, "safe": "visible"}
+
+    assert redact_value(value) == {
+        "nested": {"access_token": "[REDACTED]"},
+        "safe": "visible",
+    }
+
+
+def test_retries_success_after_transient_failure_without_spooling(tmp_path):
+    client = FlakyClient(failures=1)
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    memory = AgentMemory(
+        client,
+        agent="bilby",
+        spool=spool,
+        retry_policy=RetryPolicy(attempts=2, backoff_seconds=0),
+    )
+
+    memory.start_session("session")
+
+    assert [name for name, _ in client.calls] == ["session_start", "session_start"]
+    assert not spool.path.exists()
+
+
+def test_non_idempotent_write_is_not_retried_but_is_spooled(tmp_path):
+    client = FlakyClient(failures=1)
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    memory = AgentMemory(
+        client,
+        agent="bilby",
+        spool=spool,
+        retry_policy=RetryPolicy(attempts=2, backoff_seconds=0),
+    )
+
+    with pytest.raises(ConnectionError):
+        memory.remember_fact("fact")
+
+    assert [name for name, _ in client.calls] == ["log_thought"]
+    assert spool.records()[0].operation == "log_thought"
+
+
+def test_failed_write_spools_redacted_payload_with_0600_mode(tmp_path):
+    client = FlakyClient(failures=3)
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    memory = AgentMemory(
+        client,
+        agent="bilby",
+        spool=spool,
+        retry_policy=RetryPolicy(attempts=2, backoff_seconds=0),
+    )
+
+    with pytest.raises(ConnectionError):
+        memory.remember_fact("token=" + token_sample("super", "secret"), namespace="bilby")
+
+    mode = os.stat(spool.path).st_mode & 0o777
+    lock_mode = os.stat(spool.lock_path).st_mode & 0o777
+    records = spool.records()
+    assert mode == 0o600
+    assert lock_mode == 0o600
+    assert len(records) == 1
+    assert records[0].operation == "log_thought"
+    assert token_sample("super", "secret") not in str(records[0].payload)
+    assert records[0].idempotency_key
+
+
+def test_live_write_payload_is_redacted_before_client_call():
+    client = FlakyClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    memory.remember_fact("password: " + token_sample("hunt", "er2"))
+
+    assert token_sample("hunt", "er2") not in client.calls[0][1]["content"]
+    assert "[REDACTED]" in client.calls[0][1]["content"]
+
+
+def test_spool_trims_old_records_by_line_count(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl", max_lines=2)
+
+    spool.append("one", {"content": "1"}, key="one")
+    spool.append("two", {"content": "2"}, key="two")
+    spool.append("three", {"content": "3"}, key="three")
+
+    assert [record.operation for record in spool.records()] == ["two", "three"]
+
+
+def test_spool_replay_removes_successes_and_keeps_failures(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    spool.append("ok", {"content": "1"}, key="ok-key")
+    spool.append("fail", {"content": "2"}, key="fail-key")
+    seen = []
+
+    def dispatch(record: SpoolRecord):
+        seen.append((record.idempotency_key, record.operation, dict(record.payload)))
+        if record.operation == "fail":
+            raise RuntimeError("still down")
+        return {"ok": True}
+
+    assert spool.replay(dispatch) == [{"ok": True}]
+    assert seen == [
+        ("ok-key", "ok", {"content": "1"}),
+        ("fail-key", "fail", {"content": "2"}),
+    ]
+    assert [record.operation for record in spool.records()] == ["fail"]
+
+
+def test_replay_records_passes_full_record():
+    records = [SpoolRecord("key", "op", {"content": "x"}, 1.0)]
+
+    assert replay_records(records, lambda record: {"key": record.idempotency_key}) == [
+        {"key": "key"}
+    ]
+
+
+def test_spool_rejects_symlink_path(tmp_path):
+    target = tmp_path / "target.jsonl"
+    link = tmp_path / "link.jsonl"
+    target.write_text("", encoding="utf-8")
+    link.symlink_to(target)
+
+    with pytest.raises(OSError, match="symlink"):
+        JsonlSpool(link).append("op", {"content": "x"})
+
+
+def test_recall_context_is_bounded_by_count_and_character_budget():
+    memory = AgentMemory(
+        FlakyClient(),
+        agent="bilby",
+        policy={"max_items": 1, "max_chars": 20, "max_item_chars": 100},
+    )
+
+    context = memory.recall("bounded")
+
+    assert len(context.items) == 1
+    assert len(context.as_prompt_text()) <= 20
+    assert context.raw == {}
+
+
+def test_safety_exports_are_public():
+    assert RetryExhaustedError
+    assert replay_records


### PR DESCRIPTION
Closes #69

## Summary
- Add safety primitives for redaction, bounded retry policy, idempotency keys, and JSONL spooling.
- Wire AgentMemory writes through conservative redaction and optional failed-write spooling.
- Keep non-idempotent writes out of automatic retry; only session_start retries by session key.
- Add bounded prompt/context tests and spool safety tests.

## Acceptance criteria
- Redacts bearer tokens, API keys, GitHub tokens, private-key blocks, env-style and colon/JSON-style secret patterns before writes/spool persistence.
- Recall output remains bounded by count and character budget.
- Retry is bounded and covered for transient session_start failure.
- Failed writes spool to JSONL with 0600 data and lock files, redacted payloads, max-line/max-byte trimming, symlink rejection, and replay ack semantics.
- Replay dispatch receives full SpoolRecord including idempotency_key and removes successful records while preserving failed ones.

## Verification
- uv run pytest in python/openbrain-memory: 45 passed, 1 skipped.
- bun test at repo root: 579 passed, 16 skipped.
- git diff --cached --check: passed.

## Notes
Live writes are intentionally redacted before calling Open Brain per #69. Non-idempotent writes are spooled on failure instead of retried in-process to avoid duplicate writes after ambiguous transport failures.