### PR TITLE
Wire core01 deploy and qmd runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    runs-on: [self-hosted, rodaddy]
+    runs-on: [self-hosted, Linux, rodaddy]
     env:
       DB_HOST: localhost
       DB_PORT: 5432
@@ -44,7 +44,7 @@ jobs:
         run: bun test
 
   python-package:
-    runs-on: [self-hosted, rodaddy]
+    runs-on: [self-hosted, Linux, rodaddy]
     defaults:
       run:
         working-directory: python/openbrain-memory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,48 +75,16 @@ jobs:
 
   deploy:
     needs: [check, python-package]
-    runs-on: [self-hosted, rodaddy]
+    runs-on: [self-hosted, macOS, core01]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency:
-      group: deploy-production
+      group: deploy-core01-production
       cancel-in-progress: false
     env:
-      DEPLOY_HOST: 10.71.20.49
-      DEPLOY_USER: rico
-      SERVICE_NAME: open-brain
-      DEPLOY_PATH: /opt/open-brain
+      RUNTIME_DIR: /Volumes/ThunderBolt/open-brain/app
 
     steps:
-      - name: Pull latest code
-        run: |
-          ssh ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
-            "cd ${{ env.DEPLOY_PATH }} && git pull origin main"
+      - uses: actions/checkout@v6
 
-      - name: Install dependencies
-        run: |
-          ssh ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
-            "cd ${{ env.DEPLOY_PATH }} && /usr/local/bin/bun install --frozen-lockfile"
-
-      - name: Run migrations
-        run: |
-          ssh ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
-            "cd ${{ env.DEPLOY_PATH }} && /usr/local/bin/bun run migrate"
-
-      - name: Restart service
-        run: |
-          ssh ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
-            "sudo systemctl restart ${{ env.SERVICE_NAME }}"
-
-      - name: Health check (with retry)
-        run: |
-          for i in 1 2 3 4 5; do
-            sleep 2
-            if ssh ${{ env.DEPLOY_USER }}@${{ env.DEPLOY_HOST }} \
-              "curl -sf --max-time 5 http://localhost:3100/health" > /dev/null 2>&1; then
-              echo "Health check passed (attempt $i)"
-              exit 0
-            fi
-            echo "Health check attempt $i failed, retrying..."
-          done
-          echo "Health check failed after 5 attempts"
-          exit 1
+      - name: Deploy to core01 launchd runtime
+        run: bash scripts/core01-deploy-local.sh

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
-    runs-on: [self-hosted, rodaddy]
+    runs-on: [self-hosted, Linux, rodaddy]
     permissions:
       contents: read
       pull-requests: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ MCP server providing a unified semantic brain over PostgreSQL + pgvector. TypeSc
 ## Stack
 
 - **Runtime:** Bun 1.3.13
-- **Database:** PostgreSQL 17 + pgvector (halfvec 768)
+- **Database:** PostgreSQL 18 + pgvector (halfvec 768)
 - **Embeddings:** Any OpenAI-compatible endpoint via `EMBEDDING_BASE_URL` (prod: local MLX server on 127.0.0.1:8791, `embeddinggemma-300m-8bit`). Hosted prod sets `EMBEDDING_WATCHDOG_RESTART_SCRIPT` so repeated provider failures bounce the local MLX embedding daemon.
 - **Auth:** Per-consumer Bearer tokens (admin, agent, discord, n8n, readonly)
-- **Deploy:** Mac Mini via launchd `com.rico.open-brain` (10.71.1.21:3100). LXC 208 decommissioned 2026-06-11; its Postgres (10.71.20.49) retained as a pre-cutover snapshot.
+- **Deploy:** core01 Mac Mini via launchd `com.rico.open-brain` (10.71.1.21:3100). Source lives in `/Volumes/ThunderBolt/Development/open-brain`; the running app lives in `/Volumes/ThunderBolt/open-brain/app`; qmd runtime/index lives in `/Volumes/ThunderBolt/qmd`. LXC 208 decommissioned 2026-06-11; its Postgres (10.71.20.49) retained as a pre-cutover snapshot.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,44 @@ bun run start:two-worker
 The public `/health` endpoint aggregates both workers. MCP and REST traffic are
 round-robin proxied to the workers.
 
+### core01 Deploy And qmd Runtime
+
+The active production service runs on core01 (`10.71.1.21`) through launchd.
+Keep the boundaries explicit:
+
+- source checkout: `/Volumes/ThunderBolt/Development/open-brain`
+- running app: `/Volumes/ThunderBolt/open-brain/app`
+- database data/backups: `/Volumes/ThunderBolt/open-brain/pgdata18` and
+  `/Volumes/ThunderBolt/open-brain/backups`
+- qmd runtime/index/models: `/Volumes/ThunderBolt/qmd`
+
+Deploys should be owned by this repository, not by hand-copying files:
+
+```bash
+bun run deploy:core01
+```
+
+On GitHub, the `deploy` job targets a core01 macOS self-hosted runner with
+labels `[self-hosted, macOS, core01]`. The job rsyncs this checkout into the
+running app directory, installs runtime dependencies there, runs migrations,
+bootstraps the pinned qmd runtime, restarts `com.rico.open-brain`, and checks
+`/health`.
+
+qmd is pinned and bootstrapped by:
+
+```bash
+bun run qmd:core01:bootstrap
+```
+
+The Open Brain runtime reads qmd through `QMD_PATH`, normally:
+
+```bash
+QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
+```
+
+Do not put qmd indexes, qmd models, Postgres data, or required production
+`node_modules` under `/Volumes/ThunderBolt/Development`.
+
 Smoke after startup:
 
 ```bash

--- a/docs/downstream-rollout.md
+++ b/docs/downstream-rollout.md
@@ -134,8 +134,9 @@ required memory mode, incompatible or unreachable contracts must fail closed.
 
 ## qmd-Derived Repo Facts
 
-qmd runs on the local GPU machine and acts as the repo-knowledge compiler. Open
-Brain is the shared runtime distribution layer for agents that cannot run qmd.
+qmd runs with Open Brain on core01 (`10.71.1.21`) and acts as the
+repo-knowledge compiler. Open Brain is the shared runtime distribution layer
+for agents that cannot run qmd.
 Required repo knowledge is promoted into Open Brain with `upsert_repo_fact` and
 read with `list_repo_facts`.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "import-kb": "bun run scripts/import-legacy-kb.ts",
     "promote:legacy-shared": "bun run scripts/promote-legacy-shared.ts",
     "promote:qmd-facts": "bun run scripts/promote-qmd-repo-facts.ts",
-    "curate": "bun run scripts/curate.ts"
+    "curate": "bun run scripts/curate.ts",
+    "deploy:core01": "bash scripts/core01-deploy-local.sh",
+    "qmd:core01:bootstrap": "bash scripts/core01-qmd-bootstrap.sh"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+RUNTIME_DIR="${RUNTIME_DIR:-/Volumes/ThunderBolt/open-brain/app}"
+ENV_FILE="${ENV_FILE:-/Users/rico/.config/open-brain/env}"
+SERVICE_LABEL="${SERVICE_LABEL:-system/com.rico.open-brain}"
+QMD_PATH_VALUE="${QMD_PATH_VALUE:-/Volumes/ThunderBolt/qmd/open-brain-qmd.ts}"
+BUN_BIN="${BUN_BIN:-}"
+
+if [[ -z "$BUN_BIN" ]]; then
+  if [[ -x "/Users/rico/Library/Application Support/reflex/bun/bin/bun" ]]; then
+    BUN_BIN="/Users/rico/Library/Application Support/reflex/bun/bin/bun"
+  elif command -v bun >/dev/null 2>&1; then
+    BUN_BIN="$(command -v bun)"
+  else
+    echo "FATAL: bun not found" >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -d "/Volumes/ThunderBolt" ]]; then
+  echo "FATAL: /Volumes/ThunderBolt is not mounted" >&2
+  exit 1
+fi
+
+if [[ ! -r "$ENV_FILE" ]]; then
+  echo "FATAL: env file missing: $ENV_FILE" >&2
+  exit 1
+fi
+
+mkdir -p "$RUNTIME_DIR"
+
+rsync -a --delete \
+  --exclude ".git/" \
+  --exclude ".github/" \
+  --exclude ".planning/" \
+  --exclude ".pi/" \
+  --exclude ".omc/" \
+  --exclude ".DS_Store" \
+  --exclude "node_modules/" \
+  --exclude "python/openbrain-memory/.venv/" \
+  --exclude ".env" \
+  --exclude ".env.*" \
+  "$REPO_DIR"/ "$RUNTIME_DIR"/
+
+"$BUN_BIN" install --cwd "$RUNTIME_DIR" --frozen-lockfile
+
+if [[ -x "$RUNTIME_DIR/scripts/core01-qmd-bootstrap.sh" ]]; then
+  "$RUNTIME_DIR/scripts/core01-qmd-bootstrap.sh"
+fi
+
+if grep -q "^QMD_PATH=" "$ENV_FILE"; then
+  perl -pi -e "s#^QMD_PATH=.*#QMD_PATH=$QMD_PATH_VALUE#" "$ENV_FILE"
+else
+  printf '\nQMD_PATH=%s\n' "$QMD_PATH_VALUE" >> "$ENV_FILE"
+fi
+
+cd "$RUNTIME_DIR"
+"$BUN_BIN" run migrate
+
+sudo launchctl kickstart -k "$SERVICE_LABEL"
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS --max-time 5 http://127.0.0.1:3100/health >/dev/null 2>&1; then
+    echo "Open Brain health check passed"
+    "$BUN_BIN" test src/tools/__tests__/search-all.test.ts
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "FATAL: Open Brain health check failed after restart" >&2
+exit 1

--- a/scripts/core01-qmd-bootstrap.sh
+++ b/scripts/core01-qmd-bootstrap.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+QMD_ROOT="${QMD_ROOT:-/Volumes/ThunderBolt/qmd}"
+QMD_VERSION="${QMD_VERSION:-2.1.0}"
+BUN_BIN="${BUN_BIN:-}"
+
+if [[ -z "$BUN_BIN" ]]; then
+  if [[ -x "/Users/rico/Library/Application Support/reflex/bun/bin/bun" ]]; then
+    BUN_BIN="/Users/rico/Library/Application Support/reflex/bun/bin/bun"
+  elif command -v bun >/dev/null 2>&1; then
+    BUN_BIN="$(command -v bun)"
+  else
+    echo "FATAL: bun not found" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$QMD_ROOT/app" "$QMD_ROOT/bin" "$QMD_ROOT/cache" "$QMD_ROOT/config" "$QMD_ROOT/logs"
+
+cat > "$QMD_ROOT/app/package.json" <<EOF
+{"name":"core01-qmd-runtime","private":true,"type":"module","dependencies":{"@tobilu/qmd":"$QMD_VERSION"}}
+EOF
+
+"$BUN_BIN" install --cwd "$QMD_ROOT/app"
+
+cat > "$QMD_ROOT/bin/qmd" <<'EOF'
+#!/bin/zsh
+export XDG_CACHE_HOME="/Volumes/ThunderBolt/qmd/cache"
+export PATH="/Users/rico/Library/Application Support/reflex/bun/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+exec "/Volumes/ThunderBolt/qmd/app/node_modules/@tobilu/qmd/bin/qmd" --index open-brain "$@"
+EOF
+chmod 755 "$QMD_ROOT/bin/qmd"
+
+cat > "$QMD_ROOT/open-brain-qmd.ts" <<'EOF'
+#!/usr/bin/env bun
+const args = Bun.argv.slice(2);
+const proc = Bun.spawn(["/Volumes/ThunderBolt/qmd/bin/qmd", ...args], {
+  stdout: "inherit",
+  stderr: "inherit",
+  env: {
+    ...process.env,
+    XDG_CACHE_HOME: "/Volumes/ThunderBolt/qmd/cache",
+    PATH:
+      "/Users/rico/Library/Application Support/reflex/bun/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+  },
+});
+process.exit(await proc.exited);
+EOF
+chmod 755 "$QMD_ROOT/open-brain-qmd.ts"
+
+"$QMD_ROOT/bin/qmd" status

--- a/scripts/core01-sync-development.sh
+++ b/scripts/core01-sync-development.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="${SOURCE_DIR:-/Volumes/ThunderBolt/Development}"
+TARGET_DIR="${TARGET_DIR:-/Volumes/ThunderBolt/Development}"
+QMD_BIN="${QMD_BIN:-/Volumes/ThunderBolt/qmd/bin/qmd}"
+
+if [[ "$SOURCE_DIR" == "$TARGET_DIR" ]]; then
+  echo "FATAL: SOURCE_DIR and TARGET_DIR are identical; run this on the sync source or set TARGET_DIR explicitly" >&2
+  exit 1
+fi
+
+rsync -a --delete \
+  --exclude ".DS_Store" \
+  --exclude "node_modules/" \
+  --exclude ".venv/" \
+  --exclude "venv/" \
+  --exclude "__pycache__/" \
+  --exclude ".pytest_cache/" \
+  --exclude ".mypy_cache/" \
+  --exclude "dist/" \
+  --exclude ".next/" \
+  --exclude "target/" \
+  --exclude "logs/" \
+  --exclude "_quarantine/" \
+  --exclude "_tmp/" \
+  --exclude ".reports/" \
+  "$SOURCE_DIR"/ "$TARGET_DIR"/
+
+if [[ -x "$QMD_BIN" ]]; then
+  "$QMD_BIN" update
+  "$QMD_BIN" embed
+fi

--- a/skill/references/search-guide.md
+++ b/skill/references/search-guide.md
@@ -50,6 +50,9 @@ mcp2cli open-brain search_all --params '{"query": "deployment", "sources": "brai
 
 # qmd only (skip brain)
 mcp2cli open-brain search_all --params '{"query": "deployment", "sources": "qmd"}'
+
+# qmd collection only
+mcp2cli open-brain search_all --params '{"query": "search_all qmd", "sources": "qmd", "collection": "open-brain-runtime"}'
 ```
 
 ## Output Format

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -96,6 +96,15 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "memory — thoughts, session events, facts), qmd (only indexed code " +
           "context). Narrow this when you know which corpus you need.",
       },
+      collection: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        description:
+          "Optional qmd collection filter. Use with sources='qmd' or " +
+          "sources='all' when you need code/document context from one indexed " +
+          "collection such as open-brain-runtime.",
+      },
       search_mode: {
         type: "enum",
         required: false,

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -971,6 +971,84 @@ describe("search_all", () => {
       }
     });
 
+    it("qmd uses 'snippet' field when other content fields are absent", async () => {
+      mockBunSpawn(
+        0,
+        qmdJson([{ path: "/s.md", snippet: "from snippet", score: 0.6 }]),
+      );
+      const pool = { query: async () => ({ rows: [] }) };
+      const { client, cleanup } = await setupClient(pool, {
+        role: "admin",
+        clientId: "admin",
+      });
+      try {
+        expect(
+          parseSearchAll(
+            await client.callTool({
+              name: "search_all",
+              arguments: { query: "snippet fb", sources: "qmd" },
+            }),
+          ).results[0].content,
+        ).toBe("from snippet");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("passes collection filter to qmd search", async () => {
+      let spawnArgs: string[] | undefined;
+      (Bun as any).spawn = (args: string[]) => {
+        spawnArgs = args;
+        const encoder = new TextEncoder();
+        return {
+          stdout: new ReadableStream({
+            start(c) {
+              c.enqueue(
+                encoder.encode(
+                  qmdJson([
+                    {
+                      path: "qmd://open-brain-runtime/src/tools/search-all.ts",
+                      snippet: "scoped qmd result",
+                      score: 0.6,
+                    },
+                  ]),
+                ),
+              );
+              c.close();
+            },
+          }),
+          stderr: new ReadableStream({
+            start(c) {
+              c.close();
+            },
+          }),
+          exited: Promise.resolve(0),
+        };
+      };
+      const pool = { query: async () => ({ rows: [] }) };
+      const { client, cleanup } = await setupClient(pool, {
+        role: "admin",
+        clientId: "admin",
+      });
+      try {
+        const parsed = parseSearchAll(
+          await client.callTool({
+            name: "search_all",
+            arguments: {
+              query: "collection scoped",
+              sources: "qmd",
+              collection: "open-brain-runtime",
+            },
+          }),
+        );
+        expect(parsed.results[0].content).toBe("scoped qmd result");
+        expect(spawnArgs).toContain("-c");
+        expect(spawnArgs).toContain("open-brain-runtime");
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("qmd 'similarity' field accepted with positive score", async () => {
       mockBunSpawn(
         0,

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -48,6 +48,7 @@ interface QmdDocument {
   content?: string;
   text?: string;
   preview?: string;
+  snippet?: string;
   score?: number;
   similarity?: number;
   collection?: string;
@@ -60,10 +61,22 @@ const QMD_TIMEOUT_MS = 10_000;
 async function searchQmd(
   query: string,
   limit: number,
+  collection?: string,
 ): Promise<UnifiedResult[]> {
   try {
+    const qmdArgs = [
+      "bun",
+      QMD_PATH,
+      "search",
+      query,
+      "--json",
+      "-n",
+      String(limit),
+    ];
+    if (collection) qmdArgs.push("-c", collection);
+
     const proc = Bun.spawn(
-      ["bun", QMD_PATH, "search", query, "--json", "-n", String(limit)],
+      qmdArgs,
       { stdout: "pipe", stderr: "pipe" },
     );
 
@@ -98,7 +111,13 @@ async function searchQmd(
     return docs.map((doc) => ({
       source: "qmd" as const,
       type: "file",
-      content: (doc.content || doc.text || doc.preview || "").slice(0, 300),
+      content: (
+        doc.content ||
+        doc.text ||
+        doc.preview ||
+        doc.snippet ||
+        ""
+      ).slice(0, 300),
       score: doc.score ?? doc.similarity ?? 0.5,
       path: doc.path || doc.file,
       collection: doc.collection,
@@ -148,6 +167,11 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
           .enum(["all", "brain", "qmd"])
           .optional()
           .describe("Which sources to search (default: all)"),
+        collection: z
+          .string()
+          .min(1)
+          .optional()
+          .describe("Optional: restrict qmd search to one collection"),
         search_mode: z
           .enum(["hybrid", "vector", "keyword"])
           .optional()
@@ -187,6 +211,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
+      const collection = args.collection as string | undefined;
       const requestedNamespace = args.namespace as string | undefined;
       if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
         return {
@@ -212,7 +237,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
           ? searchOB(deps, auth, args.query, totalNeeded, mode, tier, namespace)
           : Promise.resolve([]),
         searchQmdSource
-          ? searchQmd(args.query, totalNeeded)
+          ? searchQmd(args.query, totalNeeded, collection)
           : Promise.resolve([]),
       ]);
 


### PR DESCRIPTION
## Summary

- Move Open Brain production deploy ownership into this repo for core01 launchd runtime instead of stale .49 systemctl deploy.
- Add core01 deploy/qmd bootstrap/sync scripts and package commands.
- Patch search_all to support qmd snippet output and qmd collection filtering.
- Document source/runtime/qmd boundaries for core01.

## Verification

- [x] `bash -n scripts/core01-deploy-local.sh scripts/core01-qmd-bootstrap.sh scripts/core01-sync-development.sh`
- [x] `bunx tsc --noEmit`
- [x] `bun test src/tools/__tests__/search-all.test.ts src/contract.test.ts` - 40 pass / 0 fail
- [x] Ran repo-owned deploy script on core01: `bash scripts/core01-deploy-local.sh`
- [x] Core01 Open Brain health check passed after launchd restart
- [x] Core01 runtime focused test passed: `bun test src/tools/__tests__/search-all.test.ts` - 34 pass / 0 fail
- [x] Live MCP qmd smoke: `search_all sources=qmd collection=open-brain-runtime` returned non-empty snippets

## Critical Self-Review

- Highest-risk behavior: GitHub deploy now depends on a core01 macOS self-hosted runner with labels `[self-hosted, macOS, core01]`.
- Assumptions that could be wrong: Core01 runner service bootstrap may still need hardening because GitHub's LaunchAgent works from `/Users/rico/actions-runner/open-brain`, while launchd could not execute the runner from `/Volumes/ThunderBolt`.
- Missing/weak tests: Full CI was not run locally; focused TypeScript/typecheck/search/contract checks passed locally and the real PR check passed on GitHub.
- Security/permission risk: Deploy script preserves env outside git and excludes `.env*` from rsync; no secrets added.
- Migration/deploy risk: Script runs migrations before launchd restart and health-checks after; rollback is existing live runtime backup/previous commit deploy.
- Downstream client/runtime risk: `search_all` input schema adds optional `collection`; existing calls remain compatible. Contract schema and search guide were updated.
- Rollback/cleanup concern: qmd runtime/index lives under `/Volumes/ThunderBolt/qmd`; production app remains `/Volumes/ThunderBolt/open-brain/app`; Development checkout is not runtime state.
- Fixes made before PR: Verified and corrected qmd `snippet` parsing, collection scoping, stale .49 deploy target, and PG/core01 docs.
- Known residual risk: Development rsync script is scaffolded and not yet scheduled; qmd worker-3 architecture is intentionally deferred.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is deploy/qmd plumbing, not a newly discovered review-swarm pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is not applicable for this PR because no service registry/secrets map change is required yet
- [ ] mcp2cli cache/skill refresh is pending after PR merge because `search_all` contract adds optional `collection`
- [x] rtech-hermes Python runtime/plugin changes are not applicable; existing search_all calls remain compatible
- [x] Hermes live rollout/canaries are not applicable for this optional qmd filter until downstream generated skill refresh

Notes/evidence:

- Core01 deploy proof: `bash scripts/core01-deploy-local.sh`, launchd health check, focused runtime test, and live MCP qmd smoke passed.
- OB receipt: `6cca9186-cf39-4e77-aa7e-4cb46f5756ef`
