### PR TITLE
docs: seed Open Brain swarm SME knowledge base

### DIFF
--- a/docs/sme/README.md
+++ b/docs/sme/README.md
@@ -1,0 +1,59 @@
+# Open Brain SME Review Knowledge
+
+This directory is the review-swarm memory for Open Brain work. It turns prior
+PR review output into reviewer-specific knowledge so future swarms do not start
+from zero.
+
+## Source Material
+
+Seeded from:
+
+- PR #72: OpenBrain Python client review comment and fixes
+- PR #73: AgentMemory facade review comment and fixes
+- PR #74: memory safety layer review comment, GitGuardian cleanup, and fixes
+- PR #75: DreamEngine review comment and fixes
+- PR #76: runtime model docs review comment and fixes
+- Issues #77-#82: post-merge review issues created from misses in #72-#76
+
+## How Future Swarms Should Use This
+
+Before spawning reviewers, inject the matching SME file into that reviewer lane:
+
+- `correctness.md` -> correctness reviewer
+- `adversarial.md` -> adversarial critic
+- `quality.md` -> quality reviewer
+- `security.md` -> security reviewer
+- `domain-backend.md` -> backend/domain reviewer
+- `gotcha-agent.md` -> extra Open Brain gotcha reviewer
+
+The gotcha reviewer is mandatory for `python/openbrain-memory/**` changes. It
+exists because the first swarm cycle still missed P1/P2 issues later captured
+as #77-#82.
+
+## Capture Rules
+
+- Capture MEDIUM+ review misses, accepted fixes, and new issue feedback.
+- Keep entries specific to Open Brain behavior, not generic coding advice.
+- Include provenance: issue or PR number, severity, source reviewer lane when
+  known, and status.
+- If a finding is fixed, keep the pattern if it could recur.
+- If later work invalidates a pattern, mark it `Status: superseded` instead of
+  deleting it.
+
+## PR Comment Requirements
+
+For each issue PR, the PR comment must document:
+
+- Swarm lanes run and model/effort.
+- Gotcha-agent findings from `gotcha-agent.md`.
+- Findings fixed, grouped by severity.
+- Findings intentionally deferred, with linked issue if any.
+- Validation evidence from local tests/builds/checks.
+- Whether any existing SME entry should be updated after the PR.
+
+## Trust Model
+
+These files are committed repo knowledge, but they are not infallible. Treat
+them as active hypotheses that must be verified against current code and the
+current issue acceptance criteria. Do not re-report a historical issue unless
+the pattern is still present or has regressed.

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -1,0 +1,68 @@
+# Adversarial SME Findings
+
+Adversarial reviewers hunt for failure states: outages, partial writes, stuck
+locks, oversized data, malformed responses, and tests that pass for the wrong
+reason.
+
+## [2026-06-11] Never hold spool locks across slow dispatch
+
+**Severity:** HIGH
+**Source:** Issue #80, PR #74 follow-up
+**Scope:** `python/openbrain-memory/src/openbrain_memory/spool.py`
+**Status:** active
+
+### Pattern
+
+`JsonlSpool.replay()` holding an exclusive file lock while calling a dispatcher
+can block foreground writers for the duration of slow or down HTTP calls. This
+is especially bad during outage recovery, when foreground writes are likely to
+need spooling too.
+
+### Review Questions
+
+- Does replay claim/snapshot records under lock, then release the lock before
+  network/slow dispatch?
+- Are new appends preserved while replay is in progress?
+- Is there a concurrent replay/append test proving append latency is bounded
+  while a dispatcher blocks?
+
+## [2026-06-11] Append success must mean the record is recoverable
+
+**Severity:** HIGH
+**Source:** Issue #80
+**Scope:** `python/openbrain-memory/src/openbrain_memory/spool.py`
+**Status:** active
+
+### Pattern
+
+An oversized single record larger than `max_bytes` can be written, trimmed away,
+and still return success. That creates silent data loss in a recovery path.
+
+### Review Questions
+
+- What happens when one record exceeds `max_bytes`?
+- Does `append()` reject, truncate with an explicit marker, or store separately?
+- Is there a regression test proving `append()` cannot report success while
+  storing nothing?
+
+## [2026-06-11] Fixes need failure-mode tests, not just happy-path tests
+
+**Severity:** MEDIUM
+**Source:** Issues #77-#82
+**Scope:** all Open Brain client/facade work
+**Status:** active
+
+### Pattern
+
+The first package swarm had good happy-path coverage, but later reviews found
+outage and malformed-input behavior: replay dispatch, live redaction, malformed
+DreamEngine reports, unbounded responses, and missing in-process transport
+contracts.
+
+### Review Questions
+
+- What fails if the server is slow, down, malformed, oversized, or partially
+  successful?
+- Does each recovery feature prove durability under its own failure mode?
+- Are tests only asserting method names, or are they asserting state after
+  failure?

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1,0 +1,84 @@
+# Correctness SME Findings
+
+Correctness reviewers check API contracts, schema compatibility, state
+transitions, and runtime behavior that tests can accidentally miss.
+
+## [2026-06-11] Python wrappers must prove server schema compatibility
+
+**Severity:** MEDIUM
+**Source:** Issues #82, PR #73 review loop
+**Scope:** `python/openbrain-memory/**`
+**Status:** active
+
+### Pattern
+
+Wrapper tests that only assert a method name or `probe=True` can pass while the
+real MCP tool rejects the payload. PR #73 needed several fixes because facade
+methods forwarded unsupported top-level fields or missed required fields.
+
+### Review Questions
+
+- Does each wrapper send only fields accepted by the server tool schema?
+- Are required fields such as `event_type` present?
+- Are optional fields allowlisted instead of passed through arbitrarily?
+- Is there a schema-backed, snapshot, or contract test for representative calls?
+
+### Bad
+
+```python
+memory.checkpoint("done", status="green")  # unsupported session_wrap field
+```
+
+### Good
+
+```python
+with pytest.raises(ValueError, match="unsupported keys"):
+    memory.checkpoint("done", status="green")
+```
+
+## [2026-06-11] MCP client tests must verify protocol details, not only wrappers
+
+**Severity:** MEDIUM
+**Source:** Issue #82, PR #72 review loop
+**Scope:** `python/openbrain-memory/src/openbrain_memory/client.py`
+**Status:** active
+
+### Pattern
+
+Fake transports can prove wrapper behavior but miss HTTP/MCP contract drift:
+headers, JSON-RPC ids, initialized notification, session id reuse, protocol
+version, and request body shape.
+
+### Review Questions
+
+- Is there an in-process HTTP/MCP test using real `OpenBrainClient` and
+  `UrllibTransport`?
+- Does the test observe `Authorization`, `X-Namespace`, `X-Agent-Id`, `X-Role`,
+  `Mcp-Session-Id`, `MCP-Protocol-Version`, JSON-RPC ids, and bodies?
+- Does it cover `/health`, initialize, initialized notification, and
+  `tools/call`?
+
+## [2026-06-11] DreamEngine must handle malformed reports intentionally
+
+**Severity:** MEDIUM
+**Source:** Issues #82, PR #75 review loop
+**Scope:** `python/openbrain-memory/src/openbrain_memory/dream.py`
+**Status:** active
+
+### Pattern
+
+DreamEngine dry-run planning can be correct for happy-path reports while
+behaving poorly on malformed or mixed valid/invalid server candidates.
+
+### Review Questions
+
+- Does malformed server output fail closed or skip invalid candidates with
+  diagnostics?
+- Is mixed valid/invalid candidate behavior locked by tests?
+- Are namespace-scoped dreams prevented from planning global tier actions?
+- Are limits bounded to the strictest downstream MCP tool schema?
+
+### Prior Fix
+
+PR #75 made `dream_once()` dry-run-only, bounded limits to 100, suppressed
+unscoped tier actions for namespace dreams, and rejected boolean numeric config.

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -1,0 +1,102 @@
+# Backend and Open Brain Domain SME Findings
+
+The backend/domain lane checks MCP-over-HTTP behavior, Open Brain tool contracts,
+namespace semantics, and package/runtime deployment boundaries.
+
+## [2026-06-11] MCP transport must be bounded and stream-aware
+
+**Severity:** HIGH
+**Source:** Issue #81, PR #72 follow-up
+**Scope:** `python/openbrain-memory/src/openbrain_memory/client.py`
+**Status:** active
+
+### Pattern
+
+Transport code that reads an entire HTTP response before parsing can hang on
+long-lived Streamable HTTP/SSE responses or consume too much memory on bad
+responses.
+
+### Review Questions
+
+- Is there a `max_response_bytes` or equivalent bounded read?
+- Does SSE parsing return on the matching JSON-RPC response instead of requiring
+  EOF?
+- If non-streaming behavior is intentional, is it explicitly negotiated or
+  documented?
+- Are oversized JSON/SSE responses tested?
+
+## [2026-06-11] Health should return structured degraded diagnostics
+
+**Severity:** MEDIUM
+**Source:** Issue #81
+**Scope:** `OpenBrainClient.health()`
+**Status:** active
+
+### Pattern
+
+`/health` can legitimately return degraded status such as HTTP 503 with a useful
+JSON body. Treating that as opaque HTTP failure hides diagnostics from callers.
+
+### Review Questions
+
+- Does `health()` return structured bodies for expected degraded health
+  responses?
+- Does it still raise for non-health failures and malformed health bodies?
+- Are degraded health responses tested?
+
+## [2026-06-11] Session lifecycle must be explicit
+
+**Severity:** MEDIUM
+**Source:** Issue #81
+**Scope:** `OpenBrainClient`
+**Status:** active
+
+### Pattern
+
+MCP sessions can accumulate under churn if the client has no explicit close or
+context-manager path and no documented TTL reliance.
+
+### Review Questions
+
+- Does `OpenBrainClient` support `close()` and context manager behavior if the
+  server supports termination?
+- If not supported, does README/API docs state lifecycle and server TTL clearly?
+- Are lifecycle tests or docs included?
+
+## [2026-06-11] Python package gates belong in CI
+
+**Severity:** HIGH
+**Source:** Issue #79
+**Scope:** `.github/workflows/**`, `python/openbrain-memory/**`
+**Status:** active
+
+### Pattern
+
+The root Bun/TypeScript gate does not protect Python package regressions,
+packaging/import failures, or wheel/sdist build failures.
+
+### Review Questions
+
+- Does CI run `uv run pytest -q` in `python/openbrain-memory`?
+- Does CI run `uv build` in `python/openbrain-memory`?
+- Are these gates triggered for package changes?
+- Are generated artifacts excluded from commits?
+
+## [2026-06-11] Runtime placement and adapter boundary are architectural contracts
+
+**Severity:** MEDIUM
+**Source:** PR #76, issue #71
+**Scope:** README, integration docs
+**Status:** active
+
+### Pattern
+
+`openbrain-memory` installs on agent hosts. The Open Brain service stays remote
+on the LXC. `rtech-hermes` owns the Hermes adapter/lifecycle integration and
+should consume this package instead of reimplementing protocol logic.
+
+### Review Questions
+
+- Does a change preserve one-way dependency direction?
+- Does open-brain avoid importing Hermes runtime code?
+- Does Hermes-specific lifecycle logic stay out of the reusable package?

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1,0 +1,103 @@
+# Open Brain Gotcha Agent
+
+This is the extra reviewer lane for Open Brain package work. It exists because
+the first PR cycle (#72-#76) passed normal swarms and local tests, then later
+reviews still produced #77-#82. This agent hunts those exact blind spots.
+
+## Mission
+
+Review the pinned diff for recurrences of prior misses. Do not duplicate generic
+correctness/security review. Ask: "Did we just repeat one of the mistakes that
+created #77-#82?"
+
+## Mandatory Checks
+
+### 1. Live Writes vs Redaction
+
+**Prior miss:** #77, from PR #74.
+
+- Live Open Brain writes must preserve original caller payloads unless an
+  explicit write policy says otherwise.
+- Diagnostic redaction must not mutate stored memories by accident.
+- Spool redaction must not be described as exact replay unless original payloads
+  are protected and recoverable.
+
+Block if tests do not prove successful live writes preserve sensitive-looking
+but legitimate content.
+
+### 2. Namespace Authority
+
+**Prior miss:** #78, from PR #73.
+
+- Generic metadata must not override `X-Namespace` or configured client
+  namespace.
+- Cross-namespace writes need explicit privileged API design.
+- Facades should reject or ignore `namespace="other"` for normal clients.
+
+Block if namespace is accepted as arbitrary metadata without policy checks.
+
+### 3. Spool Durability and Locking
+
+**Prior miss:** #80, from PR #74.
+
+- Replay must not hold the spool lock while dispatching network calls.
+- New appends must be preserved during replay.
+- Oversized records must not disappear after `append()` returns success.
+- Replay tests must map spooled operations back through fake client/facade calls,
+  not only ad-hoc lambdas.
+
+Block if append success can mean "not actually recoverable."
+
+### 4. MCP Transport Bounds and Streaming
+
+**Prior miss:** #81, from PR #72.
+
+- HTTP responses need size bounds before reading into memory.
+- SSE/Streamable HTTP must not wait for EOF on long-lived streams.
+- Health degraded responses should expose structured diagnostics.
+- Session lifecycle must be implemented or clearly documented.
+
+Block if a new transport path reads unbounded response bodies or assumes EOF for
+streamed JSON-RPC responses.
+
+### 5. Contract Tests Over Wrapper Name Tests
+
+**Prior miss:** #82, from PRs #72-#75.
+
+- Tests must prove headers, JSON-RPC ids, protocol version, session id, and
+  request bodies against an in-process server when transport behavior changes.
+- Wrapper tests should prove schema-compatible payloads, not just method names.
+- DreamEngine must define malformed-report behavior.
+
+Block if tests would pass while server schema, headers, or protocol order are
+wrong.
+
+### 6. Python Package CI
+
+**Prior miss:** #79.
+
+- Package changes need CI for `uv run pytest -q` and `uv build`.
+- Local-only validation is not enough after package code lands.
+
+Flag as blocking for CI/workflow PRs, or as follow-up if unrelated code changes
+touch package behavior before #79 is closed.
+
+## Output Format
+
+Return only findings related to these gotchas:
+
+```text
+- SEVERITY
+- FILE:LINE
+- GOTCHA: which prior issue/PR this maps to
+- DESCRIPTION
+- SUGGESTED FIX
+```
+
+If clean:
+
+```text
+CLEAN -- no recurrence of #77-#82 gotchas found.
+Checked: live redaction, namespace authority, spool durability, transport bounds,
+contract tests, package CI relevance.
+```

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -1,0 +1,66 @@
+# Quality SME Findings
+
+Quality reviewers check whether abstractions communicate their contracts and
+whether future maintainers can safely extend the package without repeating past
+mistakes.
+
+## [2026-06-11] Separate live-write policy, diagnostics policy, and replay policy
+
+**Severity:** HIGH
+**Source:** Issue #77, PR #74 follow-up
+**Scope:** `python/openbrain-memory/src/openbrain_memory/agent.py`,
+`python/openbrain-memory/src/openbrain_memory/spool.py`
+**Status:** active
+
+### Pattern
+
+PR #74 conflated live storage safety, diagnostics/log redaction, and offline
+replay durability. Redacting before live writes protects secrets but can corrupt
+legitimate memories. Redacting before spool persistence protects disk logs but
+can make replay lossy.
+
+### Review Questions
+
+- Does live write use the original payload unless an explicit write policy says
+  otherwise?
+- Are diagnostic/log/spool protections separate from live storage behavior?
+- Is the spool contract exact replay, encrypted replay, or audit-only?
+- Does the public API make that contract obvious?
+
+## [2026-06-11] Documentation must state authority boundaries, not only examples
+
+**Severity:** MEDIUM
+**Source:** Issues #78, #81, PR #76 review
+**Scope:** `python/openbrain-memory/README.md`, public facade docs
+**Status:** active
+
+### Pattern
+
+Examples are not enough for security-sensitive package behavior. Docs must state
+which layer owns namespace authority, transport security, session lifecycle, and
+Hermes integration boundaries.
+
+### Review Questions
+
+- Does README distinguish service location from package install location?
+- Does it say token/server/header namespace authority beats convenience metadata?
+- Does it document HTTP as trusted-lab opt-in only?
+- Does it document session close/TTL behavior if explicit close is unsupported?
+
+## [2026-06-11] PR comments are training data for the next swarm
+
+**Severity:** MEDIUM
+**Source:** User process feedback after PRs #72-#76
+**Scope:** review process
+**Status:** active
+
+### Pattern
+
+PR comments that list findings and fixes are not optional bookkeeping. They are
+the source material for SME updates and future gotcha-agent prompts.
+
+### Review Questions
+
+- Does the PR comment say what each lane found?
+- Does it say what was fixed and what was intentionally deferred?
+- Are new review misses promoted into `docs/sme/` before the next related PR?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -1,0 +1,88 @@
+# Security SME Findings
+
+Security reviewers focus on boundaries: namespaces, bearer tokens, secret
+handling, trusted headers, redirect behavior, and plaintext transport.
+
+## [2026-06-11] Namespace metadata must not bypass client/header authority
+
+**Severity:** HIGH
+**Source:** Issue #78, PR #73 follow-up
+**Scope:** `python/openbrain-memory/src/openbrain_memory/agent.py`
+**Status:** active
+
+### Pattern
+
+`AgentMemory.remember_fact()` and `remember_decision()` accepted free-form
+`namespace` metadata and forwarded it into tool arguments. That can conflict
+with or attempt to override `OpenBrainClient`'s `X-Namespace` authority.
+
+### Review Questions
+
+- Is `namespace` removed from generic metadata pass-through, or verified against
+  the configured client namespace?
+- If namespace override is required, is it an explicit privileged API rather
+  than arbitrary metadata?
+- Are there tests for `namespace="other"` on normal clients?
+- Do docs explain bearer token, server policy, headers, and facade behavior?
+
+## [2026-06-11] Redaction must protect diagnostics without corrupting data
+
+**Severity:** HIGH
+**Source:** Issue #77
+**Scope:** `python/openbrain-memory/src/openbrain_memory/agent.py`,
+`python/openbrain-memory/src/openbrain_memory/policy.py`,
+`python/openbrain-memory/src/openbrain_memory/spool.py`
+**Status:** active
+
+### Pattern
+
+Redacting the payload before calling Open Brain can silently persist legitimate
+memory content as `[REDACTED]`. Redacting before durable spool persistence can
+make replay unable to restore the original write.
+
+### Review Questions
+
+- Are live writes preserving caller content?
+- Are logs/errors redacted separately?
+- Is spool data protected without pretending lossy redacted data is exact replay?
+- Do tests prove successful live writes are not silently redacted?
+
+## [2026-06-11] Redaction coverage must include common unlabeled credential shapes
+
+**Severity:** MEDIUM
+**Source:** Issue #82, PR #72/#74 follow-up
+**Scope:** `python/openbrain-memory/src/openbrain_memory/policy.py`
+**Status:** active
+
+### Pattern
+
+Label-based redaction catches `token=` and `password:` but misses common
+unlabelled shapes: AWS access key IDs, AWS secret-like values, Slack tokens,
+Google API keys, and bare JWT-like strings.
+
+### Review Questions
+
+- Are there tests for AWS access key IDs and secret-like values?
+- Are Slack token and Google API key shapes covered?
+- Are bare JWT-like strings covered without over-redacting normal prose?
+- Are test fixtures split to avoid secret scanner false positives?
+
+## [2026-06-11] Bearer-token HTTP must be opt-in and non-redirecting
+
+**Severity:** HIGH
+**Source:** PR #72 review, PR #76 docs review
+**Scope:** `python/openbrain-memory/src/openbrain_memory/client.py`, README
+**Status:** active
+
+### Pattern
+
+Bearer-token MCP calls over non-local HTTP or through redirects leak credentials.
+PR #72 fixed HTTPS enforcement and redirect disabling. PR #76 hardened docs to
+default to HTTPS and require `OPENBRAIN_ALLOW_INSECURE_HTTP=1` for trusted lab
+HTTP.
+
+### Review Questions
+
+- Are non-local `http://` URLs rejected unless explicitly allowed?
+- Are redirects disabled for auth-bearing requests?
+- Do docs avoid making plaintext HTTP the default copy-paste path?


### PR DESCRIPTION
## Summary
- Add docs/sme review knowledge base seeded from PR #72-#76 comments and post-merge issues #77-#82.
- Split knowledge by reviewer lane: correctness, adversarial, quality, security, backend/domain.
- Add a mandatory Open Brain gotcha-agent lane focused on the misses that produced #77-#82.
- Document how future swarms should inject and update the SME files.

## Process notes
This follows the King Capital learning-loop model: PR comments and post-review issues become durable swarm memory, not one-off bookkeeping. Future swarms should read these files before reviewing and update them when new MEDIUM+ misses are found.

## Validation
- git diff --cached --check: passed before commit
- Docs-only change; no runtime tests required

## Not included
- Existing local .github/workflows/ci.yml modifications were not staged or committed.