### PR TITLE
Fix search timeout fallback when embeddings hang

### DIFF
--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -53,6 +53,9 @@ const setupClient = (
   embed = createMockEmbed(),
 ) => setupMcpClient(registerSearchAll, mockPool, embed, auth);
 
+const neverResolvingEmbed = async () =>
+  new Promise<number[] | null>(() => undefined);
+
 /** Parse search_all structured response. */
 function parseSearchAll(result: any) {
   return parseToolResult(result) as {
@@ -615,6 +618,38 @@ describe("search_all", () => {
   });
 
   describe("Edge cases", () => {
+    it("returns qmd-only when vector embedding times out", async () => {
+      const previousTimeout = process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
+      process.env.SEARCH_EMBEDDING_TIMEOUT_MS = "10";
+      mockBunSpawn(
+        0,
+        qmdJson([{ path: "/f.md", content: "qmd only", score: 0.7 }]),
+      );
+      const pool = { query: async () => ({ rows: makeMockRowsWithMeta(2) }) };
+      const { client, cleanup } = await setupClient(
+        pool,
+        { role: "admin", clientId: "admin" },
+        neverResolvingEmbed,
+      );
+      try {
+        const parsed = parseSearchAll(
+          await client.callTool({
+            name: "search_all",
+            arguments: { query: "embed timeout", search_mode: "vector" },
+          }),
+        );
+        expect(parsed.brain_hits).toBe(0);
+        expect(parsed.qmd_hits).toBe(1);
+      } finally {
+        if (previousTimeout === undefined) {
+          delete process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
+        } else {
+          process.env.SEARCH_EMBEDDING_TIMEOUT_MS = previousTimeout;
+        }
+        await cleanup();
+      }
+    });
+
     it("returns qmd-only when embedFn returns null (brain skipped)", async () => {
       mockBunSpawn(
         0,

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -15,6 +15,9 @@ const setup = (
   embed = createMockEmbed(),
 ) => setupMcpClient(registerSearchBrain, mockPool, embed, auth);
 
+const neverResolvingEmbed = async () =>
+  new Promise<number[] | null>(() => undefined);
+
 /** Pool that returns rows for search queries and empty for links. */
 const searchPool = (rows: any[]) => ({
   query: async (...args: any[]) => {
@@ -624,6 +627,30 @@ describe("search_brain", () => {
           "Failed to generate query embedding",
         );
       } finally {
+        await cleanup();
+      }
+    });
+
+    it("falls back to keyword search when hybrid embedding times out", async () => {
+      const previousTimeout = process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
+      process.env.SEARCH_EMBEDDING_TIMEOUT_MS = "10";
+      const pool = searchPool(makeMockRows(2));
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setup(pool, auth, neverResolvingEmbed);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: { query: "embed timeout" },
+        });
+        expect(result.isError).toBeFalsy();
+        expect(parseToolResult(result).length).toBe(2);
+      } finally {
+        if (previousTimeout === undefined) {
+          delete process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
+        } else {
+          process.env.SEARCH_EMBEDDING_TIMEOUT_MS = previousTimeout;
+        }
         await cleanup();
       }
     });

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -33,6 +33,7 @@ const RRF_K = 60;
 
 /** Over-fetch multiplier for hybrid mode (fetch N*3 from each path, merge to N) */
 const HYBRID_FETCH_MULTIPLIER = 3;
+const DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS = 3000;
 
 /** Tier-based RRF score adjustments for cognitive tiering */
 export const TIER_BOOST: Record<Tier, number> = {
@@ -55,6 +56,42 @@ const TABLE_WEIGHT: Record<string, number> = {
   session: 0.8,
   entity: 1.0,
 };
+
+function searchEmbeddingTimeoutMs(): number {
+  const raw =
+    process.env.SEARCH_EMBEDDING_TIMEOUT_MS ??
+    process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS;
+  if (!raw) return DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) || parsed < 1
+    ? DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS
+    : parsed;
+}
+
+async function generateSearchEmbedding(
+  deps: ToolDeps,
+  query: string,
+): Promise<number[] | null> {
+  const timeoutMs = searchEmbeddingTimeoutMs();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      deps.embedFn(query),
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => {
+          logger.warn("search_embedding_timeout", {
+            timeoutMs,
+            query: query.slice(0, 50),
+          });
+          resolve(null);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
 
 /** Gentle recency factor: today=1.0, 30d=0.97, 90d=0.92, 365d=0.73 */
 function recencyFactor(createdAt: string): number {
@@ -652,7 +689,7 @@ export async function executeSearch(
   }
 
   // Vector and hybrid both need an embedding
-  const embedding = await deps.embedFn(query);
+  const embedding = await generateSearchEmbedding(deps, query);
   if (!embedding) {
     // Fall back to keyword-only if embedding fails in hybrid mode
     if (mode === "hybrid") {


### PR DESCRIPTION
Closes #138\n\n## Summary\n- add a search-specific timeout around query embedding generation\n- let hybrid search fall back to keyword results when embedding generation stalls\n- keep vector-only search failing quickly so search_all can return other available sources\n- add hung-embedding regression tests for search_brain and search_all\n\n## Validation\n- bun test src/tools/__tests__/search-brain.test.ts src/tools/__tests__/search-all.test.ts\n- bunx tsc --noEmit\n- bun test