### PR TITLE
feat: add Open Brain memory substrate plan and hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Deploy to core01 launchd runtime
-        run: bash scripts/core01-deploy-local.sh
+        run: /opt/homebrew/bin/bash scripts/core01-deploy-local.sh

--- a/_AGENTS.md
+++ b/_AGENTS.md
@@ -1,0 +1,126 @@
+# Open Brain Repo-Local Codex Flow
+
+This file is the repo-local flow adapter for Codex. Read it after
+`/Volumes/ThunderBolt/Development/AGENTS.md` and before doing repo work here.
+
+## Checkout And Runtime Boundaries
+
+- Do not assume one checkout represents every Open Brain state. Distinguish:
+  - operator/workstation checkout: `/Volumes/ThunderBolt/Development/open-brain`
+  - GitHub Actions runner checkout: runner-owned `_work/open-brain/open-brain`
+  - live source checkout on the Open Brain host: `/Volumes/ThunderBolt/Development/open-brain`
+  - live runtime: `/Volumes/ThunderBolt/open-brain/app`
+- Before deploy, install, or hosted-proof advice, inspect the live host state.
+  Do not infer live state only from local repo docs, local tests, or CI logs.
+- Current repo docs name the hosted Open Brain target as core01
+  (`10.71.1.21:3100`), launchd service `com.rico.open-brain`, runtime
+  `/Volumes/ThunderBolt/open-brain/app`. If Rico says `base01` or another
+  host name, resolve that exact name from hostmap or live SSH before acting.
+- The live host may carry an operational branch or local deploy-script patch
+  that is not yet in `origin/main`. Treat that as real state to reconcile, not
+  as noise to overwrite.
+
+## Required Startup
+
+For non-trivial work:
+
+1. Read `../AGENTS.md`, this file, and `AGENTS.md`.
+2. Read the repo Open Brain lane before planning or acting:
+
+   ```bash
+   mcp2cli open-brain session_context --params '{"session_key":"repo:/Volumes/ThunderBolt/Development/open-brain","event_limit":20}'
+   ```
+
+   If `session_context` cannot find the lane, create/resume it with:
+
+   ```bash
+   mcp2cli open-brain session_start --params '{"session_key":"repo:/Volumes/ThunderBolt/Development/open-brain","project":"open-brain","agent":"codex","topic":"Open Brain repo-local workflow and deploy/runtime operating memory"}'
+   ```
+
+   Treat this lane as required repo operating memory. It contains corrections
+   about checkout/runtime/runner boundaries and live proof requirements.
+3. Read the relevant Development SOPs:
+   - code changes: `_DOCS/CODING_STANDARDS.md`
+   - git/PR/issues: `_DOCS/GIT_STANDARDS.md`
+   - long-running/review/worker work: `_DOCS/AGENT_WORKFLOW.md`
+   - deploy/host/runner work: `_DOCS/INFRASTRUCTURE_SOP.md`
+4. Check `pwd`, `git status --short --branch`, and `git log --oneline -5`.
+5. If the current checkout is dirty or on an unrelated branch, do implementation
+   from a clean worktree under `/Volumes/ThunderBolt/_tmp`.
+
+## Implementation Flow
+
+- Do not code on `main`; create or use a focused branch.
+- Keep fixes scoped to the issue. Do not fold deploy-script, workflow, or docs
+  cleanup into a contract/API fix unless it is required to complete the issue.
+- For MCP/public contract, transport, Python client, auth, namespace, or
+  agent-facing changes, read `docs/downstream-rollout.md` before claiming done.
+- For changes touching `docs/memory-contract.md`, `brain_answer`, lifecycle
+  tools, eval fixtures, or Codex durable-memory instructions, read
+  `docs/memory-contract.md`.
+- Namespace isolation is a security boundary. Any ID-based read or mutation
+  must rely on server-side auth-derived namespace predicates unless the role is
+  intentionally global.
+
+## Review And PR Flow
+
+- Public contracts, auth/namespace behavior, deploy/runtime behavior, and
+  Python package changes require review-swarm sizing before PR readiness.
+- A PR that changes public contract behavior must include:
+  - critical self-review receipt
+  - validation commands and results
+  - downstream rollout classification from `docs/downstream-rollout.md`
+  - review-swarm or explicitly sized review evidence
+- CI on PR is not deploy proof. PR deploy jobs skip by design unless the event is
+  a push to `main`.
+
+## Deploy Flow
+
+- Standard repo command is `bun run deploy:core01`, which runs
+  `scripts/core01-deploy-local.sh`.
+- Standard runtime target from current repo docs:
+  - runtime: `/Volumes/ThunderBolt/open-brain/app`
+  - staging: `/Volumes/ThunderBolt/open-brain/app.next`
+  - previous: `/Volumes/ThunderBolt/open-brain/app.previous`
+  - env file: `/Users/rico/.config/open-brain/env`
+  - qmd path: `/Volumes/ThunderBolt/qmd/open-brain-qmd.ts`
+- Never hand-copy files into the runtime as the normal path. Use the repo-owned
+  deploy script or explicitly document why the repo-owned path is unavailable.
+- Before prescribing a deploy fix, inspect what is actually on the live host:
+  source branch/status, deploy script content, env file existence, runtime
+  files, launchd label, and `/health`.
+- If GitHub Actions deploy fails, inspect whether the runner checkout has the
+  same env/service assumptions as the live source checkout. Do not assume the
+  runner has `/Users/rico/.config/open-brain/env` behavior unless verified.
+
+## Hosted Proof Flow
+
+Local tests are not enough for hosted Open Brain work.
+
+For public contract/runtime changes, done requires live hosted proof such as:
+
+```bash
+mcp2cli open-brain get_contract --params '{}'
+```
+
+For issue #201-class work, specifically verify:
+
+- `contract_version` is the expected version.
+- `capabilities` includes the new tool when applicable.
+- `tool_contracts.<tool_name>` exists with the expected input schema.
+- `curl -fsS http://127.0.0.1:3100/health` passes on the host or the equivalent
+  hosted health check passes from the controller machine.
+
+After hosted proof, complete the applicable downstream rollout from
+`docs/downstream-rollout.md` before closing the loop for Hermes/mcp2cli users.
+
+## Dirty-State Flow
+
+- This repo often has operational deploy branches. Do not overwrite or revert
+  local dirty deploy-script changes unless Rico explicitly asks.
+- If dirty state blocks work, classify each path as user-owned, agent-owned,
+  generated, merged, obsolete, or next-branch work.
+- For implementation unrelated to dirty state, create a clean temp worktree from
+  current `origin/main` under `/Volumes/ThunderBolt/_tmp`.
+- Clean only current-run temp artifacts that you created. Do not delete repo
+  runtime/build artifacts or user-owned changes as cleanup.

--- a/docs/agent-memory-substrate-plan.md
+++ b/docs/agent-memory-substrate-plan.md
@@ -1,0 +1,142 @@
+# Open Brain Agent Memory Substrate Plan
+
+## Objective
+
+Make Open Brain the first-class memory substrate for local Codex, Hermes agents,
+thin clients, and future Closed Brain workflows. Agents should not need to
+manually step back into ad hoc MCP calls for normal lifecycle memory. The client
+adapter should handle start, recall, compact, wrap, receipt capture, and shared
+knowledge nomination as part of the agent runtime.
+
+Target completion for the first usable slice: Sunday, 2026-06-28.
+
+## Non-Goals
+
+- Do not turn Open Brain into OKF. OKF is an export/import disclosure profile.
+- Do not store raw transcripts, secrets, or unbounded command output.
+- Do not auto-promote lane-local facts into `shared-kb`.
+- Do not make Closed Brain depend on lightweight OB receipts for privileged
+  audit requirements. Closed Brain can consume the pattern, but it needs a
+  stricter receipt ledger.
+
+## Architecture
+
+Open Brain remains authoritative for storage, namespace isolation, graph links,
+search, session lanes, session events, repo facts, promotion, and public
+contract discovery.
+
+Clients become lifecycle-aware memory managers:
+
+- `session_start`: establish the lane and hydrate recent context.
+- `recall`: search lane, shared knowledge, repo facts, and optional qmd.
+- `append_event`: write distilled facts, decisions, actions, blockers, receipts,
+  artifacts, and handoffs.
+- `compact`: locally distill current work before context loss and write a wrap.
+- `wrap`: checkpoint the lane with summary, decisions, next steps, and receipts.
+- `record_receipt`: capture files read/touched, artifact hashes, commands,
+  validation checks, channel/session identity, and source references.
+- `nominate_shared`: mark only useful, non-private events for server-side
+  promotion review.
+- `export_disclosure_bundle`: generate OKF-like `index.md`, `log.md`, concept
+  files, citations, and receipt appendices without changing OB storage.
+
+## Memory Lanes
+
+A lane is the active memory object. It must carry enough metadata for local
+agents, Hermes, and future Closed Brain to explain what happened later:
+
+- stable `session_key`
+- project, agent, source, channel, thread, and color/visual metadata
+- current context markdown
+- scoped event journal
+- linked graph entities
+- repo facts used or produced
+- artifacts and receipts
+- share-candidate nominations
+- optional `metadata.okf` export metadata
+
+## Receipts
+
+Open Brain should support lightweight receipts now and leave hooks for Closed
+Brain's stricter model. Receipt records should represent:
+
+- source files read, with path, URI, repo, commit, and hash where available
+- files written or touched, with before/after hash where available
+- generated artifacts, with path, hash, producer, and validation status
+- base documents/templates, including known-good PDFs and structure sources
+- commands/tool calls that materially produced output
+- external channels such as Discord, Hermes, n8n, or user prompts
+- timestamps, agent identity, session key, namespace, and source references
+
+## Promotion
+
+Clients may set `metadata.share_candidate = true`, but server-side policy owns
+promotion into `shared-kb`. The server must continue to reject secrets/private
+content synchronously and run async worthiness, deduplication, and provenance
+checks before promotion.
+
+## OKF Disclosure Profile
+
+The public contract exposes `interchange_profiles.okf` and `metadata.okf` as
+compatibility hooks. Exporters should map:
+
+- lane/project/repo grouping to `index.md`
+- scoped session events and wraps to `log.md`
+- distilled concepts to regular Markdown files with YAML frontmatter
+- `source_ref`, `artifact_path`, repo fact source URLs, and receipts to
+  `# Citations`
+
+Imports should stage candidate OB records. They must not bypass namespace,
+receipt, promotion, or secret handling rules.
+
+## Friday-Sunday Timeline
+
+### Friday, 2026-06-26
+
+- Land the architecture plan and issue set.
+- Keep the contract hooks for OKF compatibility discoverable.
+- Define the adapter and receipt schemas.
+- Start Codex lifecycle integration design.
+
+### Saturday, 2026-06-27
+
+- Implement the TypeScript thin client/lifecycle adapter.
+- Add receipt helper APIs and fake-transport tests.
+- Add Codex local session start, compact, and wrap integration.
+- Add Hermes adapter contract and call-shape fixtures.
+
+### Sunday, 2026-06-28
+
+- Add promotion/disclosure export paths.
+- Add evals for compaction, privacy, receipts, and recall.
+- Run local and hosted Open Brain validation.
+- Complete mcp2cli/Hermes downstream rollout classification and canaries.
+
+## Issue Plan
+
+| Order | Issue | Target Date | Component | Surface | Phase |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Define agent memory adapter contract | 2026-06-26 | Memory Protocol | All Surfaces | P0 Planning |
+| 2 | Define receipt schema and provenance model | 2026-06-26 | Memory Protocol | Server/API | P1 Server Canonicalization |
+| 3 | Add TypeScript thin client memory wrapper | 2026-06-27 | Client Runtime | MCP/mcp2cli | P2 Client Runtime |
+| 4 | Wire Codex local lifecycle memory adapter | 2026-06-27 | Client Runtime | Codex Skill | P2 Client Runtime |
+| 5 | Wire Hermes lifecycle memory adapter contract | 2026-06-27 | Client Runtime | Hermes/Runtime | P2 Client Runtime |
+| 6 | Add receipt capture helpers and tests | 2026-06-27 | Server Canonicalization | Server/API | P1 Server Canonicalization |
+| 7 | Harden share-candidate promotion provenance | 2026-06-28 | Legacy Promoter | Server/API | P4 Legacy Promoter |
+| 8 | Add OKF disclosure export bundle | 2026-06-28 | Synthesis | Docs/Process | P5 Review/Validation |
+| 9 | Add memory substrate eval harness | 2026-06-28 | Eval Harness | Eval Harness | P5 Review/Validation |
+| 10 | Run downstream rollout and hosted canaries | 2026-06-28 | Deploy/Canary | Deploy/Canary | P6 Deploy/Canary Follow-On |
+
+## Definition Of Done
+
+- Agents can start, recall, compact, wrap, and receipt-log through a first-class
+  adapter without manually composing raw MCP calls for normal lifecycle memory.
+- Private lane data stays out of `shared-kb` unless deliberately nominated and
+  server-approved.
+- Receipts can explain which files, channels, artifacts, and validations shaped
+  a material output.
+- OKF export can disclose the bundle progressively without becoming the storage
+  model.
+- Local tests, Python adapter tests, contract tests, and targeted evals pass.
+- Hosted Open Brain, mcp2cli, generated skill, and Hermes canary impacts are
+  either completed or explicitly classified not applicable.

--- a/docs/downstream-rollout.md
+++ b/docs/downstream-rollout.md
@@ -74,7 +74,7 @@ If none of those apply, say so explicitly in the PR and release notes.
      ```bash
      cd /mnt/collab/agent-backups/rtech-hermes
      git pull --ff-only origin main
-     bash scripts/update.sh
+     /opt/homebrew/bin/bash scripts/update.sh
      ```
 
    - Run this for each opted-in agent/profile that should receive the Open
@@ -117,6 +117,7 @@ The manifest includes:
 - `min_client_versions`
 - `compatible_client_ranges`
 - `transport`
+- `interchange_profiles`
 - `capabilities`
 - `tool_contracts`
 

--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -204,6 +204,36 @@ when evidence is missing, stale, mixed, or unsafe to cite. When no readable or
 citable evidence is available, `answer` is `null`; the tool must not fabricate
 uncited facts.
 
+### OKF Compatibility Hooks
+
+Open Brain does not implement OKF as its storage model. Treat OKF as an edge
+profile for disclosure, export, import staging, and portable review bundles.
+The canonical memory record remains the Open Brain lane/event/entity row, and
+Closed Brain provenance receipts remain stricter than OKF frontmatter.
+
+Clients may add optional `metadata.okf` objects to session events, lane
+metadata, and curated repo facts when the record should later export cleanly to
+an OKF-like bundle. The compatibility shape should use OKF vocabulary where it
+fits: `type`, `title`, `description`, `resource`, `tags`, `timestamp`,
+`links`, and `citations`. Unknown keys are allowed and should be preserved by
+clients and exporters. The `get_contract` manifest advertises this as the
+`interchange_profiles.okf` profile so thin clients can discover the hook without
+guessing.
+
+Export mapping is intentionally one-way until an importer exists:
+- Concept bodies: distilled OB thoughts, entities, repo facts, or important
+  session events become non-reserved Markdown files with YAML frontmatter.
+- `index.md`: generated from lane/project/repo grouping metadata and used only
+  as a progressive-disclosure navigation surface.
+- `log.md`: generated from scoped session events and wraps.
+- `# Citations`: generated from `source_ref`, `artifact_path`, receipt metadata,
+  repo fact source URLs, and Closed Brain receipt entries.
+
+Do not auto-promote imported OKF content into `shared-kb`. Imports should create
+candidate lane events, entities, or repo facts first, then use the normal
+promotion and namespace checks. Do not store secrets, raw transcripts, or
+private source bodies merely because an OKF bundle contains them.
+
 ### Difference From Hermes Agents
 
 Hermes agents are long-running services that can keep platform state, channels,

--- a/hooks/open-brain-session-save.ts
+++ b/hooks/open-brain-session-save.ts
@@ -44,15 +44,42 @@ try {
     /* ignore */
   }
 
+  // Capture dirty state so compact recovery can separate real work from noise.
+  let dirtyState = "";
+  try {
+    const statusResult = Bun.spawnSync(["git", "status", "--short"], {
+      cwd,
+      timeout: 3000,
+    });
+    if (statusResult.exitCode === 0) {
+      dirtyState = statusResult.stdout.toString().trim();
+    }
+  } catch {
+    /* no git or not a repo */
+  }
+
   // Build summary
   const summaryParts = [`Session before ${trigger} compaction`];
+  summaryParts.push(`CWD: ${cwd}`);
+  summaryParts.push("Policy state: context is stale after compaction; next agent action must refresh active routers/SOPs before risky edits, git, infra, deploy, or worker orchestration.");
+  summaryParts.push("Pony style: identify the owning boundary, make the smallest correct owned change, preserve callers/invariants, and verify.");
+  summaryParts.push("Critical mode: challenge weak assumptions, surface concrete risk, ask when ambiguity matters, then proceed.");
+  summaryParts.push("Source order: live/source files and current system state beat OB/qmd, which beat compacted memory or summaries.");
   if (branch) summaryParts.push(`Branch: ${branch}`);
+  summaryParts.push(dirtyState ? `Dirty state:\n${dirtyState}` : "Dirty state: clean or unavailable");
   if (key_decisions.length) summaryParts.push(`Recent: ${key_decisions[0]}`);
   if (custom_instructions) summaryParts.push(custom_instructions);
   const summary = summaryParts.join(". ");
 
   // Build tags
-  const tags = ["auto-save", "pre-compact", trigger];
+  const tags = [
+    "auto-save",
+    "pre-compact",
+    "policy-refresh-required",
+    "pony-style",
+    "critical-mode",
+    trigger,
+  ];
   if (branch) {
     const branchType = branch.split("/")[0];
     if (["feat", "fix", "wip", "chore"].includes(branchType))
@@ -64,8 +91,17 @@ try {
     summary,
     project,
     tags,
-    next_steps: [],
-    key_decisions,
+    next_steps: [
+      "Reread active AGENTS/CLAUDE router and triggered SOPs before risky action.",
+      "Restate Pony style, critical mode, source-of-truth order, and next concrete action.",
+      "Inspect cwd, branch, and dirty state before editing; do not mix unrelated dirty files into the next phase.",
+      "Run /Volumes/ThunderBolt/Development/_ob/scripts/policy-refresh-gate.ts --event refresh --agent claude after refresh.",
+    ],
+    key_decisions: [
+      "Compaction requires forced relearn before risky action.",
+      "Pony style and critical mode are hard layer-1 defaults.",
+      ...key_decisions,
+    ],
   });
 
   const result = Bun.spawnSync(

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "promote:legacy-shared": "bun run scripts/promote-legacy-shared.ts",
     "promote:qmd-facts": "bun run scripts/promote-qmd-repo-facts.ts",
     "curate": "bun run scripts/curate.ts",
-    "deploy:core01": "bash scripts/core01-deploy-local.sh",
-    "qmd:core01:bootstrap": "bash scripts/core01-qmd-bootstrap.sh"
+    "deploy:core01": "/opt/homebrew/bin/bash scripts/core01-deploy-local.sh",
+    "qmd:core01:bootstrap": "/opt/homebrew/bin/bash scripts/core01-qmd-bootstrap.sh"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import RetryPolicy, redact_text, with_retry
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-26.memory-tools.v7"
+CURRENT_CONTRACT_VERSION = "2026-06-26.memory-tools.v8"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -456,7 +456,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-26.memory-tools.v7"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-26.memory-tools.v8"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -31,6 +31,11 @@ if [[ ! -r "$ENV_FILE" ]]; then
   exit 1
 fi
 
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
 rm -rf "$STAGING_DIR"
 mkdir -p "$STAGING_DIR"
 

--- a/scripts/core01-sync-development.sh
+++ b/scripts/core01-sync-development.sh
@@ -2,32 +2,118 @@
 set -euo pipefail
 
 SOURCE_DIR="${SOURCE_DIR:-/Volumes/ThunderBolt/Development}"
-TARGET_DIR="${TARGET_DIR:-/Volumes/ThunderBolt/Development}"
+TARGET_DIR="${TARGET_DIR:-10.71.1.21:/Volumes/ThunderBolt/Development}"
+TARGET_PATH="${TARGET_PATH:-/Volumes/ThunderBolt/Development}"
 QMD_BIN="${QMD_BIN:-/Volumes/ThunderBolt/qmd/bin/qmd}"
+QMD_MASK="${QMD_MASK:-**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,sh,py,toml}}"
+CLEAN_EXCLUDED="${CLEAN_EXCLUDED:-1}"
+
+EXCLUDED_DIR_NAMES=(
+  node_modules
+  .venv
+  venv
+  __pycache__
+  .pytest_cache
+  .mypy_cache
+  dist
+  .next
+  target
+  _quarantine
+  _tmp
+  .reports
+)
+
+RSYNC_EXCLUDES=(
+  --exclude ".DS_Store"
+)
+
+for name in "${EXCLUDED_DIR_NAMES[@]}"; do
+  RSYNC_EXCLUDES+=(--exclude "$name/")
+done
 
 if [[ "$SOURCE_DIR" == "$TARGET_DIR" ]]; then
-  echo "FATAL: SOURCE_DIR and TARGET_DIR are identical; run this on the sync source or set TARGET_DIR explicitly" >&2
+  echo "FATAL: SOURCE_DIR and TARGET_DIR are identical; set TARGET_DIR to the core01 mirror target" >&2
   exit 1
 fi
 
-rsync -a --delete \
-  --exclude ".DS_Store" \
-  --exclude "node_modules/" \
-  --exclude ".venv/" \
-  --exclude "venv/" \
-  --exclude "__pycache__/" \
-  --exclude ".pytest_cache/" \
-  --exclude ".mypy_cache/" \
-  --exclude "dist/" \
-  --exclude ".next/" \
-  --exclude "target/" \
-  --exclude "logs/" \
-  --exclude "_quarantine/" \
-  --exclude "_tmp/" \
-  --exclude ".reports/" \
+rsync -rltz --delete --no-perms --no-owner --no-group --omit-dir-times --stats --human-readable \
+  "${RSYNC_EXCLUDES[@]}" \
   "$SOURCE_DIR"/ "$TARGET_DIR"/
 
-if [[ -x "$QMD_BIN" ]]; then
+target_host=""
+target_root="$TARGET_DIR"
+if [[ "$TARGET_DIR" == *:* ]]; then
+  target_host="${TARGET_DIR%%:*}"
+  target_root="${TARGET_DIR#*:}"
+fi
+
+cleanup_excluded_dirs() {
+  local root="$1"
+  find "$root" -type d -name .git -prune -o -type d \( \
+    -name node_modules -o \
+    -name .venv -o \
+    -name venv -o \
+    -name __pycache__ -o \
+    -name .pytest_cache -o \
+    -name .mypy_cache -o \
+    -name dist -o \
+    -name .next -o \
+    -name target -o \
+    -name _quarantine -o \
+    -name _tmp -o \
+    -name .reports \
+  \) -prune -print -exec sudo rm -rf {} +
+}
+
+if [[ "$CLEAN_EXCLUDED" == "1" ]]; then
+  if [[ -n "$target_host" ]]; then
+    ssh "$target_host" "$(declare -f cleanup_excluded_dirs); cleanup_excluded_dirs '$target_root'"
+  else
+    cleanup_excluded_dirs "$target_root"
+  fi
+fi
+
+run_qmd_ingest() {
+  if [[ ! -x "$QMD_BIN" ]]; then
+    echo "WARN: qmd not found at $QMD_BIN; skipping qmd update/embed" >&2
+    exit 0
+  fi
+
+  ensure_collection() {
+    local name="$1"
+    local path="$2"
+
+    if [[ ! -d "$path" ]]; then
+      echo "WARN: qmd collection path missing, skipping $name: $path" >&2
+      return
+    fi
+
+    if "$QMD_BIN" collection list | grep -q "^$name ("; then
+      return
+    fi
+
+    "$QMD_BIN" collection add "$path" --name "$name" --mask "$QMD_MASK"
+  }
+
+  ensure_collection "rtech-infra" "$TARGET_PATH/rtech-infra"
+  ensure_collection "rtech-consulting" "$TARGET_PATH/rtech-consulting"
+  ensure_collection "rtech-hermes" "$TARGET_PATH/ai-agents/platforms/rtech-hermes"
+
+  while IFS= read -r repo_path; do
+    repo_rel="${repo_path#"$TARGET_PATH"/}"
+    collection_name="${repo_rel//\//-}"
+    ensure_collection "$collection_name" "$repo_path"
+  done < <(find "$TARGET_PATH/king-capital" -maxdepth 2 -type d -name .git -prune -print | while IFS= read -r git_dir; do dirname "$git_dir"; done | sort)
+
   "$QMD_BIN" update
   "$QMD_BIN" embed
+}
+
+if [[ -n "$target_host" ]]; then
+  {
+    declare -f run_qmd_ingest
+    echo "run_qmd_ingest"
+  } | ssh "$target_host" "QMD_BIN='$QMD_BIN' TARGET_PATH='$TARGET_PATH' QMD_MASK='$QMD_MASK' /opt/homebrew/bin/bash -s"
+else
+  run_qmd_ingest
 fi

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -543,6 +543,16 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
               "de-duplicates against shared-kb, and promotes survivors. Do NOT set " +
               "true for secrets, credentials, or private/personal content.",
           },
+          okf: {
+            type: "object",
+            required: false,
+            description:
+              "Optional Open Knowledge Format compatibility metadata for future " +
+              "edge export/import. Open Brain remains authoritative; this object " +
+              "is only a disclosure/interchange hook. Use OKF-like keys such as " +
+              "type, title, description, resource, tags, timestamp, citations, " +
+              "and links. Unknown keys should be preserved by clients/exporters.",
+          },
         },
       },
     },

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -14,6 +14,19 @@ describe("Open Brain contract manifest", () => {
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
+    expect(contract.interchange_profiles.okf.status).toBe(
+      "compatibility-hooks",
+    );
+    expect(contract.interchange_profiles.okf.metadata_path).toBe(
+      "metadata.okf",
+    );
+    expect(contract.interchange_profiles.okf.reserved_files).toEqual([
+      "index.md",
+      "log.md",
+    ]);
+    expect(contract.interchange_profiles.okf.required_frontmatter).toEqual([
+      "type",
+    ]);
     expect(contract.capabilities.map((c) => c.name)).toContain(
       "upsert_repo_fact",
     );
@@ -97,7 +110,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-26.memory-tools.v7");
+    expect(contract.contract_version).toBe("2026-06-26.memory-tools.v8");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
@@ -113,6 +126,10 @@ describe("Open Brain contract manifest", () => {
     // so a contract-driven agent learns the behavior, not just the type.
     expect(shareCandidate.description).toContain("share_candidate_rejected");
     expect(shareCandidate.description.toLowerCase()).toContain("secret");
+    const okf = (appendEvent?.input_schema as any).metadata.fields.okf;
+    expect(okf.type).toBe("object");
+    expect(okf.description).toContain("edge export/import");
+    expect(okf.description).toContain("Unknown keys should be preserved");
   });
 
   it("keeps the schema hash stable when only generated_at changes", () => {
@@ -133,6 +150,7 @@ describe("Open Brain contract manifest", () => {
       min_client_versions: base.min_client_versions,
       compatible_client_ranges: base.compatible_client_ranges,
       transport: base.transport,
+      interchange_profiles: base.interchange_profiles,
       capabilities: [
         ...base.capabilities,
         {
@@ -161,6 +179,7 @@ describe("Open Brain contract manifest", () => {
       min_client_versions: base.min_client_versions,
       compatible_client_ranges: base.compatible_client_ranges,
       transport: base.transport,
+      interchange_profiles: base.interchange_profiles,
       capabilities: base.capabilities,
       tool_contracts: {
         ...base.tool_contracts,
@@ -193,6 +212,7 @@ describe("Open Brain contract manifest", () => {
       min_client_versions: base.min_client_versions,
       compatible_client_ranges: base.compatible_client_ranges,
       transport: base.transport,
+      interchange_profiles: base.interchange_profiles,
       capabilities: base.capabilities,
       tool_contracts: {
         ...base.tool_contracts,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -32,16 +32,16 @@ export interface OpenBrainContract {
       version: "draft";
       role: "edge-export-import-profile";
       metadata_path: "metadata.okf";
-      reserved_files: ["index.md", "log.md"];
-      required_frontmatter: ["type"];
-      recommended_frontmatter: [
+      reserved_files: readonly ["index.md", "log.md"];
+      required_frontmatter: readonly ["type"];
+      recommended_frontmatter: readonly [
         "title",
         "description",
         "resource",
         "tags",
         "timestamp",
       ];
-      export_surfaces: ["concept", "index", "log", "citations"];
+      export_surfaces: readonly ["concept", "index", "log", "citations"];
     };
   };
   capabilities: ContractCapability[];

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-26.memory-tools.v7";
+export const CONTRACT_VERSION = "2026-06-26.memory-tools.v8";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -25,6 +25,24 @@ export interface OpenBrainContract {
     auth: "bearer";
     namespace_boundary: "authorization";
     session_required: true;
+  };
+  interchange_profiles: {
+    okf: {
+      status: "compatibility-hooks";
+      version: "draft";
+      role: "edge-export-import-profile";
+      metadata_path: "metadata.okf";
+      reserved_files: ["index.md", "log.md"];
+      required_frontmatter: ["type"];
+      recommended_frontmatter: [
+        "title",
+        "description",
+        "resource",
+        "tags",
+        "timestamp",
+      ];
+      export_surfaces: ["concept", "index", "log", "citations"];
+    };
   };
   capabilities: ContractCapability[];
   tool_contracts: Record<
@@ -213,6 +231,24 @@ export function buildContract(
       auth: "bearer" as const,
       namespace_boundary: "authorization" as const,
       session_required: true as const,
+    },
+    interchange_profiles: {
+      okf: {
+        status: "compatibility-hooks" as const,
+        version: "draft" as const,
+        role: "edge-export-import-profile" as const,
+        metadata_path: "metadata.okf" as const,
+        reserved_files: ["index.md", "log.md"] as const,
+        required_frontmatter: ["type"] as const,
+        recommended_frontmatter: [
+          "title",
+          "description",
+          "resource",
+          "tags",
+          "timestamp",
+        ] as const,
+        export_surfaces: ["concept", "index", "log", "citations"] as const,
+      },
     },
     capabilities: [...CONTRACT_CAPABILITIES].sort((a, b) =>
       a.name.localeCompare(b.name),


### PR DESCRIPTION
## Summary
- add repo-local Open Brain workflow adapter docs and harden core01 deploy/session-save workflow context
- expose OKF compatibility hooks in the public contract as `interchange_profiles.okf` and `metadata.okf`, bumping the memory contract to v8
- add the Open Brain agent memory substrate plan and link it to the Friday-Sunday issue/timeline set (#207-#216)

## Validation
- `bunx tsc --noEmit`
- `bun test src/contract.test.ts`
- `uv run pytest -q python/openbrain-memory/tests/test_contract.py python/openbrain-memory/tests/test_client.py -q`
- `/opt/homebrew/bin/bash -n scripts/core01-deploy-local.sh scripts/core01-sync-development.sh`
- `git diff --check`

## Critical Self-Review
- Highest-risk behavior: public contract version bump to `2026-06-26.memory-tools.v8` means downstream consumers must refresh/validate contract compatibility.
- Assumptions that could be wrong: treating OKF as an edge disclosure profile may need adjustment if Google OKF evolves into a stricter standard.
- Missing/weak tests: no runtime OKF export implementation yet; only contract/docs hooks are tested.
- Security/permission risk: `metadata.okf` must stay metadata-only and must not bypass namespace, secret, or promotion rules.
- Migration/deploy risk: core01 deploy script now sources the env file before staging; syntax passes but live deploy proof is not included in this PR.
- Downstream client/runtime risk: mcp2cli/generated skills/Hermes must classify and refresh because `get_contract` shape changed.
- Rollback/cleanup concern: revert the branch commits if contract consumers cannot accept v8 yet.
- Fixes made before PR: split deploy/session-save cleanup from memory-substrate contract planning in separate commits; added a CI fix for readonly OKF contract tuple typing.
- Known residual risk: full memory substrate implementation is tracked by #207-#216 and is not delivered by this PR.
- SME review-memory update: [ ] docs/sme/ updated [x] not applicable because: this planning/contract-hook PR did not surface a new MEDIUM+ review pattern.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below [x] not applicable because: hosted rollout and live canaries are explicitly tracked by #216 before operational rollout; this PR only lands local contract/docs hooks and deploy-script cleanup.

## Downstream rollout classification
Applies. This PR changes the public Open Brain contract manifest and Python contract pin. Before declaring full rollout complete, follow `docs/downstream-rollout.md` for hosted Open Brain, mcp2cli/generated skill, rtech-hermes, and live Hermes canary checks.