### PR TITLE
feat: add Mini two-worker launch mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ LITELLM_API_KEY=
 
 # Server
 PORT=3100
+DB_POOL_MAX=10
+OPEN_BRAIN_RUN_MIGRATIONS=1
 
 # CORS allowed origins (comma-separated, empty for none)
 ALLOWED_ORIGINS=

--- a/.env.schema
+++ b/.env.schema
@@ -24,6 +24,8 @@ EXTRACTION_MODEL=@optional
 
 # Server
 PORT=3100
+DB_POOL_MAX=10
+OPEN_BRAIN_RUN_MIGRATIONS=1
 
 # CORS allowed origins (comma-separated)
 ALLOWED_ORIGINS=@optional

--- a/README.md
+++ b/README.md
@@ -119,6 +119,46 @@ bun run start
 
 The MCP server listens on `http://localhost:3100` with Streamable HTTP transport.
 
+### Mini two-worker mode
+
+For the Mini deployment, run two local Open Brain workers behind one stable
+entrypoint:
+
+```bash
+bun run start:two-worker
+```
+
+Defaults:
+
+- Public entrypoint: `http://localhost:3100`
+- Worker ports: `3101,3102`
+- Worker count: `2`
+- DB pool per worker: `5`
+- Migrations: only worker 1 runs migrations; worker 2 starts with
+  `OPEN_BRAIN_RUN_MIGRATIONS=0`
+
+Useful overrides:
+
+```bash
+OPEN_BRAIN_PUBLIC_PORT=3100 \
+OPEN_BRAIN_WORKERS=2 \
+OPEN_BRAIN_WORKER_PORTS=3101,3102 \
+OPEN_BRAIN_WORKER_DB_POOL_MAX=5 \
+bun run start:two-worker
+```
+
+The public `/health` endpoint aggregates both workers. MCP and REST traffic are
+round-robin proxied to the workers.
+
+Smoke after startup:
+
+```bash
+curl -fsS http://127.0.0.1:3100/health
+mcp2cli cache warm open-brain
+mcp2cli cache diff open-brain
+OPEN_BRAIN_CODEX_SMOKE_WRITE=1 bun run codex-memory-smoke
+```
+
 ## Auth & Permissions
 
 Each consumer gets a scoped Bearer token. Roles control which tables are readable/writable:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "start": "bun run src/index.ts",
+    "start:two-worker": "bun run scripts/run-two-worker.ts",
     "migrate": "bun run scripts/migrate.ts",
     "test": "bun test",
     "typecheck": "bunx tsc --noEmit",

--- a/scripts/run-two-worker.ts
+++ b/scripts/run-two-worker.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+
+type WorkerConfig = {
+  name: string;
+  port: number;
+  runMigrations: boolean;
+};
+
+const publicPort = parseInt(process.env.OPEN_BRAIN_PUBLIC_PORT ?? "3100", 10);
+const workerPorts = (process.env.OPEN_BRAIN_WORKER_PORTS ?? "3101,3102")
+  .split(",")
+  .map((port) => parseInt(port.trim(), 10))
+  .filter((port) => Number.isFinite(port) && port > 0);
+const workerCount = parseInt(process.env.OPEN_BRAIN_WORKERS ?? "2", 10);
+const poolMax = process.env.OPEN_BRAIN_WORKER_DB_POOL_MAX ?? "5";
+
+if (workerCount < 1) {
+  throw new Error("OPEN_BRAIN_WORKERS must be at least 1");
+}
+if (workerPorts.length < workerCount) {
+  throw new Error(
+    `OPEN_BRAIN_WORKER_PORTS must include at least ${workerCount} ports`,
+  );
+}
+
+const workers: WorkerConfig[] = Array.from({ length: workerCount }, (_, index) => {
+  const port = workerPorts[index];
+  if (!port) {
+    throw new Error(`Missing worker port for worker ${index + 1}`);
+  }
+  return {
+    name: `open-brain-worker-${index + 1}`,
+    port,
+    runMigrations: index === 0,
+  };
+});
+
+const children = workers.map((worker) => {
+  const child = Bun.spawn(["bun", "run", "src/index.ts"], {
+    env: {
+      ...process.env,
+      PORT: String(worker.port),
+      DB_POOL_MAX: poolMax,
+      OPEN_BRAIN_RUN_MIGRATIONS: worker.runMigrations ? "1" : "0",
+      OPEN_BRAIN_WORKER_NAME: worker.name,
+    },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  console.log(
+    `${worker.name} starting on :${worker.port} migrations=${worker.runMigrations}`,
+  );
+  return { worker, child };
+});
+
+let nextWorker = 0;
+
+async function workerHealth(worker: WorkerConfig) {
+  try {
+    const response = await fetch(`http://127.0.0.1:${worker.port}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    const body = await response.json().catch(() => null);
+    return {
+      name: worker.name,
+      port: worker.port,
+      ok: response.ok,
+      status: response.status,
+      body,
+    };
+  } catch (err) {
+    return {
+      name: worker.name,
+      port: worker.port,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function proxyRequest(request: Request): Promise<Response> {
+  const worker = workers[nextWorker % workers.length];
+  if (!worker) {
+    return Response.json({ error: "No Open Brain workers configured" }, { status: 503 });
+  }
+  nextWorker += 1;
+
+  const incomingUrl = new URL(request.url);
+  const targetUrl = new URL(incomingUrl.pathname + incomingUrl.search, `http://127.0.0.1:${worker.port}`);
+  const headers = new Headers(request.headers);
+  headers.set("x-open-brain-worker", worker.name);
+  headers.delete("host");
+
+  return fetch(targetUrl, {
+    method: request.method,
+    headers,
+    body:
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : request.body,
+    redirect: "manual",
+    signal: request.signal,
+  });
+}
+
+const proxy = Bun.serve({
+  port: publicPort,
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/health") {
+      const results = await Promise.all(workers.map(workerHealth));
+      const healthy = results.every((result) => result.ok);
+      return Response.json(
+        {
+          status: healthy ? "healthy" : "degraded",
+          workers: results,
+          timestamp: new Date().toISOString(),
+        },
+        { status: healthy ? 200 : 503 },
+      );
+    }
+
+    return proxyRequest(request);
+  },
+});
+
+console.log(
+  `open-brain proxy listening on :${publicPort} for workers ${workers
+    .map((worker) => `:${worker.port}`)
+    .join(", ")}`,
+);
+
+async function shutdown() {
+  console.log("Shutting down open-brain two-worker launcher...");
+  proxy.stop(true);
+  await Promise.all(
+    children.map(async ({ child }) => {
+      child.kill("SIGTERM");
+      await child.exited;
+    }),
+  );
+  process.exit(0);
+}
+
+process.on("SIGINT", () => {
+  void shutdown();
+});
+process.on("SIGTERM", () => {
+  void shutdown();
+});
+
+const exits = children.map(async ({ worker, child }) => {
+  const code = await child.exited;
+  throw new Error(`${worker.name} exited with code ${code}`);
+});
+
+await Promise.race(exits);

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -3,6 +3,12 @@ import pgvector from "pgvector/pg";
 import { logger } from "../logger.ts";
 import type { PoolHealth } from "../types.ts";
 
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export function createPool(overrides?: Partial<pg.PoolConfig>): pg.Pool {
   const host = process.env.DB_HOST;
   if (!host) throw new Error("DB_HOST environment variable is required");
@@ -15,7 +21,7 @@ export function createPool(overrides?: Partial<pg.PoolConfig>): pg.Pool {
     database: process.env.DB_NAME || "open_brain",
     user,
     password: process.env.DB_PASSWORD,
-    max: 10,
+    max: parsePositiveInt(process.env.DB_POOL_MAX, 10),
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 5000,
     maxUses: 7500,

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,14 +177,20 @@ if (import.meta.main) {
 
   const pool = createPool();
 
-  try {
-    await runMigrations(pool);
-    logger.info("Migrations complete");
-  } catch (err) {
-    logger.error("migration_failed", {
-      error: String(err),
+  if (process.env.OPEN_BRAIN_RUN_MIGRATIONS !== "0") {
+    try {
+      await runMigrations(pool);
+      logger.info("Migrations complete");
+    } catch (err) {
+      logger.error("migration_failed", {
+        error: String(err),
+      });
+      process.exit(1);
+    }
+  } else {
+    logger.info("Skipping migrations for worker", {
+      OPEN_BRAIN_RUN_MIGRATIONS: process.env.OPEN_BRAIN_RUN_MIGRATIONS,
     });
-    process.exit(1);
   }
 
   const tokenMap = buildTokenMap(


### PR DESCRIPTION
Closes #119.\n\n## Summary\n- Add open-brain-worker-1 starting on :3101 migrations=true
open-brain-worker-2 starting on :3102 migrations=false
open-brain proxy listening on :3100 for workers :3101, :3102 for two local Open Brain workers behind one stable Bun proxy entrypoint.\n- Add aggregate public  for both workers and round-robin proxying for MCP/REST traffic.\n- Add  support so only worker 1 runs migrations.\n- Add  so two-worker deployments can cap per-worker Postgres pool size.\n- Document Mini two-worker startup and smoke commands.\n\n## Verification\n- \n- bun test v1.3.13 (bf2e2cec) -> 654 pass, 16 skip, 0 fail\n\n## Smoke plan after merge\n- Update Mini checkout to merged main.\n- Switch  from  to open-brain-worker-1 starting on :3101 migrations=true
open-brain-worker-2 starting on :3102 migrations=false
open-brain proxy listening on :3100 for workers :3101, :3102.\n- Verify aggregate , No schema drift detected for "open-brain". Cache is current., Codex memory smoke, and 25-concurrent mixed stress.