### PR TITLE
Add scoped source references for closed-brain deployments

### DIFF
--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -223,6 +223,11 @@ them through namespace-only reads unless every generic read surface redacts by
 default. Scope filters must also account for every identifier accepted on
 `source_refs`; accepting `path` or `dms_id` without allowing the same fields in
 `source_scope` creates write-only provenance that cannot be safely returned.
+The scope gate and the returned-source-ref filter must validate refs at the same
+granularity: all-or-nothing array validation can silently drop a valid matching
+ref when any sibling ref is malformed, and SQL gates that do not require a
+document identifier can let row content pass a scope that no returned citation
+can satisfy.
 
 ### Review Questions
 
@@ -240,3 +245,8 @@ default. Scope filters must also account for every identifier accepted on
   returning unscoped evidence?
 - Do regression tests cover parameterization, same-ref matching, scoped output
   filtering, and unscoped read redaction?
+- Does returned-source-ref filtering keep valid matching refs even when a
+  sibling ref is malformed, instead of dropping the whole array?
+- Does the SQL scope gate require the matched array element to be a real
+  citable ref (`document_id`, `path`, or `dms_id`) so row visibility and
+  returned citations agree?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -201,3 +201,42 @@ promotion -- the forward path and its reversal path diverged in authority.
   grant the same roles? Asymmetry is usually a bug.
 - Does the parity regression suite enumerate every gate (REST and MCP variants
   separately) rather than spot-checking one?
+
+## [2026-07-06] Privileged source-scope predicates must match one source reference
+
+**Severity:** HIGH
+**Source:** PR #255 pre-PR and initial swarm review for Issue #118
+**Scope:** `src/source-refs.ts`, `src/tools/get-entry.ts`,
+`src/tools/search-brain.ts`, `src/tools/search-all.ts`,
+`src/tools/brain-answer.ts`, generic full-row REST reads
+**Status:** fixed in PR #255; keep as active checklist
+
+### Pattern
+
+Structured source metadata is a privilege boundary for closed-brain deployments.
+A JSONB predicate that checks `client_id`, `matter_id`, and `document_id` with
+independent containment clauses can match those keys across separate
+`source_refs` objects on the same row. That lets one row satisfy a scoped query
+even though no single cited source belongs to the requested client/matter/doc.
+Adding privileged `source_refs` to shared full-row projections can also leak
+them through namespace-only reads unless every generic read surface redacts by
+default. Scope filters must also account for every identifier accepted on
+`source_refs`; accepting `path` or `dms_id` without allowing the same fields in
+`source_scope` creates write-only provenance that cannot be safely returned.
+
+### Review Questions
+
+- Do multi-key source-scope filters require all supplied keys to match the same
+  `source_refs` array element, for example through `jsonb_array_elements` and
+  one `EXISTS` predicate?
+- Are all accepted source-ref identifiers represented in `source_scope`
+  (`client_id`, `matter_id`, `document_id`, `path`, and `dms_id`)?
+- Are scoped filters parameterized and applied consistently to search,
+  answer/citation, compact fetch, and full fetch paths?
+- Do unscoped namespace-only reads redact privileged `source_refs` by default?
+- Does any generic shared projection include privileged source metadata without
+  a caller-specific redaction or scope gate?
+- Do scoped searches exclude result families without `source_refs` rather than
+  returning unscoped evidence?
+- Do regression tests cover parameterization, same-ref matching, scoped output
+  filtering, and unscoped read redaction?

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -41,7 +41,7 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v18"
+CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v19"
 COMPATIBLE_CONTRACT_VERSIONS = (CURRENT_CONTRACT_VERSION,)
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -579,7 +579,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v18"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v19"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/specs/open-issues-and-prs-completion-roadmap.html
+++ b/specs/open-issues-and-prs-completion-roadmap.html
@@ -175,17 +175,17 @@
   <!-- ===== HEADER + UPDATABLE METADATA ===== -->
   <header>
     <h1>Plan: Open Brain — Work All Open Issues &amp; Complete All Open PRs</h1>
-    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: 1 open PR (#244) · 11 open issues as of 2026-07-06; #176 is in pre-merge-gauntlet review, Phase 3 Claude findings are fixed locally, and deploy remains skipped.</p>
+    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 is open; the branch includes the antagonist source-scope auth fix from <code>a859b89</code>, local validation passes, push/CI is pending for the updated branch, and deploy remains deferred.</p>
     <details class="meta">
       <summary>Metadata</summary>
       <dl>
         <dt>created</dt>      <dd>2026-07-05T00:39:00-08:00</dd>
-        <dt>modified</dt>     <dd>2026-07-05T00:39:00-08:00, 2026-07-05T01:55:00-08:00, 2026-07-05T12:55:00-04:00, 2026-07-05T13:42:05-04:00, 2026-07-05T14:20:00-04:00, 2026-07-05T18:25:00-04:00, 2026-07-06T02:15:00-04:00, 2026-07-06T02:35:00-04:00, 2026-07-06T02:45:00-04:00, 2026-07-06T03:10:00-04:00, 2026-07-06T03:25:00-04:00</dd>
-        <dt>commits</dt>      <dd>b4a3020 (branch HEAD at authoring time)</dd>
-        <dt>agent name</dt>        <dd>claude-fable-5 (Claude Code)</dd>
-        <dt>session id</dt>      <dd>open-brain planf3 session 2026-07-05</dd>
+        <dt>modified</dt>     <dd>2026-07-05T00:39:00-08:00, 2026-07-05T01:55:00-08:00, 2026-07-05T12:55:00-04:00, 2026-07-05T13:42:05-04:00, 2026-07-05T14:20:00-04:00, 2026-07-05T18:25:00-04:00, 2026-07-06T02:15:00-04:00, 2026-07-06T02:35:00-04:00, 2026-07-06T02:45:00-04:00, 2026-07-06T03:10:00-04:00, 2026-07-06T03:25:00-04:00, 2026-07-06T16:22:31-04:00</dd>
+        <dt>commits</dt>      <dd>a859b89 (source-scope auth fix), 6b73431 (Python contract pin), 74f391d (initial swarm fixes)</dd>
+        <dt>agent name</dt>        <dd>admin255-board-roadmap</dd>
+        <dt>session id</dt>      <dd>open-brain plan3f session 2026-07-06</dd>
         <dt>back refs</dt>    <dd>goal-run.md (memory-substrate goal run), docs/realtime-agent-memory-research.md (PR #225), docs/downstream-rollout.md, docs/memory-contract.md</dd>
-        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: none; remaining issues are #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
+        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (updated branch pending push/CI). Remaining issues include #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
       </dl>
     </details>
   </header>
@@ -199,7 +199,7 @@
   <!-- ===== PURPOSE / PROBLEM / SOLUTION ===== -->
   <section id="purpose">
     <h2>Purpose</h2>
-    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is 0 open PRs and 9 open issues (#229, #224, #223, #222, #221, #192, #167, #137, #118). PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, and #244 are merged; #165, #204, #176, and #166 are closed. PR #240 made deploy optional through the release SOP; no production deploy has been performed. #167 remains open only for live migration/release-gated work. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
+    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test). The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>. Push/CI is pending for the updated branch, and deploy remains intentionally deferred. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
     <p>Drive the open-brain repo to a clean board: every open PR merged or explicitly held, and all remaining open issues either closed with tested, rollout-gated changes or explicitly dispositioned as roadmap items with a documented decision. The plan sequences work so infrastructure fixes (review pipeline, CI Postgres) land first and protect everything after them, and groups issues into coherent PR-sized batches that respect the repo's pre-merge gauntlet, critical self-review gate, and downstream rollout gate.</p>
   </section>
 
@@ -230,7 +230,7 @@
       <tr><td>3</td><td>#168, #166, #167</td><td>n8n→ob-admin rename · stale collab docs · retire collab</td><td class="chg">Partial (#166 lives in mcp2cli skill refs; #167 touches read-fallback)</td></tr>
       <tr><td>4</td><td>#177, #204, #176</td><td>Installable Python client · UUID resolver · structured share_candidate rejection</td><td class="yes">Yes — all three</td></tr>
       <tr><td>5</td><td>#223, #222, #221, #224, #229</td><td>Realtime memory epic (#220 family), strict order</td><td class="yes">Yes — Hermes canary per slice</td></tr>
-      <tr><td>6</td><td>#192, #137, #118</td><td>Condensed retrieval · qmd deep-lookup · file refs roadmap</td><td class="chg">Decision-dependent</td></tr>
+      <tr><td>6</td><td>#192, #137, #118</td><td>Condensed retrieval · qmd deep-lookup · file refs roadmap</td><td class="chg">#118 is roadmap-bound and under review; deploy deferred</td></tr>
     </table>
   </section>
 
@@ -528,7 +528,7 @@
     <!-- ============ PHASE 6 ============ -->
     <div class="phase">
       <h3><code class="status">[]</code> Phase 6: Roadmap disposition — #192, #137, #118</h3>
-      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc.</p>
+      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc. Current #118 state is PR #255 with the updated branch pending push/CI, board status <code>In Review</code>, review gate <code>Fix Verification Running</code>, validation pending after the source-scope auth fix, with deploy deferred.</p>
 
       <figure>
         <!-- {{PHASE_IMAGE: dark triage board with three cards routing to lanes labeled "build", "defer + doc", "roadmap", amber accent}} -->
@@ -551,7 +551,7 @@
       <h4>3. #118 — File references / closed-brain roadmap</h4>
       <ul class="checklist">
         <li><code class="status">[]</code> Capture the source-reference design (matter-scoped grounding, audit trail, ethical walls) into <code>docs/roadmap/file-references.md</code> so the thinking survives outside the issue.</li>
-        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call.</li>
+        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call. Current execution evidence: PR #255 updated branch, local validation passed, source-scope auth finding fixed, push/CI pending, deploy deferred.</li>
       </ul>
 
       <h4>4. Testing Strategy</h4>

--- a/specs/open-issues-and-prs-completion-roadmap.html
+++ b/specs/open-issues-and-prs-completion-roadmap.html
@@ -175,17 +175,17 @@
   <!-- ===== HEADER + UPDATABLE METADATA ===== -->
   <header>
     <h1>Plan: Open Brain — Work All Open Issues &amp; Complete All Open PRs</h1>
-    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 is open; the branch includes the antagonist source-scope auth fix from <code>a859b89</code>, local validation and CI passed before the roadmap-only blocker update, fix-verification is clean, Phase 3 Claude cross-review is blocked, and deploy remains deferred.</p>
+    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 includes the Phase 3 source-scope fixes from <code>3e04d5a</code>; local validation passed, GitHub CI passed, deploy jobs skipped by design, Claude/Opus cross-review completed through a code-focused packet, Phase 3 findings were fixed, Phase 4 fix-verification is clean, and deploy remains deferred.</p>
     <details class="meta">
       <summary>Metadata</summary>
       <dl>
         <dt>created</dt>      <dd>2026-07-05T00:39:00-08:00</dd>
-        <dt>modified</dt>     <dd>2026-07-05T00:39:00-08:00, 2026-07-05T01:55:00-08:00, 2026-07-05T12:55:00-04:00, 2026-07-05T13:42:05-04:00, 2026-07-05T14:20:00-04:00, 2026-07-05T18:25:00-04:00, 2026-07-06T02:15:00-04:00, 2026-07-06T02:35:00-04:00, 2026-07-06T02:45:00-04:00, 2026-07-06T03:10:00-04:00, 2026-07-06T03:25:00-04:00, 2026-07-06T16:22:31-04:00</dd>
-        <dt>commits</dt>      <dd>a859b89 (source-scope auth fix), 6b73431 (Python contract pin), 74f391d (initial swarm fixes)</dd>
+        <dt>modified</dt>     <dd>2026-07-05T00:39:00-08:00, 2026-07-05T01:55:00-08:00, 2026-07-05T12:55:00-04:00, 2026-07-05T13:42:05-04:00, 2026-07-05T14:20:00-04:00, 2026-07-05T18:25:00-04:00, 2026-07-06T02:15:00-04:00, 2026-07-06T02:35:00-04:00, 2026-07-06T02:45:00-04:00, 2026-07-06T03:10:00-04:00, 2026-07-06T03:25:00-04:00, 2026-07-06T16:22:31-04:00, 2026-07-06T18:11:18-04:00</dd>
+        <dt>commits</dt>      <dd>3e04d5a (Phase 3 source-scope fixes), a859b89 (source-scope auth fix), 6b73431 (Python contract pin), 74f391d (initial swarm fixes)</dd>
         <dt>agent name</dt>        <dd>admin255-board-roadmap</dd>
         <dt>session id</dt>      <dd>open-brain plan3f session 2026-07-06</dd>
         <dt>back refs</dt>    <dd>goal-run.md (memory-substrate goal run), docs/realtime-agent-memory-research.md (PR #225), docs/downstream-rollout.md, docs/memory-contract.md</dd>
-        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (CI passed before roadmap-only blocker update; fix-verification clean; Phase 3 Claude cross-review blocked). Remaining issues include #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
+        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (CI passed, deploy skipped, Phase 3 Claude/Opus findings fixed, Phase 4 fix-verification clean). Remaining issues: #223, #167, #137, #118. #167 is live migration/release gated; #223 is the realtime transport foundation; #137 is optional qmd wrapper; #118 is represented by PR #255. Project 8 sync is in progress for the final PR #255 gate. No core01 deploy performed.</dd>
       </dl>
     </details>
   </header>
@@ -199,7 +199,7 @@
   <!-- ===== PURPOSE / PROBLEM / SOLUTION ===== -->
   <section id="purpose">
     <h2>Purpose</h2>
-    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test), and GitHub CI passed with deploy jobs skipped by design before this roadmap-only blocker update. The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>. Fix-verification is clean, but Phase 3 Claude cross-review is blocked because <code>claude -p</code> produced no usable review output and bare mode could not use the active login. Deploy remains intentionally deferred. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
+    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test, Python ruff/mypy/pytest), and GitHub CI passed with deploy jobs skipped by design. The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>; Claude/Opus Phase 3 cross-review completed through a code-focused diff packet and its findings were fixed in <code>3e04d5a</code>. Phase 4 fix-verification is clean. Deploy remains intentionally deferred. The remaining open issues are #223, #167, #137, and #118.</p>
     <p>Drive the open-brain repo to a clean board: every open PR merged or explicitly held, and all remaining open issues either closed with tested, rollout-gated changes or explicitly dispositioned as roadmap items with a documented decision. The plan sequences work so infrastructure fixes (review pipeline, CI Postgres) land first and protect everything after them, and groups issues into coherent PR-sized batches that respect the repo's pre-merge gauntlet, critical self-review gate, and downstream rollout gate.</p>
   </section>
 
@@ -215,7 +215,7 @@
 
   <section id="solution">
     <h2>Solution</h2>
-    <p>Execute in six ordered phases. Phase 1 repairs and lands PR #231 so the review pipeline itself is trustworthy. Phase 2 closes the CI Postgres gap (#165) and the unbounded-logs bug (#193) so every later PR gets real DB-backed test coverage. Phase 3 retires legacy auth/namespace debt (#168 → #166 → #167) in dependency order. Phase 4 ships the client-facing contract batch (#177 installable package, #204 resolver tool, #176 structured rejection) — each triggering the downstream rollout gate. Phase 5 delivers the realtime memory epic (#223 → #222 → #221 → #224 → #229) in its research-mandated order: transport foundation first, then hot working set, recovery WAL, promotion lifecycle, and finally the operational hardening follow-up. Phase 6 dispositions the three long-horizon items (#192, #137, #118) — implement, defer with a dated decision, or convert to roadmap docs — so nothing is left silently open. One branch + one PR per issue or tightly-coupled pair; every non-trivial PR runs the critical self-review receipt and the pre-merge gauntlet.</p>
+    <p>Execute in six ordered phases. Phase 1 repairs and lands PR #231 so the review pipeline itself is trustworthy. Phase 2 closes the CI Postgres gap (#165) and the unbounded-logs bug (#193) so every later PR gets real DB-backed test coverage. Phase 3 retires legacy auth/namespace debt (#168 → #166 → #167) in dependency order. Phase 4 ships the client-facing contract batch (#177 installable package, #204 resolver tool, #176 structured rejection) — each triggering the downstream rollout gate. Phase 5 delivers the realtime memory epic (#223 → #222 → #221 → #224 → #229) in its research-mandated order: transport foundation first, then hot working set, recovery WAL, promotion lifecycle, and finally the operational hardening follow-up. Phase 6 currently has two live roadmap/disposition items (#137, #118): #118 is covered by PR #255 and #137 is optional/design-gated. One branch + one PR per issue or tightly-coupled pair; every non-trivial PR runs the critical self-review receipt and the pre-merge gauntlet.</p>
     <figure>
       <!-- {{SOLUTION_IMAGE: same graph untangled into six ordered vertical lanes, violet to cyan gradient left to right, green checkmarks accumulating}} -->
       <div class="img-placeholder">SOLUTION IMAGE PLACEHOLDER — six ordered lanes, dependencies resolved top-to-bottom</div>
@@ -230,7 +230,7 @@
       <tr><td>3</td><td>#168, #166, #167</td><td>n8n→ob-admin rename · stale collab docs · retire collab</td><td class="chg">Partial (#166 lives in mcp2cli skill refs; #167 touches read-fallback)</td></tr>
       <tr><td>4</td><td>#177, #204, #176</td><td>Installable Python client · UUID resolver · structured share_candidate rejection</td><td class="yes">Yes — all three</td></tr>
       <tr><td>5</td><td>#223, #222, #221, #224, #229</td><td>Realtime memory epic (#220 family), strict order</td><td class="yes">Yes — Hermes canary per slice</td></tr>
-      <tr><td>6</td><td>#192, #137, #118</td><td>Condensed retrieval · qmd deep-lookup · file refs roadmap</td><td class="chg">#118 is roadmap-bound and under review; deploy deferred</td></tr>
+      <tr><td>6</td><td>#137, #118</td><td>qmd deep-lookup · file refs roadmap</td><td class="chg">#118 is covered by PR #255; #137 is optional/design-gated; deploy deferred</td></tr>
     </table>
   </section>
 
@@ -527,38 +527,35 @@
 
     <!-- ============ PHASE 6 ============ -->
     <div class="phase">
-      <h3><code class="status">[]</code> Phase 6: Roadmap disposition — #192, #137, #118</h3>
-      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc. Current #118 state is PR #255 with CI passed before this roadmap-only blocker update, board status <code>In Review</code>, review gate blocked at Phase 3 Claude cross-review, fix-verification clean after the source-scope auth fix, with deploy deferred.</p>
+      <h3><code class="status">[]</code> Phase 6: Roadmap disposition — #137, #118</h3>
+      <p>Live Phase 6 state: #192 is no longer open. The remaining roadmap/disposition items are #137 and #118. #118 is covered by PR #255: local validation passed, GitHub CI passed, deploy jobs skipped by design, Phase 3 Claude/Opus cross-review completed through a code-focused packet, fixes landed in <code>3e04d5a</code>, and Phase 4 security + antagonist fix-verification returned clean. #137 remains optional/design-gated; the only safe local-only branch after #255 is a narrowed docs/contract decision slice, not an infra-building implementation. #167 and #223 remain release/deploy or design gated.</p>
 
       <figure>
         <!-- {{PHASE_IMAGE: dark triage board with three cards routing to lanes labeled "build", "defer + doc", "roadmap", amber accent}} -->
-        <div class="img-placeholder">PHASE 6 IMAGE PLACEHOLDER — triage board routing #192 / #137 / #118 to build, defer, roadmap lanes</div>
+        <div class="img-placeholder">PHASE 6 IMAGE PLACEHOLDER — triage board routing #137 / #118 to defer, document, or merge-ready lanes</div>
         <figcaption>Nothing left silently open: every remaining issue gets an explicit, dated disposition.</figcaption>
       </figure>
 
-      <h4>1. #192 — Condensed retrieval (Part A) + decomposition (Part B)</h4>
-      <ul class="checklist">
-        <li><code class="status">[]</code> Part A: add a compact-retrieval mode (stored condensed column or projection-level truncation contract) to <code>get_entry</code>/<code>brain_answer</code> so large entries can be recalled cheap; contract-doc the new knob.</li>
-        <li><code class="status">[]</code> Part B: write the design decision — dream-driven decomposition stays behind DreamEngine's dry-run-by-default rule; open a scoped follow-up issue or fold into a roadmap doc, then close #192 against Part A + the doc.</li>
-      </ul>
-
-      <h4>2. #137 — Controlled remote qmd deep-lookup wrapper</h4>
+      <h4>1. #137 — Controlled remote qmd deep-lookup wrapper</h4>
       <ul class="checklist">
         <li><code class="status">[]</code> Confirm the preconditions in the issue still hold (durable OB path working, qmd healthy on the GPU Mac) and decide: build the mcp2cli wrapper now or defer.</li>
+        <li><code class="status">[]</code> Safe local-only slice: document the optional remote-qmd escape hatch and failure semantics without building infra. Likely files: <code>docs/downstream-rollout.md</code>, <code>docs/memory-contract.md</code>, <code>python/openbrain-memory/README.md</code>.</li>
         <li><code class="status">[]</code> If deferred: date the decision in the issue, label roadmap/optional, and keep the non-goals (no Hermes dependency on qmd) recorded; close or keep open per Rico's call.</li>
       </ul>
 
-      <h4>3. #118 — File references / closed-brain roadmap</h4>
+      <h4>2. #118 — File references / closed-brain roadmap</h4>
       <ul class="checklist">
-        <li><code class="status">[]</code> Capture the source-reference design (matter-scoped grounding, audit trail, ethical walls) into <code>docs/roadmap/file-references.md</code> so the thinking survives outside the issue.</li>
-        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call. Current execution evidence: PR #255 local validation passed, CI passed before the roadmap-only blocker update, source-scope auth finding fixed, fix-verification clean, Phase 3 Claude cross-review blocked, deploy deferred.</li>
+        <li><code class="status">[x]</code> Capture the source-reference design and implementation into PR #255: structured <code>source_refs</code> storage, scoped read/search/answer filtering, privileged source-ref redaction, contract updates, and regression tests.</li>
+        <li><code class="status">[x]</code> Complete pre-merge-gauntlet phases 1-4: critical self-review, initial swarm fixes, Claude/Opus cross-review, Phase 3 fixes, focused security + antagonist fix-verification, local validation, CI, and board sync.</li>
+        <li><code class="status">[]</code> Merge PR #255 after the controller's final PR-body/roadmap sync commit passes CI. No core01 deploy; normal squash merge to <code>main</code> does not trigger deploy under current remote workflow conditions.</li>
       </ul>
 
-      <h4>4. Testing Strategy</h4>
-      <p>Part A of #192 is real code and gets the full ladder (unit + DB-backed CI + contract fixtures + downstream gate since it changes retrieval payloads). Disposition items are validated by artifact existence and issue state.</p>
+      <h4>3. Testing Strategy</h4>
+      <p>#118 is real code and already ran the full local ladder plus GitHub CI. #137 docs/contract disposition is validated by artifact existence, issue state, <code>git diff --check</code>, and a focused typecheck if any package-facing docs/examples change.</p>
       <ul class="checklist">
-        <li><code class="status">[]</code> <code>bun test</code> — condensed-retrieval tests: large entry stored → compact recall under the size bound → full recall still available.</li>
-        <li><code class="status">[]</code> Downstream check for the retrieval-contract change per <code>docs/downstream-rollout.md</code>.</li>
+        <li><code class="status">[x]</code> PR #255 focused and full local validation passed; Python package validation passed.</li>
+        <li><code class="status">[x]</code> PR #255 GitHub checks passed; deploy skipped by design.</li>
+        <li><code class="status">[]</code> For #137 docs/contract slice, run <code>git diff --check</code> and the smallest relevant doc/example validation before PR.</li>
         <li><code class="status">[]</code> <code>gh issue list --state open</code> — every remaining open issue carries a roadmap/deferred label and a dated disposition comment.</li>
       </ul>
       <div class="loop">
@@ -632,10 +629,16 @@
     <h2>Amendments</h2>
     <!-- Append-only; populated by Update Plan / Update References workflows. -->
     <details class="amend">
+      <summary>2026-07-06 — PR #255 gauntlet clean; merge path verified no-deploy</summary>
+      <p>PR #255 is the active #118 implementation PR. Phase 3 Claude/Opus cross-review initially stalled on the full diff, then completed against a code-focused diff packet. Findings were posted and fixed in <code>3e04d5a</code>: per-element source-ref filtering preserves valid matching refs beside malformed siblings, SQL/JS scope parity now requires a citable identifier, compact <code>get_entry</code> source-scope behavior is contract-documented, and duplicate <code>session_wrap</code> source-ref semantics are explicit.</p>
+      <p>Phase 4 fix-verification is clean. Worker receipts: security lane <code>open-brain-20260706T220625Z-65907-23031</code>; antagonist lane <code>open-brain-20260706T220637Z-72561-17542</code>. Admin sync posted final PR evidence in <code>issuecomment-4898069444</code>, set the #118 board item <code>PVTI_lAHOABBGmc4BbDBtzgx1NcQ</code> to Review Gate <code>Zero Known Issues</code> and Validation <code>CI Passed</code>, and recorded the next action as ready for controller merge/no deploy. A separate validation lane confirmed a normal squash merge to <code>main</code> does not deploy core01 under the current remote workflow; deploy only runs for a <code>v*</code> tag push or manual dispatch with <code>deploy_core01=true</code>.</p>
+      <p>Live open issues after recon are #223, #167, #137, and #118. After #255, none of the remaining issues is a full local-only implementation issue: #167 is release/deploy gated, #223 is deploy/design gated, and #137 is optional/design-gated. The only safe local-only follow-up is a narrowed #137 docs/contract disposition slice unless Rico approves release/deploy work.</p>
+    </details>
+    <details class="amend">
       <summary>2026-07-06 — #244 merged, #166 closed, local-only next slice selected</summary>
       <p>Controller merged PR #244 as <code>dcd5c6b743e8cf58395deacd17ec0a8f16184a26</code>; issue #176 closed at <code>2026-07-06T03:15:03Z</code>. Phase 4 fixes landed as <code>ad49c0b9b63782d3b5dbe0b9cae249c6600d1b66</code>, all posted PR findings were addressed, focused Claude/Opus fix-verification returned clean, and GitHub checks passed for <code>check</code>, <code>db-integration</code>, <code>python-package</code>, PR-body <code>validate</code>, and GitGuardian; <code>deploy</code> skipped. Project 8 marks #176 and PR #244 done with Review Gate <code>Zero Known Issues</code> and Validation <code>CI Passed</code>. No production deploy was performed.</p>
-      <p>Issue #166 was verified already fixed from a clean worktree: live generated mcp2cli Open Brain skill refs contain no stale collab defaults, server <code>promote_entry</code>/<code>scan_namespace</code> defaults resolve to <code>shared-kb</code>, and focused tests passed. Evidence was posted in issue comment <code>issuecomment-4888801608</code>; #166 is closed and Project 8 marks it done with Validation <code>Local Passed</code>. Live state after these closures: 0 open PRs and 9 open issues (#229, #224, #223, #222, #221, #192, #167, #137, #118).</p>
-      <p>#167 remains open by design because its remaining acceptance criteria require live backup, migration dry-run/execute, reconciliation, release deploy, and downstream canary. Under the current local-only instruction, do not work toward core01. The next local-only roadmap candidate is #192 Part A unless Rico redirects; run a normal branch, local validation, critical self-review, and <code>pre-merge-gauntlet</code> before merge.</p>
+      <p>Issue #166 was verified already fixed from a clean worktree: live generated mcp2cli Open Brain skill refs contain no stale collab defaults, server <code>promote_entry</code>/<code>scan_namespace</code> defaults resolve to <code>shared-kb</code>, and focused tests passed. Evidence was posted in issue comment <code>issuecomment-4888801608</code>; #166 is closed and Project 8 marks it done with Validation <code>Local Passed</code>. This snapshot is superseded by the PR #255 amendment above; live open issues are now #223, #167, #137, and #118.</p>
+      <p>#167 remains open by design because its remaining acceptance criteria require live backup, migration dry-run/execute, reconciliation, release deploy, and downstream canary. Under the current local-only instruction, do not work toward core01. Superseded next-slice decision: #192 is no longer open; after PR #255, the only safe local-only follow-up identified is a narrowed #137 docs/contract disposition slice unless Rico redirects.</p>
     </details>
     <details class="amend">
       <summary>2026-07-05 — Execution progress: Phases 1–3 in flight under merge hold</summary>
@@ -643,7 +646,7 @@
     </details>
     <details class="amend">
       <summary>2026-07-06 — #204 merged; #176 local implementation validated</summary>
-      <p>PR #234 merged as <code>a16398c4d344f2c57ea0d508f998fcd05cbe8e07</code>; issue #165 closed at <code>2026-07-06T00:47:00Z</code>. PR #240 merged as <code>b12e33e22b8b97c5322ef43ea3831752652c4eeb</code>. PR #243 merged as <code>3b8e47ac5d4b3b614fdd26f5609242b73204f928</code>; issue #204 closed at <code>2026-07-06T01:54:16Z</code>. Live GitHub state is now 1 open PR (#244) and 11 open issues (#229, #224, #223, #222, #221, #192, #176, #167, #166, #137, #118).</p>
+      <p>PR #234 merged as <code>a16398c4d344f2c57ea0d508f998fcd05cbe8e07</code>; issue #165 closed at <code>2026-07-06T00:47:00Z</code>. PR #240 merged as <code>b12e33e22b8b97c5322ef43ea3831752652c4eeb</code>. PR #243 merged as <code>3b8e47ac5d4b3b614fdd26f5609242b73204f928</code>; issue #204 closed at <code>2026-07-06T01:54:16Z</code>. Historical snapshot at that time: 1 open PR (#244) and 11 open issues (#229, #224, #223, #222, #221, #192, #176, #167, #166, #137, #118).</p>
       <p>#176 implementation is on <code>feat/176-structured-rejection</code> in <code>/Volumes/ThunderBolt/_tmp/open-brain/issue-176-structured-rejection</code>. Phase 1 critical pass fixed the client-attempt trust issue. Phase 2 swarm fixed the resend root-rotation bug and fix-verification passed. Phase 3 Claude cross-review posted five findings; local fixes now bound omitted-lineage retries from observed lane rejects, distinguish invalid roots, avoid retry-state DB work for clean resubmits, count all firing secret detector spans, and omit retry metadata on blocked responses. Latest local validation passed: focused append-session-event tests (47 pass, 5 skip), focused contract bundle (94 pass, 5 skip), <code>bunx tsc --noEmit</code>, full <code>bun test</code> (1059 pass, 46 skip), Python focused pytest (69 pass), Python mypy, Python ruff, <code>git diff --check</code>, and scoped GitGuardian path scan. Next: push Phase 3 fixes, run fix-verification, reply to every finding with the fixing commit or waiver, then merge only after the gauntlet is clean. No production deploy.</p>
     </details>
     <details class="amend">

--- a/specs/open-issues-and-prs-completion-roadmap.html
+++ b/specs/open-issues-and-prs-completion-roadmap.html
@@ -175,7 +175,7 @@
   <!-- ===== HEADER + UPDATABLE METADATA ===== -->
   <header>
     <h1>Plan: Open Brain — Work All Open Issues &amp; Complete All Open PRs</h1>
-    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 is open; the branch includes the antagonist source-scope auth fix from <code>a859b89</code>, local validation and CI pass for pushed head <code>107c173</code>, fix-verification is running, and deploy remains deferred.</p>
+    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 is open; the branch includes the antagonist source-scope auth fix from <code>a859b89</code>, local validation and CI passed before the roadmap-only blocker update, fix-verification is clean, Phase 3 Claude cross-review is blocked, and deploy remains deferred.</p>
     <details class="meta">
       <summary>Metadata</summary>
       <dl>
@@ -185,7 +185,7 @@
         <dt>agent name</dt>        <dd>admin255-board-roadmap</dd>
         <dt>session id</dt>      <dd>open-brain plan3f session 2026-07-06</dd>
         <dt>back refs</dt>    <dd>goal-run.md (memory-substrate goal run), docs/realtime-agent-memory-research.md (PR #225), docs/downstream-rollout.md, docs/memory-contract.md</dd>
-        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (CI passed for pushed head <code>107c173</code>; fix-verification running). Remaining issues include #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
+        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (CI passed before roadmap-only blocker update; fix-verification clean; Phase 3 Claude cross-review blocked). Remaining issues include #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
       </dl>
     </details>
   </header>
@@ -199,7 +199,7 @@
   <!-- ===== PURPOSE / PROBLEM / SOLUTION ===== -->
   <section id="purpose">
     <h2>Purpose</h2>
-    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test), and GitHub CI passed for pushed head <code>107c173</code> with deploy jobs skipped by design. The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>. Fix-verification is running, and deploy remains intentionally deferred. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
+    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test), and GitHub CI passed with deploy jobs skipped by design before this roadmap-only blocker update. The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>. Fix-verification is clean, but Phase 3 Claude cross-review is blocked because <code>claude -p</code> produced no usable review output and bare mode could not use the active login. Deploy remains intentionally deferred. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
     <p>Drive the open-brain repo to a clean board: every open PR merged or explicitly held, and all remaining open issues either closed with tested, rollout-gated changes or explicitly dispositioned as roadmap items with a documented decision. The plan sequences work so infrastructure fixes (review pipeline, CI Postgres) land first and protect everything after them, and groups issues into coherent PR-sized batches that respect the repo's pre-merge gauntlet, critical self-review gate, and downstream rollout gate.</p>
   </section>
 
@@ -528,7 +528,7 @@
     <!-- ============ PHASE 6 ============ -->
     <div class="phase">
       <h3><code class="status">[]</code> Phase 6: Roadmap disposition — #192, #137, #118</h3>
-      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc. Current #118 state is PR #255 with CI passed for pushed head <code>107c173</code>, board status <code>In Review</code>, review gate <code>Fix Verification Running</code>, fix-verification running after the source-scope auth fix, with deploy deferred.</p>
+      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc. Current #118 state is PR #255 with CI passed before this roadmap-only blocker update, board status <code>In Review</code>, review gate blocked at Phase 3 Claude cross-review, fix-verification clean after the source-scope auth fix, with deploy deferred.</p>
 
       <figure>
         <!-- {{PHASE_IMAGE: dark triage board with three cards routing to lanes labeled "build", "defer + doc", "roadmap", amber accent}} -->
@@ -551,7 +551,7 @@
       <h4>3. #118 — File references / closed-brain roadmap</h4>
       <ul class="checklist">
         <li><code class="status">[]</code> Capture the source-reference design (matter-scoped grounding, audit trail, ethical walls) into <code>docs/roadmap/file-references.md</code> so the thinking survives outside the issue.</li>
-        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call. Current execution evidence: PR #255 pushed head <code>107c173</code>, local validation and CI passed, source-scope auth finding fixed, fix-verification running, deploy deferred.</li>
+        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call. Current execution evidence: PR #255 local validation passed, CI passed before the roadmap-only blocker update, source-scope auth finding fixed, fix-verification clean, Phase 3 Claude cross-review blocked, deploy deferred.</li>
       </ul>
 
       <h4>4. Testing Strategy</h4>

--- a/specs/open-issues-and-prs-completion-roadmap.html
+++ b/specs/open-issues-and-prs-completion-roadmap.html
@@ -175,7 +175,7 @@
   <!-- ===== HEADER + UPDATABLE METADATA ===== -->
   <header>
     <h1>Plan: Open Brain — Work All Open Issues &amp; Complete All Open PRs</h1>
-    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 is open; the branch includes the antagonist source-scope auth fix from <code>a859b89</code>, local validation passes, push/CI is pending for the updated branch, and deploy remains deferred.</p>
+    <p class="tagline">Six-phase execution roadmap: land PR #231, harden CI, retire legacy auth/namespace debt, ship the client contract batch, deliver the realtime memory epic, and disposition the roadmap backlog. Current correction: PR #255 is open; the branch includes the antagonist source-scope auth fix from <code>a859b89</code>, local validation and CI pass for pushed head <code>107c173</code>, fix-verification is running, and deploy remains deferred.</p>
     <details class="meta">
       <summary>Metadata</summary>
       <dl>
@@ -185,7 +185,7 @@
         <dt>agent name</dt>        <dd>admin255-board-roadmap</dd>
         <dt>session id</dt>      <dd>open-brain plan3f session 2026-07-06</dd>
         <dt>back refs</dt>    <dd>goal-run.md (memory-substrate goal run), docs/realtime-agent-memory-research.md (PR #225), docs/downstream-rollout.md, docs/memory-contract.md</dd>
-        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (updated branch pending push/CI). Remaining issues include #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
+        <dt>forward refs</dt> <dd>Merged PRs #231, #233, #234, #235, #237, #238, #239, #240, #243, #244; open PRs: #255 (CI passed for pushed head <code>107c173</code>; fix-verification running). Remaining issues include #229, #224, #223, #222, #221, #192, #167, #137, #118. #167 is live migration/release gated; #166 was verified already fixed and closed. Project 8 synced 2026-07-06. No core01 deploy performed.</dd>
       </dl>
     </details>
   </header>
@@ -199,7 +199,7 @@
   <!-- ===== PURPOSE / PROBLEM / SOLUTION ===== -->
   <section id="purpose">
     <h2>Purpose</h2>
-    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test). The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>. Push/CI is pending for the updated branch, and deploy remains intentionally deferred. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
+    <p><strong>Live correction:</strong> this roadmap was authored from an older snapshot. Current live state is PR #255 open with #118 actively in review on the board. Local validation has passed (focused tests, typecheck, diff-check, full bun test), and GitHub CI passed for pushed head <code>107c173</code> with deploy jobs skipped by design. The prior Python contract snapshot CI failure was fixed in <code>6b73431</code>; the antagonist/gotcha source-scope auth finding was fixed in <code>a859b89</code>. Fix-verification is running, and deploy remains intentionally deferred. The next local-only issue candidate is #192 Part A unless Rico redirects.</p>
     <p>Drive the open-brain repo to a clean board: every open PR merged or explicitly held, and all remaining open issues either closed with tested, rollout-gated changes or explicitly dispositioned as roadmap items with a documented decision. The plan sequences work so infrastructure fixes (review pipeline, CI Postgres) land first and protect everything after them, and groups issues into coherent PR-sized batches that respect the repo's pre-merge gauntlet, critical self-review gate, and downstream rollout gate.</p>
   </section>
 
@@ -528,7 +528,7 @@
     <!-- ============ PHASE 6 ============ -->
     <div class="phase">
       <h3><code class="status">[]</code> Phase 6: Roadmap disposition — #192, #137, #118</h3>
-      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc. Current #118 state is PR #255 with the updated branch pending push/CI, board status <code>In Review</code>, review gate <code>Fix Verification Running</code>, validation pending after the source-scope auth fix, with deploy deferred.</p>
+      <p>Three long-horizon items that should not sit silently open. Each gets an explicit disposition: implement now, defer with a dated decision + roadmap doc, or close as superseded. Default recommendation: implement #192 Part A (condensed retrieval — it directly cheapens the Phase 5 working-set/promotion flows), defer #192 Part B (dream-driven decomposition) behind DreamEngine dry-run guarantees, defer #137 (qmd wrapper — explicitly optional by its own text) and keep #118 as a labeled roadmap issue with the design captured in a doc. Current #118 state is PR #255 with CI passed for pushed head <code>107c173</code>, board status <code>In Review</code>, review gate <code>Fix Verification Running</code>, fix-verification running after the source-scope auth fix, with deploy deferred.</p>
 
       <figure>
         <!-- {{PHASE_IMAGE: dark triage board with three cards routing to lanes labeled "build", "defer + doc", "roadmap", amber accent}} -->
@@ -551,7 +551,7 @@
       <h4>3. #118 — File references / closed-brain roadmap</h4>
       <ul class="checklist">
         <li><code class="status">[]</code> Capture the source-reference design (matter-scoped grounding, audit trail, ethical walls) into <code>docs/roadmap/file-references.md</code> so the thinking survives outside the issue.</li>
-        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call. Current execution evidence: PR #255 updated branch, local validation passed, source-scope auth finding fixed, push/CI pending, deploy deferred.</li>
+        <li><code class="status">[]</code> Keep the issue open as a labeled roadmap epic or close it pointing at the doc — Rico's disposition call. Current execution evidence: PR #255 pushed head <code>107c173</code>, local validation and CI passed, source-scope auth finding fixed, fix-verification running, deploy deferred.</li>
       </ul>
 
       <h4>4. Testing Strategy</h4>

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -318,7 +318,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       source_scope: SOURCE_SCOPE_CONTRACT,
     },
     output_shape:
-      "full readable entry row JSON text payload with source_refs redacted unless source_scope is supplied, or compact envelope with content_preview/content_length/content_truncated/source_ref/fetch_path",
+      "full readable entry row JSON text payload with source_refs redacted unless source_scope is supplied, or compact envelope with content_preview/content_length/content_truncated/source_ref/fetch_path; compact source_scope filters visibility only and carries source_scope in fetch_path for full ref retrieval",
   },
   decompose_entry: {
     version: 1,
@@ -1154,7 +1154,8 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       },
       source_refs: SOURCE_REFS_CONTRACT,
     },
-    output_shape: "session wrap checkpoint/source_refs JSON text payload",
+    output_shape:
+      "session wrap checkpoint/source_refs JSON text payload; duplicate content_hash checkpoints are immutable no-ops and do not merge later source_refs",
   },
   upsert_repo_fact: {
     version: 2,

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -2,6 +2,10 @@ import {
   REPO_FACT_METADATA_CONTRACT,
   REPO_FACT_VALIDATION_CONTRACT,
 } from "./tools/repo-facts.ts";
+import {
+  SOURCE_REFS_CONTRACT,
+  SOURCE_SCOPE_CONTRACT,
+} from "./source-refs.ts";
 
 export interface ToolContract {
   version: number;
@@ -311,9 +315,10 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "Maximum compact content_preview length in characters. Applies only " +
           "when render is compact.",
       },
+      source_scope: SOURCE_SCOPE_CONTRACT,
     },
     output_shape:
-      "full readable entry row JSON text payload, or compact envelope with content_preview/content_length/content_truncated/source_ref/fetch_path",
+      "full readable entry row JSON text payload with source_refs redacted unless source_scope is supplied, or compact envelope with content_preview/content_length/content_truncated/source_ref/fetch_path",
   },
   decompose_entry: {
     version: 1,
@@ -423,8 +428,10 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "auth-derived namespace; leave unset unless a global/admin token " +
           "is intentionally writing into another namespace (e.g. shared-kb).",
       },
+      source_refs: SOURCE_REFS_CONTRACT,
     },
-    output_shape: "thought id/namespace/embedded/merged JSON text payload",
+    output_shape:
+      "thought id/namespace/embedded/merged/source_refs JSON text payload",
   },
   search_all: {
     version: 2,
@@ -501,8 +508,10 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "important), warm (mid), cold (archival). Omit to search all " +
           "tiers; set only when you want to restrict by significance.",
       },
+      source_scope: SOURCE_SCOPE_CONTRACT,
     },
-    output_shape: "unified search results JSON text payload",
+    output_shape:
+      "unified search results JSON text payload; source_scope filters Open Brain results and suppresses qmd results",
   },
   session_start: {
     version: 2,
@@ -1143,8 +1152,9 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         description:
           "Project this wrap belongs to, for scoping and later filtering.",
       },
+      source_refs: SOURCE_REFS_CONTRACT,
     },
-    output_shape: "session wrap checkpoint JSON text payload",
+    output_shape: "session wrap checkpoint/source_refs JSON text payload",
   },
   upsert_repo_fact: {
     version: 2,

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "12a802ff076c613f92122b599a43c758de632649429a87104c3d4e8e6fd08194",
+      "c16c090d925c005bfecfe4f4dd76c7780d2a7cc8982e43ce748687f82613f554",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "4e47700d6fabfc25a439aca9e78dd3e843758d22c488bb6e34119f485b68e553",
+      "12a802ff076c613f92122b599a43c758de632649429a87104c3d4e8e6fd08194",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -388,8 +388,23 @@ describe("Open Brain contract manifest", () => {
       max: 2000,
       default: 500,
     });
+    expect((getEntry?.input_schema as any).source_scope.fields).toMatchObject({
+      client_id: { type: "string", required: false, minLength: 1, maxLength: 300 },
+      matter_id: { type: "string", required: false, minLength: 1, maxLength: 300 },
+      document_id: { type: "string", required: false, minLength: 1, maxLength: 500 },
+      path: { type: "string", required: false, minLength: 1, maxLength: 1000 },
+      dms_id: { type: "string", required: false, minLength: 1, maxLength: 500 },
+    });
     expect(getEntry?.output_shape).toContain("compact envelope");
+    expect(getEntry?.output_shape).toContain("source_refs redacted");
     expect((getEntry?.input_schema as any).namespace).toBeUndefined();
+    const logThought = contract.tool_contracts.log_thought;
+    expect((logThought?.input_schema as any).source_refs).toMatchObject({
+      type: "array",
+      required: false,
+      maxItems: 25,
+    });
+    expect(logThought?.output_shape).toContain("source_refs");
     const decomposeEntry = contract.tool_contracts.decompose_entry;
     expect(decomposeEntry).toBeDefined();
     expect(decomposeEntry?.version).toBe(1);
@@ -433,6 +448,13 @@ describe("Open Brain contract manifest", () => {
       "warm",
       "cold",
     ]);
+    expect((searchAll?.input_schema as any).source_scope.fields.path).toMatchObject({
+      type: "string",
+      required: false,
+      minLength: 1,
+      maxLength: 1000,
+    });
+    expect(searchAll?.output_shape).toContain("suppresses qmd");
     const laneUpsert = contract.tool_contracts.lane_upsert;
     expect(laneUpsert).toBeDefined();
     expect((laneUpsert?.input_schema as any).current_context_md.maxLength).toBe(
@@ -451,6 +473,13 @@ describe("Open Brain contract manifest", () => {
     expect(
       (upsertRepoFact?.input_schema as any).validation.source_url.repo_match,
     ).toContain("metadata.repo");
+    const sessionWrap = contract.tool_contracts.session_wrap;
+    expect((sessionWrap?.input_schema as any).source_refs).toMatchObject({
+      type: "array",
+      required: false,
+      maxItems: 25,
+    });
+    expect(sessionWrap?.output_shape).toContain("source_refs");
   });
 
   it("pins the contract version and append_session_event nomination contract", () => {
@@ -460,7 +489,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v18");
+    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v19");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "c16c090d925c005bfecfe4f4dd76c7780d2a7cc8982e43ce748687f82613f554",
+      "45224e3f2ae54daf2c2c3706340e6610879f8a98fe29af77b5cf0b3e98ae48b9",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -397,6 +397,9 @@ describe("Open Brain contract manifest", () => {
     });
     expect(getEntry?.output_shape).toContain("compact envelope");
     expect(getEntry?.output_shape).toContain("source_refs redacted");
+    expect(getEntry?.output_shape).toContain(
+      "compact source_scope filters visibility only",
+    );
     expect((getEntry?.input_schema as any).namespace).toBeUndefined();
     const logThought = contract.tool_contracts.log_thought;
     expect((logThought?.input_schema as any).source_refs).toMatchObject({
@@ -480,6 +483,9 @@ describe("Open Brain contract manifest", () => {
       maxItems: 25,
     });
     expect(sessionWrap?.output_shape).toContain("source_refs");
+    expect(sessionWrap?.output_shape).toContain(
+      "duplicate content_hash checkpoints are immutable no-ops",
+    );
   });
 
   it("pins the contract version and append_session_event nomination contract", () => {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-07-06.memory-tools.v18";
+export const CONTRACT_VERSION = "2026-07-06.memory-tools.v19";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {

--- a/src/db/migrations/021_source_refs.sql
+++ b/src/db/migrations/021_source_refs.sql
@@ -1,0 +1,15 @@
+-- Structured file/document references for closed-brain source grounding.
+-- Kept on each durable memory row so retrieval and answer citations can
+-- enforce source scope before evidence leaves the server.
+
+ALTER TABLE thoughts ADD COLUMN IF NOT EXISTS source_refs JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE decisions ADD COLUMN IF NOT EXISTS source_refs JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS source_refs JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS source_refs JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS source_refs JSONB DEFAULT '[]'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_thoughts_source_refs ON thoughts USING gin (source_refs);
+CREATE INDEX IF NOT EXISTS idx_decisions_source_refs ON decisions USING gin (source_refs);
+CREATE INDEX IF NOT EXISTS idx_relationships_source_refs ON relationships USING gin (source_refs);
+CREATE INDEX IF NOT EXISTS idx_projects_source_refs ON projects USING gin (source_refs);
+CREATE INDEX IF NOT EXISTS idx_sessions_source_refs ON sessions USING gin (source_refs);

--- a/src/rest-api.test.ts
+++ b/src/rest-api.test.ts
@@ -216,6 +216,33 @@ describe("REST API", () => {
       expect(json.promoted_from).toEqual({ source_id: "source-uuid" });
     });
 
+    it("redacts source refs from generic entry reads", async () => {
+      const pool = createMockPool([
+        {
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          content: "test thought",
+          namespace: "bilby",
+          source_refs: [
+            {
+              document_id: "doc-1",
+              client_id: "acme",
+              matter_id: "lit-1",
+            },
+          ],
+        },
+      ]);
+      const app = buildApp({ role: "admin", clientId: "rico" }, pool);
+
+      const { status, json } = await req(
+        app,
+        "get",
+        "/api/v1/entries/thoughts/123e4567-e89b-12d3-a456-426614174000",
+      );
+
+      expect(status).toBe(200);
+      expect(json.source_refs).toBeUndefined();
+    });
+
     it("adds namespace predicate for non-admin entry reads", async () => {
       const pool = createRecordingPool([
         {

--- a/src/rest-api.ts
+++ b/src/rest-api.ts
@@ -563,7 +563,8 @@ export function createRestRouter(deps: RestDeps): Router {
       return;
     }
 
-    res.json(rows[0]);
+    const { source_refs: _sourceRefs, ...entry } = rows[0];
+    res.json(entry);
   }));
 
   // GET /api/v1/namespaces

--- a/src/source-refs.test.ts
+++ b/src/source-refs.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+import {
+  appendSourceScopeParam,
+  sourceRefSchema,
+  sourceRefsSchema,
+  sourceScopeFilterSql,
+} from "./source-refs.ts";
+
+describe("source refs", () => {
+  it("accepts refs identified by document_id, path, or dms_id", () => {
+    expect(sourceRefSchema.parse({ document_id: "doc-1" }).document_id).toBe(
+      "doc-1",
+    );
+    expect(sourceRefSchema.parse({ path: "matters/acme/file.pdf" }).path).toBe(
+      "matters/acme/file.pdf",
+    );
+    expect(sourceRefSchema.parse({ dms_id: "imanage-123" }).dms_id).toBe(
+      "imanage-123",
+    );
+  });
+
+  it("rejects refs without a document identifier", () => {
+    expect(() =>
+      sourceRefSchema.parse({ client_id: "acme", matter_id: "lit-1" }),
+    ).toThrow();
+  });
+
+  it("rejects inverted text and excerpt bounds", () => {
+    expect(() =>
+      sourceRefSchema.parse({
+        document_id: "doc-1",
+        text_span: { start: 12, end: 3 },
+      }),
+    ).toThrow();
+    expect(() =>
+      sourceRefSchema.parse({
+        document_id: "doc-1",
+        excerpt_bounds: { start: 12, end: 3 },
+      }),
+    ).toThrow();
+  });
+
+  it("bounds the number of refs accepted per row", () => {
+    const refs = Array.from({ length: 26 }, (_, index) => ({
+      document_id: `doc-${index}`,
+    }));
+
+    expect(() => sourceRefsSchema.parse(refs)).toThrow();
+  });
+
+  it("accepts bounded privilege and locator metadata", () => {
+    const parsed = sourceRefSchema.parse({
+      document_id: "doc-1",
+      client_id: "acme",
+      matter_id: "lit-1",
+      tenant_id: "tenant-a",
+      access_group: "trial-team",
+      role_policy: "attorney-only",
+      ethical_wall: true,
+      legal_hold: true,
+      page: 3,
+      paragraph: "12",
+      section: "Argument",
+      source_hash: "sha256:abc123",
+      ingested_at: "2026-07-06T12:00:00.000Z",
+    });
+
+    expect(parsed.client_id).toBe("acme");
+    expect(parsed.matter_id).toBe("lit-1");
+    expect(parsed.ethical_wall).toBe(true);
+    expect(parsed.page).toBe(3);
+  });
+
+  it("builds parameterized source-scope predicates", () => {
+    const params: unknown[] = ["query"];
+    const index = appendSourceScopeParam(params, {
+      client_id: "acme",
+      matter_id: "lit-1",
+      document_id: "doc-1",
+    });
+    const predicate = sourceScopeFilterSql("t", index);
+
+    expect(predicate).toContain("COALESCE(t.source_refs, '[]'::jsonb)");
+    expect(predicate).toContain("jsonb_array_elements");
+    expect(predicate).toContain(
+      "source_ref.ref->>'client_id' = $2::jsonb->>'client_id'",
+    );
+    expect(predicate).toContain(
+      "source_ref.ref->>'matter_id' = $2::jsonb->>'matter_id'",
+    );
+    expect(predicate).toContain(
+      "source_ref.ref->>'document_id' = $2::jsonb->>'document_id'",
+    );
+    expect(predicate).toContain("$2::jsonb");
+    expect(predicate).not.toContain("@> jsonb_build_array");
+    expect(predicate).not.toContain("acme");
+    expect(predicate).not.toContain("lit-1");
+    expect(predicate).not.toContain("doc-1");
+    expect(params).toEqual([
+      "query",
+      JSON.stringify({
+        client_id: "acme",
+        matter_id: "lit-1",
+        document_id: "doc-1",
+      }),
+    ]);
+  });
+});

--- a/src/source-refs.test.ts
+++ b/src/source-refs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   appendSourceScopeParam,
+  filterSourceRefsForScope,
   sourceRefSchema,
   sourceRefsSchema,
   sourceScopeFilterSql,
@@ -77,6 +78,8 @@ describe("source refs", () => {
       client_id: "acme",
       matter_id: "lit-1",
       document_id: "doc-1",
+      path: "matters/acme/strategy.pdf",
+      dms_id: "imanage-1",
     });
     const predicate = sourceScopeFilterSql("t", index);
 
@@ -91,6 +94,12 @@ describe("source refs", () => {
     expect(predicate).toContain(
       "source_ref.ref->>'document_id' = $2::jsonb->>'document_id'",
     );
+    expect(predicate).toContain(
+      "source_ref.ref->>'path' = $2::jsonb->>'path'",
+    );
+    expect(predicate).toContain(
+      "source_ref.ref->>'dms_id' = $2::jsonb->>'dms_id'",
+    );
     expect(predicate).toContain("$2::jsonb");
     expect(predicate).not.toContain("@> jsonb_build_array");
     expect(predicate).not.toContain("acme");
@@ -102,7 +111,38 @@ describe("source refs", () => {
         client_id: "acme",
         matter_id: "lit-1",
         document_id: "doc-1",
+        path: "matters/acme/strategy.pdf",
+        dms_id: "imanage-1",
       }),
     ]);
+  });
+
+  it("filters returned refs to the same matching source-scope object", () => {
+    const refs = [
+      {
+        document_id: "doc-1",
+        client_id: "acme",
+        matter_id: "lit-1",
+        path: "matters/acme/strategy.pdf",
+      },
+      {
+        document_id: "doc-2",
+        client_id: "acme",
+        matter_id: "lit-2",
+        path: "matters/acme/other.pdf",
+      },
+    ];
+
+    expect(
+      filterSourceRefsForScope(refs, {
+        client_id: "acme",
+        matter_id: "lit-1",
+      }),
+    ).toEqual([{ ...refs[0]!, source_type: "file" }]);
+    expect(
+      filterSourceRefsForScope(refs, {
+        path: "matters/acme/other.pdf",
+      }),
+    ).toEqual([{ ...refs[1]!, source_type: "file" }]);
   });
 });

--- a/src/source-refs.test.ts
+++ b/src/source-refs.test.ts
@@ -100,6 +100,9 @@ describe("source refs", () => {
     expect(predicate).toContain(
       "source_ref.ref->>'dms_id' = $2::jsonb->>'dms_id'",
     );
+    expect(predicate).toContain("source_ref.ref ? 'document_id'");
+    expect(predicate).toContain("source_ref.ref ? 'path'");
+    expect(predicate).toContain("source_ref.ref ? 'dms_id'");
     expect(predicate).toContain("$2::jsonb");
     expect(predicate).not.toContain("@> jsonb_build_array");
     expect(predicate).not.toContain("acme");
@@ -144,5 +147,32 @@ describe("source refs", () => {
         path: "matters/acme/other.pdf",
       }),
     ).toEqual([{ ...refs[1]!, source_type: "file" }]);
+  });
+
+  it("keeps valid matching refs when sibling refs are invalid", () => {
+    const refs = [
+      {
+        document_id: "doc-1",
+        client_id: "acme",
+        matter_id: "lit-1",
+      },
+      {
+        source_type: "legacy-unknown",
+        document_id: "doc-2",
+        client_id: "acme",
+        matter_id: "lit-1",
+      },
+      {
+        client_id: "acme",
+        matter_id: "lit-1",
+      },
+    ];
+
+    expect(
+      filterSourceRefsForScope(refs, {
+        client_id: "acme",
+        matter_id: "lit-1",
+      }),
+    ).toEqual([{ ...refs[0]!, source_type: "file" }]);
   });
 });

--- a/src/source-refs.ts
+++ b/src/source-refs.ts
@@ -110,7 +110,8 @@ export function sourceScopeFilterSql(
     AND EXISTS (
       SELECT 1
       FROM jsonb_array_elements(COALESCE(${alias}.source_refs, '[]'::jsonb)) AS source_ref(ref)
-      WHERE (NOT (${scopeRef}::jsonb ? 'client_id') OR source_ref.ref->>'client_id' = ${scopeRef}::jsonb->>'client_id')
+      WHERE (source_ref.ref ? 'document_id' OR source_ref.ref ? 'path' OR source_ref.ref ? 'dms_id')
+        AND (NOT (${scopeRef}::jsonb ? 'client_id') OR source_ref.ref->>'client_id' = ${scopeRef}::jsonb->>'client_id')
         AND (NOT (${scopeRef}::jsonb ? 'matter_id') OR source_ref.ref->>'matter_id' = ${scopeRef}::jsonb->>'matter_id')
         AND (NOT (${scopeRef}::jsonb ? 'document_id') OR source_ref.ref->>'document_id' = ${scopeRef}::jsonb->>'document_id')
         AND (NOT (${scopeRef}::jsonb ? 'path') OR source_ref.ref->>'path' = ${scopeRef}::jsonb->>'path')
@@ -138,9 +139,14 @@ export function filterSourceRefsForScope(
   sourceRefs: unknown,
   sourceScope: SourceScope,
 ): SourceReference[] {
-  const parsed = sourceRefsSchema.safeParse(sourceRefs);
-  if (!parsed.success) return [];
-  return parsed.data.filter((ref) => sourceRefMatchesScope(ref, sourceScope));
+  if (!Array.isArray(sourceRefs)) return [];
+  return sourceRefs
+    .slice(0, 25)
+    .flatMap((sourceRef) => {
+      const parsed = sourceRefSchema.safeParse(sourceRef);
+      return parsed.success ? [parsed.data] : [];
+    })
+    .filter((ref) => sourceRefMatchesScope(ref, sourceScope));
 }
 
 export const SOURCE_REFS_CONTRACT = {

--- a/src/source-refs.ts
+++ b/src/source-refs.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { AuthInfo } from "./types.ts";
 
 const isoDateTime = z.string().datetime();
 
@@ -76,6 +77,20 @@ export const sourceScopeSchema = z
 
 export type SourceScope = z.infer<typeof sourceScopeSchema>;
 
+export function sourceScopeAuthorizationError(
+  auth: AuthInfo,
+  sourceScope?: SourceScope,
+): string | undefined {
+  if (!sourceScope) return undefined;
+  if (auth.role !== "admin" && auth.role !== "ob-admin") {
+    return "Permission denied: source_scope requires token-sourced admin or ob-admin";
+  }
+  if (auth.namespaceSource === "header") {
+    return "Permission denied: delegated namespace sessions cannot use source_scope";
+  }
+  return undefined;
+}
+
 export function appendSourceScopeParam(
   params: unknown[],
   sourceScope?: SourceScope,
@@ -152,5 +167,7 @@ export const SOURCE_SCOPE_CONTRACT = {
   description:
     "Optional source-reference scope for closed-brain deployments. When set, " +
     "all supplied keys must match the same source_refs array element before " +
-    "source-scoped evidence or source_refs are returned.",
+    "source-scoped evidence or source_refs are returned. Until auth-bound " +
+    "source claims exist, source_scope is restricted to token-sourced admin " +
+    "or ob-admin callers.",
 } as const;

--- a/src/source-refs.ts
+++ b/src/source-refs.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+const isoDateTime = z.string().datetime();
+
+export const sourceRefSchema = z
+  .object({
+    source_type: z.enum(["file", "document", "dms", "url"]).default("file"),
+    document_id: z.string().trim().min(1).max(500).optional(),
+    path: z.string().trim().min(1).max(1000).optional(),
+    dms_id: z.string().trim().min(1).max(500).optional(),
+    title: z.string().trim().min(1).max(500).optional(),
+    client_id: z.string().trim().min(1).max(300).optional(),
+    matter_id: z.string().trim().min(1).max(300).optional(),
+    tenant_id: z.string().trim().min(1).max(300).optional(),
+    access_group: z.string().trim().min(1).max(300).optional(),
+    role_policy: z.string().trim().min(1).max(300).optional(),
+    ethical_wall: z.boolean().optional(),
+    retention_policy: z.string().trim().min(1).max(300).optional(),
+    legal_hold: z.boolean().optional(),
+    page: z.number().int().min(1).optional(),
+    paragraph: z.string().trim().min(1).max(100).optional(),
+    section: z.string().trim().min(1).max(300).optional(),
+    text_span: z
+      .object({
+        start: z.number().int().min(0),
+        end: z.number().int().min(0),
+      })
+      .refine((value) => value.end >= value.start, {
+        message: "text_span.end must be greater than or equal to start",
+      })
+      .optional(),
+    source_hash: z.string().trim().min(1).max(200).optional(),
+    ingested_at: isoDateTime.optional(),
+    excerpt_bounds: z
+      .object({
+        start: z.number().int().min(0),
+        end: z.number().int().min(0),
+      })
+      .refine((value) => value.end >= value.start, {
+        message: "excerpt_bounds.end must be greater than or equal to start",
+      })
+      .optional(),
+  })
+  .refine((value) => Boolean(value.document_id ?? value.path ?? value.dms_id), {
+    message: "source_refs require document_id, path, or dms_id",
+    path: ["document_id"],
+  });
+
+export const sourceRefsSchema = z.array(sourceRefSchema).max(25);
+
+export type SourceReference = z.infer<typeof sourceRefSchema>;
+
+export const sourceScopeSchema = z
+  .object({
+    client_id: z.string().trim().min(1).max(300).optional(),
+    matter_id: z.string().trim().min(1).max(300).optional(),
+    document_id: z.string().trim().min(1).max(500).optional(),
+  })
+  .refine(
+    (value) => Boolean(value.client_id ?? value.matter_id ?? value.document_id),
+    {
+      message: "source_scope requires client_id, matter_id, or document_id",
+      path: ["client_id"],
+    },
+  );
+
+export type SourceScope = z.infer<typeof sourceScopeSchema>;
+
+export function appendSourceScopeParam(
+  params: unknown[],
+  sourceScope?: SourceScope,
+): number | undefined {
+  if (!sourceScope) return undefined;
+  params.push(JSON.stringify(sourceScope));
+  return params.length;
+}
+
+export function sourceScopeFilterSql(
+  alias: string,
+  sourceScopeParamIndex?: number,
+): string {
+  if (!sourceScopeParamIndex) return "";
+  const scopeRef = `$${sourceScopeParamIndex}`;
+  return `
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(COALESCE(${alias}.source_refs, '[]'::jsonb)) AS source_ref(ref)
+      WHERE (NOT (${scopeRef}::jsonb ? 'client_id') OR source_ref.ref->>'client_id' = ${scopeRef}::jsonb->>'client_id')
+        AND (NOT (${scopeRef}::jsonb ? 'matter_id') OR source_ref.ref->>'matter_id' = ${scopeRef}::jsonb->>'matter_id')
+        AND (NOT (${scopeRef}::jsonb ? 'document_id') OR source_ref.ref->>'document_id' = ${scopeRef}::jsonb->>'document_id')
+    )`;
+}
+
+export const SOURCE_REFS_CONTRACT = {
+  type: "array",
+  required: false,
+  maxItems: 25,
+  description:
+    "Structured file/document provenance for closed-brain deployments. " +
+    "Each ref must identify a document via document_id, path, or dms_id, " +
+    "and may include client_id, matter_id, page/section/span locators, " +
+    "source_hash, ingestion timestamp, and privilege/isolation metadata.",
+} as const;

--- a/src/source-refs.ts
+++ b/src/source-refs.ts
@@ -55,11 +55,21 @@ export const sourceScopeSchema = z
     client_id: z.string().trim().min(1).max(300).optional(),
     matter_id: z.string().trim().min(1).max(300).optional(),
     document_id: z.string().trim().min(1).max(500).optional(),
+    path: z.string().trim().min(1).max(1000).optional(),
+    dms_id: z.string().trim().min(1).max(500).optional(),
   })
   .refine(
-    (value) => Boolean(value.client_id ?? value.matter_id ?? value.document_id),
+    (value) =>
+      Boolean(
+        value.client_id ??
+          value.matter_id ??
+          value.document_id ??
+          value.path ??
+          value.dms_id,
+      ),
     {
-      message: "source_scope requires client_id, matter_id, or document_id",
+      message:
+        "source_scope requires client_id, matter_id, document_id, path, or dms_id",
       path: ["client_id"],
     },
   );
@@ -88,7 +98,34 @@ export function sourceScopeFilterSql(
       WHERE (NOT (${scopeRef}::jsonb ? 'client_id') OR source_ref.ref->>'client_id' = ${scopeRef}::jsonb->>'client_id')
         AND (NOT (${scopeRef}::jsonb ? 'matter_id') OR source_ref.ref->>'matter_id' = ${scopeRef}::jsonb->>'matter_id')
         AND (NOT (${scopeRef}::jsonb ? 'document_id') OR source_ref.ref->>'document_id' = ${scopeRef}::jsonb->>'document_id')
+        AND (NOT (${scopeRef}::jsonb ? 'path') OR source_ref.ref->>'path' = ${scopeRef}::jsonb->>'path')
+        AND (NOT (${scopeRef}::jsonb ? 'dms_id') OR source_ref.ref->>'dms_id' = ${scopeRef}::jsonb->>'dms_id')
     )`;
+}
+
+export function sourceRefMatchesScope(
+  ref: SourceReference,
+  sourceScope: SourceScope,
+): boolean {
+  return (
+    (sourceScope.client_id === undefined ||
+      ref.client_id === sourceScope.client_id) &&
+    (sourceScope.matter_id === undefined ||
+      ref.matter_id === sourceScope.matter_id) &&
+    (sourceScope.document_id === undefined ||
+      ref.document_id === sourceScope.document_id) &&
+    (sourceScope.path === undefined || ref.path === sourceScope.path) &&
+    (sourceScope.dms_id === undefined || ref.dms_id === sourceScope.dms_id)
+  );
+}
+
+export function filterSourceRefsForScope(
+  sourceRefs: unknown,
+  sourceScope: SourceScope,
+): SourceReference[] {
+  const parsed = sourceRefsSchema.safeParse(sourceRefs);
+  if (!parsed.success) return [];
+  return parsed.data.filter((ref) => sourceRefMatchesScope(ref, sourceScope));
 }
 
 export const SOURCE_REFS_CONTRACT = {
@@ -100,4 +137,20 @@ export const SOURCE_REFS_CONTRACT = {
     "Each ref must identify a document via document_id, path, or dms_id, " +
     "and may include client_id, matter_id, page/section/span locators, " +
     "source_hash, ingestion timestamp, and privilege/isolation metadata.",
+} as const;
+
+export const SOURCE_SCOPE_CONTRACT = {
+  type: "object",
+  required: false,
+  fields: {
+    client_id: { type: "string", required: false, minLength: 1, maxLength: 300 },
+    matter_id: { type: "string", required: false, minLength: 1, maxLength: 300 },
+    document_id: { type: "string", required: false, minLength: 1, maxLength: 500 },
+    path: { type: "string", required: false, minLength: 1, maxLength: 1000 },
+    dms_id: { type: "string", required: false, minLength: 1, maxLength: 500 },
+  },
+  description:
+    "Optional source-reference scope for closed-brain deployments. When set, " +
+    "all supplied keys must match the same source_refs array element before " +
+    "source-scoped evidence or source_refs are returned.",
 } as const;

--- a/src/table-projections.ts
+++ b/src/table-projections.ts
@@ -2,13 +2,13 @@ import type { Table } from "./types.ts";
 
 export const TABLE_COLUMNS: Record<Table, string> = {
   thoughts:
-    "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace, promoted_from",
+    "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, source_refs, namespace, promoted_from",
   decisions:
-    "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, namespace, promoted_from",
+    "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, source_refs, namespace, promoted_from",
   relationships:
-    "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
+    "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, source_refs, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
   projects:
-    "id, name, status, description, metadata, tags, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
+    "id, name, status, description, metadata, source_refs, tags, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
   sessions:
-    "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, created_by, created_at, updated_at, tier, namespace, promoted_from",
+    "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, source_refs, created_by, created_at, updated_at, tier, namespace, promoted_from",
 };

--- a/src/tools/__tests__/brain-answer.test.ts
+++ b/src/tools/__tests__/brain-answer.test.ts
@@ -198,6 +198,28 @@ describe("brain_answer", () => {
     }
   });
 
+  it("denies source scope for non-admin callers before retrieval", async () => {
+    const { setup, queries } = setupClient([row()], {
+      role: "agent",
+      clientId: "bilby",
+    });
+    const { client, cleanup } = await setup;
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: {
+          query: "memory",
+          source_scope: { client_id: "acme" },
+        },
+      });
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("source_scope requires");
+      expect(queries).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("surfaces stale evidence as uncertainty", async () => {
     const { setup } = setupClient([
       row({

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -124,7 +124,11 @@ describe("get_entry", () => {
         };
       },
     };
-    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "admin",
+      namespaceSource: "token",
+    };
     const { client, cleanup } = await setupMcpClient(
       registerGetEntry,
       mockPool,
@@ -155,13 +159,46 @@ describe("get_entry", () => {
       );
       expect(queries[0]?.params).toEqual([
         "550e8400-e29b-41d4-a716-446655440021",
-        ["bilby", "shared-kb"],
         JSON.stringify({
           client_id: "acme",
           matter_id: "lit-1",
           document_id: "doc-1",
         }),
       ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies source scope for non-admin callers before querying", async () => {
+    let queried = false;
+    const mockPool = {
+      query: async () => {
+        queried = true;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440021",
+          source_scope: { client_id: "acme" },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("source_scope requires");
+      expect(queried).toBe(false);
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -47,6 +47,118 @@ describe("get_entry", () => {
     }
   });
 
+  it("redacts source refs from full reads unless source scope is supplied", async () => {
+    const mockPool = {
+      query: async () => ({
+        rows: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440020",
+            namespace: "bilby",
+            content: "privileged summary",
+            source_refs: [
+              {
+                document_id: "doc-1",
+                client_id: "acme",
+                matter_id: "lit-1",
+                path: "matters/acme/strategy.pdf",
+              },
+            ],
+          },
+        ],
+      }),
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440020",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.content).toBe("privileged summary");
+      expect(parsed.source_refs).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("requires matching source scope before returning source refs", async () => {
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const sourceRefs = [
+      {
+        document_id: "doc-1",
+        client_id: "acme",
+        matter_id: "lit-1",
+        path: "matters/acme/strategy.pdf",
+      },
+    ];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        return {
+          rows: [
+            {
+              id: params?.[0],
+              namespace: "bilby",
+              content: "scoped summary",
+              source_refs: sourceRefs,
+            },
+          ],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      mockPool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "thoughts",
+          id: "550e8400-e29b-41d4-a716-446655440021",
+          source_scope: {
+            client_id: "acme",
+            matter_id: "lit-1",
+            document_id: "doc-1",
+          },
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result).source_refs).toEqual(sourceRefs);
+      expect(queries[0]?.sql).toContain(
+        "COALESCE(t.source_refs, '[]'::jsonb)",
+      );
+      expect(queries[0]?.params).toEqual([
+        "550e8400-e29b-41d4-a716-446655440021",
+        ["bilby", "shared-kb"],
+        JSON.stringify({
+          client_id: "acme",
+          matter_id: "lit-1",
+          document_id: "doc-1",
+        }),
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("returns not found when scoped namespace filter excludes the row", async () => {
     const mockPool = { query: async () => ({ rows: [] }) };
     const auth: AuthInfo = {

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -102,6 +102,12 @@ describe("get_entry", () => {
         matter_id: "lit-1",
         path: "matters/acme/strategy.pdf",
       },
+      {
+        document_id: "doc-2",
+        client_id: "acme",
+        matter_id: "lit-2",
+        path: "matters/acme/other.pdf",
+      },
     ];
     const mockPool = {
       query: async (sql: string, params?: unknown[]) => {
@@ -141,7 +147,9 @@ describe("get_entry", () => {
       });
 
       expect(result.isError).toBeFalsy();
-      expect(parseToolResult(result).source_refs).toEqual(sourceRefs);
+      expect(parseToolResult(result).source_refs).toEqual([
+        { ...sourceRefs[0], source_type: "file" },
+      ]);
       expect(queries[0]?.sql).toContain(
         "COALESCE(t.source_refs, '[]'::jsonb)",
       );

--- a/src/tools/__tests__/log-decision.test.ts
+++ b/src/tools/__tests__/log-decision.test.ts
@@ -114,6 +114,98 @@ describe("log_decision", () => {
         await cleanup();
       }
     });
+
+    it("stores structured source refs with decision entries", async () => {
+      let capturedSql = "";
+      let capturedParams: unknown[] = [];
+      const sourceRefs = [
+        {
+          source_type: "file",
+          document_id: "decision-doc-1",
+          path: "matters/acme/strategy-memo.pdf",
+          client_id: "acme",
+          matter_id: "lit-2026-001",
+          page: 9,
+          paragraph: "12",
+          source_hash: "sha256:decisionhash",
+          ingested_at: "2026-07-06T14:00:00.000Z",
+        },
+      ];
+      const mockPool = {
+        query: async (sql: string, params?: unknown[]) => {
+          capturedSql = sql;
+          capturedParams = params ?? [];
+          return {
+            rows: [
+              {
+                id: "decision-source-ref-uuid",
+                is_new: true,
+                source_refs: sourceRefs,
+              },
+            ],
+          };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupDecisionClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_decision",
+          arguments: {
+            title: "Use source-grounded answer",
+            rationale: "Legal workflow answers need matter-scoped citations.",
+            source_refs: sourceRefs,
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(capturedSql).toContain("source_refs");
+        expect(JSON.parse(capturedParams[11] as string)).toEqual(sourceRefs);
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.source_refs).toEqual(sourceRefs);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("rejects invalid source refs before writing decisions", async () => {
+      let queried = false;
+      const mockPool = {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+      const { client, cleanup } = await setupDecisionClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_decision",
+          arguments: {
+            title: "Bad source ref",
+            rationale: "Should fail validation.",
+            source_refs: [{ client_id: "acme", matter_id: "lit-1" }],
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(queried).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe("embedding text construction", () => {

--- a/src/tools/__tests__/log-thought.test.ts
+++ b/src/tools/__tests__/log-thought.test.ts
@@ -76,6 +76,88 @@ describe("log_thought", () => {
         await cleanup();
       }
     });
+
+    it("stores structured source refs with thought entries", async () => {
+      let capturedSql = "";
+      let capturedParams: unknown[] = [];
+      const sourceRefs = [
+        {
+          source_type: "file",
+          document_id: "doc-123",
+          path: "matters/acme/complaint.pdf",
+          client_id: "acme",
+          matter_id: "lit-2026-001",
+          page: 4,
+          section: "Background",
+          source_hash: "sha256:testhash",
+          ingested_at: "2026-07-06T12:00:00.000Z",
+        },
+      ];
+      const mockPool = {
+        query: async (sql: string, params?: unknown[]) => {
+          capturedSql = sql;
+          capturedParams = params ?? [];
+          return {
+            rows: [{ id: "source-ref-uuid", is_new: true, source_refs: sourceRefs }],
+          };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "test-client" };
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_thought",
+          arguments: {
+            content: "Complaint states venue facts.",
+            source_refs: sourceRefs,
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(capturedSql).toContain("source_refs");
+        expect(JSON.parse(capturedParams[8] as string)).toEqual(sourceRefs);
+        const parsed = JSON.parse((result.content as any)[0].text);
+        expect(parsed.source_refs).toEqual(sourceRefs);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("rejects source refs without a document identifier", async () => {
+      let queried = false;
+      const mockPool = {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "test-client" };
+      const { client, cleanup } = await setupToolClient(
+        mockPool,
+        createMockEmbed(),
+        auth,
+      );
+
+      try {
+        const result = await client.callTool({
+          name: "log_thought",
+          arguments: {
+            content: "Bad source ref",
+            source_refs: [{ client_id: "acme", matter_id: "lit-1" }],
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(queried).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   describe("embedding failure (graceful degradation)", () => {

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -241,6 +241,35 @@ describe("search_all", () => {
       }
     });
 
+    it("denies source scope for non-admin callers before searching", async () => {
+      let queried = false;
+      mockBunSpawn(0, qmdJson([{ path: "/a.md", content: "hello" }]));
+      const pool = {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+      const { client, cleanup } = await setupClient(pool, auth);
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: {
+            query: "scoped",
+            sources: "all",
+            source_scope: { client_id: "acme" },
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(getErrorText(result)).toContain("source_scope requires");
+        expect(queried).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("returns empty results when both sources return nothing", async () => {
       mockBunSpawn(0, qmdJson([]));
       const pool = { query: async () => ({ rows: [] }) };

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -190,6 +190,57 @@ describe("search_all", () => {
       }
     });
 
+    it("rejects qmd-only source scoped searches", async () => {
+      mockBunSpawn(0, qmdJson([{ path: "/a.md", content: "hello" }]));
+      const pool = { query: async () => ({ rows: [] }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(pool, auth);
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: {
+            query: "qmd only",
+            sources: "qmd",
+            source_scope: { client_id: "acme" },
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(getErrorText(result)).toContain(
+          "source_scope applies only to Open Brain source_refs",
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("suppresses qmd hits when an all-source search is source scoped", async () => {
+      mockBunSpawn(0, qmdJson([{ path: "/a.md", content: "hello" }]));
+      const pool = { query: async () => ({ rows: makeMockRowsWithMeta(1) }) };
+      const auth: AuthInfo = { role: "admin", clientId: "admin" };
+      const { client, cleanup } = await setupClient(pool, auth);
+      try {
+        const result = await client.callTool({
+          name: "search_all",
+          arguments: {
+            query: "scoped",
+            sources: "all",
+            source_scope: { client_id: "acme" },
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = parseSearchAll(result);
+        expect(parsed.brain_hits).toBe(1);
+        expect(parsed.qmd_hits).toBe(0);
+        expect(parsed.results.every((r: any) => r.source === "brain")).toBe(
+          true,
+        );
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("returns empty results when both sources return nothing", async () => {
       mockBunSpawn(0, qmdJson([]));
       const pool = { query: async () => ({ rows: [] }) };

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -121,6 +121,57 @@ describe("search_brain", () => {
       }
     });
 
+    it("parameterizes source scope in keyword SQL", async () => {
+      const queryCalls: any[] = [];
+      const pool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          const [sql] = args;
+          if (String(sql).includes("FROM ob_links")) return { rows: [] };
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "matter scoped search",
+            namespace: "team-kb",
+            search_mode: "keyword",
+            source_scope: {
+              client_id: "acme",
+              matter_id: "lit-1",
+              document_id: "doc-1",
+            },
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const [sql, params] = queryCalls[0];
+        const sourceScopeJson = JSON.stringify({
+          client_id: "acme",
+          matter_id: "lit-1",
+          document_id: "doc-1",
+        });
+        const sourceScopeParamIndex = (params as unknown[]).indexOf(
+          sourceScopeJson,
+        ) + 1;
+        expect(sourceScopeParamIndex).toBeGreaterThan(0);
+        expect(String(sql)).toContain(
+          `COALESCE(t.source_refs, '[]'::jsonb)`,
+        );
+        expect(String(sql)).toContain(`$${sourceScopeParamIndex}::jsonb`);
+        expect(String(sql)).not.toContain("acme");
+        expect(String(sql)).not.toContain("lit-1");
+        expect(String(sql)).not.toContain("doc-1");
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("parameterizes namespace in default hybrid SQL", async () => {
       const maliciousNamespace = "' OR 1=1 --";
       const searchCalls: any[] = [];

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -206,6 +206,67 @@ describe("search_brain", () => {
       }
     });
 
+    it("denies source scope for non-admin callers before querying", async () => {
+      let queried = false;
+      const pool = {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "matter scoped search",
+            source_scope: { client_id: "acme" },
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(getErrorText(result)).toContain("source_scope requires");
+        expect(queried).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("denies source scope for delegated admin sessions", async () => {
+      let queried = false;
+      const pool = {
+        query: async () => {
+          queried = true;
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = {
+        role: "admin",
+        clientId: "bilby",
+        tokenClientId: "admin",
+        namespaceSource: "header",
+      };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "matter scoped search",
+            source_scope: { client_id: "acme" },
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(getErrorText(result)).toContain("delegated namespace");
+        expect(queried).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("parameterizes namespace in default hybrid SQL", async () => {
       const maliciousNamespace = "' OR 1=1 --";
       const searchCalls: any[] = [];

--- a/src/tools/__tests__/search-brain.test.ts
+++ b/src/tools/__tests__/search-brain.test.ts
@@ -172,6 +172,40 @@ describe("search_brain", () => {
       }
     });
 
+    it("excludes unscoped entity rows when source scope is supplied", async () => {
+      const queryCalls: any[] = [];
+      const pool = {
+        query: async (...args: any[]) => {
+          queryCalls.push(args);
+          const [sql] = args;
+          if (String(sql).includes("FROM ob_links")) return { rows: [] };
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "admin-client" };
+      const { client, cleanup } = await setup(pool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: "matter scoped search",
+            search_mode: "keyword",
+            source_scope: {
+              client_id: "acme",
+            },
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const [sql] = queryCalls[0];
+        expect(String(sql)).not.toContain("entities_fts");
+        expect(String(sql)).not.toContain("FROM ob_entities");
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("parameterizes namespace in default hybrid SQL", async () => {
       const maliciousNamespace = "' OR 1=1 --";
       const searchCalls: any[] = [];

--- a/src/tools/__tests__/session-wrap.test.ts
+++ b/src/tools/__tests__/session-wrap.test.ts
@@ -185,6 +185,65 @@ describe("session_wrap", () => {
     }
   });
 
+  it("stores structured source refs on session checkpoints", async () => {
+    let insertParams: unknown[] = [];
+      const sourceRefs = [
+        {
+          source_type: "file",
+          document_id: "doc-456",
+          dms_id: "iManage-456",
+        title: "Engagement Letter",
+        client_id: "acme",
+        matter_id: "onboarding-2026",
+        ethical_wall: true,
+        ingested_at: "2026-07-06T13:00:00.000Z",
+      },
+    ];
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        if (sql.includes("FROM ob_session_lanes")) {
+          return { rows: [MOCK_LANE] };
+        }
+        if (sql.includes("count(*)")) {
+          return { rows: [{ cnt: 2 }] };
+        }
+        if (sql.includes("INSERT INTO sessions")) {
+          insertParams = params ?? [];
+          return {
+            rows: [
+              {
+                id: "session-source-ref",
+                created_at: "2026-07-06T13:10:00Z",
+                source_refs: sourceRefs,
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "session_wrap",
+        arguments: {
+          session_key: "ob-v2-dev",
+          summary: "Closed-brain checkpoint with source grounding.",
+          source_refs: sourceRefs,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(JSON.parse(insertParams[10] as string)).toEqual(sourceRefs);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.source_refs).toEqual(sourceRefs);
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ── KEEP_ACTIVE ──
 
   it("checkpoint never changes lane status — lane stays active", async () => {

--- a/src/tools/__tests__/session-wrap.test.ts
+++ b/src/tools/__tests__/session-wrap.test.ts
@@ -574,6 +574,7 @@ describe("session_wrap", () => {
         arguments: {
           session_key: "ob-v2-dev",
           summary: "Already wrapped this.",
+          source_refs: [{ document_id: "new-doc" }],
         },
       });
 
@@ -583,6 +584,8 @@ describe("session_wrap", () => {
       expect(parsed.lane_id).toBe("lane-uuid-1");
       expect(parsed.lane_status).toBe("wrapped");
       expect(parsed.message).toContain("identical content");
+      expect(parsed.message).toContain("source_refs are not merged");
+      expect(parsed.source_refs).toBeUndefined();
     } finally {
       await cleanup();
     }

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -142,7 +142,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         source_scope: sourceScopeSchema
           .optional()
           .describe(
-            "Optional: require matching source_refs client_id, matter_id, or document_id before citing brain evidence",
+            "Optional: require matching source_refs client_id, matter_id, document_id, path, or dms_id before citing brain evidence",
           ),
         max_age_days: z
           .number()

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -11,9 +11,11 @@ import {
   executeSearchWithSharedFallback,
   type SearchMode,
   type SearchRow,
+  type SourceScope,
   type SourceRef,
 } from "./search-brain.ts";
 import { isSharedNamespace } from "../shared-namespace.ts";
+import { sourceScopeSchema } from "../source-refs.ts";
 
 type NamespaceFilter = string | string[];
 
@@ -137,6 +139,11 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
           .enum(["hot", "warm", "cold"])
           .optional()
           .describe("Optional cognitive tier filter"),
+        source_scope: sourceScopeSchema
+          .optional()
+          .describe(
+            "Optional: require matching source_refs client_id, matter_id, or document_id before citing brain evidence",
+          ),
         max_age_days: z
           .number()
           .int()
@@ -202,6 +209,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
       const limit = args.limit ?? 5;
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
+      const sourceScope = args.source_scope as SourceScope | undefined;
       const maxAgeDays = args.max_age_days ?? 180;
       const namespace = namespaceFilterFor(
         auth,
@@ -222,6 +230,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
                 0,
                 namespace,
                 false,
+                sourceScope,
               )
             : await executeSearchWithScopedSharedFallback(
                 deps,
@@ -233,6 +242,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
                 0,
                 namespace,
                 false,
+                sourceScope,
               );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -15,7 +15,10 @@ import {
   type SourceRef,
 } from "./search-brain.ts";
 import { isSharedNamespace } from "../shared-namespace.ts";
-import { sourceScopeSchema } from "../source-refs.ts";
+import {
+  sourceScopeAuthorizationError,
+  sourceScopeSchema,
+} from "../source-refs.ts";
 
 type NamespaceFilter = string | string[];
 
@@ -210,6 +213,13 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
       const sourceScope = args.source_scope as SourceScope | undefined;
+      const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
+      if (sourceScopeError) {
+        return {
+          content: [{ type: "text" as const, text: sourceScopeError }],
+          isError: true,
+        };
+      }
       const maxAgeDays = args.max_age_days ?? 180;
       const namespace = namespaceFilterFor(
         auth,

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -8,6 +8,7 @@ import { TABLE_COLUMNS } from "../table-projections.ts";
 import {
   appendSourceScopeParam,
   filterSourceRefsForScope,
+  sourceScopeAuthorizationError,
   sourceScopeFilterSql,
   sourceScopeSchema,
   type SourceScope,
@@ -95,6 +96,13 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
 
       const render = args.render ?? "full";
       const sourceScope = args.source_scope as SourceScope | undefined;
+      const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
+      if (sourceScopeError) {
+        return {
+          content: [{ type: "text" as const, text: sourceScopeError }],
+          isError: true,
+        };
+      }
       if (render === "compact") {
         const maxChars = args.max_chars ?? DEFAULT_COMPACT_MAX_CHARS;
         const alias = TABLE_ALIAS[table];

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -6,6 +6,12 @@ import type { AuthInfo, Table } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { TABLE_COLUMNS } from "../table-projections.ts";
 import {
+  appendSourceScopeParam,
+  sourceScopeFilterSql,
+  sourceScopeSchema,
+  type SourceScope,
+} from "../source-refs.ts";
+import {
   CONTENT_PREVIEW,
   SOURCE_LABELS,
   TABLE_ALIAS,
@@ -57,6 +63,11 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Maximum compact content_preview length in characters (default 500, max 2000). Ignored for full render.",
           ),
+        source_scope: sourceScopeSchema
+          .optional()
+          .describe(
+            "Optional: require matching source_refs client_id, matter_id, or document_id before returning source_refs",
+          ),
       },
       annotations: {
         title: "Get Entry",
@@ -82,6 +93,7 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
       }
 
       const render = args.render ?? "full";
+      const sourceScope = args.source_scope as SourceScope | undefined;
       if (render === "compact") {
         const maxChars = args.max_chars ?? DEFAULT_COMPACT_MAX_CHARS;
         const alias = TABLE_ALIAS[table];
@@ -98,6 +110,14 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
           params.push(readable);
           namespacePredicate = ` AND ${alias}.namespace = ANY($${params.length}::text[])`;
         }
+        const sourceScopeParamIndex = appendSourceScopeParam(
+          params,
+          sourceScope,
+        );
+        const sourceScopeFilter = sourceScopeFilterSql(
+          alias,
+          sourceScopeParamIndex,
+        );
         params.push(maxChars);
         const maxCharsParam = `$${params.length}`;
         const contentExpr = `regexp_replace(COALESCE((${compactContent})::text, ''), '[[:space:]]+', ' ', 'g')`;
@@ -110,7 +130,7 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
              SELECT ${alias}.id, ${alias}.namespace, ${alias}.created_by, ${alias}.created_at, ${updatedAtExpr} AS updated_at, ${alias}.tier, ${alias}.tags,
                ${contentExpr} AS content_text
              FROM ${table} ${alias}
-             WHERE ${alias}.id = $1 AND ${alias}.archived_at IS NULL${namespacePredicate}
+             WHERE ${alias}.id = $1 AND ${alias}.archived_at IS NULL${namespacePredicate}${sourceScopeFilter}
            ) entry`,
           params,
         );
@@ -158,7 +178,9 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
                 full_available: true,
                 fetch_path: {
                   tool: "get_entry",
-                  arguments: { table, id: row.id, render: "full" },
+                  arguments: sourceScope
+                    ? { table, id: row.id, render: "full", source_scope: sourceScope }
+                    : { table, id: row.id, render: "full" },
                 },
               }),
             },
@@ -167,13 +189,17 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
       }
 
       const columns = TABLE_COLUMNS[table];
+      const alias = TABLE_ALIAS[table];
       const readable = readableNamespaces(auth);
+      const params: unknown[] = [args.id];
       const namespacePredicate = readable
-        ? " AND namespace = ANY($2::text[])"
+        ? ` AND ${alias}.namespace = ANY($${params.push(readable)}::text[])`
         : "";
+      const sourceScopeParamIndex = appendSourceScopeParam(params, sourceScope);
+      const sourceScopeFilter = sourceScopeFilterSql(alias, sourceScopeParamIndex);
       const { rows } = await deps.pool.query(
-        `SELECT ${columns} FROM ${table} WHERE id = $1 AND archived_at IS NULL${namespacePredicate}`,
-        readable ? [args.id, readable] : [args.id],
+        `SELECT ${columns} FROM ${table} ${alias} WHERE ${alias}.id = $1 AND ${alias}.archived_at IS NULL${namespacePredicate}${sourceScopeFilter}`,
+        params,
       );
 
       if (rows.length === 0) {
@@ -188,11 +214,16 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
         };
       }
 
+      const row = { ...rows[0] };
+      if (!sourceScope) {
+        delete row.source_refs;
+      }
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(rows[0]),
+            text: JSON.stringify(row),
           },
         ],
       };

--- a/src/tools/get-entry.ts
+++ b/src/tools/get-entry.ts
@@ -7,6 +7,7 @@ import type { ToolDeps } from "./index.ts";
 import { TABLE_COLUMNS } from "../table-projections.ts";
 import {
   appendSourceScopeParam,
+  filterSourceRefsForScope,
   sourceScopeFilterSql,
   sourceScopeSchema,
   type SourceScope,
@@ -66,7 +67,7 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
         source_scope: sourceScopeSchema
           .optional()
           .describe(
-            "Optional: require matching source_refs client_id, matter_id, or document_id before returning source_refs",
+            "Optional: require matching source_refs client_id, matter_id, document_id, path, or dms_id before returning source_refs",
           ),
       },
       annotations: {
@@ -215,7 +216,9 @@ export function registerGetEntry(server: McpServer, deps: ToolDeps): void {
       }
 
       const row = { ...rows[0] };
-      if (!sourceScope) {
+      if (sourceScope) {
+        row.source_refs = filterSourceRefsForScope(row.source_refs, sourceScope);
+      } else {
         delete row.source_refs;
       }
 

--- a/src/tools/log-decision.ts
+++ b/src/tools/log-decision.ts
@@ -7,6 +7,7 @@ import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import { backgroundExtract } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
+import { sourceRefsSchema } from "../source-refs.ts";
 import type { ToolDeps } from "./index.ts";
 
 export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
@@ -30,6 +31,9 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
           .max(500)
           .optional()
           .describe("Namespace to store in (defaults to caller's clientId)"),
+        source_refs: sourceRefsSchema
+          .optional()
+          .describe("Structured file/document refs for closed-brain provenance"),
       },
       annotations: {
         title: "Log Decision",
@@ -79,8 +83,8 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
       });
 
       const { rows } = await deps.pool.query(
-        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        `INSERT INTO decisions (title, rationale, alternatives, tags, context, created_by, namespace, embedding, content_hash, embedded_at, embedding_model, source_refs)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)
          ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
          DO UPDATE SET
            tags = (
@@ -88,8 +92,12 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
              FROM unnest(decisions.tags || EXCLUDED.tags) AS tag
              WHERE tag IS NOT NULL
            ),
+           source_refs = CASE
+             WHEN EXCLUDED.source_refs = '[]'::jsonb THEN decisions.source_refs
+             ELSE EXCLUDED.source_refs
+           END,
            updated_at = NOW()
-         RETURNING id, (xmax = 0) AS is_new`,
+         RETURNING id, (xmax = 0) AS is_new, source_refs`,
         [
           args.title,
           args.rationale,
@@ -104,6 +112,7 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
           hash,
           embedding ? new Date().toISOString() : null,
           embedding ? EMBEDDING_MODEL : null,
+          JSON.stringify(args.source_refs ?? []),
         ],
       );
 
@@ -129,6 +138,7 @@ export function registerLogDecision(server: McpServer, deps: ToolDeps): void {
               namespace: ns,
               embedded: !!embedding,
               merged: !isNew,
+              source_refs: rows[0].source_refs,
             }),
           },
         ],

--- a/src/tools/log-thought.ts
+++ b/src/tools/log-thought.ts
@@ -11,6 +11,7 @@ import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import { backgroundExtract } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
+import { sourceRefsSchema } from "../source-refs.ts";
 import type { ToolDeps } from "./index.ts";
 
 export function registerLogThought(server: McpServer, deps: ToolDeps): void {
@@ -27,6 +28,9 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
           .max(500)
           .optional()
           .describe("Namespace to store in (defaults to caller's clientId)"),
+        source_refs: sourceRefsSchema
+          .optional()
+          .describe("Structured file/document refs for closed-brain provenance"),
       },
       annotations: {
         title: "Log Thought",
@@ -75,8 +79,8 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
       });
 
       const { rows } = await deps.pool.query(
-        `INSERT INTO thoughts (content, tags, source, created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7, $8)
+        `INSERT INTO thoughts (content, tags, source, created_by, namespace, embedding, content_hash, embedded_at, embedding_model, source_refs)
+         VALUES ($1, $2, 'mcp', $3, $4, $5, $6, $7, $8, $9::jsonb)
          ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
          DO UPDATE SET
            tags = (
@@ -84,8 +88,12 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
              FROM unnest(thoughts.tags || EXCLUDED.tags) AS tag
              WHERE tag IS NOT NULL
            ),
+           source_refs = CASE
+             WHEN EXCLUDED.source_refs = '[]'::jsonb THEN thoughts.source_refs
+             ELSE EXCLUDED.source_refs
+           END,
            updated_at = NOW()
-         RETURNING id, (xmax = 0) AS is_new`,
+         RETURNING id, (xmax = 0) AS is_new, source_refs`,
         [
           args.content,
           args.tags ?? [],
@@ -95,6 +103,7 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
           hash,
           embedding ? new Date().toISOString() : null,
           embedding ? EMBEDDING_MODEL : null,
+          JSON.stringify(args.source_refs ?? []),
         ],
       );
 
@@ -120,6 +129,7 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
               namespace: canonicalNamespace(ns),
               embedded: !!embedding,
               merged: !isNew,
+              source_refs: rows[0].source_refs,
             }),
           },
         ],

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -189,7 +189,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
         source_scope: sourceScopeSchema
           .optional()
           .describe(
-            "Optional: require matching source_refs client_id, matter_id, or document_id before returning brain results",
+            "Optional: require matching source_refs client_id, matter_id, document_id, path, or dms_id before returning brain results. QMD results are suppressed while this is set.",
           ),
       },
       annotations: {
@@ -221,6 +221,17 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const sourceScope = args.source_scope as SourceScope | undefined;
       const collection = args.collection as string | undefined;
       const requestedNamespace = args.namespace as string | undefined;
+      if (sourceScope && sources === "qmd") {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "source_scope applies only to Open Brain source_refs; use sources='brain' or omit source_scope for qmd.",
+            },
+          ],
+          isError: true,
+        };
+      }
       if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
         return {
           content: [
@@ -234,7 +245,8 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       }
       const namespace = namespaceFilterFor(auth, requestedNamespace);
       const searchBrain = sources === "all" || sources === "brain";
-      const searchQmdSource = sources === "all" || sources === "qmd";
+      const searchQmdSource =
+        !sourceScope && (sources === "all" || sources === "qmd");
 
       // Over-fetch to cover offset + limit, then slice after merge
       const totalNeeded = offset + limit;

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -18,7 +18,10 @@ import {
   type SourceRef,
 } from "./search-brain.ts";
 import { isSharedNamespace } from "../shared-namespace.ts";
-import { sourceScopeSchema } from "../source-refs.ts";
+import {
+  sourceScopeAuthorizationError,
+  sourceScopeSchema,
+} from "../source-refs.ts";
 
 type NamespaceFilter = string | string[];
 
@@ -221,6 +224,13 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const sourceScope = args.source_scope as SourceScope | undefined;
       const collection = args.collection as string | undefined;
       const requestedNamespace = args.namespace as string | undefined;
+      const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
+      if (sourceScopeError) {
+        return {
+          content: [{ type: "text" as const, text: sourceScopeError }],
+          isError: true,
+        };
+      }
       if (sourceScope && sources === "qmd") {
         return {
           content: [

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -14,9 +14,11 @@ import {
   TIER_BOOST,
   type SearchMode,
   type SearchRow,
+  type SourceScope,
   type SourceRef,
 } from "./search-brain.ts";
 import { isSharedNamespace } from "../shared-namespace.ts";
+import { sourceScopeSchema } from "../source-refs.ts";
 
 type NamespaceFilter = string | string[];
 
@@ -184,6 +186,11 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Optional: filter brain results to a specific cognitive tier",
           ),
+        source_scope: sourceScopeSchema
+          .optional()
+          .describe(
+            "Optional: require matching source_refs client_id, matter_id, or document_id before returning brain results",
+          ),
       },
       annotations: {
         title: "Search All",
@@ -211,6 +218,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       const sources = (args.sources as "all" | "brain" | "qmd") ?? "all";
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
+      const sourceScope = args.source_scope as SourceScope | undefined;
       const collection = args.collection as string | undefined;
       const requestedNamespace = args.namespace as string | undefined;
       if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
@@ -234,7 +242,16 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       // Launch both searches in parallel
       const [brainResults, qmdResults] = await Promise.all([
         searchBrain
-          ? searchOB(deps, auth, args.query, totalNeeded, mode, tier, namespace)
+          ? searchOB(
+              deps,
+              auth,
+              args.query,
+              totalNeeded,
+              mode,
+              tier,
+              namespace,
+              sourceScope,
+            )
           : Promise.resolve([]),
         searchQmdSource
           ? searchQmd(args.query, totalNeeded, collection)
@@ -288,6 +305,7 @@ async function searchOB(
   mode: SearchMode = "hybrid",
   tier?: Tier,
   namespace?: NamespaceFilter,
+  sourceScope?: SourceScope,
 ): Promise<UnifiedResult[]> {
   const accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
   if (accessibleTables.length === 0) return [];
@@ -306,6 +324,7 @@ async function searchOB(
             0,
             namespace,
             false,
+            sourceScope,
           )
         : await executeSearchWithScopedSharedFallback(
             deps,
@@ -317,6 +336,7 @@ async function searchOB(
             0,
             namespace,
             false,
+            sourceScope,
           );
   } catch (err) {
     logger.warn("searchOB_failed", {

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -779,6 +779,10 @@ export async function executeSearch(
   includeLinks?: boolean,
   sourceScope?: SourceScope,
 ): Promise<SearchRow[]> {
+  if (sourceScope) {
+    accessibleTables = accessibleTables.filter((table) => table !== "entities");
+    if (accessibleTables.length === 0) return [];
+  }
   let rows: SearchRow[];
   if (mode === "keyword") {
     rows = await ftsSearch(
@@ -1087,7 +1091,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         source_scope: sourceScopeSchema
           .optional()
           .describe(
-            "Optional: require matching source reference client_id, matter_id, and/or document_id.",
+            "Optional: require matching source reference client_id, matter_id, document_id, path, and/or dms_id.",
           ),
       },
       annotations: {
@@ -1166,6 +1170,19 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const tier = args.tier as Tier | undefined;
       const requestedNamespace = args.namespace as string | undefined;
       const sourceScope = args.source_scope as SourceScope | undefined;
+      if (sourceScope) {
+        accessibleTables = accessibleTables.filter((table) => table !== "entities");
+      }
+      if (accessibleTables.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "No source-scoped tables are readable",
+            },
+          ],
+        };
+      }
       if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
         return {
           content: [

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -8,6 +8,12 @@ import {
   isSharedNamespace,
   sharedNamespaceConfig,
 } from "../shared-namespace.ts";
+import {
+  appendSourceScopeParam,
+  sourceScopeFilterSql,
+  sourceScopeSchema,
+  type SourceScope,
+} from "../source-refs.ts";
 import type { AuthInfo, LinkRelation, Table, Tier } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
@@ -32,6 +38,7 @@ const LABEL_TO_TABLE: Record<string, Table> = Object.fromEntries(
 export type SearchMode = "hybrid" | "vector" | "keyword";
 type NamespaceFilter = string | string[];
 type SearchTable = Table | "entities";
+export type { SourceScope };
 
 /** RRF constant -- standard value from Cormack et al. 2009 */
 const RRF_K = 60;
@@ -404,6 +411,7 @@ function buildTableCTE(
   tier?: Tier,
   namespaceParamIndex?: number,
   namespaceIsArray = false,
+  sourceScopeParamIndex?: number,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   if (table === "entities") {
@@ -445,6 +453,7 @@ function buildTableCTE(
       ? ` AND ${alias}.namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
       : ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
     : "";
+  const sourceScopeFilter = sourceScopeFilterSql(alias, sourceScopeParamIndex);
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
     : "NULL::jsonb AS extracted_metadata";
@@ -465,7 +474,7 @@ function buildTableCTE(
     COALESCE(${alias}.access_count, 0) AS access_count,
     ${metaCol}
   FROM ${table} ${alias}
-  WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}
+  WHERE ${alias}.embedding IS NOT NULL AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}${sourceScopeFilter}
   ORDER BY ${alias}.embedding <=> (SELECT emb FROM query_embedding) ASC
   LIMIT ${perTableLimit}
 )`;
@@ -477,6 +486,7 @@ function buildFtsCTE(
   tier?: Tier,
   namespaceParamIndex?: number,
   namespaceIsArray = false,
+  sourceScopeParamIndex?: number,
 ): string {
   if (tier && !VALID_TIERS.has(tier)) throw new Error(`Invalid tier: ${tier}`);
   if (table === "entities") {
@@ -524,6 +534,7 @@ function buildFtsCTE(
       ? ` AND ${alias}.namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
       : ` AND ${alias}.namespace = ${paramRef(namespaceParamIndex)}`
     : "";
+  const sourceScopeFilter = sourceScopeFilterSql(alias, sourceScopeParamIndex);
 
   const metaCol = HAS_EXTRACTED_METADATA.has(table)
     ? `${alias}.extracted_metadata`
@@ -546,7 +557,7 @@ function buildFtsCTE(
     ${metaCol}
   FROM ${table} ${alias}
   WHERE ${alias}.search_vector @@ plainto_tsquery('english', (SELECT q FROM fts_query))
-    AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}
+    AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}${sourceScopeFilter}
   ORDER BY fts_rank DESC
   LIMIT ${perTableLimit}
 )`;
@@ -560,13 +571,22 @@ async function vectorSearch(
   tier?: Tier,
   offset = 0,
   namespace?: NamespaceFilter,
+  sourceScope?: SourceScope,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const params = [toSql(embedding), fetchLimit, offset];
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
+  const sourceScopeParamIndex = appendSourceScopeParam(params, sourceScope);
   const namespaceIsArray = Array.isArray(namespace);
   const ctes = accessibleTables.map((t) =>
-    buildTableCTE(t, perTableLimit, tier, namespaceParamIndex, namespaceIsArray),
+    buildTableCTE(
+      t,
+      perTableLimit,
+      tier,
+      namespaceParamIndex,
+      namespaceIsArray,
+      sourceScopeParamIndex,
+    ),
   );
   const cteNames = accessibleTables.map((t) => `${t}_results`);
   const unionAll = cteNames
@@ -595,13 +615,22 @@ async function ftsSearch(
   tier?: Tier,
   offset = 0,
   namespace?: NamespaceFilter,
+  sourceScope?: SourceScope,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const params = [query, fetchLimit, offset];
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
+  const sourceScopeParamIndex = appendSourceScopeParam(params, sourceScope);
   const namespaceIsArray = Array.isArray(namespace);
   const ctes = accessibleTables.map((t) =>
-    buildFtsCTE(t, perTableLimit, tier, namespaceParamIndex, namespaceIsArray),
+    buildFtsCTE(
+      t,
+      perTableLimit,
+      tier,
+      namespaceParamIndex,
+      namespaceIsArray,
+      sourceScopeParamIndex,
+    ),
   );
   const cteNames = accessibleTables.map((t) => `${t}_fts`);
   const unionAll = cteNames
@@ -748,6 +777,7 @@ export async function executeSearch(
   offset = 0,
   namespace?: NamespaceFilter,
   includeLinks?: boolean,
+  sourceScope?: SourceScope,
 ): Promise<SearchRow[]> {
   let rows: SearchRow[];
   if (mode === "keyword") {
@@ -759,6 +789,7 @@ export async function executeSearch(
       tier,
       offset,
       namespace,
+      sourceScope,
     );
     if (includeLinks !== false) {
       rows = await attachExplicitLinks(deps, rows, namespace);
@@ -782,6 +813,7 @@ export async function executeSearch(
         tier,
         offset,
         namespace,
+        sourceScope,
       );
       if (includeLinks !== false) {
         rows = await attachExplicitLinks(deps, rows, namespace);
@@ -801,6 +833,7 @@ export async function executeSearch(
       tier,
       offset,
       namespace,
+      sourceScope,
     );
     if (includeLinks !== false) {
       rows = await attachExplicitLinks(deps, rows, namespace);
@@ -821,8 +854,18 @@ export async function executeSearch(
       tier,
       0,
       namespace,
+      sourceScope,
     ),
-    ftsSearch(deps, accessibleTables, query, fetchLimit, tier, 0, namespace),
+    ftsSearch(
+      deps,
+      accessibleTables,
+      query,
+      fetchLimit,
+      tier,
+      0,
+      namespace,
+      sourceScope,
+    ),
   ]);
 
   const merged = rrfMerge(vectorRows, ftsRows, totalNeeded);
@@ -843,6 +886,7 @@ export async function executeSearchWithSharedFallback(
   offset: number,
   namespace: NamespaceFilter | undefined,
   includeLinks?: boolean,
+  sourceScope?: SourceScope,
 ): Promise<SearchRow[]> {
   const config = sharedNamespaceConfig();
   if (
@@ -862,6 +906,7 @@ export async function executeSearchWithSharedFallback(
         offset,
         namespace,
         includeLinks,
+        sourceScope,
       ),
     );
   }
@@ -876,6 +921,7 @@ export async function executeSearchWithSharedFallback(
     0,
     config.sharedNamespace,
     includeLinks,
+    sourceScope,
   );
   if (
     sharedRows.length >= limit ||
@@ -894,6 +940,7 @@ export async function executeSearchWithSharedFallback(
     0,
     config.legacySharedNamespace,
     includeLinks,
+    sourceScope,
   );
   return withCanonicalNamespaces(
     mergeFallbackSearchRows(sharedRows, legacyRows, limit),
@@ -910,6 +957,7 @@ export async function executeSearchWithScopedSharedFallback(
   offset: number,
   namespace: NamespaceFilter | undefined,
   includeLinks?: boolean,
+  sourceScope?: SourceScope,
 ): Promise<SearchRow[]> {
   const config = sharedNamespaceConfig();
   const scopedNamespaces = Array.isArray(namespace) ? namespace : [];
@@ -930,6 +978,7 @@ export async function executeSearchWithScopedSharedFallback(
         offset,
         namespace,
         includeLinks,
+        sourceScope,
       ),
     );
   }
@@ -945,6 +994,7 @@ export async function executeSearchWithScopedSharedFallback(
       0,
       namespace,
       includeLinks,
+      sourceScope,
     ),
     executeSearch(
       deps,
@@ -956,6 +1006,7 @@ export async function executeSearchWithScopedSharedFallback(
       0,
       config.physicalSharedNamespace,
       includeLinks,
+      sourceScope,
     ),
   ]);
   if (
@@ -975,6 +1026,7 @@ export async function executeSearchWithScopedSharedFallback(
     0,
     config.legacySharedNamespace,
     includeLinks,
+    sourceScope,
   );
   return withCanonicalNamespaces(
     mergeFallbackSearchRows(primaryRows, legacyRows, limit),
@@ -1032,6 +1084,11 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           .enum(["hot", "warm", "cold"])
           .optional()
           .describe("Optional: filter results to a specific cognitive tier"),
+        source_scope: sourceScopeSchema
+          .optional()
+          .describe(
+            "Optional: require matching source reference client_id, matter_id, and/or document_id.",
+          ),
       },
       annotations: {
         title: "Search Brain",
@@ -1108,6 +1165,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const mode = (args.search_mode as SearchMode) ?? "hybrid";
       const tier = args.tier as Tier | undefined;
       const requestedNamespace = args.namespace as string | undefined;
+      const sourceScope = args.source_scope as SourceScope | undefined;
       if (requestedNamespace && !canReadNamespace(auth, requestedNamespace)) {
         return {
           content: [
@@ -1135,6 +1193,8 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
               tier,
               offset,
               namespace,
+              undefined,
+              sourceScope,
             )
           : await executeSearchWithScopedSharedFallback(
               deps,
@@ -1145,6 +1205,8 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
               tier,
               offset,
               namespace,
+              undefined,
+              sourceScope,
             );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -10,6 +10,7 @@ import {
 } from "../shared-namespace.ts";
 import {
   appendSourceScopeParam,
+  sourceScopeAuthorizationError,
   sourceScopeFilterSql,
   sourceScopeSchema,
   type SourceScope,
@@ -1170,6 +1171,13 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const tier = args.tier as Tier | undefined;
       const requestedNamespace = args.namespace as string | undefined;
       const sourceScope = args.source_scope as SourceScope | undefined;
+      const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
+      if (sourceScopeError) {
+        return {
+          content: [{ type: "text" as const, text: sourceScopeError }],
+          isError: true,
+        };
+      }
       if (sourceScope) {
         accessibleTables = accessibleTables.filter((table) => table !== "entities");
       }

--- a/src/tools/session-wrap.ts
+++ b/src/tools/session-wrap.ts
@@ -6,6 +6,7 @@ import { canWriteNamespace } from "../namespace-policy.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
+import { sourceRefsSchema } from "../source-refs.ts";
 import type { ToolDeps } from "./index.ts";
 
 export function registerSessionWrap(server: McpServer, deps: ToolDeps): void {
@@ -46,6 +47,9 @@ export function registerSessionWrap(server: McpServer, deps: ToolDeps): void {
           .max(500)
           .optional()
           .describe("Project name for the session record"),
+        source_refs: sourceRefsSchema
+          .optional()
+          .describe("Structured file/document refs for closed-brain provenance"),
       },
       annotations: {
         title: "Session Wrap",
@@ -154,10 +158,10 @@ WHERE namespace = $1 AND session_key = $2`,
         // Step 4: Insert session record (ON CONFLICT handles double-wrap)
         const { rows: sessionRows } = await deps.pool.query(
           `INSERT INTO sessions
-  (summary, key_decisions, next_steps, project, namespace, embedding, content_hash, embedded_at, embedding_model, created_by)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+  (summary, key_decisions, next_steps, project, namespace, embedding, content_hash, embedded_at, embedding_model, created_by, source_refs)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
 ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL DO NOTHING
-RETURNING id, created_at`,
+RETURNING id, created_at, source_refs`,
           [
             args.summary,
             args.key_decisions ?? [],
@@ -169,6 +173,7 @@ RETURNING id, created_at`,
             embeddedAt,
             model,
             auth.clientId,
+            JSON.stringify(args.source_refs ?? []),
           ],
         );
 
@@ -205,6 +210,7 @@ RETURNING id, created_at`,
           lane_status: lane.status,
           event_count: eventCount,
           created_at: createdAt,
+          source_refs: sessionRows[0].source_refs,
         };
 
         logger.info("session_wrap_ok", {

--- a/src/tools/session-wrap.ts
+++ b/src/tools/session-wrap.ts
@@ -194,7 +194,7 @@ RETURNING id, created_at, source_refs`,
                   lane_id: lane.id,
                   lane_status: lane.status,
                   message:
-                    "Session with identical content already checkpointed",
+                    "Session with identical content already checkpointed; duplicate source_refs are not merged",
                 }),
               },
             ],


### PR DESCRIPTION
## Summary

Refs #118.

- Adds structured `source_refs` storage for durable Open Brain rows.
- Adds scoped read/search/answer filtering through `source_scope`.
- Redacts privileged `source_refs` from namespace-only full reads and generic REST entry reads.
- Adds regression coverage for source ref validation, source-scope SQL parameterization, same-ref matching, REST redaction, and write-path persistence.
- Fixes Phase 2 swarm findings for entity/QMD scope bypass, scoped ref redaction, path/dms scoping, and stale contract manifest drift.
- Fixes Phase 3 Claude/Opus findings for malformed sibling source refs, SQL/JS scope parity, compact scoped read contract clarity, and duplicate `session_wrap` source-ref semantics.

## Validation

- Focused post-auth tests: `bun test src/source-refs.test.ts src/contract.test.ts src/tools/__tests__/get-entry.test.ts src/tools/__tests__/search-brain.test.ts src/tools/__tests__/search-all.test.ts src/tools/__tests__/brain-answer.test.ts` -> 113 pass, 2 skip, 0 fail
- Focused Phase 3 fix tests: `bun test src/source-refs.test.ts src/contract.test.ts src/tools/__tests__/session-wrap.test.ts` -> 33 pass, 0 fail
- `bunx tsc --noEmit` -> pass
- `git diff --check` -> pass
- Full `bun test` -> 1154 pass, 51 skip, 0 fail
- Python package: `uv run ruff check src tests` -> pass; `uv run mypy src/openbrain_memory` -> pass; `uv run pytest -q` -> 200 passed, 5 skipped

## Critical self-review

- Highest-risk behavior: privileged `source_refs` leaking through namespace-only reads or search/answer citations.
- Assumptions that could be wrong: downstream callers may expect raw full-row projections from REST; this PR intentionally redacts `source_refs` there until a scoped REST contract exists.
- Missing/weak tests: live Postgres migration/canary tests are env-gated and were not run in this local-only phase.
- Security/permission risk: mitigated by same-source-ref `EXISTS jsonb_array_elements(...)` matching, scoped return filtering, entity exclusion under `source_scope`, QMD suppression under scoped `search_all`, and redaction without `source_scope`.
- Migration/deploy risk: migration adds JSONB columns and GIN indexes to five durable tables; hosted migration/deploy is deferred.
- Downstream client/runtime risk: applies because MCP tool schemas and output contracts change for source-scoped workflows; mcp2cli/Hermes/live canaries are deferred to release/deploy phase.
- Rollback/cleanup concern: rollback would require dropping `source_refs` columns/indexes only if migration is applied; no core01 deploy in this PR phase.
- Fixes made before PR: fixed source-scope auth in commit `a859b89`; Phase 3 Claude/Opus findings fixed in `3e04d5a`.
- Known residual risk: full live downstream verification remains pending until Rico approves release/deploy work; Phase 4 fix-verification and GitHub CI are clean.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no core01 deploy in this PR; release/deploy canary is deferred to the optional release/deploy phase

## Deploy

No core01 deploy in this PR. This is local/branch/PR work only; release/deploy remains optional and separate.

