### PR TITLE
feat(#223): add local NATS runtime boundary

### DIFF
--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -232,3 +232,28 @@ row just to preserve lineage.
   the owning relationship model instead?
 - Do tests assert the insert parameters keep replacement rows out of chunk-only
   semantics?
+
+## [2026-07-07] Second transports must mirror the authoritative contract bounds
+
+**Severity:** MEDIUM
+**Source:** PR #260 initial swarm for Issue #223
+**Scope:** `src/nats-runtime.ts`, `src/tools/agent-context-pack.ts`, transport bridge schemas
+**Status:** fixed in PR #260; keep as active checklist
+
+### Pattern
+
+A first-class second transport can still drift if its planning envelope accepts
+fields, section names, budgets, or metadata shapes that the authoritative
+HTTP/MCP tool would reject. Planned-only bridge code is contract surface area:
+callers can build against it before runtime rollout. NATS `agent_context_pack`
+must use the same section enum and comparable bounds for query, budget, client
+context refs, and metadata.
+
+### Review Questions
+
+- Does the secondary transport import or mirror the same enum/bounds as the
+  authoritative tool or manifest?
+- Are unknown section names and oversized metadata rejected before bridge
+  planning?
+- Are query and budget limits no looser than the primary tool schema?
+- Do tests cover drift cases, not only the happy-path envelope?

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -243,17 +243,17 @@ row just to preserve lineage.
 ### Pattern
 
 A first-class second transport can still drift if its planning envelope accepts
-fields, section names, budgets, or metadata shapes that the authoritative
-HTTP/MCP tool would reject. Planned-only bridge code is contract surface area:
-callers can build against it before runtime rollout. NATS `agent_context_pack`
-must use the same section enum and comparable bounds for query, budget, client
-context refs, and metadata.
+fields, section names, or budgets that the authoritative HTTP/MCP tool would
+reject. Planned-only bridge code is contract surface area: callers can build
+against it before runtime rollout. NATS `agent_context_pack` must use the same
+section enum, comparable bounds for query/budget, and a strict body schema so
+unsupported planned fields fail before fallback planning.
 
 ### Review Questions
 
 - Does the secondary transport import or mirror the same enum/bounds as the
   authoritative tool or manifest?
-- Are unknown section names and oversized metadata rejected before bridge
-  planning?
+- Are unknown section names and unsupported body fields rejected before bridge
+  planning instead of being stripped silently?
 - Are query and budget limits no looser than the primary tool schema?
 - Do tests cover drift cases, not only the happy-path envelope?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -250,3 +250,25 @@ can satisfy.
 - Does the SQL scope gate require the matched array element to be a real
   citable ref (`document_id`, `path`, or `dms_id`) so row visibility and
   returned citations agree?
+
+## [2026-07-07] Transport URLs must not be logged with userinfo or hosts
+
+**Severity:** MEDIUM
+**Source:** PR #260 initial swarm for Issue #223
+**Scope:** `src/index.ts`, transport startup warnings, NATS/HTTP/stream config
+**Status:** fixed in PR #260; keep as active checklist
+
+### Pattern
+
+Transport configuration often arrives as a URL. A URL such as
+`nats://user:pass@host:4222` carries credentials in `username/password`, and
+even host/IP fields can be sensitive in durable logs. Startup warnings and
+diagnostics should record only safe facts: configured/not configured, protocol,
+and whether credentials were present.
+
+### Review Questions
+
+- Does any log include an env-sourced transport URL verbatim?
+- If a URL may contain userinfo, tokens, hosts, or internal IPs, is the log
+  reduced to safe booleans/enums rather than redacted text with residual shape?
+- Do tests prove credential-bearing URLs do not appear in log helper output?

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ import { logger } from "./logger.ts";
 import { requestLogger } from "./middleware/request-logger.ts";
 import { createRestRouter } from "./rest-api.ts";
 import { createPromotionRouter } from "./rest-promotion.ts";
-import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
+import {
+  readNatsRuntimeBoundary,
+  summarizeNatsUrlForLog,
+} from "./nats-runtime.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
@@ -202,7 +205,7 @@ if (import.meta.main) {
       fallback_transport: natsRuntimeBoundary.fallback_transport,
       fallback_http: natsRuntimeBoundary.nats.fallback_http,
       context_pack_subject: natsRuntimeBoundary.nats.context_pack_subject,
-      nats_url: natsRuntimeBoundary.nats.url,
+      nats_url: summarizeNatsUrlForLog(natsRuntimeBoundary.nats.url),
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { logger } from "./logger.ts";
 import { requestLogger } from "./middleware/request-logger.ts";
 import { createRestRouter } from "./rest-api.ts";
 import { createPromotionRouter } from "./rest-promotion.ts";
+import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
@@ -193,6 +194,17 @@ if (import.meta.main) {
   const tokenMap = buildTokenMap(
     process.env as Record<string, string | undefined>,
   );
+
+  const natsRuntimeBoundary = readNatsRuntimeBoundary(process.env);
+  if (natsRuntimeBoundary.requested_transport === "nats") {
+    logger.warn("OPENBRAIN_TRANSPORT=nats requested before local bridge exists", {
+      availability: natsRuntimeBoundary.nats.availability,
+      fallback_transport: natsRuntimeBoundary.fallback_transport,
+      fallback_http: natsRuntimeBoundary.nats.fallback_http,
+      context_pack_subject: natsRuntimeBoundary.nats.context_pack_subject,
+      nats_url: natsRuntimeBoundary.nats.url,
+    });
+  }
 
   if (tokenMap.size === 0) {
     logger.error("No auth tokens configured -- cannot start");

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "bun:test";
+import {
+  planNatsContextPackBridge,
+  readNatsRuntimeBoundary,
+} from "./nats-runtime.ts";
+
+const baseEnvelope = {
+  schema: "openbrain.nats.request.v1",
+  operation: "agent_context_pack",
+  request_id: "req-123",
+  identity: {
+    namespace_source: "authorization",
+    agent: "nagatha",
+    platform: "discord",
+    server_id: "rodaddy-live",
+    channel_id: "open-brain",
+    thread_id: null,
+    session_key: "discord:rodaddy-live:open-brain:nagatha",
+  },
+  body: {
+    query: "what is the current task state?",
+    requested_sections: ["working_set", "durable_memory"],
+    include_unreviewed_recovery: true,
+    user_id: "user-1",
+    repo: "rodaddy/open-brain",
+    task: "issue-223",
+    client_context_refs: [
+      { kind: "repo_path", path: "docs/nats-jetstream-foundation.md" },
+    ],
+    metadata: { route_name: "discord_reply" },
+    budget: { max_tokens: 3500, max_latency_ms: 750 },
+  },
+  metadata: {
+    client: "openbrain-memory",
+    client_version: "0.1.0",
+    transport: "nats",
+  },
+} as const;
+
+describe("readNatsRuntimeBoundary", () => {
+  it("defaults to HTTP/MCP and the planned context-pack subject", () => {
+    const boundary = readNatsRuntimeBoundary({});
+
+    expect(boundary).toEqual({
+      requested_transport: "http",
+      fallback_transport: "http_mcp",
+      nats: {
+        availability: "not_runtime_available",
+        url: null,
+        context_pack_subject: "ob.memory.context_pack",
+        fallback_http: true,
+      },
+    });
+  });
+
+  it("records explicit NATS env without claiming runtime availability", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT: "ob.memory.context_pack",
+      OPENBRAIN_NATS_FALLBACK_HTTP: "true",
+    });
+
+    expect(boundary.requested_transport).toBe("nats");
+    expect(boundary.nats).toMatchObject({
+      availability: "not_runtime_available",
+      url: "nats://127.0.0.1:4222",
+      context_pack_subject: "ob.memory.context_pack",
+      fallback_http: true,
+    });
+  });
+});
+
+describe("planNatsContextPackBridge", () => {
+  it("maps the planned NATS envelope to the existing MCP tool call with HTTP fallback", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const plan = planNatsContextPackBridge(boundary, {
+      subject: "ob.memory.context_pack",
+      envelope: baseEnvelope,
+      bearerToken: " bearer-token ",
+    });
+
+    expect(plan).toEqual({
+      status: "http_mcp_fallback",
+      request_id: "req-123",
+      subject: "ob.memory.context_pack",
+      operation: "agent_context_pack",
+      bearerToken: "bearer-token",
+      mcpToolCall: {
+        name: "agent_context_pack",
+        arguments: {
+          agent: "nagatha",
+          platform: "discord",
+          server_id: "rodaddy-live",
+          channel_id: "open-brain",
+          session_key: "discord:rodaddy-live:open-brain:nagatha",
+          query: "what is the current task state?",
+          requested_sections: ["working_set", "durable_memory"],
+          include_unreviewed_recovery: true,
+          user_id: "user-1",
+          repo: "rodaddy/open-brain",
+          task: "issue-223",
+          client_context_refs: [
+            { kind: "repo_path", path: "docs/nats-jetstream-foundation.md" },
+          ],
+          metadata: { route_name: "discord_reply" },
+          budget: { max_tokens: 3500, max_latency_ms: 750 },
+        },
+      },
+    });
+  });
+
+  it("preserves optional thread_id when the caller scoped the request to a thread", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    const plan = planNatsContextPackBridge(boundary, {
+      subject: "ob.memory.context_pack",
+      envelope: {
+        ...baseEnvelope,
+        identity: {
+          ...baseEnvelope.identity,
+          thread_id: "thread-7",
+        },
+      },
+      bearerToken: "token",
+    });
+
+    expect(plan.mcpToolCall.arguments.thread_id).toBe("thread-7");
+  });
+
+  it("rejects fallback planning when no bearer token is available", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.context_pack",
+        envelope: baseEnvelope,
+        bearerToken: " ",
+      }),
+    ).toThrow("Bearer token is required for NATS bridge fallback");
+  });
+
+  it("rejects unsupported subjects before touching envelope contents", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.wrap",
+        envelope: baseEnvelope,
+        bearerToken: "token",
+      }),
+    ).toThrow(
+      "Unsupported NATS subject 'ob.memory.wrap'; expected 'ob.memory.context_pack'",
+    );
+  });
+
+  it("rejects runtime fallback when explicitly disabled", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_FALLBACK_HTTP: "false",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.context_pack",
+        envelope: baseEnvelope,
+        bearerToken: "token",
+      }),
+    ).toThrow("NATS runtime is unavailable and HTTP/MCP fallback is disabled");
+  });
+
+  it("rejects non-context-pack operations so the bridge cannot widen scope silently", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.context_pack",
+        envelope: {
+          ...baseEnvelope,
+          operation: "session_wrap",
+        },
+        bearerToken: "token",
+      }),
+    ).toThrow();
+  });
+});

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   planNatsContextPackBridge,
   readNatsRuntimeBoundary,
+  summarizeNatsUrlForLog,
 } from "./nats-runtime.ts";
 
 const baseEnvelope = {
@@ -67,6 +68,16 @@ describe("readNatsRuntimeBoundary", () => {
       url: "nats://127.0.0.1:4222",
       context_pack_subject: "ob.memory.context_pack",
       fallback_http: true,
+    });
+  });
+});
+
+describe("summarizeNatsUrlForLog", () => {
+  it("omits host and credentials while preserving safe configuration facts", () => {
+    expect(summarizeNatsUrlForLog("nats://user:pass@10.71.1.21:4222")).toEqual({
+      configured: true,
+      protocol: "nats",
+      contains_credentials: true,
     });
   });
 });
@@ -190,6 +201,46 @@ describe("planNatsContextPackBridge", () => {
         envelope: {
           ...baseEnvelope,
           operation: "session_wrap",
+        },
+        bearerToken: "token",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects requested sections outside the current agent_context_pack contract", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.context_pack",
+        envelope: {
+          ...baseEnvelope,
+          body: {
+            ...baseEnvelope.body,
+            requested_sections: ["working_set", "unknown_section"],
+          },
+        },
+        bearerToken: "token",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects unbounded metadata and context references before fallback planning", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.context_pack",
+        envelope: {
+          ...baseEnvelope,
+          body: {
+            ...baseEnvelope.body,
+            metadata: { large: "x".repeat(3000) },
+          },
         },
         bearerToken: "token",
       }),

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   readNatsRuntimeBoundary,
   summarizeNatsUrlForLog,
 } from "./nats-runtime.ts";
+import { agentContextPackInputSchema } from "./tools/agent-context-pack.ts";
 
 const baseEnvelope = {
   schema: "openbrain.nats.request.v1",
@@ -22,13 +23,6 @@ const baseEnvelope = {
     query: "what is the current task state?",
     requested_sections: ["working_set", "durable_memory"],
     include_unreviewed_recovery: true,
-    user_id: "user-1",
-    repo: "rodaddy/open-brain",
-    task: "issue-223",
-    client_context_refs: [
-      { kind: "repo_path", path: "docs/nats-jetstream-foundation.md" },
-    ],
-    metadata: { route_name: "discord_reply" },
     budget: { max_tokens: 3500, max_latency_ms: 750 },
   },
   metadata: {
@@ -112,17 +106,28 @@ describe("planNatsContextPackBridge", () => {
           query: "what is the current task state?",
           requested_sections: ["working_set", "durable_memory"],
           include_unreviewed_recovery: true,
-          user_id: "user-1",
-          repo: "rodaddy/open-brain",
-          task: "issue-223",
-          client_context_refs: [
-            { kind: "repo_path", path: "docs/nats-jetstream-foundation.md" },
-          ],
-          metadata: { route_name: "discord_reply" },
           budget: { max_tokens: 3500, max_latency_ms: 750 },
         },
       },
     });
+  });
+
+  it("keeps fallback tool arguments within the implemented agent_context_pack schema", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+
+    const plan = planNatsContextPackBridge(boundary, {
+      subject: "ob.memory.context_pack",
+      envelope: baseEnvelope,
+      bearerToken: "token",
+    });
+
+    expect(
+      Object.keys(plan.mcpToolCall.arguments).filter(
+        (key) => !(key in agentContextPackInputSchema),
+      ),
+    ).toEqual([]);
   });
 
   it("preserves optional thread_id when the caller scoped the request to a thread", () => {
@@ -227,7 +232,7 @@ describe("planNatsContextPackBridge", () => {
     ).toThrow();
   });
 
-  it("rejects unbounded metadata and context references before fallback planning", () => {
+  it("rejects unsupported body fields before fallback planning", () => {
     const boundary = readNatsRuntimeBoundary({
       OPENBRAIN_TRANSPORT: "nats",
     });
@@ -239,7 +244,7 @@ describe("planNatsContextPackBridge", () => {
           ...baseEnvelope,
           body: {
             ...baseEnvelope.body,
-            metadata: { large: "x".repeat(3000) },
+            metadata: { route_name: "discord_reply" },
           },
         },
         bearerToken: "token",

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -1,9 +1,44 @@
 import { z } from "zod";
+import { SECTION_NAMES } from "./tools/agent-context-pack.ts";
 
 const NATS_CONTEXT_PACK_OPERATION = "agent_context_pack";
 const DEFAULT_NATS_SUBJECT = "ob.memory.context_pack";
+const MAX_CONTEXT_PACK_QUERY_CHARS = 4000;
+const MAX_METADATA_KEYS = 50;
+const MAX_METADATA_JSON_CHARS = 2000;
+const MAX_CLIENT_CONTEXT_REFS = 20;
 
-const requestedSectionsSchema = z.array(z.string().min(1).max(200)).max(32);
+const requestedSectionsSchema = z.array(z.enum(SECTION_NAMES)).max(32);
+
+const boundedJsonRecordSchema = z
+  .record(z.string(), z.unknown())
+  .superRefine((value, ctx) => {
+    if (Object.keys(value).length > MAX_METADATA_KEYS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `metadata exceeds ${MAX_METADATA_KEYS} keys`,
+      });
+      return;
+    }
+
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(value);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "metadata must be JSON-serializable",
+      });
+      return;
+    }
+
+    if (serialized.length > MAX_METADATA_JSON_CHARS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `metadata exceeds ${MAX_METADATA_JSON_CHARS} serialized characters`,
+      });
+    }
+  });
 
 const identitySchema = z.object({
   namespace_source: z.literal("authorization"),
@@ -21,24 +56,31 @@ const requestEnvelopeSchema = z.object({
   request_id: z.string().min(1).max(500),
   identity: identitySchema,
   body: z.object({
-    query: z.string().min(1).max(20_000),
+    query: z.string().min(1).max(MAX_CONTEXT_PACK_QUERY_CHARS),
     requested_sections: requestedSectionsSchema.optional(),
     include_unreviewed_recovery: z.boolean().optional(),
     user_id: z.string().max(500).optional(),
     repo: z.string().max(500).optional(),
     task: z.string().max(500).optional(),
-    client_context_refs: z.array(z.record(z.string(), z.unknown())).max(64).optional(),
-    metadata: z.record(z.string(), z.unknown()).optional(),
-    budget: z.object({
-      max_tokens: z.number().int().positive().max(200_000).optional(),
-      max_latency_ms: z.number().int().positive().max(120_000).optional(),
-    }).optional(),
+    client_context_refs: z
+      .array(boundedJsonRecordSchema)
+      .max(MAX_CLIENT_CONTEXT_REFS)
+      .optional(),
+    metadata: boundedJsonRecordSchema.optional(),
+    budget: z
+      .object({
+        max_tokens: z.number().int().min(100).max(20_000).optional(),
+        max_latency_ms: z.number().int().min(1).max(10_000).optional(),
+      })
+      .optional(),
   }),
   metadata: z.object({
     client: z.string().min(1).max(200),
     client_version: z.string().min(1).max(200),
     transport: z.literal("nats"),
-  }).passthrough(),
+    trace_id: z.string().max(500).optional(),
+    route_name: z.string().max(200).optional(),
+  }),
 });
 
 export type NatsContextPackEnvelope = z.infer<typeof requestEnvelopeSchema>;
@@ -52,6 +94,12 @@ export interface NatsRuntimeBoundary {
     context_pack_subject: string;
     fallback_http: boolean;
   };
+}
+
+export interface NatsUrlLogSummary {
+  configured: boolean;
+  protocol: string | null;
+  contains_credentials: boolean;
 }
 
 export interface NatsBridgePlanInput {
@@ -94,6 +142,31 @@ export interface NatsBridgePlan {
 function trimEnv(value: string | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+export function summarizeNatsUrlForLog(url: string | null): NatsUrlLogSummary {
+  if (!url) {
+    return {
+      configured: false,
+      protocol: null,
+      contains_credentials: false,
+    };
+  }
+
+  try {
+    const parsed = new URL(url);
+    return {
+      configured: true,
+      protocol: parsed.protocol.replace(/:$/, "") || null,
+      contains_credentials: Boolean(parsed.username || parsed.password),
+    };
+  } catch {
+    return {
+      configured: true,
+      protocol: null,
+      contains_credentials: url.includes("@"),
+    };
+  }
 }
 
 export function readNatsRuntimeBoundary(

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -1,0 +1,186 @@
+import { z } from "zod";
+
+const NATS_CONTEXT_PACK_OPERATION = "agent_context_pack";
+const DEFAULT_NATS_SUBJECT = "ob.memory.context_pack";
+
+const requestedSectionsSchema = z.array(z.string().min(1).max(200)).max(32);
+
+const identitySchema = z.object({
+  namespace_source: z.literal("authorization"),
+  agent: z.string().min(1).max(200),
+  platform: z.string().min(1).max(200),
+  server_id: z.string().min(1).max(500),
+  channel_id: z.string().min(1).max(500),
+  thread_id: z.string().max(500).nullable().optional(),
+  session_key: z.string().min(1).max(500),
+});
+
+const requestEnvelopeSchema = z.object({
+  schema: z.literal("openbrain.nats.request.v1"),
+  operation: z.literal(NATS_CONTEXT_PACK_OPERATION),
+  request_id: z.string().min(1).max(500),
+  identity: identitySchema,
+  body: z.object({
+    query: z.string().min(1).max(20_000),
+    requested_sections: requestedSectionsSchema.optional(),
+    include_unreviewed_recovery: z.boolean().optional(),
+    user_id: z.string().max(500).optional(),
+    repo: z.string().max(500).optional(),
+    task: z.string().max(500).optional(),
+    client_context_refs: z.array(z.record(z.string(), z.unknown())).max(64).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    budget: z.object({
+      max_tokens: z.number().int().positive().max(200_000).optional(),
+      max_latency_ms: z.number().int().positive().max(120_000).optional(),
+    }).optional(),
+  }),
+  metadata: z.object({
+    client: z.string().min(1).max(200),
+    client_version: z.string().min(1).max(200),
+    transport: z.literal("nats"),
+  }).passthrough(),
+});
+
+export type NatsContextPackEnvelope = z.infer<typeof requestEnvelopeSchema>;
+
+export interface NatsRuntimeBoundary {
+  requested_transport: "http" | "nats";
+  fallback_transport: "http_mcp";
+  nats: {
+    availability: "not_runtime_available";
+    url: string | null;
+    context_pack_subject: string;
+    fallback_http: boolean;
+  };
+}
+
+export interface NatsBridgePlanInput {
+  subject: string;
+  envelope: unknown;
+  bearerToken: string | null | undefined;
+}
+
+export interface NatsBridgePlan {
+  status: "http_mcp_fallback";
+  request_id: string;
+  subject: string;
+  operation: "agent_context_pack";
+  bearerToken: string;
+  mcpToolCall: {
+    name: "agent_context_pack";
+    arguments: {
+      agent: string;
+      platform: string;
+      server_id: string;
+      channel_id: string;
+      thread_id?: string;
+      session_key: string;
+      query: string;
+      requested_sections?: string[];
+      include_unreviewed_recovery?: boolean;
+      user_id?: string;
+      repo?: string;
+      task?: string;
+      client_context_refs?: Array<Record<string, unknown>>;
+      metadata?: Record<string, unknown>;
+      budget?: {
+        max_tokens?: number;
+        max_latency_ms?: number;
+      };
+    };
+  };
+}
+
+function trimEnv(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function readNatsRuntimeBoundary(
+  env: NodeJS.ProcessEnv,
+): NatsRuntimeBoundary {
+  const requestedTransport =
+    env.OPENBRAIN_TRANSPORT?.trim().toLowerCase() === "nats"
+      ? "nats"
+      : "http";
+
+  return {
+    requested_transport: requestedTransport,
+    fallback_transport: "http_mcp",
+    nats: {
+      availability: "not_runtime_available",
+      url: trimEnv(env.OPENBRAIN_NATS_URL),
+      context_pack_subject:
+        trimEnv(env.OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT) ?? DEFAULT_NATS_SUBJECT,
+      fallback_http: env.OPENBRAIN_NATS_FALLBACK_HTTP?.trim().toLowerCase() !== "false",
+    },
+  };
+}
+
+export function planNatsContextPackBridge(
+  boundary: NatsRuntimeBoundary,
+  input: NatsBridgePlanInput,
+): NatsBridgePlan {
+  if (boundary.nats.availability !== "not_runtime_available") {
+    throw new Error("Unexpected runtime availability state");
+  }
+
+  if (!boundary.nats.fallback_http) {
+    throw new Error("NATS runtime is unavailable and HTTP/MCP fallback is disabled");
+  }
+
+  if (input.subject !== boundary.nats.context_pack_subject) {
+    throw new Error(
+      `Unsupported NATS subject '${input.subject}'; expected '${boundary.nats.context_pack_subject}'`,
+    );
+  }
+
+  const bearerToken = input.bearerToken?.trim();
+  if (!bearerToken) {
+    throw new Error("Bearer token is required for NATS bridge fallback");
+  }
+
+  const envelope = requestEnvelopeSchema.parse(input.envelope);
+  const toolArgs: NatsBridgePlan["mcpToolCall"]["arguments"] = {
+    agent: envelope.identity.agent,
+    platform: envelope.identity.platform,
+    server_id: envelope.identity.server_id,
+    channel_id: envelope.identity.channel_id,
+    session_key: envelope.identity.session_key,
+    query: envelope.body.query,
+  };
+
+  if (
+    envelope.identity.thread_id !== null &&
+    envelope.identity.thread_id !== undefined
+  ) {
+    toolArgs.thread_id = envelope.identity.thread_id;
+  }
+  if (envelope.body.requested_sections) {
+    toolArgs.requested_sections = envelope.body.requested_sections;
+  }
+  if (envelope.body.include_unreviewed_recovery !== undefined) {
+    toolArgs.include_unreviewed_recovery =
+      envelope.body.include_unreviewed_recovery;
+  }
+  if (envelope.body.user_id) toolArgs.user_id = envelope.body.user_id;
+  if (envelope.body.repo) toolArgs.repo = envelope.body.repo;
+  if (envelope.body.task) toolArgs.task = envelope.body.task;
+  if (envelope.body.client_context_refs) {
+    toolArgs.client_context_refs = envelope.body.client_context_refs;
+  }
+  if (envelope.body.metadata) toolArgs.metadata = envelope.body.metadata;
+  if (envelope.body.budget) toolArgs.budget = envelope.body.budget;
+
+  return {
+    status: "http_mcp_fallback",
+    request_id: envelope.request_id,
+    subject: input.subject,
+    operation: NATS_CONTEXT_PACK_OPERATION,
+    bearerToken,
+    mcpToolCall: {
+      name: "agent_context_pack",
+      arguments: toolArgs,
+    },
+  };
+}

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -4,41 +4,8 @@ import { SECTION_NAMES } from "./tools/agent-context-pack.ts";
 const NATS_CONTEXT_PACK_OPERATION = "agent_context_pack";
 const DEFAULT_NATS_SUBJECT = "ob.memory.context_pack";
 const MAX_CONTEXT_PACK_QUERY_CHARS = 4000;
-const MAX_METADATA_KEYS = 50;
-const MAX_METADATA_JSON_CHARS = 2000;
-const MAX_CLIENT_CONTEXT_REFS = 20;
 
-const requestedSectionsSchema = z.array(z.enum(SECTION_NAMES)).max(32);
-
-const boundedJsonRecordSchema = z
-  .record(z.string(), z.unknown())
-  .superRefine((value, ctx) => {
-    if (Object.keys(value).length > MAX_METADATA_KEYS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `metadata exceeds ${MAX_METADATA_KEYS} keys`,
-      });
-      return;
-    }
-
-    let serialized: string;
-    try {
-      serialized = JSON.stringify(value);
-    } catch {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "metadata must be JSON-serializable",
-      });
-      return;
-    }
-
-    if (serialized.length > MAX_METADATA_JSON_CHARS) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `metadata exceeds ${MAX_METADATA_JSON_CHARS} serialized characters`,
-      });
-    }
-  });
+const requestedSectionsSchema = z.array(z.enum(SECTION_NAMES));
 
 const identitySchema = z.object({
   namespace_source: z.literal("authorization"),
@@ -55,25 +22,19 @@ const requestEnvelopeSchema = z.object({
   operation: z.literal(NATS_CONTEXT_PACK_OPERATION),
   request_id: z.string().min(1).max(500),
   identity: identitySchema,
-  body: z.object({
-    query: z.string().min(1).max(MAX_CONTEXT_PACK_QUERY_CHARS),
-    requested_sections: requestedSectionsSchema.optional(),
-    include_unreviewed_recovery: z.boolean().optional(),
-    user_id: z.string().max(500).optional(),
-    repo: z.string().max(500).optional(),
-    task: z.string().max(500).optional(),
-    client_context_refs: z
-      .array(boundedJsonRecordSchema)
-      .max(MAX_CLIENT_CONTEXT_REFS)
-      .optional(),
-    metadata: boundedJsonRecordSchema.optional(),
-    budget: z
-      .object({
-        max_tokens: z.number().int().min(100).max(20_000).optional(),
-        max_latency_ms: z.number().int().min(1).max(10_000).optional(),
-      })
-      .optional(),
-  }),
+  body: z
+    .object({
+      query: z.string().min(1).max(MAX_CONTEXT_PACK_QUERY_CHARS),
+      requested_sections: requestedSectionsSchema.optional(),
+      include_unreviewed_recovery: z.boolean().optional(),
+      budget: z
+        .object({
+          max_tokens: z.number().int().min(100).max(20_000).optional(),
+          max_latency_ms: z.number().int().min(1).max(10_000).optional(),
+        })
+        .optional(),
+    })
+    .strict(),
   metadata: z.object({
     client: z.string().min(1).max(200),
     client_version: z.string().min(1).max(200),
@@ -126,11 +87,6 @@ export interface NatsBridgePlan {
       query: string;
       requested_sections?: string[];
       include_unreviewed_recovery?: boolean;
-      user_id?: string;
-      repo?: string;
-      task?: string;
-      client_context_refs?: Array<Record<string, unknown>>;
-      metadata?: Record<string, unknown>;
       budget?: {
         max_tokens?: number;
         max_latency_ms?: number;
@@ -236,13 +192,6 @@ export function planNatsContextPackBridge(
     toolArgs.include_unreviewed_recovery =
       envelope.body.include_unreviewed_recovery;
   }
-  if (envelope.body.user_id) toolArgs.user_id = envelope.body.user_id;
-  if (envelope.body.repo) toolArgs.repo = envelope.body.repo;
-  if (envelope.body.task) toolArgs.task = envelope.body.task;
-  if (envelope.body.client_context_refs) {
-    toolArgs.client_context_refs = envelope.body.client_context_refs;
-  }
-  if (envelope.body.metadata) toolArgs.metadata = envelope.body.metadata;
   if (envelope.body.budget) toolArgs.budget = envelope.body.budget;
 
   return {

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -29,7 +29,7 @@ export const SECTION_NAMES = [
   "candidate_memory",
 ] as const;
 
-const scopeInputSchema = {
+export const scopeInputSchema = {
   namespace: z
     .string()
     .max(500)
@@ -53,6 +53,22 @@ const scopeInputSchema = {
     .min(1)
     .max(500)
     .describe("Stable active-session key"),
+};
+
+export const agentContextPackInputSchema = {
+  ...scopeInputSchema,
+  query: z.string().max(4000).optional(),
+  requested_sections: z.array(z.enum(SECTION_NAMES)).optional(),
+  include_unreviewed_recovery: z
+    .boolean()
+    .optional()
+    .describe("Explicitly include exact-scope quarantined recovery summary"),
+  budget: z
+    .object({
+      max_tokens: z.number().int().min(100).max(20000).optional(),
+      max_latency_ms: z.number().int().min(1).max(10000).optional(),
+    })
+    .optional(),
 };
 
 export function registerWorkingSetAppend(
@@ -309,21 +325,7 @@ export function registerAgentContextPack(
         "Build a scoped realtime agent context pack. The working_set section " +
         "is included only for the exact namespace/agent/platform/server/" +
         "channel/thread/session scope.",
-      inputSchema: {
-        ...scopeInputSchema,
-        query: z.string().max(4000).optional(),
-        requested_sections: z.array(z.enum(SECTION_NAMES)).optional(),
-        include_unreviewed_recovery: z
-          .boolean()
-          .optional()
-          .describe("Explicitly include exact-scope quarantined recovery summary"),
-        budget: z
-          .object({
-            max_tokens: z.number().int().min(100).max(20000).optional(),
-            max_latency_ms: z.number().int().min(1).max(10000).optional(),
-          })
-          .optional(),
-      },
+      inputSchema: agentContextPackInputSchema,
       annotations: {
         title: "Agent Context Pack",
         readOnlyHint: true,

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -17,7 +17,7 @@ import {
 } from "../realtime/recovery-wal.ts";
 import type { ToolDeps } from "./index.ts";
 
-const SECTION_NAMES = [
+export const SECTION_NAMES = [
   "working_set",
   "recovery",
   "durable_lane_context",


### PR DESCRIPTION
Refs #223.

## Summary

- Adds the local boundary for NATS as a first-class opt-in second transport for `agent_context_pack` request envelopes.
- Keeps NATS marked `not_runtime_available` until release-gated rollout, and maps the planned envelope to the existing HTTP/MCP tool-call authority path.
- Warns when `OPENBRAIN_TRANSPORT=nats` is requested before a live bridge exists, without starting NATS or changing defaults.

## Validation

- [x] `bunx tsc --noEmit`
- [x] `bun test src/nats-runtime.test.ts`
- [x] `git diff --check`

## Deploy

- [x] No core01 deploy. No NATS install, stream creation, launchd change, or Hermes canary.

## Critical Self-Review

- Highest-risk behavior: A first-class NATS option could be mistaken for live runtime availability. Mitigation: the boundary reports `not_runtime_available`, requires HTTP fallback, and only plans an existing MCP tool call until release-gated rollout.
- Assumptions that could be wrong: The final live bridge may need different subject coverage or request metadata once core01 NATS is approved.
- Missing/weak tests: No live NATS parity test because no live NATS service is in scope. Focused tests cover envelope validation, subject pinning, bearer requirement, fallback-disabled rejection, and non-context-pack rejection.
- Security/permission risk: The bridge must not bypass server auth or namespace predicates. This PR requires a bearer token and maps to the existing server-authoritative `agent_context_pack` path.
- Migration/deploy risk: None applied. Runtime/deploy remains release-gated.
- Downstream client/runtime risk: Advisory/local-only; downstream cache, mcp2cli, Hermes, and live canaries remain deferred to the release/deploy phase.
- Rollback/cleanup concern: Revert this PR to remove the local seam; no live cleanup required.
- Fixes made before PR: Kept runtime availability false and avoided core01/Hermes changes.
- Known residual risk: #223 still requires approved live NATS implementation, parity tests, and canary evidence before closure; NATS is intended as a first-class opt-in second transport, not the default.
- SME review-memory update: [x] docs/sme/ updated or [ ] not applicable because: docs/sme/security.md and docs/sme/domain-backend.md updated with NATS transport findings.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content.
- [x] MEDIUM+ review findings were captured in `docs/sme/security.md` and `docs/sme/domain-backend.md`.
- [x] Initial review-swarm findings posted.
- [x] Fix-verification / zero-unresolved status posted.
- Live Open Brain checks: [ ] linked below or [x] not applicable because: local-only runtime boundary, no hosted transport deployed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
  - Deferred until approved release/deploy phase.
- [x] mcp2cli cache/skill refresh is complete or not applicable
  - Deferred until hosted Open Brain deploy/release phase.
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
  - Deferred; Hermes must stay on HTTP fallback until NATS is deployed and canaried.
- [x] Hermes live rollout/canaries are complete or not applicable
  - Deferred; no core01 deploy or live canary performed.



