### PR TITLE
fix(redaction): superset parity — unlabeled high-entropy + bare 3-seg token detectors (#92)

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/policy.py
+++ b/python/openbrain-memory/src/openbrain_memory/policy.py
@@ -55,6 +55,31 @@ LABELED_LONG_SECRET_RE = (
     r"(?i)(client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)"
     r"\s*[:=]\s*[A-Za-z0-9._/+=-]{20,}"
 )
+# Superset-parity detectors ported from the rtech-hermes fork (#92) so this
+# package is a true SUPERSET of that fork's redaction and the fork can retire.
+# These catch UNLABELED high-entropy material that the labeled detectors above
+# miss (opaque bearer-less tokens, raw base64 secret bodies, session ids pasted
+# without a `key=` prefix).
+#
+# Bare 3-segment dotted token `x.y.z` -- the non-`eyJ` sibling of JWT_LIKE_RE.
+# JWTs are already caught by JWT_LIKE_RE; this covers opaque `token.a.sig`
+# shapes with no `eyJ` header.
+BARE_THREE_SEGMENT_TOKEN_RE = (
+    r"\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b"
+)
+# Unlabeled 40+ char high-entropy blob that CONTAINS at least one of `- _ + / =`.
+# ANTI-SHA GUARD: the `(?=.*[+/=_-])` lookahead is load-bearing -- it requires a
+# symbol so a benign 40-hex git SHA / content hash (which is pure `[0-9a-f]`,
+# no symbol) is NOT redacted. This is exactly why the package originally
+# narrowed to LABELED_LONG_SECRET_RE; the symbol requirement restores the fork's
+# catch-all coverage without reintroducing SHA over-redaction. The negative
+# lookbehind/lookahead pin the run to a full token boundary.
+UNLABELED_HIGH_ENTROPY_BLOB_RE = (
+    r"(?<![A-Za-z0-9+/=_-])"
+    r"(?=[A-Za-z0-9+/=_-]{40,}(?![A-Za-z0-9+/=_-]))"
+    r"(?=.*[+/=_-])"
+    r"[A-Za-z0-9+/=_-]+"
+)
 
 SECRET_PATTERNS = [
     re.compile(r"(?i)authorization\s*[:=]\s*bearer\s+[^\s,;]+"),
@@ -76,6 +101,25 @@ SECRET_PATTERNS = [
     re.compile(URL_USERINFO_CRED_RE),
     re.compile(LABELED_LONG_SECRET_RE),
 ]
+# Heuristic catch-all detectors ported from the rtech-hermes fork (#92) to make
+# redaction a true SUPERSET of that fork. They are DELIBERATELY kept OUT of
+# ``SECRET_PATTERNS`` above because ``SECRET_PATTERNS`` also drives the
+# fail-closed receipt reject gate (``agent._reject_secret_payload``). These two
+# patterns are aggressive by design (any 40+ high-entropy run with a symbol; any
+# bare dotted 3-segment token) and WILL match benign material such as a 40+ char
+# slash/dash/underscore file path (e.g. ``python/openbrain-memory/tests/...``).
+# That aggressiveness is correct for cosmetic redaction of displayed recall
+# text (redact-if-in-doubt) but wrong for a fail-closed availability gate, where
+# it would reject legitimate receipts. So ``redact_text`` applies BOTH lists;
+# the reject gate keeps using only the high-confidence ``SECRET_PATTERNS``. The
+# fork itself only ever used these for redaction, so this preserves fork parity
+# where it matters (redaction) without importing false rejections.
+HEURISTIC_REDACTION_PATTERNS = [
+    re.compile(BARE_THREE_SEGMENT_TOKEN_RE),
+    re.compile(UNLABELED_HIGH_ENTROPY_BLOB_RE),
+]
+# All patterns applied by ``redact_text`` (high-confidence + heuristic catch-all).
+REDACTION_PATTERNS = SECRET_PATTERNS + HEURISTIC_REDACTION_PATTERNS
 SENSITIVE_KEY_RE = re.compile(
     r"(?i)(token|secret|password|api[_-]?key|credential|authorization|session[_-]?id)"
 )
@@ -109,7 +153,7 @@ def idempotency_key() -> str:
 
 def redact_text(text: str) -> str:
     redacted = text
-    for pattern in SECRET_PATTERNS:
+    for pattern in REDACTION_PATTERNS:
         redacted = pattern.sub("[REDACTED]", redacted)
     return redacted
 

--- a/python/openbrain-memory/tests/test_safety.py
+++ b/python/openbrain-memory/tests/test_safety.py
@@ -212,6 +212,81 @@ def test_redaction_keeps_benign_40_character_hex_ids_visible():
     assert "[REDACTED]" not in redacted
 
 
+def test_redaction_scrubs_bare_three_segment_non_jwt_token():
+    # Non-`eyJ` opaque `token.a.sig` shape (#92 superset parity with the
+    # rtech-hermes fork). JWTs are already covered; this is the bare sibling.
+    token = token_sample(
+        "AbCdEfGhIjKlMnOpQrStUv",  # 20+ head
+        ".abcdef",  # 6+ middle
+        ".WxYzWxYzWxYzWxYzWxYzWx",  # 20+ tail
+    )
+
+    redacted = redact_text(f"opaque token {token}")
+
+    assert token not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_scrubs_unlabeled_high_entropy_blob_with_dash():
+    blob = token_sample("a" * 20, "-", "b" * 25)
+
+    redacted = redact_text(f"opaque {blob}")
+
+    assert blob not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_scrubs_unlabeled_high_entropy_blob_with_underscore():
+    blob = token_sample("a" * 20, "_", "b" * 25)
+
+    redacted = redact_text(f"opaque {blob}")
+
+    assert blob not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_scrubs_unlabeled_high_entropy_blob_with_base64_symbols():
+    blob = token_sample("a" * 20, "+/=", "b" * 25)
+
+    redacted = redact_text(f"opaque {blob}")
+
+    assert blob not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_redaction_keeps_benign_64_character_git_sha_visible():
+    # ANTI-SHA GUARD regression: a full-length content hash / git object SHA is
+    # pure hex (no `- _ + / =` symbol), so the unlabeled high-entropy detector
+    # must leave it in the clear even though it is well over 40 chars.
+    sha = token_sample(
+        "68be7d3fa4",
+        "6ec75266ea",
+        "f407a4ed91",
+        "1ac046588e",
+        "a1148136a3",
+        "2a516aca79",
+        "6120",
+    )
+    assert len(sha) == 64
+
+    redacted = redact_text(f"schema_hash {sha}")
+
+    assert sha in redacted
+    assert "[REDACTED]" not in redacted
+
+
+def test_redaction_keeps_benign_40_character_hex_sha_visible():
+    # 40-char short git SHA -- exactly the length of the high-entropy blob
+    # trigger but with no symbol, so the anti-SHA guard keeps it visible.
+    sha = token_sample("0123456789", "abcdef0123", "456789abcd", "ef01234567")
+    assert len(sha) == 40
+
+    redacted = redact_text(f"commit {sha}")
+
+    assert sha in redacted
+    assert "[REDACTED]" not in redacted
+
+
 def test_redact_value_recurses_sensitive_keys():
     value = {
         "nested": {


### PR DESCRIPTION
## Why
Makes `openbrain-memory` redaction a true **superset** of the rtech-hermes vendored fork so that fork can retire (rtech-hermes #92: "use OB, not a fork; if there are issues, fix them in OB"). The fork's B2 parity report found the package UNDER-redacts 4 classes it catches.

## What
Adds two heuristic catch-all detectors ported from the fork:
1. **Bare 3-segment non-JWT token** `x.y.z` (the non-`eyJ` sibling of JWT_LIKE_RE — opaque `token.a.sig` shapes).
2. **Unlabeled 40+ char high-entropy blob containing a symbol** (`- _ + / =`).

**Anti-SHA guard preserved:** the `(?=.*[+/=_-])` symbol-requirement lookahead is load-bearing — a pure-hex git SHA / content hash has no symbol, so it is NOT redacted. This is exactly why the package originally narrowed to `LABELED_LONG_SECRET_RE`; the symbol requirement restores the fork's catch-all coverage without reintroducing SHA over-redaction.

## ⚠️ Design decision the reviewer should scrutinize (not a defect — a deliberate layering)
`SECRET_PATTERNS` has **two** consumers in this package: `redact_text` (cosmetic redaction) AND `agent._reject_secret_payload` (a **fail-closed receipt reject gate**). The fork only ever used these patterns for redaction.

A verbatim add to `SECRET_PATTERNS` broke the reject gate: the high-entropy heuristic matches benign 40+ char slash/underscore **file paths** (a test receipt command path is exactly 40 chars), causing a valid receipt to be **falsely rejected** (`test_record_receipt_routes_to_receipt_session_event` went RED).

**Resolution:** the two heuristics live in a new `HEURISTIC_REDACTION_PATTERNS` list, and `REDACTION_PATTERNS = SECRET_PATTERNS + HEURISTIC_REDACTION_PATTERNS`. `redact_text` (and `redact_value` → `_redact_value` → `redact_text`, and the spool payload path) apply BOTH lists. The fail-closed reject gate keeps using ONLY the high-confidence `SECRET_PATTERNS`.

**The posture this creates (call it out explicitly):** an unlabeled high-entropy secret in a payload is now REDACTED in recall text but still ACCEPTED by the receipt reject gate (written to OB, redacted). This preserves fork parity (the fork redacts, has no reject gate) without importing false rejections into the availability gate. If reviewers think the reject gate SHOULD also fail-closed on these classes, that's a follow-up decision — flagged here deliberately.

## Redaction table (proven at runtime)
| Class | before | after |
|---|:---:|:---:|
| bare 3-seg non-`eyJ` token | clear (LEAK) | **REDACTED** |
| 40+ high-entropy w/ dash | clear (LEAK) | **REDACTED** |
| 40+ high-entropy w/ underscore | clear (LEAK) | **REDACTED** |
| 40+ blob w/ `+/=` base64 | clear (LEAK) | **REDACTED** |
| 40-hex git SHA (negative) | clear | **clear** (guard holds) |
| 64-hex content hash (negative) | clear | **clear** (guard holds) |
| benign 40-char file-path receipt (reject gate) | accepted | **accepted** (gate untouched) |

## Tests + gates
- 6 new tests in `test_safety.py` (4 positive classes + 2 SHA negatives). Runtime-assembled samples, no literal secrets.
- `uv run pytest` → 178 passed, 5 skipped (pre-existing live-canary skips). `ruff check` clean, `mypy` clean, new test format-clean, ggshield clean.

## Critical pass (pre-PR, done)
- `redact_value` consistency verified — delegates to `redact_text` via `_redact_value:169`, so dict/list/spool paths get the heuristics too. No inconsistency.
- Pre-existing dead-param nit at `test_safety.py:572` (`dispatch(record)` unused) is OUTSIDE this diff — out of scope, not touched.

## After this lands (rtech-hermes #92)
Re-pin the package → re-run the parity harness to `local-only = 0` → swap rtech-hermes to package-only redaction, delete the vendored fork. Still gated there on open-brain#177 + live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)