### PR TITLE
feat(tiering): lane -> own-durable memory tiering (#160)

### DIFF
--- a/scripts/tier-lane-durable.test.ts
+++ b/scripts/tier-lane-durable.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { parseArgs, runLaneTiering } from "./tier-lane-durable.ts";
+
+// The DB-driven loop of runLaneTiering is covered indirectly: it composes the
+// same classifyLaneEvent / findDurableDuplicate / graduateLaneEvent functions
+// exercised by src/tiering.test.ts and the live-Postgres block in
+// src/tools/__tests__/tier-lane.test.ts. Here we cover the pieces that do not
+// need a database: the kill switch and argument parsing.
+
+describe("tier-lane-durable parseArgs", () => {
+  test("defaults to dry-run with sane bounds", () => {
+    const args = parseArgs([]);
+    expect(args.apply).toBe(false);
+    expect(args.batchSize).toBe(20);
+    expect(args.maxApply).toBe(5);
+    expect(args.dupThreshold).toBe(0.08);
+    expect(args.minContentLength).toBe(24);
+  });
+
+  test("parses apply + tuning flags", () => {
+    const args = parseArgs([
+      "--apply",
+      "--batch-size",
+      "50",
+      "--max-apply",
+      "10",
+      "--dup-threshold",
+      "0.05",
+      "--min-content-length",
+      "40",
+    ]);
+    expect(args.apply).toBe(true);
+    expect(args.batchSize).toBe(50);
+    expect(args.maxApply).toBe(10);
+    expect(args.dupThreshold).toBe(0.05);
+    expect(args.minContentLength).toBe(40);
+  });
+});
+
+describe("tier-lane-durable kill switch", () => {
+  afterEach(() => {
+    delete process.env.OPENBRAIN_PROMOTION_KILL_SWITCH;
+  });
+
+  test("runLaneTiering throws before touching the DB when the kill switch is set", async () => {
+    process.env.OPENBRAIN_PROMOTION_KILL_SWITCH = "1";
+    // Throws before createPool, so no DB connection is attempted.
+    expect(runLaneTiering(parseArgs([]))).rejects.toThrow(
+      "OPENBRAIN_PROMOTION_KILL_SWITCH is enabled",
+    );
+  });
+});

--- a/scripts/tier-lane-durable.ts
+++ b/scripts/tier-lane-durable.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env bun
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { createPool } from "../src/db/pool.ts";
+import { generateEmbedding } from "../src/embedding.ts";
+import { logger } from "../src/logger.ts";
+import {
+  classifyLaneEvent,
+  findDurableDuplicate,
+  graduateLaneEvent,
+  type LaneEventRow,
+} from "../src/tiering.ts";
+
+/**
+ * Background runner for lane → own-durable memory tiering (Issue #160).
+ *
+ * Mirrors scripts/promote-legacy-shared.ts (cursor/state/receipt/args, dry-run
+ * default, resumable cursor, kill-switch). DIFFERENCE: instead of promoting
+ * between table namespaces, it reads ob_session_events joined to their lane and
+ * graduates substantive events into the lane agent's OWN durable `thoughts`
+ * table within the SAME namespace.
+ */
+
+interface Cursor {
+  created_at?: string;
+  id?: string;
+}
+
+interface State {
+  version: 1;
+  cursors: Record<string, Cursor>;
+  last_receipt?: Receipt;
+}
+
+interface Receipt {
+  started_at: string;
+  finished_at: string;
+  dry_run: boolean;
+  scanned: number;
+  graduated: number;
+  would_graduate: number;
+  kept: number;
+  archived: number;
+  manual_review: number;
+  duplicates: number;
+  failed: number;
+  namespaces: Record<string, NamespaceReceipt>;
+  failures: Array<{ namespace: string; id: string; error: string }>;
+}
+
+interface NamespaceReceipt {
+  scanned: number;
+  graduated: number;
+  would_graduate: number;
+  kept: number;
+  archived: number;
+  manual_review: number;
+  duplicates: number;
+  failed: number;
+}
+
+interface Args {
+  apply: boolean;
+  stateFile: string;
+  batchSize: number;
+  maxApply: number;
+  delayMs: number;
+  loop: boolean;
+  intervalMs: number;
+  minContentLength: number;
+  dupThreshold: number;
+}
+
+function usage(exitCode = 2): never {
+  console.error(
+    [
+      "Usage: bun run scripts/tier-lane-durable.ts [--apply] [--once]",
+      "       [--state-file <path>] [--batch-size 20] [--max-apply 5]",
+      "       [--delay-ms 250] [--loop] [--interval-ms 60000]",
+      "       [--min-content-length 24] [--dup-threshold 0.08]",
+      "",
+      "Dry-run is the default and does not advance the persistent cursor.",
+      "Apply mode is bounded by --max-apply graduations and graduates lane",
+      "events into the lane agent's OWN durable thoughts namespace.",
+    ].join("\n"),
+  );
+  process.exit(exitCode);
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    apply: false,
+    stateFile:
+      process.env.OPENBRAIN_LANE_TIERING_STATE ??
+      `${process.env.HOME ?? "."}/.local/state/open-brain/lane-tiering/state.json`,
+    batchSize: Number(process.env.OPENBRAIN_LANE_TIERING_BATCH_SIZE ?? 20),
+    maxApply: Number(process.env.OPENBRAIN_LANE_TIERING_MAX_APPLY ?? 5),
+    delayMs: Number(process.env.OPENBRAIN_LANE_TIERING_DELAY_MS ?? 250),
+    loop: false,
+    intervalMs: Number(
+      process.env.OPENBRAIN_LANE_TIERING_INTERVAL_MS ?? 60000,
+    ),
+    minContentLength: Number(
+      process.env.OPENBRAIN_LANE_TIERING_MIN_CONTENT_LENGTH ?? 24,
+    ),
+    dupThreshold: Number(
+      process.env.OPENBRAIN_LANE_TIERING_DUP_THRESHOLD ?? 0.08,
+    ),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--apply") args.apply = true;
+    else if (arg === "--once") args.loop = false;
+    else if (arg === "--loop") args.loop = true;
+    else if (arg === "--state-file") args.stateFile = argv[++i] ?? "";
+    else if (arg === "--batch-size") args.batchSize = Number(argv[++i] ?? 0);
+    else if (arg === "--max-apply") args.maxApply = Number(argv[++i] ?? 0);
+    else if (arg === "--delay-ms") args.delayMs = Number(argv[++i] ?? 0);
+    else if (arg === "--interval-ms") args.intervalMs = Number(argv[++i] ?? 0);
+    else if (arg === "--min-content-length") {
+      args.minContentLength = Number(argv[++i] ?? 0);
+    } else if (arg === "--dup-threshold") {
+      args.dupThreshold = Number(argv[++i] ?? 0);
+    } else if (arg === "--help" || arg === "-h") {
+      usage(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      usage();
+    }
+  }
+
+  if (
+    !args.stateFile ||
+    !Number.isInteger(args.batchSize) ||
+    args.batchSize < 1 ||
+    args.batchSize > 250 ||
+    !Number.isInteger(args.maxApply) ||
+    args.maxApply < 0 ||
+    args.maxApply > 100 ||
+    !Number.isInteger(args.delayMs) ||
+    args.delayMs < 0 ||
+    !Number.isInteger(args.intervalMs) ||
+    args.intervalMs < 1000 ||
+    !Number.isInteger(args.minContentLength) ||
+    args.minContentLength < 0 ||
+    !Number.isFinite(args.dupThreshold) ||
+    args.dupThreshold < 0 ||
+    args.dupThreshold > 1
+  ) {
+    usage();
+  }
+
+  return args;
+}
+
+function defaultState(): State {
+  return { version: 1, cursors: {} };
+}
+
+function loadState(args: Args): State {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(args.stateFile, "utf8"));
+  } catch {
+    // First run or corrupt state: start conservatively from the beginning.
+    return defaultState();
+  }
+  if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
+    const state = parsed as State;
+    if (state.version === 1) {
+      state.cursors ??= {};
+      return state;
+    }
+  }
+  return defaultState();
+}
+
+function saveState(path: string, state: State): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function newNamespaceReceipt(): NamespaceReceipt {
+  return {
+    scanned: 0,
+    graduated: 0,
+    would_graduate: 0,
+    kept: 0,
+    archived: 0,
+    manual_review: 0,
+    duplicates: 0,
+    failed: 0,
+  };
+}
+
+function addCount(
+  receipt: Receipt,
+  namespace: string,
+  field: keyof NamespaceReceipt,
+): void {
+  const nsReceipt = (receipt.namespaces[namespace] ??= newNamespaceReceipt());
+  nsReceipt[field] += 1;
+  receipt[field] += 1;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function sanitizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return (err.message.split("\n")[0] ?? err.name).slice(0, 240);
+  }
+  return String(err).slice(0, 240);
+}
+
+async function listNamespaces(
+  pool: ReturnType<typeof createPool>,
+): Promise<string[]> {
+  const { rows } = await pool.query(
+    `SELECT DISTINCT namespace FROM ob_session_lanes ORDER BY namespace ASC`,
+  );
+  return rows.map((row) => row.namespace as string);
+}
+
+async function candidateEvents(
+  pool: ReturnType<typeof createPool>,
+  namespace: string,
+  cursor: Cursor | undefined,
+  limit: number,
+): Promise<LaneEventRow[]> {
+  const params: unknown[] = [namespace, limit];
+  let cursorSql = "";
+  if (cursor?.created_at && cursor.id) {
+    params.push(cursor.created_at, cursor.id);
+    cursorSql = ` AND (e.created_at, e.id) > ($3::timestamptz, $4::uuid)`;
+  }
+  const { rows } = await pool.query(
+    `SELECT
+       e.id, e.lane_id, l.namespace, l.agent, l.session_key,
+       e.event_type, e.content, e.importance, e.content_hash, e.created_at
+     FROM ob_session_events e
+     JOIN ob_session_lanes l ON e.lane_id = l.id
+     WHERE l.namespace = $1${cursorSql}
+     ORDER BY e.created_at ASC, e.id ASC
+     LIMIT $2`,
+    params,
+  );
+  return rows as LaneEventRow[];
+}
+
+export async function runLaneTiering(args: Args): Promise<Receipt> {
+  if (process.env.OPENBRAIN_PROMOTION_KILL_SWITCH === "1") {
+    throw new Error("OPENBRAIN_PROMOTION_KILL_SWITCH is enabled");
+  }
+
+  const state = loadState(args);
+  const receipt: Receipt = {
+    started_at: new Date().toISOString(),
+    finished_at: "",
+    dry_run: !args.apply,
+    scanned: 0,
+    graduated: 0,
+    would_graduate: 0,
+    kept: 0,
+    archived: 0,
+    manual_review: 0,
+    duplicates: 0,
+    failed: 0,
+    namespaces: {},
+    failures: [],
+  };
+
+  const pool = createPool({
+    max: 2,
+    statement_timeout: 30000,
+    application_name: "openbrain-lane-tiering",
+  });
+  let applied = 0;
+
+  try {
+    const namespaces = await listNamespaces(pool);
+    namespaces:
+    for (const namespace of namespaces) {
+      const events = await candidateEvents(
+        pool,
+        namespace,
+        state.cursors[namespace],
+        args.batchSize,
+      );
+      for (const event of events) {
+        addCount(receipt, namespace, "scanned");
+        const nextCursor = {
+          created_at: new Date(event.created_at).toISOString(),
+          id: event.id,
+        };
+
+        const classification = classifyLaneEvent(event, args.minContentLength);
+        if (classification === "keep") {
+          addCount(receipt, namespace, "kept");
+          if (args.apply) state.cursors[namespace] = nextCursor;
+          continue;
+        }
+        if (classification === "archive") {
+          addCount(receipt, namespace, "archived");
+          if (args.apply) state.cursors[namespace] = nextCursor;
+          continue;
+        }
+        if (classification === "manual-review") {
+          addCount(receipt, namespace, "manual_review");
+          if (args.apply) state.cursors[namespace] = nextCursor;
+          continue;
+        }
+
+        // classification === "graduate"
+        if (args.apply && applied >= args.maxApply) {
+          break namespaces;
+        }
+
+        try {
+          let embedding: number[] | null = null;
+          try {
+            embedding = await generateEmbedding(event.content);
+          } catch {
+            embedding = null;
+          }
+
+          const duplicate = await findDurableDuplicate(
+            pool,
+            namespace,
+            event.content_hash,
+            embedding,
+            args.dupThreshold,
+          );
+          if (duplicate) {
+            addCount(receipt, namespace, "duplicates");
+            if (args.apply) state.cursors[namespace] = nextCursor;
+            continue;
+          }
+
+          if (!args.apply) {
+            addCount(receipt, namespace, "would_graduate");
+            continue;
+          }
+
+          await graduateLaneEvent(
+            pool,
+            event,
+            namespace,
+            "openbrain-lane-tiering",
+            embedding,
+            `lane tiering: ${event.event_type}/${event.importance}`,
+          );
+          applied += 1;
+          addCount(receipt, namespace, "graduated");
+          state.cursors[namespace] = nextCursor;
+        } catch (err) {
+          addCount(receipt, namespace, "failed");
+          receipt.failures.push({
+            namespace,
+            id: event.id,
+            error: sanitizeError(err),
+          });
+          break namespaces;
+        }
+
+        if (args.delayMs > 0) await sleep(args.delayMs);
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+
+  receipt.finished_at = new Date().toISOString();
+  state.last_receipt = receipt;
+  saveState(args.stateFile, state);
+  return receipt;
+}
+
+if (import.meta.main) {
+  const args = parseArgs(Bun.argv.slice(2));
+  const runOnce = async (): Promise<void> => {
+    const receiptPath = resolve(
+      dirname(args.stateFile),
+      `receipt-${new Date().toISOString().replace(/[:.]/g, "-")}.json`,
+    );
+    const receipt = await runLaneTiering(args);
+    mkdirSync(dirname(receiptPath), { recursive: true });
+    writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+    logger.info("lane_tiering_receipt", {
+      receipt_path: receiptPath,
+      dry_run: receipt.dry_run,
+      scanned: receipt.scanned,
+      graduated: receipt.graduated,
+      would_graduate: receipt.would_graduate,
+      kept: receipt.kept,
+      archived: receipt.archived,
+      manual_review: receipt.manual_review,
+      duplicates: receipt.duplicates,
+      failed: receipt.failed,
+    });
+    console.log(JSON.stringify({ ...receipt, receipt_path: receiptPath }));
+  };
+  const run = async (): Promise<void> => {
+    do {
+      await runOnce();
+      if (args.loop) await sleep(args.intervalMs);
+    } while (args.loop);
+  };
+  run().catch((err) => {
+    logger.error("lane_tiering_failed", { error: sanitizeError(err) });
+    process.exit(1);
+  });
+}

--- a/scripts/tier-lane-durable.ts
+++ b/scripts/tier-lane-durable.ts
@@ -2,7 +2,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { createPool } from "../src/db/pool.ts";
-import { generateEmbedding } from "../src/embedding.ts";
+import { contentHash, generateEmbedding } from "../src/embedding.ts";
 import { logger } from "../src/logger.ts";
 import {
   classifyLaneEvent,
@@ -87,7 +87,7 @@ function usage(exitCode = 2): never {
   process.exit(exitCode);
 }
 
-function parseArgs(argv: string[]): Args {
+export function parseArgs(argv: string[]): Args {
   const args: Args = {
     apply: false,
     stateFile:
@@ -326,10 +326,14 @@ export async function runLaneTiering(args: Args): Promise<Receipt> {
             embedding = null;
           }
 
+          // Recompute the hash when the event row has none, matching the tool
+          // path — otherwise a null-hash event skips exact dedup and gets
+          // mis-reported as graduated/would_graduate.
+          const dedupHash = event.content_hash ?? contentHash(event.content);
           const duplicate = await findDurableDuplicate(
             pool,
             namespace,
-            event.content_hash,
+            dedupHash,
             embedding,
             args.dupThreshold,
           );

--- a/src/tiering.test.ts
+++ b/src/tiering.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "bun:test";
+import {
+  classifyLaneEvent,
+  DEFAULT_MIN_CONTENT_LENGTH,
+  type Classification,
+  type EventType,
+  type Importance,
+} from "./tiering.ts";
+
+const EVENT_TYPES: EventType[] = [
+  "fact",
+  "decision",
+  "blocker",
+  "action",
+  "artifact",
+  "receipt",
+  "question",
+  "correction",
+  "handoff",
+];
+
+const IMPORTANCES: Importance[] = ["hot", "warm", "cold"];
+
+const GRADUATE_TYPES = new Set<EventType>(["fact", "decision", "handoff"]);
+const ARCHIVE_TYPES = new Set<EventType>(["question", "action"]);
+// "keep" default: blocker, artifact, receipt, correction (when not cold).
+const KEEP_TYPES = new Set<EventType>([
+  "blocker",
+  "artifact",
+  "receipt",
+  "correction",
+]);
+
+/** Content comfortably above the default min length (24). */
+const LONG = "x".repeat(DEFAULT_MIN_CONTENT_LENGTH + 10);
+/** Content below the default min length. */
+const SHORT = "x".repeat(DEFAULT_MIN_CONTENT_LENGTH - 1);
+
+/** Oracle the matrix tests assert against (mirrors the rule spec). */
+function expected(
+  type: EventType,
+  importance: Importance,
+  content: string,
+  minLen: number,
+): Classification {
+  if (importance === "cold" || ARCHIVE_TYPES.has(type)) return "archive";
+  if (GRADUATE_TYPES.has(type)) {
+    return content.trim().length >= minLen ? "graduate" : "manual-review";
+  }
+  return "keep";
+}
+
+describe("classifyLaneEvent — full matrix", () => {
+  for (const type of EVENT_TYPES) {
+    for (const importance of IMPORTANCES) {
+      for (const [label, content] of [
+        ["long", LONG],
+        ["short", SHORT],
+        ["empty", ""],
+      ] as const) {
+        it(`${type}/${importance}/${label}`, () => {
+          const got = classifyLaneEvent({
+            event_type: type,
+            importance,
+            content,
+          });
+          expect(got).toBe(
+            expected(type, importance, content, DEFAULT_MIN_CONTENT_LENGTH),
+          );
+        });
+      }
+    }
+  }
+});
+
+describe("classifyLaneEvent — graduate rule", () => {
+  for (const type of GRADUATE_TYPES) {
+    it(`graduates ${type} hot+long`, () => {
+      expect(
+        classifyLaneEvent({ event_type: type, importance: "hot", content: LONG }),
+      ).toBe("graduate");
+    });
+    it(`graduates ${type} warm+long`, () => {
+      expect(
+        classifyLaneEvent({ event_type: type, importance: "warm", content: LONG }),
+      ).toBe("graduate");
+    });
+    it(`archives ${type} when cold even if long (cold precedence)`, () => {
+      expect(
+        classifyLaneEvent({ event_type: type, importance: "cold", content: LONG }),
+      ).toBe("archive");
+    });
+    it(`manual-review for ${type} warm+short (ambiguous)`, () => {
+      expect(
+        classifyLaneEvent({
+          event_type: type,
+          importance: "warm",
+          content: SHORT,
+        }),
+      ).toBe("manual-review");
+    });
+  }
+});
+
+describe("classifyLaneEvent — archive rule", () => {
+  for (const type of ARCHIVE_TYPES) {
+    for (const importance of IMPORTANCES) {
+      it(`archives ${type}/${importance} regardless of length`, () => {
+        expect(
+          classifyLaneEvent({ event_type: type, importance, content: LONG }),
+        ).toBe("archive");
+      });
+    }
+  }
+  it("archives any type when importance is cold", () => {
+    for (const type of EVENT_TYPES) {
+      expect(
+        classifyLaneEvent({ event_type: type, importance: "cold", content: LONG }),
+      ).toBe("archive");
+    }
+  });
+});
+
+describe("classifyLaneEvent — keep default", () => {
+  for (const type of KEEP_TYPES) {
+    it(`keeps ${type} hot+long`, () => {
+      expect(
+        classifyLaneEvent({ event_type: type, importance: "hot", content: LONG }),
+      ).toBe("keep");
+    });
+    it(`keeps ${type} warm+short`, () => {
+      expect(
+        classifyLaneEvent({
+          event_type: type,
+          importance: "warm",
+          content: SHORT,
+        }),
+      ).toBe("keep");
+    });
+  }
+});
+
+describe("classifyLaneEvent — minContentLength boundary", () => {
+  it("graduates at exactly minContentLength (>= boundary)", () => {
+    const content = "y".repeat(DEFAULT_MIN_CONTENT_LENGTH);
+    expect(
+      classifyLaneEvent({ event_type: "fact", importance: "warm", content }),
+    ).toBe("graduate");
+  });
+
+  it("manual-review one char below minContentLength", () => {
+    const content = "y".repeat(DEFAULT_MIN_CONTENT_LENGTH - 1);
+    expect(
+      classifyLaneEvent({ event_type: "fact", importance: "warm", content }),
+    ).toBe("manual-review");
+  });
+
+  it("respects a custom minContentLength", () => {
+    const content = "y".repeat(10);
+    expect(
+      classifyLaneEvent(
+        { event_type: "decision", importance: "hot", content },
+        5,
+      ),
+    ).toBe("graduate");
+    expect(
+      classifyLaneEvent(
+        { event_type: "decision", importance: "hot", content },
+        50,
+      ),
+    ).toBe("manual-review");
+  });
+
+  it("trims whitespace before measuring length", () => {
+    const padded = `   ${"z".repeat(5)}   `;
+    // 5 real chars, well under default 24 → manual-review for a graduate type.
+    expect(
+      classifyLaneEvent({
+        event_type: "handoff",
+        importance: "warm",
+        content: padded,
+      }),
+    ).toBe("manual-review");
+  });
+
+  it("minContentLength of 0 graduates even empty graduate-type content", () => {
+    expect(
+      classifyLaneEvent(
+        { event_type: "fact", importance: "warm", content: "" },
+        0,
+      ),
+    ).toBe("graduate");
+  });
+});

--- a/src/tiering.ts
+++ b/src/tiering.ts
@@ -194,6 +194,14 @@ export async function graduateLaneEvent(
   embedding: number[] | null,
   reason: string,
 ): Promise<GraduateResult> {
+  // Defense-in-depth: a lane event must only graduate into ITS OWN namespace.
+  // Callers already scope the source read by namespace, but assert here so a
+  // future caller that constructs rows differently cannot write cross-namespace.
+  if (event.namespace !== namespace) {
+    throw new Error(
+      `lane event namespace '${event.namespace}' does not match graduation target '${namespace}'`,
+    );
+  }
   const hash = event.content_hash ?? contentHash(event.content);
   const tags = [
     "tiered-from-lane",

--- a/src/tiering.ts
+++ b/src/tiering.ts
@@ -1,0 +1,345 @@
+import type pg from "pg";
+import { toSql } from "pgvector/pg";
+import { contentHash, EMBEDDING_MODEL } from "./embedding.ts";
+import type { generateEmbedding } from "./embedding.ts";
+
+/**
+ * Lane → own-durable memory tiering (Issue #160).
+ *
+ * Graduates `ob_session_events` lane events into the agent's OWN durable
+ * `thoughts` table within the SAME namespace. This is distinct from shared-kb
+ * promotion (#161): no cross-namespace move, no promoter role required.
+ */
+
+export type EventType =
+  | "fact"
+  | "decision"
+  | "blocker"
+  | "action"
+  | "artifact"
+  | "receipt"
+  | "question"
+  | "correction"
+  | "handoff";
+
+export type Importance = "hot" | "warm" | "cold";
+
+export type Classification = "graduate" | "keep" | "archive" | "manual-review";
+
+/** Default minimum content length for a graduate-eligible event. */
+export const DEFAULT_MIN_CONTENT_LENGTH = 24;
+
+/** Default cosine-distance threshold for near-duplicate detection. */
+export const DEFAULT_DUP_THRESHOLD = 0.08;
+
+/** Event types whose substance warrants durable graduation. */
+const GRADUATE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
+  "fact",
+  "decision",
+  "handoff",
+]);
+
+/** Event types that are operational noise — archive rather than graduate. */
+const ARCHIVE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
+  "question",
+  "action",
+]);
+
+/** Minimal shape the classifier needs from a lane event. */
+export interface ClassifiableEvent {
+  event_type: EventType;
+  content: string;
+  importance: Importance;
+}
+
+/**
+ * Pure classifier — no DB, no I/O. Decides how a single lane event should be
+ * tiered. Duplicate detection is handled separately (see `findDurableDuplicate`)
+ * because it needs the target table.
+ *
+ * Rules:
+ * - graduate: type ∈ {fact, decision, handoff} AND importance !== "cold"
+ *   AND trimmed content length >= minContentLength.
+ * - archive: type ∈ {question, action} OR importance === "cold".
+ * - manual-review: graduate-eligible by type/importance but content is too
+ *   short to be sure (ambiguous).
+ * - keep: everything else (default short-term retention).
+ *
+ * Archive precedence note: a `cold` fact/decision/handoff archives rather than
+ * graduating — cold importance means the agent has down-tiered it.
+ */
+export function classifyLaneEvent(
+  event: ClassifiableEvent,
+  minContentLength: number = DEFAULT_MIN_CONTENT_LENGTH,
+): Classification {
+  const isColdOrArchiveType =
+    event.importance === "cold" || ARCHIVE_TYPES.has(event.event_type);
+  if (isColdOrArchiveType) {
+    return "archive";
+  }
+
+  if (GRADUATE_TYPES.has(event.event_type)) {
+    // type + importance qualify; length decides graduate vs ambiguous.
+    const length = event.content.trim().length;
+    return length >= minContentLength ? "graduate" : "manual-review";
+  }
+
+  return "keep";
+}
+
+/** A lane event row joined with its lane's namespace + agent. */
+export interface LaneEventRow {
+  id: string;
+  lane_id: string;
+  namespace: string;
+  agent: string | null;
+  session_key: string;
+  event_type: EventType;
+  content: string;
+  importance: Importance;
+  content_hash: string | null;
+  created_at: string;
+}
+
+export type DuplicateKind = "exact" | "near";
+
+export interface DuplicateMatch {
+  kind: DuplicateKind;
+  thought_id: string;
+  distance?: number;
+}
+
+/**
+ * Check whether an event is already present in the target durable `thoughts`
+ * table for its namespace. Two passes:
+ *  - exact: identical content_hash in thoughts(namespace).
+ *  - near: cosine distance `embedding <=> embedding < threshold` to an existing
+ *    thought in that namespace (mirrors find-duplicates.ts convention).
+ *
+ * Returns the first match found, or null. SQL is fully parameterized.
+ */
+export async function findDurableDuplicate(
+  pool: pg.Pool,
+  namespace: string,
+  hash: string | null,
+  embedding: number[] | null,
+  threshold: number = DEFAULT_DUP_THRESHOLD,
+): Promise<DuplicateMatch | null> {
+  if (hash) {
+    const { rows } = await pool.query(
+      `SELECT id FROM thoughts
+       WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL
+       LIMIT 1`,
+      [hash, namespace],
+    );
+    if (rows.length > 0) {
+      return { kind: "exact", thought_id: rows[0].id as string };
+    }
+  }
+
+  if (embedding) {
+    const { rows } = await pool.query(
+      `SELECT id, embedding <=> $1 AS distance
+       FROM thoughts
+       WHERE namespace = $2
+         AND archived_at IS NULL
+         AND embedding IS NOT NULL
+         AND embedding <=> $1 < $3
+       ORDER BY distance ASC
+       LIMIT 1`,
+      [toSql(embedding), namespace, threshold],
+    );
+    if (rows.length > 0) {
+      return {
+        kind: "near",
+        thought_id: rows[0].id as string,
+        distance: Number(rows[0].distance),
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Provenance payload recorded on graduated thoughts. */
+export interface LaneGraduationProvenance {
+  source: "session-lane";
+  lane_id: string;
+  session_key: string;
+  event_id: string;
+  event_type: EventType;
+  importance: Importance;
+  agent: string | null;
+  classification: Classification;
+  reason: string;
+  graduated_at: string;
+}
+
+export interface GraduateResult {
+  thought_id: string;
+  is_new: boolean;
+}
+
+/**
+ * Insert a graduated lane event into the agent's own `thoughts` namespace.
+ * Idempotent via ON CONFLICT (content_hash, namespace) — re-running a batch
+ * produces no duplicate rows (mirrors log-thought.ts). Provenance is stored in
+ * `promoted_from` (the existing provenance column) and surfaced in tags.
+ */
+export async function graduateLaneEvent(
+  pool: pg.Pool,
+  event: LaneEventRow,
+  namespace: string,
+  createdBy: string,
+  embedding: number[] | null,
+  reason: string,
+): Promise<GraduateResult> {
+  const hash = event.content_hash ?? contentHash(event.content);
+  const tags = [
+    "tiered-from-lane",
+    `lane:${event.session_key}`,
+    `event-type:${event.event_type}`,
+  ];
+  const provenance: LaneGraduationProvenance = {
+    source: "session-lane",
+    lane_id: event.lane_id,
+    session_key: event.session_key,
+    event_id: event.id,
+    event_type: event.event_type,
+    importance: event.importance,
+    agent: event.agent,
+    classification: "graduate",
+    reason,
+    graduated_at: new Date().toISOString(),
+  };
+
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts
+       (content, tags, source, created_by, namespace, embedding, content_hash,
+        embedded_at, embedding_model, promoted_from)
+     VALUES ($1, $2, 'lane-tiering', $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
+     DO UPDATE SET
+       tags = (
+         SELECT COALESCE(array_agg(DISTINCT tag), '{}')
+         FROM unnest(thoughts.tags || EXCLUDED.tags) AS tag
+         WHERE tag IS NOT NULL
+       ),
+       updated_at = NOW()
+     RETURNING id, (xmax = 0) AS is_new`,
+    [
+      event.content,
+      tags,
+      createdBy,
+      namespace,
+      embedding ? toSql(embedding) : null,
+      hash,
+      embedding ? new Date().toISOString() : null,
+      embedding ? EMBEDDING_MODEL : null,
+      JSON.stringify(provenance),
+    ],
+  );
+
+  return {
+    thought_id: rows[0].id as string,
+    is_new: rows[0].is_new as boolean,
+  };
+}
+
+export interface TierReceipt {
+  scanned: number;
+  graduated: number;
+  kept: number;
+  archived: number;
+  manual_review: number;
+  duplicates: number;
+  dry_run: boolean;
+}
+
+export function newTierReceipt(dryRun: boolean): TierReceipt {
+  return {
+    scanned: 0,
+    graduated: 0,
+    kept: 0,
+    archived: 0,
+    manual_review: 0,
+    duplicates: 0,
+    dry_run: dryRun,
+  };
+}
+
+export interface TierEventOptions {
+  pool: pg.Pool;
+  embedFn: typeof generateEmbedding;
+  namespace: string;
+  createdBy: string;
+  minContentLength?: number;
+  dupThreshold?: number;
+  dryRun: boolean;
+}
+
+/**
+ * Classify + dedup + (optionally) graduate a single lane event, mutating the
+ * receipt in place. Shared by the on-demand `tier_lane` tool and the background
+ * runner so both paths apply identical policy.
+ */
+export async function tierLaneEvent(
+  event: LaneEventRow,
+  receipt: TierReceipt,
+  opts: TierEventOptions,
+): Promise<void> {
+  receipt.scanned += 1;
+
+  const minContentLength = opts.minContentLength ?? DEFAULT_MIN_CONTENT_LENGTH;
+  const classification = classifyLaneEvent(event, minContentLength);
+
+  if (classification === "keep") {
+    receipt.kept += 1;
+    return;
+  }
+  if (classification === "archive") {
+    receipt.archived += 1;
+    return;
+  }
+  if (classification === "manual-review") {
+    receipt.manual_review += 1;
+    return;
+  }
+
+  // classification === "graduate" — needs an embedding for near-dup detection
+  // and for the durable thought. Embedding failures degrade to hash-only dedup.
+  let embedding: number[] | null = null;
+  try {
+    embedding = await opts.embedFn(event.content);
+  } catch {
+    embedding = null;
+  }
+
+  const hash = event.content_hash ?? contentHash(event.content);
+  const duplicate = await findDurableDuplicate(
+    opts.pool,
+    opts.namespace,
+    hash,
+    embedding,
+    opts.dupThreshold ?? DEFAULT_DUP_THRESHOLD,
+  );
+  if (duplicate) {
+    receipt.duplicates += 1;
+    return;
+  }
+
+  if (opts.dryRun) {
+    receipt.graduated += 1;
+    return;
+  }
+
+  await graduateLaneEvent(
+    opts.pool,
+    event,
+    opts.namespace,
+    opts.createdBy,
+    embedding,
+    `lane tiering: ${event.event_type}/${event.importance}`,
+  );
+  receipt.graduated += 1;
+}

--- a/src/tools/__tests__/tier-lane.test.ts
+++ b/src/tools/__tests__/tier-lane.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, afterAll } from "bun:test";
+import { Pool } from "pg";
+import { toSql } from "pgvector/pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerTierLane } from "../tier-lane.ts";
+import { contentHash } from "../../embedding.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+/** A graduate-eligible event row joined with its lane. */
+function laneEventRow(overrides: Record<string, unknown> = {}) {
+  const content =
+    "This is a substantive durable fact that exceeds the minimum length";
+  return {
+    id: "evt-1",
+    lane_id: "lane-1",
+    namespace: "bilby",
+    agent: "bilby",
+    session_key: "task-42",
+    event_type: "fact",
+    content,
+    importance: "warm",
+    content_hash: contentHash(content),
+    created_at: "2026-06-07T15:30:00Z",
+    ...overrides,
+  };
+}
+
+/**
+ * Mock pool that routes by SQL shape:
+ *  - JOIN ob_session_events → lane events
+ *  - exact dedup (content_hash = ...) → controllable hit/miss
+ *  - near dedup (embedding <=> ...) → controllable hit/miss
+ *  - INSERT INTO thoughts → records a write
+ */
+function createMockPool(opts: {
+  events: Array<Record<string, unknown>>;
+  exactDup?: boolean;
+  nearDup?: boolean;
+}) {
+  const writes: Array<{ sql: string; params: any[] }> = [];
+  const pool = {
+    writes,
+    query: async (sql: string, params: any[] = []) => {
+      if (sql.includes("FROM ob_session_events")) {
+        return { rows: opts.events };
+      }
+      if (sql.includes("INSERT INTO thoughts")) {
+        writes.push({ sql, params });
+        return { rows: [{ id: "thought-new", is_new: true }] };
+      }
+      // exact dedup query
+      if (sql.includes("content_hash = $1") && sql.includes("FROM thoughts")) {
+        return { rows: opts.exactDup ? [{ id: "dup-exact" }] : [] };
+      }
+      // near dedup query
+      if (sql.includes("embedding <=> $1") && sql.includes("FROM thoughts")) {
+        return {
+          rows: opts.nearDup ? [{ id: "dup-near", distance: 0.02 }] : [],
+        };
+      }
+      return { rows: [] };
+    },
+  };
+  return pool;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+  embedFn?: (text: string) => Promise<number[] | null>,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = {
+    pool: mockPool as any,
+    embedFn: embedFn ?? createMockEmbed(),
+  };
+  registerTierLane(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) =>
+    originalSend(message, { ...options, authInfo: auth });
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("tier_lane", () => {
+  // ── AUTH ──
+
+  it("denies when auth is missing entirely", async () => {
+    const mockPool = { query: async () => ({ rows: [] }) };
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+    registerTierLane(server, deps);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "tc", version: "1.0.0" });
+    await server.connect(st);
+    await client.connect(ct);
+
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42" },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies readonly role", async () => {
+    const mockPool = createMockPool({ events: [] });
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42" },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("agent CAN tier its OWN namespace", async () => {
+    const mockPool = createMockPool({ events: [] });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42", namespace: "bilby" },
+      });
+      expect(res.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("agent CANNOT tier another agent's namespace", async () => {
+    const mockPool = createMockPool({ events: [] });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42", namespace: "skippy" },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("agent with X-Namespace header cannot tier a different namespace", async () => {
+    const mockPool = createMockPool({ events: [] });
+    const auth: AuthInfo = {
+      role: "agent",
+      clientId: "bilby",
+      namespaceSource: "header",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42", namespace: "other" },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DRY RUN ──
+
+  it("dry-run (default) performs NO writes and reports would-graduate", async () => {
+    const mockPool = createMockPool({ events: [laneEventRow()] });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42", namespace: "bilby" },
+      });
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.dry_run).toBe(true);
+      expect(parsed.scanned).toBe(1);
+      expect(parsed.graduated).toBe(1);
+      expect(mockPool.writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── APPLY ──
+
+  it("apply mode writes a graduated thought", async () => {
+    const mockPool = createMockPool({ events: [laneEventRow()] });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: {
+          session_key: "task-42",
+          namespace: "bilby",
+          dry_run: false,
+        },
+      });
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.graduated).toBe(1);
+      expect(mockPool.writes.length).toBe(1);
+      // provenance + tags carried into the INSERT params
+      const write = mockPool.writes[0]!;
+      const provenance = JSON.parse(write.params[8]);
+      expect(provenance.source).toBe("session-lane");
+      expect(provenance.lane_id).toBe("lane-1");
+      expect(provenance.event_id).toBe("evt-1");
+      const tags = write.params[1];
+      expect(tags).toContain("tiered-from-lane");
+      expect(tags).toContain("lane:task-42");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── DEDUP ──
+
+  it("skips an exact-hash duplicate (no write)", async () => {
+    const mockPool = createMockPool({
+      events: [laneEventRow()],
+      exactDup: true,
+    });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: {
+          session_key: "task-42",
+          namespace: "bilby",
+          dry_run: false,
+        },
+      });
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.duplicates).toBe(1);
+      expect(parsed.graduated).toBe(0);
+      expect(mockPool.writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips a near-embedding duplicate (no write)", async () => {
+    const mockPool = createMockPool({
+      events: [laneEventRow({ content_hash: null })],
+      nearDup: true,
+    });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: {
+          session_key: "task-42",
+          namespace: "bilby",
+          dry_run: false,
+        },
+      });
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.duplicates).toBe(1);
+      expect(parsed.graduated).toBe(0);
+      expect(mockPool.writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── RECEIPT SHAPE / CLASSIFICATION ──
+
+  it("returns the full receipt shape across mixed event types", async () => {
+    const long = "x".repeat(40);
+    const mockPool = createMockPool({
+      events: [
+        laneEventRow({ id: "e-fact", event_type: "fact", content: long }),
+        laneEventRow({
+          id: "e-q",
+          event_type: "question",
+          content: long,
+          content_hash: contentHash(`q-${long}`),
+        }),
+        laneEventRow({
+          id: "e-blocker",
+          event_type: "blocker",
+          content: long,
+          content_hash: contentHash(`b-${long}`),
+        }),
+        laneEventRow({
+          id: "e-short",
+          event_type: "decision",
+          content: "tiny",
+          content_hash: contentHash("tiny"),
+        }),
+        laneEventRow({
+          id: "e-cold",
+          event_type: "handoff",
+          importance: "cold",
+          content: long,
+          content_hash: contentHash(`c-${long}`),
+        }),
+      ],
+    });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42", namespace: "bilby" },
+      });
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.scanned).toBe(5);
+      expect(parsed.graduated).toBe(1); // fact/warm/long
+      expect(parsed.archived).toBe(2); // question + cold handoff
+      expect(parsed.kept).toBe(1); // blocker
+      expect(parsed.manual_review).toBe(1); // short decision
+      expect(parsed).toHaveProperty("duplicates");
+      expect(parsed).toHaveProperty("dry_run");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("defaults namespace to caller clientId", async () => {
+    const mockPool = createMockPool({ events: [] });
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42" },
+      });
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.namespace).toBe("bilby");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns isError when the DB query throws", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection refused");
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool as any, auth);
+    try {
+      const res = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "task-42", namespace: "bilby" },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("connection refused");
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ── DB-BACKED INTEGRATION ──
+// Mocks can't catch real Postgres halfvec/embedding behavior, the ON CONFLICT
+// idempotency, or cosine-distance dedup. Gated on OPENBRAIN_TEST_DATABASE_URL.
+//   OPENBRAIN_TEST_DATABASE_URL=postgres://... bun test src/tools/__tests__/tier-lane.test.ts
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("tier_lane (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-tier-lane-live";
+  const sessionKey = "live-tier-lane";
+  // Deterministic embeddings so near-dup behavior is testable.
+  const baseEmbedding = Array(768).fill(0.1);
+  const embedFn = createMockEmbed(baseEmbedding);
+
+  async function callTierLane(args: Record<string, unknown>, auth: AuthInfo) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn };
+    registerTierLane(server, deps);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const original = ct.send.bind(ct);
+    ct.send = (m: any, o?: any) => original(m, { ...o, authInfo: auth });
+    const client = new Client({ name: "tc", version: "1.0.0" });
+    await server.connect(st);
+    await client.connect(ct);
+    const res = await client.callTool({ name: "tier_lane", arguments: args });
+    await client.close();
+    await server.close();
+    return res;
+  }
+
+  async function seedLaneWithEvent(content: string, eventType = "fact") {
+    const { rows } = await pool.query(
+      `INSERT INTO ob_session_lanes (session_key, namespace, agent, created_by)
+       VALUES ($1, $2, $3, $3)
+       ON CONFLICT (namespace, session_key) DO UPDATE SET updated_at = NOW()
+       RETURNING id`,
+      [sessionKey, ns, ns],
+    );
+    const laneId = rows[0].id as string;
+    await pool.query(
+      `INSERT INTO ob_session_events
+         (lane_id, event_type, content, importance, content_hash, embedding, created_by)
+       VALUES ($1, $2, $3, 'warm', $4, $5, $6)
+       ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL
+       DO NOTHING`,
+      [laneId, eventType, content, contentHash(content), toSql(baseEmbedding), ns],
+    );
+    return laneId;
+  }
+
+  async function cleanup() {
+    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+    await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+  }
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("graduates a fact into the namespace with provenance, idempotent on re-run", async () => {
+    await cleanup();
+    const content =
+      "Live durable fact about the open-brain tiering integration test path";
+    await seedLaneWithEvent(content);
+    const auth: AuthInfo = { role: "agent", clientId: ns };
+
+    const first = await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+    expect(first.isError).toBeFalsy();
+    expect(JSON.parse((first.content as any)[0].text).graduated).toBe(1);
+
+    const { rows: afterFirst } = await pool.query(
+      "SELECT id, promoted_from, tags FROM thoughts WHERE namespace = $1",
+      [ns],
+    );
+    expect(afterFirst.length).toBe(1);
+    expect(afterFirst[0].promoted_from.source).toBe("session-lane");
+    expect(afterFirst[0].tags).toContain("tiered-from-lane");
+
+    // Re-run: ON CONFLICT idempotency — exact-hash dedup skips, no new row.
+    const second = await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+    expect(second.isError).toBeFalsy();
+    expect(JSON.parse((second.content as any)[0].text).duplicates).toBe(1);
+
+    const { rows: afterSecond } = await pool.query(
+      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1",
+      [ns],
+    );
+    expect(afterSecond[0].n).toBe(1);
+  });
+
+  it("skips a near-duplicate by embedding distance", async () => {
+    await cleanup();
+    const auth: AuthInfo = { role: "agent", clientId: ns };
+    // First event graduates.
+    await seedLaneWithEvent(
+      "Original durable statement that should graduate into thoughts cleanly",
+    );
+    await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+
+    // Second event: different text + hash but identical embedding → near-dup.
+    await seedLaneWithEvent(
+      "A slightly reworded but semantically identical durable statement here",
+    );
+    const res = await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+    const parsed = JSON.parse((res.content as any)[0].text);
+    // The tool re-scans the whole lane, so BOTH events are now duplicates:
+    // event 1 by exact content_hash (already graduated), event 2 by near
+    // embedding distance. The point is that the near-dup event 2 did NOT
+    // graduate (no new row), proving embedding dedup works.
+    expect(parsed.graduated).toBe(0);
+    expect(parsed.duplicates).toBe(2);
+
+    const { rows } = await pool.query(
+      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1",
+      [ns],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -42,6 +42,7 @@ import { registerAdjacentContext } from "./adjacent-context.ts";
 import { registerPromoteEntry } from "./promote-entry.ts";
 import { registerDemoteEntry } from "./demote-entry.ts";
 import { registerScanNamespace } from "./scan-namespace.ts";
+import { registerTierLane } from "./tier-lane.ts";
 import { registerGetContract } from "./get-contract.ts";
 import { registerListRepoFacts, registerUpsertRepoFact } from "./repo-facts.ts";
 
@@ -92,6 +93,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerPromoteEntry(server, deps);
   registerDemoteEntry(server, deps);
   registerScanNamespace(server, deps);
+  registerTierLane(server, deps);
   registerGetContract(server, deps);
   registerUpsertRepoFact(server, deps);
   registerListRepoFacts(server, deps);

--- a/src/tools/tier-lane.ts
+++ b/src/tools/tier-lane.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
+import {
+  canonicalNamespace,
+  physicalNamespace,
+} from "../shared-namespace.ts";
+import {
+  newTierReceipt,
+  tierLaneEvent,
+  type LaneEventRow,
+} from "../tiering.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+export function registerTierLane(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "tier_lane",
+    {
+      description:
+        "Graduate substantive events from a single session lane into the agent's " +
+        "OWN durable thoughts (same namespace). Classifies each event, skips " +
+        "duplicates, and graduates facts/decisions/handoffs. Dry-run by default. " +
+        "An agent may only tier a lane in a namespace it can write.",
+      inputSchema: {
+        session_key: z
+          .string()
+          .min(1)
+          .max(500)
+          .describe("Stable lane identifier to tier"),
+        namespace: z
+          .string()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Namespace of the lane (defaults to caller's clientId)"),
+        dry_run: z
+          .boolean()
+          .optional()
+          .describe("Preview without writing durable thoughts (default true)"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Max lane events to scan (default 100)"),
+      },
+      annotations: {
+        title: "Tier Session Lane",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canWrite(auth.role, "thoughts")) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot write to thoughts",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const requestedNamespace = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, requestedNamespace);
+      if (!nsCheck.allowed) {
+        logger.warn("tier_lane_denied", {
+          role: auth.role,
+          clientId: auth.clientId,
+          namespace: requestedNamespace,
+          reason: nsCheck.reason,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: ${nsCheck.reason}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const ns = physicalNamespace(requestedNamespace);
+      const dryRun = args.dry_run ?? true;
+      const limit = args.limit ?? 100;
+
+      try {
+        // Lane is resolved by (namespace, session_key); events are joined to
+        // their lane so each row carries the lane's namespace + agent.
+        const { rows } = await deps.pool.query(
+          `SELECT
+             e.id, e.lane_id, l.namespace, l.agent, l.session_key,
+             e.event_type, e.content, e.importance, e.content_hash, e.created_at
+           FROM ob_session_events e
+           JOIN ob_session_lanes l ON e.lane_id = l.id
+           WHERE l.namespace = $1 AND l.session_key = $2
+           ORDER BY e.created_at ASC, e.id ASC
+           LIMIT $3`,
+          [ns, args.session_key, limit],
+        );
+
+        const receipt = newTierReceipt(dryRun);
+        for (const row of rows as LaneEventRow[]) {
+          await tierLaneEvent(row, receipt, {
+            pool: deps.pool,
+            embedFn: deps.embedFn,
+            namespace: ns,
+            createdBy: auth.clientId,
+            dryRun,
+          });
+        }
+
+        logger.info("tier_lane_ok", {
+          session_key: args.session_key,
+          namespace: ns,
+          ...receipt,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                session_key: args.session_key,
+                namespace: canonicalNamespace(ns),
+                ...receipt,
+              }),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("tier_lane_db_error", {
+          session_key: args.session_key,
+          namespace: ns,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Database error during lane tiering: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Implements #160 — continuous within-namespace memory tiering: graduate an agent's short-term lane events (`ob_session_events`) into its own durable `thoughts`. No shared-write trust bar (agent owns the destination); distinct from the lane→shared-kb sibling #161.

- `src/tiering.ts`: pure `classifyLaneEvent` (graduate|keep|archive|manual-review) + DB-backed dedup + idempotent graduate.
- `src/tools/tier-lane.ts`: on-demand `tier_lane` MCP tool (agent tiers its OWN namespace only; dry-run default; receipt). Registered in tools/index.ts.
- `scripts/tier-lane-durable.ts`: background runner on the proven promote-legacy-shared.ts skeleton.

## Design

- **Classifier (rule-based, no LLM per Non-Goals):** graduate `event_type ∈ {fact, decision, handoff}` with `importance ≠ cold` and content ≥ min length; archive `{question, action}` or cold; manual-review = graduate-eligible but too short; else keep short-term. Pure + exhaustively unit-tested.
- **Dedup (rule-based + embedding):** exact `content_hash` in target namespace OR cosine `embedding <=> < 0.08` (reuses the find-duplicates.ts convention) → skip.
- **Idempotency:** `INSERT ... ON CONFLICT (content_hash, namespace)` (mirrors log-thought.ts) — re-running a batch produces no new rows.
- **Provenance:** source lane_id/session_key/event_id/event_type/importance/agent/classification/reason/graduated_at in `thoughts.promoted_from` + tags.
- **Auth:** `tier_lane` requires `canWriteNamespace(auth, ns)` — within-namespace, no promoter role. Agent can tier its own namespace, rejected for others.

## Validation

- `bunx tsc --noEmit` clean. Full suite green.
- **Live-Postgres integration tests (env-gated): 14/14 pass** — graduation+provenance, idempotency on re-run, embedding near-dup skip. The live run caught and fixed a near-dup test-expectation bug that the mock harness could not surface (the tool re-scans the full lane, so both events dedup on rescan).

## Critical Self-Review

- Highest-risk behavior: The DB-backed dedup + idempotent INSERT (SQL the mock can't execute). Mitigated by env-gated live-PG tests run against the hosted OB DB (14/14), proving real ON CONFLICT idempotency and real halfvec cosine dedup — not just mock assertions.
- Assumptions that could be wrong: That `{fact, decision, handoff}` is the right graduate allowlist and cold-archives is correct intent (encoded explicitly, unit-tested; easy to adjust). That `thoughts.promoted_from` is the right provenance column (it's the existing provenance JSONB slot; no migration added to keep scope tight — a dedicated `tiered_from` column is a one-line migration if preferred).
- Missing/weak tests: The background runner script's cursor advance against Postgres is exercised by the tool's live tests for the core logic but the standalone script's loop isn't separately live-tested; the classifier + tool paths are.
- Security/permission risk: Within-namespace only. `tier_lane` uses canWriteNamespace; an agent cannot tier another namespace (no promoter/cross-namespace power). Verified by mock auth tests.
- Migration/deploy risk: No schema change. Background runner is opt-in (dry-run default); MCP tool is additive.
- Downstream client/runtime risk: Additive MCP tool; no change to existing tools/contracts.
- Rollback/cleanup concern: Additive; revertible. No state migration.
- Fixes made before PR: corrected the near-dup live test expectation (logic was right; test assumed single-event rescan).
- Known residual risk: Per the issue's Trap, graduation trusts that lane writes landed — that reliability is rtech-hermes#84 (separate repo). Tiering operates on whatever events exist; it doesn't fix upstream write loss.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this reuses the now-established DB-backed-test discipline (already captured in docs/sme/correctness.md from #162); no new reviewer pattern emerged.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live checks: DB-backed integration tests pass against hosted OB Postgres (14/14), covering graduation, provenance, idempotency, and embedding dedup.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Adds a `tier_lane` MCP tool — a new client-facing surface. It is additive (no change to existing tools), within-namespace, and agent-self-serviceable. Downstream agents/skills can adopt it when ready; nothing is forced. The background runner is server-side opt-in (dry-run default). No contract/schema break.
