### PR TITLE
fix: strengthen memory package contracts

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -18,6 +18,7 @@ EVENT_TYPES = {
     "correction",
     "handoff",
 }
+IMPORTANCE_LEVELS = {"hot", "warm", "cold"}
 PROTECTED_KEYS = {
     "agent",
     "authorization",
@@ -179,16 +180,25 @@ class AgentMemory:
         event_type = str(metadata.pop("event_type", "fact"))
         if event_type not in EVENT_TYPES:
             raise ValueError(f"Unsupported event_type: {event_type}")
+        artifact_path = metadata.pop("artifact_path", None)
+        importance = metadata.pop("importance", None)
         self._reject_reserved_metadata(metadata)
         key = idempotency_key()
-        payload = self._session_payload(
-            {
-                "event_type": event_type,
-                "content": content,
-                "source": role,
-                "metadata": {**dict(metadata), "idempotency_key": key},
-            }
-        )
+        payload = {
+            "event_type": event_type,
+            "content": content,
+            "source": role,
+            "metadata": {**dict(metadata), "idempotency_key": key},
+            "session_key": self.conversation_key,
+        }
+        if artifact_path is not None:
+            payload["artifact_path"] = _required_str(artifact_path, "artifact_path")
+        if importance is not None:
+            payload["importance"] = _enum_value(
+                importance,
+                "importance",
+                IMPORTANCE_LEVELS,
+            )
         return self._call_write(
             "append_session_event",
             payload,
@@ -214,9 +224,10 @@ class AgentMemory:
             "rationale": text,
             "tags": [f"idempotency:{idem}"],
         }
-        for key in DECISION_KEYS:
-            if key in metadata:
-                payload[key] = metadata[key]
+        if "alternatives" in metadata:
+            payload["alternatives"] = _str_list(metadata["alternatives"], "alternatives")
+        if "context" in metadata:
+            payload["context"] = _required_str(metadata["context"], "context")
         if "tags" in metadata:
             payload["tags"] = _tags(f"idempotency:{idem}", metadata["tags"])
         return self._call_write("log_decision", payload, self.client.log_decision, key=idem)
@@ -442,6 +453,26 @@ def _tags(required: str, value: Any) -> list[str]:
     if isinstance(value, list):
         tags.extend(str(item) for item in value if item != required)
     return tags
+
+
+def _required_str(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _str_list(value: Any, name: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{name} must be a list of non-empty strings")
+    return value
+
+
+def _enum_value(value: Any, name: str, allowed: set[str]) -> str:
+    text = _required_str(value, name)
+    if text not in allowed:
+        choices = ", ".join(sorted(allowed))
+        raise ValueError(f"{name} must be one of: {choices}")
+    return text
 
 
 def _bounded_metadata(result: Mapping[str, Any]) -> dict[str, Any]:

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -9,6 +9,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
+from .policy import redact_text
+
 
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
@@ -677,13 +679,6 @@ def _validate_base_url(base_url: str, *, allow_insecure_http: bool) -> None:
     )
 
 
-SECRET_PATTERNS = [
-    re.compile(r"(?i)authorization\s*[:=]\s*bearer\s+[^\s,;]+"),
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
-    re.compile(r"(?i)mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+"),
-    re.compile(r'(?i)"?(api[_-]?key|github[_-]?token|token|password|secret)"?\s*:\s*"[^"]+"'),
-    re.compile(r"(?i)(api[_-]?key|github[_-]?token|token|password|secret)\s*[:=]\s*[^\s,;]+"),
-]
 SENSITIVE_KEY_PATTERN = re.compile(
     r"(?i)(token|secret|password|api[_-]?key|credential|authorization|session[_-]?id)"
 )
@@ -722,8 +717,7 @@ def _redact(
     for secret in (token, session_id):
         if secret:
             redacted = redacted.replace(secret, "[REDACTED]")
-    for pattern in SECRET_PATTERNS:
-        redacted = pattern.sub("[REDACTED]", redacted)
+    redacted = redact_text(redacted)
     if len(redacted) > max_length:
         redacted = redacted[:max_length] + "...[truncated]"
     return redacted

--- a/python/openbrain-memory/src/openbrain_memory/dream.py
+++ b/python/openbrain-memory/src/openbrain_memory/dream.py
@@ -288,11 +288,13 @@ def _float_between(value: Any, default: float, name: str) -> float:
 
 def _candidate_items(report: Any, key: str) -> list[Mapping[str, Any]]:
     if not isinstance(report, Mapping):
-        return []
+        raise ValueError("Dream report was not an object")
     items = report.get(key, [])
     if not isinstance(items, list):
-        return []
-    return [item for item in items if isinstance(item, Mapping)]
+        raise ValueError(f"Dream report {key} was not a list")
+    if not all(isinstance(item, Mapping) for item in items):
+        raise ValueError(f"Dream report {key} contained non-object candidates")
+    return items
 
 
 def _required_str(mapping: Mapping[str, Any], key: str) -> str:

--- a/python/openbrain-memory/src/openbrain_memory/policy.py
+++ b/python/openbrain-memory/src/openbrain_memory/policy.py
@@ -10,6 +10,27 @@ from uuid import uuid4
 SK_PREFIX = "sk" + "-"
 GITHUB_PREFIX_RE = "gh" + r"[pousr]_"
 GITHUB_PAT_PREFIX = "github" + r"_pat_"
+AWS_ACCESS_KEY_PREFIX_RE = r"A[KS]IA[0-9A-Z]{16}"
+AWS_SECRET_LIKE_RE = (
+    r"(?<![A-Za-z0-9/+=])"
+    r"(?=[A-Za-z0-9/+=]*[A-Z])"
+    r"(?=[A-Za-z0-9/+=]*[a-z])"
+    r"(?=[A-Za-z0-9/+=]*[0-9])"
+    r"(?=[A-Za-z0-9/+=]*[/+=])"
+    r"[A-Za-z0-9/+=]{40}"
+    r"(?![A-Za-z0-9/+=])"
+)
+AWS_SECRET_CONTEXT_RE = (
+    r"(?i)(aws[_ -]?(secret|secret[_ -]?access[_ -]?key))\s*[:=]\s*"
+    r"[A-Za-z0-9/+=]{40}"
+)
+SLACK_TOKEN_RE = r"xox[baprs]-[A-Za-z0-9-]{10,}"
+GOOGLE_API_KEY_PREFIX = "AIza"
+JWT_LIKE_RE = (
+    r"eyJ[A-Za-z0-9_-]{8,}\."
+    r"[A-Za-z0-9_-]{8,}\."
+    r"[A-Za-z0-9_-]{8,}"
+)
 PRIVATE_KEY_BLOCK_RE = (
     "-----BEGIN [A-Z ]*PRIVATE "
     "KEY-----.*?-----END [A-Z ]*PRIVATE "
@@ -19,14 +40,23 @@ PRIVATE_KEY_BLOCK_RE = (
 SECRET_PATTERNS = [
     re.compile(r"(?i)authorization\s*[:=]\s*bearer\s+[^\s,;]+"),
     re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+"),
     re.compile(rf"\b{SK_PREFIX}[A-Za-z0-9_-]{{10,}}\b"),
     re.compile(rf"(?i){GITHUB_PAT_PREFIX}[A-Za-z0-9_]+"),
     re.compile(rf"(?i){GITHUB_PREFIX_RE}[A-Za-z0-9_]{{20,}}"),
+    re.compile(rf"\b{AWS_ACCESS_KEY_PREFIX_RE}\b"),
+    re.compile(AWS_SECRET_CONTEXT_RE),
+    re.compile(AWS_SECRET_LIKE_RE),
+    re.compile(rf"\b{SLACK_TOKEN_RE}\b"),
+    re.compile(rf"\b{GOOGLE_API_KEY_PREFIX}[A-Za-z0-9_-]{{35}}\b"),
+    re.compile(rf"\b{JWT_LIKE_RE}\b"),
     re.compile(r"(?i)(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+"),
     re.compile(r'(?i)"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"'),
     re.compile(PRIVATE_KEY_BLOCK_RE, re.S),
 ]
-SENSITIVE_KEY_RE = re.compile(r"(?i)(token|secret|password|api[_-]?key|credential|authorization)")
+SENSITIVE_KEY_RE = re.compile(
+    r"(?i)(token|secret|password|api[_-]?key|credential|authorization|session[_-]?id)"
+)
 
 
 class RetryExhaustedError(RuntimeError):

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+import re
+
 import pytest
 
 from openbrain_memory import (
@@ -58,6 +61,62 @@ class FakeClient:
         return self._record("session_wrap", arguments)
 
 
+TOOL_SCHEMA_FILES = {
+    "append_session_event": "append-session-event.ts",
+    "log_decision": "log-decision.ts",
+    "log_thought": "log-thought.ts",
+    "search_all": "search-all.ts",
+    "session_start": "session-start.ts",
+    "session_wrap": "session-wrap.ts",
+}
+
+def server_tool_schema_block(name: str) -> str:
+    repo_root = Path(__file__).resolve().parents[3]
+    source = repo_root / "src" / "tools" / TOOL_SCHEMA_FILES[name]
+    text = source.read_text(encoding="utf-8")
+    return text.split("inputSchema:", 1)[1].split("annotations:", 1)[0]
+
+
+def server_tool_keys(name: str) -> set[str]:
+    block = server_tool_schema_block(name)
+    return set(re.findall(r"^\s{8}([A-Za-z_][A-Za-z0-9_]*)\s*:", block, flags=re.MULTILINE))
+
+
+def server_required_tool_keys(name: str) -> set[str]:
+    block = server_tool_schema_block(name)
+    keys = []
+    current_key = None
+    current_lines = []
+    for line in block.splitlines():
+        match = re.match(r"^\s{8}([A-Za-z_][A-Za-z0-9_]*)\s*:", line)
+        if match:
+            if current_key is not None and ".optional()" not in "\n".join(current_lines):
+                keys.append(current_key)
+            current_key = match.group(1)
+            current_lines = [line]
+            continue
+        if current_key is not None:
+            current_lines.append(line)
+    if current_key is not None and ".optional()" not in "\n".join(current_lines):
+        keys.append(current_key)
+    return set(keys)
+
+
+def assert_server_contract_call(name: str, payload: dict) -> None:
+    assert set(payload) <= server_tool_keys(name)
+    assert server_required_tool_keys(name) <= set(payload)
+    for key, value in payload.items():
+        if key in {"limit", "offset"}:
+            assert isinstance(value, int)
+        elif key in {"alternatives", "key_decisions", "next_steps", "tags"}:
+            assert isinstance(value, list)
+            assert all(isinstance(item, str) for item in value)
+        elif key == "metadata":
+            assert isinstance(value, dict)
+        else:
+            assert isinstance(value, str)
+
+
 def test_start_session_records_runtime_agnostic_conversation_key():
     client = FakeClient()
     memory = AgentMemory(client, agent="bilby", project="open-brain")
@@ -90,6 +149,7 @@ def test_append_event_routes_to_session_event_wrapper():
     assert payload["event_type"] == "action"
     assert payload["content"] == "Here is the update."
     assert payload["source"] == "assistant"
+    assert "project" not in payload
     assert payload["metadata"]["turn"] == 3
     assert payload["metadata"]["idempotency_key"].startswith("obmem-")
     assert payload["session_key"] == "conversation"
@@ -119,6 +179,42 @@ def test_remember_decision_routes_to_decision_logging_semantics():
     assert client.calls[0][1]["title"] == "Use OpenBrainClient wrappers, not raw protocol calls."
     assert client.calls[0][1]["rationale"] == "Use OpenBrainClient wrappers, not raw protocol calls."
     assert client.calls[0][1]["tags"][0].startswith("idempotency:obmem-")
+
+
+def test_representative_facade_payloads_match_server_tool_contracts():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    memory.start_session("conversation", channel_id="c1", thread_id="t1", topic="contract")
+    memory.append_event(
+        "assistant",
+        "event",
+        event_type="action",
+        artifact_path="/tmp/a",
+        importance="hot",
+    )
+    memory.remember_fact("fact", tags=["contract"])
+    memory.remember_decision(
+        "decision",
+        alternatives=["other option"],
+        context="short context",
+        tags=["contract"],
+    )
+    memory.recall("contract", limit=3)
+    memory.checkpoint("checkpoint", key_decisions=["decision"])
+    memory.wrap_session("wrapped", next_steps=["ship"])
+
+    for name, payload in client.calls:
+        assert_server_contract_call(name, payload)
+
+    append = [payload for name, payload in client.calls if name == "append_session_event"][0]
+    assert append["artifact_path"] == "/tmp/a"
+    assert append["importance"] == "hot"
+    assert "artifact_path" not in append["metadata"]
+    assert "importance" not in append["metadata"]
+    decision = [payload for name, payload in client.calls if name == "log_decision"][0]
+    assert isinstance(decision["context"], str)
+    assert all(isinstance(item, str) for item in decision["alternatives"])
 
 
 def test_recall_assembles_bounded_prompt_context():
@@ -234,20 +330,23 @@ def test_reserved_metadata_cannot_spoof_identity_or_semantics():
         memory.append_event("assistant", "event", headers={"X_Namespace": "spoofed"})
 
 
-def test_nested_semantic_context_can_use_non_authority_names():
+def test_decision_context_and_alternatives_must_match_server_schema():
     client = FakeClient()
     memory = AgentMemory(client, agent="bilby")
 
     memory.remember_decision(
         "decision",
-        context={"source": "customer interview", "summary": "plain note"},
-        alternatives=[{"title": "Other path", "rationale": "too costly"}],
+        context="customer interview summary",
+        alternatives=["Other path was too costly"],
     )
 
-    assert client.calls[0][1]["context"] == {
-        "source": "customer interview",
-        "summary": "plain note",
-    }
+    assert client.calls[0][1]["context"] == "customer interview summary"
+    assert client.calls[0][1]["alternatives"] == ["Other path was too costly"]
+
+    with pytest.raises(ValueError, match="context"):
+        memory.remember_decision("decision", context={"summary": "plain note"})
+    with pytest.raises(ValueError, match="alternatives"):
+        memory.remember_decision("decision", alternatives=[{"title": "Other path"}])
 
 
 def test_unsupported_metadata_is_rejected_before_tool_calls():
@@ -263,6 +362,8 @@ def test_unsupported_metadata_is_rejected_before_tool_calls():
         memory.checkpoint("summary", status="green")
     with pytest.raises(ValueError, match="unsupported keys"):
         memory.wrap_session("summary", outcome="merged")
+    with pytest.raises(ValueError, match="importance"):
+        memory.append_event("assistant", "event", importance="urgent")
 
 
 def test_namespace_metadata_is_not_accepted_by_memory_facade():

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -421,6 +421,34 @@ def test_error_body_redaction_scrubs_json_secret_fields():
     assert "failed" in message
 
 
+def test_error_body_redaction_scrubs_unlabelled_secret_shapes():
+    transport = FakeTransport()
+    transport.next_status = 500
+    aws_access_key = "AKIA" + "ABCDEFGHIJKLMNOP"
+    aws_secret = "abcdEFGH" + "ijklMNOP" + "qrstUVWX" + "yz012345" + "6789+/ab"
+    slack_token = "xoxb-" + "123456789012-" + "abcdefghijklmnop"
+    google_key = "AIza" + "ABCDEFGHIJKLMNOPQRSTUVWX" + "YZabcdefghi"
+    jwt_token = (
+        "eyJ" + "hbGciOiJIUzI1NiJ9."
+        "eyJzdWIiOiJvcGVuLWJyYWluIn0."
+        "c2lnbmF0dXJlX3ZhbHVl"
+    )
+    transport.next_text = "\n".join(
+        [aws_access_key, aws_secret, slack_token, google_key, jwt_token]
+    )
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError) as exc_info:
+        client.search_all(query="x")
+
+    message = str(exc_info.value)
+    assert aws_access_key not in message
+    assert aws_secret not in message
+    assert slack_token not in message
+    assert google_key not in message
+    assert jwt_token not in message
+
+
 def test_missing_session_id_is_protocol_error():
     class MissingSessionTransport(FakeTransport):
         def post(self, url, *, headers, json_body, timeout):

--- a/python/openbrain-memory/tests/test_dream.py
+++ b/python/openbrain-memory/tests/test_dream.py
@@ -126,6 +126,56 @@ def test_namespace_dream_suppresses_unscoped_tier_actions():
     assert [action.tool for action in result.actions] == ["promote_entry"]
 
 
+def test_dream_once_fails_closed_on_malformed_tier_candidate():
+    client = FakeDreamClient()
+    client.responses["tier_recommendations"]["promote"] = {
+        "candidates": [
+            {
+                "id": "hot-1",
+                "table": "thoughts",
+                "suggested_tier": "hot",
+            },
+            {
+                "id": "bad-1",
+                "table": "thoughts",
+            },
+        ]
+    }
+    engine = DreamEngine(client)
+
+    with pytest.raises(ValueError, match="suggested_tier"):
+        engine.dream_once()
+
+
+def test_dream_once_fails_closed_on_mixed_namespace_scan_candidates():
+    client = FakeDreamClient()
+    client.responses["scan_namespace"] = {
+        "candidates": [
+            {"id": "promote-1", "table": "thoughts"},
+            {"id": "bad-1"},
+        ],
+    }
+    engine = DreamEngine(client)
+
+    with pytest.raises(ValueError, match="table"):
+        engine.dream_once(namespace="bilby")
+
+
+def test_dream_once_fails_closed_on_malformed_report_shapes():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    client.responses["tier_recommendations"]["promote"] = {"candidates": "bad"}
+    with pytest.raises(ValueError, match="candidates"):
+        engine.dream_once()
+
+    client = FakeDreamClient()
+    client.responses["tier_recommendations"]["promote"] = "bad"
+    engine = DreamEngine(client)
+    with pytest.raises(ValueError, match="object"):
+        engine.dream_once()
+
+
 def test_wrapper_methods_pass_arguments_correctly():
     client = FakeDreamClient()
     engine = DreamEngine(client, policy={"target_namespace": "team"})

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -91,11 +91,72 @@ def test_redaction_scrubs_common_secret_shapes():
     assert redacted.count("[REDACTED]") >= 4
 
 
+def test_redaction_scrubs_unlabelled_cloud_and_token_shapes():
+    aws_access_key = token_sample("AKIA", "ABCDEFGHIJKLMNOP")
+    aws_secret = token_sample("abcdEFGH", "ijklMNOP", "qrstUVWX", "yz012345", "6789+/ab")
+    slack_token = token_sample("xoxb-", "123456789012-", "abcdefghijklmnop")
+    google_key = token_sample("AIza", "ABCDEFGHIJKLMNOPQRSTUVWX", "YZabcdefghi")
+    jwt_token = token_sample(
+        "eyJ", "hbGciOiJIUzI1NiJ9.",
+        "eyJzdWIiOiJvcGVuLWJyYWluIn0.",
+        "c2lnbmF0dXJlX3ZhbHVl",
+    )
+    text = "\n".join(
+        [
+            f"aws access {aws_access_key}",
+            f"aws secret {aws_secret}",
+            f"slack {slack_token}",
+            f"google {google_key}",
+            f"jwt {jwt_token}",
+            "plain sentence with punctuation should stay visible",
+        ]
+    )
+
+    redacted = redact_text(text)
+
+    assert aws_access_key not in redacted
+    assert aws_secret not in redacted
+    assert slack_token not in redacted
+    assert google_key not in redacted
+    assert jwt_token not in redacted
+    assert "plain sentence with punctuation should stay visible" in redacted
+    assert redacted.count("[REDACTED]") == 5
+
+
+def test_redaction_scrubs_labelled_alphanumeric_aws_secret():
+    aws_secret = token_sample("abcdEFGH", "ijklMNOP", "qrstUVWX", "yz012345", "6789")
+
+    redacted = redact_text(f"aws_secret_access_key={aws_secret}")
+
+    assert aws_secret not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_keeps_benign_40_character_hex_ids_visible():
+    sha_like_id = token_sample("0123456789", "abcdef0123", "456789abcd", "ef01234567")
+
+    redacted = redact_text(f"commit {sha_like_id}")
+
+    assert sha_like_id in redacted
+    assert "[REDACTED]" not in redacted
+
+
 def test_redact_value_recurses_sensitive_keys():
-    value = {"nested": {"access_token": "secret-token"}, "safe": "visible"}
+    value = {
+        "nested": {
+            "access_token": "secret-token",
+            "session_id": "session-123",
+            "mcp_session_id": "session-456",
+        },
+        "safe": "visible",
+    }
 
     assert redact_value(value) == {
-        "nested": {"access_token": "[REDACTED]"},
+        "nested": {
+            "access_token": "[REDACTED]",
+            "session_id": "[REDACTED]",
+            "mcp_session_id": "[REDACTED]",
+        },
         "safe": "visible",
     }
 


### PR DESCRIPTION
## Summary

- Expand shared Python redaction coverage for AWS access keys, AWS secret-shaped values, Slack tokens, Google API keys, JWT-like strings, and MCP/session ids.
- Route client diagnostics through the shared redactor so package redaction behavior does not drift between `client.py` and `policy.py`.
- Strengthen `AgentMemory` facade contracts against server tool schemas by deriving accepted/required fields from TypeScript tool schema blocks and validating representative payload types.
- Fix facade schema drift for `append_session_event` (`artifact_path`/`importance` top-level, no unsupported `project`) and `log_decision` (`context` string, `alternatives` string list).
- Make DreamEngine fail closed on malformed report containers, non-list candidates, and malformed candidate fields.

Closes #82.

## Validation

- `uv run pytest tests/test_agent.py tests/test_client.py tests/test_safety.py tests/test_dream.py`: 74 passed
- `uv run pytest`: 74 passed, 1 skipped
- `uv build`: built sdist and wheel
- `bun test`: 579 passed, 16 skipped
- `git diff --check`: passed
