### PR TITLE
fix: preserve replayable memory spool payloads

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -104,6 +104,17 @@ memory.wrap_session("Ready for PR review.")
 prompt_context = context.as_prompt_text()
 ```
 
+## Safety and Spooling
+
+`AgentMemory` sends the original caller payload to Open Brain. Redaction helpers
+are for diagnostics and display only; they do not mutate live writes.
+
+`JsonlSpool` stores exact failed-write payloads so replay can faithfully rebuild
+the original client call. Spool and lock files are created with `0600`
+permissions and should be treated as trusted local recovery storage. Use
+`SpoolRecord.redacted_payload()` or `JsonlSpool.redacted_records()` before
+showing spool contents in logs, UIs, or debug output.
+
 ## DreamEngine
 
 `DreamEngine` wraps Open Brain curation tools with a dry-run-first API. The

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping, Protocol
 
 from .client import JSON
-from .policy import RetryPolicy, idempotency_key, redact_value, with_retry
+from .policy import RetryPolicy, idempotency_key, with_retry
 
 
 EVENT_TYPES = {
@@ -284,17 +284,20 @@ class AgentMemory:
         *,
         key: str | None = None,
     ) -> JSON:
-        safe_payload = redact_value(dict(payload))
+        write_payload = dict(payload)
         try:
             if operation == "session_start":
                 return with_retry(
-                    lambda: call(**safe_payload),
+                    lambda: call(**write_payload),
                     retry_policy=self.retry_policy,
                 )
-            return call(**safe_payload)
-        except Exception:
+            return call(**write_payload)
+        except Exception as error:
             if self.spool is not None:
-                self.spool.append(operation, safe_payload, key=key)
+                try:
+                    self.spool.append(operation, write_payload, key=key)
+                except Exception as spool_error:
+                    error.add_note(f"Failed to spool {operation}: {spool_error}")
             raise
 
 

--- a/python/openbrain-memory/src/openbrain_memory/spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/spool.py
@@ -21,6 +21,17 @@ class SpoolRecord:
     payload: Mapping[str, Any]
     created_at: float
 
+    def redacted_payload(self) -> Mapping[str, Any]:
+        return redact_value(dict(self.payload))
+
+    def redacted(self) -> SpoolRecord:
+        return SpoolRecord(
+            idempotency_key=self.idempotency_key,
+            operation=self.operation,
+            payload=self.redacted_payload(),
+            created_at=self.created_at,
+        )
+
 
 class JsonlSpool:
     def __init__(
@@ -52,10 +63,12 @@ class JsonlSpool:
         record = {
             "idempotency_key": safe_key,
             "operation": operation,
-            "payload": redact_value(dict(payload)),
+            "payload": dict(payload),
             "created_at": time.time(),
         }
         line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+        if len(line.encode("utf-8")) > self.max_bytes:
+            raise ValueError("spool record exceeds max_bytes")
         lock_fd = self._lock()
         try:
             flags = os.O_CREAT | os.O_APPEND | os.O_WRONLY
@@ -93,16 +106,32 @@ class JsonlSpool:
                 )
         return records
 
+    def redacted_records(self) -> list[SpoolRecord]:
+        return [record.redacted() for record in self.records()]
+
     def replay(self, dispatcher: Callable[[SpoolRecord], JSON]) -> list[JSON]:
         results = []
-        remaining = []
         lock_fd = self._lock()
         try:
-            for record in self.records():
-                try:
-                    results.append(dispatcher(record))
-                except Exception:
-                    remaining.append(record)
+            snapshot = self.records()
+        finally:
+            self._unlock(lock_fd)
+
+        replayed_keys = set()
+        for record in snapshot:
+            try:
+                results.append(dispatcher(record))
+                replayed_keys.add(record.idempotency_key)
+            except Exception:
+                pass
+
+        lock_fd = self._lock()
+        try:
+            remaining = [
+                record
+                for record in self.records()
+                if record.idempotency_key not in replayed_keys
+            ]
             self._rewrite_records(remaining)
         finally:
             self._unlock(lock_fd)
@@ -125,7 +154,7 @@ class JsonlSpool:
                 {
                     "idempotency_key": record.idempotency_key,
                     "operation": record.operation,
-                    "payload": redact_value(dict(record.payload)),
+                    "payload": dict(record.payload),
                     "created_at": record.created_at,
                 },
                 sort_keys=True,

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 
 import pytest
 
@@ -132,7 +133,7 @@ def test_non_idempotent_write_is_not_retried_but_is_spooled(tmp_path):
     assert spool.records()[0].operation == "log_thought"
 
 
-def test_failed_write_spools_redacted_payload_with_0600_mode(tmp_path):
+def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tmp_path):
     client = FlakyClient(failures=3)
     spool = JsonlSpool(tmp_path / "spool.jsonl")
     memory = AgentMemory(
@@ -143,27 +144,51 @@ def test_failed_write_spools_redacted_payload_with_0600_mode(tmp_path):
     )
 
     with pytest.raises(ConnectionError):
-        memory.remember_fact("token=" + token_sample("super", "secret"), namespace="bilby")
+        memory.remember_fact(
+            "token=" + token_sample("super", "secret"),
+            namespace="bilby",
+            tags=["incident", "memory"],
+        )
 
     mode = os.stat(spool.path).st_mode & 0o777
     lock_mode = os.stat(spool.lock_path).st_mode & 0o777
     records = spool.records()
+    replayed = []
+
+    def dispatch(record: SpoolRecord):
+        replayed.append(record)
+        return {"ok": True}
+
     assert mode == 0o600
     assert lock_mode == 0o600
     assert len(records) == 1
     assert records[0].operation == "log_thought"
-    assert token_sample("super", "secret") not in str(records[0].payload)
+    assert records[0].payload == client.calls[0][1]
+    assert records[0].payload["namespace"] == "bilby"
+    assert records[0].payload["tags"] == [
+        "fact",
+        "incident",
+        "memory",
+        f"idempotency:{records[0].idempotency_key}",
+    ]
+    assert token_sample("super", "secret") in str(records[0].payload)
+    assert token_sample("super", "secret") not in str(records[0].redacted_payload())
+    assert token_sample("super", "secret") not in str(spool.redacted_records()[0].payload)
     assert records[0].idempotency_key
+    assert spool.replay(dispatch) == [{"ok": True}]
+    assert replayed[0].operation == records[0].operation
+    assert replayed[0].idempotency_key == records[0].idempotency_key
+    assert replayed[0].payload == records[0].payload
 
 
-def test_live_write_payload_is_redacted_before_client_call():
+def test_live_write_payload_preserves_original_content():
     client = FlakyClient()
     memory = AgentMemory(client, agent="bilby")
 
     memory.remember_fact("password: " + token_sample("hunt", "er2"))
 
-    assert token_sample("hunt", "er2") not in client.calls[0][1]["content"]
-    assert "[REDACTED]" in client.calls[0][1]["content"]
+    assert token_sample("hunt", "er2") in client.calls[0][1]["content"]
+    assert "[REDACTED]" not in client.calls[0][1]["content"]
 
 
 def test_spool_trims_old_records_by_line_count(tmp_path):
@@ -194,6 +219,77 @@ def test_spool_replay_removes_successes_and_keeps_failures(tmp_path):
         ("fail-key", "fail", {"content": "2"}),
     ]
     assert [record.operation for record in spool.records()] == ["fail"]
+
+
+def test_spool_replay_allows_appends_during_dispatch(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    spool.append("ok", {"content": "1"}, key="ok-key")
+    appended = threading.Event()
+
+    def dispatch(record: SpoolRecord):
+        thread = threading.Thread(
+            target=lambda: (spool.append("new", {"content": "2"}, key="new-key"), appended.set())
+        )
+        thread.start()
+        thread.join(timeout=1)
+        assert appended.is_set()
+        return {"ok": True}
+
+    assert spool.replay(dispatch) == [{"ok": True}]
+    assert [record.idempotency_key for record in spool.records()] == ["new-key"]
+
+
+def test_spool_rejects_oversized_record_before_success(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl", max_bytes=120)
+
+    with pytest.raises(ValueError, match="max_bytes"):
+        spool.append("large", {"content": "x" * 500}, key="large-key")
+
+    assert spool.records() == []
+
+
+def test_spool_failure_does_not_mask_original_write_error(tmp_path):
+    client = FlakyClient(failures=1)
+    spool = JsonlSpool(tmp_path / "spool.jsonl", max_bytes=120)
+    memory = AgentMemory(client, agent="bilby", spool=spool)
+
+    with pytest.raises(ConnectionError) as error:
+        memory.remember_fact("x" * 500)
+
+    assert any("Failed to spool log_thought" in note for note in error.value.__notes__)
+    assert spool.records() == []
+
+
+def test_spooled_operation_can_replay_through_real_client_method(tmp_path):
+    client = FlakyClient(failures=1)
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    memory = AgentMemory(client, agent="bilby", spool=spool)
+    secret = "password: " + token_sample("hunt", "er2")
+
+    with pytest.raises(ConnectionError):
+        memory.remember_fact(secret, namespace="bilby", tags=["replay"])
+
+    key = spool.records()[0].idempotency_key
+    replay_client = FlakyClient()
+
+    def dispatch(record: SpoolRecord):
+        return getattr(replay_client, record.operation)(**record.payload)
+
+    assert spool.replay(dispatch) == [{"ok": True}]
+    assert replay_client.calls == [
+        (
+            "log_thought",
+            {
+                "content": secret,
+                "namespace": "bilby",
+                "tags": [
+                    "fact",
+                    "replay",
+                    f"idempotency:{key}",
+                ],
+            },
+        )
+    ]
 
 
 def test_replay_records_passes_full_record():


### PR DESCRIPTION
## Summary
- Preserve original caller payloads for live AgentMemory writes instead of applying diagnostic redaction before client calls.
- Store exact failed-write payloads in JsonlSpool so replay can reconstruct the original Open Brain call, while adding redacted diagnostic views for safe display.
- Prevent fake spool success for oversized records, preserve the original live-write exception if local spooling fails, and replay records without holding the append lock during dispatcher calls.
- Document the safety/spooling contract in openbrain-memory README.

## Validation
- uv run pytest tests/test_safety.py
- uv run pytest
- bun test
- git diff --check

Closes #77