### PR TITLE
Expose get_entry in public Open Brain contract

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -78,6 +78,7 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 | link_entities | Create relationship between entries | write |
 | adjacent_context | Traverse link graph from a node | read |
 | get_contract | Read the public Open Brain contract manifest | read |
+| get_entry | Fetch a full readable memory row by table and ID | read |
 | upsert_repo_fact | Store curated qmd-derived repo fact metadata | write |
 | list_repo_facts | Read curated qmd-derived repo facts | read |
 | search_brain | Semantic search across all tables | read |

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,10 +15,11 @@ from .policy import RetryPolicy, redact_text, with_retry
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-19.memory-tools.v5"
+CURRENT_CONTRACT_VERSION = "2026-06-25.memory-tools.v6"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",
+    "get_entry",
     "lane_load",
     "lane_upsert",
     "list_repo_facts",
@@ -34,6 +35,7 @@ CURRENT_TOOL_HELP: Mapping[str, str] = {
     "brain_answer": "Return cited answer bullets from readable Open Brain evidence.",
     "get_entity": "Fetch a graph entity by ID.",
     "get_contract": "Read the canonical Open Brain public contract manifest.",
+    "get_entry": "Fetch one full readable memory row by table and UUID.",
     "hydrate_entities": "Refresh missing graph entity embeddings.",
     "lane_load": "Load durable session lanes by filters.",
     "lane_upsert": "Create or update durable session lane metadata.",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -456,7 +456,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-19.memory-tools.v5"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-25.memory-tools.v6"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:
@@ -499,7 +499,7 @@ def test_required_contract_matches_server_source_of_truth():
 
 
 def test_current_agent_read_helpers_have_first_class_wrappers():
-    for tool_name in ("brain_answer", "list_repo_facts", "get_contract"):
+    for tool_name in ("brain_answer", "list_repo_facts", "get_contract", "get_entry"):
         assert hasattr(OpenBrainClient, tool_name), tool_name
         assert tool_name in CURRENT_TOOL_HELP
 

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -15,6 +15,28 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     input_schema: {},
     output_shape: "OpenBrainContract JSON text payload",
   },
+  get_entry: {
+    version: 1,
+    input_schema: {
+      table: {
+        type: "enum",
+        required: true,
+        values: ["thoughts", "decisions", "relationships", "projects", "sessions"],
+        description:
+          "Readable table containing the target row. Use the plural table " +
+          "name derived from search result source_type.",
+      },
+      id: {
+        type: "string",
+        required: true,
+        format: "uuid",
+        description:
+          "Entry UUID to fetch. The server applies auth-derived namespace " +
+          "predicates before returning any row.",
+      },
+    },
+    output_shape: "full readable entry row JSON text payload",
+  },
   log_thought: {
     version: 2,
     input_schema: {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -19,6 +19,7 @@ describe("Open Brain contract manifest", () => {
     );
     for (const tool of [
       "get_contract",
+      "get_entry",
       "log_thought",
       "search_all",
       "session_start",
@@ -34,6 +35,21 @@ describe("Open Brain contract manifest", () => {
     }
     const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
     expect(upsertRepoFact).toBeDefined();
+    const getEntry = contract.tool_contracts.get_entry;
+    expect(getEntry).toBeDefined();
+    expect(getEntry?.version).toBe(1);
+    expect((getEntry?.input_schema as any).table).toEqual({
+      type: "enum",
+      required: true,
+      values: ["thoughts", "decisions", "relationships", "projects", "sessions"],
+      description:
+        "Readable table containing the target row. Use the plural table " +
+        "name derived from search result source_type.",
+    });
+    expect((getEntry?.input_schema as any).id.type).toBe("string");
+    expect((getEntry?.input_schema as any).id.required).toBe(true);
+    expect((getEntry?.input_schema as any).id.format).toBe("uuid");
+    expect((getEntry?.input_schema as any).namespace).toBeUndefined();
     const searchAll = contract.tool_contracts.search_all;
     expect(searchAll).toBeDefined();
     expect((searchAll?.input_schema as any).namespace.type).toBe("string");
@@ -81,7 +97,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-19.memory-tools.v5");
+    expect(contract.contract_version).toBe("2026-06-25.memory-tools.v6");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-19.memory-tools.v5";
+export const CONTRACT_VERSION = "2026-06-25.memory-tools.v6";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -43,6 +43,14 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
     version: 1,
     kind: "tool",
     description: "Read the canonical Open Brain public contract manifest.",
+  },
+  {
+    name: "get_entry",
+    version: 1,
+    kind: "tool",
+    description:
+      "Fetch one full readable memory row by table and UUID. Server-side auth " +
+      "and namespace predicates remain the security boundary for ID reads.",
   },
   {
     name: "upsert_repo_fact",


### PR DESCRIPTION
## Summary

- Expose `get_entry` in the public `get_contract` capabilities and `tool_contracts` manifest.
- Pin the `get_entry` input contract to `table` plus UUID `id`, with namespace authority kept server-side.
- Bump the contract to `2026-06-25.memory-tools.v6` and sync Python required-tool validation/help.

Closes #201

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
  - `bun test src/contract.test.ts src/tools/__tests__/get-contract.test.ts src/tools/__tests__/get-entry.test.ts`
  - `bunx tsc --noEmit`
  - `bun test` (927 pass, 33 skip)
- [x] Python package checks passed or are not applicable
  - `uv run ruff check src tests`
  - `uv run mypy src/openbrain_memory`
  - `uv run pytest -q` (161 pass, 5 skip)
- [ ] Live Open Brain smoke passed or is not applicable
  - Pending merge/deploy to core01; required smoke is hosted `mcp2cli open-brain get_contract --params "{}"` showing `tool_contracts.get_entry`.

## Critical Self-Review

- Highest-risk behavior: public contract drift could still hide `get_entry` from Hermes if TS and Python pins diverge.
- Assumptions that could be wrong: contract-driven clients accept this existing DSL shape with `format: "uuid"`; existing schema conversion tests cover representative shapes but not this exact field format conversion.
- Missing/weak tests: no live hosted smoke until the deploy job runs on core01 after merge.
- Security/permission risk: `get_entry` is an ID read surface, but the manifest exposes no namespace override and the existing server tool keeps auth-derived namespace predicates as the boundary.
- Migration/deploy risk: no database migration; deploy risk is limited to replacing the core01 launchd runtime and restarting `com.rico.open-brain`.
- Downstream client/runtime risk: Hermes/Nagatha must refresh provider contract cache or restart before seeing the new tool.
- Rollback/cleanup concern: rollback is previous core01 runtime or revert this contract bump if clients unexpectedly reject v6.
- Fixes made before PR: added contract capability/schema, Python pin/tool list/help, tests, and docs.
- Known residual risk: live acceptance remains pending until core01 deploy and Nagatha canary run.
- SME review-memory update: [ ] `docs/sme/` updated [x] not applicable because: no new missed-review pattern was discovered; issue was a known contract-manifest omission.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below [x] not applicable because: cannot complete until this PR is merged and the main-branch core01 deploy job runs.

Review-swarm: PASS
Pinned diff: origin/main..1a953f1
Fresh-context lanes: correctness, adversarial, security, quality, Open Brain/Hermes domain; five subagent reviewers.
Findings: correctness, quality, and security reported no findings on the fixed diff. Adversarial/domain lanes inspected the unfixed original checkout and reported the expected blocker that `main` still lacks this change; treated as deployment guard, not a defect in this PR diff.

Fix-verification: PASS
Zero known unresolved issues: yes
Validation: `bun test`, `bunx tsc --noEmit`, `uv run ruff check src tests`, `uv run mypy src/openbrain_memory`, `uv run pytest -q`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
  - rtech-hermes PR #188 is already merged per issue #201.
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- After merge/deploy, verify hosted `get_contract` returns `tool_contracts.get_entry`.
- Then refresh/warm mcp2cli Open Brain cache and restart/refresh Nagatha provider contract cache.
- Rerun Nagatha source-type canary using `get_entry(table=sessions, id=...)` as the contract-native fetch path.
