### PR TITLE
Document core01 Open Brain install path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Deploy to core01 launchd runtime
-        run: bash scripts/core01-deploy-local.sh
+        run: /opt/homebrew/bin/bash scripts/core01-deploy-local.sh

--- a/README.md
+++ b/README.md
@@ -168,17 +168,32 @@ Keep the boundaries explicit:
   `/Volumes/ThunderBolt/open-brain/backups`
 - qmd runtime/index/models: `/Volumes/ThunderBolt/qmd`
 
-Deploys should be owned by this repository, not by hand-copying files:
+Deploys should be owned by this repository, not by hand-copying files. To
+install a new Open Brain version on core01, merge the reviewed change to
+`main` and let the repo deploy job run, or run the same repo-owned deploy
+command on core01 from this checkout:
 
 ```bash
 bun run deploy:core01
 ```
+
+That command installs the checked-out repo version into
+`/Volumes/ThunderBolt/open-brain/app`. Do not install Open Brain into
+`/Volumes/ThunderBolt/Development`; that is the source/mirror area, not the
+runtime. Do not install qmd or Postgres data under the source checkout either.
 
 On GitHub, the `deploy` job targets a core01 macOS self-hosted runner with
 labels `[self-hosted, macOS, core01]`. The job rsyncs this checkout into the
 running app directory, installs runtime dependencies there, runs migrations,
 bootstraps the pinned qmd runtime, restarts `com.rico.open-brain`, and checks
 `/health`.
+
+macOS shell rule: never call `/bin/bash` or rely on the old Apple bash. Use the
+Homebrew bash path explicitly in automation:
+
+```bash
+/opt/homebrew/bin/bash scripts/core01-deploy-local.sh
+```
 
 qmd is pinned and bootstrapped by:
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "promote:legacy-shared": "bun run scripts/promote-legacy-shared.ts",
     "promote:qmd-facts": "bun run scripts/promote-qmd-repo-facts.ts",
     "curate": "bun run scripts/curate.ts",
-    "deploy:core01": "bash scripts/core01-deploy-local.sh",
-    "qmd:core01:bootstrap": "bash scripts/core01-qmd-bootstrap.sh"
+    "deploy:core01": "/opt/homebrew/bin/bash scripts/core01-deploy-local.sh",
+    "qmd:core01:bootstrap": "/opt/homebrew/bin/bash scripts/core01-qmd-bootstrap.sh"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -31,6 +31,11 @@ if [[ ! -r "$ENV_FILE" ]]; then
   exit 1
 fi
 
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
 rm -rf "$STAGING_DIR"
 mkdir -p "$STAGING_DIR"
 


### PR DESCRIPTION
## Summary
- document the core01 Open Brain install/update path and runtime/source boundaries
- use Homebrew bash explicitly for core01 deploy automation
- export the core01 env file before migrations in the deploy script

## Validation
- /opt/homebrew/bin/bash -n scripts/core01-deploy-local.sh
- bun test src/tools/__tests__/contract.test.ts src/tools/__tests__/search-all.test.ts
- Installed latest origin/main on core01 manually: 3bbf4a18e923ada879c605b47162805bc6714eb9
- Verified core01 /health healthy with embedding connected
- Verified core01 process table has no /bin/bash processes; runner and MLX use /opt/homebrew/bin/bash

## Critical Self-Review
- Highest-risk behavior: deploy automation changes can break core01 restart or migrations.
- Assumptions that could be wrong: Homebrew bash path could differ on a future macOS runner if the runner baseline changes.
- Missing/weak tests: no full live GitHub deploy rerun from this PR yet; local deploy syntax and focused tests passed.
- Security/permission risk: no secrets added; README still warns against committed tokens.
- Migration/deploy risk: env export fix makes migrations use the core01 env file; current latest version was installed manually and health passed.
- Downstream client/runtime risk: low; this touches docs/package/workflow/deploy script only.
- Rollback/cleanup concern: core01 runtime uses previous-directory rollback in the deploy script; manual latest install removed previous only after health passed.
- Fixes made before PR: switched automation to /opt/homebrew/bin/bash and documented runtime/source/qmd boundaries.
- Known residual risk: launchd service baseline for non-OB core01 services is outside this repo and should be captured in infra ownership.
- SME review-memory update: [x] not applicable because: this is a deploy-doc/runbook fix, not a new review finding pattern.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Live Open Brain checks:
- core01 /health returned healthy with both workers, database connected, and embedding connected.
- get_contract includes get_entry in contract_version 2026-06-25.memory-tools.v6.
