### PR TITLE
feat: add Codex memory workflow eval scenarios

### DIFF
--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -27,7 +27,7 @@ when the report is intended to be durable; otherwise write scratch reports under
 - `fixtures/memory-smoke.json`: synthetic corpus plus sealed probe expectations.
 - `fixtures/codex-workflows.json`: Codex session-resume, decision reuse,
   validation-evidence, preference, stale-memory, citation, synthesis-tool
-  selection, and unreadable-namespace scenarios.
+  selection, simulated-current-evidence, and unreadable-namespace scenarios.
 - `runner.ts`: deterministic retrieval, scoring, uncertainty, and scorecard code.
 - `__tests__/runner.test.ts`: tests for sealed answers, namespace isolation,
   stale/contradiction uncertainty, Codex workflow scenarios, and aggregate
@@ -51,6 +51,7 @@ when the report is intended to be durable; otherwise write scratch reports under
   namespace and calls `search_brain` / `brain_answer`.
 - Add live-adapter probes once the eval harness can call `brain_answer` through
   MCP. The current offline fixture checks that Codex retrieves the right
-  synthesis-tool policy and citations; it does not execute `brain_answer`.
+  synthesis-tool policy and can render cited answer evidence; it does not
+  execute `brain_answer` or read the live repo.
 - Publish durable scorecards only when the corpus and command are intentionally
   pinned for comparison.

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -26,8 +26,8 @@ when the report is intended to be durable; otherwise write scratch reports under
 
 - `fixtures/memory-smoke.json`: synthetic corpus plus sealed probe expectations.
 - `fixtures/codex-workflows.json`: Codex session-resume, decision reuse,
-  validation-evidence, preference, stale-memory, citation, synthesis, and
-  unreadable-namespace scenarios.
+  validation-evidence, preference, stale-memory, citation, synthesis-tool
+  selection, and unreadable-namespace scenarios.
 - `runner.ts`: deterministic retrieval, scoring, uncertainty, and scorecard code.
 - `__tests__/runner.test.ts`: tests for sealed answers, namespace isolation,
   stale/contradiction uncertainty, Codex workflow scenarios, and aggregate
@@ -49,8 +49,8 @@ when the report is intended to be durable; otherwise write scratch reports under
 
 - Add a live Open Brain adapter that loads synthetic fixtures into an isolated
   namespace and calls `search_brain` / `brain_answer`.
-- Extend the Codex workflow fixture with live-adapter probes once the eval
-  harness can call `brain_answer` through MCP instead of checking the offline
-  synthesis contract.
+- Add live-adapter probes once the eval harness can call `brain_answer` through
+  MCP. The current offline fixture checks that Codex retrieves the right
+  synthesis-tool policy and citations; it does not execute `brain_answer`.
 - Publish durable scorecards only when the corpus and command are intentionally
   pinned for comparison.

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -13,6 +13,7 @@ issues a place to add live adapters and Codex workflow scenarios.
 
 ```bash
 bun run eval:memory
+bun run eval:memory -- --fixture eval/open-brain/fixtures/codex-workflows.json
 bun run eval:memory -- --json
 bun run eval:memory -- --report eval/open-brain/reports/latest.json
 ```
@@ -24,9 +25,13 @@ when the report is intended to be durable; otherwise write scratch reports under
 ## Fixture Layout
 
 - `fixtures/memory-smoke.json`: synthetic corpus plus sealed probe expectations.
+- `fixtures/codex-workflows.json`: Codex session-resume, decision reuse,
+  validation-evidence, preference, stale-memory, citation, synthesis, and
+  unreadable-namespace scenarios.
 - `runner.ts`: deterministic retrieval, scoring, uncertainty, and scorecard code.
 - `__tests__/runner.test.ts`: tests for sealed answers, namespace isolation,
-  stale/contradiction uncertainty, and aggregate scorecards.
+  stale/contradiction uncertainty, Codex workflow scenarios, and aggregate
+  scorecards.
 
 ## Current Categories
 
@@ -37,13 +42,15 @@ when the report is intended to be durable; otherwise write scratch reports under
 - Citation grounding: expected source refs are cited.
 - Contradiction handling: conflicting memories are surfaced as uncertainty.
 - Namespace isolation: unreadable namespace entries are not returned.
+- Codex workflows: coding-agent memory tasks resolve the right durable evidence.
 - Scale/performance: smoke latency is tracked against an expanded-corpus target.
 
 ## Next Expansion Points
 
 - Add a live Open Brain adapter that loads synthetic fixtures into an isolated
   namespace and calls `search_brain` / `brain_answer`.
-- Add Codex workflow probes for session resume, user decision reuse, validation
-  receipt lookup, stale-memory avoidance, and memory citation behavior.
+- Extend the Codex workflow fixture with live-adapter probes once the eval
+  harness can call `brain_answer` through MCP instead of checking the offline
+  synthesis contract.
 - Publish durable scorecards only when the corpus and command are intentionally
   pinned for comparison.

--- a/eval/open-brain/__tests__/runner.test.ts
+++ b/eval/open-brain/__tests__/runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import codexFixture from "../fixtures/codex-workflows.json" assert { type: "json" };
 import fixture from "../fixtures/memory-smoke.json" assert { type: "json" };
-import { retrieve, runEvalSuite, scoreProbe } from "../runner.ts";
+import { answerForProbe, retrieve, runEvalSuite, scoreProbe } from "../runner.ts";
 import type { EvalFixture } from "../types.ts";
 
 const typedFixture = fixture as EvalFixture;
@@ -136,6 +136,24 @@ describe("Open Brain memory eval runner", () => {
     expect(score.retrieved_ids).toContain("repo-current-bun-runtime");
     expect(score.retrieved_ids).toContain("repo-stale-node-runtime");
     expect(score.uncertainty).toEqual(["stale"]);
+    const answer = answerForProbe(
+      retrieve(typedCodexFixture.corpus, probe!).map(({ entry }) => entry),
+      probe!,
+    );
+    expect(answer).toContain("Current repo file AGENTS.md");
+    expect(answer).toContain("contradicts memory ids repo-stale-node-runtime");
+  });
+
+  it("checks final-answer citation shape for memory-derived facts", () => {
+    const probe = typedCodexFixture.probes.find(
+      (item) => item.id === "codex-cite-memory-derived-facts",
+    );
+    expect(probe).toBeDefined();
+    const entries = retrieve(typedCodexFixture.corpus, probe!).map(({ entry }) => entry);
+    const answer = answerForProbe(entries, probe!);
+    expect(scoreProbe(typedCodexFixture.corpus, probe!).passed).toBe(true);
+    expect(answer).toContain("[decision-citation-contract]");
+    expect(answer).toContain("Memory-derived final answers must include citations");
   });
 
   it("refuses unreadable Codex workflow facts", () => {

--- a/eval/open-brain/__tests__/runner.test.ts
+++ b/eval/open-brain/__tests__/runner.test.ts
@@ -133,8 +133,9 @@ describe("Open Brain memory eval runner", () => {
     expect(probe).toBeDefined();
     const score = scoreProbe(typedCodexFixture.corpus, probe!);
     expect(score.passed).toBe(true);
-    expect(score.retrieved_ids).toEqual(["repo-current-bun-runtime"]);
-    expect(score.uncertainty).toEqual([]);
+    expect(score.retrieved_ids).toContain("repo-current-bun-runtime");
+    expect(score.retrieved_ids).toContain("repo-stale-node-runtime");
+    expect(score.uncertainty).toEqual(["stale"]);
   });
 
   it("refuses unreadable Codex workflow facts", () => {
@@ -146,5 +147,59 @@ describe("Open Brain memory eval runner", () => {
     expect(score.passed).toBe(true);
     expect(score.retrieved_ids).toEqual([]);
     expect(score.failures).toEqual([]);
+  });
+
+  it("proves the unreadable namespace probe has a positive control", () => {
+    const probe = typedCodexFixture.probes.find(
+      (item) => item.id === "codex-unreadable-namespace-refusal",
+    );
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedCodexFixture.corpus, {
+      ...probe!,
+      readable_namespaces: ["skippy", "private-agent"],
+      relevant_ids: ["private-user-secret"],
+      expect_no_results: false,
+    });
+    expect(score.retrieved_ids).toContain("private-user-secret");
+  });
+
+  it("runs the CLI against an alternate fixture", async () => {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "scripts/eval-open-brain-memory.ts",
+        "--fixture",
+        "eval/open-brain/fixtures/codex-workflows.json",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    expect(await proc.exited).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("corpus=open-brain-codex-workflows-v1");
+    expect(stdout).toContain("- codex: 6/6 pass");
+    expect(stdout).not.toContain("0/0 pass");
+  });
+
+  it("returns a controlled CLI error for a missing fixture", async () => {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        "scripts/eval-open-brain-memory.ts",
+        "--fixture",
+        "eval/open-brain/fixtures/does-not-exist.json",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    expect(await proc.exited).toBe(2);
+    expect(stdout).toBe("");
+    expect(stderr).toContain(
+      "Failed to load Open Brain eval fixture eval/open-brain/fixtures/does-not-exist.json",
+    );
   });
 });

--- a/eval/open-brain/__tests__/runner.test.ts
+++ b/eval/open-brain/__tests__/runner.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import codexFixture from "../fixtures/codex-workflows.json" assert { type: "json" };
 import fixture from "../fixtures/memory-smoke.json" assert { type: "json" };
 import { retrieve, runEvalSuite, scoreProbe } from "../runner.ts";
 import type { EvalFixture } from "../types.ts";
 
 const typedFixture = fixture as EvalFixture;
+const typedCodexFixture = codexFixture as EvalFixture;
 
 describe("Open Brain memory eval runner", () => {
   it("keeps gold answers sealed outside retrieved public results", () => {
@@ -98,5 +100,51 @@ describe("Open Brain memory eval runner", () => {
     expect(scorecard.probes_failed).toBe(0);
     expect(scorecard.metrics.namespace_leak_count).toBe(0);
     expect(scorecard.metrics.recall_at_k).toBeGreaterThanOrEqual(1);
+  });
+
+  it("covers Codex durable memory workflow scenarios", () => {
+    const scorecard = runEvalSuite(typedCodexFixture, {
+      commit: "test",
+      generatedAt: "2026-06-15T00:00:00.000Z",
+    });
+    expect(scorecard.corpus_id).toBe("open-brain-codex-workflows-v1");
+    expect(scorecard.probes_total).toBe(8);
+    expect(scorecard.probes_failed).toBe(0);
+    expect(scorecard.categories.codex.probes_total).toBe(6);
+    expect(scorecard.categories.citation.probes_passed).toBe(1);
+    expect(scorecard.categories.namespace.probes_passed).toBe(1);
+  });
+
+  it("prefers durable Codex preferences over one-off task instructions", () => {
+    const probe = typedCodexFixture.probes.find(
+      (item) => item.id === "codex-durable-preference-not-oneoff",
+    );
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedCodexFixture.corpus, probe!);
+    expect(score.passed).toBe(true);
+    expect(score.retrieved_ids).toContain("preference-thunderbolt-temp");
+    expect(score.retrieved_ids).not.toContain("oneoff-use-system-tmp");
+  });
+
+  it("keeps current repo evidence ahead of stale memory", () => {
+    const probe = typedCodexFixture.probes.find(
+      (item) => item.id === "codex-current-repo-over-stale-memory",
+    );
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedCodexFixture.corpus, probe!);
+    expect(score.passed).toBe(true);
+    expect(score.retrieved_ids).toEqual(["repo-current-bun-runtime"]);
+    expect(score.uncertainty).toEqual([]);
+  });
+
+  it("refuses unreadable Codex workflow facts", () => {
+    const probe = typedCodexFixture.probes.find(
+      (item) => item.id === "codex-unreadable-namespace-refusal",
+    );
+    expect(probe).toBeDefined();
+    const score = scoreProbe(typedCodexFixture.corpus, probe!);
+    expect(score.passed).toBe(true);
+    expect(score.retrieved_ids).toEqual([]);
+    expect(score.failures).toEqual([]);
   });
 });

--- a/eval/open-brain/fixtures/codex-workflows.json
+++ b/eval/open-brain/fixtures/codex-workflows.json
@@ -1,0 +1,296 @@
+{
+  "schema_version": 1,
+  "corpus_id": "open-brain-codex-workflows-v1",
+  "generated_at": "2026-06-15T00:00:00.000Z",
+  "corpus": [
+    {
+      "id": "session-issue-110-next-action",
+      "namespace": "skippy",
+      "type": "session",
+      "title": "Open Brain issue 110 handoff",
+      "content": "Repo /Volumes/ThunderBolt/Development/open-brain is working issue #110 on branch codex/codex-memory-eval-scenarios. Next action: add a Codex workflow eval fixture, runner fixture loading, and targeted tests before opening the PR.",
+      "tags": ["codex", "resume", "open-brain", "issue-110", "next-action"],
+      "aliases": ["issue 110 resume", "codex workflow eval next action"],
+      "created_at": "2026-06-15T14:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "session",
+        "id": "session-issue-110-next-action",
+        "namespace": "skippy",
+        "label": "Open Brain issue 110 handoff",
+        "preview": "Next action: add a Codex workflow eval fixture, runner fixture loading, and targeted tests.",
+        "created_at": "2026-06-15T14:00:00.000Z"
+      }
+    },
+    {
+      "id": "decision-fixture-loading",
+      "namespace": "skippy",
+      "type": "decision",
+      "title": "Codex eval fixture loading decision",
+      "content": "Decision: keep the original memory smoke fixture stable and add Codex workflow scenarios as a separate fixture loaded with --fixture.",
+      "tags": ["codex", "decision", "eval", "fixture"],
+      "aliases": ["separate codex fixture", "--fixture workflow"],
+      "created_at": "2026-06-15T14:05:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-fixture-loading",
+        "namespace": "skippy",
+        "label": "Codex eval fixture loading decision",
+        "preview": "Keep the original memory smoke fixture stable and add Codex workflow scenarios as a separate fixture loaded with --fixture.",
+        "created_at": "2026-06-15T14:05:00.000Z"
+      }
+    },
+    {
+      "id": "session-pr114-validation",
+      "namespace": "collab",
+      "type": "session",
+      "title": "PR 114 validation evidence",
+      "content": "Validation evidence for PR #114: bun run eval:memory passed with recall@k=1.000, citation=1.000, namespace_leaks=0; bun test eval/open-brain/__tests__/runner.test.ts passed; bun run typecheck passed.",
+      "tags": ["validation", "pr-114", "eval", "typecheck"],
+      "aliases": ["PR 114 evidence", "memory eval validation"],
+      "created_at": "2026-06-15T13:30:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "session",
+        "id": "session-pr114-validation",
+        "namespace": "collab",
+        "label": "PR 114 validation evidence",
+        "preview": "PR #114 validation: eval runner, targeted tests, and typecheck passed.",
+        "created_at": "2026-06-15T13:30:00.000Z"
+      }
+    },
+    {
+      "id": "preference-thunderbolt-temp",
+      "namespace": "skippy",
+      "type": "decision",
+      "title": "Durable Codex temp preference",
+      "content": "Durable preference: Codex temporary worktrees, scratch reports, review checkouts, and generated artifacts should use /Volumes/ThunderBolt/_tmp when available.",
+      "tags": ["durable", "preference", "temp", "codex"],
+      "aliases": ["ThunderBolt temp preference", "temporary worktree root"],
+      "created_at": "2026-06-11T08:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "preference-thunderbolt-temp",
+        "namespace": "skippy",
+        "label": "Durable Codex temp preference",
+        "preview": "Codex temporary work should use /Volumes/ThunderBolt/_tmp when available.",
+        "created_at": "2026-06-11T08:00:00.000Z"
+      }
+    },
+    {
+      "id": "oneoff-use-system-tmp",
+      "namespace": "skippy",
+      "type": "thought",
+      "title": "One-off system tmp instruction",
+      "content": "One-off task instruction: for this single tool compatibility check, write the transient socket probe under /tmp and delete it immediately.",
+      "tags": ["one-off", "tmp", "tool-compatibility"],
+      "aliases": ["single tool compatibility check"],
+      "created_at": "2026-06-12T08:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "thought",
+        "id": "oneoff-use-system-tmp",
+        "namespace": "skippy",
+        "label": "One-off system tmp instruction",
+        "preview": "For this single compatibility check, write the transient socket probe under /tmp.",
+        "created_at": "2026-06-12T08:00:00.000Z"
+      }
+    },
+    {
+      "id": "repo-current-bun-runtime",
+      "namespace": "collab",
+      "type": "project",
+      "title": "Current Open Brain runtime evidence",
+      "content": "Current repo evidence from AGENTS.md: Open Brain uses Bun 1.3.13 for TypeScript commands and bun run typecheck for validation.",
+      "tags": ["open-brain", "runtime", "current", "bun"],
+      "aliases": ["current repo runtime", "Bun 1.3.13"],
+      "created_at": "2026-06-15T12:00:00.000Z",
+      "updated_at": "2026-06-15T12:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "project",
+        "id": "repo-current-bun-runtime",
+        "namespace": "collab",
+        "label": "Current Open Brain runtime evidence",
+        "preview": "Current repo evidence: Open Brain uses Bun 1.3.13 for TypeScript commands.",
+        "created_at": "2026-06-15T12:00:00.000Z",
+        "last_updated_at": "2026-06-15T12:00:00.000Z"
+      }
+    },
+    {
+      "id": "repo-stale-node-runtime",
+      "namespace": "collab",
+      "type": "project",
+      "title": "Stale Open Brain runtime note",
+      "content": "Old note: Open Brain should use npm and Node 20 scripts for TypeScript validation.",
+      "tags": ["open-brain", "runtime", "stale", "node"],
+      "aliases": ["old node runtime", "npm typecheck"],
+      "created_at": "2024-02-01T00:00:00.000Z",
+      "updated_at": "2024-02-01T00:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "project",
+        "id": "repo-stale-node-runtime",
+        "namespace": "collab",
+        "label": "Stale Open Brain runtime note",
+        "preview": "Old note: Open Brain should use npm and Node 20 scripts.",
+        "created_at": "2024-02-01T00:00:00.000Z",
+        "last_updated_at": "2024-02-01T00:00:00.000Z"
+      }
+    },
+    {
+      "id": "decision-citation-contract",
+      "namespace": "skippy",
+      "type": "decision",
+      "title": "Codex memory citation contract",
+      "content": "When Codex answers from memory without live verification, the final answer must include memory citations and note when the fact may be stale.",
+      "tags": ["codex", "citation", "memory", "answer"],
+      "aliases": ["memory citation contract", "cite memory-derived facts"],
+      "created_at": "2026-06-15T11:00:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-citation-contract",
+        "namespace": "skippy",
+        "label": "Codex memory citation contract",
+        "preview": "Memory-derived final answers must include citations and stale-fact caveats.",
+        "created_at": "2026-06-15T11:00:00.000Z"
+      }
+    },
+    {
+      "id": "decision-brain-answer-tool",
+      "namespace": "skippy",
+      "type": "decision",
+      "title": "brain_answer synthesis tool",
+      "content": "Use brain_answer when Codex needs a cited extractive answer from readable Open Brain rows instead of raw search hits.",
+      "tags": ["brain_answer", "synthesis", "codex", "tool"],
+      "aliases": ["brain answer", "cited synthesis"],
+      "created_at": "2026-06-15T12:30:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "decision-brain-answer-tool",
+        "namespace": "skippy",
+        "label": "brain_answer synthesis tool",
+        "preview": "Use brain_answer when Codex needs a cited extractive answer from readable Open Brain rows.",
+        "created_at": "2026-06-15T12:30:00.000Z"
+      }
+    },
+    {
+      "id": "private-user-secret",
+      "namespace": "private-agent",
+      "type": "decision",
+      "title": "Private namespace fact",
+      "content": "Private namespace zetaquartz credential routing note that a skippy-only caller must refuse or flag as unreadable.",
+      "tags": ["private", "namespace", "zetaquartz"],
+      "aliases": ["zetaquartz credential route"],
+      "created_at": "2026-06-15T12:45:00.000Z",
+      "source_ref": {
+        "source": "brain",
+        "type": "decision",
+        "id": "private-user-secret",
+        "namespace": "private-agent",
+        "label": "Private namespace fact",
+        "preview": "Private namespace zetaquartz credential routing note.",
+        "created_at": "2026-06-15T12:45:00.000Z"
+      }
+    }
+  ],
+  "probes": [
+    {
+      "id": "codex-resume-next-action",
+      "category": "codex",
+      "query": "Resume Open Brain issue 110 and identify the next action for Codex workflow evals",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 1,
+      "relevant_ids": ["session-issue-110-next-action"],
+      "expected_citation_ids": ["session-issue-110-next-action"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "codex-recover-user-decision",
+      "category": "codex",
+      "query": "What decision did we make about keeping memory smoke stable and loading Codex workflow scenarios?",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 1,
+      "relevant_ids": ["decision-fixture-loading"],
+      "expected_citation_ids": ["decision-fixture-loading"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "codex-validation-evidence",
+      "category": "codex",
+      "query": "Find previous validation evidence for PR 114 memory eval typecheck runner tests",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 1,
+      "relevant_ids": ["session-pr114-validation"],
+      "expected_citation_ids": ["session-pr114-validation"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "codex-durable-preference-not-oneoff",
+      "category": "codex",
+      "query": "What durable preference controls Codex temporary worktrees and scratch reports?",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 2,
+      "relevant_ids": ["preference-thunderbolt-temp"],
+      "junk_ids": ["oneoff-use-system-tmp"],
+      "expected_citation_ids": ["preference-thunderbolt-temp"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 0.5
+    },
+    {
+      "id": "codex-current-repo-over-stale-memory",
+      "category": "codex",
+      "query": "Current Open Brain runtime evidence TypeScript validation Bun 1.3.13",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 1,
+      "relevant_ids": ["repo-current-bun-runtime"],
+      "junk_ids": ["repo-stale-node-runtime"],
+      "expected_citation_ids": ["repo-current-bun-runtime"],
+      "max_age_days": 30,
+      "as_of": "2026-06-15T12:00:00.000Z",
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "codex-cite-memory-derived-facts",
+      "category": "citation",
+      "query": "How should Codex cite memory-derived facts in final answers?",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 1,
+      "relevant_ids": ["decision-citation-contract"],
+      "expected_citation_ids": ["decision-citation-contract"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "codex-brain-answer-synthesis",
+      "category": "codex",
+      "query": "Which tool gives Codex a cited extractive answer from readable Open Brain rows?",
+      "readable_namespaces": ["skippy", "collab"],
+      "top_k": 1,
+      "relevant_ids": ["decision-brain-answer-tool"],
+      "expected_citation_ids": ["decision-brain-answer-tool"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    },
+    {
+      "id": "codex-unreadable-namespace-refusal",
+      "category": "namespace",
+      "query": "zetaquartz credential route",
+      "readable_namespaces": ["skippy"],
+      "top_k": 3,
+      "relevant_ids": [],
+      "expect_no_results": true,
+      "expected_forbidden_ids": ["private-user-secret"],
+      "min_recall_at_k": 1,
+      "min_precision_at_k": 1
+    }
+  ]
+}

--- a/eval/open-brain/fixtures/codex-workflows.json
+++ b/eval/open-brain/fixtures/codex-workflows.json
@@ -253,6 +253,17 @@
       "relevant_ids": ["repo-current-bun-runtime"],
       "expected_citation_ids": ["repo-current-bun-runtime"],
       "expected_uncertainty": ["stale"],
+      "current_evidence": {
+        "id": "repo://AGENTS.md#stack",
+        "label": "AGENTS.md Stack",
+        "content": "Current repo file AGENTS.md says Runtime: Bun 1.3.13 and validation command bunx tsc --noEmit.",
+        "contradicts_ids": ["repo-stale-node-runtime"]
+      },
+      "expected_answer_terms": [
+        "Current repo file AGENTS.md",
+        "Bun 1.3.13",
+        "contradicts memory ids repo-stale-node-runtime"
+      ],
       "max_age_days": 30,
       "as_of": "2026-06-15T12:00:00.000Z",
       "min_recall_at_k": 1,
@@ -266,6 +277,10 @@
       "top_k": 1,
       "relevant_ids": ["decision-citation-contract"],
       "expected_citation_ids": ["decision-citation-contract"],
+      "expected_answer_terms": [
+        "decision-citation-contract",
+        "Memory-derived final answers must include citations"
+      ],
       "min_recall_at_k": 1,
       "min_precision_at_k": 1
     },

--- a/eval/open-brain/fixtures/codex-workflows.json
+++ b/eval/open-brain/fixtures/codex-workflows.json
@@ -84,9 +84,9 @@
       "namespace": "skippy",
       "type": "thought",
       "title": "One-off system tmp instruction",
-      "content": "One-off task instruction: for this single tool compatibility check, write the transient socket probe under /tmp and delete it immediately.",
-      "tags": ["one-off", "tmp", "tool-compatibility"],
-      "aliases": ["single tool compatibility check"],
+      "content": "One-off task instruction: for this single tool compatibility check, write Codex temporary worktrees and scratch reports under /tmp and delete them immediately.",
+      "tags": ["one-off", "tmp", "tool-compatibility", "codex"],
+      "aliases": ["single tool compatibility check", "temporary worktrees scratch reports"],
       "created_at": "2026-06-12T08:00:00.000Z",
       "source_ref": {
         "source": "brain",
@@ -94,7 +94,7 @@
         "id": "oneoff-use-system-tmp",
         "namespace": "skippy",
         "label": "One-off system tmp instruction",
-        "preview": "For this single compatibility check, write the transient socket probe under /tmp.",
+        "preview": "For this single compatibility check, write Codex temporary worktrees and scratch reports under /tmp.",
         "created_at": "2026-06-12T08:00:00.000Z"
       }
     },
@@ -124,9 +124,9 @@
       "namespace": "collab",
       "type": "project",
       "title": "Stale Open Brain runtime note",
-      "content": "Old note: Open Brain should use npm and Node 20 scripts for TypeScript validation.",
-      "tags": ["open-brain", "runtime", "stale", "node"],
-      "aliases": ["old node runtime", "npm typecheck"],
+      "content": "Old repo evidence: Open Brain runtime TypeScript validation should use npm and Node 20 scripts.",
+      "tags": ["open-brain", "runtime", "stale", "node", "typescript"],
+      "aliases": ["old node runtime", "npm typecheck", "Open Brain runtime TypeScript validation"],
       "created_at": "2024-02-01T00:00:00.000Z",
       "updated_at": "2024-02-01T00:00:00.000Z",
       "source_ref": {
@@ -135,7 +135,7 @@
         "id": "repo-stale-node-runtime",
         "namespace": "collab",
         "label": "Stale Open Brain runtime note",
-        "preview": "Old note: Open Brain should use npm and Node 20 scripts.",
+        "preview": "Old repo evidence: Open Brain runtime TypeScript validation should use npm and Node 20 scripts.",
         "created_at": "2024-02-01T00:00:00.000Z",
         "last_updated_at": "2024-02-01T00:00:00.000Z"
       }
@@ -235,9 +235,9 @@
     {
       "id": "codex-durable-preference-not-oneoff",
       "category": "codex",
-      "query": "What durable preference controls Codex temporary worktrees and scratch reports?",
+      "query": "Codex temporary worktrees scratch reports durable preference",
       "readable_namespaces": ["skippy", "collab"],
-      "top_k": 2,
+      "top_k": 1,
       "relevant_ids": ["preference-thunderbolt-temp"],
       "junk_ids": ["oneoff-use-system-tmp"],
       "expected_citation_ids": ["preference-thunderbolt-temp"],
@@ -247,16 +247,16 @@
     {
       "id": "codex-current-repo-over-stale-memory",
       "category": "codex",
-      "query": "Current Open Brain runtime evidence TypeScript validation Bun 1.3.13",
+      "query": "Open Brain runtime TypeScript validation evidence",
       "readable_namespaces": ["skippy", "collab"],
-      "top_k": 1,
+      "top_k": 2,
       "relevant_ids": ["repo-current-bun-runtime"],
-      "junk_ids": ["repo-stale-node-runtime"],
       "expected_citation_ids": ["repo-current-bun-runtime"],
+      "expected_uncertainty": ["stale"],
       "max_age_days": 30,
       "as_of": "2026-06-15T12:00:00.000Z",
       "min_recall_at_k": 1,
-      "min_precision_at_k": 1
+      "min_precision_at_k": 0.5
     },
     {
       "id": "codex-cite-memory-derived-facts",

--- a/eval/open-brain/runner.ts
+++ b/eval/open-brain/runner.ts
@@ -148,6 +148,7 @@ export function scoreProbe(corpus: EvalCorpusEntry[], probe: EvalProbe): ProbeSc
   const precision = precisionAtK(retrievedIds, probe.relevant_ids);
   const citationIds = entries.map((entry) => entry.source_ref.id);
   const forbiddenIds = probe.expected_forbidden_ids ?? [];
+  const answer = answerForProbe(entries, probe);
 
   if (recall < (probe.min_recall_at_k ?? 1)) {
     failures.push(`recall ${recall.toFixed(3)} below threshold`);
@@ -169,6 +170,11 @@ export function scoreProbe(corpus: EvalCorpusEntry[], probe: EvalProbe): ProbeSc
   for (const expectedCitation of probe.expected_citation_ids ?? []) {
     if (!citationIds.includes(expectedCitation)) {
       failures.push(`missing expected citation ${expectedCitation}`);
+    }
+  }
+  for (const expectedTerm of probe.expected_answer_terms ?? []) {
+    if (!answer.toLowerCase().includes(expectedTerm.toLowerCase())) {
+      failures.push(`missing expected answer term ${expectedTerm}`);
     }
   }
   if (entries.some((entry) => isStale(entry, probe))) {
@@ -198,6 +204,23 @@ export function scoreProbe(corpus: EvalCorpusEntry[], probe: EvalProbe): ProbeSc
     uncertainty,
     failures,
   };
+}
+
+export function answerForProbe(entries: EvalCorpusEntry[], probe: EvalProbe): string {
+  const lines = entries.map(
+    (entry) => `- ${entry.source_ref.preview} [${entry.source_ref.id}]`,
+  );
+  if (probe.current_evidence) {
+    lines.push(
+      `- Current evidence (${probe.current_evidence.label}): ${probe.current_evidence.content} [${probe.current_evidence.id}]`,
+    );
+  }
+  if (probe.current_evidence?.contradicts_ids?.length) {
+    lines.push(
+      `Known gap: current evidence contradicts memory ids ${probe.current_evidence.contradicts_ids.join(", ")}.`,
+    );
+  }
+  return lines.join("\n");
 }
 
 function mean(values: number[]): number {

--- a/eval/open-brain/runner.ts
+++ b/eval/open-brain/runner.ts
@@ -267,6 +267,7 @@ export function formatScorecard(scorecard: EvalScorecard): string {
   ];
   for (const category of CATEGORY_ORDER) {
     const result = scorecard.categories[category];
+    if (result.probes_total === 0) continue;
     lines.push(
       `- ${category}: ${result.probes_passed}/${result.probes_total} pass recall=${result.recall_at_k.toFixed(3)} precision=${result.precision_at_k.toFixed(3)}`,
     );

--- a/eval/open-brain/runner.ts
+++ b/eval/open-brain/runner.ts
@@ -16,6 +16,7 @@ const CATEGORY_ORDER: EvalCategory[] = [
   "citation",
   "contradiction",
   "namespace",
+  "codex",
   "scale",
 ];
 

--- a/eval/open-brain/types.ts
+++ b/eval/open-brain/types.ts
@@ -42,6 +42,13 @@ export interface EvalProbe {
   readable_namespaces: string[];
   top_k: number;
   relevant_ids: string[];
+  current_evidence?: {
+    id: string;
+    label: string;
+    content: string;
+    contradicts_ids?: string[];
+  };
+  expected_answer_terms?: string[];
   junk_ids?: string[];
   expect_no_results?: boolean;
   expected_citation_ids?: string[];

--- a/eval/open-brain/types.ts
+++ b/eval/open-brain/types.ts
@@ -6,6 +6,7 @@ export type EvalCategory =
   | "citation"
   | "contradiction"
   | "namespace"
+  | "codex"
   | "scale";
 
 export type CorpusEntryType = "thought" | "decision" | "relationship" | "project" | "session";

--- a/scripts/eval-open-brain-memory.ts
+++ b/scripts/eval-open-brain-memory.ts
@@ -22,20 +22,34 @@ async function gitCommit(): Promise<string> {
   return code === 0 ? output.trim() : "unknown";
 }
 
-async function loadFixture(path = "eval/open-brain/fixtures/memory-smoke.json"): Promise<EvalFixture> {
-  const file = Bun.file(path);
-  const fixture = (await file.json()) as EvalFixture;
-  if (fixture.schema_version !== 1 || !Array.isArray(fixture.corpus) || !Array.isArray(fixture.probes)) {
-    throw new Error(`Invalid Open Brain eval fixture: ${path}`);
+async function loadFixture(
+  path = "eval/open-brain/fixtures/memory-smoke.json",
+): Promise<EvalFixture> {
+  try {
+    const file = Bun.file(path);
+    const fixture = (await file.json()) as EvalFixture;
+    if (
+      fixture.schema_version !== 1 ||
+      !Array.isArray(fixture.corpus) ||
+      !Array.isArray(fixture.probes)
+    ) {
+      throw new Error("expected schema_version=1 with corpus and probes arrays");
+    }
+    return fixture;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load Open Brain eval fixture ${path}: ${message}`);
   }
-  return fixture;
 }
 
 const reportPath = argValue("report");
 const fixturePath = argValue("fixture");
 const jsonOnly = Bun.argv.includes("--json");
 const commit = await gitCommit();
-const fixture = await loadFixture(fixturePath);
+const fixture = await loadFixture(fixturePath).catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+});
 const scorecard = runEvalSuite(fixture, { commit });
 
 if (reportPath) {

--- a/scripts/eval-open-brain-memory.ts
+++ b/scripts/eval-open-brain-memory.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-import fixture from "../eval/open-brain/fixtures/memory-smoke.json" assert { type: "json" };
 import { formatScorecard, runEvalSuite } from "../eval/open-brain/runner.ts";
 import type { EvalFixture } from "../eval/open-brain/types.ts";
 
@@ -23,10 +22,21 @@ async function gitCommit(): Promise<string> {
   return code === 0 ? output.trim() : "unknown";
 }
 
+async function loadFixture(path = "eval/open-brain/fixtures/memory-smoke.json"): Promise<EvalFixture> {
+  const file = Bun.file(path);
+  const fixture = (await file.json()) as EvalFixture;
+  if (fixture.schema_version !== 1 || !Array.isArray(fixture.corpus) || !Array.isArray(fixture.probes)) {
+    throw new Error(`Invalid Open Brain eval fixture: ${path}`);
+  }
+  return fixture;
+}
+
 const reportPath = argValue("report");
+const fixturePath = argValue("fixture");
 const jsonOnly = Bun.argv.includes("--json");
 const commit = await gitCommit();
-const scorecard = runEvalSuite(fixture as EvalFixture, { commit });
+const fixture = await loadFixture(fixturePath);
+const scorecard = runEvalSuite(fixture, { commit });
 
 if (reportPath) {
   await Bun.write(reportPath, `${JSON.stringify(scorecard, null, 2)}\n`);


### PR DESCRIPTION
Closes #110.

## Summary
- add a dedicated Codex workflow eval fixture covering session resume, decision reuse, validation evidence lookup, durable preference vs one-off instruction, stale-memory avoidance, memory citation, synthesis-tool selection, and unreadable namespace refusal
- add `--fixture` support to `bun run eval:memory` while keeping the original smoke fixture as the default
- extend runner tests and docs for the new `codex` scorecard category

## Validation
- `bun run eval:memory -- --fixture eval/open-brain/fixtures/codex-workflows.json --report /Volumes/ThunderBolt/_tmp/open-brain-memory-eval-110-scorecard.json` PASS: 8/8 probes, recall@k=1.000, precision@k=0.938, citation=1.000, namespace_leaks=0
- `bun test eval/open-brain/__tests__/runner.test.ts` PASS: 11 pass
- `bun run typecheck` PASS
- `git diff --check` PASS
- `bun test` PASS: 644 pass, 16 skip

## Open PR Hygiene
- Checked open PRs #89 and #101 before opening this PR. Neither is appropriate to close from this goal run: both contain commits not present on current main; #101 is the larger embedding/local-provider branch tied to the original dirty checkout, and #89 has non-trivial Python/deploy changes that conflict with current main rather than being superseded.
