### PR TITLE
fix(#229): harden first-write session lanes

### DIFF
--- a/docs/plan-3f-open-issues.md
+++ b/docs/plan-3f-open-issues.md
@@ -84,8 +84,12 @@ Local status:
   lane content-hash uniqueness). Fix verification then found denied scoped
   content could be embedded before rejection; Claude also flagged archive CTE
   limit fragility, rollback-error masking, and silent non-transactional fallback.
-  All findings are fixed locally and awaiting commit/push, CI, final fix
-  verification, and repeat Claude cross-review.
+  Follow-up Claude re-review found only LOW issues: the archive parameter
+  alignment is now commented, and post-commit embedding fill remains a known
+  residual risk if the process crashes or the embedding provider stays down
+  after commit. A future embedding backfill for `embedding IS NULL` lanes/events
+  can close that residual, but it is outside #229's local hardening scope. All
+  material findings are fixed locally and awaiting final commit/push/CI.
 
 Required local work:
 

--- a/docs/plan-3f-open-issues.md
+++ b/docs/plan-3f-open-issues.md
@@ -58,8 +58,10 @@ Local status:
 - F6 implemented: `create_if_missing` append uses one pooled-client transaction
   for lane lookup/create plus event insert, with rollback coverage for an event
   insert failure after lane creation. Gauntlet fix: lane and event embedding
-  calls are prepared before `BEGIN` for first-write appends, so a slow or wedged
-  embedding provider cannot hold an open transaction or pooled DB client.
+  calls are filled after the accepted append commits for first-write appends, so
+  a slow or wedged embedding provider cannot hold an open transaction or pooled
+  DB client, and rejected scoped writes do not send denied content to the
+  embedding provider.
 - F8 implemented: first-write lanes embed from `topic` plus `project`, using
   the same lane content-hash shape as `lane_upsert`. Gauntlet fix: migration
   `020_session_lane_namespace_hash.sql` scopes `ob_session_lanes.content_hash`
@@ -72,15 +74,18 @@ Local status:
   execute step rechecks the same idle predicates in the `UPDATE` CTE, so lanes
   that receive a new event after candidate selection are not archived.
 - Local validation on this branch after gauntlet fixes: focused
-  append/lane/script tests pass (`88 pass, 10 skip, 0 fail`), `bunx tsc
+  append/lane/script tests pass (`90 pass, 10 skip, 0 fail`), `bunx tsc
   --noEmit` passes, `git diff --check` passes, and full `bun test` passes
-  (`1070 pass, 50 skip, 0 fail`). DB-backed suites remain skipped locally
+  (`1072 pass, 50 skip, 0 fail`). DB-backed suites remain skipped locally
   because `/Users/rico/.config/open-brain/env.release-test` is missing; CI
   `db-integration` must supply the live Postgres gate before merge.
 - Review gate status: initial swarm found three real blockers on PR #249
   (transaction-open embedding calls, stale archive execute update, and global
-  lane content-hash uniqueness). All three are fixed locally and awaiting
-  commit/push, CI, fix verification, and Claude cross-review.
+  lane content-hash uniqueness). Fix verification then found denied scoped
+  content could be embedded before rejection; Claude also flagged archive CTE
+  limit fragility, rollback-error masking, and silent non-transactional fallback.
+  All findings are fixed locally and awaiting commit/push, CI, final fix
+  verification, and repeat Claude cross-review.
 
 Required local work:
 

--- a/docs/plan-3f-open-issues.md
+++ b/docs/plan-3f-open-issues.md
@@ -88,8 +88,11 @@ Local status:
   alignment is now commented, and post-commit embedding fill remains a known
   residual risk if the process crashes or the embedding provider stays down
   after commit. A future embedding backfill for `embedding IS NULL` lanes/events
-  can close that residual, but it is outside #229's local hardening scope. All
-  material findings are fixed locally and awaiting final commit/push/CI.
+  can close that residual, but it is outside #229's local hardening scope.
+  PR #249 head `9de385d` passed the full local suite and GitHub checks after
+  rerunning the duplicate flaky `db-integration` failure; all material findings
+  are fixed or explicitly dispositioned. Next gate: merge PR #249 without
+  core01 deploy, then verify issue #229 closure and update Project 8.
 
 Required local work:
 

--- a/docs/plan-3f-open-issues.md
+++ b/docs/plan-3f-open-issues.md
@@ -57,18 +57,30 @@ Local status:
 
 - F6 implemented: `create_if_missing` append uses one pooled-client transaction
   for lane lookup/create plus event insert, with rollback coverage for an event
-  insert failure after lane creation.
+  insert failure after lane creation. Gauntlet fix: lane and event embedding
+  calls are prepared before `BEGIN` for first-write appends, so a slow or wedged
+  embedding provider cannot hold an open transaction or pooled DB client.
 - F8 implemented: first-write lanes embed from `topic` plus `project`, using
-  the same lane content-hash shape as `lane_upsert`.
+  the same lane content-hash shape as `lane_upsert`. Gauntlet fix: migration
+  `020_session_lane_namespace_hash.sql` scopes `ob_session_lanes.content_hash`
+  uniqueness by `(content_hash, namespace)`, matching namespace isolation for
+  identical first-write lane context across tenants.
 - F7 implemented as a dry-run-by-default local maintenance script,
   `scripts/archive-idle-session-lanes.ts`, rather than a scheduler or deploy
   change. It defaults to Discord/realtime lanes, refuses a broad sweep unless
-  narrowed, and requires `--execute` to archive candidates.
-- Local validation on this branch: focused append/lane/script tests pass,
-  nearby lane/session tests pass, `bunx tsc --noEmit` passes, `git diff
-  --check` passes, and full `bun test` passes. DB-backed suites remain skipped
-  locally because `/Users/rico/.config/open-brain/env.release-test` is missing;
-  CI `db-integration` must supply the live Postgres gate before merge.
+  narrowed, and requires `--execute` to archive candidates. Gauntlet fix: the
+  execute step rechecks the same idle predicates in the `UPDATE` CTE, so lanes
+  that receive a new event after candidate selection are not archived.
+- Local validation on this branch after gauntlet fixes: focused
+  append/lane/script tests pass (`88 pass, 10 skip, 0 fail`), `bunx tsc
+  --noEmit` passes, `git diff --check` passes, and full `bun test` passes
+  (`1070 pass, 50 skip, 0 fail`). DB-backed suites remain skipped locally
+  because `/Users/rico/.config/open-brain/env.release-test` is missing; CI
+  `db-integration` must supply the live Postgres gate before merge.
+- Review gate status: initial swarm found three real blockers on PR #249
+  (transaction-open embedding calls, stale archive execute update, and global
+  lane content-hash uniqueness). All three are fixed locally and awaiting
+  commit/push, CI, fix verification, and Claude cross-review.
 
 Required local work:
 

--- a/docs/plan-3f-open-issues.md
+++ b/docs/plan-3f-open-issues.md
@@ -50,6 +50,26 @@ Owning boundary:
 `append_session_event.create_if_missing` lane creation and lane lifecycle
 metadata.
 
+Current implementation branch:
+`fix/229-first-write-lane-hardening`.
+
+Local status:
+
+- F6 implemented: `create_if_missing` append uses one pooled-client transaction
+  for lane lookup/create plus event insert, with rollback coverage for an event
+  insert failure after lane creation.
+- F8 implemented: first-write lanes embed from `topic` plus `project`, using
+  the same lane content-hash shape as `lane_upsert`.
+- F7 implemented as a dry-run-by-default local maintenance script,
+  `scripts/archive-idle-session-lanes.ts`, rather than a scheduler or deploy
+  change. It defaults to Discord/realtime lanes, refuses a broad sweep unless
+  narrowed, and requires `--execute` to archive candidates.
+- Local validation on this branch: focused append/lane/script tests pass,
+  nearby lane/session tests pass, `bunx tsc --noEmit` passes, `git diff
+  --check` passes, and full `bun test` passes. DB-backed suites remain skipped
+  locally because `/Users/rico/.config/open-brain/env.release-test` is missing;
+  CI `db-integration` must supply the live Postgres gate before merge.
+
 Required local work:
 
 - F6: make lane-create + event-insert atomic, or add the smallest helper needed

--- a/scripts/archive-idle-session-lanes.test.ts
+++ b/scripts/archive-idle-session-lanes.test.ts
@@ -32,6 +32,9 @@ describe("archiveIdleSessionLanes", () => {
     const db = {
       query: async (sql: string, params?: unknown[]) => {
         calls.push({ sql, params });
+        if (sql.includes("UPDATE ob_session_lanes")) {
+          return { rows: [], rowCount: 1 };
+        }
         if (sql.includes("SELECT l.id")) {
           return {
             rows: [
@@ -70,11 +73,14 @@ describe("archiveIdleSessionLanes", () => {
     expect(selectCall.params).toEqual([7, 100, "discord"]);
   });
 
-  it("execute archives only the selected candidate ids", async () => {
+  it("execute rechecks idle predicates while archiving selected candidate ids", async () => {
     const calls: Array<{ sql: string; params?: unknown[] }> = [];
     const db = {
       query: async (sql: string, params?: unknown[]) => {
         calls.push({ sql, params });
+        if (sql.includes("UPDATE ob_session_lanes")) {
+          return { rows: [], rowCount: 1 };
+        }
         if (sql.includes("SELECT l.id")) {
           return {
             rows: [
@@ -89,9 +95,6 @@ describe("archiveIdleSessionLanes", () => {
               },
             ],
           };
-        }
-        if (sql.includes("UPDATE ob_session_lanes")) {
-          return { rows: [], rowCount: 1 };
         }
         throw new Error("unexpected query");
       },
@@ -115,8 +118,57 @@ describe("archiveIdleSessionLanes", () => {
     expect(selectCall.sql).toContain("l.session_key LIKE $4");
     expect(selectCall.params).toEqual([14, 10, "discord", "discord:%"]);
     expect(updateCall.sql).toContain("status = 'archived'");
+    expect(updateCall.sql).toContain("WITH eligible AS");
+    expect(updateCall.sql).toContain("LEFT JOIN LATERAL");
+    expect(updateCall.sql).toContain("COALESCE(last_event.last_event_at, l.created_at)");
+    expect(updateCall.sql).toContain("l.source = $3");
+    expect(updateCall.sql).toContain("l.session_key LIKE $4");
+    expect(updateCall.sql).toContain("l.id = ANY($5::uuid[])");
     expect(updateCall.params).toEqual([
+      14,
+      10,
+      "discord",
+      "discord:%",
       ["00000000-0000-0000-0000-000000000001"],
     ]);
+  });
+
+  it("reports zero archived rows when the execute-time recheck no longer matches", async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        if (sql.includes("UPDATE ob_session_lanes")) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (sql.includes("SELECT l.id")) {
+          return {
+            rows: [
+              {
+                id: "00000000-0000-0000-0000-000000000001",
+                namespace: "nagatha",
+                session_key: "discord:guild:channel:nagatha",
+                source: "discord",
+                last_event_at: "2026-01-01T00:00:00.000Z",
+                lane_created_at: "2026-01-01T00:00:00.000Z",
+                lane_updated_at: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          };
+        }
+        throw new Error("unexpected query");
+      },
+    };
+
+    const report = await archiveIdleSessionLanes(db as any, {
+      execute: true,
+      olderThanDays: 14,
+      limit: 10,
+      source: "discord",
+    });
+
+    expect(report.dry_run).toBe(false);
+    expect(report.archived).toBe(0);
+    expect(calls).toHaveLength(2);
   });
 });

--- a/scripts/archive-idle-session-lanes.test.ts
+++ b/scripts/archive-idle-session-lanes.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import {
+  archiveIdleSessionLanes,
+  parseArgs,
+} from "./archive-idle-session-lanes.ts";
+
+describe("archive-idle-session-lanes args", () => {
+  it("defaults to dry-run Discord lanes older than 30 days", () => {
+    const args = parseArgs([]);
+    expect(args.execute).toBe(false);
+    expect(args.source).toBe("discord");
+    expect(args.olderThanDays).toBe(30);
+    expect(args.limit).toBe(500);
+  });
+
+  it("requires a scope when disabling the default source", () => {
+    expect(() => parseArgs(["--source", "*"])).toThrow(
+      "Refusing broad idle-lane sweep",
+    );
+  });
+
+  it("accepts an explicit namespace when source filtering is disabled", () => {
+    const args = parseArgs(["--source", "*", "--namespace", "nagatha"]);
+    expect(args.source).toBeUndefined();
+    expect(args.namespace).toBe("nagatha");
+  });
+});
+
+describe("archiveIdleSessionLanes", () => {
+  it("dry-run lists idle candidates without mutating", async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        if (sql.includes("SELECT l.id")) {
+          return {
+            rows: [
+              {
+                id: "00000000-0000-0000-0000-000000000001",
+                namespace: "nagatha",
+                session_key: "discord:guild:channel:nagatha",
+                source: "discord",
+                last_event_at: "2026-01-01T00:00:00.000Z",
+                lane_created_at: "2026-01-01T00:00:00.000Z",
+                lane_updated_at: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          };
+        }
+        throw new Error("unexpected query");
+      },
+    };
+
+    const report = await archiveIdleSessionLanes(db as any, {
+      execute: false,
+      olderThanDays: 7,
+      limit: 100,
+      source: "discord",
+    });
+
+    expect(report.dry_run).toBe(true);
+    expect(report.archived).toBe(0);
+    expect(report.candidates).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+    const selectCall = calls[0];
+    if (!selectCall) throw new Error("expected select call");
+    expect(selectCall.sql).toContain("l.status = 'active'");
+    expect(selectCall.sql).toContain("l.ended_at IS NULL");
+    expect(selectCall.sql).toContain("l.source = $3");
+    expect(selectCall.params).toEqual([7, 100, "discord"]);
+  });
+
+  it("execute archives only the selected candidate ids", async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        if (sql.includes("SELECT l.id")) {
+          return {
+            rows: [
+              {
+                id: "00000000-0000-0000-0000-000000000001",
+                namespace: "nagatha",
+                session_key: "discord:guild:channel:nagatha",
+                source: "discord",
+                last_event_at: "2026-01-01T00:00:00.000Z",
+                lane_created_at: "2026-01-01T00:00:00.000Z",
+                lane_updated_at: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          };
+        }
+        if (sql.includes("UPDATE ob_session_lanes")) {
+          return { rows: [], rowCount: 1 };
+        }
+        throw new Error("unexpected query");
+      },
+    };
+
+    const report = await archiveIdleSessionLanes(db as any, {
+      execute: true,
+      olderThanDays: 14,
+      limit: 10,
+      source: "discord",
+      sessionKeyPrefix: "discord:",
+    });
+
+    expect(report.dry_run).toBe(false);
+    expect(report.archived).toBe(1);
+    expect(calls).toHaveLength(2);
+    const selectCall = calls[0];
+    const updateCall = calls[1];
+    if (!selectCall || !updateCall) throw new Error("expected select + update");
+    expect(selectCall.sql).toContain("l.source = $3");
+    expect(selectCall.sql).toContain("l.session_key LIKE $4");
+    expect(selectCall.params).toEqual([14, 10, "discord", "discord:%"]);
+    expect(updateCall.sql).toContain("status = 'archived'");
+    expect(updateCall.params).toEqual([
+      ["00000000-0000-0000-0000-000000000001"],
+    ]);
+  });
+});

--- a/scripts/archive-idle-session-lanes.ts
+++ b/scripts/archive-idle-session-lanes.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+/**
+ * Archive idle session lanes.
+ *
+ * Safety model:
+ * - Dry-run by default; no rows mutate unless --execute is passed.
+ * - Narrow by default to Discord/realtime lanes via source='discord'.
+ * - Parameterized SQL only; caller values are never interpolated.
+ * - Idempotent: already archived/wrapped lanes are skipped.
+ */
+import type pg from "pg";
+import { createPool } from "../src/db/pool.ts";
+
+type Queryable = Pick<pg.Pool | pg.PoolClient, "query">;
+
+export interface ArchiveIdleLaneArgs {
+  execute: boolean;
+  olderThanDays: number;
+  limit: number;
+  source?: string;
+  namespace?: string;
+  sessionKeyPrefix?: string;
+}
+
+export interface ArchiveIdleLaneCandidate {
+  id: string;
+  namespace: string;
+  session_key: string;
+  source: string | null;
+  last_event_at: string | null;
+  lane_created_at: string;
+  lane_updated_at: string;
+}
+
+export interface ArchiveIdleLaneReport {
+  dry_run: boolean;
+  older_than_days: number;
+  limit: number;
+  source: string | null;
+  namespace: string | null;
+  session_key_prefix: string | null;
+  candidates: ArchiveIdleLaneCandidate[];
+  archived: number;
+}
+
+export function parseArgs(argv: string[]): ArchiveIdleLaneArgs {
+  const args: ArchiveIdleLaneArgs = {
+    execute: false,
+    olderThanDays: 30,
+    limit: 500,
+    source: "discord",
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (!value) throw new Error(`${arg} requires a value`);
+      return value;
+    };
+
+    if (arg === "--execute") args.execute = true;
+    else if (arg === "--older-than-days") {
+      args.olderThanDays = parsePositiveInt(next(), arg);
+    } else if (arg === "--limit") {
+      args.limit = parsePositiveInt(next(), arg);
+    } else if (arg === "--source") {
+      const value = next();
+      args.source = value === "*" ? undefined : value;
+    } else if (arg === "--namespace") {
+      args.namespace = next();
+    } else if (arg === "--session-key-prefix") {
+      args.sessionKeyPrefix = next();
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.source && !args.namespace && !args.sessionKeyPrefix) {
+    throw new Error(
+      "Refusing broad idle-lane sweep: provide --source, --namespace, or --session-key-prefix",
+    );
+  }
+
+  return args;
+}
+
+function parsePositiveInt(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function buildFilters(args: ArchiveIdleLaneArgs): {
+  where: string[];
+  params: unknown[];
+} {
+  const params: unknown[] = [args.olderThanDays, args.limit];
+  const where = [
+    "l.status = 'active'",
+    "l.ended_at IS NULL",
+    "COALESCE(last_event.last_event_at, l.created_at) < NOW() - ($1::int * INTERVAL '1 day')",
+  ];
+
+  if (args.source) {
+    params.push(args.source);
+    where.push(`l.source = $${params.length}`);
+  }
+  if (args.namespace) {
+    params.push(args.namespace);
+    where.push(`l.namespace = $${params.length}`);
+  }
+  if (args.sessionKeyPrefix) {
+    params.push(`${args.sessionKeyPrefix}%`);
+    where.push(`l.session_key LIKE $${params.length}`);
+  }
+
+  return { where, params };
+}
+
+export async function archiveIdleSessionLanes(
+  db: Queryable,
+  args: ArchiveIdleLaneArgs,
+): Promise<ArchiveIdleLaneReport> {
+  const { where, params } = buildFilters(args);
+  const whereSql = where.join("\n       AND ");
+
+  const { rows: candidates } = await db.query(
+    `SELECT l.id, l.namespace, l.session_key, l.source,
+            last_event.last_event_at,
+            l.created_at AS lane_created_at,
+            l.updated_at AS lane_updated_at
+       FROM ob_session_lanes l
+       LEFT JOIN LATERAL (
+         SELECT MAX(e.created_at) AS last_event_at
+           FROM ob_session_events e
+          WHERE e.lane_id = l.id
+       ) last_event ON TRUE
+      WHERE ${whereSql}
+      ORDER BY COALESCE(last_event.last_event_at, l.created_at) ASC, l.id ASC
+      LIMIT $2`,
+    params,
+  );
+
+  let archived = 0;
+  if (args.execute && candidates.length > 0) {
+    const ids = candidates.map((row) => row.id);
+    const result = await db.query(
+      `UPDATE ob_session_lanes
+          SET status = 'archived',
+              ended_at = COALESCE(ended_at, NOW()),
+              updated_at = NOW()
+        WHERE id = ANY($1::uuid[])
+          AND status = 'active'
+          AND ended_at IS NULL`,
+      [ids],
+    );
+    archived = result.rowCount ?? 0;
+  }
+
+  return {
+    dry_run: !args.execute,
+    older_than_days: args.olderThanDays,
+    limit: args.limit,
+    source: args.source ?? null,
+    namespace: args.namespace ?? null,
+    session_key_prefix: args.sessionKeyPrefix ?? null,
+    candidates: candidates as ArchiveIdleLaneCandidate[],
+    archived,
+  };
+}
+
+function printUsage(): void {
+  console.error(`Usage:
+  bun run scripts/archive-idle-session-lanes.ts [--execute] [options]
+
+Options:
+  --older-than-days N      Archive lanes idle longer than N days (default 30)
+  --limit N               Maximum lanes per run (default 500)
+  --source VALUE          Lane source to sweep (default discord, "*" disables)
+  --namespace VALUE       Restrict to one namespace
+  --session-key-prefix P  Restrict to session_key LIKE "P%"
+`);
+}
+
+if (import.meta.main) {
+  try {
+    const args = parseArgs(Bun.argv.slice(2));
+    if (!process.env.DB_HOST || !process.env.DB_USER) {
+      throw new Error(
+        "DB_HOST and DB_USER are required (DB_NAME defaults to open_brain).",
+      );
+    }
+    const pool = createPool({
+      max: 2,
+      statement_timeout: 60000,
+      application_name: "openbrain-archive-idle-session-lanes",
+    });
+    try {
+      const report = await archiveIdleSessionLanes(pool, args);
+      console.log(JSON.stringify(report, null, 2));
+      if (report.dry_run) {
+        console.error(
+          "\nDRY-RUN complete. No rows were mutated. Re-run with --execute to apply.",
+        );
+      }
+    } finally {
+      await pool.end();
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    printUsage();
+    process.exit(1);
+  }
+}

--- a/scripts/archive-idle-session-lanes.ts
+++ b/scripts/archive-idle-session-lanes.ts
@@ -150,15 +150,29 @@ export async function archiveIdleSessionLanes(
   let archived = 0;
   if (args.execute && candidates.length > 0) {
     const ids = candidates.map((row) => row.id);
+    const updateParams = [...params, ids];
+    const idParam = updateParams.length;
     const result = await db.query(
-      `UPDATE ob_session_lanes
+      `WITH eligible AS (
+         SELECT l.id
+           FROM ob_session_lanes l
+           LEFT JOIN LATERAL (
+             SELECT MAX(e.created_at) AS last_event_at
+               FROM ob_session_events e
+              WHERE e.lane_id = l.id
+           ) last_event ON TRUE
+          WHERE ${whereSql}
+            AND l.id = ANY($${idParam}::uuid[])
+          ORDER BY COALESCE(last_event.last_event_at, l.created_at) ASC, l.id ASC
+          LIMIT $2
+       )
+       UPDATE ob_session_lanes l
           SET status = 'archived',
-              ended_at = COALESCE(ended_at, NOW()),
+              ended_at = COALESCE(l.ended_at, NOW()),
               updated_at = NOW()
-        WHERE id = ANY($1::uuid[])
-          AND status = 'active'
-          AND ended_at IS NULL`,
-      [ids],
+         FROM eligible
+        WHERE l.id = eligible.id`,
+      updateParams,
     );
     archived = result.rowCount ?? 0;
   }

--- a/scripts/archive-idle-session-lanes.ts
+++ b/scripts/archive-idle-session-lanes.ts
@@ -150,6 +150,9 @@ export async function archiveIdleSessionLanes(
   let archived = 0;
   if (args.execute && candidates.length > 0) {
     const ids = candidates.map((row) => row.id);
+    // Keep the original params so reused whereSql placeholders ($3+) stay
+    // aligned. $2 is the SELECT limit and is intentionally unused by UPDATE;
+    // selected ids already bound the execute set.
     const updateParams = [...params, ids];
     const idParam = updateParams.length;
     const result = await db.query(

--- a/scripts/archive-idle-session-lanes.ts
+++ b/scripts/archive-idle-session-lanes.ts
@@ -164,7 +164,6 @@ export async function archiveIdleSessionLanes(
           WHERE ${whereSql}
             AND l.id = ANY($${idParam}::uuid[])
           ORDER BY COALESCE(last_event.last_event_at, l.created_at) ASC, l.id ASC
-          LIMIT $2
        )
        UPDATE ob_session_lanes l
           SET status = 'archived',

--- a/src/db/migrations/020_session_lane_namespace_hash.sql
+++ b/src/db/migrations/020_session_lane_namespace_hash.sql
@@ -1,0 +1,10 @@
+-- Migration 020: namespace-scope session lane content_hash uniqueness
+-- First-write lane embedding stores content_hash on ob_session_lanes. Match the
+-- durable-table namespace isolation contract so identical lane context in two
+-- namespaces cannot collide on a global hash index.
+
+DROP INDEX IF EXISTS idx_session_lanes_content_hash;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_lanes_content_hash
+  ON ob_session_lanes (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -6,6 +6,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAppendSessionEvent } from "../append-session-event.ts";
 import type { ToolDeps } from "../index.ts";
 import type { AuthInfo } from "../../types.ts";
+import { EMBEDDING_MODEL, contentHash } from "../../embedding.ts";
 
 function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
   return async (_text: string) => result;
@@ -263,7 +264,8 @@ describe("append_session_event", () => {
     const captured: {
       laneInsertParams?: any[];
       eventInsertParams?: any[];
-    } = {};
+      embedInputs: string[];
+    } = { embedInputs: [] };
     const mockPool = {
       query: async (sql: string, params?: any[]) => {
         if (sql.includes("INSERT INTO ob_session_lanes")) {
@@ -295,7 +297,10 @@ describe("append_session_event", () => {
       },
     };
     const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    const { client, cleanup } = await setupToolClient(mockPool, auth, async (text) => {
+      captured.embedInputs.push(text);
+      return Array(768).fill(0.1);
+    });
 
     try {
       const result = await client.callTool({
@@ -321,7 +326,7 @@ describe("append_session_event", () => {
       expect(parsed.event_id).toBe("event-uuid-1");
       expect(parsed.lane_id).toBe("lane-uuid-new");
       expect(parsed.lane_created).toBe(true);
-      expect(captured.laneInsertParams).toEqual([
+      expect(captured.laneInsertParams?.slice(0, 9)).toEqual([
         "discord:guild-1:channel-1:thread-1:nagatha",
         "nagatha",
         "nagatha",
@@ -331,7 +336,19 @@ describe("append_session_event", () => {
         "rtech-hermes",
         "Nagatha Discord scoped memory",
         JSON.stringify({ server_id: "guild-1" }),
-        "nagatha",
+      ]);
+      expect(captured.laneInsertParams?.[9]).not.toBeNull();
+      expect(captured.laneInsertParams?.[10]).toBe(
+        contentHash(
+          "discord:guild-1:channel-1:thread-1:nagatha|Nagatha Discord scoped memory",
+        ),
+      );
+      expect(captured.laneInsertParams?.[11]).not.toBeNull();
+      expect(captured.laneInsertParams?.[12]).toBe(EMBEDDING_MODEL);
+      expect(captured.laneInsertParams?.[13]).toBe("nagatha");
+      expect(captured.embedInputs).toEqual([
+        "Nagatha Discord scoped memory\nrtech-hermes",
+        "GitHub issue URLs must use live gh first.",
       ]);
       expect(captured.eventInsertParams?.[0]).toBe("lane-uuid-new");
     } finally {
@@ -692,6 +709,85 @@ describe("append_session_event", () => {
       expect(parsed.error).toBe("retryable_outage");
       expect(parsed.retryable).toBe(true);
       expect(parsed.message).toContain("connection timeout");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rolls back a first-write lane when event insert fails after lane creation", async () => {
+    const calls: string[] = [];
+    let released = false;
+    const client = {
+      query: async (sql: string, _params?: any[]) => {
+        calls.push(sql);
+        if (sql === "BEGIN" || sql === "ROLLBACK" || sql === "COMMIT") {
+          return { rows: [] };
+        }
+        if (sql.includes("FROM ob_session_lanes")) {
+          return { rows: [] };
+        }
+        if (sql.includes("INSERT INTO ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-new",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: null,
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          throw new Error("event insert failed");
+        }
+        return { rows: [] };
+      },
+      release: () => {
+        released = true;
+      },
+    };
+    const mockPool = {
+      connect: async () => client,
+      query: async () => {
+        throw new Error("pool.query should not be used inside transaction");
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client: toolClient, cleanup } = await setupToolClient(
+      mockPool as any,
+      auth,
+      createMockEmbed(null),
+    );
+
+    try {
+      const result = await toolClient.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          topic: "Nagatha Discord scoped memory",
+          event_type: "fact",
+          content: "This event insert fails.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("retryable_outage");
+      expect(parsed.retryable).toBe(true);
+      expect(parsed.message).toContain("event insert failed");
+      expect(calls).toContain("BEGIN");
+      expect(calls).toContain("ROLLBACK");
+      expect(calls).not.toContain("COMMIT");
+      expect(released).toBe(true);
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -760,7 +760,10 @@ describe("append_session_event", () => {
     const { client: toolClient, cleanup } = await setupToolClient(
       mockPool as any,
       auth,
-      createMockEmbed(null),
+      async (text) => {
+        calls.push(`embed:${text}`);
+        return null;
+      },
     );
 
     try {
@@ -787,6 +790,12 @@ describe("append_session_event", () => {
       expect(calls).toContain("BEGIN");
       expect(calls).toContain("ROLLBACK");
       expect(calls).not.toContain("COMMIT");
+      expect(calls.indexOf("embed:Nagatha Discord scoped memory")).toBeLessThan(
+        calls.indexOf("BEGIN"),
+      );
+      expect(calls.indexOf("embed:This event insert fails.")).toBeLessThan(
+        calls.indexOf("BEGIN"),
+      );
       expect(released).toBe(true);
     } finally {
       await cleanup();
@@ -1733,15 +1742,17 @@ const dbDescribe = DB_URL ? describe : describe.skip;
 dbDescribe("append_session_event create_if_missing (live Postgres)", () => {
   const pool = new Pool({ connectionString: DB_URL });
   const ns = "test-append-live";
+  const otherNs = "test-append-live-other";
 
   async function callAppend(
     args: Record<string, unknown>,
     auth: AuthInfo = { role: "agent", clientId: ns },
+    embedFn = createMockEmbed(null),
   ) {
     const server = new McpServer({ name: "test", version: "1.0.0" });
     const deps: ToolDeps = {
       pool: pool as any,
-      embedFn: createMockEmbed(null),
+      embedFn,
     };
     registerAppendSessionEvent(server, deps);
     const [ct, st] = InMemoryTransport.createLinkedPair();
@@ -1763,10 +1774,13 @@ dbDescribe("append_session_event create_if_missing (live Postgres)", () => {
     // Events cascade from lanes; delete by namespace-scoped lane ids.
     await pool.query(
       `DELETE FROM ob_session_events WHERE lane_id IN
-         (SELECT id FROM ob_session_lanes WHERE namespace = $1)`,
-      [ns],
+         (SELECT id FROM ob_session_lanes WHERE namespace = ANY($1::text[]))`,
+      [[ns, otherNs]],
     );
-    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+    await pool.query(
+      "DELETE FROM ob_session_lanes WHERE namespace = ANY($1::text[])",
+      [[ns, otherNs]],
+    );
   }
 
   afterAll(async () => {
@@ -1843,6 +1857,100 @@ dbDescribe("append_session_event create_if_missing (live Postgres)", () => {
         [ns, "live-race"],
       );
       expect(rows[0].n).toBe(1);
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("embeds first-write lane topic/project metadata on the real lane row", async () => {
+    await cleanupNs();
+    try {
+      const res = await callAppend(
+        {
+          session_key: "live-embedded-lane",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          project: "rtech-hermes",
+          topic: "Nagatha Discord scoped memory",
+          event_type: "fact",
+          content: "first embedded scoped event",
+        },
+        { role: "agent", clientId: ns },
+        createMockEmbed(Array(768).fill(0.1)),
+      );
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse((res.content as any)[0].text);
+      expect(parsed.lane_created).toBe(true);
+
+      const { rows } = await pool.query(
+        `SELECT content_hash, embedded_at, embedding_model, embedding IS NOT NULL AS has_embedding
+           FROM ob_session_lanes
+          WHERE namespace=$1 AND session_key=$2`,
+        [ns, "live-embedded-lane"],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].content_hash).toBe(
+        contentHash("live-embedded-lane|Nagatha Discord scoped memory"),
+      );
+      expect(rows[0].embedded_at).not.toBeNull();
+      expect(rows[0].embedding_model).toBe(EMBEDDING_MODEL);
+      expect(rows[0].has_embedding).toBe(true);
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("allows identical first-write lane hashes in separate namespaces", async () => {
+    await cleanupNs();
+    try {
+      const args = {
+        session_key: "live-shared-topic",
+        namespace: ns,
+        create_if_missing: true,
+        agent: "nagatha",
+        platform: "discord",
+        server_id: "guild-1",
+        channel_id: "channel-1",
+        project: "rtech-hermes",
+        topic: "Shared operational context",
+        event_type: "fact",
+        content: "namespace A first event",
+      };
+      const first = await callAppend(
+        args,
+        { role: "admin", clientId: ns },
+        createMockEmbed(Array(768).fill(0.1)),
+      );
+      expect(first.isError).toBeFalsy();
+
+      const second = await callAppend(
+        {
+          ...args,
+          namespace: otherNs,
+          content: "namespace B first event",
+        },
+        { role: "admin", clientId: ns },
+        createMockEmbed(Array(768).fill(0.2)),
+      );
+      expect(second.isError).toBeFalsy();
+
+      const expectedHash = contentHash(
+        "live-shared-topic|Shared operational context",
+      );
+      const { rows } = await pool.query(
+        `SELECT namespace, content_hash
+           FROM ob_session_lanes
+          WHERE namespace = ANY($1::text[]) AND session_key=$2
+          ORDER BY namespace`,
+        [[ns, otherNs], "live-shared-topic"],
+      );
+      expect(rows).toEqual([
+        { namespace: ns, content_hash: expectedHash },
+        { namespace: otherNs, content_hash: expectedHash },
+      ]);
     } finally {
       await cleanupNs();
     }

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -22,11 +22,13 @@ async function setupToolClient(
   mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
   auth: AuthInfo,
   embedFn?: (text: string) => Promise<number[] | null>,
+  allowNonTransactionalAppendFallback = true,
 ): Promise<{ client: Client; cleanup: () => Promise<void> }> {
   const server = new McpServer({ name: "test", version: "1.0.0" });
   const deps: ToolDeps = {
     pool: mockPool as any,
     embedFn: embedFn ?? createMockEmbed(),
+    allowNonTransactionalAppendFallback,
   };
   registerAppendSessionEvent(server, deps);
 
@@ -337,14 +339,14 @@ describe("append_session_event", () => {
         "Nagatha Discord scoped memory",
         JSON.stringify({ server_id: "guild-1" }),
       ]);
-      expect(captured.laneInsertParams?.[9]).not.toBeNull();
+      expect(captured.laneInsertParams?.[9]).toBeNull();
       expect(captured.laneInsertParams?.[10]).toBe(
         contentHash(
           "discord:guild-1:channel-1:thread-1:nagatha|Nagatha Discord scoped memory",
         ),
       );
-      expect(captured.laneInsertParams?.[11]).not.toBeNull();
-      expect(captured.laneInsertParams?.[12]).toBe(EMBEDDING_MODEL);
+      expect(captured.laneInsertParams?.[11]).toBeNull();
+      expect(captured.laneInsertParams?.[12]).toBeNull();
       expect(captured.laneInsertParams?.[13]).toBe("nagatha");
       expect(captured.embedInputs).toEqual([
         "Nagatha Discord scoped memory\nrtech-hermes",
@@ -378,6 +380,9 @@ describe("append_session_event", () => {
           return {
             rows: [{ id: "event-uuid-1", created_at: "2026-06-28T18:00:00Z" }],
           };
+        }
+        if (sql.includes("UPDATE ob_session_events")) {
+          return { rows: [] };
         }
         throw new Error(`unexpected query: ${sql}`);
       },
@@ -471,6 +476,7 @@ describe("append_session_event", () => {
 
   it("denies append when supplied exact scope conflicts with the existing lane", async () => {
     let eventInsertAttempted = false;
+    const embedInputs: string[] = [];
     const mockPool = {
       query: async (sql: string, _params?: any[]) => {
         if (sql.includes("FROM ob_session_lanes")) {
@@ -495,7 +501,14 @@ describe("append_session_event", () => {
       },
     };
     const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    const { client, cleanup } = await setupToolClient(
+      mockPool,
+      auth,
+      async (text) => {
+        embedInputs.push(text);
+        return Array(768).fill(0.1);
+      },
+    );
 
     try {
       const result = await client.callTool({
@@ -519,6 +532,7 @@ describe("append_session_event", () => {
       expect(parsed.retryable).toBe(false);
       expect(parsed.conflicts).toEqual(["channel_id"]);
       expect(eventInsertAttempted).toBe(false);
+      expect(embedInputs).toEqual([]);
     } finally {
       await cleanup();
     }
@@ -790,13 +804,113 @@ describe("append_session_event", () => {
       expect(calls).toContain("BEGIN");
       expect(calls).toContain("ROLLBACK");
       expect(calls).not.toContain("COMMIT");
-      expect(calls.indexOf("embed:Nagatha Discord scoped memory")).toBeLessThan(
-        calls.indexOf("BEGIN"),
-      );
-      expect(calls.indexOf("embed:This event insert fails.")).toBeLessThan(
-        calls.indexOf("BEGIN"),
-      );
+      expect(calls).not.toContain("embed:Nagatha Discord scoped memory");
+      expect(calls).not.toContain("embed:This event insert fails.");
       expect(released).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves the original append error when rollback also fails", async () => {
+    const client = {
+      query: async (sql: string, _params?: any[]) => {
+        if (sql === "BEGIN") return { rows: [] };
+        if (sql === "ROLLBACK") throw new Error("rollback connection reset");
+        if (sql.includes("FROM ob_session_lanes")) {
+          return { rows: [] };
+        }
+        if (sql.includes("INSERT INTO ob_session_lanes")) {
+          return {
+            rows: [
+              {
+                id: "lane-uuid-new",
+                status: "active",
+                agent: "nagatha",
+                source: "discord",
+                channel_id: "channel-1",
+                thread_id: null,
+                metadata: { server_id: "guild-1" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("INSERT INTO ob_session_events")) {
+          throw new Error("event insert failed");
+        }
+        return { rows: [] };
+      },
+      release: () => {},
+    };
+    const mockPool = {
+      connect: async () => client,
+      query: async () => {
+        throw new Error("pool.query should not be used inside transaction");
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client: toolClient, cleanup } = await setupToolClient(
+      mockPool as any,
+      auth,
+      createMockEmbed(null),
+    );
+
+    try {
+      const result = await toolClient.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content: "This event insert fails before rollback also fails.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("retryable_outage");
+      expect(parsed.message).toContain("event insert failed");
+      expect(parsed.message).not.toContain("rollback connection reset");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("fails loud when create_if_missing cannot get a transactional pool", async () => {
+    const mockPool = {
+      query: async () => ({ rows: [] }),
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
+    const { client, cleanup } = await setupToolClient(
+      mockPool,
+      auth,
+      createMockEmbed(null),
+      false,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "discord:guild-1:channel-1:nagatha",
+          create_if_missing: true,
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "guild-1",
+          channel_id: "channel-1",
+          event_type: "fact",
+          content: "This should not run non-atomically.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("retryable_outage");
+      expect(parsed.message).toContain("requires a transactional pg Pool");
     } finally {
       await cleanup();
     }

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -64,7 +64,15 @@ async function withAppendDb<T>(
   transactional: boolean,
   fn: (db: Queryable) => Promise<T>,
 ): Promise<T> {
-  if (!transactional || typeof deps.pool.connect !== "function") {
+  if (!transactional) {
+    return fn(deps.pool);
+  }
+  if (typeof deps.pool.connect !== "function") {
+    if (!deps.allowNonTransactionalAppendFallback) {
+      throw new Error(
+        "append_session_event create_if_missing requires a transactional pg Pool",
+      );
+    }
     return fn(deps.pool);
   }
 
@@ -75,7 +83,16 @@ async function withAppendDb<T>(
     await client.query("COMMIT");
     return result;
   } catch (err) {
-    await client.query("ROLLBACK");
+    try {
+      await client.query("ROLLBACK");
+    } catch (rollbackErr) {
+      logger.warn("append_session_event_rollback_failed", {
+        error:
+          rollbackErr instanceof Error
+            ? rollbackErr.message
+            : String(rollbackErr),
+      });
+    }
     throw err;
   } finally {
     client.release();
@@ -96,9 +113,7 @@ async function firstWriteLaneEmbedding(
   model: string | null;
 }> {
   const contextText = args.topic || "";
-  const contentHashValue = contextText
-    ? contentHash(args.session_key + "|" + contextText)
-    : null;
+  const contentHashValue = firstWriteLaneContentHash(args);
 
   let embedding: number[] | null = null;
   if (contextText) {
@@ -122,6 +137,26 @@ async function firstWriteLaneEmbedding(
   };
 }
 
+function firstWriteLaneContentHash(args: {
+  session_key: string;
+  topic?: string;
+}): string | null {
+  const contextText = args.topic || "";
+  return contextText ? contentHash(args.session_key + "|" + contextText) : null;
+}
+
+function firstWriteLaneHashOnly(args: {
+  session_key: string;
+  topic?: string;
+}): PreparedLaneEmbedding {
+  return {
+    embeddingVal: null,
+    contentHashValue: firstWriteLaneContentHash(args),
+    embeddedAt: null,
+    model: null,
+  };
+}
+
 async function appendEventEmbedding(
   deps: ToolDeps,
   args: { session_key: string; content: string },
@@ -142,6 +177,73 @@ async function appendEventEmbedding(
     embeddedAt: embedding ? new Date().toISOString() : null,
     model: embedding ? EMBEDDING_MODEL : null,
   };
+}
+
+async function fillAcceptedLaneEmbedding(
+  deps: ToolDeps,
+  laneId: string,
+  args: {
+    session_key: string;
+    project?: string;
+    topic?: string;
+  },
+): Promise<void> {
+  const laneEmbedding = await firstWriteLaneEmbedding(deps, args);
+  if (!laneEmbedding.embeddingVal) return;
+
+  try {
+    await deps.pool.query(
+      `UPDATE ob_session_lanes
+          SET embedding = $1,
+              embedded_at = $2,
+              embedding_model = $3,
+              updated_at = NOW()
+        WHERE id = $4`,
+      [
+        laneEmbedding.embeddingVal,
+        laneEmbedding.embeddedAt,
+        laneEmbedding.model,
+        laneId,
+      ],
+    );
+  } catch (err) {
+    logger.warn("append_session_event_lane_embedding_update_error", {
+      session_key: args.session_key,
+      lane_id: laneId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function fillAcceptedEventEmbedding(
+  deps: ToolDeps,
+  eventId: string,
+  args: { session_key: string; content: string },
+): Promise<void> {
+  const eventEmbedding = await appendEventEmbedding(deps, args);
+  if (!eventEmbedding.embeddingVal) return;
+
+  try {
+    await deps.pool.query(
+      `UPDATE ob_session_events
+          SET embedding = $1,
+              embedded_at = $2,
+              embedding_model = $3
+        WHERE id = $4`,
+      [
+        eventEmbedding.embeddingVal,
+        eventEmbedding.embeddedAt,
+        eventEmbedding.model,
+        eventId,
+      ],
+    );
+  } catch (err) {
+    logger.warn("append_session_event_embedding_update_error", {
+      session_key: args.session_key,
+      event_id: eventId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 function scopeConflicts(
@@ -686,14 +788,10 @@ export function registerAppendSessionEvent(
 
       try {
         const transactionalAppend = args.create_if_missing === true;
-        const preparedLaneEmbedding = transactionalAppend
-          ? await firstWriteLaneEmbedding(deps, args)
-          : undefined;
-        const preparedEventEmbedding = transactionalAppend
-          ? await appendEventEmbedding(deps, args)
-          : undefined;
+        let acceptedLaneForEmbedding: string | null = null;
+        let acceptedEventForEmbedding: string | null = null;
 
-        return await withAppendDb(
+        const response = await withAppendDb(
           deps,
           transactionalAppend,
           async (db) => {
@@ -715,7 +813,9 @@ export function registerAppendSessionEvent(
                     : args.thread_id,
                 project: args.project,
                 topic: args.topic,
-                laneEmbedding: preparedLaneEmbedding,
+                laneEmbedding: transactionalAppend
+                  ? firstWriteLaneHashOnly(args)
+                  : undefined,
               },
               auth,
             );
@@ -733,6 +833,9 @@ export function registerAppendSessionEvent(
             }
 
             const laneId = String(laneResult.lane.id);
+            if (transactionalAppend && laneResult.created) {
+              acceptedLaneForEmbedding = laneId;
+            }
 
             // Hybrid sync gate: a share_candidate nomination carrying a secret or
             // person-private content is rejected inline (cheap, no embedding) and
@@ -772,8 +875,14 @@ export function registerAppendSessionEvent(
               });
             }
 
-            const eventEmbedding =
-              preparedEventEmbedding ?? (await appendEventEmbedding(deps, args));
+            const eventEmbedding: PreparedEventEmbedding = transactionalAppend
+              ? {
+                  embeddingVal: null,
+                  contentHashValue: contentHash(args.content),
+                  embeddedAt: null,
+                  model: null,
+                }
+              : await appendEventEmbedding(deps, args);
 
             const { rows } = await db.query(
               `INSERT INTO ob_session_events
@@ -839,6 +948,9 @@ export function registerAppendSessionEvent(
                   }
                 : {}),
             };
+            if (transactionalAppend) {
+              acceptedEventForEmbedding = String(result.event_id);
+            }
 
             logger.info("append_session_event_ok", {
               event_id: result.event_id,
@@ -857,6 +969,15 @@ export function registerAppendSessionEvent(
             };
           },
         );
+
+        if (acceptedLaneForEmbedding) {
+          await fillAcceptedLaneEmbedding(deps, acceptedLaneForEmbedding, args);
+        }
+        if (acceptedEventForEmbedding) {
+          await fillAcceptedEventEmbedding(deps, acceptedEventForEmbedding, args);
+        }
+
+        return response;
       } catch (err) {
         logger.error("append_session_event_db_error", {
           session_key: args.session_key,

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -46,6 +46,18 @@ function appendSessionEventError(
 }
 
 type Queryable = Pick<pg.Pool | pg.PoolClient, "query">;
+type PreparedLaneEmbedding = {
+  embeddingVal: ReturnType<typeof toSql> | null;
+  contentHashValue: string | null;
+  embeddedAt: string | null;
+  model: string | null;
+};
+type PreparedEventEmbedding = {
+  embeddingVal: ReturnType<typeof toSql> | null;
+  contentHashValue: string;
+  embeddedAt: string | null;
+  model: string | null;
+};
 
 async function withAppendDb<T>(
   deps: ToolDeps,
@@ -110,6 +122,28 @@ async function firstWriteLaneEmbedding(
   };
 }
 
+async function appendEventEmbedding(
+  deps: ToolDeps,
+  args: { session_key: string; content: string },
+): Promise<PreparedEventEmbedding> {
+  let embedding: number[] | null = null;
+  try {
+    embedding = await deps.embedFn(args.content);
+  } catch (err) {
+    logger.warn("append_session_event_embed_error", {
+      session_key: args.session_key,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return {
+    embeddingVal: embedding ? toSql(embedding) : null,
+    contentHashValue: contentHash(args.content),
+    embeddedAt: embedding ? new Date().toISOString() : null,
+    model: embedding ? EMBEDDING_MODEL : null,
+  };
+}
+
 function scopeConflicts(
   lane: Record<string, unknown>,
   args: {
@@ -162,6 +196,7 @@ async function ensureLaneForAppend(
     thread_id?: string | null;
     project?: string;
     topic?: string;
+    laneEmbedding?: PreparedLaneEmbedding;
   },
   auth: AuthInfo,
 ): Promise<
@@ -186,7 +221,8 @@ WHERE namespace = $1 AND session_key = $2`,
     attemptedCreate = true;
     const metadata =
       args.server_id === undefined ? {} : { server_id: args.server_id };
-    const laneEmbedding = await firstWriteLaneEmbedding(deps, args);
+    const laneEmbedding =
+      args.laneEmbedding ?? (await firstWriteLaneEmbedding(deps, args));
     const { rows: insertedRows } = await db.query(
       `INSERT INTO ob_session_lanes
   (session_key, namespace, status, agent, source, channel_id, thread_id,
@@ -649,9 +685,17 @@ export function registerAppendSessionEvent(
       });
 
       try {
+        const transactionalAppend = args.create_if_missing === true;
+        const preparedLaneEmbedding = transactionalAppend
+          ? await firstWriteLaneEmbedding(deps, args)
+          : undefined;
+        const preparedEventEmbedding = transactionalAppend
+          ? await appendEventEmbedding(deps, args)
+          : undefined;
+
         return await withAppendDb(
           deps,
-          args.create_if_missing === true,
+          transactionalAppend,
           async (db) => {
             const laneResult = await ensureLaneForAppend(
               db,
@@ -671,6 +715,7 @@ export function registerAppendSessionEvent(
                     : args.thread_id,
                 project: args.project,
                 topic: args.topic,
+                laneEmbedding: preparedLaneEmbedding,
               },
               auth,
             );
@@ -727,21 +772,8 @@ export function registerAppendSessionEvent(
               });
             }
 
-            // Generate embedding (non-fatal)
-            let embedding: number[] | null = null;
-            try {
-              embedding = await deps.embedFn(args.content);
-            } catch (err) {
-              logger.warn("append_session_event_embed_error", {
-                session_key: args.session_key,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
-
-            const hash = contentHash(args.content);
-            const embeddingVal = embedding ? toSql(embedding) : null;
-            const embeddedAt = embedding ? new Date().toISOString() : null;
-            const model = embedding ? EMBEDDING_MODEL : null;
+            const eventEmbedding =
+              preparedEventEmbedding ?? (await appendEventEmbedding(deps, args));
 
             const { rows } = await db.query(
               `INSERT INTO ob_session_events
@@ -758,10 +790,10 @@ export function registerAppendSessionEvent(
                 args.artifact_path ?? null,
                 importance,
                 JSON.stringify(metadata),
-                embeddingVal,
-                hash,
-                embeddedAt,
-                model,
+                eventEmbedding.embeddingVal,
+                eventEmbedding.contentHashValue,
+                eventEmbedding.embeddedAt,
+                eventEmbedding.model,
                 auth.clientId,
               ],
             );

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type pg from "pg";
 import { toSql } from "pgvector/pg";
 import { canWrite } from "../permissions.ts";
 import { canWriteNamespace } from "../namespace-policy.ts";
@@ -44,6 +45,71 @@ function appendSessionEventError(
   };
 }
 
+type Queryable = Pick<pg.Pool | pg.PoolClient, "query">;
+
+async function withAppendDb<T>(
+  deps: ToolDeps,
+  transactional: boolean,
+  fn: (db: Queryable) => Promise<T>,
+): Promise<T> {
+  if (!transactional || typeof deps.pool.connect !== "function") {
+    return fn(deps.pool);
+  }
+
+  const client = await deps.pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function firstWriteLaneEmbedding(
+  deps: ToolDeps,
+  args: {
+    session_key: string;
+    project?: string;
+    topic?: string;
+  },
+): Promise<{
+  embeddingVal: ReturnType<typeof toSql> | null;
+  contentHashValue: string | null;
+  embeddedAt: string | null;
+  model: string | null;
+}> {
+  const contextText = args.topic || "";
+  const contentHashValue = contextText
+    ? contentHash(args.session_key + "|" + contextText)
+    : null;
+
+  let embedding: number[] | null = null;
+  if (contextText) {
+    const embedParts = [contextText];
+    if (args.project) embedParts.push(args.project);
+    try {
+      embedding = await deps.embedFn(embedParts.join("\n"));
+    } catch (err) {
+      logger.warn("append_session_event_lane_embed_error", {
+        session_key: args.session_key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    embeddingVal: embedding ? toSql(embedding) : null,
+    contentHashValue,
+    embeddedAt: embedding ? new Date().toISOString() : null,
+    model: embedding ? EMBEDDING_MODEL : null,
+  };
+}
+
 function scopeConflicts(
   lane: Record<string, unknown>,
   args: {
@@ -83,6 +149,7 @@ function scopeConflicts(
 }
 
 async function ensureLaneForAppend(
+  db: Queryable,
   deps: ToolDeps,
   args: {
     session_key: string;
@@ -104,7 +171,7 @@ async function ensureLaneForAppend(
   const laneColumns =
     "id, status, agent, source, channel_id, thread_id, metadata";
   const laneParams = [args.namespace, args.session_key];
-  const { rows: laneRows } = await deps.pool.query(
+  const { rows: laneRows } = await db.query(
     `SELECT ${laneColumns}
 FROM ob_session_lanes
 WHERE namespace = $1 AND session_key = $2`,
@@ -119,11 +186,13 @@ WHERE namespace = $1 AND session_key = $2`,
     attemptedCreate = true;
     const metadata =
       args.server_id === undefined ? {} : { server_id: args.server_id };
-    const { rows: insertedRows } = await deps.pool.query(
+    const laneEmbedding = await firstWriteLaneEmbedding(deps, args);
+    const { rows: insertedRows } = await db.query(
       `INSERT INTO ob_session_lanes
   (session_key, namespace, status, agent, source, channel_id, thread_id,
-   project, topic, metadata, created_by)
-VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9, $10)
+   project, topic, metadata, embedding, content_hash, embedded_at,
+   embedding_model, created_by)
+VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 ON CONFLICT (namespace, session_key) DO NOTHING
 RETURNING ${laneColumns}`,
       [
@@ -136,6 +205,10 @@ RETURNING ${laneColumns}`,
         args.project ?? null,
         args.topic ?? null,
         JSON.stringify(metadata),
+        laneEmbedding.embeddingVal,
+        laneEmbedding.contentHashValue,
+        laneEmbedding.embeddedAt,
+        laneEmbedding.model,
         auth.clientId,
       ],
     );
@@ -143,7 +216,7 @@ RETURNING ${laneColumns}`,
       lane = insertedRows[0] as Record<string, unknown>;
       created = true;
     } else {
-      const { rows: racedRows } = await deps.pool.query(
+      const { rows: racedRows } = await db.query(
         `SELECT ${laneColumns}
 FROM ob_session_lanes
 WHERE namespace = $1 AND session_key = $2`,
@@ -294,7 +367,7 @@ function requestedResubmitAttempt(metadata: Record<string, unknown>): number {
 }
 
 async function effectiveResubmitState(
-  deps: ToolDeps,
+  db: Queryable,
   laneId: string,
   metadata: Record<string, unknown>,
 ): Promise<{
@@ -304,7 +377,7 @@ async function effectiveResubmitState(
   const resubmitOf = sanitizedResubmitOf(metadata);
   const requested = requestedResubmitAttempt(metadata);
   if (!resubmitOf) {
-    const { rows } = await deps.pool.query(
+    const { rows } = await db.query(
       `SELECT COUNT(*)::int AS rejected_count
          FROM ob_session_events
         WHERE lane_id = $1
@@ -321,7 +394,7 @@ async function effectiveResubmitState(
     return { attempt: Math.max(requested, observedAttempt) };
   }
 
-  const { rows } = await deps.pool.query(
+  const { rows } = await db.query(
     `SELECT
         (
           SELECT COUNT(*)::int
@@ -576,174 +649,182 @@ export function registerAppendSessionEvent(
       });
 
       try {
-        const laneResult = await ensureLaneForAppend(
+        return await withAppendDb(
           deps,
-          {
-            session_key: args.session_key,
-            namespace: ns,
-            create_if_missing: args.create_if_missing,
-            agent: args.agent,
-            platform: args.platform,
-            server_id: args.server_id,
-            channel_id: args.channel_id,
-            thread_id:
-              args.create_if_missing === true && args.channel_id !== undefined
-                ? (args.thread_id ?? null)
-                : args.thread_id,
-            project: args.project,
-            topic: args.topic,
-          },
-          auth,
-        );
-        if (!laneResult.ok) {
-          return laneResult.response;
-        }
+          args.create_if_missing === true,
+          async (db) => {
+            const laneResult = await ensureLaneForAppend(
+              db,
+              deps,
+              {
+                session_key: args.session_key,
+                namespace: ns,
+                create_if_missing: args.create_if_missing,
+                agent: args.agent,
+                platform: args.platform,
+                server_id: args.server_id,
+                channel_id: args.channel_id,
+                thread_id:
+                  args.create_if_missing === true &&
+                  args.channel_id !== undefined
+                    ? (args.thread_id ?? null)
+                    : args.thread_id,
+                project: args.project,
+                topic: args.topic,
+              },
+              auth,
+            );
+            if (!laneResult.ok) {
+              return laneResult.response;
+            }
 
-        if (laneResult.lane.status === "archived") {
-          return appendSessionEventError(
-            "unsupported_operation",
-            `Lane "${args.session_key}" is archived; reactivate before appending events`,
-            false,
-            { session_key: args.session_key, namespace: ns },
-          );
-        }
+            if (laneResult.lane.status === "archived") {
+              return appendSessionEventError(
+                "unsupported_operation",
+                `Lane "${args.session_key}" is archived; reactivate before appending events`,
+                false,
+                { session_key: args.session_key, namespace: ns },
+              );
+            }
 
-        const laneId = String(laneResult.lane.id);
+            const laneId = String(laneResult.lane.id);
 
-        // Hybrid sync gate: a share_candidate nomination carrying a secret or
-        // person-private content is rejected inline (cheap, no embedding) and
-        // its nomination stripped before persist, so the async promoter never
-        // sees it. Worthiness/dedup/promote remain async.
-        let nomination = adjudicateNominationSync(
-          args.event_type,
-          importance,
-          args.content,
-          args.metadata ?? {},
-        );
-        if (nomination.rejected) {
-          const resubmit = await effectiveResubmitState(
-            deps,
-            laneId,
-            args.metadata ?? {},
-          );
-          nomination = adjudicateNominationSync(
-            args.event_type,
-            importance,
-            args.content,
-            args.metadata ?? {},
-            resubmit.attempt,
-            resubmit.blockedReason,
-          );
-        }
-        const metadata = appendWriterProvenance(nomination.metadata, auth);
-        if (nomination.rejected) {
-          logger.warn("append_session_event_share_rejected", {
-            session_key: args.session_key,
-            namespace: ns,
-            decision: nomination.rejected,
-            matched_kind: nomination.rejectDetail?.matched_kind,
-            span_count: nomination.rejectDetail?.span_count,
-            resubmittable: nomination.rejectDetail?.resubmittable,
-            clientId: auth.clientId,
-          });
-        }
+            // Hybrid sync gate: a share_candidate nomination carrying a secret or
+            // person-private content is rejected inline (cheap, no embedding) and
+            // its nomination stripped before persist, so the async promoter never
+            // sees it. Worthiness/dedup/promote remain async.
+            let nomination = adjudicateNominationSync(
+              args.event_type,
+              importance,
+              args.content,
+              args.metadata ?? {},
+            );
+            if (nomination.rejected) {
+              const resubmit = await effectiveResubmitState(
+                db,
+                laneId,
+                args.metadata ?? {},
+              );
+              nomination = adjudicateNominationSync(
+                args.event_type,
+                importance,
+                args.content,
+                args.metadata ?? {},
+                resubmit.attempt,
+                resubmit.blockedReason,
+              );
+            }
+            const metadata = appendWriterProvenance(nomination.metadata, auth);
+            if (nomination.rejected) {
+              logger.warn("append_session_event_share_rejected", {
+                session_key: args.session_key,
+                namespace: ns,
+                decision: nomination.rejected,
+                matched_kind: nomination.rejectDetail?.matched_kind,
+                span_count: nomination.rejectDetail?.span_count,
+                resubmittable: nomination.rejectDetail?.resubmittable,
+                clientId: auth.clientId,
+              });
+            }
 
-        // Generate embedding (non-fatal)
-        let embedding: number[] | null = null;
-        try {
-          embedding = await deps.embedFn(args.content);
-        } catch (err) {
-          logger.warn("append_session_event_embed_error", {
-            session_key: args.session_key,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
+            // Generate embedding (non-fatal)
+            let embedding: number[] | null = null;
+            try {
+              embedding = await deps.embedFn(args.content);
+            } catch (err) {
+              logger.warn("append_session_event_embed_error", {
+                session_key: args.session_key,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
 
-        const hash = contentHash(args.content);
-        const embeddingVal = embedding ? toSql(embedding) : null;
-        const embeddedAt = embedding ? new Date().toISOString() : null;
-        const model = embedding ? EMBEDDING_MODEL : null;
+            const hash = contentHash(args.content);
+            const embeddingVal = embedding ? toSql(embedding) : null;
+            const embeddedAt = embedding ? new Date().toISOString() : null;
+            const model = embedding ? EMBEDDING_MODEL : null;
 
-        const { rows } = await deps.pool.query(
-          `INSERT INTO ob_session_events
+            const { rows } = await db.query(
+              `INSERT INTO ob_session_events
              (lane_id, event_type, content, source, artifact_path, importance,
               metadata, embedding, content_hash, embedded_at, embedding_model, created_by)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
            ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL DO NOTHING
            RETURNING id, created_at`,
-          [
-            laneId,
-            args.event_type,
-            args.content,
-            args.source ?? null,
-            args.artifact_path ?? null,
-            importance,
-            JSON.stringify(metadata),
-            embeddingVal,
-            hash,
-            embeddedAt,
-            model,
-            auth.clientId,
-          ],
+              [
+                laneId,
+                args.event_type,
+                args.content,
+                args.source ?? null,
+                args.artifact_path ?? null,
+                importance,
+                JSON.stringify(metadata),
+                embeddingVal,
+                hash,
+                embeddedAt,
+                model,
+                auth.clientId,
+              ],
+            );
+
+            if (rows.length === 0) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: JSON.stringify({
+                      duplicate: true,
+                      message:
+                        "Event with identical content already exists in this lane",
+                      ...provenance,
+                    }),
+                  },
+                ],
+              };
+            }
+
+            const result = {
+              event_id: rows[0].id,
+              lane_id: laneId,
+              lane_created: laneResult.created,
+              event_type: args.event_type,
+              importance,
+              created_at: rows[0].created_at,
+              ...provenance,
+              // Surface the sync nomination outcome so a contract-driven agent
+              // learns its share_candidate was refused (and why) without polling.
+              ...(nomination.rejected
+                ? {
+                    share_candidate_rejected: nomination.rejected,
+                    ...(nomination.rejectDetail
+                      ? {
+                          reject_detail: attachResubmitTarget(
+                            nomination.rejectDetail,
+                            rows[0].id,
+                            nomination.metadata,
+                          ),
+                        }
+                      : {}),
+                  }
+                : {}),
+            };
+
+            logger.info("append_session_event_ok", {
+              event_id: result.event_id,
+              lane_id: result.lane_id,
+              event_type: result.event_type,
+              importance: result.importance,
+            });
+
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(result),
+                },
+              ],
+            };
+          },
         );
-
-        if (rows.length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify({
-                  duplicate: true,
-                  message:
-                    "Event with identical content already exists in this lane",
-                  ...provenance,
-                }),
-              },
-            ],
-          };
-        }
-
-        const result = {
-          event_id: rows[0].id,
-          lane_id: laneId,
-          lane_created: laneResult.created,
-          event_type: args.event_type,
-          importance,
-          created_at: rows[0].created_at,
-          ...provenance,
-          // Surface the sync nomination outcome so a contract-driven agent
-          // learns its share_candidate was refused (and why) without polling.
-          ...(nomination.rejected
-            ? {
-                share_candidate_rejected: nomination.rejected,
-                ...(nomination.rejectDetail
-                  ? {
-                      reject_detail: attachResubmitTarget(
-                        nomination.rejectDetail,
-                        rows[0].id,
-                        nomination.metadata,
-                      ),
-                    }
-                  : {}),
-              }
-            : {}),
-        };
-
-        logger.info("append_session_event_ok", {
-          event_id: result.event_id,
-          lane_id: result.lane_id,
-          event_type: result.event_type,
-          importance: result.importance,
-        });
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(result),
-            },
-          ],
-        };
       } catch (err) {
         logger.error("append_session_event_db_error", {
           session_key: args.session_key,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -51,6 +51,7 @@ import { registerListRepoFacts, registerUpsertRepoFact } from "./repo-facts.ts";
 export interface ToolDeps {
   pool: pg.Pool;
   embedFn: typeof generateEmbedding;
+  allowNonTransactionalAppendFallback?: boolean;
 }
 
 export function registerAllTools(server: McpServer, deps: ToolDeps): void {


### PR DESCRIPTION
Fixes #229.

## Summary

- Makes `append_session_event.create_if_missing` first-write lane creation atomic with the first event insert by using a pooled-client transaction only for `create_if_missing` appends.
- Adds first-write lane embedding parity with `lane_upsert` by embedding from `topic` plus `project` and storing lane `content_hash`, `embedded_at`, and `embedding_model`.
- Adds migration `020_session_lane_namespace_hash.sql` so lane `content_hash` uniqueness is namespace-scoped, matching the app's namespace isolation boundary.
- Adds `scripts/archive-idle-session-lanes.ts`, a dry-run-by-default local maintenance sweep for idle realtime lanes, with explicit `--execute` required and broad-sweep refusal unless scoped.
- Updates Plan 3F with the current #229 branch status, gauntlet findings, fixes, and validation gap.
- Addresses second-round gauntlet findings by filling accepted first-write embeddings after commit, preserving the original error when rollback fails, failing loud if a transactional pool is unavailable, and removing the redundant archive execute CTE limit.

## Validation

- `bun test src/tools/__tests__/append-session-event.test.ts scripts/archive-idle-session-lanes.test.ts` - 56 pass, 7 skip, 0 fail.
- `bun test src/tools/__tests__/append-session-event.test.ts src/tools/__tests__/lane-upsert.test.ts src/tools/__tests__/session-start.test.ts scripts/archive-idle-session-lanes.test.ts` - 90 pass, 10 skip, 0 fail.
- `bunx tsc --noEmit` - pass.
- `git diff --check` - pass.
- `bun test` - 1072 pass, 50 skip, 0 fail.
- CI after gauntlet fixes: `validate`, `check`, `db-integration`, `python-package`, and GitGuardian pass; `deploy` skipped.

Local DB-backed suites were not run because `/Users/rico/.config/open-brain/env.release-test` is missing on this box. CI `db-integration` supplied the live Postgres gate.

## Critical Self-Review

- Highest-risk behavior: a failed event insert after speculative lane creation must not leave an orphan realtime lane; covered by rollback test with `BEGIN`/`ROLLBACK` and no `COMMIT`.
- Assumptions that could be wrong: first-write lane embedding should match `lane_upsert` topic/project behavior even though future lane search is not shipped yet.
- Missing/weak tests: local real-Postgres suites are skipped without `OPENBRAIN_TEST_DATABASE_URL`; CI `db-integration` must supply that coverage.
- Security/permission risk: namespace and scope authorization paths are unchanged; idle-lane archive script defaults narrow and refuses an unscoped broad sweep.
- Migration/deploy risk: migration `020_session_lane_namespace_hash.sql` changes only the lane `content_hash` index from global uniqueness to namespace-scoped uniqueness; no core01 deploy is included. Production idle-lane archival is operator-run only and dry-run by default.
- Downstream client/runtime risk: append response shape is unchanged, but `create_if_missing` appends now use a transaction and first-write lanes become searchable once lane search ships.
- Rollback/cleanup concern: reverting restores prior non-transactional append behavior, global lane hash uniqueness, and removes the local archival script.
- Fixes made before PR: narrowed transactions to `create_if_missing` appends only and added explicit F7 script/test coverage instead of deferring silently.
- Fixes made during gauntlet: moved first-write embedding work out of the transaction, then tightened it to run only after an append is accepted; rechecked archive execute eligibility in the `UPDATE` CTE; namespace-scoped lane `content_hash` uniqueness with a live Postgres regression; preserved the original append error if rollback also fails; and made missing transactional pool support fail loud outside explicit tests.
- Known residual risk: local release-test env is absent, so CI DB-backed tests remain the required merge gate for live Postgres coverage. First-write lane/event embeddings are now filled after commit; if the process crashes or the embedding provider stays down after a successful append, those accepted rows can remain `embedding IS NULL` until a future backfill handles them.
- SME review-memory update: [x] not applicable because: the gauntlet findings are fixed in this PR with regression coverage and do not require a new reusable SME rule beyond the existing namespace-isolation and transaction-boundary guidance.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured and fixed: transaction-open embedding calls, stale archive execute update, and global lane content-hash uniqueness.
- Live Open Brain checks: [x] not applicable because: this is local-only code/test/script hardening with no core01 deploy or hosted runtime change.

## Downstream Rollout

Not applicable for this PR before merge: no public contract version, Python package, mcp2cli, Hermes plugin, or hosted runtime change is introduced. Full release/deploy remains optional and separate under `docs/local-release-deploy-sop.md`.

## No Deploy

This PR must not deploy core01. Merge and deploy remain separate phases.
