### PR TITLE
fix(lane-upsert): default status to 'active' on new-lane INSERT (NOT NULL violation)

### DIFF
--- a/src/tools/__tests__/lane-upsert.test.ts
+++ b/src/tools/__tests__/lane-upsert.test.ts
@@ -663,6 +663,55 @@ describe("lane_upsert", () => {
     }
   });
 
+  it("inserts status 'active' for a new lane when status is omitted (NOT NULL regression)", async () => {
+    // Regression for lane_upsert_db_error: omitting status previously bound an
+    // explicit NULL into the NOT NULL status column, so creating a NEW lane
+    // failed the constraint. The INSERT value must default to 'active' while
+    // the ON CONFLICT path keeps a nullable status to preserve existing rows.
+    let capturedSql = "";
+    let capturedParams: any[] = [];
+    const mockPool = {
+      query: async (sql: string, params: any[]) => {
+        capturedSql = sql;
+        capturedParams = params;
+        return {
+          rows: [
+            {
+              id: "uuid-new",
+              is_new: true,
+              status: "active",
+              updated_at: "2026-06-07T15:30:00Z",
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "lane_upsert",
+        arguments: { session_key: "new-lane-no-status" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      // $3 (ON CONFLICT / status-preserve source) stays NULL on omission.
+      expect(capturedParams[2]).toBeNull();
+      // $24 (INSERT VALUES status) defaults to 'active' so the NOT NULL
+      // column is satisfied for brand-new lanes.
+      expect(capturedParams[23]).toBe("active");
+      // ended_at must key off $3 (nullable), NOT EXCLUDED.status, otherwise a
+      // status-omitted update would reactivate a wrapped/archived lane. The
+      // ended_at clause is the segment after the embedding_model update line.
+      const endedAtClause = capturedSql.slice(capturedSql.indexOf("ended_at ="));
+      expect(endedAtClause).toContain("$3 = 'active'");
+      expect(endedAtClause).not.toContain("EXCLUDED.status");
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── MINIMAL CALL ──
 
   it("succeeds with only the required session_key", async () => {

--- a/src/tools/lane-upsert.ts
+++ b/src/tools/lane-upsert.ts
@@ -123,7 +123,13 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
           isError: true,
         };
       }
+      // $3 stays nullable so the ON CONFLICT CASE branches can detect
+      // "status omitted" and preserve the existing lane status. insertStatus
+      // is used only for the INSERT VALUES, where the NOT NULL column must
+      // receive the 'active' default for brand-new lanes (an explicit NULL
+      // overrides the column default and trips the NOT NULL constraint).
       const status = args.status ?? null;
+      const insertStatus = args.status ?? "active";
 
       logger.debug("lane_upsert_start", {
         session_key: args.session_key,
@@ -183,7 +189,7 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
              (session_key, namespace, status, agent, source, channel_id, thread_id,
               project, topic, current_context_md, metadata,
               embedding, content_hash, embedded_at, embedding_model, created_by)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+           VALUES ($1, $2, $24, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
            ON CONFLICT (namespace, session_key)
            DO UPDATE SET
              status = CASE WHEN $3 IS NULL THEN ob_session_lanes.status ELSE EXCLUDED.status END,
@@ -201,9 +207,9 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
              content_hash = COALESCE(EXCLUDED.content_hash, ob_session_lanes.content_hash),
              embedded_at = COALESCE(EXCLUDED.embedded_at, ob_session_lanes.embedded_at),
              embedding_model = COALESCE(EXCLUDED.embedding_model, ob_session_lanes.embedding_model),
-             ended_at = CASE WHEN EXCLUDED.status = 'wrapped' OR EXCLUDED.status = 'archived'
+             ended_at = CASE WHEN $3 = 'wrapped' OR $3 = 'archived'
                         THEN COALESCE(ob_session_lanes.ended_at, NOW())
-                        WHEN EXCLUDED.status = 'active'
+                        WHEN $3 = 'active'
                         THEN NULL
                         ELSE ob_session_lanes.ended_at END
            RETURNING id, (xmax = 0) AS is_new, status, updated_at`,
@@ -232,6 +238,9 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
             args.project === "",
             args.topic === "",
             args.current_context_md === "",
+            // $24 — INSERT VALUES status; never NULL so new lanes satisfy the
+            // NOT NULL constraint. ON CONFLICT logic keys off $3 (nullable).
+            insertStatus,
           ],
         );
 


### PR DESCRIPTION
## Summary

- Fix `lane_upsert` failing to CREATE a new session lane when the caller omits `status` (`null value in column "status" violates not-null constraint`).
- `src/tools/lane-upsert.ts:126` bound `args.status ?? null` into the INSERT VALUES for the `NOT NULL` `status` column (default `'active'`). An explicit NULL overrides the column default → constraint violation on every new-lane INSERT.
- Fix: separate `insertStatus = args.status ?? 'active'` (new `$24`) feeds the INSERT VALUES; `$3` stays nullable for the ON CONFLICT preserve-logic; `ended_at` CASE re-pointed from `EXCLUDED.status` to `$3`.
- Regression test added. Closes #162.

## Root cause

The UPDATE path (`ON CONFLICT DO UPDATE`) was made null-aware (`CASE WHEN $3 IS NULL THEN ob_session_lanes.status ...`), so existing-lane updates preserve status correctly. But the INSERT path binds the same `$3 = null` into the `NOT NULL` column, so the **first** write to any new `session_key` fails while subsequent updates succeed — which is why it looked intermittent and why a worker bounce appeared to "fix" it (a bounce only changed which keys were new).

Origin: the null-aware `status`/`ended_at` design was introduced in `bfbadad` (feat: durable session lanes #34/#43), whose review-swarm changes ("Fix status silently resetting to 'active'", "preserve ended_at on null status") added the UPDATE-side null handling without defaulting the INSERT-side value.

## The `EXCLUDED.status` / `ended_at` coupling (why the naive fix is wrong)

A naive `COALESCE($3,'active')` in VALUES would make `EXCLUDED.status = 'active'` on a status-omitted UPDATE, tripping `WHEN EXCLUDED.status = 'active' THEN NULL` and wiping `ended_at` — silently reactivating a wrapped/archived lane. The fix avoids this by keeping `$3` nullable for ALL ON CONFLICT logic and re-pointing the `ended_at` CASE onto `$3`, so a status-omitted update falls to `ELSE ob_session_lanes.ended_at` (preserve). `ended_at` behavior is unchanged for every case.

## Validation

- `bun test` → 726 pass, 0 fail
- `bunx tsc --noEmit` → clean
- Live blast radius (hosted OB, skippy-oc/10.71.1.21): 240 `lane_upsert_db_error` in 24h (69 bilby, 171 skippy), all this violation.

## Critical Self-Review

- Highest-risk behavior: The `ended_at` CASE re-point from `EXCLUDED.status` to `$3`. If wrong, a status-omitted update could reactivate a wrapped/archived lane. Verified by case table: explicit status branches are byte-equivalent ($3 == old EXCLUDED.status); omitted-status falls to ELSE-preserve, matching prior behavior (old EXCLUDED.status was also null on omission).
- Assumptions that could be wrong: That every caller path that omits status wants the column default. The schema default is `'active'`; new lanes are active by definition, so defaulting the INSERT to 'active' matches intent.
- Missing/weak tests: The mock pool cannot fire the real NOT NULL constraint or a real UPDATE's `ended_at`, so the regression test asserts the bind-param/SQL contract (omitted status → `$24='active'`, `$3=null`, `ended_at` keys off `$3`) rather than a live DB outcome. A live-pg integration test would be a stronger guard — noted as follow-up.
- Security/permission risk: None. No auth/namespace logic touched.
- Migration/deploy risk: No schema change. Behavior change is strictly "new lanes without status now succeed as 'active'" — previously they errored. Deploy needed on hosted OB to stop live failures.
- Downstream client/runtime risk: Positive — Hermes lane writes that failed server-side and spooled will succeed once deployed. Surfacing of such failures is rtech-hermes#84's F2 (separate repo), which is why these 240 failures were invisible behind a healthy-looking "active" status.
- Rollback/cleanup concern: Pure code change, trivially revertible. One diagnostic `log_thought` (id `5f3db27d`, tag diagnostic/write-probe) was left in bilby's namespace during live diagnosis — flagged for cleanup (issue owner to remove).
- Fixes made before PR: separate insert-status param; `ended_at` re-point; regression test.
- Known residual risk: 34 `lane_upsert` entries in Bilby's spool stay stuck until this deploys AND replay is nudged (see Deploy & follow-up).
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a single SQL upsert defect, not a new reviewer-lane pattern; existing correctness/domain lanes already cover INSERT-vs-UPSERT and NOT NULL semantics.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: fix is code + bind-param regression; live verification happens at deploy (lane_upsert against hosted OB), tracked in Deploy & follow-up.

## Deploy & follow-up

- **Deploy required** on `com.rico.open-brain` (10.71.1.21) — the 240/24h failures continue until the running server has this commit.
- **Bilby spool drain (rtech-hermes side, owner-driven):** 65 entries spooled (34 stuck `lane_upsert` on this bug, 31 drainable), backed up to `~/.hermes/openbrain_spool.jsonl.bak-20260619-pre-drain` (nothing lost). The 34 stuck entries drain only after this fix is live; opportunistic replay won't self-fire (chicken-and-egg) and needs a nudge post-deploy.
- **Cleanup:** remove diagnostic `log_thought` id `5f3db27d` (tag diagnostic/write-probe) from bilby's namespace.
- **Related:** rtech-hermes#84 (F2 surfacing) is why these server-side failures were invisible — separate repo, already tracked.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No client/schema/contract change — this is a server-side SQL fix. rtech-hermes items are unchecked because the spool drain + F2 surfacing (rtech-hermes#84) are real downstream follow-ups, owner-driven, post-deploy.
