### PR TITLE
feat: add contract schema helpers

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -208,6 +208,27 @@ behavior. Read them with three boundaries in mind:
   Passing `namespace` inside a wrapper's arguments does not create or override
   delegation.
 
+### Schema Helpers
+
+`openbrain_memory.schema` converts the server's `get_contract()` DSL into JSON
+Schema-shaped input definitions for downstream validators and tool registries.
+The live `get_contract()` manifest remains the source of truth; these helpers
+only translate a manifest the caller already obtained or a package test fixture.
+They do not prove that a deployed Open Brain endpoint, Hermes adapter, or agent
+runtime is wired correctly.
+
+Use `contract_field_to_json_schema()` for one field node and
+`contract_input_to_json_schema()` for one tool's `input_schema` mapping. Use
+`tool_contract_to_input_schema()` when you already selected one tool contract,
+and `tool_contracts_to_tool_schemas()` when converting a manifest's
+`tool_contracts` into a list of `{name, input_schema}` entries.
+
+Malformed contract DSL raises `ContractSchemaError` with the failing path rather
+than emitting invalid JSON Schema. Open Brain-specific constraints that do not
+map cleanly to standard JSON Schema are preserved with `x-openbrain-*` vendor
+extensions. Hermes policy, readiness checks, and runtime enforcement remain
+downstream integration responsibilities.
+
 ### Transport
 
 Today this package talks directly to the Open Brain service over HTTP endpoints

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -19,6 +19,13 @@ from .client import (
 from .contract import ContractValidationResult, validate_contract_manifest
 from .dream import DreamAction, DreamClient, DreamEngine, DreamPolicy, DreamRun
 from .policy import RetryExhaustedError, RetryPolicy, redact_text, redact_value
+from .schema import (
+    ContractSchemaError,
+    contract_field_to_json_schema,
+    contract_input_to_json_schema,
+    tool_contract_to_input_schema,
+    tool_contracts_to_tool_schemas,
+)
 from .spool import JsonlSpool, SpoolRecord, replay_records
 
 __all__ = [
@@ -42,12 +49,17 @@ __all__ = [
     "CURRENT_TOOL_HELP",
     "REQUIRED_CONTRACT_TOOLS",
     "ContractValidationResult",
+    "ContractSchemaError",
     "JsonlSpool",
     "RetryExhaustedError",
     "RetryPolicy",
     "SpoolRecord",
+    "contract_field_to_json_schema",
+    "contract_input_to_json_schema",
     "redact_text",
     "redact_value",
     "replay_records",
+    "tool_contract_to_input_schema",
+    "tool_contracts_to_tool_schemas",
     "validate_contract_manifest",
 ]

--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -236,8 +236,9 @@ def _apply_object_fields(
         enum_refs={**enum_refs, **_collect_enum_refs(fields)},
     )
     schema["properties"] = child_schema["properties"]
-    if "required" in child_schema:
-        schema["required"] = child_schema["required"]
+    for key in ("required", "anyOf", "allOf"):
+        if key in child_schema:
+            schema[key] = child_schema[key]
 
 
 def _fields_to_object_schema(

--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -1,0 +1,438 @@
+"""Convert Open Brain contract DSL nodes into JSON Schema.
+
+The server publishes a small human-authored contract dialect through
+``get_contract``. This module translates that dialect into JSON Schema shapes
+that downstream clients can feed into tool-schema validators.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+JSONSchema = dict[str, Any]
+
+_PRIMITIVE_TYPES = frozenset(
+    {"string", "integer", "number", "boolean", "array", "object"},
+)
+_SEMANTIC_STRING_TYPES = frozenset(
+    {"datetime_not_future", "git_sha", "https_github_url"},
+)
+_PRESERVED_KEYS = frozenset(
+    {
+        "additionalProperties",
+        "default",
+        "description",
+        "maxLength",
+        "minLength",
+        "propertyNames",
+    },
+)
+
+
+class ContractSchemaError(ValueError):
+    """Raised when a contract DSL node cannot be converted safely."""
+
+
+def contract_field_to_json_schema(node: Any, *, path: str = "$") -> JSONSchema:
+    return _contract_field_to_json_schema(node, path=path, enum_refs={})
+
+
+def contract_input_to_json_schema(
+    input_schema: Mapping[str, Any],
+    *,
+    title: str | None = None,
+) -> JSONSchema:
+    if not isinstance(input_schema, Mapping):
+        raise ContractSchemaError("$: input_schema must be a mapping")
+
+    enum_refs = _collect_enum_refs(input_schema)
+    schema = _fields_to_object_schema(input_schema, path="$", enum_refs=enum_refs)
+    if title is not None:
+        schema["title"] = title
+    return schema
+
+
+def tool_contract_to_input_schema(
+    tool_name: str,
+    tool_contract: Mapping[str, Any],
+) -> JSONSchema:
+    if not isinstance(tool_contract, Mapping):
+        raise ContractSchemaError(
+            f"$.tool_contracts.{tool_name}: tool contract must be a mapping",
+        )
+    input_schema = tool_contract.get("input_schema")
+    if not isinstance(input_schema, Mapping):
+        raise ContractSchemaError(
+            f"$.tool_contracts.{tool_name}.input_schema: input_schema "
+            "must be a mapping",
+        )
+    return contract_input_to_json_schema(input_schema, title=tool_name)
+
+
+def tool_contracts_to_tool_schemas(
+    manifest: Mapping[str, Any],
+    *,
+    tool_names: Iterable[str] | None = None,
+) -> list[JSONSchema]:
+    if not isinstance(manifest, Mapping):
+        raise ContractSchemaError("$: manifest must be a mapping")
+    tool_contracts = manifest.get("tool_contracts")
+    if not isinstance(tool_contracts, Mapping):
+        raise ContractSchemaError("$.tool_contracts: tool_contracts must be a mapping")
+
+    selected_names = (
+        list(tool_names) if tool_names is not None else sorted(tool_contracts)
+    )
+    enum_refs = _collect_manifest_enum_refs(tool_contracts)
+    schemas: list[JSONSchema] = []
+    for tool_name in selected_names:
+        if tool_name not in tool_contracts:
+            raise ContractSchemaError(
+                f"$.tool_contracts.{tool_name}: tool contract is missing",
+            )
+        tool_contract = tool_contracts[tool_name]
+        if not isinstance(tool_contract, Mapping):
+            raise ContractSchemaError(
+                f"$.tool_contracts.{tool_name}: tool contract must be a mapping",
+            )
+        input_schema = tool_contract.get("input_schema")
+        if not isinstance(input_schema, Mapping):
+            raise ContractSchemaError(
+                f"$.tool_contracts.{tool_name}.input_schema: input_schema "
+                "must be a mapping",
+            )
+        schemas.append(
+            {
+                "name": tool_name,
+                "input_schema": _fields_to_object_schema(
+                    input_schema,
+                    path=f"$.tool_contracts.{tool_name}.input_schema",
+                    enum_refs=enum_refs,
+                ),
+            },
+        )
+    return schemas
+
+
+def _contract_field_to_json_schema(
+    node: Any,
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> JSONSchema:
+    if isinstance(node, str):
+        return _resolve_string_ref(node, path=path, enum_refs=enum_refs)
+    if not isinstance(node, Mapping):
+        raise ContractSchemaError(f"{path}: contract node must be a mapping")
+
+    if "type" not in node:
+        return _typeless_node_to_json_schema(node, path=path, enum_refs=enum_refs)
+
+    raw_type = node.get("type")
+    if not isinstance(raw_type, str):
+        raise ContractSchemaError(f"{path}.type: type must be a string")
+
+    if raw_type == "enum":
+        return _enum_node_to_json_schema(node, path=path)
+    if raw_type == "literal":
+        return _literal_node_to_json_schema(node, path=path)
+    if raw_type in _SEMANTIC_STRING_TYPES:
+        schema: JSONSchema = {"type": "string"}
+        if raw_type == "datetime_not_future":
+            schema["format"] = "date-time"
+        _preserve_metadata(node, schema, path=path, enum_refs=enum_refs)
+        return schema
+    if raw_type not in _PRIMITIVE_TYPES:
+        raise ContractSchemaError(
+            f"{path}.type: unsupported contract type {raw_type!r}",
+        )
+
+    schema = {"type": raw_type}
+    if raw_type == "array":
+        schema["items"] = _array_items_schema(node, path=path, enum_refs=enum_refs)
+    elif raw_type == "object":
+        _apply_object_fields(node, schema, path=path, enum_refs=enum_refs)
+
+    _preserve_metadata(node, schema, path=path, enum_refs=enum_refs)
+    _preserve_numeric_bounds(node, schema)
+    return schema
+
+
+def _typeless_node_to_json_schema(
+    node: Mapping[str, Any],
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> JSONSchema:
+    if _has_explicit_object_marker(node):
+        schema: JSONSchema = {"type": "object"}
+        _apply_object_fields(node, schema, path=path, enum_refs=enum_refs)
+        _preserve_metadata(node, schema, path=path, enum_refs=enum_refs)
+        return schema
+
+    if node and all(_is_contract_field_node(value) for value in node.values()):
+        return _fields_to_object_schema(node, path=path, enum_refs=enum_refs)
+
+    if any(_is_contract_field_node(value) for value in node.values()):
+        raise ContractSchemaError(
+            f"{path}: typeless contract node mixes contract fields with "
+            "unsupported metadata",
+        )
+
+    if _is_json_metadata_value(node):
+        return _metadata_value_to_json_schema(node)
+
+    raise ContractSchemaError(
+        f"{path}: typeless contract node is ambiguous; add type:'object', "
+        "fields, propertyNames, or additionalProperties",
+    )
+
+
+def _enum_node_to_json_schema(node: Mapping[str, Any], *, path: str) -> JSONSchema:
+    values = node.get("values")
+    if not isinstance(values, list) or not values:
+        raise ContractSchemaError(
+            f"{path}.values: enum values must be a non-empty list",
+        )
+    inferred_type = _infer_enum_type(values)
+    if inferred_type is None:
+        raise ContractSchemaError(
+            f"{path}.values: enum values must share one primitive type",
+        )
+    schema: JSONSchema = {"type": inferred_type, "enum": list(values)}
+    _preserve_metadata(node, schema, path=path, enum_refs={})
+    return schema
+
+
+def _literal_node_to_json_schema(node: Mapping[str, Any], *, path: str) -> JSONSchema:
+    if "value" not in node:
+        raise ContractSchemaError(f"{path}.value: literal node must define value")
+    schema: JSONSchema = {"const": node["value"]}
+    inferred_type = _json_primitive_type(node["value"])
+    if inferred_type is not None:
+        schema["type"] = inferred_type
+    _preserve_metadata(node, schema, path=path, enum_refs={})
+    return schema
+
+
+def _apply_object_fields(
+    node: Mapping[str, Any],
+    schema: JSONSchema,
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> None:
+    fields = node.get("fields")
+    if fields is None:
+        return
+    if not isinstance(fields, Mapping):
+        raise ContractSchemaError(f"{path}.fields: fields must be a mapping")
+    child_schema = _fields_to_object_schema(
+        fields,
+        path=f"{path}.fields",
+        enum_refs={**enum_refs, **_collect_enum_refs(fields)},
+    )
+    schema["properties"] = child_schema["properties"]
+    if "required" in child_schema:
+        schema["required"] = child_schema["required"]
+
+
+def _fields_to_object_schema(
+    fields: Mapping[str, Any],
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> JSONSchema:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, field in fields.items():
+        if not isinstance(name, str):
+            raise ContractSchemaError(f"{path}: field names must be strings")
+        field_path = f"{path}.{name}"
+        properties[name] = _contract_field_to_json_schema(
+            field,
+            path=field_path,
+            enum_refs=enum_refs,
+        )
+        if isinstance(field, Mapping) and field.get("required") is True:
+            required.append(name)
+
+    schema: JSONSchema = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _array_items_schema(
+    node: Mapping[str, Any],
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> JSONSchema:
+    if "items" not in node:
+        raise ContractSchemaError(f"{path}.items: array node must define items")
+    return _contract_field_to_json_schema(
+        node["items"],
+        path=f"{path}.items",
+        enum_refs=enum_refs,
+    )
+
+
+def _preserve_metadata(
+    node: Mapping[str, Any],
+    schema: JSONSchema,
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> None:
+    for key in _PRESERVED_KEYS:
+        if key not in node:
+            continue
+        value = node[key]
+        if key == "propertyNames":
+            schema[key] = _contract_field_to_json_schema(
+                value,
+                path=f"{path}.{key}",
+                enum_refs=enum_refs,
+            )
+        elif key == "additionalProperties" and isinstance(value, Mapping):
+            schema[key] = _contract_field_to_json_schema(
+                value,
+                path=f"{path}.{key}",
+                enum_refs=enum_refs,
+            )
+        else:
+            schema[key] = value
+
+
+def _preserve_numeric_bounds(node: Mapping[str, Any], schema: JSONSchema) -> None:
+    if "min" in node:
+        schema["minimum"] = node["min"]
+    if "max" in node:
+        schema["maximum"] = node["max"]
+
+
+def _resolve_string_ref(
+    ref: str,
+    *,
+    path: str,
+    enum_refs: Mapping[str, JSONSchema],
+) -> JSONSchema:
+    if ref in _PRIMITIVE_TYPES:
+        return {"type": ref}
+    if ref in _SEMANTIC_STRING_TYPES:
+        schema: JSONSchema = {"type": "string"}
+        if ref == "datetime_not_future":
+            schema["format"] = "date-time"
+        return schema
+    if ref in enum_refs:
+        return dict(enum_refs[ref])
+    raise ContractSchemaError(f"{path}: unresolved contract schema reference {ref!r}")
+
+
+def _collect_manifest_enum_refs(
+    tool_contracts: Mapping[str, Any],
+) -> dict[str, JSONSchema]:
+    refs: dict[str, JSONSchema] = {}
+    for tool_contract in tool_contracts.values():
+        if not isinstance(tool_contract, Mapping):
+            continue
+        input_schema = tool_contract.get("input_schema")
+        if isinstance(input_schema, Mapping):
+            refs.update(_collect_enum_refs(input_schema))
+    return refs
+
+
+def _collect_enum_refs(fields: Mapping[str, Any]) -> dict[str, JSONSchema]:
+    refs: dict[str, JSONSchema] = {}
+    for name, field in fields.items():
+        if not isinstance(name, str) or not isinstance(field, Mapping):
+            continue
+        if field.get("type") == "enum":
+            refs[name] = _enum_node_to_json_schema(field, path=f"$.{name}")
+            if name.endswith("_type"):
+                refs[f"session_{name}"] = refs[name]
+        nested_fields = field.get("fields")
+        if isinstance(nested_fields, Mapping):
+            refs.update(_collect_enum_refs(nested_fields))
+    return refs
+
+
+def _has_explicit_object_marker(node: Mapping[str, Any]) -> bool:
+    return any(
+        key in node for key in ("fields", "propertyNames", "additionalProperties")
+    )
+
+
+def _is_contract_field_node(value: Any) -> bool:
+    if isinstance(value, str):
+        return True
+    if not isinstance(value, Mapping):
+        return False
+    raw_type = value.get("type")
+    return isinstance(raw_type, str) or _has_explicit_object_marker(value)
+
+
+def _is_json_metadata_value(value: Any) -> bool:
+    if value is None or isinstance(value, str | int | float | bool):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_metadata_value(item) for item in value)
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str) and _is_json_metadata_value(child)
+            for key, child in value.items()
+        )
+    return False
+
+
+def _metadata_value_to_json_schema(value: Any) -> JSONSchema:
+    if isinstance(value, Mapping):
+        properties = {
+            key: _metadata_value_to_json_schema(child) for key, child in value.items()
+        }
+        schema: JSONSchema = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": False,
+        }
+        if properties:
+            schema["required"] = list(properties)
+        return schema
+    if isinstance(value, list):
+        item_schemas = [_metadata_value_to_json_schema(item) for item in value]
+        schema = {"type": "array"}
+        if item_schemas:
+            schema["prefixItems"] = item_schemas
+            schema["minItems"] = len(item_schemas)
+            schema["maxItems"] = len(item_schemas)
+        return schema
+    inferred_type = _json_primitive_type(value)
+    if inferred_type is None:
+        return {"type": "null", "const": None}
+    return {"type": inferred_type, "const": value}
+
+
+def _infer_enum_type(values: list[Any]) -> str | None:
+    inferred = {_json_primitive_type(value) for value in values}
+    if len(inferred) != 1:
+        return None
+    value = inferred.pop()
+    return value if value in {"string", "integer", "number", "boolean"} else None
+
+
+def _json_primitive_type(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return None

--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -23,6 +23,7 @@ _PRESERVED_KEYS = frozenset(
         "additionalProperties",
         "default",
         "description",
+        "maxItems",
         "maxLength",
         "minLength",
         "propertyNames",
@@ -155,7 +156,8 @@ def _contract_field_to_json_schema(
         _apply_object_fields(node, schema, path=path, enum_refs=enum_refs)
 
     _preserve_metadata(node, schema, path=path, enum_refs=enum_refs)
-    _preserve_numeric_bounds(node, schema)
+    _preserve_numeric_bounds(node, schema, path=path)
+    _preserve_nonstandard_bounds(node, schema, path=path)
     return schema
 
 
@@ -246,6 +248,7 @@ def _fields_to_object_schema(
 ) -> JSONSchema:
     properties: dict[str, Any] = {}
     required: list[str] = []
+    required_groups: dict[str, list[str]] = {}
     for name, field in fields.items():
         if not isinstance(name, str):
             raise ContractSchemaError(f"{path}: field names must be strings")
@@ -255,8 +258,18 @@ def _fields_to_object_schema(
             path=field_path,
             enum_refs=enum_refs,
         )
-        if isinstance(field, Mapping) and field.get("required") is True:
-            required.append(name)
+        if isinstance(field, Mapping) and "required" in field:
+            required_value = field["required"]
+            if required_value is True:
+                required.append(name)
+            elif required_value is False:
+                continue
+            elif isinstance(required_value, str):
+                required_groups.setdefault(required_value, []).append(name)
+            else:
+                raise ContractSchemaError(
+                    f"{field_path}.required: required must be a boolean or string",
+                )
 
     schema: JSONSchema = {
         "type": "object",
@@ -265,6 +278,15 @@ def _fields_to_object_schema(
     }
     if required:
         schema["required"] = required
+    if required_groups:
+        group_constraints = [
+            {"anyOf": [{"required": [name]} for name in group_names]}
+            for group_names in required_groups.values()
+        ]
+        if len(group_constraints) == 1:
+            schema.update(group_constraints[0])
+        else:
+            schema["allOf"] = group_constraints
     return schema
 
 
@@ -306,15 +328,67 @@ def _preserve_metadata(
                 path=f"{path}.{key}",
                 enum_refs=enum_refs,
             )
+        elif key == "additionalProperties":
+            if not isinstance(value, bool):
+                raise ContractSchemaError(
+                    f"{path}.{key}: additionalProperties must be a boolean "
+                    "or mapping",
+                )
+            schema[key] = value
+        elif key in {"minLength", "maxLength", "maxItems"}:
+            schema[key] = _nonnegative_integer(value, path=f"{path}.{key}")
+        elif key == "description":
+            if not isinstance(value, str):
+                raise ContractSchemaError(f"{path}.{key}: description must be a string")
+            schema[key] = value
         else:
             schema[key] = value
 
 
-def _preserve_numeric_bounds(node: Mapping[str, Any], schema: JSONSchema) -> None:
+def _preserve_numeric_bounds(
+    node: Mapping[str, Any],
+    schema: JSONSchema,
+    *,
+    path: str,
+) -> None:
     if "min" in node:
-        schema["minimum"] = node["min"]
+        schema["minimum"] = _number(node["min"], path=f"{path}.min")
     if "max" in node:
-        schema["maximum"] = node["max"]
+        schema["maximum"] = _number(node["max"], path=f"{path}.max")
+
+
+def _preserve_nonstandard_bounds(
+    node: Mapping[str, Any],
+    schema: JSONSchema,
+    *,
+    path: str,
+) -> None:
+    if "maxItemLength" in node:
+        value = _nonnegative_integer(
+            node["maxItemLength"],
+            path=f"{path}.maxItemLength",
+        )
+        items = schema.get("items")
+        if (
+            schema.get("type") != "array"
+            or not isinstance(items, dict)
+            or items.get("type") != "string"
+        ):
+            raise ContractSchemaError(
+                f"{path}.maxItemLength: maxItemLength only maps to string "
+                "array items",
+            )
+        items["maxLength"] = value
+    if "maxKeys" in node:
+        schema["x-openbrain-maxKeys"] = _nonnegative_integer(
+            node["maxKeys"],
+            path=f"{path}.maxKeys",
+        )
+    if "maxJsonBytes" in node:
+        schema["x-openbrain-maxJsonBytes"] = _nonnegative_integer(
+            node["maxJsonBytes"],
+            path=f"{path}.maxJsonBytes",
+        )
 
 
 def _resolve_string_ref(
@@ -339,28 +413,61 @@ def _collect_manifest_enum_refs(
     tool_contracts: Mapping[str, Any],
 ) -> dict[str, JSONSchema]:
     refs: dict[str, JSONSchema] = {}
-    for tool_contract in tool_contracts.values():
+    for tool_name, tool_contract in tool_contracts.items():
         if not isinstance(tool_contract, Mapping):
             continue
         input_schema = tool_contract.get("input_schema")
         if isinstance(input_schema, Mapping):
-            refs.update(_collect_enum_refs(input_schema))
+            _merge_enum_refs(
+                refs,
+                _collect_enum_refs(
+                    input_schema,
+                    path=f"$.tool_contracts.{tool_name}.input_schema",
+                    scoped_session_aliases=tool_name == "append_session_event",
+                ),
+            )
     return refs
 
 
-def _collect_enum_refs(fields: Mapping[str, Any]) -> dict[str, JSONSchema]:
+def _collect_enum_refs(
+    fields: Mapping[str, Any],
+    *,
+    path: str = "$",
+    scoped_session_aliases: bool = False,
+) -> dict[str, JSONSchema]:
     refs: dict[str, JSONSchema] = {}
     for name, field in fields.items():
         if not isinstance(name, str) or not isinstance(field, Mapping):
             continue
+        field_path = f"{path}.{name}"
         if field.get("type") == "enum":
-            refs[name] = _enum_node_to_json_schema(field, path=f"$.{name}")
-            if name.endswith("_type"):
-                refs[f"session_{name}"] = refs[name]
+            schema = _enum_node_to_json_schema(field, path=field_path)
+            _merge_enum_refs(refs, {name: schema}, path=field_path)
+            if scoped_session_aliases and name == "event_type":
+                _merge_enum_refs(refs, {"session_event_type": schema}, path=field_path)
         nested_fields = field.get("fields")
         if isinstance(nested_fields, Mapping):
-            refs.update(_collect_enum_refs(nested_fields))
+            _merge_enum_refs(
+                refs,
+                _collect_enum_refs(
+                    nested_fields,
+                    path=f"{field_path}.fields",
+                    scoped_session_aliases=scoped_session_aliases,
+                ),
+            )
     return refs
+
+
+def _merge_enum_refs(
+    refs: dict[str, JSONSchema],
+    candidates: Mapping[str, JSONSchema],
+    *,
+    path: str = "$",
+) -> None:
+    for name, schema in candidates.items():
+        if name in refs and refs[name] != schema:
+            raise ContractSchemaError(f"{path}: conflicting enum reference {name!r}")
+        refs[name] = dict(schema)
 
 
 def _has_explicit_object_marker(node: Mapping[str, Any]) -> bool:
@@ -436,3 +543,15 @@ def _json_primitive_type(value: Any) -> str | None:
     if isinstance(value, str):
         return "string"
     return None
+
+
+def _number(value: Any, *, path: str) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ContractSchemaError(f"{path}: bound must be a number")
+    return value
+
+
+def _nonnegative_integer(value: Any, *, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ContractSchemaError(f"{path}: bound must be a non-negative integer")
+    return value

--- a/python/openbrain-memory/tests/test_schema.py
+++ b/python/openbrain-memory/tests/test_schema.py
@@ -352,6 +352,26 @@ def test_multiple_required_string_groups_require_each_group():
     }
 
 
+def test_typed_object_fields_preserve_required_string_groups():
+    assert contract_field_to_json_schema(
+        {
+            "type": "object",
+            "fields": {
+                "symbol": {"type": "string", "required": "symbol_or_subject"},
+                "subject": {"type": "string", "required": "symbol_or_subject"},
+            },
+        },
+        path="$.metadata",
+    ) == {
+        "type": "object",
+        "properties": {
+            "symbol": {"type": "string"},
+            "subject": {"type": "string"},
+        },
+        "anyOf": [{"required": ["symbol"]}, {"required": ["subject"]}],
+    }
+
+
 def test_current_dsl_bounds_convert_or_use_vendor_extensions():
     assert contract_field_to_json_schema(
         {

--- a/python/openbrain-memory/tests/test_schema.py
+++ b/python/openbrain-memory/tests/test_schema.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import pytest
+
+from openbrain_memory import (
+    ContractSchemaError,
+    contract_field_to_json_schema,
+    contract_input_to_json_schema,
+    tool_contract_to_input_schema,
+    tool_contracts_to_tool_schemas,
+)
+
+
+def test_enum_values_convert_with_inferred_type():
+    assert contract_field_to_json_schema(
+        {
+            "type": "enum",
+            "values": ["hybrid", "vector", "keyword"],
+            "description": "Search mode.",
+            "default": "hybrid",
+        },
+        path="$.search_mode",
+    ) == {
+        "type": "string",
+        "enum": ["hybrid", "vector", "keyword"],
+        "description": "Search mode.",
+        "default": "hybrid",
+    }
+
+
+def test_literal_value_converts_to_const():
+    assert contract_field_to_json_schema(
+        {
+            "type": "literal",
+            "value": "qmd",
+            "description": "Source system.",
+        },
+        path="$.metadata.source_system",
+    ) == {
+        "const": "qmd",
+        "type": "string",
+        "description": "Source system.",
+    }
+
+
+def test_min_max_constraints_convert_to_json_schema_bounds():
+    assert contract_field_to_json_schema(
+        {"type": "number", "min": 0, "max": 1, "default": 1},
+        path="$.confidence",
+    ) == {"type": "number", "default": 1, "minimum": 0, "maximum": 1}
+
+
+def test_nested_fields_convert_to_properties_and_required_list():
+    assert contract_field_to_json_schema(
+        {
+            "type": "object",
+            "fields": {
+                "share_candidate": {"type": "boolean", "required": False},
+                "reason": {"type": "string", "required": True},
+            },
+        },
+        path="$.metadata",
+    ) == {
+        "type": "object",
+        "properties": {
+            "share_candidate": {"type": "boolean"},
+            "reason": {"type": "string"},
+        },
+        "required": ["reason"],
+    }
+
+
+def test_arrays_convert_string_item_refs_and_manifest_enum_refs():
+    manifest = {
+        "tool_contracts": {
+            "append_session_event": {
+                "version": 3,
+                "input_schema": {
+                    "event_type": {
+                        "type": "enum",
+                        "required": True,
+                        "values": ["fact", "decision", "blocker"],
+                    },
+                },
+                "output_shape": "event",
+            },
+            "session_context": {
+                "version": 2,
+                "input_schema": {
+                    "event_types": {
+                        "type": "array",
+                        "items": "session_event_type",
+                    },
+                    "tags": {"type": "array", "items": "string"},
+                },
+                "output_shape": "context",
+            },
+        },
+    }
+
+    [schema] = tool_contracts_to_tool_schemas(
+        manifest,
+        tool_names=["session_context"],
+    )
+
+    assert schema["input_schema"]["properties"]["tags"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+    assert schema["input_schema"]["properties"]["event_types"] == {
+        "type": "array",
+        "items": {
+            "type": "string",
+            "enum": ["fact", "decision", "blocker"],
+        },
+    }
+
+
+def test_typeless_contract_field_maps_convert_to_object_properties():
+    assert contract_field_to_json_schema(
+        {
+            "source_system": {"type": "literal", "value": "qmd", "required": True},
+            "repo": {"type": "string", "required": True, "maxLength": 300},
+            "confidence": {"type": "number", "min": 0, "max": 1, "default": 1},
+        },
+        path="$.metadata",
+    ) == {
+        "type": "object",
+        "properties": {
+            "source_system": {"const": "qmd", "type": "string"},
+            "repo": {"type": "string", "maxLength": 300},
+            "confidence": {
+                "type": "number",
+                "default": 1,
+                "minimum": 0,
+                "maximum": 1,
+            },
+        },
+        "additionalProperties": False,
+        "required": ["source_system", "repo"],
+    }
+
+
+def test_typeless_object_markers_convert_property_names_and_additional_properties():
+    assert contract_field_to_json_schema(
+        {
+            "propertyNames": {"type": "string", "maxLength": 100},
+            "additionalProperties": {"type": "string"},
+            "description": "Metadata.",
+        },
+        path="$.metadata",
+    ) == {
+        "type": "object",
+        "propertyNames": {"type": "string", "maxLength": 100},
+        "additionalProperties": {"type": "string"},
+        "description": "Metadata.",
+    }
+
+
+def test_real_repo_fact_metadata_typeless_contract_converts_to_object_schema():
+    schema = contract_field_to_json_schema(
+        {
+            "source_system": {
+                "type": "literal",
+                "value": "qmd",
+                "required": True,
+            },
+            "repo": {"type": "string", "required": True, "maxLength": 300},
+            "collection": {"type": "string", "required": True, "maxLength": 300},
+            "path": {"type": "string", "required": True, "maxLength": 1000},
+            "symbol": {
+                "type": "string",
+                "required": "symbol_or_subject",
+                "maxLength": 300,
+            },
+            "subject": {
+                "type": "string",
+                "required": "symbol_or_subject",
+                "maxLength": 500,
+            },
+            "fact_type": {
+                "type": "enum",
+                "required": True,
+                "values": ["ownership", "gotcha", "api_contract"],
+            },
+            "fact": {"type": "string", "required": True, "maxLength": 2000},
+            "source_commit": {"type": "git_sha", "required": True},
+            "source_url": {"type": "https_github_url", "required": True},
+            "verified_at": {"type": "datetime_not_future", "required": True},
+            "confidence": {"type": "number", "min": 0, "max": 1, "default": 1},
+            "staleness_policy": {
+                "type": "enum",
+                "required": True,
+                "values": ["stable_fact_verify_source", "commit_pinned"],
+            },
+            "refresh_hint": {"type": "string", "required": False, "maxLength": 1000},
+        },
+        path="$.tool_contracts.upsert_repo_fact.input_schema.metadata",
+    )
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == [
+        "source_system",
+        "repo",
+        "collection",
+        "path",
+        "fact_type",
+        "fact",
+        "source_commit",
+        "source_url",
+        "verified_at",
+        "staleness_policy",
+    ]
+    assert schema["properties"]["source_system"] == {
+        "const": "qmd",
+        "type": "string",
+    }
+    assert schema["properties"]["source_commit"] == {"type": "string"}
+    assert schema["properties"]["verified_at"] == {
+        "type": "string",
+        "format": "date-time",
+    }
+    assert schema["properties"]["fact_type"] == {
+        "type": "string",
+        "enum": ["ownership", "gotcha", "api_contract"],
+    }
+    assert schema["properties"]["confidence"] == {
+        "type": "number",
+        "default": 1,
+        "minimum": 0,
+        "maximum": 1,
+    }
+
+
+def test_real_repo_fact_validation_metadata_converts_to_conservative_schema():
+    schema = contract_field_to_json_schema(
+        {
+            "source_url": {
+                "allowed_hosts": ["github.com", "raw.githubusercontent.com"],
+                "protocol": "https",
+                "credentials_allowed": False,
+                "local_private_hosts_allowed": False,
+                "github_url_shapes": [
+                    "/<owner>/<repo>/blob/<source_commit>/<repo_relative_path>",
+                    "/<owner>/<repo>/<source_commit>/<repo_relative_path>",
+                ],
+                "repo_match": "url repo segment must match metadata.repo slug",
+                "commit_match": "source_commit must be a path segment",
+                "path_match": "exact repo-relative path match",
+            },
+            "fact_body": {
+                "raw_code_chunks_allowed": False,
+                "credential_like_material_allowed": False,
+                "max_lines": 6,
+                "rejected_secret_shapes": [
+                    "labelled token/password/secret/api_key/authorization values",
+                    "AWS access key IDs",
+                ],
+            },
+        },
+        path="$.tool_contracts.upsert_repo_fact.input_schema.validation",
+    )
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["source_url", "fact_body"]
+    assert schema["properties"]["source_url"]["properties"]["protocol"] == {
+        "type": "string",
+        "const": "https",
+    }
+    assert schema["properties"]["source_url"]["properties"]["allowed_hosts"] == {
+        "type": "array",
+        "prefixItems": [
+            {"type": "string", "const": "github.com"},
+            {"type": "string", "const": "raw.githubusercontent.com"},
+        ],
+        "minItems": 2,
+        "maxItems": 2,
+    }
+    assert schema["properties"]["fact_body"]["properties"]["max_lines"] == {
+        "type": "integer",
+        "const": 6,
+    }
+
+
+def test_mixed_typeless_contract_and_metadata_nodes_fail_with_path():
+    with pytest.raises(
+        ContractSchemaError,
+        match=r"\$\.metadata: typeless contract node mixes contract fields",
+    ):
+        contract_field_to_json_schema(
+            {
+                "repo": {"type": "string"},
+                "validation_notes": {"allowed_hosts": ["github.com"]},
+            },
+            path="$.metadata",
+        )
+
+
+def test_contract_input_to_json_schema_wraps_field_mapping():
+    assert contract_input_to_json_schema(
+        {
+            "query": {"type": "string", "required": True, "minLength": 1},
+            "limit": {"type": "integer", "required": False, "min": 1, "max": 20},
+        },
+        title="search_all",
+    ) == {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "minLength": 1},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 20},
+        },
+        "additionalProperties": False,
+        "required": ["query"],
+        "title": "search_all",
+    }
+
+
+def test_tool_contract_to_input_schema_converts_input_schema():
+    assert tool_contract_to_input_schema(
+        "search_all",
+        {
+            "version": 2,
+            "input_schema": {"query": {"type": "string", "required": True}},
+            "output_shape": "results",
+        },
+    ) == {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "additionalProperties": False,
+        "required": ["query"],
+        "title": "search_all",
+    }
+
+
+def test_tool_contracts_to_tool_schemas_filters_selected_tools():
+    manifest = {
+        "tool_contracts": {
+            "search_all": {
+                "version": 2,
+                "input_schema": {"query": {"type": "string", "required": True}},
+                "output_shape": "results",
+            },
+            "get_contract": {
+                "version": 1,
+                "input_schema": {},
+                "output_shape": "contract",
+            },
+        },
+    }
+
+    assert tool_contracts_to_tool_schemas(
+        manifest,
+        tool_names=["get_contract"],
+    ) == [
+        {
+            "name": "get_contract",
+            "input_schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+def test_unresolved_array_ref_fails_with_path():
+    with pytest.raises(ContractSchemaError, match=r"\$\.event_types\.items"):
+        contract_input_to_json_schema(
+            {"event_types": {"type": "array", "items": "session_event_type"}},
+        )

--- a/python/openbrain-memory/tests/test_schema.py
+++ b/python/openbrain-memory/tests/test_schema.py
@@ -50,6 +50,27 @@ def test_min_max_constraints_convert_to_json_schema_bounds():
     ) == {"type": "number", "default": 1, "minimum": 0, "maximum": 1}
 
 
+def test_malformed_schema_keyword_types_fail_with_path():
+    invalid_nodes = [
+        ("$.score.min", {"type": "number", "min": "0"}),
+        ("$.name.maxLength", {"type": "string", "maxLength": "100"}),
+        ("$.tags.maxItems", {"type": "array", "items": "string", "maxItems": 3.5}),
+        (
+            "$.metadata.additionalProperties",
+            {"type": "object", "additionalProperties": "no"},
+        ),
+        (
+            "$.tags.maxItemLength",
+            {"type": "array", "items": "string", "maxItemLength": -1},
+        ),
+    ]
+
+    for expected_path, node in invalid_nodes:
+        path_match = expected_path.replace("$", r"\$")
+        with pytest.raises(ContractSchemaError, match=path_match):
+            contract_field_to_json_schema(node, path=expected_path.rsplit(".", 1)[0])
+
+
 def test_nested_fields_convert_to_properties_and_required_list():
     assert contract_field_to_json_schema(
         {
@@ -114,6 +135,52 @@ def test_arrays_convert_string_item_refs_and_manifest_enum_refs():
             "enum": ["fact", "decision", "blocker"],
         },
     }
+
+
+def test_manifest_enum_ref_conflicts_fail_with_path():
+    manifest = {
+        "tool_contracts": {
+            "first": {
+                "input_schema": {
+                    "status": {"type": "enum", "values": ["open", "closed"]},
+                },
+            },
+            "second": {
+                "input_schema": {
+                    "status": {"type": "enum", "values": ["hot", "cold"]},
+                },
+            },
+        },
+    }
+
+    with pytest.raises(
+        ContractSchemaError,
+        match=r"conflicting enum reference 'status'",
+    ):
+        tool_contracts_to_tool_schemas(manifest)
+
+
+def test_session_event_type_alias_is_scoped_to_append_session_event():
+    manifest = {
+        "tool_contracts": {
+            "other_tool": {
+                "input_schema": {
+                    "event_type": {"type": "enum", "values": ["unrelated"]},
+                },
+            },
+            "session_context": {
+                "input_schema": {
+                    "event_types": {"type": "array", "items": "session_event_type"},
+                },
+            },
+        },
+    }
+
+    with pytest.raises(
+        ContractSchemaError,
+        match=r"\$\.tool_contracts\.session_context\.input_schema\.event_types\.items",
+    ):
+        tool_contracts_to_tool_schemas(manifest, tool_names=["session_context"])
 
 
 def test_typeless_contract_field_maps_convert_to_object_properties():
@@ -231,6 +298,91 @@ def test_real_repo_fact_metadata_typeless_contract_converts_to_object_schema():
         "minimum": 0,
         "maximum": 1,
     }
+    assert schema["anyOf"] == [{"required": ["symbol"]}, {"required": ["subject"]}]
+
+
+def test_required_string_groups_convert_to_anyof_required_alternatives():
+    assert contract_input_to_json_schema(
+        {
+            "session_key": {"type": "string", "required": "session_key_or_channel_id"},
+            "channel_id": {"type": "string", "required": "session_key_or_channel_id"},
+        },
+    ) == {
+        "type": "object",
+        "properties": {
+            "session_key": {"type": "string"},
+            "channel_id": {"type": "string"},
+        },
+        "additionalProperties": False,
+        "anyOf": [{"required": ["session_key"]}, {"required": ["channel_id"]}],
+    }
+
+
+def test_multiple_required_string_groups_require_each_group():
+    assert contract_input_to_json_schema(
+        {
+            "session_key": {"type": "string", "required": "session_key_or_channel_id"},
+            "channel_id": {"type": "string", "required": "session_key_or_channel_id"},
+            "symbol": {"type": "string", "required": "symbol_or_subject"},
+            "subject": {"type": "string", "required": "symbol_or_subject"},
+        },
+    ) == {
+        "type": "object",
+        "properties": {
+            "session_key": {"type": "string"},
+            "channel_id": {"type": "string"},
+            "symbol": {"type": "string"},
+            "subject": {"type": "string"},
+        },
+        "additionalProperties": False,
+        "allOf": [
+            {
+                "anyOf": [
+                    {"required": ["session_key"]},
+                    {"required": ["channel_id"]},
+                ],
+            },
+            {
+                "anyOf": [
+                    {"required": ["symbol"]},
+                    {"required": ["subject"]},
+                ],
+            },
+        ],
+    }
+
+
+def test_current_dsl_bounds_convert_or_use_vendor_extensions():
+    assert contract_field_to_json_schema(
+        {
+            "type": "array",
+            "items": "string",
+            "maxItems": 4,
+            "maxItemLength": 20,
+        },
+        path="$.tags",
+    ) == {
+        "type": "array",
+        "items": {"type": "string", "maxLength": 20},
+        "maxItems": 4,
+    }
+
+    assert contract_field_to_json_schema(
+        {"type": "object", "maxKeys": 8, "maxJsonBytes": 4096},
+        path="$.metadata",
+    ) == {
+        "type": "object",
+        "x-openbrain-maxKeys": 8,
+        "x-openbrain-maxJsonBytes": 4096,
+    }
+
+
+def test_max_item_length_on_non_string_array_fails_with_path():
+    with pytest.raises(ContractSchemaError, match=r"\$\.ids\.maxItemLength"):
+        contract_field_to_json_schema(
+            {"type": "array", "items": "integer", "maxItemLength": 20},
+            path="$.ids",
+        )
 
 
 def test_real_repo_fact_validation_metadata_converts_to_conservative_schema():
@@ -370,3 +522,103 @@ def test_unresolved_array_ref_fails_with_path():
         contract_input_to_json_schema(
             {"event_types": {"type": "array", "items": "session_event_type"}},
         )
+
+
+def test_representative_get_contract_manifest_converts_current_shapes():
+    manifest = {
+        "tool_contracts": {
+            "append_session_event": {
+                "version": 3,
+                "input_schema": {
+                    "session_key": {
+                        "type": "string",
+                        "required": "session_key_or_channel_id",
+                    },
+                    "channel_id": {
+                        "type": "string",
+                        "required": "session_key_or_channel_id",
+                    },
+                    "event_type": {
+                        "type": "enum",
+                        "required": True,
+                        "values": ["fact", "decision", "blocker"],
+                    },
+                },
+                "output_shape": "event",
+            },
+            "session_context": {
+                "version": 2,
+                "input_schema": {
+                    "event_types": {
+                        "type": "array",
+                        "items": "session_event_type",
+                        "maxItems": 12,
+                    },
+                },
+                "output_shape": "context",
+            },
+            "upsert_repo_fact": {
+                "version": 1,
+                "input_schema": {
+                    "metadata": {
+                        "source_system": {
+                            "type": "literal",
+                            "value": "qmd",
+                            "required": True,
+                        },
+                        "symbol": {
+                            "type": "string",
+                            "required": "symbol_or_subject",
+                            "maxLength": 300,
+                        },
+                        "subject": {
+                            "type": "string",
+                            "required": "symbol_or_subject",
+                            "maxLength": 500,
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": "string",
+                            "maxItems": 5,
+                            "maxItemLength": 40,
+                        },
+                    },
+                    "validation": {
+                        "fact_body": {
+                            "type": "object",
+                            "maxJsonBytes": 4096,
+                            "maxKeys": 8,
+                        },
+                    },
+                },
+                "output_shape": "repo_fact",
+            },
+        },
+    }
+
+    schemas = {
+        schema["name"]: schema["input_schema"]
+        for schema in tool_contracts_to_tool_schemas(manifest)
+    }
+
+    assert schemas["session_context"]["properties"]["event_types"] == {
+        "type": "array",
+        "items": {"type": "string", "enum": ["fact", "decision", "blocker"]},
+        "maxItems": 12,
+    }
+    assert schemas["append_session_event"]["anyOf"] == [
+        {"required": ["session_key"]},
+        {"required": ["channel_id"]},
+    ]
+    metadata = schemas["upsert_repo_fact"]["properties"]["metadata"]
+    assert metadata["anyOf"] == [{"required": ["symbol"]}, {"required": ["subject"]}]
+    assert metadata["properties"]["tags"]["items"] == {
+        "type": "string",
+        "maxLength": 40,
+    }
+    validation = schemas["upsert_repo_fact"]["properties"]["validation"]
+    assert validation["properties"]["fact_body"] == {
+        "type": "object",
+        "x-openbrain-maxKeys": 8,
+        "x-openbrain-maxJsonBytes": 4096,
+    }


### PR DESCRIPTION
## Summary

Adds package-owned helpers that translate the Open Brain `get_contract` DSL into
JSON Schema-compatible tool input schemas.

This covers the Run C package boundary for #179 so `rtech-hermes` can consume a
shared package helper instead of maintaining a Hermes-only contract normalizer.

## What changed

- Added `openbrain_memory.schema` with:
  - `contract_field_to_json_schema`
  - `contract_input_to_json_schema`
  - `tool_contract_to_input_schema`
  - `tool_contracts_to_tool_schemas`
  - `ContractSchemaError`
- Exported the helper API from `openbrain_memory`.
- Added tests for:
  - `type: "enum"` + `values`
  - `type: "literal"` + `value`
  - min/max conversion
  - semantic string types
  - nested object fields
  - arrays with primitive and enum string refs
  - typeless repo-fact metadata field maps
  - typeless repo-fact validation metadata
  - unsupported/mixed typeless nodes with path-bearing failures

## Critical Self-Review

- Highest-risk behavior: typeless contract nodes. `upsert_repo_fact.metadata`
  is a typeless contract field map, while `validation` is typeless validation
  metadata. The converter now distinguishes field maps from metadata maps and
  rejects mixed shapes.
- Assumptions that could be wrong: package consumers may need a different outer
  tool-schema envelope than `{name, input_schema}`. The lower-level
  `tool_contract_to_input_schema` API is available so Hermes can wrap the output
  in its own tool format without moving Hermes policy here.
- Missing/weak tests: tests model the known repo-fact constants but do not load
  the live TypeScript contract directly. Hermes will still verify against live
  `get_contract` during the downstream PR.
- Security/permission risk: no auth, namespace, transport, or server-side
  permission behavior changed. The package does not add Hermes allowlists or
  session policy.
- Migration/deploy risk: this is an additive package export. Existing package
  callers should be unaffected.
- Downstream client/runtime risk: applicable. This is intended for
  `rtech-hermes`; the Hermes PR must consume the helper, preserve allowlists and
  protected `session_key`, and pass canaries before agent rollout is complete.
- Rollback/cleanup concern: rollback is removing the additive module/export and
  returning Hermes to its existing local normalizer until the helper is fixed.
- Fixes made before PR: added real repo-fact metadata/validation tests after a
  controller repro showed the first implementation rejected `metadata`.
- Known residual risk: #181 lane/spool/canary helper expansion is not included
  in this slice.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: initial author-side change adds no new MEDIUM+ review finding yet; swarm findings will be posted before merge and promoted if needed.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this PR changes only the Python package helper/export and does not change hosted server runtime behavior or MCP schemas.

## Downstream rollout classification

Applies under `docs/downstream-rollout.md` because this changes
`python/openbrain-memory` package behavior and exports.

- Open Brain local verification: complete, see validation below.
- Hosted Open Brain deploy/smoke: not applicable for this PR by itself; server
  runtime behavior and MCP schemas are unchanged.
- rtech-mcps/mcp2cli generated skill refresh: not applicable; no MCP tool or
  server contract changed.
- rtech-hermes runtime/plugin check: required in the follow-up Hermes Phase 2
  PR before claiming agent readiness.
- Hermes live rollout: deferred to the Hermes PR/canary phase after package
  consumption lands.

## Validation

From `python/openbrain-memory`:

```text
uv run ruff check src tests
uv run mypy src/openbrain_memory
uv run pytest -q
uv build
```

Results:

```text
ruff: All checks passed
mypy: Success: no issues found in 8 source files
pytest: 136 passed, 1 skipped
uv build: built sdist and wheel successfully
```

Closes #179.
