### PR TITLE
fix: retry expired Open Brain MCP sessions

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -314,12 +314,11 @@ class OpenBrainClient:
             "method": "tools/call",
             "params": {"name": name, "arguments": dict(arguments or {})},
         }
-        response = self.transport.post(
-            self._url("mcp"),
-            headers=self._mcp_headers(include_session=True),
-            json_body=payload,
-            timeout=self.timeout,
-        )
+        response = self._post_tool_call(payload)
+        if self._is_expired_session_response(response):
+            self._session_id = None
+            self._ensure_session()
+            response = self._post_tool_call(payload)
         self._raise_for_status(response, context=f"call_tool:{name}")
         message = self._decode_jsonrpc_response(
             response,
@@ -508,6 +507,38 @@ class OpenBrainClient:
             timeout=self.timeout,
         )
         self._raise_for_status(response, context="initialized")
+
+    def _post_tool_call(self, payload: JSON) -> TransportResponse:
+        return self.transport.post(
+            self._url("mcp"),
+            headers=self._mcp_headers(include_session=True),
+            json_body=payload,
+            timeout=self.timeout,
+        )
+
+    def _is_expired_session_response(self, response: TransportResponse) -> bool:
+        if response.status_code == 404:
+            return True
+        if response.status_code != 400:
+            return False
+        messages = {
+            "bad request: missing session or not an initialize request",
+            "invalid or missing session",
+        }
+        try:
+            body = response.json()
+        except json.JSONDecodeError:
+            return response.text.strip().lower() in messages
+        if not isinstance(body, dict):
+            return False
+        error = body.get("error")
+        if isinstance(error, str):
+            return error.strip().lower() in messages
+        if isinstance(error, dict):
+            message = error.get("message")
+            return isinstance(message, str) and message.strip().lower() in messages
+        return False
+
 
     def _url(self, path: str) -> str:
         return urljoin(self.base_url, path)

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -647,6 +647,215 @@ def test_initialize_error_does_not_establish_session():
     assert client.session_id is None
 
 
+def test_expired_session_400_reinitializes_and_retries_tool_call_once():
+    class ExpiredSessionTransport(FakeTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sessions = iter(["session-old", "session-new"])
+            self.expired_once = False
+
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "initialize":
+                session_id = next(self.sessions)
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=200,
+                    headers={
+                        "content-type": "application/json",
+                        "mcp-session-id": session_id,
+                    },
+                    text=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": json_body["id"],
+                            "result": {"protocolVersion": "2025-03-26"},
+                        }
+                    ),
+                )
+            if json_body.get("method") == "tools/call" and not self.expired_once:
+                self.expired_once = True
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=400,
+                    headers={"content-type": "application/json"},
+                    text=(
+                        '{"error":"Bad request: missing session or not an '
+                        'initialize request"}'
+                    ),
+                )
+            return super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+
+    transport = ExpiredSessionTransport()
+    client = make_client(transport)
+
+    assert client.search_all(query="x")["tool"] == "search_all"
+    assert client.session_id == "session-new"
+    assert [request["json"].get("method") for request in post_requests(transport)] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+    ]
+
+    tool_calls = tool_requests(transport)
+    assert len(tool_calls) == 2
+    assert header_value(tool_calls[0]["headers"], "Mcp-Session-Id") == "session-old"
+    assert header_value(tool_calls[1]["headers"], "Mcp-Session-Id") == "session-new"
+    assert tool_calls[0]["json"] == tool_calls[1]["json"]
+
+
+def test_expired_session_404_reinitializes_and_retries_tool_call_once():
+    class GoneSessionTransport(FakeTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sessions = iter(["session-old", "session-new"])
+            self.expired_once = False
+
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "initialize":
+                session_id = next(self.sessions)
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=200,
+                    headers={
+                        "content-type": "application/json",
+                        "mcp-session-id": session_id,
+                    },
+                    text=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": json_body["id"],
+                            "result": {"protocolVersion": "2025-03-26"},
+                        }
+                    ),
+                )
+            if json_body.get("method") == "tools/call" and not self.expired_once:
+                self.expired_once = True
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=404,
+                    headers={"content-type": "application/json"},
+                    text='{"error":"session not found"}',
+                )
+            return super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+
+    transport = GoneSessionTransport()
+    client = make_client(transport)
+
+    assert client.search_all(query="x")["tool"] == "search_all"
+    assert client.session_id == "session-new"
+    assert len(tool_requests(transport)) == 2
+
+
+def test_auth_error_does_not_reinitialize_or_retry_tool_call():
+    class AuthErrorTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "tools/call":
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=401,
+                    headers={"content-type": "application/json"},
+                    text='{"error":"unauthorized"}',
+                )
+            return super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+
+    transport = AuthErrorTransport()
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError, match="status=401"):
+        client.search_all(query="x")
+
+    assert [request["json"].get("method") for request in post_requests(transport)] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+    ]
+
+
+def test_tool_validation_400_missing_session_text_does_not_retry():
+    class ValidationErrorTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "tools/call":
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=400,
+                    headers={"content-type": "application/json"},
+                    text='{"error":"missing session_key argument"}',
+                )
+            return super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+
+    transport = ValidationErrorTransport()
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError, match="missing session_key"):
+        client.session_context()
+
+    assert client.session_id == "session-123"
+    assert [request["json"].get("method") for request in post_requests(transport)] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+    ]
+
+
 def test_sse_mcp_responses_are_decoded():
     class SseTransport(FakeTransport):
         def post(self, url, *, headers, json_body, timeout):


### PR DESCRIPTION
## What

Closes #103 by teaching the Python OpenBrainClient to recover from expired MCP sessions.

## Scope

- Detect expired-session tool-call responses from Open Brain MCP transport:
  - 404 session-gone responses
  - exact 400 transport messages: missing/invalid MCP session
- Clear the cached session, re-run initialize + notifications/initialized, and retry the original tool call exactly once
- Do not retry auth failures or unrelated 400 validation errors
- Preserve the original JSON-RPC tool-call payload across retry

## Review

Initial 3-lane review:
- Domain/backend: pass
- Gotcha-agent: pass
- Adversarial: found broad 400 matching risk

Fix verification:
- DomainFix: pass
- AdversarialFix: pass

## Validation

From python/openbrain-memory:
- uv run mypy src/openbrain_memory
- uv run ruff check src tests
- uv run pytest -q (86 passed, 1 skipped)
- uv run pytest -q tests/test_client.py -k 'expired_session or auth_error or tool_validation_400' (4 passed)
- uv build