### PR TITLE
Document identity and self-review gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,18 @@
 - [ ] Python package checks passed or are not applicable
 - [ ] Live Open Brain smoke passed or is not applicable
 
+## Critical Self-Review
+
+- Highest-risk behavior:
+- Assumptions that could be wrong:
+- Missing/weak tests:
+- Security/permission risk:
+- Migration/deploy risk:
+- Downstream client/runtime risk:
+- Rollback/cleanup concern:
+- Fixes made before PR:
+- Known residual risk:
+
 ## Downstream Rollout
 
 - [ ] I checked `docs/downstream-rollout.md`

--- a/docs/identity-boundary.md
+++ b/docs/identity-boundary.md
@@ -28,7 +28,9 @@ write `bilby`; a `skippy` token can write `skippy`. They may not direct-write
 `shared-kb` writes require an explicit promoter service identity:
 `openbrain-promoter` or `hermes-promoter`. The promoter path must include
 provenance describing the source namespace, source table/id, source identity
-when known, promotion actor, reason, confidence when available, and timestamp.
+when known, authenticated promoter identity, reason, confidence when available,
+and timestamp. The authoritative `promoted_by` value is derived from the bearer
+token identity, not caller-supplied request text.
 
 `X-Namespace` is delegation context for trusted `admin` and `n8n` callers. It is
 not shared-write authority by itself. A non-promoter `admin` token delegated with
@@ -46,3 +48,14 @@ both namespaces.
 Host, runtime, project, Discord channel, or thread identity belongs in metadata
 and provenance. It must not replace the bearer-token person, agent, or promoter
 identity that defines the namespace boundary.
+
+## Verification hooks
+
+The namespace and auth tests cover this boundary:
+
+- named `AUTH_TOKEN_USER_*` identities map to person, agent, and promoter
+  identities;
+- normal agents can read `shared-kb` but cannot direct-write shared truth;
+- promoter service identities can write approved `shared-kb` promotions;
+- `X-Namespace` delegation does not grant normal-agent shared-write authority;
+- promotion provenance records authenticated promoter identity.


### PR DESCRIPTION
## Summary
- Tighten the identity boundary docs so `promoted_by` is explicitly auth-derived bearer-token identity.
- Add verification hooks for person/agent/promoter identities and shared-kb write boundaries.
- Add the critical self-review receipt directly to the PR template so non-trivial PRs carry the gate by default.

Closes #147
Closes #148

## Verification
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

## Critical Self-Review
- Highest-risk behavior: docs/template could overstate enforcement; this PR only templates and documents the gate, while repo policy remains the enforcement layer.
- Assumptions that could be wrong: GitHub PR template is the right practical process check for #148.
- Missing/weak tests: docs/template change has no runtime test; validated by focused auth/namespace/promotion tests and typecheck for referenced behavior.
- Security/permission risk: identity doc now explicitly says `promoted_by` is bearer-token derived, not caller-supplied text.
- Migration/deploy risk: none; docs/template only.
- Downstream client/runtime risk: none for runtime behavior; PR template affects future contributor workflow.
- Rollback/cleanup concern: revert this PR to remove the template/docs wording.
- Fixes made before PR: aligned identity docs with #149 implementation and added PR template receipt.
- Known residual risk: process compliance still depends on reviewers/controllers checking the receipt content is real, not boilerplate.

## Downstream Rollout
- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:
- Docs/template only; no MCP schema or runtime client contract change.
- `git diff --check`
- `bun test src/auth.test.ts src/namespace-policy.test.ts src/rest-promotion.test.ts src/tools/__tests__/promote-entry.test.ts` -> 48 pass
- `bunx tsc --noEmit`