### PR TITLE
fix: make OpenBrainClient namespace delegation opt-in

### DIFF
--- a/docs/goal-runs/goal_run_b_openbrain_memory_direct_client.md
+++ b/docs/goal-runs/goal_run_b_openbrain_memory_direct_client.md
@@ -1,0 +1,110 @@
+# goal_run_b: OpenBrain Direct Package Client
+
+## Objective
+
+Unblock deeper `rtech-hermes` package adoption by making
+`openbrain-memory`'s direct `OpenBrainClient` compatible with agent-role tokens,
+then use that evidence to drive the next Hermes adapter migration.
+
+Run B starts in `open-brain` because the first blocker is package-owned:
+`OpenBrainClient` must not send `X-Namespace` unless the caller explicitly opts
+into namespace delegation.
+
+## Control Plane
+
+- Open Brain repo: `rodaddy/open-brain`
+- Open Brain board: Project #8, Open Brain Work Board
+- Hermes repo: `rodaddy/rtech-hermes`
+- Hermes board: Project #9, rtech-hermes Operational Work Board
+- Controller: main Codex session
+- Workers: standard subagents only; no CSV row workers
+- Review rule: every PR gets a standard review swarm
+- Package review rule: any PR touching `python/openbrain-memory/` includes the
+  gotcha-agent lane from `docs/sme/gotcha-agent.md`
+
+## Issue Map
+
+### Open Brain
+
+- [open-brain #184](https://github.com/rodaddy/open-brain/issues/184)
+  - Let `openbrain_memory.OpenBrainClient` omit `X-Namespace` for agent-role
+    tokens.
+- [open-brain #179](https://github.com/rodaddy/open-brain/issues/179)
+  - Add contract DSL to JSON Schema/tool-schema conversion, or decide an
+    explicit consumer-local adapter boundary.
+- [open-brain #181](https://github.com/rodaddy/open-brain/issues/181)
+  - Expand lane facade, spool manager, docs, and live canary coverage.
+- [open-brain #177](https://github.com/rodaddy/open-brain/issues/177)
+  - Umbrella for installable/canonical package adoption.
+
+### rtech-hermes Follow-Up
+
+- [rtech-hermes #92](https://github.com/rodaddy/rtech-hermes/issues/92)
+  - Adopt `openbrain-memory` package and retire vendored OB fork.
+- [rtech-hermes #94](https://github.com/rodaddy/rtech-hermes/issues/94)
+  - Replace fork with package-backed runtime adapter.
+- [rtech-hermes #95](https://github.com/rodaddy/rtech-hermes/issues/95)
+  - Migrate plugin clients and tool schema surfaces.
+- [rtech-hermes #96](https://github.com/rodaddy/rtech-hermes/issues/96)
+  - Remove duplicated transport/redaction/schema code after parity proof.
+
+## Phase 1: Fix Direct Client Namespace Delegation
+
+- [x] Add an `OpenBrainClient` option equivalent to
+      `delegate_namespace: bool = False`.
+- [x] Omit `X-Namespace` by default for normal agent-role clients.
+- [x] Send `X-Namespace` only when explicit delegation is enabled.
+- [x] Keep `X-Agent-Id` and `X-Role` behavior unchanged.
+- [x] Preserve session lifecycle behavior for initialize, initialized,
+      tool calls, and close.
+- [x] Add fake-transport tests for default omission and explicit delegation.
+- [x] Update README identity/namespace authority documentation.
+- [x] Run focused package validation:
+  - [x] `cd python/openbrain-memory && uv run pytest tests/test_client.py -q`
+        passed: 45 tests.
+  - [x] `cd python/openbrain-memory && uv run pytest -q` passed:
+        122 passed, 1 skipped.
+  - [x] `cd python/openbrain-memory && uv run ruff check src tests`
+        passed.
+  - [x] `cd python/openbrain-memory && uv run ruff format --check src tests`
+        passed.
+  - [x] `cd python/openbrain-memory && uv run mypy src/openbrain_memory`
+        passed.
+
+Completion for Phase 1:
+
+- [x] open-brain #184 acceptance criteria are implemented and tested locally.
+- [ ] PR has critical self-review, review swarm, gotcha-agent lane, and
+      fix-verification evidence.
+- [ ] #184 is closed only after merge and controller verification.
+
+## Phase 2: Decide Schema Conversion Boundary
+
+- [ ] Inspect open-brain #179 against Hermes #95 needs.
+- [ ] Decide whether schema conversion belongs in `openbrain-memory` now or
+      remains a Hermes-local adapter backed by package-owned DSL tests.
+- [ ] If package-owned, implement/test the conversion helper in open-brain.
+- [ ] If Hermes-local, record the boundary in both repos before Hermes work.
+
+Completion for Phase 2:
+
+- [ ] #179 has implementation or an explicit boundary decision.
+- [ ] Run C deletion work is not started until this boundary is settled.
+
+## Phase 3: Hermes Adapter Migration Prep
+
+- [ ] Return to `rtech-hermes` after #184 lands.
+- [ ] Update the Hermes adapter plan for #94/#95 from the package evidence.
+- [ ] Prove a direct package facade can perform `get_contract` with an
+      agent-role token before replacing provider/client code.
+- [ ] Preserve Hermes session-key protection and read allowlist.
+- [ ] Keep Nagatha as the first canary before Bilby or Skippy.
+
+## goal_run_b Is Complete Only When
+
+- [ ] #184 is merged and verified.
+- [ ] Direct package client behavior is tested for both default agent mode and
+      explicit delegation mode.
+- [ ] The schema conversion boundary for #179/#95 is decided or implemented.
+- [ ] Hermes migration work has a concrete next PR plan based on package
+      evidence, not another custom client fork.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -90,7 +90,8 @@ version, and request body shape.
 
 - Is there an in-process HTTP/MCP test using real `OpenBrainClient` and
   `UrllibTransport`?
-- Does the test observe `Authorization`, `X-Namespace`, `X-Agent-Id`, `X-Role`,
+- Does the test observe `Authorization`, default omission of `X-Namespace`,
+  explicit delegated `X-Namespace` when enabled, `X-Agent-Id`, `X-Role`,
   `Mcp-Session-Id`, `MCP-Protocol-Version`, JSON-RPC ids, and bodies?
 - Does it cover `/health`, initialize, initialized notification, and
   `tools/call`?

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -29,8 +29,8 @@ but legitimate content.
 
 **Prior miss:** #78, from PR #73.
 
-- Generic metadata must not override `X-Namespace` or configured client
-  namespace.
+- Generic metadata must not create `X-Namespace`, override token-derived
+  namespace, or override an explicit privileged delegation path.
 - Cross-namespace writes need explicit privileged API design.
 - Facades should reject or ignore `namespace="other"` for normal clients.
 

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -3,7 +3,7 @@
 Security reviewers focus on boundaries: namespaces, bearer tokens, secret
 handling, trusted headers, redirect behavior, and plaintext transport.
 
-## [2026-06-11] Namespace metadata must not bypass client/header authority
+## [2026-06-11] Namespace metadata must not bypass token/header authority
 
 **Severity:** HIGH
 **Source:** Issue #78, PR #73 follow-up
@@ -14,12 +14,13 @@ handling, trusted headers, redirect behavior, and plaintext transport.
 
 `AgentMemory.remember_fact()` and `remember_decision()` accepted free-form
 `namespace` metadata and forwarded it into tool arguments. That can conflict
-with or attempt to override `OpenBrainClient`'s `X-Namespace` authority.
+with or attempt to override the server's token-derived namespace authority or
+an explicit privileged `X-Namespace` delegation path.
 
 ### Review Questions
 
 - Is `namespace` removed from generic metadata pass-through, or verified against
-  the configured client namespace?
+  the authenticated server-side namespace/delegation policy?
 - If namespace override is required, is it an explicit privileged API rather
   than arbitrary metadata?
 - Are there tests for `namespace="other"` on normal clients?

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -112,6 +112,12 @@ memory = AgentMemory(
 )
 ```
 
+Normal agent-role tokens derive namespace authority server-side from the token.
+`OpenBrainClient` therefore does not send `X-Namespace` by default. Trusted
+admin or n8n callers that intentionally need namespace delegation can opt in
+with `delegate_namespace=True`; doing so sends `X-Namespace` and requires a
+server role that is allowed to delegate.
+
 ## Quickstart
 
 ```python
@@ -195,9 +201,12 @@ behavior. Read them with three boundaries in mind:
   is misconfigured, or the service is unreachable, writes can fail and be spooled
   locally (see [Safety and Spooling](#safety-and-spooling)) rather than landing
   in Open Brain. Verify live writes; do not treat "spooled" as "saved."
-- **The server owns namespace authority.** Namespace is bound from the client's
-  configured `X-Namespace`, not from caller metadata. Passing `namespace` inside
-  a wrapper's arguments does not override it.
+- **The server owns namespace authority.** Normal agent-role tokens derive the
+  caller namespace server-side, so `OpenBrainClient` omits `X-Namespace` by
+  default. `delegate_namespace=True` is an explicit privileged delegation mode
+  for roles such as admin or n8n that are allowed to send `X-Namespace`.
+  Passing `namespace` inside a wrapper's arguments does not create or override
+  delegation.
 
 ### Transport
 
@@ -218,14 +227,16 @@ documented, Hermes agents should configure `OPENBRAIN_BASE_URL`,
 are for diagnostics and display only; they do not mutate live writes.
 
 Namespace authority belongs to the configured `OpenBrainClient` and the Open
-Brain service. `OpenBrainClient` sends the configured namespace through
-`X-Namespace` when present, and the server validates that header against the
-bearer token role. `AgentMemory` never accepts `namespace` as facade metadata.
-Nested user-owned structures such as decision context remain available for
-semantic fields, but authority-shaped keys such as `namespace`, `authorization`,
-`headers`, `role`, `token`, or `X-Namespace` are rejected before client calls.
-Cross-namespace writes require an explicit privileged client/server path rather
-than facade metadata.
+Brain service. `OpenBrainClient` does not send `X-Namespace` for normal agent
+clients; the server derives the namespace from the bearer token. When a trusted
+admin/n8n-style caller passes `delegate_namespace=True`, the client sends its
+configured namespace through `X-Namespace`, and the server validates that
+delegation against the bearer token role. `AgentMemory` never accepts
+`namespace` as facade metadata. Nested user-owned structures such as decision
+context remain available for semantic fields, but authority-shaped keys such as
+`namespace`, `authorization`, `headers`, `role`, `token`, or `X-Namespace` are
+rejected before client calls. Cross-namespace writes require an explicit
+privileged client/server path rather than facade metadata.
 
 `UrllibTransport` bounds JSON and SSE response reads with `max_response_bytes`
 and returns from SSE responses after the first JSON-RPC response event rather
@@ -300,6 +311,10 @@ OPENBRAIN_TOKEN=... \
 OPENBRAIN_NAMESPACE=bilby \
 uv run pytest tests/test_live_canary.py
 ```
+
+Set `OPENBRAIN_ROLE`/`OPENBRAIN_AGENT_ID` for the identity labels expected by
+the target deployment. Do not enable namespace delegation for normal agent-role
+tokens; the server should derive their namespace from the token.
 
 Non-local `http://` endpoints are rejected by default because MCP requests carry
 bearer tokens. For trusted lab-only HTTP endpoints, set

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -278,6 +278,7 @@ class OpenBrainClient:
         timeout: float = 30.0,
         transport: Transport | None = None,
         allow_insecure_http: bool = False,
+        delegate_namespace: bool = False,
     ) -> None:
         _validate_base_url(base_url, allow_insecure_http=allow_insecure_http)
         self.base_url = base_url.rstrip("/") + "/"
@@ -287,6 +288,7 @@ class OpenBrainClient:
         self.role = role
         self.timeout = timeout
         self.transport = transport or UrllibTransport()
+        self.delegate_namespace = delegate_namespace
         self._session_id: str | None = None
         self._protocol_version = MCP_PROTOCOL_VERSION
         self._ids = count(1)
@@ -622,8 +624,9 @@ class OpenBrainClient:
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
-            "X-Namespace": self.namespace,
         }
+        if self.delegate_namespace:
+            headers["X-Namespace"] = self.namespace
         if self.agent_id:
             headers["X-Agent-Id"] = self.agent_id
         if self.role:

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -130,6 +130,19 @@ def make_client(transport: FakeTransport) -> OpenBrainClient:
     )
 
 
+def make_delegating_client(transport: FakeTransport) -> OpenBrainClient:
+    return OpenBrainClient(
+        "https://brain.example",
+        "secret-token",
+        "bilby",
+        agent_id="bilby-agent",
+        role="agent",
+        timeout=12.5,
+        transport=transport,
+        delegate_namespace=True,
+    )
+
+
 def post_requests(transport: FakeTransport):
     return [request for request in transport.requests if request["method"] == "POST"]
 
@@ -204,7 +217,7 @@ def test_http_error_redacts_deep_json_without_recursion_error():
     assert "secret-token" not in str(error)
 
 
-def test_initialize_sends_auth_namespace_and_stores_session_id():
+def test_initialize_omits_namespace_delegation_by_default_and_stores_session_id():
     transport = FakeTransport()
     client = make_client(transport)
 
@@ -215,12 +228,25 @@ def test_initialize_sends_auth_namespace_and_stores_session_id():
     assert headers["Authorization"] == "Bearer secret-token"
     assert headers["Accept"] == "application/json, text/event-stream"
     assert headers["Content-Type"] == "application/json"
-    assert headers["X-Namespace"] == "bilby"
+    assert "X-Namespace" not in headers
     assert headers["X-Agent-Id"] == "bilby-agent"
     assert headers["X-Role"] == "agent"
     assert "Mcp-Session-Id" not in headers
     assert initialize["json"]["method"] == "initialize"
     assert client.session_id == "session-123"
+
+
+def test_initialize_sends_namespace_only_when_delegation_is_enabled():
+    transport = FakeTransport()
+    client = make_delegating_client(transport)
+
+    client.call_tool("search_all", {"query": "namespace routing"})
+
+    initialize = post_requests(transport)[0]
+    headers = initialize["headers"]
+    assert headers["X-Namespace"] == "bilby"
+    assert headers["X-Agent-Id"] == "bilby-agent"
+    assert headers["X-Role"] == "agent"
 
 
 def test_initialized_notification_and_tool_calls_reuse_session_header():
@@ -256,7 +282,7 @@ def test_close_sends_delete_once_and_context_manager_closes():
     delete = delete_requests[0]
     assert delete["url"] == "https://brain.example/mcp"
     assert delete["headers"]["Authorization"] == "Bearer secret-token"
-    assert delete["headers"]["X-Namespace"] == "bilby"
+    assert "X-Namespace" not in delete["headers"]
     assert delete["headers"]["X-Agent-Id"] == "bilby-agent"
     assert delete["headers"]["X-Role"] == "agent"
     assert delete["headers"]["Mcp-Session-Id"] == "session-123"
@@ -460,10 +486,10 @@ def test_current_agent_read_helpers_have_first_class_wrappers():
         assert tool_name in CURRENT_TOOL_HELP
 
 
-def test_upsert_repo_fact_sends_payload_and_binds_namespace_header():
+def test_upsert_repo_fact_sends_payload_without_default_namespace_delegation():
     # A write wrapper must (1) reach the server as the matching tool with the
-    # caller payload intact, and (2) keep X-Namespace bound to the client's
-    # configured namespace even when caller metadata tries to override it.
+    # caller payload intact, and (2) keep caller metadata from creating a
+    # delegation header. Agent-role tokens derive namespace server-side.
     transport = FakeTransport()
     client = make_client(transport)
 
@@ -480,7 +506,20 @@ def test_upsert_repo_fact_sends_payload_and_binds_namespace_header():
         "repo": "rodaddy/open-brain",
         "metadata": {"namespace": "other-namespace", "fact": "x"},
     }
-    # Server-authoritative namespace header must not be overridden by metadata.
+    assert header_value(calls[0]["headers"], "X-Namespace") is None
+
+
+def test_upsert_repo_fact_sends_delegation_header_when_enabled():
+    transport = FakeTransport()
+    client = make_delegating_client(transport)
+
+    client.upsert_repo_fact(
+        repo="rodaddy/open-brain",
+        metadata={"namespace": "other-namespace", "fact": "x"},
+    )
+
+    calls = tool_requests(transport)
+    assert len(calls) == 1
     assert header_value(calls[0]["headers"], "X-Namespace") == "bilby"
 
 
@@ -1097,7 +1136,7 @@ def test_openbrain_client_streams_until_matching_sse_jsonrpc_response():
 
     initialize, initialized, call = seen
     assert header_value(initialize["headers"], "Authorization") == "Bearer secret-token"
-    assert header_value(initialize["headers"], "X-Namespace") == "bilby"
+    assert header_value(initialize["headers"], "X-Namespace") is None
     assert header_value(initialize["headers"], "X-Agent-Id") == "bilby-agent"
     assert header_value(initialize["headers"], "X-Role") == "agent"
     assert header_value(initialize["headers"], "Mcp-Session-Id") is None
@@ -1113,6 +1152,75 @@ def test_openbrain_client_streams_until_matching_sse_jsonrpc_response():
         "method": "tools/call",
         "params": {"name": "search_all", "arguments": {"query": "stream"}},
     }
+
+
+def test_urllib_transport_sends_namespace_when_delegation_is_enabled():
+    seen = []
+
+    class DelegatingMcpHandler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            content_length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(content_length))
+            seen.append(
+                {
+                    "headers": dict(self.headers.items()),
+                    "json": payload,
+                }
+            )
+            method = payload.get("method")
+            if method == "initialize":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Mcp-Session-Id", "session-delegated")
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": payload["id"],
+                            "result": {"protocolVersion": "2025-03-26"},
+                        }
+                    ).encode("utf-8")
+                )
+                return
+            if method == "notifications/initialized":
+                self.send_response(202)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            self.send_response(400)
+            self.end_headers()
+
+        def log_message(self, _format, *args):
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), DelegatingMcpHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client = OpenBrainClient(
+            f"http://127.0.0.1:{server.server_port}",
+            "secret-token",
+            "bilby",
+            agent_id="bilby-agent",
+            role="agent",
+            timeout=2,
+            transport=UrllibTransport(),
+            delegate_namespace=True,
+        )
+        client._ensure_session()
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+    initialize, initialized = seen
+    assert header_value(initialize["headers"], "Authorization") == "Bearer secret-token"
+    assert header_value(initialize["headers"], "X-Namespace") == "bilby"
+    assert header_value(initialize["headers"], "X-Agent-Id") == "bilby-agent"
+    assert header_value(initialize["headers"], "X-Role") == "agent"
+    assert header_value(initialize["headers"], "Mcp-Session-Id") is None
+    assert header_value(initialized["headers"], "X-Namespace") == "bilby"
+    assert header_value(initialized["headers"], "Mcp-Session-Id") == "session-delegated"
 
 
 def test_urllib_transport_bounds_json_response_size():


### PR DESCRIPTION
## Summary

- makes `OpenBrainClient` namespace delegation opt-in with `delegate_namespace=False` by default
- omits `X-Namespace` for normal agent-role clients while preserving `X-Agent-Id`, `X-Role`, session lifecycle, and close behavior
- adds fake-transport coverage for default omission and explicit delegated `X-Namespace`
- updates README and SME review guidance for token-derived namespace authority and explicit privileged delegation
- adds the Run B tracker doc for the direct package client and downstream Hermes migration path

## Linked issues

- Closes #184
- Supports #177
- Supports #181

## Validation

- `cd python/openbrain-memory && uv run pytest tests/test_client.py -q` PASS: 45 passed
- `cd python/openbrain-memory && uv run pytest -q` PASS: 122 passed, 1 skipped
- `cd python/openbrain-memory && uv run ruff check src tests` PASS
- `cd python/openbrain-memory && uv run ruff format --check src tests` PASS
- `cd python/openbrain-memory && uv run mypy src/openbrain_memory` PASS
- `git diff --check` PASS

## Critical Self-Review

- Highest-risk behavior: changing default `X-Namespace` behavior could break privileged callers that depended on implicit delegation. The new `delegate_namespace=True` flag preserves that path explicitly.
- Assumptions that could be wrong: agent-role tokens always derive namespace server-side in the deployed Open Brain auth policy. This matches the Nagatha failure and existing Hermes bridge behavior, but live package-facade canary still belongs after merge.
- Missing/weak tests: tests use fake/in-process transports, not a live hosted token. Live canary remains Run B follow-up before Hermes adapter replacement.
- Security/permission risk: safer default for agent tokens; delegation is now explicit and still server-validated. README and SME docs were updated so reviewers do not demand the stale always-header behavior.
- Migration/deploy risk: downstream Hermes still uses a provider bridge. This package change does not by itself update Hermes runtime/plugin code.
- Downstream client/runtime risk: `rtech-hermes` #94/#95 still need a follow-up PR to consume the direct package facade. Do not claim live agent readiness from this PR alone.
- Rollback/cleanup concern: rollback restores prior implicit delegation behavior by reverting this commit. No data/server migration is included.
- Fixes made before PR: added default and delegated header tests, added in-process `UrllibTransport` delegated-header coverage, updated streaming test expectation, README identity docs, SME review guidance, and Run B tracker.
- Known residual risk: contract DSL schema conversion remains open in #179, and expanded package canary/spool coverage remains open in #181.
- SME review-memory update: [x] `docs/sme/` updated [ ] not applicable because: -

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`.
- [x] Open Brain local verification complete: Python package tests/lint/typecheck above.
- [x] Hosted Open Brain deploy/smoke is not applicable for this PR because no server runtime or MCP schema changes are included.
- [x] rtech-mcps handoff is not applicable because no registry/tool/schema change is included.
- [x] mcp2cli cache/skill refresh is not applicable because no MCP tool schema or generated skill behavior changes are included.
- [ ] rtech-hermes Python runtime/plugin follow-up is required before claiming agent readiness.
- [ ] Hermes live rollout/canary is required after the Hermes follow-up PR, with Nagatha first.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below [x] not applicable because: package-client behavior change only; no hosted Open Brain server deployment is included in this PR. Live Hermes/Nagatha canary is required after the downstream Hermes package-consumption PR.

Review swarm required before merge. Because this touches `python/openbrain-memory/`, include the gotcha-agent lane from `docs/sme/gotcha-agent.md`.
