### PR TITLE
feat(#222): add scoped working set context pack

### DIFF
--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -1,6 +1,7 @@
 # Agent Context Pack Contract
 
-Status: planned contract, not runtime-available yet.
+Status: locally runtime-available over MCP for scoped working-set context; NATS
+transport and broader section assembly remain planned.
 Parent issue: #220.
 Research receipt: PR #225, `docs/realtime-agent-memory-research.md`.
 
@@ -12,9 +13,10 @@ context bundle so a runtime does not have to stitch together lane reads, broad
 semantic search, repo facts, profile guidance, and stale-evidence warnings on
 every turn.
 
-This contract defines the envelope and scope rules before transport or runtime
-implementation. It must not be advertised as an available tool until server
-code, tests, and downstream client support exist.
+This contract defines the envelope and scope rules. The MCP
+`agent_context_pack` tool currently exposes the exact-scope `working_set`
+section from RAM-first working context. NATS transport and broader durable
+section assembly remain planned until their owning issues land.
 
 ## Ownership Boundary
 
@@ -150,6 +152,33 @@ Known section names (the `sections` object members; this list is what
   promotion. A client must record a separate lifecycle action before anything
   moves.
 
+### Working Set Local Runtime Boundary
+
+#222 defines the first RAM-first working-set boundary in
+`src/realtime/working-set.ts`. The MCP `working_set_append` tool adds scoped
+RAM-only entries, and the MCP `agent_context_pack` tool returns them in the
+`working_set` section only on exact-scope match. This does not make NATS
+transport available.
+
+Working-set items are labeled `working_context` and set
+`not_durable_memory=true`. They must not be inserted into `thoughts`,
+`decisions`, `sessions`, shared-kb, search indexes, or normal durable recall
+unless a later explicit client-owned lifecycle action promotes or nominates
+separate candidate memory.
+
+Default RAM budget:
+
+- TTL: 30 minutes (`ttl_ms=1800000`);
+- per-session cap: 24 items;
+- global in-process cap: 1024 items;
+- active-session cap: 128 sessions;
+- per-item content cap: 4000 characters.
+
+The working-set boundary exposes counters for dropped, expired, and trimmed
+items. Dropped items are rejected before inclusion, expired items leave RAM
+after TTL, and trimmed items are evicted by per-session/global/session-count
+budget pressure.
+
 `warnings`, `budget`, and `citations` are always-present top-level envelope
 fields, not section members. They are mirrored by
 `get_contract().agent_context_pack.envelope_fields` and cannot be toggled
@@ -209,7 +238,8 @@ The response must make the source boundary explicit:
 - No NATS/JetStream runtime implementation. #223 owns the planned transport
   foundation in `docs/nats-jetstream-foundation.md`.
 - No recovery WAL implementation. #221 owns recovery.
-- No RAM working-set implementation. #222 owns hot state.
+- No NATS `agent_context_pack` tool availability. #222 owns the local MCP
+  working-set append/read path; transport exposure remains planned under #223.
 - No promote/relegate implementation. #224 owns lifecycle actions.
 - No server-side auto-promotion from working trace, recovery evidence, or
   candidate memory.
@@ -250,12 +280,20 @@ authoritative shape):
 ```json
 {
   "agent_context_pack": {
-    "status": "planned-contract",
-    "availability": "not_runtime_available",
-    "contract_doc": "docs/agent-context-pack-contract.md"
+    "status": "runtime-available",
+    "availability": "mcp_tool_available",
+    "contract_doc": "docs/agent-context-pack-contract.md",
+    "working_set": {
+      "status": "local-runtime-boundary",
+      "availability": "mcp_tool_available",
+      "implementation": "src/realtime/working-set.ts",
+      "item_label": "working_context",
+      "not_durable_memory": true,
+      "counters": ["dropped", "expired", "trimmed"]
+    }
   }
 }
 ```
 
-It must not appear in `tool_contracts` or in required client tool lists until
-the runtime tool exists.
+It appears in `tool_contracts` for MCP clients once the runtime tool exists.
+NATS subjects and downstream rollout are still release-gated separately.

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -172,7 +172,8 @@ Default RAM budget:
 - per-session cap: 24 items;
 - global in-process cap: 1024 items;
 - active-session cap: 128 sessions;
-- per-item content cap: 4000 characters.
+- per-item content cap: 4000 characters;
+- per-item metadata cap: 2000 serialized JSON characters.
 
 The working-set boundary exposes counters for dropped, expired, and trimmed
 items. Dropped items are rejected before inclusion, expired items leave RAM

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -41,10 +41,11 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v15"
+CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v16"
 COMPATIBLE_CONTRACT_VERSIONS = (CURRENT_CONTRACT_VERSION,)
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
+    "agent_context_pack",
     "get_contract",
     "get_entry",
     "resolve_entry",
@@ -57,9 +58,13 @@ REQUIRED_CONTRACT_TOOLS = (
     "session_start",
     "session_wrap",
     "upsert_repo_fact",
+    "working_set_append",
 )
 CURRENT_TOOL_HELP: Mapping[str, str] = {
     "append_session_event": "Append a durable event to a session lane journal.",
+    "agent_context_pack": (
+        "Build a scoped realtime context pack with exact-scope working context."
+    ),
     "brain_answer": "Return cited answer bullets from readable Open Brain evidence.",
     "get_entity": "Fetch a graph entity by ID.",
     "get_contract": "Read the canonical Open Brain public contract manifest.",
@@ -80,6 +85,7 @@ CURRENT_TOOL_HELP: Mapping[str, str] = {
     "session_start": "Find or create a durable session lane and return recent events.",
     "session_wrap": "Checkpoint a session lane with a durable summary.",
     "upsert_repo_fact": "Upsert a curated qmd-derived repository fact.",
+    "working_set_append": "Append RAM-only working context for one exact active scope.",
 }
 
 
@@ -438,6 +444,12 @@ class OpenBrainClient:
 
     def session_context(self, **arguments: Any) -> JSON:
         return self.call_tool("session_context", arguments)
+
+    def agent_context_pack(self, **arguments: Any) -> JSON:
+        return self.call_tool("agent_context_pack", arguments)
+
+    def working_set_append(self, **arguments: Any) -> JSON:
+        return self.call_tool("working_set_append", arguments)
 
     def append_session_event(self, **arguments: Any) -> JSON:
         return self.call_tool("append_session_event", arguments)

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -447,7 +447,8 @@ def test_thin_wrappers_cover_current_issue_scope():
     client.log_decision(title="decision", rationale="because")
     client.search_brain(query="decision")
 
-    assert [call["json"]["params"]["name"] for call in tool_requests(transport)] == [
+    calls = tool_requests(transport)
+    assert [call["json"]["params"]["name"] for call in calls] == [
         "session_context",
         "working_set_append",
         "agent_context_pack",
@@ -456,6 +457,23 @@ def test_thin_wrappers_cover_current_issue_scope():
         "log_decision",
         "search_brain",
     ]
+    assert calls[1]["json"]["params"]["arguments"] == {
+        "agent": "nagatha",
+        "platform": "discord",
+        "server_id": "guild",
+        "channel_id": "chan",
+        "session_key": "session",
+        "kind": "current_intent",
+        "content": "finish the local slice",
+    }
+    assert calls[2]["json"]["params"]["arguments"] == {
+        "agent": "nagatha",
+        "platform": "discord",
+        "server_id": "guild",
+        "channel_id": "chan",
+        "session_key": "session",
+        "requested_sections": ["working_set"],
+    }
 
 
 def test_all_registered_tool_wrappers_call_matching_tool_names():

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -425,6 +425,23 @@ def test_thin_wrappers_cover_current_issue_scope():
     client = make_client(transport)
 
     client.session_context(session_key="s")
+    client.working_set_append(
+        agent="nagatha",
+        platform="discord",
+        server_id="guild",
+        channel_id="chan",
+        session_key="session",
+        kind="current_intent",
+        content="finish the local slice",
+    )
+    client.agent_context_pack(
+        agent="nagatha",
+        platform="discord",
+        server_id="guild",
+        channel_id="chan",
+        session_key="session",
+        requested_sections=["working_set"],
+    )
     client.session_wrap(session_key="s", summary="done")
     client.log_thought(content="fact")
     client.log_decision(title="decision", rationale="because")
@@ -432,6 +449,8 @@ def test_thin_wrappers_cover_current_issue_scope():
 
     assert [call["json"]["params"]["name"] for call in tool_requests(transport)] == [
         "session_context",
+        "working_set_append",
+        "agent_context_pack",
         "session_wrap",
         "log_thought",
         "log_decision",
@@ -446,6 +465,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
         "access_report",
         "adjacent_context",
         "append_session_event",
+        "agent_context_pack",
         "archive_entity",
         "archive_entry",
         "brain_answer",
@@ -477,6 +497,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
         "search_all",
         "search_brain",
         "session_context",
+        "working_set_append",
         "session_load",
         "session_save",
         "session_start",
@@ -499,7 +520,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v15"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v16"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -15,6 +15,110 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     input_schema: {},
     output_shape: "OpenBrainContract JSON text payload",
   },
+  working_set_append: {
+    version: 1,
+    input_schema: {
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Namespace for isolation. Defaults to the auth-derived clientId; " +
+          "the server enforces write authority before accepting RAM working context.",
+      },
+      agent: { type: "string", required: true, minLength: 1, maxLength: 200 },
+      platform: { type: "string", required: true, minLength: 1, maxLength: 200 },
+      server_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      channel_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      thread_id: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description: "Optional thread id. Missing means unthreaded scope only.",
+      },
+      session_key: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
+      kind: {
+        type: "enum",
+        required: true,
+        values: [
+          "recent_event",
+          "structured_event",
+          "current_intent",
+          "active_correction",
+          "task_state",
+          "linked_durable_ref",
+          "next_turn_guidance",
+        ],
+      },
+      content: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 4000,
+        description:
+          "Bounded RAM-only working context. This does not create durable " +
+          "memory, shared-kb, or searchable recall rows.",
+      },
+      confidence: { type: "number", required: false, min: 0, max: 1 },
+      stale_at: { type: "string", required: false, maxLength: 100 },
+      trace_id: { type: "string", required: false, maxLength: 500 },
+      source_ref: { type: "string", required: false, maxLength: 1000 },
+      durable_ref: { type: "object", required: false },
+      metadata: { type: "object", required: false },
+    },
+    output_shape:
+      "RAM-only working-set append receipt with accepted/reason/item/counters/not_durable_memory",
+  },
+  agent_context_pack: {
+    version: 1,
+    input_schema: {
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Namespace for isolation. Defaults to auth-derived clientId; the " +
+          "server enforces read authority before returning any scoped context.",
+      },
+      agent: { type: "string", required: true, minLength: 1, maxLength: 200 },
+      platform: { type: "string", required: true, minLength: 1, maxLength: 200 },
+      server_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      channel_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      thread_id: { type: "string", required: false, maxLength: 500 },
+      session_key: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
+      query: { type: "string", required: false, maxLength: 4000 },
+      requested_sections: {
+        type: "array",
+        required: false,
+        items: {
+          type: "enum",
+          values: [
+            "working_set",
+            "durable_lane_context",
+            "durable_memory",
+            "profile_guidance",
+            "process_guidance",
+            "repo_facts",
+            "pointers",
+            "candidate_memory",
+          ],
+        },
+      },
+      budget: { type: "object", required: false },
+    },
+    output_shape:
+      "agent_context_pack envelope with exact-scope working_set section, warnings, budget, citations",
+  },
   get_entry: {
     version: 2,
     input_schema: {

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -68,8 +68,22 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       stale_at: { type: "string", required: false, maxLength: 100 },
       trace_id: { type: "string", required: false, maxLength: 500 },
       source_ref: { type: "string", required: false, maxLength: 1000 },
-      durable_ref: { type: "object", required: false },
-      metadata: { type: "object", required: false },
+      durable_ref: {
+        type: "object",
+        required: false,
+        fields: {
+          table: { type: "string", required: true, minLength: 1, maxLength: 100 },
+          id: { type: "string", required: true, minLength: 1, maxLength: 200 },
+        },
+      },
+      metadata: {
+        type: "object",
+        required: false,
+        maxSerializedChars: 2000,
+        description:
+          "Optional bounded JSON metadata. Serialized metadata larger than " +
+          "2000 characters is rejected before retention.",
+      },
     },
     output_shape:
       "RAM-only working-set append receipt with accepted/reason/item/counters/not_durable_memory",
@@ -114,7 +128,24 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           ],
         },
       },
-      budget: { type: "object", required: false },
+      budget: {
+        type: "object",
+        required: false,
+        fields: {
+          max_tokens: {
+            type: "integer",
+            required: false,
+            min: 100,
+            max: 20000,
+          },
+          max_latency_ms: {
+            type: "integer",
+            required: false,
+            min: 1,
+            max: 10000,
+          },
+        },
+      },
     },
     output_shape:
       "agent_context_pack envelope with exact-scope working_set section, warnings, budget, citations",

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "92872c8499f1e70608569fb32d00bc1c726e4e91ddf641551399f510573c3d44",
+      "820112d965cafc92c1574b8d30c741495b5f5e5f73aa2bf32860bda4c49e52e7",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -129,8 +129,8 @@ describe("Open Brain contract manifest", () => {
       status: "client-wrapper",
     });
     expect(contract.agent_context_pack).toMatchObject({
-      status: "planned-contract",
-      availability: "not_runtime_available",
+      status: "runtime-available",
+      availability: "mcp_tool_available",
       contract_doc: "docs/agent-context-pack-contract.md",
       parent_issue: 220,
       exact_scope_required: true,
@@ -167,6 +167,24 @@ describe("Open Brain contract manifest", () => {
     expect(contract.agent_context_pack.warning_fields).toContain(
       "scope_denials",
     );
+    expect(contract.agent_context_pack.working_set).toEqual({
+      status: "local-runtime-boundary",
+      parent_issue: 222,
+      implementation: "src/realtime/working-set.ts",
+      storage: "ram_first_in_process",
+      availability: "mcp_tool_available",
+      item_label: "working_context",
+      not_durable_memory: true,
+      exact_scope_required: true,
+      budget_defaults: {
+        ttl_ms: 1800000,
+        max_sessions: 128,
+        max_items_per_session: 24,
+        max_global_items: 1024,
+        max_item_chars: 4000,
+      },
+      counters: ["dropped", "expired", "trimmed"],
+    });
     expect(contract.receipt_contract).toMatchObject({
       status: "lightweight-openbrain-receipts",
       event_type: "receipt",
@@ -240,12 +258,23 @@ describe("Open Brain contract manifest", () => {
       "lane_load",
       "append_session_event",
       "session_wrap",
+      "working_set_append",
+      "agent_context_pack",
       "list_repo_facts",
       "upsert_repo_fact",
     ]) {
       expect(contract.tool_contracts[tool]).toBeDefined();
     }
-    expect(contract.tool_contracts.agent_context_pack).toBeUndefined();
+    const workingSetAppend = contract.tool_contracts.working_set_append;
+    const agentContextPack = contract.tool_contracts.agent_context_pack;
+    expect(workingSetAppend).toBeDefined();
+    expect(agentContextPack).toBeDefined();
+    expect(workingSetAppend?.output_shape).toContain(
+      "RAM-only",
+    );
+    expect(agentContextPack?.output_shape).toContain(
+      "exact-scope working_set",
+    );
     const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
     expect(upsertRepoFact).toBeDefined();
     const getEntry = contract.tool_contracts.get_entry;
@@ -333,7 +362,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v15");
+    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v16");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "820112d965cafc92c1574b8d30c741495b5f5e5f73aa2bf32860bda4c49e52e7",
+      "95b71133b604f37e3b94c4cbbfc9bccbca9c1dfd22fb7bec3a1f7e8969a2953f",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -182,6 +182,7 @@ describe("Open Brain contract manifest", () => {
         max_items_per_session: 24,
         max_global_items: 1024,
         max_item_chars: 4000,
+        max_metadata_chars: 2000,
       },
       counters: ["dropped", "expired", "trimmed"],
     });
@@ -275,6 +276,37 @@ describe("Open Brain contract manifest", () => {
     expect(agentContextPack?.output_shape).toContain(
       "exact-scope working_set",
     );
+    expect((workingSetAppend?.input_schema as any).durable_ref).toEqual({
+      type: "object",
+      required: false,
+      fields: {
+        table: { type: "string", required: true, minLength: 1, maxLength: 100 },
+        id: { type: "string", required: true, minLength: 1, maxLength: 200 },
+      },
+    });
+    expect((workingSetAppend?.input_schema as any).metadata).toMatchObject({
+      type: "object",
+      required: false,
+      maxSerializedChars: 2000,
+    });
+    expect((agentContextPack?.input_schema as any).budget).toEqual({
+      type: "object",
+      required: false,
+      fields: {
+        max_tokens: {
+          type: "integer",
+          required: false,
+          min: 100,
+          max: 20000,
+        },
+        max_latency_ms: {
+          type: "integer",
+          required: false,
+          min: 1,
+          max: 10000,
+        },
+      },
+    });
     const upsertRepoFact = contract.tool_contracts.upsert_repo_fact;
     expect(upsertRepoFact).toBeDefined();
     const getEntry = contract.tool_contracts.get_entry;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-07-06.memory-tools.v15";
+export const CONTRACT_VERSION = "2026-07-06.memory-tools.v16";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -102,8 +102,8 @@ export interface OpenBrainContract {
     >;
   };
   agent_context_pack: {
-    status: "planned-contract";
-    availability: "not_runtime_available";
+    status: "runtime-available";
+    availability: "mcp_tool_available";
     contract_doc: "docs/agent-context-pack-contract.md";
     parent_issue: 220;
     exact_scope_required: true;
@@ -135,6 +135,24 @@ export interface OpenBrainContract {
       "truncation",
       "uncertainty",
     ];
+    working_set: {
+      status: "local-runtime-boundary";
+      parent_issue: 222;
+      implementation: "src/realtime/working-set.ts";
+      storage: "ram_first_in_process";
+      availability: "mcp_tool_available";
+      item_label: "working_context";
+      not_durable_memory: true;
+      exact_scope_required: true;
+      budget_defaults: {
+        ttl_ms: 1800000;
+        max_sessions: 128;
+        max_items_per_session: 24;
+        max_global_items: 1024;
+        max_item_chars: 4000;
+      };
+      counters: readonly ["dropped", "expired", "trimmed"];
+    };
   };
   receipt_contract: {
     status: "lightweight-openbrain-receipts";
@@ -321,11 +339,20 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   {
     name: "agent_context_pack",
     version: 1,
-    kind: "schema",
+    kind: "tool",
     description:
-      "Planned first-class realtime context-pack contract for Hermes and " +
-      "future agents. It is not an available runtime tool until a later " +
-      "implementation exposes it explicitly.",
+      "First-class realtime context-pack tool for Hermes and future agents. " +
+      "It currently exposes the exact-scope RAM working_set section over MCP; " +
+      "NATS transport remains planned.",
+  },
+  {
+    name: "working_set_append",
+    version: 1,
+    kind: "tool",
+    description:
+      "Append one RAM-only working-context item for an exact active " +
+      "namespace/agent/platform/server/channel/thread/session scope. This " +
+      "does not create durable memory or shared-kb rows.",
   },
   {
     name: "agent_memory_adapter",
@@ -561,8 +588,8 @@ export function buildContract(
       },
     },
     agent_context_pack: {
-      status: "planned-contract" as const,
-      availability: "not_runtime_available" as const,
+      status: "runtime-available" as const,
+      availability: "mcp_tool_available" as const,
       contract_doc: "docs/agent-context-pack-contract.md" as const,
       parent_issue: 220 as const,
       exact_scope_required: true as const,
@@ -594,6 +621,24 @@ export function buildContract(
         "truncation",
         "uncertainty",
       ] as const,
+      working_set: {
+        status: "local-runtime-boundary" as const,
+        parent_issue: 222 as const,
+        implementation: "src/realtime/working-set.ts" as const,
+        storage: "ram_first_in_process" as const,
+        availability: "mcp_tool_available" as const,
+        item_label: "working_context" as const,
+        not_durable_memory: true as const,
+        exact_scope_required: true as const,
+        budget_defaults: {
+          ttl_ms: 1800000 as const,
+          max_sessions: 128 as const,
+          max_items_per_session: 24 as const,
+          max_global_items: 1024 as const,
+          max_item_chars: 4000 as const,
+        },
+        counters: ["dropped", "expired", "trimmed"] as const,
+      },
     },
     receipt_contract: {
       status: "lightweight-openbrain-receipts" as const,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -150,6 +150,7 @@ export interface OpenBrainContract {
         max_items_per_session: 24;
         max_global_items: 1024;
         max_item_chars: 4000;
+        max_metadata_chars: 2000;
       };
       counters: readonly ["dropped", "expired", "trimmed"];
     };
@@ -636,6 +637,7 @@ export function buildContract(
           max_items_per_session: 24 as const,
           max_global_items: 1024 as const,
           max_item_chars: 4000 as const,
+          max_metadata_chars: 2000 as const,
         },
         counters: ["dropped", "expired", "trimmed"] as const,
       },

--- a/src/realtime/working-set.test.ts
+++ b/src/realtime/working-set.test.ts
@@ -176,6 +176,42 @@ describe("WorkingSetStore", () => {
     expect(store.buildContextPackFragment(BASE_SCOPE, BASE_TIME).working_set.items).toEqual([]);
   });
 
+  it("drops unserializable metadata without throwing", () => {
+    const store = new WorkingSetStore();
+    const cyclicMetadata: Record<string, unknown> = {};
+    cyclicMetadata.self = cyclicMetadata;
+
+    const cyclic = store.append(
+      BASE_SCOPE,
+      {
+        kind: "recent_event",
+        content: "valid content",
+        metadata: cyclicMetadata,
+      },
+      BASE_TIME,
+    );
+    const bigint = store.append(
+      BASE_SCOPE,
+      {
+        kind: "recent_event",
+        content: "valid content",
+        metadata: { count: BigInt(1) },
+      },
+      BASE_TIME,
+    );
+
+    expect(cyclic).toMatchObject({
+      accepted: false,
+      reason: "metadata_too_large",
+    });
+    expect(bigint).toMatchObject({
+      accepted: false,
+      reason: "metadata_too_large",
+    });
+    expect(store.getCounters().dropped).toBe(2);
+    expect(store.buildContextPackFragment(BASE_SCOPE, BASE_TIME).working_set.items).toEqual([]);
+  });
+
   it("does not disclose cross-namespace working-set presence in scope denials", () => {
     const store = new WorkingSetStore();
     store.append(BASE_SCOPE, { kind: "task_state", content: "base" }, BASE_TIME);

--- a/src/realtime/working-set.test.ts
+++ b/src/realtime/working-set.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_WORKING_SET_BUDGET,
+  WORKING_SET_LABEL,
+  WorkingSetStore,
+  compareWorkingSetScope,
+  normalizeWorkingSetScope,
+  workingSetScopeKey,
+  type WorkingSetScope,
+} from "./working-set.ts";
+
+const BASE_SCOPE: WorkingSetScope = {
+  namespace: "shared-kb",
+  agent: "nagatha",
+  platform: "discord",
+  server_id: "rodaddy-live",
+  channel_id: "open-brain",
+  thread_id: null,
+  session_key: "discord:rodaddy-live:open-brain:nagatha",
+};
+
+const BASE_TIME = new Date("2026-07-06T13:15:00.000Z");
+
+function variant(
+  patch: Partial<WorkingSetScope>,
+): WorkingSetScope {
+  return { ...BASE_SCOPE, ...patch };
+}
+
+describe("WorkingSetStore", () => {
+  it("includes only exact-scope working context in a context-pack fragment", () => {
+    const store = new WorkingSetStore();
+    const append = store.append(
+      BASE_SCOPE,
+      {
+        kind: "current_intent",
+        content: "Finish issue #222 local working-set slice.",
+        confidence: 0.92,
+        trace_id: "trace-222",
+      },
+      BASE_TIME,
+    );
+
+    expect(append.accepted).toBe(true);
+
+    const fragment = store.buildContextPackFragment(BASE_SCOPE, BASE_TIME);
+
+    expect(fragment.working_set.schema).toBe("openbrain.working_set.v1");
+    expect(fragment.working_set.label).toBe(WORKING_SET_LABEL);
+    expect(fragment.working_set.not_durable_memory).toBe(true);
+    expect(fragment.working_set.exact_scope_required).toBe(true);
+    expect(fragment.working_set.item_count).toBe(1);
+    expect(fragment.working_set.items[0]).toMatchObject({
+      kind: "current_intent",
+      label: WORKING_SET_LABEL,
+      content: "Finish issue #222 local working-set slice.",
+      trace_id: "trace-222",
+    });
+    expect(fragment.warnings.scope_denials).toEqual([]);
+  });
+
+  it.each([
+    ["namespace", variant({ namespace: "other-ns" })],
+    ["agent", variant({ agent: "skippy" })],
+    ["platform", variant({ platform: "slack" })],
+    ["server_id", variant({ server_id: "other-server" })],
+    ["channel_id", variant({ channel_id: "other-channel" })],
+    ["thread_id", variant({ thread_id: "thread-1" })],
+    ["session_key", variant({ session_key: "different-session" })],
+  ] as const)(
+    "denies working-set content across different %s",
+    (field, adjacentScope) => {
+      const store = new WorkingSetStore();
+      store.append(
+        BASE_SCOPE,
+        {
+          kind: "task_state",
+          content: "base scope task",
+        },
+        BASE_TIME,
+      );
+      store.append(
+        adjacentScope,
+        {
+          kind: "task_state",
+          content: `adjacent ${field} task`,
+        },
+        BASE_TIME,
+      );
+
+      const fragment = store.buildContextPackFragment(BASE_SCOPE, BASE_TIME);
+
+      expect(fragment.working_set.items.map((item) => item.content)).toEqual([
+        "base scope task",
+      ]);
+      expect(fragment.warnings.scope_denials).toHaveLength(1);
+      expect(fragment.warnings.scope_denials[0]?.reasons).toContain(field);
+    },
+  );
+
+  it("treats missing thread and threaded scope as different exact scopes", () => {
+    const unthreaded = normalizeWorkingSetScope(BASE_SCOPE);
+    const threaded = normalizeWorkingSetScope(variant({ thread_id: "t-1" }));
+
+    expect(unthreaded.thread_id).toBeNull();
+    expect(threaded.thread_id).toBe("t-1");
+    expect(workingSetScopeKey(unthreaded)).not.toBe(
+      workingSetScopeKey(threaded),
+    );
+    expect(compareWorkingSetScope(unthreaded, threaded)).toEqual(["thread_id"]);
+  });
+
+  it("expires RAM-first items and exposes the expired counter", () => {
+    const store = new WorkingSetStore({ ttl_ms: 1000 });
+    store.append(
+      BASE_SCOPE,
+      {
+        kind: "recent_event",
+        content: "temporary event",
+      },
+      BASE_TIME,
+    );
+
+    const afterTtl = new Date(BASE_TIME.getTime() + 1001);
+    const fragment = store.buildContextPackFragment(BASE_SCOPE, afterTtl);
+
+    expect(fragment.working_set.items).toEqual([]);
+    expect(fragment.working_set.counters.expired).toBe(1);
+  });
+
+  it("drops invalid or oversized items and exposes dropped counters", () => {
+    const store = new WorkingSetStore({ max_item_chars: 8 });
+
+    const empty = store.append(
+      BASE_SCOPE,
+      {
+        kind: "recent_event",
+        content: "   ",
+      },
+      BASE_TIME,
+    );
+    const oversized = store.append(
+      BASE_SCOPE,
+      {
+        kind: "recent_event",
+        content: "too long for budget",
+      },
+      BASE_TIME,
+    );
+
+    expect(empty).toMatchObject({ accepted: false, reason: "empty_content" });
+    expect(oversized).toMatchObject({
+      accepted: false,
+      reason: "content_too_large",
+    });
+    expect(store.getCounters().dropped).toBe(2);
+  });
+
+  it("trims per-session and global budgets and exposes trimmed counters", () => {
+    const store = new WorkingSetStore({
+      max_items_per_session: 2,
+      max_global_items: 3,
+      max_sessions: DEFAULT_WORKING_SET_BUDGET.max_sessions,
+    });
+
+    store.append(BASE_SCOPE, { kind: "recent_event", content: "one" }, BASE_TIME);
+    store.append(BASE_SCOPE, { kind: "recent_event", content: "two" }, BASE_TIME);
+    store.append(
+      BASE_SCOPE,
+      { kind: "recent_event", content: "three" },
+      BASE_TIME,
+    );
+
+    const perSession = store.buildContextPackFragment(BASE_SCOPE, BASE_TIME);
+    expect(perSession.working_set.items.map((item) => item.content)).toEqual([
+      "two",
+      "three",
+    ]);
+    expect(perSession.working_set.counters.trimmed).toBe(1);
+
+    store.append(
+      variant({ session_key: "session-2" }),
+      { kind: "recent_event", content: "four" },
+      BASE_TIME,
+    );
+    store.append(
+      variant({ session_key: "session-3" }),
+      { kind: "recent_event", content: "five" },
+      BASE_TIME,
+    );
+
+    expect(store.getCounters().trimmed).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses documented budget defaults", () => {
+    const store = new WorkingSetStore();
+
+    expect(store.budget).toEqual(DEFAULT_WORKING_SET_BUDGET);
+    expect(store.budget).toMatchObject({
+      ttl_ms: 1_800_000,
+      max_sessions: 128,
+      max_items_per_session: 24,
+      max_global_items: 1024,
+    });
+  });
+});

--- a/src/realtime/working-set.test.ts
+++ b/src/realtime/working-set.test.ts
@@ -60,7 +60,6 @@ describe("WorkingSetStore", () => {
   });
 
   it.each([
-    ["namespace", variant({ namespace: "other-ns" })],
     ["agent", variant({ agent: "skippy" })],
     ["platform", variant({ platform: "slack" })],
     ["server_id", variant({ server_id: "other-server" })],
@@ -156,6 +155,49 @@ describe("WorkingSetStore", () => {
     expect(store.getCounters().dropped).toBe(2);
   });
 
+  it("drops oversized metadata before retaining RAM working context", () => {
+    const store = new WorkingSetStore({ max_metadata_chars: 12 });
+
+    const result = store.append(
+      BASE_SCOPE,
+      {
+        kind: "recent_event",
+        content: "valid content",
+        metadata: { large: "x".repeat(20) },
+      },
+      BASE_TIME,
+    );
+
+    expect(result).toMatchObject({
+      accepted: false,
+      reason: "metadata_too_large",
+    });
+    expect(store.getCounters().dropped).toBe(1);
+    expect(store.buildContextPackFragment(BASE_SCOPE, BASE_TIME).working_set.items).toEqual([]);
+  });
+
+  it("does not disclose cross-namespace working-set presence in scope denials", () => {
+    const store = new WorkingSetStore();
+    store.append(BASE_SCOPE, { kind: "task_state", content: "base" }, BASE_TIME);
+    store.append(
+      variant({ namespace: "other-ns" }),
+      { kind: "task_state", content: "foreign" },
+      BASE_TIME,
+    );
+    store.append(
+      variant({ channel_id: "adjacent-channel" }),
+      { kind: "task_state", content: "same namespace adjacent" },
+      BASE_TIME,
+    );
+
+    const fragment = store.buildContextPackFragment(BASE_SCOPE, BASE_TIME);
+
+    expect(fragment.warnings.scope_denials).toHaveLength(1);
+    expect(fragment.warnings.scope_denials[0]?.reasons).toEqual([
+      "channel_id",
+    ]);
+  });
+
   it("trims per-session and global budgets and exposes trimmed counters", () => {
     const store = new WorkingSetStore({
       max_items_per_session: 2,
@@ -201,6 +243,7 @@ describe("WorkingSetStore", () => {
       max_sessions: 128,
       max_items_per_session: 24,
       max_global_items: 1024,
+      max_metadata_chars: 2000,
     });
   });
 });

--- a/src/realtime/working-set.ts
+++ b/src/realtime/working-set.ts
@@ -219,7 +219,11 @@ export class WorkingSetStore {
       return this.result(false, "content_too_large");
     }
     const metadata = input.metadata ?? {};
-    if (JSON.stringify(metadata).length > this.budget.max_metadata_chars) {
+    const metadataChars = serializedJsonLength(metadata);
+    if (
+      metadataChars === null ||
+      metadataChars > this.budget.max_metadata_chars
+    ) {
       this.counters.dropped += 1;
       return this.result(false, "metadata_too_large");
     }
@@ -395,4 +399,12 @@ function requireScopePart(value: string, field: string): string {
     throw new Error(`working set scope requires non-empty ${field}`);
   }
   return trimmed;
+}
+
+function serializedJsonLength(value: unknown): number | null {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return null;
+  }
 }

--- a/src/realtime/working-set.ts
+++ b/src/realtime/working-set.ts
@@ -1,0 +1,386 @@
+import { createHash } from "node:crypto";
+
+export const WORKING_SET_LABEL = "working_context" as const;
+export const WORKING_SET_SCHEMA = "openbrain.working_set.v1" as const;
+
+export const WORKING_SET_ITEM_KINDS = [
+  "recent_event",
+  "structured_event",
+  "current_intent",
+  "active_correction",
+  "task_state",
+  "linked_durable_ref",
+  "next_turn_guidance",
+] as const;
+
+export type WorkingSetItemKind = (typeof WORKING_SET_ITEM_KINDS)[number];
+
+export interface WorkingSetScope {
+  namespace: string;
+  agent: string;
+  platform: string;
+  server_id: string;
+  channel_id: string;
+  thread_id?: string | null;
+  session_key: string;
+}
+
+export interface NormalizedWorkingSetScope {
+  namespace: string;
+  agent: string;
+  platform: string;
+  server_id: string;
+  channel_id: string;
+  thread_id: string | null;
+  session_key: string;
+}
+
+export interface WorkingSetBudget {
+  ttl_ms: number;
+  max_sessions: number;
+  max_items_per_session: number;
+  max_global_items: number;
+  max_item_chars: number;
+}
+
+export interface WorkingSetCounters {
+  dropped: number;
+  expired: number;
+  trimmed: number;
+}
+
+export interface WorkingSetItemInput {
+  id?: string;
+  kind: WorkingSetItemKind;
+  content: string;
+  confidence?: number;
+  stale_at?: string | null;
+  trace_id?: string | null;
+  source_ref?: string | null;
+  durable_ref?: { table: string; id: string } | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface WorkingSetItem {
+  id: string;
+  kind: WorkingSetItemKind;
+  label: typeof WORKING_SET_LABEL;
+  content: string;
+  confidence: number | null;
+  stale_at: string | null;
+  trace_id: string | null;
+  source_ref: string | null;
+  durable_ref: { table: string; id: string } | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  expires_at: string;
+}
+
+export interface WorkingSetAppendResult {
+  accepted: boolean;
+  reason?: "content_too_large" | "empty_content" | "invalid_kind";
+  item?: WorkingSetItem;
+  counters: WorkingSetCounters;
+}
+
+export interface WorkingSetScopeDenial {
+  scope_hash: string;
+  reasons: Array<keyof NormalizedWorkingSetScope>;
+}
+
+export interface WorkingSetContextSection {
+  schema: typeof WORKING_SET_SCHEMA;
+  label: typeof WORKING_SET_LABEL;
+  exact_scope_required: true;
+  not_durable_memory: true;
+  scope: NormalizedWorkingSetScope;
+  items: WorkingSetItem[];
+  item_count: number;
+  budget: WorkingSetBudget;
+  counters: WorkingSetCounters;
+}
+
+export interface WorkingSetContextPackFragment {
+  working_set: WorkingSetContextSection;
+  warnings: {
+    scope_denials: WorkingSetScopeDenial[];
+  };
+  budget: {
+    working_set: WorkingSetBudget;
+  };
+}
+
+export const DEFAULT_WORKING_SET_BUDGET: WorkingSetBudget = {
+  ttl_ms: 30 * 60 * 1000,
+  max_sessions: 128,
+  max_items_per_session: 24,
+  max_global_items: 1024,
+  max_item_chars: 4000,
+};
+
+const WORKING_SET_ITEM_KIND_SET = new Set<string>(WORKING_SET_ITEM_KINDS);
+
+interface WorkingSetSession {
+  scope: NormalizedWorkingSetScope;
+  items: WorkingSetItem[];
+  updated_at_ms: number;
+}
+
+export function normalizeWorkingSetScope(
+  scope: WorkingSetScope,
+): NormalizedWorkingSetScope {
+  return {
+    namespace: requireScopePart(scope.namespace, "namespace"),
+    agent: requireScopePart(scope.agent, "agent"),
+    platform: requireScopePart(scope.platform, "platform"),
+    server_id: requireScopePart(scope.server_id, "server_id"),
+    channel_id: requireScopePart(scope.channel_id, "channel_id"),
+    thread_id:
+      scope.thread_id === undefined || scope.thread_id === null
+        ? null
+        : requireScopePart(scope.thread_id, "thread_id"),
+    session_key: requireScopePart(scope.session_key, "session_key"),
+  };
+}
+
+export function workingSetScopeKey(scope: WorkingSetScope): string {
+  const normalized = normalizeWorkingSetScope(scope);
+  return JSON.stringify([
+    normalized.namespace,
+    normalized.agent,
+    normalized.platform,
+    normalized.server_id,
+    normalized.channel_id,
+    normalized.thread_id,
+    normalized.session_key,
+  ]);
+}
+
+export function workingSetScopeHash(scope: WorkingSetScope): string {
+  return createHash("sha256")
+    .update(workingSetScopeKey(scope))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function compareWorkingSetScope(
+  left: WorkingSetScope,
+  right: WorkingSetScope,
+): Array<keyof NormalizedWorkingSetScope> {
+  const a = normalizeWorkingSetScope(left);
+  const b = normalizeWorkingSetScope(right);
+  const fields: Array<keyof NormalizedWorkingSetScope> = [
+    "namespace",
+    "agent",
+    "platform",
+    "server_id",
+    "channel_id",
+    "thread_id",
+    "session_key",
+  ];
+  return fields.filter((field) => a[field] !== b[field]);
+}
+
+export class WorkingSetStore {
+  readonly budget: WorkingSetBudget;
+  private sessions = new Map<string, WorkingSetSession>();
+  private counters: WorkingSetCounters = { dropped: 0, expired: 0, trimmed: 0 };
+  private nextId = 1;
+
+  constructor(budget: Partial<WorkingSetBudget> = {}) {
+    this.budget = { ...DEFAULT_WORKING_SET_BUDGET, ...budget };
+  }
+
+  append(
+    scope: WorkingSetScope,
+    input: WorkingSetItemInput,
+    now: Date = new Date(),
+  ): WorkingSetAppendResult {
+    this.purgeExpired(now);
+
+    if (!WORKING_SET_ITEM_KIND_SET.has(input.kind)) {
+      this.counters.dropped += 1;
+      return this.result(false, "invalid_kind");
+    }
+
+    const content = input.content.trim();
+    if (content.length === 0) {
+      this.counters.dropped += 1;
+      return this.result(false, "empty_content");
+    }
+    if (content.length > this.budget.max_item_chars) {
+      this.counters.dropped += 1;
+      return this.result(false, "content_too_large");
+    }
+
+    const normalizedScope = normalizeWorkingSetScope(scope);
+    const key = workingSetScopeKey(normalizedScope);
+    const nowMs = now.getTime();
+    const session = this.sessions.get(key) ?? {
+      scope: normalizedScope,
+      items: [],
+      updated_at_ms: nowMs,
+    };
+
+    const item: WorkingSetItem = {
+      id: input.id ?? `ws-${this.nextId++}`,
+      kind: input.kind,
+      label: WORKING_SET_LABEL,
+      content,
+      confidence: input.confidence ?? null,
+      stale_at: input.stale_at ?? null,
+      trace_id: input.trace_id ?? null,
+      source_ref: input.source_ref ?? null,
+      durable_ref: input.durable_ref ?? null,
+      metadata: input.metadata ?? {},
+      created_at: now.toISOString(),
+      expires_at: new Date(nowMs + this.budget.ttl_ms).toISOString(),
+    };
+
+    session.items.push(item);
+    session.updated_at_ms = nowMs;
+    this.sessions.set(key, session);
+    this.trimSession(session);
+    this.trimGlobal();
+    this.trimSessions();
+
+    return { accepted: true, item, counters: this.getCounters() };
+  }
+
+  buildContextPackFragment(
+    scope: WorkingSetScope,
+    now: Date = new Date(),
+  ): WorkingSetContextPackFragment {
+    this.purgeExpired(now);
+    const normalizedScope = normalizeWorkingSetScope(scope);
+    const key = workingSetScopeKey(normalizedScope);
+    const items = this.sessions.get(key)?.items ?? [];
+
+    return {
+      working_set: {
+        schema: WORKING_SET_SCHEMA,
+        label: WORKING_SET_LABEL,
+        exact_scope_required: true,
+        not_durable_memory: true,
+        scope: normalizedScope,
+        items: [...items],
+        item_count: items.length,
+        budget: this.budget,
+        counters: this.getCounters(),
+      },
+      warnings: {
+        scope_denials: this.scopeDenialsFor(normalizedScope),
+      },
+      budget: {
+        working_set: this.budget,
+      },
+    };
+  }
+
+  getCounters(): WorkingSetCounters {
+    return { ...this.counters };
+  }
+
+  private result(
+    accepted: false,
+    reason: WorkingSetAppendResult["reason"],
+  ): WorkingSetAppendResult {
+    return { accepted, reason, counters: this.getCounters() };
+  }
+
+  private purgeExpired(now: Date): void {
+    const nowMs = now.getTime();
+    for (const [key, session] of this.sessions.entries()) {
+      const kept = session.items.filter(
+        (item) => Date.parse(item.expires_at) > nowMs,
+      );
+      const expired = session.items.length - kept.length;
+      if (expired > 0) {
+        this.counters.expired += expired;
+        session.items = kept;
+      }
+      if (session.items.length === 0) {
+        this.sessions.delete(key);
+      }
+    }
+  }
+
+  private trimSession(session: WorkingSetSession): void {
+    const overflow = session.items.length - this.budget.max_items_per_session;
+    if (overflow > 0) {
+      session.items.splice(0, overflow);
+      this.counters.trimmed += overflow;
+    }
+  }
+
+  private trimGlobal(): void {
+    while (this.globalItemCount() > this.budget.max_global_items) {
+      const oldest = this.oldestSession();
+      if (!oldest) {
+        return;
+      }
+      oldest.items.shift();
+      this.counters.trimmed += 1;
+      if (oldest.items.length === 0) {
+        this.sessions.delete(workingSetScopeKey(oldest.scope));
+      }
+    }
+  }
+
+  private trimSessions(): void {
+    while (this.sessions.size > this.budget.max_sessions) {
+      const oldest = this.oldestSession();
+      if (!oldest) {
+        return;
+      }
+      this.counters.trimmed += oldest.items.length;
+      this.sessions.delete(workingSetScopeKey(oldest.scope));
+    }
+  }
+
+  private oldestSession(): WorkingSetSession | null {
+    let oldest: WorkingSetSession | null = null;
+    for (const session of this.sessions.values()) {
+      if (!oldest || session.updated_at_ms < oldest.updated_at_ms) {
+        oldest = session;
+      }
+    }
+    return oldest;
+  }
+
+  private globalItemCount(): number {
+    let count = 0;
+    for (const session of this.sessions.values()) {
+      count += session.items.length;
+    }
+    return count;
+  }
+
+  private scopeDenialsFor(
+    requestedScope: NormalizedWorkingSetScope,
+  ): WorkingSetScopeDenial[] {
+    const requestedKey = workingSetScopeKey(requestedScope);
+    const denials: WorkingSetScopeDenial[] = [];
+    for (const [key, session] of this.sessions.entries()) {
+      if (key === requestedKey) {
+        continue;
+      }
+      const reasons = compareWorkingSetScope(requestedScope, session.scope);
+      if (reasons.length > 0) {
+        denials.push({
+          scope_hash: workingSetScopeHash(session.scope),
+          reasons,
+        });
+      }
+    }
+    return denials;
+  }
+}
+
+function requireScopePart(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`working set scope requires non-empty ${field}`);
+  }
+  return trimmed;
+}

--- a/src/realtime/working-set.ts
+++ b/src/realtime/working-set.ts
@@ -41,6 +41,7 @@ export interface WorkingSetBudget {
   max_items_per_session: number;
   max_global_items: number;
   max_item_chars: number;
+  max_metadata_chars: number;
 }
 
 export interface WorkingSetCounters {
@@ -78,7 +79,11 @@ export interface WorkingSetItem {
 
 export interface WorkingSetAppendResult {
   accepted: boolean;
-  reason?: "content_too_large" | "empty_content" | "invalid_kind";
+  reason?:
+    | "content_too_large"
+    | "empty_content"
+    | "invalid_kind"
+    | "metadata_too_large";
   item?: WorkingSetItem;
   counters: WorkingSetCounters;
 }
@@ -116,6 +121,7 @@ export const DEFAULT_WORKING_SET_BUDGET: WorkingSetBudget = {
   max_items_per_session: 24,
   max_global_items: 1024,
   max_item_chars: 4000,
+  max_metadata_chars: 2000,
 };
 
 const WORKING_SET_ITEM_KIND_SET = new Set<string>(WORKING_SET_ITEM_KINDS);
@@ -212,6 +218,11 @@ export class WorkingSetStore {
       this.counters.dropped += 1;
       return this.result(false, "content_too_large");
     }
+    const metadata = input.metadata ?? {};
+    if (JSON.stringify(metadata).length > this.budget.max_metadata_chars) {
+      this.counters.dropped += 1;
+      return this.result(false, "metadata_too_large");
+    }
 
     const normalizedScope = normalizeWorkingSetScope(scope);
     const key = workingSetScopeKey(normalizedScope);
@@ -232,7 +243,7 @@ export class WorkingSetStore {
       trace_id: input.trace_id ?? null,
       source_ref: input.source_ref ?? null,
       durable_ref: input.durable_ref ?? null,
-      metadata: input.metadata ?? {},
+      metadata,
       created_at: now.toISOString(),
       expires_at: new Date(nowMs + this.budget.ttl_ms).toISOString(),
     };
@@ -268,9 +279,7 @@ export class WorkingSetStore {
         budget: this.budget,
         counters: this.getCounters(),
       },
-      warnings: {
-        scope_denials: this.scopeDenialsFor(normalizedScope),
-      },
+      warnings: { scope_denials: this.scopeDenialsFor(normalizedScope) },
       budget: {
         working_set: this.budget,
       },
@@ -363,6 +372,9 @@ export class WorkingSetStore {
     const denials: WorkingSetScopeDenial[] = [];
     for (const [key, session] of this.sessions.entries()) {
       if (key === requestedKey) {
+        continue;
+      }
+      if (session.scope.namespace !== requestedScope.namespace) {
         continue;
       }
       const reasons = compareWorkingSetScope(requestedScope, session.scope);

--- a/src/tools/__tests__/agent-context-pack.test.ts
+++ b/src/tools/__tests__/agent-context-pack.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  registerAgentContextPack,
+  registerWorkingSetAppend,
+} from "../agent-context-pack.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+import { WorkingSetStore } from "../../realtime/working-set.ts";
+
+function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
+  return async (_text: string) => result;
+}
+
+async function setupToolClient(
+  auth: AuthInfo,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = {
+    pool: { query: async () => ({ rows: [] }) } as any,
+    embedFn: createMockEmbed(),
+    workingSetStore: new WorkingSetStore(),
+  };
+  registerWorkingSetAppend(server, deps);
+  registerAgentContextPack(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) => {
+    return originalSend(message, { ...options, authInfo: auth });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+const SCOPE = {
+  namespace: "rico",
+  agent: "nagatha",
+  platform: "discord",
+  server_id: "rodaddy-live",
+  channel_id: "open-brain",
+  session_key: "discord:rodaddy-live:open-brain:nagatha",
+};
+
+describe("agent_context_pack and working_set_append", () => {
+  it("round-trips RAM-only working context through exact-scope context pack", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth);
+
+    try {
+      const append = await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          kind: "current_intent",
+          content: "Finish #222 without deploying core01.",
+          trace_id: "trace-222",
+        },
+      });
+
+      expect(append.isError).toBeFalsy();
+      const appendPayload = JSON.parse((append.content as any)[0].text);
+      expect(appendPayload).toMatchObject({
+        accepted: true,
+        not_durable_memory: true,
+      });
+      expect(appendPayload.item).toMatchObject({
+        kind: "current_intent",
+        label: "working_context",
+      });
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+        },
+      });
+
+      expect(pack.isError).toBeFalsy();
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(payload).toMatchObject({
+        schema: "openbrain.agent_context_pack.v1",
+        status: "ok",
+      });
+      expect(payload.sections.working_set).toMatchObject({
+        label: "working_context",
+        exact_scope_required: true,
+        not_durable_memory: true,
+        item_count: 1,
+      });
+      expect(payload.sections.working_set.items[0]).toMatchObject({
+        content: "Finish #222 without deploying core01.",
+        label: "working_context",
+        trace_id: "trace-222",
+      });
+      expect(payload.warnings.scope_denials).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not include adjacent-scope working context and reports scope denial", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth);
+
+    try {
+      await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          kind: "task_state",
+          content: "base task",
+        },
+      });
+      await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          channel_id: "adjacent-channel",
+          kind: "task_state",
+          content: "adjacent task",
+        },
+      });
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(payload.sections.working_set.items.map((item: any) => item.content)).toEqual([
+        "base task",
+      ]);
+      expect(payload.warnings.scope_denials).toHaveLength(1);
+      expect(payload.warnings.scope_denials[0].reasons).toContain("channel_id");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects RAM working-set writes for readonly auth", async () => {
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupToolClient(auth);
+
+    try {
+      const append = await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          namespace: "viewer",
+          kind: "current_intent",
+          content: "readonly should fail",
+        },
+      });
+
+      expect(append.isError).toBe(true);
+      expect((append.content as any)[0].text).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/agent-context-pack.test.ts
+++ b/src/tools/__tests__/agent-context-pack.test.ts
@@ -156,6 +156,73 @@ describe("agent_context_pack and working_set_append", () => {
     }
   });
 
+  it("does not disclose foreign-namespace working-set denials", async () => {
+    const adminAuth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(adminAuth);
+
+    try {
+      await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          kind: "task_state",
+          content: "base task",
+        },
+      });
+      await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          namespace: "kevin",
+          kind: "task_state",
+          content: "foreign task",
+        },
+      });
+
+      const viewer = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+        },
+      });
+
+      const payload = JSON.parse((viewer.content as any)[0].text);
+      expect(payload.sections.working_set.items.map((item: any) => item.content)).toEqual([
+        "base task",
+      ]);
+      expect(payload.warnings.scope_denials).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects oversized metadata before retaining RAM context", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth);
+
+    try {
+      const append = await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          kind: "current_intent",
+          content: "valid content",
+          metadata: { large: "x".repeat(3000) },
+        },
+      });
+
+      expect(append.isError).toBe(true);
+      const payload = JSON.parse((append.content as any)[0].text);
+      expect(payload).toMatchObject({
+        accepted: false,
+        reason: "metadata_too_large",
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("rejects RAM working-set writes for readonly auth", async () => {
     const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
     const { client, cleanup } = await setupToolClient(auth);

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -1,0 +1,239 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead, canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
+import { canReadNamespace } from "../read-policy.ts";
+import type { AuthInfo } from "../types.ts";
+import {
+  WORKING_SET_ITEM_KINDS,
+  WorkingSetStore,
+  normalizeWorkingSetScope,
+  type WorkingSetScope,
+} from "../realtime/working-set.ts";
+import type { ToolDeps } from "./index.ts";
+
+const SECTION_NAMES = [
+  "working_set",
+  "durable_lane_context",
+  "durable_memory",
+  "profile_guidance",
+  "process_guidance",
+  "repo_facts",
+  "pointers",
+  "candidate_memory",
+] as const;
+
+const scopeInputSchema = {
+  namespace: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Namespace for isolation; defaults to auth-derived clientId"),
+  agent: z.string().min(1).max(200).describe("Active agent identity"),
+  platform: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe("Runtime platform/source, such as discord"),
+  server_id: z.string().min(1).max(500).describe("Server/guild/workspace id"),
+  channel_id: z.string().min(1).max(500).describe("Channel/conversation id"),
+  thread_id: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Optional thread id; missing means unthreaded only"),
+  session_key: z
+    .string()
+    .min(1)
+    .max(500)
+    .describe("Stable active-session key"),
+};
+
+export function registerWorkingSetAppend(
+  server: McpServer,
+  deps: ToolDeps,
+): void {
+  server.registerTool(
+    "working_set_append",
+    {
+      description:
+        "Append one RAM-only scoped working-set item for the exact active " +
+        "namespace/agent/platform/server/channel/thread/session. This does " +
+        "not write durable memory or shared-kb.",
+      inputSchema: {
+        ...scopeInputSchema,
+        kind: z.enum(WORKING_SET_ITEM_KINDS).describe("Working-set item kind"),
+        content: z
+          .string()
+          .min(1)
+          .max(4000)
+          .describe("Bounded working context content, not durable memory"),
+        confidence: z.number().min(0).max(1).optional(),
+        stale_at: z.string().max(100).optional(),
+        trace_id: z.string().max(500).optional(),
+        source_ref: z.string().max(1000).optional(),
+        durable_ref: z
+          .object({
+            table: z.string().min(1).max(100),
+            id: z.string().min(1).max(200),
+          })
+          .optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      },
+      annotations: {
+        title: "Working Set Append",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canWrite(auth.role, "sessions")) {
+        return textError("Permission denied: cannot write working set");
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return textError(nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`);
+      }
+
+      const result = storeFor(deps).append({
+        namespace: ns,
+        agent: args.agent,
+        platform: args.platform,
+        server_id: args.server_id,
+        channel_id: args.channel_id,
+        thread_id: args.thread_id ?? null,
+        session_key: args.session_key,
+      }, {
+        kind: args.kind,
+        content: args.content,
+        confidence: args.confidence,
+        stale_at: args.stale_at ?? null,
+        trace_id: args.trace_id ?? null,
+        source_ref: args.source_ref ?? null,
+        durable_ref: args.durable_ref ?? null,
+        metadata: args.metadata,
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              accepted: result.accepted,
+              reason: result.reason ?? null,
+              item: result.item ?? null,
+              counters: result.counters,
+              not_durable_memory: true,
+            }),
+          },
+        ],
+        isError: !result.accepted,
+      };
+    },
+  );
+}
+
+export function registerAgentContextPack(
+  server: McpServer,
+  deps: ToolDeps,
+): void {
+  server.registerTool(
+    "agent_context_pack",
+    {
+      description:
+        "Build a scoped realtime agent context pack. The working_set section " +
+        "is included only for the exact namespace/agent/platform/server/" +
+        "channel/thread/session scope.",
+      inputSchema: {
+        ...scopeInputSchema,
+        query: z.string().max(4000).optional(),
+        requested_sections: z.array(z.enum(SECTION_NAMES)).optional(),
+        budget: z
+          .object({
+            max_tokens: z.number().int().min(100).max(20000).optional(),
+            max_latency_ms: z.number().int().min(1).max(10000).optional(),
+          })
+          .optional(),
+      },
+      annotations: {
+        title: "Agent Context Pack",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canRead(auth.role, "sessions")) {
+        return textError("Permission denied: cannot read agent context pack");
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      if (!canReadNamespace(auth, ns)) {
+        return textError(`Permission denied: cannot read namespace '${ns}'`);
+      }
+
+      const scope: WorkingSetScope = {
+        namespace: ns,
+        agent: args.agent,
+        platform: args.platform,
+        server_id: args.server_id,
+        channel_id: args.channel_id,
+        thread_id: args.thread_id ?? null,
+        session_key: args.session_key,
+      };
+      const normalizedScope = normalizeWorkingSetScope(scope);
+      const includeWorkingSet =
+        !args.requested_sections ||
+        args.requested_sections.includes("working_set");
+      const workingSet = storeFor(deps).buildContextPackFragment(scope);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              schema: "openbrain.agent_context_pack.v1",
+              status: "ok",
+              scope: {
+                namespace_source: "authorization",
+                ...normalizedScope,
+              },
+              sections: includeWorkingSet
+                ? { working_set: workingSet.working_set }
+                : {},
+              warnings: includeWorkingSet
+                ? workingSet.warnings
+                : { scope_denials: [] },
+              budget: {
+                requested: args.budget ?? null,
+                ...workingSet.budget,
+              },
+              citations: [],
+              query: args.query ?? null,
+            }),
+          },
+        ],
+      };
+    },
+  );
+}
+
+function storeFor(deps: ToolDeps): WorkingSetStore {
+  deps.workingSetStore ??= new WorkingSetStore();
+  return deps.workingSetStore;
+}
+
+function textError(text: string): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [{ type: "text", text }],
+    isError: true,
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -47,59 +47,72 @@ import { registerTierLane } from "./tier-lane.ts";
 import { registerPromoteShared } from "./promote-shared.ts";
 import { registerGetContract } from "./get-contract.ts";
 import { registerListRepoFacts, registerUpsertRepoFact } from "./repo-facts.ts";
+import {
+  registerAgentContextPack,
+  registerWorkingSetAppend,
+} from "./agent-context-pack.ts";
+import { WorkingSetStore } from "../realtime/working-set.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
   embedFn: typeof generateEmbedding;
   allowNonTransactionalAppendFallback?: boolean;
+  workingSetStore?: WorkingSetStore;
 }
 
 export function registerAllTools(server: McpServer, deps: ToolDeps): void {
-  registerLogThought(server, deps);
-  registerLogDecision(server, deps);
-  registerSearchBrain(server, deps);
-  registerFindPerson(server, deps);
-  registerSessionSave(server, deps);
-  registerSessionLoad(server, deps);
-  registerArchiveEntry(server, deps);
-  registerListRecent(server, deps);
-  registerListStale(server, deps);
-  registerUpdateEntry(server, deps);
-  registerRateEntry(server, deps);
-  registerSearchAll(server, deps);
-  registerBrainAnswer(server, deps);
-  registerUpsertPerson(server, deps);
-  registerSetTier(server, deps);
-  registerGetEntry(server, deps);
-  registerResolveEntry(server, deps);
-  registerGetStats(server, deps);
-  registerAccessReport(server, deps);
-  registerBulkSetTier(server, deps);
-  registerFindDuplicates(server, deps);
-  registerCurateEntries(server, deps);
-  registerBulkArchive(server, deps);
-  registerListNamespaces(server, deps);
-  registerTierRecommendations(server, deps);
-  registerLaneUpsert(server, deps);
-  registerLaneLoad(server, deps);
-  registerAppendSessionEvent(server, deps);
-  registerSessionContext(server, deps);
-  registerSessionStart(server, deps);
-  registerSessionWrap(server, deps);
-  registerUpsertEntity(server, deps);
-  registerArchiveEntity(server, deps);
-  registerGetEntity(server, deps);
-  registerHydrateEntities(server, deps);
-  registerListEntities(server, deps);
-  registerLinkEntities(server, deps);
-  registerUnlinkEntities(server, deps);
-  registerAdjacentContext(server, deps);
-  registerPromoteEntry(server, deps);
-  registerDemoteEntry(server, deps);
-  registerScanNamespace(server, deps);
-  registerTierLane(server, deps);
-  registerPromoteShared(server, deps);
-  registerGetContract(server, deps);
-  registerUpsertRepoFact(server, deps);
-  registerListRepoFacts(server, deps);
+  const toolDeps: ToolDeps = {
+    ...deps,
+    workingSetStore: deps.workingSetStore ?? new WorkingSetStore(),
+  };
+
+  registerLogThought(server, toolDeps);
+  registerLogDecision(server, toolDeps);
+  registerSearchBrain(server, toolDeps);
+  registerFindPerson(server, toolDeps);
+  registerSessionSave(server, toolDeps);
+  registerSessionLoad(server, toolDeps);
+  registerArchiveEntry(server, toolDeps);
+  registerListRecent(server, toolDeps);
+  registerListStale(server, toolDeps);
+  registerUpdateEntry(server, toolDeps);
+  registerRateEntry(server, toolDeps);
+  registerSearchAll(server, toolDeps);
+  registerBrainAnswer(server, toolDeps);
+  registerUpsertPerson(server, toolDeps);
+  registerSetTier(server, toolDeps);
+  registerGetEntry(server, toolDeps);
+  registerResolveEntry(server, toolDeps);
+  registerGetStats(server, toolDeps);
+  registerAccessReport(server, toolDeps);
+  registerBulkSetTier(server, toolDeps);
+  registerFindDuplicates(server, toolDeps);
+  registerCurateEntries(server, toolDeps);
+  registerBulkArchive(server, toolDeps);
+  registerListNamespaces(server, toolDeps);
+  registerTierRecommendations(server, toolDeps);
+  registerLaneUpsert(server, toolDeps);
+  registerLaneLoad(server, toolDeps);
+  registerAppendSessionEvent(server, toolDeps);
+  registerSessionContext(server, toolDeps);
+  registerSessionStart(server, toolDeps);
+  registerSessionWrap(server, toolDeps);
+  registerUpsertEntity(server, toolDeps);
+  registerArchiveEntity(server, toolDeps);
+  registerGetEntity(server, toolDeps);
+  registerHydrateEntities(server, toolDeps);
+  registerListEntities(server, toolDeps);
+  registerLinkEntities(server, toolDeps);
+  registerUnlinkEntities(server, toolDeps);
+  registerAdjacentContext(server, toolDeps);
+  registerPromoteEntry(server, toolDeps);
+  registerDemoteEntry(server, toolDeps);
+  registerScanNamespace(server, toolDeps);
+  registerTierLane(server, toolDeps);
+  registerPromoteShared(server, toolDeps);
+  registerWorkingSetAppend(server, toolDeps);
+  registerAgentContextPack(server, toolDeps);
+  registerGetContract(server, toolDeps);
+  registerUpsertRepoFact(server, toolDeps);
+  registerListRepoFacts(server, toolDeps);
 }


### PR DESCRIPTION
## Summary

Closes #222.

- Add RAM-first scoped working-set storage with exact-scope keys:
  `namespace + agent + platform + server_id + channel_id + thread_id + session_key`.
- Add local MCP tools:
  - `working_set_append` for scoped RAM-only working context writes.
  - `agent_context_pack` for exact-scope working-set reads.
- Keep working-set content explicitly labeled `working_context` and `not_durable_memory`.
- Expose TTL/budget/counter metadata for dropped, expired, and trimmed entries.
- Update TypeScript contract metadata to `2026-07-06.memory-tools.v16`.
- Update Python `openbrain-memory` contract snapshot and thin wrappers.

## Validation

- `bun test src/realtime/working-set.test.ts src/tools/__tests__/agent-context-pack.test.ts src/contract.test.ts`
- `bunx tsc --noEmit`
- `uv run pytest -q tests/test_client.py tests/test_contract.py`
- `uv run mypy src/openbrain_memory`
- `uv run ruff check src tests`
- `git diff --check`

## Deploy / Rollout

- Local-only implementation and validation.
- No core01 deploy performed.
- NATS transport remains planned under #223 and is not enabled here.
- Downstream live rollout remains separate from this PR.

## Critical self-review

- Highest-risk behavior: working-set scope isolation must not leak active context across namespace, agent, platform, server, channel, thread, or session.
- Assumptions that could be wrong: in-process RAM is enough for #222 before #221 recovery WAL lands; restart behavior intentionally loses working-set state until #221.
- Missing/weak tests: no live hosted canary; tests cover local MCP protocol and exact-scope denial with fake transport only.
- Security/permission risk: new append/read tools must enforce server-side auth and namespace authority. Tests cover readonly append denial and exact-scope read denial metadata.
- Migration/deploy risk: no DB migration and no deploy in this PR; contract version bumps to v16 and downstream consumers need release-gated rollout.
- Downstream client/runtime risk: Python snapshot and wrappers are updated; Hermes/mcp2cli live rollout is deferred.
- Rollback/cleanup concern: disabling/removing the tools reverts working-set availability; no durable data migration to roll back.
- Fixes made before PR: critical self-review found module-only implementation was insufficient, so this PR wires MCP tools and Python wrappers before opening.
- Known residual risk: working-set state is process-local and non-recoverable until #221 implements recovery WAL.
- SME review-memory update: [ ] `docs/sme/` updated [x] not applicable because: no new MEDIUM+ review pattern has been identified before the initial swarm.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured before merge; initial swarm is running and findings will be posted as PR comments before readiness.
- Live Open Brain checks: [ ] linked below [x] not applicable because: this is a local-only PR with no core01 deploy or live runtime rollout.
