### PR TITLE
feat: add DreamEngine dry-run facade

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -30,6 +30,45 @@ memory.wrap_session("Ready for PR review.")
 prompt_context = context.as_prompt_text()
 ```
 
+## DreamEngine
+
+`DreamEngine` wraps Open Brain curation tools with a dry-run-first API. The
+default `dream_once()` call gathers stale entries, tier recommendations,
+duplicates, and optional namespace promotion candidates without mutating tiers
+or promotions.
+
+```python
+from openbrain_memory import DreamEngine, OpenBrainClient
+
+client = OpenBrainClient(
+    "https://brain.example",
+    token="...",
+    namespace="bilby",
+    agent_id="bilby",
+    role="n8n",
+)
+dreams = DreamEngine(client)
+
+plan = dreams.dream_once(namespace="bilby")
+for action in plan.actions:
+    print(action.as_dict())
+```
+
+`dream_once()` is dry-run-only in the first release, so it never applies a whole
+dream cycle in bulk. When `namespace` is supplied it only plans namespace
+promotion actions because tier recommendations are not namespace-scoped by the
+Open Brain tool contract. Namespace promotion planning calls `scan_namespace`,
+which requires an admin or n8n-capable Open Brain role.
+
+Mutation is opt-in at the wrapper level. `set_tier()` and `promote_entry()` only
+write to Open Brain when called directly with `dry_run=False`. There is no
+archive/apply behavior by default.
+
+```python
+dreams.set_tier("thoughts", "<entry-id>", "hot", dry_run=False)
+dreams.promote_entry("thoughts", "<entry-id>", reason="useful", dry_run=False)
+```
+
 ## Test
 
 ```bash

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -13,11 +13,17 @@ from .client import (
     OpenBrainProtocolError,
     OpenBrainToolError,
 )
+from .dream import DreamAction, DreamClient, DreamEngine, DreamPolicy, DreamRun
 from .policy import RetryExhaustedError, RetryPolicy, redact_text, redact_value
 from .spool import JsonlSpool, SpoolRecord, replay_records
 
 __all__ = [
     "AgentMemory",
+    "DreamAction",
+    "DreamClient",
+    "DreamEngine",
+    "DreamPolicy",
+    "DreamRun",
     "MemoryClient",
     "MemoryContext",
     "MemoryItem",

--- a/python/openbrain-memory/src/openbrain_memory/dream.py
+++ b/python/openbrain-memory/src/openbrain_memory/dream.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+from .client import JSON
+
+CURATION_LIMIT_MAX = 100
+
+
+class DreamClient(Protocol):
+    def list_stale(self, **arguments: Any) -> JSON:
+        ...
+
+    def tier_recommendations(self, **arguments: Any) -> JSON:
+        ...
+
+    def set_tier(self, **arguments: Any) -> JSON:
+        ...
+
+    def scan_namespace(self, **arguments: Any) -> JSON:
+        ...
+
+    def promote_entry(self, **arguments: Any) -> JSON:
+        ...
+
+    def find_duplicates(self, **arguments: Any) -> JSON:
+        ...
+
+
+@dataclass(frozen=True)
+class DreamPolicy:
+    limit: int = 20
+    stale_days: int = 30
+    duplicate_threshold: float = 0.08
+    promote_threshold_days: int = 7
+    demote_threshold_days: int = 30
+    target_namespace: str = "collab"
+
+    def __post_init__(self) -> None:
+        if type(self.limit) is not int or not 1 <= self.limit <= CURATION_LIMIT_MAX:
+            raise ValueError(f"DreamPolicy.limit must be between 1 and {CURATION_LIMIT_MAX}")
+        if type(self.stale_days) is not int or self.stale_days < 1:
+            raise ValueError("DreamPolicy.stale_days must be >= 1")
+        if type(self.promote_threshold_days) is not int or self.promote_threshold_days < 1:
+            raise ValueError("DreamPolicy.promote_threshold_days must be >= 1")
+        if type(self.demote_threshold_days) is not int or self.demote_threshold_days < 1:
+            raise ValueError("DreamPolicy.demote_threshold_days must be >= 1")
+        if (
+            isinstance(self.duplicate_threshold, bool)
+            or not isinstance(self.duplicate_threshold, int | float)
+            or not 0 <= self.duplicate_threshold <= 1
+        ):
+            raise ValueError("DreamPolicy.duplicate_threshold must be between 0 and 1")
+        if not self.target_namespace:
+            raise ValueError("DreamPolicy.target_namespace must not be empty")
+
+
+@dataclass(frozen=True)
+class DreamAction:
+    tool: str
+    arguments: Mapping[str, Any]
+    reason: str | None = None
+    dry_run: bool = True
+    result: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> JSON:
+        payload: JSON = {
+            "tool": self.tool,
+            "arguments": dict(self.arguments),
+            "dry_run": self.dry_run,
+        }
+        if self.reason is not None:
+            payload["reason"] = self.reason
+        if self.result is not None:
+            payload["result"] = dict(self.result)
+        return payload
+
+
+@dataclass(frozen=True)
+class DreamRun:
+    dry_run: bool
+    reports: Mapping[str, Any]
+    actions: tuple[DreamAction, ...] = field(default_factory=tuple)
+
+    def as_dict(self) -> JSON:
+        return {
+            "dry_run": self.dry_run,
+            "reports": dict(self.reports),
+            "actions": [action.as_dict() for action in self.actions],
+        }
+
+
+class DreamEngine:
+    def __init__(
+        self,
+        client: DreamClient,
+        policy: DreamPolicy | Mapping[str, Any] | None = None,
+    ) -> None:
+        self.client = client
+        self.policy = _coerce_policy(policy)
+
+    def dream_once(
+        self,
+        dry_run: bool = True,
+        namespace: str | None = None,
+        **filters: Any,
+    ) -> DreamRun:
+        if dry_run is not True:
+            raise ValueError("dream_once currently supports dry_run=True only; call set_tier/promote_entry explicitly")
+        limit = _bounded_int(filters.get("limit"), self.policy.limit, "limit", CURATION_LIMIT_MAX)
+        table_filter = _optional_str(filters.get("table"))
+        reports: dict[str, Any] = {}
+
+        reports["stale"] = self.list_stale(
+            **_only(
+                filters,
+                {"table", "tier", "offset", "response_format"},
+                limit=limit,
+                days=_bounded_int(filters.get("days"), self.policy.stale_days, "days", 365),
+            )
+        )
+        reports["promote_recommendations"] = self.tier_recommendations(
+            "promote",
+            limit=limit,
+            threshold_days=_bounded_int(
+                filters.get("promote_threshold_days"),
+                self.policy.promote_threshold_days,
+                "promote_threshold_days",
+                365,
+            ),
+        )
+        reports["demote_recommendations"] = self.tier_recommendations(
+            "demote",
+            limit=limit,
+            threshold_days=_bounded_int(
+                filters.get("demote_threshold_days"),
+                self.policy.demote_threshold_days,
+                "demote_threshold_days",
+                365,
+            ),
+        )
+        reports["duplicates"] = self.find_duplicates(
+            **_only(
+                filters,
+                {"table"},
+                limit=limit,
+                threshold=_float_between(
+                    filters.get("threshold"),
+                    self.policy.duplicate_threshold,
+                    "threshold",
+                ),
+            )
+        )
+
+        if namespace is not None:
+            reports["namespace_scan"] = self.scan_namespace(
+                namespace,
+                **_only(filters, {"table", "since"}, limit=limit),
+            )
+
+        actions = self._planned_actions(reports, namespace=namespace, table_filter=table_filter)
+        return DreamRun(dry_run=True, reports=reports, actions=tuple(actions))
+
+    def list_stale(self, **filters: Any) -> JSON:
+        return self.client.list_stale(**filters)
+
+    def tier_recommendations(self, action: str, **filters: Any) -> JSON:
+        if action not in {"promote", "demote"}:
+            raise ValueError("tier_recommendations action must be 'promote' or 'demote'")
+        return self.client.tier_recommendations(action=action, **filters)
+
+    def set_tier(
+        self,
+        table: str,
+        entry_id: str,
+        tier: str,
+        *,
+        dry_run: bool = True,
+    ) -> JSON:
+        arguments = {"table": table, "id": entry_id, "tier": tier}
+        if dry_run:
+            return DreamAction("set_tier", arguments).as_dict()
+        return self.client.set_tier(**arguments)
+
+    def scan_namespace(self, namespace: str, **filters: Any) -> JSON:
+        if not namespace:
+            raise ValueError("namespace must not be empty")
+        return self.client.scan_namespace(namespace=namespace, **filters)
+
+    def promote_entry(
+        self,
+        table: str,
+        entry_id: str,
+        *,
+        reason: str | None = None,
+        target_namespace: str | None = None,
+        dry_run: bool = True,
+    ) -> JSON:
+        arguments: dict[str, Any] = {
+            "table": table,
+            "id": entry_id,
+            "target_namespace": target_namespace or self.policy.target_namespace,
+        }
+        if reason is not None:
+            arguments["reason"] = reason
+        if dry_run:
+            return DreamAction("promote_entry", arguments, reason=reason).as_dict()
+        return self.client.promote_entry(**arguments)
+
+    def find_duplicates(self, **filters: Any) -> JSON:
+        return self.client.find_duplicates(**filters)
+
+    def _planned_actions(
+        self,
+        reports: Mapping[str, Any],
+        *,
+        namespace: str | None,
+        table_filter: str | None,
+    ) -> list[DreamAction]:
+        actions: list[DreamAction] = []
+        for report_name in ("promote_recommendations", "demote_recommendations"):
+            if namespace is not None:
+                continue
+            report = reports.get(report_name)
+            for candidate in _candidate_items(report, "candidates"):
+                table = _required_str(candidate, "table")
+                if table_filter is not None and table != table_filter:
+                    continue
+                entry_id = _required_str(candidate, "id")
+                tier = _required_str(candidate, "suggested_tier")
+                actions.append(
+                    DreamAction(
+                        "set_tier",
+                        {"table": table, "id": entry_id, "tier": tier},
+                        reason=_optional_str(candidate.get("reasoning")),
+                    )
+                )
+
+        if namespace is not None:
+            scan = reports.get("namespace_scan")
+            for candidate in _candidate_items(scan, "candidates"):
+                table = _required_str(candidate, "table")
+                entry_id = _required_str(candidate, "id")
+                actions.append(
+                    DreamAction(
+                        "promote_entry",
+                        {
+                            "table": table,
+                            "id": entry_id,
+                            "target_namespace": self.policy.target_namespace,
+                            "reason": f"DreamEngine promotion candidate from {namespace}",
+                        },
+                        reason="namespace promotion candidate",
+                    )
+                )
+        return actions
+
+def _coerce_policy(policy: DreamPolicy | Mapping[str, Any] | None) -> DreamPolicy:
+    if policy is None:
+        return DreamPolicy()
+    if isinstance(policy, DreamPolicy):
+        return policy
+    return DreamPolicy(**dict(policy))
+
+
+def _only(source: Mapping[str, Any], keys: set[str], **defaults: Any) -> dict[str, Any]:
+    result = {key: source[key] for key in keys if key in source}
+    result.update(defaults)
+    return {key: value for key, value in result.items() if value is not None}
+
+
+def _bounded_int(value: Any, default: int, name: str, maximum: int) -> int:
+    if value is None:
+        return default
+    if type(value) is not int or not 1 <= value <= maximum:
+        raise ValueError(f"{name} must be an integer between 1 and {maximum}")
+    return value
+
+
+def _float_between(value: Any, default: float, name: str) -> float:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int | float) or not 0 <= float(value) <= 1:
+        raise ValueError(f"{name} must be between 0 and 1")
+    return float(value)
+
+
+def _candidate_items(report: Any, key: str) -> list[Mapping[str, Any]]:
+    if not isinstance(report, Mapping):
+        return []
+    items = report.get(key, [])
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, Mapping)]
+
+
+def _required_str(mapping: Mapping[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Dream recommendation missing {key}")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/python/openbrain-memory/tests/test_dream.py
+++ b/python/openbrain-memory/tests/test_dream.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import pytest
+
+from openbrain_memory import DreamAction, DreamEngine, DreamPolicy, DreamRun
+
+
+class FakeDreamClient:
+    def __init__(self) -> None:
+        self.calls = []
+        self.responses = {
+            "list_stale": {"entries": [{"id": "stale-1", "table": "thoughts"}]},
+            "tier_recommendations": {
+                "promote": {
+                    "candidates": [
+                        {
+                            "id": "hot-1",
+                            "table": "thoughts",
+                            "suggested_tier": "hot",
+                            "reasoning": "frequently accessed",
+                        },
+                        {
+                            "id": "hot-2",
+                            "table": "decisions",
+                            "suggested_tier": "hot",
+                            "reasoning": "frequently accessed",
+                        }
+                    ]
+                },
+                "demote": {
+                    "candidates": [
+                        {
+                            "id": "cold-1",
+                            "table": "decisions",
+                            "suggested_tier": "cold",
+                            "reasoning": "stale and low access",
+                        }
+                    ]
+                },
+            },
+            "find_duplicates": {"duplicates": [{"table": "thoughts"}]},
+            "scan_namespace": {
+                "candidates": [{"id": "promote-1", "table": "thoughts"}],
+                "duplicates": [],
+                "already_promoted": [],
+            },
+        }
+
+    def _record(self, name, arguments):
+        self.calls.append((name, arguments))
+        return {"tool": name, "arguments": arguments}
+
+    def list_stale(self, **arguments):
+        self.calls.append(("list_stale", arguments))
+        return self.responses["list_stale"]
+
+    def tier_recommendations(self, **arguments):
+        self.calls.append(("tier_recommendations", arguments))
+        return self.responses["tier_recommendations"][arguments["action"]]
+
+    def set_tier(self, **arguments):
+        return self._record("set_tier", arguments)
+
+    def scan_namespace(self, **arguments):
+        self.calls.append(("scan_namespace", arguments))
+        return self.responses["scan_namespace"]
+
+    def promote_entry(self, **arguments):
+        return self._record("promote_entry", arguments)
+
+    def find_duplicates(self, **arguments):
+        self.calls.append(("find_duplicates", arguments))
+        return self.responses["find_duplicates"]
+
+
+def test_dream_once_defaults_to_dry_run_and_does_not_mutate():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    result = engine.dream_once(namespace="bilby", table="thoughts", limit=5)
+
+    assert isinstance(result, DreamRun)
+    assert result.dry_run is True
+    assert [name for name, _ in client.calls] == [
+        "list_stale",
+        "tier_recommendations",
+        "tier_recommendations",
+        "find_duplicates",
+        "scan_namespace",
+    ]
+    assert [action.tool for action in result.actions] == [
+        "promote_entry",
+    ]
+    assert [action.arguments["table"] for action in result.actions] == [
+        "thoughts",
+    ]
+    assert all(action.dry_run for action in result.actions)
+
+
+def test_dream_once_is_dry_run_only_for_first_release():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    with pytest.raises(ValueError, match="dry_run=True only"):
+        engine.dream_once(dry_run=False, namespace="bilby")
+
+    assert client.calls == []
+
+
+def test_dream_without_namespace_does_not_scan_or_promote():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    result = engine.dream_once()
+
+    assert "scan_namespace" not in [name for name, _ in client.calls]
+    assert [action.tool for action in result.actions] == ["set_tier", "set_tier", "set_tier"]
+
+
+def test_namespace_dream_suppresses_unscoped_tier_actions():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    result = engine.dream_once(namespace="bilby")
+
+    assert [action.tool for action in result.actions] == ["promote_entry"]
+
+
+def test_wrapper_methods_pass_arguments_correctly():
+    client = FakeDreamClient()
+    engine = DreamEngine(client, policy={"target_namespace": "team"})
+
+    assert engine.list_stale(table="thoughts", tier="warm") == client.responses["list_stale"]
+    assert engine.tier_recommendations("promote", limit=3) == client.responses["tier_recommendations"]["promote"]
+    assert engine.find_duplicates(table="decisions", threshold=0.05) == client.responses["find_duplicates"]
+    assert engine.scan_namespace("bilby", table="thoughts") == client.responses["scan_namespace"]
+
+    assert client.calls[:4] == [
+        ("list_stale", {"table": "thoughts", "tier": "warm"}),
+        ("tier_recommendations", {"action": "promote", "limit": 3}),
+        ("find_duplicates", {"table": "decisions", "threshold": 0.05}),
+        ("scan_namespace", {"namespace": "bilby", "table": "thoughts"}),
+    ]
+
+    assert engine.set_tier("thoughts", "id-1", "hot") == {
+        "tool": "set_tier",
+        "arguments": {"table": "thoughts", "id": "id-1", "tier": "hot"},
+        "dry_run": True,
+    }
+    assert engine.promote_entry("decisions", "id-2", reason="useful") == {
+        "tool": "promote_entry",
+        "arguments": {
+            "table": "decisions",
+            "id": "id-2",
+            "target_namespace": "team",
+            "reason": "useful",
+        },
+        "dry_run": True,
+        "reason": "useful",
+    }
+
+
+def test_mutating_wrappers_require_explicit_dry_run_false():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    tier_result = engine.set_tier("thoughts", "id-1", "hot", dry_run=False)
+    promote_result = engine.promote_entry(
+        "thoughts",
+        "id-2",
+        target_namespace="shared",
+        dry_run=False,
+    )
+
+    assert tier_result == {
+        "tool": "set_tier",
+        "arguments": {"table": "thoughts", "id": "id-1", "tier": "hot"},
+    }
+    assert promote_result == {
+        "tool": "promote_entry",
+        "arguments": {"table": "thoughts", "id": "id-2", "target_namespace": "shared"},
+    }
+
+
+def test_dream_structures_can_render_to_dicts():
+    action = DreamAction("set_tier", {"table": "thoughts", "id": "id-1", "tier": "cold"})
+    run = DreamRun(dry_run=True, reports={"stale": {}}, actions=(action,))
+
+    assert run.as_dict() == {
+        "dry_run": True,
+        "reports": {"stale": {}},
+        "actions": [
+            {
+                "tool": "set_tier",
+                "arguments": {"table": "thoughts", "id": "id-1", "tier": "cold"},
+                "dry_run": True,
+            }
+        ],
+    }
+
+
+def test_policy_and_inputs_are_validated():
+    with pytest.raises(ValueError, match="limit"):
+        DreamPolicy(limit=0)
+    with pytest.raises(ValueError, match="limit"):
+        DreamPolicy(limit=101)
+    with pytest.raises(ValueError, match="limit"):
+        DreamPolicy(limit=True)
+    with pytest.raises(ValueError, match="stale_days"):
+        DreamPolicy(stale_days=True)
+    with pytest.raises(ValueError, match="threshold"):
+        DreamPolicy(duplicate_threshold=True)
+    with pytest.raises(ValueError, match="threshold"):
+        DreamPolicy(duplicate_threshold=2)
+
+    engine = DreamEngine(FakeDreamClient())
+    with pytest.raises(ValueError, match="action"):
+        engine.tier_recommendations("archive")
+    with pytest.raises(ValueError, match="namespace"):
+        engine.scan_namespace("")
+    with pytest.raises(ValueError, match="limit"):
+        engine.dream_once(limit=0)
+    with pytest.raises(ValueError, match="limit"):
+        engine.dream_once(limit=101)
+    with pytest.raises(ValueError, match="days"):
+        engine.dream_once(days=True)
+    with pytest.raises(ValueError, match="threshold"):
+        engine.dream_once(threshold=True)


### PR DESCRIPTION
## Summary
- Add openbrain_memory.DreamEngine with dry-run-first curation planning over list_stale, tier_recommendations, find_duplicates, scan_namespace, set_tier, and promote_entry wrappers.
- Keep dream_once dry-run-only for the first release; explicit single-action mutations remain opt-in through set_tier(..., dry_run=False) and promote_entry(..., dry_run=False).
- Export DreamEngine public types and document role/dry-run behavior in python/openbrain-memory README.

## Review swarm
- Round 1 fixed HIGH partial-apply risk by refusing dream_once(dry_run=False) in this release.
- Round 1 fixed MEDIUM limit/schema drift by bounding dream orchestration limits to the strict MCP max of 100.
- Round 1 fixed MEDIUM table scoping by filtering planned tier actions locally when tier_recommendations cannot accept table filters.
- Round 2 fixed MEDIUM bool validation in DreamPolicy constructor.
- Round 2 fixed MEDIUM namespace scoping drift by suppressing unscoped tier actions when namespace is supplied; namespace dreams only plan promotion actions.

## Validation
- cd python/openbrain-memory && uv run pytest tests/test_dream.py: 8 passed
- cd python/openbrain-memory && uv run pytest: 53 passed, 1 skipped
- bun test: 579 passed, 16 skipped
- git diff --check: passed

Closes #70