### PR TITLE
docs(#167): add collab retirement preflight

### DIFF
--- a/docs/collab-retirement-preflight.md
+++ b/docs/collab-retirement-preflight.md
@@ -1,0 +1,295 @@
+# Collab Retirement Release Preflight
+
+Issue: #167  
+Branch: `release/167-retire-collab`  
+Scope: release-preflight only
+
+This document turns the remaining `collab` retirement work into an exact
+release checklist. It is intentionally local-first and must not be used to
+justify live mutation from an unapproved planning lane.
+
+## Hard Guardrails
+
+- Do not run any live DB mutation, production migration, deploy, or canary from
+  this planning lane.
+- Do not point scratch validation at production credentials or the core01 DB.
+- `scripts/retire-collab-migration.ts` is dry-run by default. `--execute` is a
+  release-only step and requires explicit approval plus a verified backup.
+- `collab` is a frozen snapshot namespace. The release objective is to
+  reconcile remaining live-unique rows into `shared-kb`, then remove the legacy
+  fallback only after reconciliation is proven complete.
+
+## Why This Is Still Blocked
+
+Local code and tests already cover the retirement mechanics:
+
+- namespace defaults are dropped by migration `019_drop_collab_namespace_defaults.sql`
+- runtime/tests treat `collab` as retired and `shared-kb` as canonical
+- `scripts/retire-collab-migration.ts` provides dry-run audit, transactional
+  execute mode, and idempotent per-step reconciliation
+
+What is still not complete is release-time evidence against live data:
+
+1. verified backup before mutation
+2. dry-run inventory against live data
+3. operator classification of remaining out-of-scope rows
+4. approved execute run against the current deployed code
+5. proof that the fallback can be removed without making live rows invisible
+6. downstream rollout and canary evidence
+
+## Expected Release Inputs
+
+These counts are the release-time baseline that must be confirmed from the
+first approved live dry-run before any execute step is authorized:
+
+- thoughts to reconcile: `69`
+- `repo_fact` entities to handle: `12`
+- collab lanes to handle: `4`
+
+If the first live dry-run does not match those expected counts, stop and treat
+the delta as a fresh release blocker. Do not improvise.
+
+## Release Order
+
+The order is load-bearing. Do not swap it.
+
+1. backup live DB
+2. run approved dry-run inventory against the current deployed code
+3. classify every out-of-scope row surfaced by the audit
+4. decide whether execute is allowed for this release window
+5. if approved, run `--execute` against the current deployed code
+6. verify zero unmirrored rows for the migrated scope
+7. only then deploy the code path that removes the legacy fallback
+8. run downstream refresh and canaries
+
+This matches the merge-order warning captured in `docs/sme/domain-backend.md`:
+migrate first, then deploy.
+
+## Step 0: Local Release Readiness
+
+Before touching live data, confirm the branch still matches the local artifact
+expectations:
+
+- `scripts/retire-collab-migration.ts` remains dry-run by default
+- the script still audits all five content tables plus non-`repo_fact`
+  entities and null-hash thoughts
+- the script still performs the full `--execute` run inside one transaction
+- migration `019` still leaves namespace columns without `collab` defaults
+- docs still describe `collab` as retired and `shared-kb` as canonical
+
+Minimum local checks:
+
+```zsh
+git diff --check
+bun test scripts/retire-collab-migration.test.ts
+rg -n "dry-run by default|--execute|backup|deploy" \
+  scripts/retire-collab-migration.ts docs/collab-retirement-preflight.md
+```
+
+## Step 1: Backup Gate
+
+Required before any live `--execute` run:
+
+- take a fresh Postgres backup or storage snapshot for the live Open Brain DB
+- record the backup timestamp, operator, target host, and restore path
+- verify the backup completed successfully before continuing
+
+Receipt template:
+
+```text
+Backup:
+- Timestamp:
+- Operator:
+- Method: pg_dump | snapshot
+- Source DB:
+- Restore path:
+- Verification:
+```
+
+No backup receipt means no execute approval.
+
+## Step 2: Approved Live Dry-Run Inventory
+
+Run the script in dry-run mode against the current deployed code and live DB.
+Do not deploy new fallback behavior first.
+
+Use the full script first:
+
+```zsh
+bun run scripts/retire-collab-migration.ts
+```
+
+Then capture the per-step view if the full report needs operator review:
+
+```zsh
+bun run scripts/retire-collab-migration.ts --thoughts
+bun run scripts/retire-collab-migration.ts --entities
+bun run scripts/retire-collab-migration.ts --lanes
+```
+
+The dry-run report must be attached to the release note or issue comment with:
+
+- `audit.total_out_of_scope`
+- `thoughts.unmirrored_before`
+- `entities.collab_repo_facts`
+- `lanes.collab_unarchived_lanes`
+
+## Step 3: Classification Gate
+
+The dry-run audit is allowed to block the release. Treat every surfaced row as
+belonging to one of these buckets:
+
+### Thoughts (`69` expected)
+
+- rows safe for direct shared copy
+- rows already mirrored but archived on the shared side
+- null-`content_hash` rows that need manual handling before execute
+
+The release note must say whether the `69` thought total is:
+
+- exactly executable by the scripted thought step
+- partially blocked by null-hash/manual review
+- changed since the last expected baseline
+
+### `repo_fact` entities (`12` expected)
+
+Classify each of the `12` collab `repo_fact` rows into:
+
+- re-tag to `shared-kb`
+- archive-in-collab due to active shared name conflict
+- archive-in-collab due to active shared canonical-id conflict
+- manual review if the row is not a clean repo-fact migration candidate
+
+Any non-`repo_fact` collab entity surfaced by the audit is an out-of-scope
+blocker until explicitly resolved or acknowledged by the release owner.
+
+### Lanes (`4` expected)
+
+The `4` lane rows are not copied; they are handled by lane status transition:
+
+- archive active/wrapped collab lanes
+- leave already archived lanes untouched
+
+If the live lane count is not `4`, stop and explain why before execute.
+
+## Step 4: Execute Authorization Gate
+
+`--execute` is allowed only when all of the following are true:
+
+- backup receipt exists
+- dry-run report is attached
+- expected counts match or the delta is explicitly approved
+- out-of-scope rows are either resolved or explicitly acknowledged by the
+  release owner
+- operator confirms the execute run will target the current deployed code, not
+  the post-fallback-removal deploy
+
+If any item above is missing, the issue stays blocked.
+
+Approved execute command:
+
+```zsh
+bun run scripts/retire-collab-migration.ts --execute
+```
+
+If the audit still reports intentional out-of-scope rows and the release owner
+explicitly accepts them, the receipt must say why before using:
+
+```zsh
+bun run scripts/retire-collab-migration.ts \
+  --execute \
+  --acknowledge-out-of-scope
+```
+
+Do not use `--acknowledge-out-of-scope` as a convenience flag.
+
+## Step 5: Post-Execute Verification
+
+After execute and before deploy:
+
+- rerun the dry-run report
+- prove the migrated scope is now reconciled
+- prove the audit state matches the approved classification
+
+Minimum success conditions:
+
+- `thoughts.unmirrored_after = 0` for scripted thought scope
+- `entities.would_retag = 0`
+- `lanes.would_archive = 0`
+- no newly introduced out-of-scope rows
+
+If any success condition fails, stop and rollback using the backup/snapshot
+plan before any fallback-removal deploy proceeds.
+
+## Step 6: Fallback Removal Deploy Gate
+
+Only after post-execute verification passes:
+
+- follow `docs/local-release-deploy-sop.md`
+- classify downstream impact with `docs/downstream-rollout.md`
+- deploy the code that removes the legacy fallback
+
+The release record must explicitly state:
+
+- data migration executed before deploy
+- fallback-removal code was not deployed against unreconciled collab data
+- any temporary escape hatch env remains off unless deliberately needed for
+  rollback
+
+## Step 7: Downstream Rollout And Canary
+
+Because this changes namespace behavior and removes a legacy read path,
+downstream rollout is applicable.
+
+Required evidence after deploy:
+
+1. hosted Open Brain health and focused namespace smoke
+2. `rtech-mcps` handoff if service/skill guidance changed
+3. `mcp2cli` schema/cache refresh and representative Open Brain call
+4. `rtech-hermes` runtime/plugin compatibility check if agent behavior depends
+   on the retired fallback
+5. live Hermes canary proving normal reads still reach `shared-kb` and do not
+   depend on implicit `collab` fallback
+
+Do not mark #167 complete on local verification alone.
+
+## Rollback
+
+Rollback plan must be written before execute:
+
+- restore the DB from the verified backup or snapshot if execute produces
+  unexpected audit results
+- if fallback-removal code already deployed and read behavior regresses,
+  redeploy the prior runtime and restore data as needed
+- do not leave the system in a mixed state where fallback is removed but the
+  live reconciliation is incomplete
+
+Receipt template:
+
+```text
+Rollback:
+- Trigger:
+- Data restore method:
+- Runtime rollback method:
+- Verification after rollback:
+```
+
+## Release Receipt Template
+
+```text
+Issue #167 release preflight:
+- Backup:
+- Dry-run timestamp:
+- Thoughts expected/observed:
+- Repo facts expected/observed:
+- Lanes expected/observed:
+- Out-of-scope rows:
+- Execute approved by:
+- Execute result:
+- Post-execute verification:
+- Fallback-removal deploy:
+- Downstream rollout:
+- Canary result:
+- Rollback readiness:
+- Residual risk:
+```

--- a/docs/collab-retirement-preflight.md
+++ b/docs/collab-retirement-preflight.md
@@ -110,18 +110,22 @@ No backup receipt means no execute approval.
 
 ## Step 2: Approved Live Dry-Run Inventory
 
-Run the script in dry-run mode against the current deployed code and live DB.
-Do not deploy new fallback behavior first.
+Run the script in dry-run mode against the current deployed code and live DB
+from the approved release/runtime environment only. Do not run this local PR
+checkout or a scratch shell against production credentials, and do not deploy
+new fallback behavior first.
 
 Use the full script first:
 
 ```zsh
+# Approved release/runtime environment only.
 bun run scripts/retire-collab-migration.ts
 ```
 
 Then capture the per-step view if the full report needs operator review:
 
 ```zsh
+# Approved release/runtime environment only.
 bun run scripts/retire-collab-migration.ts --thoughts
 bun run scripts/retire-collab-migration.ts --entities
 bun run scripts/retire-collab-migration.ts --lanes
@@ -183,12 +187,16 @@ If the live lane count is not `4`, stop and explain why before execute.
   release owner
 - operator confirms the execute run will target the current deployed code, not
   the post-fallback-removal deploy
+- operator confirms the execute run is being launched from the approved
+  release/runtime environment, not from this local PR checkout or a scratch shell
+  with production credentials
 
 If any item above is missing, the issue stays blocked.
 
-Approved execute command:
+Execute command after explicit release approval:
 
 ```zsh
+# Approved release/runtime environment only.
 bun run scripts/retire-collab-migration.ts --execute
 ```
 
@@ -196,6 +204,7 @@ If the audit still reports intentional out-of-scope rows and the release owner
 explicitly accepts them, the receipt must say why before using:
 
 ```zsh
+# Approved release/runtime environment only.
 bun run scripts/retire-collab-migration.ts \
   --execute \
   --acknowledge-out-of-scope

--- a/docs/collab-retirement-preflight.md
+++ b/docs/collab-retirement-preflight.md
@@ -36,7 +36,8 @@ sentinel in the approved shell:
 export OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED=core01-live-db-after-backup
 ```
 
-All live command blocks below include a shell guard for that sentinel. If the
+All live command blocks below include a shell guard for that sentinel, and the
+script itself refuses `--execute` unless the same sentinel is present. If the
 guard fails, stop; do not delete the guard or rerun from a different shell to get
 past it.
 

--- a/docs/collab-retirement-preflight.md
+++ b/docs/collab-retirement-preflight.md
@@ -19,6 +19,27 @@ justify live mutation from an unapproved planning lane.
   reconcile remaining live-unique rows into `shared-kb`, then remove the legacy
   fallback only after reconciliation is proven complete.
 
+## Approved Release/Runtime Environment
+
+For this preflight, an approved release/runtime environment means a release
+operator is running the script from the approved live Open Brain runtime checkout
+for the current deployed code, with the live DB environment intentionally loaded,
+after the backup receipt has been recorded and execute approval has been granted
+for this release window.
+
+It does not mean this PR worktree, a local planning checkout, a scratch shell, or
+any shell that merely has production credentials available. Before running any
+live dry-run or execute command, the release operator must set this explicit
+sentinel in the approved shell:
+
+```zsh
+export OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED=core01-live-db-after-backup
+```
+
+All live command blocks below include a shell guard for that sentinel. If the
+guard fails, stop; do not delete the guard or rerun from a different shell to get
+past it.
+
 ## Why This Is Still Blocked
 
 Local code and tests already cover the retirement mechanics:
@@ -118,14 +139,20 @@ new fallback behavior first.
 Use the full script first:
 
 ```zsh
-# Approved release/runtime environment only.
+[ "$OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED" = "core01-live-db-after-backup" ] || {
+  echo "Blocked: not in the approved collab-retirement release/runtime environment" >&2
+  exit 1
+}
 bun run scripts/retire-collab-migration.ts
 ```
 
 Then capture the per-step view if the full report needs operator review:
 
 ```zsh
-# Approved release/runtime environment only.
+[ "$OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED" = "core01-live-db-after-backup" ] || {
+  echo "Blocked: not in the approved collab-retirement release/runtime environment" >&2
+  exit 1
+}
 bun run scripts/retire-collab-migration.ts --thoughts
 bun run scripts/retire-collab-migration.ts --entities
 bun run scripts/retire-collab-migration.ts --lanes
@@ -196,7 +223,10 @@ If any item above is missing, the issue stays blocked.
 Execute command after explicit release approval:
 
 ```zsh
-# Approved release/runtime environment only.
+[ "$OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED" = "core01-live-db-after-backup" ] || {
+  echo "Blocked: not in the approved collab-retirement release/runtime environment" >&2
+  exit 1
+}
 bun run scripts/retire-collab-migration.ts --execute
 ```
 
@@ -204,7 +234,10 @@ If the audit still reports intentional out-of-scope rows and the release owner
 explicitly accepts them, the receipt must say why before using:
 
 ```zsh
-# Approved release/runtime environment only.
+[ "$OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED" = "core01-live-db-after-backup" ] || {
+  echo "Blocked: not in the approved collab-retirement release/runtime environment" >&2
+  exit 1
+}
 bun run scripts/retire-collab-migration.ts \
   --execute \
   --acknowledge-out-of-scope

--- a/docs/collab-retirement-preflight.md
+++ b/docs/collab-retirement-preflight.md
@@ -135,7 +135,9 @@ No backup receipt means no execute approval.
 Run the script in dry-run mode against the current deployed code and live DB
 from the approved release/runtime environment only. Do not run this local PR
 checkout or a scratch shell against production credentials, and do not deploy
-new fallback behavior first.
+new fallback behavior first. The script also fails closed before any DB query
+when `DB_HOST` is non-local unless the release approval sentinel is present; the
+shell guard below is operator feedback, not the only enforcement layer.
 
 Use the full script first:
 
@@ -250,7 +252,16 @@ Do not use `--acknowledge-out-of-scope` as a convenience flag.
 
 After execute and before deploy:
 
-- rerun the dry-run report
+- rerun the dry-run report from the approved release/runtime environment:
+
+```zsh
+[ "$OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED" = "core01-live-db-after-backup" ] || {
+  echo "Blocked: not in the approved collab-retirement release/runtime environment" >&2
+  exit 1
+}
+bun run scripts/retire-collab-migration.ts
+```
+
 - prove the migrated scope is now reconciled
 - prove the audit state matches the approved classification
 
@@ -259,7 +270,10 @@ Minimum success conditions:
 - `thoughts.unmirrored_after = 0` for scripted thought scope
 - `entities.would_retag = 0`
 - `lanes.would_archive = 0`
-- no newly introduced out-of-scope rows
+- `audit.total_out_of_scope` is `0` or exactly matches the release-owner-approved
+  acknowledged classification, with each surviving row enumerated in the release
+  record before fallback removal
+- no newly introduced out-of-scope rows beyond that approved classification
 
 If any success condition fails, stop and rollback using the backup/snapshot
 plan before any fallback-removal deploy proceeds.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -216,7 +216,7 @@ send a payload the server rejects.
 - Does contract/help text name the cross-field invariant so generated clients
   can mirror it?
 
-## [2026-07-07] Release docs must not read as local live-execute approval
+## [2026-07-06] Release docs must not read as local live-execute approval
 
 **Severity:** MEDIUM
 **Source:** PR #259 initial and fix-verification swarms for Issue #167

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -215,3 +215,26 @@ send a payload the server rejects.
   making a client call?
 - Does contract/help text name the cross-field invariant so generated clients
   can mirror it?
+
+## [2026-07-07] Release docs must not read as local live-execute approval
+
+**Severity:** MEDIUM
+**Source:** PR #259 initial swarm for Issue #167
+**Scope:** release preflight docs, migration runbooks, any live DB command block
+**Status:** fixed in PR #259; keep as active checklist
+
+### Pattern
+
+A runbook can correctly say "dry-run first" but still create operational risk if
+it labels a destructive command as approved before the release gate is complete.
+For live DB migrations, command blocks must say the approved release/runtime
+environment is required and that local PR checkouts or scratch shells must not
+be pointed at production credentials.
+
+### Review Questions
+
+- Does any command block with `--execute` look pre-approved rather than
+  approval-gated?
+- Does the doc name where the command is allowed to run?
+- Does it explicitly forbid local PR checkouts or scratch shells with
+  production credentials when that boundary matters?

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -219,8 +219,8 @@ send a payload the server rejects.
 ## [2026-07-07] Release docs must not read as local live-execute approval
 
 **Severity:** MEDIUM
-**Source:** PR #259 initial swarm for Issue #167
-**Scope:** release preflight docs, migration runbooks, any live DB command block
+**Source:** PR #259 initial and fix-verification swarms for Issue #167
+**Scope:** release preflight docs, migration runbooks, live DB command blocks, destructive script entrypoints
 **Status:** fixed in PR #259; keep as active checklist
 
 ### Pattern
@@ -229,7 +229,9 @@ A runbook can correctly say "dry-run first" but still create operational risk if
 it labels a destructive command as approved before the release gate is complete.
 For live DB migrations, command blocks must say the approved release/runtime
 environment is required and that local PR checkouts or scratch shells must not
-be pointed at production credentials.
+be pointed at production credentials. If a script owns the destructive action,
+the script should also fail closed before DB access; a copy-pasteable comment or
+doc-only shell guard is not enough by itself.
 
 ### Review Questions
 
@@ -238,3 +240,5 @@ be pointed at production credentials.
 - Does the doc name where the command is allowed to run?
 - Does it explicitly forbid local PR checkouts or scratch shells with
   production credentials when that boundary matters?
+- Does the script entrypoint enforce the approval gate before any DB query or
+  transaction starts?

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -2,6 +2,9 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import pg from "pg";
 import { runMigrations } from "../src/db/migrate.ts";
 import {
+  COLLAB_RETIRE_APPROVAL_ENV,
+  COLLAB_RETIRE_APPROVAL_VALUE,
+  assertExecuteApproval,
   auditOutOfScope,
   migrateEntities,
   migrateLanes,
@@ -11,6 +14,10 @@ import {
 } from "./retire-collab-migration.ts";
 
 const { Client, Pool } = pg;
+
+const approvedReleaseEnv = {
+  [COLLAB_RETIRE_APPROVAL_ENV]: COLLAB_RETIRE_APPROVAL_VALUE,
+};
 
 // -----------------------------------------------------------------------------
 // Pure arg-parsing tests (always run).
@@ -55,6 +62,31 @@ describe("retire-collab-migration args", () => {
 // roll back the whole execute run.
 // -----------------------------------------------------------------------------
 describe("retire-collab-migration transaction", () => {
+  it("refuses --execute without explicit release approval before DB access", async () => {
+    expect(() => assertExecuteApproval({})).toThrow(COLLAB_RETIRE_APPROVAL_ENV);
+
+    const pool = {
+      query: async () => {
+        throw new Error("db should not be touched without execute approval");
+      },
+      connect: async () => {
+        throw new Error("connect should not be touched without execute approval");
+      },
+    };
+
+    await expect(
+      runMigration(
+        pool as any,
+        {
+          execute: true,
+          acknowledgeOutOfScope: false,
+          steps: new Set(["lanes"]),
+        } as any,
+        {},
+      ),
+    ).rejects.toThrow(COLLAB_RETIRE_APPROVAL_ENV);
+  });
+
   it("rolls back the transaction when a step fails mid-run", async () => {
     const clientQueries: string[] = [];
     let released = false;
@@ -83,11 +115,15 @@ describe("retire-collab-migration transaction", () => {
     };
 
     await expect(
-      runMigration(pool as any, {
-        execute: true,
-        acknowledgeOutOfScope: false,
-        steps: new Set(["lanes"]),
-      } as any),
+      runMigration(
+        pool as any,
+        {
+          execute: true,
+          acknowledgeOutOfScope: false,
+          steps: new Set(["lanes"]),
+        } as any,
+        approvedReleaseEnv,
+      ),
     ).rejects.toThrow("simulated lane failure");
 
     expect(clientQueries[0]).toBe("BEGIN");
@@ -273,11 +309,15 @@ dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => 
 
   it("refuses --execute while out-of-scope content exists and mutates nothing", async () => {
     await expect(
-      runMigration(pool, {
-        execute: true,
-        acknowledgeOutOfScope: false,
-        steps: new Set(["thoughts", "entities", "lanes"]),
-      } as any),
+      runMigration(
+        pool,
+        {
+          execute: true,
+          acknowledgeOutOfScope: false,
+          steps: new Set(["thoughts", "entities", "lanes"]),
+        } as any,
+        approvedReleaseEnv,
+      ),
     ).rejects.toThrow("OUTSIDE the migrated scope");
 
     const sharedCount = await pool.query(
@@ -292,11 +332,15 @@ dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => 
   });
 
   it("executes with --acknowledge-out-of-scope: copies, re-tags, archives", async () => {
-    const report = await runMigration(pool, {
-      execute: true,
-      acknowledgeOutOfScope: true,
-      steps: new Set(["thoughts", "entities", "lanes"]),
-    } as any);
+    const report = await runMigration(
+      pool,
+      {
+        execute: true,
+        acknowledgeOutOfScope: true,
+        steps: new Set(["thoughts", "entities", "lanes"]),
+      } as any,
+      approvedReleaseEnv,
+    );
 
     expect(report.thoughts?.copied).toBe(3);
     expect(report.thoughts?.unmirrored_after).toBe(0);

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -6,6 +6,7 @@ import {
   COLLAB_RETIRE_APPROVAL_VALUE,
   assertExecuteApproval,
   auditOutOfScope,
+  dbHostRequiresReleaseApproval,
   migrateEntities,
   migrateLanes,
   migrateThoughts,
@@ -83,6 +84,33 @@ describe("retire-collab-migration transaction", () => {
           steps: new Set(["lanes"]),
         } as any,
         {},
+      ),
+    ).rejects.toThrow(COLLAB_RETIRE_APPROVAL_ENV);
+  });
+
+  it("refuses live dry-runs without explicit release approval before DB access", async () => {
+    expect(
+      dbHostRequiresReleaseApproval({ DB_HOST: "10.71.1.21" }),
+    ).toBe(true);
+    expect(dbHostRequiresReleaseApproval({ DB_HOST: "127.0.0.1" })).toBe(
+      false,
+    );
+
+    const pool = {
+      query: async () => {
+        throw new Error("db should not be touched without release approval");
+      },
+    };
+
+    await expect(
+      runMigration(
+        pool as any,
+        {
+          execute: false,
+          acknowledgeOutOfScope: false,
+          steps: new Set(["lanes"]),
+        } as any,
+        { DB_HOST: "core01" },
       ),
     ).rejects.toThrow(COLLAB_RETIRE_APPROVAL_ENV);
   });

--- a/scripts/retire-collab-migration.ts
+++ b/scripts/retire-collab-migration.ts
@@ -53,6 +53,7 @@ const REPO_FACT_ENTITY_TYPE = "repo_fact";
 export const COLLAB_RETIRE_APPROVAL_ENV =
   "OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED";
 export const COLLAB_RETIRE_APPROVAL_VALUE = "core01-live-db-after-backup";
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 /** Content tables affected by the legacy fallback removal (allowlist). */
 const CONTENT_TABLES = [
@@ -519,6 +520,14 @@ async function runSteps(
   }
 }
 
+export function dbHostRequiresReleaseApproval(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const host = env.DB_HOST?.trim().toLowerCase();
+  if (!host) return false;
+  return !LOCAL_DB_HOSTS.has(host);
+}
+
 /**
  * Runs the pre-flight audit and the requested steps. In execute mode the audit
  * gate is enforced first, then every step runs inside ONE transaction so a
@@ -534,7 +543,7 @@ export async function runMigration(
   args: Args,
   env: Record<string, string | undefined> = process.env,
 ): Promise<Report> {
-  if (args.execute) {
+  if (args.execute || dbHostRequiresReleaseApproval(env)) {
     assertExecuteApproval(env);
   }
 

--- a/scripts/retire-collab-migration.ts
+++ b/scripts/retire-collab-migration.ts
@@ -50,6 +50,9 @@ import { createPool } from "../src/db/pool.ts";
 const LEGACY_NAMESPACE = "collab";
 const SHARED_NAMESPACE = "shared-kb";
 const REPO_FACT_ENTITY_TYPE = "repo_fact";
+export const COLLAB_RETIRE_APPROVAL_ENV =
+  "OPENBRAIN_COLLAB_RETIRE_RELEASE_APPROVED";
+export const COLLAB_RETIRE_APPROVAL_VALUE = "core01-live-db-after-backup";
 
 /** Content tables affected by the legacy fallback removal (allowlist). */
 const CONTENT_TABLES = [
@@ -168,6 +171,7 @@ function usage(exitCode = 2): never {
       "       [--acknowledge-out-of-scope] [--thoughts] [--entities] [--lanes]",
       "",
       "Dry-run is the DEFAULT. Pass --execute to mutate.",
+      `--execute also requires ${COLLAB_RETIRE_APPROVAL_ENV}=${COLLAB_RETIRE_APPROVAL_VALUE} in the approved release shell.`,
       "With no step flags all steps run; pass a subset to scope the run.",
       "If the pre-flight audit finds live collab content outside the migrated",
       "scope, --execute refuses to run unless --acknowledge-out-of-scope is",
@@ -201,6 +205,23 @@ export function parseArgs(argv: string[]): Args {
       ? requested
       : new Set<StepName>(["thoughts", "entities", "lanes"]);
   return { execute, acknowledgeOutOfScope, steps };
+}
+
+export function assertExecuteApproval(
+  env: Record<string, string | undefined> = process.env,
+): void {
+  if (env[COLLAB_RETIRE_APPROVAL_ENV] === COLLAB_RETIRE_APPROVAL_VALUE) {
+    return;
+  }
+  throw new Error(
+    [
+      `--execute requires ${COLLAB_RETIRE_APPROVAL_ENV}=`,
+      COLLAB_RETIRE_APPROVAL_VALUE,
+      ` in the approved release/runtime environment after backup and explicit`,
+      ` release approval. Do not run live mutation from a PR worktree, local`,
+      ` planning checkout, scratch shell, or credential-only shell.`,
+    ].join(""),
+  );
 }
 
 async function countScalar(
@@ -511,7 +532,12 @@ export async function runMigration(
     connect?: () => Promise<Queryable & { release: () => void }>;
   },
   args: Args,
+  env: Record<string, string | undefined> = process.env,
 ): Promise<Report> {
+  if (args.execute) {
+    assertExecuteApproval(env);
+  }
+
   const report: Report = {
     dry_run: !args.execute,
     legacy_namespace: LEGACY_NAMESPACE,


### PR DESCRIPTION
Refs #167.

## Summary

- Adds `docs/collab-retirement-preflight.md`, a release-gated checklist for retiring the legacy `collab` namespace.
- Captures backup, live dry-run inventory, classification, execute authorization, post-execute verification, fallback-removal deploy, downstream canary, and rollback gates.
- Explicitly keeps this branch local/preflight only; no live DB mutation, deploy, or canary is authorized here.

## Validation

- [x] `git diff --check`
- [x] targeted readback for no-live-mutation, `--execute` release-only, verified backup, and no local-only closure wording.

## Deploy

- [x] No core01 deploy. No production DB mutation, migration execute, or canary.

## Critical Self-Review

- Highest-risk behavior: A release checklist could be misread as permission to mutate live data. Mitigation: the doc repeatedly gates `--execute` behind explicit approval and verified backup.
- Assumptions that could be wrong: The expected live counts may have changed since the issue baseline; the doc requires stopping if live dry-run counts differ.
- Missing/weak tests: Docs-only; validation is readback/grep rather than runtime tests.
- Security/permission risk: No secrets or credentials added; live credential use is explicitly out of scope.
- Migration/deploy risk: This PR does not execute migration or remove fallback code. It defines the release gate.
- Downstream client/runtime risk: None from the doc itself; downstream rollout is required after the eventual fallback-removal deploy.
- Rollback/cleanup concern: Revert the doc if the release procedure changes.
- Fixes made before PR: Added explicit backup, execute authorization, rollback, and no-local-closure language.
- Known residual risk: #167 remains blocked until approved live backup, dry-run, execute, deploy, downstream rollout, and canary evidence are complete.
- SME review-memory update: [x] docs/sme/ updated or [ ] not applicable because: docs/sme/gotcha-agent.md updated with the release-execute approval gotcha.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content.
- [x] MEDIUM+ review findings were captured in `docs/sme/gotcha-agent.md`.
- [x] Initial review-swarm findings posted.
- [x] Fix-verification / zero-unresolved status posted.
- Live Open Brain checks: [ ] linked below or [x] not applicable because: preflight doc only; no live memory path changed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
  - Not applicable to this doc-only preflight PR.
- [x] mcp2cli cache/skill refresh is complete or not applicable
  - Not applicable until fallback-removal deploy.
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
  - Not applicable until fallback-removal deploy.
- [x] Hermes live rollout/canaries are complete or not applicable
  - Not applicable; #167 remains blocked for release work.



