### PR TITLE
feat: define agent context pack contract

### DIFF
--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -60,7 +60,9 @@ Optional fields:
 
 - `thread_id`: distinguishes Discord threads or equivalent platform threads.
 - `user_id`: caller/user identity when safe and useful for profile scoping.
-- `requested_sections`: subset of known response sections.
+- `requested_sections`: subset of the known section names listed under
+  "Response Shape". It selects `sections` members only; it does not toggle the
+  always-present envelope fields (`warnings`, `budget`, `citations`).
 - `repo`: repo slug for repo-fact filtering, such as `rodaddy/open-brain`.
 - `task`: short current task label for ranking and warnings.
 - `include_unreviewed_recovery`: false by default; true only for explicit
@@ -79,6 +81,10 @@ The scope key is:
 ```text
 namespace + agent + platform + server_id + channel_id + thread_id + session_key
 ```
+
+`session_key` is the canonical, contract-pinned name for the per-session scope
+element that the #225 research note (`docs/realtime-agent-memory-research.md`)
+refers to as `session_id`; they denote the same element.
 
 Exact-scope filters must run before semantic search, ranking, or truncation.
 Working-set and recovery sections require an exact match. Missing `thread_id`
@@ -122,7 +128,9 @@ Top-level fields:
 }
 ```
 
-Known section names:
+Known section names (the `sections` object members; this list is what
+`requested_sections` selects from, and it is mirrored by
+`get_contract().agent_context_pack.sections`):
 
 - `working_set`: exact-scope hot state only; labeled working context, not
   durable memory.
@@ -139,6 +147,11 @@ Known section names:
   follow-up fetching.
 - `candidate_memory`: explicit candidates only; presence in the pack is not a
   durable write or shared-kb promotion.
+
+`warnings`, `budget`, and `citations` are always-present top-level envelope
+fields, not section members. They are mirrored by
+`get_contract().agent_context_pack.envelope_fields` and cannot be toggled
+through `requested_sections`.
 
 Warning fields:
 
@@ -174,8 +187,7 @@ Hermes should be able to request:
     "durable_lane_context",
     "durable_memory",
     "repo_facts",
-    "pointers",
-    "warnings"
+    "pointers"
   ],
   "budget": {
     "max_tokens": 3500,
@@ -202,11 +214,15 @@ The response must make the source boundary explicit:
 
 ## Acceptance Fixtures
 
-Implementation must include fixtures that prove:
+Implementation must include the fixtures below. Working-set/recovery denial
+coverage MUST include one explicit denial case per scope key (all seven keys
+from "Exact Scope Predicate"), not a subset:
 
 - same namespace/agent/platform/server/channel/session can receive working-set
   context;
+- different namespace is denied working-set context;
 - different agent is denied working-set context;
+- different platform/source is denied working-set context;
 - different server/guild is denied working-set context;
 - different channel is denied working-set context;
 - different thread is denied working-set context;
@@ -219,7 +235,10 @@ Implementation must include fixtures that prove:
 
 ## Contract Availability
 
-`get_contract` exposes this as:
+`get_contract` exposes this as (abbreviated; the emitted object also carries
+`parent_issue`, `exact_scope_required`, `scope_keys`, `sections`,
+`envelope_fields`, and `warning_fields` — see `src/contract.ts` for the full
+authoritative shape):
 
 ```json
 {

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -1,0 +1,235 @@
+# Agent Context Pack Contract
+
+Status: planned contract, not runtime-available yet.
+Parent issue: #220.
+Research receipt: PR #225, `docs/realtime-agent-memory-research.md`.
+
+## Purpose
+
+`agent_context_pack` is the planned first-class realtime memory surface for
+Hermes and future agents. It returns one scoped, inspectable, prompt-ready
+context bundle so a runtime does not have to stitch together lane reads, broad
+semantic search, repo facts, profile guidance, and stale-evidence warnings on
+every turn.
+
+This contract defines the envelope and scope rules before transport or runtime
+implementation. It must not be advertised as an available tool until server
+code, tests, and downstream client support exist.
+
+## Ownership Boundary
+
+Open Brain owns:
+
+- bearer-token identity and namespace predicates;
+- exact-scope filtering before vector or ranking behavior;
+- server-side assembly of readable lane, memory, repo fact, pointer, warning,
+  budget, and citation sections;
+- source refs, staleness markers, and scope-denial metadata;
+- public contract discovery through `get_contract`.
+
+Clients own:
+
+- the active agent/platform/session identity they send;
+- prompt placement and model-specific shaping after the pack is returned;
+- client-owned promotion, relegation, discard, or shared-kb nomination actions;
+- retry/spool behavior when Open Brain is unavailable.
+
+Open Brain remains durable operational memory. It is not raw transcript storage,
+not a behavior layer, and not the authority for Hermes profile policy.
+
+## Request Shape
+
+Required fields:
+
+```json
+{
+  "agent": "bilby",
+  "platform": "discord",
+  "server_id": "guild-id",
+  "channel_id": "channel-id",
+  "session_key": "stable-session-key",
+  "query": "what the user just asked",
+  "budget": {
+    "max_tokens": 4000,
+    "max_latency_ms": 500
+  }
+}
+```
+
+Optional fields:
+
+- `thread_id`: distinguishes Discord threads or equivalent platform threads.
+- `user_id`: caller/user identity when safe and useful for profile scoping.
+- `requested_sections`: subset of known response sections.
+- `repo`: repo slug for repo-fact filtering, such as `rodaddy/open-brain`.
+- `task`: short current task label for ranking and warnings.
+- `include_unreviewed_recovery`: false by default; true only for explicit
+  recovery flows defined by #221.
+- `client_context_refs`: client-side profile/process/doc references for
+  source-aware merge. Raw private source bodies should not be sent.
+- `metadata`: bounded JSON for runtime version, route name, and trace ids.
+
+`namespace` may be accepted only when the caller token is authorized for that
+namespace. Normal clients should rely on auth-derived namespace identity.
+
+## Exact Scope Predicate
+
+The scope key is:
+
+```text
+namespace + agent + platform + server_id + channel_id + thread_id + session_key
+```
+
+Exact-scope filters must run before semantic search, ranking, or truncation.
+Working-set and recovery sections require an exact match. Missing `thread_id`
+matches only unthreaded scope; it must not match every thread in a channel.
+
+The pack must never leak working or recovery data across:
+
+- namespaces;
+- agents;
+- platforms/sources;
+- servers/guilds;
+- channels;
+- threads;
+- sessions.
+
+Durable shared memory and repo facts may be broader than the active scope, but
+they still require readable auth scope and source refs. Any denied source should
+be reported as metadata, not silently ignored when it affects answer quality.
+
+## Response Shape
+
+Top-level fields:
+
+```json
+{
+  "schema": "openbrain.agent_context_pack.v1",
+  "status": "ok",
+  "scope": {
+    "namespace_source": "authorization",
+    "agent": "bilby",
+    "platform": "discord",
+    "server_id": "guild-id",
+    "channel_id": "channel-id",
+    "thread_id": null,
+    "session_key": "stable-session-key"
+  },
+  "sections": {},
+  "warnings": [],
+  "budget": {},
+  "citations": []
+}
+```
+
+Known section names:
+
+- `working_set`: exact-scope hot state only; labeled working context, not
+  durable memory.
+- `durable_lane_context`: lane metadata, current context, and selected recent
+  events for the scoped lane.
+- `durable_memory`: cited thoughts, decisions, session wraps, and shared facts
+  that are readable under auth.
+- `profile_guidance`: profile/persona pointers or summaries safe for this
+  agent/runtime.
+- `process_guidance`: SOP or operating-rule pointers relevant to the request.
+- `repo_facts`: curated repo facts with source URLs, commits, and staleness
+  policies.
+- `pointers`: entities, repos, services, files, or receipts worth deliberate
+  follow-up fetching.
+- `candidate_memory`: explicit candidates only; presence in the pack is not a
+  durable write or shared-kb promotion.
+
+Warning fields:
+
+- `missing_facts`;
+- `stale_sources`;
+- `degraded_sources`;
+- `scope_denials`;
+- `truncation`;
+- `uncertainty`.
+
+Budget metadata should include requested token/latency limits, estimated output
+tokens, omitted section counts, and truncation decisions.
+
+Every included durable fact, repo fact, lane event, pointer, or candidate should
+carry a citation or source ref. Working context may cite trace ids or event ids;
+it must be labeled as unpromoted working state.
+
+## Hermes One-Call Example
+
+Hermes should be able to request:
+
+```json
+{
+  "agent": "nagatha",
+  "platform": "discord",
+  "server_id": "rodaddy-live",
+  "channel_id": "ob-dev",
+  "thread_id": null,
+  "session_key": "discord:rodaddy-live:ob-dev:nagatha",
+  "query": "what is the actual current state of OB?",
+  "requested_sections": [
+    "working_set",
+    "durable_lane_context",
+    "durable_memory",
+    "repo_facts",
+    "pointers",
+    "warnings"
+  ],
+  "budget": {
+    "max_tokens": 3500,
+    "max_latency_ms": 750
+  }
+}
+```
+
+The response must make the source boundary explicit:
+
+- contract/tool availability is contract evidence;
+- live repo, PR, issue, and runtime state still require live verification;
+- broad semantic search is fallback evidence, not authority for current state.
+
+## Non-Goals For This Contract
+
+- No NATS/JetStream implementation. #223 owns transport.
+- No recovery WAL implementation. #221 owns recovery.
+- No RAM working-set implementation. #222 owns hot state.
+- No promote/relegate implementation. #224 owns lifecycle actions.
+- No server-side auto-promotion from working trace, recovery evidence, or
+  candidate memory.
+- No replacement of HTTP/MCP compatibility paths.
+
+## Acceptance Fixtures
+
+Implementation must include fixtures that prove:
+
+- same namespace/agent/platform/server/channel/session can receive working-set
+  context;
+- different agent is denied working-set context;
+- different server/guild is denied working-set context;
+- different channel is denied working-set context;
+- different thread is denied working-set context;
+- different session key is denied working-set context;
+- denied working/recovery sources appear in `warnings.scope_denials`;
+- durable memory and repo facts remain citation-backed and readable only under
+  server auth predicates;
+- candidate memory is labeled as candidate-only and does not create a durable
+  memory row or shared-kb nomination.
+
+## Contract Availability
+
+`get_contract` exposes this as:
+
+```json
+{
+  "agent_context_pack": {
+    "status": "planned-contract",
+    "availability": "not_runtime_available",
+    "contract_doc": "docs/agent-context-pack-contract.md"
+  }
+}
+```
+
+It must not appear in `tool_contracts` or in required client tool lists until
+the runtime tool exists.

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import RetryPolicy, redact_text, with_retry
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-26.memory-tools.v9"
+CURRENT_CONTRACT_VERSION = "2026-06-28.memory-tools.v10"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -456,7 +456,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-26.memory-tools.v9"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-28.memory-tools.v10"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -91,7 +91,7 @@ describe("Open Brain contract manifest", () => {
       "thread_id",
       "session_key",
     ]);
-    expect(contract.agent_context_pack.output_sections).toEqual([
+    expect(contract.agent_context_pack.sections).toEqual([
       "working_set",
       "durable_lane_context",
       "durable_memory",
@@ -99,6 +99,14 @@ describe("Open Brain contract manifest", () => {
       "process_guidance",
       "repo_facts",
       "pointers",
+      "candidate_memory",
+    ]);
+    // candidate_memory carries the candidate-only / not-a-durable-write label,
+    // so it must appear in the machine-readable section enumeration.
+    expect(contract.agent_context_pack.sections).toContain("candidate_memory");
+    // Envelope fields are top-level response keys, not section members; keep
+    // them distinct so requested_sections stays a true subset of sections.
+    expect(contract.agent_context_pack.envelope_fields).toEqual([
       "warnings",
       "budget",
       "citations",

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -75,6 +75,37 @@ describe("Open Brain contract manifest", () => {
       owner: "client",
       status: "client-wrapper",
     });
+    expect(contract.agent_context_pack).toMatchObject({
+      status: "planned-contract",
+      availability: "not_runtime_available",
+      contract_doc: "docs/agent-context-pack-contract.md",
+      parent_issue: 220,
+      exact_scope_required: true,
+    });
+    expect(contract.agent_context_pack.scope_keys).toEqual([
+      "namespace",
+      "agent",
+      "platform",
+      "server_id",
+      "channel_id",
+      "thread_id",
+      "session_key",
+    ]);
+    expect(contract.agent_context_pack.output_sections).toEqual([
+      "working_set",
+      "durable_lane_context",
+      "durable_memory",
+      "profile_guidance",
+      "process_guidance",
+      "repo_facts",
+      "pointers",
+      "warnings",
+      "budget",
+      "citations",
+    ]);
+    expect(contract.agent_context_pack.warning_fields).toContain(
+      "scope_denials",
+    );
     expect(contract.receipt_contract).toMatchObject({
       status: "lightweight-openbrain-receipts",
       event_type: "receipt",
@@ -109,6 +140,9 @@ describe("Open Brain contract manifest", () => {
       "agent_memory_adapter",
     );
     expect(contract.capabilities.map((c) => c.name)).toContain(
+      "agent_context_pack",
+    );
+    expect(contract.capabilities.map((c) => c.name)).toContain(
       "receipt_contract",
     );
     for (const tool of [
@@ -127,6 +161,7 @@ describe("Open Brain contract manifest", () => {
     ]) {
       expect(contract.tool_contracts[tool]).toBeDefined();
     }
+    expect(contract.tool_contracts.agent_context_pack).toBeUndefined();
     const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
     expect(upsertRepoFact).toBeDefined();
     const getEntry = contract.tool_contracts.get_entry;
@@ -191,7 +226,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-26.memory-tools.v9");
+    expect(contract.contract_version).toBe("2026-06-28.memory-tools.v10");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
@@ -233,6 +268,7 @@ describe("Open Brain contract manifest", () => {
       transport: base.transport,
       interchange_profiles: base.interchange_profiles,
       agent_memory_adapter: base.agent_memory_adapter,
+      agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
       capabilities: [
         ...base.capabilities,
@@ -264,6 +300,7 @@ describe("Open Brain contract manifest", () => {
       transport: base.transport,
       interchange_profiles: base.interchange_profiles,
       agent_memory_adapter: base.agent_memory_adapter,
+      agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
       capabilities: base.capabilities,
       tool_contracts: {
@@ -299,6 +336,7 @@ describe("Open Brain contract manifest", () => {
       transport: base.transport,
       interchange_profiles: base.interchange_profiles,
       agent_memory_adapter: base.agent_memory_adapter,
+      agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
       capabilities: base.capabilities,
       tool_contracts: {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -85,7 +85,7 @@ export interface OpenBrainContract {
       "thread_id",
       "session_key",
     ];
-    output_sections: readonly [
+    sections: readonly [
       "working_set",
       "durable_lane_context",
       "durable_memory",
@@ -93,10 +93,9 @@ export interface OpenBrainContract {
       "process_guidance",
       "repo_facts",
       "pointers",
-      "warnings",
-      "budget",
-      "citations",
+      "candidate_memory",
     ];
+    envelope_fields: readonly ["warnings", "budget", "citations"];
     warning_fields: readonly [
       "missing_facts",
       "stale_sources",
@@ -423,7 +422,7 @@ export function buildContract(
         "thread_id",
         "session_key",
       ] as const,
-      output_sections: [
+      sections: [
         "working_set",
         "durable_lane_context",
         "durable_memory",
@@ -431,10 +430,9 @@ export function buildContract(
         "process_guidance",
         "repo_facts",
         "pointers",
-        "warnings",
-        "budget",
-        "citations",
+        "candidate_memory",
       ] as const,
+      envelope_fields: ["warnings", "budget", "citations"] as const,
       warning_fields: [
         "missing_facts",
         "stale_sources",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-26.memory-tools.v9";
+export const CONTRACT_VERSION = "2026-06-28.memory-tools.v10";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -69,6 +69,42 @@ export interface OpenBrainContract {
         status: "available" | "client-wrapper" | "planned";
       }
     >;
+  };
+  agent_context_pack: {
+    status: "planned-contract";
+    availability: "not_runtime_available";
+    contract_doc: "docs/agent-context-pack-contract.md";
+    parent_issue: 220;
+    exact_scope_required: true;
+    scope_keys: readonly [
+      "namespace",
+      "agent",
+      "platform",
+      "server_id",
+      "channel_id",
+      "thread_id",
+      "session_key",
+    ];
+    output_sections: readonly [
+      "working_set",
+      "durable_lane_context",
+      "durable_memory",
+      "profile_guidance",
+      "process_guidance",
+      "repo_facts",
+      "pointers",
+      "warnings",
+      "budget",
+      "citations",
+    ];
+    warning_fields: readonly [
+      "missing_facts",
+      "stale_sources",
+      "degraded_sources",
+      "scope_denials",
+      "truncation",
+      "uncertainty",
+    ];
   };
   receipt_contract: {
     status: "lightweight-openbrain-receipts";
@@ -211,6 +247,15 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
     version: 1,
     kind: "schema",
     description: "Durable session lanes, events, context, and wraps.",
+  },
+  {
+    name: "agent_context_pack",
+    version: 1,
+    kind: "schema",
+    description:
+      "Planned first-class realtime context-pack contract for Hermes and " +
+      "future agents. It is not an available runtime tool until a later " +
+      "implementation exposes it explicitly.",
   },
   {
     name: "agent_memory_adapter",
@@ -362,6 +407,42 @@ export function buildContract(
           status: "client-wrapper" as const,
         },
       },
+    },
+    agent_context_pack: {
+      status: "planned-contract" as const,
+      availability: "not_runtime_available" as const,
+      contract_doc: "docs/agent-context-pack-contract.md" as const,
+      parent_issue: 220 as const,
+      exact_scope_required: true as const,
+      scope_keys: [
+        "namespace",
+        "agent",
+        "platform",
+        "server_id",
+        "channel_id",
+        "thread_id",
+        "session_key",
+      ] as const,
+      output_sections: [
+        "working_set",
+        "durable_lane_context",
+        "durable_memory",
+        "profile_guidance",
+        "process_guidance",
+        "repo_facts",
+        "pointers",
+        "warnings",
+        "budget",
+        "citations",
+      ] as const,
+      warning_fields: [
+        "missing_facts",
+        "stale_sources",
+        "degraded_sources",
+        "scope_denials",
+        "truncation",
+        "uncertainty",
+      ] as const,
     },
     receipt_contract: {
       status: "lightweight-openbrain-receipts" as const,


### PR DESCRIPTION
## Summary
- Adds `docs/agent-context-pack-contract.md` for the planned `agent_context_pack` surface from #220.
- Exposes `agent_context_pack` in `get_contract` as a planned schema capability only.
- Keeps `agent_context_pack` out of `tool_contracts` so clients cannot treat it as runtime-available.
- Bumps the TS/Python contract version lockstep to `2026-06-28.memory-tools.v10`.

Closes #220.

## Verification
- `bun test src/contract.test.ts`
- `bunx tsc --noEmit`
- `uv run pytest python/openbrain-memory/tests/test_client.py python/openbrain-memory/tests/test_contract.py`
- `git diff --check origin/main..HEAD`

## Critical self-review
- Highest-risk behavior: downstream agents may confuse the planned context-pack schema with an available tool.
- Assumptions that could be wrong: a schema-only contract version bump may still require downstream refresh expectations even though no runtime tool is exposed.
- Missing/weak tests: no runtime scope-denial fixtures yet because this PR defines the contract only; #222/#221/#224 own implementation fixtures.
- Security/permission risk: low runtime risk; no server tool or storage path is added. The doc explicitly requires exact-scope filtering before ranking.
- Migration/deploy risk: no migration or deploy script changes.
- Downstream client/runtime risk: contract manifest version changes; downstream rollout is applicable for manifest consumers, but runtime canaries for an unavailable tool are not applicable yet.
- Rollback/cleanup concern: rollback removes the planned schema/doc and contract version bump; no data cleanup needed.
- Fixes made before PR: kept `agent_context_pack` out of `tool_contracts` and required client wrappers to prevent false availability.
- Known residual risk: implementation PRs still need actual cross-scope denial fixtures, hosted `get_contract` rollout, mcp2cli cache refresh, generated skill refresh, and Hermes compatibility checks before agent readiness.
- SME review-memory update: [x] not applicable because: this is a contract-definition PR with no new review finding pattern to add.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR has not been merged or deployed; hosted `get_contract` verification is required in the downstream rollout after merge.
- Requested review scope: contract/schema correctness, exact-scope safety rules, and whether planned availability is clearly separated from runtime availability.
- Not requested: NATS implementation review, working-set implementation review, recovery WAL implementation review, or Hermes runtime implementation review.
- Current validation: focused local contract and Python client checks passed; CI is running.

## Downstream rollout classification
- Applies: public contract manifest and Python client contract-version pin changed.
- Local verification: complete, commands listed above.
- Hosted Open Brain deploy/get_contract smoke: required after merge before claiming hosted availability.
- mcp2cli cache/generated skills refresh: required after hosted rollout.
- rtech-hermes runtime/live canaries: not applicable to this PR as a runtime tool canary because `agent_context_pack` is explicitly `not_runtime_available`; compatibility review still applies before any agent claims use it.

## Notes
This PR depends on the research/control-plane receipt from #225, now merged into `main`.