### PR TITLE
feat: add cited brain answer tool

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -113,6 +113,13 @@ Search before answering when prior context matters:
 mcp2cli open-brain search_all --params '{"query":"<query>","limit":10}'
 ```
 
+Ask for an extractive, cited memory answer when Codex needs prose instead of
+raw hits:
+
+```bash
+mcp2cli open-brain brain_answer --params '{"query":"what did we decide about codex memory?","limit":5}'
+```
+
 Dry-run the Codex lifecycle command sequence without writing memory:
 
 ```bash
@@ -135,6 +142,11 @@ Search result `source_ref` values intentionally expose only citation-safe
 identity, label/preview, creator, namespace, and timestamps for the readable row.
 They do not expose raw promotion provenance such as a private source namespace
 or source id.
+
+`brain_answer` answers only from readable Open Brain rows, cites every material
+bullet with a `source_ref`, and returns `known_gaps` / `uncertainty` when
+evidence is missing, stale, or contradictory. When no readable evidence is
+available, `answer` is `null`; the tool must not fabricate uncited facts.
 
 ## Capability Audit Gate
 

--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -75,6 +75,7 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 | adjacent_context | Traverse link graph from a node | read |
 | search_brain | Semantic search across all tables | read |
 | search_all | Federated search (OB + qmd) | read |
+| brain_answer | Extractive cited evidence bullets from Open Brain | read |
 | log_thought | Record a learning/insight | write |
 | log_decision | Record a decision with rationale | write |
 
@@ -113,8 +114,8 @@ Search before answering when prior context matters:
 mcp2cli open-brain search_all --params '{"query":"<query>","limit":10}'
 ```
 
-Ask for an extractive, cited memory answer when Codex needs prose instead of
-raw hits:
+Ask for extractive, cited memory evidence when Codex needs a concise rendered
+answer surface instead of raw hits:
 
 ```bash
 mcp2cli open-brain brain_answer --params '{"query":"what did we decide about codex memory?","limit":5}'
@@ -143,10 +144,11 @@ identity, label/preview, creator, namespace, and timestamps for the readable row
 They do not expose raw promotion provenance such as a private source namespace
 or source id.
 
-`brain_answer` answers only from readable Open Brain rows, cites every material
-bullet with a `source_ref`, and returns `known_gaps` / `uncertainty` when
-evidence is missing, stale, or contradictory. When no readable evidence is
-available, `answer` is `null`; the tool must not fabricate uncited facts.
+`brain_answer` renders only citable snippets from readable Open Brain rows. It
+cites every bullet with a `source_ref`, and returns `known_gaps` / `uncertainty`
+when evidence is missing, stale, mixed, or unsafe to cite. When no readable or
+citable evidence is available, `answer` is `null`; the tool must not fabricate
+uncited facts.
 
 ## Capability Audit Gate
 
@@ -156,6 +158,7 @@ or deciding what Codex memory already supports, inspect current capabilities:
 ```bash
 mcp2cli open-brain --help
 mcp2cli schema open-brain.search_all
+mcp2cli schema open-brain.brain_answer
 mcp2cli schema open-brain.session_start
 mcp2cli schema open-brain.append_session_event
 mcp2cli schema open-brain.session_context

--- a/src/tools/__tests__/brain-answer.test.ts
+++ b/src/tools/__tests__/brain-answer.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "bun:test";
+import { registerBrainAnswer } from "../brain-answer.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  setupMcpClient,
+  parseToolResult,
+  getErrorText,
+} from "./test-helpers.ts";
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    source_type: "thought",
+    id: "thought-1",
+    namespace: "skippy",
+    content_preview: "Use Open Brain for durable Codex memory.",
+    distance: 0.1,
+    tags: ["memory"],
+    created_by: "codex",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    usefulness: 0.7,
+    ...overrides,
+  };
+}
+
+function setupClient(
+  rows: Record<string, unknown>[],
+  auth: AuthInfo | null = { role: "admin", clientId: "admin" },
+) {
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []) => {
+      queries.push({ sql, params });
+      return { rows };
+    },
+  };
+  return {
+    queries,
+    setup: setupMcpClient(registerBrainAnswer, pool, createMockEmbed(), auth),
+  };
+}
+
+describe("brain_answer", () => {
+  it("returns cited answer bullets tied to source refs", async () => {
+    const { setup } = setupClient([
+      row({
+        id: "decision-1",
+        source_type: "decision",
+        content_preview: "Prefer Open Brain as the durable Codex memory system.",
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "What memory system should Codex use?" },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.answer).toContain("[1]");
+      expect(parsed.answer).toContain("Prefer Open Brain");
+      expect(parsed.citations).toHaveLength(1);
+      expect(parsed.citations[0].source_ref).toMatchObject({
+        source: "brain",
+        type: "decision",
+        id: "decision-1",
+        namespace: "skippy",
+      });
+      expect(parsed.citations[0].excerpt).toContain("Prefer Open Brain");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("fails closed with a gap instead of fabricating when no evidence is readable", async () => {
+    const { setup } = setupClient([]);
+    const { client, cleanup } = await setup;
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "Unknown policy" },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.answer).toBeNull();
+      expect(parsed.citations).toEqual([]);
+      expect(parsed.known_gaps[0]).toContain("No readable Open Brain evidence");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("uses namespace predicates before synthesis", async () => {
+    const { setup, queries } = setupClient([row()]);
+    const { client, cleanup } = await setup;
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "memory", namespace: "skippy" },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(queries.some(({ params }) => params.includes("skippy"))).toBe(true);
+      expect(queries.some(({ sql }) => sql.includes("namespace"))).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unreadable namespace filters", async () => {
+    const { setup } = setupClient([], { role: "agent", clientId: "agent-a" });
+    const { client, cleanup } = await setup;
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "memory", namespace: "other-agent" },
+      });
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("namespace read access denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("surfaces stale evidence as uncertainty", async () => {
+    const { setup } = setupClient([
+      row({
+        created_at: "2020-01-01T00:00:00Z",
+        updated_at: "2020-01-01T00:00:00Z",
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "old memory", max_age_days: 30 },
+        }),
+      );
+      expect(parsed.citations[0].stale).toBe(true);
+      expect(parsed.uncertainty.join(" ")).toContain("older than 30 days");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("surfaces contradictory evidence as uncertainty", async () => {
+    const { setup } = setupClient([
+      row({
+        id: "yes-1",
+        content_preview: "Codex should use Open Brain for durable memory.",
+      }),
+      row({
+        id: "no-1",
+        content_preview: "Codex should not use Open Brain for durable memory.",
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "should codex use open brain" },
+        }),
+      );
+      expect(parsed.citations).toHaveLength(2);
+      expect(parsed.uncertainty.join(" ")).toContain(
+        "affirmative and negative",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/brain-answer.test.ts
+++ b/src/tools/__tests__/brain-answer.test.ts
@@ -112,6 +112,25 @@ describe("brain_answer", () => {
     }
   });
 
+  it("does not perform usage-tracking writes from the read-only answer tool", async () => {
+    const { setup, queries } = setupClient([row()]);
+    const { client, cleanup } = await setup;
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "memory" },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(
+        queries.some(({ sql }) =>
+          /\b(UPDATE|INSERT\s+INTO\s+entry_access_log)\b/i.test(sql),
+        ),
+      ).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("denies unreadable namespace filters", async () => {
     const { setup } = setupClient([], { role: "agent", clientId: "agent-a" });
     const { client, cleanup } = await setup;
@@ -177,6 +196,34 @@ describe("brain_answer", () => {
     }
   });
 
+  it("surfaces imperative use and do-not-use contradictions as uncertainty", async () => {
+    const { setup } = setupClient([
+      row({
+        id: "use-1",
+        content_preview: "Use the lowercase Codex home path only.",
+      }),
+      row({
+        id: "do-not-1",
+        content_preview: "Do not use the lowercase Codex home path only.",
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "which codex home path should be used" },
+        }),
+      );
+      expect(parsed.citations).toHaveLength(2);
+      expect(parsed.uncertainty.join(" ")).toContain(
+        "affirmative and negative",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("does not flag reinforcing do-not and use guidance as contradiction", async () => {
     const { setup } = setupClient([
       row({
@@ -226,6 +273,37 @@ describe("brain_answer", () => {
         "lacked citation metadata or usable preview text",
       );
       expect(parsed.raw_results).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("omits null previews and counts only citable evidence", async () => {
+    const { setup } = setupClient([
+      row({
+        id: "valid-1",
+        content_preview: "Use Open Brain when prior Codex context matters.",
+      }),
+      row({
+        id: "null-1",
+        content_preview: null,
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "codex memory" },
+        }),
+      );
+      expect(parsed.evidence_count).toBe(1);
+      expect(parsed.citations).toHaveLength(1);
+      expect(parsed.answer).toContain("Use Open Brain");
+      expect(parsed.known_gaps.join(" ")).toContain(
+        "lacked citation metadata or usable preview text",
+      );
+      expect(parsed.uncertainty.join(" ")).toContain("omitted");
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/brain-answer.test.ts
+++ b/src/tools/__tests__/brain-answer.test.ts
@@ -54,12 +54,13 @@ describe("brain_answer", () => {
     try {
       const result = await client.callTool({
         name: "brain_answer",
-        arguments: { query: "What memory system should Codex use?" },
+        arguments: { query: "What memory system should Codex use?", limit: 1 },
       });
       expect(result.isError).toBeFalsy();
       const parsed = parseToolResult(result);
       expect(parsed.answer).toContain("[1]");
       expect(parsed.answer).toContain("Prefer Open Brain");
+      expect(parsed.known_gaps).toEqual([]);
       expect(parsed.citations).toHaveLength(1);
       expect(parsed.citations[0].source_ref).toMatchObject({
         source: "brain",
@@ -101,7 +102,11 @@ describe("brain_answer", () => {
       });
       expect(result.isError).toBeFalsy();
       expect(queries.some(({ params }) => params.includes("skippy"))).toBe(true);
-      expect(queries.some(({ sql }) => sql.includes("namespace"))).toBe(true);
+      expect(
+        queries.some(({ sql }) =>
+          /WHERE[\s\S]*\.namespace\s*=/.test(sql),
+        ),
+      ).toBe(true);
     } finally {
       await cleanup();
     }
@@ -144,7 +149,7 @@ describe("brain_answer", () => {
     }
   });
 
-  it("surfaces contradictory evidence as uncertainty", async () => {
+  it("surfaces mixed affirmative and negative evidence as uncertainty", async () => {
     const { setup } = setupClient([
       row({
         id: "yes-1",
@@ -167,6 +172,60 @@ describe("brain_answer", () => {
       expect(parsed.uncertainty.join(" ")).toContain(
         "affirmative and negative",
       );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not flag reinforcing do-not and use guidance as contradiction", async () => {
+    const { setup } = setupClient([
+      row({
+        id: "avoid-1",
+        content_preview:
+          "Do not use ~/.codex-clean; use the lowercase Codex home path only.",
+      }),
+      row({
+        id: "use-1",
+        content_preview: "Use the lowercase Codex home path only.",
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "which codex home path should be used" },
+        }),
+      );
+      expect(parsed.uncertainty.join(" ")).not.toContain(
+        "affirmative and negative",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("omits malformed evidence and reports a gap instead of uncited bullets", async () => {
+    const { setup } = setupClient([
+      row({
+        id: "blank-1",
+        content_preview: "   ",
+      }),
+    ]);
+    const { client, cleanup } = await setup;
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "malformed evidence", include_raw: true },
+        }),
+      );
+      expect(parsed.answer).toBeNull();
+      expect(parsed.citations).toEqual([]);
+      expect(parsed.known_gaps.join(" ")).toContain(
+        "lacked citation metadata or usable preview text",
+      );
+      expect(parsed.raw_results).toHaveLength(1);
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/protocol.test.ts
+++ b/src/tools/__tests__/protocol.test.ts
@@ -161,6 +161,59 @@ describe("Protocol tests: write tools via InMemoryTransport", () => {
     });
   });
 
+  describe("brain_answer via protocol", () => {
+    it("returns cited evidence through the full tool registry", async () => {
+      const searchRows = [
+        {
+          source_type: "thought",
+          id: "answer-uuid",
+          namespace: "proto-admin",
+          content_preview: "Use Open Brain for cited Codex memory.",
+          distance: 0.05,
+          tags: ["memory"],
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ];
+      const auth: AuthInfo = { role: "admin", clientId: "proto-admin" };
+      const { client, cleanup } = await createProtocolClient(auth, searchRows);
+
+      try {
+        const result = await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "codex memory" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.answer).toContain("[1]");
+        expect(parsed.citations[0].source_ref).toMatchObject({
+          source: "brain",
+          type: "thought",
+          id: "answer-uuid",
+          namespace: "proto-admin",
+        });
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("returns validation error for empty query", async () => {
+      const auth: AuthInfo = { role: "admin", clientId: "proto-admin" };
+      const { client, cleanup } = await createProtocolClient(auth);
+
+      try {
+        const result = await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "" },
+        });
+
+        expect(result.isError).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+
   describe("find_person via protocol", () => {
     it("name mode returns valid JSON array with admin auth", async () => {
       const personRows = [

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -1,0 +1,267 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import { canReadNamespace, namespaceFilterFor } from "../read-policy.ts";
+import type { AuthInfo, Tier } from "../types.ts";
+import type { ToolDeps } from "./index.ts";
+import {
+  ALL_TABLES,
+  executeSearch,
+  trackUsage,
+  type SearchMode,
+  type SearchRow,
+  type SourceRef,
+} from "./search-brain.ts";
+
+type NamespaceFilter = string | string[];
+
+interface Citation {
+  index: number;
+  source_ref: SourceRef;
+  excerpt: string;
+  score: number;
+  stale: boolean;
+}
+
+function scoreFor(row: SearchRow): number {
+  return row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5);
+}
+
+function sentenceFor(row: SearchRow): string {
+  return row.content_preview.replace(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function rowTimestamp(row: SearchRow): Date | null {
+  const raw = row.source_ref?.last_updated_at ?? row.source_ref?.created_at;
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isStale(row: SearchRow, maxAgeDays: number): boolean {
+  const timestamp = rowTimestamp(row);
+  if (!timestamp) return true;
+  const ageMs = Date.now() - timestamp.getTime();
+  return ageMs > maxAgeDays * 24 * 60 * 60 * 1000;
+}
+
+function polarity(text: string): "positive" | "negative" | "unknown" {
+  const lower = text.toLowerCase();
+  if (/\b(no|not|never|disable|disabled|forbid|avoid|reject)\b/.test(lower)) {
+    return "negative";
+  }
+  if (/\b(yes|should|must|use|enable|enabled|allow|prefer|approved)\b/.test(lower)) {
+    return "positive";
+  }
+  return "unknown";
+}
+
+function hasContradiction(rows: SearchRow[]): boolean {
+  const polarities = new Set(rows.map((row) => polarity(row.content_preview)));
+  return polarities.has("positive") && polarities.has("negative");
+}
+
+function gapMessage(query: string): string {
+  return `No readable Open Brain evidence was found for: ${query}`;
+}
+
+export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "brain_answer",
+    {
+      description:
+        "Answer from readable Open Brain evidence only. Returns cited extractive prose plus known gaps and uncertainty.",
+      inputSchema: {
+        query: z.string().min(1).describe("Question to answer from memory"),
+        namespace: z
+          .string()
+          .trim()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Optional namespace filter; must be readable by caller"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(25)
+          .optional()
+          .describe("Maximum evidence entries to cite (default 5)"),
+        search_mode: z
+          .enum(["hybrid", "vector", "keyword"])
+          .optional()
+          .describe("Retrieval mode (default hybrid)"),
+        tier: z
+          .enum(["hot", "warm", "cold"])
+          .optional()
+          .describe("Optional cognitive tier filter"),
+        max_age_days: z
+          .number()
+          .int()
+          .min(1)
+          .max(3650)
+          .optional()
+          .describe("Evidence older than this is flagged stale (default 180)"),
+        include_raw: z
+          .boolean()
+          .optional()
+          .describe("Include raw retrieved rows for debugging (default false)"),
+      },
+      annotations: {
+        title: "Brain Answer",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const requestedNamespace = args.namespace as string | undefined;
+      if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: namespace read access denied",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const accessibleTables = ALL_TABLES.filter((table) =>
+        canRead(auth.role, table),
+      );
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: no readable tables",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const query = args.query;
+      const limit = args.limit ?? 5;
+      const mode = (args.search_mode as SearchMode) ?? "hybrid";
+      const tier = args.tier as Tier | undefined;
+      const maxAgeDays = args.max_age_days ?? 180;
+      const namespace = namespaceFilterFor(
+        auth,
+        requestedNamespace,
+      ) as NamespaceFilter;
+
+      let rows: SearchRow[];
+      try {
+        rows = await executeSearch(
+          deps,
+          accessibleTables,
+          query,
+          limit,
+          mode,
+          tier,
+          0,
+          namespace,
+          false,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: message }],
+          isError: true,
+        };
+      }
+
+      trackUsage(deps, rows, query, "search", auth.clientId);
+
+      if (rows.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                query,
+                answer: null,
+                evidence_count: 0,
+                citations: [],
+                known_gaps: [gapMessage(query)],
+                uncertainty: ["No readable evidence was available to cite."],
+              }),
+            },
+          ],
+        };
+      }
+
+      const citations: Citation[] = rows.map((row, index) => ({
+        index: index + 1,
+        source_ref: row.source_ref!,
+        excerpt: sentenceFor(row),
+        score: scoreFor(row),
+        stale: isStale(row, maxAgeDays),
+      }));
+      const staleCount = citations.filter((citation) => citation.stale).length;
+      const contradictory = hasContradiction(rows);
+      const knownGaps: string[] = [];
+      const uncertainty: string[] = [];
+
+      if (staleCount > 0) {
+        uncertainty.push(
+          `${staleCount} cited entr${staleCount === 1 ? "y is" : "ies are"} older than ${maxAgeDays} days or missing a usable timestamp.`,
+        );
+      }
+      if (contradictory) {
+        uncertainty.push(
+          "Retrieved evidence contains both affirmative and negative signals; verify before treating this as settled.",
+        );
+      }
+      if (rows.length < limit) {
+        knownGaps.push(
+          `Only ${rows.length} readable evidence entr${rows.length === 1 ? "y was" : "ies were"} found for this query.`,
+        );
+      }
+      if (knownGaps.length === 0 && uncertainty.length === 0) {
+        knownGaps.push("No obvious gaps were detected in the cited evidence.");
+      }
+
+      const answer = [
+        "Based only on retrieved Open Brain evidence:",
+        "",
+        ...citations.map(
+          (citation) => `- ${citation.excerpt} [${citation.index}]`,
+        ),
+      ].join("\n");
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              query,
+              answer,
+              evidence_count: rows.length,
+              citations,
+              known_gaps: knownGaps,
+              uncertainty,
+              raw_results: args.include_raw ? rows : undefined,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -7,7 +7,6 @@ import type { ToolDeps } from "./index.ts";
 import {
   ALL_TABLES,
   executeSearch,
-  trackUsage,
   type SearchMode,
   type SearchRow,
   type SourceRef,
@@ -34,7 +33,10 @@ function scoreFor(row: SearchRow): number {
 }
 
 function excerptFor(row: SearchRow): string | null {
-  const excerpt = row.content_preview.replace(/\s+/g, " ").trim().slice(0, 500);
+  const excerpt = (row.content_preview ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 500);
   return excerpt.length > 0 ? excerpt : null;
 }
 
@@ -86,7 +88,7 @@ function hasConflictingUseTargets(evidence: Evidence[]): boolean {
     }
     for (const target of useTargets(
       lower,
-      /\b(?:should|must)\s+use\s+([^.;,]+)/g,
+      /\b(?<!not\s)(?:should\s+use|must\s+use|use)\s+([^.;,]+)/g,
     )) {
       affirmativeTargets.add(target);
     }
@@ -224,8 +226,6 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      trackUsage(deps, rows, query, "answer", auth.clientId);
-
       if (rows.length === 0) {
         return {
           content: [
@@ -326,10 +326,10 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({
-              query,
-              answer,
-              evidence_count: rows.length,
+              text: JSON.stringify({
+                query,
+                answer,
+                evidence_count: evidence.length,
               citations,
               known_gaps: knownGaps,
               uncertainty,

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -23,12 +23,19 @@ interface Citation {
   stale: boolean;
 }
 
+interface Evidence {
+  row: SearchRow;
+  excerpt: string;
+  source_ref: SourceRef;
+}
+
 function scoreFor(row: SearchRow): number {
   return row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5);
 }
 
-function sentenceFor(row: SearchRow): string {
-  return row.content_preview.replace(/\s+/g, " ").trim().slice(0, 500);
+function excerptFor(row: SearchRow): string | null {
+  const excerpt = row.content_preview.replace(/\s+/g, " ").trim().slice(0, 500);
+  return excerpt.length > 0 ? excerpt : null;
 }
 
 function rowTimestamp(row: SearchRow): Date | null {
@@ -45,20 +52,50 @@ function isStale(row: SearchRow, maxAgeDays: number): boolean {
   return ageMs > maxAgeDays * 24 * 60 * 60 * 1000;
 }
 
-function polarity(text: string): "positive" | "negative" | "unknown" {
-  const lower = text.toLowerCase();
-  if (/\b(no|not|never|disable|disabled|forbid|avoid|reject)\b/.test(lower)) {
-    return "negative";
-  }
-  if (/\b(yes|should|must|use|enable|enabled|allow|prefer|approved)\b/.test(lower)) {
-    return "positive";
-  }
-  return "unknown";
+function normalizeUseTarget(target: string): string {
+  return target
+    .toLowerCase()
+    .replace(/[`~"'()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
-function hasContradiction(rows: SearchRow[]): boolean {
-  const polarities = new Set(rows.map((row) => polarity(row.content_preview)));
-  return polarities.has("positive") && polarities.has("negative");
+function useTargets(
+  text: string,
+  pattern: RegExp,
+): Set<string> {
+  const targets = new Set<string>();
+  for (const match of text.matchAll(pattern)) {
+    const target = normalizeUseTarget(match[1] ?? "");
+    if (target) targets.add(target);
+  }
+  return targets;
+}
+
+function hasConflictingUseTargets(evidence: Evidence[]): boolean {
+  const negativeTargets = new Set<string>();
+  const affirmativeTargets = new Set<string>();
+
+  for (const item of evidence) {
+    const lower = item.excerpt.toLowerCase();
+    for (const target of useTargets(
+      lower,
+      /\b(?:should not|must not|do not|don't|never)\s+use\s+([^.;,]+)/g,
+    )) {
+      negativeTargets.add(target);
+    }
+    for (const target of useTargets(
+      lower,
+      /\b(?:should|must)\s+use\s+([^.;,]+)/g,
+    )) {
+      affirmativeTargets.add(target);
+    }
+  }
+
+  for (const target of negativeTargets) {
+    if (affirmativeTargets.has(target)) return true;
+  }
+  return false;
 }
 
 function gapMessage(query: string): string {
@@ -70,7 +107,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
     "brain_answer",
     {
       description:
-        "Answer from readable Open Brain evidence only. Returns cited extractive prose plus known gaps and uncertainty.",
+        "Render cited evidence from readable Open Brain rows only. Returns extractive bullets plus known gaps and uncertainty.",
       inputSchema: {
         query: z.string().min(1).describe("Question to answer from memory"),
         namespace: z
@@ -187,7 +224,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      trackUsage(deps, rows, query, "search", auth.clientId);
+      trackUsage(deps, rows, query, "answer", auth.clientId);
 
       if (rows.length === 0) {
         return {
@@ -207,39 +244,78 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      const citations: Citation[] = rows.map((row, index) => ({
-        index: index + 1,
-        source_ref: row.source_ref!,
-        excerpt: sentenceFor(row),
-        score: scoreFor(row),
-        stale: isStale(row, maxAgeDays),
-      }));
-      const staleCount = citations.filter((citation) => citation.stale).length;
-      const contradictory = hasContradiction(rows);
+      const evidence: Evidence[] = [];
       const knownGaps: string[] = [];
       const uncertainty: string[] = [];
+
+      for (const row of rows) {
+        const excerpt = excerptFor(row);
+        if (!row.source_ref || !excerpt) {
+          knownGaps.push(
+            `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
+          );
+          continue;
+        }
+        evidence.push({ row, excerpt, source_ref: row.source_ref });
+      }
+
+      if (evidence.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                query,
+                answer: null,
+                evidence_count: 0,
+                citations: [],
+                known_gaps: [
+                  ...knownGaps,
+                  "No retrieved evidence had both citation metadata and usable preview text.",
+                ],
+                uncertainty: [
+                  "Readable rows were retrieved, but none were safe to cite.",
+                ],
+                raw_results: args.include_raw ? rows : undefined,
+              }),
+            },
+          ],
+        };
+      }
+
+      const citations: Citation[] = evidence.map((item, index) => ({
+        index: index + 1,
+        source_ref: item.source_ref,
+        excerpt: item.excerpt,
+        score: scoreFor(item.row),
+        stale: isStale(item.row, maxAgeDays),
+      }));
+      const staleCount = citations.filter((citation) => citation.stale).length;
+      const hasMixedUseTargets = hasConflictingUseTargets(evidence);
 
       if (staleCount > 0) {
         uncertainty.push(
           `${staleCount} cited entr${staleCount === 1 ? "y is" : "ies are"} older than ${maxAgeDays} days or missing a usable timestamp.`,
         );
       }
-      if (contradictory) {
+      if (hasMixedUseTargets) {
         uncertainty.push(
-          "Retrieved evidence contains both affirmative and negative signals; verify before treating this as settled.",
+          "Retrieved evidence contains both affirmative and negative wording; verify whether these are truly contradictory before treating this as settled.",
         );
       }
-      if (rows.length < limit) {
+      if (evidence.length < rows.length) {
+        uncertainty.push(
+          "Some retrieved rows were omitted because they were not safe to cite.",
+        );
+      }
+      if (evidence.length < limit) {
         knownGaps.push(
-          `Only ${rows.length} readable evidence entr${rows.length === 1 ? "y was" : "ies were"} found for this query.`,
+          `Only ${evidence.length} citable evidence entr${evidence.length === 1 ? "y was" : "ies were"} found for this query.`,
         );
-      }
-      if (knownGaps.length === 0 && uncertainty.length === 0) {
-        knownGaps.push("No obvious gaps were detected in the cited evidence.");
       }
 
       const answer = [
-        "Based only on retrieved Open Brain evidence:",
+        "Cited Open Brain evidence:",
         "",
         ...citations.map(
           (citation) => `- ${citation.excerpt} [${citation.index}]`,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,7 @@ import { registerListStale } from "./list-stale.ts";
 import { registerUpdateEntry } from "./update-entry.ts";
 import { registerRateEntry } from "./rate-entry.ts";
 import { registerSearchAll } from "./search-all.ts";
+import { registerBrainAnswer } from "./brain-answer.ts";
 import { registerUpsertPerson } from "./upsert-person.ts";
 import { registerSetTier } from "./set-tier.ts";
 import { registerGetEntry } from "./get-entry.ts";
@@ -55,6 +56,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerUpdateEntry(server, deps);
   registerRateEntry(server, deps);
   registerSearchAll(server, deps);
+  registerBrainAnswer(server, deps);
   registerUpsertPerson(server, deps);
   registerSetTier(server, deps);
   registerGetEntry(server, deps);

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -286,21 +286,24 @@ async function searchOB(
 
   trackUsage(deps, rows, query, "search", auth.clientId);
 
-  return rows.map((row) => ({
-    source: "brain" as const,
-    type: row.source_type,
-    content: row.content_preview.slice(0, 300),
-    score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
-    source_ref: row.source_ref ?? {
+  return rows.map((row) => {
+    const preview = row.content_preview ?? "";
+    return {
       source: "brain" as const,
       type: row.source_type,
+      content: preview.slice(0, 300),
+      score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
+      source_ref: row.source_ref ?? {
+        source: "brain" as const,
+        type: row.source_type,
+        id: row.id,
+        label: preview.slice(0, 120),
+        preview: preview.slice(0, 300),
+      },
       id: row.id,
-      label: row.content_preview.slice(0, 120),
-      preview: row.content_preview.slice(0, 300),
-    },
-    id: row.id,
-    tags: row.tags ?? undefined,
-    tier: row.tier,
-    explicit_links: row.explicit_links,
-  }));
+      tags: row.tags ?? undefined,
+      tier: row.tier,
+      explicit_links: row.explicit_links,
+    };
+  });
 }

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -89,7 +89,7 @@ export interface SearchRow {
   source_type: string;
   id: string;
   namespace?: string;
-  content_preview: string;
+  content_preview: string | null;
   tags: string[] | null;
   created_by?: string | null;
   created_at: string;
@@ -145,8 +145,8 @@ function withSourceRefs(rows: SearchRow[]): SearchRow[] {
       created_by: row.created_by,
       created_at: toIsoString(row.created_at),
       last_updated_at: toIsoString(row.updated_at) ?? toIsoString(row.created_at),
-      label: row.content_preview.slice(0, 120),
-      preview: row.content_preview.slice(0, 300),
+      label: (row.content_preview ?? "").slice(0, 120),
+      preview: (row.content_preview ?? "").slice(0, 300),
     },
   }));
 }


### PR DESCRIPTION
## Summary

- Adds `brain_answer`, a read-only extractive memory answer tool over Open Brain retrieval.
- Returns cited answer bullets, citation source refs, known gaps, and uncertainty instead of fabricating uncited facts.
- Preserves readable namespace enforcement before synthesis and documents Codex usage.

## Behavior

- Uses hybrid Open Brain retrieval by default.
- Cites every answer bullet with returned `source_ref` identity.
- Returns `answer: null` with gaps when no readable evidence exists.
- Flags stale evidence and simple contradictory evidence as uncertainty.
- Supports `include_raw` for debugging while keeping default output citation-focused.

Closes #107

## Validation

- `bun test src/tools/__tests__/brain-answer.test.ts` passed.
- `bun run typecheck` passed.
- `git diff --check` passed.
- `bun test` passed, 626 pass / 16 skip / 0 fail.
