### PR TITLE
docs: clarify openbrain-memory runtime model

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -5,6 +5,80 @@ Python client package for talking to a remote Open Brain service.
 This package is installed on agent hosts. The Open Brain service remains remote
 and exposes HTTP endpoints such as `/health` and `/mcp`.
 
+## Runtime Model
+
+`openbrain-memory` is client-side code. Installing this package on an agent host
+does not move the Open Brain service or database onto that host.
+
+| Component | Runs where | Responsibility |
+| --- | --- | --- |
+| Open Brain service | Remote LXC, for example `http://10.71.20.49:3100` | Owns MCP-over-HTTP, auth, namespace policy, storage, search, curation tools. |
+| `openbrain-memory` | Bilby, Skippy, Nagatha, automation hosts, or any Python agent runtime | Reusable Python client, memory facade, safety/retry/spool helpers, and dry-run dream planning. |
+| Hermes provider | `rtech-hermes` | Thin adapter from Hermes lifecycle/events into this package. |
+
+Dependency direction is one-way:
+
+- `open-brain` owns the reusable client and memory brain package.
+- `rtech-hermes` owns the Hermes adapter and lifecycle integration.
+- The Python package should not import Hermes runtime code.
+- Hermes should consume this package instead of reimplementing MCP-over-HTTP.
+
+## Install
+
+Install from the package subdirectory until the package is published:
+
+```bash
+uv pip install "git+ssh://git@github.com/rodaddy/open-brain.git#subdirectory=python/openbrain-memory"
+```
+
+Future package install:
+
+```bash
+uv pip install openbrain-memory
+```
+
+## Runtime Config
+
+Provide the remote service URL, token, namespace, and agent/project identity from
+the host process. Keep tokens in the host secret manager or an uncommitted env
+file; do not paste real tokens into shell history or commit them.
+
+```bash
+export OPENBRAIN_BASE_URL="https://brain.example"
+export OPENBRAIN_TOKEN="..."
+export OPENBRAIN_NAMESPACE="bilby"
+export OPENBRAIN_AGENT_ID="bilby"
+export OPENBRAIN_PROJECT="open-brain"
+```
+
+For trusted lab-only HTTP endpoints, such as `http://10.71.20.49:3100`, opt in
+explicitly:
+
+```bash
+export OPENBRAIN_BASE_URL="http://10.71.20.49:3100"
+export OPENBRAIN_ALLOW_INSECURE_HTTP="1"
+```
+
+```python
+import os
+
+from openbrain_memory import AgentMemory, OpenBrainClient
+
+client = OpenBrainClient(
+    os.environ["OPENBRAIN_BASE_URL"],
+    token=os.environ["OPENBRAIN_TOKEN"],
+    namespace=os.environ["OPENBRAIN_NAMESPACE"],
+    agent_id=os.environ.get("OPENBRAIN_AGENT_ID"),
+    role="agent",
+    allow_insecure_http=os.environ.get("OPENBRAIN_ALLOW_INSECURE_HTTP") == "1",
+)
+memory = AgentMemory(
+    client,
+    agent=os.environ.get("OPENBRAIN_AGENT_ID", "agent"),
+    project=os.environ.get("OPENBRAIN_PROJECT"),
+)
+```
+
 ## Quickstart
 
 ```python
@@ -72,6 +146,7 @@ dreams.promote_entry("thoughts", "<entry-id>", reason="useful", dry_run=False)
 ## Test
 
 ```bash
+cd python/openbrain-memory
 uv run pytest
 ```
 


### PR DESCRIPTION
## Summary
- Document that openbrain-memory installs on agent hosts while the Open Brain service remains remote on the LXC.
- Clarify dependency direction: open-brain owns the reusable client/package, rtech-hermes owns the Hermes adapter.
- Add subdirectory install command, future package install, runtime env config, and package test command.
- Default docs to HTTPS and mark lab HTTP as an explicit trusted-network opt-in.

## Review swarm
- Docs correctness lane: no blocking issues; suggested making insecure HTTP opt-in explicit.
- Security/adversarial lane: fixed MEDIUM copy-paste HTTP token transport by defaulting to HTTPS and gating lab HTTP with OPENBRAIN_ALLOW_INSECURE_HTTP=1.
- Security/adversarial lane: fixed INFO shell-history concern by telling users to use host secret manager or uncommitted env files.

## Validation
- cd python/openbrain-memory && uv run pytest: 53 passed, 1 skipped
- git diff --check: passed

Closes #71