### PR TITLE
fix: expose session event writer provenance

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import RetryPolicy, redact_text, with_retry
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-25.memory-tools.v6"
+CURRENT_CONTRACT_VERSION = "2026-06-26.memory-tools.v7"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -456,7 +456,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-25.memory-tools.v6"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-26.memory-tools.v7"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -444,7 +444,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     output_shape: "session lane array JSON text payload",
   },
   append_session_event: {
-    version: 3,
+    version: 4,
     input_schema: {
       session_key: {
         type: "string",
@@ -546,7 +546,9 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         },
       },
     },
-    output_shape: "session event JSON text payload",
+    output_shape:
+      "session event JSON text payload with writer_identity, token_identity, " +
+      "delegated_agent_id, and namespace_source provenance fields",
   },
   session_wrap: {
     version: 2,

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -104,6 +104,8 @@ describe("Open Brain contract manifest", () => {
     expect(appendEvent?.version).toBe(4);
     expect(appendEvent?.output_shape).toContain("writer_identity");
     expect(appendEvent?.output_shape).toContain("token_identity");
+    expect(appendEvent?.output_shape).toContain("delegated_agent_id");
+    expect(appendEvent?.output_shape).toContain("namespace_source");
     const shareCandidate = (appendEvent?.input_schema as any).metadata.fields
       .share_candidate;
     expect(shareCandidate.type).toBe("boolean");

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -93,15 +93,17 @@ describe("Open Brain contract manifest", () => {
   it("pins the contract version and append_session_event nomination contract", () => {
     // The Python client pins CURRENT_CONTRACT_VERSION and cross-checks it
     // against this source, but nothing on the TS side caught a forgotten bump.
-    // Pin the version string and the append_session_event v2 nomination
+    // Pin the version string and the append_session_event nomination/provenance
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-25.memory-tools.v6");
+    expect(contract.contract_version).toBe("2026-06-26.memory-tools.v7");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
-    expect(appendEvent?.version).toBe(3);
+    expect(appendEvent?.version).toBe(4);
+    expect(appendEvent?.output_shape).toContain("writer_identity");
+    expect(appendEvent?.output_shape).toContain("token_identity");
     const shareCandidate = (appendEvent?.input_schema as any).metadata.fields
       .share_candidate;
     expect(shareCandidate.type).toBe("boolean");

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-25.memory-tools.v6";
+export const CONTRACT_VERSION = "2026-06-26.memory-tools.v7";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -130,7 +130,7 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "append_session_event",
-    version: 3,
+    version: 4,
     kind: "tool",
     description:
       "Append one durable, typed event (fact, decision, blocker, action, etc.) " +

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -341,6 +341,10 @@ describe("append_session_event", () => {
       const parsed = JSON.parse((result.content as any)[0].text);
       expect(parsed.duplicate).toBe(true);
       expect(parsed.message).toContain("identical content");
+      expect(parsed.writer_identity).toBe("skippy");
+      expect(parsed.token_identity).toBe("skippy");
+      expect(parsed.delegated_agent_id).toBeNull();
+      expect(parsed.namespace_source).toBe("token");
     } finally {
       await cleanup();
     }
@@ -575,6 +579,48 @@ describe("append_session_event", () => {
     }
   });
 
+  it("does not treat X-Agent-Id as delegated provenance without X-Namespace", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = {
+      role: "agent",
+      clientId: "skippy",
+      tokenClientId: "skippy",
+      agentId: "spoofed-agent",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Non-delegated agent id should not become provenance",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.writer_identity).toBe("skippy");
+      expect(parsed.token_identity).toBe("skippy");
+      expect(parsed.delegated_agent_id).toBeNull();
+      expect(parsed.namespace_source).toBe("token");
+
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!._openbrain).toEqual({
+        writer: {
+          client_id: "skippy",
+          token_client_id: "skippy",
+          agent_id: null,
+          namespace_source: "token",
+        },
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("records delegated namespace writer separately from token provenance", async () => {
     const mockPool = createCapturingPool();
     const auth: AuthInfo = {
@@ -613,6 +659,44 @@ describe("append_session_event", () => {
           token_client_id: "rico",
           agent_id: "nagatha",
           namespace_source: "header",
+        },
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves caller _openbrain metadata while stamping trusted writer provenance", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Caller metadata should not clobber OpenBrain provenance",
+          metadata: {
+            _openbrain: { writer: { client_id: "spoofed" } },
+            user_value: "kept",
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.user_value).toBe("kept");
+      expect(mockPool.captured.metadata!._caller_openbrain_metadata).toEqual({
+        writer: { client_id: "spoofed" },
+      });
+      expect(mockPool.captured.metadata!._openbrain).toEqual({
+        writer: {
+          client_id: "skippy",
+          token_client_id: "skippy",
+          agent_id: null,
+          namespace_source: "token",
         },
       });
     } finally {

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -507,7 +507,11 @@ describe("append_session_event", () => {
 
   /** Lane-found pool that captures the params of the events INSERT. */
   function createCapturingPool() {
-    const captured: { metadata: Record<string, unknown> | null } = {
+    const captured: {
+      createdBy: string | null;
+      metadata: Record<string, unknown> | null;
+    } = {
+      createdBy: null,
       metadata: null,
     };
     const pool = {
@@ -519,12 +523,102 @@ describe("append_session_event", () => {
         // INSERT INTO ob_session_events — $7 (index 6) is the metadata JSON.
         if (params && typeof params[6] === "string") {
           captured.metadata = JSON.parse(params[6]);
+          captured.createdBy = params[11] ?? null;
         }
         return { rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }] };
       },
     };
     return pool;
   }
+
+  it("records distinct writer and token provenance for cross-namespace writes", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "rico",
+      tokenClientId: "rico",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          namespace: "nagatha",
+          event_type: "fact",
+          content: "Nagatha delegated write provenance canary",
+          source: "nagatha",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.writer_identity).toBe("rico");
+      expect(parsed.token_identity).toBe("rico");
+      expect(parsed.delegated_agent_id).toBeNull();
+      expect(parsed.namespace_source).toBe("token");
+
+      expect(mockPool.captured.createdBy).toBe("rico");
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!._openbrain).toEqual({
+        writer: {
+          client_id: "rico",
+          token_client_id: "rico",
+          agent_id: null,
+          namespace_source: "token",
+        },
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("records delegated namespace writer separately from token provenance", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "nagatha",
+      tokenClientId: "rico",
+      agentId: "nagatha",
+      namespaceSource: "header",
+    };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          namespace: "nagatha",
+          event_type: "fact",
+          content: "Nagatha header delegated write provenance canary",
+          source: "nagatha",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.writer_identity).toBe("nagatha");
+      expect(parsed.token_identity).toBe("rico");
+      expect(parsed.delegated_agent_id).toBe("nagatha");
+      expect(parsed.namespace_source).toBe("header");
+
+      expect(mockPool.captured.createdBy).toBe("nagatha");
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!._openbrain).toEqual({
+        writer: {
+          client_id: "nagatha",
+          token_client_id: "rico",
+          agent_id: "nagatha",
+          namespace_source: "header",
+        },
+      });
+    } finally {
+      await cleanup();
+    }
+  });
 
   it("strips share_candidate and reports reject-secret when content carries a secret", async () => {
     const mockPool = createCapturingPool();

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -66,6 +66,27 @@ function adjudicateNominationSync(
   return { metadata, rejected: null };
 }
 
+function appendWriterProvenance(
+  metadata: Record<string, unknown>,
+  auth: AuthInfo,
+): Record<string, unknown> {
+  const { _openbrain: callerOpenBrainMetadata, ...rest } = metadata;
+  return {
+    ...rest,
+    ...(callerOpenBrainMetadata === undefined
+      ? {}
+      : { _caller_openbrain_metadata: callerOpenBrainMetadata }),
+    _openbrain: {
+      writer: {
+        client_id: auth.clientId,
+        token_client_id: auth.tokenClientId ?? auth.clientId,
+        agent_id: auth.agentId ?? null,
+        namespace_source: auth.namespaceSource ?? "token",
+      },
+    },
+  };
+}
+
 export function registerAppendSessionEvent(
   server: McpServer,
   deps: ToolDeps,
@@ -224,6 +245,7 @@ export function registerAppendSessionEvent(
           args.content,
           args.metadata ?? {},
         );
+        const metadata = appendWriterProvenance(nomination.metadata, auth);
         if (nomination.rejected) {
           logger.warn("append_session_event_share_rejected", {
             session_key: args.session_key,
@@ -263,7 +285,7 @@ export function registerAppendSessionEvent(
             args.source ?? null,
             args.artifact_path ?? null,
             importance,
-            JSON.stringify(nomination.metadata),
+            JSON.stringify(metadata),
             embeddingVal,
             hash,
             embeddedAt,
@@ -293,6 +315,10 @@ export function registerAppendSessionEvent(
           event_type: args.event_type,
           importance,
           created_at: rows[0].created_at,
+          writer_identity: auth.clientId,
+          token_identity: auth.tokenClientId ?? auth.clientId,
+          delegated_agent_id: auth.agentId ?? null,
+          namespace_source: auth.namespaceSource ?? "token",
           // Surface the sync nomination outcome so a contract-driven agent
           // learns its share_candidate was refused (and why) without polling.
           ...(nomination.rejected

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -66,22 +66,41 @@ function adjudicateNominationSync(
   return { metadata, rejected: null };
 }
 
+function writerProvenance(auth: AuthInfo): {
+  writer_identity: string;
+  token_identity: string;
+  delegated_agent_id: string | null;
+  namespace_source: "token" | "header";
+} {
+  const namespaceSource = auth.namespaceSource ?? "token";
+  return {
+    writer_identity: auth.clientId,
+    token_identity: auth.tokenClientId ?? auth.clientId,
+    delegated_agent_id: namespaceSource === "header" ? (auth.agentId ?? null) : null,
+    namespace_source: namespaceSource,
+  };
+}
+
 function appendWriterProvenance(
   metadata: Record<string, unknown>,
   auth: AuthInfo,
 ): Record<string, unknown> {
   const { _openbrain: callerOpenBrainMetadata, ...rest } = metadata;
+  const provenance = writerProvenance(auth);
   return {
     ...rest,
     ...(callerOpenBrainMetadata === undefined
       ? {}
       : { _caller_openbrain_metadata: callerOpenBrainMetadata }),
+    // The public metadata limit applies to caller input. OpenBrain adds this
+    // small bounded block after validation so later readback can audit writer
+    // provenance without trusting caller-supplied metadata.
     _openbrain: {
       writer: {
-        client_id: auth.clientId,
-        token_client_id: auth.tokenClientId ?? auth.clientId,
-        agent_id: auth.agentId ?? null,
-        namespace_source: auth.namespaceSource ?? "token",
+        client_id: provenance.writer_identity,
+        token_client_id: provenance.token_identity,
+        agent_id: provenance.delegated_agent_id,
+        namespace_source: provenance.namespace_source,
       },
     },
   };
@@ -188,6 +207,7 @@ export function registerAppendSessionEvent(
         };
       }
       const importance = args.importance ?? "warm";
+      const provenance = writerProvenance(auth);
 
       logger.debug("append_session_event_start", {
         session_key: args.session_key,
@@ -303,6 +323,7 @@ export function registerAppendSessionEvent(
                   duplicate: true,
                   message:
                     "Event with identical content already exists in this lane",
+                  ...provenance,
                 }),
               },
             ],
@@ -315,10 +336,7 @@ export function registerAppendSessionEvent(
           event_type: args.event_type,
           importance,
           created_at: rows[0].created_at,
-          writer_identity: auth.clientId,
-          token_identity: auth.tokenClientId ?? auth.clientId,
-          delegated_agent_id: auth.agentId ?? null,
-          namespace_source: auth.namespaceSource ?? "token",
+          ...provenance,
           // Surface the sync nomination outcome so a contract-driven agent
           // learns its share_candidate was refused (and why) without polling.
           ...(nomination.rejected


### PR DESCRIPTION
## Summary
- add explicit writer/token/delegation provenance to append_session_event responses
- persist the same provenance under metadata._openbrain.writer for session_context/readback
- bump required memory contract to 2026-06-26.memory-tools.v7 and append_session_event to v4
- update python/openbrain-memory contract pin to match

## Why
Fixes #205 by making the ambiguous Nagatha case auditable. If a Rico token writes into namespace=nagatha without delegated headers, created_by remains rico and the event now says writer_identity=rico/token_identity=rico. If the request is correctly delegated with X-Namespace/X-Agent-Id, the event says writer_identity=nagatha/token_identity=rico and created_by is nagatha.

This intentionally does not let caller-provided source spoof created_by.

## Critical Self-Review
- Highest-risk behavior: treating caller-provided source as authorship would allow spoofed created_by values; the implementation keeps created_by tied to authenticated effective identity.
- Assumptions that could be wrong: downstream clients may parse only event_id and ignore new provenance fields, so live Nagatha verification still has to inspect metadata._openbrain.writer through session_context.
- Missing/weak tests: no hosted live Open Brain write was run before PR because deployment happens after merge; local protocol and contract tests cover the server behavior.
- Security/permission risk: exposing token_identity could leak service identity labels, but not tokens or secrets; it is needed to audit delegated writes.
- Migration/deploy risk: contract bump to 2026-06-26.memory-tools.v7 requires hosted Open Brain deployment and mcp2cli cache/skill refresh before agents rely on it.
- Downstream client/runtime risk: rtech-hermes/Nagatha still may need mcp2cli or transport header changes if live writes show namespace_source=token and writer_identity=rico.
- Rollback/cleanup concern: rollback is reverting this PR and contract pin to v6; events written during rollout may retain _openbrain writer metadata as harmless extra metadata.
- Fixes made before PR: added regression tests for token-sourced cross-namespace writes and header-delegated writes, then bumped TS and Python contract pins.
- Known residual risk: this PR clarifies provenance but does not force Nagatha to authenticate as herself over the wire; that remains a downstream rollout verification item.
- SME review-memory update: [ ] docs/sme/ updated [x] not applicable because: no durable SME review lesson changed; this is an issue-specific auth/provenance fix.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below [x] not applicable because: this PR is pre-merge server code; live hosted validation is the required downstream rollout after merge.

## Validation
- bun test src/tools/__tests__/append-session-event.test.ts src/contract.test.ts
- bunx tsc --noEmit
- cd python/openbrain-memory && uv run pytest tests/test_client.py tests/test_contract.py -q
- bun test
- cd python/openbrain-memory && uv run pytest -q
- git diff --check
- ggshield secret scan repo .