### PR TITLE
feat: support first scoped append lane creation

### DIFF
--- a/docs/agent-memory-adapter-contract.md
+++ b/docs/agent-memory-adapter-contract.md
@@ -46,7 +46,7 @@ adapter facade.
 | --- | --- | --- | --- | --- |
 | `start` | client + server | `session_start`, optional `lane_upsert` | available | Open or resume a lane using stable `session_key`, `project`, `agent`, optional `channel_id`, `thread_id`, `topic`, color, and metadata. |
 | `recall` | client + server | `session_context`, `search_all`, `brain_answer` | available | Retrieve lane context and cited memory evidence. Clients choose prompt shaping; Open Brain returns readable, namespace-safe rows only. |
-| `append_event` | client + server | `append_session_event` | available | Write distilled `fact`, `decision`, `blocker`, `action`, `artifact`, `receipt`, `question`, `correction`, or `handoff` events. |
+| `append_event` | client + server | `append_session_event` | available | Write distilled `fact`, `decision`, `blocker`, `action`, `artifact`, `receipt`, `question`, `correction`, or `handoff` events. Realtime agents may set `create_if_missing=true` with exact scope fields so the first scoped append creates the lane instead of requiring manual setup. |
 | `compact` | client | `session_context`, caller-provided local distillation, `session_wrap` | client-wrapper | Read current context, distill it through caller policy or an explicit summary, then checkpoint via `session_wrap`. Open Brain does not store raw compaction transcripts. |
 | `wrap` | client + server | `session_wrap` | available | Checkpoint a completed work phase with summary, key decisions, next steps, and optional receipt references. Use `compact` when the adapter should read current session context before wrapping. |
 | `record_receipt` | client + server | `append_session_event` with `event_type=receipt` | client-wrapper | Assemble citation-safe receipt metadata locally and write it as a receipt event. |
@@ -66,6 +66,27 @@ All adapter calls should carry:
   available.
 - `metadata`: bounded JSON for color, display labels, OKF hooks, caller version,
   and local runtime facts.
+
+For realtime first-write lane creation, `append_session_event` accepts
+`create_if_missing=true` plus exact-scope fields:
+
+- `agent`;
+- `platform`;
+- `server_id`;
+- `channel_id`;
+- `thread_id`.
+
+When the lane is missing, Open Brain creates it and appends the event in the
+same tool call. When the lane already exists, any supplied exact-scope field
+must match the stored lane scope; mismatches fail with a structured
+`scope_validation` error instead of silently spilling events across agents,
+servers, channels, threads, or sessions.
+
+Structured append failures use the `error` classes `retryable_outage`,
+`auth_denied`, `scope_validation`, `unsupported_operation`, and
+`conflict_retry`, plus `retryable` so Hermes can decide whether to spool/retry
+or stop. Clients should not parse generic text such as "lane not found" for
+control flow.
 
 ## Disclosure Export
 
@@ -121,10 +142,16 @@ runtime code into this repo:
 - `metadata.transport`: `openbrain-memory`, `mcp2cli`, or direct provider path;
 - `record_receipt`: external channel, spool, validation, and handoff receipts.
 
+For Nagatha-style realtime Discord writes, Hermes should call
+`append_session_event` with `create_if_missing=true` and the Discord exact scope.
+Missing lanes are normal first-write state. Hermes should spool and retry
+`retryable_outage` failures, stop on `auth_denied` or `scope_validation`, and
+avoid falling back from scoped session events to unscoped `log_thought`.
+
 Open Brain local tests may fixture these call shapes through fake transports.
 Actual rtech-hermes runtime/plugin changes, hosted verification, and live
-Hermes canaries belong to #216 unless Rico explicitly approves that rollout
-phase.
+Hermes canaries belong to the consuming Hermes issue unless Rico explicitly
+approves that rollout phase.
 
 ## Lightweight Receipt Schema
 

--- a/docs/agent-memory-adapter-contract.md
+++ b/docs/agent-memory-adapter-contract.md
@@ -135,12 +135,20 @@ adapter to map platform identity into lane metadata without importing Hermes
 runtime code into this repo:
 
 - `agent`: Hermes agent identity such as `bilby` or `skippy`;
-- `source`: Hermes runtime/plugin source, such as `hermes-discord`;
+- `platform`: platform label such as `discord` — stored as the lane `source`
+  column and compared on subsequent scoped appends;
+- `server_id`: server/guild identity — stored in `metadata.server_id` and
+  compared on subsequent scoped appends;
 - `channel_id` and `thread_id`: Discord channel/thread identifiers;
-- `metadata.platform`: `discord` or another platform label;
 - `metadata.agent_profile`: profile/config identifier safe to store;
 - `metadata.transport`: `openbrain-memory`, `mcp2cli`, or direct provider path;
 - `record_receipt`: external channel, spool, validation, and handoff receipts.
+
+Scope comparison treats a null/absent stored value as unconstrained: a lane
+created by `session_start`/`lane_upsert` (which do not record `source` or
+`metadata.server_id`) accepts a first scoped append instead of failing
+`scope_validation`. Only a non-null mismatch on agent, platform, server_id,
+channel_id, or thread_id is rejected as a cross-scope spill.
 
 For Nagatha-style realtime Discord writes, Hermes should call
 `append_session_event` with `create_if_missing=true` and the Discord exact scope.
@@ -150,8 +158,8 @@ avoid falling back from scoped session events to unscoped `log_thought`.
 
 Open Brain local tests may fixture these call shapes through fake transports.
 Actual rtech-hermes runtime/plugin changes, hosted verification, and live
-Hermes canaries belong to the consuming Hermes issue unless Rico explicitly
-approves that rollout phase.
+Hermes canaries belong to the consuming Hermes issue (rtech-hermes#276) unless
+Rico explicitly approves that rollout phase.
 
 ## Lightweight Receipt Schema
 

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -178,6 +178,49 @@ exact write paths the discipline rule exists to protect had zero CI coverage.
 PR #171 set `OPENBRAIN_TEST_DATABASE_URL` in the CI `check` job env, built from
 the existing `DB_*` values, enabling all env-gated suites in CI.
 
+## [2026-06-28] Cross-tool write/read shape coherence on shared rows
+
+**Severity:** MEDIUM
+**Source:** PR #228 full swarm (issue #227), correctness + domain lanes
+**Scope:** any validator that reads fields off a row created by more than one tool
+(`scopeConflicts` in `src/tools/append-session-event.ts`; lane writers
+`session-start.ts`, `lane-upsert.ts`)
+**Status:** fixed in PR #228
+
+### Pattern
+
+`append_session_event.create_if_missing` added a `scopeConflicts` check that
+compared caller scope fields against an existing lane with strict `!==`. But
+lanes are also created by `session_start` and `lane_upsert`, which do **not**
+write the `source` column or `metadata.server_id`. So a lane created by
+`session_start` (source `NULL`) hit `args.platform="discord" !== null` and the
+legitimate first scoped append was **falsely rejected** with `scope_validation`
+(retryable=false → a hard stall, since the contract tells Hermes to stop, not
+retry). The adapter-contract doc compounded it: it mapped `source:
+hermes-discord` + `metadata.platform: discord`, contradicting the code's
+`platform → source` / compare-`args.platform`-vs-`lane.source` axis.
+
+### Review Questions
+
+- For every field a validator READS off a shared row, does EVERY tool that
+  creates/updates that row write the same field in the same place (column vs
+  JSONB key)?
+- Does a strict-equality scope/identity check treat a NULL/absent stored value
+  as a conflict? It should usually mean "unconstrained" (skip), with only a
+  non-null mismatch rejected — otherwise partially-populated rows from a sibling
+  tool false-deny.
+- Does the contract doc's field placement match the field the comparison code
+  actually reads?
+
+### Prior Fix
+
+PR #228 made `scopeConflicts` treat a null/absent existing value as
+unconstrained (skip), so a non-null mismatch still conflicts and cross-scope
+spill protection is preserved. Doc field mapping aligned with the comparison
+axis. Regression tests: scoped append onto a `session_start`-shaped (null
+source) lane succeeds; non-null channel mismatch still denies; live-Postgres
+suite proves the real ON CONFLICT create/race + scope denial.
+
 ## [2026-06-27] Disclosure exporters must accept server-shaped citation fields
 
 **Severity:** MEDIUM

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -15,7 +15,7 @@ from .policy import RetryPolicy, redact_text, with_retry
 JSON = dict[str, Any]
 MCP_PROTOCOL_VERSION = "2025-03-26"
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
-CURRENT_CONTRACT_VERSION = "2026-06-28.memory-tools.v10"
+CURRENT_CONTRACT_VERSION = "2026-06-28.memory-tools.v11"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -456,7 +456,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-28.memory-tools.v10"
+    assert CURRENT_CONTRACT_VERSION == "2026-06-28.memory-tools.v11"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -444,7 +444,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     output_shape: "session lane array JSON text payload",
   },
   append_session_event: {
-    version: 4,
+    version: 5,
     input_schema: {
       session_key: {
         type: "string",
@@ -452,8 +452,8 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         minLength: 1,
         maxLength: 500,
         description:
-          "Identifier of the lane to append to. Must match a lane you " +
-          "started or upserted; the event is journaled under this lane.",
+          "Identifier of the lane to append to. With create_if_missing=true, " +
+          "a missing lane is created first and the event is journaled under it.",
       },
       namespace: {
         type: "string",
@@ -462,6 +462,68 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         description:
           "Memory partition for the event. Defaults to your own " +
           "auth-derived namespace; override only when authorized for another.",
+      },
+      create_if_missing: {
+        type: "boolean",
+        required: false,
+        description:
+          "Create the session lane when it is missing, then append the event. " +
+          "Use for first-write realtime agent scopes so callers do not have to " +
+          "pre-provision lanes manually. Repeated calls with the same " +
+          "namespace/session_key return or reuse the same lane.",
+      },
+      agent: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Agent identity to bind when create_if_missing creates a lane, and " +
+          "to validate against an existing lane when supplied.",
+      },
+      platform: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Platform/source identity to bind when create_if_missing creates a " +
+          "lane, such as discord. Stored as the lane source.",
+      },
+      server_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Server/guild identity for exact realtime scope. Stored in lane metadata.",
+      },
+      channel_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Channel identity to bind when create_if_missing creates a lane, and " +
+          "to validate against an existing lane when supplied.",
+      },
+      thread_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Thread identity to bind when create_if_missing creates a lane, and " +
+          "to validate against an existing lane when supplied.",
+      },
+      project: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Project name to set if create_if_missing creates the lane.",
+      },
+      topic: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Human-readable topic to set if create_if_missing creates the lane.",
       },
       event_type: {
         type: "enum",
@@ -557,8 +619,10 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       },
     },
     output_shape:
-      "session event JSON text payload with writer_identity, token_identity, " +
-      "delegated_agent_id, and namespace_source provenance fields",
+      "session event JSON text payload with lane_created, writer_identity, " +
+      "token_identity, delegated_agent_id, and namespace_source provenance " +
+      "fields; error payloads use error classes retryable_outage, auth_denied, " +
+      "scope_validation, unsupported_operation, or conflict_retry",
   },
   session_wrap: {
     version: 2,

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -234,15 +234,31 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-28.memory-tools.v10");
+    expect(contract.contract_version).toBe("2026-06-28.memory-tools.v11");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
-    expect(appendEvent?.version).toBe(4);
+    expect(appendEvent?.version).toBe(5);
     expect(appendEvent?.output_shape).toContain("writer_identity");
     expect(appendEvent?.output_shape).toContain("token_identity");
     expect(appendEvent?.output_shape).toContain("delegated_agent_id");
     expect(appendEvent?.output_shape).toContain("namespace_source");
+    expect(appendEvent?.output_shape).toContain("lane_created");
+    expect(appendEvent?.output_shape).toContain("retryable_outage");
+    const appendInput = appendEvent?.input_schema as any;
+    expect(appendInput.create_if_missing.type).toBe("boolean");
+    expect(appendInput.create_if_missing.description).toContain(
+      "first-write realtime agent scopes",
+    );
+    expect(appendInput.agent.description).toContain("validate against an existing lane");
+    expect(appendInput.platform.description).toContain("Stored as the lane source");
+    expect(appendInput.server_id.description).toContain("exact realtime scope");
+    expect(appendInput.channel_id.description).toContain(
+      "validate against an existing lane",
+    );
+    expect(appendInput.thread_id.description).toContain(
+      "validate against an existing lane",
+    );
     const shareCandidate = (appendEvent?.input_schema as any).metadata.fields
       .share_candidate;
     expect(shareCandidate.type).toBe("boolean");

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-28.memory-tools.v10";
+export const CONTRACT_VERSION = "2026-06-28.memory-tools.v11";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -218,12 +218,13 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "append_session_event",
-    version: 4,
+    version: 5,
     kind: "tool",
     description:
       "Append one durable, typed event (fact, decision, blocker, action, etc.) " +
       "to a session lane's journal. This is the main way to record what happened " +
-      "during a session so it survives and can be recalled later.",
+      "during a session so it survives and can be recalled later. Supports " +
+      "first-write lane creation with create_if_missing for realtime agents.",
   },
   {
     name: "session_wrap",

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -554,6 +554,118 @@ describe("append_session_event", () => {
     }
   });
 
+  it("appends to a session_start-created lane with null scope without false conflict", async () => {
+    // Lanes created by session_start/lane_upsert do not write the `source`
+    // column or `metadata.server_id`. A later scoped realtime append must
+    // attach to such a lane rather than fail scope_validation on null vs
+    // "discord"/"guild-1".
+    let eventInsertAttempted = false;
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("FROM ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-sessionstart",
+                status: "active",
+                agent: "nagatha",
+                source: null,
+                channel_id: "channel-1",
+                thread_id: null,
+                metadata: {},
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          eventInsertAttempted = true;
+          return {
+            rows: [{ id: "event-uuid-1", created_at: "2026-06-28T10:00:00Z" }],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content: "Scoped append onto a session_start-created lane.",
+        },
+      });
+
+      expect(result.isError).toBeUndefined();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.event_id).toBe("event-uuid-1");
+      expect(eventInsertAttempted).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("still denies a non-null scope mismatch against an existing lane", async () => {
+    // The null-tolerance above must not weaken real spill protection: a lane
+    // that DID assert a channel still rejects a mismatched scoped append.
+    let eventInsertAttempted = false;
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("FROM ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-asserted",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: null,
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          eventInsertAttempted = true;
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-2",
+          event_type: "fact",
+          content: "Mismatched channel must still be denied.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.conflicts).toEqual(["channel_id"]);
+      expect(eventInsertAttempted).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("returns retryable_outage when the database fails before append", async () => {
     const mockPool = {
       query: async () => {

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -258,6 +258,332 @@ describe("append_session_event", () => {
     }
   });
 
+  it("creates a scoped lane on first append when create_if_missing is true", async () => {
+    const captured: {
+      laneInsertParams?: any[];
+      eventInsertParams?: any[];
+    } = {};
+    const mockPool = {
+      query: async (sql: string, params?: any[]) => {
+        if (sql.includes("INSERT INTO ob_session_lanes")) {
+          captured.laneInsertParams = params;
+          return {
+            rows: [
+              {
+                id: "lane-uuid-new",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: "thread-1",
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("FROM ob_session_lanes")) {
+          return { rows: [] };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          captured.eventInsertParams = params;
+          return {
+            rows: [{ id: "event-uuid-1", created_at: "2026-06-28T18:00:00Z" }],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:thread-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          thread_id: "thread-1",
+          project: "rtech-hermes",
+          topic: "Nagatha Discord scoped memory",
+          event_type: "correction",
+          content: "GitHub issue URLs must use live gh first.",
+          source: "nagatha",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.event_id).toBe("event-uuid-1");
+      expect(parsed.lane_id).toBe("lane-uuid-new");
+      expect(parsed.lane_created).toBe(true);
+      expect(captured.laneInsertParams).toEqual([
+        "discord:guild-1:channel-1:thread-1:nagatha",
+        "nagatha",
+        "nagatha",
+        "discord",
+        "channel-1",
+        "thread-1",
+        "rtech-hermes",
+        "Nagatha Discord scoped memory",
+        JSON.stringify({ server_id: "guild-1" }),
+        "nagatha",
+      ]);
+      expect(captured.eventInsertParams?.[0]).toBe("lane-uuid-new");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reuses an existing scoped lane when create_if_missing is true", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("FROM ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-existing",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: "thread-1",
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          return {
+            rows: [{ id: "event-uuid-1", created_at: "2026-06-28T18:00:00Z" }],
+          };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:thread-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          thread_id: "thread-1",
+          event_type: "fact",
+          content: "Existing scoped lane append succeeds.",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.lane_id).toBe("lane-uuid-existing");
+      expect(parsed.lane_created).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("handles first-write lane creation races by returning the existing lane", async () => {
+    let laneSelects = 0;
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("INSERT INTO ob_session_lanes")) {
+          return { rows: [] };
+        }
+        if (sql.includes("FROM ob_session_lanes")) {
+          laneSelects += 1;
+          if (laneSelects === 1) return { rows: [] };
+          return {
+            rows: [
+              {
+                id: "lane-uuid-raced",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: null,
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          return {
+            rows: [{ id: "event-uuid-1", created_at: "2026-06-28T18:00:00Z" }],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content: "Raced lane creation still appends.",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.lane_id).toBe("lane-uuid-raced");
+      expect(parsed.lane_created).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies append when supplied exact scope conflicts with the existing lane", async () => {
+    let eventInsertAttempted = false;
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("FROM ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-1",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: "thread-1",
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          eventInsertAttempted = true;
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:thread-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "other-channel",
+          thread_id: "thread-1",
+          event_type: "fact",
+          content: "This should not spill into another channel.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.retryable).toBe(false);
+      expect(parsed.conflicts).toEqual(["channel_id"]);
+      expect(eventInsertAttempted).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unthreaded realtime append against an existing threaded lane", async () => {
+    const mockPool = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql.includes("FROM ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-threaded",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: "thread-1",
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content: "Unthreaded writes must not target threaded lanes.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.conflicts).toEqual(["thread_id"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns retryable_outage when the database fails before append", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("connection timeout");
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          create_if_missing: true,
+          event_type: "fact",
+          content: "This should be spooled by Hermes.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("retryable_outage");
+      expect(parsed.retryable).toBe(true);
+      expect(parsed.message).toContain("connection timeout");
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── ARCHIVED LANE ──
 
   it("rejects append to archived lane", async () => {

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, afterAll } from "bun:test";
+import { Pool } from "pg";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -1329,6 +1330,198 @@ describe("append_session_event", () => {
       expect((result.content as any)[0].text).toContain("Database error");
     } finally {
       await cleanup();
+    }
+  });
+});
+
+// ── LIVE POSTGRES (real ON CONFLICT / race / scope-isolation coverage) ──
+// Mock pools cannot execute ON CONFLICT, real UNIQUE constraints, or genuine
+// concurrent inserts, so the create_if_missing race + scope-isolation guarantee
+// the contract depends on (consumed by rtech-hermes#276) is proven here against
+// a real pool. Gated on OPENBRAIN_TEST_DATABASE_URL; CI sets it (ci.yml), the
+// default infra-free suite skips. Run locally with:
+//   OPENBRAIN_TEST_DATABASE_URL=postgres://... bun test src/tools/__tests__/append-session-event.test.ts
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("append_session_event create_if_missing (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-append-live";
+
+  async function callAppend(
+    args: Record<string, unknown>,
+    auth: AuthInfo = { role: "agent", clientId: ns },
+  ) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: pool as any,
+      embedFn: createMockEmbed(null),
+    };
+    registerAppendSessionEvent(server, deps);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const original = ct.send.bind(ct);
+    ct.send = (m: any, o?: any) => original(m, { ...o, authInfo: auth });
+    const client = new Client({ name: "tc", version: "1.0.0" });
+    await server.connect(st);
+    await client.connect(ct);
+    const res = await client.callTool({
+      name: "append_session_event",
+      arguments: args,
+    });
+    await client.close();
+    await server.close();
+    return res;
+  }
+
+  async function cleanupNs() {
+    // Events cascade from lanes; delete by namespace-scoped lane ids.
+    await pool.query(
+      `DELETE FROM ob_session_events WHERE lane_id IN
+         (SELECT id FROM ob_session_lanes WHERE namespace = $1)`,
+      [ns],
+    );
+    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+  }
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("creates the lane on first write and reuses it idempotently on the second", async () => {
+    await cleanupNs();
+    try {
+      const first = await callAppend({
+        session_key: "live-first",
+        create_if_missing: true,
+        agent: "nagatha",
+        platform: "discord",
+        server_id: "guild-1",
+        channel_id: "channel-1",
+        event_type: "fact",
+        content: "first scoped event",
+      });
+      expect(first.isError).toBeFalsy();
+      const p1 = JSON.parse((first.content as any)[0].text);
+      expect(p1.lane_created).toBe(true);
+
+      const second = await callAppend({
+        session_key: "live-first",
+        create_if_missing: true,
+        agent: "nagatha",
+        platform: "discord",
+        server_id: "guild-1",
+        channel_id: "channel-1",
+        event_type: "fact",
+        content: "second scoped event",
+      });
+      expect(second.isError).toBeFalsy();
+      const p2 = JSON.parse((second.content as any)[0].text);
+      expect(p2.lane_created).toBe(false);
+      expect(p2.lane_id).toBe(p1.lane_id);
+
+      const { rows } = await pool.query(
+        "SELECT COUNT(*)::int AS n FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
+        [ns, "live-first"],
+      );
+      expect(rows[0].n).toBe(1);
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("creates exactly one lane under a genuine concurrent first-write race", async () => {
+    await cleanupNs();
+    try {
+      const mk = (content: string) =>
+        callAppend({
+          session_key: "live-race",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content,
+        });
+      const [a, b] = await Promise.all([mk("racer A"), mk("racer B")]);
+      expect(a.isError).toBeFalsy();
+      expect(b.isError).toBeFalsy();
+      const pa = JSON.parse((a.content as any)[0].text);
+      const pb = JSON.parse((b.content as any)[0].text);
+      // Exactly one call reports it created the lane; both resolve to the same lane.
+      expect(Number(pa.lane_created) + Number(pb.lane_created)).toBe(1);
+      expect(pa.lane_id).toBe(pb.lane_id);
+
+      const { rows } = await pool.query(
+        "SELECT COUNT(*)::int AS n FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
+        [ns, "live-race"],
+      );
+      expect(rows[0].n).toBe(1);
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("denies a scoped append that conflicts with the real stored lane scope", async () => {
+    await cleanupNs();
+    try {
+      await callAppend({
+        session_key: "live-conflict",
+        create_if_missing: true,
+        agent: "nagatha",
+        platform: "discord",
+        server_id: "guild-1",
+        channel_id: "channel-1",
+        event_type: "fact",
+        content: "owns channel-1",
+      });
+      const conflict = await callAppend({
+        session_key: "live-conflict",
+        create_if_missing: true,
+        agent: "nagatha",
+        platform: "discord",
+        server_id: "guild-1",
+        channel_id: "channel-2",
+        event_type: "fact",
+        content: "must not spill into channel-2",
+      });
+      expect(conflict.isError).toBe(true);
+      const parsed = JSON.parse((conflict.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.conflicts).toEqual(["channel_id"]);
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("denies cross-namespace create_if_missing for a non-global token", async () => {
+    await cleanupNs();
+    try {
+      const res = await callAppend(
+        {
+          session_key: "live-cross-ns",
+          namespace: "some-other-namespace",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content: "should never be written",
+        },
+        { role: "agent", clientId: ns },
+      );
+      expect(res.isError).toBe(true);
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.error).toBe("auth_denied");
+      // No lane may have been created in the foreign namespace.
+      const { rows } = await pool.query(
+        "SELECT COUNT(*)::int AS n FROM ob_session_lanes WHERE namespace=$1",
+        ["some-other-namespace"],
+      );
+      expect(rows[0].n).toBe(0);
+    } finally {
+      await cleanupNs();
     }
   });
 });

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -65,6 +65,12 @@ function scopeConflicts(
 
   for (const [field, existing, requested] of checks) {
     if (requested === undefined) continue;
+    // A null/absent existing value means this lane never asserted that scope
+    // dimension (e.g. a lane created by session_start/lane_upsert, which do not
+    // write `source` or `metadata.server_id`). Treat it as unconstrained so a
+    // first scoped append attaches instead of falsely failing scope_validation.
+    // Only a non-null mismatch is a real cross-scope spill.
+    if (existing === null || existing === undefined) continue;
     if (existing !== requested) conflicts.push(field);
   }
 

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -10,6 +10,193 @@ import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
 import { EVENT_TYPES, IMPORTANCE_LEVELS } from "./table-constants.ts";
 
+type AppendErrorClass =
+  | "retryable_outage"
+  | "auth_denied"
+  | "scope_validation"
+  | "unsupported_operation"
+  | "conflict_retry";
+
+function appendSessionEventError(
+  errorClass: AppendErrorClass,
+  message: string,
+  retryable: boolean,
+  details: Record<string, unknown> = {},
+) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          error: errorClass,
+          message,
+          retryable,
+          ...details,
+        }),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function scopeConflicts(
+  lane: Record<string, unknown>,
+  args: {
+    agent?: string;
+    platform?: string;
+    server_id?: string;
+    channel_id?: string;
+    thread_id?: string | null;
+  },
+): string[] {
+  const conflicts: string[] = [];
+  const metadata =
+    lane.metadata && typeof lane.metadata === "object"
+      ? (lane.metadata as Record<string, unknown>)
+      : {};
+
+  const checks: Array<[string, unknown, unknown]> = [
+    ["agent", lane.agent, args.agent],
+    ["platform", lane.source, args.platform],
+    ["server_id", metadata.server_id, args.server_id],
+    ["channel_id", lane.channel_id, args.channel_id],
+    ["thread_id", lane.thread_id, args.thread_id],
+  ];
+
+  for (const [field, existing, requested] of checks) {
+    if (requested === undefined) continue;
+    if (existing !== requested) conflicts.push(field);
+  }
+
+  return conflicts;
+}
+
+async function ensureLaneForAppend(
+  deps: ToolDeps,
+  args: {
+    session_key: string;
+    namespace: string;
+    create_if_missing?: boolean;
+    agent?: string;
+    platform?: string;
+    server_id?: string;
+    channel_id?: string;
+    thread_id?: string | null;
+    project?: string;
+    topic?: string;
+  },
+  auth: AuthInfo,
+): Promise<
+  | { ok: true; lane: Record<string, unknown>; created: boolean }
+  | { ok: false; response: ReturnType<typeof appendSessionEventError> }
+> {
+  const laneColumns =
+    "id, status, agent, source, channel_id, thread_id, metadata";
+  const laneParams = [args.namespace, args.session_key];
+  const { rows: laneRows } = await deps.pool.query(
+    `SELECT ${laneColumns}
+FROM ob_session_lanes
+WHERE namespace = $1 AND session_key = $2`,
+    laneParams,
+  );
+
+  let lane = laneRows[0] as Record<string, unknown> | undefined;
+  let created = false;
+  let attemptedCreate = false;
+
+  if (!lane && args.create_if_missing === true) {
+    attemptedCreate = true;
+    const metadata =
+      args.server_id === undefined ? {} : { server_id: args.server_id };
+    const { rows: insertedRows } = await deps.pool.query(
+      `INSERT INTO ob_session_lanes
+  (session_key, namespace, status, agent, source, channel_id, thread_id,
+   project, topic, metadata, created_by)
+VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (namespace, session_key) DO NOTHING
+RETURNING ${laneColumns}`,
+      [
+        args.session_key,
+        args.namespace,
+        args.agent ?? null,
+        args.platform ?? null,
+        args.channel_id ?? null,
+        args.thread_id ?? null,
+        args.project ?? null,
+        args.topic ?? null,
+        JSON.stringify(metadata),
+        auth.clientId,
+      ],
+    );
+    if (insertedRows.length > 0) {
+      lane = insertedRows[0] as Record<string, unknown>;
+      created = true;
+    } else {
+      const { rows: racedRows } = await deps.pool.query(
+        `SELECT ${laneColumns}
+FROM ob_session_lanes
+WHERE namespace = $1 AND session_key = $2`,
+        laneParams,
+      );
+      lane = racedRows[0] as Record<string, unknown> | undefined;
+    }
+  }
+
+  if (!lane) {
+    logger.info("append_session_event_lane_not_found", {
+      session_key: args.session_key,
+      namespace: args.namespace,
+      create_if_missing: args.create_if_missing === true,
+    });
+    if (attemptedCreate) {
+      return {
+        ok: false,
+        response: appendSessionEventError(
+          "conflict_retry",
+          "Lane creation raced but the lane was not visible after retry lookup",
+          true,
+          {
+            session_key: args.session_key,
+            namespace: args.namespace,
+          },
+        ),
+      };
+    }
+    return {
+      ok: false,
+      response: appendSessionEventError(
+        "scope_validation",
+        `Lane not found for session_key "${args.session_key}" in namespace "${args.namespace}"`,
+        false,
+        {
+          session_key: args.session_key,
+          namespace: args.namespace,
+          remedy: "Call session_start first or retry append_session_event with create_if_missing=true.",
+        },
+      ),
+    };
+  }
+
+  const conflicts = scopeConflicts(lane, args);
+  if (conflicts.length > 0) {
+    return {
+      ok: false,
+      response: appendSessionEventError(
+        "scope_validation",
+        "Existing lane scope does not match requested append scope",
+        false,
+        {
+          session_key: args.session_key,
+          namespace: args.namespace,
+          conflicts,
+        },
+      ),
+    };
+  }
+
+  return { ok: true, lane, created };
+}
+
 /**
  * Hybrid-timing sync gate for the share_candidate nomination (Issue #161, Q1).
  *
@@ -115,7 +302,9 @@ export function registerAppendSessionEvent(
     {
       description:
         "Append an event to a session lane's journal. Events are append-only " +
-        "and capture discrete facts, decisions, blockers, actions, etc.",
+        "and capture discrete facts, decisions, blockers, actions, etc. " +
+        "For realtime agents, create_if_missing can create the scoped lane on " +
+        "first write instead of requiring manual pre-provisioning.",
       inputSchema: {
         session_key: z
           .string()
@@ -129,6 +318,50 @@ export function registerAppendSessionEvent(
           .max(500)
           .optional()
           .describe("Namespace for isolation (defaults to agent's clientId)"),
+        create_if_missing: z
+          .boolean()
+          .optional()
+          .describe(
+            "Create the session lane when missing, then append the event. " +
+              "Use for first-write realtime agent scopes; repeated calls are idempotent.",
+          ),
+        agent: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Agent identity for first-write lane creation and scope checks"),
+        platform: z
+          .string()
+          .max(500)
+          .optional()
+          .describe(
+            "Platform/source identity for first-write lane creation, such as discord",
+          ),
+        server_id: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Server/guild identity for exact realtime lane scope"),
+        channel_id: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Channel identity for exact realtime lane scope"),
+        thread_id: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Thread identity for exact realtime lane scope"),
+        project: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Project name to set when first-write creates the lane"),
+        topic: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Human-readable lane topic to set when first-write creates the lane"),
         event_type: z
           .enum(EVENT_TYPES)
           .describe(
@@ -182,29 +415,22 @@ export function registerAppendSessionEvent(
           clientId: auth?.clientId ?? "none",
           session_key: args.session_key,
         });
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: "Permission denied: cannot write to session events",
-            },
-          ],
-          isError: true,
-        };
+        return appendSessionEventError(
+          "auth_denied",
+          "Permission denied: cannot write to session events",
+          false,
+        );
       }
 
       const ns = args.namespace ?? auth.clientId;
       const nsCheck = canWriteNamespace(auth, ns);
       if (!nsCheck.allowed) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Permission denied: ${nsCheck.reason}`,
-            },
-          ],
-          isError: true,
-        };
+        return appendSessionEventError(
+          "auth_denied",
+          `Permission denied: ${nsCheck.reason}`,
+          false,
+          { namespace: ns },
+        );
       }
       const importance = args.importance ?? "warm";
       const provenance = writerProvenance(auth);
@@ -219,41 +445,39 @@ export function registerAppendSessionEvent(
       });
 
       try {
-        // Look up the lane
-        const { rows: laneRows } = await deps.pool.query(
-          `SELECT id, status FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
-          [ns, args.session_key],
-        );
-
-        if (laneRows.length === 0) {
-          logger.info("append_session_event_lane_not_found", {
+        const laneResult = await ensureLaneForAppend(
+          deps,
+          {
             session_key: args.session_key,
             namespace: ns,
-          });
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Lane not found for session_key "${args.session_key}" in namespace "${ns}"`,
-              },
-            ],
-            isError: true,
-          };
+            create_if_missing: args.create_if_missing,
+            agent: args.agent,
+            platform: args.platform,
+            server_id: args.server_id,
+            channel_id: args.channel_id,
+            thread_id:
+              args.create_if_missing === true && args.channel_id !== undefined
+                ? (args.thread_id ?? null)
+                : args.thread_id,
+            project: args.project,
+            topic: args.topic,
+          },
+          auth,
+        );
+        if (!laneResult.ok) {
+          return laneResult.response;
         }
 
-        if (laneRows[0].status === "archived") {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Lane "${args.session_key}" is archived; reactivate before appending events`,
-              },
-            ],
-            isError: true,
-          };
+        if (laneResult.lane.status === "archived") {
+          return appendSessionEventError(
+            "unsupported_operation",
+            `Lane "${args.session_key}" is archived; reactivate before appending events`,
+            false,
+            { session_key: args.session_key, namespace: ns },
+          );
         }
 
-        const laneId = laneRows[0].id;
+        const laneId = laneResult.lane.id;
 
         // Hybrid sync gate: a share_candidate nomination carrying a secret or
         // person-private content is rejected inline (cheap, no embedding) and
@@ -333,6 +557,7 @@ export function registerAppendSessionEvent(
         const result = {
           event_id: rows[0].id,
           lane_id: laneId,
+          lane_created: laneResult.created,
           event_type: args.event_type,
           importance,
           created_at: rows[0].created_at,
@@ -370,7 +595,13 @@ export function registerAppendSessionEvent(
           content: [
             {
               type: "text" as const,
-              text: `Database error during event append: ${err instanceof Error ? err.message : String(err)}`,
+              text: JSON.stringify({
+                error: "retryable_outage",
+                message: `Database error during event append: ${err instanceof Error ? err.message : String(err)}`,
+                retryable: true,
+                session_key: args.session_key,
+                namespace: ns,
+              }),
             },
           ],
           isError: true,


### PR DESCRIPTION
## Summary
- Adds `append_session_event.create_if_missing` so a first scoped realtime append can create its session lane and write the event in one call.
- Binds and validates exact scope fields for agent/platform/server/channel/thread to prevent scoped writes from spilling across Discord scopes.
- Bumps the public contract to `2026-06-28.memory-tools.v11` with `append_session_event` contract version `5`, and updates the Python package pin.

Closes #227.
Unblocks rodaddy/rtech-hermes#276.

## Validation
- `bun test src/tools/__tests__/append-session-event.test.ts src/contract.test.ts`
- `cd python/openbrain-memory && uv run pytest tests/test_client.py::test_required_contract_tools_have_first_class_wrappers_and_help -q`
- `bunx tsc --noEmit`
- `bun test src/tools/__tests__/append-session-event.test.ts src/contract.test.ts src/__tests__/agent-memory.test.ts`
- `git diff --check`
- `cd python/openbrain-memory && uv run pytest tests/test_client.py::test_required_contract_matches_server_source_of_truth tests/test_contract.py -q`
- `cd python/openbrain-memory && uv run ruff check src tests`
- `cd python/openbrain-memory && uv run mypy src/openbrain_memory`
- `bun test`
- `cd python/openbrain-memory && uv run pytest -q`

## Critical Self-Review
- Highest-risk behavior: first-write lane creation could append into an existing lane with a mismatched Discord scope if scope comparison were too loose.
- Assumptions that could be wrong: Hermes will provide stable exact-scope fields when using `create_if_missing`; if it omits those fields, Open Brain can only enforce namespace/session_key and supplied fields.
- Missing/weak tests: local tests cover first-write create, existing append, race reuse, scope conflict, unthreaded-vs-threaded denial, and retryable DB failure; live hosted canary is deferred until deployment.
- Security/permission risk: namespace authorization still uses existing server-side `canWriteNamespace`; caller metadata is not trusted for writer provenance.
- Migration/deploy risk: no DB migration is required because existing lane columns and JSONB metadata are reused; hosted service must still be deployed before Hermes relies on `memory-tools.v11`.
- Downstream client/runtime risk: mcp2cli/generated skill refresh and rtech-hermes Nagatha integration must happen after Open Brain deploy; this PR only makes the server contract available.
- Rollback/cleanup concern: rolling back removes `create_if_missing` and returns Hermes to explicit `session_start`/manual ensure behavior; pending Hermes spool entries remain a Hermes-side concern.
- Fixes made before PR: tightened thread semantics so omitted `thread_id` in a realtime scoped append means unthreaded, not "any thread".
- Known residual risk: no live Nagatha canary has run yet because that belongs after hosted Open Brain rollout and rtech-hermes#276.
- SME review-memory update: [x] not applicable because: this PR adds tested contract behavior for a new issue and did not reveal a new missed-review pattern requiring `docs/sme/` capture.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR has not been deployed to hosted Open Brain; hosted `get_contract` and Nagatha canary are downstream rollout work after merge/deploy.
- Requested review scope: correctness/security review of first-write lane creation, exact-scope conflict checks, and public contract compatibility.
- Not requested: recovery WAL, hot working set, NATS/JetStream, promotion/relegation lifecycle, hosted deploy, or Hermes runtime changes.
- Current validation: local TypeScript, full Bun test suite, Python package tests, Python ruff, Python mypy, and PR body validator pass.

## Downstream Rollout
- Applies because this changes a public Open Brain tool contract, manifest version, and runtime write behavior.
- Deferred after merge/deploy: hosted Open Brain `get_contract` must report `2026-06-28.memory-tools.v11`, mcp2cli/generated skills must refresh the append schema, and rtech-hermes#276 must consume the new first-write behavior before the Nagatha live canary.
