### PR TITLE
docs: clarify OpenBrain package install config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Built for AI agents that need persistent, searchable memory across conversations
 
 ## Features
 
-- **15 MCP tools** for reading, writing, and managing knowledge
+- **Contract-first MCP tools** for reading, writing, and managing knowledge
 - **Hybrid search** — reciprocal rank fusion (RRF) over HNSW vector similarity + PostgreSQL full-text search
 - **Cognitive tiering** — hot/warm/cold memory lifecycle with usage-based scoring
 - **Per-consumer auth** — role-based access control with scoped tokens (admin, agent, readonly, etc.)
@@ -16,25 +16,19 @@ Built for AI agents that need persistent, searchable memory across conversations
 - **Session management** — stateful MCP sessions with upsert, deduplication, and TTL expiry
 - **Curation pipeline** — automated duplicate detection, staleness decay, and LLM-as-judge quality scoring
 
-## Tools
+## Tools and Contract
 
-| Tool | Description |
-|------|-------------|
-| `search_brain` | Hybrid semantic + keyword search across any table. Supports vector, keyword, or fused mode with tier boosting and recency weighting. |
-| `search_all` | Unified search across Open Brain tables and external knowledge bases. |
-| `log_thought` | Store a thought, idea, or observation. Auto-embeds and extracts metadata. |
-| `log_decision` | Record a decision with rationale and considered alternatives. |
-| `find_person` | Search contacts by name (partial match) or semantic similarity. |
-| `upsert_person` | Create or update a contact record (name, relationship, warmth, notes). |
-| `session_save` | Save a session summary with structured fields. Supports upsert via session ID. |
-| `session_load` | Load the most recent session, optionally filtered by project. |
-| `list_recent` | List recent entries across all tables with offset pagination and tier filtering. |
-| `get_entry` | Fetch a single entry by table and ID. |
-| `update_entry` | Update content, tags, or metadata on an existing entry. |
-| `archive_entry` | Soft-delete an entry with an optional reason. |
-| `rate_entry` | Score an entry's usefulness (0–1) for quality feedback. |
-| `list_stale` | Find entries not accessed recently — candidates for tier demotion (hot→warm→cold). Filterable by table, current tier, and staleness threshold. |
-| `set_tier` | Move an entry between cognitive tiers (hot/warm/cold). |
+`get_contract` is the source of truth for the Open Brain tool surface and input
+contract. Downstream clients should not hard-code the tool list from this
+README; they should fetch the live contract and, when they need model tool
+schemas, convert it through the `openbrain-memory` Python package.
+
+Major tool groups include search and synthesis (`search_brain`, `search_all`,
+`brain_answer`), memory writes (`log_thought`, `log_decision`,
+`append_session_event`, `session_wrap`), session lifecycle (`session_start`,
+`session_context`, `session_load`, `session_save`), repo facts
+(`upsert_repo_fact`, `list_repo_facts`), lane state (`lane_upsert`,
+`lane_load`), contacts, entries, tiers, and curation.
 
 ## Prerequisites
 
@@ -80,10 +74,15 @@ PORT=3100
 # Auth tokens (generate with: openssl rand -hex 32)
 AUTH_TOKEN_ADMIN=
 AUTH_TOKEN_AGENT=
+AUTH_TOKEN_DISCORD=
+AUTH_TOKEN_N8N=
+AUTH_TOKEN_PROMOTER=
 AUTH_TOKEN_READONLY=
 ```
 
-A helper script is also available for token management:
+A helper script is also available for the standard admin, agent, discord, n8n,
+and readonly token set. Manage `AUTH_TOKEN_PROMOTER` explicitly until the
+helper supports promoter rotation:
 
 ```bash
 ./scripts/generate-tokens.sh           # show all tokens
@@ -151,6 +150,58 @@ mcp2cli cache diff open-brain
 OPEN_BRAIN_CODEX_SMOKE_WRITE=1 bun run codex-memory-smoke
 ```
 
+## Python Client Package
+
+The reusable Python package lives in `python/openbrain-memory/`. Install it on
+agent hosts, automation hosts, or any Python runtime that talks to Open Brain.
+Installing the package does not run the Open Brain service locally; the service
+remains remote.
+
+Preferred install sources:
+
+```bash
+# Published/internal package, once available
+uv pip install --python /path/to/venv/bin/python openbrain-memory==<version>
+
+# Reviewed wheel artifact
+uv pip install --python /path/to/venv/bin/python /path/to/openbrain_memory-<version>-py3-none-any.whl
+
+# Transitional git-subdirectory install, pinned to a reviewed commit
+uv pip install --python /path/to/venv/bin/python \
+  "git+https://github.com/rodaddy/open-brain.git@<40-char-commit>#subdirectory=python/openbrain-memory"
+```
+
+Do not use a moving branch or unpinned package for host installs. Use a
+reviewed wheel, exact package version, or a full 40-character commit pin.
+
+Runtime configuration for package consumers:
+
+```bash
+export OPENBRAIN_BASE_URL="https://open-brain.rodaddy.live"
+export OPENBRAIN_TOKEN="..."              # bearer token; never commit this
+export OPENBRAIN_NAMESPACE="nagatha"      # normal agent token namespace
+export OPENBRAIN_AGENT_ID="nagatha"
+```
+
+For normal agent-role tokens, namespace authority is enforced by the server from
+the bearer token. `OPENBRAIN_NAMESPACE` must match the token-bound identity;
+cross-namespace access requires an explicit delegated privileged role/path.
+
+Trusted lab-only direct HTTP to the active Mac Mini endpoint requires an
+explicit opt-in because bearer tokens travel over the request:
+
+```bash
+export OPENBRAIN_BASE_URL="http://10.71.1.21:3100"
+export OPENBRAIN_ALLOW_INSECURE_HTTP=1
+```
+
+`10.71.20.49` is a retained pre-cutover snapshot, not the active production
+Open Brain endpoint. Use `https://open-brain.rodaddy.live` or direct
+`10.71.1.21:3100` for current host canaries.
+
+For full package usage, schema helper, live canary, and Hermes integration
+guidance, see [`python/openbrain-memory/README.md`](python/openbrain-memory/README.md).
+
 ## Auth & Permissions
 
 Each consumer gets a scoped Bearer token. Roles control which tables are readable/writable:
@@ -161,9 +212,14 @@ Each consumer gets a scoped Bearer token. Roles control which tables are readabl
 | `agent` | All tables | thoughts, decisions, relationships, sessions | — |
 | `discord` | — | thoughts | — |
 | `n8n` | All tables | All tables | All tables |
+| `promoter` | Shared promotion scope | Curated shared-kb promotions | — |
 | `readonly` | All tables | — | — |
 
-Set tokens via `AUTH_TOKEN_ADMIN`, `AUTH_TOKEN_AGENT`, etc. in your `.env`. You can also add custom per-user tokens with the `AUTH_TOKEN_USER_*` pattern.
+Set tokens via `AUTH_TOKEN_ADMIN`, `AUTH_TOKEN_AGENT`, `AUTH_TOKEN_DISCORD`,
+`AUTH_TOKEN_N8N`, `AUTH_TOKEN_PROMOTER`, and `AUTH_TOKEN_READONLY` in your
+`.env`. You can also add custom per-user tokens with the `AUTH_TOKEN_USER_*`
+pattern. `promoter` is for controlled shared-kb promotion flows, not normal
+agent identity.
 
 ## Database Schema
 
@@ -292,6 +348,12 @@ To connect from an MCP client (e.g., Claude Desktop, Claude Code):
   }
 }
 ```
+
+Hermes and Python package consumers normally use direct HTTP through
+`openbrain-memory`, not a local mcp2cli daemon. Configure them with
+`OPENBRAIN_BASE_URL`, `OPENBRAIN_TOKEN`, `OPENBRAIN_NAMESPACE`, and
+`OPENBRAIN_AGENT_ID`; use `OPENBRAIN_ALLOW_INSECURE_HTTP=1` only for trusted
+lab HTTP endpoints such as `http://10.71.1.21:3100`.
 
 ## Documentation
 

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -47,10 +47,9 @@ when the report is intended to be durable; otherwise write scratch reports under
 
 ## Next Expansion Points
 
-- Add a live Open Brain adapter that loads synthetic fixtures into an isolated
-  namespace and calls `search_brain` / `brain_answer`.
-- Add live-adapter probes once the eval harness can call `brain_answer` through
-  MCP. The current offline fixture checks that Codex retrieves the right
+- Add a live Open Brain adapter that loads fixtures into an isolated namespace
+  and calls `search_brain` / `brain_answer` through the current contract/direct
+  HTTP client. The current offline fixture checks that Codex retrieves the right
   synthesis-tool policy and can render cited answer evidence; it does not
   execute `brain_answer` or read the live repo.
 - Publish durable scorecards only when the corpus and command are intentionally

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -37,7 +37,7 @@ Preferred options, in order:
    published to the chosen package index or internal wheelhouse:
 
    ```bash
-   uv pip install openbrain-memory
+   uv pip install "openbrain-memory==<version>"
    ```
 
 2. **Prebuilt CI/release wheel artifact.** Use this for pinned rollout when
@@ -64,11 +64,19 @@ Preferred options, in order:
    artifact is available:
 
    ```bash
-   uv pip install "git+ssh://git@github.com/rodaddy/open-brain.git#subdirectory=python/openbrain-memory"
+   uv pip install \
+     "git+https://github.com/rodaddy/open-brain.git@<40-char-commit>#subdirectory=python/openbrain-memory"
    ```
 
-For deterministic host installs, pin the git dependency to a reviewed commit or
-tag rather than a moving branch.
+For deterministic host installs, pin the package to an exact version or reviewed
+wheel, or pin the git dependency to a reviewed commit or tag rather than a
+moving branch.
+
+Hermes deployments usually do not call `uv pip install` by hand. In
+`rtech-hermes`, set `openbrain_memory.package_spec` in the target agent manifest
+or set `OPENBRAIN_MEMORY_PACKAGE_SPEC` for an emergency override. Both paths
+must use a reviewed wheel, exact package version, or full commit-pinned
+git-subdirectory URL.
 
 ## Runtime Config
 
@@ -83,6 +91,20 @@ export OPENBRAIN_NAMESPACE="bilby"
 export OPENBRAIN_AGENT_ID="bilby"
 export OPENBRAIN_PROJECT="open-brain"
 ```
+
+Current production-style examples:
+
+```bash
+# Caddy/TLS in front of the Mac Mini Open Brain service
+export OPENBRAIN_BASE_URL="https://open-brain.rodaddy.live"
+
+# Trusted lab direct endpoint; requires explicit insecure-HTTP opt-in
+export OPENBRAIN_BASE_URL="http://10.71.1.21:3100"
+export OPENBRAIN_ALLOW_INSECURE_HTTP="1"
+```
+
+Do not use retained pre-cutover LXC snapshots such as `10.71.20.49` for current
+host canaries.
 
 For trusted lab-only HTTP endpoints, such as `http://10.71.1.21:3100`, opt in
 explicitly:
@@ -222,6 +244,11 @@ Use `contract_field_to_json_schema()` for one field node and
 `tool_contract_to_input_schema()` when you already selected one tool contract,
 and `tool_contracts_to_tool_schemas()` when converting a manifest's
 `tool_contracts` into a list of `{name, input_schema}` entries.
+
+`tool_contracts_to_tool_schemas()` accepts the live `get_contract()` manifest
+and reads its `tool_contracts` mapping. Downstream callers should keep tests
+pinned to the package version they install and should not hand-maintain a
+second converter in the consuming repo.
 
 Malformed contract DSL raises `ContractSchemaError` with the failing path rather
 than emitting invalid JSON Schema. Open Brain-specific constraints that do not


### PR DESCRIPTION
## Summary

- Replace stale static tool-count docs with `get_contract` as the source of truth.
- Document `openbrain-memory` package install/config for agent and automation hosts.
- Clarify active endpoints, trusted lab HTTP opt-in, namespace authority, and pinned package install requirements.
- Update eval README to describe future live adapters through the current contract/direct HTTP client.

## Validation

- `git diff --check`
- Targeted stale-doc scan for unpinned package installs, stale `10.71.20.49` as active, `brain_answer through MCP`, and unpinned git-subdirectory install examples.

## Critical Self-Review

- Highest-risk behavior: docs could send operators to an unpinned package, stale endpoint, or wrong namespace model.
- Assumptions that could be wrong: `AUTH_TOKEN_PROMOTER` is documented as a role but the helper does not yet manage it; the README now states that explicitly.
- Missing/weak tests: docs-only change; no runtime tests needed beyond CI and stale-text scans.
- Security/permission risk: token values are not included; namespace authority is documented as server/token-derived.
- Migration/deploy risk: docs point agent hosts to exact package versions, reviewed wheels, or full commit pins; moving branches are rejected as install guidance.
- Downstream client/runtime risk: Hermes/Python consumers are directed to direct HTTP/package config and `get_contract` as source of truth.
- Rollback/cleanup concern: docs-only PR; rollback is reverting the README changes.
- Fixes made before PR: fixed unpinned package example, namespace authority caveat, and promoter helper caveat from review findings.
- Known residual risk: token helper still does not manage promoter; documented rather than changed in this docs PR.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: review findings matched existing package-doc and namespace-authority SME patterns; no new reusable missed pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: docs-only install/config change; no live service behavior changed

Review-swarm: PASS
Pinned diff: working-tree diff on `docs/openbrain-install-config` before commit `0819af4`.
Fresh-context lanes: Open Brain domain docs reviewer, Open Brain package gotcha reviewer.
Findings fixed:
- Package docs initially showed unpinned `uv pip install openbrain-memory`; changed to exact `openbrain-memory==<version>` and reinforced reviewed wheel/full commit pin policy.
- Root README initially showed `OPENBRAIN_NAMESPACE` without namespace-authority caveat; added token-derived namespace authority warning.
- Root README initially implied `generate-tokens.sh` handled `AUTH_TOKEN_PROMOTER`; clarified helper currently covers admin/agent/discord/n8n/readonly and promoter must be managed separately.

Fix-verification: PASS
Zero known unresolved issues: yes
Validation: `git diff --check`; fix-verification lanes confirmed no recurrence of package gotchas and no endpoint/direct-HTTP regressions.
