### PR TITLE
feat(#224): add memory promotion lifecycle

### DIFF
--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -146,7 +146,9 @@ Known section names (the `sections` object members; this list is what
 - `pointers`: entities, repos, services, files, or receipts worth deliberate
   follow-up fetching.
 - `candidate_memory`: explicit candidates only; presence in the pack is not a
-  durable write or shared-kb promotion.
+  durable write, durable memory promotion, shared-kb nomination, or shared-kb
+  promotion. A client must record a separate lifecycle action before anything
+  moves.
 
 `warnings`, `budget`, and `citations` are always-present top-level envelope
 fields, not section members. They are mirrored by
@@ -233,6 +235,10 @@ from "Exact Scope Predicate"), not a subset:
   server auth predicates;
 - candidate memory is labeled as candidate-only and does not create a durable
   memory row or shared-kb nomination.
+- user correction candidate memory is labeled
+  `memory_lifecycle_action=candidate` and `candidate_type=negative_example`
+  until a client/user explicitly chooses promote, relegate, discard, or
+  nominate_shared.
 
 ## Contract Availability
 

--- a/docs/agent-memory-adapter-contract.md
+++ b/docs/agent-memory-adapter-contract.md
@@ -89,7 +89,8 @@ Candidate metadata should include:
   override.
 - `candidate_confidence`: client confidence from 0 to 1.
 - `evidence_refs`: citation-safe ids, issue URLs, repo paths, commits, or
-  source refs.
+  source refs. The server bounds each reference and rejects secret-like
+  evidence metadata.
 - `candidate_staleness_policy`: expiry or revalidation policy.
 - `candidate_reason`: explicit reason for the action.
 

--- a/docs/agent-memory-adapter-contract.md
+++ b/docs/agent-memory-adapter-contract.md
@@ -15,7 +15,8 @@ Server-owned behavior:
 - Bearer-token identity, role checks, and namespace predicates.
 - Session lane and session event storage.
 - Shared knowledge promotion policy, secret rejection, deduplication, and
-  provenance stamped from trusted auth context.
+  provenance stamped from trusted auth context after an explicit client
+  nomination action.
 - Public contract discovery through `get_contract`.
 
 Client-owned behavior:
@@ -25,9 +26,15 @@ Client-owned behavior:
 - Retry/spool behavior for unavailable memory service calls.
 - Receipt assembly from local file, command, artifact, and channel evidence.
 - OKF-like disclosure bundle export until a server exporter exists.
+- Memory lifecycle decisions: candidate extraction, candidate type, promote,
+  relegate, discard, and shared-kb nomination intent.
 
 Clients must not treat convenience checks as security controls. Any ID-based
 read or mutation still depends on server-side auth-derived namespace checks.
+Candidate presence is inert storage metadata: it does not create a durable
+thought/decision, and it does not create or queue a shared-kb write unless the
+client explicitly records `memory_lifecycle_action=nominate_shared` together
+with `share_candidate=true`.
 
 The TypeScript wrapper in `src/agent-memory.ts` uses a caller-provided
 `callTool(name, args)` transport and validates local call shape and metadata
@@ -50,8 +57,45 @@ adapter facade.
 | `compact` | client | `session_context`, caller-provided local distillation, `session_wrap` | client-wrapper | Read current context, distill it through caller policy or an explicit summary, then checkpoint via `session_wrap`. Open Brain does not store raw compaction transcripts. |
 | `wrap` | client + server | `session_wrap` | available | Checkpoint a completed work phase with summary, key decisions, next steps, and optional receipt references. Use `compact` when the adapter should read current session context before wrapping. |
 | `record_receipt` | client + server | `append_session_event` with `event_type=receipt` | client-wrapper | Assemble citation-safe receipt metadata locally and write it as a receipt event. |
-| `nominate_shared` | client + server | `append_session_event.metadata.share_candidate` | available | Nominate only non-private, durable facts or decisions for server-side shared-kb promotion. Server rejection and promoter adjudication remain authoritative. |
+| `candidate_memory` | client | `append_session_event.metadata.memory_lifecycle_action=candidate` | client-wrapper | Record review-only candidate memory with candidate type, scope, confidence, evidence refs, staleness policy, and reason. This is not a durable memory write or shared-kb nomination. |
+| `promote_candidate` | client | explicit durable write via `remember_fact`/`remember_decision` plus `append_session_event.metadata.memory_lifecycle_action=promote` | client-wrapper | Implement the explicit "remember this" path. The client chooses what becomes durable, then records the lifecycle action with provenance. |
+| `relegate_candidate` | client | `append_session_event.metadata.memory_lifecycle_action=relegate` | client-wrapper | Record that a candidate was intentionally kept out of durable/shared promotion, with reason and evidence. |
+| `discard_candidate` | client | `append_session_event.metadata.memory_lifecycle_action=discard` | client-wrapper | Record that a candidate was intentionally discarded, with reason and evidence. |
+| `nominate_shared` | client + server | `append_session_event.metadata.share_candidate` + `append_session_event.metadata.memory_lifecycle_action=nominate_shared` | available | Explicitly nominate only non-private, durable facts or decisions for server-side shared-kb promotion. Server rejection and promoter adjudication remain authoritative. |
 | `export_disclosure_bundle` | client | `interchange_profiles.okf` | client-wrapper | Generate an OKF-like bundle from readable lane events, repo facts, citations, and receipt metadata without changing Open Brain storage. |
+
+## Candidate Promotion Lifecycle
+
+`append_session_event` is the lifecycle journal for candidate memory. The client
+must choose one of these explicit actions in `metadata.memory_lifecycle_action`:
+
+- `candidate`: review-only candidate; no durable memory or shared-kb write.
+- `promote`: explicit client promotion intent for a separate durable write
+  flow, such as a reviewed `log_thought`, `log_decision`, or repo fact write.
+- `relegate`: intentionally keep out of durable/shared promotion.
+- `discard`: intentionally drop as not useful or unsafe.
+- `nominate_shared`: explicit shared-kb nomination; the shared promoter may
+  consider it only when `share_candidate=true` is also present.
+
+Candidate metadata should include:
+
+- `candidate_type`: `user_preference`, `process_rule`, `channel_server_rule`,
+  `code_repo_fact`, `positive_example`, `negative_example`,
+  `durable_decision`, or `shared_kb_nomination`.
+- `candidate_scope`: citation-safe scope/provenance such as repo, project,
+  agent, server/channel/thread ids, or session key. It is never an auth
+  override.
+- `candidate_confidence`: client confidence from 0 to 1.
+- `evidence_refs`: citation-safe ids, issue URLs, repo paths, commits, or
+  source refs.
+- `candidate_staleness_policy`: expiry or revalidation policy.
+- `candidate_reason`: explicit reason for the action.
+
+A user correction that should teach future behavior starts as
+`memory_lifecycle_action=candidate` and `candidate_type=negative_example`.
+It must not also set `share_candidate=true` unless the client/user explicitly
+chooses the shared nomination workflow. A context pack may include candidate
+sections, but that presence alone remains read-only context.
 
 ## Payload Expectations
 

--- a/docs/agent-memory-adapter-contract.md
+++ b/docs/agent-memory-adapter-contract.md
@@ -58,7 +58,7 @@ adapter facade.
 | `wrap` | client + server | `session_wrap` | available | Checkpoint a completed work phase with summary, key decisions, next steps, and optional receipt references. Use `compact` when the adapter should read current session context before wrapping. |
 | `record_receipt` | client + server | `append_session_event` with `event_type=receipt` | client-wrapper | Assemble citation-safe receipt metadata locally and write it as a receipt event. |
 | `candidate_memory` | client | `append_session_event.metadata.memory_lifecycle_action=candidate` | client-wrapper | Record review-only candidate memory with candidate type, scope, confidence, evidence refs, staleness policy, and reason. This is not a durable memory write or shared-kb nomination. |
-| `promote_candidate` | client | explicit durable write via `remember_fact`/`remember_decision` plus `append_session_event.metadata.memory_lifecycle_action=promote` | client-wrapper | Implement the explicit "remember this" path. The client chooses what becomes durable, then records the lifecycle action with provenance. |
+| `promote_candidate` | client | `append_session_event.metadata.memory_lifecycle_action=promote` | client-wrapper | Record the explicit client/user promotion decision with provenance. The durable write itself is a separate explicit client action such as `remember_fact`, `remember_decision`, or a repo-fact write. |
 | `relegate_candidate` | client | `append_session_event.metadata.memory_lifecycle_action=relegate` | client-wrapper | Record that a candidate was intentionally kept out of durable/shared promotion, with reason and evidence. |
 | `discard_candidate` | client | `append_session_event.metadata.memory_lifecycle_action=discard` | client-wrapper | Record that a candidate was intentionally discarded, with reason and evidence. |
 | `nominate_shared` | client + server | `append_session_event.metadata.share_candidate` + `append_session_event.metadata.memory_lifecycle_action=nominate_shared` | available | Explicitly nominate only non-private, durable facts or decisions for server-side shared-kb promotion. Server rejection and promoter adjudication remain authoritative. |
@@ -70,8 +70,10 @@ adapter facade.
 must choose one of these explicit actions in `metadata.memory_lifecycle_action`:
 
 - `candidate`: review-only candidate; no durable memory or shared-kb write.
-- `promote`: explicit client promotion intent for a separate durable write
-  flow, such as a reviewed `log_thought`, `log_decision`, or repo fact write.
+- `promote`: explicit client/user promotion decision recorded in the lifecycle
+  journal. This marker does not itself create durable memory; the durable write
+  remains a separate explicit client action such as a reviewed `log_thought`,
+  `log_decision`, or repo fact write.
 - `relegate`: intentionally keep out of durable/shared promotion.
 - `discard`: intentionally drop as not useful or unsafe.
 - `nominate_shared`: explicit shared-kb nomination; the shared promoter may

--- a/docs/plan-3f-open-issues.md
+++ b/docs/plan-3f-open-issues.md
@@ -7,10 +7,10 @@ Updated: 2026-07-06.
 Live GitHub and Project 8 state are the source of truth. Older roadmap
 snapshots and untracked sidecar plans are historical evidence only.
 
-Current live state as of 2026-07-06 during the #223 review-fix phase:
+Current live state as of 2026-07-06 11:35 EDT during the #224 local-validation
+phase:
 
-- Open PRs: 1.
-  - #250 `feat(#223): define NATS JetStream foundation`
+- Open PRs: 0.
 - Open issues: 8.
   - #247 `Design DreamEngine decomposition for oversized Open Brain entries`
   - #224 `Define client-owned promotion and relegation lifecycle for realtime memory`
@@ -24,11 +24,14 @@ Current live state as of 2026-07-06 during the #223 review-fix phase:
 - #229 is closed by PR #249; merge commit
   `e4fc7def43735163e1e0d4997ace5ce510494f4d`. It is historical context only,
   not active Plan 3F work.
+- PR #250 for the local-only #223 NATS/JetStream foundation is merged as
+  `aba24c0beb1b6164dfe6270a535f3ed117646229`. It is historical context only.
+  #223 remains open for the later runtime/deploy slice.
 - #204 is closed. Do not continue stale #204 worktrees for this run.
 
-Critical correction: the active Plan 3F surface is the 8 open issues above plus
-PR #250. Closed issues may explain predecessor state, but they must not occupy
-worker lanes or be counted as remaining work.
+Critical correction: the active Plan 3F surface is the 8 open issues above and
+0 open PRs. Closed issues and merged PRs may explain predecessor state, but they
+must not occupy worker lanes or be counted as remaining work.
 
 ## Operating Boundary
 
@@ -52,7 +55,7 @@ splits into disjoint files or review lanes.
 
 | Issue | Branch | Temp worktree | Workers | Local target | Deploy allowed | Closure rule |
 | --- | --- | --- | ---: | --- | --- | --- |
-| #223 NATS/JetStream foundation | `feat/223-nats-jetstream-foundation` | `/Volumes/ThunderBolt/_tmp/open-brain/issue-223-nats-jetstream-foundation` | 1 controller + 2 review lanes | Finish PR #250 gauntlet and merge local foundation only | No | Do not close #223 unless issue is explicitly narrowed; current PR is `Refs #223` |
+| #223 NATS/JetStream runtime slice | `feat/223-nats-jetstream-runtime` | `/Volumes/ThunderBolt/_tmp/open-brain/issue-223-nats-jetstream-runtime` | 1 implementation + 1 runtime/review sidecar | Later runtime implementation only after local-only #224/#222/#221 sequencing or explicit controller decision | No | Do not close #223 from the merged foundation PR; closing requires real runtime/deploy tests or explicit issue narrowing |
 | #222 scoped hot working set | `feat/222-scoped-hot-working-set` | `/Volumes/ThunderBolt/_tmp/open-brain/issue-222-scoped-hot-working-set` | 1 implementation + 1 test/review sidecar | Exact-scope working-set contract, pack inclusion, denial tests | No | Close only with code/tests proving cross-scope isolation and TTL/budget behavior |
 | #221 recovery WAL | `feat/221-recovery-wal` | `/Volumes/ThunderBolt/_tmp/open-brain/issue-221-recovery-wal` | 1 implementation + 1 adversarial/test sidecar | Quarantined recovery evidence contract, restart transitions, exclusion from normal recall | No | Close only with tests proving WAL evidence cannot leak into durable/search paths |
 | #224 promotion/relegation lifecycle | `feat/224-promotion-lifecycle` | `/Volumes/ThunderBolt/_tmp/open-brain/issue-224-promotion-lifecycle` | 1 implementation + 1 domain/review sidecar | Explicit promote/relegate/discard/nominate workflow for candidate memory | No | Close only with tests proving no implicit durable/shared-kb promotion |
@@ -63,9 +66,8 @@ splits into disjoint files or review lanes.
 
 ## Controller Execution Rules
 
-1. Finish or explicitly park #250 before merging other branches that depend on
-   its contract shape. It may remain open while workers start on independent
-   issue branches, but the controller must keep its dirty state isolated.
+1. Treat PR #250 as merged historical context. Do not reopen its branch as
+   active work. #223 remains open for a future runtime/deploy slice.
 2. Create each worktree from fresh `origin/main` unless the issue intentionally
    builds on a merged predecessor. If a predecessor is not merged, the dependent
    branch may only inspect it or stack with an explicit note in Plan 3F.
@@ -86,63 +88,35 @@ splits into disjoint files or review lanes.
 
 ## Open Issue Execution Order
 
-### 1. #223 NATS/JetStream foundation
+### 1. #223 NATS/JetStream runtime follow-up
 
 Owning boundary:
-Local transport contract and bridge design for realtime Open Brain memory RPC,
-with HTTP/MCP retained as fallback.
+Runtime transport implementation and release/deploy gate for realtime Open
+Brain memory RPC, with HTTP/MCP retained as fallback.
 
 Current implementation branch:
-`feat/223-nats-jetstream-foundation`.
+None active. The local-only foundation branch is merged.
 
 Local status:
 
-- In review via PR #250. Project 8 marks #223/PR #250 in review. CI passed on
-  head `dcef94d`, then Claude cross-review found that planned-only NATS
-  metadata should not churn the required fail-closed contract version/hash.
-  Local fix keeps the required Open Brain memory contract at v14, treats
-  `realtime_transport.nats_jetstream` as advisory planned metadata outside the
-  required schema hash, and keeps the Python package pinned to the same server
-  contract snapshot. Focused validation passed: `uv run pytest -q
-  tests/test_contract.py tests/test_client.py` (`70 pass`), `uv run mypy
-  src/openbrain_memory`, `uv run ruff check src tests`, and `git diff --check`.
-- Local-only slice adds `docs/nats-jetstream-foundation.md` and advisory planned
-  `get_contract().realtime_transport.nats_jetstream` metadata. It does not
-  bump the package artifact version, required contract version, schema hash, or
-  required `openbrain-memory` minimum compatibility because NATS is not runtime
-  available in this slice.
-- No core01 NATS install/config, live JetStream stream creation, launchd change,
-  or Hermes runtime switch is in scope for this branch.
-- Local validation passed after the review-fix commit: `bun test
-  src/contract.test.ts` (`6 pass`), `bunx tsc --noEmit`, full `bun test`
-  (`1072 pass, 50 skip, 0 fail`), focused Python contract/client pytest (`70
-  pass`), full Python pytest (`193 pass, 5 skip`), `uv run mypy
-  src/openbrain_memory`, `uv run ruff check src tests`, PR body validator, and
-  `git diff --check`.
-- Downstream rollout classification: no deploy in this PR. Required-memory
-  fail-closed version/hash remains v14; planned NATS metadata is advisory and
-  not runtime available. Hosted deploy, mcp2cli refresh, rtech-mcps handoff,
-  rtech-hermes changes, Hermes live rollout, and canaries remain deferred to an
-  approved release/deploy phase.
-- Initial review findings being fixed:
-  HIGH: do not raise required Python client compatibility for a planned-only
-  transport; MEDIUM: do not auto-close #223 without the runtime/client slice;
-  MEDIUM: split bridge/requester credential permissions and prevent broad NATS
-  credentials; MEDIUM: forbid raw request/query/context persistence in
-  JetStream; MEDIUM: define the future Python transport interface and fallback
-  gate; LOW: remove misleading runtime capability advertisement; LOW: add
-  rollback and clean stale plan wording.
+- PR #250 merged as `aba24c0beb1b6164dfe6270a535f3ed117646229` with gauntlet
+  clean, CI passed, and deploy skipped.
+- The merged local-only slice adds `docs/nats-jetstream-foundation.md` and
+  advisory planned `get_contract().realtime_transport.nats_jetstream` metadata.
+  It does not make NATS runtime-available.
+- #223 remains open for the later runtime/deploy slice. No core01 NATS
+  install/config, live JetStream stream creation, launchd change, or Hermes
+  runtime switch has been performed or authorized.
+- Downstream rollout classification: hosted deploy, mcp2cli refresh,
+  rtech-mcps handoff, rtech-hermes changes, Hermes live rollout, and canaries
+  remain deferred to an approved release/deploy phase.
 
-Required local work:
+Future runtime/deploy work:
 
-- Document core01 NATS/JetStream config plan: ports, monitoring, storage path,
-  auth boundary, streams, retention, and rollback.
-- Define request/reply subjects and envelope contract, starting with
-  `agent_context_pack`.
-- Add local TypeScript/Python contract metadata only where it is testable
-  without a live NATS server.
-- Document Hermes opt-in and HTTP fallback.
-- Add contract/fixture tests when code is introduced.
+- Implement and test an actual NATS transport when a runtime slice is approved.
+- Add live NATS parity tests and HTTP fallback tests.
+- Run the release/deploy gate before any core01 install/config, live stream
+  creation, launchd change, or Hermes runtime switch.
 
 Deferred:
 core01 install/config, hosted canary, and making NATS the default Hermes path.
@@ -180,14 +154,45 @@ Owning boundary:
 Explicit client actions for moving candidate memory into durable memory or
 shared-kb nomination.
 
-Required local work:
+Active branch:
+`feat/224-promotion-lifecycle` in
+`/Volumes/ThunderBolt/_tmp/open-brain/issue-224-promotion-lifecycle`.
 
-- Define promote/relegate/discard/nominate actions.
-- Distinguish working context, recovery evidence, candidate memory, durable
-  memory, and shared-kb nomination.
-- Add fixture showing a user correction becomes a candidate negative example,
-  not an immediate durable rule.
-- Prove shared-kb nomination requires explicit promotion workflow.
+Local status:
+
+- Pre-PR blocker fixes are applied for server-side lifecycle metadata
+  validation, candidate events not auto-tiering into durable thoughts,
+  `scan_namespace`/DreamEngine explicit nomination semantics, Python lifecycle
+  call-shape tests, and v15 contract/hash alignment.
+- Project 8 marks #224 `In Progress`, Review Gate `Zero Known Issues`, and
+  Validation `Local Passed` for the pre-PR blocker pass.
+- Local validation passed:
+  - `bunx tsc --noEmit`
+  - focused lifecycle/contract/tiering/scan/promoter tests: `210 pass`, `20`
+    DB-gated skips, `0 fail`
+  - full `bun test`: `1078 pass`, `51` DB/migration/live skips, `0 fail`
+  - focused Python tests: `120 passed`
+  - full Python pytest: `197 passed`, `5 skipped`
+  - `uv run mypy src/openbrain_memory`
+  - `uv run ruff check src tests`
+  - `git diff --check`
+- Residual local risk: DB-backed/live Postgres suites are still skipped without
+  `OPENBRAIN_TEST_DATABASE_URL`; CI `db-integration` must supply that gate after
+  PR. No core01 deploy is in scope.
+
+Completed local work:
+
+- Defined promote/relegate/discard/nominate actions.
+- Distinguished working context, recovery evidence, candidate memory, durable
+  memory, and shared-kb nomination in the contract/docs.
+- Added tests showing lifecycle candidates remain explicit candidate events
+  instead of automatic durable/shared-kb writes.
+- Proved shared-kb nomination requires explicit nomination metadata.
+
+Next local work:
+
+- Complete critical self-review, commit/push, open PR, and run the
+  pre-merge-gauntlet before any merge decision.
 
 ### 5. #247 DreamEngine decomposition
 
@@ -242,12 +247,12 @@ explicit release/deploy approval.
 
 - Controller lane: owns live issue/PR/board state, branch integration, PR body,
   review receipts, merge decisions, and this Plan 3F file.
-- #223 active lane: controller finishes the Python contract transition fix on
-  PR #250, reruns focused Python validation, reruns gauntlet fix-verification,
-  updates the PR, and only then considers merge.
-- Parallel implementation lanes after #250 is parked or clean: dispatch workers
-  for #222, #221, #224, and #247 first because they have local testable owning
-  boundaries and no live deploy requirement.
+- #224 active lane: controller prepares PR from
+  `feat/224-promotion-lifecycle`, includes the critical self-review receipt,
+  pushes the branch, opens the PR, then runs the required pre-merge-gauntlet.
+- Parallel implementation lanes after #224 PR is opened or parked clean:
+  dispatch workers for #222, #221, and #247 first because they have local
+  testable owning boundaries and no live deploy requirement.
 - Planning/disposition lanes: dispatch #137 and #118 workers after the realtime
   lanes are not blocked. #137 must prove qmd is optional; #118 must split or
   implement a real source-ref slice.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -337,3 +337,32 @@ nomination.
 PR #251 strips `share_candidate`, `memory_lifecycle_action`, candidate detail
 fields, and `evidence_refs` from rejected nominations before stamping the
 rejection marker. Regression tests cover secret/private rejected nominations.
+
+## [2026-07-06] REST and MCP promotion scanners must share nomination predicates
+
+**Severity:** MEDIUM
+**Source:** PR #251 focused fix-verification for Issue #224
+**Scope:** `src/rest-promotion.ts`, `src/tools/scan-namespace.ts`, shared promotion candidate selection
+**Status:** fixed in PR #251
+
+### Pattern
+
+Fixing only the MCP tool can leave sibling REST endpoints exposing the old
+contract. In PR #251, `scan_namespace` was tightened to explicit shared-kb
+nominations, but REST `/api/v1/scan/:namespace` still selected every
+non-archived row and returned ordinary memories as promotion candidates.
+
+### Review Questions
+
+- When a tool contract changes, do REST, MCP, Python facade fixtures, and docs
+  all use the same predicate and response shape?
+- Is the candidate predicate pushed into SQL before `ORDER BY` and `LIMIT` in
+  every scanner, or does one path still filter after the limit?
+- Does test coverage include sibling endpoints, not only the tool path that was
+  directly reported?
+
+### Prior Fix
+
+PR #251 moved explicit shared nomination selection into a shared helper used by
+both MCP and REST scanners, removed REST's stale `already_promoted` response
+bucket, and updated Python DreamEngine fixtures to match the current contract.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -275,3 +275,65 @@ PR #246 gave compact `get_entry` its own full-readable-content expression for
 `sessions`, computed normalized content once in a subquery, added a mock SQL
 shape guard, and added an `OPENBRAIN_TEST_DATABASE_URL`-gated live Postgres
 test for long session compact length/truncation.
+
+## [2026-07-06] Shared-kb nominations and own-durable graduation are orthogonal
+
+**Severity:** HIGH
+**Source:** PR #251 Claude cross-review for Issue #224
+**Scope:** `src/tiering.ts`, lifecycle metadata actions, any own-durable lane classifier
+**Status:** fixed in PR #251
+
+### Pattern
+
+Lifecycle metadata can be audit/control-plane intent without changing the
+memory's own-lane graduation semantics. In PR #251, `classifyLaneEvent`
+initially short-circuited every `memory_lifecycle_action`, including
+`nominate_shared`, into the own-durable lane. That meant an explicit shared-kb
+nomination could prevent otherwise hot/fact/long content from graduating by its
+normal own-durable rules.
+
+### Review Questions
+
+- Is the lifecycle action a durable-lane control action, or a shared-kb
+  nomination/audit marker that should remain orthogonal?
+- Does adding metadata to support one promotion path accidentally suppress a
+  sibling promotion/classification path?
+- Do tests cover the same event qualifying for shared-kb nomination and
+  own-durable graduation at the same time?
+
+### Prior Fix
+
+PR #251 restricted own-durable lifecycle short-circuiting to explicit
+`candidate`, `promote`, `relegate`, and `discard` actions. `nominate_shared`
+now follows normal graduation rules while still recording shared-kb intent.
+
+## [2026-07-06] Rejected nominations must strip all coupled lifecycle metadata
+
+**Severity:** MEDIUM
+**Source:** PR #251 Claude cross-review for Issue #224
+**Scope:** `src/tools/append-session-event.ts`, synchronous shared-kb nomination rejection
+**Status:** fixed in PR #251
+
+### Pattern
+
+Rejected shared nominations must not leave partial metadata that downstream
+tools interpret as intent. In PR #251, the sync rejection path stripped
+`share_candidate` for secret/private nominations but initially left
+`memory_lifecycle_action=nominate_shared` and candidate detail fields behind.
+That created an orphan lifecycle marker after the server had rejected the
+nomination.
+
+### Review Questions
+
+- When the server rejects a flag or lifecycle action, are all coupled metadata
+  fields stripped as one invariant-preserving group?
+- Can any downstream scanner, contract consumer, or audit path still read a
+  rejected event as pending nomination intent?
+- Do rejection tests assert absence of the entire metadata group, not only the
+  primary boolean flag?
+
+### Prior Fix
+
+PR #251 strips `share_candidate`, `memory_lifecycle_action`, candidate detail
+fields, and `evidence_refs` from rejected nominations before stamping the
+rejection marker. Regression tests cover secret/private rejected nominations.

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -115,3 +115,32 @@ PR #244 first runs the sync share-candidate gate without DB retry state. Only
 after a hard reject does it derive effective attempt state and rebuild the safe
 rejection detail. A regression test asserts clean sanitized resubmits do not run
 the retry-state query.
+
+## [2026-07-06] Tool output contracts must not advertise unreachable buckets
+
+**Severity:** MEDIUM
+**Source:** PR #251 Claude cross-review for Issue #224
+**Scope:** `src/tools/scan-namespace.ts`, tool schemas/docs that filter candidates before grouping
+**Status:** fixed in PR #251
+
+### Pattern
+
+Changing query semantics can make an output bucket dead while the schema still
+advertises it. In PR #251, `scan_namespace` was tightened to return only
+pending explicit shared-kb nominations, but the response contract still exposed
+an `already_promoted` bucket from the older scan-all design. That made clients
+and future reviewers reason about states the tool could no longer produce.
+
+### Review Questions
+
+- After pushing a filter into SQL, do all response buckets still have reachable
+  inputs?
+- Does the tool description name the actual candidate set, not the historical
+  broader scan behavior?
+- Do tests assert removed/dead buckets are absent rather than empty, so clients
+  cannot depend on obsolete shape?
+
+### Prior Fix
+
+PR #251 removed the unreachable `already_promoted` bucket and updated the tool
+description and tests to describe pending explicit shared-kb nominations only.

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -28,6 +28,23 @@ EVENT_TYPES = {
     "handoff",
 }
 IMPORTANCE_LEVELS = {"hot", "warm", "cold"}
+CANDIDATE_TYPES = {
+    "user_preference",
+    "process_rule",
+    "channel_server_rule",
+    "code_repo_fact",
+    "positive_example",
+    "negative_example",
+    "durable_decision",
+    "shared_kb_nomination",
+}
+MEMORY_LIFECYCLE_ACTIONS = {
+    "candidate",
+    "promote",
+    "relegate",
+    "discard",
+    "nominate_shared",
+}
 PROTECTED_KEYS = {
     "agent",
     "authorization",
@@ -485,6 +502,216 @@ class AgentMemory:
             self.client.append_session_event,
             key=key,
         )
+
+    def candidate_memory(
+        self,
+        role: str,
+        content: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None = None,
+        scope: Mapping[str, Any] | None = None,
+        evidence_refs: list[Mapping[str, Any]] | None = None,
+        staleness_policy: str | None = None,
+        **metadata: Any,
+    ) -> JSON:
+        return self._lifecycle_candidate_event(
+            "candidate",
+            role,
+            content,
+            candidate_type=candidate_type,
+            reason=reason,
+            confidence=confidence,
+            scope=scope,
+            evidence_refs=evidence_refs,
+            staleness_policy=staleness_policy,
+            **metadata,
+        )
+
+    def promote_candidate(
+        self,
+        role: str,
+        content: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None = None,
+        scope: Mapping[str, Any] | None = None,
+        evidence_refs: list[Mapping[str, Any]] | None = None,
+        staleness_policy: str | None = None,
+        **metadata: Any,
+    ) -> JSON:
+        return self._lifecycle_candidate_event(
+            "promote",
+            role,
+            content,
+            candidate_type=candidate_type,
+            reason=reason,
+            confidence=confidence,
+            scope=scope,
+            evidence_refs=evidence_refs,
+            staleness_policy=staleness_policy,
+            **metadata,
+        )
+
+    def relegate_candidate(
+        self,
+        role: str,
+        content: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None = None,
+        scope: Mapping[str, Any] | None = None,
+        evidence_refs: list[Mapping[str, Any]] | None = None,
+        staleness_policy: str | None = None,
+        **metadata: Any,
+    ) -> JSON:
+        return self._lifecycle_candidate_event(
+            "relegate",
+            role,
+            content,
+            candidate_type=candidate_type,
+            reason=reason,
+            confidence=confidence,
+            scope=scope,
+            evidence_refs=evidence_refs,
+            staleness_policy=staleness_policy,
+            **metadata,
+        )
+
+    def discard_candidate(
+        self,
+        role: str,
+        content: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None = None,
+        scope: Mapping[str, Any] | None = None,
+        evidence_refs: list[Mapping[str, Any]] | None = None,
+        staleness_policy: str | None = None,
+        **metadata: Any,
+    ) -> JSON:
+        return self._lifecycle_candidate_event(
+            "discard",
+            role,
+            content,
+            candidate_type=candidate_type,
+            reason=reason,
+            confidence=confidence,
+            scope=scope,
+            evidence_refs=evidence_refs,
+            staleness_policy=staleness_policy,
+            **metadata,
+        )
+
+    def nominate_shared(
+        self,
+        role: str,
+        content: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None = None,
+        scope: Mapping[str, Any] | None = None,
+        evidence_refs: list[Mapping[str, Any]] | None = None,
+        staleness_policy: str | None = None,
+        **metadata: Any,
+    ) -> JSON:
+        lifecycle_metadata = self._lifecycle_candidate_metadata(
+            "nominate_shared",
+            candidate_type=candidate_type,
+            reason=reason,
+            confidence=confidence,
+            scope=scope,
+            evidence_refs=evidence_refs,
+            staleness_policy=staleness_policy,
+        )
+        return self.append_event(
+            role,
+            content,
+            share_candidate=True,
+            **{**metadata, **lifecycle_metadata},
+        )
+
+    def _lifecycle_candidate_event(
+        self,
+        action: str,
+        role: str,
+        content: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None,
+        scope: Mapping[str, Any] | None,
+        evidence_refs: list[Mapping[str, Any]] | None,
+        staleness_policy: str | None,
+        **metadata: Any,
+    ) -> JSON:
+        lifecycle_metadata = self._lifecycle_candidate_metadata(
+            action,
+            candidate_type=candidate_type,
+            reason=reason,
+            confidence=confidence,
+            scope=scope,
+            evidence_refs=evidence_refs,
+            staleness_policy=staleness_policy,
+        )
+        return self.append_event(
+            role,
+            content,
+            **{**metadata, **lifecycle_metadata},
+        )
+
+    def _lifecycle_candidate_metadata(
+        self,
+        action: str,
+        *,
+        candidate_type: str,
+        reason: str,
+        confidence: float | None,
+        scope: Mapping[str, Any] | None,
+        evidence_refs: list[Mapping[str, Any]] | None,
+        staleness_policy: str | None,
+    ) -> dict[str, Any]:
+        if action not in MEMORY_LIFECYCLE_ACTIONS:
+            raise ValueError(f"Unsupported memory lifecycle action: {action}")
+        lifecycle_metadata: dict[str, Any] = {
+            "memory_lifecycle_action": action,
+            "candidate_type": _enum_value(
+                candidate_type,
+                "candidate_type",
+                CANDIDATE_TYPES,
+            ),
+            "candidate_reason": _required_str(reason, "reason"),
+        }
+        if confidence is not None:
+            if (
+                isinstance(confidence, bool)
+                or not isinstance(confidence, int | float)
+                or confidence < 0
+                or confidence > 1
+            ):
+                raise ValueError("confidence must be a number from 0 to 1")
+            lifecycle_metadata["candidate_confidence"] = confidence
+        if scope is not None:
+            lifecycle_metadata["candidate_scope"] = _mapping_list(
+                [scope],
+                "scope",
+            )[0]
+        if evidence_refs is not None:
+            lifecycle_metadata["evidence_refs"] = _mapping_list(
+                evidence_refs,
+                "evidence_refs",
+            )
+        if staleness_policy is not None:
+            lifecycle_metadata["candidate_staleness_policy"] = _required_str(
+                staleness_policy,
+                "staleness_policy",
+            )
+        return lifecycle_metadata
 
     def remember_fact(self, text: str, **metadata: Any) -> JSON:
         self._reject_reserved_metadata(metadata)

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -41,7 +41,7 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v14"
+CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v15"
 COMPATIBLE_CONTRACT_VERSIONS = (CURRENT_CONTRACT_VERSION,)
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -192,6 +192,106 @@ def test_append_event_routes_to_session_event_wrapper():
     assert payload["session_key"] == "conversation"
 
 
+def test_candidate_memory_records_user_correction_as_candidate_only_negative_example():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+    memory.start_session("conversation")
+
+    memory.candidate_memory(
+        "user",
+        "Correction: do not promote share candidates without explicit nomination.",
+        event_type="correction",
+        candidate_type="negative_example",
+        reason="User corrected an unsafe promotion assumption.",
+        confidence=0.95,
+        scope={"repo": "rodaddy/open-brain"},
+        evidence_refs=[
+            {"kind": "issue", "url": "https://github.com/rodaddy/open-brain/issues/224"}
+        ],
+        staleness_policy="Revalidate when promotion lifecycle changes.",
+    )
+
+    name, payload = client.calls[-1]
+    assert name == "append_session_event"
+    assert payload["event_type"] == "correction"
+    assert payload["source"] == "user"
+    assert payload["metadata"]["memory_lifecycle_action"] == "candidate"
+    assert payload["metadata"]["candidate_type"] == "negative_example"
+    assert payload["metadata"]["candidate_reason"] == (
+        "User corrected an unsafe promotion assumption."
+    )
+    assert payload["metadata"]["candidate_confidence"] == 0.95
+    assert payload["metadata"]["candidate_scope"] == {"repo": "rodaddy/open-brain"}
+    assert payload["metadata"]["evidence_refs"] == [
+        {"kind": "issue", "url": "https://github.com/rodaddy/open-brain/issues/224"}
+    ]
+    assert payload["metadata"]["candidate_staleness_policy"] == (
+        "Revalidate when promotion lifecycle changes."
+    )
+    assert "share_candidate" not in payload["metadata"]
+
+
+def test_nominate_shared_requires_explicit_lifecycle_action():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+    memory.start_session("conversation")
+
+    memory.nominate_shared(
+        "assistant",
+        "This reviewed fact is ready for shared nomination.",
+        event_type="fact",
+        candidate_type="shared_kb_nomination",
+        reason="Reviewed fact is suitable for shared-kb nomination.",
+    )
+
+    name, payload = client.calls[-1]
+    assert name == "append_session_event"
+    assert payload["metadata"]["share_candidate"] is True
+    assert payload["metadata"]["memory_lifecycle_action"] == "nominate_shared"
+    assert payload["metadata"]["candidate_type"] == "shared_kb_nomination"
+    assert (
+        payload["metadata"]["candidate_reason"]
+        == "Reviewed fact is suitable for shared-kb nomination."
+    )
+
+
+def test_lifecycle_helpers_record_promote_relegate_and_discard_actions():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby")
+    memory.start_session("conversation")
+
+    memory.promote_candidate(
+        "assistant",
+        "Promote reviewed process rule.",
+        candidate_type="process_rule",
+        reason="User explicitly said to remember this rule.",
+    )
+    memory.relegate_candidate(
+        "assistant",
+        "Keep repo fact local for now.",
+        candidate_type="code_repo_fact",
+        reason="Useful only in the current repo.",
+    )
+    memory.discard_candidate(
+        "assistant",
+        "Discard stale preference.",
+        candidate_type="user_preference",
+        reason="Superseded by later user correction.",
+    )
+
+    lifecycle_payloads = [
+        payload["metadata"]
+        for name, payload in client.calls
+        if name == "append_session_event"
+    ]
+    assert [item["memory_lifecycle_action"] for item in lifecycle_payloads] == [
+        "promote",
+        "relegate",
+        "discard",
+    ]
+    assert all("share_candidate" not in item for item in lifecycle_payloads)
+
+
 def test_remember_fact_routes_to_thought_memory_write_semantics():
     client = FakeClient()
     memory = AgentMemory(client, agent="bilby", project="open-brain")

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -262,9 +262,9 @@ def test_lifecycle_helpers_record_promote_relegate_and_discard_actions():
 
     memory.promote_candidate(
         "assistant",
-        "Promote reviewed process rule.",
+        "Record promotion approval for reviewed process rule.",
         candidate_type="process_rule",
-        reason="User explicitly said to remember this rule.",
+        reason="User approved this rule for a separate durable write.",
     )
     memory.relegate_candidate(
         "assistant",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -499,7 +499,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v14"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v15"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:
@@ -1515,10 +1515,11 @@ def test_urllib_transport_does_not_follow_redirects_with_auth_headers():
     assert response.status_code == 302
 
 
-def test_append_session_event_carries_share_candidate_nomination():
-    # Issue #161: an agent nominates a session event for sharing by setting
-    # metadata.share_candidate=true. The Python client must carry that
-    # nomination through to the server as a tools/call argument, untouched.
+def test_append_session_event_carries_explicit_share_candidate_nomination():
+    # Issue #224: an agent nominates a session event for sharing by setting
+    # metadata.share_candidate=true and memory_lifecycle_action=nominate_shared.
+    # The low-level Python client must carry that nomination through to the
+    # server as a tools/call argument, untouched.
     transport = FakeTransport()
     client = make_client(transport)
 
@@ -1526,7 +1527,11 @@ def test_append_session_event_carries_share_candidate_nomination():
         session_key="chan/thread",
         event_type="fact",
         content="Promotable knowledge.",
-        metadata={"share_candidate": True, "source": "agent"},
+        metadata={
+            "share_candidate": True,
+            "memory_lifecycle_action": "nominate_shared",
+            "source": "agent",
+        },
     )
 
     calls = tool_requests(transport)
@@ -1537,10 +1542,19 @@ def test_append_session_event_carries_share_candidate_nomination():
         "session_key": "chan/thread",
         "event_type": "fact",
         "content": "Promotable knowledge.",
-        "metadata": {"share_candidate": True, "source": "agent"},
+        "metadata": {
+            "share_candidate": True,
+            "memory_lifecycle_action": "nominate_shared",
+            "source": "agent",
+        },
     }
-    # The nomination flag must reach the server as a genuine boolean True.
+    # The nomination flag must reach the server as a genuine boolean True, and
+    # the explicit lifecycle action must remain attached.
     assert params["arguments"]["metadata"]["share_candidate"] is True
+    assert (
+        params["arguments"]["metadata"]["memory_lifecycle_action"]
+        == "nominate_shared"
+    )
 
 
 def test_append_session_event_surfaces_share_candidate_rejection():

--- a/python/openbrain-memory/tests/test_dream.py
+++ b/python/openbrain-memory/tests/test_dream.py
@@ -45,7 +45,6 @@ class FakeDreamClient:
                     {"id": "promote-2", "table": "decisions"},
                 ],
                 "duplicates": [],
-                "already_promoted": [],
             },
         }
 

--- a/scripts/promote-lane-shared.test.ts
+++ b/scripts/promote-lane-shared.test.ts
@@ -128,6 +128,13 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
     );
   }
 
+  function explicitNominationMetadata(): Record<string, unknown> {
+    return {
+      share_candidate: true,
+      memory_lifecycle_action: "nominate_shared",
+    };
+  }
+
   async function seedLane(): Promise<string> {
     const { rows } = await pool.query(
       `INSERT INTO ob_session_lanes (session_key, namespace, status, created_by)
@@ -152,7 +159,7 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
       [
         laneId,
         content,
-        JSON.stringify({ share_candidate: true }),
+        JSON.stringify(explicitNominationMetadata()),
         // unique-ish hash so ON CONFLICT (lane_id, content_hash) won't collide
         `hash-${content.length}-${createdAt}`,
         createdAt,
@@ -170,7 +177,7 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
          (content, namespace, extracted_metadata, created_by, created_at)
        VALUES ($1, $2, $3::jsonb, 'test', $4::timestamptz)
        RETURNING id`,
-      [content, ns, JSON.stringify({ share_candidate: true }), createdAt],
+      [content, ns, JSON.stringify(explicitNominationMetadata()), createdAt],
     );
     return rows[0].id as string;
   }
@@ -199,6 +206,54 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
   } {
     return JSON.parse(readFileSync(stateFile, "utf8"));
   }
+
+  test("candidate-only rows are not shared-kb nominations", async () => {
+    const laneId = await seedLane();
+    await pool.query(
+      `INSERT INTO ob_session_events
+         (lane_id, event_type, content, importance, metadata, content_hash, created_by, created_at)
+       VALUES ($1, 'correction', $2, 'warm', $3::jsonb, $4, 'test', $5::timestamptz)`,
+      [
+        laneId,
+        "User correction: treat share candidates as review-only unless explicitly nominated.",
+        JSON.stringify({
+          memory_lifecycle_action: "candidate",
+          candidate_type: "negative_example",
+          candidate_reason: "User corrected unsafe auto-promotion assumption.",
+          candidate_confidence: 0.95,
+        }),
+        "candidate-only-event-hash",
+        "2026-01-01T00:00:00Z",
+      ],
+    );
+    await pool.query(
+      `INSERT INTO thoughts
+         (content, namespace, extracted_metadata, created_by, created_at)
+       VALUES ($1, $2, $3::jsonb, 'test', $4::timestamptz)`,
+      [
+        "Candidate-only thought should not be promoted by presence alone.",
+        ns,
+        JSON.stringify({
+          share_candidate: true,
+          memory_lifecycle_action: "candidate",
+          candidate_type: "code_repo_fact",
+          candidate_reason: "Needs explicit nomination before sharing.",
+        }),
+        "2026-01-02T00:00:00Z",
+      ],
+    );
+
+    const receipt = await runSharedPromoter(makeArgs(true));
+    expect(receipt.scanned).toBe(0);
+
+    const { rows: sharedCopies } = await pool.query(
+      `SELECT id FROM thoughts
+        WHERE namespace = $1
+          AND content = 'Candidate-only thought should not be promoted by presence alone.'`,
+      [ns + "-shared"],
+    );
+    expect(sharedCopies.length).toBe(0);
+  });
 
   beforeEach(async () => {
     applyDbEnv(DB_URL as string);
@@ -267,7 +322,7 @@ dbDescribe("runSharedPromoter cursor-stall fix (live Postgres)", () => {
       [
         content,
         ns,
-        JSON.stringify({ share_candidate: true }),
+        JSON.stringify(explicitNominationMetadata()),
         createdAt,
         vecLiteral,
         `src-hash-${createdAt}`,

--- a/scripts/promote-lane-shared.ts
+++ b/scripts/promote-lane-shared.ts
@@ -21,8 +21,10 @@ import type { AuthInfo } from "../src/types.ts";
  * Mirrors scripts/promote-legacy-shared.ts and scripts/tier-lane-durable.ts
  * (cursor/state/receipt/args, dry-run default, resumable cursor, kill-switch).
  *
- * Runs as the PROMOTER identity and sweeps THREE sources for the nomination flag
- * `metadata->>'share_candidate' = 'true'`:
+ * Runs as the PROMOTER identity and sweeps THREE sources only when the client
+ * has explicitly nominated the candidate:
+ * `metadata->>'share_candidate' = 'true'` AND
+ * `metadata->>'memory_lifecycle_action' = 'nominate_shared'`:
  *   - thoughts   → classify → promoteEntry into shared-kb.
  *   - decisions  → classify → promoteEntry into shared-kb.
  *   - ob_session_events JOIN ob_session_lanes → classify → focused
@@ -105,7 +107,8 @@ function usage(exitCode = 2): never {
       "",
       "Dry-run is the default and does not advance the persistent cursor.",
       "Apply mode is bounded by --max-apply promotions, runs as the promoter",
-      "identity, and only promotes entries nominated via metadata share_candidate.",
+      "identity, and only promotes entries explicitly nominated via metadata ",
+      "share_candidate + memory_lifecycle_action=nominate_shared.",
     ].join("\n"),
   );
   process.exit(exitCode);
@@ -284,6 +287,7 @@ async function nominatedTableRows(
             extracted_metadata AS metadata
      FROM ${table}
      WHERE extracted_metadata->>'share_candidate' = 'true'
+       AND extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'
        AND archived_at IS NULL${cursorSql}
      ORDER BY created_at ASC, id ASC
      LIMIT $1`,
@@ -327,7 +331,8 @@ async function nominatedEventRows(
        l.metadata->>'repo' AS repo, l.project AS project
      FROM ob_session_events e
      JOIN ob_session_lanes l ON e.lane_id = l.id
-     WHERE e.metadata->>'share_candidate' = 'true'${cursorSql}
+     WHERE e.metadata->>'share_candidate' = 'true'
+       AND e.metadata->>'memory_lifecycle_action' = 'nominate_shared'${cursorSql}
      ORDER BY e.created_at ASC, e.id ASC
      LIMIT $1`,
     params,
@@ -407,9 +412,10 @@ export async function shareEventToSharedKb(
 }
 
 /**
- * Clear the share_candidate nomination from a source row so it is not re-swept.
- * Drops the flag and stamps a processed marker. Idempotent. `column` is the
- * metadata jsonb column for the table (extracted_metadata vs metadata).
+ * Clear the explicit shared nomination from a source row so it is not re-swept.
+ * Drops the share flag and lifecycle action, then stamps a processed marker.
+ * Idempotent. `column` is the metadata jsonb column for the table
+ * (extracted_metadata vs metadata).
  */
 async function clearNomination(
   pool: ReturnType<typeof createPool>,
@@ -420,7 +426,7 @@ async function clearNomination(
 ): Promise<void> {
   await pool.query(
     `UPDATE ${table}
-     SET ${column} = (${column} - 'share_candidate')
+     SET ${column} = (${column} - 'share_candidate' - 'memory_lifecycle_action')
        || jsonb_build_object('share_promoted_at', $2::text)
      WHERE id = $1`,
     [id, now],

--- a/scripts/tier-lane-durable.ts
+++ b/scripts/tier-lane-durable.ts
@@ -239,7 +239,8 @@ async function candidateEvents(
   const { rows } = await pool.query(
     `SELECT
        e.id, e.lane_id, l.namespace, l.agent, l.session_key,
-       e.event_type, e.content, e.importance, e.content_hash, e.created_at
+       e.event_type, e.content, e.importance, e.content_hash, e.created_at,
+       e.metadata
      FROM ob_session_events e
      JOIN ob_session_lanes l ON e.lane_id = l.id
      WHERE l.namespace = $1${cursorSql}

--- a/src/__tests__/agent-memory.test.ts
+++ b/src/__tests__/agent-memory.test.ts
@@ -156,7 +156,7 @@ describe("AgentMemory TypeScript wrapper", () => {
     });
   });
 
-  it("appends events and nominations without caller-controlled authority keys", async () => {
+  it("appends events, candidate-only corrections, and explicit nominations", async () => {
     const transport = new FakeTransport();
     const memory = new AgentMemory(transport, { agent: "codex", source: "codex" });
     await memory.start({ sessionKey: "open-brain/run" });
@@ -168,9 +168,29 @@ describe("AgentMemory TypeScript wrapper", () => {
       importance: "hot",
       metadata: { issue: 209 },
     });
+    await memory.candidateMemory({
+      eventType: "correction",
+      content:
+        "Correction: do not treat share_candidate as durable memory without explicit nomination.",
+      candidateType: "negative_example",
+      reason: "User corrected an unsafe promotion assumption.",
+      confidence: 0.9,
+      scope: { repo: "rodaddy/open-brain" },
+      evidenceRefs: [{ kind: "issue", url: "https://github.com/rodaddy/open-brain/issues/224" }],
+    });
+    await memory.promoteCandidate({
+      eventType: "decision",
+      content: "Client explicitly promoted the corrected process rule.",
+      candidateType: "process_rule",
+      reason: "The user correction should become durable guidance.",
+      confidence: 1,
+      scope: { repo: "rodaddy/open-brain" },
+    });
     await memory.nominateShared({
       eventType: "decision",
       content: "Use a caller-provided transport for the TS memory wrapper.",
+      candidateType: "shared_kb_nomination",
+      reason: "Reviewed contract decision is suitable for shared-kb nomination.",
       metadata: { reason: "keeps server auth boundary owned by Open Brain" },
     });
 
@@ -185,10 +205,41 @@ describe("AgentMemory TypeScript wrapper", () => {
     });
     expect(transport.calls[2]!.args).toMatchObject({
       session_key: "open-brain/run",
+      event_type: "correction",
+      metadata: {
+        memory_lifecycle_action: "candidate",
+        candidate_type: "negative_example",
+        candidate_reason: "User corrected an unsafe promotion assumption.",
+        candidate_confidence: 0.9,
+        candidate_scope: { repo: "rodaddy/open-brain" },
+        evidence_refs: [
+          { kind: "issue", url: "https://github.com/rodaddy/open-brain/issues/224" },
+        ],
+      },
+    });
+    expect((transport.calls[2]!.args.metadata as JsonObject).share_candidate).toBeUndefined();
+    expect(transport.calls[3]!.args).toMatchObject({
+      session_key: "open-brain/run",
+      event_type: "decision",
+      metadata: {
+        memory_lifecycle_action: "promote",
+        candidate_type: "process_rule",
+        candidate_reason: "The user correction should become durable guidance.",
+        candidate_confidence: 1,
+        candidate_scope: { repo: "rodaddy/open-brain" },
+      },
+    });
+    expect((transport.calls[3]!.args.metadata as JsonObject).share_candidate).toBeUndefined();
+    expect(transport.calls[4]!.args).toMatchObject({
+      session_key: "open-brain/run",
       event_type: "decision",
       metadata: {
         reason: "keeps server auth boundary owned by Open Brain",
+        candidate_type: "shared_kb_nomination",
+        candidate_reason:
+          "Reviewed contract decision is suitable for shared-kb nomination.",
         share_candidate: true,
+        memory_lifecycle_action: "nominate_shared",
       },
     });
   });

--- a/src/__tests__/agent-memory.test.ts
+++ b/src/__tests__/agent-memory.test.ts
@@ -180,9 +180,9 @@ describe("AgentMemory TypeScript wrapper", () => {
     });
     await memory.promoteCandidate({
       eventType: "decision",
-      content: "Client explicitly promoted the corrected process rule.",
+      content: "Client recorded promotion approval for the corrected process rule.",
       candidateType: "process_rule",
-      reason: "The user correction should become durable guidance.",
+      reason: "The user correction was approved for a separate durable write.",
       confidence: 1,
       scope: { repo: "rodaddy/open-brain" },
     });
@@ -224,7 +224,8 @@ describe("AgentMemory TypeScript wrapper", () => {
       metadata: {
         memory_lifecycle_action: "promote",
         candidate_type: "process_rule",
-        candidate_reason: "The user correction should become durable guidance.",
+        candidate_reason:
+          "The user correction was approved for a separate durable write.",
         candidate_confidence: 1,
         candidate_scope: { repo: "rodaddy/open-brain" },
       },

--- a/src/agent-memory.ts
+++ b/src/agent-memory.ts
@@ -19,6 +19,21 @@ export type MemoryEventType =
   | "handoff";
 
 export type MemoryImportance = "hot" | "warm" | "cold";
+export type CandidateType =
+  | "user_preference"
+  | "process_rule"
+  | "channel_server_rule"
+  | "code_repo_fact"
+  | "positive_example"
+  | "negative_example"
+  | "durable_decision"
+  | "shared_kb_nomination";
+export type MemoryLifecycleAction =
+  | "candidate"
+  | "promote"
+  | "relegate"
+  | "discard"
+  | "nominate_shared";
 
 export interface OpenBrainToolTransport {
   callTool(name: string, args: JsonObject): Promise<unknown> | unknown;
@@ -64,6 +79,15 @@ export interface AppendEventOptions {
   artifactPath?: string;
   importance?: MemoryImportance;
   metadata?: JsonObject;
+}
+
+export interface CandidateMemoryOptions extends AppendEventOptions {
+  candidateType: CandidateType;
+  reason: string;
+  confidence?: number;
+  scope?: JsonObject;
+  evidenceRefs?: JsonObject[];
+  stalenessPolicy?: string;
 }
 
 export interface CompactOptions {
@@ -131,6 +155,16 @@ const EVENT_TYPES = new Set<MemoryEventType>([
 ]);
 
 const IMPORTANCE_LEVELS = new Set<MemoryImportance>(["hot", "warm", "cold"]);
+const CANDIDATE_TYPES = new Set<CandidateType>([
+  "user_preference",
+  "process_rule",
+  "channel_server_rule",
+  "code_repo_fact",
+  "positive_example",
+  "negative_example",
+  "durable_decision",
+  "shared_kb_nomination",
+]);
 const SEARCH_MODES = new Set(["hybrid", "vector", "keyword"]);
 const PROTECTED_KEYS = new Set([
   "agent",
@@ -365,14 +399,35 @@ export class AgentMemory {
     });
   }
 
-  async nominateShared(options: AppendEventOptions): Promise<unknown> {
+  async nominateShared(options: CandidateMemoryOptions): Promise<unknown> {
+    const lifecycleMetadata = lifecycleCandidateMetadata(
+      "nominate_shared",
+      options,
+    );
     return this.appendEvent({
       ...options,
       metadata: {
         ...(options.metadata ?? {}),
+        ...lifecycleMetadata,
         share_candidate: true,
       },
     });
+  }
+
+  async candidateMemory(options: CandidateMemoryOptions): Promise<unknown> {
+    return this.appendLifecycleEvent("candidate", options);
+  }
+
+  async promoteCandidate(options: CandidateMemoryOptions): Promise<unknown> {
+    return this.appendLifecycleEvent("promote", options);
+  }
+
+  async relegateCandidate(options: CandidateMemoryOptions): Promise<unknown> {
+    return this.appendLifecycleEvent("relegate", options);
+  }
+
+  async discardCandidate(options: CandidateMemoryOptions): Promise<unknown> {
+    return this.appendLifecycleEvent("discard", options);
   }
 
   exportDisclosureBundle(input: Omit<DisclosureBundleInput, "lane"> & {
@@ -414,6 +469,20 @@ export class AgentMemory {
       validation: safeMetadata(options.validation),
     };
     return this.transport.callTool("upsert_repo_fact", payload);
+  }
+
+  private async appendLifecycleEvent(
+    action: Exclude<MemoryLifecycleAction, "nominate_shared">,
+    options: CandidateMemoryOptions,
+  ): Promise<unknown> {
+    const lifecycleMetadata = lifecycleCandidateMetadata(action, options);
+    return this.appendEvent({
+      ...options,
+      metadata: {
+        ...(options.metadata ?? {}),
+        ...lifecycleMetadata,
+      },
+    });
   }
 
   private requireSession(method: string): asserts this is this & { sessionKey: string } {
@@ -469,6 +538,34 @@ function mappingList(values: JsonObject[], name: string): JsonObject[] {
     }
     return { ...(value as JsonObject) };
   });
+}
+
+function lifecycleCandidateMetadata(
+  action: MemoryLifecycleAction,
+  options: CandidateMemoryOptions,
+): JsonObject {
+  const metadata: JsonObject = {
+    memory_lifecycle_action: action,
+    candidate_type: enumValue(options.candidateType, "candidateType", CANDIDATE_TYPES),
+    candidate_reason: requiredString(options.reason, "reason"),
+  };
+  if (options.confidence !== undefined) {
+    if (
+      typeof options.confidence !== "number" ||
+      !Number.isFinite(options.confidence) ||
+      options.confidence < 0 ||
+      options.confidence > 1
+    ) {
+      throw new Error("confidence must be a number from 0 to 1");
+    }
+    metadata.candidate_confidence = options.confidence;
+  }
+  if (options.scope !== undefined) metadata.candidate_scope = safeMetadata(options.scope);
+  if (options.evidenceRefs !== undefined) {
+    metadata.evidence_refs = mappingList(options.evidenceRefs, "evidenceRefs");
+  }
+  setOptional(metadata, "candidate_staleness_policy", options.stalenessPolicy);
+  return metadata;
 }
 
 function validationList(values: ReceiptValidation[]): JsonObject[] {

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -710,10 +710,14 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
             required: false,
             items: "object",
             maxItems: 20,
+            maxItemJsonBytes: 2000,
+            maxTotalJsonBytes: 10000,
             description:
               "Citation-safe evidence references for the candidate, such as " +
               "event ids, issue URLs, repo paths, commit SHAs, or source refs. " +
-              "Do not include raw private transcripts or secrets.",
+              "The server bounds serialized evidence metadata and rejects " +
+              "secret-like evidence refs. Do not include raw private transcripts " +
+              "or secrets.",
           },
           share_candidate: {
             type: "boolean",

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -633,21 +633,100 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         maxJsonBytes: 100000,
         description:
           "Arbitrary structured key/value metadata for the event (max 50 " +
-          "keys, 100KB JSON), plus the recognized share_candidate flag below.",
+          "keys, 100KB JSON), plus the recognized explicit memory lifecycle " +
+          "fields below.",
         fields: {
+          memory_lifecycle_action: {
+            type: "enum",
+            required: false,
+            values: [
+              "candidate",
+              "promote",
+              "relegate",
+              "discard",
+              "nominate_shared",
+            ],
+            description:
+              "Client-owned lifecycle action for memory extracted from this " +
+              "event. candidate marks review-only material; promote/relegate/" +
+              "discard record explicit client handling; nominate_shared is the " +
+              "only action eligible for the shared-kb promoter, and still " +
+              "requires share_candidate=true plus server safety checks.",
+          },
+          candidate_type: {
+            type: "enum",
+            required: false,
+            values: [
+              "user_preference",
+              "process_rule",
+              "channel_server_rule",
+              "code_repo_fact",
+              "positive_example",
+              "negative_example",
+              "durable_decision",
+              "shared_kb_nomination",
+            ],
+            description:
+              "Candidate classification chosen by the client/runtime. User " +
+              "corrections that should teach future behavior without immediate " +
+              "durable promotion should use negative_example.",
+          },
+          candidate_reason: {
+            type: "string",
+            required: false,
+            maxLength: 2000,
+            description:
+              "Explicit client reason for creating, promoting, relegating, " +
+              "discarding, or nominating the candidate.",
+          },
+          candidate_confidence: {
+            type: "number",
+            required: false,
+            min: 0,
+            max: 1,
+            description:
+              "Client confidence that the candidate is useful and correctly " +
+              "scoped. This is advisory; Open Brain still enforces auth and " +
+              "safety.",
+          },
+          candidate_scope: {
+            type: "object",
+            required: false,
+            description:
+              "Client-declared scope for the candidate, such as repo, project, " +
+              "agent, server_id, channel_id, thread_id, or session_key. It is " +
+              "provenance, not an authorization override.",
+          },
+          candidate_staleness_policy: {
+            type: "string",
+            required: false,
+            maxLength: 1000,
+            description:
+              "When the candidate should expire, be revalidated, or be treated " +
+              "as historical context only.",
+          },
+          evidence_refs: {
+            type: "array",
+            required: false,
+            items: "object",
+            maxItems: 20,
+            description:
+              "Citation-safe evidence references for the candidate, such as " +
+              "event ids, issue URLs, repo paths, commit SHAs, or source refs. " +
+              "Do not include raw private transcripts or secrets.",
+          },
           share_candidate: {
             type: "boolean",
             required: false,
             description:
-              "Nominate this event for shared-kb promotion (shared truth every " +
-              "agent reads). Set true on a substantive fact/decision/handoff worth " +
-              "sharing. Adjudication is two-stage: SYNCHRONOUSLY the server refuses " +
-              "and strips the nomination if the content looks like a secret or " +
-              "person-private data — when that happens the event still saves but the " +
-              "response carries share_candidate_rejected with the reason. " +
-              "ASYNCHRONOUSLY a promoter-gated sweep re-classifies worthiness, " +
-              "de-duplicates against shared-kb, and promotes survivors. Do NOT set " +
-              "true for secrets, credentials, or private/personal content.",
+              "Shared-kb nomination marker. By itself this is candidate " +
+              "metadata only and must not create a shared-kb write. The " +
+              "promoter only considers rows where share_candidate=true AND " +
+              "memory_lifecycle_action=nominate_shared. SYNCHRONOUSLY the " +
+              "server refuses and strips the nomination if content looks like " +
+              "a secret or person-private data; the event still saves and the " +
+              "response carries share_candidate_rejected with the reason. Do " +
+              "NOT set true for secrets, credentials, or private/personal content.",
           },
           sanitized_resubmit_of: {
             type: "string",

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "ad89a4d253ec224bce1175cd0045b6da54de6837c3e4081304e25a5af9147873",
+      "4b3b07665bcaa2087e8fd3e75dfda86974c047529f85b42c0a0b5631bc4fd994",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -84,11 +84,15 @@ describe("Open Brain contract manifest", () => {
     );
     expect(Object.keys(contract.agent_memory_adapter.methods).sort()).toEqual([
       "append_event",
+      "candidate_memory",
       "compact",
+      "discard_candidate",
       "export_disclosure_bundle",
       "nominate_shared",
+      "promote_candidate",
       "recall",
       "record_receipt",
+      "relegate_candidate",
       "start",
       "wrap",
     ]);
@@ -103,7 +107,23 @@ describe("Open Brain contract manifest", () => {
     ]);
     expect(adapterMethods.nominate_shared!.maps_to).toEqual([
       "append_session_event:metadata.share_candidate",
+      "append_session_event:metadata.memory_lifecycle_action=nominate_shared",
     ]);
+    expect(adapterMethods.candidate_memory).toEqual({
+      maps_to: [
+        "append_session_event:metadata.memory_lifecycle_action=candidate",
+      ],
+      owner: "client",
+      status: "client-wrapper",
+    });
+    expect(adapterMethods.promote_candidate).toEqual({
+      maps_to: [
+        "append_session_event:metadata.memory_lifecycle_action=promote",
+        "log_thought/log_decision explicit durable write",
+      ],
+      owner: "client",
+      status: "client-wrapper",
+    });
     expect(adapterMethods.export_disclosure_bundle).toEqual({
       maps_to: ["interchange_profiles.okf"],
       owner: "client",
@@ -175,6 +195,25 @@ describe("Open Brain contract manifest", () => {
       "approval_chain",
       "redaction_policy",
     ]);
+    expect(contract.promotion_lifecycle).toMatchObject({
+      status: "explicit-client-owned-lifecycle",
+      parent_issue: 224,
+      contract_doc: "docs/agent-memory-adapter-contract.md",
+      candidate_presence_effect: "no_durable_write_no_shared_write",
+    });
+    expect(contract.promotion_lifecycle.candidate_types).toContain(
+      "negative_example",
+    );
+    expect(contract.promotion_lifecycle.actions).toEqual([
+      "candidate",
+      "promote",
+      "relegate",
+      "discard",
+      "nominate_shared",
+    ]);
+    expect(contract.promotion_lifecycle.shared_nomination_requires).toContain(
+      "memory_lifecycle_action_nominate_shared",
+    );
     expect(contract.capabilities.map((c) => c.name)).toContain(
       "upsert_repo_fact",
     );
@@ -186,6 +225,9 @@ describe("Open Brain contract manifest", () => {
     );
     expect(contract.capabilities.map((c) => c.name)).toContain(
       "receipt_contract",
+    );
+    expect(contract.capabilities.map((c) => c.name)).toContain(
+      "memory_promotion_lifecycle",
     );
     for (const tool of [
       "get_contract",
@@ -292,7 +334,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v14");
+    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v15");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
@@ -323,9 +365,33 @@ describe("Open Brain contract manifest", () => {
     const shareCandidate = (appendEvent?.input_schema as any).metadata.fields
       .share_candidate;
     expect(shareCandidate.type).toBe("boolean");
-    // The help must document the two-stage (sync reject / async promote) model
-    // so a contract-driven agent learns the behavior, not just the type.
+    const lifecycleAction = (appendEvent?.input_schema as any).metadata.fields
+      .memory_lifecycle_action;
+    expect(lifecycleAction.values).toEqual([
+      "candidate",
+      "promote",
+      "relegate",
+      "discard",
+      "nominate_shared",
+    ]);
+    expect(lifecycleAction.description).toContain(
+      "only action eligible for the shared-kb promoter",
+    );
+    const candidateType = (appendEvent?.input_schema as any).metadata.fields
+      .candidate_type;
+    expect(candidateType.values).toContain("negative_example");
+    expect(
+      (appendEvent?.input_schema as any).metadata.fields.candidate_confidence,
+    ).toMatchObject({ type: "number", min: 0, max: 1 });
+    expect(
+      (appendEvent?.input_schema as any).metadata.fields.evidence_refs,
+    ).toMatchObject({ type: "array", maxItems: 20 });
+    // The help must document explicit nomination and sync rejection so a
+    // contract-driven agent learns the behavior, not just the type.
     expect(shareCandidate.description).toContain("share_candidate_rejected");
+    expect(shareCandidate.description).toContain(
+      "memory_lifecycle_action=nominate_shared",
+    );
     expect(shareCandidate.description.toLowerCase()).toContain("secret");
     expect(appendInput.metadata.fields.sanitized_resubmit_of.type).toBe("string");
     expect(appendInput.metadata.fields.sanitized_resubmit_of.description).toContain(
@@ -372,6 +438,7 @@ describe("Open Brain contract manifest", () => {
       agent_memory_adapter: base.agent_memory_adapter,
       agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
+      promotion_lifecycle: base.promotion_lifecycle,
       capabilities: base.capabilities,
       tool_contracts: base.tool_contracts,
     };
@@ -394,6 +461,7 @@ describe("Open Brain contract manifest", () => {
       agent_memory_adapter: base.agent_memory_adapter,
       agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
+      promotion_lifecycle: base.promotion_lifecycle,
       capabilities: [
         ...base.capabilities,
         {
@@ -427,6 +495,7 @@ describe("Open Brain contract manifest", () => {
       agent_memory_adapter: base.agent_memory_adapter,
       agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
+      promotion_lifecycle: base.promotion_lifecycle,
       capabilities: base.capabilities,
       tool_contracts: {
         ...base.tool_contracts,
@@ -464,6 +533,7 @@ describe("Open Brain contract manifest", () => {
       agent_memory_adapter: base.agent_memory_adapter,
       agent_context_pack: base.agent_context_pack,
       receipt_contract: base.receipt_contract,
+      promotion_lifecycle: base.promotion_lifecycle,
       capabilities: base.capabilities,
       tool_contracts: {
         ...base.tool_contracts,

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "4128fbca61acc40bf566a9fed3b6a7e31eb323c69206d21f829da0e9b08dc681",
+      "92872c8499f1e70608569fb32d00bc1c726e4e91ddf641551399f510573c3d44",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "4b3b07665bcaa2087e8fd3e75dfda86974c047529f85b42c0a0b5631bc4fd994",
+      "4128fbca61acc40bf566a9fed3b6a7e31eb323c69206d21f829da0e9b08dc681",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -119,7 +119,6 @@ describe("Open Brain contract manifest", () => {
     expect(adapterMethods.promote_candidate).toEqual({
       maps_to: [
         "append_session_event:metadata.memory_lifecycle_action=promote",
-        "log_thought/log_decision explicit durable write",
       ],
       owner: "client",
       status: "client-wrapper",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -535,7 +535,6 @@ export function buildContract(
         promote_candidate: {
           maps_to: [
             "append_session_event:metadata.memory_lifecycle_action=promote",
-            "log_thought/log_decision explicit durable write",
           ] as const,
           owner: "client" as const,
           status: "client-wrapper" as const,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-07-06.memory-tools.v14";
+export const CONTRACT_VERSION = "2026-07-06.memory-tools.v15";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -144,6 +144,35 @@ export interface OpenBrainContract {
     recommended_fields: readonly string[];
     closed_brain_strict_fields: readonly string[];
     secret_safe: true;
+  };
+  promotion_lifecycle: {
+    status: "explicit-client-owned-lifecycle";
+    parent_issue: 224;
+    contract_doc: "docs/agent-memory-adapter-contract.md";
+    candidate_types: readonly [
+      "user_preference",
+      "process_rule",
+      "channel_server_rule",
+      "code_repo_fact",
+      "positive_example",
+      "negative_example",
+      "durable_decision",
+      "shared_kb_nomination",
+    ];
+    actions: readonly [
+      "candidate",
+      "promote",
+      "relegate",
+      "discard",
+      "nominate_shared",
+    ];
+    candidate_presence_effect: "no_durable_write_no_shared_write";
+    shared_nomination_requires: readonly [
+      "explicit_client_action",
+      "share_candidate_true",
+      "memory_lifecycle_action_nominate_shared",
+      "server_auth_scope_safety_provenance_secret_checks",
+    ];
   };
   capabilities: ContractCapability[];
   tool_contracts: Record<
@@ -317,6 +346,15 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
       "session events, with stricter Closed Brain fields marked separately.",
   },
   {
+    name: "memory_promotion_lifecycle",
+    version: 1,
+    kind: "schema",
+    description:
+      "Explicit client-owned lifecycle for candidate memory, durable promotion, " +
+      "relegation/discard, and shared-kb nomination. Candidate presence alone " +
+      "does not write durable memory or shared-kb.",
+  },
+  {
     name: "streamable_http_auth",
     version: 1,
     kind: "transport",
@@ -480,9 +518,41 @@ export function buildContract(
           status: "client-wrapper" as const,
         },
         nominate_shared: {
-          maps_to: ["append_session_event:metadata.share_candidate"] as const,
+          maps_to: [
+            "append_session_event:metadata.share_candidate",
+            "append_session_event:metadata.memory_lifecycle_action=nominate_shared",
+          ] as const,
           owner: "client_and_server" as const,
           status: "available" as const,
+        },
+        candidate_memory: {
+          maps_to: [
+            "append_session_event:metadata.memory_lifecycle_action=candidate",
+          ] as const,
+          owner: "client" as const,
+          status: "client-wrapper" as const,
+        },
+        promote_candidate: {
+          maps_to: [
+            "append_session_event:metadata.memory_lifecycle_action=promote",
+            "log_thought/log_decision explicit durable write",
+          ] as const,
+          owner: "client" as const,
+          status: "client-wrapper" as const,
+        },
+        relegate_candidate: {
+          maps_to: [
+            "append_session_event:metadata.memory_lifecycle_action=relegate",
+          ] as const,
+          owner: "client" as const,
+          status: "client-wrapper" as const,
+        },
+        discard_candidate: {
+          maps_to: [
+            "append_session_event:metadata.memory_lifecycle_action=discard",
+          ] as const,
+          owner: "client" as const,
+          status: "client-wrapper" as const,
         },
         export_disclosure_bundle: {
           maps_to: ["interchange_profiles.okf"] as const,
@@ -558,6 +628,35 @@ export function buildContract(
         "redaction_policy",
       ] as const,
       secret_safe: true as const,
+    },
+    promotion_lifecycle: {
+      status: "explicit-client-owned-lifecycle" as const,
+      parent_issue: 224 as const,
+      contract_doc: "docs/agent-memory-adapter-contract.md" as const,
+      candidate_types: [
+        "user_preference",
+        "process_rule",
+        "channel_server_rule",
+        "code_repo_fact",
+        "positive_example",
+        "negative_example",
+        "durable_decision",
+        "shared_kb_nomination",
+      ] as const,
+      actions: [
+        "candidate",
+        "promote",
+        "relegate",
+        "discard",
+        "nominate_shared",
+      ] as const,
+      candidate_presence_effect: "no_durable_write_no_shared_write" as const,
+      shared_nomination_requires: [
+        "explicit_client_action",
+        "share_candidate_true",
+        "memory_lifecycle_action_nominate_shared",
+        "server_auth_scope_safety_provenance_secret_checks",
+      ] as const,
     },
     capabilities: [...CONTRACT_CAPABILITIES].sort((a, b) =>
       a.name.localeCompare(b.name),

--- a/src/promotion-nomination.ts
+++ b/src/promotion-nomination.ts
@@ -1,0 +1,35 @@
+import type { Table } from "./types.ts";
+
+export function promotionMetadataSelect(table: Table, alias = "t"): string {
+  if (table === "thoughts" || table === "decisions") {
+    return `${alias}.extracted_metadata`;
+  }
+  if (table === "relationships" || table === "projects") {
+    return `${alias}.metadata`;
+  }
+  return "NULL::jsonb";
+}
+
+export function explicitSharedNominationSqlPredicate(
+  table: Table,
+  alias = "t",
+): string {
+  if (table === "thoughts" || table === "decisions") {
+    return ` AND ${alias}.extracted_metadata->>'share_candidate' = 'true' AND ${alias}.extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'`;
+  }
+  if (table === "relationships" || table === "projects") {
+    return ` AND ${alias}.metadata->>'share_candidate' = 'true' AND ${alias}.metadata->>'memory_lifecycle_action' = 'nominate_shared'`;
+  }
+  return " AND false";
+}
+
+export function isExplicitSharedNomination(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return (
+    metadata != null &&
+    (metadata?.share_candidate === true ||
+      metadata?.share_candidate === "true") &&
+    metadata.memory_lifecycle_action === "nominate_shared"
+  );
+}

--- a/src/promotion-service.ts
+++ b/src/promotion-service.ts
@@ -34,6 +34,13 @@ const STRIPPED_PROMOTION_METADATA_KEYS = [
   "share_candidate",
   "share_rejected_sync",
   "share_promoted_at",
+  "memory_lifecycle_action",
+  "candidate_type",
+  "candidate_reason",
+  "candidate_confidence",
+  "candidate_scope",
+  "candidate_staleness_policy",
+  "evidence_refs",
 ] as const;
 
 /**

--- a/src/rest-promotion.test.ts
+++ b/src/rest-promotion.test.ts
@@ -430,7 +430,10 @@ describe("promotion REST API", () => {
           namespace: "bilby",
           content_hash: "hash-1",
           created_at: "2026-06-10T00:00:00.000Z",
-          promoted_from: null,
+          metadata: {
+            share_candidate: true,
+            memory_lifecycle_action: "nominate_shared",
+          },
         },
       ],
       [{ id: "team-1" }],
@@ -458,6 +461,106 @@ describe("promotion REST API", () => {
         },
       ],
     });
+    expect(json.already_promoted).toBeUndefined();
+    expect(json.summary.already_promoted).toBeUndefined();
     expect(json.duplicates[0].existing_collab_id).toBeUndefined();
+  });
+
+  it("only returns explicit shared lifecycle nominations from REST scan", async () => {
+    const pool = createSequencePool([
+      [
+        {
+          id: "ordinary",
+          namespace: "bilby",
+          content_hash: null,
+          created_at: "2026-06-10T00:00:00.000Z",
+          metadata: { share_candidate: true },
+        },
+        {
+          id: "explicit-boolean",
+          namespace: "bilby",
+          content_hash: null,
+          created_at: "2026-06-11T00:00:00.000Z",
+          metadata: {
+            share_candidate: true,
+            memory_lifecycle_action: "nominate_shared",
+          },
+        },
+        {
+          id: "explicit-string",
+          namespace: "bilby",
+          content_hash: null,
+          created_at: "2026-06-12T00:00:00.000Z",
+          metadata: {
+            share_candidate: "true",
+            memory_lifecycle_action: "nominate_shared",
+          },
+        },
+      ],
+    ]);
+    const app = buildApp({ role: "admin", clientId: "rico" }, pool);
+
+    const { status, json } = await req(
+      app,
+      "get",
+      "/api/v1/scan/bilby?table=thoughts&target_namespace=shared-kb",
+    );
+
+    expect(status).toBe(200);
+    expect(json.candidates).toEqual([
+      {
+        table: "thoughts",
+        id: "explicit-boolean",
+        created_at: "2026-06-11T00:00:00.000Z",
+      },
+      {
+        table: "thoughts",
+        id: "explicit-string",
+        created_at: "2026-06-12T00:00:00.000Z",
+      },
+    ]);
+    expect(json.already_promoted).toBeUndefined();
+    expect(json.summary.already_promoted).toBeUndefined();
+  });
+
+  it("filters REST scan nominations in SQL before ordering and limit", async () => {
+    const pool = createSequencePool([
+      [
+        {
+          id: "older-explicit",
+          namespace: "bilby",
+          content_hash: null,
+          created_at: "2026-06-09T00:00:00.000Z",
+          metadata: {
+            share_candidate: true,
+            memory_lifecycle_action: "nominate_shared",
+          },
+        },
+      ],
+    ]);
+    const app = buildApp({ role: "admin", clientId: "rico" }, pool);
+
+    const { status, json } = await req(
+      app,
+      "get",
+      "/api/v1/scan/bilby?table=thoughts&limit=1",
+    );
+
+    expect(status).toBe(200);
+    const sql = pool.calls[0]!.sql;
+    const nominationIndex = sql.indexOf(
+      "t.extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'",
+    );
+    expect(nominationIndex).toBeGreaterThan(-1);
+    expect(nominationIndex).toBeLessThan(sql.indexOf("ORDER BY"));
+    expect(nominationIndex).toBeLessThan(sql.indexOf("LIMIT $2"));
+    expect(pool.calls[0]!.params).toEqual(["bilby", 1]);
+    expect(json.candidates).toEqual([
+      {
+        table: "thoughts",
+        id: "older-explicit",
+        created_at: "2026-06-09T00:00:00.000Z",
+      },
+    ]);
   });
 });

--- a/src/rest-promotion.ts
+++ b/src/rest-promotion.ts
@@ -13,6 +13,11 @@ import {
   physicalNamespace,
   sharedNamespaceConfig,
 } from "./shared-namespace.ts";
+import {
+  explicitSharedNominationSqlPredicate,
+  isExplicitSharedNomination,
+  promotionMetadataSelect,
+} from "./promotion-nomination.ts";
 
 interface RestDeps {
   pool: pg.Pool;
@@ -193,31 +198,31 @@ export function createPromotionRouter(deps: RestDeps): Router {
     const tables = table ? [table] : ALL_TABLES;
     const candidates: any[] = [];
     const duplicateEntries: any[] = [];
-    const alreadyPromoted: any[] = [];
 
     for (const t of tables) {
       const sinceFilter = since ? ` AND t.created_at >= $3` : "";
       const params: unknown[] = [namespace.data, limit];
       if (since) params.push(since);
+      const metadataSelect = promotionMetadataSelect(t);
+      const nominationFilter = explicitSharedNominationSqlPredicate(t);
 
       const { rows } = await deps.pool.query(
-        `SELECT t.id, t.content_hash, t.namespace, t.created_at, t.promoted_from,
+        `SELECT t.id, t.content_hash, t.namespace, t.created_at,
+                ${metadataSelect} AS metadata,
                 '${t}' AS table_name
          FROM ${t} t
-         WHERE t.namespace = $1 AND t.archived_at IS NULL${sinceFilter}
+         WHERE t.namespace = $1 AND t.archived_at IS NULL${nominationFilter}${sinceFilter}
          ORDER BY t.created_at DESC
          LIMIT $2`,
         params,
       );
 
       for (const row of rows) {
-        if (row.promoted_from) {
-          alreadyPromoted.push({ table: t, id: row.id, created_at: row.created_at });
-          continue;
-        }
         if (row.content_hash) {
           const { rows: targetDupes } = await deps.pool.query(
-            `SELECT id FROM ${t} WHERE content_hash = $1 AND namespace = $2 LIMIT 1`,
+            `SELECT id FROM ${t}
+             WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL
+             LIMIT 1`,
             [row.content_hash, targetPhysicalNamespace],
           );
           if (targetDupes.length > 0) {
@@ -232,7 +237,11 @@ export function createPromotionRouter(deps: RestDeps): Router {
             continue;
           }
         }
-        candidates.push({ table: t, id: row.id, created_at: row.created_at });
+
+        const metadata = row.metadata as Record<string, unknown> | null;
+        if (isExplicitSharedNomination(metadata)) {
+          candidates.push({ table: t, id: row.id, created_at: row.created_at });
+        }
       }
     }
 
@@ -241,11 +250,9 @@ export function createPromotionRouter(deps: RestDeps): Router {
       target_namespace: targetCanonicalNamespace,
       candidates,
       duplicates: duplicateEntries,
-      already_promoted: alreadyPromoted,
       summary: {
         candidates: candidates.length,
         duplicates: duplicateEntries.length,
-        already_promoted: alreadyPromoted.length,
       },
     });
   });

--- a/src/sharing.ts
+++ b/src/sharing.ts
@@ -2,7 +2,8 @@
  * Lane/own-durable → shared-kb shared-worthiness classifier (Issue #161).
  *
  * Pure, no DB, no I/O. Decides whether a nominated entry (a thought, decision,
- * or session event flagged `share_candidate`) is safe and worthwhile to promote
+ * or session event explicitly nominated with `share_candidate=true` and
+ * `memory_lifecycle_action=nominate_shared`) is safe and worthwhile to promote
  * into the shared-kb namespace — shared TRUTH that every agent reads.
  *
  * The highest-stakes rule is `reject-secret`: a secret reaching shared truth is

--- a/src/tiering.test.ts
+++ b/src/tiering.test.ts
@@ -102,6 +102,23 @@ describe("classifyLaneEvent — graduate rule", () => {
   }
 });
 
+describe("classifyLaneEvent — memory lifecycle boundary", () => {
+  it("keeps candidate lifecycle facts instead of graduating them", () => {
+    expect(
+      classifyLaneEvent({
+        event_type: "fact",
+        importance: "hot",
+        content: LONG,
+        metadata: {
+          memory_lifecycle_action: "candidate",
+          candidate_type: "negative_example",
+          candidate_reason: "User correction requires review before durable memory.",
+        },
+      }),
+    ).toBe("keep");
+  });
+});
+
 describe("classifyLaneEvent — archive rule", () => {
   for (const type of ARCHIVE_TYPES) {
     for (const importance of IMPORTANCES) {

--- a/src/tiering.test.ts
+++ b/src/tiering.test.ts
@@ -117,6 +117,23 @@ describe("classifyLaneEvent — memory lifecycle boundary", () => {
       }),
     ).toBe("keep");
   });
+
+  it("allows explicit shared nominations to use normal own-durable graduation", () => {
+    expect(
+      classifyLaneEvent({
+        event_type: "fact",
+        importance: "hot",
+        content: LONG,
+        metadata: {
+          share_candidate: true,
+          memory_lifecycle_action: "nominate_shared",
+          candidate_type: "shared_kb_nomination",
+          candidate_reason:
+            "Shared nomination should not block own-durable graduation.",
+        },
+      }),
+    ).toBe("graduate");
+  });
 });
 
 describe("classifyLaneEvent — archive rule", () => {

--- a/src/tiering.ts
+++ b/src/tiering.ts
@@ -50,6 +50,7 @@ export interface ClassifiableEvent {
   event_type: EventType;
   content: string;
   importance: Importance;
+  metadata?: Record<string, unknown> | null;
 }
 
 /**
@@ -72,6 +73,10 @@ export function classifyLaneEvent(
   event: ClassifiableEvent,
   minContentLength: number = DEFAULT_MIN_CONTENT_LENGTH,
 ): Classification {
+  if (event.metadata?.memory_lifecycle_action !== undefined) {
+    return "keep";
+  }
+
   const isColdOrArchiveType =
     event.importance === "cold" || ARCHIVE_TYPES.has(event.event_type);
   if (isColdOrArchiveType) {
@@ -99,6 +104,7 @@ export interface LaneEventRow {
   importance: Importance;
   content_hash: string | null;
   created_at: string;
+  metadata: Record<string, unknown> | null;
 }
 
 export type DuplicateKind = "exact" | "near";

--- a/src/tiering.ts
+++ b/src/tiering.ts
@@ -45,6 +45,14 @@ const ARCHIVE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
   "action",
 ]);
 
+/** Lifecycle actions that explicitly keep a candidate out of automatic own-durable graduation. */
+const OWN_DURABLE_KEEP_LIFECYCLE_ACTIONS: ReadonlySet<string> = new Set([
+  "candidate",
+  "promote",
+  "relegate",
+  "discard",
+]);
+
 /** Minimal shape the classifier needs from a lane event. */
 export interface ClassifiableEvent {
   event_type: EventType;
@@ -73,7 +81,11 @@ export function classifyLaneEvent(
   event: ClassifiableEvent,
   minContentLength: number = DEFAULT_MIN_CONTENT_LENGTH,
 ): Classification {
-  if (event.metadata?.memory_lifecycle_action !== undefined) {
+  const lifecycleAction = event.metadata?.memory_lifecycle_action;
+  if (
+    typeof lifecycleAction === "string" &&
+    OWN_DURABLE_KEEP_LIFECYCLE_ACTIONS.has(lifecycleAction)
+  ) {
     return "keep";
   }
 

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -1162,7 +1162,8 @@ describe("append_session_event", () => {
   // flag is STRIPPED before persist (so the async promoter never sweeps it), a
   // share_rejected_sync marker is stamped on the persisted metadata, and the
   // tool response surfaces share_candidate_rejected. Clean/absent nominations
-  // pass through untouched — worthiness stays for the async cron, NOT this gate.
+  // pass through untouched. The shared promoter only sweeps explicit
+  // memory_lifecycle_action=nominate_shared rows, not candidate presence alone.
   //
   // We assert the persisted metadata by capturing the INSERT params on the mock
   // pool. The metadata is the 7th INSERT param ($7, index 6), JSON.stringify'd.
@@ -1712,7 +1713,7 @@ describe("append_session_event", () => {
     }
   });
 
-  it("keeps share_candidate for clean substantive content — async cron owns worthiness", async () => {
+  it("keeps clean share_candidate metadata without making candidate presence a write", async () => {
     const mockPool = createCapturingPool();
     const auth: AuthInfo = { role: "admin", clientId: "skippy" };
     const { client, cleanup } = await setupToolClient(mockPool, auth);
@@ -1734,10 +1735,114 @@ describe("append_session_event", () => {
       // No sync rejection — the sync gate ONLY hard-rejects secret/private.
       expect(parsed.share_candidate_rejected).toBeUndefined();
 
-      // Nomination survives to persist; the async promoter decides worthiness.
+      // The marker survives as event metadata. Without the explicit
+      // memory_lifecycle_action=nominate_shared action, the shared promoter
+      // must treat this as inert candidate state.
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBe(true);
+      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves an explicit shared nomination lifecycle action for the promoter", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content:
+            "Chose explicit nomination workflow before shared-kb promotion.",
+          metadata: {
+            share_candidate: true,
+            memory_lifecycle_action: "nominate_shared",
+            candidate_type: "shared_kb_nomination",
+            candidate_reason: "Reviewed fact is safe to nominate for shared-kb.",
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.share_candidate_rejected).toBeUndefined();
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.share_candidate).toBe(true);
+      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBe(
+        "nominate_shared",
+      );
+      expect(mockPool.captured.metadata!.candidate_type).toBe(
+        "shared_kb_nomination",
+      );
+      expect(mockPool.captured.metadata!.candidate_reason).toBe(
+        "Reviewed fact is safe to nominate for shared-kb.",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects malformed lifecycle metadata before persistence", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Malformed lifecycle candidate should not persist.",
+          metadata: {
+            memory_lifecycle_action: "candidate",
+            candidate_type: "negative_example",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.message).toContain("candidate_reason");
+      expect(mockPool.captured.metadata).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects share_candidate on non-nomination lifecycle actions", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Candidate-only state must not also enter the shared queue.",
+          metadata: {
+            share_candidate: true,
+            memory_lifecycle_action: "candidate",
+            candidate_type: "negative_example",
+            candidate_reason: "Candidate-only correction.",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.message).toContain("nominate_shared");
+      expect(mockPool.captured.metadata).toBeNull();
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -1424,6 +1424,7 @@ describe("append_session_event", () => {
       // Persisted metadata: nomination stripped, audit marker stamped.
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
         "reject-secret",
       );
@@ -1466,6 +1467,7 @@ describe("append_session_event", () => {
         },
       });
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
         "reject-secret",
       );
@@ -1507,6 +1509,7 @@ describe("append_session_event", () => {
 
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
         "reject-private",
       );
@@ -1788,6 +1791,54 @@ describe("append_session_event", () => {
     }
   });
 
+  it("strips lifecycle candidate metadata from rejected shared nominations", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content:
+            "Secret nomination contains key " + "sk-" + "b".repeat(20),
+          metadata: {
+            share_candidate: true,
+            memory_lifecycle_action: "nominate_shared",
+            candidate_type: "shared_kb_nomination",
+            candidate_reason: "Candidate must be rejected before promotion.",
+            candidate_confidence: 0.9,
+            candidate_scope: { repo: "rodaddy/open-brain" },
+            candidate_staleness_policy: "revalidate before sharing",
+            evidence_refs: [{ issue: 224 }],
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.share_candidate_rejected).toBe("reject-secret");
+      expect(mockPool.captured.metadata).not.toBeNull();
+      expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
+      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
+      expect(mockPool.captured.metadata!.candidate_type).toBeUndefined();
+      expect(mockPool.captured.metadata!.candidate_reason).toBeUndefined();
+      expect(mockPool.captured.metadata!.candidate_confidence).toBeUndefined();
+      expect(mockPool.captured.metadata!.candidate_scope).toBeUndefined();
+      expect(
+        mockPool.captured.metadata!.candidate_staleness_policy,
+      ).toBeUndefined();
+      expect(mockPool.captured.metadata!.evidence_refs).toBeUndefined();
+      expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
+        "reject-secret",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("rejects malformed lifecycle metadata before persistence", async () => {
     const mockPool = createCapturingPool();
     const auth: AuthInfo = { role: "admin", clientId: "skippy" };
@@ -1811,6 +1862,39 @@ describe("append_session_event", () => {
       const parsed = JSON.parse((result.content as any)[0].text);
       expect(parsed.error).toBe("scope_validation");
       expect(parsed.message).toContain("candidate_reason");
+      expect(mockPool.captured.metadata).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects lifecycle evidence refs that contain secrets", async () => {
+    const mockPool = createCapturingPool();
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "test",
+          event_type: "fact",
+          content: "Candidate metadata evidence must be citation-safe.",
+          metadata: {
+            memory_lifecycle_action: "candidate",
+            candidate_type: "negative_example",
+            candidate_reason: "Evidence refs should not persist secrets.",
+            evidence_refs: [
+              { note: "token=" + "sk-" + "c".repeat(20) },
+            ],
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.message).toContain("evidence_refs");
       expect(mockPool.captured.metadata).toBeNull();
     } finally {
       await cleanup();

--- a/src/tools/__tests__/scan-namespace.test.ts
+++ b/src/tools/__tests__/scan-namespace.test.ts
@@ -126,6 +126,8 @@ describe("scan_namespace", () => {
           },
         ],
       });
+      expect(parseToolResult(result).already_promoted).toBeUndefined();
+      expect(parseToolResult(result).summary.already_promoted).toBeUndefined();
       expect(parseToolResult(result).duplicates[0].existing_collab_id).toBeUndefined();
     } finally {
       await cleanup();

--- a/src/tools/__tests__/scan-namespace.test.ts
+++ b/src/tools/__tests__/scan-namespace.test.ts
@@ -125,6 +125,70 @@ describe("scan_namespace", () => {
     }
   });
 
+  it("only returns explicit shared lifecycle nominations as promotion candidates", async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params: unknown[]) => {
+        calls.push({ sql, params });
+        if (calls.length === 1) {
+          return {
+            rows: [
+              {
+                id: "ordinary",
+                namespace: "bilby",
+                content_hash: "hash-ordinary",
+                created_at: "2026-06-10T00:00:00.000Z",
+                promoted_from: null,
+                metadata: { share_candidate: true },
+              },
+              {
+                id: "explicit",
+                namespace: "bilby",
+                content_hash: "hash-explicit",
+                created_at: "2026-06-11T00:00:00.000Z",
+                promoted_from: null,
+                metadata: {
+                  share_candidate: true,
+                  memory_lifecycle_action: "nominate_shared",
+                },
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerScanNamespace,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "scan_namespace",
+        arguments: {
+          namespace: "bilby",
+          target_namespace: "shared-kb",
+          table: "thoughts",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result).candidates).toEqual([
+        {
+          table: "thoughts",
+          id: "explicit",
+          created_at: "2026-06-11T00:00:00.000Z",
+        },
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("denies delegated admin duplicate checks against unreadable target namespaces", async () => {
     const mockPool = { query: async () => ({ rows: [] }) };
     const auth: AuthInfo = {

--- a/src/tools/__tests__/scan-namespace.test.ts
+++ b/src/tools/__tests__/scan-namespace.test.ts
@@ -65,7 +65,7 @@ describe("scan_namespace", () => {
     }
   });
 
-  it("checks duplicates in the requested target namespace", async () => {
+  it("checks duplicates in the requested target namespace for explicit nominations", async () => {
     const calls: Array<{ sql: string; params: unknown[] }> = [];
     const mockPool = {
       query: async (sql: string, params: unknown[]) => {
@@ -79,6 +79,10 @@ describe("scan_namespace", () => {
                 content_hash: "hash-1",
                 created_at: "2026-06-10T00:00:00.000Z",
                 promoted_from: null,
+                metadata: {
+                  share_candidate: true,
+                  memory_lifecycle_action: "nominate_shared",
+                },
               },
             ],
           };
@@ -105,6 +109,9 @@ describe("scan_namespace", () => {
       });
 
       expect(result.isError).toBeFalsy();
+      expect(calls[0]!.sql).toContain(
+        "t.extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'",
+      );
       expect(calls[1]!.sql).toContain("namespace = $2");
       expect(calls[1]!.params).toEqual(["hash-1", "team"]);
       expect(parseToolResult(result)).toMatchObject({
@@ -182,6 +189,71 @@ describe("scan_namespace", () => {
           table: "thoughts",
           id: "explicit",
           created_at: "2026-06-11T00:00:00.000Z",
+        },
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("filters explicit nominations in SQL before ordering and limit", async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    const mockPool = {
+      query: async (sql: string, params: unknown[]) => {
+        calls.push({ sql, params });
+        if (calls.length === 1) {
+          return {
+            rows: [
+              {
+                id: "older-explicit",
+                namespace: "bilby",
+                content_hash: "hash-explicit",
+                created_at: "2026-06-09T00:00:00.000Z",
+                promoted_from: null,
+                metadata: {
+                  share_candidate: true,
+                  memory_lifecycle_action: "nominate_shared",
+                },
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupMcpClient(
+      registerScanNamespace,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "scan_namespace",
+        arguments: {
+          namespace: "bilby",
+          target_namespace: "shared-kb",
+          table: "thoughts",
+          limit: 1,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const sql = calls[0]!.sql;
+      const nominationIndex = sql.indexOf(
+        "t.extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'",
+      );
+      expect(nominationIndex).toBeGreaterThan(-1);
+      expect(nominationIndex).toBeLessThan(sql.indexOf("ORDER BY"));
+      expect(nominationIndex).toBeLessThan(sql.indexOf("LIMIT $2"));
+      expect(calls[0]!.params).toEqual(["bilby", 1]);
+      expect(parseToolResult(result).candidates).toEqual([
+        {
+          table: "thoughts",
+          id: "older-explicit",
+          created_at: "2026-06-09T00:00:00.000Z",
         },
       ]);
     } finally {

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -7,6 +7,7 @@ import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import {
   classifyShareCandidate,
+  containsSecret,
   SHARE_REJECTION_MAX_RESUBMIT_ATTEMPTS,
   type ShareRejectionDetail,
   shareRejectionDetail,
@@ -496,9 +497,20 @@ function adjudicateNominationSync(
     metadata,
   });
   if (decision === "reject-secret" || decision === "reject-private") {
-    // Strip the nomination so the async promoter never sweeps it. Stamp a
+    // Strip nomination/candidate metadata so the async promoter never sweeps it
+    // and persisted metadata does not violate lifecycle invariants. Stamp a
     // marker for auditability; the event content itself is untouched.
-    const { share_candidate: _drop, ...rest } = metadata;
+    const {
+      share_candidate: _dropShareCandidate,
+      memory_lifecycle_action: _dropLifecycleAction,
+      candidate_type: _dropCandidateType,
+      candidate_reason: _dropCandidateReason,
+      candidate_confidence: _dropCandidateConfidence,
+      candidate_scope: _dropCandidateScope,
+      candidate_staleness_policy: _dropCandidateStalenessPolicy,
+      evidence_refs: _dropEvidenceRefs,
+      ...rest
+    } = metadata;
     return {
       metadata: { ...rest, share_rejected_sync: decision },
       rejected: decision,
@@ -576,6 +588,20 @@ function validateMemoryLifecycleMetadata(
     }
     if (metadata.evidence_refs.some((item) => !isRecord(item))) {
       return "metadata.evidence_refs items must be objects";
+    }
+    let totalEvidenceBytes = 0;
+    for (const item of metadata.evidence_refs) {
+      const serialized = JSON.stringify(item);
+      totalEvidenceBytes += Buffer.byteLength(serialized, "utf8");
+      if (Buffer.byteLength(serialized, "utf8") > 2000) {
+        return "metadata.evidence_refs items must be at most 2000 JSON bytes";
+      }
+      if (containsSecret(serialized)) {
+        return "metadata.evidence_refs must not contain secrets";
+      }
+    }
+    if (totalEvidenceBytes > 10000) {
+      return "metadata.evidence_refs must be at most 10000 total JSON bytes";
     }
   }
   return null;

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -58,6 +58,23 @@ type PreparedEventEmbedding = {
   embeddedAt: string | null;
   model: string | null;
 };
+const MEMORY_LIFECYCLE_ACTIONS = new Set([
+  "candidate",
+  "promote",
+  "relegate",
+  "discard",
+  "nominate_shared",
+]);
+const CANDIDATE_TYPES = new Set([
+  "user_preference",
+  "process_rule",
+  "channel_server_rule",
+  "code_repo_fact",
+  "positive_example",
+  "negative_example",
+  "durable_decision",
+  "shared_kb_nomination",
+]);
 
 async function withAppendDb<T>(
   deps: ToolDeps,
@@ -491,6 +508,79 @@ function adjudicateNominationSync(
   return { metadata, rejected: null, rejectDetail: null };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasShareCandidate(metadata: Record<string, unknown>): boolean {
+  return metadata.share_candidate === true || metadata.share_candidate === "true";
+}
+
+function validateMemoryLifecycleMetadata(
+  metadata: Record<string, unknown>,
+): string | null {
+  const action = metadata.memory_lifecycle_action;
+  if (action === undefined) return null;
+  if (typeof action !== "string" || !MEMORY_LIFECYCLE_ACTIONS.has(action)) {
+    return "metadata.memory_lifecycle_action is not a supported lifecycle action";
+  }
+
+  const shareCandidate = hasShareCandidate(metadata);
+  if (shareCandidate && action !== "nominate_shared") {
+    return "metadata.share_candidate=true is only valid with memory_lifecycle_action=nominate_shared";
+  }
+  if (action === "nominate_shared" && !shareCandidate) {
+    return "metadata.memory_lifecycle_action=nominate_shared requires share_candidate=true";
+  }
+  if (
+    typeof metadata.candidate_type !== "string" ||
+    !CANDIDATE_TYPES.has(metadata.candidate_type)
+  ) {
+    return "metadata.candidate_type is required for memory lifecycle actions";
+  }
+  if (
+    typeof metadata.candidate_reason !== "string" ||
+    metadata.candidate_reason.trim().length === 0 ||
+    metadata.candidate_reason.length > 2000
+  ) {
+    return "metadata.candidate_reason is required for memory lifecycle actions";
+  }
+  if (
+    metadata.candidate_confidence !== undefined &&
+    (typeof metadata.candidate_confidence !== "number" ||
+      !Number.isFinite(metadata.candidate_confidence) ||
+      metadata.candidate_confidence < 0 ||
+      metadata.candidate_confidence > 1)
+  ) {
+    return "metadata.candidate_confidence must be a number from 0 to 1";
+  }
+  if (
+    metadata.candidate_scope !== undefined &&
+    !isRecord(metadata.candidate_scope)
+  ) {
+    return "metadata.candidate_scope must be an object";
+  }
+  if (
+    metadata.candidate_staleness_policy !== undefined &&
+    (typeof metadata.candidate_staleness_policy !== "string" ||
+      metadata.candidate_staleness_policy.length > 1000)
+  ) {
+    return "metadata.candidate_staleness_policy must be a string of at most 1000 characters";
+  }
+  if (metadata.evidence_refs !== undefined) {
+    if (!Array.isArray(metadata.evidence_refs)) {
+      return "metadata.evidence_refs must be an array";
+    }
+    if (metadata.evidence_refs.length > 20) {
+      return "metadata.evidence_refs must contain at most 20 items";
+    }
+    if (metadata.evidence_refs.some((item) => !isRecord(item))) {
+      return "metadata.evidence_refs items must be objects";
+    }
+  }
+  return null;
+}
+
 function sanitizedResubmitOf(metadata: Record<string, unknown>): string | null {
   const raw = metadata.sanitized_resubmit_of;
   if (typeof raw !== "string") return null;
@@ -776,6 +866,15 @@ export function registerAppendSessionEvent(
       }
       const importance = args.importance ?? "warm";
       const provenance = writerProvenance(auth);
+      const lifecycleError = validateMemoryLifecycleMetadata(args.metadata ?? {});
+      if (lifecycleError) {
+        return appendSessionEventError(
+          "scope_validation",
+          lifecycleError,
+          false,
+          { session_key: args.session_key, namespace: ns },
+        );
+      }
 
       logger.debug("append_session_event_start", {
         session_key: args.session_key,

--- a/src/tools/scan-namespace.ts
+++ b/src/tools/scan-namespace.ts
@@ -103,13 +103,19 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
             : table === "relationships" || table === "projects"
               ? "t.metadata"
               : "NULL::jsonb";
+        const nominationFilter =
+          table === "thoughts" || table === "decisions"
+            ? " AND t.extracted_metadata->>'share_candidate' = 'true' AND t.extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'"
+            : table === "relationships" || table === "projects"
+              ? " AND t.metadata->>'share_candidate' = 'true' AND t.metadata->>'memory_lifecycle_action' = 'nominate_shared'"
+              : " AND false";
 
         const { rows } = await deps.pool.query(
           `SELECT t.id, t.content_hash, t.namespace, t.created_at, t.promoted_from,
                   ${metadataSelect} AS metadata,
                   '${table}' AS table_name
            FROM ${table} t
-           WHERE t.namespace = $1 AND t.archived_at IS NULL${sinceFilter}
+           WHERE t.namespace = $1 AND t.archived_at IS NULL${nominationFilter}${sinceFilter}
            ORDER BY t.created_at DESC
            LIMIT $2`,
           params,

--- a/src/tools/scan-namespace.ts
+++ b/src/tools/scan-namespace.ts
@@ -97,8 +97,16 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
         const params: unknown[] = [args.namespace, limit];
         if (args.since) params.push(args.since);
 
+        const metadataSelect =
+          table === "thoughts" || table === "decisions"
+            ? "t.extracted_metadata"
+            : table === "relationships" || table === "projects"
+              ? "t.metadata"
+              : "NULL::jsonb";
+
         const { rows } = await deps.pool.query(
           `SELECT t.id, t.content_hash, t.namespace, t.created_at, t.promoted_from,
+                  ${metadataSelect} AS metadata,
                   '${table}' AS table_name
            FROM ${table} t
            WHERE t.namespace = $1 AND t.archived_at IS NULL${sinceFilter}
@@ -139,11 +147,18 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
             }
           }
 
-          candidates.push({
-            table: table,
-            id: row.id,
-            created_at: row.created_at,
-          });
+          const metadata = row.metadata as Record<string, unknown> | null;
+          if (
+            (metadata?.share_candidate === true ||
+              metadata?.share_candidate === "true") &&
+            metadata.memory_lifecycle_action === "nominate_shared"
+          ) {
+            candidates.push({
+              table: table,
+              id: row.id,
+              created_at: row.created_at,
+            });
+          }
         }
       }
 

--- a/src/tools/scan-namespace.ts
+++ b/src/tools/scan-namespace.ts
@@ -16,8 +16,8 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
     "scan_namespace",
     {
       description:
-        "Scan an agent namespace for promotion candidates. Returns entries categorized as " +
-        "candidates, duplicates in the target namespace, or already_promoted.",
+        "Scan an agent namespace for pending explicit shared-kb nominations. " +
+        "Returns nominated candidates and duplicates in the target namespace.",
       inputSchema: {
         namespace: z.string().min(1).max(500).describe("Agent namespace to scan"),
         target_namespace: z
@@ -90,7 +90,6 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
       }
       const candidates: any[] = [];
       const duplicates: any[] = [];
-      const alreadyPromoted: any[] = [];
 
       for (const table of tables) {
         const sinceFilter = args.since ? ` AND t.created_at >= $3` : "";
@@ -111,7 +110,7 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
               : " AND false";
 
         const { rows } = await deps.pool.query(
-          `SELECT t.id, t.content_hash, t.namespace, t.created_at, t.promoted_from,
+          `SELECT t.id, t.content_hash, t.namespace, t.created_at,
                   ${metadataSelect} AS metadata,
                   '${table}' AS table_name
            FROM ${table} t
@@ -122,16 +121,6 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
         );
 
         for (const row of rows) {
-          if (row.promoted_from) {
-            alreadyPromoted.push({
-              table: table,
-              id: row.id,
-              created_at: row.created_at,
-              promoted_to: row.promoted_from,
-            });
-            continue;
-          }
-
           if (row.content_hash) {
             const { rows: targetDupes } = await deps.pool.query(
               `SELECT id FROM ${table}
@@ -173,7 +162,6 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
         target_namespace: targetCanonicalNamespace,
         candidates: candidates.length,
         duplicates: duplicates.length,
-        already_promoted: alreadyPromoted.length,
       });
 
       return {
@@ -184,11 +172,9 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
             target_namespace: targetCanonicalNamespace,
             candidates,
             duplicates,
-            already_promoted: alreadyPromoted,
             summary: {
               candidates: candidates.length,
               duplicates: duplicates.length,
-              already_promoted: alreadyPromoted.length,
             },
           }),
         }],

--- a/src/tools/scan-namespace.ts
+++ b/src/tools/scan-namespace.ts
@@ -6,6 +6,11 @@ import {
   physicalNamespace,
   sharedNamespaceConfig,
 } from "../shared-namespace.ts";
+import {
+  explicitSharedNominationSqlPredicate,
+  isExplicitSharedNomination,
+  promotionMetadataSelect,
+} from "../promotion-nomination.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -96,18 +101,8 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
         const params: unknown[] = [args.namespace, limit];
         if (args.since) params.push(args.since);
 
-        const metadataSelect =
-          table === "thoughts" || table === "decisions"
-            ? "t.extracted_metadata"
-            : table === "relationships" || table === "projects"
-              ? "t.metadata"
-              : "NULL::jsonb";
-        const nominationFilter =
-          table === "thoughts" || table === "decisions"
-            ? " AND t.extracted_metadata->>'share_candidate' = 'true' AND t.extracted_metadata->>'memory_lifecycle_action' = 'nominate_shared'"
-            : table === "relationships" || table === "projects"
-              ? " AND t.metadata->>'share_candidate' = 'true' AND t.metadata->>'memory_lifecycle_action' = 'nominate_shared'"
-              : " AND false";
+        const metadataSelect = promotionMetadataSelect(table);
+        const nominationFilter = explicitSharedNominationSqlPredicate(table);
 
         const { rows } = await deps.pool.query(
           `SELECT t.id, t.content_hash, t.namespace, t.created_at,
@@ -143,11 +138,7 @@ export function registerScanNamespace(server: McpServer, deps: ToolDeps): void {
           }
 
           const metadata = row.metadata as Record<string, unknown> | null;
-          if (
-            (metadata?.share_candidate === true ||
-              metadata?.share_candidate === "true") &&
-            metadata.memory_lifecycle_action === "nominate_shared"
-          ) {
+          if (isExplicitSharedNomination(metadata)) {
             candidates.push({
               table: table,
               id: row.id,

--- a/src/tools/tier-lane.ts
+++ b/src/tools/tier-lane.ts
@@ -99,7 +99,8 @@ export function registerTierLane(server: McpServer, deps: ToolDeps): void {
         const { rows } = await deps.pool.query(
           `SELECT
              e.id, e.lane_id, l.namespace, l.agent, l.session_key,
-             e.event_type, e.content, e.importance, e.content_hash, e.created_at
+             e.event_type, e.content, e.importance, e.content_hash, e.created_at,
+             e.metadata
            FROM ob_session_events e
            JOIN ob_session_lanes l ON e.lane_id = l.id
            WHERE l.namespace = $1 AND l.session_key = $2


### PR DESCRIPTION
Fixes #224.

## Summary

- Adds a first-class client-owned memory lifecycle to the Open Brain contract: `candidate`, `promote`, `relegate`, `discard`, and `nominate_shared`.
- Adds TypeScript and Python client helpers for candidate memory actions, with explicit candidate type, reason, confidence, scope, evidence refs, and staleness policy metadata.
- Validates lifecycle metadata server-side before `append_session_event` persistence, including invalid action, malformed candidate fields, and invalid `share_candidate` usage.
- Prevents lifecycle candidate events from automatically tiering into durable thoughts, and restricts shared-kb scan/promoter candidates to explicit `nominate_shared` lifecycle nominations.
- Updates Plan 3F with live state: 0 open PRs, 8 open issues, #250 merged, #224 local validation passed, and deploy still separate.

## Validation

- `bunx tsc --noEmit` - pass.
- `bun test src/contract.test.ts src/__tests__/agent-memory.test.ts src/tools/__tests__/append-session-event.test.ts src/tiering.test.ts src/tools/__tests__/tier-lane.test.ts src/tools/__tests__/scan-namespace.test.ts scripts/promote-lane-shared.test.ts` - 210 pass, 20 skip, 0 fail.
- `bun test` - 1078 pass, 51 skip, 0 fail.
- `uv run pytest -q tests/test_agent.py tests/test_client.py tests/test_contract.py tests/test_dream.py` - 120 passed.
- `uv run pytest -q` - 197 passed, 5 skipped.
- `uv run mypy src/openbrain_memory` - pass.
- `uv run ruff check src tests` - pass.
- `git diff --check` - pass.

Local DB-backed/live Postgres tests still skip without `OPENBRAIN_TEST_DATABASE_URL`; CI `db-integration` must supply that gate.

## Critical self-review

- Highest-risk behavior: lifecycle candidate metadata could accidentally become a durable memory or shared-kb nomination without an explicit client action. Mitigation: tiering keeps any `memory_lifecycle_action` event in-lane, scan/promoter logic only treats `nominate_shared` plus `share_candidate=true` as a shared nomination, and tests cover both paths.
- Assumptions that could be wrong: representing lifecycle actions as validated session-event metadata may be enough for this slice; future runtime work might want dedicated server tools for durable promotion/relegation rather than wrapper-only verbs.
- Missing/weak tests: local live Postgres tests are skipped without `OPENBRAIN_TEST_DATABASE_URL`; CI must prove DB-backed promoter/tier/session-event behavior. No hosted Open Brain smoke is included because deploy is out of scope.
- Security/permission risk: caller-supplied lifecycle metadata is untrusted and now validated server-side before persistence. Existing namespace/auth predicates remain the write boundary; no client-side-only permission check is relied on.
- Migration/deploy risk: no schema migration or core01 deploy is included. Contract version/hash changes require downstream cache/runtime rollout only in an approved release/deploy phase.
- Downstream client/runtime risk: this changes public contract and `openbrain-memory` behavior, so downstream rollout applies. mcp2cli/rtech-mcps/rtech-hermes/Hermes live rollout are deferred; this PR only lands the local contract/client/server behavior.
- Rollback/cleanup concern: reverting this PR removes v15 lifecycle contract fields, client helpers, metadata validation, and the tier/scan/promoter lifecycle guards. Any downstream client adopting v15 must not deploy before the release gate.
- Fixes made before PR: added server-side lifecycle validation, blocked candidate auto-tiering, tightened scan/promoter explicit nomination semantics, added Python lifecycle helper tests, aligned v15 contract/hash, and updated Plan 3F.
- Known residual risk: future #222/#221 runtime flows still need integration tests proving working/recovery/candidate sections do not blur once realtime context pack data exists.
- SME review-memory update: [x] not applicable because: the pre-PR blocker findings were fixed with regression coverage and do not add a new reusable review pattern beyond existing auth/namespace/downstream gates.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] Pre-PR antagonist blocker findings were fixed and locally verified.
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable.
- [ ] Initial swarm pending after PR creation.
- [ ] Opposite-runtime cross-review pending after initial swarm.
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a local-only PR with no core01 deploy or hosted runtime rollout.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`.
- [x] Open Brain local verification complete.
- [x] rtech-mcps handoff is deferred to approved release/deploy phase.
- [x] mcp2cli cache/skill refresh is deferred to approved release/deploy phase.
- [x] rtech-hermes Python runtime/plugin changes are deferred to approved release/deploy phase.
- [x] Hermes live rollout/canaries are deferred to approved release/deploy phase.

## No Deploy

This PR must not deploy core01. Merge and deploy remain separate phases.
