### PR TITLE
fix: scope read tools and harden followups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
     needs: [check, python-package]
     runs-on: [self-hosted, rodaddy]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
     env:
       DEPLOY_HOST: 10.71.20.49
       DEPLOY_USER: rico

--- a/python/openbrain-memory/src/openbrain_memory/dream.py
+++ b/python/openbrain-memory/src/openbrain_memory/dream.py
@@ -130,26 +130,27 @@ class DreamEngine:
                 ),
             )
         )
-        reports["promote_recommendations"] = self.tier_recommendations(
-            "promote",
-            limit=limit,
-            threshold_days=_bounded_int(
-                filters.get("promote_threshold_days"),
-                self.policy.promote_threshold_days,
-                "promote_threshold_days",
-                365,
-            ),
-        )
-        reports["demote_recommendations"] = self.tier_recommendations(
-            "demote",
-            limit=limit,
-            threshold_days=_bounded_int(
-                filters.get("demote_threshold_days"),
-                self.policy.demote_threshold_days,
-                "demote_threshold_days",
-                365,
-            ),
-        )
+        if namespace is None:
+            reports["promote_recommendations"] = self.tier_recommendations(
+                "promote",
+                limit=limit,
+                threshold_days=_bounded_int(
+                    filters.get("promote_threshold_days"),
+                    self.policy.promote_threshold_days,
+                    "promote_threshold_days",
+                    365,
+                ),
+            )
+            reports["demote_recommendations"] = self.tier_recommendations(
+                "demote",
+                limit=limit,
+                threshold_days=_bounded_int(
+                    filters.get("demote_threshold_days"),
+                    self.policy.demote_threshold_days,
+                    "demote_threshold_days",
+                    365,
+                ),
+            )
         reports["duplicates"] = self.find_duplicates(
             **_only(
                 filters,
@@ -260,6 +261,8 @@ class DreamEngine:
             scan = reports.get("namespace_scan")
             for candidate in _candidate_items(scan, "candidates"):
                 table = _required_str(candidate, "table")
+                if table_filter is not None and table != table_filter:
+                    continue
                 entry_id = _required_str(candidate, "id")
                 actions.append(
                     DreamAction(

--- a/python/openbrain-memory/src/openbrain_memory/spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/spool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import logging
 import os
 import stat
 import tempfile
@@ -13,6 +14,8 @@ from typing import Any, cast
 
 from .client import JSON
 from .policy import idempotency_key, redact_value
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -93,19 +96,59 @@ class JsonlSpool:
         self._reject_symlink(self.path)
         records: list[SpoolRecord] = []
         with self.path.open("r", encoding="utf-8") as handle:
-            for line in handle:
+            for line_number, line in enumerate(handle, start=1):
                 if not line.strip():
                     continue
-                payload = json.loads(line)
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping corrupted spool record",
+                        extra={
+                            "spool_path": str(self.path),
+                            "spool_line": line_number,
+                        },
+                        exc_info=True,
+                    )
+                    continue
+                if not isinstance(payload, dict):
+                    self._warn_corrupted_record(line_number)
+                    continue
+                try:
+                    idempotency = str(payload["idempotency_key"])
+                    operation = str(payload["operation"])
+                    record_payload = payload.get("payload", {})
+                    created_at = float(payload.get("created_at", 0))
+                except (KeyError, TypeError, ValueError):
+                    self._warn_corrupted_record(line_number, exc_info=True)
+                    continue
+                if not isinstance(record_payload, dict):
+                    self._warn_corrupted_record(line_number)
+                    continue
                 records.append(
                     SpoolRecord(
-                        idempotency_key=str(payload["idempotency_key"]),
-                        operation=str(payload["operation"]),
-                        payload=payload.get("payload", {}),
-                        created_at=float(payload.get("created_at", 0)),
+                        idempotency_key=idempotency,
+                        operation=operation,
+                        payload=record_payload,
+                        created_at=created_at,
                     )
                 )
         return records
+
+    def _warn_corrupted_record(
+        self,
+        line_number: int,
+        *,
+        exc_info: bool = False,
+    ) -> None:
+        logger.warning(
+            "Skipping corrupted spool record",
+            extra={
+                "spool_path": str(self.path),
+                "spool_line": line_number,
+            },
+            exc_info=exc_info,
+        )
 
     def redacted_records(self) -> list[SpoolRecord]:
         return [record.redacted() for record in self.records()]

--- a/python/openbrain-memory/tests/test_dream.py
+++ b/python/openbrain-memory/tests/test_dream.py
@@ -40,7 +40,10 @@ class FakeDreamClient:
             },
             "find_duplicates": {"duplicates": [{"table": "thoughts"}]},
             "scan_namespace": {
-                "candidates": [{"id": "promote-1", "table": "thoughts"}],
+                "candidates": [
+                    {"id": "promote-1", "table": "thoughts"},
+                    {"id": "promote-2", "table": "decisions"},
+                ],
                 "duplicates": [],
                 "already_promoted": [],
             },
@@ -83,8 +86,6 @@ def test_dream_once_defaults_to_dry_run_and_does_not_mutate():
     assert result.dry_run is True
     assert [name for name, _ in client.calls] == [
         "list_stale",
-        "tier_recommendations",
-        "tier_recommendations",
         "find_duplicates",
         "scan_namespace",
     ]
@@ -121,13 +122,28 @@ def test_dream_without_namespace_does_not_scan_or_promote():
     ]
 
 
+def test_dream_table_filter_scopes_tier_actions_without_namespace():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    result = engine.dream_once(table="thoughts")
+
+    assert [action.tool for action in result.actions] == ["set_tier"]
+    assert [action.arguments["table"] for action in result.actions] == ["thoughts"]
+    assert [action.arguments["id"] for action in result.actions] == ["hot-1"]
+
+
 def test_namespace_dream_suppresses_unscoped_tier_actions():
     client = FakeDreamClient()
     engine = DreamEngine(client)
 
     result = engine.dream_once(namespace="bilby")
 
-    assert [action.tool for action in result.actions] == ["promote_entry"]
+    assert [action.tool for action in result.actions] == [
+        "promote_entry",
+        "promote_entry",
+    ]
+    assert "tier_recommendations" not in [name for name, _ in client.calls]
 
 
 def test_namespace_dream_scans_against_policy_target_namespace():
@@ -147,6 +163,18 @@ def test_namespace_dream_scans_against_policy_target_namespace():
         },
     )
     assert result.actions[0].arguments["target_namespace"] == "team"
+    assert [action.arguments["table"] for action in result.actions] == ["thoughts"]
+
+
+def test_namespace_dream_table_filter_skips_non_matching_scan_candidates():
+    client = FakeDreamClient()
+    engine = DreamEngine(client)
+
+    result = engine.dream_once(namespace="bilby", table="decisions")
+
+    assert [action.tool for action in result.actions] == ["promote_entry"]
+    assert [action.arguments["table"] for action in result.actions] == ["decisions"]
+    assert [action.arguments["id"] for action in result.actions] == ["promote-2"]
 
 
 def test_dream_once_fails_closed_on_malformed_tier_candidate():

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -220,6 +220,42 @@ def test_non_idempotent_write_is_not_retried_but_is_spooled(tmp_path):
     assert spool.records()[0].operation == "log_thought"
 
 
+def test_spool_records_skip_corrupted_jsonl_lines(tmp_path, caplog):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    spool.path.write_text(
+        "\n".join(
+            [
+                '{"created_at":1,"idempotency_key":"good-1","operation":"one","payload":{"content":"ok"}}',
+                '{"created_at":2,"idempotency_key":"bad","operation":',
+                "{}",
+                "[]",
+                '{"idempotency_key":"missing-operation"}',
+                (
+                    '{"created_at":"not-a-float","idempotency_key":"bad-time",'
+                    '"operation":"bad","payload":{}}'
+                ),
+                (
+                    '{"created_at":2,"idempotency_key":"bad-payload",'
+                    '"operation":"bad","payload":[]}'
+                ),
+                (
+                    '{"created_at":3,"idempotency_key":"good-2",'
+                    '"operation":"two","payload":{"content":"still ok"}}'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    records = spool.records()
+
+    assert [record.idempotency_key for record in records] == ["good-1", "good-2"]
+    assert [record.operation for record in records] == ["one", "two"]
+    assert "Skipping corrupted spool record" in caplog.text
+    assert caplog.text.count("Skipping corrupted spool record") == 6
+
+
 def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tmp_path):
     client = FlakyClient(failures=3)
     spool = JsonlSpool(tmp_path / "spool.jsonl")

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -185,7 +185,7 @@ describe("authMiddleware", () => {
 
   test("uses X-Namespace as effective clientId and keeps token identity", () => {
     const req = mockReq({
-      authorization: "Bearer valid-agent-token",
+      authorization: "Bearer valid-admin-token",
       "x-namespace": "bilby",
       "x-agent-id": "bilby",
       "x-role": "agent",
@@ -196,13 +196,28 @@ describe("authMiddleware", () => {
     middleware(req as any, res as any, next);
 
     expect((req as any).auth).toEqual({
-      role: "agent",
+      role: "admin",
       clientId: "bilby",
-      tokenClientId: "agent",
+      tokenClientId: "admin",
       agentId: "bilby",
       namespaceSource: "header",
     });
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 403 when agent token sends X-Namespace", () => {
+    const req = mockReq({
+      authorization: "Bearer valid-agent-token",
+      "x-namespace": "bilby",
+    });
+    const res = mockRes();
+    const next = mock(() => {});
+
+    middleware(req as any, res as any, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Role not permitted to delegate namespace" });
+    expect(next).not.toHaveBeenCalled();
   });
 
   test("returns 403 when readonly token sends X-Namespace", () => {
@@ -222,7 +237,7 @@ describe("authMiddleware", () => {
 
   test("rejects invalid delegated namespace header", () => {
     const req = mockReq({
-      authorization: "Bearer valid-agent-token",
+      authorization: "Bearer valid-admin-token",
       "x-namespace": "../bilby",
     });
     const res = mockRes();

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -99,7 +99,7 @@ export function authMiddleware(
 
     if (matched) {
       const namespace = headerValue(req.headers["x-namespace"]);
-      if (namespace && matched.role !== "admin" && matched.role !== "n8n" && matched.role !== "agent") {
+      if (namespace && matched.role !== "admin" && matched.role !== "n8n") {
         res.status(403).json({ error: "Role not permitted to delegate namespace" });
         return;
       }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -201,7 +201,7 @@ describe("POST /mcp", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "X-Namespace": "bilby",
         "X-Agent-Id": "bilby",
@@ -218,7 +218,7 @@ describe("POST /mcp", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "Mcp-Session-Id": sessionId!,
         "X-Namespace": "skippy",
@@ -239,7 +239,7 @@ describe("POST /mcp", () => {
     const mismatchedGet = await fetch(`${baseUrl}/mcp`, {
       method: "GET",
       headers: {
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "Mcp-Session-Id": sessionId!,
         "X-Namespace": "skippy",
@@ -253,7 +253,7 @@ describe("POST /mcp", () => {
     const mismatchedDelete = await fetch(`${baseUrl}/mcp`, {
       method: "DELETE",
       headers: {
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "Mcp-Session-Id": sessionId!,
         "X-Namespace": "skippy",
@@ -267,7 +267,7 @@ describe("POST /mcp", () => {
     const cleanup = await fetch(`${baseUrl}/mcp`, {
       method: "DELETE",
       headers: {
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "Mcp-Session-Id": sessionId!,
         "X-Namespace": "bilby",
@@ -295,7 +295,7 @@ describe("POST /mcp", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "X-Namespace": "bilby",
         "X-Agent-Id": "bilby",
@@ -312,7 +312,7 @@ describe("POST /mcp", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "Mcp-Session-Id": sessionId!,
         "X-Namespace": "bilby",
@@ -330,7 +330,7 @@ describe("POST /mcp", () => {
     const cleanup = await fetch(`${baseUrl}/mcp`, {
       method: "DELETE",
       headers: {
-        Authorization: "Bearer agent-token-123",
+        Authorization: "Bearer test-token-123",
         Accept: "application/json, text/event-stream",
         "Mcp-Session-Id": sessionId!,
         "X-Namespace": "bilby",

--- a/src/tools/__tests__/access-report.test.ts
+++ b/src/tools/__tests__/access-report.test.ts
@@ -43,6 +43,9 @@ describe("access_report", () => {
   it("returns access report for a valid entry", async () => {
     const mockPool = {
       query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("SELECT id FROM")) {
+          return { rows: [{ id: "550e8400-e29b-41d4-a716-446655440000" }] };
+        }
         if (sql.includes("COUNT(*) AS total")) {
           return { rows: [{ total: "25" }] };
         }
@@ -77,6 +80,7 @@ describe("access_report", () => {
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse((result.content as any)[0].text);
       expect(parsed.entry_id).toBe("550e8400-e29b-41d4-a716-446655440000");
+      expect(parsed.source_table).toBe("thoughts");
       expect(parsed.total_accesses).toBe(25);
       expect(parsed.unique_queries).toBe(8);
       expect(parsed.unique_agents).toBe(3);
@@ -91,6 +95,9 @@ describe("access_report", () => {
   it("returns stable trend when recent equals previous", async () => {
     const mockPool = {
       query: async (sql: string) => {
+        if (sql.includes("SELECT id FROM")) {
+          return { rows: [{ id: "550e8400-e29b-41d4-a716-446655440001" }] };
+        }
         if (sql.includes("COUNT(*) AS total")) return { rows: [{ total: "10" }] };
         if (sql.includes("DISTINCT query_text")) return { rows: [{ unique_queries: "5" }] };
         if (sql.includes("DISTINCT accessed_by")) return { rows: [{ unique_agents: "2" }] };
@@ -111,6 +118,36 @@ describe("access_report", () => {
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse((result.content as any)[0].text);
       expect(parsed.trend).toBe("stable");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("requires the reported entry to be in a readable namespace", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "access_report",
+        arguments: { entry_id: "550e8400-e29b-41d4-a716-446655440010" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("not readable");
+      expect(calls[0]!.sql).toContain("namespace = ANY($2::text[])");
+      expect(calls[0]!.params).toEqual([
+        "550e8400-e29b-41d4-a716-446655440010",
+        ["bilby", "collab"],
+      ]);
+      expect(calls.every((call) => !call.sql.includes("entry_access_log"))).toBe(true);
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/adjacent-context.test.ts
+++ b/src/tools/__tests__/adjacent-context.test.ts
@@ -327,6 +327,35 @@ describe("adjacent_context", () => {
     }
   });
 
+  it("denies explicit unreadable namespace for agent role", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "adjacent_context",
+        arguments: {
+          type: "entity",
+          id: SOURCE_ID,
+          namespace: "skippy",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+      expect(calls).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── EMPTY RESULTS ──
 
   it("returns empty links array when no links found", async () => {

--- a/src/tools/__tests__/find-duplicates.test.ts
+++ b/src/tools/__tests__/find-duplicates.test.ts
@@ -103,6 +103,38 @@ describe("find_duplicates", () => {
     }
   });
 
+  it("scopes duplicate pair reads to readable namespaces", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "find_duplicates",
+        arguments: { table: "thoughts", threshold: 0.08 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(calls[0]!.sql).toContain("a.namespace = ANY($3::text[])");
+      expect(calls[0]!.sql).toContain("b.namespace = ANY($4::text[])");
+      expect(calls[0]!.params).toEqual([
+        0.08,
+        20,
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("denies discord role (no read access)", async () => {
     const mockPool = {
       query: async () => ({ rows: [] }),

--- a/src/tools/__tests__/find-person.test.ts
+++ b/src/tools/__tests__/find-person.test.ts
@@ -101,6 +101,34 @@ describe("find_person", () => {
         await cleanup();
       }
     });
+
+    it("scopes name search to readable namespaces", async () => {
+      const calls: Array<{ sql: string; params?: any[] }> = [];
+      const mockPool = {
+        query: async (sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "find_person",
+          arguments: { query: "Alice", mode: "name" },
+        });
+
+        expect(calls[0]!.sql).toContain("namespace = ANY($4::text[])");
+        expect(calls[0]!.params).toEqual(["%Alice%", 5, 0, ["bilby", "collab"]]);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe("semantic mode", () => {
@@ -130,6 +158,34 @@ describe("find_person", () => {
         const parsed = JSON.parse((result.content as any)[0].text);
         expect(parsed[0].distance).toBe(0.123);
         expect(parsed[0].person_name).toBe("Alice Johnson");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("scopes semantic search to readable namespaces", async () => {
+      const calls: Array<{ sql: string; params?: any[] }> = [];
+      const mockPool = {
+        query: async (sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        await client.callTool({
+          name: "find_person",
+          arguments: { query: "Alice", mode: "semantic" },
+        });
+
+        expect(calls[0]!.sql).toContain("namespace = ANY($4::text[])");
+        expect(calls[0]!.params?.slice(1)).toEqual([5, 0, ["bilby", "collab"]]);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/get-stats.test.ts
+++ b/src/tools/__tests__/get-stats.test.ts
@@ -88,6 +88,75 @@ describe("get_stats", () => {
     }
   });
 
+  it("scopes aggregate queries to readable namespaces", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        if (sql.includes("COUNT(*) FILTER")) {
+          return { rows: [{ table_name: "thoughts", active: "1", archived: "0" }] };
+        }
+        if (sql.includes("GROUP BY tier")) {
+          return { rows: [] };
+        }
+        if (sql.includes("GROUP BY namespace")) {
+          return { rows: [] };
+        }
+        if (sql.includes("total_log_entries")) {
+          return { rows: [{ total_log_entries: "1", unique_entries_accessed: "1" }] };
+        }
+        if (sql.includes("AVG")) {
+          return { rows: [{ avg_access: "0" }] };
+        }
+        if (sql.includes("access_count, 0) = 0")) {
+          return { rows: [{ table_name: "thoughts", count: "0" }] };
+        }
+        if (sql.includes("ORDER BY access_count DESC")) {
+          return { rows: [] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "get_stats",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const countCall = calls.find((call) => call.sql.includes("COUNT(*) FILTER"));
+      expect(countCall!.sql).toContain("WHERE namespace = ANY($1::text[])");
+      expect(countCall!.params).toEqual([["bilby", "collab"]]);
+      const accessCall = calls.find((call) => call.sql.includes("total_log_entries"));
+      expect(accessCall!.sql).toContain("source.namespace = ANY($1::text[])");
+      expect(accessCall!.sql).toContain("source.namespace = ANY($5::text[])");
+      expect(accessCall!.params).toEqual([
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+      ]);
+      const topAccessedCall = calls.find((call) =>
+        call.sql.includes("ORDER BY access_count DESC")
+      );
+      expect(topAccessedCall!.sql).toContain("namespace = ANY($1::text[])");
+      expect(topAccessedCall!.params).toEqual([
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+        ["bilby", "collab"],
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("denies readonly with no tables", async () => {
     const mockPool = {
       query: async () => ({ rows: [] }),

--- a/src/tools/__tests__/lane-load.test.ts
+++ b/src/tools/__tests__/lane-load.test.ts
@@ -288,6 +288,31 @@ describe("lane_load", () => {
     }
   });
 
+  it("denies explicit unreadable namespace for agent role", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [MOCK_LANE] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "lane_load",
+        arguments: { namespace: "skippy" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+      expect(calls).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── STATUS DEFAULTING ──
 
   it("defaults status to 'active' when not specified", async () => {

--- a/src/tools/__tests__/session-context.test.ts
+++ b/src/tools/__tests__/session-context.test.ts
@@ -444,6 +444,31 @@ describe("session_context", () => {
     }
   });
 
+  it("denies explicit unreadable namespace for agent role", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [MOCK_LANE] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_context",
+        arguments: { session_key: "ob-v2-dev", namespace: "skippy" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+      expect(calls).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── EVENT LIMIT ──
 
   it("respects event_limit parameter by returning limited events", async () => {

--- a/src/tools/__tests__/session-load.test.ts
+++ b/src/tools/__tests__/session-load.test.ts
@@ -80,6 +80,31 @@ describe("session_load", () => {
         await cleanup();
       }
     });
+
+    it("scopes project load to readable namespaces", async () => {
+      const calls: Array<{ sql: string; params?: any[] }> = [];
+      const mockPool = {
+        query: async (sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "session_load",
+          arguments: { project: "open-brain" },
+        });
+
+        expect(calls[0]!.sql).toContain("namespace = ANY($2::text[])");
+        expect(calls[0]!.params).toEqual(["open-brain", ["bilby", "collab"]]);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe("without project filter (global)", () => {
@@ -101,6 +126,31 @@ describe("session_load", () => {
         const parsed = JSON.parse((result.content as any)[0].text);
         expect(parsed.id).toBe("session-uuid");
         expect(parsed.summary).toBe("Implemented auth system");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("scopes global load to readable namespaces", async () => {
+      const calls: Array<{ sql: string; params?: any[] }> = [];
+      const mockPool = {
+        query: async (sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        await client.callTool({
+          name: "session_load",
+          arguments: {},
+        });
+
+        expect(calls[0]!.sql).toContain("namespace = ANY($1::text[])");
+        expect(calls[0]!.params).toEqual([["bilby", "collab"]]);
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/tier-recommendations.test.ts
+++ b/src/tools/__tests__/tier-recommendations.test.ts
@@ -119,6 +119,71 @@ describe("tier_recommendations", () => {
     }
   });
 
+  it("scopes recommendation reads to readable namespaces", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "tier_recommendations",
+        arguments: { action: "demote", threshold_days: 30 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(calls[0]!.sql).toContain("namespace = ANY($3::text[])");
+      expect(calls[0]!.params).toEqual([30, 20, ["bilby", "collab"]]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("scopes promote access counts to the source table", async () => {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "tier_recommendations",
+        arguments: {
+          action: "promote",
+          threshold_days: 7,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(calls).toHaveLength(5);
+      expect(calls.every((call) => call.sql.includes("eal.source_table ="))).toBe(true);
+      expect(calls.some((call) => call.sql.includes("eal.source_table = 'thoughts'"))).toBe(
+        true,
+      );
+      expect(calls.every((call) => call.sql.includes("namespace = ANY($3::text[])"))).toBe(
+        true,
+      );
+      const scopedParams = JSON.stringify([7, 20, ["bilby", "collab"]]);
+      expect(
+        calls.every((call) => JSON.stringify(call.params) === scopedParams),
+      ).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("denies unauthenticated requests", async () => {
     const server = new McpServer({ name: "test", version: "1.0.0" });
     const mockPool = { query: async () => ({ rows: [] }) };

--- a/src/tools/access-report.ts
+++ b/src/tools/access-report.ts
@@ -1,9 +1,31 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
-import type { AuthInfo } from "../types.ts";
+import { appendReadNamespacePredicate } from "../read-policy.ts";
+import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
+import { ALL_TABLES } from "./table-constants.ts";
+
+async function findReadableEntryTable(
+  deps: ToolDeps,
+  auth: AuthInfo,
+  entryId: string,
+): Promise<Table | null> {
+  const readableTables = ALL_TABLES.filter((table) => canRead(auth.role, table));
+  for (const table of readableTables) {
+    const params: unknown[] = [entryId];
+    const namespacePredicate = appendReadNamespacePredicate(auth, params);
+    const { rows } = await deps.pool.query(
+      `SELECT id FROM ${table} WHERE id = $1 AND archived_at IS NULL${namespacePredicate} LIMIT 1`,
+      params,
+    );
+    if (rows.length > 0) {
+      return table;
+    }
+  }
+  return null;
+}
 
 export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
@@ -42,8 +64,6 @@ export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      // Check if user can read at least one table
-      const { ALL_TABLES } = await import("./table-constants.ts");
       const hasReadAccess = ALL_TABLES.some((t) => canRead(auth.role, t));
       if (!hasReadAccess) {
         return {
@@ -59,14 +79,27 @@ export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
 
       const entryId = args.entry_id;
       const days = args.days ?? 30;
+      const sourceTable = await findReadableEntryTable(deps, auth, entryId);
+      if (sourceTable === null) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Entry not found or not readable",
+            },
+          ],
+          isError: true,
+        };
+      }
 
       // Total accesses in period
       const totalResult = await deps.pool.query(
         `SELECT COUNT(*) AS total
          FROM entry_access_log
          WHERE entry_id = $1
-           AND accessed_at >= NOW() - INTERVAL '1 day' * $2`,
-        [entryId, days],
+           AND accessed_at >= NOW() - INTERVAL '1 day' * $2
+           AND source_table = $3`,
+        [entryId, days, sourceTable],
       );
 
       // Unique queries
@@ -75,8 +108,9 @@ export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
          FROM entry_access_log
          WHERE entry_id = $1
            AND accessed_at >= NOW() - INTERVAL '1 day' * $2
+           AND source_table = $3
            AND query_text IS NOT NULL`,
-        [entryId, days],
+        [entryId, days, sourceTable],
       );
 
       // Unique agents
@@ -85,8 +119,9 @@ export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
          FROM entry_access_log
          WHERE entry_id = $1
            AND accessed_at >= NOW() - INTERVAL '1 day' * $2
+           AND source_table = $3
            AND accessed_by IS NOT NULL`,
-        [entryId, days],
+        [entryId, days, sourceTable],
       );
 
       // Access trend: last 7 days vs previous 7 days
@@ -95,16 +130,18 @@ export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
            COUNT(*) FILTER (WHERE accessed_at >= NOW() - INTERVAL '7 days') AS recent_7d,
            COUNT(*) FILTER (WHERE accessed_at >= NOW() - INTERVAL '14 days' AND accessed_at < NOW() - INTERVAL '7 days') AS previous_7d
          FROM entry_access_log
-         WHERE entry_id = $1`,
-        [entryId],
+         WHERE entry_id = $1
+           AND source_table = $2`,
+        [entryId, sourceTable],
       );
 
       // Last accessed
       const lastAccessResult = await deps.pool.query(
         `SELECT MAX(accessed_at) AS last_accessed
          FROM entry_access_log
-         WHERE entry_id = $1`,
-        [entryId],
+         WHERE entry_id = $1
+           AND source_table = $2`,
+        [entryId, sourceTable],
       );
 
       const recent7d = Number(trendResult.rows[0]?.recent_7d ?? 0);
@@ -128,6 +165,7 @@ export function registerAccessReport(server: McpServer, deps: ToolDeps): void {
 
       const report = {
         entry_id: entryId,
+        source_table: sourceTable,
         period_days: days,
         total_accesses: Number(totalResult.rows[0]?.total ?? 0),
         unique_queries: Number(uniqueQueriesResult.rows[0]?.unique_queries ?? 0),

--- a/src/tools/adjacent-context.ts
+++ b/src/tools/adjacent-context.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { canReadNamespace } from "../read-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -72,6 +73,17 @@ export function registerAdjacentContext(
       }
 
       const ns = args.namespace ?? auth.clientId;
+      if (!canReadNamespace(auth, ns)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: cannot read namespace '${ns}'`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const direction = args.direction ?? "both";
       const limit = args.limit ?? 50;
 

--- a/src/tools/find-duplicates.ts
+++ b/src/tools/find-duplicates.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { appendReadNamespacePredicate } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -106,6 +107,17 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
         const remaining = limit - duplicates.length;
         const previewA = contentPreviewForAlias(table, "a");
         const previewB = contentPreviewForAlias(table, "b");
+        const params: unknown[] = [threshold, remaining];
+        const namespacePredicateA = appendReadNamespacePredicate(
+          auth,
+          params,
+          "a.namespace",
+        );
+        const namespacePredicateB = appendReadNamespacePredicate(
+          auth,
+          params,
+          "b.namespace",
+        );
 
         // Table name is validated by Zod enum -- safe for interpolation
         const { rows } = await deps.pool.query(
@@ -122,9 +134,11 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
           WHERE a.archived_at IS NULL
             AND a.embedding IS NOT NULL
             AND a.embedding <=> b.embedding < $1
+            ${namespacePredicateA}
+            ${namespacePredicateB}
           ORDER BY distance ASC
           LIMIT $2`,
-          [threshold, remaining],
+          params,
         );
 
         for (const row of rows) {

--- a/src/tools/find-person.ts
+++ b/src/tools/find-person.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { canRead } from "../permissions.ts";
+import { appendReadNamespacePredicate } from "../read-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 
@@ -65,10 +66,10 @@ export function registerFindPerson(server: McpServer, deps: ToolDeps): void {
       const offset = args.offset ?? 0;
 
       if (mode === "semantic") {
-        return handleSemanticSearch(deps, args.query, limit, offset);
+        return handleSemanticSearch(deps, args.query, limit, offset, auth);
       }
 
-      return handleNameSearch(deps, args.query, limit, offset);
+      return handleNameSearch(deps, args.query, limit, offset, auth);
     },
   );
 }
@@ -78,17 +79,20 @@ async function handleNameSearch(
   query: string,
   limit: number,
   offset: number,
+  auth: AuthInfo,
 ) {
   // Escape ILIKE special characters before wrapping with %
   const escaped = query.replace(/%/g, "\\%").replace(/_/g, "\\_");
+  const params: unknown[] = [`%${escaped}%`, limit, offset];
+  const namespacePredicate = appendReadNamespacePredicate(auth, params);
 
   const sql = `SELECT ${SELECT_COLUMNS}
 FROM relationships
-WHERE person_name ILIKE $1 AND archived_at IS NULL
+WHERE person_name ILIKE $1 AND archived_at IS NULL${namespacePredicate}
 ORDER BY warmth DESC NULLS LAST, last_contact DESC NULLS LAST
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [`%${escaped}%`, limit, offset]);
+  const { rows } = await deps.pool.query(sql, params);
 
   if (rows.length === 0) {
     return {
@@ -116,6 +120,7 @@ async function handleSemanticSearch(
   query: string,
   limit: number,
   offset: number,
+  auth: AuthInfo,
 ) {
   const embedding = await deps.embedFn(query);
   if (!embedding) {
@@ -130,18 +135,17 @@ async function handleSemanticSearch(
     };
   }
 
+  const params: unknown[] = [toSql(embedding), limit, offset];
+  const namespacePredicate = appendReadNamespacePredicate(auth, params);
+
   const sql = `SELECT ${SELECT_COLUMNS},
   embedding <=> $1::halfvec(768) AS distance
 FROM relationships
-WHERE embedding IS NOT NULL AND archived_at IS NULL
+WHERE embedding IS NOT NULL AND archived_at IS NULL${namespacePredicate}
 ORDER BY distance ASC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, [
-    toSql(embedding),
-    limit,
-    offset,
-  ]);
+  const { rows } = await deps.pool.query(sql, params);
 
   if (rows.length === 0) {
     return {

--- a/src/tools/get-stats.ts
+++ b/src/tools/get-stats.ts
@@ -1,10 +1,40 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { appendReadNamespacePredicate } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 import { ALL_TABLES, CONTENT_PREVIEW, TABLE_ALIAS } from "./table-constants.ts";
+
+function readWhereClause(
+  auth: AuthInfo,
+  params: unknown[],
+  column = "namespace",
+): string {
+  const predicate = appendReadNamespacePredicate(auth, params, column);
+  return predicate ? `WHERE ${predicate.slice(" AND ".length)}` : "";
+}
+
+function accessLogScopeClause(
+  auth: AuthInfo,
+  tables: Table[],
+  params: unknown[],
+): string {
+  const existsParts = tables.map((table) => {
+    const predicate = appendReadNamespacePredicate(
+      auth,
+      params,
+      "source.namespace",
+    );
+    return `EXISTS (
+      SELECT 1 FROM ${table} source
+      WHERE source.id = eal.entry_id
+        AND eal.source_table = '${table}'${predicate}
+    )`;
+  });
+  return existsParts.length > 0 ? `WHERE ${existsParts.join(" OR ")}` : "";
+}
 
 export function registerGetStats(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
@@ -48,73 +78,103 @@ export function registerGetStats(server: McpServer, deps: ToolDeps): void {
       }
 
       // 1. Entry counts per table (active vs archived)
-      const countQueries = accessibleTables.map((table) =>
-        deps.pool.query(
+      const countQueries = accessibleTables.map((table) => {
+        const params: unknown[] = [];
+        const whereClause = readWhereClause(auth, params);
+        return deps.pool.query(
           `SELECT
             '${table}' AS table_name,
             COUNT(*) FILTER (WHERE archived_at IS NULL) AS active,
             COUNT(*) FILTER (WHERE archived_at IS NOT NULL) AS archived
-          FROM ${table}`,
-        ),
-      );
+          FROM ${table}
+          ${whereClause}`,
+          params,
+        );
+      });
 
       // 2. Tier distribution per table
-      const tierQueries = accessibleTables.map((table) =>
-        deps.pool.query(
+      const tierQueries = accessibleTables.map((table) => {
+        const params: unknown[] = [];
+        const namespacePredicate = appendReadNamespacePredicate(auth, params);
+        return deps.pool.query(
           `SELECT
             '${table}' AS table_name,
             COALESCE(tier, 'warm') AS tier,
             COUNT(*) AS count
           FROM ${table}
-          WHERE archived_at IS NULL
+          WHERE archived_at IS NULL${namespacePredicate}
           GROUP BY tier`,
-        ),
-      );
+          params,
+        );
+      });
 
       // 3. Namespace breakdown (top 10)
-      const nsQueries = accessibleTables.map((table) =>
-        deps.pool.query(
+      const nsQueries = accessibleTables.map((table) => {
+        const params: unknown[] = [];
+        const namespacePredicate = appendReadNamespacePredicate(auth, params);
+        return deps.pool.query(
           `SELECT
             '${table}' AS table_name,
             namespace,
             COUNT(*) AS count
           FROM ${table}
-          WHERE archived_at IS NULL
+          WHERE archived_at IS NULL${namespacePredicate}
           GROUP BY namespace
           ORDER BY count DESC
           LIMIT 10`,
-        ),
-      );
+          params,
+        );
+      });
 
       // 4. Access stats
+      const accessStatsParams: unknown[] = [];
+      const accessStatsScope = accessLogScopeClause(
+        auth,
+        accessibleTables,
+        accessStatsParams,
+      );
       const accessStatsQuery = deps.pool.query(
         `SELECT
           COUNT(*) AS total_log_entries,
           COUNT(DISTINCT entry_id) AS unique_entries_accessed
-        FROM entry_access_log`,
+        FROM entry_access_log eal
+        ${accessStatsScope}`,
+        accessStatsParams,
       );
 
       // 5. Average access_count across all tables
-      const avgAccessQueries = accessibleTables.map((table) =>
-        deps.pool.query(
-          `SELECT AVG(COALESCE(access_count, 0)) AS avg_access FROM ${table} WHERE archived_at IS NULL`,
-        ),
-      );
+      const avgAccessQueries = accessibleTables.map((table) => {
+        const params: unknown[] = [];
+        const namespacePredicate = appendReadNamespacePredicate(auth, params);
+        return deps.pool.query(
+          `SELECT AVG(COALESCE(access_count, 0)) AS avg_access FROM ${table} WHERE archived_at IS NULL${namespacePredicate}`,
+          params,
+        );
+      });
 
       // 6. Zero-access entries per table
-      const zeroAccessQueries = accessibleTables.map((table) =>
-        deps.pool.query(
+      const zeroAccessQueries = accessibleTables.map((table) => {
+        const params: unknown[] = [];
+        const namespacePredicate = appendReadNamespacePredicate(auth, params);
+        return deps.pool.query(
           `SELECT '${table}' AS table_name, COUNT(*) AS count
           FROM ${table}
-          WHERE archived_at IS NULL AND COALESCE(access_count, 0) = 0`,
-        ),
-      );
+          WHERE archived_at IS NULL AND COALESCE(access_count, 0) = 0${namespacePredicate}`,
+          params,
+        );
+      });
 
       // 7. Top 10 most accessed entries
+      const topAccessedParams: unknown[] = [];
       const topAccessedParts = accessibleTables.map((table) => {
         const alias = TABLE_ALIAS[table];
         const preview = CONTENT_PREVIEW[table];
-        return `SELECT ${alias}.id, '${table}' AS table_name, ${preview} AS content_preview, COALESCE(${alias}.access_count, 0) AS access_count FROM ${table} ${alias} WHERE ${alias}.archived_at IS NULL`;
+        const namespacePredicate = appendReadNamespacePredicate(
+          auth,
+          topAccessedParams,
+          `${alias}.namespace`,
+        );
+        return `SELECT ${alias}.id, '${table}' AS table_name, ${preview} AS content_preview, COALESCE(${alias}.access_count, 0) AS access_count FROM ${table} ${alias} WHERE ${alias}.archived_at IS NULL${namespacePredicate}`;
       });
       const topAccessedSql = `SELECT id, table_name, LEFT(content_preview, 200) AS content_preview, access_count FROM (${topAccessedParts.join(" UNION ALL ")}) AS combined ORDER BY access_count DESC LIMIT 10`;
 
@@ -133,7 +193,7 @@ export function registerGetStats(server: McpServer, deps: ToolDeps): void {
         accessStatsQuery,
         Promise.all(avgAccessQueries),
         Promise.all(zeroAccessQueries),
-        deps.pool.query(topAccessedSql),
+        deps.pool.query(topAccessedSql, topAccessedParams),
       ]);
 
       // Build entry counts

--- a/src/tools/lane-load.ts
+++ b/src/tools/lane-load.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { canReadNamespace } from "../read-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
@@ -76,6 +77,17 @@ export function registerLaneLoad(server: McpServer, deps: ToolDeps): void {
 
       // Namespace filter
       const ns = args.namespace ?? auth.clientId;
+      if (!canReadNamespace(auth, ns)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: cannot read namespace '${ns}'`,
+            },
+          ],
+          isError: true,
+        };
+      }
       conditions.push(`namespace = $${paramIdx++}`);
       params.push(ns);
 

--- a/src/tools/session-context.ts
+++ b/src/tools/session-context.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { canReadNamespace } from "../read-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
@@ -101,6 +102,17 @@ export function registerSessionContext(
       }
 
       const ns = args.namespace ?? auth.clientId;
+      if (!canReadNamespace(auth, ns)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: cannot read namespace '${ns}'`,
+            },
+          ],
+          isError: true,
+        };
+      }
       const includeEvents = args.include_events !== false;
       const eventLimit = args.event_limit ?? 50;
 

--- a/src/tools/session-load.ts
+++ b/src/tools/session-load.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { appendReadNamespacePredicate } from "../read-policy.ts";
 import type { AuthInfo } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
@@ -44,10 +45,10 @@ export function registerSessionLoad(server: McpServer, deps: ToolDeps): void {
       }
 
       if (args.project) {
-        return handleProjectLoad(deps, args.project, auth.clientId);
+        return handleProjectLoad(deps, args.project, auth);
       }
 
-      return handleGlobalLoad(deps, auth.clientId);
+      return handleGlobalLoad(deps, auth);
     },
   );
 }
@@ -66,14 +67,16 @@ function logSessionAccess(deps: ToolDeps, sessionId: string, accessedBy?: string
     });
 }
 
-async function handleProjectLoad(deps: ToolDeps, project: string, accessedBy?: string) {
+async function handleProjectLoad(deps: ToolDeps, project: string, auth: AuthInfo) {
+  const params: unknown[] = [project];
+  const namespacePredicate = appendReadNamespacePredicate(auth, params);
   const sql = `SELECT ${SELECT_COLUMNS}
 FROM sessions
-WHERE project = $1 AND archived_at IS NULL
+WHERE project = $1 AND archived_at IS NULL${namespacePredicate}
 ORDER BY created_at DESC
 LIMIT 1`;
 
-  const { rows } = await deps.pool.query(sql, [project]);
+  const { rows } = await deps.pool.query(sql, params);
 
   if (rows.length === 0) {
     return {
@@ -86,7 +89,7 @@ LIMIT 1`;
     };
   }
 
-  logSessionAccess(deps, rows[0].id, accessedBy);
+  logSessionAccess(deps, rows[0].id, auth.clientId);
 
   return {
     content: [
@@ -98,14 +101,19 @@ LIMIT 1`;
   };
 }
 
-async function handleGlobalLoad(deps: ToolDeps, accessedBy?: string) {
+async function handleGlobalLoad(deps: ToolDeps, auth: AuthInfo) {
+  const params: unknown[] = [];
+  const namespacePredicate = appendReadNamespacePredicate(auth, params);
+  const whereClause = namespacePredicate
+    ? `WHERE archived_at IS NULL${namespacePredicate}`
+    : "WHERE archived_at IS NULL";
   const sql = `SELECT ${SELECT_COLUMNS}
 FROM sessions
-WHERE archived_at IS NULL
+${whereClause}
 ORDER BY created_at DESC
 LIMIT 1`;
 
-  const { rows } = await deps.pool.query(sql);
+  const { rows } = await deps.pool.query(sql, params);
 
   if (rows.length === 0) {
     return {
@@ -118,7 +126,7 @@ LIMIT 1`;
     };
   }
 
-  logSessionAccess(deps, rows[0].id, accessedBy);
+  logSessionAccess(deps, rows[0].id, auth.clientId);
 
   return {
     content: [

--- a/src/tools/tier-recommendations.ts
+++ b/src/tools/tier-recommendations.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
+import { appendReadNamespacePredicate } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -87,6 +88,12 @@ export function registerTierRecommendations(server: McpServer, deps: ToolDeps): 
         const remaining = limit - candidates.length;
         const alias = TABLE_ALIAS[table];
         const preview = CONTENT_PREVIEW[table];
+        const params: unknown[] = [thresholdDays, remaining];
+        const namespacePredicate = appendReadNamespacePredicate(
+          auth,
+          params,
+          `${alias}.namespace`,
+        );
 
         if (action === "demote") {
           // Find warm entries not accessed recently with low access_count
@@ -102,9 +109,10 @@ export function registerTierRecommendations(server: McpServer, deps: ToolDeps): 
               AND COALESCE(${alias}.tier, 'warm') = 'warm'
               AND (${alias}.last_accessed_at IS NULL OR ${alias}.last_accessed_at < NOW() - INTERVAL '1 day' * $1)
               AND COALESCE(${alias}.access_count, 0) < 3
+              ${namespacePredicate}
             ORDER BY COALESCE(${alias}.access_count, 0) ASC, ${alias}.created_at ASC
             LIMIT $2`,
-            [thresholdDays, remaining],
+            params,
           );
 
           for (const row of rows) {
@@ -138,15 +146,17 @@ export function registerTierRecommendations(server: McpServer, deps: ToolDeps): 
                 ${alias}.last_accessed_at,
                 (SELECT COUNT(*) FROM entry_access_log eal
                  WHERE eal.entry_id = ${alias}.id
+                   AND eal.source_table = '${table}'
                    AND eal.accessed_at >= NOW() - INTERVAL '1 day' * $1) AS recent_accesses
               FROM ${table} ${alias}
               WHERE ${alias}.archived_at IS NULL
                 AND COALESCE(${alias}.tier, 'warm') IN ('warm', 'cold')
+                ${namespacePredicate}
             ) sub
             WHERE sub.recent_accesses > 5
             ORDER BY sub.recent_accesses DESC
             LIMIT $2`,
-            [thresholdDays, remaining],
+            params,
           );
 
           for (const row of rows) {


### PR DESCRIPTION
## Summary
- scope the remaining read-only tools from #96 to readable namespaces, including the follow-up session graph namespace-argument bypass found by review
- harden access-log reads with readable source-table checks and source_table filters
- skip malformed spool JSONL records safely and keep later valid records replayable
- add deploy concurrency and apply DreamEngine namespace/table filters for promotion candidates

Closes #96.
Closes #97.
Closes #98.
Closes #99.

## Validation
- `bun test` (619 pass, 16 skip)
- `bun run typecheck`
- `uv run --python 3.11 pytest -q` (81 passed, 1 skipped)
- `uv run --python 3.11 ruff check src tests`
- `uv run --python 3.11 mypy src/openbrain_memory`
- `git diff --check`
- review swarm round 1 found and fixed auth delegation, spool shape, and tier source_table issues
- review swarm round 2 found and fixed the session graph namespace-argument bypass
