### PR TITLE
feat(#192): add compact get_entry render

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -80,7 +80,7 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 | link_entities | Create relationship between entries | write |
 | adjacent_context | Traverse link graph from a node | read |
 | get_contract | Read the public Open Brain contract manifest | read |
-| get_entry | Fetch a full readable memory row by table and ID | read |
+| get_entry | Fetch a readable memory row by table and ID; use `render: "compact"` for bounded exact-UUID recall | read |
 | upsert_repo_fact | Store curated qmd-derived repo fact metadata | write |
 | list_repo_facts | Read curated qmd-derived repo facts | read |
 | search_brain | Semantic search across all tables | read |
@@ -205,6 +205,13 @@ cites every bullet with a `source_ref`, and returns `known_gaps` / `uncertainty`
 when evidence is missing, stale, mixed, or unsafe to cite. When no readable or
 citable evidence is available, `answer` is `null`; the tool must not fabricate
 uncited facts.
+
+`get_entry` defaults to the full readable row for exact UUID fetches. For large
+entries, callers can pass `render: "compact"` and optional `max_chars`
+(80-2000, default 500) to receive a bounded envelope with `content_preview`,
+`content_length`, `content_truncated`, `source_ref`, and a `fetch_path` for the
+full row. The same server-side auth and namespace predicates apply to both
+renders.
 
 ### OKF Compatibility Hooks
 

--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -211,7 +211,9 @@ entries, callers can pass `render: "compact"` and optional `max_chars`
 (80-2000, default 500) to receive a bounded envelope with `content_preview`,
 `content_length`, `content_truncated`, `source_ref`, and a `fetch_path` for the
 full row. The same server-side auth and namespace predicates apply to both
-renders.
+renders. `content_length` and `content_truncated` describe the readable compact
+projection used for `content_preview`; callers that need every raw stored column
+should follow `fetch_path` with `render: "full"`.
 
 ### OKF Compatibility Hooks
 

--- a/docs/roadmap/condensed-retrieval-and-decomposition.md
+++ b/docs/roadmap/condensed-retrieval-and-decomposition.md
@@ -1,0 +1,41 @@
+# Condensed Retrieval And Dream Decomposition
+
+Status: #192 local-complete decision, 2026-07-06.
+
+## Decision
+
+Open Brain supports cheap exact-UUID recall through `get_entry` compact render.
+Callers that know an entry UUID can request:
+
+```json
+{"table":"thoughts","id":"<uuid>","render":"compact","max_chars":500}
+```
+
+The response is a bounded envelope with `content_preview`, `content_length`,
+`content_truncated`, `source_ref`, and a `fetch_path` for the full row. The full
+row remains the default for backward compatibility.
+
+## Why This Shape
+
+- It fixes the immediate token-cost problem without a schema migration.
+- It reuses the existing per-table preview expressions used by search results.
+- It keeps server-side auth and namespace predicates as the exact same boundary
+  as full `get_entry`.
+- It gives clients an explicit full-fetch path when the compact preview is not
+  enough.
+
+## Deferred Work
+
+Dream-driven decomposition remains the preferred long-term way to keep Open
+Brain entries naturally small and linked. It should not mutate entries until the
+DreamEngine dry-run-by-default rule has a scoped design and tests for:
+
+- oversized-entry detection;
+- proposed smaller replacement entries with links back to the source;
+- dry-run review output;
+- explicit operator or client approval before archive, promote, demote, or tier
+  mutation;
+- namespace-safe provenance for every generated replacement.
+
+Track that as a separate DreamEngine/decomposition issue before implementing
+mutating behavior. Do not fold it into compact `get_entry` rendering.

--- a/docs/roadmap/condensed-retrieval-and-decomposition.md
+++ b/docs/roadmap/condensed-retrieval-and-decomposition.md
@@ -38,5 +38,5 @@ DreamEngine dry-run-by-default rule has a scoped design and tests for:
   mutation;
 - namespace-safe provenance for every generated replacement.
 
-Track that as a separate DreamEngine/decomposition issue before implementing
-mutating behavior. Do not fold it into compact `get_entry` rendering.
+Track that in #247 before implementing mutating behavior. Do not fold it into
+compact `get_entry` rendering.

--- a/docs/roadmap/condensed-retrieval-and-decomposition.md
+++ b/docs/roadmap/condensed-retrieval-and-decomposition.md
@@ -18,7 +18,8 @@ row remains the default for backward compatibility.
 ## Why This Shape
 
 - It fixes the immediate token-cost problem without a schema migration.
-- It reuses the existing per-table preview expressions used by search results.
+- It reuses existing per-table readable-content projections where safe, with a
+  full-summary compact projection for sessions so length/truncation are exact.
 - It keeps server-side auth and namespace predicates as the exact same boundary
   as full `get_entry`.
 - It gives clients an explicit full-fetch path when the compact preview is not

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -242,3 +242,36 @@ from real `session_context` / `search_all` shaped rows.
 - Do tests include raw server-shaped rows, not only hand-authored camelCase
   fixtures?
 - Does TS/Python parity test compare the full generated bundle, not fragments?
+
+## [2026-07-06] Exact compact renders must not reuse already-clipped search previews
+
+**Severity:** MEDIUM
+**Source:** PR #246 initial swarm for Issue #192
+**Scope:** `src/tools/get-entry.ts`, `src/tools/table-constants.ts`, any bounded exact-fetch projection
+**Status:** fixed in PR #246
+
+### Pattern
+
+Search/list preview expressions can be intentionally display-clipped. In PR
+#246, compact `get_entry` initially reused `CONTENT_PREVIEW[table]` for
+`content_length` and `content_truncated`. For `sessions`, `CONTENT_PREVIEW`
+already applied `LEFT(s.summary, 300)`, so compact exact fetch could report a
+shorter length and `content_truncated=false` for a long stored session summary.
+
+### Review Questions
+
+- Is a compact/exact-fetch render measuring the underlying readable content, or
+  a search/list preview that may already be clipped?
+- Do `content_length` and `content_truncated` reflect the same unbounded text
+  that `content_preview` is truncating?
+- Does the test suite include a long-row regression for any source family whose
+  search preview is intentionally abbreviated?
+- Is novel SQL projection covered by a real Postgres-gated test when a mock pool
+  cannot execute the query?
+
+### Prior Fix
+
+PR #246 gave compact `get_entry` its own full-readable-content expression for
+`sessions`, computed normalized content once in a subquery, added a mock SQL
+shape guard, and added an `OPENBRAIN_TEST_DATABASE_URL`-gated live Postgres
+test for long session compact length/truncation.

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -229,6 +229,12 @@ a package bug.
 ```python
 contract = client.get_contract()
 answer = client.brain_answer(query="what did we decide?", limit=5)
+compact = client.get_entry(
+    table="thoughts",
+    id="<uuid>",
+    render="compact",
+    max_chars=500,
+)
 facts = client.list_repo_facts(repo="rodaddy/open-brain", limit=10)
 client.upsert_repo_fact(metadata={...})
 ```

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -41,7 +41,7 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v13"
+CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v14"
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
     "get_contract",
@@ -62,7 +62,10 @@ CURRENT_TOOL_HELP: Mapping[str, str] = {
     "brain_answer": "Return cited answer bullets from readable Open Brain evidence.",
     "get_entity": "Fetch a graph entity by ID.",
     "get_contract": "Read the canonical Open Brain public contract manifest.",
-    "get_entry": "Fetch one full readable memory row by table and UUID.",
+    "get_entry": (
+        "Fetch one readable memory row by table and UUID; render=compact "
+        "returns a bounded preview."
+    ),
     "resolve_entry": "Resolve a UUID to its readable source type and fetch path.",
     "hydrate_entities": "Refresh missing graph entity embeddings.",
     "lane_load": "Load durable session lanes by filters.",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -499,7 +499,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v13"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v14"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -10,7 +10,7 @@ from openbrain_memory import (
     validate_required_memory_contract,
 )
 
-CURRENT_CLIENT_VERSION = "0.1.3"
+CURRENT_CLIENT_VERSION = "0.1.4"
 
 
 def safe_string_display(value: str) -> str:
@@ -31,7 +31,7 @@ def representative_contract_manifest() -> dict:
             "rtech-hermes-runtime": "0.1.0",
         },
         "compatible_client_ranges": {
-            "openbrain-memory": ">=0.1.3 <1.0.0",
+            "openbrain-memory": ">=0.1.4 <1.0.0",
             "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
         },
         "transport": {
@@ -225,7 +225,7 @@ def test_validate_contract_manifest_reports_min_client_version_failure():
         f"{safe_string_display(CURRENT_CLIENT_VERSION)}",
         "openbrain-memory "
         f"{safe_string_display('0.0.9')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.3 <1.0.0')}",
+        f"{safe_string_display('>=0.1.4 <1.0.0')}",
     )
 
 
@@ -238,7 +238,7 @@ def test_validate_contract_manifest_reports_compatible_range_failure():
     assert result.reasons == (
         "openbrain-memory "
         f"{safe_string_display('1.0.0')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.3 <1.0.0')}",
+        f"{safe_string_display('>=0.1.4 <1.0.0')}",
     )
 
 
@@ -289,11 +289,11 @@ def test_validate_contract_manifest_rejects_unsupported_range_operator():
 def test_validate_contract_manifest_rejects_prerelease_client_version():
     manifest = representative_contract_manifest()
 
-    result = validate_contract_manifest(manifest, client_version="0.1.3-alpha")
+    result = validate_contract_manifest(manifest, client_version="0.1.4-alpha")
 
     assert result.ok is False
     assert result.reasons == (
-        "client_version '0.1.3-alpha' is not a supported semver version",
+        "client_version '0.1.4-alpha' is not a supported semver version",
     )
 
 

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -16,7 +16,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     output_shape: "OpenBrainContract JSON text payload",
   },
   get_entry: {
-    version: 1,
+    version: 2,
     input_schema: {
       table: {
         type: "enum",
@@ -34,8 +34,28 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "Entry UUID to fetch. The server applies auth-derived namespace " +
           "predicates before returning any row.",
       },
+      render: {
+        type: "enum",
+        required: false,
+        values: ["full", "compact"],
+        default: "full",
+        description:
+          "Response shape. full returns the complete readable row; compact " +
+          "returns a bounded exact-UUID preview envelope for cheap recall.",
+      },
+      max_chars: {
+        type: "integer",
+        required: false,
+        min: 80,
+        max: 2000,
+        default: 500,
+        description:
+          "Maximum compact content_preview length in characters. Applies only " +
+          "when render is compact.",
+      },
     },
-    output_shape: "full readable entry row JSON text payload",
+    output_shape:
+      "full readable entry row JSON text payload, or compact envelope with content_preview/content_length/content_truncated/source_ref/fetch_path",
   },
   resolve_entry: {
     version: 1,

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -175,7 +175,7 @@ describe("Open Brain contract manifest", () => {
     expect(upsertRepoFact).toBeDefined();
     const getEntry = contract.tool_contracts.get_entry;
     expect(getEntry).toBeDefined();
-    expect(getEntry?.version).toBe(1);
+    expect(getEntry?.version).toBe(2);
     expect((getEntry?.input_schema as any).table).toEqual({
       type: "enum",
       required: true,
@@ -187,6 +187,20 @@ describe("Open Brain contract manifest", () => {
     expect((getEntry?.input_schema as any).id.type).toBe("string");
     expect((getEntry?.input_schema as any).id.required).toBe(true);
     expect((getEntry?.input_schema as any).id.format).toBe("uuid");
+    expect((getEntry?.input_schema as any).render).toMatchObject({
+      type: "enum",
+      required: false,
+      values: ["full", "compact"],
+      default: "full",
+    });
+    expect((getEntry?.input_schema as any).max_chars).toMatchObject({
+      type: "integer",
+      required: false,
+      min: 80,
+      max: 2000,
+      default: 500,
+    });
+    expect(getEntry?.output_shape).toContain("compact envelope");
     expect((getEntry?.input_schema as any).namespace).toBeUndefined();
     const resolveEntry = contract.tool_contracts.resolve_entry;
     expect(resolveEntry).toBeDefined();
@@ -244,7 +258,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v13");
+    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v14");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-07-06.memory-tools.v13";
+export const CONTRACT_VERSION = "2026-07-06.memory-tools.v14";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -134,11 +134,13 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "get_entry",
-    version: 1,
+    version: 2,
     kind: "tool",
     description:
-      "Fetch one full readable memory row by table and UUID. Server-side auth " +
-      "and namespace predicates remain the security boundary for ID reads.",
+      "Fetch one readable memory row by table and UUID. Defaults to full row " +
+      "output; compact render returns a bounded exact-UUID preview envelope. " +
+      "Server-side auth and namespace predicates remain the security boundary " +
+      "for ID reads.",
   },
   {
     name: "resolve_entry",
@@ -323,12 +325,12 @@ export function buildContract(
     contract_scope: "required_openbrain_memory_contract" as const,
     schema_version: CONTRACT_SCHEMA_VERSION,
     min_client_versions: {
-      "openbrain-memory": "0.1.3",
+      "openbrain-memory": "0.1.4",
       "rtech-hermes-runtime": "0.1.0",
       mcp2cli: "0.3.6",
     },
     compatible_client_ranges: {
-      "openbrain-memory": ">=0.1.3 <1.0.0",
+      "openbrain-memory": ">=0.1.4 <1.0.0",
       "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
       mcp2cli: ">=0.3.6 <1.0.0",
     },

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
 import { registerGetEntry } from "../get-entry.ts";
 import type { AuthInfo } from "../../types.ts";
 import {
@@ -150,6 +151,7 @@ describe("get_entry", () => {
       });
       expect(queries[0]?.sql).toContain("LEFT(");
       expect(queries[0]?.sql).toContain("content_preview");
+      expect(queries[0]?.sql).toContain("entry.content_text");
       expect(queries[0]?.sql).toContain("namespace = ANY($2::text[])");
       expect(queries[0]?.params).toEqual([
         "550e8400-e29b-41d4-a716-446655440010",
@@ -158,6 +160,117 @@ describe("get_entry", () => {
       ]);
     } finally {
       await cleanup();
+    }
+  });
+
+  it("builds session compact content from the full summary, not the clipped search preview", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        return {
+          rows: [
+            {
+              id: params?.[0],
+              namespace: "bilby",
+              created_by: "codex",
+              created_at: "2026-07-06T00:00:00.000Z",
+              updated_at: "2026-07-06T00:01:00.000Z",
+              tier: "warm",
+              tags: [],
+              content_preview: "session preview",
+              content_length: "450",
+              content_truncated: true,
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "sessions",
+          id: "550e8400-e29b-41d4-a716-446655440011",
+          render: "compact",
+          max_chars: 120,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result).content_truncated).toBe(true);
+      expect(queries[0]?.sql).toContain("COALESCE(s.summary, '')");
+      expect(queries[0]?.sql).not.toContain("LEFT(s.summary, 300)");
+      expect(queries[0]?.sql).toContain("length(entry.content_text)");
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// Gated on OPENBRAIN_TEST_DATABASE_URL. CI's db-integration job sets this and
+// catches real Postgres SQL failures that mock-pool tests cannot execute.
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("get_entry compact render (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-get-entry-compact";
+  const sessionId = "550e8400-e29b-41d4-a716-446655440099";
+
+  async function cleanupNs() {
+    await pool.query("DELETE FROM sessions WHERE namespace = $1", [ns]);
+  }
+
+  afterAll(async () => {
+    await cleanupNs();
+    await pool.end();
+  });
+
+  it("reports session length and truncation from the full readable content", async () => {
+    await cleanupNs();
+    const longSummary = "x".repeat(450);
+    await pool.query(
+      `INSERT INTO sessions (id, namespace, project, summary, created_by, tags)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [sessionId, ns, "proj", longSummary, "codex", ["compact"]],
+    );
+
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      pool as any,
+      createMockEmbed(),
+      { role: "agent", clientId: ns },
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "sessions",
+          id: sessionId,
+          render: "compact",
+          max_chars: 80,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.content_preview).toBe(`proj: ${"x".repeat(74)}`);
+      expect(parsed.content_length).toBe(456);
+      expect(parsed.content_truncated).toBe(true);
+      expect(parsed.content_preview).toHaveLength(80);
+    } finally {
+      await cleanup();
+      await cleanupNs();
     }
   });
 });

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -78,6 +78,79 @@ describe("get_entry", () => {
     }
   });
 
+  it("denies compact render before querying when the role cannot read the table", async () => {
+    let queried = false;
+    const mockPool = {
+      query: async () => {
+        queried = true;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "discord", clientId: "discord" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440012",
+          render: "compact",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("Permission denied");
+      expect(queried).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns not found for compact render when scoped namespace filter excludes the row", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440013",
+          render: "compact",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("Entry not found");
+      expect(queries[0]?.sql).toContain("namespace = ANY($2::text[])");
+      expect(queries[0]?.params).toEqual([
+        "550e8400-e29b-41d4-a716-446655440013",
+        ["bilby", "shared-kb"],
+        500,
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("returns a bounded compact envelope without emitting the full row", async () => {
     const queries: Array<{ sql: string; params?: unknown[] }> = [];
     const mockPool = {

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -76,4 +76,88 @@ describe("get_entry", () => {
       await cleanup();
     }
   });
+
+  it("returns a bounded compact envelope without emitting the full row", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        return {
+          rows: [
+            {
+              id: params?.[0],
+              namespace: "bilby",
+              created_by: "codex",
+              created_at: "2026-07-06T00:00:00.000Z",
+              updated_at: "2026-07-06T00:01:00.000Z",
+              tier: "warm",
+              tags: ["large"],
+              content_preview: "Large entry preview",
+              content_length: "1200",
+              content_truncated: true,
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440010",
+          render: "compact",
+          max_chars: 120,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed).toMatchObject({
+        id: "550e8400-e29b-41d4-a716-446655440010",
+        table: "thoughts",
+        source_type: "thought",
+        namespace: "bilby",
+        render: "compact",
+        max_chars: 120,
+        content_preview: "Large entry preview",
+        content_length: 1200,
+        content_truncated: true,
+        full_available: true,
+      });
+      expect(parsed.content).toBeUndefined();
+      expect(parsed.source_ref).toMatchObject({
+        source: "brain",
+        type: "thought",
+        id: "550e8400-e29b-41d4-a716-446655440010",
+        namespace: "bilby",
+      });
+      expect(parsed.fetch_path).toEqual({
+        tool: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440010",
+          render: "full",
+        },
+      });
+      expect(queries[0]?.sql).toContain("LEFT(");
+      expect(queries[0]?.sql).toContain("content_preview");
+      expect(queries[0]?.sql).toContain("namespace = ANY($2::text[])");
+      expect(queries[0]?.params).toEqual([
+        "550e8400-e29b-41d4-a716-446655440010",
+        ["bilby", "shared-kb"],
+        120,
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -5,13 +5,20 @@ import { readableNamespaces } from "../read-policy.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { TABLE_COLUMNS } from "../table-projections.ts";
+import {
+  CONTENT_PREVIEW,
+  SOURCE_LABELS,
+  TABLE_ALIAS,
+} from "./table-constants.ts";
+
+const DEFAULT_COMPACT_MAX_CHARS = 500;
 
 export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
     "get_entry",
     {
       description:
-        "Fetch the full content of an entry by table and ID. Use after search to get complete details beyond the 200-char preview.",
+        "Fetch a readable entry by table and ID. Defaults to full content; use render=compact for a bounded exact-UUID preview.",
       inputSchema: {
         table: z
           .enum([
@@ -25,6 +32,21 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
             "Which table the entry is in (from search result source_type + 's')",
           ),
         id: z.string().uuid().describe("Entry UUID from search results"),
+        render: z
+          .enum(["full", "compact"])
+          .optional()
+          .describe(
+            "Response shape: full returns the complete row (default); compact returns a bounded preview envelope.",
+          ),
+        max_chars: z
+          .number()
+          .int()
+          .min(80)
+          .max(2000)
+          .optional()
+          .describe(
+            "Maximum compact content_preview length in characters (default 500, max 2000). Ignored for full render.",
+          ),
       },
       annotations: {
         title: "Get Entry",
@@ -46,6 +68,87 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
             },
           ],
           isError: true,
+        };
+      }
+
+      const render = args.render ?? "full";
+      if (render === "compact") {
+        const maxChars = args.max_chars ?? DEFAULT_COMPACT_MAX_CHARS;
+        const alias = TABLE_ALIAS[table];
+        const preview = CONTENT_PREVIEW[table];
+        const sourceType = SOURCE_LABELS[table];
+        const updatedAtExpr =
+          table === "relationships" || table === "projects"
+            ? "NULL::timestamptz"
+            : `${alias}.updated_at`;
+        const params: unknown[] = [args.id];
+        let namespacePredicate = "";
+        const readable = readableNamespaces(auth);
+        if (readable) {
+          params.push(readable);
+          namespacePredicate = ` AND ${alias}.namespace = ANY($${params.length}::text[])`;
+        }
+        params.push(maxChars);
+        const maxCharsParam = `$${params.length}`;
+        const previewExpr = `regexp_replace(COALESCE((${preview})::text, ''), '[[:space:]]+', ' ', 'g')`;
+        const { rows } = await deps.pool.query(
+          `SELECT ${alias}.id, ${alias}.namespace, ${alias}.created_by, ${alias}.created_at, ${updatedAtExpr} AS updated_at, ${alias}.tier, ${alias}.tags,
+            LEFT(${previewExpr}, ${maxCharsParam}) AS content_preview,
+            length(${previewExpr}) AS content_length,
+            length(${previewExpr}) > ${maxCharsParam} AS content_truncated
+           FROM ${table} ${alias}
+           WHERE ${alias}.id = $1 AND ${alias}.archived_at IS NULL${namespacePredicate}`,
+          params,
+        );
+
+        if (rows.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Entry not found or archived",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const row = rows[0] as Record<string, unknown>;
+        const namespace =
+          typeof row.namespace === "string" ? row.namespace : null;
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                id: row.id,
+                table,
+                source_type: sourceType,
+                namespace,
+                render: "compact",
+                max_chars: maxChars,
+                content_preview: row.content_preview,
+                content_length: Number(row.content_length ?? 0),
+                content_truncated: Boolean(row.content_truncated),
+                created_by: row.created_by,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                tier: row.tier,
+                tags: row.tags,
+                source_ref: {
+                  source: "brain",
+                  type: sourceType,
+                  id: row.id,
+                  namespace,
+                },
+                full_available: true,
+                fetch_path: {
+                  tool: "get_entry",
+                  arguments: { table, id: row.id, render: "full" },
+                },
+              }),
+            },
+          ],
         };
       }
 

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -13,6 +13,16 @@ import {
 
 const DEFAULT_COMPACT_MAX_CHARS = 500;
 
+const COMPACT_CONTENT: Record<Table, string> = {
+  ...CONTENT_PREVIEW,
+  sessions:
+    "COALESCE(s.project || ': ', '') || COALESCE(s.summary, '')" +
+    " || CASE WHEN s.key_decisions IS NOT NULL AND array_length(s.key_decisions, 1) > 0" +
+    " THEN E'\\nDecisions: ' || immutable_array_to_string(s.key_decisions, '; ') ELSE '' END" +
+    " || CASE WHEN s.next_steps IS NOT NULL AND array_length(s.next_steps, 1) > 0" +
+    " THEN E'\\nNext: ' || immutable_array_to_string(s.next_steps, '; ') ELSE '' END",
+};
+
 export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
     "get_entry",
@@ -75,7 +85,7 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
       if (render === "compact") {
         const maxChars = args.max_chars ?? DEFAULT_COMPACT_MAX_CHARS;
         const alias = TABLE_ALIAS[table];
-        const preview = CONTENT_PREVIEW[table];
+        const compactContent = COMPACT_CONTENT[table];
         const sourceType = SOURCE_LABELS[table];
         const updatedAtExpr =
           table === "relationships" || table === "projects"
@@ -90,14 +100,18 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
         }
         params.push(maxChars);
         const maxCharsParam = `$${params.length}`;
-        const previewExpr = `regexp_replace(COALESCE((${preview})::text, ''), '[[:space:]]+', ' ', 'g')`;
+        const contentExpr = `regexp_replace(COALESCE((${compactContent})::text, ''), '[[:space:]]+', ' ', 'g')`;
         const { rows } = await deps.pool.query(
-          `SELECT ${alias}.id, ${alias}.namespace, ${alias}.created_by, ${alias}.created_at, ${updatedAtExpr} AS updated_at, ${alias}.tier, ${alias}.tags,
-            LEFT(${previewExpr}, ${maxCharsParam}) AS content_preview,
-            length(${previewExpr}) AS content_length,
-            length(${previewExpr}) > ${maxCharsParam} AS content_truncated
-           FROM ${table} ${alias}
-           WHERE ${alias}.id = $1 AND ${alias}.archived_at IS NULL${namespacePredicate}`,
+          `SELECT entry.id, entry.namespace, entry.created_by, entry.created_at, entry.updated_at, entry.tier, entry.tags,
+            LEFT(entry.content_text, ${maxCharsParam}) AS content_preview,
+            length(entry.content_text) AS content_length,
+            length(entry.content_text) > ${maxCharsParam} AS content_truncated
+           FROM (
+             SELECT ${alias}.id, ${alias}.namespace, ${alias}.created_by, ${alias}.created_at, ${updatedAtExpr} AS updated_at, ${alias}.tier, ${alias}.tags,
+               ${contentExpr} AS content_text
+             FROM ${table} ${alias}
+             WHERE ${alias}.id = $1 AND ${alias}.archived_at IS NULL${namespacePredicate}
+           ) entry`,
           params,
         );
 


### PR DESCRIPTION
## Summary

- add `get_entry` compact render for cheap exact-UUID recall without changing the default full-row behavior
- bump the public contract to `2026-07-06.memory-tools.v14` and `openbrain-memory` snapshot/package version to `0.1.4`
- document #192 Part B as deferred DreamEngine decomposition work behind dry-run-by-default safeguards and track it in follow-up #247

Closes #192.

## Validation

- `bun test src/tools/__tests__/get-entry.test.ts src/contract.test.ts` - 12 pass, 2 skip, 0 fail
- `bunx tsc --noEmit` - passed
- `bun test` - 1063 pass, 48 skip, 0 fail
- `cd python/openbrain-memory && uv run pytest -q tests/test_client.py tests/test_contract.py` - 69 passed
- `cd python/openbrain-memory && uv run pytest -q` - 193 passed, 5 skipped
- `cd python/openbrain-memory && uv run mypy src/openbrain_memory` - passed
- `cd python/openbrain-memory && uv run ruff check src tests` - passed
- `git diff --check` - passed

## Critical Self-Review

- Highest-risk behavior: compact exact fetch could accidentally bypass the existing `get_entry` namespace/read boundary or become a new schema surface clients cannot discover.
- Assumptions that could be wrong: a projection-level compact preview is sufficient for #192 Part A without a stored summary column; dream decomposition can remain deferred if the deferral is explicit and durable.
- Missing/weak tests: compact render now has mock-pool boundary tests plus an `OPENBRAIN_TEST_DATABASE_URL`-gated live Postgres regression for long session length/truncation; no live table-by-table matrix beyond the session bug found in review.
- Security/permission risk: compact render uses the same table allowlist, `canRead`, `readableNamespaces`, archived-row exclusion, and namespace predicate as full render.
- Migration/deploy risk: no DB migration; hosted deploy and live canary are deferred by the current local-only instruction.
- Downstream client/runtime risk: this changes the public `get_entry` contract, contract version, and Python snapshot. mcp2cli/Hermes/generated skill rollout is deferred to the release phase.
- Rollback/cleanup concern: rollback is reverting this PR and contract/package version bump; no persisted data shape changes. Because the server contract and `openbrain-memory` snapshot are exact-version pinned, release/rollback must keep server and downstream client refresh in lockstep.
- Fixes made before PR: added Part B roadmap disposition doc so #192 does not close with dream-driven decomposition silently unresolved.
- Fixes made during gauntlet: corrected session compact render to measure full readable content, added compact permission/not-found tests, added a live Postgres compact-session regression, updated `docs/sme/correctness.md`, created follow-up #247 for DreamEngine decomposition, and clarified content-length semantics.
- Known residual risk: downstream clients will not see `render=compact` until the later release/deploy/schema-refresh phase.
- SME review-memory update: [x] `docs/sme/` updated with the compact-render/search-preview clipping pattern from this PR.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured: initial swarm findings posted at https://github.com/rodaddy/open-brain/pull/246#issuecomment-4888934298
- [x] Fixes receipt posted at https://github.com/rodaddy/open-brain/pull/246#issuecomment-4888988006
- [x] Fix-verification receipt posted at https://github.com/rodaddy/open-brain/pull/246#issuecomment-4889006461
- [x] Phase 3 Claude/Opus cross-review posted at https://github.com/rodaddy/open-brain/pull/246#issuecomment-4889027510
- Live Open Brain checks: [x] not applicable because: current scope is local-only; hosted deploy, schema refresh, downstream rollout, and live canaries are deferred to the release phase.

## Downstream Rollout

- Checked `docs/downstream-rollout.md`.
- Local Open Brain verification is complete.
- Hosted Open Brain deploy, mcp2cli cache/schema refresh, generated skills, rtech-mcps handoff, rtech-hermes runtime checks, Hermes rollout, and live canaries are deferred by Rico's current local-only instruction.
- Release/rollback note: server `get_contract` v14 and `openbrain-memory` 0.1.4 must roll forward/back together during the later deploy phase because contract validation is exact-version pinned.
- No core01 deploy performed.

## Notes

- Compact render returns a bounded envelope with `content_preview`, `content_length`, `content_truncated`, `source_ref`, `full_available`, and a full-row `fetch_path`.
- `content_length` and `content_truncated` describe the readable compact projection, not every raw stored column; callers that need every stored column should follow `fetch_path` with `render: "full"`.
- Full `get_entry` remains the default and backward-compatible.
