### PR TITLE
feat: add Open Brain memory eval harness

### DIFF
--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -1,0 +1,49 @@
+# Open Brain Memory Evals
+
+This is the first Open Brain-native memory quality harness for the Codex durable
+memory goal. It borrows the benchmark shape from BrainBench/gbrain-evals:
+synthetic public corpus, sealed expected answers, deterministic runner,
+scorecard output, and reproducible local commands.
+
+The smoke suite is intentionally offline. It does not call PostgreSQL,
+LiteLLM, or private memory. It validates the harness contract and gives later
+issues a place to add live adapters and Codex workflow scenarios.
+
+## Run
+
+```bash
+bun run eval:memory
+bun run eval:memory -- --json
+bun run eval:memory -- --report eval/open-brain/reports/latest.json
+```
+
+Reports are only written when `--report` is supplied. Use a visible repo path
+when the report is intended to be durable; otherwise write scratch reports under
+`/Volumes/ThunderBolt/_tmp`.
+
+## Fixture Layout
+
+- `fixtures/memory-smoke.json`: synthetic corpus plus sealed probe expectations.
+- `runner.ts`: deterministic retrieval, scoring, uncertainty, and scorecard code.
+- `__tests__/runner.test.ts`: tests for sealed answers, namespace isolation,
+  stale/contradiction uncertainty, and aggregate scorecards.
+
+## Current Categories
+
+- Recall: relevant memory appears in top K.
+- Precision: top K is not mostly junk.
+- Temporal correctness: stale facts are surfaced.
+- Identity resolution: similar people are distinguished.
+- Citation grounding: expected source refs are cited.
+- Contradiction handling: conflicting memories are surfaced as uncertainty.
+- Namespace isolation: unreadable namespace entries are not returned.
+- Scale/performance: smoke latency is tracked against an expanded-corpus target.
+
+## Next Expansion Points
+
+- Add a live Open Brain adapter that loads synthetic fixtures into an isolated
+  namespace and calls `search_brain` / `brain_answer`.
+- Add Codex workflow probes for session resume, user decision reuse, validation
+  receipt lookup, stale-memory avoidance, and memory citation behavior.
+- Publish durable scorecards only when the corpus and command are intentionally
+  pinned for comparison.

--- a/eval/open-brain/__tests__/runner.test.ts
+++ b/eval/open-brain/__tests__/runner.test.ts
@@ -20,6 +20,26 @@ describe("Open Brain memory eval runner", () => {
     const score = scoreProbe(typedFixture.corpus, probe!);
     expect(score.passed).toBe(true);
     expect(score.retrieved_ids).not.toContain("private-secret-project");
+    expect(score.retrieved_ids).toEqual([]);
+  });
+
+  it("fails namespace probes when readable junk is retrieved", () => {
+    const probe = typedFixture.probes.find((item) => item.id === "namespace-private-leak");
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedFixture.corpus, {
+      ...probe!,
+      readable_namespaces: ["skippy", "collab"],
+    });
+    expect(score.passed).toBe(false);
+    expect(score.failures).toContain("expected no retrievable evidence");
+  });
+
+  it("fails probes that retrieve declared junk ids", () => {
+    const probe = typedFixture.probes.find((item) => item.id === "identity-rico-rika");
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedFixture.corpus, { ...probe!, top_k: 3 });
+    expect(score.passed).toBe(false);
+    expect(score.failures).toContain("retrieved declared junk person-rika");
   });
 
   it("surfaces stale and contradictory memory as uncertainty", () => {
@@ -33,6 +53,40 @@ describe("Open Brain memory eval runner", () => {
     );
     expect(temporal.uncertainty).toContain("stale");
     expect(contradiction.uncertainty).toContain("contradiction");
+  });
+
+  it("does not flag a single negative use statement as a contradiction", () => {
+    const score = scoreProbe(
+      [
+        {
+          id: "negative-only",
+          namespace: "skippy",
+          type: "decision",
+          title: "Negative only",
+          content: "Do not use ~/.codex-clean for active work.",
+          tags: [],
+          created_at: "2026-06-15T00:00:00.000Z",
+          source_ref: {
+            source: "brain",
+            type: "decision",
+            id: "negative-only",
+            namespace: "skippy",
+            label: "Negative only",
+            preview: "Do not use ~/.codex-clean for active work.",
+            created_at: "2026-06-15T00:00:00.000Z",
+          },
+        },
+      ],
+      {
+        id: "negative-only-probe",
+        category: "contradiction",
+        query: "codex clean active work",
+        readable_namespaces: ["skippy"],
+        top_k: 5,
+        relevant_ids: ["negative-only"],
+      },
+    );
+    expect(score.uncertainty).not.toContain("contradiction");
   });
 
   it("produces a passing aggregate scorecard for the smoke fixture", () => {

--- a/eval/open-brain/__tests__/runner.test.ts
+++ b/eval/open-brain/__tests__/runner.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import fixture from "../fixtures/memory-smoke.json" assert { type: "json" };
+import { retrieve, runEvalSuite, scoreProbe } from "../runner.ts";
+import type { EvalFixture } from "../types.ts";
+
+const typedFixture = fixture as EvalFixture;
+
+describe("Open Brain memory eval runner", () => {
+  it("keeps gold answers sealed outside retrieved public results", () => {
+    const probe = typedFixture.probes.find((item) => item.id === "recall-temp-root");
+    expect(probe).toBeDefined();
+    const results = retrieve(typedFixture.corpus, probe!);
+    expect(results[0]?.entry.id).toBe("thought-temp-root");
+    expect(results[0]).not.toHaveProperty("relevant_ids");
+  });
+
+  it("blocks unreadable namespace evidence", () => {
+    const probe = typedFixture.probes.find((item) => item.id === "namespace-private-leak");
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedFixture.corpus, probe!);
+    expect(score.passed).toBe(true);
+    expect(score.retrieved_ids).not.toContain("private-secret-project");
+  });
+
+  it("surfaces stale and contradictory memory as uncertainty", () => {
+    const temporal = scoreProbe(
+      typedFixture.corpus,
+      typedFixture.probes.find((item) => item.id === "temporal-runner-policy")!,
+    );
+    const contradiction = scoreProbe(
+      typedFixture.corpus,
+      typedFixture.probes.find((item) => item.id === "contradiction-codex-home")!,
+    );
+    expect(temporal.uncertainty).toContain("stale");
+    expect(contradiction.uncertainty).toContain("contradiction");
+  });
+
+  it("produces a passing aggregate scorecard for the smoke fixture", () => {
+    const scorecard = runEvalSuite(typedFixture, {
+      commit: "test",
+      generatedAt: "2026-06-15T00:00:00.000Z",
+    });
+    expect(scorecard.probes_total).toBe(8);
+    expect(scorecard.probes_failed).toBe(0);
+    expect(scorecard.metrics.namespace_leak_count).toBe(0);
+    expect(scorecard.metrics.recall_at_k).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/eval/open-brain/fixtures/memory-smoke.json
+++ b/eval/open-brain/fixtures/memory-smoke.json
@@ -1,0 +1,321 @@
+{
+  "schema_version": 1,
+  "corpus_id": "open-brain-memory-smoke-v1",
+  "generated_at": "2026-06-15T00:00:00.000Z",
+  "corpus": [
+    {
+      "id": "decision-codex-home",
+      "namespace": "skippy",
+      "type": "decision",
+      "title": "Codex home path decision",
+      "content": "Use the lowercase Codex home path only. ~/.codex-clean is the clean sidecar and must not be treated as the live home.",
+      "tags": ["codex", "policy", "path"],
+      "aliases": ["lowercase Codex home", "codex home"],
+      "created_at": "2026-06-01T10:00:00.000Z",
+      "updated_at": "2026-06-10T10:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-codex-home",
+        "namespace": "skippy",
+        "label": "Codex home path decision",
+        "preview": "Use the lowercase Codex home path only.",
+        "created_at": "2026-06-01T10:00:00.000Z",
+        "last_updated_at": "2026-06-10T10:00:00.000Z"
+      }
+    },
+    {
+      "id": "thought-temp-root",
+      "namespace": "skippy",
+      "type": "thought",
+      "title": "ThunderBolt temp root",
+      "content": "Codex temporary worktrees, review checkouts, generated patches, downloads, and one-off test artifacts belong under /Volumes/ThunderBolt/_tmp.",
+      "tags": ["codex", "temp", "workflow"],
+      "aliases": ["tmp root", "temporary worktree path"],
+      "created_at": "2026-06-11T08:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "thought",
+        "id": "thought-temp-root",
+        "namespace": "skippy",
+        "label": "ThunderBolt temp root",
+        "preview": "Codex temporary work belongs under /Volumes/ThunderBolt/_tmp.",
+        "created_at": "2026-06-11T08:00:00.000Z"
+      }
+    },
+    {
+      "id": "decision-pai-memory",
+      "namespace": "collab",
+      "type": "decision",
+      "title": "PAI memory operating model",
+      "content": "Open Brain is the durable operational memory for PAI agents. Memory-derived answers must cite source references and call out known gaps.",
+      "tags": ["memory", "open-brain", "citations"],
+      "aliases": ["durable memory", "open brain memory"],
+      "created_at": "2026-06-14T12:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-pai-memory",
+        "namespace": "collab",
+        "label": "PAI memory operating model",
+        "preview": "Open Brain is the durable operational memory for PAI agents.",
+        "created_at": "2026-06-14T12:00:00.000Z"
+      }
+    },
+    {
+      "id": "person-rico",
+      "namespace": "collab",
+      "type": "relationship",
+      "title": "Rico profile",
+      "content": "Rico prefers board-first goal runs, live evidence, and critical review gates before merging production-impacting PRs.",
+      "tags": ["person", "rico", "workflow"],
+      "aliases": ["Rico", "rodaddy"],
+      "created_at": "2026-06-13T09:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "relationship",
+        "id": "person-rico",
+        "namespace": "collab",
+        "label": "Rico profile",
+        "preview": "Rico prefers board-first goal runs and live evidence.",
+        "created_at": "2026-06-13T09:00:00.000Z"
+      }
+    },
+    {
+      "id": "person-rika",
+      "namespace": "collab",
+      "type": "relationship",
+      "title": "Rika profile",
+      "content": "Rika is a synthetic designer persona who prefers playful mockups and is unrelated to Rico's infrastructure workflow.",
+      "tags": ["person", "rika", "synthetic"],
+      "aliases": ["Rika"],
+      "created_at": "2026-06-13T09:05:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "relationship",
+        "id": "person-rika",
+        "namespace": "collab",
+        "label": "Rika profile",
+        "preview": "Rika is a synthetic designer persona.",
+        "created_at": "2026-06-13T09:05:00.000Z"
+      }
+    },
+    {
+      "id": "decision-runner-old",
+      "namespace": "collab",
+      "type": "decision",
+      "title": "Old runner policy",
+      "content": "Old note: use GitHub-hosted runners for King Capital automation.",
+      "tags": ["runner", "stale"],
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-runner-old",
+        "namespace": "collab",
+        "label": "Old runner policy",
+        "preview": "Old note: use GitHub-hosted runners.",
+        "created_at": "2024-01-01T00:00:00.000Z"
+      }
+    },
+    {
+      "id": "decision-runner-new",
+      "namespace": "collab",
+      "type": "decision",
+      "title": "Current runner policy",
+      "content": "Current policy: King Capital automation should use the King self-hosted runner fleet, not personal local quota.",
+      "tags": ["runner", "current", "king-capital"],
+      "created_at": "2026-06-12T00:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-runner-new",
+        "namespace": "collab",
+        "label": "Current runner policy",
+        "preview": "King Capital automation should use the King self-hosted runner fleet.",
+        "created_at": "2026-06-12T00:00:00.000Z"
+      }
+    },
+    {
+      "id": "contradict-use-home",
+      "namespace": "skippy",
+      "type": "thought",
+      "title": "Use live Codex home",
+      "content": "Use the lowercase Codex home path only.",
+      "tags": ["codex", "contradiction-fixture"],
+      "created_at": "2026-06-14T00:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "thought",
+        "id": "contradict-use-home",
+        "namespace": "skippy",
+        "label": "Use live Codex home",
+        "preview": "Use the lowercase Codex home path only.",
+        "created_at": "2026-06-14T00:00:00.000Z"
+      }
+    },
+    {
+      "id": "contradict-do-not-use-home",
+      "namespace": "skippy",
+      "type": "thought",
+      "title": "Conflicting Codex home claim",
+      "content": "Do not use the lowercase Codex home path only.",
+      "tags": ["codex", "contradiction-fixture"],
+      "created_at": "2026-06-14T00:05:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "thought",
+        "id": "contradict-do-not-use-home",
+        "namespace": "skippy",
+        "label": "Conflicting Codex home claim",
+        "preview": "Do not use the lowercase Codex home path only.",
+        "created_at": "2026-06-14T00:05:00.000Z"
+      }
+    },
+    {
+      "id": "private-secret-project",
+      "namespace": "private-agent",
+      "type": "project",
+      "title": "Private project fixture",
+      "content": "Private namespace fixture that must never appear for a skippy-only caller.",
+      "tags": ["private", "namespace"],
+      "created_at": "2026-06-15T00:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "project",
+        "id": "private-secret-project",
+        "namespace": "private-agent",
+        "label": "Private project fixture",
+        "preview": "Private namespace fixture.",
+        "created_at": "2026-06-15T00:00:00.000Z"
+      }
+    },
+    {
+      "id": "junk-browser-memory",
+      "namespace": "collab",
+      "type": "thought",
+      "title": "Browser memory pressure",
+      "content": "Browser tab sleeping and discarding can reduce local macOS memory pressure.",
+      "tags": ["browser", "memory", "macos"],
+      "created_at": "2026-06-14T15:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "thought",
+        "id": "junk-browser-memory",
+        "namespace": "collab",
+        "label": "Browser memory pressure",
+        "preview": "Browser tab sleeping can reduce memory pressure.",
+        "created_at": "2026-06-14T15:00:00.000Z"
+      }
+    },
+    {
+      "id": "scale-codex-memory-001",
+      "namespace": "collab",
+      "type": "session",
+      "title": "Scale fixture target",
+      "content": "Scale target: Codex durable memory eval harness should remain fast over a synthetic expanded corpus.",
+      "tags": ["scale", "eval", "target"],
+      "created_at": "2026-06-15T01:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "session",
+        "id": "scale-codex-memory-001",
+        "namespace": "collab",
+        "label": "Scale fixture target",
+        "preview": "Codex durable memory eval harness should remain fast.",
+        "created_at": "2026-06-15T01:00:00.000Z"
+      }
+    }
+  ],
+  "probes": [
+    {
+      "id": "recall-temp-root",
+      "category": "recall",
+      "query": "Where should Codex put temporary worktrees?",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 3,
+      "relevant_ids": ["thought-temp-root"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.33
+    },
+    {
+      "id": "precision-memory-model",
+      "category": "precision",
+      "query": "Open Brain durable operational memory citations known gaps",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 3,
+      "relevant_ids": ["decision-pai-memory"],
+      "junk_ids": ["junk-browser-memory"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.33
+    },
+    {
+      "id": "temporal-runner-policy",
+      "category": "temporal",
+      "query": "current King Capital runner policy",
+      "readable_namespaces": ["collab"],
+      "top_k": 3,
+      "relevant_ids": ["decision-runner-new"],
+      "expected_uncertainty": ["stale"],
+      "max_age_days": 30,
+      "as_of": "2026-06-15T00:00:00.000Z",
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.33
+    },
+    {
+      "id": "identity-rico-rika",
+      "category": "identity",
+      "query": "Rico board first workflow preference",
+      "readable_namespaces": ["collab"],
+      "top_k": 3,
+      "relevant_ids": ["person-rico"],
+      "junk_ids": ["person-rika"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.33
+    },
+    {
+      "id": "citation-brain-answer",
+      "category": "citation",
+      "query": "What should memory-derived Open Brain answers include?",
+      "readable_namespaces": ["collab"],
+      "top_k": 3,
+      "relevant_ids": ["decision-pai-memory"],
+      "expected_citation_ids": ["decision-pai-memory"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.33
+    },
+    {
+      "id": "contradiction-codex-home",
+      "category": "contradiction",
+      "query": "should Codex use the lowercase Codex home path only",
+      "readable_namespaces": ["skippy"],
+      "top_k": 5,
+      "relevant_ids": ["contradict-use-home", "contradict-do-not-use-home"],
+      "expected_uncertainty": ["contradiction"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.4
+    },
+    {
+      "id": "namespace-private-leak",
+      "category": "namespace",
+      "query": "private namespace fixture project",
+      "readable_namespaces": ["skippy"],
+      "top_k": 5,
+      "relevant_ids": [],
+      "expected_forbidden_ids": ["private-secret-project"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "scale-smoke",
+      "category": "scale",
+      "query": "synthetic expanded corpus Codex durable memory eval target",
+      "readable_namespaces": ["collab"],
+      "top_k": 5,
+      "relevant_ids": ["scale-codex-memory-001"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.2,
+      "max_latency_ms": 50
+    }
+  ]
+}

--- a/eval/open-brain/fixtures/memory-smoke.json
+++ b/eval/open-brain/fixtures/memory-smoke.json
@@ -243,7 +243,7 @@
       "category": "precision",
       "query": "Open Brain durable operational memory citations known gaps",
       "readable_namespaces": ["skippy", "collab"],
-      "top_k": 3,
+      "top_k": 1,
       "relevant_ids": ["decision-pai-memory"],
       "junk_ids": ["junk-browser-memory"],
       "min_recall_at_k": 1,
@@ -267,7 +267,7 @@
       "category": "identity",
       "query": "Rico board first workflow preference",
       "readable_namespaces": ["collab"],
-      "top_k": 3,
+      "top_k": 1,
       "relevant_ids": ["person-rico"],
       "junk_ids": ["person-rika"],
       "min_recall_at_k": 1,
@@ -303,8 +303,9 @@
       "top_k": 5,
       "relevant_ids": [],
       "expected_forbidden_ids": ["private-secret-project"],
+      "expect_no_results": true,
       "min_recall_at_k": 1,
-      "min_precision_at_k": 1
+      "min_precision_at_k": 0
     },
     {
       "id": "scale-smoke",

--- a/eval/open-brain/runner.ts
+++ b/eval/open-brain/runner.ts
@@ -76,7 +76,7 @@ function recallAtK(retrievedIds: string[], relevantIds: string[]): number {
 
 function precisionAtK(retrievedIds: string[], relevantIds: string[]): number {
   if (retrievedIds.length === 0) return relevantIds.length === 0 ? 1 : 0;
-  if (relevantIds.length === 0) return 1;
+  if (relevantIds.length === 0) return 0;
   const hits = retrievedIds.filter((id) => relevantIds.includes(id)).length;
   return hits / retrievedIds.length;
 }
@@ -105,17 +105,23 @@ function hasUseContradiction(entries: EvalCorpusEntry[]): boolean {
   const affirmative = new Set<string>();
   const negative = new Set<string>();
   for (const entry of entries) {
-    for (const target of normalizedUseTargets(
+    const negativeTargets = normalizedUseTargets(
       entry.content,
+      /\b(?:should not|must not|do not|don't|never)\s+use\s+([^.;,]+)/g,
+    );
+    for (const target of negativeTargets) {
+      negative.add(target);
+    }
+
+    const withoutNegativeUse = entry.content.replace(
+      /\b(?:should not|must not|do not|don't|never)\s+use\s+[^.;,]+/gi,
+      " ",
+    );
+    for (const target of normalizedUseTargets(
+      withoutNegativeUse,
       /\b(?:should\s+use|must\s+use|use)\s+([^.;,]+)/g,
     )) {
       affirmative.add(target);
-    }
-    for (const target of normalizedUseTargets(
-      entry.content,
-      /\b(?:should not|must not|do not|don't|never)\s+use\s+([^.;,]+)/g,
-    )) {
-      negative.add(target);
     }
   }
   return Array.from(negative).some((target) => affirmative.has(target));
@@ -150,6 +156,14 @@ export function scoreProbe(corpus: EvalCorpusEntry[], probe: EvalProbe): ProbeSc
   }
   if (forbiddenIds.some((id) => retrievedIds.includes(id))) {
     failures.push("retrieved forbidden namespace evidence");
+  }
+  if (probe.expect_no_results && retrievedIds.length > 0) {
+    failures.push("expected no retrievable evidence");
+  }
+  for (const junkId of probe.junk_ids ?? []) {
+    if (retrievedIds.includes(junkId)) {
+      failures.push(`retrieved declared junk ${junkId}`);
+    }
   }
   for (const expectedCitation of probe.expected_citation_ids ?? []) {
     if (!citationIds.includes(expectedCitation)) {

--- a/eval/open-brain/runner.ts
+++ b/eval/open-brain/runner.ts
@@ -1,0 +1,260 @@
+import type {
+  EvalCategory,
+  EvalCorpusEntry,
+  EvalFixture,
+  EvalProbe,
+  EvalScorecard,
+  ProbeScore,
+  RankedEvalResult,
+} from "./types.ts";
+
+const CATEGORY_ORDER: EvalCategory[] = [
+  "recall",
+  "precision",
+  "temporal",
+  "identity",
+  "citation",
+  "contradiction",
+  "namespace",
+  "scale",
+];
+
+function tokenize(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .toLowerCase()
+        .replace(/[^a-z0-9/_-]+/g, " ")
+        .split(/\s+/)
+        .filter((token) => token.length > 2),
+    ),
+  );
+}
+
+function entryText(entry: EvalCorpusEntry): string {
+  return [
+    entry.title,
+    entry.content,
+    entry.tags.join(" "),
+    (entry.aliases ?? []).join(" "),
+  ].join(" ");
+}
+
+function scoreEntry(queryTokens: string[], entry: EvalCorpusEntry): number {
+  const textTokens = new Set(tokenize(entryText(entry)));
+  const overlap = queryTokens.filter((token) => textTokens.has(token)).length;
+  const aliasBoost = (entry.aliases ?? []).some((alias) =>
+    queryTokens.some((token) => tokenize(alias).includes(token)),
+  )
+    ? 0.5
+    : 0;
+  return overlap + aliasBoost;
+}
+
+export function retrieve(
+  corpus: EvalCorpusEntry[],
+  probe: EvalProbe,
+): RankedEvalResult[] {
+  const queryTokens = tokenize(probe.query);
+  return corpus
+    .filter((entry) => probe.readable_namespaces.includes(entry.namespace))
+    .map((entry) => ({ entry, score: scoreEntry(queryTokens, entry) }))
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return a.entry.id.localeCompare(b.entry.id);
+    })
+    .slice(0, probe.top_k)
+    .map((result, index) => ({ ...result, rank: index + 1 }));
+}
+
+function recallAtK(retrievedIds: string[], relevantIds: string[]): number {
+  if (relevantIds.length === 0) return 1;
+  const hits = relevantIds.filter((id) => retrievedIds.includes(id)).length;
+  return hits / relevantIds.length;
+}
+
+function precisionAtK(retrievedIds: string[], relevantIds: string[]): number {
+  if (retrievedIds.length === 0) return relevantIds.length === 0 ? 1 : 0;
+  if (relevantIds.length === 0) return 1;
+  const hits = retrievedIds.filter((id) => relevantIds.includes(id)).length;
+  return hits / retrievedIds.length;
+}
+
+function isStale(entry: EvalCorpusEntry, probe: EvalProbe): boolean {
+  if (!probe.max_age_days || !probe.as_of) return false;
+  const asOf = new Date(probe.as_of).getTime();
+  const updatedAt = new Date(entry.updated_at ?? entry.created_at).getTime();
+  if (Number.isNaN(asOf) || Number.isNaN(updatedAt)) return true;
+  return asOf - updatedAt > probe.max_age_days * 24 * 60 * 60 * 1000;
+}
+
+function normalizedUseTargets(content: string, pattern: RegExp): string[] {
+  const targets: string[] = [];
+  for (const match of content.toLowerCase().matchAll(pattern)) {
+    const target = (match[1] ?? "")
+      .replace(/[`~"'()]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (target) targets.push(target);
+  }
+  return targets;
+}
+
+function hasUseContradiction(entries: EvalCorpusEntry[]): boolean {
+  const affirmative = new Set<string>();
+  const negative = new Set<string>();
+  for (const entry of entries) {
+    for (const target of normalizedUseTargets(
+      entry.content,
+      /\b(?:should\s+use|must\s+use|use)\s+([^.;,]+)/g,
+    )) {
+      affirmative.add(target);
+    }
+    for (const target of normalizedUseTargets(
+      entry.content,
+      /\b(?:should not|must not|do not|don't|never)\s+use\s+([^.;,]+)/g,
+    )) {
+      negative.add(target);
+    }
+  }
+  return Array.from(negative).some((target) => affirmative.has(target));
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index] ?? 0;
+}
+
+export function scoreProbe(corpus: EvalCorpusEntry[], probe: EvalProbe): ProbeScore {
+  const started = performance.now();
+  const ranked = retrieve(corpus, probe);
+  const latencyMs = Math.max(0, performance.now() - started);
+  const retrievedIds = ranked.map(({ entry }) => entry.id);
+  const entries = ranked.map(({ entry }) => entry);
+  const failures: string[] = [];
+  const uncertainty: string[] = [];
+
+  const recall = recallAtK(retrievedIds, probe.relevant_ids);
+  const precision = precisionAtK(retrievedIds, probe.relevant_ids);
+  const citationIds = entries.map((entry) => entry.source_ref.id);
+  const forbiddenIds = probe.expected_forbidden_ids ?? [];
+
+  if (recall < (probe.min_recall_at_k ?? 1)) {
+    failures.push(`recall ${recall.toFixed(3)} below threshold`);
+  }
+  if (precision < (probe.min_precision_at_k ?? 0)) {
+    failures.push(`precision ${precision.toFixed(3)} below threshold`);
+  }
+  if (forbiddenIds.some((id) => retrievedIds.includes(id))) {
+    failures.push("retrieved forbidden namespace evidence");
+  }
+  for (const expectedCitation of probe.expected_citation_ids ?? []) {
+    if (!citationIds.includes(expectedCitation)) {
+      failures.push(`missing expected citation ${expectedCitation}`);
+    }
+  }
+  if (entries.some((entry) => isStale(entry, probe))) {
+    uncertainty.push("stale");
+  }
+  if (hasUseContradiction(entries)) {
+    uncertainty.push("contradiction");
+  }
+  for (const expected of probe.expected_uncertainty ?? []) {
+    if (!uncertainty.includes(expected)) {
+      failures.push(`missing expected uncertainty ${expected}`);
+    }
+  }
+  if (probe.max_latency_ms && latencyMs > probe.max_latency_ms) {
+    failures.push(`latency ${latencyMs.toFixed(3)}ms above threshold`);
+  }
+
+  return {
+    id: probe.id,
+    category: probe.category,
+    passed: failures.length === 0,
+    recall_at_k: recall,
+    precision_at_k: precision,
+    latency_ms: Number(latencyMs.toFixed(3)),
+    retrieved_ids: retrievedIds,
+    citation_ids: citationIds,
+    uncertainty,
+    failures,
+  };
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function runEvalSuite(
+  fixture: EvalFixture,
+  opts: { commit?: string; generatedAt?: string } = {},
+): EvalScorecard {
+  const probes = fixture.probes.map((probe) => scoreProbe(fixture.corpus, probe));
+  const categories = Object.fromEntries(
+    CATEGORY_ORDER.map((category) => {
+      const categoryProbes = probes.filter((probe) => probe.category === category);
+      return [
+        category,
+        {
+          probes_total: categoryProbes.length,
+          probes_passed: categoryProbes.filter((probe) => probe.passed).length,
+          recall_at_k: Number(mean(categoryProbes.map((probe) => probe.recall_at_k)).toFixed(3)),
+          precision_at_k: Number(
+            mean(categoryProbes.map((probe) => probe.precision_at_k)).toFixed(3),
+          ),
+        },
+      ];
+    }),
+  ) as EvalScorecard["categories"];
+  const citationProbes = probes.filter((probe) => probe.category === "citation");
+
+  return {
+    schema_version: 1,
+    suite: "open-brain-memory",
+    corpus_id: fixture.corpus_id,
+    commit: opts.commit ?? "unknown",
+    generated_at: opts.generatedAt ?? new Date().toISOString(),
+    probes_total: probes.length,
+    probes_passed: probes.filter((probe) => probe.passed).length,
+    probes_failed: probes.filter((probe) => !probe.passed).length,
+    metrics: {
+      recall_at_k: Number(mean(probes.map((probe) => probe.recall_at_k)).toFixed(3)),
+      precision_at_k: Number(mean(probes.map((probe) => probe.precision_at_k)).toFixed(3)),
+      citation_grounding: Number(
+        mean(citationProbes.map((probe) => (probe.failures.length === 0 ? 1 : 0))).toFixed(3),
+      ),
+      namespace_leak_count: probes.filter((probe) =>
+        probe.failures.includes("retrieved forbidden namespace evidence"),
+      ).length,
+      p95_latency_ms: Number(percentile(probes.map((probe) => probe.latency_ms), 95).toFixed(3)),
+    },
+    categories,
+    probes,
+  };
+}
+
+export function formatScorecard(scorecard: EvalScorecard): string {
+  const verdict =
+    scorecard.probes_failed === 0
+      ? "PASS"
+      : `FAIL (${scorecard.probes_failed}/${scorecard.probes_total} failed)`;
+  const lines = [
+    `Open Brain memory eval: ${verdict}`,
+    `corpus=${scorecard.corpus_id} commit=${scorecard.commit}`,
+    `recall@k=${scorecard.metrics.recall_at_k.toFixed(3)} precision@k=${scorecard.metrics.precision_at_k.toFixed(3)} citation=${scorecard.metrics.citation_grounding.toFixed(3)} namespace_leaks=${scorecard.metrics.namespace_leak_count} p95=${scorecard.metrics.p95_latency_ms.toFixed(3)}ms`,
+    "",
+    "Categories:",
+  ];
+  for (const category of CATEGORY_ORDER) {
+    const result = scorecard.categories[category];
+    lines.push(
+      `- ${category}: ${result.probes_passed}/${result.probes_total} pass recall=${result.recall_at_k.toFixed(3)} precision=${result.precision_at_k.toFixed(3)}`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/eval/open-brain/types.ts
+++ b/eval/open-brain/types.ts
@@ -42,6 +42,7 @@ export interface EvalProbe {
   top_k: number;
   relevant_ids: string[];
   junk_ids?: string[];
+  expect_no_results?: boolean;
   expected_citation_ids?: string[];
   expected_uncertainty?: string[];
   expected_forbidden_ids?: string[];

--- a/eval/open-brain/types.ts
+++ b/eval/open-brain/types.ts
@@ -1,0 +1,108 @@
+export type EvalCategory =
+  | "recall"
+  | "precision"
+  | "temporal"
+  | "identity"
+  | "citation"
+  | "contradiction"
+  | "namespace"
+  | "scale";
+
+export type CorpusEntryType = "thought" | "decision" | "relationship" | "project" | "session";
+
+export interface EvalSourceRef {
+  source: "brain";
+  type: CorpusEntryType;
+  id: string;
+  namespace: string;
+  label: string;
+  preview: string;
+  created_at: string;
+  last_updated_at?: string;
+}
+
+export interface EvalCorpusEntry {
+  id: string;
+  namespace: string;
+  type: CorpusEntryType;
+  title: string;
+  content: string;
+  tags: string[];
+  aliases?: string[];
+  created_at: string;
+  updated_at?: string;
+  source_ref: EvalSourceRef;
+}
+
+export interface EvalProbe {
+  id: string;
+  category: EvalCategory;
+  query: string;
+  readable_namespaces: string[];
+  top_k: number;
+  relevant_ids: string[];
+  junk_ids?: string[];
+  expected_citation_ids?: string[];
+  expected_uncertainty?: string[];
+  expected_forbidden_ids?: string[];
+  max_age_days?: number;
+  as_of?: string;
+  min_recall_at_k?: number;
+  min_precision_at_k?: number;
+  max_latency_ms?: number;
+}
+
+export interface EvalFixture {
+  schema_version: 1;
+  corpus_id: string;
+  generated_at: string;
+  corpus: EvalCorpusEntry[];
+  probes: EvalProbe[];
+}
+
+export interface RankedEvalResult {
+  entry: EvalCorpusEntry;
+  score: number;
+  rank: number;
+}
+
+export interface ProbeScore {
+  id: string;
+  category: EvalCategory;
+  passed: boolean;
+  recall_at_k: number;
+  precision_at_k: number;
+  latency_ms: number;
+  retrieved_ids: string[];
+  citation_ids: string[];
+  uncertainty: string[];
+  failures: string[];
+}
+
+export interface EvalScorecard {
+  schema_version: 1;
+  suite: "open-brain-memory";
+  corpus_id: string;
+  commit: string;
+  generated_at: string;
+  probes_total: number;
+  probes_passed: number;
+  probes_failed: number;
+  metrics: {
+    recall_at_k: number;
+    precision_at_k: number;
+    citation_grounding: number;
+    namespace_leak_count: number;
+    p95_latency_ms: number;
+  };
+  categories: Record<
+    EvalCategory,
+    {
+      probes_total: number;
+      probes_passed: number;
+      recall_at_k: number;
+      precision_at_k: number;
+    }
+  >;
+  probes: ProbeScore[];
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "bunx tsc --noEmit",
     "backfill": "bun run scripts/backfill.ts",
     "codex-memory-smoke": "bun run scripts/codex-memory-smoke.ts",
+    "eval:memory": "bun run scripts/eval-open-brain-memory.ts",
     "import-kb": "bun run scripts/import-legacy-kb.ts",
     "curate": "bun run scripts/curate.ts"
   },

--- a/scripts/eval-open-brain-memory.ts
+++ b/scripts/eval-open-brain-memory.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+import fixture from "../eval/open-brain/fixtures/memory-smoke.json" assert { type: "json" };
+import { formatScorecard, runEvalSuite } from "../eval/open-brain/runner.ts";
+import type { EvalFixture } from "../eval/open-brain/types.ts";
+
+function argValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of Bun.argv.slice(2)) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  const index = Bun.argv.indexOf(`--${name}`);
+  const next = index >= 0 ? Bun.argv[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+async function gitCommit(): Promise<string> {
+  const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  return code === 0 ? output.trim() : "unknown";
+}
+
+const reportPath = argValue("report");
+const jsonOnly = Bun.argv.includes("--json");
+const commit = await gitCommit();
+const scorecard = runEvalSuite(fixture as EvalFixture, { commit });
+
+if (reportPath) {
+  await Bun.write(reportPath, `${JSON.stringify(scorecard, null, 2)}\n`);
+}
+
+if (jsonOnly) {
+  console.log(JSON.stringify(scorecard, null, 2));
+} else {
+  console.log(formatScorecard(scorecard));
+  if (reportPath) console.log(`\nWrote report: ${reportPath}`);
+}
+
+if (scorecard.probes_failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- Adds an offline Open Brain memory eval harness under eval/open-brain.
- Adds synthetic/public corpus fixtures with sealed probe expectations across recall, precision, temporal, identity, citation, contradiction, namespace, and scale categories.
- Adds bun run eval:memory plus focused runner tests and docs.

Closes #109

## Validation
- bun run eval:memory -- --report /Volumes/ThunderBolt/_tmp/open-brain-memory-eval-109-scorecard.json: PASS, recall@k=1.000, precision@k=0.469, citation=1.000, namespace_leaks=0, p95=3.828ms
- bun test eval/open-brain/__tests__/runner.test.ts: 4 pass
- bun run typecheck: pass
- git diff --check HEAD~1 HEAD: pass
- bun test: 637 pass, 16 skip
