### PR TITLE
Deploy core01 through staging swap

### DIFF
--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -7,6 +7,8 @@ ENV_FILE="${ENV_FILE:-/Users/rico/.config/open-brain/env}"
 SERVICE_LABEL="${SERVICE_LABEL:-system/com.rico.open-brain}"
 QMD_PATH_VALUE="${QMD_PATH_VALUE:-/Volumes/ThunderBolt/qmd/open-brain-qmd.ts}"
 BUN_BIN="${BUN_BIN:-}"
+STAGING_DIR="${STAGING_DIR:-${RUNTIME_DIR}.next}"
+PREVIOUS_DIR="${PREVIOUS_DIR:-${RUNTIME_DIR}.previous}"
 
 if [[ -z "$BUN_BIN" ]]; then
   if [[ -x "/Users/rico/Library/Application Support/reflex/bun/bin/bun" ]]; then
@@ -29,27 +31,28 @@ if [[ ! -r "$ENV_FILE" ]]; then
   exit 1
 fi
 
-mkdir -p "$RUNTIME_DIR"
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
 
-rsync -rlpt --delete-delay --timeout=120 \
-  --exclude ".git/" \
-  --exclude ".github/" \
-  --exclude ".planning/" \
-  --exclude ".pi/" \
-  --exclude ".omc/" \
-  --exclude ".DS_Store" \
-  --exclude "node_modules/" \
-  --exclude "dist/" \
-  --exclude "python/openbrain-memory/.venv/" \
-  --exclude "python/openbrain-memory/dist/" \
-  --exclude ".env" \
-  --exclude ".env.*" \
-  "$REPO_DIR"/ "$RUNTIME_DIR"/
+tar \
+  --exclude "./.git" \
+  --exclude "./.github" \
+  --exclude "./.planning" \
+  --exclude "./.pi" \
+  --exclude "./.omc" \
+  --exclude "./.DS_Store" \
+  --exclude "./node_modules" \
+  --exclude "./dist" \
+  --exclude "./python/openbrain-memory/.venv" \
+  --exclude "./python/openbrain-memory/dist" \
+  --exclude "./.env" \
+  --exclude "./.env.*" \
+  -C "$REPO_DIR" -cf - . | tar -C "$STAGING_DIR" -xf -
 
-"$BUN_BIN" install --cwd "$RUNTIME_DIR" --frozen-lockfile
+"$BUN_BIN" install --cwd "$STAGING_DIR" --frozen-lockfile
 
-if [[ -x "$RUNTIME_DIR/scripts/core01-qmd-bootstrap.sh" ]]; then
-  "$RUNTIME_DIR/scripts/core01-qmd-bootstrap.sh"
+if [[ -x "$STAGING_DIR/scripts/core01-qmd-bootstrap.sh" ]]; then
+  "$STAGING_DIR/scripts/core01-qmd-bootstrap.sh"
 fi
 
 if grep -q "^QMD_PATH=" "$ENV_FILE"; then
@@ -58,8 +61,14 @@ else
   printf '\nQMD_PATH=%s\n' "$QMD_PATH_VALUE" >> "$ENV_FILE"
 fi
 
-cd "$RUNTIME_DIR"
+cd "$STAGING_DIR"
 "$BUN_BIN" run migrate
+
+rm -rf "$PREVIOUS_DIR"
+if [[ -d "$RUNTIME_DIR" ]]; then
+  mv "$RUNTIME_DIR" "$PREVIOUS_DIR"
+fi
+mv "$STAGING_DIR" "$RUNTIME_DIR"
 
 sudo launchctl kickstart -k "$SERVICE_LABEL"
 
@@ -67,10 +76,17 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
   if curl -fsS --max-time 5 http://127.0.0.1:3100/health >/dev/null 2>&1; then
     echo "Open Brain health check passed"
     "$BUN_BIN" test src/tools/__tests__/search-all.test.ts
+    rm -rf "$PREVIOUS_DIR"
     exit 0
   fi
   sleep 2
 done
+
+if [[ -d "$PREVIOUS_DIR" ]]; then
+  rm -rf "$RUNTIME_DIR"
+  mv "$PREVIOUS_DIR" "$RUNTIME_DIR"
+  sudo launchctl kickstart -k "$SERVICE_LABEL"
+fi
 
 echo "FATAL: Open Brain health check failed after restart" >&2
 exit 1


### PR DESCRIPTION
## Summary

- Replace core01 deploy rsync with a staging-directory copy and swap.
- Build the next runtime tree in `/Volumes/ThunderBolt/open-brain/app.next`.
- Install dependencies and run migrations from staging before swapping into `/Volumes/ThunderBolt/open-brain/app`.
- Keep `/Volumes/ThunderBolt/open-brain/app.previous` as rollback state until post-restart health passes.

## Verification

- [x] `bash -n scripts/core01-deploy-local.sh`
- [x] `tar --exclude './.git' --exclude './node_modules' -C /Volumes/ThunderBolt/Development/open-brain -cf /dev/null .`
- [x] Confirmed two main deploy attempts hung in local macOS rsync; orphaned rsync from the first canceled deploy was cleaned up.
- [x] Existing Open Brain health remained OK during canceled deploy attempts.

## Critical Self-Review

- Highest-risk behavior: This changes the production deploy swap path for core01.
- Assumptions that could be wrong: Moving the runtime app directory before launchd restart may expose path timing issues; rollback restores `app.previous` and restarts if health fails.
- Missing/weak tests: The proof must be the main deploy after merge; PR checks cannot exercise the main-only deploy job.
- Security/permission risk: `.env*` remains excluded and production env stays outside git.
- Migration/deploy risk: Migrations run before the swap; service restart happens only after the staged app becomes the runtime app.
- Downstream client/runtime risk: No API or contract changes.
- Rollback/cleanup concern: On health success, `.previous` is removed; on health failure, current app is replaced with `.previous` and launchd is restarted.
- Fixes made before PR: Replaced the rsync path after bounded rsync still hung on core01.
- Known residual risk: Main deploy after merge must be watched end to end.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a narrow deploy-script hotfix, not a new review-swarm pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is not applicable
- [x] mcp2cli cache/skill refresh is not applicable
- [x] rtech-hermes Python runtime/plugin changes are not applicable
- [x] Hermes live rollout/canaries are not applicable

Notes/evidence:

- Open Brain health stayed OK after canceling hung deploy runs.
