### PR TITLE
fix: scope nested OpenBrain enum aliases

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -479,16 +479,6 @@ def _collect_enum_refs(
             _merge_enum_refs(refs, {name: schema}, path=field_path)
             if scoped_session_aliases and name == "event_type":
                 _merge_enum_refs(refs, {"session_event_type": schema}, path=field_path)
-        nested_fields = field.get("fields")
-        if isinstance(nested_fields, Mapping):
-            _merge_enum_refs(
-                refs,
-                _collect_enum_refs(
-                    nested_fields,
-                    path=f"{field_path}.fields",
-                    scoped_session_aliases=scoped_session_aliases,
-                ),
-            )
     return refs
 
 

--- a/python/openbrain-memory/src/openbrain_memory/schema.py
+++ b/python/openbrain-memory/src/openbrain_memory/schema.py
@@ -186,7 +186,11 @@ def _typeless_node_to_json_schema(
         return schema
 
     if node and all(_is_contract_field_node(value) for value in node.values()):
-        return _fields_to_object_schema(node, path=path, enum_refs=enum_refs)
+        return _fields_to_object_schema(
+            node,
+            path=path,
+            enum_refs={**enum_refs, **_collect_enum_refs(node, path=path)},
+        )
 
     if any(_is_contract_field_node(value) for value in node.values()):
         raise ContractSchemaError(

--- a/python/openbrain-memory/tests/test_schema.py
+++ b/python/openbrain-memory/tests/test_schema.py
@@ -326,6 +326,48 @@ def test_typeless_contract_field_maps_convert_to_object_properties():
     }
 
 
+def test_typeless_contract_field_maps_resolve_sibling_enum_refs_locally():
+    assert contract_field_to_json_schema(
+        {
+            "status": {"type": "enum", "values": ["green", "yellow", "red"]},
+            "history": {"type": "array", "items": "status"},
+        },
+        path="$.metadata",
+    ) == {
+        "type": "object",
+        "properties": {
+            "status": {"type": "string", "enum": ["green", "yellow", "red"]},
+            "history": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["green", "yellow", "red"]},
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+def test_typeless_nested_enum_refs_shadow_outer_aliases():
+    assert contract_input_to_json_schema(
+        {
+            "status": {"type": "enum", "values": ["active", "wrapped", "archived"]},
+            "metadata": {
+                "status": {"type": "enum", "values": ["green", "yellow", "red"]},
+                "history": {"type": "array", "items": "status"},
+            },
+        },
+    )["properties"]["metadata"] == {
+        "type": "object",
+        "properties": {
+            "status": {"type": "string", "enum": ["green", "yellow", "red"]},
+            "history": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["green", "yellow", "red"]},
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
 def test_typeless_object_markers_convert_property_names_and_additional_properties():
     assert contract_field_to_json_schema(
         {

--- a/python/openbrain-memory/tests/test_schema.py
+++ b/python/openbrain-memory/tests/test_schema.py
@@ -192,6 +192,41 @@ def test_selected_tool_conversion_ignores_unrelated_enum_name_collisions():
     }
 
 
+def test_nested_inline_enums_do_not_create_bare_alias_collisions():
+    manifest = {
+        "tool_contracts": {
+            "lane_update": {
+                "input_schema": {
+                    "status": {
+                        "type": "enum",
+                        "values": ["active", "wrapped", "archived"],
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "fields": {
+                            "status": {
+                                "type": "enum",
+                                "values": ["green", "yellow", "red"],
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    [schema] = tool_contracts_to_tool_schemas(manifest)
+
+    assert schema["input_schema"]["properties"]["status"] == {
+        "type": "string",
+        "enum": ["active", "wrapped", "archived"],
+    }
+    assert schema["input_schema"]["properties"]["metadata"]["properties"]["status"] == {
+        "type": "string",
+        "enum": ["green", "yellow", "red"],
+    }
+
+
 def test_selected_tool_local_session_event_type_enum_shadows_shared_alias():
     manifest = {
         "tool_contracts": {


### PR DESCRIPTION
## Summary

Addresses the remaining `openbrain-memory` enum-alias collision tracked by Open Brain issue 190.

The previous fix scoped top-level enum references per tool, but the converter still recursively collected nested inline enums into the same bare-name alias map. A tool with a top-level `status` enum and a nested `metadata.status` enum could still fail with:

```text
openbrain-memory tool schema conversion failed: $: conflicting enum reference 'status'
```

This PR keeps implicit enum aliases scoped to the field map currently being converted:

- nested inline enums are not promoted into the parent/tool alias map;
- nested inline enums still convert in place;
- typeless nested field maps now create their own local enum-ref scope;
- explicit shared aliases, including `session_event_type`, remain supported through the existing manifest/shared-alias path.

Tracks Open Brain issue 190. Do not close that issue until downstream rollout and live Hermes canary verification are complete.

## Validation

From `python/openbrain-memory`:

```text
uv run pytest tests/test_schema.py -q
29 passed in 0.04s

uv run pytest -q
159 passed, 5 skipped in 4.74s

uv run ruff check src tests
All checks passed!

uv run ruff format --check src tests
15 files already formatted

uv run mypy src/openbrain_memory
Success: no issues found in 8 source files
```

Also verified the checked-out package converts the live `get_contract` payload successfully.

## Downstream Rollout

Applies: yes. This changes `python/openbrain-memory` behavior consumed by Hermes agents.

Pending before issue closure:

- publish/install the fixed package path used by Hermes agents;
- verify Bilby, Skippy, and Nagatha import the updated schema converter;
- restart or refresh Hermes sessions where tool schemas are snapshotted;
- confirm recent gateway logs no longer emit the `conflicting enum reference 'status'` warning;
- record downstream receipts in the active `rtech-hermes` goal run.

## Critical Self-Review

- Highest-risk behavior: accidentally removing enum aliases needed by string refs.
- Assumptions that could be wrong: nested inline enums are only needed in-place or within their local field map, not as implicit parent/tool aliases.
- Missing/weak tests: live package rollout is not proven by local tests; canary verification is still required.
- Security/permission risk: none expected; no auth, namespace, or secret-handling code changed.
- Migration/deploy risk: Hermes agents currently show package drift, so this must be installed into live agent venvs before closure.
- Downstream client/runtime risk: Hermes dynamic tool schema injection depends on this converter and needs live log verification.
- Rollback/cleanup concern: rollback is reverting this small package change or reinstalling the previous package.
- Fixes made before PR: added regressions for top-level `status` plus nested `metadata.status`, typeless sibling enum refs, and nested enum refs shadowing outer aliases.
- Known residual risk: if any real contract uses nested inline enum names as cross-object aliases, that contract should define an explicit shared alias instead.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the swarm finding is covered by the new regression tests and does not reveal a reusable review-memory pattern beyond existing schema-compatible contract checks.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured.
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this PR changes the Python package converter only; hosted service checks do not prove agent package rollout, which is tracked under Downstream Rollout pending canaries.
