### PR TITLE
fix: scope package enum refs per tool

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -85,7 +85,6 @@ def tool_contracts_to_tool_schemas(
     selected_names = (
         list(tool_names) if tool_names is not None else sorted(tool_contracts)
     )
-    enum_refs = _collect_manifest_enum_refs(tool_contracts)
     schemas: list[JSONSchema] = []
     for tool_name in selected_names:
         if tool_name not in tool_contracts:
@@ -102,6 +101,19 @@ def tool_contracts_to_tool_schemas(
             raise ContractSchemaError(
                 f"$.tool_contracts.{tool_name}.input_schema: input_schema "
                 "must be a mapping",
+            )
+        enum_refs = _collect_enum_refs(
+            input_schema,
+            path=f"$.tool_contracts.{tool_name}.input_schema",
+            scoped_session_aliases=tool_name == "append_session_event",
+        )
+        if "session_event_type" not in enum_refs and _uses_string_ref(
+            input_schema, "session_event_type"
+        ):
+            _merge_enum_refs(
+                enum_refs,
+                _collect_manifest_shared_enum_refs(tool_contracts),
+                path="$.tool_contracts.append_session_event.input_schema.event_type",
             )
         schemas.append(
             {
@@ -408,24 +420,47 @@ def _resolve_string_ref(
     raise ContractSchemaError(f"{path}: unresolved contract schema reference {ref!r}")
 
 
-def _collect_manifest_enum_refs(
+def _collect_manifest_shared_enum_refs(
     tool_contracts: Mapping[str, Any],
 ) -> dict[str, JSONSchema]:
+    """Collect explicit cross-tool enum aliases.
+
+    Inline enum fields are scoped to their own tool contract. Only aliases that
+    the contract deliberately exposes across tools belong in this manifest-wide
+    map.
+    """
+
     refs: dict[str, JSONSchema] = {}
-    for tool_name, tool_contract in tool_contracts.items():
-        if not isinstance(tool_contract, Mapping):
-            continue
+    tool_contract = tool_contracts.get("append_session_event")
+    if isinstance(tool_contract, Mapping):
         input_schema = tool_contract.get("input_schema")
-        if isinstance(input_schema, Mapping):
+        event_type = (
+            input_schema.get("event_type")
+            if isinstance(input_schema, Mapping)
+            else None
+        )
+        if isinstance(event_type, Mapping) and event_type.get("type") == "enum":
             _merge_enum_refs(
                 refs,
-                _collect_enum_refs(
-                    input_schema,
-                    path=f"$.tool_contracts.{tool_name}.input_schema",
-                    scoped_session_aliases=tool_name == "append_session_event",
-                ),
+                {
+                    "session_event_type": _enum_node_to_json_schema(
+                        event_type,
+                        path="$.tool_contracts.append_session_event.input_schema.event_type",
+                    ),
+                },
+                path="$.tool_contracts.append_session_event.input_schema.event_type",
             )
     return refs
+
+
+def _uses_string_ref(node: Any, ref: str) -> bool:
+    if node == ref:
+        return True
+    if isinstance(node, Mapping):
+        return any(_uses_string_ref(value, ref) for value in node.values())
+    if isinstance(node, list):
+        return any(_uses_string_ref(value, ref) for value in node)
+    return False
 
 
 def _collect_enum_refs(

--- a/python/openbrain-memory/tests/test_schema.py
+++ b/python/openbrain-memory/tests/test_schema.py
@@ -137,7 +137,7 @@ def test_arrays_convert_string_item_refs_and_manifest_enum_refs():
     }
 
 
-def test_manifest_enum_ref_conflicts_fail_with_path():
+def test_same_named_enums_are_scoped_to_each_tool_contract():
     manifest = {
         "tool_contracts": {
             "first": {
@@ -153,11 +153,94 @@ def test_manifest_enum_ref_conflicts_fail_with_path():
         },
     }
 
-    with pytest.raises(
-        ContractSchemaError,
-        match=r"conflicting enum reference 'status'",
-    ):
-        tool_contracts_to_tool_schemas(manifest)
+    schemas = tool_contracts_to_tool_schemas(manifest)
+
+    assert schemas[0]["name"] == "first"
+    assert schemas[0]["input_schema"]["properties"]["status"] == {
+        "type": "string",
+        "enum": ["open", "closed"],
+    }
+    assert schemas[1]["name"] == "second"
+    assert schemas[1]["input_schema"]["properties"]["status"] == {
+        "type": "string",
+        "enum": ["hot", "cold"],
+    }
+
+
+def test_selected_tool_conversion_ignores_unrelated_enum_name_collisions():
+    manifest = {
+        "tool_contracts": {
+            "first": {
+                "input_schema": {
+                    "status": {"type": "enum", "values": ["open", "closed"]},
+                },
+            },
+            "second": {
+                "input_schema": {
+                    "status": {"type": "enum", "values": ["hot", "cold"]},
+                },
+            },
+        },
+    }
+
+    [schema] = tool_contracts_to_tool_schemas(manifest, tool_names=["second"])
+
+    assert schema["name"] == "second"
+    assert schema["input_schema"]["properties"]["status"] == {
+        "type": "string",
+        "enum": ["hot", "cold"],
+    }
+
+
+def test_selected_tool_local_session_event_type_enum_shadows_shared_alias():
+    manifest = {
+        "tool_contracts": {
+            "append_session_event": {
+                "input_schema": {
+                    "event_type": {"type": "enum", "values": ["fact", "decision"]},
+                },
+            },
+            "selected": {
+                "input_schema": {
+                    "session_event_type": {
+                        "type": "enum",
+                        "values": ["local", "only"],
+                    },
+                },
+            },
+        },
+    }
+
+    [schema] = tool_contracts_to_tool_schemas(manifest, tool_names=["selected"])
+
+    assert schema["input_schema"]["properties"]["session_event_type"] == {
+        "type": "string",
+        "enum": ["local", "only"],
+    }
+
+
+def test_selected_tool_without_shared_ref_does_not_validate_unrelated_alias_source():
+    manifest = {
+        "tool_contracts": {
+            "append_session_event": {
+                "input_schema": {
+                    "event_type": {
+                        "type": "enum",
+                        "values": "malformed",
+                    },
+                },
+            },
+            "selected": {
+                "input_schema": {
+                    "query": {"type": "string"},
+                },
+            },
+        },
+    }
+
+    [schema] = tool_contracts_to_tool_schemas(manifest, tool_names=["selected"])
+
+    assert schema["input_schema"]["properties"]["query"] == {"type": "string"}
 
 
 def test_session_event_type_alias_is_scoped_to_append_session_event():


### PR DESCRIPTION
## Summary

Fixes the `openbrain-memory` contract converter so inline enum refs are scoped to the selected tool schema instead of being collected manifest-wide by bare field name.

This addresses the live Hermes/Nagatha failure mode where the v5 contract contains unrelated same-named enum fields such as `status`, causing package tool-schema conversion to fail with:

```text
ContractSchemaError: $: conflicting enum reference 'status'
```

## Changes

- Remove manifest-wide inline enum collection from `tool_contracts_to_tool_schemas`.
- Keep explicit cross-tool sharing limited to the deliberate `session_event_type` alias derived from `append_session_event.event_type`.
- Resolve that shared alias only when the selected schema actually references `session_event_type` and lacks a local enum of the same name.
- Delete the old manifest-wide collector to avoid reintroducing the same bug.
- Add regressions for unrelated same-named enums, selected-tool isolation, local `session_event_type` shadowing, and malformed unrelated alias sources.

## Validation

From `python/openbrain-memory`:

- `uv run ruff check src tests` passed.
- `uv run ruff format --check src tests` passed.
- `uv run mypy src/openbrain_memory` passed.
- `uv run pytest -q` passed: `156 passed, 5 skipped`.
- Live Nagatha cached v5 contract conversion passed: `schemas 11` for `append_session_event,get_contract,lane_load,lane_upsert,list_repo_facts,log_thought,search_all,session_context,session_start,session_wrap,upsert_repo_fact`.

## Review-swarm: PASS

Pinned diff: branch `fix/openbrain-memory-enum-ref-scope` commit `168749a` before PR creation.
Fresh-context lanes: correctness/domain, adversarial/gotcha, security, quality/maintainability, fix-verification.

Findings:

- Correctness/domain: zero findings.
- Security: zero findings.
- Adversarial/gotcha: found two issues before fix:
  - selected local `session_event_type` enum could collide with shared alias;
  - selected tool conversion validated malformed unrelated `append_session_event.event_type` even without using the alias.
- Quality: found dead old manifest-wide collector.

Fixes made before PR:

- Shared alias is now collected only when the selected schema references `session_event_type` and lacks a local enum ref.
- Local selected-tool enum refs shadow shared aliases.
- Dead manifest-wide collector removed.
- Added regression tests for all findings.

## Fix-verification: PASS

Zero known unresolved issues: yes
Validation: focused `tests/test_schema.py` passed with 26 tests; `git diff --check` clean; full package gates listed above passed.

## Critical Self-Review

- Highest-risk behavior: string enum ref resolution for tool schemas consumed by Hermes agents.
- Assumptions that could be wrong: `session_event_type` is the only current deliberate cross-tool alias. The code now limits sharing to that explicit alias and tests shadowing behavior.
- Missing/weak tests: no server live call is included in this PR; validation uses Nagatha's cached live v5 manifest as contract evidence without mutating hosts.
- Security/permission risk: no token, namespace, auth, or write behavior changes.
- Migration/deploy risk: package must be consumed by `rtech-hermes` and canaried on Nagatha only after merge; no live rollout in this PR.
- Downstream client/runtime risk: Hermes model-facing OpenBrain tool schemas currently fail until this package fix is consumed downstream.
- Rollback/cleanup concern: rollback restores old manifest-wide collision behavior.
- Fixes made before PR: adversarial/quality findings fixed and verified.
- Known residual risk: downstream rollout remains pending; do not claim Hermes live readiness until Nagatha canary passes on tracked package code.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: findings were direct regressions in this PR and are covered by new tests plus PR review receipt; no reusable SME pattern beyond existing gotcha-agent #82 guidance.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured.
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live check evidence: converter validation against Nagatha's cached live v5 contract passed with 11 schemas. No live service deploy or write canary was performed in this PR; downstream Nagatha-only canary remains pending after Hermes consumes the merged package fix.

## Downstream rollout classification

Applies: this changes `python/openbrain-memory` client/tool-schema behavior.

Completed here:

- local package validation;
- converter validation against Nagatha's cached live v5 contract.

Pending after merge:

- update/consume this package in `rtech-hermes`;
- canary Nagatha only first;
- do not roll Bilby or Skippy until explicitly approved and Nagatha is clean.

Live endpoint correction: Open Brain deploy target is Mac Mini `10.71.1.21:3100` via `open-brain.rodaddy.live`; `10.71.20.49` is a retained pre-cutover snapshot per repo `AGENTS.md`, not the active Run C server.
