### PR TITLE
Include lane tools in Open Brain memory contract

### DIFF
--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -23,6 +23,8 @@ describe("Open Brain contract manifest", () => {
       "search_all",
       "session_start",
       "session_context",
+      "lane_upsert",
+      "lane_load",
       "append_session_event",
       "session_wrap",
       "list_repo_facts",
@@ -52,6 +54,18 @@ describe("Open Brain contract manifest", () => {
       "warm",
       "cold",
     ]);
+    const laneUpsert = contract.tool_contracts.lane_upsert;
+    expect(laneUpsert).toBeDefined();
+    expect((laneUpsert?.input_schema as any).current_context_md.maxLength).toBe(
+      100000,
+    );
+    expect((laneUpsert?.input_schema as any).metadata.propertyNames.maxLength).toBe(
+      100,
+    );
+    const laneLoad = contract.tool_contracts.lane_load;
+    expect(laneLoad).toBeDefined();
+    expect((laneLoad?.input_schema as any).status.default).toBe("active");
+    expect((laneLoad?.input_schema as any).limit.max).toBe(50);
     expect(
       (upsertRepoFact?.input_schema as any).metadata.source_url.required,
     ).toBe(true);

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -4,7 +4,7 @@ import {
   REPO_FACT_VALIDATION_CONTRACT,
 } from "./tools/repo-facts.ts";
 
-export const CONTRACT_VERSION = "2026-06-18.memory-tools.v1";
+export const CONTRACT_VERSION = "2026-06-18.memory-tools.v2";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -86,6 +86,20 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
     version: 1,
     kind: "tool",
     description: "Read durable session lane state and recent events.",
+  },
+  {
+    name: "lane_upsert",
+    version: 1,
+    kind: "tool",
+    description:
+      "Create or update durable session lane metadata and current context.",
+  },
+  {
+    name: "lane_load",
+    version: 1,
+    kind: "tool",
+    description:
+      "Load durable session lanes by key, project, agent, channel, or status.",
   },
   {
     name: "append_session_event",
@@ -272,6 +286,60 @@ export function buildContract(
           },
         },
         output_shape: "session lane plus recent events JSON text payload",
+      },
+      lane_upsert: {
+        version: 1,
+        input_schema: {
+          session_key: {
+            type: "string",
+            required: true,
+            minLength: 1,
+            maxLength: 500,
+          },
+          namespace: { type: "string", required: false, maxLength: 500 },
+          status: {
+            type: "enum",
+            required: false,
+            values: ["active", "wrapped", "archived"],
+          },
+          agent: { type: "string", required: false, maxLength: 500 },
+          source: { type: "string", required: false, maxLength: 500 },
+          channel_id: { type: "string", required: false, maxLength: 500 },
+          thread_id: { type: "string", required: false, maxLength: 500 },
+          project: { type: "string", required: false, maxLength: 500 },
+          topic: { type: "string", required: false, maxLength: 500 },
+          current_context_md: {
+            type: "string",
+            required: false,
+            maxLength: 100000,
+          },
+          metadata: {
+            type: "object",
+            required: false,
+            propertyNames: { type: "string", maxLength: 100 },
+            maxKeys: 50,
+            maxJsonBytes: 100000,
+          },
+        },
+        output_shape: "session lane JSON text payload",
+      },
+      lane_load: {
+        version: 1,
+        input_schema: {
+          session_key: { type: "string", required: false },
+          namespace: { type: "string", required: false },
+          project: { type: "string", required: false },
+          agent: { type: "string", required: false },
+          channel_id: { type: "string", required: false },
+          status: {
+            type: "enum",
+            required: false,
+            default: "active",
+            values: ["active", "wrapped", "archived"],
+          },
+          limit: { type: "integer", required: false, min: 1, max: 50 },
+        },
+        output_shape: "session lane array JSON text payload",
       },
       append_session_event: {
         version: 1,

--- a/src/tools/__tests__/get-contract.test.ts
+++ b/src/tools/__tests__/get-contract.test.ts
@@ -29,7 +29,7 @@ describe("get_contract", () => {
       expect(parsed.service).toBe("open-brain");
       expect(parsed.schema_hash).toMatch(/^[0-9a-f]{64}$/);
       expect(parsed.capabilities.map((c: { name: string }) => c.name)).toContain(
-        "list_repo_facts",
+        "lane_upsert",
       );
     } finally {
       await cleanup();


### PR DESCRIPTION
## Summary

- bump the required Open Brain memory contract to `2026-06-18.memory-tools.v2`
- include `lane_upsert` and `lane_load` in the public capabilities and tool contracts
- document the `current_context_md` lane-upsert shape Hermes needs for durable current/short-term memory

## New Contract

- `contract_version`: `2026-06-18.memory-tools.v2`
- `schema_hash`: `2774b88174b97d8e7205c88fde511de9923afa224e8e9c4fb574e712809bb92c`

## Validation

- `bun test src/contract.test.ts src/tools/__tests__/get-contract.test.ts` -> 7 pass
- `bunx tsc --noEmit` -> passed
- `git diff --check` -> passed

## Why

Hermes required-memory work needs `lane_upsert.current_context_md` for durable current/short-term memory and `lane_load`/`session_context` for direct lane reload. The hosted tools already exist, but they were not part of the required contract Hermes validates, so clients could not safely require them.

## Review Fixes

- matched `lane_load` contract fields to the exposed MCP schema and documented `status` default `active`
- added `lane_upsert.metadata.propertyNames.maxLength` so contract validation matches the tool schema key limit
