### PR TITLE
Fix Open Brain session pressure and validation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ bun run start
 
 The MCP server listens on `http://localhost:3100` with Streamable HTTP transport.
 
+### MCP Session Limits
+
+Open Brain keeps stateful Streamable HTTP sessions in memory and expires idle
+sessions after 30 minutes. Initialize requests over the active-session cap return
+HTTP 429 with `Retry-After` and a machine-readable
+`session_cap_exceeded` response.
+
+Defaults:
+
+- `OPEN_BRAIN_MAX_SESSIONS=100`
+- `OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS=2`
+
+`OPEN_BRAIN_MAX_SESSIONS` is a safety cap, not the primary fleet-throttling
+mechanism. Prefer client retry/backoff behavior and explicit session cleanup
+before raising it.
+
 ### Mini two-worker mode
 
 For the Mini deployment, run two local Open Brain workers behind one stable

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -140,6 +140,34 @@ admin or n8n callers that intentionally need namespace delegation can opt in
 with `delegate_namespace=True`; doing so sends `X-Namespace` and requires a
 server role that is allowed to delegate.
 
+### Retry policy
+
+`OpenBrainClient` retries MCP `initialize` when the service returns HTTP 429 for
+session-cap pressure. The default retry policy is conservative and honors
+server `Retry-After` or `retry_after_seconds` metadata, capped by
+`max_backoff_seconds`.
+
+```python
+from openbrain_memory import OpenBrainClient, RetryPolicy
+
+client = OpenBrainClient(
+    "https://brain.example",
+    token="...",
+    namespace="bilby",
+    agent_id="bilby",
+    retry_policy=RetryPolicy(
+        attempts=3,
+        backoff_seconds=0.25,
+        max_backoff_seconds=5.0,
+        honor_retry_after=True,
+    ),
+)
+```
+
+Set `honor_retry_after=False` only for controlled tests or a caller-managed
+backoff policy. Session pressure is expected to be handled by client backoff and
+session cleanup, not by raising the server cap as the first response.
+
 ## Quickstart
 
 ```python

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -10,7 +10,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
-from .policy import redact_text
+from .policy import RetryPolicy, redact_text, with_retry
 
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
@@ -241,9 +241,11 @@ class OpenBrainError(RuntimeError):
         body: str | None = None,
         token: str | None = None,
         session_id: str | None = None,
+        retry_after_seconds: float | None = None,
     ) -> None:
         self.status_code = status_code
         self.context = context
+        self.retry_after_seconds = retry_after_seconds
         self.body = _redact(body or "", token=token, session_id=session_id)
         parts = [message]
         if status_code is not None:
@@ -279,6 +281,7 @@ class OpenBrainClient:
         transport: Transport | None = None,
         allow_insecure_http: bool = False,
         delegate_namespace: bool = False,
+        retry_policy: RetryPolicy | Mapping[str, Any] | None = None,
     ) -> None:
         _validate_base_url(base_url, allow_insecure_http=allow_insecure_http)
         self.base_url = base_url.rstrip("/") + "/"
@@ -289,6 +292,7 @@ class OpenBrainClient:
         self.timeout = timeout
         self.transport = transport or UrllibTransport()
         self.delegate_namespace = delegate_namespace
+        self.retry_policy = _coerce_retry_policy(retry_policy)
         self._session_id: str | None = None
         self._protocol_version = MCP_PROTOCOL_VERSION
         self._ids = count(1)
@@ -521,6 +525,13 @@ class OpenBrainClient:
     def _ensure_session(self) -> None:
         if self._session_id:
             return
+        with_retry(
+            self._initialize_session,
+            retry_policy=self.retry_policy,
+            retryable=_is_rate_limit_error,
+        )
+
+    def _initialize_session(self) -> None:
         request_id = next(self._ids)
         payload: JSON = {
             "jsonrpc": "2.0",
@@ -645,6 +656,7 @@ class OpenBrainClient:
     def _raise_for_status(self, response: TransportResponse, *, context: str) -> None:
         if 200 <= response.status_code < 300:
             return
+        retry_after = _retry_after_seconds(response)
         raise OpenBrainHTTPError(
             "Open Brain HTTP error",
             status_code=response.status_code,
@@ -652,6 +664,7 @@ class OpenBrainClient:
             body=response.text,
             token=self.token,
             session_id=self._session_id,
+            retry_after_seconds=retry_after,
         )
 
     def _decode_json_response(
@@ -751,6 +764,41 @@ def _header(headers: Mapping[str, str], name: str) -> str | None:
         if key.lower() == wanted:
             return value
     return None
+
+
+def _retry_after_seconds(response: TransportResponse) -> float | None:
+    header = _header(response.headers, "retry-after")
+    if header is not None:
+        try:
+            parsed = float(header)
+            if parsed >= 0:
+                return parsed
+        except ValueError:
+            pass
+    try:
+        body = response.json()
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    value = body.get("retry_after_seconds")
+    if isinstance(value, (int, float)) and value >= 0:
+        return float(value)
+    return None
+
+
+def _coerce_retry_policy(
+    policy: RetryPolicy | Mapping[str, Any] | None,
+) -> RetryPolicy:
+    if policy is None:
+        return RetryPolicy()
+    if isinstance(policy, RetryPolicy):
+        return policy
+    return RetryPolicy(**dict(policy))
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    return getattr(exc, "status_code", None) == 429
 
 
 def _last_sse_data(text: str, *, expected_id: int | None = None) -> str:

--- a/python/openbrain-memory/src/openbrain_memory/policy.py
+++ b/python/openbrain-memory/src/openbrain_memory/policy.py
@@ -91,12 +91,16 @@ class RetryExhaustedError(RuntimeError):
 class RetryPolicy:
     attempts: int = 2
     backoff_seconds: float = 0.05
+    max_backoff_seconds: float = 2.0
+    honor_retry_after: bool = True
 
     def __post_init__(self) -> None:
         if self.attempts < 1:
             raise ValueError("RetryPolicy.attempts must be >= 1")
         if self.backoff_seconds < 0:
             raise ValueError("RetryPolicy.backoff_seconds must be >= 0")
+        if self.max_backoff_seconds < 0:
+            raise ValueError("RetryPolicy.max_backoff_seconds must be >= 0")
 
 
 def idempotency_key() -> str:
@@ -149,7 +153,15 @@ def with_retry(
             last_error = exc
             if attempt >= retry_policy.attempts or not retryable(exc):
                 raise
-            time.sleep(retry_policy.backoff_seconds * attempt)
+            delay = retry_policy.backoff_seconds * attempt
+            retry_after = getattr(exc, "retry_after_seconds", None)
+            if retry_policy.honor_retry_after and isinstance(
+                retry_after, (int, float)
+            ):
+                delay = max(delay, float(retry_after))
+            if retry_policy.max_backoff_seconds > 0:
+                delay = min(delay, retry_policy.max_backoff_seconds)
+            time.sleep(delay)
     raise RetryExhaustedError("retry attempts exhausted") from last_error
 
 

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -17,6 +17,7 @@ from openbrain_memory import (
     OpenBrainHTTPError,
     OpenBrainProtocolError,
     OpenBrainToolError,
+    RetryPolicy,
 )
 from openbrain_memory.client import TransportResponse, UrllibTransport
 
@@ -127,6 +128,23 @@ def make_client(transport: FakeTransport) -> OpenBrainClient:
         role="agent",
         timeout=12.5,
         transport=transport,
+    )
+
+
+def make_retrying_client(transport: FakeTransport) -> OpenBrainClient:
+    return OpenBrainClient(
+        "https://brain.example",
+        "secret-token",
+        "bilby",
+        agent_id="bilby-agent",
+        role="agent",
+        timeout=12.5,
+        transport=transport,
+        retry_policy=RetryPolicy(
+            attempts=3,
+            backoff_seconds=0,
+            max_backoff_seconds=0,
+        ),
     )
 
 
@@ -672,6 +690,106 @@ def test_missing_session_id_is_protocol_error():
 
     with pytest.raises(OpenBrainProtocolError, match="mcp-session-id"):
         client.search_all(query="x")
+
+
+def test_initialize_rate_limit_retries_with_retry_after_metadata():
+    class RateLimitedInitializeTransport(FakeTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self.rate_limited_once = False
+
+        def post(self, url, *, headers, json_body, timeout):
+            if (
+                json_body.get("method") == "initialize"
+                and not self.rate_limited_once
+            ):
+                self.rate_limited_once = True
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=429,
+                    headers={
+                        "content-type": "application/json",
+                        "retry-after": "0",
+                    },
+                    text=json.dumps(
+                        {
+                            "error": "Too many active sessions",
+                            "code": "session_cap_exceeded",
+                            "active_sessions": 100,
+                            "max_sessions": 100,
+                            "retry_after_seconds": 0,
+                        }
+                    ),
+                )
+            return super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+
+    transport = RateLimitedInitializeTransport()
+    client = make_retrying_client(transport)
+
+    assert client.search_all(query="x")["tool"] == "search_all"
+    assert [
+        request["json"]["method"]
+        for request in post_requests(transport)
+        if request["json"].get("method") == "initialize"
+    ] == ["initialize", "initialize"]
+
+
+def test_initialize_rate_limit_exhaustion_surfaces_retry_after():
+    class AlwaysRateLimitedInitializeTransport(FakeTransport):
+        def post(self, url, *, headers, json_body, timeout):
+            if json_body.get("method") == "initialize":
+                self.requests.append(
+                    {
+                        "method": "POST",
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": json_body,
+                        "timeout": timeout,
+                    }
+                )
+                return TransportResponse(
+                    status_code=429,
+                    headers={
+                        "content-type": "application/json",
+                        "retry-after": "0.25",
+                    },
+                    text=json.dumps(
+                        {
+                            "error": "Too many active sessions",
+                            "code": "session_cap_exceeded",
+                            "active_sessions": 100,
+                            "max_sessions": 100,
+                            "retry_after_seconds": 0.25,
+                        }
+                    ),
+                )
+            return super().post(
+                url, headers=headers, json_body=json_body, timeout=timeout
+            )
+
+    transport = AlwaysRateLimitedInitializeTransport()
+    client = make_retrying_client(transport)
+
+    with pytest.raises(OpenBrainHTTPError) as exc_info:
+        client.search_all(query="x")
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.retry_after_seconds == 0.25
+    assert [
+        request["json"]["method"]
+        for request in post_requests(transport)
+        if request["json"].get("method") == "initialize"
+    ] == ["initialize", "initialize", "initialize"]
 
 
 def test_initialized_failure_does_not_commit_session_and_retry_reinitializes():

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -8,6 +8,7 @@ import {
   afterEach,
 } from "bun:test";
 import { createApp } from "./index.ts";
+import { getSessionCount } from "./transport.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 import type { Server } from "node:http";
 
@@ -194,6 +195,56 @@ describe("POST /mcp", () => {
     const sessionId = res.headers.get("mcp-session-id");
     expect(sessionId).toBeTruthy();
     expect(typeof sessionId).toBe("string");
+  });
+
+  it("returns retryable session-cap diagnostics when initialize is over cap", async () => {
+    const originalMax = process.env.OPEN_BRAIN_MAX_SESSIONS;
+    const originalRetryAfter = process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS;
+    const cappedAt = getSessionCount();
+    process.env.OPEN_BRAIN_MAX_SESSIONS = String(cappedAt);
+    process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS = "7";
+
+    try {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token-123",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "test", version: "1.0.0" },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(429);
+      expect(res.headers.get("Retry-After")).toBe("7");
+      expect(await res.json()).toEqual({
+        error: "Too many active sessions",
+        code: "session_cap_exceeded",
+        active_sessions: cappedAt,
+        max_sessions: cappedAt,
+        retry_after_seconds: 7,
+      });
+    } finally {
+      if (originalMax === undefined) {
+        delete process.env.OPEN_BRAIN_MAX_SESSIONS;
+      } else {
+        process.env.OPEN_BRAIN_MAX_SESSIONS = originalMax;
+      }
+      if (originalRetryAfter === undefined) {
+        delete process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS;
+      } else {
+        process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS = originalRetryAfter;
+      }
+    }
   });
 
   it("rejects session reuse under a different delegated namespace", async () => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -200,7 +200,27 @@ describe("POST /mcp", () => {
   it("returns retryable session-cap diagnostics when initialize is over cap", async () => {
     const originalMax = process.env.OPEN_BRAIN_MAX_SESSIONS;
     const originalRetryAfter = process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS;
+    const seed = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer test-token-123",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      }),
+    });
+    expect(seed.status).toBe(200);
     const cappedAt = getSessionCount();
+    expect(cappedAt).toBeGreaterThan(0);
     process.env.OPEN_BRAIN_MAX_SESSIONS = String(cappedAt);
     process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS = "7";
 
@@ -229,7 +249,7 @@ describe("POST /mcp", () => {
       expect(await res.json()).toEqual({
         error: "Too many active sessions",
         code: "session_cap_exceeded",
-        active_sessions: cappedAt,
+        active_sessions: getSessionCount(),
         max_sessions: cappedAt,
         retry_after_seconds: 7,
       });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,26 +1,37 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { validateToolInputWithSummary } from "./validation-errors.ts";
 
+type ToolInputValidator = (
+  tool: unknown,
+  args: unknown,
+  toolName: string,
+) => Promise<unknown>;
+
+function installValidationSummaryFormatter(server: McpServer): void {
+  const candidate = server as unknown as {
+    validateToolInput?: ToolInputValidator;
+  };
+
+  if (typeof candidate.validateToolInput !== "function") {
+    throw new Error(
+      "MCP SDK contract changed: McpServer.validateToolInput is unavailable",
+    );
+  }
+
+  // SDK-private hook: @modelcontextprotocol/sdk/server/mcp.js currently calls
+  // validateToolInput(tool, args, toolName) before dispatch. Keep validation
+  // semantics intact while replacing only the failure message formatting.
+  candidate.validateToolInput =
+    validateToolInputWithSummary as ToolInputValidator;
+}
+
 export function createBrainServer(): McpServer {
   const server = new McpServer({
     name: "open-brain",
     version: "1.0.0",
   });
 
-  // The SDK's default tool-input validation message can expose a raw validator
-  // dump that clients truncate. Keep the same validation semantics, but format
-  // failures as bounded JSON with field-level detail.
-  (server as unknown as {
-    validateToolInput: (
-      tool: unknown,
-      args: unknown,
-      toolName: string,
-    ) => Promise<unknown>;
-  }).validateToolInput = validateToolInputWithSummary as (
-    tool: unknown,
-    args: unknown,
-    toolName: string,
-  ) => Promise<unknown>;
+  installValidationSummaryFormatter(server);
 
   return server;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,26 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { validateToolInputWithSummary } from "./validation-errors.ts";
 
 export function createBrainServer(): McpServer {
-  return new McpServer({
+  const server = new McpServer({
     name: "open-brain",
     version: "1.0.0",
   });
+
+  // The SDK's default tool-input validation message can expose a raw validator
+  // dump that clients truncate. Keep the same validation semantics, but format
+  // failures as bounded JSON with field-level detail.
+  (server as unknown as {
+    validateToolInput: (
+      tool: unknown,
+      args: unknown,
+      toolName: string,
+    ) => Promise<unknown>;
+  }).validateToolInput = validateToolInputWithSummary as (
+    tool: unknown,
+    args: unknown,
+    toolName: string,
+  ) => Promise<unknown>;
+
+  return server;
 }

--- a/src/tools/__tests__/protocol.test.ts
+++ b/src/tools/__tests__/protocol.test.ts
@@ -91,6 +91,41 @@ describe("Protocol tests: write tools via InMemoryTransport", () => {
         await cleanup();
       }
     });
+
+    it("returns a machine-readable failing-field summary", async () => {
+      const auth: AuthInfo = { role: "admin", clientId: "proto-admin" };
+      const { client, cleanup } = await createProtocolClient(auth);
+
+      try {
+        const result = await client.callTool({
+          name: "append_session_event",
+          arguments: {
+            session_key: "test",
+            event_type: "invalid-event-type",
+            content: "bad enum",
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as any)[0].text as string;
+        expect(text).toContain("Input validation error: ");
+        const summary = JSON.parse(
+          text.slice(text.indexOf("Input validation error: ") + 24),
+        );
+        expect(summary).toMatchObject({
+          error: "input_validation_failed",
+          tool: "append_session_event",
+        });
+        expect(summary.fields).toContainEqual(
+          expect.objectContaining({
+            field: "event_type",
+            code: "invalid_value",
+          }),
+        );
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe("search_brain via protocol", () => {

--- a/src/tools/__tests__/protocol.test.ts
+++ b/src/tools/__tests__/protocol.test.ts
@@ -108,9 +108,10 @@ describe("Protocol tests: write tools via InMemoryTransport", () => {
 
         expect(result.isError).toBe(true);
         const text = (result.content as any)[0].text as string;
-        expect(text).toContain("Input validation error: ");
+        const prefix = "Input validation error: ";
+        expect(text).toContain(prefix);
         const summary = JSON.parse(
-          text.slice(text.indexOf("Input validation error: ") + 24),
+          text.slice(text.indexOf(prefix) + prefix.length),
         );
         expect(summary).toMatchObject({
           error: "input_validation_failed",

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -9,7 +9,8 @@ import { logger } from "./logger.ts";
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const CLOSE_TIMEOUT_MS = 5_000; // 5 seconds max for transport.close()
-const MAX_SESSIONS = 100;
+const DEFAULT_MAX_SESSIONS = 100;
+const DEFAULT_SESSION_RETRY_AFTER_SECONDS = 2;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -21,6 +22,42 @@ interface SessionEntry {
 }
 
 const sessions: Map<string, SessionEntry> = new Map();
+
+function readPositiveInt(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function maxSessions(): number {
+  return readPositiveInt(
+    process.env.OPEN_BRAIN_MAX_SESSIONS,
+    DEFAULT_MAX_SESSIONS,
+  );
+}
+
+function retryAfterSeconds(): number {
+  return readPositiveInt(
+    process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS,
+    DEFAULT_SESSION_RETRY_AFTER_SECONDS,
+  );
+}
+
+function rejectSessionCap(res: Response): void {
+  const max = maxSessions();
+  const retryAfter = retryAfterSeconds();
+  res.setHeader("Retry-After", String(retryAfter));
+  res.status(429).json({
+    error: "Too many active sessions",
+    code: "session_cap_exceeded",
+    active_sessions: sessions.size,
+    max_sessions: max,
+    retry_after_seconds: retryAfter,
+  });
+}
 
 async function expireSession(sessionId: string, reason: string): Promise<void> {
   const entry = sessions.get(sessionId);
@@ -134,8 +171,8 @@ export function createTransportHandlers(
       }
 
       if (!sessionId && isInitializeRequest(req.body)) {
-        if (sessions.size >= MAX_SESSIONS) {
-          res.status(503).json({ error: "Too many active sessions" });
+        if (sessions.size >= maxSessions()) {
+          rejectSessionCap(res);
           return;
         }
 
@@ -151,11 +188,12 @@ export function createTransportHandlers(
             // initial cap check above and this callback: a concurrent request could
             // slip through. This is acceptable given MAX_SESSIONS=100 provides
             // headroom and the transport is closed immediately if exceeded.
-            if (sessions.size >= MAX_SESSIONS) {
+            const max = maxSessions();
+            if (sessions.size >= max) {
               logger.warn("session_cap_race", {
                 id,
                 active: sessions.size,
-                max: MAX_SESSIONS,
+                max,
                 message:
                   "Concurrent request slipped past initial cap check; closing transport",
               });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -22,6 +22,7 @@ interface SessionEntry {
 }
 
 const sessions: Map<string, SessionEntry> = new Map();
+let pendingInitializes = 0;
 
 function readPositiveInt(
   value: string | undefined,
@@ -53,7 +54,7 @@ function rejectSessionCap(res: Response): void {
   res.status(429).json({
     error: "Too many active sessions",
     code: "session_cap_exceeded",
-    active_sessions: sessions.size,
+    active_sessions: sessions.size + pendingInitializes,
     max_sessions: max,
     retry_after_seconds: retryAfter,
   });
@@ -171,7 +172,7 @@ export function createTransportHandlers(
       }
 
       if (!sessionId && isInitializeRequest(req.body)) {
-        if (sessions.size >= maxSessions()) {
+        if (sessions.size + pendingInitializes >= maxSessions()) {
           rejectSessionCap(res);
           return;
         }
@@ -181,13 +182,11 @@ export function createTransportHandlers(
           return;
         }
 
+        pendingInitializes++;
+        let initialized = false;
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (id: string) => {
-            // Re-check cap at registration time. A narrow race exists between the
-            // initial cap check above and this callback: a concurrent request could
-            // slip through. This is acceptable given MAX_SESSIONS=100 provides
-            // headroom and the transport is closed immediately if exceeded.
             const max = maxSessions();
             if (sessions.size >= max) {
               logger.warn("session_cap_race", {
@@ -195,12 +194,11 @@ export function createTransportHandlers(
                 active: sessions.size,
                 max,
                 message:
-                  "Concurrent request slipped past initial cap check; closing transport",
+                  "Admitted initialize completed while active sessions met or exceeded current cap",
               });
-              void transport.close().catch(() => {}); // clean up untracked transport
-              return;
             }
 
+            initialized = true;
             const timer = setTimeout(() => {
               expireSession(id, "inactivity");
             }, SESSION_TTL_MS);
@@ -227,14 +225,18 @@ export function createTransportHandlers(
         };
 
         const server = serverFactory();
-        await server.connect(transport);
         try {
+          await server.connect(transport);
           await transport.handleRequest(req, res, req.body);
         } catch (err) {
           // If handleRequest fails after session was registered, clean up
           const id = transport.sessionId;
           if (id) expireSession(id, "init-error");
           throw err;
+        } finally {
+          if (initialized || pendingInitializes > 0) {
+            pendingInitializes--;
+          }
         }
         return;
       }

--- a/src/validation-errors.ts
+++ b/src/validation-errors.ts
@@ -1,0 +1,119 @@
+import type { AnySchema, ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import {
+  getParseErrorMessage,
+  normalizeObjectSchema,
+  safeParseAsync,
+} from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+export interface ValidationFieldIssue {
+  field: string;
+  code: string;
+  message: string;
+  constraint?: string;
+  expected?: unknown;
+  received?: unknown;
+  options?: unknown[];
+}
+
+export interface ValidationSummary {
+  error: "input_validation_failed";
+  tool: string;
+  fields: ValidationFieldIssue[];
+}
+
+interface ToolWithInputSchema {
+  inputSchema?: AnySchema | ZodRawShapeCompat;
+}
+
+interface ZodIssueLike {
+  path?: Array<string | number>;
+  code?: string;
+  message?: string;
+  expected?: unknown;
+  received?: unknown;
+  options?: unknown[];
+  values?: unknown[];
+  minimum?: unknown;
+  maximum?: unknown;
+}
+
+function fieldPath(path: ZodIssueLike["path"]): string {
+  if (!path || path.length === 0) return "$";
+  return path.map(String).join(".");
+}
+
+function constraintFor(issue: ZodIssueLike): string | undefined {
+  if (issue.code === "invalid_value" && issue.values) {
+    return `must be one of ${issue.values.map(String).join(", ")}`;
+  }
+  if (issue.code === "invalid_enum_value" && issue.options) {
+    return `must be one of ${issue.options.map(String).join(", ")}`;
+  }
+  if (issue.minimum !== undefined) return `minimum ${String(issue.minimum)}`;
+  if (issue.maximum !== undefined) return `maximum ${String(issue.maximum)}`;
+  return issue.message;
+}
+
+export function summarizeValidationError(
+  toolName: string,
+  error: unknown,
+): ValidationSummary {
+  const issues =
+    typeof error === "object" && error !== null && "issues" in error
+      ? ((error as { issues?: unknown }).issues as unknown)
+      : undefined;
+
+  const fields = Array.isArray(issues)
+    ? issues.slice(0, 20).map((raw): ValidationFieldIssue => {
+        const issue = raw as ZodIssueLike;
+        return {
+          field: fieldPath(issue.path),
+          code: issue.code ?? "invalid",
+          message: issue.message ?? "Invalid value",
+          constraint: constraintFor(issue),
+          expected: issue.expected,
+          received: issue.received,
+          options: issue.options ?? issue.values,
+        };
+      })
+    : [
+        {
+          field: "$",
+          code: "invalid",
+          message: getParseErrorMessage(error),
+        },
+      ];
+
+  return {
+    error: "input_validation_failed",
+    tool: toolName,
+    fields,
+  };
+}
+
+export function formatValidationSummary(summary: ValidationSummary): string {
+  const json = JSON.stringify(summary);
+  return `Input validation error: ${json}`;
+}
+
+export async function validateToolInputWithSummary(
+  tool: ToolWithInputSchema,
+  args: unknown,
+  toolName: string,
+): Promise<unknown> {
+  if (!tool.inputSchema) return undefined;
+
+  const inputObj = normalizeObjectSchema(tool.inputSchema);
+  const schemaToParse = inputObj ?? tool.inputSchema;
+  const parseResult = await safeParseAsync(schemaToParse as AnySchema, args);
+  if (!parseResult.success) {
+    const error = "error" in parseResult ? parseResult.error : "Unknown error";
+    const summary = summarizeValidationError(toolName, error);
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      formatValidationSummary(summary),
+    );
+  }
+  return parseResult.data;
+}


### PR DESCRIPTION
## Summary

Closes #194.
Closes #195.

This PR keeps the default Open Brain session cap unchanged and makes session pressure explicit and retryable:

- returns HTTP 429 for MCP initialize requests over the active-session cap
- includes `Retry-After` and a machine-readable `session_cap_exceeded` body
- counts pending initialize requests so concurrent session pressure does not hand clients dead sessions
- teaches `openbrain-memory` to retry initialize on 429 and honor retry-after metadata
- formats SDK tool-input validation failures as bounded JSON with field-level details instead of raw validator dumps

## Helper / downstream notes

- Helps the Hermes fleet recovery work by giving clients a stable rate-limit contract instead of a generic 503/session failure.
- Companion rtech-hermes client work is on branch `fix/hermes-fleet-incident-cleanup`; that repo consumes this via `openbrain-memory` retry policy and legacy direct-HTTP initialize retry handling.
- Downstream rollout applies because this touches Streamable HTTP behavior, error envelopes, and the Python client. Hermes readiness is not claimed by this PR alone; the rtech-hermes PR and live agent canary remain separate rollout steps.

## Validation

- `bunx tsc --noEmit`
- `bun test src/server.test.ts -t "returns retryable session-cap diagnostics" --timeout 20000`
- `bun test src/server.test.ts src/tools/__tests__/protocol.test.ts --timeout 20000`
- `bun test`
- `cd python/openbrain-memory && uv run ruff check src tests`
- `cd python/openbrain-memory && uv run mypy src/openbrain_memory`
- `cd python/openbrain-memory && uv run pytest -q tests/test_client.py tests/test_safety.py`
- `cd python/openbrain-memory && uv run pytest -q`
- `git diff --check`
- `ggshield secret scan repo .`

## Critical Self-Review

- Highest-risk behavior: MCP initialize pressure now returns 429 instead of 503, so downstream clients that special-case only 503 need rollout updates.
- Assumptions that could be wrong: using 429 for session-cap pressure is the intended long-term contract; default `Retry-After` of 2 seconds is conservative enough for current fleet behavior.
- Missing/weak tests: local tests cover server diagnostics and Python retry behavior with fake transports, but live fleet-load behavior still needs hosted smoke and Hermes canary.
- Security/permission risk: validation summaries intentionally expose failing field names/codes/messages, not secrets or raw request dumps.
- Migration/deploy risk: deployed clients may need the updated `openbrain-memory` constructor support before Hermes passes retry policy.
- Downstream client/runtime risk: rtech-hermes has companion client changes; mcp2cli/generated skills should be checked under the downstream rollout contract.
- Rollback/cleanup concern: rollback restores prior 503 behavior and removes Python retry-after handling; clients should tolerate both during rollout.
- Fixes made before PR: added machine-readable validation summaries, 429 session-cap diagnostics, Python retry policy support, pending-initialize admission tracking, docs, and regression tests.
- Known residual risk: hosted deployment and live Hermes canary are still required before declaring the fleet fully recovered.
- SME review-memory update: [ ] `docs/sme/` updated [x] not applicable because: findings were PR-local implementation/test/doc issues already fixed here and did not create a reusable new review pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below [ ] not applicable because -

Live checks are tracked in the downstream rollout notes and will be completed after PR review/merge as required by `docs/downstream-rollout.md`.
