### PR TITLE
Add Open Brain contract and repo fact tools

### DIFF
--- a/docs/downstream-rollout.md
+++ b/docs/downstream-rollout.md
@@ -100,3 +100,55 @@ steps above are either:
 Do not close the issue or report the rollout done after only local tests,
 hosted Open Brain tests, or mcp2cli schema checks when Hermes agent behavior is
 in scope.
+
+## Contract Manifest
+
+Downstream runtimes must not infer Open Brain compatibility from memory,
+generated docs, or partial tool discovery. Open Brain exposes a canonical
+contract manifest through `get_contract`.
+
+The manifest includes:
+
+- `contract_version`
+- `schema_version`
+- `schema_hash`
+- `generated_at`
+- `min_client_versions`
+- `compatible_client_ranges`
+- `transport`
+- `capabilities`
+
+`schema_hash` is deterministic and excludes `generated_at`. Downstream clients
+such as `rtech-hermes` should validate `contract_version`, `schema_hash`,
+minimum client version, compatible range, and required capabilities at startup.
+In required memory mode, incompatible or unreachable contracts must fail closed.
+
+## qmd-Derived Repo Facts
+
+qmd runs on the local GPU machine and acts as the repo-knowledge compiler. Open
+Brain is the shared runtime distribution layer for agents that cannot run qmd.
+Required repo knowledge is promoted into Open Brain with `upsert_repo_fact` and
+read with `list_repo_facts`.
+
+Repo facts are curated operating knowledge plus source pointers. They are not
+raw qmd/code chunks. Each fact is stored as an `ob_entities` graph entity with
+`entity_type = 'repo_fact'`, a deterministic `canonical_id`, and metadata that
+includes:
+
+- `source_system: "qmd"`
+- `repo`
+- `collection`
+- `path`
+- `symbol` or `subject`
+- `fact_type`
+- `fact`
+- `source_commit`
+- `source_url`
+- `verified_at`
+- `confidence`
+- `staleness_policy`
+- `refresh_hint`
+
+Promotion rule: if distributed agents are expected to rely on a qmd-derived repo
+fact during normal work, that fact must be present in Open Brain. Remote qmd can
+exist as a best-effort deep lookup path, but it is not the memory contract.

--- a/docs/downstream-rollout.md
+++ b/docs/downstream-rollout.md
@@ -110,6 +110,7 @@ contract manifest through `get_contract`.
 The manifest includes:
 
 - `contract_version`
+- `contract_scope`
 - `schema_version`
 - `schema_hash`
 - `generated_at`
@@ -117,11 +118,19 @@ The manifest includes:
 - `compatible_client_ranges`
 - `transport`
 - `capabilities`
+- `tool_contracts`
 
-`schema_hash` is deterministic and excludes `generated_at`. Downstream clients
-such as `rtech-hermes` should validate `contract_version`, `schema_hash`,
-minimum client version, compatible range, and required capabilities at startup.
-In required memory mode, incompatible or unreachable contracts must fail closed.
+`contract_scope` is `required_openbrain_memory_contract`. The manifest is the
+canonical compatibility contract for required memory/session/repo-fact behavior
+that Hermes, mcp2cli, and generated Open Brain skills must depend on. It is not
+yet a typed schema export for every optional Open Brain MCP tool.
+
+`schema_hash` is deterministic and excludes `generated_at`. It includes the
+required capability list, required tool contracts, repo-fact metadata contract,
+and repo-fact validation semantics. Downstream clients such as `rtech-hermes`
+should validate `contract_version`, `contract_scope`, `schema_hash`, minimum
+client version, compatible range, and required capabilities at startup. In
+required memory mode, incompatible or unreachable contracts must fail closed.
 
 ## qmd-Derived Repo Facts
 
@@ -148,6 +157,14 @@ includes:
 - `confidence`
 - `staleness_policy`
 - `refresh_hint`
+
+`source_url` must be an HTTPS GitHub source URL with no embedded credentials.
+For `github.com`, it must match
+`/<owner>/<repo>/blob/<source_commit>/<repo_relative_path>`. For
+`raw.githubusercontent.com`, it must match
+`/<owner>/<repo>/<source_commit>/<repo_relative_path>`. The URL repo segment
+must match the repo fact's `repo` slug, and the source commit must be a path
+segment, not a query string or fragment.
 
 Promotion rule: if distributed agents are expected to rely on a qmd-derived repo
 fact during normal work, that fact must be present in Open Brain. Remote qmd can

--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -77,6 +77,9 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 | list_entities | List graph entities by type/name/namespace | read |
 | link_entities | Create relationship between entries | write |
 | adjacent_context | Traverse link graph from a node | read |
+| get_contract | Read the public Open Brain contract manifest | read |
+| upsert_repo_fact | Store curated qmd-derived repo fact metadata | write |
+| list_repo_facts | Read curated qmd-derived repo facts | read |
 | search_brain | Semantic search across all tables | read |
 | search_all | Federated search (OB + qmd) | read |
 | brain_answer | Extractive cited evidence bullets from Open Brain | read |
@@ -164,6 +167,23 @@ relationships, validated artifacts, and promoted shared knowledge. Use
 `log_decision`, `log_thought`, entity/link tools, and promotion flows when a
 fact should survive beyond the current lane. Do not promote raw chat logs,
 secrets, private source identifiers, or unvalidated guesses.
+
+### Repo Knowledge From qmd
+
+qmd is the local GPU-backed code knowledge compiler. It can index source, embed
+chunks, and attach context to paths. Agents that do not run on that machine
+cannot depend on qmd during normal memory flow, so required qmd-derived repo
+facts must be promoted into Open Brain.
+
+Use `upsert_repo_fact` for curated, durable operating knowledge such as
+ownership, gotchas, dependency rules, import rules, validation notes, and source
+pointers. The fact must include source provenance and staleness metadata:
+`repo`, `collection`, `path`, `source_commit`, `verified_at`, `fact_type`,
+`staleness_policy`, and either `symbol` or `subject` when applicable.
+
+Do not mirror raw qmd chunks or full code excerpts into Open Brain by default.
+For volatile implementation details, store a stable fact plus a source pointer
+and verify the live source through `gh` or a checkout before editing.
 
 ### Citation And Answering Rules
 

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { buildContract, contractHash } from "./contract.ts";
+
+describe("Open Brain contract manifest", () => {
+  it("builds a manifest with required compatibility fields", () => {
+    const contract = buildContract("2026-06-18T00:00:00.000Z");
+
+    expect(contract.service).toBe("open-brain");
+    expect(contract.contract_version).toContain("repo-facts");
+    expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
+    expect(contract.transport.namespace_boundary).toBe("authorization");
+    expect(contract.capabilities.map((c) => c.name)).toContain(
+      "upsert_repo_fact",
+    );
+  });
+
+  it("keeps the schema hash stable when only generated_at changes", () => {
+    const first = buildContract("2026-06-18T00:00:00.000Z");
+    const second = buildContract("2026-06-18T01:00:00.000Z");
+
+    expect(first.generated_at).not.toBe(second.generated_at);
+    expect(first.schema_hash).toBe(second.schema_hash);
+  });
+
+  it("changes the schema hash when public capabilities change", () => {
+    const base = buildContract("2026-06-18T00:00:00.000Z");
+    const changedPayload = {
+      service: base.service,
+      contract_version: base.contract_version,
+      schema_version: base.schema_version,
+      min_client_versions: base.min_client_versions,
+      compatible_client_ranges: base.compatible_client_ranges,
+      transport: base.transport,
+      capabilities: [
+        ...base.capabilities,
+        {
+          name: "example_new_public_tool",
+          version: 1,
+          kind: "tool" as const,
+          description: "Fixture capability used to prove hash drift.",
+        },
+      ],
+    };
+
+    expect(contractHash(changedPayload)).not.toBe(base.schema_hash);
+  });
+});

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import type { OpenBrainContract } from "./contract.ts";
 import { buildContract, contractHash } from "./contract.ts";
+
+type ContractPayload = Omit<OpenBrainContract, "generated_at" | "schema_hash">;
 
 describe("Open Brain contract manifest", () => {
   it("builds a manifest with required compatibility fields", () => {
@@ -13,6 +16,11 @@ describe("Open Brain contract manifest", () => {
     expect(contract.capabilities.map((c) => c.name)).toContain(
       "upsert_repo_fact",
     );
+    const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
+    expect(upsertRepoFact).toBeDefined();
+    expect((upsertRepoFact?.input_schema as any).metadata.source_url.required).toBe(
+      true,
+    );
   });
 
   it("keeps the schema hash stable when only generated_at changes", () => {
@@ -25,7 +33,7 @@ describe("Open Brain contract manifest", () => {
 
   it("changes the schema hash when public capabilities change", () => {
     const base = buildContract("2026-06-18T00:00:00.000Z");
-    const changedPayload = {
+    const changedPayload: ContractPayload = {
       service: base.service,
       contract_version: base.contract_version,
       schema_version: base.schema_version,
@@ -41,6 +49,38 @@ describe("Open Brain contract manifest", () => {
           description: "Fixture capability used to prove hash drift.",
         },
       ],
+      tool_contracts: base.tool_contracts,
+    };
+
+    expect(contractHash(changedPayload)).not.toBe(base.schema_hash);
+  });
+
+  it("changes the schema hash when repo fact metadata contract changes", () => {
+    const base = buildContract("2026-06-18T00:00:00.000Z");
+    const upsertRepoFact = base.tool_contracts.upsert_repo_fact;
+    expect(upsertRepoFact).toBeDefined();
+
+    const changedPayload: ContractPayload = {
+      service: base.service,
+      contract_version: base.contract_version,
+      schema_version: base.schema_version,
+      min_client_versions: base.min_client_versions,
+      compatible_client_ranges: base.compatible_client_ranges,
+      transport: base.transport,
+      capabilities: base.capabilities,
+      tool_contracts: {
+        ...base.tool_contracts,
+        upsert_repo_fact: {
+          ...upsertRepoFact!,
+          input_schema: {
+            ...(upsertRepoFact!.input_schema as any),
+            metadata: {
+              ...((upsertRepoFact!.input_schema as any).metadata as any),
+              fact: { type: "string", required: true, maxLength: 1000 },
+            },
+          },
+        },
+      },
     };
 
     expect(contractHash(changedPayload)).not.toBe(base.schema_hash);

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -10,6 +10,7 @@ describe("Open Brain contract manifest", () => {
 
     expect(contract.service).toBe("open-brain");
     expect(contract.contract_version).toContain("repo-facts");
+    expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -20,6 +21,9 @@ describe("Open Brain contract manifest", () => {
     expect(upsertRepoFact).toBeDefined();
     expect((upsertRepoFact?.input_schema as any).metadata.source_url.required).toBe(
       true,
+    );
+    expect((upsertRepoFact?.input_schema as any).validation.source_url.repo_match).toContain(
+      "metadata.repo",
     );
   });
 
@@ -36,6 +40,7 @@ describe("Open Brain contract manifest", () => {
     const changedPayload: ContractPayload = {
       service: base.service,
       contract_version: base.contract_version,
+      contract_scope: base.contract_scope,
       schema_version: base.schema_version,
       min_client_versions: base.min_client_versions,
       compatible_client_ranges: base.compatible_client_ranges,
@@ -63,6 +68,7 @@ describe("Open Brain contract manifest", () => {
     const changedPayload: ContractPayload = {
       service: base.service,
       contract_version: base.contract_version,
+      contract_scope: base.contract_scope,
       schema_version: base.schema_version,
       min_client_versions: base.min_client_versions,
       compatible_client_ranges: base.compatible_client_ranges,
@@ -77,6 +83,42 @@ describe("Open Brain contract manifest", () => {
             metadata: {
               ...((upsertRepoFact!.input_schema as any).metadata as any),
               fact: { type: "string", required: true, maxLength: 1000 },
+            },
+          },
+        },
+      },
+    };
+
+    expect(contractHash(changedPayload)).not.toBe(base.schema_hash);
+  });
+
+  it("changes the schema hash when repo fact validation semantics change", () => {
+    const base = buildContract("2026-06-18T00:00:00.000Z");
+    const upsertRepoFact = base.tool_contracts.upsert_repo_fact;
+    expect(upsertRepoFact).toBeDefined();
+
+    const changedPayload: ContractPayload = {
+      service: base.service,
+      contract_version: base.contract_version,
+      contract_scope: base.contract_scope,
+      schema_version: base.schema_version,
+      min_client_versions: base.min_client_versions,
+      compatible_client_ranges: base.compatible_client_ranges,
+      transport: base.transport,
+      capabilities: base.capabilities,
+      tool_contracts: {
+        ...base.tool_contracts,
+        upsert_repo_fact: {
+          ...upsertRepoFact!,
+          input_schema: {
+            ...(upsertRepoFact!.input_schema as any),
+            validation: {
+              ...((upsertRepoFact!.input_schema as any).validation as any),
+              fact_body: {
+                ...((upsertRepoFact!.input_schema as any).validation as any)
+                  .fact_body,
+                max_lines: 20,
+              },
             },
           },
         },

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { REPO_FACT_METADATA_CONTRACT } from "./tools/repo-facts.ts";
 
 export const CONTRACT_VERSION = "2026-06-18.repo-facts.v1";
 export const CONTRACT_SCHEMA_VERSION = 1;
@@ -25,6 +26,14 @@ export interface OpenBrainContract {
     session_required: true;
   };
   capabilities: ContractCapability[];
+  tool_contracts: Record<
+    string,
+    {
+      version: number;
+      input_schema: unknown;
+      output_shape: string;
+    }
+  >;
 }
 
 export const CONTRACT_CAPABILITIES: ContractCapability[] = [
@@ -114,6 +123,39 @@ export function buildContract(generatedAt = new Date().toISOString()): OpenBrain
     capabilities: [...CONTRACT_CAPABILITIES].sort((a, b) =>
       a.name.localeCompare(b.name),
     ),
+    tool_contracts: {
+      get_contract: {
+        version: 1,
+        input_schema: {},
+        output_shape: "OpenBrainContract JSON text payload",
+      },
+      upsert_repo_fact: {
+        version: 1,
+        input_schema: {
+          namespace: { type: "string", required: false, maxLength: 500 },
+          metadata: REPO_FACT_METADATA_CONTRACT,
+        },
+        output_shape: "ob_entities repo_fact row JSON text payload",
+      },
+      list_repo_facts: {
+        version: 1,
+        input_schema: {
+          namespace: { type: "string", required: false, maxLength: 500 },
+          repo: { type: "string", required: false, maxLength: 300 },
+          collection: { type: "string", required: false, maxLength: 300 },
+          path: { type: "string", required: false, maxLength: 1000 },
+          fact_type: {
+            type: "enum",
+            required: false,
+            values: REPO_FACT_METADATA_CONTRACT.fact_type.values,
+          },
+          subject: { type: "string", required: false, maxLength: 500 },
+          limit: { type: "integer", required: false, min: 1, max: 250 },
+          offset: { type: "integer", required: false, min: 0 },
+        },
+        output_shape: "repo_fact ob_entities row array JSON text payload",
+      },
+    },
   };
 
   return {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
-import { REPO_FACT_METADATA_CONTRACT } from "./tools/repo-facts.ts";
+import {
+  REPO_FACT_METADATA_CONTRACT,
+  REPO_FACT_VALIDATION_CONTRACT,
+} from "./tools/repo-facts.ts";
 
 export const CONTRACT_VERSION = "2026-06-18.repo-facts.v1";
 export const CONTRACT_SCHEMA_VERSION = 1;
@@ -14,6 +17,7 @@ export interface ContractCapability {
 export interface OpenBrainContract {
   service: "open-brain";
   contract_version: string;
+  contract_scope: "required_openbrain_memory_contract";
   schema_version: number;
   schema_hash: string;
   generated_at: string;
@@ -103,6 +107,7 @@ export function buildContract(generatedAt = new Date().toISOString()): OpenBrain
   const payload = {
     service: "open-brain" as const,
     contract_version: CONTRACT_VERSION,
+    contract_scope: "required_openbrain_memory_contract" as const,
     schema_version: CONTRACT_SCHEMA_VERSION,
     min_client_versions: {
       "openbrain-memory": "0.1.0",
@@ -134,6 +139,7 @@ export function buildContract(generatedAt = new Date().toISOString()): OpenBrain
         input_schema: {
           namespace: { type: "string", required: false, maxLength: 500 },
           metadata: REPO_FACT_METADATA_CONTRACT,
+          validation: REPO_FACT_VALIDATION_CONTRACT,
         },
         output_shape: "ob_entities repo_fact row JSON text payload",
       },

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,0 +1,124 @@
+import { createHash } from "node:crypto";
+
+export const CONTRACT_VERSION = "2026-06-18.repo-facts.v1";
+export const CONTRACT_SCHEMA_VERSION = 1;
+
+export interface ContractCapability {
+  name: string;
+  version: number;
+  kind: "tool" | "transport" | "schema";
+  description: string;
+}
+
+export interface OpenBrainContract {
+  service: "open-brain";
+  contract_version: string;
+  schema_version: number;
+  schema_hash: string;
+  generated_at: string;
+  min_client_versions: Record<string, string>;
+  compatible_client_ranges: Record<string, string>;
+  transport: {
+    mcp: "streamable-http";
+    auth: "bearer";
+    namespace_boundary: "authorization";
+    session_required: true;
+  };
+  capabilities: ContractCapability[];
+}
+
+export const CONTRACT_CAPABILITIES: ContractCapability[] = [
+  {
+    name: "get_contract",
+    version: 1,
+    kind: "tool",
+    description: "Read the canonical Open Brain public contract manifest.",
+  },
+  {
+    name: "upsert_repo_fact",
+    version: 1,
+    kind: "tool",
+    description:
+      "Upsert a curated qmd-derived repository fact into graph entity metadata.",
+  },
+  {
+    name: "list_repo_facts",
+    version: 1,
+    kind: "tool",
+    description:
+      "Read curated qmd-derived repository facts with namespace scoping.",
+  },
+  {
+    name: "entity_graph",
+    version: 2,
+    kind: "schema",
+    description:
+      "Open Brain graph entities and links, including archived entity lifecycle.",
+  },
+  {
+    name: "session_lanes",
+    version: 1,
+    kind: "schema",
+    description: "Durable session lanes, events, context, and wraps.",
+  },
+  {
+    name: "streamable_http_auth",
+    version: 1,
+    kind: "transport",
+    description:
+      "Bearer-token identity establishes namespace boundaries for MCP sessions.",
+  },
+];
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, val]) => [key, sortValue(val)]),
+    );
+  }
+  return value;
+}
+
+export function stableJson(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+export function contractHash(payload: Omit<OpenBrainContract, "generated_at" | "schema_hash">): string {
+  return createHash("sha256").update(stableJson(payload)).digest("hex");
+}
+
+export function buildContract(generatedAt = new Date().toISOString()): OpenBrainContract {
+  const payload = {
+    service: "open-brain" as const,
+    contract_version: CONTRACT_VERSION,
+    schema_version: CONTRACT_SCHEMA_VERSION,
+    min_client_versions: {
+      "openbrain-memory": "0.1.0",
+      "rtech-hermes-runtime": "0.1.0",
+      mcp2cli: "0.3.6",
+    },
+    compatible_client_ranges: {
+      "openbrain-memory": ">=0.1.0 <1.0.0",
+      "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
+      mcp2cli: ">=0.3.6 <1.0.0",
+    },
+    transport: {
+      mcp: "streamable-http" as const,
+      auth: "bearer" as const,
+      namespace_boundary: "authorization" as const,
+      session_required: true as const,
+    },
+    capabilities: [...CONTRACT_CAPABILITIES].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    ),
+  };
+
+  return {
+    ...payload,
+    schema_hash: contractHash(payload),
+    generated_at: generatedAt,
+  };
+}

--- a/src/tools/__tests__/get-contract.test.ts
+++ b/src/tools/__tests__/get-contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { registerGetContract } from "../get-contract.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  getErrorText,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+describe("get_contract", () => {
+  it("allows readonly clients to read the contract manifest", async () => {
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetContract,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_contract",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.service).toBe("open-brain");
+      expect(parsed.schema_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(parsed.capabilities.map((c: { name: string }) => c.name)).toContain(
+        "list_repo_facts",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unauthenticated contract reads", async () => {
+    const { client, cleanup } = await setupMcpClient(
+      registerGetContract,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      null,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_contract",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/repo-facts.test.ts
+++ b/src/tools/__tests__/repo-facts.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "bun:test";
+import {
+  registerListRepoFacts,
+  registerUpsertRepoFact,
+} from "../repo-facts.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  getErrorText,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+const repoFact = {
+  source_system: "qmd",
+  repo: "king-core",
+  collection: "king",
+  path: "king-core/src/types/api.ts",
+  symbol: "ApiResponse",
+  fact_type: "api_contract",
+  fact: "Use ApiResponse<T> from @king-capital/core/types; do not hand-roll response envelopes.",
+  source_commit: "3e48e2f0085a0ff03ddbccb84ae826d21c77aed4",
+  source_url:
+    "https://github.com/rodaddy/king-core/blob/3e48e2f0085a0ff03ddbccb84ae826d21c77aed4/src/types/api.ts",
+  verified_at: "2026-06-18T06:00:00.000Z",
+  confidence: 1,
+  staleness_policy: "stable_fact_verify_source",
+  refresh_hint: "Verify live shape in source before editing response contracts.",
+} as const;
+
+describe("repo fact tools", () => {
+  it("upserts a curated qmd repo fact as a graph entity", async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        return {
+          rows: [
+            {
+              id: "550e8400-e29b-41d4-a716-446655440000",
+              is_new: true,
+              entity_type: "repo_fact",
+              name: params?.[0],
+              canonical_id: params?.[1],
+              namespace: params?.[2],
+              metadata: JSON.parse(params?.[3] as string),
+              created_at: "2026-06-18T06:00:00.000Z",
+              updated_at: "2026-06-18T06:00:00.000Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: { namespace: "collab", metadata: repoFact },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.entity_type).toBe("repo_fact");
+      expect(parsed.namespace).toBe("collab");
+      expect(parsed.canonical_id).toContain("repo_fact:qmd:king-core");
+      expect(parsed.metadata.source_system).toBe("qmd");
+      expect(parsed.metadata.source_commit).toBe(repoFact.source_commit);
+      expect(calls[0]?.sql).toContain("entity_type, name, canonical_id");
+      expect(calls[0]?.sql).toContain("ON CONFLICT");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects fact bodies that look like raw code chunks", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            fact: "export interface ApiResponse<T> {\n  success: boolean;\n  data?: T;\n}",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("raw code chunk");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("enforces namespace write policy", async () => {
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: { namespace: "collab", metadata: repoFact },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("lists repo facts with readable namespace scoping", async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        return {
+          rows: [
+            {
+              id: "550e8400-e29b-41d4-a716-446655440000",
+              entity_type: "repo_fact",
+              name: "king-core:api",
+              namespace: "collab",
+              metadata: repoFact,
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerListRepoFacts,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "list_repo_facts",
+        arguments: { repo: "king-core", subject: "ApiResponse", limit: 10 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result)).toHaveLength(1);
+      expect(calls[0]?.sql).toContain("entity_type = 'repo_fact'");
+      expect(calls[0]?.sql).toContain("namespace = ANY($1::text[])");
+      expect(calls[0]?.sql).toContain("metadata->>'repo' = $2");
+      expect(calls[0]?.sql).toContain("metadata->>'subject' = $3 OR metadata->>'symbol' = $3");
+      expect(calls[0]?.params).toEqual([
+        ["bilby", "collab"],
+        "king-core",
+        "ApiResponse",
+        10,
+        0,
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects unreadable explicit namespaces when listing repo facts", async () => {
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerListRepoFacts,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "list_repo_facts",
+        arguments: { namespace: "other" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("namespace read access denied");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/repo-facts.test.ts
+++ b/src/tools/__tests__/repo-facts.test.ts
@@ -106,6 +106,198 @@ describe("repo fact tools", () => {
     }
   });
 
+  it("rejects short Python code chunks", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            fact: "def load_contract(path):\n    return open(path).read()",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("raw code chunk");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects credential-like material before embedding or storage", async () => {
+    let queried = false;
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            fact: ["token=", "not-a-real-token-value"].join(""),
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("credential-like material");
+      expect(queried).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("requires either symbol or subject", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    const { symbol: _symbol, ...metadataWithoutSubject } = repoFact;
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: { metadata: metadataWithoutSubject },
+      });
+      expect(result.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("requires trusted HTTPS GitHub source URLs", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            source_url: "http://localhost/source",
+          },
+        },
+      });
+      expect(result.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects future verification timestamps", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            verified_at: "2999-01-01T00:00:00.000Z",
+          },
+        },
+      });
+      expect(result.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("adds a digest to canonical IDs so long truncated paths do not collide", async () => {
+    const ids: string[] = [];
+    const mockPool = {
+      query: async (_sql: string, params?: unknown[]) => {
+        ids.push(params?.[1] as string);
+        return {
+          rows: [
+            {
+              id: `id-${ids.length}`,
+              is_new: true,
+              entity_type: "repo_fact",
+              name: params?.[0],
+              canonical_id: params?.[1],
+              namespace: params?.[2],
+              metadata: JSON.parse(params?.[3] as string),
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const longPath = `${"a".repeat(220)}/api.ts`;
+      await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            path: longPath,
+            source_url: `https://github.com/rodaddy/king-core/blob/${repoFact.source_commit}/${longPath}`,
+          },
+        },
+      });
+      await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            path: `${"a".repeat(220)}/db.ts`,
+            source_url: `https://github.com/rodaddy/king-core/blob/${repoFact.source_commit}/${"a".repeat(220)}/db.ts`,
+          },
+        },
+      });
+
+      expect(ids[0]).not.toBe(ids[1]);
+      expect(ids[0]?.split(":").at(-1)).toMatch(/^[0-9a-f]{16}$/);
+      expect(ids[1]?.split(":").at(-1)).toMatch(/^[0-9a-f]{16}$/);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("enforces namespace write policy", async () => {
     const auth: AuthInfo = { role: "agent", clientId: "bilby" };
     const { client, cleanup } = await setupMcpClient(

--- a/src/tools/__tests__/repo-facts.test.ts
+++ b/src/tools/__tests__/repo-facts.test.ts
@@ -167,6 +167,40 @@ describe("repo fact tools", () => {
     }
   });
 
+  it("rejects AWS secret-access-key-like material before embedding or storage", async () => {
+    let queried = false;
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            fact: "Never store this fixture: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("credential-like material");
+      expect(queried).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("requires either symbol or subject", async () => {
     const auth: AuthInfo = { role: "admin", clientId: "rico" };
     const { client, cleanup } = await setupMcpClient(
@@ -238,6 +272,72 @@ describe("repo fact tools", () => {
       expect(getErrorText(result)).toContain(
         "source_url must include source_commit and source path",
       );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects source commit hidden in query or fragment", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      for (const source_url of [
+        `https://github.com/rodaddy/king-core/blob/main/src/types/api.ts?commit=${repoFact.source_commit}`,
+        `https://github.com/rodaddy/king-core/blob/main/src/types/api.ts#${repoFact.source_commit}`,
+      ]) {
+        const result = await client.callTool({
+          name: "upsert_repo_fact",
+          arguments: {
+            metadata: {
+              ...repoFact,
+              source_url,
+            },
+          },
+        });
+        expect(result.isError).toBe(true);
+        expect(getErrorText(result)).toContain(
+          "source_url must include source_commit and source path",
+        );
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects source URLs from a different repository or suffix path", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      for (const source_url of [
+        `https://github.com/rodaddy/other-repo/blob/${repoFact.source_commit}/src/types/api.ts`,
+        `https://github.com/rodaddy/king-core/blob/${repoFact.source_commit}/src/types/api.ts.evil`,
+      ]) {
+        const result = await client.callTool({
+          name: "upsert_repo_fact",
+          arguments: {
+            metadata: {
+              ...repoFact,
+              source_url,
+            },
+          },
+        });
+        expect(result.isError).toBe(true);
+        expect(getErrorText(result)).toContain(
+          "source_url must include source_commit and source path",
+        );
+      }
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/repo-facts.test.ts
+++ b/src/tools/__tests__/repo-facts.test.ts
@@ -214,6 +214,35 @@ describe("repo fact tools", () => {
     }
   });
 
+  it("requires source URLs to include the source commit and path", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            source_url:
+              "https://github.com/rodaddy/king-core/blob/main/src/types/api.ts",
+          },
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain(
+        "source_url must include source_commit and source path",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("rejects future verification timestamps", async () => {
     const auth: AuthInfo = { role: "admin", clientId: "rico" };
     const { client, cleanup } = await setupMcpClient(
@@ -234,6 +263,47 @@ describe("repo fact tools", () => {
         },
       });
       expect(result.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("allows normal prose with colon punctuation", async () => {
+    const mockPool = {
+      query: async (_sql: string, params?: unknown[]) => ({
+        rows: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            is_new: true,
+            entity_type: "repo_fact",
+            name: params?.[0],
+            canonical_id: params?.[1],
+            namespace: params?.[2],
+            metadata: JSON.parse(params?.[3] as string),
+          },
+        ],
+      }),
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerUpsertRepoFact,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "upsert_repo_fact",
+        arguments: {
+          metadata: {
+            ...repoFact,
+            fact: "Note: read the source pointer before changing the response envelope.",
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
     } finally {
       await cleanup();
     }

--- a/src/tools/get-contract.ts
+++ b/src/tools/get-contract.ts
@@ -1,0 +1,45 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import type { AuthInfo } from "../types.ts";
+import { buildContract } from "../contract.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerGetContract(server: McpServer, _deps: ToolDeps): void {
+  server.registerTool(
+    "get_contract",
+    {
+      description:
+        "Return the canonical Open Brain public contract manifest for downstream clients.",
+      inputSchema: {},
+      annotations: {
+        title: "Get Contract",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (_args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canRead(auth.role, "sessions")) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot read contract",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(buildContract()),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -42,6 +42,8 @@ import { registerAdjacentContext } from "./adjacent-context.ts";
 import { registerPromoteEntry } from "./promote-entry.ts";
 import { registerDemoteEntry } from "./demote-entry.ts";
 import { registerScanNamespace } from "./scan-namespace.ts";
+import { registerGetContract } from "./get-contract.ts";
+import { registerListRepoFacts, registerUpsertRepoFact } from "./repo-facts.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -90,4 +92,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerPromoteEntry(server, deps);
   registerDemoteEntry(server, deps);
   registerScanNamespace(server, deps);
+  registerGetContract(server, deps);
+  registerUpsertRepoFact(server, deps);
+  registerListRepoFacts(server, deps);
 }

--- a/src/tools/repo-facts.ts
+++ b/src/tools/repo-facts.ts
@@ -93,36 +93,36 @@ const sourceUrl = z
 
 export const repoFactMetadata = z
   .object({
-  source_system: z.literal("qmd").describe("Fact source system."),
-  repo: z.string().trim().min(1).max(300),
-  collection: z.string().trim().min(1).max(300),
-  path: z.string().trim().min(1).max(1000),
-  symbol: z.string().trim().min(1).max(300).optional(),
-  subject: z.string().trim().min(1).max(500).optional(),
-  fact_type: z.enum(FACT_TYPES),
-  fact: z.string().trim().min(1).max(2000),
-  source_commit: sourceCommit,
-  source_url: sourceUrl,
-  verified_at: z
-    .string()
-    .datetime()
-    .refine((value) => Date.parse(value) <= Date.now(), {
-      message: "verified_at cannot be in the future",
-    }),
-  confidence: z.number().min(0).max(1).default(1),
-  staleness_policy: z.enum(STALENESS_POLICIES),
-  refresh_hint: z.string().trim().min(1).max(1000).optional(),
-})
+    source_system: z.literal("qmd").describe("Fact source system."),
+    repo: z.string().trim().min(1).max(300),
+    collection: z.string().trim().min(1).max(300),
+    path: z.string().trim().min(1).max(1000),
+    symbol: z.string().trim().min(1).max(300).optional(),
+    subject: z.string().trim().min(1).max(500).optional(),
+    fact_type: z.enum(FACT_TYPES),
+    fact: z.string().trim().min(1).max(2000),
+    source_commit: sourceCommit,
+    source_url: sourceUrl,
+    verified_at: z
+      .string()
+      .datetime()
+      .refine((value) => Date.parse(value) <= Date.now(), {
+        message: "verified_at cannot be in the future",
+      }),
+    confidence: z.number().min(0).max(1).default(1),
+    staleness_policy: z.enum(STALENESS_POLICIES),
+    refresh_hint: z.string().trim().min(1).max(1000).optional(),
+  })
   .refine((value) => Boolean(value.symbol ?? value.subject), {
     message: "repo facts require symbol or subject",
     path: ["subject"],
   })
   .refine(
     (value) =>
-      !value.source_url.includes(value.source_commit) ||
+      value.source_url.includes(value.source_commit) &&
       sourceUrlContainsPath(value.source_url, value.path),
     {
-      message: "source_url must include source path when commit-pinned",
+      message: "source_url must include source_commit and source path",
       path: ["source_url"],
     },
   );
@@ -202,7 +202,7 @@ function looksLikeRawCodeDump(fact: string): boolean {
     /^\s*class\s+\w+[:(]/m,
     /^\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER)\s+/im,
     /^\s*#!\/(?:usr\/bin\/env\s+)?(?:ba|z|fi)?sh/m,
-    /^\s*[a-zA-Z_][\w-]*:\s*[{["\w-]/m,
+    /^\s*[a-zA-Z_][\w-]*:\s*[{["]/m,
     /```/,
     /=>\s*[{(]/,
     /\b(return|await|try|catch|finally)\b/,

--- a/src/tools/repo-facts.ts
+++ b/src/tools/repo-facts.ts
@@ -63,21 +63,46 @@ function isTrustedSourceUrl(rawUrl: string): boolean {
   }
 }
 
-function sourceUrlContainsPath(rawUrl: string, path: string): boolean {
+function sourceUrlMatchesSource(
+  rawUrl: string,
+  repo: string,
+  path: string,
+  commit: string,
+): boolean {
   try {
     const parsed = new URL(rawUrl);
-    const decodedPath = decodeURIComponent(parsed.pathname);
+    const decodedPath = decodeURIComponent(parsed.pathname).replace(/^\/+/, "");
     const normalizedPath = path.replace(/^\/+/, "");
+    const repoSlug = repo.replace(/^\/+|\/+$/g, "").split("/").at(-1) ?? repo;
     const pathParts = normalizedPath.split("/");
-    const withoutRepoPrefix =
-      pathParts.length > 1 ? pathParts.slice(1).join("/") : normalizedPath;
+    const repoRelativePath =
+      pathParts[0] === repoSlug && pathParts.length > 1
+        ? pathParts.slice(1).join("/")
+        : normalizedPath;
 
-    return (
-      decodedPath.includes(normalizedPath) ||
-      decodedPath.includes(encodeURI(normalizedPath)) ||
-      decodedPath.includes(withoutRepoPrefix) ||
-      decodedPath.includes(encodeURI(withoutRepoPrefix))
-    );
+    if (parsed.hostname.toLowerCase() === "github.com") {
+      const [owner, urlRepo, blob, urlCommit, ...sourceParts] =
+        decodedPath.split("/");
+      void owner;
+      return (
+        urlRepo === repoSlug &&
+        blob === "blob" &&
+        urlCommit === commit &&
+        sourceParts.join("/") === repoRelativePath
+      );
+    }
+
+    if (parsed.hostname.toLowerCase() === "raw.githubusercontent.com") {
+      const [owner, urlRepo, urlCommit, ...sourceParts] = decodedPath.split("/");
+      void owner;
+      return (
+        urlRepo === repoSlug &&
+        urlCommit === commit &&
+        sourceParts.join("/") === repoRelativePath
+      );
+    }
+
+    return false;
   } catch {
     return false;
   }
@@ -119,8 +144,12 @@ export const repoFactMetadata = z
   })
   .refine(
     (value) =>
-      value.source_url.includes(value.source_commit) &&
-      sourceUrlContainsPath(value.source_url, value.path),
+      sourceUrlMatchesSource(
+        value.source_url,
+        value.repo,
+        value.path,
+        value.source_commit,
+      ),
     {
       message: "source_url must include source_commit and source path",
       path: ["source_url"],
@@ -148,6 +177,35 @@ export const REPO_FACT_METADATA_CONTRACT = {
     values: STALENESS_POLICIES,
   },
   refresh_hint: { type: "string", required: false, maxLength: 1000 },
+} as const;
+
+export const REPO_FACT_VALIDATION_CONTRACT = {
+  source_url: {
+    allowed_hosts: ["github.com", "raw.githubusercontent.com"],
+    protocol: "https",
+    credentials_allowed: false,
+    local_private_hosts_allowed: false,
+    github_url_shapes: [
+      "/<owner>/<repo>/blob/<source_commit>/<repo_relative_path>",
+      "/<owner>/<repo>/<source_commit>/<repo_relative_path>",
+    ],
+    repo_match: "url repo segment must match metadata.repo slug",
+    commit_match: "source_commit must be a path segment, not query or fragment",
+    path_match: "exact repo-relative path match; suffix matches are rejected",
+  },
+  fact_body: {
+    raw_code_chunks_allowed: false,
+    credential_like_material_allowed: false,
+    max_lines: 6,
+    rejected_secret_shapes: [
+      "labelled token/password/secret/api_key/authorization values",
+      "AWS access key IDs",
+      "AWS secret-access-key-like 40 character base64 values",
+      "Slack xox tokens",
+      "Google API keys",
+      "JWT-like strings",
+    ],
+  },
 } as const;
 
 function slugPart(value: string): string {
@@ -217,6 +275,7 @@ function containsSecretLikeValue(fact: string): boolean {
   const secretSignals = [
     /\b(?:token|password|passwd|secret|api[_-]?key|authorization)\s*[:=]\s*\S{8,}/i,
     /\bAKIA[0-9A-Z]{16}\b/,
+    /(^|[^A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}($|[^A-Za-z0-9/+=])/,
     /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
     /\bAIza[0-9A-Za-z_-]{20,}\b/,
     /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,

--- a/src/tools/repo-facts.ts
+++ b/src/tools/repo-facts.ts
@@ -1,0 +1,332 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toSql } from "pgvector/pg";
+import { canRead, canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
+import { canReadNamespace, namespaceFilterFor } from "../read-policy.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+const FACT_TYPES = [
+  "ownership",
+  "gotcha",
+  "api_contract",
+  "workflow",
+  "dependency",
+  "migration",
+  "validation",
+  "source_pointer",
+] as const;
+
+const STALENESS_POLICIES = [
+  "stable_fact_verify_source",
+  "commit_pinned",
+  "refresh_required",
+  "volatile_pointer_only",
+] as const;
+
+const sourceCommit = z
+  .string()
+  .regex(/^[0-9a-fA-F]{7,64}$/, "source_commit must be a git SHA");
+
+const sourceUrl = z
+  .string()
+  .url()
+  .optional()
+  .describe("Optional source URL, usually a GitHub file URL.");
+
+const repoFactMetadata = z.object({
+  source_system: z.literal("qmd").describe("Fact source system."),
+  repo: z.string().trim().min(1).max(300),
+  collection: z.string().trim().min(1).max(300),
+  path: z.string().trim().min(1).max(1000),
+  symbol: z.string().trim().min(1).max(300).optional(),
+  subject: z.string().trim().min(1).max(500).optional(),
+  fact_type: z.enum(FACT_TYPES),
+  fact: z.string().trim().min(1).max(2000),
+  source_commit: sourceCommit,
+  source_url: sourceUrl,
+  verified_at: z.string().datetime(),
+  confidence: z.number().min(0).max(1).default(1),
+  staleness_policy: z.enum(STALENESS_POLICIES),
+  refresh_hint: z.string().trim().min(1).max(1000).optional(),
+});
+
+type RepoFactMetadata = z.infer<typeof repoFactMetadata>;
+
+function slugPart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 180);
+}
+
+function factSubject(metadata: RepoFactMetadata): string {
+  return metadata.symbol ?? metadata.subject ?? metadata.path;
+}
+
+function canonicalId(metadata: RepoFactMetadata): string {
+  return [
+    "repo_fact",
+    metadata.source_system,
+    slugPart(metadata.repo),
+    slugPart(metadata.collection),
+    slugPart(metadata.path),
+    slugPart(factSubject(metadata)),
+    metadata.fact_type,
+  ].join(":");
+}
+
+function entityName(metadata: RepoFactMetadata): string {
+  return `${metadata.repo}:${metadata.path}:${factSubject(metadata)}:${metadata.fact_type}`;
+}
+
+function looksLikeRawCodeDump(fact: string): boolean {
+  const lines = fact.split(/\r?\n/);
+  if (lines.length > 8) return true;
+
+  const codeSignals = [
+    /^\s*(export\s+)?(async\s+)?function\s+\w+/m,
+    /^\s*(export\s+)?(interface|type|class|enum)\s+\w+/m,
+    /^\s*(const|let|var)\s+\w+\s*=/m,
+    /```/,
+    /;\s*$/m,
+    /\{\s*$/m,
+  ];
+
+  return codeSignals.filter((re) => re.test(fact)).length >= 2;
+}
+
+function namespaceClause(
+  namespace: string | string[] | undefined,
+  params: unknown[],
+): string {
+  if (namespace === undefined) return "";
+  params.push(namespace);
+  return Array.isArray(namespace)
+    ? ` AND namespace = ANY($${params.length}::text[])`
+    : ` AND namespace = $${params.length}`;
+}
+
+export function registerUpsertRepoFact(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "upsert_repo_fact",
+    {
+      description:
+        "Upsert a curated qmd-derived repository fact into Open Brain graph entity metadata. " +
+        "This stores stable operating knowledge plus source pointers, not raw code chunks.",
+      inputSchema: {
+        namespace: z
+          .string()
+          .trim()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)."),
+        metadata: repoFactMetadata.describe(
+          "Curated qmd-derived repository fact metadata.",
+        ),
+      },
+      annotations: {
+        title: "Upsert Repo Fact",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canWrite(auth.role, "sessions")) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot write repo facts",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const metadata = repoFactMetadata.parse(args.metadata);
+      if (looksLikeRawCodeDump(metadata.fact)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Rejected repo fact: fact appears to contain a raw code chunk",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const factCanonicalId = canonicalId(metadata);
+      const name = entityName(metadata);
+      const storedMetadata = {
+        ...metadata,
+        fact_id: factCanonicalId,
+        promoted_as: "repo_fact",
+      };
+
+      let embedding: number[] | null = null;
+      try {
+        embedding = await deps.embedFn(
+          `${metadata.repo} ${metadata.path} ${factSubject(metadata)} ${metadata.fact}`,
+        );
+      } catch (err) {
+        logger.warn("upsert_repo_fact_embed_error", {
+          canonical_id: factCanonicalId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      const { rows } = await deps.pool.query(
+        `INSERT INTO ob_entities
+           (entity_type, name, canonical_id, namespace, metadata, embedding, created_by)
+         VALUES ('repo_fact', $1, $2, $3, $4::jsonb, $5, $6)
+         ON CONFLICT (namespace, entity_type, lower(name))
+         WHERE archived_at IS NULL
+         DO UPDATE SET
+           canonical_id = EXCLUDED.canonical_id,
+           metadata = EXCLUDED.metadata,
+           embedding = COALESCE(EXCLUDED.embedding, ob_entities.embedding),
+           archived_at = NULL,
+           updated_at = NOW()
+         RETURNING id, (xmax = 0) AS is_new, entity_type, name, canonical_id, namespace, metadata, created_at, updated_at`,
+        [
+          name,
+          factCanonicalId,
+          ns,
+          JSON.stringify(storedMetadata),
+          embedding ? toSql(embedding) : null,
+          auth.clientId,
+        ],
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(rows[0]),
+          },
+        ],
+      };
+    },
+  );
+}
+
+export function registerListRepoFacts(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "list_repo_facts",
+    {
+      description:
+        "List curated qmd-derived repository facts from Open Brain graph entity metadata.",
+      inputSchema: {
+        namespace: z.string().trim().min(1).max(500).optional(),
+        repo: z.string().trim().min(1).max(300).optional(),
+        collection: z.string().trim().min(1).max(300).optional(),
+        path: z.string().trim().min(1).max(1000).optional(),
+        fact_type: z.enum(FACT_TYPES).optional(),
+        subject: z.string().trim().min(1).max(500).optional(),
+        limit: z.number().int().min(1).max(250).optional(),
+        offset: z.number().int().min(0).optional(),
+      },
+      annotations: {
+        title: "List Repo Facts",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canRead(auth.role, "sessions")) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot read repo facts",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const requestedNamespace = args.namespace as string | undefined;
+      if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: namespace read access denied",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const params: unknown[] = [];
+      const filters = ["entity_type = 'repo_fact'", "archived_at IS NULL"];
+      const namespace = namespaceFilterFor(auth, requestedNamespace);
+      const ns = namespaceClause(namespace, params);
+      if (ns) filters.push(ns.slice(" AND ".length));
+      if (args.repo) {
+        params.push(args.repo);
+        filters.push(`metadata->>'repo' = $${params.length}`);
+      }
+      if (args.collection) {
+        params.push(args.collection);
+        filters.push(`metadata->>'collection' = $${params.length}`);
+      }
+      if (args.path) {
+        params.push(args.path);
+        filters.push(`metadata->>'path' = $${params.length}`);
+      }
+      if (args.fact_type) {
+        params.push(args.fact_type);
+        filters.push(`metadata->>'fact_type' = $${params.length}`);
+      }
+      if (args.subject) {
+        params.push(args.subject);
+        filters.push(
+          `(metadata->>'subject' = $${params.length} OR metadata->>'symbol' = $${params.length})`,
+        );
+      }
+
+      const limit = args.limit ?? 50;
+      const offset = args.offset ?? 0;
+      params.push(limit, offset);
+
+      const { rows } = await deps.pool.query(
+        `SELECT id, entity_type, name, canonical_id, namespace, metadata, created_by, created_at, updated_at
+         FROM ob_entities
+         WHERE ${filters.join(" AND ")}
+         ORDER BY updated_at DESC, created_at DESC
+         LIMIT $${params.length - 1} OFFSET $${params.length}`,
+        params,
+      );
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(rows) }],
+      };
+    },
+  );
+}

--- a/src/tools/repo-facts.ts
+++ b/src/tools/repo-facts.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
@@ -8,7 +9,7 @@ import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 
-const FACT_TYPES = [
+export const FACT_TYPES = [
   "ownership",
   "gotcha",
   "api_contract",
@@ -19,7 +20,7 @@ const FACT_TYPES = [
   "source_pointer",
 ] as const;
 
-const STALENESS_POLICIES = [
+export const STALENESS_POLICIES = [
   "stable_fact_verify_source",
   "commit_pinned",
   "refresh_required",
@@ -30,13 +31,68 @@ const sourceCommit = z
   .string()
   .regex(/^[0-9a-fA-F]{7,64}$/, "source_commit must be a git SHA");
 
+function isPrivateOrLocalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host.startsWith("127.") || host === "::1") return true;
+  if (host.startsWith("10.") || host.startsWith("192.168.")) return true;
+  const parts = host.split(".").map((part) => Number.parseInt(part, 10));
+  if (
+    parts.length === 4 &&
+    parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
+  ) {
+    const first = parts[0] ?? -1;
+    const second = parts[1] ?? -1;
+    if (first === 172 && second >= 16 && second <= 31) return true;
+    if (first === 169 && second === 254) return true;
+  }
+  return false;
+}
+
+function isTrustedSourceUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "https:") return false;
+    if (parsed.username || parsed.password) return false;
+    if (isPrivateOrLocalHost(parsed.hostname)) return false;
+    return ["github.com", "raw.githubusercontent.com"].includes(
+      parsed.hostname.toLowerCase(),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function sourceUrlContainsPath(rawUrl: string, path: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    const decodedPath = decodeURIComponent(parsed.pathname);
+    const normalizedPath = path.replace(/^\/+/, "");
+    const pathParts = normalizedPath.split("/");
+    const withoutRepoPrefix =
+      pathParts.length > 1 ? pathParts.slice(1).join("/") : normalizedPath;
+
+    return (
+      decodedPath.includes(normalizedPath) ||
+      decodedPath.includes(encodeURI(normalizedPath)) ||
+      decodedPath.includes(withoutRepoPrefix) ||
+      decodedPath.includes(encodeURI(withoutRepoPrefix))
+    );
+  } catch {
+    return false;
+  }
+}
+
 const sourceUrl = z
   .string()
   .url()
-  .optional()
-  .describe("Optional source URL, usually a GitHub file URL.");
+  .refine(isTrustedSourceUrl, {
+    message: "source_url must be an HTTPS GitHub source URL without credentials",
+  })
+  .describe("HTTPS GitHub source URL for the verified source pointer.");
 
-const repoFactMetadata = z.object({
+export const repoFactMetadata = z
+  .object({
   source_system: z.literal("qmd").describe("Fact source system."),
   repo: z.string().trim().min(1).max(300),
   collection: z.string().trim().min(1).max(300),
@@ -47,13 +103,52 @@ const repoFactMetadata = z.object({
   fact: z.string().trim().min(1).max(2000),
   source_commit: sourceCommit,
   source_url: sourceUrl,
-  verified_at: z.string().datetime(),
+  verified_at: z
+    .string()
+    .datetime()
+    .refine((value) => Date.parse(value) <= Date.now(), {
+      message: "verified_at cannot be in the future",
+    }),
   confidence: z.number().min(0).max(1).default(1),
   staleness_policy: z.enum(STALENESS_POLICIES),
   refresh_hint: z.string().trim().min(1).max(1000).optional(),
-});
+})
+  .refine((value) => Boolean(value.symbol ?? value.subject), {
+    message: "repo facts require symbol or subject",
+    path: ["subject"],
+  })
+  .refine(
+    (value) =>
+      !value.source_url.includes(value.source_commit) ||
+      sourceUrlContainsPath(value.source_url, value.path),
+    {
+      message: "source_url must include source path when commit-pinned",
+      path: ["source_url"],
+    },
+  );
 
 type RepoFactMetadata = z.infer<typeof repoFactMetadata>;
+
+export const REPO_FACT_METADATA_CONTRACT = {
+  source_system: { type: "literal", value: "qmd", required: true },
+  repo: { type: "string", required: true, maxLength: 300 },
+  collection: { type: "string", required: true, maxLength: 300 },
+  path: { type: "string", required: true, maxLength: 1000 },
+  symbol: { type: "string", required: "symbol_or_subject", maxLength: 300 },
+  subject: { type: "string", required: "symbol_or_subject", maxLength: 500 },
+  fact_type: { type: "enum", required: true, values: FACT_TYPES },
+  fact: { type: "string", required: true, maxLength: 2000 },
+  source_commit: { type: "git_sha", required: true },
+  source_url: { type: "https_github_url", required: true },
+  verified_at: { type: "datetime_not_future", required: true },
+  confidence: { type: "number", min: 0, max: 1, default: 1 },
+  staleness_policy: {
+    type: "enum",
+    required: true,
+    values: STALENESS_POLICIES,
+  },
+  refresh_hint: { type: "string", required: false, maxLength: 1000 },
+} as const;
 
 function slugPart(value: string): string {
   return value
@@ -69,6 +164,15 @@ function factSubject(metadata: RepoFactMetadata): string {
 }
 
 function canonicalId(metadata: RepoFactMetadata): string {
+  const tuple = [
+    metadata.source_system,
+    metadata.repo,
+    metadata.collection,
+    metadata.path,
+    factSubject(metadata),
+    metadata.fact_type,
+  ].join("\0");
+  const digest = createHash("sha256").update(tuple).digest("hex").slice(0, 16);
   return [
     "repo_fact",
     metadata.source_system,
@@ -77,6 +181,7 @@ function canonicalId(metadata: RepoFactMetadata): string {
     slugPart(metadata.path),
     slugPart(factSubject(metadata)),
     metadata.fact_type,
+    digest,
   ].join(":");
 }
 
@@ -86,18 +191,37 @@ function entityName(metadata: RepoFactMetadata): string {
 
 function looksLikeRawCodeDump(fact: string): boolean {
   const lines = fact.split(/\r?\n/);
-  if (lines.length > 8) return true;
+  if (lines.length > 6) return true;
 
   const codeSignals = [
     /^\s*(export\s+)?(async\s+)?function\s+\w+/m,
     /^\s*(export\s+)?(interface|type|class|enum)\s+\w+/m,
     /^\s*(const|let|var)\s+\w+\s*=/m,
+    /^\s*(from\s+\S+\s+)?import\s+/m,
+    /^\s*def\s+\w+\s*\(/m,
+    /^\s*class\s+\w+[:(]/m,
+    /^\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER)\s+/im,
+    /^\s*#!\/(?:usr\/bin\/env\s+)?(?:ba|z|fi)?sh/m,
+    /^\s*[a-zA-Z_][\w-]*:\s*[{["\w-]/m,
     /```/,
+    /=>\s*[{(]/,
+    /\b(return|await|try|catch|finally)\b/,
     /;\s*$/m,
     /\{\s*$/m,
   ];
 
-  return codeSignals.filter((re) => re.test(fact)).length >= 2;
+  return codeSignals.filter((re) => re.test(fact)).length >= 1;
+}
+
+function containsSecretLikeValue(fact: string): boolean {
+  const secretSignals = [
+    /\b(?:token|password|passwd|secret|api[_-]?key|authorization)\s*[:=]\s*\S{8,}/i,
+    /\bAKIA[0-9A-Z]{16}\b/,
+    /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
+    /\bAIza[0-9A-Za-z_-]{20,}\b/,
+    /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  ];
+  return secretSignals.some((re) => re.test(fact));
 }
 
 function namespaceClause(
@@ -172,6 +296,17 @@ export function registerUpsertRepoFact(server: McpServer, deps: ToolDeps): void 
             {
               type: "text" as const,
               text: "Rejected repo fact: fact appears to contain a raw code chunk",
+            },
+          ],
+          isError: true,
+        };
+      }
+      if (containsSecretLikeValue(metadata.fact)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Rejected repo fact: fact appears to contain credential-like material",
             },
           ],
           isError: true,


### PR DESCRIPTION
## Summary
- add get_contract as the canonical Open Brain contract/capability manifest for downstream runtime validation
- add upsert_repo_fact and list_repo_facts for curated qmd-derived repo facts stored as graph entities
- document downstream contract validation and qmd-to-OB repo fact promotion rules

Closes #127
Refs #132

## Validation
- bun test src/contract.test.ts src/tools/__tests__/get-contract.test.ts src/tools/__tests__/repo-facts.test.ts
- bunx tsc --noEmit
- bun test

## Downstream rollout
This changes the public MCP tool surface. Do not merge/deploy until the review gate completes and the follow-up rtech-mcps -> mcp2cli -> hosted mcp2cli -> Hermes validation path is run.