### PR TITLE
Bound core01 deploy rsync

### DIFF
--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -31,7 +31,7 @@ fi
 
 mkdir -p "$RUNTIME_DIR"
 
-rsync -a --delete \
+rsync -rlpt --delete-delay --timeout=120 \
   --exclude ".git/" \
   --exclude ".github/" \
   --exclude ".planning/" \
@@ -39,7 +39,9 @@ rsync -a --delete \
   --exclude ".omc/" \
   --exclude ".DS_Store" \
   --exclude "node_modules/" \
+  --exclude "dist/" \
   --exclude "python/openbrain-memory/.venv/" \
+  --exclude "python/openbrain-memory/dist/" \
   --exclude ".env" \
   --exclude ".env.*" \
   "$REPO_DIR"/ "$RUNTIME_DIR"/


### PR DESCRIPTION
## Summary

- Bound the core01 deploy rsync path after the first main deploy hung in local `rsync --delete-before`.
- Avoid owner/group/device preservation for local source-to-runtime sync.
- Use `--delete-delay` and `--timeout=120`.
- Exclude generated `dist/` directories from runtime source sync.

## Verification

- [x] `bash -n scripts/core01-deploy-local.sh`
- [x] Real main deploy failure mode observed on core01: deploy run `28152167346` hung in local rsync for over 2 minutes with 0 CPU and runtime still at old commit.
- [x] Existing Open Brain health remained OK during the canceled deploy.

## Critical Self-Review

- Highest-risk behavior: This changes the production deploy copy path for core01.
- Assumptions that could be wrong: The stall may have been a one-off macOS rsync state issue, but the patch still improves bounded behavior and removes unnecessary metadata preservation.
- Missing/weak tests: No full deploy yet for this exact patch; the PR exists to get CI and then re-run main deploy after merge.
- Security/permission risk: No secrets touched; rsync still excludes `.env*`.
- Migration/deploy risk: Runtime `node_modules` remains excluded/protected; generated dist folders are intentionally not source-synced.
- Downstream client/runtime risk: No API or client contract changes.
- Rollback/cleanup concern: Revert this one script change if it regresses deploy sync.
- Fixes made before PR: Canceled hung main deploy safely; Open Brain health stayed OK.
- Known residual risk: First successful main deploy after this PR must be watched end to end.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a narrow deploy-script hotfix, not a new review-swarm pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is not applicable
- [x] mcp2cli cache/skill refresh is not applicable
- [x] rtech-hermes Python runtime/plugin changes are not applicable
- [x] Hermes live rollout/canaries are not applicable

Notes/evidence:

- Open Brain health stayed OK after canceling hung deploy run `28152167346`.
