### PR TITLE
ci(#165): ephemeral pgvector DB-integration job with anti-skip guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ env:
 jobs:
   check:
     runs-on: [self-hosted, Linux, rodaddy]
+    # Self-hosted runner: never execute untrusted fork code. Run on all pushes
+    # and on same-repo PRs only; fork PRs skip (a maintainer re-pushes the
+    # branch to this repo to test).
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DB_HOST: localhost
       DB_PORT: 5432
@@ -58,9 +62,19 @@ jobs:
   # Docker, which the macOS/core01 production runner must not run.
   db-integration:
     runs-on: [self-hosted, Linux, rodaddy]
+    # Docker-capable self-hosted runner: never execute untrusted fork code.
+    # Run on all pushes and on same-repo PRs only; fork PRs skip (a maintainer
+    # re-pushes the branch to this repo to test). `push` keeps this job alive
+    # on main so `deploy` (which needs it) still runs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     services:
       postgres:
-        image: pgvector/pgvector:pg18
+        # Digest-pinned: this job gates deploy, so a mutable tag must not be
+        # able to change under us. Digest below is pgvector/pgvector:pg18
+        # (multi-arch index) as of 2026-07-05. To bump: run
+        #   docker buildx imagetools inspect pgvector/pgvector:pg18
+        # and replace the sha256 with the new index digest.
+        image: pgvector/pgvector:pg18@sha256:212765b63c1462883de295c4c415edcd22191b8d8d46853e86ad05d4b577a4cb
         env:
           POSTGRES_USER: ci
           # Throwaway, CI-only credential for an ephemeral container that is
@@ -153,6 +167,8 @@ jobs:
 
   python-package:
     runs-on: [self-hosted, Linux, rodaddy]
+    # Self-hosted runner: same trusted-source gate as `check`/`db-integration`.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
         working-directory: python/openbrain-memory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       DB_USER: test
       DB_PASSWORD: test
       DB_NAME: open_brain_test
+      DB_NAME_TEST: open_brain_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
       # Enable the env-gated real-Pool integration tests in CI (issue #165).
       # Without this, every `dbDescribe`-gated suite (lane_upsert, the #161
       # cursor-stall promoter tests) silently SKIPs and the SQL write paths get
@@ -44,8 +45,19 @@ jobs:
       - name: Run migrations
         run: bun run migrate
 
+      - name: Create isolated migration-test database
+        run: |
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME_TEST}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
       - name: Test
         run: bun test
+
+      - name: Drop isolated migration-test database
+        if: always()
+        run: PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
 
   # Issue #165: authoritative DB-backed integration gate.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,79 @@ jobs:
       - name: Test
         run: bun test
 
+  # Issue #165: authoritative DB-backed integration gate.
+  #
+  # The `check` job above runs against whatever Postgres happens to be reachable
+  # at localhost on the runner. This job instead stands up an EPHEMERAL,
+  # ISOLATED pgvector Postgres as a service container (its own Docker network per
+  # run — parallel CI runs cannot collide, and the container is torn down
+  # automatically when the job ends). It then MIGRATES that DB, runs the full
+  # suite, and — critically — asserts via the anti-skip guard that the
+  # `dbDescribe`/live-Postgres suites actually EXECUTED. A silent skip fails the
+  # job instead of going green with zero SQL-path coverage.
+  #
+  # Pinned to the Linux self-hosted runner because service containers require
+  # Docker, which the macOS/core01 production runner must not run.
+  db-integration:
+    runs-on: [self-hosted, Linux, rodaddy]
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: ci
+          # Throwaway, CI-only credential for an ephemeral container that is
+          # destroyed at job end. Never a real Open Brain database.
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: open_brain_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ci -d open_brain_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USER: ci
+      DB_PASSWORD: ci
+      # The dbDescribe suites write to DB_NAME; the destructive 001_init
+      # migration test uses DB_NAME_TEST. Keep them on SEPARATE databases so the
+      # migration test's DROP TABLE cannot clobber the live-Postgres suites.
+      DB_NAME: open_brain_ci
+      DB_NAME_TEST: open_brain_ci_migrations
+      OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@localhost:5432/open_brain_ci
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Create isolated migration-test database
+        run: |
+          PGPASSWORD=ci psql -h localhost -p 5432 -U ci -d open_brain_ci \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE DATABASE ${DB_NAME_TEST};"
+          PGPASSWORD=ci psql -h localhost -p 5432 -U ci -d "${DB_NAME_TEST}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+      - name: Run migrations against ephemeral Postgres
+        run: bun run migrate
+
+      - name: Test (JUnit reporter for the anti-skip guard)
+        run: >-
+          bun test
+          --reporter=junit
+          --reporter-outfile=${{ runner.temp }}/junit-db.xml
+
+      - name: Assert DB-backed integration tests actually ran (anti-skip guard)
+        run: bun run scripts/assert-db-tests-ran.ts ${{ runner.temp }}/junit-db.xml
+
   python-package:
     runs-on: [self-hosted, Linux, rodaddy]
     defaults:
@@ -74,7 +147,7 @@ jobs:
         run: uv build
 
   deploy:
-    needs: [check, python-package]
+    needs: [check, db-integration, python-package]
     runs-on: [self-hosted, macOS, core01]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     # branch to this repo to test).
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     env:
-      DB_HOST: localhost
+      DB_HOST: 127.0.0.1
       DB_PORT: 5432
       DB_USER: test
       DB_PASSWORD: test
@@ -27,7 +27,7 @@ jobs:
       # Without this, every `dbDescribe`-gated suite (lane_upsert, the #161
       # cursor-stall promoter tests) silently SKIPs and the SQL write paths get
       # zero CI coverage — the exact gap that let the #162 lane_upsert bugs ship.
-      OPENBRAIN_TEST_DATABASE_URL: postgres://test:test@localhost:5432/open_brain_test
+      OPENBRAIN_TEST_DATABASE_URL: postgres://test:test@127.0.0.1:5432/open_brain_test
     steps:
       - uses: actions/checkout@v6
 
@@ -50,7 +50,7 @@ jobs:
   # Issue #165: authoritative DB-backed integration gate.
   #
   # The `check` job above runs against whatever Postgres happens to be reachable
-  # at localhost on the runner. This job instead stands up an EPHEMERAL,
+  # at 127.0.0.1 on the runner. This job instead stands up an EPHEMERAL,
   # ISOLATED pgvector Postgres in Docker, MIGRATES it, runs the full suite, and
   # — critically — asserts via the anti-skip guard that the
   # `dbDescribe`/live-Postgres suites actually EXECUTED. A silent skip fails the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,10 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
-      DB_HOST: localhost
+      # 127.0.0.1 (not localhost): the service port is published on IPv4 only,
+      # and `localhost` can resolve to ::1, yielding "server closed the
+      # connection unexpectedly".
+      DB_HOST: 127.0.0.1
       DB_USER: ci
       DB_PASSWORD: ci
       # The dbDescribe suites write to DB_NAME; the destructive 001_init
@@ -104,10 +107,10 @@ jobs:
         env:
           PGPORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          PGPASSWORD=ci psql -h localhost -p "${PGPORT}" -U ci -d open_brain_ci \
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${PGPORT}" -U ci -d open_brain_ci \
             -v ON_ERROR_STOP=1 \
             -c "CREATE DATABASE ${DB_NAME_TEST};"
-          PGPASSWORD=ci psql -h localhost -p "${PGPORT}" -U ci -d "${DB_NAME_TEST}" \
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${PGPORT}" -U ci -d "${DB_NAME_TEST}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
@@ -119,7 +122,7 @@ jobs:
       - name: Test (JUnit reporter for the anti-skip guard)
         env:
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}
-          OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@localhost:${{ job.services.postgres.ports['5432'] }}/open_brain_ci
+          OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/open_brain_ci
         run: >-
           bun test
           --reporter=junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,11 @@ jobs:
           POSTGRES_PASSWORD: ci
           POSTGRES_DB: open_brain_ci
         ports:
-          - 5432:5432
+          # No fixed host port: the runner host already has a Postgres bound to
+          # 5432 (used by the `check` job), and parallel runs would collide.
+          # Publish to a Docker-assigned ephemeral host port and read it back via
+          # job.services.postgres.ports['5432'].
+          - 5432
         options: >-
           --health-cmd "pg_isready -U ci -d open_brain_ci"
           --health-interval 5s
@@ -76,7 +80,6 @@ jobs:
           --health-retries 20
     env:
       DB_HOST: localhost
-      DB_PORT: 5432
       DB_USER: ci
       DB_PASSWORD: ci
       # The dbDescribe suites write to DB_NAME; the destructive 001_init
@@ -84,7 +87,9 @@ jobs:
       # migration test's DROP TABLE cannot clobber the live-Postgres suites.
       DB_NAME: open_brain_ci
       DB_NAME_TEST: open_brain_ci_migrations
-      OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@localhost:5432/open_brain_ci
+      # DB_PORT / OPENBRAIN_TEST_DATABASE_URL are set per-step below because they
+      # depend on the dynamically-assigned host port, which is only resolvable in
+      # step context (job.services.*).
     steps:
       - uses: actions/checkout@v6
 
@@ -96,18 +101,25 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Create isolated migration-test database
+        env:
+          PGPORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          PGPASSWORD=ci psql -h localhost -p 5432 -U ci -d open_brain_ci \
+          PGPASSWORD=ci psql -h localhost -p "${PGPORT}" -U ci -d open_brain_ci \
             -v ON_ERROR_STOP=1 \
             -c "CREATE DATABASE ${DB_NAME_TEST};"
-          PGPASSWORD=ci psql -h localhost -p 5432 -U ci -d "${DB_NAME_TEST}" \
+          PGPASSWORD=ci psql -h localhost -p "${PGPORT}" -U ci -d "${DB_NAME_TEST}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
       - name: Run migrations against ephemeral Postgres
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: bun run migrate
 
       - name: Test (JUnit reporter for the anti-skip guard)
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
+          OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@localhost:${{ job.services.postgres.ports['5432'] }}/open_brain_ci
         run: >-
           bun test
           --reporter=junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,22 @@ jobs:
   #
   # The `check` job above runs against whatever Postgres happens to be reachable
   # at localhost on the runner. This job instead stands up an EPHEMERAL,
-  # ISOLATED pgvector Postgres as a service container (its own Docker network per
-  # run — parallel CI runs cannot collide, and the container is torn down
-  # automatically when the job ends). It then MIGRATES that DB, runs the full
-  # suite, and — critically — asserts via the anti-skip guard that the
+  # ISOLATED pgvector Postgres in Docker, MIGRATES it, runs the full suite, and
+  # — critically — asserts via the anti-skip guard that the
   # `dbDescribe`/live-Postgres suites actually EXECUTED. A silent skip fails the
   # job instead of going green with zero SQL-path coverage.
   #
-  # Pinned to the Linux self-hosted runner because service containers require
-  # Docker, which the macOS/core01 production runner must not run.
+  # Mechanism note: this uses an explicit `docker run --network host` on a
+  # dynamically-chosen free loopback port instead of a `services:` container.
+  # GitHub service containers rely on bridge-network port forwarding, which is
+  # BROKEN on runners ct106/ct107 (host cannot reach any bridge container;
+  # verified empirically — only ct108 forwards). Host networking bypasses the
+  # bridge entirely and works on all three runners. Isolation still holds: a
+  # unique container name + unique port per run, loopback-only listener, and an
+  # `if: always()` teardown.
+  #
+  # Pinned to the Linux self-hosted runners because this needs Docker, which
+  # the macOS/core01 production runner must not run.
   db-integration:
     runs-on: [self-hosted, Linux, rodaddy]
     # Docker-capable self-hosted runner: never execute untrusted fork code.
@@ -67,46 +74,28 @@ jobs:
     # re-pushes the branch to this repo to test). `push` keeps this job alive
     # on main so `deploy` (which needs it) still runs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    services:
-      postgres:
-        # Digest-pinned: this job gates deploy, so a mutable tag must not be
-        # able to change under us. Digest below is pgvector/pgvector:pg18
-        # (multi-arch index) as of 2026-07-05. To bump: run
-        #   docker buildx imagetools inspect pgvector/pgvector:pg18
-        # and replace the sha256 with the new index digest.
-        image: pgvector/pgvector:pg18@sha256:212765b63c1462883de295c4c415edcd22191b8d8d46853e86ad05d4b577a4cb
-        env:
-          POSTGRES_USER: ci
-          # Throwaway, CI-only credential for an ephemeral container that is
-          # destroyed at job end. Never a real Open Brain database.
-          POSTGRES_PASSWORD: ci
-          POSTGRES_DB: open_brain_ci
-        ports:
-          # No fixed host port: the runner host already has a Postgres bound to
-          # 5432 (used by the `check` job), and parallel runs would collide.
-          # Publish to a Docker-assigned ephemeral host port and read it back via
-          # job.services.postgres.ports['5432'].
-          - 5432
-        options: >-
-          --health-cmd "pg_isready -U ci -d open_brain_ci"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 20
     env:
-      # 127.0.0.1 (not localhost): the service port is published on IPv4 only,
-      # and `localhost` can resolve to ::1, yielding "server closed the
-      # connection unexpectedly".
+      # 127.0.0.1 (not localhost): the ephemeral Postgres listens on the IPv4
+      # loopback only; `localhost` can resolve to ::1.
       DB_HOST: 127.0.0.1
       DB_USER: ci
+      # Throwaway, CI-only credential for an ephemeral loopback-only container
+      # that is destroyed at job end. Never a real Open Brain database.
       DB_PASSWORD: ci
       # The dbDescribe suites write to DB_NAME; the destructive 001_init
       # migration test uses DB_NAME_TEST. Keep them on SEPARATE databases so the
       # migration test's DROP TABLE cannot clobber the live-Postgres suites.
       DB_NAME: open_brain_ci
       DB_NAME_TEST: open_brain_ci_migrations
-      # DB_PORT / OPENBRAIN_TEST_DATABASE_URL are set per-step below because they
-      # depend on the dynamically-assigned host port, which is only resolvable in
-      # step context (job.services.*).
+      OB_CI_PG_CONTAINER: obci-pg-${{ github.run_id }}-${{ github.run_attempt }}
+      # Digest-pinned image: this job gates deploy, so a mutable tag must not
+      # be able to change under us. Digest is pgvector/pgvector:pg18
+      # (multi-arch index) as of 2026-07-05. To bump: run
+      #   docker buildx imagetools inspect pgvector/pgvector:pg18
+      # and replace the sha256 with the new index digest.
+      OB_CI_PG_IMAGE: pgvector/pgvector:pg18@sha256:212765b63c1462883de295c4c415edcd22191b8d8d46853e86ad05d4b577a4cb
+      # DB_PORT is chosen at runtime (free loopback port) and exported via
+      # GITHUB_ENV by the start step below.
     steps:
       - uses: actions/checkout@v6
 
@@ -117,46 +106,63 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Wait for Postgres to accept real TCP connections
-        env:
-          PGPORT: ${{ job.services.postgres.ports['5432'] }}
-        # The service health-check can report "healthy" against the pg image's
-        # transient initdb server before the final server is listening on the
-        # published TCP port (symptom: "server closed the connection
-        # unexpectedly"). Poll a real query from the runner host before use.
+      - name: Start ephemeral pgvector Postgres (host network, loopback only)
         run: |
+          started=no
+          for _attempt in 1 2 3 4 5; do
+            PORT="$(shuf -i 20000-60000 -n 1)"
+            if ss -ltn "( sport = :${PORT} )" | grep -q LISTEN; then
+              echo "port ${PORT} busy, retrying..."
+              continue
+            fi
+            echo "starting ${OB_CI_PG_CONTAINER} on 127.0.0.1:${PORT}"
+            if docker run -d --name "${OB_CI_PG_CONTAINER}" \
+                --network host \
+                -e POSTGRES_USER=ci \
+                -e POSTGRES_PASSWORD=ci \
+                -e POSTGRES_DB=open_brain_ci \
+                "${OB_CI_PG_IMAGE}" \
+                -c "port=${PORT}" -c "listen_addresses=127.0.0.1"; then
+              started=yes
+              break
+            fi
+            docker rm -f "${OB_CI_PG_CONTAINER}" >/dev/null 2>&1 || true
+          done
+          if [ "${started}" != "yes" ]; then
+            echo "could not start ephemeral Postgres container" >&2
+            exit 1
+          fi
+          # Wait for a REAL host-side connection, not just in-container
+          # readiness: the pg image runs a transient initdb server first.
           for i in $(seq 1 30); do
-            if PGPASSWORD=ci psql -h 127.0.0.1 -p "${PGPORT}" -U ci \
+            if PGPASSWORD=ci psql -h 127.0.0.1 -p "${PORT}" -U ci \
                 -d open_brain_ci -tc "SELECT 1;" >/dev/null 2>&1; then
-              echo "Postgres reachable on 127.0.0.1:${PGPORT}"
+              echo "Postgres reachable on 127.0.0.1:${PORT}"
+              echo "DB_PORT=${PORT}" >> "${GITHUB_ENV}"
               exit 0
             fi
             echo "waiting for Postgres (attempt ${i})..."
             sleep 2
           done
-          echo "Postgres did not become reachable on 127.0.0.1:${PGPORT}" >&2
+          echo "Postgres did not become reachable on 127.0.0.1:${PORT}" >&2
+          docker logs "${OB_CI_PG_CONTAINER}" 2>&1 | tail -20 || true
           exit 1
 
       - name: Create isolated migration-test database
-        env:
-          PGPORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          PGPASSWORD=ci psql -h 127.0.0.1 -p "${PGPORT}" -U ci -d open_brain_ci \
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d open_brain_ci \
             -v ON_ERROR_STOP=1 \
             -c "CREATE DATABASE ${DB_NAME_TEST};"
-          PGPASSWORD=ci psql -h 127.0.0.1 -p "${PGPORT}" -U ci -d "${DB_NAME_TEST}" \
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d "${DB_NAME_TEST}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
       - name: Run migrations against ephemeral Postgres
-        env:
-          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: bun run migrate
 
       - name: Test (JUnit reporter for the anti-skip guard)
         env:
-          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
-          OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/open_brain_ci
+          OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@127.0.0.1:${{ env.DB_PORT }}/open_brain_ci
         run: >-
           bun test
           --reporter=junit
@@ -164,6 +170,10 @@ jobs:
 
       - name: Assert DB-backed integration tests actually ran (anti-skip guard)
         run: bun run scripts/assert-db-tests-ran.ts ${{ runner.temp }}/junit-db.xml
+
+      - name: Tear down ephemeral Postgres
+        if: always()
+        run: docker rm -f "${OB_CI_PG_CONTAINER}" >/dev/null 2>&1 || true
 
   python-package:
     runs-on: [self-hosted, Linux, rodaddy]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,26 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Wait for Postgres to accept real TCP connections
+        env:
+          PGPORT: ${{ job.services.postgres.ports['5432'] }}
+        # The service health-check can report "healthy" against the pg image's
+        # transient initdb server before the final server is listening on the
+        # published TCP port (symptom: "server closed the connection
+        # unexpectedly"). Poll a real query from the runner host before use.
+        run: |
+          for i in $(seq 1 30); do
+            if PGPASSWORD=ci psql -h 127.0.0.1 -p "${PGPORT}" -U ci \
+                -d open_brain_ci -tc "SELECT 1;" >/dev/null 2>&1; then
+              echo "Postgres reachable on 127.0.0.1:${PGPORT}"
+              exit 0
+            fi
+            echo "waiting for Postgres (attempt ${i})..."
+            sleep 2
+          done
+          echo "Postgres did not become reachable on 127.0.0.1:${PGPORT}" >&2
+          exit 1
+
       - name: Create isolated migration-test database
         env:
           PGPORT: ${{ job.services.postgres.ports['5432'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,12 +161,11 @@ jobs:
         run: bun run migrate
 
       - name: Test (JUnit reporter for the anti-skip guard)
-        env:
-          OPENBRAIN_TEST_DATABASE_URL: postgres://ci:ci@127.0.0.1:${{ env.DB_PORT }}/open_brain_ci
-        run: >-
-          bun test
-          --reporter=junit
-          --reporter-outfile=${{ runner.temp }}/junit-db.xml
+        run: |
+          export OPENBRAIN_TEST_DATABASE_URL="postgres://ci:ci@127.0.0.1:${DB_PORT}/open_brain_ci"
+          bun test \
+            --reporter=junit \
+            --reporter-outfile=${{ runner.temp }}/junit-db.xml
 
       - name: Assert DB-backed integration tests actually ran (anti-skip guard)
         run: bun run scripts/assert-db-tests-ran.ts ${{ runner.temp }}/junit-db.xml

--- a/scripts/assert-db-tests-ran.test.ts
+++ b/scripts/assert-db-tests-ran.test.ts
@@ -159,4 +159,35 @@ describe("assert-db-tests-ran anti-skip guard", () => {
       ),
     ).toBe(true);
   });
+
+  it("fails when one required suite has no executed testcases but the global floor is met", () => {
+    const skippedName = "lane_upsert (live Postgres)";
+    const extraName = "runSharedPromoter cursor-stall fix (live Postgres)";
+    const suites = REQUIRED_SUITES.map((s) => {
+      if (s.name === skippedName) {
+        return suiteXml(s.name, {
+          tests: s.minTests,
+          testcases: Array.from(
+            { length: s.minTests },
+            (_, i) =>
+              `<testcase name="case ${i}" classname="${s.name}"><skipped /></testcase>`,
+          ).join("\n"),
+        });
+      }
+      if (s.name === extraName) {
+        return suiteXml(s.name, { tests: s.minTests + 2 });
+      }
+      return suiteXml(s.name, { tests: s.minTests });
+    }).join("\n");
+
+    const result = evaluateJunit(wrap(suites));
+    expect(result.executedLiveTestcases).toBe(17);
+    expect(
+      result.errors.some((e) =>
+        e.includes(
+          `"${skippedName}" executed 0 non-skipped live-Postgres testcases`,
+        ),
+      ),
+    ).toBe(true);
+  });
 });

--- a/scripts/assert-db-tests-ran.test.ts
+++ b/scripts/assert-db-tests-ran.test.ts
@@ -1,0 +1,162 @@
+// Tests for the issue #165 anti-skip guard (scripts/assert-db-tests-ran.ts).
+// Synthetic JUnit fixtures cover the four regressions the guard must catch:
+// silent skip, missing suite, failures, and — per the cross-model review —
+// suites/testcases reporting errors="1" / <error> children, which the original
+// guard false-passed.
+import { describe, it, expect } from "bun:test";
+import { evaluateJunit, REQUIRED_SUITES } from "./assert-db-tests-ran.ts";
+
+function suiteXml(
+  name: string,
+  opts: {
+    tests: number;
+    failures?: number;
+    errors?: number;
+    skipped?: number;
+    testcases?: string;
+  },
+): string {
+  const { tests, failures = 0, errors = 0, skipped = 0 } = opts;
+  const cases =
+    opts.testcases ??
+    Array.from(
+      { length: tests },
+      (_, i) =>
+        `<testcase name="case ${i}" classname="${name}" time="0.01" />`,
+    ).join("\n");
+  return (
+    `<testsuite name="${name}" tests="${tests}" failures="${failures}" ` +
+    `errors="${errors}" skipped="${skipped}" time="0.1">\n${cases}\n</testsuite>`
+  );
+}
+
+function allSuitesGreen(): string {
+  return REQUIRED_SUITES.map((s) => suiteXml(s.name, { tests: s.minTests })).join(
+    "\n",
+  );
+}
+
+function wrap(inner: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n${inner}\n</testsuites>`;
+}
+
+describe("assert-db-tests-ran anti-skip guard", () => {
+  it("passes when every required live-Postgres suite executed cleanly", () => {
+    const result = evaluateJunit(wrap(allSuitesGreen()));
+    expect(result.errors).toEqual([]);
+    expect(result.executedLiveTestcases).toBe(17);
+  });
+
+  it("fails when a required suite is missing entirely", () => {
+    const xml = wrap(
+      REQUIRED_SUITES.filter(
+        (s) => s.name !== "lane_upsert (live Postgres)",
+      )
+        .map((s) => suiteXml(s.name, { tests: s.minTests }))
+        .join("\n"),
+    );
+    const result = evaluateJunit(xml);
+    expect(
+      result.errors.some((e) =>
+        e.includes('MISSING suite "lane_upsert (live Postgres)"'),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when a required suite reports skipped tests", () => {
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === "tier_lane (live Postgres)"
+        ? suiteXml(s.name, {
+            tests: s.minTests,
+            skipped: s.minTests,
+            testcases: Array.from(
+              { length: s.minTests },
+              (_, i) =>
+                `<testcase name="case ${i}" classname="${s.name}"><skipped /></testcase>`,
+            ).join("\n"),
+          })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) =>
+        e.includes('SKIPPED tests in "tier_lane (live Postgres)"'),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when a required suite reports failures", () => {
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === "promote_shared (live Postgres)"
+        ? suiteXml(s.name, { tests: s.minTests, failures: 1 })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) =>
+        e.includes('FAILURES in "promote_shared (live Postgres)"'),
+      ),
+    ).toBe(true);
+  });
+
+  it('fails when a required suite reports errors="1" (cross-model P3)', () => {
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === "lane_upsert (live Postgres)"
+        ? suiteXml(s.name, { tests: s.minTests, errors: 1 })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) =>
+        e.includes('ERRORS in "lane_upsert (live Postgres)": errors=1'),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when a live-Postgres testcase carries an <error> element", () => {
+    const name = "append_session_event create_if_missing (live Postgres)";
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === name
+        ? suiteXml(s.name, {
+            tests: s.minTests,
+            testcases:
+              `<testcase name="boom" classname="${name}"><error message="thrown" /></testcase>\n` +
+              Array.from(
+                { length: s.minTests - 1 },
+                (_, i) =>
+                  `<testcase name="case ${i}" classname="${name}" />`,
+              ).join("\n"),
+          })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) => e.includes("carry an <error> element")),
+    ).toBe(true);
+  });
+
+  it("fails when total executed live testcases fall below the floor", () => {
+    // All suites present, but lane_upsert testcases are all skipped while its
+    // suite attrs lie (tests counted, skipped attr zeroed) — the independent
+    // testcase-level count still catches the shortfall.
+    const name = "lane_upsert (live Postgres)";
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === name
+        ? suiteXml(s.name, {
+            tests: s.minTests,
+            testcases: Array.from(
+              { length: s.minTests },
+              (_, i) =>
+                `<testcase name="case ${i}" classname="${name}"><skipped /></testcase>`,
+            ).join("\n"),
+          })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) =>
+        e.includes("live-Postgres testcases executed; expected at least"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -1,0 +1,157 @@
+/**
+ * Anti-skip guard for DB-backed integration tests (issue #165).
+ *
+ * The `dbDescribe`/`describe.skipIf` blocks that exercise the real Postgres SQL
+ * write paths (lane_upsert, promote_shared, tier_lane, append_session_event,
+ * runSharedPromoter) are env-gated on OPENBRAIN_TEST_DATABASE_URL. If the CI
+ * Postgres is ever missing or misconfigured, those suites SILENTLY SKIP and the
+ * job still goes green with ZERO coverage of the exact SQL paths that shipped
+ * the #162 lane_upsert bugs.
+ *
+ * This guard parses the JUnit XML emitted by `bun test --reporter=junit` and
+ * FAILS the job unless every required live-Postgres suite actually executed:
+ *   - each required suite is present,
+ *   - it ran at least its expected number of testcases,
+ *   - none of its testcases were skipped,
+ *   - none of its testcases failed.
+ *
+ * Usage:
+ *   bun test --reporter=junit --reporter-outfile=junit.xml
+ *   bun run scripts/assert-db-tests-ran.ts junit.xml
+ */
+
+import { readFileSync } from "node:fs";
+
+// Required live-Postgres suites and the minimum executed testcase count each
+// must contribute. Counts are lower bounds: adding tests must not require
+// touching this guard, but deleting/skipping them will trip it.
+const REQUIRED_SUITES: ReadonlyArray<{ name: string; minTests: number }> = [
+  { name: "lane_upsert (live Postgres)", minTests: 2 },
+  { name: "promote_shared (live Postgres)", minTests: 1 },
+  { name: "tier_lane (live Postgres)", minTests: 2 },
+  {
+    name: "append_session_event create_if_missing (live Postgres)",
+    minTests: 4,
+  },
+  { name: "runSharedPromoter cursor-stall fix (live Postgres)", minTests: 8 },
+];
+
+// Absolute floor on total executed (non-skipped) live-Postgres testcases,
+// independent of the per-suite breakdown above.
+const MIN_TOTAL_LIVE_TESTCASES = 17;
+
+interface SuiteStats {
+  tests: number;
+  failures: number;
+  skipped: number;
+}
+
+function attr(tag: string, name: string): string | undefined {
+  const m = tag.match(new RegExp(`\\b${name}="([^"]*)"`));
+  return m ? m[1] : undefined;
+}
+
+function main(): void {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("usage: assert-db-tests-ran.ts <junit.xml>");
+    process.exit(2);
+  }
+
+  let xml: string;
+  try {
+    xml = readFileSync(path, "utf8");
+  } catch (err) {
+    console.error(
+      `anti-skip guard: could not read JUnit report at ${path}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    process.exit(2);
+  }
+
+  // Collect per-suite stats from <testsuite ...> opening tags.
+  const suiteStats = new Map<string, SuiteStats>();
+  for (const tag of xml.match(/<testsuite\b[^>]*>/g) ?? []) {
+    const name = attr(tag, "name");
+    if (!name || !name.includes("(live Postgres)")) continue;
+    const prev = suiteStats.get(name) ?? { tests: 0, failures: 0, skipped: 0 };
+    suiteStats.set(name, {
+      tests: prev.tests + Number(attr(tag, "tests") ?? "0"),
+      failures: prev.failures + Number(attr(tag, "failures") ?? "0"),
+      skipped: prev.skipped + Number(attr(tag, "skipped") ?? "0"),
+    });
+  }
+
+  // Count executed (non-skipped) live-Postgres testcases directly, as an
+  // independent cross-check on the suite-level attributes. A skipped testcase
+  // carries a <skipped .../> child or a skipped="true" attribute.
+  let executedLiveTestcases = 0;
+  const testcaseRe = /<testcase\b[^>]*?(\/>|>[\s\S]*?<\/testcase>)/g;
+  for (const block of xml.match(testcaseRe) ?? []) {
+    const open = block.match(/<testcase\b[^>]*>/)?.[0] ?? block;
+    const classname = attr(open, "classname") ?? "";
+    if (!classname.includes("(live Postgres)")) continue;
+    const isSkipped =
+      /<skipped\b/.test(block) || attr(open, "skipped") === "true";
+    if (!isSkipped) executedLiveTestcases += 1;
+  }
+
+  const errors: string[] = [];
+
+  for (const req of REQUIRED_SUITES) {
+    const s = suiteStats.get(req.name);
+    if (!s) {
+      errors.push(
+        `MISSING suite "${req.name}" — it did not run at all (SKIPPED or ` +
+          `never registered). The CI Postgres / OPENBRAIN_TEST_DATABASE_URL ` +
+          `is not wired correctly.`,
+      );
+      continue;
+    }
+    if (s.skipped > 0) {
+      errors.push(
+        `SKIPPED tests in "${req.name}": skipped=${s.skipped}. DB-backed ` +
+          `coverage was silently disabled.`,
+      );
+    }
+    if (s.failures > 0) {
+      errors.push(`FAILURES in "${req.name}": failures=${s.failures}.`);
+    }
+    if (s.tests < req.minTests) {
+      errors.push(
+        `"${req.name}" ran ${s.tests} tests, expected at least ` +
+          `${req.minTests}.`,
+      );
+    }
+  }
+
+  if (executedLiveTestcases < MIN_TOTAL_LIVE_TESTCASES) {
+    errors.push(
+      `Only ${executedLiveTestcases} live-Postgres testcases executed; ` +
+        `expected at least ${MIN_TOTAL_LIVE_TESTCASES}. DB-backed suites are ` +
+        `being skipped.`,
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error("anti-skip guard FAILED (issue #165):");
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error(
+      "\nThe DB-backed integration tests must RUN against a real pgvector " +
+        "Postgres in CI. A silent skip is a coverage regression, not a pass.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `anti-skip guard PASSED: ${executedLiveTestcases} live-Postgres ` +
+      `testcases executed across ${REQUIRED_SUITES.length} required suites ` +
+      `(0 skipped, 0 failed).`,
+  );
+  for (const req of REQUIRED_SUITES) {
+    const s = suiteStats.get(req.name)!;
+    console.log(`  - ${req.name}: ${s.tests} tests`);
+  }
+}
+
+main();

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -51,6 +51,7 @@ export interface SuiteStats {
 export interface GuardResult {
   errors: string[];
   executedLiveTestcases: number;
+  executedLiveTestcasesBySuite: Map<string, number>;
   suiteStats: Map<string, SuiteStats>;
 }
 
@@ -85,6 +86,7 @@ export function evaluateJunit(xml: string): GuardResult {
   // <error .../> child.
   let executedLiveTestcases = 0;
   let erroredLiveTestcases = 0;
+  const executedLiveTestcasesBySuite = new Map<string, number>();
   const testcaseRe = /<testcase\b[^>]*?(\/>|>[\s\S]*?<\/testcase>)/g;
   for (const block of xml.match(testcaseRe) ?? []) {
     const open = block.match(/<testcase\b[^>]*>/)?.[0] ?? block;
@@ -94,6 +96,10 @@ export function evaluateJunit(xml: string): GuardResult {
       /<skipped\b/.test(block) || attr(open, "skipped") === "true";
     if (isSkipped) continue;
     executedLiveTestcases += 1;
+    executedLiveTestcasesBySuite.set(
+      classname,
+      (executedLiveTestcasesBySuite.get(classname) ?? 0) + 1,
+    );
     if (/<error\b/.test(block)) erroredLiveTestcases += 1;
   }
 
@@ -127,6 +133,13 @@ export function evaluateJunit(xml: string): GuardResult {
           `${req.minTests}.`,
       );
     }
+    const executed = executedLiveTestcasesBySuite.get(req.name) ?? 0;
+    if (executed < req.minTests) {
+      errors.push(
+        `"${req.name}" executed ${executed} non-skipped live-Postgres ` +
+          `testcases, expected at least ${req.minTests}.`,
+      );
+    }
   }
 
   if (erroredLiveTestcases > 0) {
@@ -144,7 +157,12 @@ export function evaluateJunit(xml: string): GuardResult {
     );
   }
 
-  return { errors, executedLiveTestcases, suiteStats };
+  return {
+    errors,
+    executedLiveTestcases,
+    executedLiveTestcasesBySuite,
+    suiteStats,
+  };
 }
 
 function main(): void {

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -13,7 +13,7 @@
  *   - each required suite is present,
  *   - it ran at least its expected number of testcases,
  *   - none of its testcases were skipped,
- *   - none of its testcases failed.
+ *   - none of its testcases failed or errored.
  *
  * Usage:
  *   bun test --reporter=junit --reporter-outfile=junit.xml
@@ -25,25 +25,33 @@ import { readFileSync } from "node:fs";
 // Required live-Postgres suites and the minimum executed testcase count each
 // must contribute. Counts are lower bounds: adding tests must not require
 // touching this guard, but deleting/skipping them will trip it.
-const REQUIRED_SUITES: ReadonlyArray<{ name: string; minTests: number }> = [
-  { name: "lane_upsert (live Postgres)", minTests: 2 },
-  { name: "promote_shared (live Postgres)", minTests: 1 },
-  { name: "tier_lane (live Postgres)", minTests: 2 },
-  {
-    name: "append_session_event create_if_missing (live Postgres)",
-    minTests: 4,
-  },
-  { name: "runSharedPromoter cursor-stall fix (live Postgres)", minTests: 8 },
-];
+export const REQUIRED_SUITES: ReadonlyArray<{ name: string; minTests: number }> =
+  [
+    { name: "lane_upsert (live Postgres)", minTests: 2 },
+    { name: "promote_shared (live Postgres)", minTests: 1 },
+    { name: "tier_lane (live Postgres)", minTests: 2 },
+    {
+      name: "append_session_event create_if_missing (live Postgres)",
+      minTests: 4,
+    },
+    { name: "runSharedPromoter cursor-stall fix (live Postgres)", minTests: 8 },
+  ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
 // independent of the per-suite breakdown above.
-const MIN_TOTAL_LIVE_TESTCASES = 17;
+export const MIN_TOTAL_LIVE_TESTCASES = 17;
 
-interface SuiteStats {
+export interface SuiteStats {
   tests: number;
   failures: number;
+  errors: number;
   skipped: number;
+}
+
+export interface GuardResult {
+  errors: string[];
+  executedLiveTestcases: number;
+  suiteStats: Map<string, SuiteStats>;
 }
 
 function attr(tag: string, name: string): string | undefined {
@@ -51,41 +59,32 @@ function attr(tag: string, name: string): string | undefined {
   return m ? m[1] : undefined;
 }
 
-function main(): void {
-  const path = process.argv[2];
-  if (!path) {
-    console.error("usage: assert-db-tests-ran.ts <junit.xml>");
-    process.exit(2);
-  }
-
-  let xml: string;
-  try {
-    xml = readFileSync(path, "utf8");
-  } catch (err) {
-    console.error(
-      `anti-skip guard: could not read JUnit report at ${path}: ` +
-        (err instanceof Error ? err.message : String(err)),
-    );
-    process.exit(2);
-  }
-
+export function evaluateJunit(xml: string): GuardResult {
   // Collect per-suite stats from <testsuite ...> opening tags.
   const suiteStats = new Map<string, SuiteStats>();
   for (const tag of xml.match(/<testsuite\b[^>]*>/g) ?? []) {
     const name = attr(tag, "name");
     if (!name || !name.includes("(live Postgres)")) continue;
-    const prev = suiteStats.get(name) ?? { tests: 0, failures: 0, skipped: 0 };
+    const prev = suiteStats.get(name) ?? {
+      tests: 0,
+      failures: 0,
+      errors: 0,
+      skipped: 0,
+    };
     suiteStats.set(name, {
       tests: prev.tests + Number(attr(tag, "tests") ?? "0"),
       failures: prev.failures + Number(attr(tag, "failures") ?? "0"),
+      errors: prev.errors + Number(attr(tag, "errors") ?? "0"),
       skipped: prev.skipped + Number(attr(tag, "skipped") ?? "0"),
     });
   }
 
-  // Count executed (non-skipped) live-Postgres testcases directly, as an
-  // independent cross-check on the suite-level attributes. A skipped testcase
-  // carries a <skipped .../> child or a skipped="true" attribute.
+  // Inspect individual live-Postgres <testcase> blocks as an independent
+  // cross-check on the suite-level attributes. A skipped testcase carries a
+  // <skipped .../> child or skipped="true"; an errored one carries an
+  // <error .../> child.
   let executedLiveTestcases = 0;
+  let erroredLiveTestcases = 0;
   const testcaseRe = /<testcase\b[^>]*?(\/>|>[\s\S]*?<\/testcase>)/g;
   for (const block of xml.match(testcaseRe) ?? []) {
     const open = block.match(/<testcase\b[^>]*>/)?.[0] ?? block;
@@ -93,7 +92,9 @@ function main(): void {
     if (!classname.includes("(live Postgres)")) continue;
     const isSkipped =
       /<skipped\b/.test(block) || attr(open, "skipped") === "true";
-    if (!isSkipped) executedLiveTestcases += 1;
+    if (isSkipped) continue;
+    executedLiveTestcases += 1;
+    if (/<error\b/.test(block)) erroredLiveTestcases += 1;
   }
 
   const errors: string[] = [];
@@ -117,12 +118,22 @@ function main(): void {
     if (s.failures > 0) {
       errors.push(`FAILURES in "${req.name}": failures=${s.failures}.`);
     }
+    if (s.errors > 0) {
+      errors.push(`ERRORS in "${req.name}": errors=${s.errors}.`);
+    }
     if (s.tests < req.minTests) {
       errors.push(
         `"${req.name}" ran ${s.tests} tests, expected at least ` +
           `${req.minTests}.`,
       );
     }
+  }
+
+  if (erroredLiveTestcases > 0) {
+    errors.push(
+      `${erroredLiveTestcases} live-Postgres testcase(s) carry an <error> ` +
+        `element — errored tests are failures, not coverage.`,
+    );
   }
 
   if (executedLiveTestcases < MIN_TOTAL_LIVE_TESTCASES) {
@@ -133,9 +144,32 @@ function main(): void {
     );
   }
 
-  if (errors.length > 0) {
+  return { errors, executedLiveTestcases, suiteStats };
+}
+
+function main(): void {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("usage: assert-db-tests-ran.ts <junit.xml>");
+    process.exit(2);
+  }
+
+  let xml: string;
+  try {
+    xml = readFileSync(path, "utf8");
+  } catch (err) {
+    console.error(
+      `anti-skip guard: could not read JUnit report at ${path}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    process.exit(2);
+  }
+
+  const result = evaluateJunit(xml);
+
+  if (result.errors.length > 0) {
     console.error("anti-skip guard FAILED (issue #165):");
-    for (const e of errors) console.error(`  - ${e}`);
+    for (const e of result.errors) console.error(`  - ${e}`);
     console.error(
       "\nThe DB-backed integration tests must RUN against a real pgvector " +
         "Postgres in CI. A silent skip is a coverage regression, not a pass.",
@@ -144,14 +178,16 @@ function main(): void {
   }
 
   console.log(
-    `anti-skip guard PASSED: ${executedLiveTestcases} live-Postgres ` +
+    `anti-skip guard PASSED: ${result.executedLiveTestcases} live-Postgres ` +
       `testcases executed across ${REQUIRED_SUITES.length} required suites ` +
-      `(0 skipped, 0 failed).`,
+      `(0 skipped, 0 failed, 0 errored).`,
   );
   for (const req of REQUIRED_SUITES) {
-    const s = suiteStats.get(req.name)!;
+    const s = result.suiteStats.get(req.name)!;
     console.log(`  - ${req.name}: ${s.tests} tests`);
   }
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
Closes #165

## Problem

The DB-backed integration suites (`dbDescribe` / `describe.skipIf`) that exercise the real Postgres SQL write paths — `lane_upsert`, `promote_shared`, `tier_lane`, `append_session_event`, `runSharedPromoter` — are env-gated on `OPENBRAIN_TEST_DATABASE_URL`. If the CI Postgres is missing or misconfigured they **silently skip** and the job still goes green with zero coverage of the exact SQL paths that shipped the #162 `lane_upsert` bugs.

## Change

New `db-integration` job in `.github/workflows/ci.yml`:

- **Ephemeral, isolated pgvector Postgres** via explicit `docker run --network host` on a dynamically-chosen free loopback port, **digest-pinned** to `pgvector/pgvector:pg18@sha256:212765b6...` (bump procedure documented inline). Mechanism note: GitHub `services:` containers depend on bridge-network forwarding, which is **empirically broken on runners ct106/ct107** (host cannot reach bridge containers by published port or container IP; only ct108 forwards) — a service container was a 1-in-3 runner lottery. Host networking bypasses the bridge and was verified working on the previously-failing runners. Isolation holds: unique container name + unique port per run, `listen_addresses=127.0.0.1` only, `if: always()` teardown (no leftover containers verified on the runner).
- Host-side readiness poll (the pg image's transient initdb server defeats naive health checks), then `bun run migrate` and the full suite with the **JUnit reporter**.
- **Anti-skip guard** (`scripts/assert-db-tests-ran.ts`) parses the JUnit XML and **fails the job** unless every required live-Postgres suite actually executed: present, non-zero count, zero skipped, zero failed, **zero errored** (`errors` testsuite attribute and `<error>` testcase children both checked, per cross-model review). Guard core is an exported `evaluateJunit()` covered by synthetic-fixture tests (`scripts/assert-db-tests-ran.test.ts`) including the `errors="1"` false-pass case.
- **Trusted-source gate** on all self-hosted jobs (`check`, `db-integration`, `python-package`): `if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository` — fork PRs never execute on the Docker-capable self-hosted runners; pushes (incl. main) still run everything `deploy` needs.
- The destructive migration test (`001_init.test.ts`, `DROP TABLE`) runs on a **separate `DB_NAME_TEST` database** so it cannot clobber the live-Postgres suites sharing `DB_NAME`.
- `deploy` now `needs: db-integration`; the existing `check` job's steps are unchanged.

## CI proof

Latest push AND pull_request runs are green with `db-integration` executing on **ct107** (a runner where the old `services:` approach failed), guard logging: **17 live-Postgres testcases executed across 5 required suites (0 skipped, 0 failed, 0 errored)** — lane_upsert=2, promote_shared=1, tier_lane=2, append_session_event=4, runSharedPromoter=8.

## Critical Self-Review

- Highest-risk behavior: the trusted-source `if:` gate — if mis-written it could silently skip `db-integration` on same-repo PRs or on main push (breaking `deploy`); verified live that both the pull_request run (same-repo) and the push run execute and pass the job.
- Assumptions that could be wrong: that `head.repo.full_name == github.repository` is the right fork discriminator for this repo's event mix (push + pull_request only; no pull_request_target/workflow_dispatch in ci.yml); that host-network port selection (shuf 20000-60000 + ss check + 5 retries) is collision-safe enough for realistic runner parallelism; that the pinned index digest stays valid until an intentional bump.
- Missing/weak tests: guard has synthetic-fixture unit tests (pass, missing suite, skipped, failures, errors="1", <error> children, executed floor); the workflow `if:` expression and port-selection shell are exercised only by live CI runs, not unit tests.
- Security/permission risk: fork PRs can no longer execute code on the Docker-capable self-hosted runners; the ephemeral Postgres listens on 127.0.0.1 only with a throwaway CI-only credential (`ci`/`ci`) and is destroyed at job end; test URL secret-masked in logs; no secrets committed.
- Migration/deploy risk: `deploy` now also needs `db-integration`; a flaky DB job would block deploy — mitigated by cross-runner verification (mechanism now works on ct106/ct107/ct108, not just ct108), readiness poll, and the digest pin removing tag drift.
- Downstream client/runtime risk: none — CI-only change, no MCP tool/schema/transport/Python-client surface touched.
- Rollback/cleanup concern: `if: always()` teardown removes the container even on failure (verified zero leftover `obci-pg-*` containers on ct107 after the green run); a hard runner crash could orphan one container, bounded to loopback and killable by name pattern; revert = delete the job, the `if:` gates, and the two guard files.
- Fixes made before PR: isolated destructive `001_init.test.ts` onto `DB_NAME_TEST`; fixed fixed-port bind collision, IPv6 resolution, and the initdb readiness race; post-review hardening: fork gate, digest pin, guard errors="1" false-pass with regression fixtures; replaced `services:` with host-network `docker run` after proving bridge forwarding is broken on 2 of 3 runners.
- Known residual risk: `001_init.test.ts` still self-skips in CI (its re-migration hits a `trigger already exists` collision on the already-migrated DB) — pre-existing migration-schema coverage gap, follow-up issue recommended. Bridge networking on ct106/ct107 remains broken for anything else that assumes GitHub `services:` — worth an infra ticket. Fork contributors' PRs show skipped CI until a maintainer re-pushes — accepted trade-off.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: CI-only wiring; the cross-model findings are encoded directly as workflow gates and guard regression tests rather than a reviewer-lane pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in \`docs/sme/\` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: CI/test-harness change only, no live Open Brain server behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)