### PR TITLE
feat(embedding): provider-agnostic embeddings + local-first deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,15 @@ DB_NAME=open_brain
 DB_USER=open_brain
 DB_PASSWORD=generate-a-secure-password
 
-# LiteLLM Proxy (embedding service)
-LITELLM_URL=http://your-litellm-host:4000
-LITELLM_API_KEY=your-litellm-api-key
+# Embedding service (OpenAI-compatible /v1/embeddings endpoint)
+EMBEDDING_BASE_URL=http://your-embedding-host:8791/v1
+EMBEDDING_API_KEY=your-embedding-api-key
+EMBEDDING_MODEL=embeddinggemma-300m-8bit
+EMBEDDING_DIMENSIONS=768
+
+# LiteLLM fallback / extraction endpoint (optional)
+LITELLM_URL=
+LITELLM_API_KEY=
 
 # Server
 PORT=3100

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DB_PASSWORD=generate-a-secure-password
 EMBEDDING_BASE_URL=http://your-embedding-host:8791/v1
 EMBEDDING_API_KEY=your-embedding-api-key
 EMBEDDING_MODEL=embeddinggemma-300m-8bit
+# Must match the DB schema (halfvec(768) columns) -- changing this requires a column migration + re-embed
 EMBEDDING_DIMENSIONS=768
 
 # LiteLLM fallback / extraction endpoint (optional)

--- a/.env.schema
+++ b/.env.schema
@@ -9,10 +9,15 @@ DB_NAME=open_brain
 DB_USER=open_brain
 DB_PASSWORD=@secret(exec(./fetch-secrets.sh DB_PASSWORD))
 
-# LiteLLM Proxy (any OpenAI-compatible embedding endpoint)
-# Replace with your LiteLLM/Ollama/OpenAI endpoint
-LITELLM_URL=http://192.168.1.60:4000
-LITELLM_API_KEY=@secret(exec(./fetch-secrets.sh LITELLM_API_KEY))
+# Embedding service (OpenAI-compatible /v1/embeddings endpoint)
+EMBEDDING_BASE_URL=http://127.0.0.1:8791/v1
+EMBEDDING_API_KEY=@secret(exec(./fetch-secrets.sh EMBEDDING_API_KEY))
+EMBEDDING_MODEL=embeddinggemma-300m-8bit
+EMBEDDING_DIMENSIONS=768
+
+# LiteLLM fallback / extraction endpoint
+LITELLM_URL=@optional
+LITELLM_API_KEY=@optional
 
 # Extraction (auto-metadata on writes)
 EXTRACTION_MODEL=@optional

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ MCP server providing a unified semantic brain over PostgreSQL + pgvector. TypeSc
 
 - **Runtime:** Bun 1.3.13
 - **Database:** PostgreSQL 17 + pgvector (halfvec 768)
-- **Embeddings:** LiteLLM proxy
+- **Embeddings:** Any OpenAI-compatible endpoint via `EMBEDDING_BASE_URL` (prod: local MLX server on 127.0.0.1:8791, `embeddinggemma-300m-8bit`); LiteLLM as optional fallback/extraction
 - **Auth:** Per-consumer Bearer tokens (admin, agent, discord, n8n, readonly)
-- **Deploy:** LXC 208 (10.71.20.15:3100)
+- **Deploy:** Mac Mini via launchd `com.rico.open-brain` (10.71.1.21:3100). LXC 208 decommissioned 2026-06-11; its Postgres (10.71.20.49) retained as a pre-cutover snapshot.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,15 @@ DB_NAME=open_brain
 DB_USER=postgres
 DB_PASSWORD=your-password
 
-# Embedding service (any OpenAI-compatible endpoint)
+# Embedding service (any OpenAI-compatible /v1/embeddings endpoint)
+EMBEDDING_BASE_URL=http://localhost:8791/v1
+EMBEDDING_API_KEY=your-key
+EMBEDDING_MODEL=embeddinggemma-300m-8bit
+EMBEDDING_DIMENSIONS=768
+
+# Optional LiteLLM fallback / extraction endpoint
 LITELLM_URL=http://localhost:4000
-LITELLM_API_KEY=your-key
+LITELLM_API_KEY=your-litellm-key
 
 # Metadata extraction model (optional — enables auto-tagging on writes)
 EXTRACTION_MODEL=gpt-4o-mini
@@ -161,7 +167,7 @@ Search modes: `hybrid` (default), `vector`, `keyword`.
 | `bun run migrate` | Run pending database migrations |
 | `bun run test` | Run test suite |
 | `bun run typecheck` | Type-check without emit |
-| `bun run backfill` | Backfill NULL embeddings across all tables |
+| `bun run backfill` | Backfill NULL embeddings across all tables (`-- --all` re-embeds every row for model migrations) |
 | `bun run curate` | Automated curation: dedup, staleness, quality scoring (`--dry-run` supported) |
 
 Additional utility scripts in `scripts/`:

--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ The MCP server listens on `http://localhost:3100` with Streamable HTTP transport
 
 Each consumer gets a scoped Bearer token. Roles control which tables are readable/writable:
 
-| Role | Read | Write |
-|------|------|-------|
-| `admin` | All tables | All tables |
-| `agent` | All tables | thoughts, decisions, sessions |
-| `discord` | thoughts, decisions, relationships | sessions |
-| `n8n` | All tables | sessions |
-| `readonly` | All tables | — |
+| Role | Read | Write | Delete |
+|------|------|-------|--------|
+| `admin` | All tables | All tables | All tables |
+| `agent` | All tables | thoughts, decisions, relationships, sessions | — |
+| `discord` | — | thoughts | — |
+| `n8n` | All tables | All tables | All tables |
+| `readonly` | All tables | — | — |
 
 Set tokens via `AUTH_TOKEN_ADMIN`, `AUTH_TOKEN_AGENT`, etc. in your `.env`. You can also add custom per-user tokens with the `AUTH_TOKEN_USER_*` pattern.
 

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -87,7 +87,8 @@ packaging/import failures, or wheel/sdist build failures.
 **Severity:** MEDIUM
 **Source:** PR #76, issue #71
 **Scope:** README, integration docs
-**Status:** active
+**Status:** superseded (2026-06-11, by "Two MCP client implementations exist" below -- Rico
+accepted a stdlib transport inside rtech-hermes-runtime instead of consuming this package)
 
 ### Pattern
 
@@ -100,3 +101,26 @@ should consume this package instead of reimplementing protocol logic.
 - Does a change preserve one-way dependency direction?
 - Does open-brain avoid importing Hermes runtime code?
 - Does Hermes-specific lifecycle logic stay out of the reusable package?
+
+## [2026-06-11] Two MCP client implementations exist -- protocol changes must check both
+
+**Severity:** MEDIUM
+**Source:** rtech-hermes feat/openbrain-http-transport (decision: Rico, 2026-06-11)
+**Scope:** `src/transport.ts`, MCP tool schemas, session lifecycle semantics
+**Status:** active
+
+### Pattern
+
+Open Brain's MCP Streamable HTTP contract has two independent client
+implementations: `python/openbrain-memory` (this repo) and
+`rtech-hermes-runtime/openbrain/http_transport.py` (stdlib, no shared code --
+deliberate, to keep agent LXC deploys dependency-free). The server contract is
+the only thing keeping them in sync.
+
+### Review Questions
+
+- Does a change to `src/transport.ts`, tool input/output schemas, the
+  initialize handshake, SSE framing, or MCP session TTL behavior get verified
+  against BOTH clients?
+- Is a breaking protocol change flagged to rtech-hermes before deploy?
+- Session TTL is 30 minutes -- do long-lived clients re-initialize cleanly?

--- a/fetch-secrets.sh
+++ b/fetch-secrets.sh
@@ -28,6 +28,9 @@ case "$FIELD" in
   LITELLM_API_KEY)
     mcp2cli vaultwarden-secrets get_credential --params '{"query":"LiteLLM"}' 2>/dev/null | jq -r '.result.fields.password // empty'
     ;;
+  EMBEDDING_API_KEY)
+    mcp2cli vaultwarden-secrets get_credential --params '{"query":"MLX Embedding Server"}' 2>/dev/null | jq -r '.result.fields.password // empty'
+    ;;
   *)
     echo "Unknown field: $FIELD" >&2
     exit 1

--- a/scripts/backfill.test.ts
+++ b/scripts/backfill.test.ts
@@ -309,13 +309,13 @@ describe("backfill", () => {
     expect(summaryLog![1]).toHaveProperty("totalFailed");
   });
 
-  it("Test 11: calls pool.end() after completion", async () => {
+  it("Test 11: does not end the injected pool (caller owns its lifecycle)", async () => {
     const { pool, mockEnd } = createMockPool(defaultQueryImpl);
     const embedFn = createMockEmbedFn();
 
     await backfill(pool, embedFn);
 
-    expect(mockEnd).toHaveBeenCalledTimes(1);
+    expect(mockEnd).not.toHaveBeenCalled();
   });
 
   it("Test 12: can re-embed all rows with all=true", async () => {
@@ -326,12 +326,14 @@ describe("backfill", () => {
 
     const selectCalls = mockQuery.mock.calls.filter(
       (call: any[]) =>
-        typeof call[0] === "string" && call[0].startsWith("SELECT * FROM"),
+        typeof call[0] === "string" && call[0].startsWith("SELECT id"),
     );
 
     expect(selectCalls.length).toBe(5);
     for (const [sql] of selectCalls as Array<[string]>) {
       expect(sql).not.toContain("WHERE embedding IS NULL");
+      // Projection, not SELECT * -- existing vectors stay out of JS memory
+      expect(sql).not.toContain("SELECT *");
     }
   });
 });

--- a/scripts/backfill.test.ts
+++ b/scripts/backfill.test.ts
@@ -317,4 +317,21 @@ describe("backfill", () => {
 
     expect(mockEnd).toHaveBeenCalledTimes(1);
   });
+
+  it("Test 12: can re-embed all rows with all=true", async () => {
+    const { pool, mockQuery } = createMockPool(defaultQueryImpl);
+    const embedFn = createMockEmbedFn();
+
+    await backfill(pool, embedFn, { all: true });
+
+    const selectCalls = mockQuery.mock.calls.filter(
+      (call: any[]) =>
+        typeof call[0] === "string" && call[0].startsWith("SELECT * FROM"),
+    );
+
+    expect(selectCalls.length).toBe(5);
+    for (const [sql] of selectCalls as Array<[string]>) {
+      expect(sql).not.toContain("WHERE embedding IS NULL");
+    }
+  });
 });

--- a/scripts/backfill.ts
+++ b/scripts/backfill.ts
@@ -43,7 +43,18 @@ const TABLE_CONFIGS: TableConfig[] = [
   },
 ];
 
-const DELAY_MS = 150;
+// Per-row delay -- default 150ms is politeness for shared/cloud embedding
+// providers. Set BACKFILL_DELAY_MS=0 for a dedicated local provider.
+const rawDelay = parseInt(process.env.BACKFILL_DELAY_MS ?? "150", 10);
+const DELAY_MS = Number.isNaN(rawDelay) || rawDelay < 0 ? 150 : rawDelay;
+
+// Concurrent embed workers -- default 1 preserves sequential behavior.
+// Capped at 8 to stay under the pg pool max (10).
+const rawConcurrency = parseInt(process.env.BACKFILL_CONCURRENCY ?? "1", 10);
+const CONCURRENCY =
+  Number.isNaN(rawConcurrency) || rawConcurrency < 1
+    ? 1
+    : Math.min(rawConcurrency, 8);
 
 interface BackfillResult {
   processed: number;
@@ -71,27 +82,50 @@ export async function backfill(
       mode: options.all ? "all" : "missing",
     });
 
-    for (const row of rows) {
-      const text = textFn(row);
-      const embedding = await embedFn(text);
+    // Worker pool over a shared cursor -- single-threaded JS makes the
+    // `next++` claim race-free; workers overlap embed round-trips.
+    let next = 0;
+    const worker = async () => {
+      while (next < rows.length) {
+        const row = rows[next++];
+        const text = textFn(row);
+        const embedding = await embedFn(text);
 
-      if (!embedding) {
-        totalFailed++;
-        continue;
+        if (!embedding) {
+          totalFailed++;
+          continue;
+        }
+
+        const hash = contentHash(text);
+        try {
+          await pool.query(
+            `UPDATE ${table}
+             SET embedding = $1, content_hash = $2, embedded_at = NOW(), embedding_model = $3
+             WHERE id = $4`,
+            [toSql(embedding), hash, EMBEDDING_MODEL, row.id],
+          );
+        } catch (err) {
+          // One bad row (e.g. content_hash unique-constraint collision on
+          // duplicate content) must not kill the whole backfill.
+          totalFailed++;
+          logger.warn("Backfill row update failed", {
+            table,
+            id: row.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+
+        totalProcessed++;
+
+        if (DELAY_MS > 0) {
+          await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+        }
       }
+    };
 
-      const hash = contentHash(text);
-      await pool.query(
-        `UPDATE ${table}
-         SET embedding = $1, content_hash = $2, embedded_at = NOW(), embedding_model = $3
-         WHERE id = $4`,
-        [toSql(embedding), hash, EMBEDDING_MODEL, row.id],
-      );
-
-      totalProcessed++;
-
-      await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
-    }
+    const workerCount = Math.max(1, Math.min(CONCURRENCY, rows.length));
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
   }
 
   logger.info("Backfill complete", { totalProcessed, totalFailed });

--- a/scripts/backfill.ts
+++ b/scripts/backfill.ts
@@ -5,7 +5,11 @@
 import type pg from "pg";
 import { toSql } from "pgvector/pg";
 import { createPool } from "../src/db/pool.ts";
-import { generateEmbedding, contentHash } from "../src/embedding.ts";
+import {
+  generateEmbedding,
+  contentHash,
+  EMBEDDING_MODEL,
+} from "../src/embedding.ts";
 import { logger } from "../src/logger.ts";
 
 type EmbedFn = (text: string) => Promise<number[] | null>;
@@ -39,7 +43,6 @@ const TABLE_CONFIGS: TableConfig[] = [
   },
 ];
 
-const EMBEDDING_MODEL = "gemini-embedding-001";
 const DELAY_MS = 150;
 
 interface BackfillResult {
@@ -47,19 +50,26 @@ interface BackfillResult {
   failed: number;
 }
 
+interface BackfillOptions {
+  all?: boolean;
+}
+
 export async function backfill(
   pool: pg.Pool,
   embedFn: EmbedFn,
+  options: BackfillOptions = {},
 ): Promise<BackfillResult> {
   let totalProcessed = 0;
   let totalFailed = 0;
+  const whereClause = options.all ? "" : " WHERE embedding IS NULL";
 
   for (const { table, textFn } of TABLE_CONFIGS) {
-    const { rows } = await pool.query(
-      `SELECT * FROM ${table} WHERE embedding IS NULL`,
-    );
+    const { rows } = await pool.query(`SELECT * FROM ${table}${whereClause}`);
 
-    logger.info(`Backfill: ${table}`, { nullCount: rows.length });
+    logger.info(`Backfill: ${table}`, {
+      nullCount: rows.length,
+      mode: options.all ? "all" : "missing",
+    });
 
     for (const row of rows) {
       const text = textFn(row);
@@ -94,7 +104,9 @@ export async function backfill(
 if (import.meta.main) {
   try {
     const pool = createPool();
-    const result = await backfill(pool, generateEmbedding);
+    const result = await backfill(pool, generateEmbedding, {
+      all: process.argv.includes("--all") || process.argv.includes("--force"),
+    });
     logger.info("Backfill finished", {
       processed: result.processed,
       failed: result.failed,

--- a/scripts/backfill.ts
+++ b/scripts/backfill.ts
@@ -16,29 +16,37 @@ type EmbedFn = (text: string) => Promise<number[] | null>;
 
 interface TableConfig {
   table: string;
+  /** Columns to fetch -- projecting instead of SELECT * keeps the existing
+   * 768-dim vectors (and other wide columns) out of JS memory on --all runs. */
+  columns: string[];
   textFn: (row: Record<string, unknown>) => string;
 }
 
 const TABLE_CONFIGS: TableConfig[] = [
   {
     table: "thoughts",
+    columns: ["id", "content"],
     textFn: (row) => row.content as string,
   },
   {
     table: "decisions",
+    columns: ["id", "title", "rationale"],
     textFn: (row) => `${row.title}\n${row.rationale}`,
   },
   {
     table: "relationships",
+    columns: ["id", "person_name", "context", "notes"],
     textFn: (row) =>
       [row.person_name, row.context, row.notes].filter(Boolean).join("\n"),
   },
   {
     table: "projects",
+    columns: ["id", "name", "description"],
     textFn: (row) => [row.name, row.description].filter(Boolean).join("\n"),
   },
   {
     table: "sessions",
+    columns: ["id", "summary"],
     textFn: (row) => row.summary as string,
   },
 ];
@@ -74,8 +82,12 @@ export async function backfill(
   let totalFailed = 0;
   const whereClause = options.all ? "" : " WHERE embedding IS NULL";
 
-  for (const { table, textFn } of TABLE_CONFIGS) {
-    const { rows } = await pool.query(`SELECT * FROM ${table}${whereClause}`);
+  for (const { table, columns, textFn } of TABLE_CONFIGS) {
+    // table/columns come from the static TABLE_CONFIGS allowlist above, never
+    // from user input -- interpolation is safe here.
+    const { rows } = await pool.query(
+      `SELECT ${columns.join(", ")} FROM ${table}${whereClause}`,
+    );
 
     logger.info(`Backfill: ${table}`, {
       nullCount: rows.length,
@@ -130,14 +142,14 @@ export async function backfill(
 
   logger.info("Backfill complete", { totalProcessed, totalFailed });
 
-  await pool.end();
-
   return { processed: totalProcessed, failed: totalFailed };
 }
 
 if (import.meta.main) {
+  // Pool lifecycle belongs to the entrypoint, not backfill() -- callers that
+  // pass a shared pool keep it alive.
+  const pool = createPool();
   try {
-    const pool = createPool();
     const result = await backfill(pool, generateEmbedding, {
       all: process.argv.includes("--all") || process.argv.includes("--force"),
     });
@@ -145,11 +157,13 @@ if (import.meta.main) {
       processed: result.processed,
       failed: result.failed,
     });
+    await pool.end();
     process.exit(0);
   } catch (err) {
     logger.error("Backfill fatal error", {
       error: err instanceof Error ? err.message : String(err),
     });
+    await pool.end().catch(() => {});
     process.exit(1);
   }
 }

--- a/scripts/bulk-import.ts
+++ b/scripts/bulk-import.ts
@@ -18,12 +18,15 @@ import { Glob } from "bun";
 import type pg from "pg";
 import { toSql } from "pgvector/pg";
 import { createPool } from "../src/db/pool.ts";
-import { contentHash, generateEmbedding } from "../src/embedding.ts";
+import {
+  contentHash,
+  generateEmbedding,
+  EMBEDDING_MODEL,
+} from "../src/embedding.ts";
 import { extractMetadata, mergeTags } from "../src/extraction.ts";
 import { logger } from "../src/logger.ts";
 
 const DELAY_MS = 200;
-const EMBEDDING_MODEL = "gemini-embedding-001";
 
 export type ImportTable = "thoughts" | "decisions" | "sessions";
 

--- a/src/embedding.test.ts
+++ b/src/embedding.test.ts
@@ -3,11 +3,16 @@ import {
   generateEmbedding,
   generateEmbeddingWithMetadata,
   contentHash,
+  EMBEDDING_MODEL,
 } from "./embedding.ts";
 
 // Helper: create a mock 768-length embedding array
 function make768(): number[] {
   return Array.from({ length: 768 }, (_, i) => i * 0.001);
+}
+
+function makeEmbedding(length: number): number[] {
+  return Array.from({ length }, (_, i) => i * 0.001);
 }
 
 // Helper: mock globalThis.fetch while satisfying Bun's extended fetch type
@@ -28,7 +33,7 @@ describe("generateEmbedding", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("returns 768-length number array on successful LiteLLM response", async () => {
+  it("returns 768-length number array on successful embedding response", async () => {
     const embedding = make768();
     mockFetch(
       async () =>
@@ -45,7 +50,7 @@ describe("generateEmbedding", () => {
     expect(result![767]).toBeCloseTo(0.767, 5);
   });
 
-  it("returns null when LiteLLM returns non-200 status", async () => {
+  it("returns null when embedding provider returns non-200 status", async () => {
     mockFetch(
       async () => new Response("Internal Server Error", { status: 500 }),
     );
@@ -89,7 +94,7 @@ describe("generateEmbedding", () => {
     expect(result).toBeNull();
   });
 
-  it("calls LiteLLM with model 'embeddings' and dimensions 768", async () => {
+  it("calls embedding provider with model and dimensions 768", async () => {
     let capturedBody: Record<string, unknown> | null = null;
     let capturedUrl = "";
 
@@ -109,9 +114,82 @@ describe("generateEmbedding", () => {
 
     expect(capturedUrl).toBe("http://fake:4000/embeddings");
     expect(capturedBody).not.toBeNull();
-    expect(capturedBody!.model).toBe("gemini-embedding-001");
+    // EMBEDDING_MODEL is captured from env at module load -- assert the
+    // exported constant so the test passes regardless of local .env config.
+    expect(capturedBody!.model).toBe(EMBEDDING_MODEL);
     expect(capturedBody!.dimensions).toBe(768);
     expect(capturedBody!.input).toBe("test input");
+  });
+
+  it("prefers EMBEDDING_BASE_URL over LITELLM_URL and normalizes trailing slash", async () => {
+    const originalEmbeddingUrl = process.env.EMBEDDING_BASE_URL;
+    const originalLiteLlmUrl = process.env.LITELLM_URL;
+    let capturedUrl = "";
+
+    process.env.EMBEDDING_BASE_URL = "http://embedding-provider:8791/v1/";
+    process.env.LITELLM_URL = "http://litellm:4000";
+
+    try {
+      mockFetch(async (input) => {
+        capturedUrl = typeof input === "string" ? input : input.toString();
+        return new Response(
+          JSON.stringify({ data: [{ embedding: make768() }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+
+      const result = await generateEmbedding("test input");
+
+      expect(result).not.toBeNull();
+      expect(capturedUrl).toBe("http://embedding-provider:8791/v1/embeddings");
+    } finally {
+      if (originalEmbeddingUrl === undefined) {
+        delete process.env.EMBEDDING_BASE_URL;
+      } else {
+        process.env.EMBEDDING_BASE_URL = originalEmbeddingUrl;
+      }
+      if (originalLiteLlmUrl === undefined) {
+        delete process.env.LITELLM_URL;
+      } else {
+        process.env.LITELLM_URL = originalLiteLlmUrl;
+      }
+    }
+  });
+
+  it("prefers EMBEDDING_API_KEY over LITELLM_API_KEY", async () => {
+    const originalEmbeddingKey = process.env.EMBEDDING_API_KEY;
+    const originalLiteLlmKey = process.env.LITELLM_API_KEY;
+    let capturedAuth = "";
+
+    process.env.EMBEDDING_API_KEY = "embedding-key";
+    process.env.LITELLM_API_KEY = "litellm-key";
+
+    try {
+      mockFetch(async (_input, init) => {
+        capturedAuth =
+          (init?.headers as Record<string, string>).Authorization ?? "";
+        return new Response(
+          JSON.stringify({ data: [{ embedding: make768() }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      });
+
+      const result = await generateEmbedding("test input", "http://fake:4000");
+
+      expect(result).not.toBeNull();
+      expect(capturedAuth).toBe("Bearer embedding-key");
+    } finally {
+      if (originalEmbeddingKey === undefined) {
+        delete process.env.EMBEDDING_API_KEY;
+      } else {
+        process.env.EMBEDDING_API_KEY = originalEmbeddingKey;
+      }
+      if (originalLiteLlmKey === undefined) {
+        delete process.env.LITELLM_API_KEY;
+      } else {
+        process.env.LITELLM_API_KEY = originalLiteLlmKey;
+      }
+    }
   });
 
   it("returns null on timeout (AbortError)", async () => {
@@ -293,16 +371,26 @@ describe("generateEmbeddingWithMetadata", () => {
     expect(result.error!.attempts).toBe(0);
   });
 
-  it("returns no_litellm_url error when no URL provided", async () => {
+  it("returns no_embedding_url error when no URL provided", async () => {
+    const origEmbeddingUrl = process.env.EMBEDDING_BASE_URL;
     const origUrl = process.env.LITELLM_URL;
+    delete process.env.EMBEDDING_BASE_URL;
     delete process.env.LITELLM_URL;
 
-    const result = await generateEmbeddingWithMetadata("hello");
-    expect(result.embedding).toBeNull();
-    expect(result.error).toBeDefined();
-    expect(result.error!.code).toBe("no_litellm_url");
+    try {
+      const result = await generateEmbeddingWithMetadata("hello");
+      expect(result.embedding).toBeNull();
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe("no_embedding_url");
+    } finally {
+      if (origEmbeddingUrl !== undefined) {
+        process.env.EMBEDDING_BASE_URL = origEmbeddingUrl;
+      }
 
-    if (origUrl !== undefined) process.env.LITELLM_URL = origUrl;
+      if (origUrl !== undefined) {
+        process.env.LITELLM_URL = origUrl;
+      }
+    }
   });
 
   it("returns malformed_response error for wrong embedding shape", async () => {
@@ -375,6 +463,71 @@ describe("generateEmbeddingWithMetadata", () => {
     expect(result.error!.code).toBe("input_invalid");
     expect(result.error!.lastStatus).toBe(400);
     expect(callCount).toBe(1);
+  });
+});
+
+describe("configurable embedding dimensions", () => {
+  let originalFetch: typeof globalThis.fetch;
+  const originalDimensions = process.env.EMBEDDING_DIMENSIONS;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalDimensions === undefined) {
+      delete process.env.EMBEDDING_DIMENSIONS;
+    } else {
+      process.env.EMBEDDING_DIMENSIONS = originalDimensions;
+    }
+  });
+
+  it("validates returned embedding length against EMBEDDING_DIMENSIONS", async () => {
+    process.env.EMBEDDING_DIMENSIONS = "3";
+    const module = await import(`./embedding.ts?dim-test=${Date.now()}`);
+    let capturedBody: Record<string, unknown> | null = null;
+
+    mockFetch(async (_input, init) => {
+      capturedBody = JSON.parse(init?.body as string) as Record<
+        string,
+        unknown
+      >;
+      return new Response(
+        JSON.stringify({ data: [{ embedding: makeEmbedding(3) }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const result = await module.generateEmbeddingWithMetadata(
+      "hello",
+      "http://fake:4000",
+    );
+
+    expect(result.embedding).toEqual(makeEmbedding(3));
+    expect(result.error).toBeUndefined();
+    expect(capturedBody!.dimensions).toBe(3);
+  });
+
+  it("rejects embeddings that do not match EMBEDDING_DIMENSIONS", async () => {
+    process.env.EMBEDDING_DIMENSIONS = "3";
+    const module = await import(`./embedding.ts?dim-test-bad=${Date.now()}`);
+
+    mockFetch(
+      async () =>
+        new Response(JSON.stringify({ data: [{ embedding: makeEmbedding(4) }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await module.generateEmbeddingWithMetadata(
+      "hello",
+      "http://fake:4000",
+    );
+
+    expect(result.embedding).toBeNull();
+    expect(result.error?.code).toBe("malformed_response");
   });
 });
 

--- a/src/embedding.test.ts
+++ b/src/embedding.test.ts
@@ -4,6 +4,7 @@ import {
   generateEmbeddingWithMetadata,
   contentHash,
   EMBEDDING_MODEL,
+  EMBEDDING_DIMENSIONS,
 } from "./embedding.ts";
 
 // Helper: create a mock 768-length embedding array
@@ -94,7 +95,7 @@ describe("generateEmbedding", () => {
     expect(result).toBeNull();
   });
 
-  it("calls embedding provider with model and dimensions 768", async () => {
+  it("calls embedding provider with configured model and dimensions", async () => {
     let capturedBody: Record<string, unknown> | null = null;
     let capturedUrl = "";
 
@@ -117,7 +118,7 @@ describe("generateEmbedding", () => {
     // EMBEDDING_MODEL is captured from env at module load -- assert the
     // exported constant so the test passes regardless of local .env config.
     expect(capturedBody!.model).toBe(EMBEDDING_MODEL);
-    expect(capturedBody!.dimensions).toBe(768);
+    expect(capturedBody!.dimensions).toBe(EMBEDDING_DIMENSIONS);
     expect(capturedBody!.input).toBe("test input");
   });
 

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -3,14 +3,17 @@ import { logger } from "./logger.ts";
 
 const rawTimeout = parseInt(process.env.EMBEDDING_TIMEOUT_MS ?? "8000", 10);
 const EMBEDDING_TIMEOUT_MS = Number.isNaN(rawTimeout) ? 8000 : rawTimeout;
+const rawDimensions = parseInt(process.env.EMBEDDING_DIMENSIONS ?? "768", 10);
+export const EMBEDDING_DIMENSIONS =
+  Number.isNaN(rawDimensions) || rawDimensions <= 0 ? 768 : rawDimensions;
 
 const MAX_RETRIES = 2;
 const BACKOFF_DELAYS_MS = [200, 800];
 
 /**
- * Embedding model identifier. Used by embedding.ts to call LiteLLM and stored
+ * Embedding model identifier. Used by embedding.ts to call the provider and stored
  * in embedding_model columns so we can track which model produced each vector.
- * Override via EMBEDDING_MODEL env var (must match LiteLLM deployment name).
+ * Override via EMBEDDING_MODEL env var (must match the provider deployment name).
  */
 export const EMBEDDING_MODEL =
   process.env.EMBEDDING_MODEL ?? "gemini-embedding-001";
@@ -23,7 +26,7 @@ export interface EmbeddingError {
     | "client_error"
     | "malformed_response"
     | "input_invalid"
-    | "no_litellm_url";
+    | "no_embedding_url";
   message: string;
   attempts: number;
   lastStatus?: number;
@@ -69,9 +72,18 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function embeddingBaseUrl(explicitUrl?: string): string | undefined {
+  const raw = explicitUrl ?? process.env.EMBEDDING_BASE_URL ?? process.env.LITELLM_URL;
+  return raw?.replace(/\/+$/, "");
+}
+
+function embeddingApiKey(): string | undefined {
+  return process.env.EMBEDDING_API_KEY ?? process.env.LITELLM_API_KEY;
+}
+
 export async function generateEmbeddingWithMetadata(
   text: string,
-  litellmUrl?: string,
+  embeddingUrl?: string,
 ): Promise<EmbeddingResult> {
   if (!text || text.trim().length === 0 || text.length > 32000) {
     const msg = "Embedding text empty or too long";
@@ -86,14 +98,14 @@ export async function generateEmbeddingWithMetadata(
     };
   }
 
-  const baseUrl = litellmUrl ?? process.env.LITELLM_URL;
+  const baseUrl = embeddingBaseUrl(embeddingUrl);
   if (!baseUrl) {
-    const msg = "No LiteLLM URL configured";
+    const msg = "No embedding URL configured";
     logger.warn(msg);
     return {
       embedding: null,
       error: {
-        code: "no_litellm_url",
+        code: "no_embedding_url",
         message: msg,
         attempts: 0,
       },
@@ -103,13 +115,13 @@ export async function generateEmbeddingWithMetadata(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
-  const apiKey = process.env.LITELLM_API_KEY;
+  const apiKey = embeddingApiKey();
   if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
   const body = JSON.stringify({
     model: EMBEDDING_MODEL,
     input: text,
-    dimensions: 768,
+    dimensions: EMBEDDING_DIMENSIONS,
   });
 
   let lastError: unknown = null;
@@ -142,8 +154,8 @@ export async function generateEmbeddingWithMetadata(
               : response.status === 401 || response.status === 403
                 ? "client_error"
                 : "client_error";
-          const msg = `LiteLLM returned ${response.status}`;
-          logger.error("Embedding request failed (non-retryable)", {
+          const msg = `Embedding provider returned ${response.status}`;
+          logger.error("Embedding provider request failed (non-retryable)", {
             status: response.status,
             attempts: attempt,
           });
@@ -180,7 +192,7 @@ export async function generateEmbeddingWithMetadata(
           embedding: null,
           error: {
             code: "server_error",
-            message: `LiteLLM returned ${response.status} after ${attempt} attempt(s)`,
+            message: `Embedding provider returned ${response.status} after ${attempt} attempt(s)`,
             attempts: attempt,
             lastStatus: response.status,
           },
@@ -193,11 +205,12 @@ export async function generateEmbeddingWithMetadata(
 
       const embedding = json.data?.[0]?.embedding;
 
-      if (!Array.isArray(embedding) || embedding.length !== 768) {
-        const msg = "LiteLLM returned malformed embedding";
+      if (!Array.isArray(embedding) || embedding.length !== EMBEDDING_DIMENSIONS) {
+        const msg = "Embedding provider returned malformed embedding";
         logger.error(msg, {
           hasData: !!json.data,
           length: Array.isArray(embedding) ? embedding.length : "not-array",
+          expectedLength: EMBEDDING_DIMENSIONS,
           attempts: attempt,
         });
         return {
@@ -290,9 +303,9 @@ export async function generateEmbeddingWithMetadata(
  */
 export async function generateEmbedding(
   text: string,
-  litellmUrl?: string,
+  embeddingUrl?: string,
 ): Promise<number[] | null> {
-  const result = await generateEmbeddingWithMetadata(text, litellmUrl);
+  const result = await generateEmbeddingWithMetadata(text, embeddingUrl);
   return result.embedding;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,8 +53,11 @@ export function createApp(
       }
     }
 
+    // LiteLLM is an optional fallback/extraction dependency, not a core one:
+    // embeddings come from EMBEDDING_BASE_URL. Only the database gates health;
+    // litellm.connected stays reported for observability.
     const status: HealthStatus = {
-      status: dbHealth.connected && litellmConnected ? "healthy" : "degraded",
+      status: dbHealth.connected ? "healthy" : "degraded",
       database: dbHealth,
       litellm: { connected: litellmConnected },
       timestamp: new Date().toISOString(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { buildTokenMap, authMiddleware } from "./auth.ts";
 import { createBrainServer } from "./server.ts";
 import { createTransportHandlers } from "./transport.ts";
 import { registerAllTools } from "./tools/index.ts";
-import { generateEmbedding } from "./embedding.ts";
+import { generateEmbedding, EMBEDDING_DIMENSIONS } from "./embedding.ts";
 import { runMigrations } from "./db/migrate.ts";
 import { logger } from "./logger.ts";
 import { requestLogger } from "./middleware/request-logger.ts";
@@ -16,6 +16,22 @@ import { createPromotionRouter } from "./rest-promotion.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 
 const LITELLM_URL = process.env.LITELLM_URL;
+const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
+
+async function probeUrl(
+  url: string,
+  headers: Record<string, string>,
+): Promise<boolean> {
+  try {
+    const resp = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
 
 export function createApp(
   pool: pg.Pool,
@@ -34,31 +50,41 @@ export function createApp(
 
   // Health endpoint -- no auth required
   app.get("/health", async (_req: Request, res: Response) => {
-    const dbHealth = await checkPoolHealth(pool);
-
-    let litellmConnected = false;
-    if (LITELLM_URL) {
-      try {
-        const headers: Record<string, string> = {};
-        const apiKey = process.env.LITELLM_API_KEY;
-        if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-        // LiteLLM uses "/health/liveliness" (not "liveness") — this is their actual endpoint spelling
-        const resp = await fetch(`${LITELLM_URL}/health/liveliness`, {
-          headers,
-          signal: AbortSignal.timeout(3000),
-        });
-        litellmConnected = resp.ok;
-      } catch {
-        litellmConnected = false;
-      }
+    const litellmHeaders: Record<string, string> = {};
+    if (process.env.LITELLM_API_KEY) {
+      litellmHeaders["Authorization"] = `Bearer ${process.env.LITELLM_API_KEY}`;
     }
+    const embeddingHeaders: Record<string, string> = {};
+    if (process.env.EMBEDDING_API_KEY) {
+      embeddingHeaders["Authorization"] =
+        `Bearer ${process.env.EMBEDDING_API_KEY}`;
+    }
+
+    const [dbHealth, litellmConnected, embeddingConnected] = await Promise.all([
+      checkPoolHealth(pool),
+      // LiteLLM uses "/health/liveliness" (not "liveness") — this is their actual endpoint spelling
+      LITELLM_URL
+        ? probeUrl(`${LITELLM_URL}/health/liveliness`, litellmHeaders)
+        : Promise.resolve(false),
+      // Any OpenAI-compatible provider serves GET {base}/models
+      EMBEDDING_BASE_URL
+        ? probeUrl(
+            `${EMBEDDING_BASE_URL.replace(/\/$/, "")}/models`,
+            embeddingHeaders,
+          )
+        : Promise.resolve(false),
+    ]);
 
     // LiteLLM is an optional fallback/extraction dependency, not a core one:
     // embeddings come from EMBEDDING_BASE_URL. Only the database gates health;
-    // litellm.connected stays reported for observability.
+    // the provider probes stay reported for observability.
     const status: HealthStatus = {
       status: dbHealth.connected ? "healthy" : "degraded",
       database: dbHealth,
+      embedding: {
+        configured: Boolean(EMBEDDING_BASE_URL),
+        connected: embeddingConnected,
+      },
       litellm: { connected: litellmConnected },
       timestamp: new Date().toISOString(),
     };
@@ -139,6 +165,16 @@ export function createApp(
 }
 
 if (import.meta.main) {
+  // The vector columns are halfvec(768) in the schema; a mismatched
+  // EMBEDDING_DIMENSIONS makes every embedding INSERT fail at runtime.
+  if (EMBEDDING_DIMENSIONS !== 768) {
+    logger.warn("EMBEDDING_DIMENSIONS does not match the halfvec(768) schema", {
+      configured: EMBEDDING_DIMENSIONS,
+      schema: 768,
+      consequence: "embedding writes will fail until columns are migrated",
+    });
+  }
+
   const pool = createPool();
 
   try {

--- a/src/tools/__tests__/log-decision.test.ts
+++ b/src/tools/__tests__/log-decision.test.ts
@@ -75,6 +75,45 @@ describe("log_decision", () => {
         await cleanup();
       }
     });
+
+    it("passes alternatives as a JSON string for the jsonb column", async () => {
+      // Regression: a raw JS array is serialized by node-postgres as a
+      // Postgres array literal ('{..}'), which jsonb rejects with
+      // "invalid input syntax for type json" whenever it is non-empty.
+      let capturedParams: any[] = [];
+      const mockPool = {
+        query: async (_sql: string, params?: any[]) => {
+          if (params) capturedParams = params;
+          return { rows: [{ id: "decision-uuid" }] };
+        },
+      };
+      const mockEmbed = createMockEmbed();
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupDecisionClient(
+        mockPool,
+        mockEmbed,
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_decision",
+          arguments: {
+            title: "Use Bun",
+            rationale: "Faster than Node.js for our use case",
+            alternatives: ["Node.js", "Deno"],
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const alternativesParam = capturedParams[2];
+        expect(typeof alternativesParam).toBe("string");
+        expect(JSON.parse(alternativesParam)).toEqual(["Node.js", "Deno"]);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe("embedding text construction", () => {

--- a/src/tools/log-decision.ts
+++ b/src/tools/log-decision.ts
@@ -93,7 +93,9 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
         [
           args.title,
           args.rationale,
-          args.alternatives ?? [],
+          // alternatives is a jsonb column -- a raw JS array serializes as a
+          // Postgres array literal ("{..}"), invalid JSON whenever non-empty.
+          JSON.stringify(args.alternatives ?? []),
           args.tags ?? [],
           args.context ?? null,
           auth.clientId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface PoolHealth {
 export interface HealthStatus {
   status: "healthy" | "degraded";
   database: PoolHealth;
+  embedding: { configured: boolean; connected: boolean };
   litellm: { connected: boolean };
   timestamp: string;
 }


### PR DESCRIPTION
## What

Rebases and preserves the provider-agnostic embedding work on current main. This decouples embeddings from LiteLLM by supporting any OpenAI-compatible embedding endpoint via EMBEDDING_BASE_URL, with local-first deployment support and LiteLLM retained for extraction/fallback paths.

## Scope

- Provider-agnostic embedding configuration and health metadata
- Local embedding provider env/schema/docs updates
- Backfill concurrency, tunable delay, and per-row failure resilience
- Log-decision jsonb alternatives serialization fix
- SME docs update for dual MCP client implementations

## Current integration status

- Rebased onto main after PR #89
- Pushed to feat/local-embedding-provider at 86ec531
- Local validation: bun run typecheck; bun test (654 pass, 16 skip)

## Notes

The old PR branch was stale against current main and was unsafe to merge as-is. The change set itself was not superseded; it has been reapplied cleanly on current main.