### PR TITLE
fix: harden MCP transport streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,28 @@ jobs:
       - name: Test
         run: bun test
 
+  python-package:
+    runs-on: [self-hosted, rodaddy]
+    defaults:
+      run:
+        working-directory: python/openbrain-memory
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Test python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run pytest -q
+
+      - name: Build python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv build
+
   deploy:
-    needs: check
+    needs: [check, python-package]
     runs-on: [self-hosted, rodaddy]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     env:

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -119,6 +119,15 @@ semantic fields, but authority-shaped keys such as `namespace`, `authorization`,
 Cross-namespace writes require an explicit privileged client/server path rather
 than facade metadata.
 
+`UrllibTransport` bounds JSON and SSE response reads with `max_response_bytes`
+and returns from SSE responses after the first JSON-RPC response event rather
+than waiting for the stream to close. It skips notification/progress SSE events
+that do not carry a JSON-RPC `id`. `health()` returns structured degraded
+health bodies for expected HTTP 503 responses. `OpenBrainClient.close()` and
+context manager exit clear the local MCP session id; the current Open Brain MCP
+surface does not expose an explicit remote session termination method, so
+server-side session cleanup remains TTL-based.
+
 `JsonlSpool` stores exact failed-write payloads so replay can faithfully rebuild
 the original client call. Spool and lock files are created with `0600`
 permissions and should be treated as trusted local recovery storage. Use

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -12,6 +12,7 @@ from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
+DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
 
 
 @dataclass(frozen=True)
@@ -42,12 +43,15 @@ class Transport(Protocol):
 
 
 class UrllibTransport:
-    def __init__(self) -> None:
+    def __init__(self, *, max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES) -> None:
+        if max_response_bytes < 1:
+            raise ValueError("max_response_bytes must be >= 1")
         self._opener = build_opener(_NoRedirectHandler)
+        self.max_response_bytes = max_response_bytes
 
     def get(self, url: str, *, headers: Mapping[str, str], timeout: float) -> TransportResponse:
         request = Request(url, headers=dict(headers), method="GET")
-        return self._send(request, timeout)
+        return self._send(request, timeout, expected_response_id=None)
 
     def post(
         self,
@@ -59,25 +63,46 @@ class UrllibTransport:
     ) -> TransportResponse:
         data = json.dumps(json_body).encode("utf-8")
         request = Request(url, data=data, headers=dict(headers), method="POST")
-        return self._send(request, timeout)
+        expected_response_id = json_body.get("id")
+        return self._send(
+            request,
+            timeout,
+            expected_response_id=expected_response_id if isinstance(expected_response_id, int) else None,
+        )
 
-    def _send(self, request: Request, timeout: float) -> TransportResponse:
+    def _send(
+        self,
+        request: Request,
+        timeout: float,
+        *,
+        expected_response_id: int | None,
+    ) -> TransportResponse:
         try:
             with self._opener.open(request, timeout=timeout) as response:
-                body = response.read().decode("utf-8")
+                headers = {k.lower(): v for k, v in response.headers.items()}
+                body = self._read_response(
+                    response,
+                    headers=headers,
+                    expected_response_id=expected_response_id,
+                ).decode("utf-8")
                 return TransportResponse(
                     status_code=response.status,
-                    headers={k.lower(): v for k, v in response.headers.items()},
+                    headers=headers,
                     text=body,
                 )
         except HTTPError as exc:
             try:
-                body = exc.read().decode("utf-8", errors="replace")
+                headers = {k.lower(): v for k, v in exc.headers.items()}
+                body = self._read_response(
+                    exc,
+                    headers=headers,
+                    expected_response_id=expected_response_id,
+                ).decode("utf-8", errors="replace")
             except OSError:
                 body = ""
             return TransportResponse(
                 status_code=exc.code,
-                headers={k.lower(): v for k, v in exc.headers.items()},
+                headers=headers,
                 text=body,
             )
         except URLError as exc:
@@ -85,6 +110,55 @@ class UrllibTransport:
                 f"Open Brain request failed: {exc.reason}",
                 context="transport",
             ) from exc
+
+    def _read_response(
+        self,
+        response: Any,
+        *,
+        headers: Mapping[str, str],
+        expected_response_id: int | None,
+    ) -> bytes:
+        content_type = _header(headers, "content-type") or ""
+        if "text/event-stream" in content_type:
+            return self._read_first_sse_event(
+                response,
+                expected_response_id=expected_response_id,
+            )
+        body = response.read(self.max_response_bytes + 1)
+        if len(body) > self.max_response_bytes:
+            raise OpenBrainHTTPError(
+                "Open Brain response exceeded max_response_bytes",
+                context="transport",
+            )
+        return body
+
+    def _read_first_sse_event(
+        self,
+        response: Any,
+        *,
+        expected_response_id: int | None,
+    ) -> bytes:
+        total = 0
+        event_lines: list[bytes] = []
+        while True:
+            line = response.readline(self.max_response_bytes + 1)
+            if line == b"":
+                break
+            total += len(line)
+            if total > self.max_response_bytes:
+                raise OpenBrainHTTPError(
+                    "Open Brain SSE response exceeded max_response_bytes",
+                    context="transport",
+                )
+            event_lines.append(line)
+            if line in {b"\n", b"\r\n"} and any(
+                item.startswith(b"data:") for item in event_lines
+            ):
+                event = b"".join(event_lines)
+                if _sse_event_has_response_id(event, expected_id=expected_response_id):
+                    return event
+                event_lines = []
+        return b"".join(event_lines)
 
 
 class _NoRedirectHandler(HTTPRedirectHandler):
@@ -162,11 +236,24 @@ class OpenBrainClient:
             headers={"Accept": "application/json"},
             timeout=self.timeout,
         )
+        if response.status_code == 503:
+            payload = self._decode_json_response(response, context="health")
+            if isinstance(payload, dict) and payload.get("status") == "degraded":
+                return payload
         self._raise_for_status(response, context="health")
         payload = self._decode_json_response(response, context="health")
         if not isinstance(payload, dict):
             raise OpenBrainProtocolError("Health response was not a JSON object", context="health")
         return payload
+
+    def close(self) -> None:
+        self._session_id = None
+
+    def __enter__(self) -> OpenBrainClient:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
 
     def call_tool(self, name: str, arguments: Mapping[str, Any] | None = None) -> JSON:
         self._ensure_session()
@@ -418,13 +505,19 @@ class OpenBrainClient:
                 session_id=self._session_id,
             ) from exc
 
-    def _decode_mcp_response(self, response: TransportResponse, *, context: str) -> Any:
+    def _decode_mcp_response(
+        self,
+        response: TransportResponse,
+        *,
+        context: str,
+        expected_id: int | None = None,
+    ) -> Any:
         text = response.text.strip()
         if not text:
             return None
         content_type = _header(response.headers, "content-type") or ""
         if "text/event-stream" in content_type or text.startswith("event:") or text.startswith("data:"):
-            text = _last_sse_data(text)
+            text = _last_sse_data(text, expected_id=expected_id)
         try:
             return json.loads(text)
         except json.JSONDecodeError as exc:
@@ -444,7 +537,11 @@ class OpenBrainClient:
         expected_id: int,
         context: str,
     ) -> JSON:
-        message = self._decode_mcp_response(response, context=context)
+        message = self._decode_mcp_response(
+            response,
+            context=context,
+            expected_id=expected_id,
+        )
         if not isinstance(message, dict):
             raise OpenBrainProtocolError("MCP response was not a JSON object", context=context)
         if message.get("jsonrpc") != "2.0":
@@ -482,7 +579,7 @@ def _header(headers: Mapping[str, str], name: str) -> str | None:
     return None
 
 
-def _last_sse_data(text: str) -> str:
+def _last_sse_data(text: str, *, expected_id: int | None = None) -> str:
     data_blocks: list[str] = []
     current: list[str] = []
     for line in text.splitlines():
@@ -497,7 +594,45 @@ def _last_sse_data(text: str) -> str:
         data_blocks.append("\n".join(current))
     if not data_blocks:
         raise OpenBrainProtocolError("MCP SSE response did not contain data")
+    if expected_id is not None:
+        for block in data_blocks:
+            try:
+                message = json.loads(block)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(message, dict) and message.get("id") == expected_id:
+                return block
     return data_blocks[-1]
+
+
+def _sse_event_has_response_id(event: bytes, *, expected_id: int | None = None) -> bool:
+    text = event.decode("utf-8", errors="replace")
+    for block in _sse_data_blocks(text):
+        try:
+            message = json.loads(block)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(message, dict) or "id" not in message:
+            continue
+        if expected_id is None or message.get("id") == expected_id:
+            return True
+    return False
+
+
+def _sse_data_blocks(text: str) -> list[str]:
+    data_blocks: list[str] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if not line:
+            if current:
+                data_blocks.append("\n".join(current))
+                current = []
+            continue
+        if line.startswith("data:"):
+            current.append(line.removeprefix("data:").strip())
+    if current:
+        data_blocks.append("\n".join(current))
+    return data_blocks
 
 
 def _tool_text(result: Mapping[str, Any]) -> str:

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import threading
+import time
 
 import pytest
 
@@ -123,6 +124,14 @@ def tool_requests(transport: FakeTransport):
     ]
 
 
+def header_value(headers: dict[str, str], name: str) -> str | None:
+    wanted = name.lower()
+    for key, value in headers.items():
+        if key.lower() == wanted:
+            return value
+    return None
+
+
 def test_health_check_uses_public_health_endpoint_without_credentials():
     transport = FakeTransport()
     client = make_client(transport)
@@ -133,6 +142,33 @@ def test_health_check_uses_public_health_endpoint_without_credentials():
     assert request["method"] == "GET"
     assert request["url"] == "https://brain.example/health"
     assert request["headers"] == {"Accept": "application/json"}
+
+
+def test_health_returns_structured_degraded_body_for_503():
+    transport = FakeTransport()
+    transport.next_status = 503
+    transport.health_payload = {
+        "status": "degraded",
+        "database": {"connected": False},
+        "error": "database unavailable",
+    }
+    client = make_client(transport)
+
+    assert client.health() == {
+        "status": "degraded",
+        "database": {"connected": False},
+        "error": "database unavailable",
+    }
+
+
+def test_health_raises_for_unstructured_503_body():
+    transport = FakeTransport()
+    transport.next_status = 503
+    transport.health_payload = {"error": "proxy unavailable"}
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError, match="status=503"):
+        client.health()
 
 
 def test_initialize_sends_auth_namespace_and_stores_session_id():
@@ -167,6 +203,22 @@ def test_initialized_notification_and_tool_calls_reuse_session_header():
     assert initialized["headers"]["MCP-Protocol-Version"] == "2025-03-26"
     assert call["headers"]["Mcp-Session-Id"] == "session-123"
     assert call["headers"]["MCP-Protocol-Version"] == "2025-03-26"
+
+
+def test_close_clears_local_session_and_context_manager_closes():
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    client.search_all(query="x")
+    assert client.session_id == "session-123"
+
+    client.close()
+    assert client.session_id is None
+
+    with make_client(FakeTransport()) as scoped:
+        scoped.search_all(query="x")
+        assert scoped.session_id == "session-123"
+    assert scoped.session_id is None
 
 
 def test_generic_call_tool_emits_json_rpc_tools_call_shape():
@@ -509,6 +561,231 @@ def test_sse_mcp_responses_are_decoded():
     client = make_client(SseTransport())
 
     assert client.search_all(query="x")["tool"] == "search_all"
+
+
+def test_openbrain_client_streams_until_matching_sse_jsonrpc_response():
+    seen = []
+
+    class StreamingMcpHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_POST(self):
+            content_length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(content_length))
+            seen.append(
+                {
+                    "headers": dict(self.headers.items()),
+                    "json": payload,
+                }
+            )
+
+            method = payload.get("method")
+            if method == "initialize":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Mcp-Session-Id", "session-stream")
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": payload["id"],
+                            "result": {"protocolVersion": "2025-03-26"},
+                        }
+                    ).encode("utf-8")
+                )
+                return
+
+            if method == "notifications/initialized":
+                self.send_response(202)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
+            if method == "tools/call":
+                result = {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "tool": payload["params"]["name"],
+                                    "ok": True,
+                                    "results": [],
+                                }
+                            ),
+                        }
+                    ]
+                }
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.end_headers()
+                self.wfile.write(
+                    b"event: message\n"
+                    b'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}\n\n'
+                )
+                self.wfile.flush()
+                self.wfile.write(
+                    b"event: message\n"
+                    b'data: {"jsonrpc":"2.0","id":999,"result":{"content":[{"type":"text","text":"{\\"tool\\":\\"wrong\\"}"}]}}\n\n'
+                )
+                self.wfile.flush()
+                self.wfile.write(
+                    b"event: message\n"
+                    + (
+                        "data: "
+                        + json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": payload["id"],
+                                "result": result,
+                            }
+                        )
+                        + "\n\n"
+                    ).encode("utf-8")
+                )
+                self.wfile.flush()
+                time.sleep(1.5)
+                return
+
+            self.send_response(400)
+            self.end_headers()
+
+        def log_message(self, _format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), StreamingMcpHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client = OpenBrainClient(
+            f"http://127.0.0.1:{server.server_port}",
+            "secret-token",
+            "bilby",
+            agent_id="bilby-agent",
+            role="agent",
+            timeout=2,
+            transport=UrllibTransport(),
+        )
+        started = time.monotonic()
+        result = client.search_all(query="stream")
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert elapsed < 1
+    assert result == {"tool": "search_all", "ok": True, "results": []}
+    assert [request["json"].get("method") for request in seen] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+    ]
+
+    initialize, initialized, call = seen
+    assert header_value(initialize["headers"], "Authorization") == "Bearer secret-token"
+    assert header_value(initialize["headers"], "X-Namespace") == "bilby"
+    assert header_value(initialize["headers"], "X-Agent-Id") == "bilby-agent"
+    assert header_value(initialize["headers"], "X-Role") == "agent"
+    assert header_value(initialize["headers"], "Mcp-Session-Id") is None
+    assert initialize["json"]["id"] == 1
+
+    assert header_value(initialized["headers"], "Mcp-Session-Id") == "session-stream"
+    assert header_value(initialized["headers"], "MCP-Protocol-Version") == "2025-03-26"
+    assert header_value(call["headers"], "Mcp-Session-Id") == "session-stream"
+    assert header_value(call["headers"], "MCP-Protocol-Version") == "2025-03-26"
+    assert call["json"] == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": "search_all", "arguments": {"query": "stream"}},
+    }
+
+
+def test_urllib_transport_bounds_json_response_size():
+    class OversizedHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b"x" * 16)
+
+        def log_message(self, _format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), OversizedHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with pytest.raises(OpenBrainHTTPError, match="max_response_bytes"):
+            UrllibTransport(max_response_bytes=8).get(
+                f"http://127.0.0.1:{server.server_port}/health",
+                headers={},
+                timeout=2,
+            )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_urllib_transport_bounds_sse_response_size():
+    class OversizedSseHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b"data: " + (b"x" * 32) + b"\n\n")
+
+        def log_message(self, _format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), OversizedSseHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with pytest.raises(OpenBrainHTTPError, match="SSE response exceeded"):
+            UrllibTransport(max_response_bytes=8).post(
+                f"http://127.0.0.1:{server.server_port}/mcp",
+                headers={"Accept": "application/json, text/event-stream"},
+                json_body={"jsonrpc": "2.0", "id": 1},
+                timeout=2,
+            )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_urllib_transport_returns_after_first_sse_event_without_waiting_for_eof():
+    class StreamingSseHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n')
+            self.wfile.flush()
+            time.sleep(1.5)
+
+        def log_message(self, _format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), StreamingSseHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        started = time.monotonic()
+        response = UrllibTransport().post(
+            f"http://127.0.0.1:{server.server_port}/mcp",
+            headers={"Accept": "application/json, text/event-stream"},
+            json_body={"jsonrpc": "2.0", "id": 1},
+            timeout=2,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert elapsed < 1
+    assert response.text == 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n'
 
 
 def test_remote_http_requires_explicit_opt_in_but_loopback_is_allowed():


### PR DESCRIPTION
## Summary

- Bound JSON and SSE response reads in `UrllibTransport` with `max_response_bytes`.
- Keep MCP SSE reads open until the matching JSON-RPC response id arrives, skipping notifications/progress and mismatched id events.
- Return structured degraded health bodies only for expected `status: degraded` 503 responses.
- Add `OpenBrainClient.close()` and context manager cleanup for local MCP session state.
- Add a Python package CI job for `python/openbrain-memory` tests and build.

Closes #81.
Completes the missing Python package CI gate follow-up from #79.

## Validation

- `uv run pytest tests/test_client.py` in `python/openbrain-memory`: 26 passed
- `uv run pytest` in `python/openbrain-memory`: 66 passed, 1 skipped
- `uv build` in `python/openbrain-memory`: built sdist and wheel
- `bun test`: 579 passed, 16 skipped
- `git diff --check`: passed
