### PR TITLE
Fix contract manifest to cover required memory tools

### DIFF
--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -9,7 +9,7 @@ describe("Open Brain contract manifest", () => {
     const contract = buildContract("2026-06-18T00:00:00.000Z");
 
     expect(contract.service).toBe("open-brain");
-    expect(contract.contract_version).toContain("repo-facts");
+    expect(contract.contract_version).toContain("memory-tools");
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
@@ -17,14 +17,27 @@ describe("Open Brain contract manifest", () => {
     expect(contract.capabilities.map((c) => c.name)).toContain(
       "upsert_repo_fact",
     );
+    for (const tool of [
+      "get_contract",
+      "log_thought",
+      "search_all",
+      "session_start",
+      "session_context",
+      "append_session_event",
+      "session_wrap",
+      "list_repo_facts",
+      "upsert_repo_fact",
+    ]) {
+      expect(contract.tool_contracts[tool]).toBeDefined();
+    }
     const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
     expect(upsertRepoFact).toBeDefined();
-    expect((upsertRepoFact?.input_schema as any).metadata.source_url.required).toBe(
-      true,
-    );
-    expect((upsertRepoFact?.input_schema as any).validation.source_url.repo_match).toContain(
-      "metadata.repo",
-    );
+    expect(
+      (upsertRepoFact?.input_schema as any).metadata.source_url.required,
+    ).toBe(true);
+    expect(
+      (upsertRepoFact?.input_schema as any).validation.source_url.repo_match,
+    ).toContain("metadata.repo");
   });
 
   it("keeps the schema hash stable when only generated_at changes", () => {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -32,6 +32,26 @@ describe("Open Brain contract manifest", () => {
     }
     const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
     expect(upsertRepoFact).toBeDefined();
+    const searchAll = contract.tool_contracts.search_all;
+    expect(searchAll).toBeDefined();
+    expect((searchAll?.input_schema as any).namespace.type).toBe("string");
+    expect((searchAll?.input_schema as any).limit.max).toBe(250);
+    expect((searchAll?.input_schema as any).offset.min).toBe(0);
+    expect((searchAll?.input_schema as any).sources.values).toEqual([
+      "all",
+      "brain",
+      "qmd",
+    ]);
+    expect((searchAll?.input_schema as any).search_mode.values).toEqual([
+      "hybrid",
+      "vector",
+      "keyword",
+    ]);
+    expect((searchAll?.input_schema as any).tier.values).toEqual([
+      "hot",
+      "warm",
+      "cold",
+    ]);
     expect(
       (upsertRepoFact?.input_schema as any).metadata.source_url.required,
     ).toBe(true);

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -4,7 +4,7 @@ import {
   REPO_FACT_VALIDATION_CONTRACT,
 } from "./tools/repo-facts.ts";
 
-export const CONTRACT_VERSION = "2026-06-18.repo-facts.v1";
+export const CONTRACT_VERSION = "2026-06-18.memory-tools.v1";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -62,6 +62,44 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
       "Read curated qmd-derived repository facts with namespace scoping.",
   },
   {
+    name: "log_thought",
+    version: 1,
+    kind: "tool",
+    description: "Write a durable thought or observation to Open Brain.",
+  },
+  {
+    name: "search_all",
+    version: 1,
+    kind: "tool",
+    description:
+      "Search Open Brain memory and optional qmd-backed code context.",
+  },
+  {
+    name: "session_start",
+    version: 1,
+    kind: "tool",
+    description:
+      "Find or create a durable session lane and return recent events.",
+  },
+  {
+    name: "session_context",
+    version: 1,
+    kind: "tool",
+    description: "Read durable session lane state and recent events.",
+  },
+  {
+    name: "append_session_event",
+    version: 1,
+    kind: "tool",
+    description: "Append a durable event to a session lane journal.",
+  },
+  {
+    name: "session_wrap",
+    version: 1,
+    kind: "tool",
+    description: "Checkpoint a session lane with a durable summary.",
+  },
+  {
     name: "entity_graph",
     version: 2,
     kind: "schema",
@@ -99,11 +137,15 @@ export function stableJson(value: unknown): string {
   return JSON.stringify(sortValue(value));
 }
 
-export function contractHash(payload: Omit<OpenBrainContract, "generated_at" | "schema_hash">): string {
+export function contractHash(
+  payload: Omit<OpenBrainContract, "generated_at" | "schema_hash">,
+): string {
   return createHash("sha256").update(stableJson(payload)).digest("hex");
 }
 
-export function buildContract(generatedAt = new Date().toISOString()): OpenBrainContract {
+export function buildContract(
+  generatedAt = new Date().toISOString(),
+): OpenBrainContract {
   const payload = {
     service: "open-brain" as const,
     contract_version: CONTRACT_VERSION,
@@ -133,6 +175,173 @@ export function buildContract(generatedAt = new Date().toISOString()): OpenBrain
         version: 1,
         input_schema: {},
         output_shape: "OpenBrainContract JSON text payload",
+      },
+      log_thought: {
+        version: 1,
+        input_schema: {
+          content: { type: "string", required: true, minLength: 1 },
+          tags: { type: "array", required: false, items: "string" },
+          namespace: {
+            type: "string",
+            required: false,
+            minLength: 1,
+            maxLength: 500,
+          },
+        },
+        output_shape: "thought id/namespace/embedded/merged JSON text payload",
+      },
+      search_all: {
+        version: 1,
+        input_schema: {
+          query: { type: "string", required: true, minLength: 1 },
+          namespace: {
+            type: "string_or_string_array",
+            required: false,
+            maxLength: 500,
+          },
+          limit: { type: "integer", required: false, min: 1, max: 100 },
+          sources: {
+            type: "enum",
+            required: false,
+            values: ["brain", "qmd", "all"],
+          },
+          search_mode: {
+            type: "enum",
+            required: false,
+            values: ["hybrid", "semantic", "lexical"],
+          },
+        },
+        output_shape: "unified search results JSON text payload",
+      },
+      session_start: {
+        version: 1,
+        input_schema: {
+          session_key: {
+            type: "string",
+            required: true,
+            minLength: 1,
+            maxLength: 500,
+          },
+          namespace: { type: "string", required: false, maxLength: 500 },
+          project: { type: "string", required: false, maxLength: 500 },
+          agent: { type: "string", required: false, maxLength: 500 },
+          channel_id: { type: "string", required: false, maxLength: 500 },
+          thread_id: { type: "string", required: false, maxLength: 500 },
+          topic: { type: "string", required: false, maxLength: 500 },
+        },
+        output_shape: "session lane plus recent events JSON text payload",
+      },
+      session_context: {
+        version: 1,
+        input_schema: {
+          session_key: {
+            type: "string",
+            required: "session_key_or_channel_id",
+            maxLength: 500,
+          },
+          namespace: { type: "string", required: false, maxLength: 500 },
+          channel_id: {
+            type: "string",
+            required: "session_key_or_channel_id",
+            maxLength: 500,
+          },
+          thread_id: { type: "string", required: false, maxLength: 500 },
+          include_events: { type: "boolean", required: false, default: true },
+          event_limit: {
+            type: "integer",
+            required: false,
+            min: 1,
+            max: 200,
+            default: 50,
+          },
+          event_types: {
+            type: "array",
+            required: false,
+            items: "session_event_type",
+          },
+          importance: {
+            type: "enum",
+            required: false,
+            values: ["hot", "warm", "cold"],
+          },
+        },
+        output_shape: "session lane plus recent events JSON text payload",
+      },
+      append_session_event: {
+        version: 1,
+        input_schema: {
+          session_key: {
+            type: "string",
+            required: true,
+            minLength: 1,
+            maxLength: 500,
+          },
+          namespace: { type: "string", required: false, maxLength: 500 },
+          event_type: {
+            type: "enum",
+            required: true,
+            values: [
+              "fact",
+              "decision",
+              "blocker",
+              "action",
+              "artifact",
+              "receipt",
+              "question",
+              "correction",
+              "handoff",
+            ],
+          },
+          content: {
+            type: "string",
+            required: true,
+            minLength: 1,
+            maxLength: 50000,
+          },
+          source: { type: "string", required: false, maxLength: 500 },
+          artifact_path: { type: "string", required: false, maxLength: 2000 },
+          importance: {
+            type: "enum",
+            required: false,
+            values: ["hot", "warm", "cold"],
+          },
+          metadata: {
+            type: "object",
+            required: false,
+            maxKeys: 50,
+            maxJsonBytes: 100000,
+          },
+        },
+        output_shape: "session event JSON text payload",
+      },
+      session_wrap: {
+        version: 1,
+        input_schema: {
+          session_key: {
+            type: "string",
+            required: true,
+            minLength: 1,
+            maxLength: 500,
+          },
+          namespace: { type: "string", required: false, maxLength: 500 },
+          summary: { type: "string", required: true, maxLength: 100000 },
+          key_decisions: {
+            type: "array",
+            required: false,
+            items: "string",
+            maxItems: 20,
+            maxItemLength: 2000,
+          },
+          next_steps: {
+            type: "array",
+            required: false,
+            items: "string",
+            maxItems: 20,
+            maxItemLength: 2000,
+          },
+          project: { type: "string", required: false, maxLength: 500 },
+        },
+        output_shape: "session wrap checkpoint JSON text payload",
       },
       upsert_repo_fact: {
         version: 1,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -195,20 +195,26 @@ export function buildContract(
         input_schema: {
           query: { type: "string", required: true, minLength: 1 },
           namespace: {
-            type: "string_or_string_array",
+            type: "string",
             required: false,
             maxLength: 500,
           },
-          limit: { type: "integer", required: false, min: 1, max: 100 },
+          limit: { type: "integer", required: false, min: 1, max: 250 },
+          offset: { type: "integer", required: false, min: 0 },
           sources: {
             type: "enum",
             required: false,
-            values: ["brain", "qmd", "all"],
+            values: ["all", "brain", "qmd"],
           },
           search_mode: {
             type: "enum",
             required: false,
-            values: ["hybrid", "semantic", "lexical"],
+            values: ["hybrid", "vector", "keyword"],
+          },
+          tier: {
+            type: "enum",
+            required: false,
+            values: ["hot", "warm", "cold"],
           },
         },
         output_shape: "unified search results JSON text payload",


### PR DESCRIPTION
## Summary
- update the Open Brain contract version to the required memory-tools contract
- add public tool contracts for Hermes memory runtime tools: log_thought, search_all, session_start, session_context, append_session_event, session_wrap
- keep repo fact tool contracts in the same required memory contract so qmd-derived facts remain covered
- align search_all contract shape with the actual registered tool schema after review

## Validation
- bun test src/contract.test.ts src/tools/__tests__/get-contract.test.ts
- bunx tsc --noEmit
- bun test

## Contract
- version: 2026-06-18.memory-tools.v1
- schema_hash: 74d9e0a7e9b6032f7fa9fa0b8fca66c1a2cf90389c22e5f6fbed22890bd7d534