### PR TITLE
feat(promotion): lane -> shared-kb promotion, promoter-gated (#161)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       DB_USER: test
       DB_PASSWORD: test
       DB_NAME: open_brain_test
+      # Enable the env-gated real-Pool integration tests in CI (issue #165).
+      # Without this, every `dbDescribe`-gated suite (lane_upsert, the #161
+      # cursor-stall promoter tests) silently SKIPs and the SQL write paths get
+      # zero CI coverage — the exact gap that let the #162 lane_upsert bugs ship.
+      OPENBRAIN_TEST_DATABASE_URL: postgres://test:test@localhost:5432/open_brain_test
     steps:
       - uses: actions/checkout@v6
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,0 +1,5 @@
+
+## [2026-06-19] Mac-only temp path breaks env-gated tests on Linux CI
+- Trigger: scripts/promote-lane-shared.test.ts used `process.env.DEV_TMP ?? "/Volumes/ThunderBolt/_tmp"` for mkdtempSync. That path is macOS-only; Linux CI runner → `ENOENT` on mkdtemp, then cascade `TypeError: path must be a string` in afterEach rmSync (tmpDir undefined).
+- Fix: fall back to `node:os` `tmpdir()` not the Mac path: `process.env.DEV_TMP ?? tmpdir()`.
+- Scope: any repo test that creates temp dirs and runs in both macOS dev and Linux CI. The Development CLAUDE.md `/Volumes/ThunderBolt/_tmp` rule is for agent scratch, NOT for committed test code that runs in CI.

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -66,3 +66,40 @@ contracts.
 - Does each recovery feature prove durability under its own failure mode?
 - Are tests only asserting method names, or are they asserting state after
   failure?
+
+## [2026-06-19] Cursor-resumable sweeps: every processed row must advance the cursor
+
+**Severity:** HIGH
+**Source:** Issue #161, PR #171 (lane→shared-kb promoter)
+**Scope:** `scripts/promote-lane-shared.ts` and any `(created_at, id) > cursor` resumable batch runner
+**Status:** active
+
+### Pattern
+
+A resumable promoter sweeps rows ordered by `(created_at, id)` and persists a
+cursor. Two ways a row can pin the cursor and cause an infinite re-sweep (and,
+for the events path, a wasted embedding call every tick):
+
+1. **Non-terminal classification (manual-review):** the row is not promoted and
+   its nomination flag is intentionally left set. If the cursor only advances on
+   `share`/terminal-reject, a trailing manual-review row is re-fetched forever.
+2. **Deterministic write failure (poison pill):** a row whose INSERT always
+   throws hits the catch block. If the catch `break`s without advancing the
+   cursor, that row blocks every row behind it on every subsequent run.
+
+### Review Questions
+
+- In apply mode, does the cursor advance for EVERY processed row, including
+  manual-review and caught-failure rows (recording the failure in the receipt
+  rather than pinning)?
+- Is there a real-DB test seeding a trailing manual-review row AND a
+  deterministically-failing row, asserting a second run makes forward progress?
+- Does dry-run intentionally NOT advance the cursor, and is `--loop` dry-run's
+  full re-scan understood as intended (not a bug)?
+
+### Prior Fix
+
+PR #171 advances the cursor for manual-review and for caught failures in both
+the thoughts/decisions and events loops; nomination flag left set + failure in
+`receipt.failures` for human follow-up. Regression tests use a test-managed
+`BEFORE INSERT` trigger to force a deterministic failure.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -119,3 +119,60 @@ behaving poorly on malformed or mixed valid/invalid server candidates.
 
 PR #75 made `dream_once()` dry-run-only, bounded limits to 100, suppressed
 unscoped tier actions for namespace dreams, and rejected boolean numeric config.
+
+## [2026-06-19] Sync and async gates on the same flag must share truthiness
+
+**Severity:** MEDIUM
+**Source:** Issue #161, PR #171 (share_candidate nomination, hybrid timing)
+**Scope:** any field validated both inline (TS) and in SQL (`->>'x' = 'true'`)
+**Status:** active
+
+### Pattern
+
+`append_session_event`'s sync gate checked `metadata.share_candidate !== true`
+(strict boolean), but the async promoter nominated on
+`metadata->>'share_candidate' = 'true'` — which also matches the JSON string
+`"true"`. A mistyped string nomination skipped the inline secret/private check
+yet was still swept async, voiding the sync gate's security guarantee.
+Defense-in-depth (the async re-classify) prevented an actual promotion hole, but
+the sync rationale was void and the agent got no rejection feedback.
+
+### Review Questions
+
+- When the same flag is gated in two places (inline code + SQL `->>`), do both
+  accept the same set of truthy values?
+- Is the inline check at least as permissive as the SQL one, so nothing the
+  async path will act on bypasses the sync guard?
+
+### Prior Fix
+
+PR #171 made the sync gate accept `=== true || === "true"` to match the SQL
+truthiness; regression test asserts a string `"true"` nomination with secret
+content is still rejected inline.
+
+## [2026-06-19] Env-gated DB tests skip silently in CI unless the URL is set
+
+**Severity:** HIGH
+**Source:** Issue #165 / #161, PR #171
+**Scope:** `.github/workflows/ci.yml`, all `dbDescribe`-gated suites
+**Status:** active
+
+### Pattern
+
+The env-gated real-Pool tests (the only ones that catch SQL bugs per the
+mock-pool finding above) gate on `OPENBRAIN_TEST_DATABASE_URL`. CI set `DB_*`
+and ran migrations against a real Postgres but never set
+`OPENBRAIN_TEST_DATABASE_URL`, so every `dbDescribe` suite SKIPPED in CI — the
+exact write paths the discipline rule exists to protect had zero CI coverage.
+
+### Review Questions
+
+- Does CI export `OPENBRAIN_TEST_DATABASE_URL` so `dbDescribe` suites actually
+  run, not skip?
+- When a critical guarantee is only covered by an env-gated test, is that env
+  wired in CI, or is it a silent gap?
+
+### Prior Fix
+
+PR #171 set `OPENBRAIN_TEST_DATABASE_URL` in the CI `check` job env, built from
+the existing `DB_*` values, enabling all env-gated suites in CI.

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -107,7 +107,7 @@ prompt_context = context.as_prompt_text()
 ## Current Open Brain Tools
 
 `OpenBrainClient` exposes first-class methods for the current required Open
-Brain memory contract, currently `2026-06-19.memory-tools.v3`. Agent runtimes
+Brain memory contract, currently `2026-06-19.memory-tools.v4`. Agent runtimes
 should call these package methods instead of carrying local copies of tool
 schemas, stale mcp2cli paths, or Hermes-specific Open Brain adapters.
 

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -107,7 +107,7 @@ prompt_context = context.as_prompt_text()
 ## Current Open Brain Tools
 
 `OpenBrainClient` exposes first-class methods for the current required Open
-Brain memory contract, currently `2026-06-18.memory-tools.v2`. Agent runtimes
+Brain memory contract, currently `2026-06-19.memory-tools.v3`. Agent runtimes
 should call these package methods instead of carrying local copies of tool
 schemas, stale mcp2cli paths, or Hermes-specific Open Brain adapters.
 

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import redact_text
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-18.memory-tools.v2"
+CURRENT_CONTRACT_VERSION = "2026-06-19.memory-tools.v3"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import redact_text
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-19.memory-tools.v3"
+CURRENT_CONTRACT_VERSION = "2026-06-19.memory-tools.v4"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import redact_text
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-19.memory-tools.v4"
+CURRENT_CONTRACT_VERSION = "2026-06-19.memory-tools.v5"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/src/openbrain_memory/policy.py
+++ b/python/openbrain-memory/src/openbrain_memory/policy.py
@@ -34,6 +34,17 @@ JWT_LIKE_RE = (
 PRIVATE_KEY_BLOCK_RE = (
     "-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----"
 )
+# Stripe-style keys use an underscore separator (sk_live_, pk_live_, rk_live_,
+# and the test variants), which the OpenAI `sk-` pattern does not catch.
+STRIPE_KEY_RE = r"[sprk]k_(live|test)_[A-Za-z0-9]{16,}"
+# Credentials embedded in a URL's userinfo (scheme://user:pass@host).
+URL_USERINFO_CRED_RE = r"[a-z][a-z0-9+.-]*://[^\s:@/]+:[^\s@/]+@[^\s/]+"
+# Context-labeled long hex/base64 secrets; requires a credential LABEL so bare
+# git SHAs / content hashes are not over-rejected.
+LABELED_LONG_SECRET_RE = (
+    r"(?i)(client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)"
+    r"\s*[:=]\s*[A-Za-z0-9._/+=-]{20,}"
+)
 
 SECRET_PATTERNS = [
     re.compile(r"(?i)authorization\s*[:=]\s*bearer\s+[^\s,;]+"),
@@ -51,6 +62,9 @@ SECRET_PATTERNS = [
     re.compile(r"(?i)(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+"),
     re.compile(r'(?i)"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"'),
     re.compile(PRIVATE_KEY_BLOCK_RE, re.S),
+    re.compile(rf"\b{STRIPE_KEY_RE}\b"),
+    re.compile(URL_USERINFO_CRED_RE),
+    re.compile(LABELED_LONG_SECRET_RE),
 ]
 SENSITIVE_KEY_RE = re.compile(
     r"(?i)(token|secret|password|api[_-]?key|credential|authorization|session[_-]?id)"

--- a/python/openbrain-memory/src/openbrain_memory/policy.py
+++ b/python/openbrain-memory/src/openbrain_memory/policy.py
@@ -37,8 +37,11 @@ PRIVATE_KEY_BLOCK_RE = (
 # Stripe-style keys use an underscore separator (sk_live_, pk_live_, rk_live_,
 # and the test variants), which the OpenAI `sk-` pattern does not catch.
 STRIPE_KEY_RE = r"[sprk]k_(live|test)_[A-Za-z0-9]{16,}"
-# Credentials embedded in a URL's userinfo (scheme://user:pass@host).
-URL_USERINFO_CRED_RE = r"[a-z][a-z0-9+.-]*://[^\s:@/]+:[^\s@/]+@[^\s/]+"
+# Credentials embedded in a URL's userinfo (scheme://user:pass@host). Userinfo
+# segments are length-bounded ({1,256}) to avoid quadratic backtracking (ReDoS)
+# on colon-heavy input without a trailing @. (?i) so uppercase schemes (HTTP://)
+# match too, keeping this 1:1 with the TS `/i`-compiled pattern.
+URL_USERINFO_CRED_RE = r"(?i)[a-z][a-z0-9+.-]*://[^\s:@/]{1,256}:[^\s@/]{1,256}@[^\s/]+"
 # Context-labeled long hex/base64 secrets; requires a credential LABEL so bare
 # git SHAs / content hashes are not over-rejected.
 LABELED_LONG_SECRET_RE = (

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -412,7 +412,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-19.memory-tools.v4"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-19.memory-tools.v5"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -412,7 +412,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-19.memory-tools.v3"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-19.memory-tools.v4"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:
@@ -1244,3 +1244,131 @@ def test_urllib_transport_does_not_follow_redirects_with_auth_headers():
         thread.join(timeout=2)
 
     assert response.status_code == 302
+
+
+def test_append_session_event_carries_share_candidate_nomination():
+    # Issue #161: an agent nominates a session event for sharing by setting
+    # metadata.share_candidate=true. The Python client must carry that
+    # nomination through to the server as a tools/call argument, untouched.
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    client.append_session_event(
+        session_key="chan/thread",
+        event_type="fact",
+        content="Promotable knowledge.",
+        metadata={"share_candidate": True, "source": "agent"},
+    )
+
+    calls = tool_requests(transport)
+    assert len(calls) == 1
+    params = calls[0]["json"]["params"]
+    assert params["name"] == "append_session_event"
+    assert params["arguments"] == {
+        "session_key": "chan/thread",
+        "event_type": "fact",
+        "content": "Promotable knowledge.",
+        "metadata": {"share_candidate": True, "source": "agent"},
+    }
+    # The nomination flag must reach the server as a genuine boolean True.
+    assert params["arguments"]["metadata"]["share_candidate"] is True
+
+
+def test_append_session_event_surfaces_share_candidate_rejection():
+    # The server may synchronously refuse a nomination (e.g. secret/private)
+    # and return share_candidate_rejected. The client must surface that field
+    # unchanged in the returned payload rather than swallowing it.
+    transport = FakeTransport()
+    transport.tool_results["append_session_event"] = {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(
+                    {
+                        "tool": "append_session_event",
+                        "ok": True,
+                        "event_id": "evt-1",
+                        "share_candidate_rejected": "reject-secret",
+                    }
+                ),
+            }
+        ]
+    }
+    client = make_client(transport)
+
+    result = client.append_session_event(
+        session_key="chan/thread",
+        event_type="fact",
+        content="Looks promotable but is secret.",
+        metadata={"share_candidate": True},
+    )
+
+    assert result["share_candidate_rejected"] == "reject-secret"
+    assert result["event_id"] == "evt-1"
+
+
+def test_append_session_event_error_still_redacts_secret_metadata_values():
+    # Adding the nomination field must not weaken error redaction. If a write
+    # carrying secret-looking metadata fails, the secret value must not leak
+    # into the raised error, matching existing redaction guarantees.
+    transport = FakeTransport()
+    transport.tool_results["append_session_event"] = {
+        "isError": True,
+        "content": [
+            {
+                "type": "text",
+                "text": "append failed: api_key=abc123456789 password=hunter2",
+            }
+        ],
+    }
+    client = make_client(transport)
+
+    with pytest.raises(OpenBrainToolError) as exc_info:
+        client.append_session_event(
+            session_key="chan/thread",
+            event_type="fact",
+            content="x",
+            metadata={"share_candidate": True, "api_key": "abc123456789"},
+        )
+
+    message = str(exc_info.value)
+    assert "context=call_tool:append_session_event" in message
+    assert "abc123456789" not in message
+    assert "hunter2" not in message
+    assert "[REDACTED]" in message
+
+
+def test_append_session_event_does_not_mutate_sensitive_looking_payload():
+    # GOTCHA (#77 / "Live Writes vs Redaction"): a legitimate but
+    # sensitive-LOOKING payload must be transmitted faithfully on the write
+    # path. Redaction/refusal is the server's job for stored memory; the client
+    # must not strip or mutate share_candidate, content, or metadata
+    # client-side. This proves the outgoing body equals the caller's payload.
+    transport = FakeTransport()
+    client = make_client(transport)
+
+    metadata = {
+        "share_candidate": True,
+        # Sensitive-looking keys/values that the diagnostic redaction layer
+        # would scrub in an ERROR body, but which are legitimate write content.
+        "api_key": "abc123456789",
+        "password": "hunter2",
+        "token": "looks-like-a-token",
+    }
+    content = "Token rotation runbook: password=hunter2 api_key=abc123456789"
+
+    client.append_session_event(
+        session_key="chan/thread",
+        event_type="fact",
+        content=content,
+        metadata=metadata,
+    )
+
+    calls = tool_requests(transport)
+    assert len(calls) == 1
+    arguments = calls[0]["json"]["params"]["arguments"]
+    # The write path transmits the payload verbatim -- no client-side scrubbing.
+    assert arguments["content"] == content
+    assert arguments["metadata"] == metadata
+    assert arguments["metadata"]["share_candidate"] is True
+    assert "[REDACTED]" not in json.dumps(arguments)

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -412,7 +412,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-18.memory-tools.v2"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-19.memory-tools.v3"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -164,6 +164,16 @@ def test_redaction_scrubs_url_embedded_credentials():
     assert "[REDACTED]" in redacted
 
 
+def test_redaction_scrubs_url_credentials_uppercase_scheme():
+    # URI schemes are case-insensitive; keep 1:1 with the TS /i-compiled pattern.
+    url = token_sample("HTTPS://", "admin:", "hunter2pw", "@host/x")
+
+    redacted = redact_text(f"db at {url}")
+
+    assert "hunter2pw" not in redacted
+    assert "[REDACTED]" in redacted
+
+
 def test_redaction_scrubs_labeled_long_secret():
     secret = token_sample("client_secret=", "Ab9" * 8, "xyz")
 

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -144,6 +144,43 @@ def test_redaction_scrubs_labelled_alphanumeric_aws_secret():
     assert "[REDACTED]" in redacted
 
 
+def test_redaction_scrubs_stripe_style_underscore_keys():
+    stripe_live = token_sample("sk", "_live_", "a" * 24)
+    stripe_test = token_sample("pk", "_test_", "b" * 24)
+
+    redacted = redact_text(f"stripe {stripe_live} and {stripe_test}")
+
+    assert stripe_live not in redacted
+    assert stripe_test not in redacted
+    assert redacted.count("[REDACTED]") == 2
+
+
+def test_redaction_scrubs_url_embedded_credentials():
+    url = token_sample("postgres://", "admin:", "hunter2pw", "@10.0.0.1:5432/app")
+
+    redacted = redact_text(f"db at {url}")
+
+    assert "hunter2pw" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_scrubs_labeled_long_secret():
+    secret = token_sample("client_secret=", "Ab9" * 8, "xyz")
+
+    redacted = redact_text(secret)
+
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_keeps_plain_url_without_credentials_visible():
+    url = "https://github.com/rodaddy/open-brain"
+
+    redacted = redact_text(f"see {url}")
+
+    assert url in redacted
+    assert "[REDACTED]" not in redacted
+
+
 def test_redaction_keeps_benign_40_character_hex_ids_visible():
     sha_like_id = token_sample("0123456789", "abcdef0123", "456789abcd", "ef01234567")
 

--- a/scripts/cluster-promoted-thought.ts
+++ b/scripts/cluster-promoted-thought.ts
@@ -1,0 +1,99 @@
+import type { createPool } from "../src/db/pool.ts";
+
+/**
+ * Thought-cluster supplementation knobs (Issue #173, piece (c) of #161).
+ *
+ * After a real promote of a new shared-kb THOUGHT, the promoter looks for the
+ * nearest EXISTING shared-kb thought by cosine distance, excluding the new row,
+ * inside the cluster band [EXACT_DUP_THRESHOLD, CLUSTER_THRESHOLD):
+ *   - dist <  EXACT_DUP_THRESHOLD → an exact/near duplicate; dedup already
+ *     handles this band, so it is NOT clustered.
+ *   - EXACT_DUP_THRESHOLD <= dist < CLUSTER_THRESHOLD → related-but-distinct;
+ *     link the new thought to that anchor with relation 'supplements'.
+ *   - dist >= CLUSTER_THRESHOLD → no in-band neighbour; the new thought is a
+ *     fresh cluster seed and gets no extra link (orphan is intentional).
+ *
+ * Both thresholds are env-overridable like the other promoter knobs. The lower
+ * bound mirrors the dedup near-embedding threshold (`<=> < 0.08`).
+ */
+export const EXACT_DUP_THRESHOLD = Number(
+  process.env.OPENBRAIN_SHARED_PROMOTER_EXACT_DUP_THRESHOLD ?? 0.08,
+);
+export const CLUSTER_THRESHOLD = Number(
+  process.env.OPENBRAIN_SHARED_PROMOTER_CLUSTER_THRESHOLD ?? 0.25,
+);
+
+/**
+ * After a REAL promote of a new shared-kb thought, find the nearest EXISTING
+ * shared-kb thought by cosine distance — excluding the new row — inside the
+ * cluster band [EXACT_DUP_THRESHOLD, CLUSTER_THRESHOLD). If one is found, create
+ * an idempotent `supplements` edge (new thought → anchor) in the shared-kb
+ * namespace, tagged with auto-cluster provenance. Returns true iff a link was
+ * created/refreshed.
+ *
+ * Caller contract: only invoked in APPLY mode (never dry-run), only for rows
+ * that actually inserted (not dedup skips). The new thought's vector is sourced
+ * directly from its own stored `embedding` column, so a row promoted without an
+ * embedding (or with no in-band neighbour) is a no-op (orphan seed).
+ */
+export async function clusterPromotedThought(
+  pool: ReturnType<typeof createPool>,
+  newThoughtId: string,
+  physicalNamespace: string,
+  promotedBy: string,
+): Promise<boolean> {
+  // Nearest existing shared-kb thought to the new row, excluding the new row and
+  // any archived rows, ordered by cosine distance (the `<=>` operator). The new
+  // row's embedding is read from its own column (a single round-trip), so this
+  // works identically for event-sourced and promoteEntry-sourced thoughts and
+  // returns nothing if the new row has no embedding.
+  const { rows } = await pool.query(
+    `WITH anchor AS (
+       SELECT embedding FROM thoughts
+        WHERE id = $2 AND namespace = $1 AND embedding IS NOT NULL
+     )
+     SELECT t.id, t.embedding <=> (SELECT embedding FROM anchor) AS distance
+       FROM thoughts t
+      WHERE t.namespace = $1
+        AND t.id <> $2
+        AND t.archived_at IS NULL
+        AND t.embedding IS NOT NULL
+        AND EXISTS (SELECT 1 FROM anchor)
+      ORDER BY t.embedding <=> (SELECT embedding FROM anchor) ASC
+      LIMIT 1`,
+    [physicalNamespace, newThoughtId],
+  );
+  const anchor = rows[0];
+  if (!anchor) return false;
+  const distance = Number(anchor.distance);
+  // Exact/near dups (handled by dedup) and far-away rows (new cluster seed) are
+  // both skipped. Only the related-but-distinct band supplements a cluster.
+  if (distance < EXACT_DUP_THRESHOLD || distance >= CLUSTER_THRESHOLD) {
+    return false;
+  }
+
+  const metadata = {
+    auto_clustered: true,
+    clustered_by: "lane-shared-promoter",
+    promoted_by: promotedBy,
+    distance,
+    cluster_band: [EXACT_DUP_THRESHOLD, CLUSTER_THRESHOLD],
+  };
+  // Idempotent on (namespace, from_type, from_id, to_type, to_id, relation) —
+  // reuses the same ON CONFLICT shape as the link_entities tool.
+  await pool.query(
+    `INSERT INTO ob_links
+       (from_type, from_id, to_type, to_id, relation, weight, namespace,
+        metadata, created_by)
+     VALUES ('thought', $1, 'thought', $2, 'supplements', 1.0, $3, $4::jsonb, $5)
+     ON CONFLICT (namespace, from_type, from_id, to_type, to_id, relation)
+     WHERE archived_at IS NULL
+     DO UPDATE SET
+       weight = EXCLUDED.weight,
+       metadata = ob_links.metadata || EXCLUDED.metadata,
+       archived_at = NULL,
+       updated_at = NOW()`,
+    [newThoughtId, anchor.id, physicalNamespace, JSON.stringify(metadata), promotedBy],
+  );
+  return true;
+}

--- a/scripts/promote-lane-shared.test.ts
+++ b/scripts/promote-lane-shared.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Pool } from "pg";
 import { parseArgs, runSharedPromoter } from "./promote-lane-shared.ts";
+import { sharedNamespaceConfig } from "../src/shared-namespace.ts";
 
 // ── Cursor-stall + dry-run-embedding coverage (Issue #161, hybrid timing) ──
 //
@@ -70,14 +71,49 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
     }
   }
 
+  // The runner's events loop inserts promoted lane events into the REAL physical
+  // shared-kb namespace (config.physicalSharedNamespace), not ns+"-shared", so we
+  // resolve it the same way the runner does for an exhaustive cleanup.
+  const sharedPhysicalNs = sharedNamespaceConfig().physicalSharedNamespace;
+
   async function cleanupNs(): Promise<void> {
-    // Events cascade-delete with their lanes; delete lanes for the test ns and
-    // any shared rows we may have inserted under provenance from this ns.
+    // Make cleanup namespace-exhaustive across EVERYTHING any test in this file
+    // can create, deleting by namespace rather than by fragile source strings.
+    //
+    // Sources of residue per test:
+    //  1. Seeded source thoughts  → namespace = ns
+    //  2. promoteEntry-promoted thought/decision COPIES → namespace = ns+"-shared".
+    //     These keep the SOURCE row's `source` value (NOT 'lane-shared-promotion')
+    //     so a source-string predicate misses them entirely.
+    //  3. Events + lanes → ob_session_events cascade-delete with ob_session_lanes.
+    //  4. Promoted lane-event copies → namespace = sharedPhysicalNs (real shared-kb),
+    //     source = 'lane-shared-promotion', provenance source_physical_namespace = ns.
+    //
+    // Lanes/events: delete lanes for the test ns (events cascade).
     await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+    // Seeded source rows AND promoteEntry-promoted copies, by namespace.
+    await pool.query(
+      "DELETE FROM thoughts WHERE namespace = ANY($1::text[])",
+      [[ns, ns + "-shared"]],
+    );
+    await pool.query(
+      "DELETE FROM decisions WHERE namespace = ANY($1::text[])",
+      [[ns, ns + "-shared"]],
+    );
+    // Promoted lane-event copies that land in the real shared-kb namespace are
+    // scoped to THIS test's provenance so we never touch unrelated shared-kb rows.
     await pool.query(
       `DELETE FROM thoughts
-       WHERE source = 'lane-shared-promotion'
-         AND promoted_from->>'source_physical_namespace' = $1`,
+       WHERE namespace = $1
+         AND source = 'lane-shared-promotion'
+         AND promoted_from->>'source_physical_namespace' = $2`,
+      [sharedPhysicalNs, ns],
+    );
+    // Belt-and-suspenders: any promoted copy whose provenance target points at
+    // this test's shared namespace, regardless of which physical ns it landed in.
+    await pool.query(
+      `DELETE FROM thoughts
+       WHERE promoted_from->>'source_physical_namespace' = $1`,
       [ns],
     );
   }
@@ -154,8 +190,11 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
     return JSON.parse(readFileSync(stateFile, "utf8"));
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     applyDbEnv(DB_URL as string);
+    // Defend against a PRIOR crashed test leaving residue that a namespace-wide
+    // scan (nominatedTableRows has no namespace filter) would re-pick up.
+    await cleanupNs();
     // DEV_TMP (macOS dev) when set; otherwise the OS temp dir so this runs on
     // the Linux CI runner (the Mac /Volumes path does not exist there).
     tmpDir = mkdtempSync(

--- a/scripts/promote-lane-shared.test.ts
+++ b/scripts/promote-lane-shared.test.ts
@@ -7,6 +7,7 @@ import {
   test,
 } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Pool } from "pg";
 import { parseArgs, runSharedPromoter } from "./promote-lane-shared.ts";
@@ -155,11 +156,10 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
 
   beforeEach(() => {
     applyDbEnv(DB_URL as string);
+    // DEV_TMP (macOS dev) when set; otherwise the OS temp dir so this runs on
+    // the Linux CI runner (the Mac /Volumes path does not exist there).
     tmpDir = mkdtempSync(
-      join(
-        process.env.DEV_TMP ?? "/Volumes/ThunderBolt/_tmp",
-        "promote-lane-shared-",
-      ),
+      join(process.env.DEV_TMP ?? tmpdir(), "promote-lane-shared-"),
     );
     stateFile = join(tmpDir, "state.json");
   });

--- a/scripts/promote-lane-shared.test.ts
+++ b/scripts/promote-lane-shared.test.ts
@@ -1,0 +1,352 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { Pool } from "pg";
+import { parseArgs, runSharedPromoter } from "./promote-lane-shared.ts";
+
+// ── Cursor-stall + dry-run-embedding coverage (Issue #161, hybrid timing) ──
+//
+// runSharedPromoter creates its OWN pool via createPool(), which reads
+// DB_HOST/DB_USER/DB_NAME/DB_PORT/DB_PASSWORD from the environment (NOT a
+// connection string). So before each DB-gated test we parse
+// OPENBRAIN_TEST_DATABASE_URL into those env vars. A separate, URL-built Pool is
+// used here only for seeding and assertions.
+//
+// SME HARD RULE (docs/sme/correctness.md): SQL write-path behavior — cursor
+// advancement persisted to the state file, the JOIN/cursor predicates, and the
+// metadata jsonb shape — CANNOT be caught by a mock pool. These tests run the
+// real query through real Postgres and are env-gated so the default suite stays
+// infra-free. Run with:
+//   OPENBRAIN_TEST_DATABASE_URL=postgres://user:pass@host:5432/db \
+//     bun test scripts/promote-lane-shared.test.ts
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const DEFAULT_MIN = 24;
+// minLen <= len < minLen*1.5 → manual-review. minLen=24 → [24, 36).
+const MANUAL_REVIEW_CONTENT = "x".repeat(30); // len 30, in the ambiguity band.
+// len >= minLen*1.5 (>=36) and a shareable type → share.
+const SHARE_CONTENT =
+  "This is a substantive shared-worthy decision about the schema design choices.";
+
+dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
+  // Build a seeding/assertion pool from the URL.
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-promote-lane-shared-live";
+  let tmpDir: string;
+  let stateFile: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  // Translate the connection URL into the env vars createPool() expects so the
+  // runner's internal pool targets the same test database.
+  function applyDbEnv(url: string): void {
+    const u = new URL(url);
+    savedEnv = {
+      DB_HOST: process.env.DB_HOST,
+      DB_PORT: process.env.DB_PORT,
+      DB_NAME: process.env.DB_NAME,
+      DB_USER: process.env.DB_USER,
+      DB_PASSWORD: process.env.DB_PASSWORD,
+    };
+    process.env.DB_HOST = u.hostname;
+    process.env.DB_PORT = u.port || "5432";
+    process.env.DB_NAME = u.pathname.replace(/^\//, "") || "open_brain";
+    process.env.DB_USER = decodeURIComponent(u.username);
+    process.env.DB_PASSWORD = decodeURIComponent(u.password);
+  }
+
+  function restoreDbEnv(): void {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  async function cleanupNs(): Promise<void> {
+    // Events cascade-delete with their lanes; delete lanes for the test ns and
+    // any shared rows we may have inserted under provenance from this ns.
+    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+    await pool.query(
+      `DELETE FROM thoughts
+       WHERE source = 'lane-shared-promotion'
+         AND promoted_from->>'source_physical_namespace' = $1`,
+      [ns],
+    );
+  }
+
+  async function seedLane(): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO ob_session_lanes (session_key, namespace, status, created_by)
+       VALUES ($1, $2, 'active', $3)
+       RETURNING id`,
+      ["promote-test-lane", ns, "test"],
+    );
+    return rows[0].id as string;
+  }
+
+  /** Seed an event. created_at is explicit so cursor ordering is deterministic. */
+  async function seedEvent(
+    laneId: string,
+    content: string,
+    createdAt: string,
+  ): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO ob_session_events
+         (lane_id, event_type, content, importance, metadata, content_hash, created_by, created_at)
+       VALUES ($1, 'fact', $2, 'warm', $3::jsonb, $4, 'test', $5::timestamptz)
+       RETURNING id`,
+      [
+        laneId,
+        content,
+        JSON.stringify({ share_candidate: true }),
+        // unique-ish hash so ON CONFLICT (lane_id, content_hash) won't collide
+        `hash-${content.length}-${createdAt}`,
+        createdAt,
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  async function seedThought(
+    content: string,
+    createdAt: string,
+  ): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts
+         (content, namespace, extracted_metadata, created_by, created_at)
+       VALUES ($1, $2, $3::jsonb, 'test', $4::timestamptz)
+       RETURNING id`,
+      [content, ns, JSON.stringify({ share_candidate: true }), createdAt],
+    );
+    return rows[0].id as string;
+  }
+
+  function makeArgs(apply: boolean): ReturnType<typeof parseArgs> {
+    const base = parseArgs([
+      "--state-file",
+      stateFile,
+      "--min-content-length",
+      String(DEFAULT_MIN),
+      "--batch-size",
+      "50",
+      "--max-apply",
+      "50",
+      "--delay-ms",
+      "0",
+    ]);
+    base.apply = apply;
+    // Pin the target namespace away from real shared-kb to avoid cross-talk.
+    base.targetNamespace = ns + "-shared";
+    return base;
+  }
+
+  function readState(): {
+    cursors: Record<string, { created_at?: string; id?: string }>;
+  } {
+    return JSON.parse(readFileSync(stateFile, "utf8"));
+  }
+
+  beforeEach(() => {
+    applyDbEnv(DB_URL as string);
+    tmpDir = mkdtempSync(
+      join(
+        process.env.DEV_TMP ?? "/Volumes/ThunderBolt/_tmp",
+        "promote-lane-shared-",
+      ),
+    );
+    stateFile = join(tmpDir, "state.json");
+  });
+
+  afterEach(async () => {
+    await cleanupNs();
+    restoreDbEnv();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  test("events loop: trailing manual-review event does NOT pin the cursor", async () => {
+    const laneId = await seedLane();
+    // share event first (earlier), manual-review event last (trailing).
+    await seedEvent(laneId, SHARE_CONTENT, "2026-01-01T00:00:00Z");
+    const manualId = await seedEvent(
+      laneId,
+      MANUAL_REVIEW_CONTENT,
+      "2026-01-02T00:00:00Z",
+    );
+
+    // First APPLY run: both rows processed, cursor must advance PAST the
+    // trailing manual-review row even though manual-review is not promoted.
+    const first = await runSharedPromoter(makeArgs(true));
+    const eventsReceipt1 = first.sources.ob_session_events;
+    expect(eventsReceipt1).toBeDefined();
+    expect(eventsReceipt1!.scanned).toBe(2);
+    expect(eventsReceipt1!.shared).toBe(1);
+    expect(eventsReceipt1!.manual_review).toBe(1);
+
+    // Cursor now sits on the manual-review row (the last processed row).
+    const cursor1 = readState().cursors.ob_session_events;
+    expect(cursor1?.id).toBe(manualId);
+
+    // Second APPLY run: the manual-review row keeps its share_candidate flag
+    // (only terminal rejects clear it), so without the cursor fix it would be
+    // re-scanned forever. With the fix, the cursor is past it → scanned 0.
+    const second = await runSharedPromoter(makeArgs(true));
+    const eventsReceipt2 = second.sources.ob_session_events;
+    // Either no events source recorded, or scanned excludes the pinned row.
+    expect(eventsReceipt2?.scanned ?? 0).toBe(0);
+  });
+
+  test("events loop: a deterministically-failing event does NOT pin the cursor (poison-pill fix)", async () => {
+    // Poison-pill regression (Issue #161 hardening): in APPLY mode, when a row's
+    // promotion throws inside the try/catch, the loop now advances the cursor
+    // PAST the failed row before `break`-ing. Without that fix the cursor stays
+    // pinned on the failing row, so it (and every row behind it) is re-fetched
+    // on every subsequent run forever.
+    //
+    // FAILURE INJECTION: shareEventToSharedKb does `INSERT INTO thoughts ...`.
+    // The thoughts schema offers no constraint the runner's own write violates
+    // (the only unique index, (content_hash, namespace), is absorbed by the
+    // INSERT's ON CONFLICT DO NOTHING). So we install a temporary BEFORE INSERT
+    // trigger on `thoughts` that RAISEs only when content carries a sentinel
+    // marker. This is a real, deterministic, server-side INSERT failure that the
+    // runner cannot anticipate — exactly the poison-pill shape. The trigger is
+    // test-managed and dropped in this test's finally block.
+    const POISON = `POISON-${Date.now()} `;
+    const poisonContent = POISON + SHARE_CONTENT; // share-worthy, but insert throws.
+
+    await pool.query(`
+      CREATE OR REPLACE FUNCTION test_poison_thought_insert()
+      RETURNS trigger AS $fn$
+      BEGIN
+        IF position('${POISON.trim()}' IN NEW.content) > 0 THEN
+          RAISE EXCEPTION 'poison-pill: deterministic insert failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $fn$ LANGUAGE plpgsql;
+    `);
+    await pool.query(`
+      DROP TRIGGER IF EXISTS test_poison_thought_trg ON thoughts;
+      CREATE TRIGGER test_poison_thought_trg
+        BEFORE INSERT ON thoughts
+        FOR EACH ROW EXECUTE FUNCTION test_poison_thought_insert();
+    `);
+
+    try {
+      const laneId = await seedLane();
+      // First (earlier) event is the poison row that will throw on insert.
+      const poisonId = await seedEvent(
+        laneId,
+        poisonContent,
+        "2026-07-01T00:00:00Z",
+      );
+      // Second (later) event is clean and share-worthy.
+      const cleanId = await seedEvent(
+        laneId,
+        SHARE_CONTENT,
+        "2026-07-02T00:00:00Z",
+      );
+
+      // First APPLY run: poison row is scanned, classified share, then its
+      // shared-kb insert throws. The sweep breaks AFTER advancing the cursor.
+      const first = await runSharedPromoter(makeArgs(true));
+      const events1 = first.sources.ob_session_events;
+      expect(events1).toBeDefined();
+      expect(events1!.scanned).toBe(1); // breaks after the failing row
+      expect(events1!.failed).toBe(1);
+      expect(events1!.shared).toBe(0);
+      // Failure recorded for human follow-up, pinned to the poison row.
+      const failure = first.failures.find((f) => f.id === poisonId);
+      expect(failure).toBeDefined();
+      expect(failure!.source).toBe("ob_session_events");
+
+      // KEY ASSERTION 1: cursor advanced PAST the failed row (not pinned).
+      const cursor1 = readState().cursors.ob_session_events;
+      expect(cursor1?.id).toBe(poisonId);
+
+      // Second APPLY run: forward progress. The poison row's nomination flag is
+      // intentionally left set, but the cursor is now past it, so the runner
+      // does NOT re-fetch it — it reaches the clean row and shares it.
+      const second = await runSharedPromoter(makeArgs(true));
+      const events2 = second.sources.ob_session_events;
+      expect(events2).toBeDefined();
+      // KEY ASSERTION 2: the poison row is NOT re-scanned; only the clean row is.
+      expect(events2!.scanned).toBe(1);
+      expect(events2!.failed).toBe(0);
+      expect(events2!.shared).toBe(1);
+      const cursor2 = readState().cursors.ob_session_events;
+      expect(cursor2?.id).toBe(cleanId);
+    } finally {
+      await pool.query(
+        "DROP TRIGGER IF EXISTS test_poison_thought_trg ON thoughts",
+      );
+      await pool.query(
+        "DROP FUNCTION IF EXISTS test_poison_thought_insert()",
+      );
+    }
+  });
+
+  test("thoughts loop: trailing manual-review thought does NOT pin the cursor", async () => {
+    await seedThought(SHARE_CONTENT, "2026-03-01T00:00:00Z");
+    const manualId = await seedThought(
+      MANUAL_REVIEW_CONTENT,
+      "2026-03-02T00:00:00Z",
+    );
+
+    const first = await runSharedPromoter(makeArgs(true));
+    const thoughtsReceipt1 = first.sources.thoughts;
+    expect(thoughtsReceipt1).toBeDefined();
+    expect(thoughtsReceipt1!.scanned).toBe(2);
+    expect(thoughtsReceipt1!.manual_review).toBe(1);
+
+    const cursor1 = readState().cursors.thoughts;
+    expect(cursor1?.id).toBe(manualId);
+
+    const second = await runSharedPromoter(makeArgs(true));
+    expect(second.sources.thoughts?.scanned ?? 0).toBe(0);
+  });
+
+  test("dry-run does NOT call the embedding endpoint for events", async () => {
+    // The events loop returns would_share BEFORE generateEmbedding when !apply.
+    // To prove the embedding endpoint is not hit, point EMBEDDING_BASE_URL at an
+    // unreachable host: a real generateEmbedding call would error or block on
+    // connect. A clean dry-run with would_share>0 and no failures proves the
+    // embedding call was structurally skipped (the only network call in this
+    // loop is the embedding endpoint). DB connectivity is unaffected because the
+    // runner's pool uses DB_HOST, not EMBEDDING_BASE_URL.
+    const laneId = await seedLane();
+    await seedEvent(laneId, SHARE_CONTENT, "2026-05-01T00:00:00Z");
+
+    const savedEmbedUrl = process.env.EMBEDDING_BASE_URL;
+    // 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — guaranteed non-routable.
+    process.env.EMBEDDING_BASE_URL = "http://192.0.2.1:1/v1";
+    try {
+      const receipt = await runSharedPromoter(makeArgs(false));
+      expect(receipt.dry_run).toBe(true);
+      const events = receipt.sources.ob_session_events;
+      expect(events).toBeDefined();
+      expect(events!.would_share).toBe(1);
+      // No write and no embedding-driven failure occurred.
+      expect(events!.shared).toBe(0);
+      expect(events!.failed).toBe(0);
+      expect(receipt.failures.length).toBe(0);
+    } finally {
+      if (savedEmbedUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      else process.env.EMBEDDING_BASE_URL = savedEmbedUrl;
+    }
+
+    // Dry-run must NOT advance the persistent cursor (it only counts).
+    const cursor = readState().cursors.ob_session_events;
+    expect(cursor?.id).toBeUndefined();
+  });
+});

--- a/scripts/promote-lane-shared.test.ts
+++ b/scripts/promote-lane-shared.test.ts
@@ -89,6 +89,16 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
     //  4. Promoted lane-event copies → namespace = sharedPhysicalNs (real shared-kb),
     //     source = 'lane-shared-promotion', provenance source_physical_namespace = ns.
     //
+    // ob_links created by thought-cluster supplementation (#173) live in the
+    // pinned shared namespace (ns+"-shared"); also sweep the real shared-kb ns
+    // for any auto-cluster links the events loop could have produced.
+    await pool.query(
+      `DELETE FROM ob_links
+        WHERE relation = 'supplements'
+          AND namespace = ANY($1::text[])
+          AND metadata->>'clustered_by' = 'lane-shared-promoter'`,
+      [[ns + "-shared", sharedPhysicalNs]],
+    );
     // Lanes/events: delete lanes for the test ns (events cascade).
     await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
     // Seeded source rows AND promoteEntry-promoted copies, by namespace.
@@ -211,6 +221,169 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
 
   afterAll(async () => {
     await pool.end();
+  });
+
+  // ── Thought-cluster supplementation (#173) ──
+  //
+  // We drive the THOUGHTS promoteEntry path with DETERMINISTIC embeddings so the
+  // cosine distance between a promoted thought and a seeded shared-kb anchor is
+  // exact and controllable — no embedding server needed. promoteEntry copies the
+  // source thought's `embedding` column verbatim into the shared-kb copy, so the
+  // promoted row's vector equals the source vector we set here.
+  //
+  // Construction: all vectors are 768-dim unit vectors in the span of basis
+  // components 0 and 1. For unit vectors u=[a,b,0…] and v=[c,d,0…] the cosine
+  // similarity is a*c + b*d, and pgvector's `<=>` (halfvec_cosine_ops) returns
+  // cosine DISTANCE = 1 - similarity. So choosing the dot product picks the band.
+  const EMBED_DIM = 768;
+
+  /** A 768-dim halfvec literal for a unit vector with the given [c0, c1] head. */
+  function unitVec(c0: number, c1: number): string {
+    const rest = new Array(EMBED_DIM - 2).fill(0);
+    return JSON.stringify([c0, c1, ...rest]);
+  }
+
+  // Promoted thought direction: pure basis-0 unit vector.
+  const NEW_VEC = unitVec(1, 0);
+  // similarity 0.85 → distance 0.15 → inside band [0.08, 0.25): supplements.
+  const IN_BAND_VEC = unitVec(0.85, Math.sqrt(1 - 0.85 * 0.85));
+  // similarity 0.5 → distance 0.5 → >= 0.25: out of band, NO link (cluster seed).
+  const FAR_VEC = unitVec(0.5, Math.sqrt(1 - 0.5 * 0.5));
+  // similarity 0.96 → distance 0.04 → < 0.08: exact-dup band, NOT clustered.
+  const DUP_VEC = unitVec(0.96, Math.sqrt(1 - 0.96 * 0.96));
+
+  /** Seed a source thought (namespace=ns) with a nomination flag + embedding. */
+  async function seedThoughtWithEmbedding(
+    content: string,
+    createdAt: string,
+    vecLiteral: string,
+  ): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts
+         (content, namespace, extracted_metadata, created_by, created_at,
+          embedding, content_hash)
+       VALUES ($1, $2, $3::jsonb, 'test', $4::timestamptz, $5::halfvec, $6)
+       RETURNING id`,
+      [
+        content,
+        ns,
+        JSON.stringify({ share_candidate: true }),
+        createdAt,
+        vecLiteral,
+        `src-hash-${createdAt}`,
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  /** Seed an EXISTING shared-kb anchor thought with a controlled embedding. */
+  async function seedSharedAnchor(
+    content: string,
+    vecLiteral: string,
+  ): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts
+         (content, namespace, created_by, embedding, content_hash)
+       VALUES ($1, $2, 'test', $3::halfvec, $4)
+       RETURNING id`,
+      [content, ns + "-shared", vecLiteral, `anchor-hash-${content.length}-${content}`],
+    );
+    return rows[0].id as string;
+  }
+
+  /** Count supplements links FROM a given new thought. */
+  async function supplementsLinks(
+    fromId: string,
+  ): Promise<Array<{ to_id: string; metadata: Record<string, unknown> }>> {
+    const { rows } = await pool.query(
+      `SELECT to_id, metadata FROM ob_links
+        WHERE from_type = 'thought' AND from_id = $1
+          AND relation = 'supplements' AND archived_at IS NULL`,
+      [fromId],
+    );
+    return rows as Array<{ to_id: string; metadata: Record<string, unknown> }>;
+  }
+
+  test("clustering: in-band neighbour gets a 'supplements' link to the anchor", async () => {
+    const anchorId = await seedSharedAnchor("Existing shared cluster anchor about schema.", IN_BAND_VEC);
+    await seedThoughtWithEmbedding(SHARE_CONTENT, "2026-08-01T00:00:00Z", NEW_VEC);
+
+    const receipt = await runSharedPromoter(makeArgs(true));
+    const thoughts = receipt.sources.thoughts;
+    expect(thoughts).toBeDefined();
+    expect(thoughts!.shared).toBe(1);
+    expect(thoughts!.clustered).toBe(1);
+    expect(receipt.clustered).toBe(1);
+
+    // Find the promoted copy in the shared ns and assert the supplements edge.
+    const { rows: copies } = await pool.query(
+      `SELECT id FROM thoughts
+        WHERE namespace = $1 AND content = $2`,
+      [ns + "-shared", SHARE_CONTENT],
+    );
+    expect(copies.length).toBe(1);
+    const links = await supplementsLinks(copies[0].id);
+    expect(links.length).toBe(1);
+    const link = links[0]!;
+    expect(link.to_id).toBe(anchorId);
+    expect(link.metadata.auto_clustered).toBe(true);
+    expect(Number(link.metadata.distance)).toBeCloseTo(0.15, 2);
+  });
+
+  test("clustering: no in-band neighbour creates NO link (orphan cluster seed)", async () => {
+    await seedSharedAnchor("Distant shared anchor, different topic entirely.", FAR_VEC);
+    await seedThoughtWithEmbedding(SHARE_CONTENT, "2026-08-02T00:00:00Z", NEW_VEC);
+
+    const receipt = await runSharedPromoter(makeArgs(true));
+    expect(receipt.sources.thoughts!.shared).toBe(1);
+    expect(receipt.sources.thoughts!.clustered).toBe(0);
+    expect(receipt.clustered).toBe(0);
+
+    const { rows: copies } = await pool.query(
+      `SELECT id FROM thoughts WHERE namespace = $1 AND content = $2`,
+      [ns + "-shared", SHARE_CONTENT],
+    );
+    const links = await supplementsLinks(copies[0].id);
+    expect(links.length).toBe(0);
+  });
+
+  test("clustering: an exact/near-dup neighbour (dist < 0.08) is NOT clustered", async () => {
+    // The anchor is within the dedup band (distance 0.04). Dedup here is
+    // content_hash-only, so promoteEntry still promotes the new row, but
+    // clustering must SKIP linking because it sits below EXACT_DUP_THRESHOLD.
+    await seedSharedAnchor("Near-duplicate shared anchor close in space.", DUP_VEC);
+    await seedThoughtWithEmbedding(SHARE_CONTENT, "2026-08-03T00:00:00Z", NEW_VEC);
+
+    const receipt = await runSharedPromoter(makeArgs(true));
+    expect(receipt.sources.thoughts!.shared).toBe(1);
+    expect(receipt.sources.thoughts!.clustered).toBe(0);
+
+    const { rows: copies } = await pool.query(
+      `SELECT id FROM thoughts WHERE namespace = $1 AND content = $2`,
+      [ns + "-shared", SHARE_CONTENT],
+    );
+    const links = await supplementsLinks(copies[0].id);
+    expect(links.length).toBe(0);
+  });
+
+  test("clustering: dry-run creates NO link even with an in-band neighbour", async () => {
+    await seedSharedAnchor("Dry-run anchor that would be in band.", IN_BAND_VEC);
+    const srcId = await seedThoughtWithEmbedding(SHARE_CONTENT, "2026-08-04T00:00:00Z", NEW_VEC);
+
+    const receipt = await runSharedPromoter(makeArgs(false));
+    expect(receipt.dry_run).toBe(true);
+    expect(receipt.sources.thoughts!.would_share).toBe(1);
+    expect(receipt.clustered).toBe(0);
+
+    // No promoted copy and therefore no link of any kind was created.
+    const { rows: copies } = await pool.query(
+      `SELECT id FROM thoughts WHERE namespace = $1 AND content = $2`,
+      [ns + "-shared", SHARE_CONTENT],
+    );
+    expect(copies.length).toBe(0);
+    // And no supplements link from the (un-promoted) source either.
+    const links = await supplementsLinks(srcId);
+    expect(links.length).toBe(0);
   });
 
   test("events loop: trailing manual-review event does NOT pin the cursor", async () => {

--- a/scripts/promote-lane-shared.ts
+++ b/scripts/promote-lane-shared.ts
@@ -490,19 +490,21 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
         );
         if (decision !== "share") {
           addCount(receipt, table, rejectionField(decision));
-          // Clear the nomination on a terminal reject so it is not re-swept.
-          // manual-review keeps the flag for a human.
-          if (
-            args.apply &&
-            decision !== "manual-review"
-          ) {
-            await clearNomination(
-              pool,
-              table,
-              "extracted_metadata",
-              row.id,
-              new Date().toISOString(),
-            );
+          if (args.apply) {
+            // Clear the nomination on a terminal reject so it is not re-swept.
+            // manual-review keeps the flag for a human to resolve.
+            if (decision !== "manual-review") {
+              await clearNomination(
+                pool,
+                table,
+                "extracted_metadata",
+                row.id,
+                new Date().toISOString(),
+              );
+            }
+            // Advance the cursor for EVERY processed row, including
+            // manual-review — otherwise a trailing manual-review row pins the
+            // cursor and the runner re-scans it forever (stuck-loop).
             state.cursors[table] = nextCursor;
           }
           continue;
@@ -551,6 +553,12 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
             id: row.id,
             error: sanitizeError(err),
           });
+          // Advance the cursor past a failed row (apply mode) before stopping
+          // the sweep, so a deterministically-failing row cannot pin the cursor
+          // and block every row behind it on the next run (poison-pill loop).
+          // The nomination flag is intentionally left set and the failure is
+          // recorded in receipt.failures for human follow-up.
+          if (args.apply) state.cursors[table] = nextCursor;
           break sources;
         }
 
@@ -583,14 +591,21 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
         );
         if (decision !== "share") {
           addCount(receipt, "ob_session_events", rejectionField(decision));
-          if (args.apply && decision !== "manual-review") {
-            await clearNomination(
-              pool,
-              "ob_session_events",
-              "metadata",
-              event.id,
-              new Date().toISOString(),
-            );
+          if (args.apply) {
+            // Clear the nomination on a terminal reject so it is not re-swept.
+            // manual-review keeps the flag for a human to resolve.
+            if (decision !== "manual-review") {
+              await clearNomination(
+                pool,
+                "ob_session_events",
+                "metadata",
+                event.id,
+                new Date().toISOString(),
+              );
+            }
+            // Advance the cursor for EVERY processed row, including
+            // manual-review — otherwise a trailing manual-review event pins the
+            // cursor and the runner re-scans it forever (stuck-loop).
             state.cursors.ob_session_events = nextCursor;
           }
           continue;
@@ -599,16 +614,19 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
         if (args.apply && applied >= args.maxApply) break events;
 
         try {
+          // Dry-run must not call the embedding endpoint: it neither writes nor
+          // needs the vector, and the embedding call is the expensive part of a
+          // sweep. Count the would-share and move on before embedding.
+          if (!args.apply) {
+            addCount(receipt, "ob_session_events", "would_share");
+            continue;
+          }
+
           let embedding: number[] | null = null;
           try {
             embedding = await generateEmbedding(event.content);
           } catch {
             embedding = null;
-          }
-
-          if (!args.apply) {
-            addCount(receipt, "ob_session_events", "would_share");
-            continue;
           }
 
           const inserted = await shareEventToSharedKb(
@@ -646,6 +664,10 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
             id: event.id,
             error: sanitizeError(err),
           });
+          // Advance past a failed event (apply mode) before stopping so a
+          // deterministically-failing event cannot pin the cursor and re-embed
+          // every run (poison-pill loop). Nomination left set; failure recorded.
+          if (args.apply) state.cursors.ob_session_events = nextCursor;
           break events;
         }
 

--- a/scripts/promote-lane-shared.ts
+++ b/scripts/promote-lane-shared.ts
@@ -1,0 +1,701 @@
+#!/usr/bin/env bun
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { toSql } from "pgvector/pg";
+import { createPool } from "../src/db/pool.ts";
+import { contentHash, EMBEDDING_MODEL, generateEmbedding } from "../src/embedding.ts";
+import { logger } from "../src/logger.ts";
+import { promoteEntry } from "../src/promotion-service.ts";
+import {
+  canonicalNamespace,
+  sharedNamespaceConfig,
+} from "../src/shared-namespace.ts";
+import { classifyShareCandidate, type ShareDecision } from "../src/sharing.ts";
+import type { AuthInfo } from "../src/types.ts";
+
+/**
+ * Background runner for lane/own-durable → shared-kb promotion (Issue #161).
+ *
+ * Mirrors scripts/promote-legacy-shared.ts and scripts/tier-lane-durable.ts
+ * (cursor/state/receipt/args, dry-run default, resumable cursor, kill-switch).
+ *
+ * Runs as the PROMOTER identity and sweeps THREE sources for the nomination flag
+ * `metadata->>'share_candidate' = 'true'`:
+ *   - thoughts   → classify → promoteEntry into shared-kb.
+ *   - decisions  → classify → promoteEntry into shared-kb.
+ *   - ob_session_events JOIN ob_session_lanes → classify → focused
+ *     event→shared-kb insert into `thoughts` (promoteEntry does not cover
+ *     events), idempotent via ON CONFLICT (content_hash, namespace).
+ *
+ * Every secret/private candidate is hard-refused before any write. After a
+ * candidate is processed the nomination flag is cleared so it is not re-swept.
+ */
+
+/** Promotable own-durable tables that promoteEntry handles directly. */
+const PROMOTE_TABLES = ["thoughts", "decisions"] as const;
+type PromoteTable = (typeof PROMOTE_TABLES)[number];
+type Source = PromoteTable | "ob_session_events";
+
+interface Cursor {
+  created_at?: string;
+  id?: string;
+}
+
+interface State {
+  version: 1;
+  target_namespace: string;
+  cursors: Partial<Record<Source, Cursor>>;
+  last_receipt?: Receipt;
+}
+
+interface SourceReceipt {
+  scanned: number;
+  shared: number;
+  would_share: number;
+  rejected_secret: number;
+  rejected_private: number;
+  rejected_noise: number;
+  manual_review: number;
+  duplicates: number;
+  failed: number;
+}
+
+interface Receipt {
+  started_at: string;
+  finished_at: string;
+  dry_run: boolean;
+  target_namespace: string;
+  scanned: number;
+  shared: number;
+  would_share: number;
+  rejected_secret: number;
+  rejected_private: number;
+  rejected_noise: number;
+  manual_review: number;
+  duplicates: number;
+  failed: number;
+  sources: Partial<Record<Source, SourceReceipt>>;
+  failures: Array<{ source: Source; id: string; error: string }>;
+}
+
+interface Args {
+  apply: boolean;
+  targetNamespace: string;
+  stateFile: string;
+  batchSize: number;
+  maxApply: number;
+  delayMs: number;
+  loop: boolean;
+  intervalMs: number;
+  minContentLength: number;
+}
+
+function usage(exitCode = 2): never {
+  console.error(
+    [
+      "Usage: bun run scripts/promote-lane-shared.ts [--apply] [--once]",
+      "       [--state-file <path>] [--batch-size 20] [--max-apply 5]",
+      "       [--delay-ms 250] [--loop] [--interval-ms 60000]",
+      "       [--min-content-length 24]",
+      "",
+      "Dry-run is the default and does not advance the persistent cursor.",
+      "Apply mode is bounded by --max-apply promotions, runs as the promoter",
+      "identity, and only promotes entries nominated via metadata share_candidate.",
+    ].join("\n"),
+  );
+  process.exit(exitCode);
+}
+
+export function parseArgs(argv: string[]): Args {
+  const config = sharedNamespaceConfig();
+  const args: Args = {
+    apply: false,
+    targetNamespace: config.canonicalSharedNamespace,
+    stateFile:
+      process.env.OPENBRAIN_SHARED_PROMOTER_STATE ??
+      `${process.env.HOME ?? "."}/.local/state/open-brain/shared-promoter/state.json`,
+    batchSize: Number(process.env.OPENBRAIN_SHARED_PROMOTER_BATCH_SIZE ?? 20),
+    maxApply: Number(process.env.OPENBRAIN_SHARED_PROMOTER_MAX_APPLY ?? 5),
+    delayMs: Number(process.env.OPENBRAIN_SHARED_PROMOTER_DELAY_MS ?? 250),
+    loop: false,
+    intervalMs: Number(
+      process.env.OPENBRAIN_SHARED_PROMOTER_INTERVAL_MS ?? 60000,
+    ),
+    minContentLength: Number(
+      process.env.OPENBRAIN_SHARED_PROMOTER_MIN_CONTENT_LENGTH ?? 24,
+    ),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--apply") args.apply = true;
+    else if (arg === "--once") args.loop = false;
+    else if (arg === "--loop") args.loop = true;
+    else if (arg === "--state-file") args.stateFile = argv[++i] ?? "";
+    else if (arg === "--batch-size") args.batchSize = Number(argv[++i] ?? 0);
+    else if (arg === "--max-apply") args.maxApply = Number(argv[++i] ?? 0);
+    else if (arg === "--delay-ms") args.delayMs = Number(argv[++i] ?? 0);
+    else if (arg === "--interval-ms") args.intervalMs = Number(argv[++i] ?? 0);
+    else if (arg === "--min-content-length") {
+      args.minContentLength = Number(argv[++i] ?? 0);
+    } else if (arg === "--help" || arg === "-h") {
+      usage(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      usage();
+    }
+  }
+
+  if (
+    !args.targetNamespace ||
+    !args.stateFile ||
+    !Number.isInteger(args.batchSize) ||
+    args.batchSize < 1 ||
+    args.batchSize > 250 ||
+    !Number.isInteger(args.maxApply) ||
+    args.maxApply < 0 ||
+    args.maxApply > 100 ||
+    !Number.isInteger(args.delayMs) ||
+    args.delayMs < 0 ||
+    !Number.isInteger(args.intervalMs) ||
+    args.intervalMs < 1000 ||
+    !Number.isInteger(args.minContentLength) ||
+    args.minContentLength < 0
+  ) {
+    usage();
+  }
+
+  return args;
+}
+
+function defaultState(args: Args): State {
+  return {
+    version: 1,
+    target_namespace: canonicalNamespace(args.targetNamespace),
+    cursors: {},
+  };
+}
+
+function loadState(args: Args): State {
+  const expectedTarget = canonicalNamespace(args.targetNamespace);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(args.stateFile, "utf8"));
+  } catch {
+    return defaultState(args);
+  }
+  if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
+    const state = parsed as State;
+    if (state.version === 1 && state.target_namespace === expectedTarget) {
+      state.cursors ??= {};
+      return state;
+    }
+  }
+  return defaultState(args);
+}
+
+function saveState(path: string, state: State): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function newSourceReceipt(): SourceReceipt {
+  return {
+    scanned: 0,
+    shared: 0,
+    would_share: 0,
+    rejected_secret: 0,
+    rejected_private: 0,
+    rejected_noise: 0,
+    manual_review: 0,
+    duplicates: 0,
+    failed: 0,
+  };
+}
+
+function addCount(
+  receipt: Receipt,
+  source: Source,
+  field: keyof SourceReceipt,
+): void {
+  const sourceReceipt = (receipt.sources[source] ??= newSourceReceipt());
+  sourceReceipt[field] += 1;
+  receipt[field] += 1;
+}
+
+/** Map a non-share classification to its receipt counter. */
+function rejectionField(decision: ShareDecision): keyof SourceReceipt {
+  switch (decision) {
+    case "reject-secret":
+      return "rejected_secret";
+    case "reject-private":
+      return "rejected_private";
+    case "reject-noise":
+      return "rejected_noise";
+    default:
+      return "manual_review";
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function sanitizeError(err: unknown): string {
+  if (err instanceof Error) {
+    return (err.message.split("\n")[0] ?? err.name).slice(0, 240);
+  }
+  return String(err).slice(0, 240);
+}
+
+interface NominatedRow {
+  id: string;
+  created_at: string;
+  content: string;
+  tags: string[] | null;
+  metadata: Record<string, unknown> | null;
+}
+
+/** Fetch nominated rows from a promoteEntry-backed table (thoughts/decisions). */
+async function nominatedTableRows(
+  pool: ReturnType<typeof createPool>,
+  table: PromoteTable,
+  cursor: Cursor | undefined,
+  limit: number,
+): Promise<NominatedRow[]> {
+  const contentSql =
+    table === "decisions"
+      ? "COALESCE(title, '') || ' ' || COALESCE(rationale, '')"
+      : "content";
+  const params: unknown[] = [limit];
+  let cursorSql = "";
+  if (cursor?.created_at && cursor.id) {
+    params.push(cursor.created_at, cursor.id);
+    cursorSql = ` AND (created_at, id) > ($2::timestamptz, $3::uuid)`;
+  }
+  const { rows } = await pool.query(
+    `SELECT id, created_at, ${contentSql} AS content, tags,
+            extracted_metadata AS metadata
+     FROM ${table}
+     WHERE extracted_metadata->>'share_candidate' = 'true'
+       AND archived_at IS NULL${cursorSql}
+     ORDER BY created_at ASC, id ASC
+     LIMIT $1`,
+    params,
+  );
+  return rows as NominatedRow[];
+}
+
+interface NominatedEventRow {
+  id: string;
+  created_at: string;
+  content: string;
+  content_hash: string | null;
+  event_type: string;
+  importance: string;
+  metadata: Record<string, unknown> | null;
+  lane_id: string;
+  namespace: string;
+  agent: string | null;
+  session_key: string;
+  repo: string | null;
+  project: string | null;
+}
+
+/** Fetch nominated lane events joined to their lane. */
+async function nominatedEventRows(
+  pool: ReturnType<typeof createPool>,
+  cursor: Cursor | undefined,
+  limit: number,
+): Promise<NominatedEventRow[]> {
+  const params: unknown[] = [limit];
+  let cursorSql = "";
+  if (cursor?.created_at && cursor.id) {
+    params.push(cursor.created_at, cursor.id);
+    cursorSql = ` AND (e.created_at, e.id) > ($2::timestamptz, $3::uuid)`;
+  }
+  const { rows } = await pool.query(
+    `SELECT
+       e.id, e.created_at, e.content, e.content_hash, e.event_type,
+       e.importance, e.metadata, e.lane_id, l.namespace, l.agent, l.session_key,
+       l.metadata->>'repo' AS repo, l.project AS project
+     FROM ob_session_events e
+     JOIN ob_session_lanes l ON e.lane_id = l.id
+     WHERE e.metadata->>'share_candidate' = 'true'${cursorSql}
+     ORDER BY e.created_at ASC, e.id ASC
+     LIMIT $1`,
+    params,
+  );
+  return rows as NominatedEventRow[];
+}
+
+/**
+ * Insert a nominated lane event into shared-kb as a thought, with the SAME
+ * provenance shape promoteEntry builds. Idempotent via ON CONFLICT
+ * (content_hash, namespace). Returns true if a new row was inserted.
+ */
+export async function shareEventToSharedKb(
+  pool: ReturnType<typeof createPool>,
+  event: NominatedEventRow,
+  targetPhysicalNamespace: string,
+  targetCanonicalNamespace: string,
+  embedding: number[] | null,
+  reason: string,
+  promotedBy: string,
+): Promise<boolean> {
+  const hash = event.content_hash ?? contentHash(event.content);
+  const provenance = {
+    source_physical_namespace: event.namespace,
+    source_namespace: event.namespace,
+    source_table: "ob_session_events",
+    source_id: event.id,
+    source_lane_id: event.lane_id,
+    source_event_id: event.id,
+    source_agent: event.agent,
+    source_identity: event.agent,
+    source_discord: {
+      server_id:
+        (event.metadata?.discord_server_id as string | undefined) ?? null,
+      channel_id:
+        (event.metadata?.discord_channel_id as string | undefined) ?? null,
+      thread_id:
+        (event.metadata?.discord_thread_id as string | undefined) ?? null,
+    },
+    source_repo: event.repo,
+    source_project: event.project,
+    target_namespace: targetCanonicalNamespace,
+    target_kind: "shared-kb",
+    promotion_reason: reason,
+    promotion_confidence: null,
+    promoted_at: new Date().toISOString(),
+    promoted_by: promotedBy,
+  };
+  const tags = [
+    "shared-from-lane",
+    `lane:${event.session_key}`,
+    `event-type:${event.event_type}`,
+  ];
+
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts
+       (content, tags, source, created_by, namespace, embedding, content_hash,
+        embedded_at, embedding_model, promoted_from)
+     VALUES ($1, $2, 'lane-shared-promotion', $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
+     DO NOTHING
+     RETURNING id`,
+    [
+      event.content,
+      tags,
+      promotedBy,
+      targetPhysicalNamespace,
+      embedding ? toSql(embedding) : null,
+      hash,
+      embedding ? new Date().toISOString() : null,
+      embedding ? EMBEDDING_MODEL : null,
+      JSON.stringify(provenance),
+    ],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Clear the share_candidate nomination from a source row so it is not re-swept.
+ * Drops the flag and stamps a processed marker. Idempotent. `column` is the
+ * metadata jsonb column for the table (extracted_metadata vs metadata).
+ */
+async function clearNomination(
+  pool: ReturnType<typeof createPool>,
+  table: string,
+  column: string,
+  id: string,
+  now: string,
+): Promise<void> {
+  await pool.query(
+    `UPDATE ${table}
+     SET ${column} = (${column} - 'share_candidate')
+       || jsonb_build_object('share_promoted_at', $2::text)
+     WHERE id = $1`,
+    [id, now],
+  );
+}
+
+export async function runSharedPromoter(args: Args): Promise<Receipt> {
+  if (process.env.OPENBRAIN_PROMOTION_KILL_SWITCH === "1") {
+    throw new Error("OPENBRAIN_PROMOTION_KILL_SWITCH is enabled");
+  }
+
+  const config = sharedNamespaceConfig();
+  const targetCanonicalNamespace = canonicalNamespace(args.targetNamespace);
+  const targetPhysicalNamespace = config.physicalSharedNamespace;
+  const state = loadState(args);
+  const receipt: Receipt = {
+    started_at: new Date().toISOString(),
+    finished_at: "",
+    dry_run: !args.apply,
+    target_namespace: targetCanonicalNamespace,
+    scanned: 0,
+    shared: 0,
+    would_share: 0,
+    rejected_secret: 0,
+    rejected_private: 0,
+    rejected_noise: 0,
+    manual_review: 0,
+    duplicates: 0,
+    failed: 0,
+    sources: {},
+    failures: [],
+  };
+
+  // Synthetic promoter identity (mirrors promote-legacy-shared.ts), but using
+  // the first-class promoter role added in #159 so canWriteNamespace permits
+  // shared-kb writes.
+  const auth: AuthInfo = {
+    role: "promoter",
+    clientId: "openbrain-promoter",
+    tokenClientId: "openbrain-promoter",
+    namespaceSource: "token",
+  };
+  const promotedBy = auth.tokenClientId ?? auth.clientId;
+  const pool = createPool({
+    max: 2,
+    statement_timeout: 30000,
+    application_name: "openbrain-shared-promoter",
+  });
+  let applied = 0;
+
+  try {
+    // ── thoughts + decisions via promoteEntry ──
+    sources: for (const table of PROMOTE_TABLES) {
+      const rows = await nominatedTableRows(
+        pool,
+        table,
+        state.cursors[table],
+        args.batchSize,
+      );
+      for (const row of rows) {
+        addCount(receipt, table, "scanned");
+        const nextCursor = {
+          created_at: new Date(row.created_at).toISOString(),
+          id: row.id,
+        };
+
+        const decision = classifyShareCandidate(
+          {
+            content: row.content,
+            tags: row.tags ?? undefined,
+            metadata: row.metadata ?? undefined,
+          },
+          { minLen: args.minContentLength },
+        );
+        if (decision !== "share") {
+          addCount(receipt, table, rejectionField(decision));
+          // Clear the nomination on a terminal reject so it is not re-swept.
+          // manual-review keeps the flag for a human.
+          if (
+            args.apply &&
+            decision !== "manual-review"
+          ) {
+            await clearNomination(
+              pool,
+              table,
+              "extracted_metadata",
+              row.id,
+              new Date().toISOString(),
+            );
+            state.cursors[table] = nextCursor;
+          }
+          continue;
+        }
+
+        if (args.apply && applied >= args.maxApply) break sources;
+
+        try {
+          const result = await promoteEntry(
+            pool,
+            table,
+            row.id,
+            args.targetNamespace,
+            "lane-shared promoter nomination",
+            auth,
+            { dryRun: !args.apply },
+          );
+          if (result.status === "duplicate") {
+            addCount(receipt, table, "duplicates");
+          } else if (result.status === "dry_run") {
+            addCount(receipt, table, "would_share");
+          } else if (result.status === "promoted") {
+            applied += 1;
+            addCount(receipt, table, "shared");
+            logger.info("shared_promoter_promoted", {
+              actor: promotedBy,
+              source: table,
+              id: row.id,
+              new_id: result.new_id,
+            });
+          }
+          if (args.apply) {
+            await clearNomination(
+              pool,
+              table,
+              "extracted_metadata",
+              row.id,
+              new Date().toISOString(),
+            );
+            state.cursors[table] = nextCursor;
+          }
+        } catch (err) {
+          addCount(receipt, table, "failed");
+          receipt.failures.push({
+            source: table,
+            id: row.id,
+            error: sanitizeError(err),
+          });
+          break sources;
+        }
+
+        if (args.delayMs > 0) await sleep(args.delayMs);
+      }
+    }
+
+    // ── ob_session_events via focused shared-kb insert ──
+    if (!(args.apply && applied >= args.maxApply)) {
+      const events = await nominatedEventRows(
+        pool,
+        state.cursors.ob_session_events,
+        args.batchSize,
+      );
+      events: for (const event of events) {
+        addCount(receipt, "ob_session_events", "scanned");
+        const nextCursor = {
+          created_at: new Date(event.created_at).toISOString(),
+          id: event.id,
+        };
+
+        const decision = classifyShareCandidate(
+          {
+            event_type: event.event_type,
+            importance: event.importance,
+            content: event.content,
+            metadata: event.metadata ?? undefined,
+          },
+          { minLen: args.minContentLength },
+        );
+        if (decision !== "share") {
+          addCount(receipt, "ob_session_events", rejectionField(decision));
+          if (args.apply && decision !== "manual-review") {
+            await clearNomination(
+              pool,
+              "ob_session_events",
+              "metadata",
+              event.id,
+              new Date().toISOString(),
+            );
+            state.cursors.ob_session_events = nextCursor;
+          }
+          continue;
+        }
+
+        if (args.apply && applied >= args.maxApply) break events;
+
+        try {
+          let embedding: number[] | null = null;
+          try {
+            embedding = await generateEmbedding(event.content);
+          } catch {
+            embedding = null;
+          }
+
+          if (!args.apply) {
+            addCount(receipt, "ob_session_events", "would_share");
+            continue;
+          }
+
+          const inserted = await shareEventToSharedKb(
+            pool,
+            event,
+            targetPhysicalNamespace,
+            targetCanonicalNamespace,
+            embedding,
+            "lane-shared promoter nomination",
+            promotedBy,
+          );
+          if (inserted) {
+            applied += 1;
+            addCount(receipt, "ob_session_events", "shared");
+            logger.info("shared_promoter_promoted", {
+              actor: promotedBy,
+              source: "ob_session_events",
+              id: event.id,
+            });
+          } else {
+            addCount(receipt, "ob_session_events", "duplicates");
+          }
+          await clearNomination(
+            pool,
+            "ob_session_events",
+            "metadata",
+            event.id,
+            new Date().toISOString(),
+          );
+          state.cursors.ob_session_events = nextCursor;
+        } catch (err) {
+          addCount(receipt, "ob_session_events", "failed");
+          receipt.failures.push({
+            source: "ob_session_events",
+            id: event.id,
+            error: sanitizeError(err),
+          });
+          break events;
+        }
+
+        if (args.delayMs > 0) await sleep(args.delayMs);
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+
+  receipt.finished_at = new Date().toISOString();
+  state.target_namespace = targetCanonicalNamespace;
+  state.last_receipt = receipt;
+  saveState(args.stateFile, state);
+  return receipt;
+}
+
+if (import.meta.main) {
+  const args = parseArgs(Bun.argv.slice(2));
+  const runOnce = async (): Promise<void> => {
+    const receiptPath = resolve(
+      dirname(args.stateFile),
+      `receipt-${new Date().toISOString().replace(/[:.]/g, "-")}.json`,
+    );
+    const receipt = await runSharedPromoter(args);
+    mkdirSync(dirname(receiptPath), { recursive: true });
+    writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+    logger.info("shared_promoter_receipt", {
+      receipt_path: receiptPath,
+      dry_run: receipt.dry_run,
+      scanned: receipt.scanned,
+      shared: receipt.shared,
+      would_share: receipt.would_share,
+      rejected_secret: receipt.rejected_secret,
+      rejected_private: receipt.rejected_private,
+      rejected_noise: receipt.rejected_noise,
+      manual_review: receipt.manual_review,
+      duplicates: receipt.duplicates,
+      failed: receipt.failed,
+    });
+    console.log(JSON.stringify({ ...receipt, receipt_path: receiptPath }));
+  };
+  const run = async (): Promise<void> => {
+    do {
+      await runOnce();
+      if (args.loop) await sleep(args.intervalMs);
+    } while (args.loop);
+  };
+  run().catch((err) => {
+    logger.error("shared_promoter_failed", { error: sanitizeError(err) });
+    process.exit(1);
+  });
+}

--- a/scripts/promote-lane-shared.ts
+++ b/scripts/promote-lane-shared.ts
@@ -6,8 +6,10 @@ import { createPool } from "../src/db/pool.ts";
 import { contentHash, EMBEDDING_MODEL, generateEmbedding } from "../src/embedding.ts";
 import { logger } from "../src/logger.ts";
 import { promoteEntry } from "../src/promotion-service.ts";
+import { clusterPromotedThought } from "./cluster-promoted-thought.ts";
 import {
   canonicalNamespace,
+  physicalNamespace,
   sharedNamespaceConfig,
 } from "../src/shared-namespace.ts";
 import { classifyShareCandidate, type ShareDecision } from "../src/sharing.ts";
@@ -58,6 +60,8 @@ interface SourceReceipt {
   manual_review: number;
   duplicates: number;
   failed: number;
+  /** New shared thoughts linked into an existing cluster (apply only, #173). */
+  clustered: number;
 }
 
 interface Receipt {
@@ -74,6 +78,7 @@ interface Receipt {
   manual_review: number;
   duplicates: number;
   failed: number;
+  clustered: number;
   sources: Partial<Record<Source, SourceReceipt>>;
   failures: Array<{ source: Source; id: string; error: string }>;
 }
@@ -210,6 +215,7 @@ function newSourceReceipt(): SourceReceipt {
     manual_review: 0,
     duplicates: 0,
     failed: 0,
+    clustered: 0,
   };
 }
 
@@ -332,7 +338,8 @@ async function nominatedEventRows(
 /**
  * Insert a nominated lane event into shared-kb as a thought, with the SAME
  * provenance shape promoteEntry builds. Idempotent via ON CONFLICT
- * (content_hash, namespace). Returns true if a new row was inserted.
+ * (content_hash, namespace). Returns the inserted thought id, or null if the
+ * row already existed (ON CONFLICT DO NOTHING).
  */
 export async function shareEventToSharedKb(
   pool: ReturnType<typeof createPool>,
@@ -342,7 +349,7 @@ export async function shareEventToSharedKb(
   embedding: number[] | null,
   reason: string,
   promotedBy: string,
-): Promise<boolean> {
+): Promise<string | null> {
   const hash = event.content_hash ?? contentHash(event.content);
   const provenance = {
     source_physical_namespace: event.namespace,
@@ -396,7 +403,7 @@ export async function shareEventToSharedKb(
       JSON.stringify(provenance),
     ],
   );
-  return rows.length > 0;
+  return rows.length > 0 ? (rows[0].id as string) : null;
 }
 
 /**
@@ -443,6 +450,7 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
     manual_review: 0,
     duplicates: 0,
     failed: 0,
+    clustered: 0,
     sources: {},
     failures: [],
   };
@@ -535,6 +543,17 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
               id: row.id,
               new_id: result.new_id,
             });
+            // Cluster-supplement (#173): thoughts only (decisions go to their
+            // own table), against the ns promoteEntry wrote to.
+            if (table === "thoughts" && result.new_id) {
+              const clustered = await clusterPromotedThought(
+                pool,
+                result.new_id,
+                physicalNamespace(args.targetNamespace),
+                promotedBy,
+              );
+              if (clustered) addCount(receipt, table, "clustered");
+            }
           }
           if (args.apply) {
             await clearNomination(
@@ -614,9 +633,8 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
         if (args.apply && applied >= args.maxApply) break events;
 
         try {
-          // Dry-run must not call the embedding endpoint: it neither writes nor
-          // needs the vector, and the embedding call is the expensive part of a
-          // sweep. Count the would-share and move on before embedding.
+          // Dry-run must not call the embedding endpoint (no write, no vector
+          // needed, and it is the expensive part of a sweep). Count and skip.
           if (!args.apply) {
             addCount(receipt, "ob_session_events", "would_share");
             continue;
@@ -629,7 +647,7 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
             embedding = null;
           }
 
-          const inserted = await shareEventToSharedKb(
+          const insertedId = await shareEventToSharedKb(
             pool,
             event,
             targetPhysicalNamespace,
@@ -638,7 +656,7 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
             "lane-shared promoter nomination",
             promotedBy,
           );
-          if (inserted) {
+          if (insertedId) {
             applied += 1;
             addCount(receipt, "ob_session_events", "shared");
             logger.info("shared_promoter_promoted", {
@@ -646,6 +664,14 @@ export async function runSharedPromoter(args: Args): Promise<Receipt> {
               source: "ob_session_events",
               id: event.id,
             });
+            // Cluster-supplement (#173): APPLY-only, post-insert, never dry-run.
+            const clustered = await clusterPromotedThought(
+              pool,
+              insertedId,
+              targetPhysicalNamespace,
+              promotedBy,
+            );
+            if (clustered) addCount(receipt, "ob_session_events", "clustered");
           } else {
             addCount(receipt, "ob_session_events", "duplicates");
           }
@@ -707,6 +733,7 @@ if (import.meta.main) {
       manual_review: receipt.manual_review,
       duplicates: receipt.duplicates,
       failed: receipt.failed,
+      clustered: receipt.clustered,
     });
     console.log(JSON.stringify({ ...receipt, receipt_path: receiptPath }));
   };

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -1,0 +1,662 @@
+import {
+  REPO_FACT_METADATA_CONTRACT,
+  REPO_FACT_VALIDATION_CONTRACT,
+} from "./tools/repo-facts.ts";
+
+export interface ToolContract {
+  version: number;
+  input_schema: unknown;
+  output_shape: string;
+}
+
+export const TOOL_CONTRACTS: Record<string, ToolContract> = {
+  get_contract: {
+    version: 1,
+    input_schema: {},
+    output_shape: "OpenBrainContract JSON text payload",
+  },
+  log_thought: {
+    version: 2,
+    input_schema: {
+      content: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        description:
+          "The thought text to store. Write a complete, self-contained " +
+          "statement that will still make sense out of context later — this " +
+          "is what gets embedded and returned by future searches.",
+      },
+      tags: {
+        type: "array",
+        required: false,
+        items: "string",
+        description:
+          "Optional freeform labels for grouping and filtering (e.g. topic, " +
+          "project, or category). Use consistent tag names so related " +
+          "thoughts cluster together.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        maxLength: 500,
+        description:
+          "Memory partition to write into. Defaults to your own " +
+          "auth-derived namespace; leave unset unless a global/admin token " +
+          "is intentionally writing into another namespace (e.g. shared-kb).",
+      },
+    },
+    output_shape: "thought id/namespace/embedded/merged JSON text payload",
+  },
+  search_all: {
+    version: 2,
+    input_schema: {
+      query: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        description:
+          "What you are looking for, in natural language. Phrase it as the " +
+          "concept or question you want to recall; hybrid/vector modes match " +
+          "on meaning, not just exact words.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Which memory partition to search. Defaults to your own " +
+          "auth-derived namespace; override only to read another namespace " +
+          "you are authorized for (e.g. shared-kb for shared knowledge).",
+      },
+      limit: {
+        type: "integer",
+        required: false,
+        min: 1,
+        max: 250,
+        description:
+          "Maximum number of results to return (1-250). Start small (e.g. " +
+          "10-20) for focused recall; raise it when you need broad coverage.",
+      },
+      offset: {
+        type: "integer",
+        required: false,
+        min: 0,
+        description:
+          "Number of results to skip before returning, for paging through a " +
+          "large result set. Leave at 0 for the first page.",
+      },
+      sources: {
+        type: "enum",
+        required: false,
+        values: ["all", "brain", "qmd"],
+        description:
+          "Which corpora to search: all (default, both), brain (only stored " +
+          "memory — thoughts, session events, facts), qmd (only indexed code " +
+          "context). Narrow this when you know which corpus you need.",
+      },
+      search_mode: {
+        type: "enum",
+        required: false,
+        values: ["hybrid", "vector", "keyword"],
+        description:
+          "How to match: hybrid (default, blends vector + keyword — use " +
+          "unless you have a reason not to), vector (semantic similarity " +
+          "only — best for fuzzy/conceptual recall), keyword (exact-term " +
+          "only — best for identifiers, error strings, or exact phrases).",
+      },
+      tier: {
+        type: "enum",
+        required: false,
+        values: ["hot", "warm", "cold"],
+        description:
+          "Optional importance/recency tier filter: hot (most recent/most " +
+          "important), warm (mid), cold (archival). Omit to search all " +
+          "tiers; set only when you want to restrict by significance.",
+      },
+    },
+    output_shape: "unified search results JSON text payload",
+  },
+  session_start: {
+    version: 2,
+    input_schema: {
+      session_key: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+        description:
+          "Stable identifier for this session lane. Reuse the same key to " +
+          "resume an existing lane; pick a new one to start a fresh lane. " +
+          "Use a deterministic value you can reconstruct later (e.g. a " +
+          "channel/thread id or task slug), not a random string.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition for the lane. Defaults to your own auth-derived " +
+          "namespace; override only when authorized to operate in another.",
+      },
+      project: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Project this session belongs to. Set it to scope and later " +
+          "filter lanes by project (e.g. in lane_load).",
+      },
+      agent: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Which agent owns this session (e.g. hermes, bilby, skippy). Set " +
+          "so lanes can be attributed and filtered by agent.",
+      },
+      channel_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Originating channel id (e.g. Discord/Slack channel). Set for " +
+          "chat-driven sessions so the lane can later be looked up by channel.",
+      },
+      thread_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Originating thread id within the channel, if the conversation is " +
+          "threaded. Set to distinguish parallel threads in one channel.",
+      },
+      topic: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Short human-readable subject for the session. Helps identify the " +
+          "lane at a glance when listing or resuming.",
+      },
+    },
+    output_shape: "session lane plus recent events JSON text payload",
+  },
+  session_context: {
+    version: 2,
+    input_schema: {
+      session_key: {
+        type: "string",
+        required: "session_key_or_channel_id",
+        maxLength: 500,
+        description:
+          "Identifier of the lane to read. Either session_key OR channel_id " +
+          "is required — provide session_key when you know the lane's key; " +
+          "otherwise resolve by channel_id.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition to read from. Defaults to your own auth-derived " +
+          "namespace; override only when authorized for another.",
+      },
+      channel_id: {
+        type: "string",
+        required: "session_key_or_channel_id",
+        maxLength: 500,
+        description:
+          "Originating channel id to resolve the lane by. Either " +
+          "channel_id OR session_key is required — use this when you have " +
+          "the chat channel but not the lane's session_key.",
+      },
+      thread_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Thread id to disambiguate when a single channel_id maps to " +
+          "multiple threaded lanes.",
+      },
+      include_events: {
+        type: "boolean",
+        required: false,
+        default: true,
+        description:
+          "Whether to include the lane's recent journal events (default " +
+          "true). Set false for a lightweight read of just lane metadata.",
+      },
+      event_limit: {
+        type: "integer",
+        required: false,
+        min: 1,
+        max: 200,
+        default: 50,
+        description:
+          "Maximum recent events to return (1-200, default 50). Lower it " +
+          "for a quick peek; raise it to rehydrate more history.",
+      },
+      event_types: {
+        type: "array",
+        required: false,
+        items: "session_event_type",
+        description:
+          "Optional filter to only these event types (e.g. decision, " +
+          "blocker). Omit to return all types; set to focus on a category.",
+      },
+      importance: {
+        type: "enum",
+        required: false,
+        values: ["hot", "warm", "cold"],
+        description:
+          "Optional filter by event importance tier: hot (most important), " +
+          "warm, cold. Omit to include all tiers.",
+      },
+    },
+    output_shape: "session lane plus recent events JSON text payload",
+  },
+  lane_upsert: {
+    version: 2,
+    input_schema: {
+      session_key: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+        description:
+          "Identifier of the lane to create or update. Reuse an existing " +
+          "key to update that lane in place; a new key creates a new lane.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition for the lane. Defaults to your own auth-derived " +
+          "namespace; override only when authorized for another.",
+      },
+      status: {
+        type: "enum",
+        required: false,
+        values: ["active", "wrapped", "archived"],
+        description:
+          "Lifecycle state: active (in progress, default for new lanes), " +
+          "wrapped (checkpointed/handed off), archived (closed out). Set to " +
+          "transition a lane; usually session_wrap manages this for you.",
+      },
+      agent: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Owning agent for the lane (e.g. hermes, bilby, skippy). Set so " +
+          "lanes can be attributed and filtered by agent.",
+      },
+      source: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Where the lane originated (e.g. cli, discord, cron). Set for " +
+          "provenance when a lane can come from multiple entry points.",
+      },
+      channel_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Originating channel id, for chat-driven lanes. Set so the lane " +
+          "can later be resolved by channel.",
+      },
+      thread_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Originating thread id within the channel, when threaded.",
+      },
+      project: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Project the lane belongs to, for scoping and filtering.",
+      },
+      topic: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Short human-readable subject for the lane.",
+      },
+      current_context_md: {
+        type: "string",
+        required: false,
+        maxLength: 100000,
+        description:
+          "Rolling working-context summary in Markdown — the lane's " +
+          '"where we are right now" scratchpad. Overwrite it as the session ' +
+          "evolves so a resuming agent gets the current picture without " +
+          "replaying every event.",
+      },
+      metadata: {
+        type: "object",
+        required: false,
+        propertyNames: { type: "string", maxLength: 100 },
+        maxKeys: 50,
+        maxJsonBytes: 100000,
+        description:
+          "Arbitrary structured key/value metadata for the lane (max 50 " +
+          "keys, 100KB JSON). Use for machine-readable tags or pointers; " +
+          "keep human narrative in current_context_md.",
+      },
+    },
+    output_shape: "session lane JSON text payload",
+  },
+  lane_load: {
+    version: 2,
+    input_schema: {
+      session_key: {
+        type: "string",
+        required: false,
+        description:
+          "Filter to a single lane by its exact key. Omit to list by other " +
+          "filters instead.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        description:
+          "Memory partition to list lanes from. Defaults to your own " +
+          "auth-derived namespace; override only when authorized for another.",
+      },
+      project: {
+        type: "string",
+        required: false,
+        description:
+          "Filter to lanes for this project. Combine with status to find " +
+          "active work on a given project.",
+      },
+      agent: {
+        type: "string",
+        required: false,
+        description:
+          "Filter to lanes owned by this agent (e.g. hermes, bilby).",
+      },
+      channel_id: {
+        type: "string",
+        required: false,
+        description:
+          "Filter to lanes from this originating chat channel.",
+      },
+      status: {
+        type: "enum",
+        required: false,
+        default: "active",
+        values: ["active", "wrapped", "archived"],
+        description:
+          "Lifecycle filter (default active). Use active to find in-progress " +
+          "lanes to resume, wrapped/archived to review past sessions.",
+      },
+      limit: {
+        type: "integer",
+        required: false,
+        min: 1,
+        max: 50,
+        description:
+          "Maximum lanes to return (1-50). Lanes come back most-recent " +
+          "first, so a small limit gives you the latest activity.",
+      },
+    },
+    output_shape: "session lane array JSON text payload",
+  },
+  append_session_event: {
+    version: 3,
+    input_schema: {
+      session_key: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+        description:
+          "Identifier of the lane to append to. Must match a lane you " +
+          "started or upserted; the event is journaled under this lane.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition for the event. Defaults to your own " +
+          "auth-derived namespace; override only when authorized for another.",
+      },
+      event_type: {
+        type: "enum",
+        required: true,
+        values: [
+          "fact",
+          "decision",
+          "blocker",
+          "action",
+          "artifact",
+          "receipt",
+          "question",
+          "correction",
+          "handoff",
+        ],
+        description:
+          "What kind of event this is — choose the closest: fact (something " +
+          "learned/true), decision (a choice made), blocker (something " +
+          "stopping progress), action (a step taken), artifact (a file/output " +
+          "produced), receipt (proof/result of an action), question (an open " +
+          "unknown), correction (fixes a prior event), handoff (context " +
+          "passed to the next session/agent). Pick accurately — type drives " +
+          "filtering and recall.",
+      },
+      content: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 50000,
+        description:
+          "The event text. Write a complete, self-contained statement that " +
+          "will make sense when recalled later without surrounding context.",
+      },
+      source: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Where this event came from (e.g. tool name, user, agent). Set " +
+          "for provenance when it aids later attribution.",
+      },
+      artifact_path: {
+        type: "string",
+        required: false,
+        maxLength: 2000,
+        description:
+          "Path or URI to a produced/referenced artifact (file, doc, URL). " +
+          "Set especially for artifact events so the output can be located.",
+      },
+      importance: {
+        type: "enum",
+        required: false,
+        values: ["hot", "warm", "cold"],
+        description:
+          "Significance tier: hot (high — surfaces first in recall), warm " +
+          "(normal), cold (low/archival). Use hot for pivotal " +
+          "facts/decisions, cold for routine noise.",
+      },
+      metadata: {
+        type: "object",
+        required: false,
+        maxKeys: 50,
+        maxJsonBytes: 100000,
+        description:
+          "Arbitrary structured key/value metadata for the event (max 50 " +
+          "keys, 100KB JSON), plus the recognized share_candidate flag below.",
+        fields: {
+          share_candidate: {
+            type: "boolean",
+            required: false,
+            description:
+              "Nominate this event for shared-kb promotion (shared truth every " +
+              "agent reads). Set true on a substantive fact/decision/handoff worth " +
+              "sharing. Adjudication is two-stage: SYNCHRONOUSLY the server refuses " +
+              "and strips the nomination if the content looks like a secret or " +
+              "person-private data — when that happens the event still saves but the " +
+              "response carries share_candidate_rejected with the reason. " +
+              "ASYNCHRONOUSLY a promoter-gated sweep re-classifies worthiness, " +
+              "de-duplicates against shared-kb, and promotes survivors. Do NOT set " +
+              "true for secrets, credentials, or private/personal content.",
+          },
+        },
+      },
+    },
+    output_shape: "session event JSON text payload",
+  },
+  session_wrap: {
+    version: 2,
+    input_schema: {
+      session_key: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+        description:
+          "Identifier of the lane to checkpoint. Must match the lane you " +
+          "have been working in.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition for the lane. Defaults to your own auth-derived " +
+          "namespace; override only when authorized for another.",
+      },
+      summary: {
+        type: "string",
+        required: true,
+        maxLength: 100000,
+        description:
+          "Narrative recap of what happened this session — enough that a " +
+          "fresh agent could resume without replaying the journal. Cover " +
+          "what was done, current state, and anything important learned.",
+      },
+      key_decisions: {
+        type: "array",
+        required: false,
+        items: "string",
+        maxItems: 20,
+        maxItemLength: 2000,
+        description:
+          "The notable decisions made this session, one per item (max 20). " +
+          "Capture choices a future session must respect or might revisit.",
+      },
+      next_steps: {
+        type: "array",
+        required: false,
+        items: "string",
+        maxItems: 20,
+        maxItemLength: 2000,
+        description:
+          "Concrete follow-up actions for the next session, one per item " +
+          "(max 20). Write them as actionable items so a resuming agent " +
+          "knows exactly what to pick up.",
+      },
+      project: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Project this wrap belongs to, for scoping and later filtering.",
+      },
+    },
+    output_shape: "session wrap checkpoint JSON text payload",
+  },
+  upsert_repo_fact: {
+    version: 2,
+    input_schema: {
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition to write the fact into. Defaults to your own " +
+          "auth-derived namespace; override only when authorized (e.g. " +
+          "promoting into shared-kb).",
+      },
+      metadata: REPO_FACT_METADATA_CONTRACT,
+      validation: REPO_FACT_VALIDATION_CONTRACT,
+    },
+    output_shape: "ob_entities repo_fact row JSON text payload",
+  },
+  list_repo_facts: {
+    version: 2,
+    input_schema: {
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition to read facts from. Defaults to your own " +
+          "auth-derived namespace; override only when authorized for another.",
+      },
+      repo: {
+        type: "string",
+        required: false,
+        maxLength: 300,
+        description:
+          "Filter to facts about this repository slug (e.g. owner/repo).",
+      },
+      collection: {
+        type: "string",
+        required: false,
+        maxLength: 300,
+        description:
+          "Filter to facts derived from this qmd collection.",
+      },
+      path: {
+        type: "string",
+        required: false,
+        maxLength: 1000,
+        description:
+          "Filter to facts about this repo-relative file path.",
+      },
+      fact_type: {
+        type: "enum",
+        required: false,
+        values: REPO_FACT_METADATA_CONTRACT.fact_type.values,
+        description:
+          "Filter to one fact category. Omit to return all types.",
+      },
+      subject: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Filter to facts whose subject/symbol matches this value.",
+      },
+      limit: {
+        type: "integer",
+        required: false,
+        min: 1,
+        max: 250,
+        description:
+          "Maximum facts to return (1-250). Keep small for focused recall.",
+      },
+      offset: {
+        type: "integer",
+        required: false,
+        min: 0,
+        description:
+          "Number of facts to skip, for paging. Leave at 0 for the first " +
+          "page.",
+      },
+    },
+    output_shape: "repo_fact ob_entities row array JSON text payload",
+  },
+};

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -74,6 +74,27 @@ describe("Open Brain contract manifest", () => {
     ).toContain("metadata.repo");
   });
 
+  it("pins the contract version and append_session_event nomination contract", () => {
+    // The Python client pins CURRENT_CONTRACT_VERSION and cross-checks it
+    // against this source, but nothing on the TS side caught a forgotten bump.
+    // Pin the version string and the append_session_event v2 nomination
+    // contract so a future TS/Python divergence fails here, in lockstep with
+    // python/openbrain-memory CURRENT_CONTRACT_VERSION.
+    const contract = buildContract("2026-06-18T00:00:00.000Z");
+    expect(contract.contract_version).toBe("2026-06-19.memory-tools.v4");
+
+    const appendEvent = contract.tool_contracts.append_session_event;
+    expect(appendEvent).toBeDefined();
+    expect(appendEvent?.version).toBe(2);
+    const shareCandidate = (appendEvent?.input_schema as any).metadata.fields
+      .share_candidate;
+    expect(shareCandidate.type).toBe("boolean");
+    // The help must document the two-stage (sync reject / async promote) model
+    // so a contract-driven agent learns the behavior, not just the type.
+    expect(shareCandidate.description).toContain("share_candidate_rejected");
+    expect(shareCandidate.description.toLowerCase()).toContain("secret");
+  });
+
   it("keeps the schema hash stable when only generated_at changes", () => {
     const first = buildContract("2026-06-18T00:00:00.000Z");
     const second = buildContract("2026-06-18T01:00:00.000Z");

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -81,11 +81,11 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-19.memory-tools.v4");
+    expect(contract.contract_version).toBe("2026-06-19.memory-tools.v5");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
-    expect(appendEvent?.version).toBe(2);
+    expect(appendEvent?.version).toBe(3);
     const shareCandidate = (appendEvent?.input_schema as any).metadata.fields
       .share_candidate;
     expect(shareCandidate.type).toBe("boolean");

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -4,7 +4,7 @@ import {
   REPO_FACT_VALIDATION_CONTRACT,
 } from "./tools/repo-facts.ts";
 
-export const CONTRACT_VERSION = "2026-06-18.memory-tools.v2";
+export const CONTRACT_VERSION = "2026-06-19.memory-tools.v3";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -384,6 +384,16 @@ export function buildContract(
             required: false,
             maxKeys: 50,
             maxJsonBytes: 100000,
+            fields: {
+              share_candidate: {
+                type: "boolean",
+                required: false,
+                description:
+                  "Nominate this event for shared-kb promotion. Set true to flag the " +
+                  "content for the promoter-gated shared-worthiness sweep; the promoter " +
+                  "identity re-classifies and may refuse (e.g. secrets/private content).",
+              },
+            },
           },
         },
         output_shape: "session event JSON text payload",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -4,7 +4,7 @@ import {
   REPO_FACT_VALIDATION_CONTRACT,
 } from "./tools/repo-facts.ts";
 
-export const CONTRACT_VERSION = "2026-06-19.memory-tools.v3";
+export const CONTRACT_VERSION = "2026-06-19.memory-tools.v4";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -103,7 +103,7 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "append_session_event",
-    version: 1,
+    version: 2,
     kind: "tool",
     description: "Append a durable event to a session lane journal.",
   },
@@ -342,7 +342,7 @@ export function buildContract(
         output_shape: "session lane array JSON text payload",
       },
       append_session_event: {
-        version: 1,
+        version: 2,
         input_schema: {
           session_key: {
             type: "string",
@@ -389,9 +389,15 @@ export function buildContract(
                 type: "boolean",
                 required: false,
                 description:
-                  "Nominate this event for shared-kb promotion. Set true to flag the " +
-                  "content for the promoter-gated shared-worthiness sweep; the promoter " +
-                  "identity re-classifies and may refuse (e.g. secrets/private content).",
+                  "Nominate this event for shared-kb promotion (shared truth every " +
+                  "agent reads). Set true on a substantive fact/decision/handoff worth " +
+                  "sharing. Adjudication is two-stage: SYNCHRONOUSLY the server refuses " +
+                  "and strips the nomination if the content looks like a secret or " +
+                  "person-private data — when that happens the event still saves but the " +
+                  "response carries share_candidate_rejected with the reason. " +
+                  "ASYNCHRONOUSLY a promoter-gated sweep re-classifies worthiness, " +
+                  "de-duplicates against shared-kb, and promotes survivors. Do NOT set " +
+                  "true for secrets, credentials, or private/personal content.",
               },
             },
           },

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,10 +1,7 @@
 import { createHash } from "node:crypto";
-import {
-  REPO_FACT_METADATA_CONTRACT,
-  REPO_FACT_VALIDATION_CONTRACT,
-} from "./tools/repo-facts.ts";
+import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-19.memory-tools.v4";
+export const CONTRACT_VERSION = "2026-06-19.memory-tools.v5";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -49,69 +46,97 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "upsert_repo_fact",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Upsert a curated qmd-derived repository fact into graph entity metadata.",
+      "Record or update one curated, citation-backed fact about a code repository " +
+      "(qmd-derived) into graph entity metadata. Use to persist durable repo " +
+      "knowledge (how a module works, an invariant, a gotcha) with a source URL " +
+      "that proves it; re-upsert with the same key to correct an existing fact.",
   },
   {
     name: "list_repo_facts",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Read curated qmd-derived repository facts with namespace scoping.",
+      "Read back curated repository facts, scoped to your namespace and filtered " +
+      "by repo, collection, path, fact_type, or subject. Use to recall what is " +
+      "already known about a repo before re-deriving it.",
   },
   {
     name: "log_thought",
-    version: 1,
+    version: 2,
     kind: "tool",
-    description: "Write a durable thought or observation to Open Brain.",
+    description:
+      "Write a single durable thought, observation, or note to long-term memory. " +
+      "Use for free-form knowledge that is not tied to a session journal; it is " +
+      "embedded for later semantic search. For session-scoped events use " +
+      "append_session_event instead.",
   },
   {
     name: "search_all",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Search Open Brain memory and optional qmd-backed code context.",
+      "Primary recall tool. Semantic + keyword search across Open Brain memory " +
+      "(thoughts, session events, facts) and optional qmd-backed code context. " +
+      "Call this before answering from assumption to ground yourself in stored " +
+      "knowledge.",
   },
   {
     name: "session_start",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Find or create a durable session lane and return recent events.",
+      "Open or resume a durable session lane and get recent events back. Call " +
+      "this at the start of a conversation/task to establish the lane other " +
+      "session tools write to, and to rehydrate prior context.",
   },
   {
     name: "session_context",
-    version: 1,
+    version: 2,
     kind: "tool",
-    description: "Read durable session lane state and recent events.",
+    description:
+      "Read a session lane's current state and recent events without creating " +
+      "one. Use to rehydrate context for an existing session (by session_key or " +
+      "channel_id) before continuing work.",
   },
   {
     name: "lane_upsert",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Create or update durable session lane metadata and current context.",
+      "Create or update the metadata and rolling context of a session lane " +
+      "(status, project, agent, topic, current_context_md). Use to set or refresh " +
+      "the lane's high-level state; use append_session_event for individual " +
+      "journal entries.",
   },
   {
     name: "lane_load",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Load durable session lanes by key, project, agent, channel, or status.",
+      "List session lanes matching filters (key, project, agent, channel, " +
+      "status). Use to discover or pick up existing lanes; defaults to active " +
+      "lanes when status is omitted.",
   },
   {
     name: "append_session_event",
-    version: 2,
+    version: 3,
     kind: "tool",
-    description: "Append a durable event to a session lane journal.",
+    description:
+      "Append one durable, typed event (fact, decision, blocker, action, etc.) " +
+      "to a session lane's journal. This is the main way to record what happened " +
+      "during a session so it survives and can be recalled later.",
   },
   {
     name: "session_wrap",
-    version: 1,
+    version: 2,
     kind: "tool",
-    description: "Checkpoint a session lane with a durable summary.",
+    description:
+      "Checkpoint a session lane with a durable summary, key decisions, and next " +
+      "steps. Call at the end of a work session so the next session can resume " +
+      "from a clean handoff.",
   },
   {
     name: "entity_graph",
@@ -184,283 +209,7 @@ export function buildContract(
     capabilities: [...CONTRACT_CAPABILITIES].sort((a, b) =>
       a.name.localeCompare(b.name),
     ),
-    tool_contracts: {
-      get_contract: {
-        version: 1,
-        input_schema: {},
-        output_shape: "OpenBrainContract JSON text payload",
-      },
-      log_thought: {
-        version: 1,
-        input_schema: {
-          content: { type: "string", required: true, minLength: 1 },
-          tags: { type: "array", required: false, items: "string" },
-          namespace: {
-            type: "string",
-            required: false,
-            minLength: 1,
-            maxLength: 500,
-          },
-        },
-        output_shape: "thought id/namespace/embedded/merged JSON text payload",
-      },
-      search_all: {
-        version: 1,
-        input_schema: {
-          query: { type: "string", required: true, minLength: 1 },
-          namespace: {
-            type: "string",
-            required: false,
-            maxLength: 500,
-          },
-          limit: { type: "integer", required: false, min: 1, max: 250 },
-          offset: { type: "integer", required: false, min: 0 },
-          sources: {
-            type: "enum",
-            required: false,
-            values: ["all", "brain", "qmd"],
-          },
-          search_mode: {
-            type: "enum",
-            required: false,
-            values: ["hybrid", "vector", "keyword"],
-          },
-          tier: {
-            type: "enum",
-            required: false,
-            values: ["hot", "warm", "cold"],
-          },
-        },
-        output_shape: "unified search results JSON text payload",
-      },
-      session_start: {
-        version: 1,
-        input_schema: {
-          session_key: {
-            type: "string",
-            required: true,
-            minLength: 1,
-            maxLength: 500,
-          },
-          namespace: { type: "string", required: false, maxLength: 500 },
-          project: { type: "string", required: false, maxLength: 500 },
-          agent: { type: "string", required: false, maxLength: 500 },
-          channel_id: { type: "string", required: false, maxLength: 500 },
-          thread_id: { type: "string", required: false, maxLength: 500 },
-          topic: { type: "string", required: false, maxLength: 500 },
-        },
-        output_shape: "session lane plus recent events JSON text payload",
-      },
-      session_context: {
-        version: 1,
-        input_schema: {
-          session_key: {
-            type: "string",
-            required: "session_key_or_channel_id",
-            maxLength: 500,
-          },
-          namespace: { type: "string", required: false, maxLength: 500 },
-          channel_id: {
-            type: "string",
-            required: "session_key_or_channel_id",
-            maxLength: 500,
-          },
-          thread_id: { type: "string", required: false, maxLength: 500 },
-          include_events: { type: "boolean", required: false, default: true },
-          event_limit: {
-            type: "integer",
-            required: false,
-            min: 1,
-            max: 200,
-            default: 50,
-          },
-          event_types: {
-            type: "array",
-            required: false,
-            items: "session_event_type",
-          },
-          importance: {
-            type: "enum",
-            required: false,
-            values: ["hot", "warm", "cold"],
-          },
-        },
-        output_shape: "session lane plus recent events JSON text payload",
-      },
-      lane_upsert: {
-        version: 1,
-        input_schema: {
-          session_key: {
-            type: "string",
-            required: true,
-            minLength: 1,
-            maxLength: 500,
-          },
-          namespace: { type: "string", required: false, maxLength: 500 },
-          status: {
-            type: "enum",
-            required: false,
-            values: ["active", "wrapped", "archived"],
-          },
-          agent: { type: "string", required: false, maxLength: 500 },
-          source: { type: "string", required: false, maxLength: 500 },
-          channel_id: { type: "string", required: false, maxLength: 500 },
-          thread_id: { type: "string", required: false, maxLength: 500 },
-          project: { type: "string", required: false, maxLength: 500 },
-          topic: { type: "string", required: false, maxLength: 500 },
-          current_context_md: {
-            type: "string",
-            required: false,
-            maxLength: 100000,
-          },
-          metadata: {
-            type: "object",
-            required: false,
-            propertyNames: { type: "string", maxLength: 100 },
-            maxKeys: 50,
-            maxJsonBytes: 100000,
-          },
-        },
-        output_shape: "session lane JSON text payload",
-      },
-      lane_load: {
-        version: 1,
-        input_schema: {
-          session_key: { type: "string", required: false },
-          namespace: { type: "string", required: false },
-          project: { type: "string", required: false },
-          agent: { type: "string", required: false },
-          channel_id: { type: "string", required: false },
-          status: {
-            type: "enum",
-            required: false,
-            default: "active",
-            values: ["active", "wrapped", "archived"],
-          },
-          limit: { type: "integer", required: false, min: 1, max: 50 },
-        },
-        output_shape: "session lane array JSON text payload",
-      },
-      append_session_event: {
-        version: 2,
-        input_schema: {
-          session_key: {
-            type: "string",
-            required: true,
-            minLength: 1,
-            maxLength: 500,
-          },
-          namespace: { type: "string", required: false, maxLength: 500 },
-          event_type: {
-            type: "enum",
-            required: true,
-            values: [
-              "fact",
-              "decision",
-              "blocker",
-              "action",
-              "artifact",
-              "receipt",
-              "question",
-              "correction",
-              "handoff",
-            ],
-          },
-          content: {
-            type: "string",
-            required: true,
-            minLength: 1,
-            maxLength: 50000,
-          },
-          source: { type: "string", required: false, maxLength: 500 },
-          artifact_path: { type: "string", required: false, maxLength: 2000 },
-          importance: {
-            type: "enum",
-            required: false,
-            values: ["hot", "warm", "cold"],
-          },
-          metadata: {
-            type: "object",
-            required: false,
-            maxKeys: 50,
-            maxJsonBytes: 100000,
-            fields: {
-              share_candidate: {
-                type: "boolean",
-                required: false,
-                description:
-                  "Nominate this event for shared-kb promotion (shared truth every " +
-                  "agent reads). Set true on a substantive fact/decision/handoff worth " +
-                  "sharing. Adjudication is two-stage: SYNCHRONOUSLY the server refuses " +
-                  "and strips the nomination if the content looks like a secret or " +
-                  "person-private data — when that happens the event still saves but the " +
-                  "response carries share_candidate_rejected with the reason. " +
-                  "ASYNCHRONOUSLY a promoter-gated sweep re-classifies worthiness, " +
-                  "de-duplicates against shared-kb, and promotes survivors. Do NOT set " +
-                  "true for secrets, credentials, or private/personal content.",
-              },
-            },
-          },
-        },
-        output_shape: "session event JSON text payload",
-      },
-      session_wrap: {
-        version: 1,
-        input_schema: {
-          session_key: {
-            type: "string",
-            required: true,
-            minLength: 1,
-            maxLength: 500,
-          },
-          namespace: { type: "string", required: false, maxLength: 500 },
-          summary: { type: "string", required: true, maxLength: 100000 },
-          key_decisions: {
-            type: "array",
-            required: false,
-            items: "string",
-            maxItems: 20,
-            maxItemLength: 2000,
-          },
-          next_steps: {
-            type: "array",
-            required: false,
-            items: "string",
-            maxItems: 20,
-            maxItemLength: 2000,
-          },
-          project: { type: "string", required: false, maxLength: 500 },
-        },
-        output_shape: "session wrap checkpoint JSON text payload",
-      },
-      upsert_repo_fact: {
-        version: 1,
-        input_schema: {
-          namespace: { type: "string", required: false, maxLength: 500 },
-          metadata: REPO_FACT_METADATA_CONTRACT,
-          validation: REPO_FACT_VALIDATION_CONTRACT,
-        },
-        output_shape: "ob_entities repo_fact row JSON text payload",
-      },
-      list_repo_facts: {
-        version: 1,
-        input_schema: {
-          namespace: { type: "string", required: false, maxLength: 500 },
-          repo: { type: "string", required: false, maxLength: 300 },
-          collection: { type: "string", required: false, maxLength: 300 },
-          path: { type: "string", required: false, maxLength: 1000 },
-          fact_type: {
-            type: "enum",
-            required: false,
-            values: REPO_FACT_METADATA_CONTRACT.fact_type.values,
-          },
-          subject: { type: "string", required: false, maxLength: 500 },
-          limit: { type: "integer", required: false, min: 1, max: 250 },
-          offset: { type: "integer", required: false, min: 0 },
-        },
-        output_shape: "repo_fact ob_entities row array JSON text payload",
-      },
-    },
+    tool_contracts: TOOL_CONTRACTS,
   };
 
   return {

--- a/src/db/migrations/018_link_relation_supplements.sql
+++ b/src/db/migrations/018_link_relation_supplements.sql
@@ -1,0 +1,26 @@
+-- Migration 018: Add 'supplements' to the ob_links relation allowlist.
+-- Issue #173 (thought-cluster supplementation, piece (c) of the #161 design):
+-- when the shared-kb promoter promotes a lane memory that RELATES to an existing
+-- shared-kb thought cluster (near, but not an exact/near duplicate), it links the
+-- new thought to the cluster anchor with relation 'supplements' rather than
+-- dropping it as a dup or leaving it as an orphan. The CHECK lives inline on the
+-- table (created in 010), so we drop and re-add it with the extra value.
+
+ALTER TABLE ob_links DROP CONSTRAINT IF EXISTS ob_links_relation_check;
+
+ALTER TABLE ob_links ADD CONSTRAINT ob_links_relation_check CHECK (relation IN (
+  'artifact',
+  'depends_on',
+  'supersedes',
+  'caused_by',
+  'same_lane',
+  'adjacent',
+  'mentions',
+  'implemented_by',
+  'blocked_by',
+  'decided_by',
+  'relates_to',
+  'contradicts',
+  'duplicates',
+  'supplements'
+));

--- a/src/promotion-service.ts
+++ b/src/promotion-service.ts
@@ -24,6 +24,42 @@ export const PROMOTION_CONTENT_COLUMNS: Record<Table, string> = {
     "session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, embedding, content_hash, embedded_at, embedding_model, tier",
 };
 
+/**
+ * Nomination/audit keys that must NOT survive into a promoted copy. A promoted
+ * row that still carries `share_candidate` would re-nominate itself on the next
+ * promoter sweep (the sweep is namespace-wide), causing an endless re-scan and
+ * re-promotion attempt. Stripped from the metadata column in the SELECT.
+ */
+const STRIPPED_PROMOTION_METADATA_KEYS = [
+  "share_candidate",
+  "share_rejected_sync",
+  "share_promoted_at",
+] as const;
+
+/**
+ * Build the SELECT projection for a promotion copy: identical to the INSERT
+ * column list, except the metadata jsonb column (`extracted_metadata` for
+ * thoughts/decisions, `metadata` for others) has the nomination keys stripped
+ * via `- key` so the promoted copy is not itself a standing nomination.
+ */
+function promotionSelectExpression(columns: string): string {
+  const metaCol = columns.includes("extracted_metadata")
+    ? "extracted_metadata"
+    : columns.includes(" metadata") || columns.startsWith("metadata")
+      ? "metadata"
+      : null;
+  if (!metaCol) return columns;
+  const stripped = STRIPPED_PROMOTION_METADATA_KEYS.map((k) => `- '${k}'`).join(
+    " ",
+  );
+  // Replace the bare column token with the stripped expression aliased back to
+  // the column name so positional INSERT/SELECT alignment is preserved.
+  return columns
+    .split(", ")
+    .map((c) => (c === metaCol ? `(${metaCol} ${stripped}) AS ${metaCol}` : c))
+    .join(", ");
+}
+
 export interface PromotionResult {
   status: "promoted" | "duplicate" | "dry_run";
   new_id?: string;
@@ -196,9 +232,10 @@ export async function promoteEntry(
   }
 
   const columns = PROMOTION_CONTENT_COLUMNS[table];
+  const selectExpr = promotionSelectExpression(columns);
   const { rows: inserted } = await pool.query(
     `INSERT INTO ${table} (${columns}, namespace, promoted_from)
-     SELECT ${columns}, $2, $3::jsonb
+     SELECT ${selectExpr}, $2, $3::jsonb
      FROM ${table} WHERE id = $1 AND namespace = $4
      ON CONFLICT DO NOTHING
      RETURNING id`,

--- a/src/sharing.test.ts
+++ b/src/sharing.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import {
+  classifyShareCandidate,
+  containsSecret,
+  DEFAULT_MIN_SHARE_LENGTH,
+  SECRET_PATTERNS,
+} from "./sharing.ts";
+
+// Clearly-fake / documentation example values, split where needed so the repo's
+// own secret scanner (ggshield) does not flag the test fixtures themselves.
+const FAKE_AWS_ACCESS_KEY = "AKIA" + "IOSFODNN7EXAMPLE";
+const FAKE_JWT =
+  "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiJ0ZXN0In0." + "abcdefghijklmnop";
+const FAKE_GH_PAT = "github" + "_pat_" + "11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ";
+const FAKE_SK = "sk" + "-" + "abcdefghijklmnopqrstuvwxyz0123456789";
+const FAKE_SLACK = "xoxb-" + "1234567890-abcdefghij";
+const LONG_FACT =
+  "The open-brain promotion runner graduates lane facts into shared-kb after classification.";
+
+describe("containsSecret", () => {
+  it("detects a fake AWS access key", () => {
+    expect(containsSecret(`key is ${FAKE_AWS_ACCESS_KEY} here`)).toBe(true);
+  });
+
+  it("detects a fake JWT", () => {
+    expect(containsSecret(`token ${FAKE_JWT}`)).toBe(true);
+  });
+
+  it("detects a GitHub PAT", () => {
+    expect(containsSecret(`use ${FAKE_GH_PAT} to auth`)).toBe(true);
+  });
+
+  it("detects an sk-style API key", () => {
+    expect(containsSecret(`OPENAI ${FAKE_SK}`)).toBe(true);
+  });
+
+  it("detects a Slack token", () => {
+    expect(containsSecret(`slack ${FAKE_SLACK}`)).toBe(true);
+  });
+
+  it("detects an AWS secret in context", () => {
+    expect(
+      containsSecret(
+        "aws_secret_access_key=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY1234",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a bearer authorization header", () => {
+    expect(containsSecret("Authorization: Bearer abcdef123456")).toBe(true);
+  });
+
+  it("detects a key=value secret assignment", () => {
+    expect(containsSecret("api_key=supersecretvalue")).toBe(true);
+  });
+
+  it("detects a private key block", () => {
+    expect(
+      containsSecret(
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n-----END RSA PRIVATE KEY-----",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag ordinary prose", () => {
+    expect(
+      containsSecret(
+        "We decided to route lane facts through the promoter identity for shared-kb.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not flag empty content", () => {
+    expect(containsSecret("")).toBe(false);
+  });
+
+  it("ships a non-trivial set of patterns", () => {
+    expect(SECRET_PATTERNS.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe("classifyShareCandidate — reject-secret", () => {
+  it("rejects a fact carrying an AWS key (secret beats everything)", () => {
+    expect(
+      classifyShareCandidate({
+        event_type: "fact",
+        importance: "hot",
+        content: `${LONG_FACT} ${FAKE_AWS_ACCESS_KEY}`,
+      }),
+    ).toBe("reject-secret");
+  });
+
+  it("rejects even a long, share-eligible decision with an embedded JWT", () => {
+    expect(
+      classifyShareCandidate({
+        importance: "hot",
+        content: `${LONG_FACT} session ${FAKE_JWT}`,
+      }),
+    ).toBe("reject-secret");
+  });
+});
+
+describe("classifyShareCandidate — reject-private", () => {
+  it("rejects when metadata.private === true", () => {
+    expect(
+      classifyShareCandidate({
+        content: LONG_FACT,
+        metadata: { private: true },
+      }),
+    ).toBe("reject-private");
+  });
+
+  it("rejects when a private tag is present", () => {
+    expect(
+      classifyShareCandidate({
+        content: LONG_FACT,
+        tags: ["work", "Personal"],
+      }),
+    ).toBe("reject-private");
+  });
+
+  it("rejects when metadata.visibility is private", () => {
+    expect(
+      classifyShareCandidate({
+        content: LONG_FACT,
+        metadata: { visibility: "private" },
+      }),
+    ).toBe("reject-private");
+  });
+
+  it("private check ranks below secret check", () => {
+    expect(
+      classifyShareCandidate({
+        content: `${LONG_FACT} ${FAKE_AWS_ACCESS_KEY}`,
+        metadata: { private: true },
+      }),
+    ).toBe("reject-secret");
+  });
+});
+
+describe("classifyShareCandidate — reject-noise", () => {
+  it("rejects a question event type", () => {
+    expect(
+      classifyShareCandidate({ event_type: "question", content: LONG_FACT }),
+    ).toBe("reject-noise");
+  });
+
+  it("rejects an action event type", () => {
+    expect(
+      classifyShareCandidate({ event_type: "action", content: LONG_FACT }),
+    ).toBe("reject-noise");
+  });
+
+  it("rejects cold importance", () => {
+    expect(
+      classifyShareCandidate({
+        event_type: "fact",
+        importance: "cold",
+        content: LONG_FACT,
+      }),
+    ).toBe("reject-noise");
+  });
+
+  it("rejects content shorter than minLen", () => {
+    expect(classifyShareCandidate({ content: "too short" })).toBe(
+      "reject-noise",
+    );
+  });
+
+  it("rejects a non-shareable lane event type (blocker)", () => {
+    expect(
+      classifyShareCandidate({ event_type: "blocker", content: LONG_FACT }),
+    ).toBe("reject-noise");
+  });
+});
+
+describe("classifyShareCandidate — share / manual-review", () => {
+  it("shares a long, hot fact event", () => {
+    expect(
+      classifyShareCandidate({
+        event_type: "fact",
+        importance: "hot",
+        content: LONG_FACT,
+      }),
+    ).toBe("share");
+  });
+
+  it("shares a thought (no event_type) that is long and warm", () => {
+    expect(
+      classifyShareCandidate({ importance: "warm", content: LONG_FACT }),
+    ).toBe("share");
+  });
+
+  it("shares a handoff event", () => {
+    expect(
+      classifyShareCandidate({ event_type: "handoff", content: LONG_FACT }),
+    ).toBe("share");
+  });
+
+  it("routes a just-over-min-length candidate to manual-review", () => {
+    const content = "x".repeat(DEFAULT_MIN_SHARE_LENGTH + 2);
+    expect(classifyShareCandidate({ event_type: "fact", content })).toBe(
+      "manual-review",
+    );
+  });
+
+  it("honors a custom minLen", () => {
+    const content = "short fact here";
+    expect(
+      classifyShareCandidate(
+        { event_type: "fact", content },
+        { minLen: 4 },
+      ),
+    ).toBe("share");
+  });
+});

--- a/src/sharing.test.ts
+++ b/src/sharing.test.ts
@@ -62,6 +62,38 @@ describe("containsSecret", () => {
     ).toBe(true);
   });
 
+  // ── #174: unlabeled credential shapes ──
+  it("detects a Stripe-style live key (underscore form)", () => {
+    expect(containsSecret("stripe " + "sk_live_" + "a".repeat(24))).toBe(true);
+    expect(containsSecret("pub " + "pk_test_" + "b".repeat(24))).toBe(true);
+  });
+
+  it("detects credentials embedded in a URL", () => {
+    expect(
+      containsSecret("db at postgres://admin:hunter2pw@10.0.0.1:5432/app"),
+    ).toBe(true);
+  });
+
+  it("detects a labeled long secret value", () => {
+    expect(
+      containsSecret("client_secret=" + "Ab9".repeat(8) + "xyz"),
+    ).toBe(true);
+  });
+
+  it("does NOT flag a bare hex content-hash / git SHA (no over-rejection)", () => {
+    // 64-char hex content_hash and a 40-char git SHA are pervasive + legitimate.
+    expect(containsSecret("content_hash " + "a1b2c3d4".repeat(8))).toBe(false);
+    expect(containsSecret("commit 4ba6c76e1f2a3b4c5d6e7f8091a2b3c4d5e6f708")).toBe(
+      false,
+    );
+  });
+
+  it("does NOT flag a plain URL without credentials (no over-rejection)", () => {
+    expect(containsSecret("see https://github.com/rodaddy/open-brain")).toBe(
+      false,
+    );
+  });
+
   it("does not flag ordinary prose", () => {
     expect(
       containsSecret(

--- a/src/sharing.test.ts
+++ b/src/sharing.test.ts
@@ -74,6 +74,11 @@ describe("containsSecret", () => {
     ).toBe(true);
   });
 
+  it("detects URL credentials regardless of scheme case", () => {
+    // URI schemes are case-insensitive; an uppercase scheme must not leak.
+    expect(containsSecret("HTTPS://admin:hunter2pw@host/x")).toBe(true);
+  });
+
   it("detects a labeled long secret value", () => {
     expect(
       containsSecret("client_secret=" + "Ab9".repeat(8) + "xyz"),

--- a/src/sharing.ts
+++ b/src/sharing.ts
@@ -48,9 +48,12 @@ const PRIVATE_KEY_BLOCK_RE =
 const STRIPE_KEY_RE = "[sprk]k_(live|test)_[A-Za-z0-9]{16,}";
 // Credentials embedded in a URL's userinfo (`scheme://user:pass@host`). The
 // password is unlabeled and a realistic lane-journal leak. Require a non-empty
-// password and a host to avoid matching `a://b:@` noise.
+// password and a host to avoid matching `a://b:@` noise. Userinfo segments are
+// length-bounded ({1,256}) so the pattern cannot backtrack quadratically on
+// colon-heavy input that lacks a trailing `@` (ReDoS guard); real credentials
+// are far shorter than 256 chars.
 const URL_USERINFO_CRED_RE =
-  "[a-z][a-z0-9+.-]*://[^\\s:@/]+:[^\\s@/]+@[^\\s/]+";
+  "[a-z][a-z0-9+.-]*://[^\\s:@/]{1,256}:[^\\s@/]{1,256}@[^\\s/]+";
 // Context-labeled long hex/base64 secrets (client_secret, access_token, etc.).
 // Deliberately requires a credential LABEL — bare high-entropy hex is left
 // alone because git SHAs and content_hashes are pervasive and legitimate here

--- a/src/sharing.ts
+++ b/src/sharing.ts
@@ -43,6 +43,21 @@ const JWT_LIKE_RE =
   "[A-Za-z0-9_-]{8,}";
 const PRIVATE_KEY_BLOCK_RE =
   "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----";
+// Stripe-style keys use an underscore separator (sk_live_, pk_live_, rk_live_,
+// and the test variants), which the OpenAI `sk-` pattern above does not catch.
+const STRIPE_KEY_RE = "[sprk]k_(live|test)_[A-Za-z0-9]{16,}";
+// Credentials embedded in a URL's userinfo (`scheme://user:pass@host`). The
+// password is unlabeled and a realistic lane-journal leak. Require a non-empty
+// password and a host to avoid matching `a://b:@` noise.
+const URL_USERINFO_CRED_RE =
+  "[a-z][a-z0-9+.-]*://[^\\s:@/]+:[^\\s@/]+@[^\\s/]+";
+// Context-labeled long hex/base64 secrets (client_secret, access_token, etc.).
+// Deliberately requires a credential LABEL — bare high-entropy hex is left
+// alone because git SHAs and content_hashes are pervasive and legitimate here
+// (avoiding the over-rejection the SME guidance warns against).
+const LABELED_LONG_SECRET_RE =
+  "(client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)" +
+  "\\s*[:=]\\s*[A-Za-z0-9._/+=-]{20,}";
 
 /**
  * Compiled secret detectors. `i` mirrors the Python `(?i)` inline flags; the
@@ -65,6 +80,9 @@ export const SECRET_PATTERNS: readonly RegExp[] = [
   /(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+/i,
   /"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"/i,
   new RegExp(PRIVATE_KEY_BLOCK_RE),
+  new RegExp(`\\b${STRIPE_KEY_RE}\\b`),
+  new RegExp(URL_USERINFO_CRED_RE, "i"),
+  new RegExp(LABELED_LONG_SECRET_RE, "i"),
 ];
 
 /**

--- a/src/sharing.ts
+++ b/src/sharing.ts
@@ -1,0 +1,195 @@
+/**
+ * Lane/own-durable → shared-kb shared-worthiness classifier (Issue #161).
+ *
+ * Pure, no DB, no I/O. Decides whether a nominated entry (a thought, decision,
+ * or session event flagged `share_candidate`) is safe and worthwhile to promote
+ * into the shared-kb namespace — shared TRUTH that every agent reads.
+ *
+ * The highest-stakes rule is `reject-secret`: a secret reaching shared truth is
+ * the worst failure mode, so `containsSecret` is deliberately conservative
+ * (false negatives are far more dangerous than false positives here). The secret
+ * patterns are ported from the Python client's `policy.py` SECRET_PATTERNS so the
+ * server enforces the same redaction surface the client already trusts.
+ */
+
+/** Default minimum trimmed content length for a share-eligible entry. */
+export const DEFAULT_MIN_SHARE_LENGTH = 24;
+
+/**
+ * Ported from python/openbrain-memory/src/openbrain_memory/policy.py
+ * SECRET_PATTERNS. Kept structurally 1:1 so the two surfaces stay in lockstep.
+ * Prefixes are split to avoid tripping repo secret scanners on the literals.
+ */
+const SK_PREFIX = "sk" + "-";
+const GITHUB_PREFIX_RE = "gh" + "[pousr]_";
+const GITHUB_PAT_PREFIX = "github" + "_pat_";
+const AWS_ACCESS_KEY_PREFIX_RE = "A[KS]IA[0-9A-Z]{16}";
+const AWS_SECRET_LIKE_RE =
+  "(?<![A-Za-z0-9/+=])" +
+  "(?=[A-Za-z0-9/+=]*[A-Z])" +
+  "(?=[A-Za-z0-9/+=]*[a-z])" +
+  "(?=[A-Za-z0-9/+=]*[0-9])" +
+  "(?=[A-Za-z0-9/+=]*[/+=])" +
+  "[A-Za-z0-9/+=]{40}" +
+  "(?![A-Za-z0-9/+=])";
+const AWS_SECRET_CONTEXT_RE =
+  "(aws[_ -]?(secret|secret[_ -]?access[_ -]?key))\\s*[:=]\\s*" +
+  "[A-Za-z0-9/+=]{40}";
+const SLACK_TOKEN_RE = "xox[baprs]-[A-Za-z0-9-]{10,}";
+const GOOGLE_API_KEY_PREFIX = "AIza";
+const JWT_LIKE_RE =
+  "eyJ[A-Za-z0-9_-]{8,}\\." +
+  "[A-Za-z0-9_-]{8,}\\." +
+  "[A-Za-z0-9_-]{8,}";
+const PRIVATE_KEY_BLOCK_RE =
+  "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----";
+
+/**
+ * Compiled secret detectors. `i` mirrors the Python `(?i)` inline flags; the
+ * private-key block uses dot-all via the explicit `[\s\S]` class so no `s` flag
+ * is required (keeps Bun/JS regex engine parity with the Python `re.S`).
+ */
+export const SECRET_PATTERNS: readonly RegExp[] = [
+  /authorization\s*[:=]\s*bearer\s+[^\s,;]+/i,
+  /bearer\s+[A-Za-z0-9._~+/=-]{8,}/i,
+  /mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+/i,
+  new RegExp(`\\b${SK_PREFIX}[A-Za-z0-9_-]{10,}\\b`),
+  new RegExp(`${GITHUB_PAT_PREFIX}[A-Za-z0-9_]+`, "i"),
+  new RegExp(`${GITHUB_PREFIX_RE}[A-Za-z0-9_]{20,}`, "i"),
+  new RegExp(`\\b${AWS_ACCESS_KEY_PREFIX_RE}\\b`),
+  new RegExp(AWS_SECRET_CONTEXT_RE, "i"),
+  new RegExp(AWS_SECRET_LIKE_RE),
+  new RegExp(`\\b${SLACK_TOKEN_RE}\\b`),
+  new RegExp(`\\b${GOOGLE_API_KEY_PREFIX}[A-Za-z0-9_-]{35}\\b`),
+  new RegExp(`\\b${JWT_LIKE_RE}\\b`),
+  /(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+/i,
+  /"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"/i,
+  new RegExp(PRIVATE_KEY_BLOCK_RE),
+];
+
+/**
+ * True if `text` contains anything matching a known secret pattern. Conservative
+ * by design: a secret must NEVER reach shared truth, so this is the hard gate
+ * `classifyShareCandidate` consults before anything else.
+ */
+export function containsSecret(text: string): boolean {
+  if (!text) return false;
+  for (const pattern of SECRET_PATTERNS) {
+    // Patterns are stateless here (no global flag) so test() is safe to reuse.
+    if (pattern.test(text)) return true;
+  }
+  return false;
+}
+
+export type ShareDecision =
+  | "share"
+  | "reject-secret"
+  | "reject-private"
+  | "reject-noise"
+  | "manual-review";
+
+/** Minimal shape the classifier needs from a share candidate. */
+export interface ShareCandidateInput {
+  /** Event type when the candidate is a lane event; omitted for thoughts/decisions. */
+  event_type?: string;
+  importance?: string;
+  content: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ClassifyShareOptions {
+  /** Minimum trimmed content length to be share-eligible. */
+  minLen?: number;
+}
+
+/** Event types that carry shareable substance. */
+const SHARE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "fact",
+  "decision",
+  "handoff",
+]);
+
+/** Event types that are operational noise — never shared truth. */
+const NOISE_EVENT_TYPES: ReadonlySet<string> = new Set(["question", "action"]);
+
+/** Tags that mark content as person-private and unfit for shared truth. */
+const PRIVATE_TAGS: ReadonlySet<string> = new Set([
+  "private",
+  "personal",
+  "secret",
+  "confidential",
+]);
+
+function isPrivate(input: ShareCandidateInput): boolean {
+  const metadata = input.metadata ?? {};
+  if (metadata.private === true || metadata.personal === true) return true;
+  // Conservative namespace-personal markers an agent may stamp on a candidate.
+  const visibility = metadata.visibility ?? metadata.scope;
+  if (typeof visibility === "string") {
+    const v = visibility.toLowerCase();
+    if (v === "private" || v === "personal") return true;
+  }
+  for (const tag of input.tags ?? []) {
+    if (PRIVATE_TAGS.has(tag.trim().toLowerCase())) return true;
+  }
+  return false;
+}
+
+/**
+ * Decide how a single share candidate should be handled. Precedence is
+ * deliberate and security-first:
+ *
+ *   1. reject-secret  — content matches any secret pattern (HARD, first).
+ *   2. reject-private — person-private markers (metadata/tags).
+ *   3. reject-noise   — noise event types, cold importance, or too short.
+ *   4. share          — substantive, eligible, and clears every gate.
+ *   5. manual-review  — share-eligible but near the minimum length (ambiguous).
+ *
+ * Eligibility: lane events qualify only for {fact, decision, handoff}; entries
+ * with no `event_type` (thoughts/decisions) are always type-eligible. Cold
+ * importance always demotes to noise — the agent has down-tiered it.
+ */
+export function classifyShareCandidate(
+  input: ShareCandidateInput,
+  options: ClassifyShareOptions = {},
+): ShareDecision {
+  const minLen = options.minLen ?? DEFAULT_MIN_SHARE_LENGTH;
+
+  // 1. Secret — hard reject, checked before anything else.
+  if (containsSecret(input.content)) {
+    return "reject-secret";
+  }
+
+  // 2. Private — person-private content must not become shared truth.
+  if (isPrivate(input)) {
+    return "reject-private";
+  }
+
+  // 3. Noise — wrong event type, cold importance, or too short.
+  const eventType = input.event_type;
+  if (eventType !== undefined && NOISE_EVENT_TYPES.has(eventType)) {
+    return "reject-noise";
+  }
+  if (input.importance === "cold") {
+    return "reject-noise";
+  }
+  const length = input.content.trim().length;
+  if (length < minLen) {
+    return "reject-noise";
+  }
+
+  // 4. Type eligibility. Lane events must be a shareable type; thoughts and
+  //    decisions (no event_type) are always type-eligible.
+  if (eventType !== undefined && !SHARE_EVENT_TYPES.has(eventType)) {
+    return "reject-noise";
+  }
+
+  // 5. Ambiguity band: just over the minimum length is share-eligible but not
+  //    obviously substantive — route to a human for review.
+  if (length < minLen * 1.5) {
+    return "manual-review";
+  }
+
+  return "share";
+}

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -494,6 +494,199 @@ describe("append_session_event", () => {
     }
   });
 
+  // ── SYNC SHARE-NOMINATION GATE (Issue #161, Q1) ──
+  // adjudicateNominationSync runs inline on the write path: a share_candidate
+  // carrying a secret or person-private content is hard-rejected, the nomination
+  // flag is STRIPPED before persist (so the async promoter never sweeps it), a
+  // share_rejected_sync marker is stamped on the persisted metadata, and the
+  // tool response surfaces share_candidate_rejected. Clean/absent nominations
+  // pass through untouched — worthiness stays for the async cron, NOT this gate.
+  //
+  // We assert the persisted metadata by capturing the INSERT params on the mock
+  // pool. The metadata is the 7th INSERT param ($7, index 6), JSON.stringify'd.
+
+  /** Lane-found pool that captures the params of the events INSERT. */
+  function createCapturingPool() {
+    const captured: { metadata: Record<string, unknown> | null } = {
+      metadata: null,
+    };
+    const pool = {
+      captured,
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
+        }
+        // INSERT INTO ob_session_events — $7 (index 6) is the metadata JSON.
+        if (params && typeof params[6] === "string") {
+          captured.metadata = JSON.parse(params[6]);
+        }
+        return { rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }] };
+      },
+    };
+    return pool;
+  }
+
+  it("strips share_candidate and reports reject-secret when content carries a secret", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          // Substantive content that also embeds an OpenAI-style key.
+          content:
+            "Configured the deploy pipeline with key " + "sk-" + "a".repeat(20),
+          metadata: { share_candidate: true },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.share_candidate_rejected).toBe("reject-secret");
+
+      // Persisted metadata: nomination stripped, audit marker stamped.
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
+        "reject-secret",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("treats string \"true\" nomination like boolean true (matches async SQL truthiness)", async () => {
+    // The async promoter nominates on `metadata->>'share_candidate' = 'true'`,
+    // which matches a JSON string "true". If the sync gate only accepted boolean
+    // true, a mistyped nomination would skip the inline secret check yet still
+    // be swept async — voiding this gate. Regression for that bypass.
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content:
+            "Configured the deploy pipeline with key " + "sk-" + "a".repeat(20),
+          metadata: { share_candidate: "true" },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.share_candidate_rejected).toBe("reject-secret");
+      expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
+        "reject-secret",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("strips share_candidate and reports reject-private when metadata.private is true", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          // Clean, substantive content — only the private marker triggers reject.
+          content: "This is a substantive personal note about my own plans.",
+          metadata: { share_candidate: true, private: true },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.share_candidate_rejected).toBe("reject-private");
+
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
+        "reject-private",
+      );
+      // The original private marker is preserved (only share_candidate stripped).
+      expect(mockPool.captured.metadata!.private).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps share_candidate for clean substantive content — async cron owns worthiness", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content:
+            "Chose pgvector halfvec(768) for the embedding column to halve storage.",
+          metadata: { share_candidate: true },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      // No sync rejection — the sync gate ONLY hard-rejects secret/private.
+      expect(parsed.share_candidate_rejected).toBeUndefined();
+
+      // Nomination survives to persist; the async promoter decides worthiness.
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.share_candidate).toBe(true);
+      expect(mockPool.captured.metadata!.share_rejected_sync).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("passes metadata through unchanged when no share_candidate is present", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          // Content that WOULD be a secret, but with no nomination the sync gate
+          // must not run — share_rejected_sync must never appear.
+          content: "password: hunter2something nominated nowhere",
+          metadata: { pr: 42 },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.share_candidate_rejected).toBeUndefined();
+
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.pr).toBe(42);
+      expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.share_rejected_sync).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── DATABASE ERROR ──
 
   it("returns isError=true with message when DB query throws", async () => {

--- a/src/tools/__tests__/promote-shared.test.ts
+++ b/src/tools/__tests__/promote-shared.test.ts
@@ -1,0 +1,394 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerPromoteShared } from "../promote-shared.ts";
+import { contentHash } from "../../embedding.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const SOURCE_ID = "550e8400-e29b-41d4-a716-446655440000";
+const LONG_FACT =
+  "The promoter graduates this substantive durable fact into shared truth for all agents.";
+const FAKE_AWS_KEY = "AKIA" + "IOSFODNN7EXAMPLE";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+/**
+ * Mock pool routed by SQL shape:
+ *  - SELECT ... FROM <table> WHERE id = $1   → the source row for classification
+ *    AND promoteEntry's own source read.
+ *  - INSERT INTO <table> ...                 → records a write.
+ *  - duplicate-check SELECT                  → controllable miss.
+ */
+function createMockPool(opts: {
+  row?: Record<string, unknown> | null;
+  table?: string;
+}) {
+  const row =
+    opts.row === undefined
+      ? { id: SOURCE_ID, content: LONG_FACT, namespace: "bilby", content_hash: contentHash(LONG_FACT) }
+      : opts.row;
+  const writes: Array<{ sql: string; params: any[] }> = [];
+  const pool = {
+    writes,
+    query: async (sql: string, params: any[] = []) => {
+      if (sql.startsWith("INSERT")) {
+        writes.push({ sql, params });
+        return { rows: [{ id: "new-shared-id" }] };
+      }
+      if (sql.includes("WHERE namespace = $1")) {
+        // findDuplicate — no existing duplicate.
+        return { rows: [] };
+      }
+      if (sql.includes("WHERE id = $1")) {
+        return { rows: row ? [row] : [] };
+      }
+      return { rows: [] };
+    },
+  };
+  return pool;
+}
+
+async function setupToolClient(
+  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+  registerPromoteShared(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) =>
+    originalSend(message, { ...options, authInfo: auth });
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("promote_shared", () => {
+  // ── AUTH (the acceptance gate) ──
+
+  it("REJECTS a normal agent token", async () => {
+    const mockPool = createMockPool({});
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+      // Refused before any DB read/write.
+      expect((mockPool as any).writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies when auth is missing entirely", async () => {
+    const mockPool = createMockPool({});
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
+    registerPromoteShared(server, deps);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "tc", version: "1.0.0" });
+    await server.connect(st);
+    await client.connect(ct);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("denies a readonly role", async () => {
+    const mockPool = createMockPool({});
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID },
+      });
+      expect(res.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ALLOWS the promoter role (dry-run, no write)", async () => {
+    const mockPool = createMockPool({});
+    const auth: AuthInfo = {
+      role: "promoter",
+      clientId: "openbrain-promoter",
+      tokenClientId: "openbrain-promoter",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID },
+      });
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.classification).toBe("share");
+      expect(parsed.status).toBe("dry_run");
+      // Dry-run performs no INSERT.
+      expect((mockPool as any).writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ALLOWS an admin-as-promoter identity and writes on apply", async () => {
+    // Admin role + the openbrain-promoter clientId is a promoter identity
+    // (backward-compat path in isPromoterIdentity), so the shared-kb write is
+    // permitted at the namespace boundary.
+    const mockPool = createMockPool({});
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "openbrain-promoter",
+      tokenClientId: "openbrain-promoter",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID, dry_run: false },
+      });
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.status).toBe("promoted");
+      expect((mockPool as any).writes.length).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("lets a PLAIN admin past the entry gate but the shared-kb write boundary still refuses", async () => {
+    // Defense in depth: the entry gate admits admin, but only a promoter
+    // IDENTITY may write shared-kb, so promoteEntry rejects a non-promoter admin.
+    const mockPool = createMockPool({});
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "admin",
+      tokenClientId: "admin",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID, dry_run: false },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("Permission denied");
+      expect((mockPool as any).writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // ── SECRET / PRIVATE REFUSAL (even for a promoter) ──
+
+  it("REFUSES a secret-bearing entry even for a promoter", async () => {
+    const mockPool = createMockPool({
+      row: {
+        id: SOURCE_ID,
+        content: `${LONG_FACT} ${FAKE_AWS_KEY}`,
+        namespace: "bilby",
+        content_hash: contentHash("secret"),
+      },
+    });
+    const auth: AuthInfo = {
+      role: "promoter",
+      clientId: "openbrain-promoter",
+      tokenClientId: "openbrain-promoter",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID, dry_run: false },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("reject-secret");
+      // Never inserted into shared truth.
+      expect((mockPool as any).writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("REFUSES a person-private entry even for a promoter", async () => {
+    const mockPool = createMockPool({
+      row: {
+        id: SOURCE_ID,
+        content: LONG_FACT,
+        namespace: "bilby",
+        content_hash: contentHash(LONG_FACT),
+        extracted_metadata: { private: true },
+      },
+    });
+    const auth: AuthInfo = {
+      role: "promoter",
+      clientId: "openbrain-promoter",
+      tokenClientId: "openbrain-promoter",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID, dry_run: false },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("reject-private");
+      expect((mockPool as any).writes.length).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns not-found for a missing source entry", async () => {
+    const mockPool = createMockPool({ row: null });
+    const auth: AuthInfo = {
+      role: "promoter",
+      clientId: "openbrain-promoter",
+      tokenClientId: "openbrain-promoter",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    try {
+      const res = await client.callTool({
+        name: "promote_shared",
+        arguments: { table: "thoughts", id: SOURCE_ID },
+      });
+      expect(res.isError).toBe(true);
+      expect((res.content as any)[0].text).toContain("not found");
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ── DB-BACKED INTEGRATION ──
+// Gated on OPENBRAIN_TEST_DATABASE_URL. Proves a nominated own-namespace thought
+// lands in shared-kb with provenance and is idempotent on re-run.
+//   OPENBRAIN_TEST_DATABASE_URL=postgres://... bun test src/tools/__tests__/promote-shared.test.ts
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("promote_shared (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-promote-shared-live";
+
+  async function callPromoteShared(
+    args: Record<string, unknown>,
+    auth: AuthInfo,
+  ) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn: createMockEmbed() };
+    registerPromoteShared(server, deps);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const original = ct.send.bind(ct);
+    ct.send = (m: any, o?: any) => original(m, { ...o, authInfo: auth });
+    const client = new Client({ name: "tc", version: "1.0.0" });
+    await server.connect(st);
+    await client.connect(ct);
+    const res = await client.callTool({
+      name: "promote_shared",
+      arguments: args,
+    });
+    await client.close();
+    await server.close();
+    return res;
+  }
+
+  async function seedThought(content: string): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts (content, namespace, created_by, content_hash)
+       VALUES ($1, $2, $2, $3)
+       RETURNING id`,
+      [content, ns, content.slice(0, 60) + Math.random().toString(36)],
+    );
+    return rows[0].id as string;
+  }
+
+  async function cleanup() {
+    await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+    await pool.query("DELETE FROM thoughts WHERE namespace = 'shared-kb' AND created_by = $1", [
+      "openbrain-promoter",
+    ]);
+  }
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("promotes a nominated thought into shared-kb with provenance, idempotent", async () => {
+    await cleanup();
+    const content =
+      "Live durable shared fact about the open-brain shared-kb promotion path test";
+    const id = await seedThought(content);
+    const auth: AuthInfo = {
+      role: "promoter",
+      clientId: "openbrain-promoter",
+      tokenClientId: "openbrain-promoter",
+      namespaceSource: "token",
+    };
+
+    const first = await callPromoteShared(
+      { table: "thoughts", id, dry_run: false },
+      auth,
+    );
+    expect(first.isError).toBeFalsy();
+    expect(JSON.parse((first.content as any)[0].text).status).toBe("promoted");
+
+    const { rows } = await pool.query(
+      "SELECT promoted_from FROM thoughts WHERE namespace = 'shared-kb' AND content = $1",
+      [content],
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].promoted_from.target_kind).toBe("shared-kb");
+    expect(rows[0].promoted_from.source_id).toBe(id);
+
+    // Re-run is idempotent (duplicate, no second row).
+    const second = await callPromoteShared(
+      { table: "thoughts", id, dry_run: false },
+      auth,
+    );
+    expect(JSON.parse((second.content as any)[0].text).status).toBe("duplicate");
+    const { rows: after } = await pool.query(
+      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = 'shared-kb' AND content = $1",
+      [content],
+    );
+    expect(after[0].n).toBe(1);
+  });
+});

--- a/src/tools/__tests__/promote-shared.test.ts
+++ b/src/tools/__tests__/promote-shared.test.ts
@@ -341,10 +341,18 @@ dbDescribe("promote_shared (live Postgres)", () => {
   }
 
   async function cleanup() {
+    // Source rows in the test's own namespace.
     await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
-    await pool.query("DELETE FROM thoughts WHERE namespace = 'shared-kb' AND created_by = $1", [
-      "openbrain-promoter",
-    ]);
+    // Promoted copies land in shared-kb. promoteEntry copies the SOURCE row's
+    // created_by verbatim (seedThought sets created_by = ns, NOT the promoter
+    // identity), so a created_by='openbrain-promoter' predicate MISSES them and
+    // the leaked row makes the next run resolve to "duplicate". Delete the
+    // promoted copies by their provenance, which points back at this test's
+    // namespace — precise and never touches unrelated shared-kb rows.
+    await pool.query(
+      "DELETE FROM thoughts WHERE namespace = 'shared-kb' AND promoted_from->>'source_physical_namespace' = $1",
+      [ns],
+    );
   }
 
   afterAll(async () => {

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -4,10 +4,67 @@ import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
 import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
+import { classifyShareCandidate } from "../sharing.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 import { EVENT_TYPES, IMPORTANCE_LEVELS } from "./table-constants.ts";
+
+/**
+ * Hybrid-timing sync gate for the share_candidate nomination (Issue #161, Q1).
+ *
+ * An agent nominates an event for shared-kb promotion by setting
+ * `metadata.share_candidate = true` on this write. The full worthiness +
+ * dedup + promote adjudication is ASYNC (the promoter cron). But the ONE check
+ * we must run synchronously is the cheap, security-critical one: a secret or
+ * person-private nomination must never even enter the promotion queue.
+ *
+ * `classifyShareCandidate` is pure (no DB, no embedding) so it is safe on the
+ * write path. We only act on its hard-reject decisions here; worthiness/noise
+ * stays for the async adjudicator. On a hard reject we STRIP the nomination
+ * flag (the event itself still persists — it is the agent's lane journal) and
+ * report it, so the cron never sees a secret/private candidate.
+ *
+ * Returns the metadata to persist (nomination stripped if rejected) and the
+ * sync decision to surface back to the agent, or null when no nomination was
+ * present.
+ */
+function adjudicateNominationSync(
+  eventType: string,
+  importance: string,
+  content: string,
+  metadata: Record<string, unknown>,
+): {
+  metadata: Record<string, unknown>;
+  rejected: "reject-secret" | "reject-private" | null;
+} {
+  // Match the async promoter's truthiness exactly: its SQL nominates on
+  // `metadata->>'share_candidate' = 'true'`, which matches both a JSON boolean
+  // true and the string "true". If the sync gate only accepted boolean true, a
+  // mistyped string nomination would skip the inline secret/private check yet
+  // still be swept async — voiding this gate's guarantee. Accept both.
+  const nominated =
+    metadata.share_candidate === true || metadata.share_candidate === "true";
+  if (!nominated) {
+    return { metadata, rejected: null };
+  }
+  const decision = classifyShareCandidate({
+    event_type: eventType,
+    importance,
+    content,
+    metadata,
+  });
+  if (decision === "reject-secret" || decision === "reject-private") {
+    // Strip the nomination so the async promoter never sweeps it. Stamp a
+    // marker for auditability; the event content itself is untouched.
+    const { share_candidate: _drop, ...rest } = metadata;
+    return {
+      metadata: { ...rest, share_rejected_sync: decision },
+      rejected: decision,
+    };
+  }
+  return { metadata, rejected: null };
+}
 
 export function registerAppendSessionEvent(
   server: McpServer,
@@ -157,6 +214,25 @@ export function registerAppendSessionEvent(
 
         const laneId = laneRows[0].id;
 
+        // Hybrid sync gate: a share_candidate nomination carrying a secret or
+        // person-private content is rejected inline (cheap, no embedding) and
+        // its nomination stripped before persist, so the async promoter never
+        // sees it. Worthiness/dedup/promote remain async.
+        const nomination = adjudicateNominationSync(
+          args.event_type,
+          importance,
+          args.content,
+          args.metadata ?? {},
+        );
+        if (nomination.rejected) {
+          logger.warn("append_session_event_share_rejected", {
+            session_key: args.session_key,
+            namespace: ns,
+            decision: nomination.rejected,
+            clientId: auth.clientId,
+          });
+        }
+
         // Generate embedding (non-fatal)
         let embedding: number[] | null = null;
         try {
@@ -187,7 +263,7 @@ export function registerAppendSessionEvent(
             args.source ?? null,
             args.artifact_path ?? null,
             importance,
-            JSON.stringify(args.metadata ?? {}),
+            JSON.stringify(nomination.metadata),
             embeddingVal,
             hash,
             embeddedAt,
@@ -217,6 +293,11 @@ export function registerAppendSessionEvent(
           event_type: args.event_type,
           importance,
           created_at: rows[0].created_at,
+          // Surface the sync nomination outcome so a contract-driven agent
+          // learns its share_candidate was refused (and why) without polling.
+          ...(nomination.rejected
+            ? { share_candidate_rejected: nomination.rejected }
+            : {}),
         };
 
         logger.info("append_session_event_ok", {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -43,6 +43,7 @@ import { registerPromoteEntry } from "./promote-entry.ts";
 import { registerDemoteEntry } from "./demote-entry.ts";
 import { registerScanNamespace } from "./scan-namespace.ts";
 import { registerTierLane } from "./tier-lane.ts";
+import { registerPromoteShared } from "./promote-shared.ts";
 import { registerGetContract } from "./get-contract.ts";
 import { registerListRepoFacts, registerUpsertRepoFact } from "./repo-facts.ts";
 
@@ -94,6 +95,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerDemoteEntry(server, deps);
   registerScanNamespace(server, deps);
   registerTierLane(server, deps);
+  registerPromoteShared(server, deps);
   registerGetContract(server, deps);
   registerUpsertRepoFact(server, deps);
   registerListRepoFacts(server, deps);

--- a/src/tools/promote-shared.ts
+++ b/src/tools/promote-shared.ts
@@ -1,0 +1,193 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { isPromoterIdentity } from "../namespace-policy.ts";
+import { promoteEntry } from "../promotion-service.ts";
+import { sharedNamespaceConfig } from "../shared-namespace.ts";
+import { classifyShareCandidate } from "../sharing.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+/** Build the classifier content string for a source row. */
+function shareContent(table: Table, row: Record<string, unknown>): string {
+  if (table === "decisions") {
+    const title = (row.title as string | null) ?? "";
+    const rationale = (row.rationale as string | null) ?? "";
+    return `${title} ${rationale}`.trim();
+  }
+  return (row.content as string | null) ?? "";
+}
+
+/**
+ * On-demand shared-kb promotion (Issue #161). A promoter or admin identity
+ * promotes a single own-namespace thought/decision into shared truth, AFTER a
+ * shared-worthiness classification that hard-refuses secrets and person-private
+ * content even when a promoter explicitly asks.
+ *
+ * Defense in depth: the tool gates on isPromoterIdentity OR admin at the entry
+ * point, then promoteEntry re-checks canWriteNamespace server-side.
+ */
+export function registerPromoteShared(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "promote_shared",
+    {
+      description:
+        "Promote a single own-namespace thought or decision into the shared-kb " +
+        "namespace (shared truth). Requires the promoter or admin identity. " +
+        "Classifies the entry first and REFUSES secrets or person-private " +
+        "content. Dry-run by default.",
+      inputSchema: {
+        table: z
+          .enum(["thoughts", "decisions"])
+          .describe("Source table holding the entry to promote"),
+        id: z.string().uuid().describe("Source entry id"),
+        reason: z
+          .string()
+          .min(1)
+          .max(2000)
+          .optional()
+          .describe("Why this entry is being promoted to shared truth"),
+        dry_run: z
+          .boolean()
+          .optional()
+          .describe("Preview without writing to shared-kb (default true)"),
+      },
+      annotations: {
+        title: "Promote To Shared KB",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      // AUTH gate (defense in depth): only a promoter identity or admin may even
+      // attempt a shared-kb promotion. A normal agent token is refused here
+      // before any DB read, independent of promoteEntry's own re-check.
+      if (!auth || !(isPromoterIdentity(auth) || auth.role === "admin")) {
+        logger.warn("promote_shared_denied", {
+          role: auth?.role,
+          clientId: auth?.clientId,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: shared-kb promotion requires the promoter or admin identity",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const table = args.table as Table;
+      const dryRun = args.dry_run ?? true;
+      const targetNamespace = sharedNamespaceConfig().canonicalSharedNamespace;
+
+      try {
+        // Read the source content for classification, scoped to what the caller
+        // can read. promoteEntry re-reads with its own namespace predicate, but
+        // we need the content here to run the shared-worthiness gate first.
+        // Column shape differs by table: thoughts has `content`; decisions has
+        // `title`/`rationale` (and no `content` column). `table` is a validated
+        // Zod enum, so this branch is a safe allowlist, not interpolation risk.
+        const contentColumns =
+          table === "decisions" ? "title, rationale" : "content";
+        const { rows } = await deps.pool.query(
+          `SELECT id, ${contentColumns}, tags, extracted_metadata
+           FROM ${table}
+           WHERE id = $1 AND archived_at IS NULL`,
+          [args.id],
+        );
+        if (rows.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Source entry not found or archived",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const row = rows[0] as Record<string, unknown>;
+        const decision = classifyShareCandidate({
+          content: shareContent(table, row),
+          tags: (row.tags as string[] | null) ?? undefined,
+          metadata:
+            (row.extracted_metadata as Record<string, unknown> | null) ??
+            undefined,
+        });
+
+        // Secret / private content must NEVER reach shared truth — refuse even
+        // when an authorized promoter explicitly requests the promotion.
+        if (decision === "reject-secret" || decision === "reject-private") {
+          logger.warn("promote_shared_refused", {
+            table,
+            id: args.id,
+            decision,
+            clientId: auth.clientId,
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Refused: entry classified as ${decision} and cannot be promoted to shared truth`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const result = await promoteEntry(
+          deps.pool,
+          table,
+          args.id,
+          targetNamespace,
+          args.reason,
+          auth,
+          { dryRun },
+        );
+
+        logger.info("promote_shared_ok", {
+          table,
+          id: args.id,
+          status: result.status,
+          decision,
+          dry_run: dryRun,
+          actor: auth.tokenClientId ?? auth.clientId,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ classification: decision, ...result }),
+            },
+          ],
+        };
+      } catch (err) {
+        const statusCode = (err as { statusCode?: number }).statusCode;
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn("promote_shared_error", {
+          table,
+          id: args.id,
+          statusCode,
+          error: message,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                statusCode && statusCode < 500
+                  ? `Permission denied: ${message}`
+                  : `Promotion failed: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/repo-facts.ts
+++ b/src/tools/repo-facts.ts
@@ -164,24 +164,120 @@ export const repoFactMetadata = z
 type RepoFactMetadata = z.infer<typeof repoFactMetadata>;
 
 export const REPO_FACT_METADATA_CONTRACT = {
-  source_system: { type: "literal", value: "qmd", required: true },
-  repo: { type: "string", required: true, maxLength: 300 },
-  collection: { type: "string", required: true, maxLength: 300 },
-  path: { type: "string", required: true, maxLength: 1000 },
-  symbol: { type: "string", required: "symbol_or_subject", maxLength: 300 },
-  subject: { type: "string", required: "symbol_or_subject", maxLength: 500 },
-  fact_type: { type: "enum", required: true, values: FACT_TYPES },
-  fact: { type: "string", required: true, maxLength: 2000 },
-  source_commit: { type: "git_sha", required: true },
-  source_url: { type: "https_github_url", required: true },
-  verified_at: { type: "datetime_not_future", required: true },
-  confidence: { type: "number", min: 0, max: 1, default: 1 },
+  source_system: {
+    type: "literal",
+    value: "qmd",
+    required: true,
+    description:
+      'Provenance marker; must be the literal "qmd". Repo facts are only ' +
+      "accepted from the qmd derivation pipeline.",
+  },
+  repo: {
+    type: "string",
+    required: true,
+    maxLength: 300,
+    description:
+      "Repository slug this fact is about (e.g. owner/repo). Must match the " +
+      "repo segment of source_url.",
+  },
+  collection: {
+    type: "string",
+    required: true,
+    maxLength: 300,
+    description:
+      "qmd collection the fact was derived from. Groups facts by their " +
+      "source index.",
+  },
+  path: {
+    type: "string",
+    required: true,
+    maxLength: 1000,
+    description:
+      "Repo-relative file path the fact concerns. Must exactly match the " +
+      "path encoded in source_url (suffix matches are rejected).",
+  },
+  symbol: {
+    type: "string",
+    required: "symbol_or_subject",
+    maxLength: 300,
+    description:
+      "The code symbol (function/class/const) the fact is about. Provide " +
+      "either symbol OR subject — use symbol when the fact targets a specific " +
+      "named identifier.",
+  },
+  subject: {
+    type: "string",
+    required: "symbol_or_subject",
+    maxLength: 500,
+    description:
+      "Human-readable subject when the fact is not about one named symbol. " +
+      "Provide either subject OR symbol — use subject for file- or " +
+      "concept-level facts.",
+  },
+  fact_type: {
+    type: "enum",
+    required: true,
+    values: FACT_TYPES,
+    description:
+      "Category of fact, used for filtering on read. Pick the value that best " +
+      "classifies what this fact asserts.",
+  },
+  fact: {
+    type: "string",
+    required: true,
+    maxLength: 2000,
+    description:
+      "The fact itself, as prose (max ~6 lines). State the durable truth " +
+      "plainly. Do NOT paste raw code chunks or any credential-like material — " +
+      "those are rejected.",
+  },
+  source_commit: {
+    type: "git_sha",
+    required: true,
+    description:
+      "Git SHA the fact was verified against. Must appear as a path segment " +
+      "in source_url so the citation is pinned to an exact commit.",
+  },
+  source_url: {
+    type: "https_github_url",
+    required: true,
+    description:
+      "HTTPS GitHub URL (github.com or raw.githubusercontent.com) proving the " +
+      "fact, pinned to source_commit and the exact path. No credentials or " +
+      "private hosts; the repo/commit/path must match the other fields.",
+  },
+  verified_at: {
+    type: "datetime_not_future",
+    required: true,
+    description:
+      "ISO timestamp when the fact was verified against source_commit. Must " +
+      "not be in the future; drives staleness evaluation.",
+  },
+  confidence: {
+    type: "number",
+    min: 0,
+    max: 1,
+    default: 1,
+    description:
+      "How confident you are in the fact, 0-1 (default 1). Lower it for " +
+      "inferred or uncertain facts so consumers can weight accordingly.",
+  },
   staleness_policy: {
     type: "enum",
     required: true,
     values: STALENESS_POLICIES,
+    description:
+      "How this fact should be treated as the repo evolves — controls when it " +
+      "is considered out of date and in need of re-verification.",
   },
-  refresh_hint: { type: "string", required: false, maxLength: 1000 },
+  refresh_hint: {
+    type: "string",
+    required: false,
+    maxLength: 1000,
+    description:
+      "Optional note on how/when to re-verify this fact (e.g. what to re-run " +
+      "or watch). Helps a future agent refresh it efficiently.",
+  },
 } as const;
 
 export const REPO_FACT_VALIDATION_CONTRACT = {

--- a/src/tools/table-constants.ts
+++ b/src/tools/table-constants.ts
@@ -70,7 +70,8 @@ export const TABLE_ALIAS: Record<Table, string> = {
 /**
  * All valid link relation types for the entity graph.
  * Keep in sync with CHECK (relation IN (...)) in 010_entity_links.sql
- * and LinkRelation type in ../types.ts.
+ * (extended by 018_link_relation_supplements.sql) and LinkRelation type in
+ * ../types.ts.
  */
 export const LINK_RELATIONS = [
   "artifact",
@@ -86,4 +87,5 @@ export const LINK_RELATIONS = [
   "relates_to",
   "contradicts",
   "duplicates",
+  "supplements",
 ] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,8 @@ export type LinkRelation =
   | "decided_by"
   | "relates_to"
   | "contradicts"
-  | "duplicates";
+  | "duplicates"
+  | "supplements";
 export type Tier = "hot" | "warm" | "cold";
 export type Permission = "read" | "write" | "delete";
 


### PR DESCRIPTION
## Summary

Implements #161 — lane→shared-kb promotion, the high-trust half of the memory pipeline. Memories are promoted into `shared-kb` as the **promoter identity** (from #159); normal agents are rejected from shared-write. Agents **nominate** via a `metadata.share_candidate` flag (set on their normal lifecycle write); a promoter process **applies**.

- `src/sharing.ts`: shared-worthiness classifier (pure). Security-first precedence — **reject-secret** (15 patterns ported from Python `policy.py`: AWS keys, JWT, Slack/Google/GitHub tokens, bearer headers, PEM blocks) checked FIRST so a secret can never reach shared truth; then reject-private, reject-noise, share, manual-review.
- `scripts/promote-lane-shared.ts`: promoter-identity background cron sweeping `thoughts`/`decisions` AND `ob_session_events` for `metadata.share_candidate='true'`, classifying, promoting survivors (promoteEntry for table entries; provenance-matched event→shared-kb insert for lane events), clearing the nomination, idempotent.
- `src/tools/promote-shared.ts`: on-demand MCP tool, promoter/admin-gated; normal agent rejected; refuses secret/private even for a promoter.
- `src/contract.ts`: document the `share_candidate` field (discoverable via `get_contract`, since downstream rtech-hermes builds its surface from the contract); bump `CONTRACT_VERSION` → `2026-06-19.memory-tools.v3`; Python `CURRENT_CONTRACT_VERSION` synced so the #157 parity drift-guard stays green.

## Architecture note

Promotion is a **centralized background job running as the promoter token**, NOT agent-real-time. Agents can't write shared truth directly (the #159 gate); they nominate by setting a metadata field on the write they already make, and the cron applies. This keeps shared truth single-audited and the agent's surface read-only. No Python promotion wrapper — the agent never promotes.

## Validation

- `bunx tsc --noEmit` clean; TS full suite 932 pass / 0 fail. Python ruff/mypy clean; parity test green with the bumped version.
- **Live-Postgres integration: 10/10 pass** — agent rejected, secret/private refused, promoter promotes with provenance, idempotent. The live run caught and fixed a real bug: the tool's source SELECT pulled `title` (a decisions column) for `thoughts`, which has no `title` — a mock could not surface it.

## Critical Self-Review

- Highest-risk behavior: A secret or person-private value reaching shared truth (the worst failure in the system). Mitigated by reject-secret being checked FIRST in the classifier, the tool refusing secret/private even for an authorized promoter (before any write), 28 classifier tests incl. realistic-fake secret fixtures, and the live-DB gate test. `containsSecret` is conservative (false negatives are the dangerous direction).
- Assumptions that could be wrong: That the ported secret patterns are complete — they mirror the Python policy.py set exactly; if that set has gaps, so does this. That `{fact,decision,handoff}` + non-cold is the right share allowlist (encoded, tested, adjustable).
- Missing/weak tests: The background cron script's full loop isn't separately live-tested (its component functions — classifier, promoteEntry, event insert — are covered via the tool's live tests and unit tests). The nomination-clearing SQL is covered by the live idempotency test.
- Security/permission risk: THIS is the security PR. Gate verified live: normal agent rejected before any DB read; plain admin passes the tool entry but the shared-kb write boundary still refuses (only a promoter identity writes shared-kb per #159); promoter/admin-as-promoter allowed. Defense in depth (tool gate + promoteEntry's canWriteNamespace).
- Migration/deploy risk: No schema change. The cron requires `AUTH_TOKEN_PROMOTER` provisioned on the host before it can run live (the #159 follow-up). Contract version bump is coordinated TS+Python so the parity guard stays green.
- Downstream client/runtime risk: Contract version bumped to v3 — the parity drift-guard (#157) is the enforcement and is green. The `share_candidate` field is additive (optional metadata). rtech-hermes (which builds its surface from get_contract) will see the documented field; the plugin setting it is separate rtech-hermes work.
- Rollback/cleanup concern: Additive (new script + tool + classifier). Revertible. Contract version revert would need the Python sync reverted too.
- Fixes made before PR: removed an unused `Table` import (lint); fixed the thoughts-table SELECT column bug found by the live-DB test.
- Known residual risk: The promoter token isn't provisioned on the host yet, so the cron can't run live until it is (code/tests don't need it). The classifier's private-detection is heuristic (metadata/tag based) — content that is private but unmarked could pass; secrets are caught by pattern regardless.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: reuses the DB-backed-test discipline already captured in docs/sme/correctness.md; no new reviewer-lane pattern emerged.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live checks: DB-backed integration tests pass against hosted OB Postgres (10/10), covering the promoter gate, secret/private refusal, shared-kb landing with provenance, and idempotency.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Contract version bump (v3) + the new `share_candidate` field are the contract-side of the rtech-hermes contract-driven plugin work. rtech-hermes items unchecked: the plugin must (a) set `share_candidate` on its internal lifecycle writes when content is shared-worthy, and (b) pick up the v3 contract — owner-driven, separate repo. The promoter cron also needs `AUTH_TOKEN_PROMOTER` provisioned before live operation.
