### PR TITLE
docs: record gh auth refresh timeout

### DIFF
--- a/goal-run.md
+++ b/goal-run.md
@@ -13,8 +13,9 @@ Updated after the 2026-07-05 PR merge batch and Project 8 sync.
     `python-package`, `validate`, GitGuardian), and `deploy` skipped.
   - Current blocker: local GitHub CLI token lacks the `workflow` OAuth scope
     required to merge a PR that changes `.github/workflows/ci.yml`.
-    In-flight repair command: `gh auth refresh -h github.com -s workflow`.
-    After authorization: re-run `gh auth status`, then
+    Latest repair attempt timed out waiting for GitHub device-flow approval.
+    Rerun `gh auth refresh -h github.com -s workflow`; after authorization,
+    re-run `gh auth status`, then
     `gh pr merge 234 --squash`.
 - Merged in this controller batch:
   - #231 merged as `c9888cc584fe68b5ff91906d56ef26c7fb40afef`;


### PR DESCRIPTION
## Summary

- update `goal-run.md` to say the latest `gh auth refresh -h github.com -s workflow` attempt timed out waiting for GitHub device-flow approval
- keep the next action explicit: rerun auth refresh, approve the device code, verify `workflow` scope, then merge #234

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed: not applicable because this is docs-only; `git diff --check` passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

## Critical Self-Review

- Highest-risk behavior: stale handoff text could make the next controller think an auth refresh is still running; fixed by recording the timeout.
- Assumptions that could be wrong: none material; #234 still needs live mergeability and auth scope recheck before merge.
- Missing/weak tests: no rendered HTML/browser check because this touches only markdown handoff text.
- Security/permission risk: no token values or secrets included; only the OAuth scope name `workflow` is referenced.
- Migration/deploy risk: none; no code, workflow, migration, or deploy files changed.
- Downstream client/runtime risk: none from docs-only status correction.
- Rollback/cleanup concern: rollback is reverting this one markdown line update.
- Fixes made before PR: replaced stale in-flight wording with timeout and rerun instructions.
- Known residual risk: #234 remains blocked until device-flow authorization succeeds.
- SME review-memory update: [x] not applicable because: docs-only status update, no review-finding pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: docs-only status update, no live server behavior changed

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- `git diff --check` passed.
- Project 8 #234/#165 Next Action was also updated with the timed-out auth attempt.
- No production deploy was performed.