### PR TITLE
Fix search timeout review findings

### DIFF
--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -37,6 +37,10 @@ export interface EmbeddingResult {
   error?: EmbeddingError;
 }
 
+export interface EmbeddingOptions {
+  signal?: AbortSignal;
+}
+
 /**
  * Classify whether an error or HTTP status is transient and worth retrying.
  * Only 5xx, AbortError (timeout), and network-level errors are retried.
@@ -84,6 +88,7 @@ function embeddingApiKey(): string | undefined {
 export async function generateEmbeddingWithMetadata(
   text: string,
   embeddingUrl?: string,
+  options: EmbeddingOptions = {},
 ): Promise<EmbeddingResult> {
   if (!text || text.trim().length === 0 || text.length > 32000) {
     const msg = "Embedding text empty or too long";
@@ -130,6 +135,14 @@ export async function generateEmbeddingWithMetadata(
 
   for (let attempt = 1; attempt <= totalAttempts; attempt++) {
     const controller = new AbortController();
+    const abortFromParent = () => controller.abort(options.signal?.reason);
+    if (options.signal?.aborted) {
+      abortFromParent();
+    } else {
+      options.signal?.addEventListener("abort", abortFromParent, {
+        once: true,
+      });
+    }
     const timeoutId = setTimeout(() => controller.abort(), EMBEDDING_TIMEOUT_MS);
     const start = Date.now();
 
@@ -281,6 +294,7 @@ export async function generateEmbeddingWithMetadata(
       };
     } finally {
       clearTimeout(timeoutId);
+      options.signal?.removeEventListener("abort", abortFromParent);
     }
   }
 
@@ -304,8 +318,9 @@ export async function generateEmbeddingWithMetadata(
 export async function generateEmbedding(
   text: string,
   embeddingUrl?: string,
+  options: EmbeddingOptions = {},
 ): Promise<number[] | null> {
-  const result = await generateEmbeddingWithMetadata(text, embeddingUrl);
+  const result = await generateEmbeddingWithMetadata(text, embeddingUrl, options);
   return result.embedding;
 }
 

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -53,8 +53,23 @@ const setupClient = (
   embed = createMockEmbed(),
 ) => setupMcpClient(registerSearchAll, mockPool, embed, auth);
 
-const neverResolvingEmbed = async () =>
-  new Promise<number[] | null>(() => undefined);
+const abortAwareNeverResolvingEmbed =
+  (onAbort: () => void) =>
+  async (
+    _text: string,
+    _embeddingUrl?: string,
+    options?: { signal?: AbortSignal },
+  ) =>
+    new Promise<number[] | null>((resolve) => {
+      options?.signal?.addEventListener(
+        "abort",
+        () => {
+          onAbort();
+          resolve(null);
+        },
+        { once: true },
+      );
+    });
 
 /** Parse search_all structured response. */
 function parseSearchAll(result: any) {
@@ -619,8 +634,9 @@ describe("search_all", () => {
 
   describe("Edge cases", () => {
     it("returns qmd-only when vector embedding times out", async () => {
-      const previousTimeout = process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
-      process.env.SEARCH_EMBEDDING_TIMEOUT_MS = "10";
+      const previousTimeout = process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS;
+      process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS = "10";
+      let aborted = false;
       mockBunSpawn(
         0,
         qmdJson([{ path: "/f.md", content: "qmd only", score: 0.7 }]),
@@ -629,7 +645,9 @@ describe("search_all", () => {
       const { client, cleanup } = await setupClient(
         pool,
         { role: "admin", clientId: "admin" },
-        neverResolvingEmbed,
+        abortAwareNeverResolvingEmbed(() => {
+          aborted = true;
+        }),
       );
       try {
         const parsed = parseSearchAll(
@@ -640,11 +658,12 @@ describe("search_all", () => {
         );
         expect(parsed.brain_hits).toBe(0);
         expect(parsed.qmd_hits).toBe(1);
+        expect(aborted).toBe(true);
       } finally {
         if (previousTimeout === undefined) {
-          delete process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
+          delete process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS;
         } else {
-          process.env.SEARCH_EMBEDDING_TIMEOUT_MS = previousTimeout;
+          process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS = previousTimeout;
         }
         await cleanup();
       }

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -15,8 +15,23 @@ const setup = (
   embed = createMockEmbed(),
 ) => setupMcpClient(registerSearchBrain, mockPool, embed, auth);
 
-const neverResolvingEmbed = async () =>
-  new Promise<number[] | null>(() => undefined);
+const abortAwareNeverResolvingEmbed =
+  (onAbort: () => void) =>
+  async (
+    _text: string,
+    _embeddingUrl?: string,
+    options?: { signal?: AbortSignal },
+  ) =>
+    new Promise<number[] | null>((resolve) => {
+      options?.signal?.addEventListener(
+        "abort",
+        () => {
+          onAbort();
+          resolve(null);
+        },
+        { once: true },
+      );
+    });
 
 /** Pool that returns rows for search queries and empty for links. */
 const searchPool = (rows: any[]) => ({
@@ -632,11 +647,18 @@ describe("search_brain", () => {
     });
 
     it("falls back to keyword search when hybrid embedding times out", async () => {
-      const previousTimeout = process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
-      process.env.SEARCH_EMBEDDING_TIMEOUT_MS = "10";
+      const previousTimeout = process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS;
+      process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS = "10";
+      let aborted = false;
       const pool = searchPool(makeMockRows(2));
       const auth: AuthInfo = { role: "admin", clientId: "admin" };
-      const { client, cleanup } = await setup(pool, auth, neverResolvingEmbed);
+      const { client, cleanup } = await setup(
+        pool,
+        auth,
+        abortAwareNeverResolvingEmbed(() => {
+          aborted = true;
+        }),
+      );
 
       try {
         const result = await client.callTool({
@@ -645,11 +667,12 @@ describe("search_brain", () => {
         });
         expect(result.isError).toBeFalsy();
         expect(parseToolResult(result).length).toBe(2);
+        expect(aborted).toBe(true);
       } finally {
         if (previousTimeout === undefined) {
-          delete process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
+          delete process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS;
         } else {
-          process.env.SEARCH_EMBEDDING_TIMEOUT_MS = previousTimeout;
+          process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS = previousTimeout;
         }
         await cleanup();
       }

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -59,8 +59,8 @@ const TABLE_WEIGHT: Record<string, number> = {
 
 function searchEmbeddingTimeoutMs(): number {
   const raw =
-    process.env.SEARCH_EMBEDDING_TIMEOUT_MS ??
-    process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS;
+    process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS ??
+    process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
   if (!raw) return DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS;
   const parsed = parseInt(raw, 10);
   return Number.isNaN(parsed) || parsed < 1
@@ -73,16 +73,18 @@ async function generateSearchEmbedding(
   query: string,
 ): Promise<number[] | null> {
   const timeoutMs = searchEmbeddingTimeoutMs();
+  const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
     return await Promise.race([
-      deps.embedFn(query),
+      deps.embedFn(query, undefined, { signal: controller.signal }),
       new Promise<null>((resolve) => {
         timeoutId = setTimeout(() => {
+          controller.abort();
           logger.warn("search_embedding_timeout", {
             timeoutMs,
-            query: query.slice(0, 50),
+            queryLength: query.length,
           });
           resolve(null);
         }, timeoutMs);
@@ -694,7 +696,7 @@ export async function executeSearch(
     // Fall back to keyword-only if embedding fails in hybrid mode
     if (mode === "hybrid") {
       logger.warn("embedding_failed_fallback_fts", {
-        query: query.slice(0, 50),
+        queryLength: query.length,
       });
       rows = await ftsSearch(
         deps,


### PR DESCRIPTION
Closes #140\n\n## Summary\n- thread optional AbortSignal support through embedding generation\n- abort timed-out search embedding calls instead of only returning around them\n- remove raw query text from timeout/fallback warning logs\n- prefer OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS over the generic alias\n- update hung-embedding tests to assert the abort path fires\n\n## Validation\n- rg -n "query\.slice|query:" src/tools/search-brain.ts src/tools/search-all.ts\n- bun test src/tools/__tests__/search-brain.test.ts src/tools/__tests__/search-all.test.ts src/embedding.test.ts\n- bunx tsc --noEmit\n- bun test