### PR TITLE
fix(logger): 1MB rolling file sink as an app config standard (#193)

### DIFF
--- a/src/logger-file.test.ts
+++ b/src/logger-file.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Black-box: the logger reads LOG_FILE / LOG_MAX_BYTES / LOG_MAX_FILES once at
+// module load, so exercise the real env wiring in a child process. Assert the
+// observable outcome: many logger.info() calls stay bounded on disk. No writes
+// escape the temp dir.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ob-logger-file-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("logger honors LOG_FILE with a size cap and rotation", async () => {
+  const logPath = join(dir, "open-brain.log");
+  const maxBytes = 32 * 1024;
+  const maxFiles = 3;
+
+  const driver = `
+    import { logger } from ${JSON.stringify(join(import.meta.dir, "logger.ts"))};
+    for (let i = 0; i < 4000; i += 1) {
+      logger.info("session-event", { i, blob: "y".repeat(60) });
+    }
+  `;
+
+  const proc = Bun.spawn(["bun", "run", "-"], {
+    stdin: new TextEncoder().encode(driver),
+    stdout: "ignore",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      LOG_FILE: logPath,
+      LOG_MAX_BYTES: String(maxBytes),
+      LOG_MAX_FILES: String(maxFiles),
+      LOG_LEVEL: "info",
+    },
+  });
+  const code = await proc.exited;
+  const stderr = await new Response(proc.stderr).text();
+  expect(code).toBe(0);
+  // No crash noise from the logger path.
+  expect(stderr).not.toContain("Error");
+
+  const files = readdirSync(dir).filter(
+    (n) => n === "open-brain.log" || n.startsWith("open-brain.log."),
+  );
+  // Active + at most maxFiles rotated.
+  expect(files.length).toBeGreaterThan(1); // proves rotation actually happened
+  expect(files.length).toBeLessThanOrEqual(maxFiles + 1);
+
+  for (const name of files) {
+    const size = statSync(join(dir, name)).size;
+    expect(size).toBeLessThanOrEqual(maxBytes + 1024);
+  }
+});
+
+test("logger without LOG_FILE writes no log files", async () => {
+  const driver = `
+    import { logger } from ${JSON.stringify(join(import.meta.dir, "logger.ts"))};
+    logger.info("no-file-sink", { ok: true });
+  `;
+  const proc = Bun.spawn(["bun", "run", "-"], {
+    stdin: new TextEncoder().encode(driver),
+    stdout: "ignore",
+    stderr: "ignore",
+    env: { ...process.env, LOG_FILE: "", LOG_LEVEL: "info" },
+  });
+  await proc.exited;
+  // Nothing was created in the temp dir.
+  expect(readdirSync(dir)).toEqual([]);
+});

--- a/src/logger-file.test.ts
+++ b/src/logger-file.test.ts
@@ -107,6 +107,29 @@ test("two workers sharing one configured LOG_FILE get divergent per-worker files
   }
 });
 
+test("LOG_MAX_BYTES=0 falls back to the 1MB default instead of a zero cap", async () => {
+  // A zero-byte cap is meaningless; it must fall back to the default rather
+  // than silently becoming something else deeper in the sink. These writes
+  // stay under the 1MB default, so exactly one file and no rotation.
+  const logPath = join(dir, "open-brain.log");
+  const proc = spawnLogger(
+    {
+      LOG_FILE: logPath,
+      LOG_MAX_BYTES: "0",
+      LOG_MAX_FILES: "3",
+      OPEN_BRAIN_WORKER_NAME: "",
+    },
+    loggerDriver(4000, 60),
+  );
+  expect(await proc.exited).toBe(0);
+
+  const files = readdirSync(dir);
+  expect(files).toEqual(["open-brain.log"]);
+  const size = statSync(logPath).size;
+  expect(size).toBeGreaterThan(100_000); // everything landed in one file
+  expect(size).toBeLessThanOrEqual(1_000_000); // still under the default cap
+});
+
 test("logger without LOG_FILE writes no log files", async () => {
   const proc = spawnLogger({ LOG_FILE: "" }, loggerDriver(1, 10));
   await proc.exited;

--- a/src/logger-file.test.ts
+++ b/src/logger-file.test.ts
@@ -1,12 +1,13 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { deriveWorkerLogPath } from "./logger.ts";
 
-// Black-box: the logger reads LOG_FILE / LOG_MAX_BYTES / LOG_MAX_FILES once at
-// module load, so exercise the real env wiring in a child process. Assert the
-// observable outcome: many logger.info() calls stay bounded on disk. No writes
-// escape the temp dir.
+// Black-box: the logger reads LOG_FILE / LOG_MAX_BYTES / LOG_MAX_FILES /
+// OPEN_BRAIN_WORKER_NAME once at module load, so exercise the real env wiring
+// in child processes. Assert only observable outcomes: files on disk stay
+// bounded and per-worker. No writes escape the temp dir.
 
 let dir: string;
 
@@ -15,33 +16,41 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
+  if (dir) rmSync(dir, { recursive: true, force: true });
 });
+
+function loggerDriver(lines: number, blob: number): string {
+  return `
+    import { logger } from ${JSON.stringify(join(import.meta.dir, "logger.ts"))};
+    for (let i = 0; i < ${lines}; i += 1) {
+      logger.info("session-event", { i, blob: "y".repeat(${blob}) });
+    }
+  `;
+}
+
+function spawnLogger(env: Record<string, string>, driver: string) {
+  return Bun.spawn(["bun", "run", "-"], {
+    stdin: new TextEncoder().encode(driver),
+    stdout: "ignore",
+    stderr: "pipe",
+    env: { ...process.env, LOG_LEVEL: "info", ...env },
+  });
+}
 
 test("logger honors LOG_FILE with a size cap and rotation", async () => {
   const logPath = join(dir, "open-brain.log");
   const maxBytes = 32 * 1024;
   const maxFiles = 3;
 
-  const driver = `
-    import { logger } from ${JSON.stringify(join(import.meta.dir, "logger.ts"))};
-    for (let i = 0; i < 4000; i += 1) {
-      logger.info("session-event", { i, blob: "y".repeat(60) });
-    }
-  `;
-
-  const proc = Bun.spawn(["bun", "run", "-"], {
-    stdin: new TextEncoder().encode(driver),
-    stdout: "ignore",
-    stderr: "pipe",
-    env: {
-      ...process.env,
+  const proc = spawnLogger(
+    {
       LOG_FILE: logPath,
       LOG_MAX_BYTES: String(maxBytes),
       LOG_MAX_FILES: String(maxFiles),
-      LOG_LEVEL: "info",
+      OPEN_BRAIN_WORKER_NAME: "",
     },
-  });
+    loggerDriver(4000, 60),
+  );
   const code = await proc.exited;
   const stderr = await new Response(proc.stderr).text();
   expect(code).toBe(0);
@@ -61,18 +70,69 @@ test("logger honors LOG_FILE with a size cap and rotation", async () => {
   }
 });
 
+test("two workers sharing one configured LOG_FILE get divergent per-worker files", async () => {
+  // Regression for the multi-worker race: run-two-worker.ts spawns children
+  // that inherit the same LOG_FILE but each gets a distinct
+  // OPEN_BRAIN_WORKER_NAME. The logger must derive divergent effective paths
+  // so the workers never share an active file or rotation chain.
+  const logPath = join(dir, "open-brain.log");
+  const maxBytes = 16 * 1024;
+
+  const workers = ["open-brain-worker-1", "open-brain-worker-2"];
+  const procs = workers.map((name) =>
+    spawnLogger(
+      {
+        LOG_FILE: logPath,
+        LOG_MAX_BYTES: String(maxBytes),
+        LOG_MAX_FILES: "2",
+        OPEN_BRAIN_WORKER_NAME: name,
+      },
+      loggerDriver(2000, 60),
+    ),
+  );
+  const codes = await Promise.all(procs.map((p) => p.exited));
+  expect(codes).toEqual([0, 0]);
+
+  const files = readdirSync(dir);
+  // The shared configured path itself is never written.
+  expect(files).not.toContain("open-brain.log");
+  // Each worker has its own active file and rotation chain.
+  for (const name of workers) {
+    const mine = files.filter((f) => f.startsWith(`open-brain.${name}.log`));
+    expect(mine.length).toBeGreaterThan(1); // rotated at least once
+    expect(mine).toContain(`open-brain.${name}.log`);
+    for (const f of mine) {
+      expect(statSync(join(dir, f)).size).toBeLessThanOrEqual(maxBytes + 1024);
+    }
+  }
+});
+
 test("logger without LOG_FILE writes no log files", async () => {
-  const driver = `
-    import { logger } from ${JSON.stringify(join(import.meta.dir, "logger.ts"))};
-    logger.info("no-file-sink", { ok: true });
-  `;
-  const proc = Bun.spawn(["bun", "run", "-"], {
-    stdin: new TextEncoder().encode(driver),
-    stdout: "ignore",
-    stderr: "ignore",
-    env: { ...process.env, LOG_FILE: "", LOG_LEVEL: "info" },
-  });
+  const proc = spawnLogger({ LOG_FILE: "" }, loggerDriver(1, 10));
   await proc.exited;
   // Nothing was created in the temp dir.
   expect(readdirSync(dir)).toEqual([]);
+});
+
+test("deriveWorkerLogPath diverges per worker and never escapes the directory", () => {
+  const base = "/var/log/open-brain.log";
+  const one = deriveWorkerLogPath(base, "open-brain-worker-1");
+  const two = deriveWorkerLogPath(base, "open-brain-worker-2");
+  expect(one).toBe("/var/log/open-brain.open-brain-worker-1.log");
+  expect(two).toBe("/var/log/open-brain.open-brain-worker-2.log");
+  expect(one).not.toBe(two);
+
+  // No worker name (or blank) leaves the configured path untouched.
+  expect(deriveWorkerLogPath(base, undefined)).toBe(base);
+  expect(deriveWorkerLogPath(base, "  ")).toBe(base);
+
+  // Extension-less paths get a plain suffix.
+  expect(deriveWorkerLogPath("/var/log/obrain", "w1")).toBe(
+    "/var/log/obrain.w1",
+  );
+
+  // Path-traversal characters in a worker name cannot change the directory.
+  const hostile = deriveWorkerLogPath(base, "../../etc/passwd");
+  expect(hostile.startsWith("/var/log/")).toBe(true);
+  expect(hostile).not.toContain("/etc/");
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -22,9 +22,28 @@ const MIN_LEVEL = resolveLevel();
  *   LOG_MAX_BYTES  rotate threshold in bytes (default 1_000_000 = 1MB)
  *   LOG_MAX_FILES  rotated files retained beyond the active file (default 3)
  *
- * Under multiple workers, give each worker a distinct LOG_FILE (e.g. include
- * OPEN_BRAIN_WORKER_NAME in the path) so rotation is single-writer safe.
+ * Rotation is only single-writer safe, so when OPEN_BRAIN_WORKER_NAME is set
+ * (the two-worker launcher sets a distinct name per child) the effective path
+ * is derived per worker automatically: `open-brain.log` becomes
+ * `open-brain.<worker-name>.log`. Two workers inheriting the same configured
+ * LOG_FILE therefore never share an active file or rotation chain.
  */
+export function deriveWorkerLogPath(
+  path: string,
+  workerName: string | undefined,
+): string {
+  const worker = workerName?.trim();
+  if (!worker) return path;
+  // Sanitize so the worker name can only alter the filename, never the dir.
+  const safe = worker.replace(/[^A-Za-z0-9._-]/g, "_");
+  const slash = path.lastIndexOf("/");
+  const dir = slash === -1 ? "" : path.slice(0, slash + 1);
+  const file = slash === -1 ? path : path.slice(slash + 1);
+  const dot = file.lastIndexOf(".");
+  if (dot <= 0) return `${dir}${file}.${safe}`;
+  return `${dir}${file.slice(0, dot)}.${safe}${file.slice(dot)}`;
+}
+
 function resolvePositiveInt(
   raw: string | undefined,
   fallback: number,
@@ -36,8 +55,12 @@ function resolvePositiveInt(
 }
 
 function resolveFileSink(): RotatingFileSink | undefined {
-  const path = process.env.LOG_FILE?.trim();
-  if (!path) return undefined;
+  const configured = process.env.LOG_FILE?.trim();
+  if (!configured) return undefined;
+  const path = deriveWorkerLogPath(
+    configured,
+    process.env.OPEN_BRAIN_WORKER_NAME,
+  );
   return createRotatingFileSink({
     path,
     maxBytes: resolvePositiveInt(process.env.LOG_MAX_BYTES, 1_000_000),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,13 +44,20 @@ export function deriveWorkerLogPath(
   return `${dir}${file.slice(0, dot)}.${safe}${file.slice(dot)}`;
 }
 
-function resolvePositiveInt(
+/**
+ * Parse an integer env value, falling back when below `min` or non-numeric.
+ * LOG_MAX_BYTES requires min 1 (a zero-byte cap is meaningless and would
+ * otherwise be silently coerced to the default deeper in the sink), while
+ * LOG_MAX_FILES=0 is a real setting (keep only the active file).
+ */
+function resolveBoundedInt(
   raw: string | undefined,
+  min: number,
   fallback: number,
 ): number {
   if (raw === undefined) return fallback;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  if (!Number.isFinite(parsed) || parsed < min) return fallback;
   return parsed;
 }
 
@@ -63,8 +70,8 @@ function resolveFileSink(): RotatingFileSink | undefined {
   );
   return createRotatingFileSink({
     path,
-    maxBytes: resolvePositiveInt(process.env.LOG_MAX_BYTES, 1_000_000),
-    maxFiles: resolvePositiveInt(process.env.LOG_MAX_FILES, 3),
+    maxBytes: resolveBoundedInt(process.env.LOG_MAX_BYTES, 1, 1_000_000),
+    maxFiles: resolveBoundedInt(process.env.LOG_MAX_FILES, 0, 3),
   });
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,8 @@
+import {
+  createRotatingFileSink,
+  type RotatingFileSink,
+} from "./rotating-file.ts";
+
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
 type LogLevel = keyof typeof LOG_LEVELS;
 
@@ -7,6 +12,40 @@ function resolveLevel(): LogLevel {
   return "info";
 }
 const MIN_LEVEL = resolveLevel();
+
+/**
+ * Optional rolling file sink (OB issue #193). When `LOG_FILE` is set the
+ * logger mirrors every emitted line into a size-capped rotating file so no
+ * single OB log can grow unbounded, independent of any host log tooling.
+ *
+ *   LOG_FILE       absolute path of the active log file (enables the sink)
+ *   LOG_MAX_BYTES  rotate threshold in bytes (default 1_000_000 = 1MB)
+ *   LOG_MAX_FILES  rotated files retained beyond the active file (default 3)
+ *
+ * Under multiple workers, give each worker a distinct LOG_FILE (e.g. include
+ * OPEN_BRAIN_WORKER_NAME in the path) so rotation is single-writer safe.
+ */
+function resolvePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+function resolveFileSink(): RotatingFileSink | undefined {
+  const path = process.env.LOG_FILE?.trim();
+  if (!path) return undefined;
+  return createRotatingFileSink({
+    path,
+    maxBytes: resolvePositiveInt(process.env.LOG_MAX_BYTES, 1_000_000),
+    maxFiles: resolvePositiveInt(process.env.LOG_MAX_FILES, 3),
+  });
+}
+
+const FILE_SINK = resolveFileSink();
 
 interface LogEntry {
   level: string;
@@ -29,6 +68,7 @@ function log(
     ...extra,
   };
   const output = JSON.stringify(entry);
+  FILE_SINK?.write(output);
   if (level === "error") {
     console.error(output);
   } else if (level === "warn") {

--- a/src/rotating-file.test.ts
+++ b/src/rotating-file.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
+  if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
 function rotatedFiles(basePath: string): string[] {
@@ -170,9 +170,9 @@ describe("createRotatingFileSink", () => {
     sink.write(huge);
     sink.write("small-after");
 
-    // The oversized line rotated the small line out, landing alone, and the
-    // trailing small line rotated again — so no file mixes the huge line with
-    // unrelated bulk. The active file stays small.
+    // The oversized line rotated the small line out, landed alone, and was
+    // rotated out again immediately (post-write rotation) — so no file mixes
+    // the huge line with unrelated bulk. The active file stays small.
     expect(statSync(path).size).toBeLessThanOrEqual(maxBytes + 64);
     // The huge line is still recoverable somewhere.
     const base = "app.log";
@@ -182,5 +182,30 @@ describe("createRotatingFileSink", () => {
       if (readFileSync(join(dir, name), "utf8").includes(huge)) found = true;
     }
     expect(found).toBe(true);
+  });
+
+  test("an oversized very first write does not linger as the active file", () => {
+    const path = join(dir, "app.log");
+    const maxBytes = 1024;
+    const sink = createRotatingFileSink({ path, maxBytes, maxFiles: 3 });
+
+    // First-ever write is far over the cap (regression: pre-write-only
+    // rotation skipped this because size was 0, leaving a huge active file
+    // until the next write, which may never come).
+    const huge = "F".repeat(20 * 1024); // 20x the cap
+    sink.write(huge);
+
+    // Immediately after the write — no follow-up write — the active file must
+    // not hold the oversized payload.
+    const activeSize = existsSync(path) ? statSync(path).size : 0;
+    expect(activeSize).toBeLessThanOrEqual(maxBytes);
+
+    // The oversized content was rotated aside, not lost.
+    expect(readFileSync(`${path}.1`, "utf8")).toContain(huge);
+
+    // Subsequent normal writes land in a fresh, capped active file.
+    sink.write("follow-up-line");
+    expect(readFileSync(path, "utf8")).toContain("follow-up-line");
+    expect(statSync(path).size).toBeLessThanOrEqual(maxBytes);
   });
 });

--- a/src/rotating-file.test.ts
+++ b/src/rotating-file.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRotatingFileSink } from "./rotating-file.ts";
+
+// Black-box: drive the sink through its public write() API in a throwaway temp
+// dir and assert only observable outcomes (file sizes, retained file count,
+// content survival). No test writes outside its own temp directory.
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ob-rotating-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function rotatedFiles(basePath: string): string[] {
+  const base = basePath.split("/").pop() as string;
+  return readdirSync(dir)
+    .filter((name) => name === base || name.startsWith(`${base}.`))
+    .sort();
+}
+
+describe("createRotatingFileSink", () => {
+  test("active file never exceeds the configured cap after heavy writing", () => {
+    const path = join(dir, "app.log");
+    const maxBytes = 64 * 1024; // 64KB cap
+    const sink = createRotatingFileSink({ path, maxBytes, maxFiles: 3 });
+
+    // Write well over 1MB total (>16x the cap) with varied line contents.
+    let total = 0;
+    for (let i = 0; i < 20000; i += 1) {
+      const line = `event-${i} ${"x".repeat((i % 50) + 10)} tail-${i * 7}`;
+      sink.write(line);
+      total += Buffer.byteLength(line, "utf8") + 1;
+    }
+    expect(total).toBeGreaterThan(1_000_000);
+
+    // Active file is bounded to ~cap (allow one line of slack for the write
+    // that triggers rotation on the *next* call).
+    const activeSize = statSync(path).size;
+    expect(activeSize).toBeLessThanOrEqual(maxBytes + 1024);
+  });
+
+  test("retained rotated file count never exceeds maxFiles", () => {
+    const path = join(dir, "app.log");
+    const maxFiles = 3;
+    const sink = createRotatingFileSink({
+      path,
+      maxBytes: 16 * 1024,
+      maxFiles,
+    });
+
+    for (let i = 0; i < 8000; i += 1) {
+      sink.write(`line ${i} ${"data".repeat(20)}`);
+    }
+
+    const files = rotatedFiles(path);
+    // active + at most maxFiles rotated siblings.
+    expect(files.length).toBeLessThanOrEqual(maxFiles + 1);
+    // and rotated files are exactly the allowed suffixes.
+    for (const name of files) {
+      if (name.endsWith(".log")) continue;
+      const suffix = Number.parseInt(name.split(".").pop() as string, 10);
+      expect(suffix).toBeGreaterThanOrEqual(1);
+      expect(suffix).toBeLessThanOrEqual(maxFiles);
+    }
+  });
+
+  test("no rotated file exceeds the cap", () => {
+    const path = join(dir, "app.log");
+    const maxBytes = 32 * 1024;
+    const sink = createRotatingFileSink({ path, maxBytes, maxFiles: 4 });
+
+    for (let i = 0; i < 6000; i += 1) {
+      sink.write(`payload-${i}-${"z".repeat(30)}`);
+    }
+
+    for (const name of rotatedFiles(path)) {
+      const size = statSync(join(dir, name)).size;
+      // A rotated file holds content accumulated up to just under the cap plus
+      // the single line that tipped it over.
+      expect(size).toBeLessThanOrEqual(maxBytes + 1024);
+    }
+  });
+
+  test("content survives across rotation boundaries", () => {
+    const path = join(dir, "app.log");
+    const sink = createRotatingFileSink({
+      path,
+      maxBytes: 8 * 1024,
+      maxFiles: 5,
+    });
+
+    // Unique markers spread across many rotations; the earliest ones will be
+    // pruned, but a contiguous recent window must survive intact and in order.
+    const written: string[] = [];
+    for (let i = 0; i < 3000; i += 1) {
+      const line = `marker#${i}#${"q".repeat(40)}`;
+      written.push(line);
+      sink.write(line);
+    }
+
+    // Concatenate active + rotated files in chronological order:
+    // highest suffix is oldest, .1 is newer, active is newest.
+    const base = "app.log";
+    const rotated = readdirSync(dir)
+      .filter((n) => n.startsWith(`${base}.`))
+      .sort((a, b) => {
+        const na = Number.parseInt(a.split(".").pop() as string, 10);
+        const nb = Number.parseInt(b.split(".").pop() as string, 10);
+        return nb - na; // oldest (largest suffix) first
+      });
+    const ordered = [...rotated, base];
+
+    let combined = "";
+    for (const name of ordered) {
+      const full = join(dir, name);
+      if (existsSync(full)) combined += readFileSync(full, "utf8");
+    }
+
+    const survivingLines = combined.split("\n").filter(Boolean);
+
+    // The most recent lines must be present, in order, with no corruption.
+    const recent = written.slice(-50);
+    for (const line of recent) {
+      expect(combined).toContain(line);
+    }
+    // Ordering: the last surviving line equals the last written line.
+    expect(survivingLines[survivingLines.length - 1]).toBe(
+      written[written.length - 1],
+    );
+  });
+
+  test("maxFiles=0 keeps only the active file (no rotated siblings)", () => {
+    const path = join(dir, "app.log");
+    const sink = createRotatingFileSink({
+      path,
+      maxBytes: 4 * 1024,
+      maxFiles: 0,
+    });
+
+    for (let i = 0; i < 4000; i += 1) {
+      sink.write(`x${i}-${"a".repeat(20)}`);
+    }
+
+    const files = rotatedFiles(path);
+    expect(files).toEqual(["app.log"]);
+    expect(statSync(path).size).toBeLessThanOrEqual(4 * 1024 + 1024);
+  });
+
+  test("a single oversized line is bounded to its own file", () => {
+    const path = join(dir, "app.log");
+    const maxBytes = 1024;
+    const sink = createRotatingFileSink({ path, maxBytes, maxFiles: 3 });
+
+    sink.write("small-first-line");
+    const huge = "H".repeat(10_000); // 10x the cap in one line
+    sink.write(huge);
+    sink.write("small-after");
+
+    // The oversized line rotated the small line out, landing alone, and the
+    // trailing small line rotated again — so no file mixes the huge line with
+    // unrelated bulk. The active file stays small.
+    expect(statSync(path).size).toBeLessThanOrEqual(maxBytes + 64);
+    // The huge line is still recoverable somewhere.
+    const base = "app.log";
+    let found = false;
+    for (const name of readdirSync(dir)) {
+      if (name !== base && !name.startsWith(`${base}.`)) continue;
+      if (readFileSync(join(dir, name), "utf8").includes(huge)) found = true;
+    }
+    expect(found).toBe(true);
+  });
+});

--- a/src/rotating-file.test.ts
+++ b/src/rotating-file.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -207,5 +209,56 @@ describe("createRotatingFileSink", () => {
     sink.write("follow-up-line");
     expect(readFileSync(path, "utf8")).toContain("follow-up-line");
     expect(statSync(path).size).toBeLessThanOrEqual(maxBytes);
+  });
+
+  test("a failed rotation never zeroes the counter (read-only parent dir)", () => {
+    // Regression (review-swarm reproduction): rotate() used to swallow rename
+    // failures while the caller unconditionally reset size=0. With a
+    // read-only parent dir, renames fail but appends to the existing file
+    // still succeed, so the phantom-zero counter let the active file grow
+    // unbounded and rotation was never retried once perms recovered.
+    const sub = join(dir, "locked");
+    mkdirSync(sub, { recursive: true });
+    const path = join(sub, "app.log");
+    const maxBytes = 1024;
+    const sink = createRotatingFileSink({ path, maxBytes, maxFiles: 2 });
+
+    try {
+      sink.write("a".repeat(900)); // near cap, under it
+      chmodSync(sub, 0o500); // dir read-only: rename/create fail, append works
+
+      for (let i = 0; i < 5; i += 1) {
+        sink.write(`blocked-${i}-${"b".repeat(200)}`);
+      }
+      // Rotation could not happen; the writes had to land in the active file.
+      expect(existsSync(`${path}.1`)).toBe(false);
+      expect(statSync(path).size).toBeGreaterThan(maxBytes);
+
+      chmodSync(sub, 0o700);
+
+      // The very next write must rotate immediately. Under the old
+      // phantom-zero behavior the counter sat near one line's worth, so this
+      // write would NOT rotate and the over-cap file would keep growing.
+      sink.write("after-restore");
+      expect(existsSync(`${path}.1`)).toBe(true);
+      expect(statSync(path).size).toBeLessThanOrEqual(maxBytes);
+      expect(readFileSync(path, "utf8")).toContain("after-restore");
+    } finally {
+      chmodSync(sub, 0o700); // always restore so afterEach cleanup succeeds
+    }
+  });
+
+  test("created log files are 0o600 and created dirs are 0o700", () => {
+    const sub = join(dir, "made", "deep");
+    const path = join(sub, "app.log");
+    const sink = createRotatingFileSink({
+      path,
+      maxBytes: 4 * 1024,
+      maxFiles: 2,
+    });
+    sink.write("private-line");
+
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(statSync(sub).mode & 0o777).toBe(0o700);
   });
 });

--- a/src/rotating-file.ts
+++ b/src/rotating-file.ts
@@ -1,0 +1,148 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Size-capped rolling file sink.
+ *
+ * Every deployment inherits a bounded log footprint: once the active file
+ * would exceed `maxBytes`, it is rotated to `<path>.1`, existing rotations
+ * shift up (`.1` -> `.2`, ...), and anything past `maxFiles` is pruned. The
+ * size check runs at write time so a long-running process never relies on an
+ * external cron/newsyslog/logrotate to keep the file bounded.
+ *
+ * Defaults (1MB, 3 rotated files) come from OB issue #193. They are
+ * configurable so an operator can tune retention without a code change.
+ */
+
+const DEFAULT_MAX_BYTES = 1_000_000; // 1 MB
+const DEFAULT_MAX_FILES = 3; // rotated siblings kept beyond the active file
+
+export interface RotatingFileOptions {
+  /** Absolute or relative path of the active log file. */
+  path: string;
+  /** Max bytes for the active file before rotation. Must be > 0. */
+  maxBytes?: number;
+  /** Number of rotated files to retain (e.g. .1 .. .N). Must be >= 0. */
+  maxFiles?: number;
+}
+
+export interface RotatingFileSink {
+  /** Append a single line (a trailing newline is added). */
+  write(line: string): void;
+  readonly path: string;
+  readonly maxBytes: number;
+  readonly maxFiles: number;
+}
+
+function currentSize(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Rotate `path` -> `path.1`, shifting existing `path.N` up by one and pruning
+ * everything past `maxFiles`. Best-effort: filesystem errors on individual
+ * rotation steps must never take down the writing process.
+ */
+function rotate(path: string, maxFiles: number): void {
+  if (maxFiles <= 0) {
+    // No retention: just drop the active file so it restarts empty.
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      /* best-effort */
+    }
+    return;
+  }
+
+  // Prune the oldest rotation that would fall off the end.
+  try {
+    rmSync(`${path}.${maxFiles}`, { force: true });
+  } catch {
+    /* best-effort */
+  }
+
+  // Shift .1..(maxFiles-1) up to .2..maxFiles, oldest first.
+  for (let i = maxFiles - 1; i >= 1; i -= 1) {
+    const from = `${path}.${i}`;
+    const to = `${path}.${i + 1}`;
+    if (existsSync(from)) {
+      try {
+        renameSync(from, to);
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  // Move the active file to .1.
+  if (existsSync(path)) {
+    try {
+      renameSync(path, `${path}.1`);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Create a size-capped rolling file sink. Never throws on write; logging must
+ * not be able to crash the server.
+ */
+export function createRotatingFileSink(
+  options: RotatingFileOptions,
+): RotatingFileSink {
+  const path = options.path;
+  const maxBytes =
+    options.maxBytes && options.maxBytes > 0
+      ? options.maxBytes
+      : DEFAULT_MAX_BYTES;
+  const maxFiles =
+    options.maxFiles !== undefined && options.maxFiles >= 0
+      ? options.maxFiles
+      : DEFAULT_MAX_FILES;
+
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    /* best-effort; write() below will no-op on failure */
+  }
+
+  // Track size in-process to avoid a stat() on every line, refreshing from
+  // disk lazily. Seed from the existing file so an already-large file rotates
+  // on the next write rather than growing further.
+  let size = currentSize(path);
+
+  function write(line: string): void {
+    const payload = line.endsWith("\n") ? line : `${line}\n`;
+    const bytes = Buffer.byteLength(payload, "utf8");
+
+    // Rotate before writing when this line would push us over the cap. A single
+    // oversized line still lands in a fresh file (bounded to that one line).
+    if (size > 0 && size + bytes > maxBytes) {
+      rotate(path, maxFiles);
+      size = 0;
+    }
+
+    try {
+      appendFileSync(path, payload);
+      size += bytes;
+    } catch {
+      // Re-sync from disk in case another process rotated underneath us; the
+      // next write retries. Never throw.
+      size = currentSize(path);
+    }
+  }
+
+  return { write, path, maxBytes, maxFiles };
+}

--- a/src/rotating-file.ts
+++ b/src/rotating-file.ts
@@ -53,16 +53,23 @@ function currentSize(path: string): number {
  * Rotate `path` -> `path.1`, shifting existing `path.N` up by one and pruning
  * everything past `maxFiles`. Best-effort: filesystem errors on individual
  * rotation steps must never take down the writing process.
+ *
+ * Returns whether the active file at `path` was actually cleared (renamed
+ * away, removed, or already absent), verified against the filesystem. Callers
+ * must only reset their size accounting when this returns true; on false the
+ * over-cap active file is still in place and the next write must retry.
+ * Failures shifting intermediate `.N` files do not affect the result — they
+ * can at worst overwrite an older rotation, never unbound the active file.
  */
-function rotate(path: string, maxFiles: number): void {
+function rotate(path: string, maxFiles: number): boolean {
   if (maxFiles <= 0) {
     // No retention: just drop the active file so it restarts empty.
     try {
       rmSync(path, { force: true });
     } catch {
-      /* best-effort */
+      /* best-effort; verified below */
     }
-    return;
+    return !existsSync(path);
   }
 
   // Prune the oldest rotation that would fall off the end.
@@ -85,14 +92,17 @@ function rotate(path: string, maxFiles: number): void {
     }
   }
 
-  // Move the active file to .1.
+  // Move the active file to .1. This is the step that matters for the cap:
+  // if it fails (EACCES on the parent dir, EXDEV, ENOSPC, ...) the active
+  // file is still over cap and the caller must not zero its counter.
   if (existsSync(path)) {
     try {
       renameSync(path, `${path}.1`);
     } catch {
-      /* best-effort */
+      /* best-effort; verified below */
     }
   }
+  return !existsSync(path);
 }
 
 /**
@@ -113,7 +123,8 @@ export function createRotatingFileSink(
       : DEFAULT_MAX_FILES;
 
   try {
-    mkdirSync(dirname(path), { recursive: true });
+    // Logs are app-owned files now; keep them private to the service user.
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   } catch {
     /* best-effort; write() below will no-op on failure */
   }
@@ -128,14 +139,17 @@ export function createRotatingFileSink(
     const bytes = Buffer.byteLength(payload, "utf8");
 
     // Rotate before writing when this line would push us over the cap, so a
-    // normal write never mixes into an already-full file.
+    // normal write never mixes into an already-full file. Only zero the
+    // counter when rotation verifiably cleared the active file; otherwise
+    // re-sync from disk so the next write still sees over-cap and retries
+    // (a phantom-zero counter here would let the file grow unbounded while
+    // appends keep succeeding, e.g. read-only parent dir).
     if (size > 0 && size + bytes > maxBytes) {
-      rotate(path, maxFiles);
-      size = 0;
+      size = rotate(path, maxFiles) ? 0 : currentSize(path);
     }
 
     try {
-      appendFileSync(path, payload);
+      appendFileSync(path, payload, { mode: 0o600 });
       size += bytes;
     } catch {
       // Re-sync from disk in case another process rotated underneath us; the
@@ -147,10 +161,10 @@ export function createRotatingFileSink(
     // cap (e.g. a single oversized line as the very first write), so the
     // active file never sits above maxBytes waiting for the next write. The
     // oversized content is bounded to that one rotated file and pruned like
-    // any other rotation.
+    // any other rotation. Same rule: never zero the counter on a failed
+    // rotation.
     if (size > maxBytes) {
-      rotate(path, maxFiles);
-      size = 0;
+      size = rotate(path, maxFiles) ? 0 : currentSize(path);
     }
   }
 

--- a/src/rotating-file.ts
+++ b/src/rotating-file.ts
@@ -127,8 +127,8 @@ export function createRotatingFileSink(
     const payload = line.endsWith("\n") ? line : `${line}\n`;
     const bytes = Buffer.byteLength(payload, "utf8");
 
-    // Rotate before writing when this line would push us over the cap. A single
-    // oversized line still lands in a fresh file (bounded to that one line).
+    // Rotate before writing when this line would push us over the cap, so a
+    // normal write never mixes into an already-full file.
     if (size > 0 && size + bytes > maxBytes) {
       rotate(path, maxFiles);
       size = 0;
@@ -141,6 +141,16 @@ export function createRotatingFileSink(
       // Re-sync from disk in case another process rotated underneath us; the
       // next write retries. Never throw.
       size = currentSize(path);
+    }
+
+    // Rotate immediately after any write that leaves the active file over the
+    // cap (e.g. a single oversized line as the very first write), so the
+    // active file never sits above maxBytes waiting for the next write. The
+    // oversized content is bounded to that one rotated file and pruned like
+    // any other rotation.
+    if (size > maxBytes) {
+      rotate(path, maxFiles);
+      size = 0;
     }
   }
 


### PR DESCRIPTION
Refs #193

This PR builds the capability but does NOT by itself bound the actual #193
file: `console.*` still writes stdout unconditionally and launchd's
`StandardOutPath` owns `/opt/homebrew/var/log/open-brain.log`, so #193 closes
only after the deploy-gated core01 plist/env step below is applied and
verified live.

## What & why

OB log files grew unbounded. The app only writes structured JSON to
stdout/stderr via the shared logger (`src/logger.ts` -> `console.*`); on core01
the launchd service `com.rico.open-brain` redirects that stream via
`StandardOutPath` to a single `/opt/homebrew/var/log/open-brain.log`, which had
no size cap (16MB and growing per the issue). launchd owns the file — the app
just writes stdout. Host newsyslog/logrotate was explicitly ruled out; the cap
must be a built-in app config standard every deployment inherits.

## Change (scoped to logging)

- `src/rotating-file.ts` — reusable size-capped rolling file sink. Rotates the
  active file to `.1` (shifting `.1->.2...`, pruning past `maxFiles`) when the
  next line would exceed `maxBytes`, and rotates again immediately after any
  write that leaves the active file over the cap (so a single oversized line —
  even as the very first write — never lingers as an over-cap active file).
  `rotate()` reports whether the active file was verifiably cleared; the size
  counter is only zeroed on verified rotation, otherwise it re-syncs from disk
  so failed rotations (read-only dir, EXDEV, ENOSPC) are retried on the next
  write instead of silently unbounding the file. Files are created `0o600`,
  directories `0o700`. Size is checked at write time (no cron), and every
  write is best-effort — logging can never throw or crash the server.
- `src/logger.ts` — when `LOG_FILE` is set, mirror every emitted line into the
  rotating sink (console output unchanged). When `OPEN_BRAIN_WORKER_NAME` is
  set (the two-worker launcher sets a distinct name per child), the effective
  path is derived per worker automatically (`open-brain.log` ->
  `open-brain.<worker>.log`, name sanitized so it cannot change the directory),
  so workers inheriting one configured `LOG_FILE` never share an active file or
  rotation chain. New env, with issue defaults:
  - `LOG_FILE` — active log path (enables the sink; unset = today's behavior)
  - `LOG_MAX_BYTES` — rotate threshold, default `1_000_000` (1MB); values < 1
    fall back to the default
  - `LOG_MAX_FILES` — rotated files retained, default `3`; `0` keeps only the
    active file

Because all OB code and sibling processes (legacy-promoter, backup) log through
this one shared logger, they all inherit the cap.

## Tests (functional, black-box)

`src/rotating-file.test.ts` and `src/logger-file.test.ts` — all writes confined
to `mkdtemp` temp dirs, asserting observable outcomes only: write >1MB through
the sink and through the real `logger.info` (child processes for env wiring);
active and rotated files stay `<= cap`; retained count `<= maxFiles`
(`maxFiles=0` keeps only the active file); recent content survives rotation
boundaries in order; oversized lines — including as the very first write — are
rotated immediately and bounded to their own file; a failed rotation
(read-only parent dir) never zeroes the counter and rotation is retried on the
next write after recovery (fails on the old behavior, verified); created files
are `0o600` and created dirs `0o700`; `LOG_MAX_BYTES=0` falls back to the 1MB
default; two workers sharing one configured `LOG_FILE` get divergent
per-worker files; `deriveWorkerLogPath` unit coverage incl. path-traversal
safety; no `LOG_FILE` ⇒ no files created. Full suite: `bunx tsc --noEmit`
clean, `bun test` 976 pass / 0 fail.

## Review fix rounds

Cross-model review (Codex gpt-5.5):
- P2-1: shared-LOG_FILE multi-worker race — fixed in code via automatic
  per-worker path derivation from `OPEN_BRAIN_WORKER_NAME` (not docs), with a
  two-worker regression test proving the effective paths diverge.
- P2-2: oversized first write bypassing the cap — fixed via post-write
  rotation, with a first-write-over-cap regression test.
- P3: test cleanup `rmSync` guarded with `if (dir)`; unused `describe` import
  removed.

Review swarm:
- P2: rotation-failure counter desync — `rotate()` now returns verified
  success and callers never zero the counter on failure (re-sync from disk,
  retry next write). Regression test reproduces the reviewer scenario
  (chmod 0500 parent dir) and fails on the old behavior.
- P3: log files created `0o600`, dirs `0o700` (mode-bits asserted in test).
- P3: `LOG_MAX_BYTES` values < 1 rejected at parse (fall back to default) so
  the zero-cap case is intentional in one place; `LOG_MAX_FILES=0` kept.
- P3: issue linkage changed from Closes to Refs (see top note) — the launchd
  `StandardOutPath` file is only bounded after the deploy-gated plist/env step
  is verified live.

## Deployment notes (documented — NOT executed anywhere host-level)

The macOS CI runner is core01 (production); nothing host-level was run here.
To activate on core01 and actually close #193, an operator must, at deploy
time:

1. Set `LOG_FILE=/opt/homebrew/var/log/open-brain.log` (and optionally
   `LOG_MAX_BYTES` / `LOG_MAX_FILES`) in `/Users/rico/.config/open-brain/env`.
   Under the two-worker launcher each worker automatically writes
   `open-brain.<worker-name>.log`; no per-worker env is needed.
2. Edit the launchd plist `com.rico.open-brain`: stop redirecting
   `StandardOutPath` to the same base path the app now owns via `LOG_FILE`
   (point it elsewhere or keep stdout minimal) to avoid double-writing.
   Keep `StandardErrorPath` for crash/bootstrap output.
3. `launchctl kickstart -k system/com.rico.open-brain` to pick up env/plist.
4. Verify live per the issue acceptance: watch the derived log files stay
   <= 1MB with <= 3 rotated siblings, then close #193.

No DB migration. No MCP tool/schema/transport/Python-client change, so
`docs/downstream-rollout.md` does not apply (internal logging config only).

## Critical Self-Review

- Highest-risk behavior: Silent cap bypass was the top risk in two forms — the multi-worker rotation race (now prevented in code: per-worker path derivation from `OPEN_BRAIN_WORKER_NAME`, proven by a two-child regression test) and the rotation-failure counter desync (now prevented: counter only zeroed on filesystem-verified rotation, proven by a read-only-dir regression test that fails on the old behavior).
- Assumptions that could be wrong: That launchd owns the 16MB file via stdout redirection — verified: logger only calls `console.*`, no plist in repo, deploy script relies on server-side `StandardOutPath`. That the launcher always sets distinct `OPEN_BRAIN_WORKER_NAME` values — verified at `scripts/run-two-worker.ts`. That `existsSync` after a rename attempt is a sufficient success check — it verifies the active path was cleared, which is exactly the invariant the counter depends on.
- Missing/weak tests: No test for two processes writing the exact same effective path concurrently (unreachable through the launcher, possible via operator misconfiguration); no ENOSPC/EXDEV simulation (the read-only-dir test covers the same failure edge — rename fails while append succeeds); byte-for-byte survival across pruned rotations is not asserted (old data is discarded by design).
- Security/permission risk: Log files are now created `0o600` and directories `0o700` (asserted in test) instead of umask-default world-readable; the worker-name path suffix is sanitized with a traversal test proving it cannot change the directory; no secrets are added (payload is the same JSON already emitted).
- Migration/deploy risk: No schema change; if `LOG_FILE` is unset behavior is identical to today (pure opt-in), so the code ships safely ahead of the plist change. During a persistent rotation-failure window (e.g. dir perms broken) the active file can exceed the cap — writes must land somewhere and log loss was judged worse — but it now rotates on the first write after recovery. Pre-existing log files keep their old modes; only newly created files get `0o600`.
- Downstream client/runtime risk: None — no client-facing, MCP, transport, or protocol surface is touched.
- Rollback/cleanup concern: Revert the commit or unset `LOG_FILE`; rotated `.1..N` files remain on disk and can be removed manually, and are bounded by design.
- Fixes made before PR: Corrected an under-sized test loop (~285KB) so the suite genuinely writes >1MB; cross-model round: per-worker path derivation, post-write rotation, guarded test cleanup; swarm round: verified-rotation counter fix (old behavior empirically fails the new test), `0o600`/`0o700` modes, bounded env parse, and Closes->Refs linkage honesty.
- Known residual risk: The actual #193 file stays unbounded until the deploy-gated core01 plist/env step is applied and verified live (why this is Refs, not Closes); an operator-forced identical worker name across processes can still recreate the shared-path race; during a sustained rotation-failure window the active file exceeds the cap until the filesystem recovers.
- SME review-memory update: [x] not applicable because: no new cross-cutting review pattern surfaced — this is a scoped, additive logging config change with functional tests, not a security/isolation predicate or contract fix that the SME lanes track.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: live 1.21 verification is a host-level deploy step held pending explicit approval per the no-live-server constraint; no live OB smoke can run from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)