### PR TITLE
feat: add Open Brain contract validation helper

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -16,6 +16,7 @@ from .client import (
     OpenBrainProtocolError,
     OpenBrainToolError,
 )
+from .contract import ContractValidationResult, validate_contract_manifest
 from .dream import DreamAction, DreamClient, DreamEngine, DreamPolicy, DreamRun
 from .policy import RetryExhaustedError, RetryPolicy, redact_text, redact_value
 from .spool import JsonlSpool, SpoolRecord, replay_records
@@ -40,6 +41,7 @@ __all__ = [
     "CURRENT_CONTRACT_VERSION",
     "CURRENT_TOOL_HELP",
     "REQUIRED_CONTRACT_TOOLS",
+    "ContractValidationResult",
     "JsonlSpool",
     "RetryExhaustedError",
     "RetryPolicy",
@@ -47,4 +49,5 @@ __all__ = [
     "redact_text",
     "redact_value",
     "replay_records",
+    "validate_contract_manifest",
 ]

--- a/python/openbrain-memory/src/openbrain_memory/contract.py
+++ b/python/openbrain-memory/src/openbrain_memory/contract.py
@@ -8,10 +8,9 @@ from typing import Any
 EXPECTED_CONTRACT_SCOPE = "required_openbrain_memory_contract"
 DEFAULT_CLIENT_NAME = "openbrain-memory"
 
-_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$")
-_RANGE_RE = re.compile(
-    r"(>=|>|<=|<|=)?\s*([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)",
-)
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+_RANGE_TOKEN_RE = re.compile(r"(>=|>|<=|<|=)?\s*([0-9]+\.[0-9]+\.[0-9]+)")
+_DISPLAY_MAX_LENGTH = 80
 
 
 @dataclass(frozen=True)
@@ -51,9 +50,10 @@ def validate_contract_manifest(
     elif compatible_contract_versions:
         compatible_versions = tuple(compatible_contract_versions)
         if contract_version not in compatible_versions:
-            expected = ", ".join(repr(item) for item in compatible_versions)
+            expected = ", ".join(_display_value(item) for item in compatible_versions)
             reasons.append(
-                f"contract_version {contract_version!r} is not compatible; "
+                "contract_version "
+                f"{_display_value(contract_version)} is not compatible; "
                 f"expected one of: {expected}",
             )
 
@@ -82,14 +82,65 @@ def _validate_required_tools(
     if not required_tools:
         return
 
+    required_tool_set = set(required_tools)
     capability_tools = _capability_tool_names(manifest.get("capabilities"))
-    tool_contract_tools = _tool_contract_names(manifest.get("tool_contracts"))
-    available_tools = capability_tools | tool_contract_tools
-    missing_tools = sorted(set(required_tools) - available_tools)
-    if missing_tools:
+    missing_capabilities = sorted(required_tool_set - capability_tools)
+    if missing_capabilities:
         reasons.append(
-            "required tool(s) missing from contract capabilities/tool_contracts: "
-            + ", ".join(missing_tools),
+            "required tool(s) missing from contract capabilities: "
+            + ", ".join(missing_capabilities),
+        )
+
+    tool_contracts = manifest.get("tool_contracts")
+    if not isinstance(tool_contracts, Mapping):
+        reasons.append("tool_contracts is missing or not a mapping")
+        return
+
+    missing_contracts = sorted(
+        required_tool_set - set(_tool_contract_names(tool_contracts)),
+    )
+    if missing_contracts:
+        reasons.append(
+            "required tool(s) missing from tool_contracts: "
+            + ", ".join(missing_contracts),
+        )
+
+    for tool_name in required_tools:
+        if tool_name in tool_contracts:
+            _validate_tool_contract_entry(
+                tool_name,
+                tool_contracts[tool_name],
+                reasons=reasons,
+            )
+
+
+def _validate_tool_contract_entry(
+    tool_name: str,
+    value: Any,
+    *,
+    reasons: list[str],
+) -> None:
+    if not isinstance(value, Mapping):
+        reasons.append(f"tool_contracts[{tool_name!r}] must be a mapping")
+        return
+
+    version = value.get("version")
+    if version is None or version == "":
+        reasons.append(f"tool_contracts[{tool_name!r}].version is missing or empty")
+
+    input_schema = value.get("input_schema")
+    if not isinstance(input_schema, Mapping):
+        reasons.append(f"tool_contracts[{tool_name!r}].input_schema must be a mapping")
+
+    output_shape = value.get("output_shape")
+    output_schema = value.get("output_schema")
+    if not (
+        (isinstance(output_shape, str) and output_shape.strip())
+        or isinstance(output_schema, Mapping)
+    ):
+        reasons.append(
+            f"tool_contracts[{tool_name!r}] must define a non-empty output_shape "
+            "or output_schema mapping",
         )
 
 
@@ -113,7 +164,12 @@ def _validate_client_version(
             reasons.append("min_client_versions is present but is not a mapping")
         else:
             min_version = min_versions.get(client_name)
-            if min_version is not None:
+            if min_version is None:
+                reasons.append(
+                    "min_client_versions is present but has no entry for "
+                    f"{client_name!r}",
+                )
+            else:
                 if not isinstance(min_version, str):
                     reasons.append(
                         f"min_client_versions[{client_name!r}] is not a string",
@@ -122,13 +178,14 @@ def _validate_client_version(
                     parsed_min_version = _parse_version(min_version)
                     if parsed_min_version is None:
                         reasons.append(
-                            f"min_client_versions[{client_name!r}]={min_version!r} "
+                            f"min_client_versions[{client_name!r}]="
+                            f"{_display_value(min_version)} "
                             "is not a supported semver version",
                         )
                     elif parsed_client_version < parsed_min_version:
                         reasons.append(
-                            f"{client_name} {client_version} is below required "
-                            f"minimum {min_version}",
+                            f"{client_name} {_display_value(client_version)} is below "
+                            f"required minimum {_display_value(min_version)}",
                         )
 
     compatible_ranges = manifest.get("compatible_client_ranges")
@@ -140,14 +197,17 @@ def _validate_client_version(
 
     compatible_range = compatible_ranges.get(client_name)
     if compatible_range is None:
+        reasons.append(
+            f"compatible_client_ranges is present but has no entry for {client_name!r}",
+        )
         return
     if not isinstance(compatible_range, str):
         reasons.append(f"compatible_client_ranges[{client_name!r}] is not a string")
         return
     if not _version_satisfies_range(client_version, compatible_range):
         reasons.append(
-            f"{client_name} {client_version} does not satisfy compatible range "
-            f"{compatible_range!r}",
+            f"{client_name} {_display_value(client_version)} does not satisfy "
+            f"compatible range {_display_value(compatible_range)}",
         )
 
 
@@ -176,7 +236,7 @@ def _version_satisfies_range(version: str, range_text: str) -> bool:
     if parsed_version is None:
         return False
 
-    constraints = _RANGE_RE.findall(range_text)
+    constraints = _parse_range_constraints(range_text)
     if not constraints:
         return False
 
@@ -198,6 +258,25 @@ def _version_satisfies_range(version: str, range_text: str) -> bool:
     return True
 
 
+def _parse_range_constraints(range_text: str) -> tuple[tuple[str, str], ...]:
+    constraints: list[tuple[str, str]] = []
+    position = 0
+    while position < len(range_text):
+        while position < len(range_text) and range_text[position].isspace():
+            position += 1
+        if position >= len(range_text):
+            break
+        match = _RANGE_TOKEN_RE.match(range_text, position)
+        if not match:
+            return ()
+        operator, constraint_version = match.groups()
+        position = match.end()
+        if position < len(range_text) and not range_text[position].isspace():
+            return ()
+        constraints.append((operator or "=", constraint_version))
+    return tuple(constraints)
+
+
 def _parse_version(version: str) -> tuple[int, int, int] | None:
     match = _VERSION_RE.match(version.strip())
     if not match:
@@ -208,5 +287,9 @@ def _parse_version(version: str) -> tuple[int, int, int] | None:
 
 def _display_value(value: Any) -> str:
     if isinstance(value, str):
-        return repr(value)
-    return f"{type(value).__name__}({value!r})"
+        display = value
+    else:
+        display = f"{type(value).__name__}"
+    if len(display) > _DISPLAY_MAX_LENGTH:
+        display = display[: _DISPLAY_MAX_LENGTH - 3] + "..."
+    return repr(display)

--- a/python/openbrain-memory/src/openbrain_memory/contract.py
+++ b/python/openbrain-memory/src/openbrain_memory/contract.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+EXPECTED_CONTRACT_SCOPE = "required_openbrain_memory_contract"
+DEFAULT_CLIENT_NAME = "openbrain-memory"
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$")
+_RANGE_RE = re.compile(
+    r"(>=|>|<=|<|=)?\s*([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)",
+)
+
+
+@dataclass(frozen=True)
+class ContractValidationResult:
+    ok: bool
+    reasons: tuple[str, ...]
+
+
+def validate_contract_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    client_name: str = DEFAULT_CLIENT_NAME,
+    client_version: str | None = None,
+    required_tools: Iterable[str] = (),
+    expected_scope: str = EXPECTED_CONTRACT_SCOPE,
+    compatible_contract_versions: Iterable[str] = (),
+) -> ContractValidationResult:
+    """Validate a live Open Brain contract manifest without network access."""
+
+    reasons: list[str] = []
+    if not isinstance(manifest, Mapping):
+        return ContractValidationResult(
+            ok=False,
+            reasons=("contract manifest must be a mapping",),
+        )
+
+    scope = manifest.get("contract_scope")
+    if scope != expected_scope:
+        reasons.append(
+            "contract_scope mismatch: "
+            f"expected {expected_scope!r}, got {_display_value(scope)}",
+        )
+
+    contract_version = manifest.get("contract_version")
+    if not isinstance(contract_version, str) or not contract_version:
+        reasons.append("contract_version is missing or not a non-empty string")
+    elif compatible_contract_versions:
+        compatible_versions = tuple(compatible_contract_versions)
+        if contract_version not in compatible_versions:
+            expected = ", ".join(repr(item) for item in compatible_versions)
+            reasons.append(
+                f"contract_version {contract_version!r} is not compatible; "
+                f"expected one of: {expected}",
+            )
+
+    _validate_required_tools(
+        manifest,
+        required_tools=tuple(required_tools),
+        reasons=reasons,
+    )
+    if client_version is not None:
+        _validate_client_version(
+            manifest,
+            client_name=client_name,
+            client_version=client_version,
+            reasons=reasons,
+        )
+
+    return ContractValidationResult(ok=not reasons, reasons=tuple(reasons))
+
+
+def _validate_required_tools(
+    manifest: Mapping[str, Any],
+    *,
+    required_tools: Sequence[str],
+    reasons: list[str],
+) -> None:
+    if not required_tools:
+        return
+
+    capability_tools = _capability_tool_names(manifest.get("capabilities"))
+    tool_contract_tools = _tool_contract_names(manifest.get("tool_contracts"))
+    available_tools = capability_tools | tool_contract_tools
+    missing_tools = sorted(set(required_tools) - available_tools)
+    if missing_tools:
+        reasons.append(
+            "required tool(s) missing from contract capabilities/tool_contracts: "
+            + ", ".join(missing_tools),
+        )
+
+
+def _validate_client_version(
+    manifest: Mapping[str, Any],
+    *,
+    client_name: str,
+    client_version: str,
+    reasons: list[str],
+) -> None:
+    parsed_client_version = _parse_version(client_version)
+    if parsed_client_version is None:
+        reasons.append(
+            f"client_version {client_version!r} is not a supported semver version",
+        )
+        return
+
+    min_versions = manifest.get("min_client_versions")
+    if min_versions is not None:
+        if not isinstance(min_versions, Mapping):
+            reasons.append("min_client_versions is present but is not a mapping")
+        else:
+            min_version = min_versions.get(client_name)
+            if min_version is not None:
+                if not isinstance(min_version, str):
+                    reasons.append(
+                        f"min_client_versions[{client_name!r}] is not a string",
+                    )
+                else:
+                    parsed_min_version = _parse_version(min_version)
+                    if parsed_min_version is None:
+                        reasons.append(
+                            f"min_client_versions[{client_name!r}]={min_version!r} "
+                            "is not a supported semver version",
+                        )
+                    elif parsed_client_version < parsed_min_version:
+                        reasons.append(
+                            f"{client_name} {client_version} is below required "
+                            f"minimum {min_version}",
+                        )
+
+    compatible_ranges = manifest.get("compatible_client_ranges")
+    if compatible_ranges is None:
+        return
+    if not isinstance(compatible_ranges, Mapping):
+        reasons.append("compatible_client_ranges is present but is not a mapping")
+        return
+
+    compatible_range = compatible_ranges.get(client_name)
+    if compatible_range is None:
+        return
+    if not isinstance(compatible_range, str):
+        reasons.append(f"compatible_client_ranges[{client_name!r}] is not a string")
+        return
+    if not _version_satisfies_range(client_version, compatible_range):
+        reasons.append(
+            f"{client_name} {client_version} does not satisfy compatible range "
+            f"{compatible_range!r}",
+        )
+
+
+def _capability_tool_names(value: Any) -> set[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return set()
+    names: set[str] = set()
+    for capability in value:
+        if (
+            isinstance(capability, Mapping)
+            and capability.get("kind") == "tool"
+            and isinstance(capability.get("name"), str)
+        ):
+            names.add(capability["name"])
+    return names
+
+
+def _tool_contract_names(value: Any) -> set[str]:
+    if not isinstance(value, Mapping):
+        return set()
+    return {key for key in value if isinstance(key, str)}
+
+
+def _version_satisfies_range(version: str, range_text: str) -> bool:
+    parsed_version = _parse_version(version)
+    if parsed_version is None:
+        return False
+
+    constraints = _RANGE_RE.findall(range_text)
+    if not constraints:
+        return False
+
+    for operator, constraint_version in constraints:
+        parsed_constraint = _parse_version(constraint_version)
+        if parsed_constraint is None:
+            return False
+        op = operator or "="
+        if op == ">=" and parsed_version < parsed_constraint:
+            return False
+        if op == ">" and parsed_version <= parsed_constraint:
+            return False
+        if op == "<=" and parsed_version > parsed_constraint:
+            return False
+        if op == "<" and parsed_version >= parsed_constraint:
+            return False
+        if op == "=" and parsed_version != parsed_constraint:
+            return False
+    return True
+
+
+def _parse_version(version: str) -> tuple[int, int, int] | None:
+    match = _VERSION_RE.match(version.strip())
+    if not match:
+        return None
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def _display_value(value: Any) -> str:
+    if isinstance(value, str):
+        return repr(value)
+    return f"{type(value).__name__}({value!r})"

--- a/python/openbrain-memory/src/openbrain_memory/contract.py
+++ b/python/openbrain-memory/src/openbrain_memory/contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from hashlib import sha256
 from typing import Any
 
 EXPECTED_CONTRACT_SCOPE = "required_openbrain_memory_contract"
@@ -10,7 +11,7 @@ DEFAULT_CLIENT_NAME = "openbrain-memory"
 
 _VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 _RANGE_TOKEN_RE = re.compile(r"(>=|>|<=|<|=)?\s*([0-9]+\.[0-9]+\.[0-9]+)")
-_DISPLAY_MAX_LENGTH = 80
+_DISPLAY_DIGEST_LENGTH = 12
 
 
 @dataclass(frozen=True)
@@ -287,9 +288,7 @@ def _parse_version(version: str) -> tuple[int, int, int] | None:
 
 def _display_value(value: Any) -> str:
     if isinstance(value, str):
-        display = value
+        digest = sha256(value.encode("utf-8")).hexdigest()[:_DISPLAY_DIGEST_LENGTH]
+        return f"str(len={len(value)}, sha256={digest})"
     else:
-        display = f"{type(value).__name__}"
-    if len(display) > _DISPLAY_MAX_LENGTH:
-        display = display[: _DISPLAY_MAX_LENGTH - 3] + "..."
-    return repr(display)
+        return repr(type(value).__name__)

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from openbrain_memory import (
+    CURRENT_CONTRACT_VERSION,
+    REQUIRED_CONTRACT_TOOLS,
+    validate_contract_manifest,
+)
+
+
+def live_shaped_manifest() -> dict:
+    return {
+        "service": "open-brain",
+        "contract_version": CURRENT_CONTRACT_VERSION,
+        "contract_scope": "required_openbrain_memory_contract",
+        "schema_version": 1,
+        "schema_hash": "abc123",
+        "generated_at": "2026-06-19T00:00:00.000Z",
+        "min_client_versions": {
+            "openbrain-memory": "0.1.0",
+            "rtech-hermes-runtime": "0.1.0",
+        },
+        "compatible_client_ranges": {
+            "openbrain-memory": ">=0.1.0 <1.0.0",
+            "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
+        },
+        "transport": {
+            "mcp": "streamable-http",
+            "auth": "bearer",
+            "namespace_boundary": "authorization",
+            "session_required": True,
+        },
+        "capabilities": [
+            {
+                "name": tool_name,
+                "version": 1,
+                "kind": "tool",
+                "description": f"{tool_name} helper",
+            }
+            for tool_name in REQUIRED_CONTRACT_TOOLS
+        ],
+        "tool_contracts": {
+            tool_name: {
+                "version": 1,
+                "input_schema": {"type": "object"},
+                "output_shape": "object",
+            }
+            for tool_name in REQUIRED_CONTRACT_TOOLS
+        },
+    }
+
+
+def test_validate_contract_manifest_accepts_live_get_contract_shape():
+    result = validate_contract_manifest(
+        live_shaped_manifest(),
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is True
+    assert result.reasons == ()
+
+
+def test_validate_contract_manifest_reports_missing_required_tool():
+    manifest = live_shaped_manifest()
+    manifest["capabilities"] = [
+        item for item in manifest["capabilities"] if item["name"] != "search_all"
+    ]
+    del manifest["tool_contracts"]["search_all"]
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is False
+    assert result.reasons == (
+        "required tool(s) missing from contract capabilities/tool_contracts: "
+        "search_all",
+    )
+
+
+def test_validate_contract_manifest_reports_scope_and_contract_version_mismatch():
+    manifest = live_shaped_manifest()
+    manifest["contract_scope"] = "optional_tool_listing"
+    manifest["contract_version"] = "2026-01-01.memory-tools.v1"
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is False
+    assert result.reasons == (
+        "contract_scope mismatch: expected "
+        "'required_openbrain_memory_contract', got 'optional_tool_listing'",
+        "contract_version '2026-01-01.memory-tools.v1' is not compatible; "
+        f"expected one of: {CURRENT_CONTRACT_VERSION!r}",
+    )
+
+
+def test_validate_contract_manifest_reports_min_client_version_failure():
+    manifest = live_shaped_manifest()
+
+    result = validate_contract_manifest(manifest, client_version="0.0.9")
+
+    assert result.ok is False
+    assert result.reasons == (
+        "openbrain-memory 0.0.9 is below required minimum 0.1.0",
+        "openbrain-memory 0.0.9 does not satisfy compatible range '>=0.1.0 <1.0.0'",
+    )
+
+
+def test_validate_contract_manifest_reports_compatible_range_failure():
+    manifest = live_shaped_manifest()
+
+    result = validate_contract_manifest(manifest, client_version="1.0.0")
+
+    assert result.ok is False
+    assert result.reasons == (
+        "openbrain-memory 1.0.0 does not satisfy compatible range '>=0.1.0 <1.0.0'",
+    )
+
+
+def test_validate_contract_manifest_reports_malformed_client_compatibility_fields():
+    manifest = deepcopy(live_shaped_manifest())
+    manifest["min_client_versions"]["openbrain-memory"] = 1
+    manifest["compatible_client_ranges"]["openbrain-memory"] = []
+
+    result = validate_contract_manifest(manifest, client_version="0.1.0")
+
+    assert result.ok is False
+    assert result.reasons == (
+        "min_client_versions['openbrain-memory'] is not a string",
+        "compatible_client_ranges['openbrain-memory'] is not a string",
+    )
+
+
+def test_validate_contract_manifest_does_not_require_snapshot_constants():
+    manifest = live_shaped_manifest()
+    manifest["contract_version"] = "2026-06-20.memory-tools.v6"
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+    )
+
+    assert result.ok is True
+    assert result.reasons == ()

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -9,7 +9,7 @@ from openbrain_memory import (
 )
 
 
-def live_shaped_manifest() -> dict:
+def representative_contract_manifest() -> dict:
     return {
         "service": "open-brain",
         "contract_version": CURRENT_CONTRACT_VERSION,
@@ -51,9 +51,9 @@ def live_shaped_manifest() -> dict:
     }
 
 
-def test_validate_contract_manifest_accepts_live_get_contract_shape():
+def test_validate_contract_manifest_accepts_representative_contract_shape():
     result = validate_contract_manifest(
-        live_shaped_manifest(),
+        representative_contract_manifest(),
         client_version="0.1.0",
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
@@ -64,7 +64,7 @@ def test_validate_contract_manifest_accepts_live_get_contract_shape():
 
 
 def test_validate_contract_manifest_reports_missing_required_tool():
-    manifest = live_shaped_manifest()
+    manifest = representative_contract_manifest()
     manifest["capabilities"] = [
         item for item in manifest["capabilities"] if item["name"] != "search_all"
     ]
@@ -79,13 +79,87 @@ def test_validate_contract_manifest_reports_missing_required_tool():
 
     assert result.ok is False
     assert result.reasons == (
-        "required tool(s) missing from contract capabilities/tool_contracts: "
-        "search_all",
+        "required tool(s) missing from contract capabilities: search_all",
+        "required tool(s) missing from tool_contracts: search_all",
     )
 
 
+def test_validate_contract_manifest_rejects_capability_only_required_tool():
+    manifest = representative_contract_manifest()
+    del manifest["tool_contracts"]["search_all"]
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is False
+    assert result.reasons == (
+        "required tool(s) missing from tool_contracts: search_all",
+    )
+
+
+def test_validate_contract_manifest_rejects_tool_contract_only_required_tool():
+    manifest = representative_contract_manifest()
+    manifest["capabilities"] = [
+        item for item in manifest["capabilities"] if item["name"] != "search_all"
+    ]
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is False
+    assert result.reasons == (
+        "required tool(s) missing from contract capabilities: search_all",
+    )
+
+
+def test_validate_contract_manifest_rejects_malformed_required_tool_contract():
+    manifest = representative_contract_manifest()
+    manifest["tool_contracts"]["search_all"] = {
+        "version": "",
+        "input_schema": "object",
+    }
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is False
+    assert result.reasons == (
+        "tool_contracts['search_all'].version is missing or empty",
+        "tool_contracts['search_all'].input_schema must be a mapping",
+        "tool_contracts['search_all'] must define a non-empty output_shape "
+        "or output_schema mapping",
+    )
+
+
+def test_validate_contract_manifest_rejects_non_mapping_required_tool_contract():
+    manifest = representative_contract_manifest()
+    manifest["tool_contracts"]["search_all"] = []
+
+    result = validate_contract_manifest(
+        manifest,
+        client_version="0.1.0",
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert result.ok is False
+    assert result.reasons == ("tool_contracts['search_all'] must be a mapping",)
+
+
 def test_validate_contract_manifest_reports_scope_and_contract_version_mismatch():
-    manifest = live_shaped_manifest()
+    manifest = representative_contract_manifest()
     manifest["contract_scope"] = "optional_tool_listing"
     manifest["contract_version"] = "2026-01-01.memory-tools.v1"
 
@@ -105,30 +179,30 @@ def test_validate_contract_manifest_reports_scope_and_contract_version_mismatch(
 
 
 def test_validate_contract_manifest_reports_min_client_version_failure():
-    manifest = live_shaped_manifest()
+    manifest = representative_contract_manifest()
 
     result = validate_contract_manifest(manifest, client_version="0.0.9")
 
     assert result.ok is False
     assert result.reasons == (
-        "openbrain-memory 0.0.9 is below required minimum 0.1.0",
-        "openbrain-memory 0.0.9 does not satisfy compatible range '>=0.1.0 <1.0.0'",
+        "openbrain-memory '0.0.9' is below required minimum '0.1.0'",
+        "openbrain-memory '0.0.9' does not satisfy compatible range '>=0.1.0 <1.0.0'",
     )
 
 
 def test_validate_contract_manifest_reports_compatible_range_failure():
-    manifest = live_shaped_manifest()
+    manifest = representative_contract_manifest()
 
     result = validate_contract_manifest(manifest, client_version="1.0.0")
 
     assert result.ok is False
     assert result.reasons == (
-        "openbrain-memory 1.0.0 does not satisfy compatible range '>=0.1.0 <1.0.0'",
+        "openbrain-memory '1.0.0' does not satisfy compatible range '>=0.1.0 <1.0.0'",
     )
 
 
 def test_validate_contract_manifest_reports_malformed_client_compatibility_fields():
-    manifest = deepcopy(live_shaped_manifest())
+    manifest = deepcopy(representative_contract_manifest())
     manifest["min_client_versions"]["openbrain-memory"] = 1
     manifest["compatible_client_ranges"]["openbrain-memory"] = []
 
@@ -141,8 +215,76 @@ def test_validate_contract_manifest_reports_malformed_client_compatibility_field
     )
 
 
+def test_validate_contract_manifest_rejects_malformed_compatible_range_text():
+    manifest = representative_contract_manifest()
+    manifest["compatible_client_ranges"]["openbrain-memory"] = ">=0.1.0 <1.0.0 trailing"
+
+    result = validate_contract_manifest(manifest, client_version="0.1.0")
+
+    assert result.ok is False
+    assert result.reasons == (
+        "openbrain-memory '0.1.0' does not satisfy compatible range "
+        "'>=0.1.0 <1.0.0 trailing'",
+    )
+
+
+def test_validate_contract_manifest_rejects_unsupported_range_operator():
+    manifest = representative_contract_manifest()
+    manifest["compatible_client_ranges"]["openbrain-memory"] = "~>0.1.0"
+
+    result = validate_contract_manifest(manifest, client_version="0.1.0")
+
+    assert result.ok is False
+    assert result.reasons == (
+        "openbrain-memory '0.1.0' does not satisfy compatible range '~>0.1.0'",
+    )
+
+
+def test_validate_contract_manifest_rejects_prerelease_client_version():
+    manifest = representative_contract_manifest()
+
+    result = validate_contract_manifest(manifest, client_version="0.1.0-alpha")
+
+    assert result.ok is False
+    assert result.reasons == (
+        "client_version '0.1.0-alpha' is not a supported semver version",
+    )
+
+
+def test_validate_contract_manifest_fails_closed_for_unknown_client_name():
+    manifest = representative_contract_manifest()
+
+    result = validate_contract_manifest(
+        manifest,
+        client_name="typoed-client",
+        client_version="0.1.0",
+    )
+
+    assert result.ok is False
+    assert result.reasons == (
+        "min_client_versions is present but has no entry for 'typoed-client'",
+        "compatible_client_ranges is present but has no entry for 'typoed-client'",
+    )
+
+
+def test_validate_contract_manifest_redacts_long_manifest_values_in_reasons():
+    manifest = representative_contract_manifest()
+    manifest["contract_scope"] = "evil-" + ("x" * 200)
+    manifest["compatible_client_ranges"]["openbrain-memory"] = ">=0.1.0 " + ("x" * 200)
+
+    result = validate_contract_manifest(manifest, client_version="0.1.0")
+
+    assert result.ok is False
+    assert len(result.reasons) == 2
+    assert "evil-" in result.reasons[0]
+    assert "xxx" in result.reasons[0]
+    assert "..." in result.reasons[0]
+    assert "x" * 100 not in result.reasons[0]
+    assert "x" * 100 not in result.reasons[1]
+
+
 def test_validate_contract_manifest_does_not_require_snapshot_constants():
-    manifest = live_shaped_manifest()
+    manifest = representative_contract_manifest()
     manifest["contract_version"] = "2026-06-20.memory-tools.v6"
 
     result = validate_contract_manifest(

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from hashlib import sha256
 
 from openbrain_memory import (
     CURRENT_CONTRACT_VERSION,
     REQUIRED_CONTRACT_TOOLS,
     validate_contract_manifest,
 )
+
+
+def safe_string_display(value: str) -> str:
+    digest = sha256(value.encode("utf-8")).hexdigest()[:12]
+    return f"str(len={len(value)}, sha256={digest})"
 
 
 def representative_contract_manifest() -> dict:
@@ -172,9 +178,11 @@ def test_validate_contract_manifest_reports_scope_and_contract_version_mismatch(
     assert result.ok is False
     assert result.reasons == (
         "contract_scope mismatch: expected "
-        "'required_openbrain_memory_contract', got 'optional_tool_listing'",
-        "contract_version '2026-01-01.memory-tools.v1' is not compatible; "
-        f"expected one of: {CURRENT_CONTRACT_VERSION!r}",
+        "'required_openbrain_memory_contract', got "
+        f"{safe_string_display('optional_tool_listing')}",
+        "contract_version "
+        f"{safe_string_display('2026-01-01.memory-tools.v1')} is not compatible; "
+        f"expected one of: {safe_string_display(CURRENT_CONTRACT_VERSION)}",
     )
 
 
@@ -185,8 +193,12 @@ def test_validate_contract_manifest_reports_min_client_version_failure():
 
     assert result.ok is False
     assert result.reasons == (
-        "openbrain-memory '0.0.9' is below required minimum '0.1.0'",
-        "openbrain-memory '0.0.9' does not satisfy compatible range '>=0.1.0 <1.0.0'",
+        "openbrain-memory "
+        f"{safe_string_display('0.0.9')} is below required minimum "
+        f"{safe_string_display('0.1.0')}",
+        "openbrain-memory "
+        f"{safe_string_display('0.0.9')} does not satisfy compatible range "
+        f"{safe_string_display('>=0.1.0 <1.0.0')}",
     )
 
 
@@ -197,7 +209,9 @@ def test_validate_contract_manifest_reports_compatible_range_failure():
 
     assert result.ok is False
     assert result.reasons == (
-        "openbrain-memory '1.0.0' does not satisfy compatible range '>=0.1.0 <1.0.0'",
+        "openbrain-memory "
+        f"{safe_string_display('1.0.0')} does not satisfy compatible range "
+        f"{safe_string_display('>=0.1.0 <1.0.0')}",
     )
 
 
@@ -223,8 +237,9 @@ def test_validate_contract_manifest_rejects_malformed_compatible_range_text():
 
     assert result.ok is False
     assert result.reasons == (
-        "openbrain-memory '0.1.0' does not satisfy compatible range "
-        "'>=0.1.0 <1.0.0 trailing'",
+        "openbrain-memory "
+        f"{safe_string_display('0.1.0')} does not satisfy compatible range "
+        f"{safe_string_display('>=0.1.0 <1.0.0 trailing')}",
     )
 
 
@@ -236,7 +251,9 @@ def test_validate_contract_manifest_rejects_unsupported_range_operator():
 
     assert result.ok is False
     assert result.reasons == (
-        "openbrain-memory '0.1.0' does not satisfy compatible range '~>0.1.0'",
+        "openbrain-memory "
+        f"{safe_string_display('0.1.0')} does not satisfy compatible range "
+        f"{safe_string_display('~>0.1.0')}",
     )
 
 
@@ -276,11 +293,39 @@ def test_validate_contract_manifest_redacts_long_manifest_values_in_reasons():
 
     assert result.ok is False
     assert len(result.reasons) == 2
-    assert "evil-" in result.reasons[0]
-    assert "xxx" in result.reasons[0]
-    assert "..." in result.reasons[0]
+    assert safe_string_display(manifest["contract_scope"]) in result.reasons[0]
+    assert (
+        safe_string_display(
+            manifest["compatible_client_ranges"]["openbrain-memory"],
+        )
+        in result.reasons[1]
+    )
+    assert "evil-" not in result.reasons[0]
+    assert "xxx" not in result.reasons[0]
     assert "x" * 100 not in result.reasons[0]
     assert "x" * 100 not in result.reasons[1]
+
+
+def test_validate_contract_manifest_redacts_token_like_manifest_values_in_reasons():
+    manifest = representative_contract_manifest()
+    token_body = "sk_live_sensitive_body_" + ("A" * 120)
+    jwt_header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    jwt_payload = "eyJzdWIiOiJzZW5zaXRpdmUtcGF5bG9hZCIsInJvbGUiOiJhZG1pbiJ9"
+    jwt_signature = "sensitive_signature_" + ("B" * 80)
+    jwt_value = f"{jwt_header}.{jwt_payload}.{jwt_signature}"
+    manifest["contract_scope"] = token_body
+    manifest["compatible_client_ranges"]["openbrain-memory"] = jwt_value
+
+    result = validate_contract_manifest(manifest, client_version="0.1.0")
+    reason_text = "\n".join(result.reasons)
+
+    assert result.ok is False
+    assert safe_string_display(token_body) in reason_text
+    assert safe_string_display(jwt_value) in reason_text
+    assert "sk_live_sensitive_body" not in reason_text
+    assert "eyJhbGci" not in reason_text
+    assert "eyJzdWIi" not in reason_text
+    assert "sensitive_signature" not in reason_text
 
 
 def test_validate_contract_manifest_does_not_require_snapshot_constants():


### PR DESCRIPTION
## Summary
- adds package-owned no-network validation for live OpenBrainClient.get_contract manifests
- validates required scope, required tools, compatible contract versions when supplied, min client version, and compatible client range
- exports ContractValidationResult and validate_contract_manifest from openbrain_memory
- keeps constants as snapshots; callers still validate the live contract response

## Linked issues
- Supports #178
- Supports #177

## Verification
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence:
- uv run pytest -q passed: 109 passed, 1 skipped
- uv run mypy src/openbrain_memory passed
- uv run ruff check src tests passed
- uv run ruff format --check src tests passed

## Critical Self-Review
- Highest-risk behavior: Runtime consumers might over-trust package snapshots instead of validating live get_contract; helper only validates supplied manifests and docs/tests preserve live-source-of-truth semantics.
- Assumptions that could be wrong: Version range grammar may need expansion beyond current contract style; implementation intentionally supports current simple forms like >=0.1.0 <1.0.0.
- Missing/weak tests: Tests use fake live-shaped manifests, not a real Open Brain endpoint; live host canary remains separate rollout work.
- Security/permission risk: Helper performs local manifest validation only and does not read tokens or perform network calls.
- Migration/deploy risk: Adding exports should be backward compatible, but Hermes still needs separate adoption work before relying on this helper.
- Downstream client/runtime risk: rtech-hermes must wire this helper into startup/provider checks in #93/#95 before it affects agents.
- Rollback/cleanup concern: Rollback removes one module, exports, and focused tests; no data or server contract migration.
- Fixes made before PR: Added failure-reason tests for missing tools, scope/version mismatch, min-version failure, range failure, malformed compatibility fields, and snapshot independence.
- Known residual risk: Full JSON Schema/tool-schema conversion remains separate issue #179.
- SME review-memory update: [x] not applicable because: no review finding has been produced yet.

## Review Gate
- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in docs/sme/ or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this helper is no-network package validation covered by fake-manifest tests; live canaries are tracked by #181/#97.

## Downstream Rollout
- [x] I checked docs/downstream-rollout.md
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:
- Downstream adoption is not complete in this PR; it is tracked in rtech-hermes #93/#95/#97 and the PR remains draft until standard review swarm completes.

## Review gate status
- Draft until standard review swarm completes. Per repo policy, python/openbrain-memory PRs require gotcha-agent lane in the swarm.
