### PR TITLE
feat: add openbrain memory readiness helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,16 @@ jobs:
 
       - uses: astral-sh/setup-uv@v8.2.0
 
+      - name: Lint python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run ruff check src tests
+
+      - name: Typecheck python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run mypy src/openbrain_memory
+
       - name: Test python package
         env:
           TMPDIR: ${{ runner.temp }}

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -344,11 +344,20 @@ bearer tokens. For trusted lab-only HTTP endpoints, set
 The default live canary now checks package helper readiness, not just `/health`:
 
 - `health()` and `search_all()` read access.
-- `get_contract()` plus `validate_contract_manifest()` against
+- `get_contract()` plus `validate_required_memory_contract()` against
   `REQUIRED_CONTRACT_TOOLS` and the package `CURRENT_CONTRACT_VERSION`.
-- Low-impact session lane writes and reads through `session_start()`,
-  `lane_upsert()`, `append_session_event()`, `session_context()`,
-  `lane_load()`, and `session_wrap()`.
+- `brain_answer()` and `list_repo_facts()` read access.
+
+Write canaries are intentionally opt-in because they create durable session
+state. To exercise lane/session writes, set:
+
+```bash
+OPENBRAIN_LIVE_CANARY_WRITE=1
+```
+
+That write canary checks `session_start()`, `lane_upsert()`,
+`append_session_event()`, `session_context()`, `lane_load()`, and
+`session_wrap()`, including proof that the appended event is readable afterward.
 
 `upsert_repo_fact()` is intentionally not part of the default canary because it
 creates curated repo-fact rows. To opt into that higher-impact write, set both:
@@ -373,9 +382,10 @@ Required coverage:
   endpoint and treat its manifest as the source of truth. Check
   `contract_version`, `contract_scope`, `schema_hash`, compatible/minimum client
   version fields, required capabilities, and required tool names before enabling
-  required-memory mode. The package exposes helpers and constants, but required
-  contract validation remains a runtime integration responsibility until a
-  shared validator lands.
+  required-memory mode. The package exposes `validate_required_memory_contract()`
+  for this check; the connected endpoint's `get_contract()` manifest remains
+  authoritative, and the runtime that consumes the package still owns the
+  fail-closed decision.
 - **Lane tools:** exercise `session_start`, `session_context`, `lane_upsert`,
   `lane_load`, and `session_wrap` for the agent namespace.
 - **Append/write:** verify `append_session_event` can write through the
@@ -391,6 +401,7 @@ Required coverage:
   decision that the failed write is acceptable for the canary.
 
 `tests/test_live_canary.py` is env-gated and suitable for package helper
-readiness checks. Host rollouts should record which live endpoint, package
+readiness checks. The default gate is read-only; write checks require explicit
+write env flags. Host rollouts should record which live endpoint, package
 version or artifact, namespace, optional write gates, and canary operations were
 verified.

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -330,7 +330,7 @@ OPENBRAIN_LIVE_CANARY=1 \
 OPENBRAIN_BASE_URL=http://127.0.0.1:3100 \
 OPENBRAIN_TOKEN=... \
 OPENBRAIN_NAMESPACE=bilby \
-uv run pytest tests/test_live_canary.py
+uv run pytest tests/test_live_canary.py -q
 ```
 
 Set `OPENBRAIN_ROLE`/`OPENBRAIN_AGENT_ID` for the identity labels expected by
@@ -340,6 +340,26 @@ tokens; the server should derive their namespace from the token.
 Non-local `http://` endpoints are rejected by default because MCP requests carry
 bearer tokens. For trusted lab-only HTTP endpoints, set
 `OPENBRAIN_ALLOW_INSECURE_HTTP=1` explicitly.
+
+The default live canary now checks package helper readiness, not just `/health`:
+
+- `health()` and `search_all()` read access.
+- `get_contract()` plus `validate_contract_manifest()` against
+  `REQUIRED_CONTRACT_TOOLS` and the package `CURRENT_CONTRACT_VERSION`.
+- Low-impact session lane writes and reads through `session_start()`,
+  `lane_upsert()`, `append_session_event()`, `session_context()`,
+  `lane_load()`, and `session_wrap()`.
+
+`upsert_repo_fact()` is intentionally not part of the default canary because it
+creates curated repo-fact rows. To opt into that higher-impact write, set both:
+
+```bash
+OPENBRAIN_LIVE_CANARY_REPO_FACT_WRITE=1 \
+OPENBRAIN_LIVE_CANARY_REPO_FACT_COMMIT=<git-sha>
+```
+
+The commit must be the source commit used in the GitHub source URL embedded in
+the repo-fact metadata.
 
 ### Canary Coverage Expectations
 
@@ -358,8 +378,10 @@ Required coverage:
   shared validator lands.
 - **Lane tools:** exercise `session_start`, `session_context`, `lane_upsert`,
   `lane_load`, and `session_wrap` for the agent namespace.
-- **Append/write:** verify `append_session_event`, `log_thought`, and
-  `upsert_repo_fact` can write through the configured token and namespace.
+- **Append/write:** verify `append_session_event` can write through the
+  configured token and namespace. Verify `upsert_repo_fact` only when the
+  explicit repo-fact write gate is enabled. Use a separate `log_thought` check
+  only when durable general-memory writes are intended for the rollout.
 - **Read:** verify `search_all`, `brain_answer`, and `list_repo_facts` can read
   expected results without crossing namespace or role boundaries.
 - **Spool distinction:** verify a successful live write is reported as saved in
@@ -368,7 +390,7 @@ Required coverage:
   Open Brain memory; readiness requires either replay success or an explicit
   decision that the failed write is acceptable for the canary.
 
-The current `tests/test_live_canary.py` is intentionally small and env-gated.
-It is a smoke test, not the full Hermes readiness canary. Host rollouts should
-record which live endpoint, package version or artifact, namespace, and canary
-operations were verified.
+`tests/test_live_canary.py` is env-gated and suitable for package helper
+readiness checks. Host rollouts should record which live endpoint, package
+version or artifact, namespace, optional write gates, and canary operations were
+verified.

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -16,7 +16,11 @@ from .client import (
     OpenBrainProtocolError,
     OpenBrainToolError,
 )
-from .contract import ContractValidationResult, validate_contract_manifest
+from .contract import (
+    ContractValidationResult,
+    validate_contract_manifest,
+    validate_required_memory_contract,
+)
 from .dream import DreamAction, DreamClient, DreamEngine, DreamPolicy, DreamRun
 from .policy import RetryExhaustedError, RetryPolicy, redact_text, redact_value
 from .schema import (
@@ -26,7 +30,7 @@ from .schema import (
     tool_contract_to_input_schema,
     tool_contracts_to_tool_schemas,
 )
-from .spool import JsonlSpool, SpoolRecord, replay_records
+from .spool import JsonlSpool, SpoolRecord, SpoolStatus, replay_records
 
 __all__ = [
     "AgentMemory",
@@ -54,6 +58,7 @@ __all__ = [
     "RetryExhaustedError",
     "RetryPolicy",
     "SpoolRecord",
+    "SpoolStatus",
     "contract_field_to_json_schema",
     "contract_input_to_json_schema",
     "redact_text",
@@ -62,4 +67,5 @@ __all__ = [
     "tool_contract_to_input_schema",
     "tool_contracts_to_tool_schemas",
     "validate_contract_manifest",
+    "validate_required_memory_contract",
 ]

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -62,12 +62,6 @@ REPO_FACT_TYPES = {
     "validation",
     "workflow",
 }
-STALENESS_POLICIES = {
-    "commit_pinned",
-    "refresh_required",
-    "stable_fact_verify_source",
-    "volatile_pointer_only",
-}
 
 
 class MemoryClient(Protocol):
@@ -203,7 +197,6 @@ class AgentMemory:
         self,
         session_key: str | None = None,
         *,
-        namespace: str | None = None,
         channel_id: str | None = None,
         thread_id: str | None = None,
         include_events: bool | None = None,
@@ -215,7 +208,6 @@ class AgentMemory:
             raise ValueError("load_session_context requires session_key or channel_id")
         payload: dict[str, Any] = {}
         _set_optional_str(payload, "session_key", session_key)
-        _set_optional_str(payload, "namespace", namespace)
         _set_optional_str(payload, "channel_id", channel_id)
         _set_optional_str(payload, "thread_id", thread_id)
         if include_events is not None:
@@ -241,7 +233,6 @@ class AgentMemory:
         self,
         session_key: str | None = None,
         *,
-        namespace: str | None = None,
         project: str | None = None,
         agent: str | None = None,
         channel_id: str | None = None,
@@ -250,7 +241,6 @@ class AgentMemory:
     ) -> JSON:
         payload: dict[str, Any] = {}
         _set_optional_str(payload, "session_key", session_key)
-        _set_optional_str(payload, "namespace", namespace)
         _set_optional_str(
             payload,
             "project",
@@ -268,7 +258,6 @@ class AgentMemory:
         self,
         session_key: str,
         *,
-        namespace: str | None = None,
         status: str | None = None,
         agent: str | None = None,
         source: str | None = None,
@@ -282,7 +271,6 @@ class AgentMemory:
         payload: dict[str, Any] = {
             "session_key": _required_str(session_key, "session_key")
         }
-        _set_optional_str(payload, "namespace", namespace)
         if status is not None:
             payload["status"] = _enum_value(status, "status", LANE_STATUSES)
         _set_optional_str(payload, "agent", agent if agent is not None else self.agent)
@@ -305,7 +293,6 @@ class AgentMemory:
         self,
         query: str,
         *,
-        namespace: str | None = None,
         limit: int | None = None,
         search_mode: str | None = None,
         tier: str | None = None,
@@ -313,7 +300,6 @@ class AgentMemory:
         include_raw: bool | None = None,
     ) -> JSON:
         payload: dict[str, Any] = {"query": _required_str(query, "query")}
-        _set_optional_str(payload, "namespace", namespace)
         if limit is not None:
             payload["limit"] = _bounded_int(limit, "limit", minimum=1, maximum=25)
         if search_mode is not None:
@@ -338,7 +324,6 @@ class AgentMemory:
     def repo_facts(
         self,
         *,
-        namespace: str | None = None,
         repo: str | None = None,
         collection: str | None = None,
         path: str | None = None,
@@ -348,7 +333,6 @@ class AgentMemory:
         offset: int | None = None,
     ) -> JSON:
         payload: dict[str, Any] = {}
-        _set_optional_str(payload, "namespace", namespace)
         _set_optional_str(payload, "repo", repo)
         _set_optional_str(payload, "collection", collection)
         _set_optional_str(payload, "path", path)
@@ -367,52 +351,15 @@ class AgentMemory:
 
     def upsert_repo_fact(
         self,
+        metadata: Mapping[str, Any],
         *,
-        repo: str,
-        collection: str,
-        path: str,
-        fact_type: str,
-        fact: str,
-        source_commit: str,
-        source_url: str,
-        verified_at: str,
-        staleness_policy: str,
-        namespace: str | None = None,
-        symbol: str | None = None,
-        subject: str | None = None,
-        confidence: int | float | None = None,
-        refresh_hint: str | None = None,
+        validation: Mapping[str, Any] | None = None,
     ) -> JSON:
-        if not symbol and not subject:
-            raise ValueError("upsert_repo_fact requires symbol or subject")
-        metadata: dict[str, Any] = {
-            "source_system": "qmd",
-            "repo": _required_str(repo, "repo"),
-            "collection": _required_str(collection, "collection"),
-            "path": _required_str(path, "path"),
-            "fact_type": _enum_value(fact_type, "fact_type", REPO_FACT_TYPES),
-            "fact": _required_str(fact, "fact"),
-            "source_commit": _required_str(source_commit, "source_commit"),
-            "source_url": _required_str(source_url, "source_url"),
-            "verified_at": _required_str(verified_at, "verified_at"),
-            "staleness_policy": _enum_value(
-                staleness_policy,
-                "staleness_policy",
-                STALENESS_POLICIES,
-            ),
-        }
-        _set_optional_str(metadata, "symbol", symbol)
-        _set_optional_str(metadata, "subject", subject)
-        _set_optional_str(metadata, "refresh_hint", refresh_hint)
-        if confidence is not None:
-            metadata["confidence"] = _bounded_number(
-                confidence,
-                "confidence",
-                minimum=0,
-                maximum=1,
-            )
-        payload: dict[str, Any] = {"metadata": metadata}
-        _set_optional_str(payload, "namespace", namespace)
+        self._reject_reserved_metadata(metadata)
+        payload: dict[str, Any] = {"metadata": dict(metadata)}
+        if validation is not None:
+            self._reject_reserved_metadata(validation)
+            payload["validation"] = dict(validation)
         return self._call_write(
             "upsert_repo_fact",
             payload,
@@ -769,22 +716,6 @@ def _bounded_int(
     if value < minimum:
         raise ValueError(f"{name} must be >= {minimum}")
     if maximum is not None and value > maximum:
-        raise ValueError(f"{name} must be <= {maximum}")
-    return value
-
-
-def _bounded_number(
-    value: Any,
-    name: str,
-    *,
-    minimum: int | float,
-    maximum: int | float,
-) -> int | float:
-    if isinstance(value, bool) or not isinstance(value, int | float):
-        raise ValueError(f"{name} must be a number")
-    if value < minimum:
-        raise ValueError(f"{name} must be >= {minimum}")
-    if value > maximum:
         raise ValueError(f"{name} must be <= {maximum}")
     return value
 

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -50,20 +50,50 @@ SESSION_START_KEYS = {"channel_id", "thread_id", "topic"}
 SESSION_WRAP_KEYS = {"key_decisions", "next_steps"}
 DECISION_KEYS = {"alternatives", "tags", "context"}
 THOUGHT_KEYS = {"tags"}
+LANE_STATUSES = {"active", "wrapped", "archived"}
+SEARCH_MODES = {"hybrid", "vector", "keyword"}
+REPO_FACT_TYPES = {
+    "api_contract",
+    "dependency",
+    "gotcha",
+    "migration",
+    "ownership",
+    "source_pointer",
+    "validation",
+    "workflow",
+}
+STALENESS_POLICIES = {
+    "commit_pinned",
+    "refresh_required",
+    "stable_fact_verify_source",
+    "volatile_pointer_only",
+}
 
 
 class MemoryClient(Protocol):
     def session_start(self, **arguments: Any) -> JSON: ...
 
+    def session_context(self, **arguments: Any) -> JSON: ...
+
     def append_session_event(self, **arguments: Any) -> JSON: ...
 
     def search_all(self, **arguments: Any) -> JSON: ...
+
+    def brain_answer(self, **arguments: Any) -> JSON: ...
+
+    def lane_load(self, **arguments: Any) -> JSON: ...
+
+    def lane_upsert(self, **arguments: Any) -> JSON: ...
+
+    def list_repo_facts(self, **arguments: Any) -> JSON: ...
 
     def log_thought(self, **arguments: Any) -> JSON: ...
 
     def log_decision(self, **arguments: Any) -> JSON: ...
 
     def session_wrap(self, **arguments: Any) -> JSON: ...
+
+    def upsert_repo_fact(self, **arguments: Any) -> JSON: ...
 
 
 class MemorySpool(Protocol):
@@ -167,6 +197,226 @@ class AgentMemory:
             items=items,
             text=_prompt_text(items, self.policy),
             raw=raw_mapping if include_raw else {},
+        )
+
+    def load_session_context(
+        self,
+        session_key: str | None = None,
+        *,
+        namespace: str | None = None,
+        channel_id: str | None = None,
+        thread_id: str | None = None,
+        include_events: bool | None = None,
+        event_limit: int | None = None,
+        event_types: list[str] | None = None,
+        importance: str | None = None,
+    ) -> JSON:
+        if not session_key and not channel_id:
+            raise ValueError("load_session_context requires session_key or channel_id")
+        payload: dict[str, Any] = {}
+        _set_optional_str(payload, "session_key", session_key)
+        _set_optional_str(payload, "namespace", namespace)
+        _set_optional_str(payload, "channel_id", channel_id)
+        _set_optional_str(payload, "thread_id", thread_id)
+        if include_events is not None:
+            payload["include_events"] = include_events
+        if event_limit is not None:
+            payload["event_limit"] = _bounded_int(
+                event_limit,
+                "event_limit",
+                minimum=1,
+                maximum=200,
+            )
+        if event_types is not None:
+            payload["event_types"] = _str_list(event_types, "event_types")
+        if importance is not None:
+            payload["importance"] = _enum_value(
+                importance,
+                "importance",
+                IMPORTANCE_LEVELS,
+            )
+        return self.client.session_context(**payload)
+
+    def load_lane(
+        self,
+        session_key: str | None = None,
+        *,
+        namespace: str | None = None,
+        project: str | None = None,
+        agent: str | None = None,
+        channel_id: str | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+    ) -> JSON:
+        payload: dict[str, Any] = {}
+        _set_optional_str(payload, "session_key", session_key)
+        _set_optional_str(payload, "namespace", namespace)
+        _set_optional_str(
+            payload,
+            "project",
+            project if project is not None else self.project,
+        )
+        _set_optional_str(payload, "agent", agent)
+        _set_optional_str(payload, "channel_id", channel_id)
+        if status is not None:
+            payload["status"] = _enum_value(status, "status", LANE_STATUSES)
+        if limit is not None:
+            payload["limit"] = _bounded_int(limit, "limit", minimum=1, maximum=50)
+        return self.client.lane_load(**payload)
+
+    def update_lane(
+        self,
+        session_key: str,
+        *,
+        namespace: str | None = None,
+        status: str | None = None,
+        agent: str | None = None,
+        source: str | None = None,
+        channel_id: str | None = None,
+        thread_id: str | None = None,
+        project: str | None = None,
+        topic: str | None = None,
+        current_context_md: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> JSON:
+        payload: dict[str, Any] = {
+            "session_key": _required_str(session_key, "session_key")
+        }
+        _set_optional_str(payload, "namespace", namespace)
+        if status is not None:
+            payload["status"] = _enum_value(status, "status", LANE_STATUSES)
+        _set_optional_str(payload, "agent", agent if agent is not None else self.agent)
+        _set_optional_str(payload, "source", source)
+        _set_optional_str(payload, "channel_id", channel_id)
+        _set_optional_str(payload, "thread_id", thread_id)
+        _set_optional_str(
+            payload,
+            "project",
+            project if project is not None else self.project,
+        )
+        _set_optional_str(payload, "topic", topic)
+        _set_optional_str(payload, "current_context_md", current_context_md)
+        if metadata is not None:
+            self._reject_reserved_metadata(metadata)
+            payload["metadata"] = dict(metadata)
+        return self._call_write("lane_upsert", payload, self.client.lane_upsert)
+
+    def answer(
+        self,
+        query: str,
+        *,
+        namespace: str | None = None,
+        limit: int | None = None,
+        search_mode: str | None = None,
+        tier: str | None = None,
+        max_age_days: int | None = None,
+        include_raw: bool | None = None,
+    ) -> JSON:
+        payload: dict[str, Any] = {"query": _required_str(query, "query")}
+        _set_optional_str(payload, "namespace", namespace)
+        if limit is not None:
+            payload["limit"] = _bounded_int(limit, "limit", minimum=1, maximum=25)
+        if search_mode is not None:
+            payload["search_mode"] = _enum_value(
+                search_mode,
+                "search_mode",
+                SEARCH_MODES,
+            )
+        if tier is not None:
+            payload["tier"] = _enum_value(tier, "tier", IMPORTANCE_LEVELS)
+        if max_age_days is not None:
+            payload["max_age_days"] = _bounded_int(
+                max_age_days,
+                "max_age_days",
+                minimum=1,
+                maximum=3650,
+            )
+        if include_raw is not None:
+            payload["include_raw"] = include_raw
+        return self.client.brain_answer(**payload)
+
+    def repo_facts(
+        self,
+        *,
+        namespace: str | None = None,
+        repo: str | None = None,
+        collection: str | None = None,
+        path: str | None = None,
+        fact_type: str | None = None,
+        subject: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> JSON:
+        payload: dict[str, Any] = {}
+        _set_optional_str(payload, "namespace", namespace)
+        _set_optional_str(payload, "repo", repo)
+        _set_optional_str(payload, "collection", collection)
+        _set_optional_str(payload, "path", path)
+        if fact_type is not None:
+            payload["fact_type"] = _enum_value(
+                fact_type,
+                "fact_type",
+                REPO_FACT_TYPES,
+            )
+        _set_optional_str(payload, "subject", subject)
+        if limit is not None:
+            payload["limit"] = _bounded_int(limit, "limit", minimum=1, maximum=250)
+        if offset is not None:
+            payload["offset"] = _bounded_int(offset, "offset", minimum=0)
+        return self.client.list_repo_facts(**payload)
+
+    def upsert_repo_fact(
+        self,
+        *,
+        repo: str,
+        collection: str,
+        path: str,
+        fact_type: str,
+        fact: str,
+        source_commit: str,
+        source_url: str,
+        verified_at: str,
+        staleness_policy: str,
+        namespace: str | None = None,
+        symbol: str | None = None,
+        subject: str | None = None,
+        confidence: int | float | None = None,
+        refresh_hint: str | None = None,
+    ) -> JSON:
+        if not symbol and not subject:
+            raise ValueError("upsert_repo_fact requires symbol or subject")
+        metadata: dict[str, Any] = {
+            "source_system": "qmd",
+            "repo": _required_str(repo, "repo"),
+            "collection": _required_str(collection, "collection"),
+            "path": _required_str(path, "path"),
+            "fact_type": _enum_value(fact_type, "fact_type", REPO_FACT_TYPES),
+            "fact": _required_str(fact, "fact"),
+            "source_commit": _required_str(source_commit, "source_commit"),
+            "source_url": _required_str(source_url, "source_url"),
+            "verified_at": _required_str(verified_at, "verified_at"),
+            "staleness_policy": _enum_value(
+                staleness_policy,
+                "staleness_policy",
+                STALENESS_POLICIES,
+            ),
+        }
+        _set_optional_str(metadata, "symbol", symbol)
+        _set_optional_str(metadata, "subject", subject)
+        _set_optional_str(metadata, "refresh_hint", refresh_hint)
+        if confidence is not None:
+            metadata["confidence"] = _bounded_number(
+                confidence,
+                "confidence",
+                minimum=0,
+                maximum=1,
+            )
+        payload: dict[str, Any] = {"metadata": metadata}
+        _set_optional_str(payload, "namespace", namespace)
+        return self._call_write(
+            "upsert_repo_fact",
+            payload,
+            self.client.upsert_repo_fact,
         )
 
     def append_event(self, role: str, content: str, **metadata: Any) -> JSON:
@@ -500,6 +750,43 @@ def _enum_value(value: Any, name: str, allowed: set[str]) -> str:
         choices = ", ".join(sorted(allowed))
         raise ValueError(f"{name} must be one of: {choices}")
     return text
+
+
+def _set_optional_str(payload: dict[str, Any], key: str, value: str | None) -> None:
+    if value is not None:
+        payload[key] = _required_str(value, key)
+
+
+def _bounded_int(
+    value: Any,
+    name: str,
+    *,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return value
+
+
+def _bounded_number(
+    value: Any,
+    name: str,
+    *,
+    minimum: int | float,
+    maximum: int | float,
+) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be a number")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    if value > maximum:
+        raise ValueError(f"{name} must be <= {maximum}")
+    return value
 
 
 def _bounded_metadata(result: Mapping[str, Any]) -> dict[str, Any]:

--- a/python/openbrain-memory/src/openbrain_memory/contract.py
+++ b/python/openbrain-memory/src/openbrain_memory/contract.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any
 
+from .client import CURRENT_CONTRACT_VERSION, REQUIRED_CONTRACT_TOOLS
+
 EXPECTED_CONTRACT_SCOPE = "required_openbrain_memory_contract"
 DEFAULT_CLIENT_NAME = "openbrain-memory"
 
@@ -72,6 +74,23 @@ def validate_contract_manifest(
         )
 
     return ContractValidationResult(ok=not reasons, reasons=tuple(reasons))
+
+
+def validate_required_memory_contract(
+    manifest: Mapping[str, Any],
+    *,
+    client_name: str = DEFAULT_CLIENT_NAME,
+    client_version: str | None = None,
+) -> ContractValidationResult:
+    """Validate the package's required Open Brain memory contract."""
+
+    return validate_contract_manifest(
+        manifest,
+        client_name=client_name,
+        client_version=client_version,
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
 
 
 def _validate_required_tools(

--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -332,8 +332,7 @@ def _preserve_metadata(
         elif key == "additionalProperties":
             if not isinstance(value, bool):
                 raise ContractSchemaError(
-                    f"{path}.{key}: additionalProperties must be a boolean "
-                    "or mapping",
+                    f"{path}.{key}: additionalProperties must be a boolean or mapping",
                 )
             schema[key] = value
         elif key in {"minLength", "maxLength", "maxItems"}:
@@ -376,8 +375,7 @@ def _preserve_nonstandard_bounds(
             or items.get("type") != "string"
         ):
             raise ContractSchemaError(
-                f"{path}.maxItemLength: maxItemLength only maps to string "
-                "array items",
+                f"{path}.maxItemLength: maxItemLength only maps to string array items",
             )
         items["maxLength"] = value
     if "maxKeys" in node:

--- a/python/openbrain-memory/src/openbrain_memory/spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/spool.py
@@ -37,6 +37,19 @@ class SpoolRecord:
         )
 
 
+@dataclass(frozen=True)
+class SpoolStatus:
+    path: str
+    exists: bool
+    pending_count: int
+    max_lines: int
+    max_bytes: int
+    oldest_created_at: float | None
+    newest_created_at: float | None
+    operation_counts: Mapping[str, int]
+    corrupted_line_count: int
+
+
 class JsonlSpool:
     def __init__(
         self,
@@ -152,6 +165,63 @@ class JsonlSpool:
 
     def redacted_records(self) -> list[SpoolRecord]:
         return [record.redacted() for record in self.records()]
+
+    def status(self) -> SpoolStatus:
+        if not self.path.exists():
+            return SpoolStatus(
+                path=str(self.path),
+                exists=False,
+                pending_count=0,
+                max_lines=self.max_lines,
+                max_bytes=self.max_bytes,
+                oldest_created_at=None,
+                newest_created_at=None,
+                operation_counts={},
+                corrupted_line_count=0,
+            )
+        self._reject_symlink(self.path)
+        operation_counts: dict[str, int] = {}
+        oldest_created_at: float | None = None
+        newest_created_at: float | None = None
+        pending_count = 0
+        corrupted_line_count = 0
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                try:
+                    payload = json.loads(line)
+                    if not isinstance(payload, dict):
+                        corrupted_line_count += 1
+                        continue
+                    operation = str(payload["operation"])
+                    record_payload = payload.get("payload", {})
+                    created_at = float(payload.get("created_at", 0))
+                    if not isinstance(record_payload, dict):
+                        corrupted_line_count += 1
+                        continue
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                    corrupted_line_count += 1
+                    continue
+
+                pending_count += 1
+                operation_counts[operation] = operation_counts.get(operation, 0) + 1
+                if oldest_created_at is None or created_at < oldest_created_at:
+                    oldest_created_at = created_at
+                if newest_created_at is None or created_at > newest_created_at:
+                    newest_created_at = created_at
+
+        return SpoolStatus(
+            path=str(self.path),
+            exists=True,
+            pending_count=pending_count,
+            max_lines=self.max_lines,
+            max_bytes=self.max_bytes,
+            oldest_created_at=oldest_created_at,
+            newest_created_at=newest_created_at,
+            operation_counts=operation_counts,
+            corrupted_line_count=corrupted_line_count,
+        )
 
     def replay(self, dispatcher: Callable[[SpoolRecord], JSON]) -> list[JSON]:
         results = []

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -44,12 +44,27 @@ class FakeClient:
     def session_start(self, **arguments):
         return self._record("session_start", arguments)
 
+    def session_context(self, **arguments):
+        return self._record("session_context", arguments)
+
     def append_session_event(self, **arguments):
         return self._record("append_session_event", arguments)
 
     def search_all(self, **arguments):
         self.calls.append(("search_all", arguments))
         return self.search_payload
+
+    def brain_answer(self, **arguments):
+        return self._record("brain_answer", arguments)
+
+    def lane_load(self, **arguments):
+        return self._record("lane_load", arguments)
+
+    def lane_upsert(self, **arguments):
+        return self._record("lane_upsert", arguments)
+
+    def list_repo_facts(self, **arguments):
+        return self._record("list_repo_facts", arguments)
 
     def log_thought(self, **arguments):
         return self._record("log_thought", arguments)
@@ -60,14 +75,23 @@ class FakeClient:
     def session_wrap(self, **arguments):
         return self._record("session_wrap", arguments)
 
+    def upsert_repo_fact(self, **arguments):
+        return self._record("upsert_repo_fact", arguments)
+
 
 TOOL_SCHEMA_FILES = {
     "append_session_event": "append-session-event.ts",
+    "brain_answer": "brain-answer.ts",
+    "lane_load": "lane-load.ts",
+    "lane_upsert": "lane-upsert.ts",
+    "list_repo_facts": "repo-facts.ts",
     "log_decision": "log-decision.ts",
     "log_thought": "log-thought.ts",
     "search_all": "search-all.ts",
+    "session_context": "session-context.ts",
     "session_start": "session-start.ts",
     "session_wrap": "session-wrap.ts",
+    "upsert_repo_fact": "repo-facts.ts",
 }
 
 
@@ -118,6 +142,11 @@ def assert_server_contract_call(name: str, payload: dict) -> None:
             assert all(isinstance(item, str) for item in value)
         elif key == "metadata":
             assert isinstance(value, dict)
+        elif key in {"include_events", "include_raw"}:
+            assert isinstance(value, bool)
+        elif key in {"event_types"}:
+            assert isinstance(value, list)
+            assert all(isinstance(item, str) for item in value)
         else:
             assert isinstance(value, str)
 
@@ -230,6 +259,146 @@ def test_representative_facade_payloads_match_server_tool_contracts():
     decision = [payload for name, payload in client.calls if name == "log_decision"][0]
     assert isinstance(decision["context"], str)
     assert all(isinstance(item, str) for item in decision["alternatives"])
+
+
+def test_agent_memory_convenience_helpers_route_to_wrapper_tools():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    memory.load_session_context(
+        "lane-1",
+        include_events=True,
+        event_limit=5,
+        event_types=["decision"],
+        importance="hot",
+    )
+    memory.load_lane(status="active", limit=3)
+    memory.update_lane(
+        "lane-1",
+        status="active",
+        current_context_md="Current state.",
+        metadata={"run_id": "run-1"},
+    )
+    memory.answer("What changed?", limit=2, search_mode="hybrid", tier="warm")
+    memory.repo_facts(repo="owner/repo", fact_type="workflow", limit=10, offset=0)
+    memory.upsert_repo_fact(
+        repo="owner/repo",
+        collection="main",
+        path="src/app.ts",
+        subject="runtime package",
+        fact_type="workflow",
+        fact="The runtime package owns memory facade helpers.",
+        source_commit="0123456789abcdef0123456789abcdef01234567",
+        source_url=(
+            "https://github.com/owner/repo/blob/"
+            "0123456789abcdef0123456789abcdef01234567/src/app.ts"
+        ),
+        verified_at="2026-06-20T00:00:00Z",
+        staleness_policy="refresh_required",
+    )
+
+    assert client.calls == [
+        (
+            "session_context",
+            {
+                "session_key": "lane-1",
+                "include_events": True,
+                "event_limit": 5,
+                "event_types": ["decision"],
+                "importance": "hot",
+            },
+        ),
+        (
+            "lane_load",
+            {"project": "open-brain", "status": "active", "limit": 3},
+        ),
+        (
+            "lane_upsert",
+            {
+                "session_key": "lane-1",
+                "status": "active",
+                "agent": "bilby",
+                "project": "open-brain",
+                "current_context_md": "Current state.",
+                "metadata": {"run_id": "run-1"},
+            },
+        ),
+        (
+            "brain_answer",
+            {
+                "query": "What changed?",
+                "limit": 2,
+                "search_mode": "hybrid",
+                "tier": "warm",
+            },
+        ),
+        (
+            "list_repo_facts",
+            {
+                "repo": "owner/repo",
+                "fact_type": "workflow",
+                "limit": 10,
+                "offset": 0,
+            },
+        ),
+        (
+            "upsert_repo_fact",
+            {
+                "metadata": {
+                    "source_system": "qmd",
+                    "repo": "owner/repo",
+                    "collection": "main",
+                    "path": "src/app.ts",
+                    "fact_type": "workflow",
+                    "fact": "The runtime package owns memory facade helpers.",
+                    "source_commit": "0123456789abcdef0123456789abcdef01234567",
+                    "source_url": (
+                        "https://github.com/owner/repo/blob/"
+                        "0123456789abcdef0123456789abcdef01234567/src/app.ts"
+                    ),
+                    "verified_at": "2026-06-20T00:00:00Z",
+                    "staleness_policy": "refresh_required",
+                    "subject": "runtime package",
+                },
+            },
+        ),
+    ]
+
+
+def test_convenience_helpers_only_include_explicit_namespace_arguments():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    memory.load_session_context("lane-1", namespace="shared-kb")
+    memory.load_lane(namespace="shared-kb")
+    memory.update_lane("lane-1", namespace="shared-kb")
+    memory.answer("question", namespace="shared-kb")
+    memory.repo_facts(namespace="shared-kb")
+    memory.upsert_repo_fact(
+        namespace="shared-kb",
+        repo="owner/repo",
+        collection="main",
+        path="src/app.ts",
+        subject="runtime package",
+        fact_type="workflow",
+        fact="The runtime package owns memory facade helpers.",
+        source_commit="0123456789abcdef0123456789abcdef01234567",
+        source_url=(
+            "https://github.com/owner/repo/blob/"
+            "0123456789abcdef0123456789abcdef01234567/src/app.ts"
+        ),
+        verified_at="2026-06-20T00:00:00Z",
+        staleness_policy="refresh_required",
+    )
+
+    for _name, payload in client.calls:
+        assert payload["namespace"] == "shared-kb"
+
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+    memory.answer("question")
+    memory.repo_facts()
+    assert all("namespace" not in payload for _name, payload in client.calls)
 
 
 def test_recall_assembles_bounded_prompt_context():

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -282,19 +282,22 @@ def test_agent_memory_convenience_helpers_route_to_wrapper_tools():
     memory.answer("What changed?", limit=2, search_mode="hybrid", tier="warm")
     memory.repo_facts(repo="owner/repo", fact_type="workflow", limit=10, offset=0)
     memory.upsert_repo_fact(
-        repo="owner/repo",
-        collection="main",
-        path="src/app.ts",
-        subject="runtime package",
-        fact_type="workflow",
-        fact="The runtime package owns memory facade helpers.",
-        source_commit="0123456789abcdef0123456789abcdef01234567",
-        source_url=(
-            "https://github.com/owner/repo/blob/"
-            "0123456789abcdef0123456789abcdef01234567/src/app.ts"
-        ),
-        verified_at="2026-06-20T00:00:00Z",
-        staleness_policy="refresh_required",
+        {
+            "source_system": "qmd",
+            "repo": "owner/repo",
+            "collection": "main",
+            "path": "src/app.ts",
+            "subject": "runtime package",
+            "fact_type": "workflow",
+            "fact": "The runtime package owns memory facade helpers.",
+            "source_commit": "0123456789abcdef0123456789abcdef01234567",
+            "source_url": (
+                "https://github.com/owner/repo/blob/"
+                "0123456789abcdef0123456789abcdef01234567/src/app.ts"
+            ),
+            "verified_at": "2026-06-20T00:00:00Z",
+            "staleness_policy": "refresh_required",
+        }
     )
 
     assert client.calls == [
@@ -365,37 +368,23 @@ def test_agent_memory_convenience_helpers_route_to_wrapper_tools():
     ]
 
 
-def test_convenience_helpers_only_include_explicit_namespace_arguments():
+def test_convenience_helpers_do_not_accept_payload_namespace():
     client = FakeClient()
     memory = AgentMemory(client, agent="bilby", project="open-brain")
 
-    memory.load_session_context("lane-1", namespace="shared-kb")
-    memory.load_lane(namespace="shared-kb")
-    memory.update_lane("lane-1", namespace="shared-kb")
-    memory.answer("question", namespace="shared-kb")
-    memory.repo_facts(namespace="shared-kb")
-    memory.upsert_repo_fact(
-        namespace="shared-kb",
-        repo="owner/repo",
-        collection="main",
-        path="src/app.ts",
-        subject="runtime package",
-        fact_type="workflow",
-        fact="The runtime package owns memory facade helpers.",
-        source_commit="0123456789abcdef0123456789abcdef01234567",
-        source_url=(
-            "https://github.com/owner/repo/blob/"
-            "0123456789abcdef0123456789abcdef01234567/src/app.ts"
-        ),
-        verified_at="2026-06-20T00:00:00Z",
-        staleness_policy="refresh_required",
-    )
+    with pytest.raises(TypeError):
+        getattr(memory, "load_session_context")("lane-1", namespace="shared-kb")
+    with pytest.raises(TypeError):
+        getattr(memory, "load_lane")(namespace="shared-kb")
+    with pytest.raises(TypeError):
+        getattr(memory, "update_lane")("lane-1", namespace="shared-kb")
+    with pytest.raises(TypeError):
+        getattr(memory, "answer")("question", namespace="shared-kb")
+    with pytest.raises(TypeError):
+        getattr(memory, "repo_facts")(namespace="shared-kb")
+    with pytest.raises(ValueError, match="reserved"):
+        memory.upsert_repo_fact({"namespace": "shared-kb", "repo": "owner/repo"})
 
-    for _name, payload in client.calls:
-        assert payload["namespace"] == "shared-kb"
-
-    client = FakeClient()
-    memory = AgentMemory(client, agent="bilby", project="open-brain")
     memory.answer("question")
     memory.repo_facts()
     assert all("namespace" not in payload for _name, payload in client.calls)

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -7,6 +7,7 @@ from openbrain_memory import (
     CURRENT_CONTRACT_VERSION,
     REQUIRED_CONTRACT_TOOLS,
     validate_contract_manifest,
+    validate_required_memory_contract,
 )
 
 
@@ -67,6 +68,30 @@ def test_validate_contract_manifest_accepts_representative_contract_shape():
 
     assert result.ok is True
     assert result.reasons == ()
+
+
+def test_validate_required_memory_contract_pins_package_contract_defaults():
+    result = validate_required_memory_contract(
+        representative_contract_manifest(),
+        client_version="0.1.0",
+    )
+
+    assert result.ok is True
+    assert result.reasons == ()
+
+
+def test_validate_required_memory_contract_reports_package_required_tool_gap():
+    manifest = representative_contract_manifest()
+    manifest["capabilities"] = [
+        item for item in manifest["capabilities"] if item["name"] != "lane_upsert"
+    ]
+
+    result = validate_required_memory_contract(manifest)
+
+    assert result.ok is False
+    assert result.reasons == (
+        "required tool(s) missing from contract capabilities: lane_upsert",
+    )
 
 
 def test_validate_contract_manifest_reports_missing_required_tool():

--- a/python/openbrain-memory/tests/test_live_canary.py
+++ b/python/openbrain-memory/tests/test_live_canary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 from uuid import uuid4
 
@@ -10,9 +11,8 @@ import pytest
 
 from openbrain_memory import (
     CURRENT_CONTRACT_VERSION,
-    REQUIRED_CONTRACT_TOOLS,
     OpenBrainClient,
-    validate_contract_manifest,
+    validate_required_memory_contract,
 )
 
 LIVE_CANARY_ENABLED = os.environ.get("OPENBRAIN_LIVE_CANARY") == "1"
@@ -59,6 +59,13 @@ def _unique_session_key() -> str:
     return f"openbrain-memory-live-canary/{uuid4()}"
 
 
+def _package_version() -> str | None:
+    try:
+        return version("openbrain-memory")
+    except PackageNotFoundError:
+        return None
+
+
 def test_live_health_and_search_all_canary(live_client: OpenBrainClient):
     health = live_client.health()
     assert "status" in health
@@ -79,10 +86,9 @@ def test_live_contract_manifest_validates_required_memory_helpers(
     manifest = _tool_payload(live_client.get_contract())
     assert isinstance(manifest, dict)
 
-    validation = validate_contract_manifest(
+    validation = validate_required_memory_contract(
         manifest,
-        required_tools=REQUIRED_CONTRACT_TOOLS,
-        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+        client_version=_package_version(),
     )
 
     assert validation.ok, validation.reasons
@@ -91,11 +97,29 @@ def test_live_contract_manifest_validates_required_memory_helpers(
     assert manifest["schema_hash"]
 
 
+def test_live_read_helpers_canary(live_client: OpenBrainClient):
+    answer = _tool_payload(
+        live_client.brain_answer(query="openbrain-memory live canary", limit=1)
+    )
+    assert isinstance(answer, dict)
+
+    facts = _tool_payload(live_client.list_repo_facts(limit=1))
+    if isinstance(facts, dict):
+        fact_items = facts.get("facts", facts.get("results", []))
+    else:
+        fact_items = facts
+    assert isinstance(fact_items, list)
+
+
 def test_live_lane_session_append_read_and_wrap_helpers(
     live_client: OpenBrainClient,
 ):
+    if os.environ.get("OPENBRAIN_LIVE_CANARY_WRITE") != "1":
+        pytest.skip("set OPENBRAIN_LIVE_CANARY_WRITE=1 to run lane/session writes")
+
     session_key = _unique_session_key()
     project = "openbrain-memory-live-canary"
+    receipt_content = "openbrain-memory live canary append/read helper check."
 
     started = _tool_payload(
         live_client.session_start(
@@ -125,7 +149,7 @@ def test_live_lane_session_append_read_and_wrap_helpers(
         live_client.append_session_event(
             session_key=session_key,
             event_type="receipt",
-            content="openbrain-memory live canary append/read helper check.",
+            content=receipt_content,
             source="tests/test_live_canary.py",
             importance="cold",
             metadata={"canary": "openbrain-memory"},
@@ -142,8 +166,12 @@ def test_live_lane_session_append_read_and_wrap_helpers(
         )
     )
     assert isinstance(context, dict)
-    assert context.get("session_key") == session_key
-    assert "events" in context
+    lane = context.get("lane")
+    assert isinstance(lane, dict)
+    assert lane.get("session_key") == session_key
+    events = context.get("events")
+    assert isinstance(events, list)
+    assert any(event.get("content") == receipt_content for event in events)
 
     lanes = _tool_payload(live_client.lane_load(session_key=session_key, limit=1))
     if isinstance(lanes, dict):

--- a/python/openbrain-memory/tests/test_live_canary.py
+++ b/python/openbrain-memory/tests/test_live_canary.py
@@ -2,17 +2,30 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
 
 import pytest
 
-from openbrain_memory import OpenBrainClient
+from openbrain_memory import (
+    CURRENT_CONTRACT_VERSION,
+    REQUIRED_CONTRACT_TOOLS,
+    OpenBrainClient,
+    validate_contract_manifest,
+)
+
+LIVE_CANARY_ENABLED = os.environ.get("OPENBRAIN_LIVE_CANARY") == "1"
 
 
-@pytest.mark.skipif(
-    os.environ.get("OPENBRAIN_LIVE_CANARY") != "1",
+pytestmark = pytest.mark.skipif(
+    not LIVE_CANARY_ENABLED,
     reason="live canary requires OPENBRAIN_LIVE_CANARY=1 and credentials",
 )
-def test_live_health_and_search_all_canary():
+
+
+@pytest.fixture()
+def live_client() -> OpenBrainClient:
     base_url = os.environ["OPENBRAIN_BASE_URL"]
     token = os.environ["OPENBRAIN_TOKEN"]
     namespace = os.environ["OPENBRAIN_NAMESPACE"]
@@ -25,18 +38,166 @@ def test_live_health_and_search_all_canary():
         timeout=float(os.environ.get("OPENBRAIN_TIMEOUT", "10")),
         allow_insecure_http=os.environ.get("OPENBRAIN_ALLOW_INSECURE_HTTP") == "1",
     )
+    try:
+        yield client
+    finally:
+        client.close()
 
-    health = client.health()
+
+def _tool_payload(result: dict[str, Any]) -> Any:
+    if "content" not in result:
+        return result
+    content = result["content"]
+    assert isinstance(content, list) and content
+    text = content[0].get("text")
+    assert isinstance(text, str)
+    payload = json.loads(text)
+    return payload
+
+
+def _unique_session_key() -> str:
+    return f"openbrain-memory-live-canary/{uuid4()}"
+
+
+def test_live_health_and_search_all_canary(live_client: OpenBrainClient):
+    health = live_client.health()
     assert "status" in health
-    result = client.search_all(query="live canary", limit=1, sources="brain")
-    assert result.get("isError") is not True
-    if "content" in result:
-        content = result["content"]
-        assert isinstance(content, list) and content
-        text = content[0].get("text")
-        assert isinstance(text, str)
-        result = json.loads(text)
+
+    result = _tool_payload(
+        live_client.search_all(query="live canary", limit=1, sources="brain")
+    )
+    assert isinstance(result, dict)
     assert {"total", "brain_hits", "qmd_hits", "results"} <= set(result)
     assert isinstance(result["results"], list)
     for item in result["results"]:
         assert item.get("source") == "brain"
+
+
+def test_live_contract_manifest_validates_required_memory_helpers(
+    live_client: OpenBrainClient,
+):
+    manifest = _tool_payload(live_client.get_contract())
+    assert isinstance(manifest, dict)
+
+    validation = validate_contract_manifest(
+        manifest,
+        required_tools=REQUIRED_CONTRACT_TOOLS,
+        compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
+    )
+
+    assert validation.ok, validation.reasons
+    assert manifest["contract_version"] == CURRENT_CONTRACT_VERSION
+    assert isinstance(manifest.get("schema_hash"), str)
+    assert manifest["schema_hash"]
+
+
+def test_live_lane_session_append_read_and_wrap_helpers(
+    live_client: OpenBrainClient,
+):
+    session_key = _unique_session_key()
+    project = "openbrain-memory-live-canary"
+
+    started = _tool_payload(
+        live_client.session_start(
+            session_key=session_key,
+            agent="openbrain-memory-canary",
+            project=project,
+            topic="Package helper readiness canary",
+        )
+    )
+    assert isinstance(started, dict)
+    assert started.get("session_key") == session_key
+
+    upserted = _tool_payload(
+        live_client.lane_upsert(
+            session_key=session_key,
+            agent="openbrain-memory-canary",
+            project=project,
+            topic="Package helper readiness canary updated",
+            current_context_md="Live canary context for package helper readiness.",
+            metadata={"canary": "openbrain-memory"},
+        )
+    )
+    assert isinstance(upserted, dict)
+    assert upserted.get("session_key") == session_key
+
+    appended = _tool_payload(
+        live_client.append_session_event(
+            session_key=session_key,
+            event_type="receipt",
+            content="openbrain-memory live canary append/read helper check.",
+            source="tests/test_live_canary.py",
+            importance="cold",
+            metadata={"canary": "openbrain-memory"},
+        )
+    )
+    assert isinstance(appended, dict)
+    assert appended.get("session_key") == session_key
+
+    context = _tool_payload(
+        live_client.session_context(
+            session_key=session_key,
+            include_events=True,
+            event_limit=5,
+        )
+    )
+    assert isinstance(context, dict)
+    assert context.get("session_key") == session_key
+    assert "events" in context
+
+    lanes = _tool_payload(live_client.lane_load(session_key=session_key, limit=1))
+    if isinstance(lanes, dict):
+        lane_items = lanes.get("lanes")
+    else:
+        lane_items = lanes
+    assert isinstance(lane_items, list)
+    assert any(lane.get("session_key") == session_key for lane in lane_items)
+
+    wrapped = _tool_payload(
+        live_client.session_wrap(
+            session_key=session_key,
+            summary="openbrain-memory live canary verified helper readiness.",
+            key_decisions=[],
+            next_steps=[],
+            project=project,
+        )
+    )
+    assert isinstance(wrapped, dict)
+    assert wrapped.get("session_key") == session_key
+
+
+def test_live_optional_repo_fact_write_canary(live_client: OpenBrainClient):
+    if os.environ.get("OPENBRAIN_LIVE_CANARY_REPO_FACT_WRITE") != "1":
+        pytest.skip("set OPENBRAIN_LIVE_CANARY_REPO_FACT_WRITE=1 to upsert repo facts")
+
+    commit = os.environ.get("OPENBRAIN_LIVE_CANARY_REPO_FACT_COMMIT")
+    if not commit:
+        pytest.fail(
+            "OPENBRAIN_LIVE_CANARY_REPO_FACT_COMMIT is required when "
+            "OPENBRAIN_LIVE_CANARY_REPO_FACT_WRITE=1"
+        )
+    metadata = {
+        "source_system": "qmd",
+        "repo": "rodaddy/open-brain",
+        "collection": "open-brain",
+        "path": "python/openbrain-memory/tests/test_live_canary.py",
+        "subject": "openbrain-memory live canary",
+        "fact_type": "validation",
+        "fact": (
+            "The openbrain-memory package live canary can opt in to repo fact "
+            "write validation."
+        ),
+        "source_commit": commit,
+        "source_url": (
+            "https://github.com/rodaddy/open-brain/blob/"
+            f"{commit}/python/openbrain-memory/tests/test_live_canary.py"
+        ),
+        "verified_at": datetime.now(UTC).isoformat(),
+        "confidence": 1,
+        "staleness_policy": "refresh_required",
+        "refresh_hint": "Re-run OPENBRAIN_LIVE_CANARY_REPO_FACT_WRITE=1 pytest canary.",
+    }
+
+    result = _tool_payload(live_client.upsert_repo_fact(metadata=metadata))
+
+    assert result

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -315,6 +315,97 @@ def test_spool_records_skip_corrupted_jsonl_lines(tmp_path, caplog):
     assert caplog.text.count("Skipping corrupted spool record") == 6
 
 
+def test_spool_status_missing_path_is_empty(tmp_path):
+    spool = JsonlSpool(tmp_path / "missing.jsonl", max_lines=7, max_bytes=700)
+
+    status = spool.status()
+
+    assert status.path == str(spool.path)
+    assert status.exists is False
+    assert status.pending_count == 0
+    assert status.max_lines == 7
+    assert status.max_bytes == 700
+    assert status.oldest_created_at is None
+    assert status.newest_created_at is None
+    assert status.operation_counts == {}
+    assert status.corrupted_line_count == 0
+
+
+def test_spool_status_empty_path_is_empty_but_existing(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    spool.path.write_text("", encoding="utf-8")
+
+    status = spool.status()
+
+    assert status.exists is True
+    assert status.pending_count == 0
+    assert status.operation_counts == {}
+    assert status.corrupted_line_count == 0
+
+
+def test_spool_status_counts_records_without_payload_leakage(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    secret = "password: " + token_sample("hunt", "er2")
+
+    spool.append("log_thought", {"content": secret}, key="one")
+    spool.append("log_thought", {"content": "safe"}, key="two")
+    spool.append("session_start", {"topic": "canary"}, key="three")
+
+    status = spool.status()
+
+    assert status.exists is True
+    assert status.pending_count == 3
+    assert status.operation_counts == {"log_thought": 2, "session_start": 1}
+    assert status.corrupted_line_count == 0
+    assert status.oldest_created_at is not None
+    assert status.newest_created_at is not None
+    assert status.oldest_created_at <= status.newest_created_at
+    assert token_sample("hunt", "er2") not in repr(status)
+    assert "content" not in repr(status)
+    assert "safe" not in repr(status)
+
+
+def test_spool_status_counts_corrupted_lines_without_changing_records(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    spool.path.write_text(
+        "\n".join(
+            [
+                '{"created_at":1,"idempotency_key":"good-1","operation":"one","payload":{"content":"ok"}}',
+                '{"created_at":2,"idempotency_key":"bad","operation":',
+                "{}",
+                "[]",
+                '{"idempotency_key":"missing-operation"}',
+                (
+                    '{"created_at":"not-a-float","idempotency_key":"bad-time",'
+                    '"operation":"bad","payload":{}}'
+                ),
+                (
+                    '{"created_at":2,"idempotency_key":"bad-payload",'
+                    '"operation":"bad","payload":[]}'
+                ),
+                (
+                    '{"created_at":3,"idempotency_key":"good-2",'
+                    '"operation":"two","payload":{"content":"still ok"}}'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    status = spool.status()
+
+    assert status.pending_count == 2
+    assert status.operation_counts == {"one": 1, "two": 1}
+    assert status.oldest_created_at == 1
+    assert status.newest_created_at == 3
+    assert status.corrupted_line_count == 6
+    assert [record.idempotency_key for record in spool.records()] == [
+        "good-1",
+        "good-2",
+    ]
+
+
 def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tmp_path):
     client = FlakyClient(failures=3)
     spool = JsonlSpool(tmp_path / "spool.jsonl")


### PR DESCRIPTION
## Summary

Closes #181.

Adds the remaining package-side helpers needed before Hermes can consume `openbrain-memory` instead of maintaining a parallel Open Brain fork:

- adds `validate_required_memory_contract()` as the package default wrapper around the canonical `get_contract` manifest validator;
- expands `AgentMemory` with reusable session/lane/query/repo-fact convenience helpers while keeping Hermes-specific policy and namespace delegation out of the package facade;
- adds `JsonlSpool.status()` / `SpoolStatus` for redacted pending-write diagnostics;
- expands env-gated live canary coverage for `get_contract`, read helpers, explicit lane/session writes, and optional repo-fact writes;
- updates README canary expectations and package helper documentation.

## Boundary

`get_contract` remains the source of truth. The package helper validates a live manifest against the package's required memory contract snapshot, required tool list, and client version compatibility when a client version is supplied.

This PR does not move Hermes-only policy into Open Brain:

- no Hermes `READ_TOOL_ALLOWLIST`;
- no Hermes protected/session-derived `session_key` behavior;
- no Hermes memory-mode gating;
- no Hermes model/tool filtering;
- no Hermes deployment/canary rollout;
- no payload-level namespace delegation in `AgentMemory`; privileged namespace delegation remains an `OpenBrainClient(delegate_namespace=True)` / server-authorized header path.

## Controller Fixes

The implementation worker initially introduced repo-fact enum values that did not match the server's canonical `src/tools/repo-facts.ts` values. I corrected the package facade constants/tests to match the server source of truth:

- `FACT_TYPES`: `ownership`, `gotcha`, `api_contract`, `workflow`, `dependency`, `migration`, `validation`, `source_pointer`
- `STALENESS_POLICIES`: `stable_fact_verify_source`, `commit_pinned`, `refresh_required`, `volatile_pointer_only`

After review, I also removed payload-level namespace forwarding from `AgentMemory`, made the default live canary read-only, added read-helper coverage, fixed `session_context` response assertions, proved appended event recovery, and added ruff/mypy to package CI.

## Validation

Run from `python/openbrain-memory`:

- `uv run ruff check src tests` -> pass
- `uv run ruff format --check src tests` -> pass
- `uv run mypy src/openbrain_memory` -> pass
- `uv run pytest -q` -> `153 passed, 5 skipped`
- `uv build` -> built sdist and wheel
- `git diff --check` -> pass

Live canary tests remain env-gated. The default live canary is read-only. Lane/session writes require `OPENBRAIN_LIVE_CANARY_WRITE=1`; repo-fact writes require `OPENBRAIN_LIVE_CANARY_REPO_FACT_WRITE=1` plus an explicit source commit.

## Downstream Rollout

Applies because this changes `python/openbrain-memory` package exports and helper behavior.

- Open Brain local verification: complete, see validation above.
- Hosted Open Brain runtime deploy: not required for package-only client helper changes; server behavior is unchanged.
- rtech-mcps / mcp2cli generated skill refresh: not applicable; no MCP tool schema/name/output changed.
- rtech-hermes runtime/plugin check: applicable next in Run C Phase 2. Hermes must consume these helpers in a separate `rtech-hermes` PR before agent readiness can be claimed.
- Hermes live rollout: deferred to Run C Phase 4 after Hermes consumption PRs merge.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below [x] not applicable because: this PR changes package helper code and env-gated canary coverage only; hosted server behavior is unchanged and live Hermes rollout is deferred to Run C Phase 4 after Hermes consumption PRs merge.
- [x] Required SME review swarm posted, including gotcha-agent lane for `python/openbrain-memory`.
- [x] Findings fixed or explicitly deferred with owner approval.
- [ ] Fix verification posted after any fixes.
- [x] GitHub checks pass or non-code external check failures are explicitly classified

## Critical Self-Review

- Highest-risk behavior: New package facade helpers could drift from server contracts or bypass namespace authority. I checked repo-fact enums against `src/tools/repo-facts.ts` and removed payload-level namespace forwarding from `AgentMemory`.
- Assumptions that could be wrong: Pinning `validate_required_memory_contract()` to `CURRENT_CONTRACT_VERSION` may be too strict for future compatible versions; for now it matches the package snapshot semantics and Hermes fail-closed needs.
- Missing/weak tests: Live canary coverage is env-gated and not run in normal CI; fake-transport tests cover helper call shapes, while hosted behavior remains a rollout-time canary.
- Security/permission risk: Package helpers must not bypass token/header namespace authority. The high-level facade no longer accepts `namespace=` and tests reject metadata namespace smuggling.
- Migration/deploy risk: Hermes still needs a separate consumption PR; this PR alone does not make agents package-backed.
- Downstream client/runtime risk: New exports are additive. Hermes must adapt through a thin policy wrapper rather than directly exposing all package helpers to model tools.
- Rollback/cleanup concern: Rollback is reverting this package PR; no server migration or hosted deploy is included.
- Fixes made before PR: Corrected repo-fact type/staleness enums to match canonical server values; after swarm, removed payload namespace forwarding, made default canary read-only, added read helper coverage, fixed session_context assertions, proved append recovery, and added ruff/mypy CI gates.
- Known residual risk: Optional write canaries are not default because they write durable state; host rollout still needs explicit live evidence later in Run C.
- SME review-memory update: [ ] `docs/sme/` updated [x] not applicable because: findings were recurrences already represented in SME files or direct PR-body/checklist hygiene; no new durable review pattern was introduced.
