### PR TITLE
feat: add Codex memory citation contract

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -16,6 +16,9 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 
 - **Not a behavior layer.** Rules, routing, and personality live in CLAUDE.md / skill files.
 - **Not raw recall.** Session transcripts and logs are separate from OB entries.
+- **Not a dumping ground.** Store distilled facts, decisions, blockers,
+  artifacts, validation receipts, and checkpoint summaries. Do not store raw
+  transcripts, secrets, or long command output.
 - **Not Honcho.** OB is the authoritative source for operational state. Honcho/session vibes are not canonical.
 
 ## Memory Tiers
@@ -50,8 +53,12 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 ## Namespace Convention
 
 - Namespace defaults to `auth.clientId` (agent identity)
-- Cross-namespace access is allowed for coordination (not a security boundary)
-- `collab` namespace for shared/cross-agent knowledge
+- Namespace isolation is a security boundary. ID-based reads and mutations must
+  include auth-derived namespace predicates unless a token-sourced global role
+  is intentionally broad.
+- `collab` namespace is for shared/cross-agent knowledge. Agents should promote
+  into `collab` through promotion flows rather than hard-coding `collab` as the
+  only destination.
 
 ## Tool Reference
 
@@ -70,3 +77,76 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 | search_all | Federated search (OB + qmd) | read |
 | log_thought | Record a learning/insight | write |
 | log_decision | Record a decision with rationale | write |
+
+## Codex Durable Memory Flow
+
+Codex should use Open Brain through daemon-mode `mcp2cli open-brain`, not direct
+MCP server config.
+
+Start or resume a lane:
+
+```bash
+mcp2cli open-brain session_start --params '{"session_key":"<stable-key>","project":"open-brain","agent":"codex","topic":"<short topic>"}'
+```
+
+Read current lane context without writing a new event:
+
+```bash
+mcp2cli open-brain session_context --params '{"session_key":"<stable-key>","include_events":true,"event_limit":50}'
+```
+
+Append only high-signal events:
+
+```bash
+mcp2cli open-brain append_session_event --params '{"session_key":"<stable-key>","event_type":"decision","content":"<distilled decision and rationale>","source":"codex","importance":"warm"}'
+```
+
+Checkpoint a compact durable summary:
+
+```bash
+mcp2cli open-brain session_wrap --params '{"session_key":"<stable-key>","project":"open-brain","summary":"<checkpoint>","key_decisions":["<decision>"],"next_steps":["<next action>"]}'
+```
+
+Search before answering when prior context matters:
+
+```bash
+mcp2cli open-brain search_all --params '{"query":"<query>","limit":10}'
+```
+
+Dry-run the Codex lifecycle command sequence without writing memory:
+
+```bash
+bun run scripts/codex-memory-smoke.ts
+```
+
+Execute the disposable live smoke only when intentionally validating the
+configured Open Brain service:
+
+```bash
+OPEN_BRAIN_CODEX_SMOKE_WRITE=1 bun run scripts/codex-memory-smoke.ts
+```
+
+Memory-derived facts should be cited with the returned source identity: for
+Open Brain entries, cite `source_ref.source`, `source_ref.type`,
+`source_ref.id`, and when useful `source_ref.namespace`; for qmd results, cite
+`source_ref.path` and `source_ref.collection`.
+
+## Capability Audit Gate
+
+Before planning Open Brain architecture, creating issues, changing schema/tools,
+or deciding what Codex memory already supports, inspect current capabilities:
+
+```bash
+mcp2cli open-brain --help
+mcp2cli schema open-brain.search_all
+mcp2cli schema open-brain.session_start
+mcp2cli schema open-brain.append_session_event
+mcp2cli schema open-brain.session_context
+mcp2cli schema open-brain.session_wrap
+mcp2cli open-brain get_stats --params '{}'
+mcp2cli open-brain list_namespaces --params '{}'
+```
+
+In this repo, also inspect `src/tools/` and `src/db/migrations/` before
+proposing new primitives. State what exists, what is missing, and what should be
+docs/protocol instead of code.

--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -116,20 +116,25 @@ mcp2cli open-brain search_all --params '{"query":"<query>","limit":10}'
 Dry-run the Codex lifecycle command sequence without writing memory:
 
 ```bash
-bun run scripts/codex-memory-smoke.ts
+bun run codex-memory-smoke
 ```
 
 Execute the disposable live smoke only when intentionally validating the
 configured Open Brain service:
 
 ```bash
-OPEN_BRAIN_CODEX_SMOKE_WRITE=1 bun run scripts/codex-memory-smoke.ts
+OPEN_BRAIN_CODEX_SMOKE_WRITE=1 bun run codex-memory-smoke
 ```
 
 Memory-derived facts should be cited with the returned source identity: for
 Open Brain entries, cite `source_ref.source`, `source_ref.type`,
 `source_ref.id`, and when useful `source_ref.namespace`; for qmd results, cite
 `source_ref.path` and `source_ref.collection`.
+
+Search result `source_ref` values intentionally expose only citation-safe
+identity, label/preview, creator, namespace, and timestamps for the readable row.
+They do not expose raw promotion provenance such as a private source namespace
+or source id.
 
 ## Capability Audit Gate
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "bun test",
     "typecheck": "bunx tsc --noEmit",
     "backfill": "bun run scripts/backfill.ts",
+    "codex-memory-smoke": "bun run scripts/codex-memory-smoke.ts",
     "import-kb": "bun run scripts/import-legacy-kb.ts",
     "curate": "bun run scripts/curate.ts"
   },

--- a/scripts/codex-memory-smoke.ts
+++ b/scripts/codex-memory-smoke.ts
@@ -4,6 +4,7 @@ type SmokeStep = {
   name: string;
   tool: string;
   params: Record<string, unknown>;
+  expectOutput?: string[];
 };
 
 const writeEnabled = process.env.OPEN_BRAIN_CODEX_SMOKE_WRITE === "1";
@@ -77,6 +78,7 @@ const steps: SmokeStep[] = [
       include_events: true,
       event_limit: 10,
     },
+    expectOutput: [sessionKey, "Disposable Codex memory smoke checkpoint"],
   },
   {
     name: "search saved checkpoint context",
@@ -86,6 +88,7 @@ const steps: SmokeStep[] = [
       sources: "brain",
       limit: 5,
     },
+    expectOutput: [sessionKey, "Disposable Codex memory smoke checkpoint"],
   },
 ];
 
@@ -114,14 +117,26 @@ for (const step of steps) {
   const command = commandFor(step);
   console.log(`\n# ${step.name}`);
   const proc = Bun.spawnSync(command, { stdout: "pipe", stderr: "pipe" });
+  const stdout = new TextDecoder().decode(proc.stdout).trim();
+  const stderr = new TextDecoder().decode(proc.stderr).trim();
   if (proc.stdout.byteLength > 0) {
-    console.log(new TextDecoder().decode(proc.stdout).trim());
+    console.log(stdout);
   }
   if (proc.stderr.byteLength > 0) {
-    console.error(new TextDecoder().decode(proc.stderr).trim());
+    console.error(stderr);
   }
   if (proc.exitCode !== 0) {
     console.error(`${step.tool} failed with exit code ${proc.exitCode}`);
     process.exit(proc.exitCode);
+  }
+  for (const expected of step.expectOutput ?? []) {
+    if (!stdout.includes(expected)) {
+      console.error(
+        `${step.tool} output did not include expected text: ${JSON.stringify(
+          expected,
+        )}`,
+      );
+      process.exit(1);
+    }
   }
 }

--- a/scripts/codex-memory-smoke.ts
+++ b/scripts/codex-memory-smoke.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+
+type SmokeStep = {
+  name: string;
+  tool: string;
+  params: Record<string, unknown>;
+};
+
+const writeEnabled = process.env.OPEN_BRAIN_CODEX_SMOKE_WRITE === "1";
+const sessionKey =
+  process.env.OPEN_BRAIN_CODEX_SMOKE_SESSION_KEY ??
+  `codex-smoke-${new Date().toISOString().slice(0, 10)}`;
+
+const steps: SmokeStep[] = [
+  {
+    name: "start or resume lane",
+    tool: "session_start",
+    params: {
+      session_key: sessionKey,
+      project: "open-brain",
+      agent: "codex-smoke",
+      topic: "Codex durable memory smoke flow",
+    },
+  },
+  {
+    name: "append decision event",
+    tool: "append_session_event",
+    params: {
+      session_key: sessionKey,
+      event_type: "decision",
+      content: "Codex smoke flow writes only distilled high-signal events.",
+      source: "scripts/codex-memory-smoke.ts",
+      importance: "cold",
+      metadata: { smoke: true },
+    },
+  },
+  {
+    name: "append validation receipt",
+    tool: "append_session_event",
+    params: {
+      session_key: sessionKey,
+      event_type: "receipt",
+      content: "Codex smoke flow reached validation receipt step.",
+      source: "scripts/codex-memory-smoke.ts",
+      importance: "cold",
+      metadata: { smoke: true },
+    },
+  },
+  {
+    name: "load lane context",
+    tool: "session_context",
+    params: {
+      session_key: sessionKey,
+      include_events: true,
+      event_limit: 10,
+    },
+  },
+  {
+    name: "checkpoint summary",
+    tool: "session_wrap",
+    params: {
+      session_key: sessionKey,
+      project: "open-brain",
+      summary:
+        "Disposable Codex memory smoke checkpoint. Confirms session_start, append_session_event, session_context, and session_wrap command shapes.",
+      key_decisions: [
+        "Codex durable memory captures distilled events instead of raw transcripts.",
+      ],
+      next_steps: ["Delete or ignore disposable smoke lane if no longer useful."],
+    },
+  },
+];
+
+function commandFor(step: SmokeStep): string[] {
+  return [
+    "mcp2cli",
+    "open-brain",
+    step.tool,
+    "--params",
+    JSON.stringify(step.params),
+  ];
+}
+
+if (!writeEnabled) {
+  console.log(
+    "Dry run only. Set OPEN_BRAIN_CODEX_SMOKE_WRITE=1 to execute writes.",
+  );
+  for (const step of steps) {
+    console.log(`\n# ${step.name}`);
+    console.log(commandFor(step).map((part) => JSON.stringify(part)).join(" "));
+  }
+  process.exit(0);
+}
+
+for (const step of steps) {
+  const command = commandFor(step);
+  console.log(`\n# ${step.name}`);
+  const proc = Bun.spawnSync(command, { stdout: "pipe", stderr: "pipe" });
+  if (proc.stdout.byteLength > 0) {
+    console.log(new TextDecoder().decode(proc.stdout).trim());
+  }
+  if (proc.stderr.byteLength > 0) {
+    console.error(new TextDecoder().decode(proc.stderr).trim());
+  }
+  if (proc.exitCode !== 0) {
+    console.error(`${step.tool} failed with exit code ${proc.exitCode}`);
+    process.exit(proc.exitCode);
+  }
+}

--- a/scripts/codex-memory-smoke.ts
+++ b/scripts/codex-memory-smoke.ts
@@ -62,10 +62,9 @@ const steps: SmokeStep[] = [
     params: {
       session_key: sessionKey,
       project: "open-brain",
-      summary:
-        "Disposable Codex memory smoke checkpoint. Confirms session_start, append_session_event, session_context, and session_wrap command shapes.",
+      summary: `Disposable Codex memory smoke checkpoint for ${sessionKey}. Confirms session_start, append_session_event, session_context, and session_wrap command shapes.`,
       key_decisions: [
-        "Codex durable memory captures distilled events instead of raw transcripts.",
+        `Codex durable memory captures distilled events instead of raw transcripts for ${sessionKey}.`,
       ],
       next_steps: ["Delete or ignore disposable smoke lane if no longer useful."],
     },
@@ -78,7 +77,10 @@ const steps: SmokeStep[] = [
       include_events: true,
       event_limit: 10,
     },
-    expectOutput: [sessionKey, "Disposable Codex memory smoke checkpoint"],
+    expectOutput: [
+      sessionKey,
+      "Codex smoke flow reached validation receipt step.",
+    ],
   },
   {
     name: "search saved checkpoint context",
@@ -88,7 +90,10 @@ const steps: SmokeStep[] = [
       sources: "brain",
       limit: 5,
     },
-    expectOutput: [sessionKey, "Disposable Codex memory smoke checkpoint"],
+    expectOutput: [
+      sessionKey,
+      `Disposable Codex memory smoke checkpoint for ${sessionKey}`,
+    ],
   },
 ];
 

--- a/scripts/codex-memory-smoke.ts
+++ b/scripts/codex-memory-smoke.ts
@@ -47,7 +47,7 @@ const steps: SmokeStep[] = [
     },
   },
   {
-    name: "load lane context",
+    name: "load lane context before checkpoint",
     tool: "session_context",
     params: {
       session_key: sessionKey,
@@ -67,6 +67,24 @@ const steps: SmokeStep[] = [
         "Codex durable memory captures distilled events instead of raw transcripts.",
       ],
       next_steps: ["Delete or ignore disposable smoke lane if no longer useful."],
+    },
+  },
+  {
+    name: "reload lane context after checkpoint",
+    tool: "session_context",
+    params: {
+      session_key: sessionKey,
+      include_events: true,
+      event_limit: 10,
+    },
+  },
+  {
+    name: "search saved checkpoint context",
+    tool: "search_all",
+    params: {
+      query: sessionKey,
+      sources: "brain",
+      limit: 5,
     },
   },
 ];

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -194,20 +194,24 @@ describe("search_all", () => {
 
     it("returns single brain result correctly", async () => {
       mockBunSpawn(1, "");
+      const queries: string[] = [];
       const pool = {
-        query: async () => ({
-          rows: [
-            {
-              source_type: "decision",
-              id: "dec-1",
-              content_preview: "Use Bun over Node",
-              distance: 0.08,
-              tags: ["runtime"],
-              created_at: "2026-01-10",
-              usefulness: 0.7,
-            },
-          ],
-        }),
+        query: async (sql: string) => {
+          queries.push(sql);
+          return {
+            rows: [
+              {
+                source_type: "decision",
+                id: "dec-1",
+                content_preview: "Use Bun over Node",
+                distance: 0.08,
+                tags: ["runtime"],
+                created_at: "2026-01-10",
+                usefulness: 0.7,
+              },
+            ],
+          };
+        },
       };
       const { client, cleanup } = await setupClient(pool, {
         role: "admin",
@@ -230,8 +234,13 @@ describe("search_all", () => {
           type: "decision",
           id: "dec-1",
           created_at: "2026-01-10T00:00:00.000Z",
-          promoted_from: null,
+          last_updated_at: "2026-01-10T00:00:00.000Z",
+          label: "Use Bun over Node",
+          preview: "Use Bun over Node",
         });
+        expect(queries.some((sql) => sql.includes("FROM ob_links"))).toBe(
+          false,
+        );
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -158,7 +158,14 @@ describe("search_all", () => {
         const parsed = parseSearchAll(result);
         expect(parsed.brain_hits).toBe(0);
         expect(parsed.qmd_hits).toBe(2);
-        expect(parsed.results.every((r: any) => r.source === "qmd")).toBe(true);
+        expect(parsed.results.every((r: any) => r.source === "qmd")).toBe(
+          true,
+        );
+        expect(parsed.results[0].source_ref).toEqual({
+          source: "qmd",
+          type: "file",
+          path: "/a.md",
+        });
       } finally {
         await cleanup();
       }
@@ -218,6 +225,13 @@ describe("search_all", () => {
         expect(parsed.results[0].type).toBe("decision");
         expect(parsed.results[0].id).toBe("dec-1");
         expect(parsed.results[0].tags).toEqual(["runtime"]);
+        expect(parsed.results[0].source_ref).toEqual({
+          source: "brain",
+          type: "decision",
+          id: "dec-1",
+          created_at: "2026-01-10T00:00:00.000Z",
+          promoted_from: null,
+        });
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -166,7 +166,17 @@ describe("search_brain", () => {
     it("returns ranked results with expected shape", async () => {
       const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
       const { client, cleanup } = await setup(
-        searchPool(makeMockRows(3)),
+        searchPool(
+          makeMockRows(3).map((row) => ({
+            ...row,
+            namespace: "collab",
+            created_by: "codex",
+            promoted_from: {
+              source_namespace: "skippy",
+              source_id: "00000000-0000-4000-8000-000000000010",
+            },
+          })),
+        ),
         auth,
       );
 
@@ -185,6 +195,18 @@ describe("search_brain", () => {
         expect(parsed[0]).toHaveProperty("distance");
         expect(parsed[0]).toHaveProperty("tags");
         expect(parsed[0]).toHaveProperty("created_at");
+        expect(parsed[0].source_ref).toEqual({
+          source: "brain",
+          type: "thought",
+          id: "uuid-0",
+          namespace: "collab",
+          created_by: "codex",
+          created_at: "2026-01-01T00:00:00.000Z",
+          promoted_from: {
+            source_namespace: "skippy",
+            source_id: "00000000-0000-4000-8000-000000000010",
+          },
+        });
       } finally {
         await cleanup();
       }

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -171,10 +171,7 @@ describe("search_brain", () => {
             ...row,
             namespace: "collab",
             created_by: "codex",
-            promoted_from: {
-              source_namespace: "skippy",
-              source_id: "00000000-0000-4000-8000-000000000010",
-            },
+            updated_at: "2026-01-02T00:00:00Z",
           })),
         ),
         auth,
@@ -202,10 +199,46 @@ describe("search_brain", () => {
           namespace: "collab",
           created_by: "codex",
           created_at: "2026-01-01T00:00:00.000Z",
-          promoted_from: {
-            source_namespace: "skippy",
-            source_id: "00000000-0000-4000-8000-000000000010",
+          last_updated_at: "2026-01-02T00:00:00.000Z",
+          label: "Content preview 0",
+          preview: "Content preview 0",
+        });
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("does not fail when a search row has an invalid timestamp", async () => {
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(
+        searchPool([
+          {
+            source_type: "thought",
+            id: "uuid-invalid-date",
+            namespace: "collab",
+            content_preview: "Invalid timestamp row",
+            distance: 0.1,
+            tags: [],
+            created_at: "not-a-date",
           },
+        ]),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: { query: "invalid date" },
+        });
+        expect(result.isError).toBeFalsy();
+        const parsed = parseToolResult(result);
+        expect(parsed[0].source_ref).toEqual({
+          source: "brain",
+          type: "thought",
+          id: "uuid-invalid-date",
+          namespace: "collab",
+          label: "Invalid timestamp row",
+          preview: "Invalid timestamp row",
         });
       } finally {
         await cleanup();

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -12,6 +12,7 @@ import {
   TIER_BOOST,
   type SearchMode,
   type SearchRow,
+  type SourceRef,
 } from "./search-brain.ts";
 
 type NamespaceFilter = string | string[];
@@ -21,12 +22,20 @@ interface UnifiedResult {
   type: string;
   content: string;
   score: number;
+  source_ref: SourceRef | QmdSourceRef;
   id?: string;
   path?: string;
   tags?: string[];
   collection?: string;
   tier?: string;
   explicit_links?: SearchRow["explicit_links"];
+}
+
+interface QmdSourceRef {
+  source: "qmd";
+  type: "file";
+  path?: string;
+  collection?: string;
 }
 
 interface QmdDocument {
@@ -90,6 +99,12 @@ async function searchQmd(
       score: doc.score ?? doc.similarity ?? 0.5,
       path: doc.path || doc.file,
       collection: doc.collection,
+      source_ref: {
+        source: "qmd" as const,
+        type: "file" as const,
+        path: doc.path || doc.file,
+        collection: doc.collection,
+      },
     }));
   } catch (err) {
     logger.warn("qmd search error", {
@@ -260,7 +275,7 @@ async function searchOB(
       tier,
       0,
       namespace,
-      false,
+      true,
     );
   } catch (err) {
     logger.warn("searchOB_failed", {
@@ -276,6 +291,12 @@ async function searchOB(
     type: row.source_type,
     content: row.content_preview.slice(0, 300),
     score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
+    source_ref: row.source_ref ?? {
+      source: "brain" as const,
+      type: row.source_type,
+      id: row.id,
+      created_at: new Date(row.created_at).toISOString(),
+    },
     id: row.id,
     tags: row.tags ?? undefined,
     tier: row.tier,

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -275,7 +275,7 @@ async function searchOB(
       tier,
       0,
       namespace,
-      true,
+      false,
     );
   } catch (err) {
     logger.warn("searchOB_failed", {
@@ -295,7 +295,8 @@ async function searchOB(
       source: "brain" as const,
       type: row.source_type,
       id: row.id,
-      created_at: new Date(row.created_at).toISOString(),
+      label: row.content_preview.slice(0, 120),
+      preview: row.content_preview.slice(0, 300),
     },
     id: row.id,
     tags: row.tags ?? undefined,

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -79,8 +79,10 @@ export interface SourceRef {
   id: string;
   namespace?: string;
   created_by?: string | null;
-  created_at: string;
-  promoted_from?: Record<string, unknown> | null;
+  created_at?: string;
+  last_updated_at?: string;
+  label: string;
+  preview: string;
 }
 
 export interface SearchRow {
@@ -91,7 +93,7 @@ export interface SearchRow {
   tags: string[] | null;
   created_by?: string | null;
   created_at: string;
-  promoted_from?: Record<string, unknown> | null;
+  updated_at?: string | null;
   usefulness: number;
   tier?: string;
   distance?: number;
@@ -125,6 +127,13 @@ function linkKey(type: string, id: string): string {
   return `${type}:${id}`;
 }
 
+function toIsoString(value: unknown): string | undefined {
+  if (typeof value !== "string" && !(value instanceof Date)) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
 function withSourceRefs(rows: SearchRow[]): SearchRow[] {
   return rows.map((row) => ({
     ...row,
@@ -134,8 +143,10 @@ function withSourceRefs(rows: SearchRow[]): SearchRow[] {
       id: row.id,
       namespace: row.namespace,
       created_by: row.created_by,
-      created_at: new Date(row.created_at).toISOString(),
-      promoted_from: row.promoted_from ?? null,
+      created_at: toIsoString(row.created_at),
+      last_updated_at: toIsoString(row.updated_at) ?? toIsoString(row.created_at),
+      label: row.content_preview.slice(0, 120),
+      preview: row.content_preview.slice(0, 300),
     },
   }));
 }
@@ -273,7 +284,7 @@ function buildTableCTE(
     ${alias}.tags,
     ${alias}.created_by,
     ${alias}.created_at,
-    ${alias}.promoted_from,
+    ${alias}.updated_at,
     ${alias}.tier,
     ${alias}.embedding <=> (SELECT emb FROM query_embedding) AS distance,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness,
@@ -318,7 +329,7 @@ function buildFtsCTE(
     ${alias}.tags,
     ${alias}.created_by,
     ${alias}.created_at,
-    ${alias}.promoted_from,
+    ${alias}.updated_at,
     ${alias}.tier,
     ts_rank_cd(${alias}.search_vector, plainto_tsquery('english', (SELECT q FROM fts_query))) AS fts_rank,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness,

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -73,18 +73,32 @@ export interface ExplicitLink {
   created_at: string;
 }
 
+export interface SourceRef {
+  source: "brain";
+  type: string;
+  id: string;
+  namespace?: string;
+  created_by?: string | null;
+  created_at: string;
+  promoted_from?: Record<string, unknown> | null;
+}
+
 export interface SearchRow {
   source_type: string;
   id: string;
+  namespace?: string;
   content_preview: string;
   tags: string[] | null;
+  created_by?: string | null;
   created_at: string;
+  promoted_from?: Record<string, unknown> | null;
   usefulness: number;
   tier?: string;
   distance?: number;
   fts_rank?: number;
   access_count?: number;
   explicit_links?: ExplicitLink[];
+  source_ref?: SourceRef;
   extracted_metadata?: {
     topics?: string[];
     people?: string[];
@@ -109,6 +123,21 @@ type LinkRow = {
 
 function linkKey(type: string, id: string): string {
   return `${type}:${id}`;
+}
+
+function withSourceRefs(rows: SearchRow[]): SearchRow[] {
+  return rows.map((row) => ({
+    ...row,
+    source_ref: {
+      source: "brain",
+      type: row.source_type,
+      id: row.id,
+      namespace: row.namespace,
+      created_by: row.created_by,
+      created_at: new Date(row.created_at).toISOString(),
+      promoted_from: row.promoted_from ?? null,
+    },
+  }));
 }
 
 function appendNamespaceParam(
@@ -239,9 +268,12 @@ function buildTableCTE(
   SELECT
     '${label}' AS source_type,
     ${alias}.id,
+    ${alias}.namespace,
     ${preview} AS content_preview,
     ${alias}.tags,
+    ${alias}.created_by,
     ${alias}.created_at,
+    ${alias}.promoted_from,
     ${alias}.tier,
     ${alias}.embedding <=> (SELECT emb FROM query_embedding) AS distance,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness,
@@ -281,9 +313,12 @@ function buildFtsCTE(
   SELECT
     '${label}' AS source_type,
     ${alias}.id,
+    ${alias}.namespace,
     ${preview} AS content_preview,
     ${alias}.tags,
+    ${alias}.created_by,
     ${alias}.created_at,
+    ${alias}.promoted_from,
     ${alias}.tier,
     ts_rank_cd(${alias}.search_vector, plainto_tsquery('english', (SELECT q FROM fts_query))) AS fts_rank,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness,
@@ -329,7 +364,7 @@ ORDER BY (distance * ${VECTOR_WEIGHT} + (1.0 - COALESCE(usefulness, 0.5)) * ${US
 LIMIT $2 OFFSET $3`;
 
   const { rows } = await deps.pool.query(sql, params);
-  return rows as SearchRow[];
+  return withSourceRefs(rows as SearchRow[]);
 }
 
 async function ftsSearch(
@@ -364,7 +399,7 @@ ORDER BY fts_rank DESC
 LIMIT $2 OFFSET $3`;
 
   const { rows } = await deps.pool.query(sql, params);
-  return rows as SearchRow[];
+  return withSourceRefs(rows as SearchRow[]);
 }
 
 /**


### PR DESCRIPTION
## Summary

- add `source_ref` citation objects to `search_brain` and `search_all` results
- include qmd citation parity through path/collection source refs
- request explicit links for federated brain search results
- document Codex durable memory flow, capability audit gate, and namespace security boundary
- add dry-run/default Codex memory lifecycle smoke script

Closes #106.
Closes #108.

## Validation

- `bun run scripts/codex-memory-smoke.ts` (dry run)
- `bun test src/tools/__tests__/search-brain.test.ts src/tools/__tests__/search-all.test.ts`
- `bun run typecheck`
- `bun test` (619 pass, 16 skip)
