### PR TITLE
feat(#204): add resolve_entry UUID resolver

### DIFF
--- a/goal-run.md
+++ b/goal-run.md
@@ -191,77 +191,82 @@ Status: verified locally and by PR checks, not merged.
 
 ### Phase 4: #177 installable package, #204 resolver, #176 structured rejection
 
-Status: PR #238 open; pre-merge-gauntlet findings addressed; waiting on live CI
-completion and explicit merge approval.
+Status: #177 is done via merged PR #238. #204 is the active local-only slice.
 
 Current worktree:
-`/Volumes/ThunderBolt/_tmp/open-brain/issue-177-openbrain-memory-package`
+`/Volumes/ThunderBolt/_tmp/open-brain/issue-204-source-type-resolver`
 
 Current branch:
-`fix/177-openbrain-memory-package` from `origin/main` at `5373c1b`.
+`feat/204-source-type-resolver` from `origin/main` at `90713f4`.
 
 Owning boundary:
-`python/openbrain-memory` package contract: installability, public API surface,
-canonical redaction policy, and package build/install proof.
+MCP/tool contract for ID-based entry resolution, with server-side auth and
+namespace predicates plus the Python client snapshot as the downstream contract
+mirror.
 
-Current findings:
+Current #204 state:
 
-- `pyproject.toml` already uses hatchling and supports `uv build`.
-- README already documents install methods, schema helpers, contract authority,
-  and canary expectations.
-- `schema.py` already implements contract DSL to JSON Schema helpers, so #177's
-  normalizer-home question is already mostly answered in package code.
-- Closed PR #232 / branch `fix/openbrain-memory-redaction-superset` is not on
-  `origin/main`; its redaction parity changes must be ported into #177.
-- `dist/` is gitignored, so package artifacts should be built and proven, not
-  committed.
-
-Next #177 checklist:
-
-1. Done: port redaction superset parity from
-   `fix/openbrain-memory-redaction-superset`.
-2. Done: add `py.typed` marker.
-3. Done: tighten README language for stable public API, SemVer/package version,
-   live contract version, and canonical redaction.
-4. Done: run Python package checks:
-   - `uv run mypy src/openbrain_memory` -> passed.
-   - `uv run ruff check src tests` -> passed.
-   - `uv run pytest -q` -> 193 passed, 5 skipped.
-   - source-tree import without installed metadata -> `0.1.1`.
-5. Done: build artifacts with `uv build`:
-   - `dist/openbrain_memory-0.1.1.tar.gz`
-   - `dist/openbrain_memory-0.1.1-py3-none-any.whl`
-6. Done: install wheel into temp venv:
-   `/Volumes/ThunderBolt/_tmp/open-brain/issue-177-wheel-smoke-6`.
-7. Done: import/API smoke from installed wheel:
-   `wheel smoke ok 0.1.1`.
-   First smoke attempt failed because the sample token was below the redaction
-   length threshold; rerun used a valid opaque token shape and passed.
-8. Done: opened PR #238:
-   https://github.com/rodaddy/open-brain/pull/238
-9. Done: ran review-swarm Phase 2 on pinned diff
-   `86d46614fb7c9914841d79d9715452235719b7a0524208536df3b4a9f4322527`.
-   Initial findings fixed:
-   - dash/underscore-bounded dotted token redaction;
-   - duplicate package version source;
-   - README redaction-superset wording.
-10. Done: fix-verification after amended head `310e955`:
-    - SME/gotcha: clean.
-    - Antagonist: found source-tree import regression from import-time
-      `importlib.metadata.version()`.
-    - Fix: `PACKAGE_VERSION` now uses installed metadata first, then falls back
-      to source `pyproject.toml`; regression test added.
-11. Done: Phase 3 cross-runtime review via local `claude -p --model opus`
-    because the GitHub `claude-review` workflow can produce false-positive
-    success around invalid-model output.
-    - Final reviewed diff SHA-256:
-      `b2d207bd380c6ad079edfa4b70cdaed192c2a6b40c15d53a81b91d85381f1d65`.
-    - Findings fixed/addressed: over-broad heuristic redaction of benign
-      identifiers, length-only dotted-token matching, slash-bearing base64
-      coverage, write-vs-display redaction boundary docs/tests, pure base62
-      false-negative docs, and 40-character heuristic floor docs.
-12. Pending: wait for final PR #238 CI on head `672b203`; do not merge without
-    explicit Rico approval.
+1. Done locally: implemented read-only `resolve_entry(id, namespace?)`.
+2. Done locally: registered the tool in `src/tools/index.ts`.
+3. Done locally: bumped the public contract to
+   `2026-07-05.memory-tools.v12` and added `resolve_entry` schema/capability
+   metadata.
+4. Done locally: updated `python/openbrain-memory` constants/help and added the
+   `OpenBrainClient.resolve_entry()` wrapper.
+5. Done locally: resolver tests cover readable found rows, admin-only archived
+   rows, non-admin archived non-disclosure, no-readable-family roles, explicit
+   unreadable namespaces, and `namespace: "all"` for global admin reads.
+6. Validation passed locally:
+   - `bun test src/tools/__tests__/resolve-entry.test.ts src/contract.test.ts`
+     -> 12 pass.
+   - `bunx tsc --noEmit` -> passed.
+   - `bun test` -> 1040 pass, 46 skip, 0 fail.
+   - `cd python/openbrain-memory && uv run pytest -q` -> 193 pass, 5 skip.
+   - `cd python/openbrain-memory && uv run mypy src/openbrain_memory` ->
+     passed.
+   - `cd python/openbrain-memory && uv run ruff check src tests` -> passed.
+   - `git diff --check` -> passed.
+7. PR #243 opened:
+   https://github.com/rodaddy/open-brain/pull/243
+8. Pre-merge-gauntlet Phase 2 initial swarm found and local fixes addressed:
+   - P2: non-admin archived UUID resolution disclosed source/namespace
+     metadata; fixed by limiting archived resolution to admin/ob-admin and
+     adding non-admin non-disclosure tests.
+   - P2: `openbrain-memory` min compatible version remained `0.1.0` after a
+     required wrapper/contract change; fixed by bumping package version and
+     manifest floor/range to `0.1.2`.
+   - P3: Python wrapper dispatch test omitted `resolve_entry`; fixed by adding
+     it to the wrapper-name dispatch regression.
+9. PR #243 fix receipt posted:
+   https://github.com/rodaddy/open-brain/pull/243#issuecomment-4888294598
+10. CI passed on amended head `ddc8bb611979fd93e28d3e40989fab163e30589e`:
+    `check`, `db-integration`, `python-package`, PR body `validate`, and
+    GitGuardian passed; `deploy` skipped as expected for local-only PR flow.
+11. Project 8 updated for #204: Status `In Review`, Validation `CI Passed`,
+    Review Gate `Fix Verification Running`, Next Action points to PR #243
+    fix-verification and no core01 deploy in this phase.
+12. Opposite-runtime Claude cross-review ran on PR #243 and found three LOW
+    observations:
+    - Promoter role resolves cross-namespace UUIDs. This is existing
+      get_entry/read-policy parity for promotion candidates and is now pinned by
+      resolver coverage.
+    - Negative responses expose `checked_sources`/`checked_tables`. This is
+      intentional contract diagnostics for the requested tool shape and does
+      not expose unreadable row metadata.
+    - Cross-table UUID collision behavior was undocumented. The resolver now
+      documents first-match `SOURCE_TABLES` order and the global UUID
+      uniqueness assumption.
+13. Focused validation after cross-review fixes:
+    - `bun test src/tools/__tests__/resolve-entry.test.ts src/contract.test.ts`
+      -> 13 pass.
+    - `cd python/openbrain-memory && uv run pytest -q tests/test_client.py tests/test_contract.py`
+      -> 69 pass.
+    - `git diff --check` -> passed.
+14. Pending: amend/push cross-review fixes, wait for current-head CI, post the
+    cross-review/fixes receipt, then merge when the gauntlet gate is clean.
+15. Deferred by current local-only instruction: downstream rollout and any
+   core01 deploy/live canary. This contract change still triggers
+   `docs/downstream-rollout.md` before issue closure/release.
 
 ---
 

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -41,11 +41,12 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-06-28.memory-tools.v11"
+CURRENT_CONTRACT_VERSION = "2026-07-05.memory-tools.v12"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",
     "get_entry",
+    "resolve_entry",
     "lane_load",
     "lane_upsert",
     "list_repo_facts",
@@ -62,6 +63,7 @@ CURRENT_TOOL_HELP: Mapping[str, str] = {
     "get_entity": "Fetch a graph entity by ID.",
     "get_contract": "Read the canonical Open Brain public contract manifest.",
     "get_entry": "Fetch one full readable memory row by table and UUID.",
+    "resolve_entry": "Resolve a UUID to its readable source type and fetch path.",
     "hydrate_entities": "Refresh missing graph entity embeddings.",
     "lane_load": "Load durable session lanes by filters.",
     "lane_upsert": "Create or update durable session lane metadata.",
@@ -462,6 +464,9 @@ class OpenBrainClient:
 
     def get_entry(self, **arguments: Any) -> JSON:
         return self.call_tool("get_entry", arguments)
+
+    def resolve_entry(self, **arguments: Any) -> JSON:
+        return self.call_tool("resolve_entry", arguments)
 
     def get_entity(self, **arguments: Any) -> JSON:
         return self.call_tool("get_entity", arguments)

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -457,6 +457,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
         "find_person",
         "get_contract",
         "get_entry",
+        "resolve_entry",
         "get_entity",
         "get_stats",
         "hydrate_entities",
@@ -498,7 +499,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-06-28.memory-tools.v11"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-05.memory-tools.v12"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -10,6 +10,8 @@ from openbrain_memory import (
     validate_required_memory_contract,
 )
 
+CURRENT_CLIENT_VERSION = "0.1.2"
+
 
 def safe_string_display(value: str) -> str:
     digest = sha256(value.encode("utf-8")).hexdigest()[:12]
@@ -25,11 +27,11 @@ def representative_contract_manifest() -> dict:
         "schema_hash": "abc123",
         "generated_at": "2026-06-19T00:00:00.000Z",
         "min_client_versions": {
-            "openbrain-memory": "0.1.0",
+            "openbrain-memory": CURRENT_CLIENT_VERSION,
             "rtech-hermes-runtime": "0.1.0",
         },
         "compatible_client_ranges": {
-            "openbrain-memory": ">=0.1.0 <1.0.0",
+            "openbrain-memory": ">=0.1.2 <1.0.0",
             "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
         },
         "transport": {
@@ -61,7 +63,7 @@ def representative_contract_manifest() -> dict:
 def test_validate_contract_manifest_accepts_representative_contract_shape():
     result = validate_contract_manifest(
         representative_contract_manifest(),
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
@@ -73,7 +75,7 @@ def test_validate_contract_manifest_accepts_representative_contract_shape():
 def test_validate_required_memory_contract_pins_package_contract_defaults():
     result = validate_required_memory_contract(
         representative_contract_manifest(),
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
     )
 
     assert result.ok is True
@@ -103,7 +105,7 @@ def test_validate_contract_manifest_reports_missing_required_tool():
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
@@ -121,7 +123,7 @@ def test_validate_contract_manifest_rejects_capability_only_required_tool():
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
@@ -140,7 +142,7 @@ def test_validate_contract_manifest_rejects_tool_contract_only_required_tool():
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
@@ -160,7 +162,7 @@ def test_validate_contract_manifest_rejects_malformed_required_tool_contract():
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
@@ -180,7 +182,7 @@ def test_validate_contract_manifest_rejects_non_mapping_required_tool_contract()
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
@@ -196,7 +198,7 @@ def test_validate_contract_manifest_reports_scope_and_contract_version_mismatch(
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         compatible_contract_versions=(CURRENT_CONTRACT_VERSION,),
     )
 
@@ -220,10 +222,10 @@ def test_validate_contract_manifest_reports_min_client_version_failure():
     assert result.reasons == (
         "openbrain-memory "
         f"{safe_string_display('0.0.9')} is below required minimum "
-        f"{safe_string_display('0.1.0')}",
+        f"{safe_string_display(CURRENT_CLIENT_VERSION)}",
         "openbrain-memory "
         f"{safe_string_display('0.0.9')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.0 <1.0.0')}",
+        f"{safe_string_display('>=0.1.2 <1.0.0')}",
     )
 
 
@@ -236,7 +238,7 @@ def test_validate_contract_manifest_reports_compatible_range_failure():
     assert result.reasons == (
         "openbrain-memory "
         f"{safe_string_display('1.0.0')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.0 <1.0.0')}",
+        f"{safe_string_display('>=0.1.2 <1.0.0')}",
     )
 
 
@@ -245,7 +247,7 @@ def test_validate_contract_manifest_reports_malformed_client_compatibility_field
     manifest["min_client_versions"]["openbrain-memory"] = 1
     manifest["compatible_client_ranges"]["openbrain-memory"] = []
 
-    result = validate_contract_manifest(manifest, client_version="0.1.0")
+    result = validate_contract_manifest(manifest, client_version=CURRENT_CLIENT_VERSION)
 
     assert result.ok is False
     assert result.reasons == (
@@ -258,12 +260,13 @@ def test_validate_contract_manifest_rejects_malformed_compatible_range_text():
     manifest = representative_contract_manifest()
     manifest["compatible_client_ranges"]["openbrain-memory"] = ">=0.1.0 <1.0.0 trailing"
 
-    result = validate_contract_manifest(manifest, client_version="0.1.0")
+    result = validate_contract_manifest(manifest, client_version=CURRENT_CLIENT_VERSION)
 
     assert result.ok is False
     assert result.reasons == (
         "openbrain-memory "
-        f"{safe_string_display('0.1.0')} does not satisfy compatible range "
+        f"{safe_string_display(CURRENT_CLIENT_VERSION)} does not satisfy "
+        "compatible range "
         f"{safe_string_display('>=0.1.0 <1.0.0 trailing')}",
     )
 
@@ -272,12 +275,13 @@ def test_validate_contract_manifest_rejects_unsupported_range_operator():
     manifest = representative_contract_manifest()
     manifest["compatible_client_ranges"]["openbrain-memory"] = "~>0.1.0"
 
-    result = validate_contract_manifest(manifest, client_version="0.1.0")
+    result = validate_contract_manifest(manifest, client_version=CURRENT_CLIENT_VERSION)
 
     assert result.ok is False
     assert result.reasons == (
         "openbrain-memory "
-        f"{safe_string_display('0.1.0')} does not satisfy compatible range "
+        f"{safe_string_display(CURRENT_CLIENT_VERSION)} does not satisfy "
+        "compatible range "
         f"{safe_string_display('~>0.1.0')}",
     )
 
@@ -285,11 +289,11 @@ def test_validate_contract_manifest_rejects_unsupported_range_operator():
 def test_validate_contract_manifest_rejects_prerelease_client_version():
     manifest = representative_contract_manifest()
 
-    result = validate_contract_manifest(manifest, client_version="0.1.0-alpha")
+    result = validate_contract_manifest(manifest, client_version="0.1.2-alpha")
 
     assert result.ok is False
     assert result.reasons == (
-        "client_version '0.1.0-alpha' is not a supported semver version",
+        "client_version '0.1.2-alpha' is not a supported semver version",
     )
 
 
@@ -299,7 +303,7 @@ def test_validate_contract_manifest_fails_closed_for_unknown_client_name():
     result = validate_contract_manifest(
         manifest,
         client_name="typoed-client",
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
     )
 
     assert result.ok is False
@@ -314,7 +318,7 @@ def test_validate_contract_manifest_redacts_long_manifest_values_in_reasons():
     manifest["contract_scope"] = "evil-" + ("x" * 200)
     manifest["compatible_client_ranges"]["openbrain-memory"] = ">=0.1.0 " + ("x" * 200)
 
-    result = validate_contract_manifest(manifest, client_version="0.1.0")
+    result = validate_contract_manifest(manifest, client_version=CURRENT_CLIENT_VERSION)
 
     assert result.ok is False
     assert len(result.reasons) == 2
@@ -341,7 +345,7 @@ def test_validate_contract_manifest_redacts_token_like_manifest_values_in_reason
     manifest["contract_scope"] = token_body
     manifest["compatible_client_ranges"]["openbrain-memory"] = jwt_value
 
-    result = validate_contract_manifest(manifest, client_version="0.1.0")
+    result = validate_contract_manifest(manifest, client_version=CURRENT_CLIENT_VERSION)
     reason_text = "\n".join(result.reasons)
 
     assert result.ok is False
@@ -359,7 +363,7 @@ def test_validate_contract_manifest_does_not_require_snapshot_constants():
 
     result = validate_contract_manifest(
         manifest,
-        client_version="0.1.0",
+        client_version=CURRENT_CLIENT_VERSION,
         required_tools=REQUIRED_CONTRACT_TOOLS,
     )
 

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/specs/open-issues-and-prs-completion-roadmap.html
+++ b/specs/open-issues-and-prs-completion-roadmap.html
@@ -430,11 +430,13 @@
       </ul>
 
       <h4>2. #204 — resolve_entry tool</h4>
+      <p><strong>Local status 2026-07-05:</strong> implementation exists on <code>feat/204-source-type-resolver</code> in <code>/Volumes/ThunderBolt/_tmp/open-brain/issue-204-source-type-resolver</code> and PR #243 is open. Full local validation after initial gauntlet fixes is green: focused resolver/contract tests, <code>bunx tsc --noEmit</code>, full <code>bun test</code> (1040 pass, 46 skip), Python pytest (193 pass, 5 skip), Python mypy, Python ruff, and <code>git diff --check</code>. CI passed on amended head <code>ddc8bb611979fd93e28d3e40989fab163e30589e</code>; <code>deploy</code> skipped as expected for local-only PR flow. Project 8 marks #204 <code>In Review</code>. Initial swarm findings were fixed and posted on PR #243; focused fix-verification passed. Opposite-runtime Claude cross-review found three LOW observations, addressed by promoter parity coverage, resolver comments, and explicit contract-diagnostic rationale. Current-head CI is rerunning after cross-review fixes. Downstream rollout/core01 deploy is deferred by the current local-only instruction.</p>
       <ul class="checklist">
-        <li><code class="status">[]</code> Implement read-only <code>resolve_entry(id, namespace?)</code> returning <code>resolved, id, source_type, namespace, fetch_path, checked_sources, status</code> — single query pass over the known tables via validated allowlist (no interpolated table names without Zod enum validation).</li>
-        <li><code class="status">[]</code> Enforce auth-derived namespace predicate on the lookup (namespace isolation is a security boundary; a resolver must not become a cross-namespace oracle).</li>
-        <li><code class="status">[]</code> Contract bump per <code>docs/memory-contract.md</code>; add to tool schema + eval fixtures.</li>
-        <li><code class="status">[]</code> Functional tests: known UUID in each table resolves; foreign-namespace UUID returns not_found_or_unreadable (regression test proving the predicate); garbage UUID handled.</li>
+        <li><code class="status">[x]</code> Implement read-only <code>resolve_entry(id, namespace?)</code> returning <code>resolved, id, source_type, namespace, fetch_path, checked_sources, checked_tables, status</code> via known source-table allowlist.</li>
+        <li><code class="status">[x]</code> Enforce auth-derived namespace predicate on the lookup, reusing repo read-policy helpers including canonical/physical shared namespace handling and global-admin <code>namespace: "all"</code>.</li>
+        <li><code class="status">[x]</code> Contract bump to <code>2026-07-05.memory-tools.v12</code>; add <code>resolve_entry</code> to the server contract, tool schema metadata, and Python client snapshot/wrapper.</li>
+        <li><code class="status">[x]</code> Functional tests cover readable found rows, admin-only archived rows, non-admin archived non-disclosure, no-readable-family roles, explicit unreadable namespaces, and admin <code>namespace: "all"</code>.</li>
+        <li><code class="status">[]</code> Push cross-review fixes, wait for current-head CI, post final gauntlet receipt, then merge; downstream rollout/core01 deploy remains deferred until release phase.</li>
       </ul>
 
       <h4>3. #176 — Structured share_candidate rejection + bounded resend</h4>

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -37,6 +37,30 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     },
     output_shape: "full readable entry row JSON text payload",
   },
+  resolve_entry: {
+    version: 1,
+    input_schema: {
+      id: {
+        type: "string",
+        required: true,
+        format: "uuid",
+        description:
+          "Entry UUID to resolve across readable source families. The server " +
+          "applies auth-derived namespace predicates before disclosing source metadata.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        maxLength: 500,
+        description:
+          "Optional namespace to constrain resolution. The server checks this " +
+          "against auth-derived read policy.",
+      },
+    },
+    output_shape:
+      "resolver JSON text payload with resolved/status/id/source_type/table/namespace/fetch_path/checked_sources/checked_tables",
+  },
   log_thought: {
     version: 2,
     input_schema: {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -156,6 +156,7 @@ describe("Open Brain contract manifest", () => {
     for (const tool of [
       "get_contract",
       "get_entry",
+      "resolve_entry",
       "log_thought",
       "search_all",
       "session_start",
@@ -187,6 +188,15 @@ describe("Open Brain contract manifest", () => {
     expect((getEntry?.input_schema as any).id.required).toBe(true);
     expect((getEntry?.input_schema as any).id.format).toBe("uuid");
     expect((getEntry?.input_schema as any).namespace).toBeUndefined();
+    const resolveEntry = contract.tool_contracts.resolve_entry;
+    expect(resolveEntry).toBeDefined();
+    expect(resolveEntry?.version).toBe(1);
+    expect((resolveEntry?.input_schema as any).id.type).toBe("string");
+    expect((resolveEntry?.input_schema as any).id.required).toBe(true);
+    expect((resolveEntry?.input_schema as any).id.format).toBe("uuid");
+    expect((resolveEntry?.input_schema as any).namespace.type).toBe("string");
+    expect((resolveEntry?.input_schema as any).namespace.required).toBe(false);
+    expect(resolveEntry?.output_shape).toContain("fetch_path");
     const searchAll = contract.tool_contracts.search_all;
     expect(searchAll).toBeDefined();
     expect((searchAll?.input_schema as any).namespace.type).toBe("string");
@@ -234,7 +244,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-06-28.memory-tools.v11");
+    expect(contract.contract_version).toBe("2026-07-05.memory-tools.v12");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-06-28.memory-tools.v11";
+export const CONTRACT_VERSION = "2026-07-05.memory-tools.v12";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -139,6 +139,14 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
     description:
       "Fetch one full readable memory row by table and UUID. Server-side auth " +
       "and namespace predicates remain the security boundary for ID reads.",
+  },
+  {
+    name: "resolve_entry",
+    version: 1,
+    kind: "tool",
+    description:
+      "Resolve one UUID across readable Open Brain source families to its " +
+      "source type, namespace, and get_entry fetch path without semantic search.",
   },
   {
     name: "upsert_repo_fact",
@@ -315,12 +323,12 @@ export function buildContract(
     contract_scope: "required_openbrain_memory_contract" as const,
     schema_version: CONTRACT_SCHEMA_VERSION,
     min_client_versions: {
-      "openbrain-memory": "0.1.0",
+      "openbrain-memory": "0.1.2",
       "rtech-hermes-runtime": "0.1.0",
       mcp2cli: "0.3.6",
     },
     compatible_client_ranges: {
-      "openbrain-memory": ">=0.1.0 <1.0.0",
+      "openbrain-memory": ">=0.1.2 <1.0.0",
       "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
       mcp2cli: ">=0.3.6 <1.0.0",
     },

--- a/src/tools/__tests__/resolve-entry.test.ts
+++ b/src/tools/__tests__/resolve-entry.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "bun:test";
+import { registerResolveEntry } from "../resolve-entry.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+const TEST_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("resolve_entry", () => {
+  it("resolves a readable UUID to source type and get_entry fetch path", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.includes("FROM thoughts")) return { rows: [] };
+        if (sql.includes("FROM decisions")) {
+          return { rows: [{ id: params?.[0], namespace: "bilby" }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID },
+      });
+
+      const payload = parseToolResult(result);
+      expect(payload).toMatchObject({
+        resolved: true,
+        status: "found",
+        id: TEST_ID,
+        source_type: "decision",
+        table: "decisions",
+        namespace: "bilby",
+        fetch_path: {
+          tool: "get_entry",
+          arguments: {
+            table: "decisions",
+            id: TEST_ID,
+          },
+        },
+      });
+      expect(payload.checked_tables).toEqual(["thoughts", "decisions"]);
+      expect(queries[0]?.sql).toContain("namespace = ANY($2::text[])");
+      expect(queries[0]?.params).toEqual([TEST_ID, ["bilby", "shared-kb"]]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("mirrors promoter cross-namespace read policy", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.includes("FROM thoughts")) {
+          return { rows: [{ id: params?.[0], namespace: "private-other" }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "promoter", clientId: "promoter" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID },
+      });
+
+      expect(parseToolResult(result)).toMatchObject({
+        resolved: true,
+        status: "found",
+        source_type: "thought",
+        table: "thoughts",
+        namespace: "private-other",
+        fetch_path: {
+          tool: "get_entry",
+          arguments: {
+            table: "thoughts",
+            id: TEST_ID,
+          },
+        },
+      });
+      expect(queries[0]?.sql).not.toContain("namespace =");
+      expect(queries[0]?.params).toEqual([TEST_ID]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not disclose archived rows to non-admin callers", async () => {
+    const queries: Array<string> = [];
+    const mockPool = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (
+          sql.includes("FROM thoughts") &&
+          sql.includes("archived_at IS NOT NULL")
+        ) {
+          return { rows: [{ id: TEST_ID, namespace: "shared-kb" }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "readonly", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID },
+      });
+
+      expect(parseToolResult(result)).toEqual({
+        resolved: false,
+        status: "not_found_or_unreadable",
+        id: TEST_ID,
+        source_type: null,
+        table: null,
+        namespace: null,
+        fetch_path: null,
+        checked_sources: ["thought", "decision", "relationship", "project", "session"],
+        checked_tables: [
+          "thoughts",
+          "decisions",
+          "relationships",
+          "projects",
+          "sessions",
+        ],
+      });
+      expect(queries.some((sql) => sql.includes("archived_at IS NULL"))).toBe(true);
+      expect(queries.some((sql) => sql.includes("archived_at IS NOT NULL"))).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("distinguishes archived rows only for admin-like callers", async () => {
+    const queries: Array<string> = [];
+    const mockPool = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (
+          sql.includes("FROM thoughts") &&
+          sql.includes("archived_at IS NOT NULL")
+        ) {
+          return { rows: [{ id: TEST_ID, namespace: "shared-kb" }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "ob-admin", clientId: "admin" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID },
+      });
+
+      expect(parseToolResult(result)).toMatchObject({
+        resolved: false,
+        status: "archived",
+        source_type: "thought",
+        table: "thoughts",
+        namespace: "shared-kb",
+        fetch_path: null,
+      });
+      expect(queries.some((sql) => sql.includes("archived_at IS NULL"))).toBe(true);
+      expect(queries.some((sql) => sql.includes("archived_at IS NOT NULL"))).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns not_readable without querying when the role has no readable source families", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("query should not run");
+      },
+    };
+    const auth: AuthInfo = { role: "discord", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID },
+      });
+
+      expect(parseToolResult(result)).toEqual({
+        resolved: false,
+        status: "not_readable",
+        id: TEST_ID,
+        source_type: null,
+        table: null,
+        namespace: null,
+        fetch_path: null,
+        checked_sources: [],
+        checked_tables: [],
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not disclose rows from an explicitly unreadable namespace", async () => {
+    const mockPool = {
+      query: async () => {
+        throw new Error("query should not run");
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID, namespace: "private-other" },
+      });
+
+      expect(parseToolResult(result)).toMatchObject({
+        resolved: false,
+        status: "not_readable",
+        namespace: "private-other",
+        checked_sources: [],
+        checked_tables: [],
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("treats namespace=all as unrestricted only for global admin reads", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.includes("FROM thoughts")) return { rows: [] };
+        if (sql.includes("FROM decisions")) {
+          return { rows: [{ id: params?.[0], namespace: "private-other" }] };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "admin" };
+    const { client, cleanup } = await setupMcpClient(
+      registerResolveEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "resolve_entry",
+        arguments: { id: TEST_ID, namespace: "all" },
+      });
+
+      expect(parseToolResult(result)).toMatchObject({
+        resolved: true,
+        status: "found",
+        source_type: "decision",
+        table: "decisions",
+        namespace: "private-other",
+      });
+      expect(queries[0]?.sql).not.toContain("namespace =");
+      expect(queries[0]?.params).toEqual([TEST_ID]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,6 +17,7 @@ import { registerBrainAnswer } from "./brain-answer.ts";
 import { registerUpsertPerson } from "./upsert-person.ts";
 import { registerSetTier } from "./set-tier.ts";
 import { registerGetEntry } from "./get-entry.ts";
+import { registerResolveEntry } from "./resolve-entry.ts";
 import { registerGetStats } from "./get-stats.ts";
 import { registerAccessReport } from "./access-report.ts";
 import { registerBulkSetTier } from "./bulk-set-tier.ts";
@@ -69,6 +70,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerUpsertPerson(server, deps);
   registerSetTier(server, deps);
   registerGetEntry(server, deps);
+  registerResolveEntry(server, deps);
   registerGetStats(server, deps);
   registerAccessReport(server, deps);
   registerBulkSetTier(server, deps);

--- a/src/tools/resolve-entry.ts
+++ b/src/tools/resolve-entry.ts
@@ -1,0 +1,276 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import {
+  canReadNamespace,
+  namespaceFilterFor,
+} from "../read-policy.ts";
+import type { AuthInfo, Table } from "../types.ts";
+import type { ToolDeps } from "./index.ts";
+
+const SOURCE_TABLES = [
+  "thoughts",
+  "decisions",
+  "relationships",
+  "projects",
+  "sessions",
+] as const satisfies readonly Table[];
+
+const SOURCE_TYPE_BY_TABLE: Record<Table, string> = {
+  thoughts: "thought",
+  decisions: "decision",
+  relationships: "relationship",
+  projects: "project",
+  sessions: "session",
+};
+
+type ResolveStatus = "found" | "archived" | "not_found_or_unreadable" | "not_readable";
+
+interface ResolvedEntry {
+  resolved: boolean;
+  status: ResolveStatus;
+  id: string;
+  source_type: string | null;
+  table: Table | null;
+  namespace: string | null;
+  fetch_path: {
+    tool: "get_entry";
+    arguments: {
+      table: Table;
+      id: string;
+    };
+  } | null;
+  // Contract diagnostics: these intentionally expose what the caller was allowed
+  // to search, not any unreadable row metadata.
+  checked_sources: string[];
+  checked_tables: Table[];
+}
+
+function unresolved(
+  status: ResolveStatus,
+  id: string,
+  checkedTables: Table[],
+  namespace: string | null,
+): ResolvedEntry {
+  return {
+    resolved: false,
+    status,
+    id,
+    source_type: null,
+    table: null,
+    namespace,
+    fetch_path: null,
+    checked_sources: checkedTables.map((table) => SOURCE_TYPE_BY_TABLE[table]),
+    checked_tables: checkedTables,
+  };
+}
+
+function buildNamespacePredicate(
+  auth: AuthInfo,
+  params: unknown[],
+  namespace?: string,
+): string {
+  const filter = namespaceFilterFor(auth, namespace);
+  if (filter === undefined) return "";
+  params.push(filter);
+  if (Array.isArray(filter)) {
+    return ` AND namespace = ANY($${params.length}::text[])`;
+  }
+  return ` AND namespace = $${params.length}`;
+}
+
+async function findRow(
+  deps: ToolDeps,
+  auth: AuthInfo,
+  id: string,
+  tables: Table[],
+  namespace: string | undefined,
+  archived: boolean,
+  checkedTables: Table[],
+): Promise<{ table: Table; namespace: string } | null> {
+  for (const table of tables) {
+    checkedTables.push(table);
+    const params: unknown[] = [id];
+    const namespacePredicate = buildNamespacePredicate(auth, params, namespace);
+    const archivedPredicate = archived
+      ? "archived_at IS NOT NULL"
+      : "archived_at IS NULL";
+    const { rows } = await deps.pool.query(
+      `SELECT id, namespace FROM ${table} WHERE id = $1 AND ${archivedPredicate}${namespacePredicate} LIMIT 1`,
+      params,
+    );
+    const row = rows[0] as { namespace?: unknown } | undefined;
+    if (typeof row?.namespace === "string") {
+      return { table, namespace: row.namespace };
+    }
+  }
+  return null;
+}
+
+function uniqueTables(tables: Table[]): Table[] {
+  return Array.from(new Set(tables));
+}
+
+function canResolveArchived(auth: AuthInfo): boolean {
+  return auth.role === "admin" || auth.role === "ob-admin";
+}
+
+export function registerResolveEntry(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "resolve_entry",
+    {
+      description:
+        "Resolve a memory UUID to its readable source type, namespace, and get_entry fetch path without semantic search.",
+      inputSchema: {
+        id: z.string().uuid().describe("Entry UUID to resolve across readable source families"),
+        namespace: z
+          .string()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe(
+            "Optional namespace to constrain resolution. The server checks this against auth-derived read policy.",
+          ),
+      },
+      annotations: {
+        title: "Resolve Entry",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot resolve entries",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const id = args.id as string;
+      const namespace =
+        typeof args.namespace === "string" ? args.namespace : undefined;
+
+      if (namespace !== undefined && !canReadNamespace(auth, namespace)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(unresolved("not_readable", id, [], namespace)),
+            },
+          ],
+        };
+      }
+
+      const readableTables = SOURCE_TABLES.filter((table) =>
+        canRead(auth.role, table),
+      );
+      if (readableTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                unresolved("not_readable", id, [], namespace ?? null),
+              ),
+            },
+          ],
+        };
+      }
+
+      const found = await findRow(
+        deps,
+        auth,
+        id,
+        readableTables,
+        namespace,
+        false,
+        [],
+      );
+      if (found) {
+        // Resolution is first-match in SOURCE_TABLES order; UUIDs are expected
+        // to be globally unique across source tables.
+        const checkedTables = uniqueTables(
+          readableTables.slice(0, readableTables.indexOf(found.table) + 1),
+        );
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                resolved: true,
+                status: "found",
+                id,
+                source_type: SOURCE_TYPE_BY_TABLE[found.table],
+                table: found.table,
+                namespace: found.namespace,
+                fetch_path: {
+                  tool: "get_entry",
+                  arguments: {
+                    table: found.table,
+                    id,
+                  },
+                },
+                checked_sources: checkedTables.map(
+                  (table) => SOURCE_TYPE_BY_TABLE[table],
+                ),
+                checked_tables: checkedTables,
+              } satisfies ResolvedEntry),
+            },
+          ],
+        };
+      }
+
+      if (canResolveArchived(auth)) {
+        const checkedTables: Table[] = [];
+        const archived = await findRow(
+          deps,
+          auth,
+          id,
+          readableTables,
+          namespace,
+          true,
+          checkedTables,
+        );
+        if (archived) {
+          const allCheckedTables = uniqueTables([...readableTables, ...checkedTables]);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ...unresolved("archived", id, allCheckedTables, archived.namespace),
+                  source_type: SOURCE_TYPE_BY_TABLE[archived.table],
+                  table: archived.table,
+                  namespace: archived.namespace,
+                } satisfies ResolvedEntry),
+              },
+            ],
+          };
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              unresolved(
+                "not_found_or_unreadable",
+                id,
+                readableTables,
+                namespace ?? null,
+              ),
+            ),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
Closes #204.

## Summary
- add read-only `resolve_entry(id, namespace?)` to resolve readable Open Brain UUIDs to source type, namespace, table, and `get_entry` fetch path without semantic search
- enforce existing auth-derived readable table and namespace policy, including canonical/physical shared namespace handling and admin `namespace: "all"` behavior
- bump the public contract to `2026-07-05.memory-tools.v12` and add the Python client snapshot/wrapper for `resolve_entry`
- update the local controller plan and roadmap with #204 local validation state

## Validation
- `bun test src/tools/__tests__/resolve-entry.test.ts src/contract.test.ts` -> 12 pass
- `bunx tsc --noEmit`
- `bun test` -> 1040 pass, 46 skip, 0 fail
- `cd python/openbrain-memory && uv run pytest -q` -> 193 pass, 5 skip
- `cd python/openbrain-memory && uv run mypy src/openbrain_memory`
- `cd python/openbrain-memory && uv run ruff check src tests`
- `git diff --check`
- `ggshield secret scan repo .` -> no secrets found

## Critical self-review
- Highest-risk behavior: the resolver could become a cross-namespace or cross-table oracle. It now filters source families by `canRead()` and namespaces through the same read-policy helper used elsewhere.
- Assumptions that could be wrong: admin-only archived resolution is enough for operator diagnostics while ordinary clients should not distinguish archived UUIDs from missing/unreadable rows.
- Missing/weak tests: tests cover found rows, admin-only archived rows, non-admin archived non-disclosure, unreadable role, explicit unreadable namespace, and admin `namespace: "all"`; live DB canary is deferred by the local-only instruction.
- Security/permission risk: table names are hard-coded allowlisted source tables; namespace predicates are server-side and parameterized.
- Migration/deploy risk: no DB migration. Public contract/client snapshot changes require downstream rollout before release.
- Downstream client/runtime risk: mcp2cli, generated skills, and rtech-hermes must refresh/adopt the new contract before claiming runtime readiness.
- Rollback/cleanup concern: rollback is reverting this PR; no data mutation is introduced.
- Fixes made before PR: replaced hand-rolled namespace predicate logic with `namespaceFilterFor()` after finding the admin `namespace: "all"` edge case, then added a regression test.
- Fixes made during gauntlet: limited archived resolution to admin/ob-admin with non-admin non-disclosure tests, bumped `openbrain-memory` package/min-compatible version to `0.1.2`, and added `resolve_entry` to the Python wrapper dispatch regression.
- Known residual risk: downstream rollout and core01/live canary are intentionally deferred until the release/deploy phase.
- SME review-memory update: [x] not applicable because: current gauntlet findings are PR-specific implementation fixes and do not add a new durable MEDIUM+ review pattern beyond existing namespace-boundary and contract-version checklists.

## Downstream rollout
- I checked `docs/downstream-rollout.md`.
- Local Open Brain verification is complete.
- Hosted Open Brain deploy, mcp2cli schema refresh/generated skills, rtech-mcps handoff, rtech-hermes runtime/plugin changes, Hermes rollout, and live agent canaries are deferred by the current local-only instruction and must be completed before issue closure/release.

## Review gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: current instruction is local-only; hosted/core01 live checks are deferred to release/deploy phase.
- `pre-merge-gauntlet` is required because this PR changes MCP tool behavior, the public contract, and the Python client snapshot.
- Phase 1 critical review completed before PR creation; Phase 2+ starts after PR opens.
