### PR TITLE
fix: reject AgentMemory namespace metadata spoofing

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -109,6 +109,16 @@ prompt_context = context.as_prompt_text()
 `AgentMemory` sends the original caller payload to Open Brain. Redaction helpers
 are for diagnostics and display only; they do not mutate live writes.
 
+Namespace authority belongs to the configured `OpenBrainClient` and the Open
+Brain service. `OpenBrainClient` sends the configured namespace through
+`X-Namespace` when present, and the server validates that header against the
+bearer token role. `AgentMemory` never accepts `namespace` as facade metadata.
+Nested user-owned structures such as decision context remain available for
+semantic fields, but authority-shaped keys such as `namespace`, `authorization`,
+`headers`, `role`, `token`, or `X-Namespace` are rejected before client calls.
+Cross-namespace writes require an explicit privileged client/server path rather
+than facade metadata.
+
 `JsonlSpool` stores exact failed-write payloads so replay can faithfully rebuild
 the original client call. Spool and lock files are created with `0600`
 permissions and should be treated as trusted local recovery storage. Use

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -20,8 +20,10 @@ EVENT_TYPES = {
 }
 PROTECTED_KEYS = {
     "agent",
+    "authorization",
     "project",
     "session_key",
+    "namespace",
     "role",
     "source",
     "event_type",
@@ -30,11 +32,22 @@ PROTECTED_KEYS = {
     "title",
     "rationale",
     "summary",
+    "token",
+    "x-namespace",
+    "x_namespace",
+}
+NESTED_AUTHORITY_KEYS = {
+    "authorization",
+    "headers",
+    "namespace",
+    "role",
+    "token",
+    "x-namespace",
 }
 SESSION_START_KEYS = {"channel_id", "thread_id", "topic"}
 SESSION_WRAP_KEYS = {"key_decisions", "next_steps"}
-DECISION_KEYS = {"alternatives", "tags", "context", "namespace"}
-THOUGHT_KEYS = {"tags", "namespace"}
+DECISION_KEYS = {"alternatives", "tags", "context"}
+THOUGHT_KEYS = {"tags"}
 
 
 class MemoryClient(Protocol):
@@ -190,8 +203,6 @@ class AgentMemory:
         tags = _tags("fact", metadata.pop("tags", None))
         tags.append(f"idempotency:{key}")
         payload: dict[str, Any] = {"content": text, "tags": tags}
-        if "namespace" in metadata:
-            payload["namespace"] = metadata["namespace"]
         return self._call_write("log_thought", payload, self.client.log_thought, key=key)
 
     def remember_decision(self, text: str, **metadata: Any) -> JSON:
@@ -258,6 +269,23 @@ class AgentMemory:
         if collisions:
             names = ", ".join(sorted(collisions))
             raise ValueError(f"metadata contains reserved keys: {names}")
+        self._reject_reserved_nested_metadata(metadata, "metadata")
+
+    def _reject_reserved_nested_metadata(self, value: Any, path: str) -> None:
+        if isinstance(value, Mapping):
+            collisions = {
+                str(key)
+                for key in value
+                if _authority_key(str(key)) in NESTED_AUTHORITY_KEYS
+            }
+            if collisions:
+                names = ", ".join(sorted(collisions))
+                raise ValueError(f"{path} contains reserved authority keys: {names}")
+            for key, item in value.items():
+                self._reject_reserved_nested_metadata(item, f"{path}.{key}")
+        elif isinstance(value, list | tuple):
+            for index, item in enumerate(value):
+                self._reject_reserved_nested_metadata(item, f"{path}[{index}]")
 
     def _reject_unknown_metadata(
         self,
@@ -419,3 +447,7 @@ def _tags(required: str, value: Any) -> list[str]:
 def _bounded_metadata(result: Mapping[str, Any]) -> dict[str, Any]:
     allowed = ("id", "path", "collection", "tags", "tier")
     return {key: result[key] for key in allowed if key in result}
+
+
+def _authority_key(key: str) -> str:
+    return key.lower().replace("_", "-")

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -218,7 +218,36 @@ def test_reserved_metadata_cannot_spoof_identity_or_semantics():
     with pytest.raises(ValueError, match="reserved keys"):
         memory.append_event("assistant", "event", session_key="spoofed")
     with pytest.raises(ValueError, match="reserved keys"):
+        memory.append_event("assistant", "event", namespace="spoofed")
+    with pytest.raises(ValueError, match="reserved keys"):
         memory.checkpoint("summary", session_key="spoofed")
+    with pytest.raises(ValueError, match="reserved authority keys"):
+        memory.remember_decision("decision", context={"namespace": "spoofed"})
+    with pytest.raises(ValueError, match="reserved authority keys"):
+        memory.remember_decision(
+            "decision",
+            context={"headers": {"X-Namespace": "spoofed"}},
+        )
+    with pytest.raises(ValueError, match="reserved authority keys"):
+        memory.remember_decision("decision", context={"Authorization": "Bearer x"})
+    with pytest.raises(ValueError, match="reserved authority keys"):
+        memory.append_event("assistant", "event", headers={"X_Namespace": "spoofed"})
+
+
+def test_nested_semantic_context_can_use_non_authority_names():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    memory.remember_decision(
+        "decision",
+        context={"source": "customer interview", "summary": "plain note"},
+        alternatives=[{"title": "Other path", "rationale": "too costly"}],
+    )
+
+    assert client.calls[0][1]["context"] == {
+        "source": "customer interview",
+        "summary": "plain note",
+    }
 
 
 def test_unsupported_metadata_is_rejected_before_tool_calls():
@@ -234,6 +263,18 @@ def test_unsupported_metadata_is_rejected_before_tool_calls():
         memory.checkpoint("summary", status="green")
     with pytest.raises(ValueError, match="unsupported keys"):
         memory.wrap_session("summary", outcome="merged")
+
+
+def test_namespace_metadata_is_not_accepted_by_memory_facade():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    with pytest.raises(ValueError, match="reserved keys"):
+        memory.remember_fact("fact", namespace="other")
+    with pytest.raises(ValueError, match="reserved keys"):
+        memory.remember_decision("decision", namespace="other")
+
+    assert client.calls == []
 
 
 def test_session_methods_require_started_session():

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -146,7 +146,6 @@ def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tm
     with pytest.raises(ConnectionError):
         memory.remember_fact(
             "token=" + token_sample("super", "secret"),
-            namespace="bilby",
             tags=["incident", "memory"],
         )
 
@@ -164,7 +163,6 @@ def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tm
     assert len(records) == 1
     assert records[0].operation == "log_thought"
     assert records[0].payload == client.calls[0][1]
-    assert records[0].payload["namespace"] == "bilby"
     assert records[0].payload["tags"] == [
         "fact",
         "incident",
@@ -267,7 +265,7 @@ def test_spooled_operation_can_replay_through_real_client_method(tmp_path):
     secret = "password: " + token_sample("hunt", "er2")
 
     with pytest.raises(ConnectionError):
-        memory.remember_fact(secret, namespace="bilby", tags=["replay"])
+        memory.remember_fact(secret, tags=["replay"])
 
     key = spool.records()[0].idempotency_key
     replay_client = FlakyClient()
@@ -281,7 +279,6 @@ def test_spooled_operation_can_replay_through_real_client_method(tmp_path):
             "log_thought",
             {
                 "content": secret,
-                "namespace": "bilby",
                 "tags": [
                     "fact",
                     "replay",


### PR DESCRIPTION
## Summary
- Remove `namespace` from generic `AgentMemory` fact and decision metadata pass-through.
- Treat namespace/header/token/role authority-shaped metadata as reserved before client calls, including nested decision context and event metadata.
- Preserve semantic nested context fields like `source`, `summary`, `title`, and `rationale` for user-owned decision context/alternatives.
- Document the namespace authority model in the openbrain-memory README.

## Validation
- `cd python/openbrain-memory && uv run pytest tests/test_agent.py tests/test_safety.py`
- `cd python/openbrain-memory && uv run pytest`
- `cd python/openbrain-memory && uv build`
- `bun test`
- `git diff --check`

Closes #78
