### PR TITLE
fix: tolerate post-deploy rollback cleanup failure

### DIFF
--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -10,6 +10,26 @@ BUN_BIN="${BUN_BIN:-}"
 STAGING_DIR="${STAGING_DIR:-${RUNTIME_DIR}.next}"
 PREVIOUS_DIR="${PREVIOUS_DIR:-${RUNTIME_DIR}.previous}"
 
+cleanup_previous_dir() {
+  local phase="$1"
+
+  if [[ ! -e "$PREVIOUS_DIR" ]]; then
+    return 0
+  fi
+
+  if rm -rf "$PREVIOUS_DIR"; then
+    return 0
+  fi
+
+  if [[ "$phase" == "post-health" ]]; then
+    echo "WARN: deployed successfully but could not remove rollback dir: $PREVIOUS_DIR" >&2
+    return 0
+  fi
+
+  echo "FATAL: could not remove stale rollback dir before deploy: $PREVIOUS_DIR" >&2
+  return 1
+}
+
 if [[ -z "$BUN_BIN" ]]; then
   if [[ -x "/Users/rico/Library/Application Support/reflex/bun/bin/bun" ]]; then
     BUN_BIN="/Users/rico/Library/Application Support/reflex/bun/bin/bun"
@@ -37,6 +57,7 @@ source "$ENV_FILE"
 set +a
 
 rm -rf "$STAGING_DIR"
+cleanup_previous_dir pre-deploy
 mkdir -p "$STAGING_DIR"
 
 tar \
@@ -69,7 +90,6 @@ fi
 cd "$STAGING_DIR"
 "$BUN_BIN" run migrate
 
-rm -rf "$PREVIOUS_DIR"
 if [[ -d "$RUNTIME_DIR" ]]; then
   mv "$RUNTIME_DIR" "$PREVIOUS_DIR"
 fi
@@ -81,7 +101,7 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
   if curl -fsS --max-time 5 http://127.0.0.1:3100/health >/dev/null 2>&1; then
     echo "Open Brain health check passed"
     "$BUN_BIN" test src/tools/__tests__/search-all.test.ts
-    rm -rf "$PREVIOUS_DIR"
+    cleanup_previous_dir post-health
     exit 0
   fi
   sleep 2


### PR DESCRIPTION
## Summary
- make core01 deploy cleanup of app.previous explicit
- keep stale rollback cleanup fatal before deploy, where it would block moving the current runtime
- make post-health rollback cleanup non-fatal so a healthy deployed service is not reported as failed because stale rollback cleanup leaves files like .DS_Store

## Validation
- /opt/homebrew/bin/bash -n scripts/core01-deploy-local.sh
- Live core01 health after failed deploy job: healthy on 10.71.1.21 with both workers, DB connected, embedding connected

## Context
Main deploy for #218 reached install, migrations, launchd restart, /health success, and search-all smoke tests, then failed on: rm cannot remove /Volumes/ThunderBolt/open-brain/app.previous: Directory not empty. The live service is healthy; this PR fixes the deploy script reporting path for the next deploy rerun.

## Critical Self-Review
- Highest-risk behavior: accidentally hiding a real rollback cleanup problem before deploy.
- Assumptions that could be wrong: post-health cleanup failure is safe to warn on because rollback is no longer required after the new runtime is healthy.
- Missing/weak tests: shell syntax only; live rerun required after merge to prove Actions status.
- Security/permission risk: none; no secrets or permission broadening.
- Migration/deploy risk: low; pre-deploy cleanup remains fatal, post-health cleanup becomes warning-only.
- Downstream client/runtime risk: none.
- Rollback/cleanup concern: stale app.previous may remain and should be cleaned manually if it accumulates; deploy success should not be marked failed after health passes.
- Fixes made before PR: scoped cleanup helper.
- Known residual risk: if macOS keeps recreating .DS_Store, the stale rollback dir can remain until manually removed.
- SME review-memory update: [x] not applicable because: this is a deploy-script cleanup hardening fix; no new review finding pattern needs promotion.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured or marked not applicable
- Live Open Brain checks: [x] linked below

Live Open Brain checks:
- core01 /health returned healthy with both workers, database connected, and embedding connected after the failed #218 deploy job.
- The failed deploy job reached health and search-all smoke success before post-health cleanup failed.
