### PR TITLE
fix(lane-upsert): cast $3::text to fix param-type inference regression (#162)

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -3,6 +3,43 @@
 Correctness reviewers check API contracts, schema compatibility, state
 transitions, and runtime behavior that tests can accidentally miss.
 
+## [2026-06-19] Mock-pool tests cannot catch SQL constraint or param-type failures
+
+**Severity:** HIGH
+**Source:** Issues #162, PRs #163 (bug) + #164 (regression fix)
+**Scope:** `src/tools/*.ts` SQL writers, `src/tools/__tests__/**`
+**Status:** active
+
+### Pattern
+
+`lane_upsert` shipped two production-breaking bugs in a row that a mock pool
+(`{ query: async () => ({ rows: [...] }) }`) could not detect because the mock
+never executes SQL:
+
+1. PR #163: bound explicit `NULL` into the `NOT NULL` `status` column on INSERT
+   — every new-lane create failed. Mock returned canned rows, test passed.
+2. PR #163's own fix repointed `status` to `$24`, leaving `$3` used only in
+   `CASE WHEN $3 IS NULL` / `$3 = 'literal'`. With no typed binding site,
+   Postgres failed at plan time: `could not determine data type of parameter
+   $3`. Again invisible to the mock.
+
+### Review Questions
+
+- Does the change touch SQL that a mock pool would not execute (INSERT/UPDATE,
+  ON CONFLICT, CASE on a bind param, casts)?
+- Is every bind param used in at least one typed position, or cast (`$n::type`)
+  when used only in `IS NULL`/equality? Unanchored params fail type inference.
+- Does an explicit `NULL` get bound into a `NOT NULL DEFAULT` column? The column
+  default only applies when the column is OMITTED, not when NULL is supplied.
+- Is there a DB-backed test (real pool, env-gated) for the representative
+  write path, not only a mock assertion on row shape?
+
+### Prior Fix
+
+PR #164 added env-gated (`OPENBRAIN_TEST_DATABASE_URL`) integration tests that
+run the real query through a real pool. Mock-shape assertions are insufficient
+for SQL writers; require a real-pool test for new/changed write paths.
+
 ## [2026-06-11] Python wrappers must prove server schema compatibility
 
 **Severity:** MEDIUM

--- a/src/tools/__tests__/lane-upsert.test.ts
+++ b/src/tools/__tests__/lane-upsert.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { Pool } from "pg";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -705,7 +706,9 @@ describe("lane_upsert", () => {
       // status-omitted update would reactivate a wrapped/archived lane. The
       // ended_at clause is the segment after the embedding_model update line.
       const endedAtClause = capturedSql.slice(capturedSql.indexOf("ended_at ="));
-      expect(endedAtClause).toContain("$3 = 'active'");
+      // $3 is cast to ::text so Postgres can infer the param type (it is no
+      // longer bound into a typed column position).
+      expect(endedAtClause).toContain("$3::text = 'active'");
       expect(endedAtClause).not.toContain("EXCLUDED.status");
     } finally {
       await cleanup();
@@ -744,6 +747,89 @@ describe("lane_upsert", () => {
       expect(parsed.embedded).toBe(false);
     } finally {
       await cleanup();
+    }
+  });
+});
+
+// ── DB-BACKED INTEGRATION ──
+// The mock harness above cannot catch Postgres parameter-type inference or the
+// real NOT NULL / ended_at behavior. These tests run the ACTUAL query through a
+// real pool and are gated on OPENBRAIN_TEST_DATABASE_URL so the default suite
+// stays infra-free. Run with:
+//   OPENBRAIN_TEST_DATABASE_URL=postgres://... bun test src/tools/__tests__/lane-upsert.test.ts
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("lane_upsert (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-lane-upsert-live";
+
+  async function callLaneUpsert(args: Record<string, unknown>) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn: createMockEmbed(null) };
+    registerLaneUpsert(server, deps);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const original = ct.send.bind(ct);
+    ct.send = (m: any, o?: any) =>
+      original(m, { ...o, authInfo: { role: "admin", clientId: ns } });
+    const client = new Client({ name: "tc", version: "1.0.0" });
+    await server.connect(st);
+    await client.connect(ct);
+    const res = await client.callTool({ name: "lane_upsert", arguments: args });
+    await client.close();
+    await server.close();
+    return res;
+  }
+
+  async function cleanupNs() {
+    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+  }
+
+  it("creates a new lane with status omitted (no $3 type-inference error, NOT NULL satisfied)", async () => {
+    await cleanupNs();
+    try {
+      const res = await callLaneUpsert({ session_key: "live-new", namespace: ns });
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.is_new).toBe(true);
+      expect(parsed.status).toBe("active");
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("preserves status and ended_at on a status-omitted update of a wrapped lane", async () => {
+    await cleanupNs();
+    try {
+      await callLaneUpsert({ session_key: "live-wrap", namespace: ns });
+      await callLaneUpsert({
+        session_key: "live-wrap",
+        namespace: ns,
+        status: "wrapped",
+      });
+      const { rows: afterWrap } = await pool.query(
+        "SELECT status, ended_at FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
+        [ns, "live-wrap"],
+      );
+      expect(afterWrap[0].status).toBe("wrapped");
+      expect(afterWrap[0].ended_at).not.toBeNull();
+
+      // status omitted: must NOT reactivate the lane
+      const res = await callLaneUpsert({
+        session_key: "live-wrap",
+        namespace: ns,
+        topic: "touch",
+      });
+      expect(res.isError).toBeFalsy();
+      const { rows: afterTouch } = await pool.query(
+        "SELECT status, ended_at FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
+        [ns, "live-wrap"],
+      );
+      expect(afterTouch[0].status).toBe("wrapped");
+      expect(afterTouch[0].ended_at).not.toBeNull();
+    } finally {
+      await cleanupNs();
+      await pool.end();
     }
   });
 });

--- a/src/tools/__tests__/lane-upsert.test.ts
+++ b/src/tools/__tests__/lane-upsert.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, afterAll } from "bun:test";
 import { Pool } from "pg";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -785,6 +785,10 @@ dbDescribe("lane_upsert (live Postgres)", () => {
     await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
   }
 
+  afterAll(async () => {
+    await pool.end();
+  });
+
   it("creates a new lane with status omitted (no $3 type-inference error, NOT NULL satisfied)", async () => {
     await cleanupNs();
     try {
@@ -829,7 +833,6 @@ dbDescribe("lane_upsert (live Postgres)", () => {
       expect(afterTouch[0].ended_at).not.toBeNull();
     } finally {
       await cleanupNs();
-      await pool.end();
     }
   });
 });

--- a/src/tools/lane-upsert.ts
+++ b/src/tools/lane-upsert.ts
@@ -192,7 +192,7 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
            VALUES ($1, $2, $24, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
            ON CONFLICT (namespace, session_key)
            DO UPDATE SET
-             status = CASE WHEN $3 IS NULL THEN ob_session_lanes.status ELSE EXCLUDED.status END,
+             status = CASE WHEN $3::text IS NULL THEN ob_session_lanes.status ELSE EXCLUDED.status END,
              agent = CASE WHEN $17 THEN EXCLUDED.agent ELSE COALESCE(EXCLUDED.agent, ob_session_lanes.agent) END,
              source = CASE WHEN $18 THEN EXCLUDED.source ELSE COALESCE(EXCLUDED.source, ob_session_lanes.source) END,
              channel_id = CASE WHEN $19 THEN EXCLUDED.channel_id ELSE COALESCE(EXCLUDED.channel_id, ob_session_lanes.channel_id) END,
@@ -207,9 +207,9 @@ export function registerLaneUpsert(server: McpServer, deps: ToolDeps): void {
              content_hash = COALESCE(EXCLUDED.content_hash, ob_session_lanes.content_hash),
              embedded_at = COALESCE(EXCLUDED.embedded_at, ob_session_lanes.embedded_at),
              embedding_model = COALESCE(EXCLUDED.embedding_model, ob_session_lanes.embedding_model),
-             ended_at = CASE WHEN $3 = 'wrapped' OR $3 = 'archived'
+             ended_at = CASE WHEN $3::text = 'wrapped' OR $3::text = 'archived'
                         THEN COALESCE(ob_session_lanes.ended_at, NOW())
-                        WHEN $3 = 'active'
+                        WHEN $3::text = 'active'
                         THEN NULL
                         ELSE ob_session_lanes.ended_at END
            RETURNING id, (xmax = 0) AS is_new, status, updated_at`,


### PR DESCRIPTION
## Summary

- Fix the regression introduced by #163: `lane_upsert` failed every call with `could not determine data type of parameter $3`.
- #163 repointed the INSERT status slot to `$24`, leaving `$3` used ONLY in `CASE` comparisons (`IS NULL` / `= 'literal'`). With no typed binding site, Postgres cannot infer `$3`'s type at plan time → every `lane_upsert` failed.
- Cast `$3::text` in all three comparison sites (status type is `TEXT`). Behavior identical: null stays null, equality unchanged.
- Adds **env-gated DB-backed integration tests** (`OPENBRAIN_TEST_DATABASE_URL`) that run the real query through a real pool — the coverage gap that let both the original NOT NULL bug and this regression through.

Fixes #162.

## Root cause

`pg` sends parameters untyped and relies on Postgres inferring each param's type from a typed usage site (e.g. a column in INSERT VALUES). After #163, `$3` was no longer bound into the `status` column — it appears only as `$3 IS NULL` and `$3 = 'wrapped'/'active'/...`. None of those pin a type, so the plan-time inference fails. Cast resolves it.

## Why #163's tests didn't catch it

#163's regression test was mock-only (the repo had no live-pg harness). A mock pool returns canned rows and never executes the SQL, so neither the original NOT NULL violation nor this type-inference failure could surface in tests. This PR closes that gap with real-pool tests.

## Validation

- Manual repro against live PG: bare `$3` in comparisons → `ERROR: could not determine data type of parameter $1`; `$3::text` → works.
- DB-backed integration tests run against live Postgres (hosted OB DB): **2 pass** — (a) new lane omitted-status creates `status='active'` with no inference error; (b) status-omitted update of a wrapped lane preserves `status` + `ended_at`.
- Default suite (mock, DB tests skip): 22 pass, 2 skip, 0 fail. `bunx tsc --noEmit` clean.

## Critical Self-Review

- Highest-risk behavior: The `::text` casts on `$3`. Verified against live PG that casts make the query plan and execute, and that null/equality semantics are unchanged (a status-omitted update still preserves status and ended_at — proven by DB test, not just reasoning).
- Assumptions that could be wrong: That `TEXT` is the correct cast target. Confirmed against migration `012_session_lanes.sql` (`status TEXT NOT NULL`).
- Missing/weak tests: Prior to this PR, the lane_upsert path had NO real-DB coverage — that is exactly why #163's regression shipped. This PR adds it (env-gated). The default CI run still won't execute them unless a test DB URL is provided; running them in CI would require provisioning a Postgres service (noted as a follow-up worth doing).
- Security/permission risk: None — no auth/namespace logic touched.
- Migration/deploy risk: No schema change. Requires redeploy on hosted OB (the previous deploy of #163 is live and broken).
- Downstream client/runtime risk: Positive — unblocks Bilby/Skippy lane writes that currently 100% fail. Bilby spool drain (rtech-hermes#84) resumes only after this is live AND verified from the client side.
- Rollback/cleanup concern: Pure SQL/test change, trivially revertible. Diagnostic `log_thought` 5f3db27d in bilby's namespace still pending owner cleanup.
- Fixes made before PR: `$3::text` casts (3 sites); DB-backed integration tests; updated the mock test's SQL assertion to match the cast.
- Known residual risk: I previously declared #163 "verified/deployed" on ~40s uptime with no real lane traffic — a false positive. This time verification is a real query through a real pool PLUS a post-deploy check against actual Bilby/Skippy lane traffic before declaring success.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live checks: DB-backed integration tests pass against the hosted OB Postgres (2 pass). Post-deploy, will verify real Bilby/Skippy lane_upsert traffic succeeds (no new `lane_upsert_db_error`) before closing #162.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Server-side SQL fix; no client/schema/contract change. rtech-hermes items unchecked: Bilby spool drain (34 stuck `lane_upsert`) resumes after this deploys and is verified client-side (rtech-hermes#84, owner-driven).
