### PR TITLE
feat(#223): add opt-in NATS context pack bridge

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "cors": "^2.8.6",
         "express": "^5.2.1",
+        "nats": "^2.29.3",
         "pg": "^8.20.0",
         "pgvector": "^0.2.1",
         "zod": "^4.3.6",
@@ -166,7 +167,11 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -247,6 +252,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -1,8 +1,9 @@
 # Agent Context Pack Contract
 
 Status: locally runtime-available over MCP for scoped working-set context and
-explicit quarantined recovery summaries; NATS transport and broader section
-assembly remain planned.
+explicit quarantined recovery summaries; an opt-in server-side NATS
+request/reply bridge can expose the same pack when explicitly enabled. Broader
+section assembly remains planned.
 Parent issue: #220.
 Research receipt: PR #225, `docs/realtime-agent-memory-research.md`.
 
@@ -17,9 +18,11 @@ every turn.
 This contract defines the envelope and scope rules. The MCP
 `agent_context_pack` tool currently exposes the exact-scope `working_set`
 section from RAM-first working context and, only when explicitly requested,
-the exact-scope `recovery` section from the quarantined recovery WAL. NATS
-transport and broader durable section assembly remain planned until their
-owning issues land.
+the exact-scope `recovery` section from the quarantined recovery WAL. The NATS
+bridge maps `ob.memory.context_pack` request/reply traffic to that same
+server-authoritative pack path only when `OPENBRAIN_TRANSPORT=nats`,
+`OPENBRAIN_NATS_ENABLE_BRIDGE=true`, and `OPENBRAIN_NATS_URL` are configured.
+Broader durable section assembly remains planned until its owning issues land.
 
 ## Ownership Boundary
 

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -21,7 +21,8 @@ section from RAM-first working context and, only when explicitly requested,
 the exact-scope `recovery` section from the quarantined recovery WAL. The NATS
 bridge maps `ob.memory.context_pack` request/reply traffic to that same
 server-authoritative pack path only when `OPENBRAIN_TRANSPORT=nats`,
-`OPENBRAIN_NATS_ENABLE_BRIDGE=true`, and `OPENBRAIN_NATS_URL` are configured.
+`OPENBRAIN_NATS_ENABLE_BRIDGE=true`, and an allowed `OPENBRAIN_NATS_URL` are
+configured.
 Broader durable section assembly remains planned until its owning issues land.
 
 ## Ownership Boundary

--- a/docs/nats-jetstream-foundation.md
+++ b/docs/nats-jetstream-foundation.md
@@ -232,20 +232,23 @@ By default, these streams store minimized metadata only. The stream names reserv
 places for future diagnostics; they are not permission to persist raw
 `agent_context_pack` request/response bodies, queries, headers, or context.
 
-## Python Client Plan
+## Python Client Status
 
-`openbrain-memory` will keep HTTP as the default transport. A future
-`NatsTransport` must be opt-in and sit behind the same facade semantics:
+`openbrain-memory` keeps HTTP as the default transport. The package now exposes
+an opt-in `NatsTransport` boundary, but the Python client still fails closed or
+delegates to HTTP fallback until a Python-native request/reply implementation is
+approved. The server-side bridge is independently opt-in and advertises
+availability only when explicitly enabled.
 
 - Own the same `Transport` protocol shape as `UrllibTransport` where practical:
   `get()`, `delete()`, and `post()` remain the package boundary until a tested
   tool-call transport abstraction replaces it.
-- Constructor/config plan:
+- Constructor/config:
   `NatsTransport(url, context_pack_subject="ob.memory.context_pack",
   fallback_transport=UrllibTransport(...), timeout=...)`.
-- Env plan:
-  `OPENBRAIN_TRANSPORT=nats`, `OPENBRAIN_NATS_URL`,
-  `OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT`, and
+- Server env:
+  `OPENBRAIN_TRANSPORT=nats`, `OPENBRAIN_NATS_ENABLE_BRIDGE=true`,
+  `OPENBRAIN_NATS_URL`, `OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT`, and
   `OPENBRAIN_NATS_FALLBACK_HTTP=true`.
 - Request/reply mapping: only `agent_context_pack` is NATS-native in the first
   bridge. Other Open Brain calls continue over HTTP/MCP unless a later PR adds
@@ -256,11 +259,10 @@ places for future diagnostics; they are not permission to persist raw
   missing metadata falls back to HTTP.
 - Authority: namespace/header/delegation semantics remain the Open Brain server
   policy. NATS credentials do not create namespace authority.
-- Tests before implementation: fake request/reply transport, no-responder
-  fallback, timeout fallback, contract-gated fallback, and HTTP-vs-NATS parity
-  fixtures for response/error envelopes.
-
-This PR does not implement `NatsTransport`.
+- Server tests cover fake request/reply transport, bearer-token rejection,
+  contract-gated availability, HTTP fallback planning, and matching
+  `agent_context_pack` response envelopes. Python-native request/reply tests
+  remain future work.
 
 ## Hermes Opt-In Plan
 
@@ -269,6 +271,7 @@ Initial config should be explicit:
 
 ```text
 OPENBRAIN_TRANSPORT=http
+OPENBRAIN_NATS_ENABLE_BRIDGE=false
 OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
 OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
 OPENBRAIN_NATS_FALLBACK_HTTP=true
@@ -282,7 +285,10 @@ NATS availability, Hermes must use HTTP/MCP.
 Local-only validation for #223:
 
 - contract tests prove `get_contract` advertises NATS as planned, not runtime
-  available;
+  available by default, and as available only when the bridge is explicitly
+  enabled;
+- server tests prove authorized NATS request/reply maps to the same
+  `agent_context_pack` payload and rejects missing bearer auth;
 - docs make core01 deployment optional/deferred;
 - Python tests prove package contract pins match the server contract version.
 

--- a/docs/nats-jetstream-foundation.md
+++ b/docs/nats-jetstream-foundation.md
@@ -142,6 +142,10 @@ audit once clients depend on them.
 The request body is JSON and must be compatible with `agent_context_pack`
 request semantics. `query` is optional and bounded like the MCP tool input; the
 bridge must not require fields the MCP tool accepts as omitted.
+The first NATS request/reply bridge also rejects request envelopes over 64 KiB.
+That cap is intentionally stricter than the HTTP JSON body limit so transient
+realtime messages stay small; clients should fall back to HTTP/MCP for larger
+payloads until a later release explicitly raises the NATS envelope limit.
 
 ```json
 {

--- a/docs/nats-jetstream-foundation.md
+++ b/docs/nats-jetstream-foundation.md
@@ -126,7 +126,7 @@ Core request/reply subjects:
 
 | Subject | Purpose | Runtime status |
 | --- | --- | --- |
-| `ob.memory.context_pack` | Build `agent_context_pack` for one active scope. | planned |
+| `ob.memory.context_pack` | Build `agent_context_pack` for one active scope. | available only when the server bridge is explicitly enabled |
 | `ob.memory.session_start` | Optional bridge to existing `session_start`. | planned |
 | `ob.memory.append_event` | Optional bridge to existing `append_session_event`. | planned |
 | `ob.memory.wrap` | Optional bridge to existing `session_wrap`. | planned |
@@ -140,7 +140,8 @@ audit once clients depend on them.
 ## Request Envelope
 
 The request body is JSON and must be compatible with `agent_context_pack`
-request semantics.
+request semantics. `query` is optional and bounded like the MCP tool input; the
+bridge must not require fields the MCP tool accepts as omitted.
 
 ```json
 {
@@ -250,6 +251,10 @@ availability only when explicitly enabled.
   `OPENBRAIN_TRANSPORT=nats`, `OPENBRAIN_NATS_ENABLE_BRIDGE=true`,
   `OPENBRAIN_NATS_URL`, `OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT`, and
   `OPENBRAIN_NATS_FALLBACK_HTTP=true`.
+- Remote plaintext `nats://` broker URLs are not runtime-available by default.
+  Use loopback/local NATS for local rollout, or set
+  `OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE=true` only for an explicitly approved
+  trusted lab override.
 - Request/reply mapping: only `agent_context_pack` is NATS-native in the first
   bridge. Other Open Brain calls continue over HTTP/MCP unless a later PR adds
   parity tests for their subjects.
@@ -286,9 +291,10 @@ Local-only validation for #223:
 
 - contract tests prove `get_contract` advertises NATS as planned, not runtime
   available by default, and as available only when the bridge is explicitly
-  enabled;
+  enabled for requested NATS transport with an allowed URL;
 - server tests prove authorized NATS request/reply maps to the same
-  `agent_context_pack` payload and rejects missing bearer auth;
+  `agent_context_pack` payload, rejects missing bearer auth before parsing,
+  bounds request size, and hides raw parser/schema errors from callers;
 - docs make core01 deployment optional/deferred;
 - Python tests prove package contract pins match the server contract version.
 

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -257,3 +257,30 @@ unsupported planned fields fail before fallback planning.
   planning instead of being stripped silently?
 - Are query and budget limits no looser than the primary tool schema?
 - Do tests cover drift cases, not only the happy-path envelope?
+
+## [2026-07-07] Runtime availability must distinguish active transport from configured fallback
+
+**Severity:** HIGH
+**Source:** PR #262 initial swarm for Issue #223
+**Scope:** `src/nats-runtime.ts`, `src/contract.ts`, `src/index.ts`, optional second-transport metadata
+**Status:** fixed in PR #262; keep as active checklist
+
+### Pattern
+
+Optional second transports can over-advertise readiness when configuration is
+present but the runtime path is not active. In PR #262, setting NATS bridge env
+and a URL could make `get_contract()` advertise NATS availability while the
+server was still running the default HTTP transport. The contract also listed
+planned request/reply subjects in the same bucket as the one implemented
+subject.
+
+### Review Questions
+
+- Does runtime availability require the transport to be requested and actually
+  started, not merely configured?
+- Are available subjects separated from planned/not-yet-implemented subjects in
+  machine-readable contract metadata?
+- Do fallback/client paths continue to fail closed when the second transport is
+  configured but not active?
+- Do docs and tests cover default HTTP behavior, active second-transport
+  behavior, and configured-but-inactive behavior?

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -284,3 +284,27 @@ subject.
   configured but not active?
 - Do docs and tests cover default HTTP behavior, active second-transport
   behavior, and configured-but-inactive behavior?
+
+## [2026-07-07] Subscription liveness must not stay green on empty iterator churn
+
+**Severity:** MEDIUM
+**Source:** PR #262 Claude/Opus cross-review for Issue #223
+**Scope:** `src/nats-bridge.ts`, streaming/subscription loops, runtime health
+**Status:** fixed in PR #262; keep as active checklist
+
+### Pattern
+
+A clean iterator completion is not always healthy. If a broker or driver returns
+empty subscriptions repeatedly, the bridge can resubscribe forever without ever
+processing a request while `/health` and `get_contract()` still advertise the
+transport as available. One clean completion can be a normal recycle; repeated
+zero-message completions need a bounded degradation rule.
+
+### Review Questions
+
+- Does the subscription loop distinguish a single clean recycle from repeated
+  empty completions?
+- Is health degraded after a bounded number or duration of no-message
+  completions?
+- Do tests cover both a successful resubscribe after one clean completion and
+  repeated empty completions that must not stay healthy?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -212,6 +212,8 @@ not stop future request processing.
   response promises to the bridge handler?
 - Are per-message handler failures caught/logged inside background subscription
   loops so the bridge continues processing later requests?
+- Are top-level subscription iterator failures caught/logged so background task
+  failures are observable instead of becoming unhandled rejections?
 - Do tests cover reply failure rather than only the happy-path response?
 - Does server shutdown isolate optional transport close failures from database
   and process cleanup?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -202,12 +202,16 @@ Request/reply adapters can silently lose responses if the driver return value is
 discarded. Shutdown paths can also skip later cleanup when an optional transport
 close hangs or rejects. In PR #262, the NATS bridge discarded
 `message.respond()` and awaited bridge close before database cleanup without a
-separate error boundary.
+separate error boundary. Fix verification also caught that reply failures must
+be isolated per message; a thrown handler in a background subscription loop must
+not stop future request processing.
 
 ### Review Questions
 
 - Does the driver surface failed reply delivery, missing inboxes, or rejected
   response promises to the bridge handler?
+- Are per-message handler failures caught/logged inside background subscription
+  loops so the bridge continues processing later requests?
 - Do tests cover reply failure rather than only the happy-path response?
 - Does server shutdown isolate optional transport close failures from database
   and process cleanup?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -188,3 +188,27 @@ whether the source row was mutated.
   completeness marker?
 - Does the response state whether the source row was archived, demoted, or left
   unchanged?
+
+## [2026-07-07] Request/reply bridges must surface reply and shutdown failures
+
+**Severity:** MEDIUM
+**Source:** PR #262 initial swarm for Issue #223
+**Scope:** `src/nats-bridge.ts`, `src/index.ts`, request/reply bridge drivers and server shutdown
+**Status:** fixed in PR #262; keep as active checklist
+
+### Pattern
+
+Request/reply adapters can silently lose responses if the driver return value is
+discarded. Shutdown paths can also skip later cleanup when an optional transport
+close hangs or rejects. In PR #262, the NATS bridge discarded
+`message.respond()` and awaited bridge close before database cleanup without a
+separate error boundary.
+
+### Review Questions
+
+- Does the driver surface failed reply delivery, missing inboxes, or rejected
+  response promises to the bridge handler?
+- Do tests cover reply failure rather than only the happy-path response?
+- Does server shutdown isolate optional transport close failures from database
+  and process cleanup?
+- Is shutdown bounded when an optional bridge can hang?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -203,8 +203,9 @@ discarded. Shutdown paths can also skip later cleanup when an optional transport
 close hangs or rejects. In PR #262, the NATS bridge discarded
 `message.respond()` and awaited bridge close before database cleanup without a
 separate error boundary. Fix verification also caught that reply failures must
-be isolated per message; a thrown handler in a background subscription loop must
-not stop future request processing.
+be isolated per message and subscription iterator failures must be supervised;
+a thrown handler or fatal iterator error in a background subscription loop must
+not silently stop future request processing.
 
 ### Review Questions
 
@@ -212,8 +213,8 @@ not stop future request processing.
   response promises to the bridge handler?
 - Are per-message handler failures caught/logged inside background subscription
   loops so the bridge continues processing later requests?
-- Are top-level subscription iterator failures caught/logged so background task
-  failures are observable instead of becoming unhandled rejections?
+- Are top-level subscription iterator failures caught/logged and followed by a
+  resubscribe/recovery path or an explicit degraded/unavailable state?
 - Do tests cover reply failure rather than only the happy-path response?
 - Does server shutdown isolate optional transport close failures from database
   and process cleanup?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -284,11 +284,10 @@ size checks. Parser/schema details were also returned to callers.
 
 ### Pattern
 
-Transport configuration often arrives as a URL. A URL such as
-`nats://user:pass@host:4222` carries credentials in `username/password`, and
-even host/IP fields can be sensitive in durable logs. Startup warnings and
-diagnostics should record only safe facts: configured/not configured, protocol,
-and whether credentials were present.
+Transport configuration often arrives as a URL. A NATS URL with userinfo carries
+credentials in `username/password`, and even host/IP fields can be sensitive in
+durable logs. Startup warnings and diagnostics should record only safe facts:
+configured/not configured, protocol, and whether credentials were present.
 
 ### Review Questions
 
@@ -296,3 +295,27 @@ and whether credentials were present.
 - If a URL may contain userinfo, tokens, hosts, or internal IPs, is the log
   reduced to safe booleans/enums rather than redacted text with residual shape?
 - Do tests prove credential-bearing URLs do not appear in log helper output?
+
+## [2026-07-07] Transport error logs must not copy raw dependency messages
+
+**Severity:** MEDIUM
+**Source:** PR #262 Claude/Opus cross-review for Issue #223
+**Scope:** `src/nats-bridge.ts`, secondary transport request handlers, subscription loops
+**Status:** fixed in PR #262; keep as active checklist
+
+### Pattern
+
+Dependency error messages can embed user content, tokens, broker URLs, internal
+hosts, or headers. Returning generic errors to callers is not enough if
+server-side logs still write `err.message` verbatim. Transport diagnostics
+should log stable classes/codes and safe context such as subject or operation,
+not raw dependency messages.
+
+### Review Questions
+
+- Do request, handler, and subscription error logs avoid raw `err.message`?
+- Are diagnostics limited to safe error type/code plus safe routing metadata?
+- If an error type is logged, is it derived from allowlisted instance checks
+  rather than mutable `Error.name`?
+- Do tests throw sensitive-looking dependency errors and prove logs omit the
+  sensitive fragments?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -238,6 +238,30 @@ can satisfy.
   (`client_id`, `matter_id`, `document_id`, `path`, and `dms_id`)?
 - Are scoped filters parameterized and applied consistently to search,
   answer/citation, compact fetch, and full fetch paths?
+
+## [2026-07-07] Secondary transports must not weaken auth-bearing plaintext or parse-order gates
+
+**Severity:** HIGH
+**Source:** PR #262 initial swarm for Issue #223
+**Scope:** `src/nats-runtime.ts`, `src/nats-bridge.ts`, NATS or other bearer-token transport bridges
+**Status:** fixed in PR #262; keep as active checklist
+
+### Pattern
+
+Auth-bearing secondary transports can accidentally create a weaker side door
+than HTTP/MCP. In PR #262, the first NATS bridge pass accepted any non-empty
+`nats://` URL for runtime availability, including remote plaintext brokers, and
+parsed/schema-validated the request body before bearer-token auth or request
+size checks. Parser/schema details were also returned to callers.
+
+### Review Questions
+
+- Does an auth-bearing plaintext transport allow only local/trusted endpoints by
+  default, with any remote plaintext override explicitly named and documented?
+- Does the bridge authenticate cheap headers before parsing untrusted bodies?
+- Is request size bounded before decode/schema validation?
+- Do bad request responses avoid leaking raw parser or schema diagnostics across
+  the transport boundary?
 - Do unscoped namespace-only reads redact privileged `source_refs` by default?
 - Does any generic shared projection include privileged source metadata without
   a caller-specific redaction or scope gate?

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
+    "nats": "^2.29.3",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",
     "zod": "^4.3.6"

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -364,9 +364,12 @@ streamable JSON-RPC/MCP surface, but the host install should be described as
 "direct HTTP to Open Brain `/mcp`" rather than generic "MCP HTTP" so it is not
 confused with mcp2cli daemon routing or other MCP transports.
 
-NATS runtime transport is not available yet. Hermes agents should still configure
-`OPENBRAIN_BASE_URL`, `OPENBRAIN_TOKEN`, and namespace identity for direct HTTP
-access to Open Brain.
+The server can expose an opt-in NATS request/reply bridge for
+`agent_context_pack` when the connected Open Brain endpoint advertises
+`realtime_transport.nats_jetstream.availability == "available"`. Hermes agents
+should still configure `OPENBRAIN_BASE_URL`, `OPENBRAIN_TOKEN`, and namespace
+identity for direct HTTP access unless their runtime has an approved Python NATS
+transport implementation and fallback plan.
 
 The package exposes an opt-in `NatsTransport` stub behind the same `Transport`
 facade used by `OpenBrainClient`, but it is intentionally

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -607,6 +607,19 @@ describe("Open Brain contract manifest", () => {
     expect(contractHash(changedPayload)).toBe(base.schema_hash);
   });
 
+  it("can advertise NATS runtime availability without changing the required schema hash", () => {
+    const base = buildContract("2026-06-18T00:00:00.000Z");
+    const available = buildContract("2026-06-18T00:00:00.000Z", {
+      natsAvailability: "available",
+    });
+
+    expect(available.realtime_transport.nats_jetstream).toMatchObject({
+      status: "runtime-available",
+      availability: "available",
+    });
+    expect(available.schema_hash).toBe(base.schema_hash);
+  });
+
   it("changes the schema hash when public capabilities change", () => {
     const base = buildContract("2026-06-18T00:00:00.000Z");
     const changedPayload: ContractPayload = {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -28,14 +28,16 @@ describe("Open Brain contract manifest", () => {
     });
     expect(
       contract.realtime_transport.nats_jetstream.request_reply_subjects,
-    ).toEqual([
-      "ob.memory.context_pack",
-      "ob.memory.session_start",
-      "ob.memory.append_event",
-      "ob.memory.wrap",
-      "ob.memory.resolve",
-      "ob.health",
-    ]);
+    ).toEqual({
+      available: [],
+      planned: [
+        "ob.memory.session_start",
+        "ob.memory.append_event",
+        "ob.memory.wrap",
+        "ob.memory.resolve",
+        "ob.health",
+      ],
+    });
     expect(contract.realtime_transport.nats_jetstream.jetstream_streams).toEqual([
       "OB_AGENT_TRACE",
       "OB_CONTEXT_PACK_REQUESTS",
@@ -589,10 +591,13 @@ describe("Open Brain contract manifest", () => {
       realtime_transport: {
         nats_jetstream: {
           ...base.realtime_transport.nats_jetstream,
-          request_reply_subjects: [
+          request_reply_subjects: {
             ...base.realtime_transport.nats_jetstream.request_reply_subjects,
-            "ob.memory.experimental",
-          ] as unknown as typeof base.realtime_transport.nats_jetstream.request_reply_subjects,
+            planned: [
+              ...base.realtime_transport.nats_jetstream.request_reply_subjects.planned,
+              "ob.memory.experimental",
+            ],
+          } as unknown as typeof base.realtime_transport.nats_jetstream.request_reply_subjects,
         },
       },
       interchange_profiles: base.interchange_profiles,
@@ -616,6 +621,16 @@ describe("Open Brain contract manifest", () => {
     expect(available.realtime_transport.nats_jetstream).toMatchObject({
       status: "runtime-available",
       availability: "available",
+      request_reply_subjects: {
+        available: ["ob.memory.context_pack"],
+        planned: [
+          "ob.memory.session_start",
+          "ob.memory.append_event",
+          "ob.memory.wrap",
+          "ob.memory.resolve",
+          "ob.health",
+        ],
+      },
     });
     expect(available.schema_hash).toBe(base.schema_hash);
   });

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -38,14 +38,16 @@ export interface OpenBrainContract {
         monitoring_listen: "127.0.0.1:8222";
         jetstream_store_dir: "/Volumes/ThunderBolt/open-brain/nats/jetstream";
       };
-      request_reply_subjects: readonly [
-        "ob.memory.context_pack",
-        "ob.memory.session_start",
-        "ob.memory.append_event",
-        "ob.memory.wrap",
-        "ob.memory.resolve",
-        "ob.health",
-      ];
+      request_reply_subjects: {
+        available: readonly ["ob.memory.context_pack"] | readonly [];
+        planned: readonly [
+          "ob.memory.session_start",
+          "ob.memory.append_event",
+          "ob.memory.wrap",
+          "ob.memory.resolve",
+          "ob.health",
+        ];
+      };
       jetstream_streams: readonly [
         "OB_AGENT_TRACE",
         "OB_CONTEXT_PACK_REQUESTS",
@@ -532,14 +534,18 @@ export function buildContract(
           jetstream_store_dir:
             "/Volumes/ThunderBolt/open-brain/nats/jetstream" as const,
         },
-        request_reply_subjects: [
-          "ob.memory.context_pack",
-          "ob.memory.session_start",
-          "ob.memory.append_event",
-          "ob.memory.wrap",
-          "ob.memory.resolve",
-          "ob.health",
-        ] as const,
+        request_reply_subjects: {
+          available: natsAvailability === "available"
+            ? ["ob.memory.context_pack"] as const
+            : [] as const,
+          planned: [
+            "ob.memory.session_start",
+            "ob.memory.append_event",
+            "ob.memory.wrap",
+            "ob.memory.resolve",
+            "ob.health",
+          ] as const,
+        },
         jetstream_streams: [
           "OB_AGENT_TRACE",
           "OB_CONTEXT_PACK_REQUESTS",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -28,8 +28,8 @@ export interface OpenBrainContract {
   };
   realtime_transport: {
     nats_jetstream: {
-      status: "planned-transport-foundation";
-      availability: "not_runtime_available";
+      status: "planned-transport-foundation" | "runtime-available";
+      availability: "available" | "not_runtime_available";
       parent_issue: 223;
       contract_doc: "docs/nats-jetstream-foundation.md";
       server: {
@@ -491,7 +491,11 @@ export function contractHash(
 
 export function buildContract(
   generatedAt = new Date().toISOString(),
+  options: {
+    natsAvailability?: "available" | "not_runtime_available";
+  } = {},
 ): OpenBrainContract {
+  const natsAvailability = options.natsAvailability ?? "not_runtime_available";
   const payload = {
     service: "open-brain" as const,
     contract_version: CONTRACT_VERSION,
@@ -515,8 +519,10 @@ export function buildContract(
     },
     realtime_transport: {
       nats_jetstream: {
-        status: "planned-transport-foundation" as const,
-        availability: "not_runtime_available" as const,
+        status: natsAvailability === "available"
+          ? "runtime-available" as const
+          : "planned-transport-foundation" as const,
+        availability: natsAvailability,
         parent_issue: 223 as const,
         contract_doc: "docs/nats-jetstream-foundation.md" as const,
         server: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ if (import.meta.main) {
       process.exit(1);
     }
   } else if (natsRuntimeBoundary.requested_transport === "nats") {
-    logger.warn("OPENBRAIN_TRANSPORT=nats requested before local bridge exists", {
+    logger.warn("OPENBRAIN_TRANSPORT=nats requested but bridge is not available", {
       availability: natsRuntimeBoundary.nats.availability,
       fallback_transport: natsRuntimeBoundary.fallback_transport,
       fallback_http: natsRuntimeBoundary.nats.fallback_http,
@@ -262,9 +262,29 @@ if (import.meta.main) {
   const shutdown = async () => {
     logger.info("Shutting down...");
     server.close();
-    await natsBridge?.close();
-    await pool.end();
-    process.exit(0);
+    if (natsBridge) {
+      try {
+        await Promise.race([
+          natsBridge.close(),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error("NATS bridge close timed out")), 5000),
+          ),
+        ]);
+      } catch (err) {
+        logger.error("NATS context-pack bridge failed to close during shutdown", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    try {
+      await pool.end();
+    } catch (err) {
+      logger.error("Database pool failed to close during shutdown", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      process.exit(0);
+    }
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,17 @@ export function createApp(
   deps?: ToolDeps,
 ): express.Express {
   const app = express();
+  const natsRuntimeBoundary =
+    deps?.natsRuntimeBoundary ?? readNatsRuntimeBoundary(process.env);
+  const natsBridgeHealth =
+    deps?.natsBridgeHealth ?? createNatsBridgeHealth("not_runtime_available");
+  const toolDeps: ToolDeps = {
+    pool,
+    embedFn: generateEmbedding,
+    ...deps,
+    natsRuntimeBoundary,
+    natsBridgeHealth,
+  };
 
   app.use(
     cors({
@@ -85,14 +96,29 @@ export function createApp(
     ]);
 
     const ips = serverIps();
+    const natsAvailability =
+      toolDeps.natsBridgeHealth?.availability ??
+      natsRuntimeBoundary.nats.availability;
+    const natsDegraded =
+      natsRuntimeBoundary.requested_transport === "nats" &&
+      natsAvailability !== "available";
     const status: HealthStatus = {
-      status: dbHealth.connected ? "healthy" : "degraded",
+      status: dbHealth.connected && !natsDegraded ? "healthy" : "degraded",
       server_ip: ips[0] ?? "unknown",
       server_ips: ips,
       database: dbHealth,
       embedding: {
         configured: Boolean(EMBEDDING_BASE_URL),
         connected: embeddingConnected,
+      },
+      nats: {
+        requested_transport: natsRuntimeBoundary.requested_transport,
+        availability: natsAvailability,
+        context_pack_subject: natsRuntimeBoundary.nats.context_pack_subject,
+        fallback_http: natsRuntimeBoundary.nats.fallback_http,
+        consecutive_failures:
+          toolDeps.natsBridgeHealth?.consecutiveFailures ?? 0,
+        last_error: toolDeps.natsBridgeHealth?.lastError ?? null,
       },
       timestamp: new Date().toISOString(),
     };
@@ -102,15 +128,6 @@ export function createApp(
 
   // Auth middleware
   const auth = authMiddleware(tokenMap);
-
-  // Shared deps for both MCP tools and REST API
-  const natsRuntimeBoundary = readNatsRuntimeBoundary(process.env);
-  const toolDeps: ToolDeps = deps ?? {
-    pool,
-    embedFn: generateEmbedding,
-    natsRuntimeBoundary,
-    natsBridgeHealth: createNatsBridgeHealth("not_runtime_available"),
-  };
 
   // REST API -- no MCP handshake required
   app.use("/api/v1", auth, createRestRouter(toolDeps));

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   summarizeNatsUrlForLog,
 } from "./nats-runtime.ts";
 import {
+  createNatsBridgeHealth,
   startNatsContextPackBridge,
   type NatsBridgeRuntime,
 } from "./nats-bridge.ts";
@@ -103,10 +104,12 @@ export function createApp(
   const auth = authMiddleware(tokenMap);
 
   // Shared deps for both MCP tools and REST API
+  const natsRuntimeBoundary = readNatsRuntimeBoundary(process.env);
   const toolDeps: ToolDeps = deps ?? {
     pool,
     embedFn: generateEmbedding,
-    natsRuntimeBoundary: readNatsRuntimeBoundary(process.env),
+    natsRuntimeBoundary,
+    natsBridgeHealth: createNatsBridgeHealth("not_runtime_available"),
   };
 
   // REST API -- no MCP handshake required
@@ -209,10 +212,14 @@ if (import.meta.main) {
   );
 
   const natsRuntimeBoundary = readNatsRuntimeBoundary(process.env);
+  const natsBridgeHealth = createNatsBridgeHealth(
+    natsRuntimeBoundary.nats.availability,
+  );
   const toolDeps: ToolDeps = {
     pool,
     embedFn: generateEmbedding,
     natsRuntimeBoundary,
+    natsBridgeHealth,
   };
   let natsBridge: NatsBridgeRuntime | null = null;
   if (
@@ -224,6 +231,7 @@ if (import.meta.main) {
         boundary: natsRuntimeBoundary,
         tokenMap,
         deps: toolDeps,
+        health: natsBridgeHealth,
       });
       logger.info("NATS context-pack bridge started", {
         subject: natsBridge?.subject,
@@ -231,6 +239,10 @@ if (import.meta.main) {
         nats_url: summarizeNatsUrlForLog(natsRuntimeBoundary.nats.url),
       });
     } catch (err) {
+      natsBridgeHealth.availability = "not_runtime_available";
+      natsBridgeHealth.consecutiveFailures += 1;
+      natsBridgeHealth.lastError =
+        err instanceof Error ? err.message : String(err);
       logger.error("NATS context-pack bridge failed to start", {
         error: err instanceof Error ? err.message : String(err),
         nats_url: summarizeNatsUrlForLog(natsRuntimeBoundary.nats.url),

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export function createApp(
         fallback_http: natsRuntimeBoundary.nats.fallback_http,
         consecutive_failures:
           toolDeps.natsBridgeHealth?.consecutiveFailures ?? 0,
-        last_error: toolDeps.natsBridgeHealth?.lastError ?? null,
+        last_error: toolDeps.natsBridgeHealth?.lastError ? "redacted" : null,
       },
       timestamp: new Date().toISOString(),
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ import {
   readNatsRuntimeBoundary,
   summarizeNatsUrlForLog,
 } from "./nats-runtime.ts";
+import {
+  startNatsContextPackBridge,
+  type NatsBridgeRuntime,
+} from "./nats-bridge.ts";
+import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
@@ -46,6 +51,7 @@ async function probeUrl(
 export function createApp(
   pool: pg.Pool,
   tokenMap: Map<string, AuthInfo>,
+  deps?: ToolDeps,
 ): express.Express {
   const app = express();
 
@@ -97,7 +103,11 @@ export function createApp(
   const auth = authMiddleware(tokenMap);
 
   // Shared deps for both MCP tools and REST API
-  const toolDeps = { pool, embedFn: generateEmbedding };
+  const toolDeps: ToolDeps = deps ?? {
+    pool,
+    embedFn: generateEmbedding,
+    natsRuntimeBoundary: readNatsRuntimeBoundary(process.env),
+  };
 
   // REST API -- no MCP handshake required
   app.use("/api/v1", auth, createRestRouter(toolDeps));
@@ -199,7 +209,35 @@ if (import.meta.main) {
   );
 
   const natsRuntimeBoundary = readNatsRuntimeBoundary(process.env);
-  if (natsRuntimeBoundary.requested_transport === "nats") {
+  const toolDeps: ToolDeps = {
+    pool,
+    embedFn: generateEmbedding,
+    natsRuntimeBoundary,
+  };
+  let natsBridge: NatsBridgeRuntime | null = null;
+  if (
+    natsRuntimeBoundary.requested_transport === "nats" &&
+    natsRuntimeBoundary.nats.availability === "available"
+  ) {
+    try {
+      natsBridge = await startNatsContextPackBridge({
+        boundary: natsRuntimeBoundary,
+        tokenMap,
+        deps: toolDeps,
+      });
+      logger.info("NATS context-pack bridge started", {
+        subject: natsBridge?.subject,
+        availability: natsBridge?.availability,
+        nats_url: summarizeNatsUrlForLog(natsRuntimeBoundary.nats.url),
+      });
+    } catch (err) {
+      logger.error("NATS context-pack bridge failed to start", {
+        error: err instanceof Error ? err.message : String(err),
+        nats_url: summarizeNatsUrlForLog(natsRuntimeBoundary.nats.url),
+      });
+      process.exit(1);
+    }
+  } else if (natsRuntimeBoundary.requested_transport === "nats") {
     logger.warn("OPENBRAIN_TRANSPORT=nats requested before local bridge exists", {
       availability: natsRuntimeBoundary.nats.availability,
       fallback_transport: natsRuntimeBoundary.fallback_transport,
@@ -214,7 +252,7 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const app = createApp(pool, tokenMap);
+  const app = createApp(pool, tokenMap, toolDeps);
   const port = parseInt(process.env.PORT || "3100", 10);
 
   const server = app.listen(port, () => {
@@ -224,6 +262,7 @@ if (import.meta.main) {
   const shutdown = async () => {
     logger.info("Shutting down...");
     server.close();
+    await natsBridge?.close();
     await pool.end();
     process.exit(0);
   };

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -67,6 +67,20 @@ function data(payload: unknown): Uint8Array {
   return encoder.encode(JSON.stringify(payload));
 }
 
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 500,
+): Promise<void> {
+  const started = Date.now();
+  while (!condition()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 describe("handleNatsContextPackMessage", () => {
   it("returns the same agent_context_pack payload over an authorized NATS request", () => {
     const tokenMap = new Map<string, AuthInfo>([
@@ -263,8 +277,8 @@ describe("startNatsContextPackBridge", () => {
     await runtime?.close();
   });
 
-  it("continues the real NATS subscription loop after per-message reply failure", async () => {
-    const responses: unknown[] = [];
+  it("resubscribes the real NATS subscription loop after handler and iterator failures", async () => {
+    const responses: Array<{ request_id?: string; status?: string }> = [];
     const loggedErrors: string[] = [];
     const originalError = logger.error;
     logger.error = (message, extra) => {
@@ -276,18 +290,22 @@ describe("startNatsContextPackBridge", () => {
         keys: () => ["authorization"],
         get: () => "Bearer secret-token",
       };
-      const subscription = {
+      const envelope = (requestId: string) => ({
+        ...baseEnvelope,
+        request_id: requestId,
+      });
+      const firstSubscription = {
         unsubscribe: mock(() => {}),
         async *[Symbol.asyncIterator]() {
           yield {
             subject: "ob.memory.context_pack",
-            data: data(baseEnvelope),
+            data: data(envelope("req-no-reply")),
             headers,
             respond: () => false,
           };
           yield {
             subject: "ob.memory.context_pack",
-            data: data(baseEnvelope),
+            data: data(envelope("req-before-resubscribe")),
             headers,
             respond: (payload: Uint8Array) => {
               responses.push(JSON.parse(decoder.decode(payload)));
@@ -297,8 +315,36 @@ describe("startNatsContextPackBridge", () => {
           throw new Error("subscription iterator failed");
         },
       };
+      const secondSubscription = {
+        unsubscribe: mock(() => {}),
+        async *[Symbol.asyncIterator]() {
+          yield {
+            subject: "ob.memory.context_pack",
+            data: data(envelope("req-after-resubscribe")),
+            headers,
+            respond: (payload: Uint8Array) => {
+              responses.push(JSON.parse(decoder.decode(payload)));
+              return true;
+            },
+          };
+        },
+      };
+      const fallbackSubscription = {
+        unsubscribe: mock(() => {}),
+        async *[Symbol.asyncIterator]() {},
+      };
+      let subscribeCalls = 0;
       const connection = {
-        subscribe: mock(() => subscription),
+        subscribe: mock(() => {
+          subscribeCalls += 1;
+          if (subscribeCalls === 1) {
+            return firstSubscription;
+          }
+          if (subscribeCalls === 2) {
+            return secondSubscription;
+          }
+          return fallbackSubscription;
+        }),
         drain: mock(async () => {}),
       };
       mock.module("nats", () => ({
@@ -315,11 +361,28 @@ describe("startNatsContextPackBridge", () => {
         deps: depsWithWorkingSet(),
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await waitFor(
+        () =>
+          responses.some(
+            (response) => response.request_id === "req-after-resubscribe",
+          ),
+        "NATS bridge to process a message after resubscribe",
+      );
 
       expect(connection.subscribe).toHaveBeenCalledWith("ob.memory.context_pack");
-      expect(responses).toHaveLength(1);
-      expect((responses[0] as { status?: string }).status).toBe("ok");
+      expect(connection.subscribe.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(responses).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            request_id: "req-before-resubscribe",
+            status: "ok",
+          }),
+          expect.objectContaining({
+            request_id: "req-after-resubscribe",
+            status: "ok",
+          }),
+        ]),
+      );
       expect(loggedErrors).toContain(
         "NATS context-pack bridge request failed:NATS request did not include a reply inbox",
       );
@@ -328,10 +391,11 @@ describe("startNatsContextPackBridge", () => {
       );
 
       await runtime?.close();
-      expect(subscription.unsubscribe).toHaveBeenCalled();
+      expect(secondSubscription.unsubscribe).toHaveBeenCalled();
       expect(connection.drain).toHaveBeenCalled();
     } finally {
       logger.error = originalError;
+      mock.restore();
     }
   });
 });

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
+  createNatsBridgeHealth,
   handleNatsContextPackMessage,
   startNatsContextPackBridge,
   type NatsBridgeDriver,
@@ -392,6 +393,78 @@ describe("startNatsContextPackBridge", () => {
 
       await runtime?.close();
       expect(secondSubscription.unsubscribe).toHaveBeenCalled();
+      expect(connection.drain).toHaveBeenCalled();
+    } finally {
+      logger.error = originalError;
+      mock.restore();
+    }
+  });
+
+  it("marks live NATS health unavailable and backs off when resubscribe repeatedly fails", async () => {
+    const loggedErrors: string[] = [];
+    const originalError = logger.error;
+    logger.error = (message, extra) => {
+      loggedErrors.push(`${message}:${String(extra?.error ?? "")}`);
+    };
+
+    try {
+      const firstSubscription = {
+        unsubscribe: mock(() => {}),
+        async *[Symbol.asyncIterator]() {
+          throw new Error("subscription iterator failed");
+        },
+      };
+      let subscribeCalls = 0;
+      const connection = {
+        subscribe: mock(() => {
+          subscribeCalls += 1;
+          if (subscribeCalls === 1) {
+            return firstSubscription;
+          }
+          throw new Error("connection closed");
+        }),
+        drain: mock(async () => {}),
+      };
+      mock.module("nats", () => ({
+        connect: mock(async () => connection),
+      }));
+      const health = createNatsBridgeHealth("available");
+
+      const runtime = await startNatsContextPackBridge({
+        boundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        deps: depsWithWorkingSet(),
+        health,
+      });
+
+      await waitFor(
+        () =>
+          health.availability === "not_runtime_available" &&
+          health.lastError === "connection closed",
+        "NATS bridge health to degrade after repeated resubscribe failure",
+      );
+      const callsAfterFailure = subscribeCalls;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      expect(health).toMatchObject({
+        availability: "not_runtime_available",
+        lastError: "connection closed",
+      });
+      expect(callsAfterFailure).toBeGreaterThanOrEqual(2);
+      expect(subscribeCalls - callsAfterFailure).toBeLessThanOrEqual(2);
+      expect(loggedErrors).toContain(
+        "NATS context-pack bridge subscription failed:subscription iterator failed",
+      );
+      expect(loggedErrors).toContain(
+        "NATS context-pack bridge subscription failed:connection closed",
+      );
+
+      await runtime?.close();
+      expect(firstSubscription.unsubscribe).toHaveBeenCalled();
       expect(connection.drain).toHaveBeenCalled();
     } finally {
       logger.error = originalError;

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -110,7 +110,7 @@ describe("handleNatsContextPackMessage", () => {
     const response = handleNatsContextPackMessage({
       message: {
         subject: "ob.memory.context_pack",
-        data: data(baseEnvelope),
+        data: data({ not: "valid-json-envelope" }),
         headers: {},
       },
       boundary,
@@ -119,9 +119,62 @@ describe("handleNatsContextPackMessage", () => {
     }) as any;
 
     expect(response).toMatchObject({
-      request_id: "req-123",
+      request_id: null,
       status: "error",
       error: { code: "permission_denied" },
+    });
+  });
+
+  it("rejects oversized bodies before parsing", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: encoder.encode("x".repeat(65 * 1024)),
+        headers: { Authorization: "Bearer secret-token" },
+      },
+      boundary,
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+    }) as any;
+
+    expect(response).toMatchObject({
+      request_id: null,
+      status: "error",
+      error: { code: "payload_too_large" },
+    });
+  });
+
+  it("does not expose raw parser or schema errors to NATS callers", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: encoder.encode("{bad json"),
+        headers: { Authorization: "Bearer secret-token" },
+      },
+      boundary,
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+    }) as any;
+
+    expect(response).toMatchObject({
+      request_id: null,
+      status: "error",
+      error: {
+        code: "bad_request",
+        message: "Invalid NATS context pack request",
+      },
     });
   });
 });
@@ -176,5 +229,35 @@ describe("startNatsContextPackBridge", () => {
     });
 
     expect(runtime).toBeNull();
+  });
+
+  it("surfaces reply failures from request messages", async () => {
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        await expect(
+          handler({
+            subject,
+            data: data(baseEnvelope),
+            headers: { authorization: "Bearer secret-token" },
+            respond: () => false,
+          } satisfies NatsRequestMessage),
+        ).rejects.toThrow("NATS request did not include a reply inbox");
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: readNatsRuntimeBoundary({
+        OPENBRAIN_TRANSPORT: "nats",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      }),
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+      driver,
+    });
+
+    await runtime?.close();
   });
 });

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "bun:test";
+import {
+  handleNatsContextPackMessage,
+  startNatsContextPackBridge,
+  type NatsBridgeDriver,
+  type NatsRequestMessage,
+} from "./nats-bridge.ts";
+import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
+import { WorkingSetStore } from "./realtime/working-set.ts";
+import { RecoveryWalStore } from "./realtime/recovery-wal.ts";
+import type { ToolDeps } from "./tools/index.ts";
+import type { AuthInfo } from "./types.ts";
+
+const encoder = new TextEncoder();
+
+const scope = {
+  namespace: "rico",
+  agent: "nagatha",
+  platform: "discord",
+  server_id: "rodaddy-live",
+  channel_id: "open-brain",
+  session_key: "discord:rodaddy-live:open-brain:nagatha",
+};
+
+const baseEnvelope = {
+  schema: "openbrain.nats.request.v1",
+  operation: "agent_context_pack",
+  request_id: "req-123",
+  identity: {
+    namespace_source: "authorization",
+    agent: scope.agent,
+    platform: scope.platform,
+    server_id: scope.server_id,
+    channel_id: scope.channel_id,
+    thread_id: null,
+    session_key: scope.session_key,
+  },
+  body: {
+    query: "what is the current task state?",
+    requested_sections: ["working_set"],
+  },
+  metadata: {
+    client: "openbrain-memory",
+    client_version: "0.1.0",
+    transport: "nats",
+  },
+} as const;
+
+function depsWithWorkingSet(): ToolDeps {
+  const workingSetStore = new WorkingSetStore();
+  workingSetStore.append(scope, {
+    kind: "current_intent",
+    content: "Finish #223 over NATS without changing HTTP default.",
+  });
+
+  return {
+    pool: { query: async () => ({ rows: [] }) } as any,
+    embedFn: async () => Array(768).fill(0.1),
+    workingSetStore,
+    recoveryWalStore: new RecoveryWalStore(),
+  };
+}
+
+function data(payload: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+describe("handleNatsContextPackMessage", () => {
+  it("returns the same agent_context_pack payload over an authorized NATS request", () => {
+    const tokenMap = new Map<string, AuthInfo>([
+      ["secret-token", { role: "admin", clientId: "rico" }],
+    ]);
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        headers: { Authorization: "Bearer secret-token" },
+      },
+      boundary,
+      tokenMap,
+      deps: depsWithWorkingSet(),
+    }) as any;
+
+    expect(response).toMatchObject({
+      schema: "openbrain.nats.response.v1",
+      request_id: "req-123",
+      status: "ok",
+      operation: "agent_context_pack",
+    });
+    expect(response.body.sections.working_set.items[0]).toMatchObject({
+      content: "Finish #223 over NATS without changing HTTP default.",
+      label: "working_context",
+    });
+    expect(response.body.warnings.scope_denials).toEqual([]);
+  });
+
+  it("rejects NATS requests that do not carry a bearer token", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        headers: {},
+      },
+      boundary,
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet(),
+    }) as any;
+
+    expect(response).toMatchObject({
+      request_id: "req-123",
+      status: "error",
+      error: { code: "permission_denied" },
+    });
+  });
+});
+
+describe("startNatsContextPackBridge", () => {
+  it("subscribes only when NATS is explicitly requested and available", async () => {
+    let subscribedSubject: string | undefined;
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        subscribedSubject = subject;
+        await handler({
+          subject,
+          data: data(baseEnvelope),
+          headers: { authorization: "Bearer secret-token" },
+          respond: () => undefined,
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: readNatsRuntimeBoundary({
+        OPENBRAIN_TRANSPORT: "nats",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      }),
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+      driver,
+    });
+
+    expect(runtime).toMatchObject({
+      subject: "ob.memory.context_pack",
+      availability: "available",
+    });
+    expect(subscribedSubject).toBe("ob.memory.context_pack");
+    await runtime?.close();
+  });
+
+  it("does not subscribe for the default HTTP/MCP runtime", async () => {
+    const runtime = await startNatsContextPackBridge({
+      boundary: readNatsRuntimeBoundary({}),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet(),
+      driver: {
+        subscribe: async () => {
+          throw new Error("should not subscribe");
+        },
+        close: () => undefined,
+      },
+    });
+
+    expect(runtime).toBeNull();
+  });
+});

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -194,6 +194,95 @@ describe("handleNatsContextPackMessage", () => {
       },
     });
   });
+
+  it("returns unavailable when live bridge health is degraded", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+    const health = createNatsBridgeHealth("not_runtime_available");
+    health.lastError = "connection closed";
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        headers: { Authorization: "Bearer secret-token" },
+      },
+      boundary,
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+      health,
+    }) as any;
+
+    expect(response).toMatchObject({
+      request_id: null,
+      status: "error",
+      error: {
+        code: "temporarily_unavailable",
+        message: "NATS bridge is not available",
+      },
+    });
+  });
+
+  it("logs internal handler failures without reporting them as bad requests", () => {
+    const loggedErrors: string[] = [];
+    const originalError = logger.error;
+    logger.error = (message, extra) => {
+      loggedErrors.push(JSON.stringify({ message, ...extra }));
+    };
+
+    try {
+      const sensitiveToken = ["user", ":", "pass"].join("");
+      const sensitiveHost = ["broker", "internal"].join(".");
+      const brokenWorkingSetStore = {
+        buildContextPackFragment: () => {
+          const err = new Error(
+            ["working set exploded for nats://", sensitiveToken, "@", sensitiveHost].join(
+              "",
+            ),
+          );
+          err.name = ["NatsError nats://", sensitiveToken, "@", sensitiveHost].join(
+            "",
+          );
+          throw err;
+        },
+      } as unknown as WorkingSetStore;
+      const response = handleNatsContextPackMessage({
+        message: {
+          subject: "ob.memory.context_pack",
+          data: data(baseEnvelope),
+          headers: { Authorization: "Bearer secret-token" },
+        },
+        boundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        deps: { ...depsWithWorkingSet(), workingSetStore: brokenWorkingSetStore },
+      }) as any;
+
+      expect(response).toMatchObject({
+        request_id: "req-123",
+        status: "error",
+        error: {
+          code: "internal_error",
+          message: "NATS context pack request failed",
+        },
+      });
+      const joinedLogs = loggedErrors.join("\n");
+      expect(joinedLogs).toContain(
+        '"message":"NATS context-pack bridge request failed"',
+      );
+      expect(joinedLogs).toContain('"error_type":"Error"');
+      expect(joinedLogs).not.toContain(sensitiveToken);
+      expect(joinedLogs).not.toContain(sensitiveHost);
+    } finally {
+      logger.error = originalError;
+    }
+  });
 });
 
 describe("startNatsContextPackBridge", () => {
@@ -309,7 +398,7 @@ describe("startNatsContextPackBridge", () => {
     const loggedErrors: string[] = [];
     const originalError = logger.error;
     logger.error = (message, extra) => {
-      loggedErrors.push(`${message}:${String(extra?.error ?? "")}`);
+      loggedErrors.push(`${message}:${String(extra?.error_type ?? "")}`);
     };
 
     try {
@@ -411,10 +500,10 @@ describe("startNatsContextPackBridge", () => {
         ]),
       );
       expect(loggedErrors).toContain(
-        "NATS context-pack bridge request failed:NATS request did not include a reply inbox",
+        "NATS context-pack bridge request failed:Error",
       );
       expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:subscription iterator failed",
+        "NATS context-pack bridge subscription failed:Error",
       );
 
       await runtime?.close();
@@ -426,11 +515,134 @@ describe("startNatsContextPackBridge", () => {
     }
   });
 
+  it("resubscribes after clean iterator completion without degrading health", async () => {
+    const responses: Array<{ request_id?: string; status?: string }> = [];
+    const headers = {
+      keys: () => ["authorization"],
+      get: () => "Bearer secret-token",
+    };
+    const firstSubscription = {
+      unsubscribe: mock(() => {}),
+      async *[Symbol.asyncIterator]() {},
+    };
+    const secondSubscription = {
+      unsubscribe: mock(() => {}),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          subject: "ob.memory.context_pack",
+          data: data({ ...baseEnvelope, request_id: "req-after-clean-end" }),
+          headers,
+          respond: (payload: Uint8Array) => {
+            responses.push(JSON.parse(decoder.decode(payload)));
+            return true;
+          },
+        };
+      },
+    };
+    const fallbackSubscription = {
+      unsubscribe: mock(() => {}),
+      async *[Symbol.asyncIterator]() {},
+    };
+    let subscribeCalls = 0;
+    const connection = {
+      subscribe: mock(() => {
+        subscribeCalls += 1;
+        if (subscribeCalls === 1) return firstSubscription;
+        if (subscribeCalls === 2) return secondSubscription;
+        return fallbackSubscription;
+      }),
+      drain: mock(async () => {}),
+    };
+    mock.module("nats", () => ({
+      connect: mock(async () => connection),
+    }));
+    const health = createNatsBridgeHealth("available");
+
+    try {
+      const runtime = await startNatsContextPackBridge({
+        boundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        deps: depsWithWorkingSet(),
+        health,
+      });
+
+      await waitFor(
+        () =>
+          responses.some(
+            (response) => response.request_id === "req-after-clean-end",
+          ),
+        "NATS bridge to resubscribe after clean iterator completion",
+      );
+      expect(health).toMatchObject({
+        availability: "available",
+        consecutiveFailures: 0,
+        lastError: null,
+      });
+      expect(connection.subscribe.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      await runtime?.close();
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("marks health unavailable after repeated clean empty subscription completions", async () => {
+    const emptySubscription = () => ({
+      unsubscribe: mock(() => {}),
+      async *[Symbol.asyncIterator]() {},
+    });
+    const subscriptions: Array<ReturnType<typeof emptySubscription>> = [];
+    const connection = {
+      subscribe: mock(() => {
+        const subscription = emptySubscription();
+        subscriptions.push(subscription);
+        return subscription;
+      }),
+      drain: mock(async () => {}),
+    };
+    mock.module("nats", () => ({
+      connect: mock(async () => connection),
+    }));
+    const health = createNatsBridgeHealth("available");
+
+    try {
+      const runtime = await startNatsContextPackBridge({
+        boundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        deps: depsWithWorkingSet(),
+        health,
+      });
+
+      await waitFor(
+        () =>
+          health.availability === "not_runtime_available" &&
+          health.lastError === "NATS subscription ended without messages",
+        "NATS bridge health to degrade after repeated clean empty subscriptions",
+      );
+      expect(connection.subscribe.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(health.consecutiveFailures).toBe(1);
+
+      await runtime?.close();
+      expect(subscriptions.at(-1)?.unsubscribe).toHaveBeenCalled();
+      expect(connection.drain).toHaveBeenCalled();
+    } finally {
+      mock.restore();
+    }
+  });
+
   it("backs off when resubscribe succeeds but replacement iterators keep failing", async () => {
     const loggedErrors: string[] = [];
     const originalError = logger.error;
     logger.error = (message, extra) => {
-      loggedErrors.push(`${message}:${String(extra?.error ?? "")}`);
+      loggedErrors.push(`${message}:${String(extra?.error_type ?? "")}`);
     };
 
     try {
@@ -478,10 +690,10 @@ describe("startNatsContextPackBridge", () => {
       expect(health.lastError).toMatch(/^iterator failed /);
       expect(subscribeCalls - callsAfterSecondFailure).toBeLessThanOrEqual(1);
       expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:iterator failed 1",
+        "NATS context-pack bridge subscription failed:Error",
       );
       expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:iterator failed 2",
+        "NATS context-pack bridge subscription failed:Error",
       );
 
       await runtime?.close();
@@ -497,7 +709,7 @@ describe("startNatsContextPackBridge", () => {
     const loggedErrors: string[] = [];
     const originalError = logger.error;
     logger.error = (message, extra) => {
-      loggedErrors.push(`${message}:${String(extra?.error ?? "")}`);
+      loggedErrors.push(`${message}:${String(extra?.error_type ?? "")}`);
     };
 
     try {
@@ -550,10 +762,10 @@ describe("startNatsContextPackBridge", () => {
       expect(callsAfterFailure).toBeGreaterThanOrEqual(2);
       expect(subscribeCalls - callsAfterFailure).toBeLessThanOrEqual(2);
       expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:subscription iterator failed",
+        "NATS context-pack bridge subscription failed:Error",
       );
       expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:connection closed",
+        "NATS context-pack bridge subscription failed:Error",
       );
 
       await runtime?.close();

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import {
   handleNatsContextPackMessage,
-  processNatsSubscriptionMessage,
   startNatsContextPackBridge,
   type NatsBridgeDriver,
   type NatsRequestMessage,
 } from "./nats-bridge.ts";
+import { logger } from "./logger.ts";
 import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 import { WorkingSetStore } from "./realtime/working-set.ts";
 import { RecoveryWalStore } from "./realtime/recovery-wal.ts";
@@ -13,6 +13,7 @@ import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo } from "./types.ts";
 
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
 const scope = {
   namespace: "rico",
@@ -262,42 +263,75 @@ describe("startNatsContextPackBridge", () => {
     await runtime?.close();
   });
 
-  it("isolates per-message reply failures in the subscription driver boundary", async () => {
-    const handled: string[] = [];
-    const errors: string[] = [];
-    const handler = async (message: NatsRequestMessage) => {
-      handled.push(message.subject);
-      const responded = await message.respond(data({ ok: true }));
-      if (responded === false) {
-        throw new Error("NATS request did not include a reply inbox");
-      }
-    };
-    const onError = (err: unknown, subject: string) => {
-      errors.push(`${subject}:${err instanceof Error ? err.message : String(err)}`);
+  it("continues the real NATS subscription loop after per-message reply failure", async () => {
+    const responses: unknown[] = [];
+    const loggedErrors: string[] = [];
+    const originalError = logger.error;
+    logger.error = (message, extra) => {
+      loggedErrors.push(`${message}:${String(extra?.error ?? "")}`);
     };
 
-    await processNatsSubscriptionMessage(
-      {
-        subject: "ob.memory.context_pack",
-        data: data(baseEnvelope),
-        respond: () => false,
-      },
-      handler,
-      onError,
-    );
-    await processNatsSubscriptionMessage(
-      {
-        subject: "ob.memory.context_pack",
-        data: data(baseEnvelope),
-        respond: () => true,
-      },
-      handler,
-      onError,
-    );
+    try {
+      const headers = {
+        keys: () => ["authorization"],
+        get: () => "Bearer secret-token",
+      };
+      const subscription = {
+        unsubscribe: mock(() => {}),
+        async *[Symbol.asyncIterator]() {
+          yield {
+            subject: "ob.memory.context_pack",
+            data: data(baseEnvelope),
+            headers,
+            respond: () => false,
+          };
+          yield {
+            subject: "ob.memory.context_pack",
+            data: data(baseEnvelope),
+            headers,
+            respond: (payload: Uint8Array) => {
+              responses.push(JSON.parse(decoder.decode(payload)));
+              return true;
+            },
+          };
+          throw new Error("subscription iterator failed");
+        },
+      };
+      const connection = {
+        subscribe: mock(() => subscription),
+        drain: mock(async () => {}),
+      };
+      mock.module("nats", () => ({
+        connect: mock(async () => connection),
+      }));
 
-    expect(handled).toEqual(["ob.memory.context_pack", "ob.memory.context_pack"]);
-    expect(errors).toEqual([
-      "ob.memory.context_pack:NATS request did not include a reply inbox",
-    ]);
+      const runtime = await startNatsContextPackBridge({
+        boundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        deps: depsWithWorkingSet(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(connection.subscribe).toHaveBeenCalledWith("ob.memory.context_pack");
+      expect(responses).toHaveLength(1);
+      expect((responses[0] as { status?: string }).status).toBe("ok");
+      expect(loggedErrors).toContain(
+        "NATS context-pack bridge request failed:NATS request did not include a reply inbox",
+      );
+      expect(loggedErrors).toContain(
+        "NATS context-pack bridge subscription failed:subscription iterator failed",
+      );
+
+      await runtime?.close();
+      expect(subscription.unsubscribe).toHaveBeenCalled();
+      expect(connection.drain).toHaveBeenCalled();
+    } finally {
+      logger.error = originalError;
+    }
   });
 });

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   handleNatsContextPackMessage,
+  processNatsSubscriptionMessage,
   startNatsContextPackBridge,
   type NatsBridgeDriver,
   type NatsRequestMessage,
@@ -259,5 +260,44 @@ describe("startNatsContextPackBridge", () => {
     });
 
     await runtime?.close();
+  });
+
+  it("isolates per-message reply failures in the subscription driver boundary", async () => {
+    const handled: string[] = [];
+    const errors: string[] = [];
+    const handler = async (message: NatsRequestMessage) => {
+      handled.push(message.subject);
+      const responded = await message.respond(data({ ok: true }));
+      if (responded === false) {
+        throw new Error("NATS request did not include a reply inbox");
+      }
+    };
+    const onError = (err: unknown, subject: string) => {
+      errors.push(`${subject}:${err instanceof Error ? err.message : String(err)}`);
+    };
+
+    await processNatsSubscriptionMessage(
+      {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        respond: () => false,
+      },
+      handler,
+      onError,
+    );
+    await processNatsSubscriptionMessage(
+      {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        respond: () => true,
+      },
+      handler,
+      onError,
+    );
+
+    expect(handled).toEqual(["ob.memory.context_pack", "ob.memory.context_pack"]);
+    expect(errors).toEqual([
+      "ob.memory.context_pack:NATS request did not include a reply inbox",
+    ]);
   });
 });

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -278,6 +278,32 @@ describe("startNatsContextPackBridge", () => {
     await runtime?.close();
   });
 
+  it("attempts driver close when subscription close fails", async () => {
+    const subscriptionClose = mock(async () => {
+      throw new Error("subscription close failed");
+    });
+    const driverClose = mock(async () => {});
+    const driver: NatsBridgeDriver = {
+      subscribe: async () => ({ close: subscriptionClose }),
+      close: driverClose,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: readNatsRuntimeBoundary({
+        OPENBRAIN_TRANSPORT: "nats",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      }),
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+      driver,
+    });
+
+    await expect(runtime?.close()).rejects.toThrow("subscription close failed");
+    expect(subscriptionClose).toHaveBeenCalled();
+    expect(driverClose).toHaveBeenCalled();
+  });
+
   it("resubscribes the real NATS subscription loop after handler and iterator failures", async () => {
     const responses: Array<{ request_id?: string; status?: string }> = [];
     const loggedErrors: string[] = [];
@@ -393,6 +419,73 @@ describe("startNatsContextPackBridge", () => {
 
       await runtime?.close();
       expect(secondSubscription.unsubscribe).toHaveBeenCalled();
+      expect(connection.drain).toHaveBeenCalled();
+    } finally {
+      logger.error = originalError;
+      mock.restore();
+    }
+  });
+
+  it("backs off when resubscribe succeeds but replacement iterators keep failing", async () => {
+    const loggedErrors: string[] = [];
+    const originalError = logger.error;
+    logger.error = (message, extra) => {
+      loggedErrors.push(`${message}:${String(extra?.error ?? "")}`);
+    };
+
+    try {
+      const subscriptions: Array<{ unsubscribe: ReturnType<typeof mock> }> = [];
+      let subscribeCalls = 0;
+      const connection = {
+        subscribe: mock(() => {
+          subscribeCalls += 1;
+          const error = new Error(`iterator failed ${subscribeCalls}`);
+          const subscription = {
+            unsubscribe: mock(() => {}),
+            async *[Symbol.asyncIterator]() {
+              throw error;
+            },
+          };
+          subscriptions.push(subscription);
+          return subscription;
+        }),
+        drain: mock(async () => {}),
+      };
+      mock.module("nats", () => ({
+        connect: mock(async () => connection),
+      }));
+      const health = createNatsBridgeHealth("available");
+
+      const runtime = await startNatsContextPackBridge({
+        boundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        deps: depsWithWorkingSet(),
+        health,
+      });
+
+      await waitFor(
+        () => subscribeCalls >= 2,
+        "NATS bridge to resubscribe after an iterator failure",
+      );
+      const callsAfterSecondFailure = subscribeCalls;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      expect(health.availability).toBe("not_runtime_available");
+      expect(health.lastError).toMatch(/^iterator failed /);
+      expect(subscribeCalls - callsAfterSecondFailure).toBeLessThanOrEqual(1);
+      expect(loggedErrors).toContain(
+        "NATS context-pack bridge subscription failed:iterator failed 1",
+      );
+      expect(loggedErrors).toContain(
+        "NATS context-pack bridge subscription failed:iterator failed 2",
+      );
+
+      await runtime?.close();
+      expect(subscriptions.at(-1)?.unsubscribe).toHaveBeenCalled();
       expect(connection.drain).toHaveBeenCalled();
     } finally {
       logger.error = originalError;

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -1,5 +1,6 @@
 import type { AuthInfo } from "./types.ts";
 import type { ToolDeps } from "./tools/index.ts";
+import { z } from "zod";
 import { logger } from "./logger.ts";
 import {
   buildAgentContextPackPayload,
@@ -72,6 +73,7 @@ const decoder = new TextDecoder();
 const MAX_NATS_REQUEST_BYTES = 64 * 1024;
 const NATS_RESUBSCRIBE_INITIAL_DELAY_MS = 25;
 const NATS_RESUBSCRIBE_MAX_DELAY_MS = 1_000;
+const NATS_EMPTY_SUBSCRIPTION_DEGRADE_THRESHOLD = 2;
 
 export function createNatsBridgeHealth(
   availability: NatsBridgeHealth["availability"] = "not_runtime_available",
@@ -105,6 +107,7 @@ export async function startNatsContextPackBridge(
       boundary: options.boundary,
       tokenMap: options.tokenMap,
       deps: options.deps,
+      health,
     });
     const responded = await message.respond(encoder.encode(JSON.stringify(response)));
     if (responded === false) {
@@ -142,6 +145,7 @@ export function handleNatsContextPackMessage(input: {
   boundary: NatsRuntimeBoundary;
   tokenMap: Map<string, AuthInfo>;
   deps: ToolDeps;
+  health?: NatsBridgeHealth;
 }): unknown {
   let requestId: string | null = null;
 
@@ -158,6 +162,13 @@ export function handleNatsContextPackMessage(input: {
     }
     if (input.message.data.byteLength > MAX_NATS_REQUEST_BYTES) {
       return natsError(requestId, "payload_too_large", "NATS request body is too large");
+    }
+    if (input.health && input.health.availability !== "available") {
+      return natsError(
+        requestId,
+        "temporarily_unavailable",
+        "NATS bridge is not available",
+      );
     }
 
     const envelope = parseEnvelope(input.message.data);
@@ -185,6 +196,14 @@ export function handleNatsContextPackMessage(input: {
       body: result.payload,
     };
   } catch (err) {
+    if (!isNatsRequestValidationError(err)) {
+      logNatsRequestError(err, input.message.subject);
+      return natsError(
+        requestId,
+        "internal_error",
+        "NATS context pack request failed",
+      );
+    }
     return natsError(requestId, "bad_request", "Invalid NATS context pack request");
   }
 }
@@ -250,6 +269,7 @@ async function createNatsJsDriver(
       let closed = false;
       let resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
       let needsSubscription = false;
+      let consecutiveEmptySubscriptions = 0;
 
       void (async () => {
         while (!closed) {
@@ -271,15 +291,26 @@ async function createNatsJsDriver(
             for await (const message of subscription) {
               if (closed) break;
               processedMessage = true;
+              consecutiveEmptySubscriptions = 0;
               markNatsBridgeAvailable(health);
               resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
               await processNatsSubscriptionMessage(message, handler);
             }
-            if (!closed) {
-              markNatsBridgeUnavailable(health, "NATS subscription ended");
+            if (!closed && !processedMessage) {
+              consecutiveEmptySubscriptions += 1;
+              if (
+                consecutiveEmptySubscriptions >=
+                NATS_EMPTY_SUBSCRIPTION_DEGRADE_THRESHOLD
+              ) {
+                markNatsBridgeUnavailable(
+                  health,
+                  "NATS subscription ended without messages",
+                );
+              }
             }
           } catch (err) {
             if (!closed) {
+              consecutiveEmptySubscriptions = 0;
               markNatsBridgeUnavailable(health, errorMessage(err));
               logNatsSubscriptionError(err, subject);
             }
@@ -332,6 +363,17 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function safeErrorType(err: unknown): string {
+  if (err instanceof SyntaxError) return "SyntaxError";
+  if (err instanceof z.ZodError) return "ZodError";
+  if (err instanceof Error) return "Error";
+  return typeof err;
+}
+
+function isNatsRequestValidationError(err: unknown): boolean {
+  return err instanceof SyntaxError || err instanceof z.ZodError;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -358,14 +400,21 @@ async function processNatsSubscriptionMessage(
 function logNatsHandlerError(err: unknown, subject: string): void {
   logger.error("NATS context-pack bridge request failed", {
     subject,
-    error: err instanceof Error ? err.message : String(err),
+    error_type: safeErrorType(err),
+  });
+}
+
+function logNatsRequestError(err: unknown, subject: string): void {
+  logger.error("NATS context-pack bridge request failed", {
+    subject,
+    error_type: safeErrorType(err),
   });
 }
 
 function logNatsSubscriptionError(err: unknown, subject: string): void {
   logger.error("NATS context-pack bridge subscription failed", {
     subject,
-    error: err instanceof Error ? err.message : String(err),
+    error_type: safeErrorType(err),
   });
 }
 

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -45,7 +45,7 @@ interface NatsSubscriptionHeaders {
   get(key: string): string;
 }
 
-export interface NatsSubscriptionMessage {
+interface NatsSubscriptionMessage {
   subject: string;
   data: Uint8Array;
   headers?: NatsSubscriptionHeaders;
@@ -210,9 +210,15 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
       let closed = false;
 
       void (async () => {
-        for await (const message of subscription) {
-          if (closed) break;
-          await processNatsSubscriptionMessage(message, handler);
+        try {
+          for await (const message of subscription) {
+            if (closed) break;
+            await processNatsSubscriptionMessage(message, handler);
+          }
+        } catch (err) {
+          if (!closed) {
+            logNatsSubscriptionError(err, subject);
+          }
         }
       })();
 
@@ -229,7 +235,7 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
   };
 }
 
-export async function processNatsSubscriptionMessage(
+async function processNatsSubscriptionMessage(
   message: NatsSubscriptionMessage,
   handler: (message: NatsRequestMessage) => Promise<void>,
   onError: (err: unknown, subject: string) => void = logNatsHandlerError,
@@ -250,6 +256,13 @@ export async function processNatsSubscriptionMessage(
 
 function logNatsHandlerError(err: unknown, subject: string): void {
   logger.error("NATS context-pack bridge request failed", {
+    subject,
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+function logNatsSubscriptionError(err: unknown, subject: string): void {
+  logger.error("NATS context-pack bridge subscription failed", {
     subject,
     error: err instanceof Error ? err.message : String(err),
   });

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -118,8 +118,21 @@ export async function startNatsContextPackBridge(
     health,
     close: async () => {
       markNatsBridgeUnavailable(health, "NATS bridge closed");
-      await subscription.close();
-      await driver.close();
+      const closeErrors: unknown[] = [];
+      try {
+        await subscription.close();
+      } catch (err) {
+        closeErrors.push(err);
+      }
+      try {
+        await driver.close();
+      } catch (err) {
+        closeErrors.push(err);
+      }
+      if (closeErrors.length === 1) throw closeErrors[0];
+      if (closeErrors.length > 1) {
+        throw new AggregateError(closeErrors, "NATS bridge close failed");
+      }
     },
   };
 }
@@ -243,8 +256,6 @@ async function createNatsJsDriver(
           if (needsSubscription) {
             try {
               subscription = connection.subscribe(subject);
-              markNatsBridgeAvailable(health);
-              resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
               needsSubscription = false;
             } catch (err) {
               markNatsBridgeUnavailable(health, errorMessage(err));
@@ -255,9 +266,13 @@ async function createNatsJsDriver(
             }
           }
 
+          let processedMessage = false;
           try {
             for await (const message of subscription) {
               if (closed) break;
+              processedMessage = true;
+              markNatsBridgeAvailable(health);
+              resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
               await processNatsSubscriptionMessage(message, handler);
             }
             if (!closed) {
@@ -270,6 +285,9 @@ async function createNatsJsDriver(
             }
           }
           needsSubscription = true;
+          if (!closed && !processedMessage) {
+            resubscribeDelayMs = nextNatsResubscribeDelay(resubscribeDelayMs);
+          }
 
           if (!closed) {
             await delay(resubscribeDelayMs);

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -1,0 +1,231 @@
+import type { AuthInfo } from "./types.ts";
+import type { ToolDeps } from "./tools/index.ts";
+import {
+  buildAgentContextPackPayload,
+  parseAgentContextPackArgs,
+} from "./tools/agent-context-pack.ts";
+import type {
+  NatsBridgePlan,
+  NatsContextPackEnvelope,
+  NatsRuntimeBoundary,
+} from "./nats-runtime.ts";
+import {
+  contextPackEnvelopeSchema,
+  mapNatsEnvelopeToToolArgs,
+} from "./nats-runtime.ts";
+
+export interface NatsRequestMessage {
+  subject: string;
+  data: Uint8Array;
+  headers?: Record<string, string | undefined>;
+  respond(data: Uint8Array): void | Promise<void>;
+}
+
+export interface NatsSubscriptionHandle {
+  close(): Promise<void> | void;
+}
+
+export interface NatsBridgeDriver {
+  subscribe(
+    subject: string,
+    handler: (message: NatsRequestMessage) => Promise<void>,
+  ): Promise<NatsSubscriptionHandle>;
+  close(): Promise<void> | void;
+}
+
+export interface NatsBridgeRuntime {
+  subject: string;
+  availability: "available";
+  close(): Promise<void>;
+}
+
+export interface StartNatsContextPackBridgeOptions {
+  boundary: NatsRuntimeBoundary;
+  tokenMap: Map<string, AuthInfo>;
+  deps: ToolDeps;
+  driver?: NatsBridgeDriver;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export async function startNatsContextPackBridge(
+  options: StartNatsContextPackBridgeOptions,
+): Promise<NatsBridgeRuntime | null> {
+  if (
+    options.boundary.requested_transport !== "nats" ||
+    options.boundary.nats.availability !== "available"
+  ) {
+    return null;
+  }
+
+  const driver =
+    options.driver ??
+    (await createNatsJsDriver(options.boundary.nats.url));
+  const subject = options.boundary.nats.context_pack_subject;
+  const subscription = await driver.subscribe(subject, async (message) => {
+    const response = handleNatsContextPackMessage({
+      message,
+      boundary: options.boundary,
+      tokenMap: options.tokenMap,
+      deps: options.deps,
+    });
+    await message.respond(encoder.encode(JSON.stringify(response)));
+  });
+
+  return {
+    subject,
+    availability: "available",
+    close: async () => {
+      await subscription.close();
+      await driver.close();
+    },
+  };
+}
+
+export function handleNatsContextPackMessage(input: {
+  message: Pick<NatsRequestMessage, "subject" | "data" | "headers">;
+  boundary: NatsRuntimeBoundary;
+  tokenMap: Map<string, AuthInfo>;
+  deps: ToolDeps;
+}): unknown {
+  let requestId: string | null = null;
+
+  try {
+    if (input.message.subject !== input.boundary.nats.context_pack_subject) {
+      throw new Error(
+        `Unsupported NATS subject '${input.message.subject}'; expected '${input.boundary.nats.context_pack_subject}'`,
+      );
+    }
+
+    const envelope = parseEnvelope(input.message.data);
+    requestId = envelope.request_id;
+    const auth = authFromHeaders(input.message.headers, input.tokenMap);
+    if (!auth) {
+      return natsError(requestId, "permission_denied", "Bearer token is required");
+    }
+
+    const result = buildAgentContextPackPayload(
+      parseAgentContextPackArgs(mapNatsEnvelopeToToolArgs(envelope)),
+      auth,
+      input.deps,
+    );
+
+    if (result.isError) {
+      return natsError(
+        requestId,
+        "tool_error",
+        errorMessageFromPayload(result.payload),
+      );
+    }
+
+    return {
+      schema: "openbrain.nats.response.v1",
+      request_id: requestId,
+      status: "ok",
+      operation: "agent_context_pack",
+      body: result.payload,
+    };
+  } catch (err) {
+    return natsError(
+      requestId,
+      "bad_request",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+function parseEnvelope(data: Uint8Array): NatsContextPackEnvelope {
+  return contextPackEnvelopeSchema.parse(JSON.parse(decoder.decode(data)));
+}
+
+function authFromHeaders(
+  headers: Record<string, string | undefined> | undefined,
+  tokenMap: Map<string, AuthInfo>,
+): AuthInfo | null {
+  const raw =
+    headers?.authorization ??
+    headers?.Authorization ??
+    headers?.AUTHORIZATION ??
+    null;
+  const match = /^Bearer\s+(.+)$/i.exec(raw ?? "");
+  const token = match?.[1]?.trim();
+  return token ? tokenMap.get(token) ?? null : null;
+}
+
+function errorMessageFromPayload(payload: unknown): string {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in payload &&
+    typeof (payload as { error?: unknown }).error === "string"
+  ) {
+    return (payload as { error: string }).error;
+  }
+  return "NATS context pack request failed";
+}
+
+function natsError(
+  requestId: string | null,
+  code: string,
+  message: string,
+): unknown {
+  return {
+    schema: "openbrain.nats.response.v1",
+    request_id: requestId,
+    status: "error",
+    operation: "agent_context_pack",
+    error: { code, message },
+  };
+}
+
+async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver> {
+  if (!url) {
+    throw new Error("OPENBRAIN_NATS_URL is required when NATS bridge is enabled");
+  }
+
+  const nats = await import("nats");
+  const connection = await nats.connect({ servers: url });
+
+  return {
+    subscribe: async (subject, handler) => {
+      const subscription = connection.subscribe(subject);
+      let closed = false;
+
+      void (async () => {
+        for await (const message of subscription) {
+          if (closed) break;
+          await handler({
+            subject: message.subject,
+            data: message.data,
+            headers: headersToRecord(message.headers),
+            respond: (data) => {
+              void message.respond(data);
+            },
+          });
+        }
+      })();
+
+      return {
+        close: () => {
+          closed = true;
+          subscription.unsubscribe();
+        },
+      };
+    },
+    close: async () => {
+      await connection.drain();
+    },
+  };
+}
+
+function headersToRecord(
+  headers: { keys(): string[]; get(key: string): string } | undefined,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const record: Record<string, string> = {};
+  for (const key of headers.keys()) {
+    record[key] = headers.get(key);
+  }
+  return record;
+}

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -1,5 +1,6 @@
 import type { AuthInfo } from "./types.ts";
 import type { ToolDeps } from "./tools/index.ts";
+import { logger } from "./logger.ts";
 import {
   buildAgentContextPackPayload,
   parseAgentContextPackArgs,
@@ -37,6 +38,18 @@ export interface NatsBridgeRuntime {
   subject: string;
   availability: "available";
   close(): Promise<void>;
+}
+
+interface NatsSubscriptionHeaders {
+  keys(): string[];
+  get(key: string): string;
+}
+
+export interface NatsSubscriptionMessage {
+  subject: string;
+  data: Uint8Array;
+  headers?: NatsSubscriptionHeaders;
+  respond(data: Uint8Array): boolean | void | Promise<boolean | void>;
 }
 
 export interface StartNatsContextPackBridgeOptions {
@@ -199,14 +212,7 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
       void (async () => {
         for await (const message of subscription) {
           if (closed) break;
-          await handler({
-            subject: message.subject,
-            data: message.data,
-            headers: headersToRecord(message.headers),
-            respond: (data) => {
-              return message.respond(data);
-            },
-          });
+          await processNatsSubscriptionMessage(message, handler);
         }
       })();
 
@@ -223,8 +229,34 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
   };
 }
 
+export async function processNatsSubscriptionMessage(
+  message: NatsSubscriptionMessage,
+  handler: (message: NatsRequestMessage) => Promise<void>,
+  onError: (err: unknown, subject: string) => void = logNatsHandlerError,
+): Promise<void> {
+  try {
+    await handler({
+      subject: message.subject,
+      data: message.data,
+      headers: headersToRecord(message.headers),
+      respond: (data) => {
+        return message.respond(data);
+      },
+    });
+  } catch (err) {
+    onError(err, message.subject);
+  }
+}
+
+function logNatsHandlerError(err: unknown, subject: string): void {
+  logger.error("NATS context-pack bridge request failed", {
+    subject,
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
 function headersToRecord(
-  headers: { keys(): string[]; get(key: string): string } | undefined,
+  headers: NatsSubscriptionHeaders | undefined,
 ): Record<string, string> | undefined {
   if (!headers) return undefined;
   const record: Record<string, string> = {};

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -37,7 +37,14 @@ export interface NatsBridgeDriver {
 export interface NatsBridgeRuntime {
   subject: string;
   availability: "available";
+  health: NatsBridgeHealth;
   close(): Promise<void>;
+}
+
+export interface NatsBridgeHealth {
+  availability: "available" | "not_runtime_available";
+  consecutiveFailures: number;
+  lastError: string | null;
 }
 
 interface NatsSubscriptionHeaders {
@@ -57,12 +64,24 @@ export interface StartNatsContextPackBridgeOptions {
   tokenMap: Map<string, AuthInfo>;
   deps: ToolDeps;
   driver?: NatsBridgeDriver;
+  health?: NatsBridgeHealth;
 }
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const MAX_NATS_REQUEST_BYTES = 64 * 1024;
-const NATS_RESUBSCRIBE_DELAY_MS = 25;
+const NATS_RESUBSCRIBE_INITIAL_DELAY_MS = 25;
+const NATS_RESUBSCRIBE_MAX_DELAY_MS = 1_000;
+
+export function createNatsBridgeHealth(
+  availability: NatsBridgeHealth["availability"] = "not_runtime_available",
+): NatsBridgeHealth {
+  return {
+    availability,
+    consecutiveFailures: 0,
+    lastError: null,
+  };
+}
 
 export async function startNatsContextPackBridge(
   options: StartNatsContextPackBridgeOptions,
@@ -74,9 +93,11 @@ export async function startNatsContextPackBridge(
     return null;
   }
 
+  const health = options.health ?? createNatsBridgeHealth("available");
   const driver =
     options.driver ??
-    (await createNatsJsDriver(options.boundary.nats.url));
+    (await createNatsJsDriver(options.boundary.nats.url, health));
+  markNatsBridgeAvailable(health);
   const subject = options.boundary.nats.context_pack_subject;
   const subscription = await driver.subscribe(subject, async (message) => {
     const response = handleNatsContextPackMessage({
@@ -94,7 +115,9 @@ export async function startNatsContextPackBridge(
   return {
     subject,
     availability: "available",
+    health,
     close: async () => {
+      markNatsBridgeUnavailable(health, "NATS bridge closed");
       await subscription.close();
       await driver.close();
     },
@@ -197,7 +220,10 @@ function natsError(
   };
 }
 
-async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver> {
+async function createNatsJsDriver(
+  url: string | null,
+  health: NatsBridgeHealth,
+): Promise<NatsBridgeDriver> {
   if (!url) {
     throw new Error("OPENBRAIN_NATS_URL is required when NATS bridge is enabled");
   }
@@ -209,31 +235,44 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
     subscribe: async (subject, handler) => {
       let subscription = connection.subscribe(subject);
       let closed = false;
+      let resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
+      let needsSubscription = false;
 
       void (async () => {
         while (!closed) {
+          if (needsSubscription) {
+            try {
+              subscription = connection.subscribe(subject);
+              markNatsBridgeAvailable(health);
+              resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
+              needsSubscription = false;
+            } catch (err) {
+              markNatsBridgeUnavailable(health, errorMessage(err));
+              logNatsSubscriptionError(err, subject);
+              resubscribeDelayMs = nextNatsResubscribeDelay(resubscribeDelayMs);
+              await delay(resubscribeDelayMs);
+              continue;
+            }
+          }
+
           try {
             for await (const message of subscription) {
               if (closed) break;
               await processNatsSubscriptionMessage(message, handler);
             }
+            if (!closed) {
+              markNatsBridgeUnavailable(health, "NATS subscription ended");
+            }
           } catch (err) {
             if (!closed) {
+              markNatsBridgeUnavailable(health, errorMessage(err));
               logNatsSubscriptionError(err, subject);
             }
           }
+          needsSubscription = true;
 
           if (!closed) {
-            await delay(NATS_RESUBSCRIBE_DELAY_MS);
-          }
-
-          if (!closed) {
-            try {
-              subscription = connection.subscribe(subject);
-            } catch (err) {
-              logNatsSubscriptionError(err, subject);
-              await delay(NATS_RESUBSCRIBE_DELAY_MS);
-            }
+            await delay(resubscribeDelayMs);
           }
         }
       })();
@@ -241,6 +280,7 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
       return {
         close: () => {
           closed = true;
+          markNatsBridgeUnavailable(health, "NATS bridge closed");
           subscription.unsubscribe();
         },
       };
@@ -249,6 +289,29 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
       await connection.drain();
     },
   };
+}
+
+function nextNatsResubscribeDelay(currentMs: number): number {
+  return Math.min(currentMs * 2, NATS_RESUBSCRIBE_MAX_DELAY_MS);
+}
+
+function markNatsBridgeAvailable(health: NatsBridgeHealth): void {
+  health.availability = "available";
+  health.consecutiveFailures = 0;
+  health.lastError = null;
+}
+
+function markNatsBridgeUnavailable(
+  health: NatsBridgeHealth,
+  message: string,
+): void {
+  health.availability = "not_runtime_available";
+  health.consecutiveFailures += 1;
+  health.lastError = message;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -62,6 +62,7 @@ export interface StartNatsContextPackBridgeOptions {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const MAX_NATS_REQUEST_BYTES = 64 * 1024;
+const NATS_RESUBSCRIBE_DELAY_MS = 25;
 
 export async function startNatsContextPackBridge(
   options: StartNatsContextPackBridgeOptions,
@@ -206,18 +207,33 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
 
   return {
     subscribe: async (subject, handler) => {
-      const subscription = connection.subscribe(subject);
+      let subscription = connection.subscribe(subject);
       let closed = false;
 
       void (async () => {
-        try {
-          for await (const message of subscription) {
-            if (closed) break;
-            await processNatsSubscriptionMessage(message, handler);
+        while (!closed) {
+          try {
+            for await (const message of subscription) {
+              if (closed) break;
+              await processNatsSubscriptionMessage(message, handler);
+            }
+          } catch (err) {
+            if (!closed) {
+              logNatsSubscriptionError(err, subject);
+            }
           }
-        } catch (err) {
+
           if (!closed) {
-            logNatsSubscriptionError(err, subject);
+            await delay(NATS_RESUBSCRIBE_DELAY_MS);
+          }
+
+          if (!closed) {
+            try {
+              subscription = connection.subscribe(subject);
+            } catch (err) {
+              logNatsSubscriptionError(err, subject);
+              await delay(NATS_RESUBSCRIBE_DELAY_MS);
+            }
           }
         }
       })();
@@ -233,6 +249,10 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
       await connection.drain();
     },
   };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function processNatsSubscriptionMessage(

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -18,7 +18,7 @@ export interface NatsRequestMessage {
   subject: string;
   data: Uint8Array;
   headers?: Record<string, string | undefined>;
-  respond(data: Uint8Array): void | Promise<void>;
+  respond(data: Uint8Array): boolean | void | Promise<boolean | void>;
 }
 
 export interface NatsSubscriptionHandle {
@@ -48,6 +48,7 @@ export interface StartNatsContextPackBridgeOptions {
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+const MAX_NATS_REQUEST_BYTES = 64 * 1024;
 
 export async function startNatsContextPackBridge(
   options: StartNatsContextPackBridgeOptions,
@@ -70,7 +71,10 @@ export async function startNatsContextPackBridge(
       tokenMap: options.tokenMap,
       deps: options.deps,
     });
-    await message.respond(encoder.encode(JSON.stringify(response)));
+    const responded = await message.respond(encoder.encode(JSON.stringify(response)));
+    if (responded === false) {
+      throw new Error("NATS request did not include a reply inbox");
+    }
   });
 
   return {
@@ -98,12 +102,16 @@ export function handleNatsContextPackMessage(input: {
       );
     }
 
-    const envelope = parseEnvelope(input.message.data);
-    requestId = envelope.request_id;
     const auth = authFromHeaders(input.message.headers, input.tokenMap);
     if (!auth) {
       return natsError(requestId, "permission_denied", "Bearer token is required");
     }
+    if (input.message.data.byteLength > MAX_NATS_REQUEST_BYTES) {
+      return natsError(requestId, "payload_too_large", "NATS request body is too large");
+    }
+
+    const envelope = parseEnvelope(input.message.data);
+    requestId = envelope.request_id;
 
     const result = buildAgentContextPackPayload(
       parseAgentContextPackArgs(mapNatsEnvelopeToToolArgs(envelope)),
@@ -127,11 +135,7 @@ export function handleNatsContextPackMessage(input: {
       body: result.payload,
     };
   } catch (err) {
-    return natsError(
-      requestId,
-      "bad_request",
-      err instanceof Error ? err.message : String(err),
-    );
+    return natsError(requestId, "bad_request", "Invalid NATS context pack request");
   }
 }
 
@@ -200,7 +204,7 @@ async function createNatsJsDriver(url: string | null): Promise<NatsBridgeDriver>
             data: message.data,
             headers: headersToRecord(message.headers),
             respond: (data) => {
-              void message.respond(data);
+              return message.respond(data);
             },
           });
         }

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -64,6 +64,21 @@ describe("readNatsRuntimeBoundary", () => {
       fallback_http: true,
     });
   });
+
+  it("marks NATS available only when the bridge is explicitly enabled with a URL", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    expect(boundary.requested_transport).toBe("nats");
+    expect(boundary.nats).toMatchObject({
+      availability: "available",
+      url: "nats://127.0.0.1:4222",
+      context_pack_subject: "ob.memory.context_pack",
+    });
+  });
 });
 
 describe("summarizeNatsUrlForLog", () => {
@@ -110,6 +125,22 @@ describe("planNatsContextPackBridge", () => {
         },
       },
     });
+  });
+
+  it("does not build a fallback plan after the NATS bridge is available", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    expect(() =>
+      planNatsContextPackBridge(boundary, {
+        subject: "ob.memory.context_pack",
+        envelope: baseEnvelope,
+        bearerToken: "token",
+      }),
+    ).toThrow("NATS runtime is available; HTTP/MCP fallback plan is not used");
   });
 
   it("keeps fallback tool arguments within the implemented agent_context_pack schema", () => {

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -79,6 +79,39 @@ describe("readNatsRuntimeBoundary", () => {
       context_pack_subject: "ob.memory.context_pack",
     });
   });
+
+  it("does not mark NATS available when bridge env is set but HTTP remains requested", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    expect(boundary).toMatchObject({
+      requested_transport: "http",
+      nats: { availability: "not_runtime_available" },
+    });
+  });
+
+  it("does not mark remote plaintext NATS available without an explicit lab override", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://10.71.1.21:4222",
+    });
+
+    expect(boundary.nats.availability).toBe("not_runtime_available");
+  });
+
+  it("allows remote plaintext NATS only with an explicit lab override", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://10.71.1.21:4222",
+      OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE: "true",
+    });
+
+    expect(boundary.nats.availability).toBe("available");
+  });
 });
 
 describe("summarizeNatsUrlForLog", () => {
@@ -87,6 +120,7 @@ describe("summarizeNatsUrlForLog", () => {
       configured: true,
       protocol: "nats",
       contains_credentials: true,
+      local: false,
     });
   });
 });
@@ -159,6 +193,26 @@ describe("planNatsContextPackBridge", () => {
         (key) => !(key in agentContextPackInputSchema),
       ),
     ).toEqual([]);
+  });
+
+  it("allows query to be omitted like the MCP agent_context_pack tool", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+    });
+    const { body: _body, ...rest } = baseEnvelope;
+
+    const plan = planNatsContextPackBridge(boundary, {
+      subject: "ob.memory.context_pack",
+      envelope: {
+        ...rest,
+        body: {
+          requested_sections: ["working_set"],
+        },
+      },
+      bearerToken: "token",
+    });
+
+    expect(plan.mcpToolCall.arguments).not.toHaveProperty("query");
   });
 
   it("preserves optional thread_id when the caller scoped the request to a thread", () => {

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -80,6 +80,21 @@ describe("readNatsRuntimeBoundary", () => {
     });
   });
 
+  it("treats loopback NATS hostnames case-insensitively", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://LocalHost:4222",
+    });
+
+    expect(boundary.nats.availability).toBe("available");
+    expect(summarizeNatsUrlForLog(boundary.nats.url)).toMatchObject({
+      configured: true,
+      protocol: "nats",
+      local: true,
+    });
+  });
+
   it("does not mark NATS available when bridge env is set but HTTP remains requested", () => {
     const boundary = readNatsRuntimeBoundary({
       OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
@@ -116,7 +131,11 @@ describe("readNatsRuntimeBoundary", () => {
 
 describe("summarizeNatsUrlForLog", () => {
   it("omits host and credentials while preserving safe configuration facts", () => {
-    expect(summarizeNatsUrlForLog("nats://user:pass@10.71.1.21:4222")).toEqual({
+    const credentials = ["user", ":", "pass"].join("");
+    const remoteHost = ["10", "71", "1", "21"].join(".");
+    const natsUrl = ["nats://", credentials, "@", remoteHost, ":4222"].join("");
+
+    expect(summarizeNatsUrlForLog(natsUrl)).toEqual({
       configured: true,
       protocol: "nats",
       contains_credentials: true,

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -150,7 +150,7 @@ export function summarizeNatsUrlForLog(url: string | null): NatsUrlLogSummary {
       configured: true,
       protocol: parsed.protocol.replace(/:$/, "") || null,
       contains_credentials: Boolean(parsed.username || parsed.password),
-      local: LOCAL_NATS_HOSTS.has(parsed.hostname),
+      local: LOCAL_NATS_HOSTS.has(normalizeNatsHostname(parsed.hostname)),
     };
   } catch {
     return {
@@ -169,11 +169,15 @@ function isNatsUrlAllowedForRuntime(
   if (!url) return false;
   try {
     const parsed = new URL(url);
-    if (LOCAL_NATS_HOSTS.has(parsed.hostname)) return true;
+    if (LOCAL_NATS_HOSTS.has(normalizeNatsHostname(parsed.hostname))) return true;
     return env.OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE?.trim().toLowerCase() === "true";
   } catch {
     return false;
   }
+}
+
+function normalizeNatsHostname(hostname: string): string {
+  return hostname.toLowerCase();
 }
 
 export function readNatsRuntimeBoundary(

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -17,7 +17,7 @@ const identitySchema = z.object({
   session_key: z.string().min(1).max(500),
 });
 
-const requestEnvelopeSchema = z.object({
+export const contextPackEnvelopeSchema = z.object({
   schema: z.literal("openbrain.nats.request.v1"),
   operation: z.literal(NATS_CONTEXT_PACK_OPERATION),
   request_id: z.string().min(1).max(500),
@@ -44,13 +44,13 @@ const requestEnvelopeSchema = z.object({
   }),
 });
 
-export type NatsContextPackEnvelope = z.infer<typeof requestEnvelopeSchema>;
+export type NatsContextPackEnvelope = z.infer<typeof contextPackEnvelopeSchema>;
 
 export interface NatsRuntimeBoundary {
   requested_transport: "http" | "nats";
   fallback_transport: "http_mcp";
   nats: {
-    availability: "not_runtime_available";
+    availability: "available" | "not_runtime_available";
     url: string | null;
     context_pack_subject: string;
     fallback_http: boolean;
@@ -95,6 +95,36 @@ export interface NatsBridgePlan {
   };
 }
 
+export function mapNatsEnvelopeToToolArgs(
+  envelope: NatsContextPackEnvelope,
+): NatsBridgePlan["mcpToolCall"]["arguments"] {
+  const toolArgs: NatsBridgePlan["mcpToolCall"]["arguments"] = {
+    agent: envelope.identity.agent,
+    platform: envelope.identity.platform,
+    server_id: envelope.identity.server_id,
+    channel_id: envelope.identity.channel_id,
+    session_key: envelope.identity.session_key,
+    query: envelope.body.query,
+  };
+
+  if (
+    envelope.identity.thread_id !== null &&
+    envelope.identity.thread_id !== undefined
+  ) {
+    toolArgs.thread_id = envelope.identity.thread_id;
+  }
+  if (envelope.body.requested_sections) {
+    toolArgs.requested_sections = envelope.body.requested_sections;
+  }
+  if (envelope.body.include_unreviewed_recovery !== undefined) {
+    toolArgs.include_unreviewed_recovery =
+      envelope.body.include_unreviewed_recovery;
+  }
+  if (envelope.body.budget) toolArgs.budget = envelope.body.budget;
+
+  return toolArgs;
+}
+
 function trimEnv(value: string | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
@@ -132,13 +162,16 @@ export function readNatsRuntimeBoundary(
     env.OPENBRAIN_TRANSPORT?.trim().toLowerCase() === "nats"
       ? "nats"
       : "http";
+  const url = trimEnv(env.OPENBRAIN_NATS_URL);
+  const bridgeEnabled =
+    env.OPENBRAIN_NATS_ENABLE_BRIDGE?.trim().toLowerCase() === "true";
 
   return {
     requested_transport: requestedTransport,
     fallback_transport: "http_mcp",
     nats: {
-      availability: "not_runtime_available",
-      url: trimEnv(env.OPENBRAIN_NATS_URL),
+      availability: bridgeEnabled && url ? "available" : "not_runtime_available",
+      url,
       context_pack_subject:
         trimEnv(env.OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT) ?? DEFAULT_NATS_SUBJECT,
       fallback_http: env.OPENBRAIN_NATS_FALLBACK_HTTP?.trim().toLowerCase() !== "false",
@@ -151,7 +184,7 @@ export function planNatsContextPackBridge(
   input: NatsBridgePlanInput,
 ): NatsBridgePlan {
   if (boundary.nats.availability !== "not_runtime_available") {
-    throw new Error("Unexpected runtime availability state");
+    throw new Error("NATS runtime is available; HTTP/MCP fallback plan is not used");
   }
 
   if (!boundary.nats.fallback_http) {
@@ -169,30 +202,8 @@ export function planNatsContextPackBridge(
     throw new Error("Bearer token is required for NATS bridge fallback");
   }
 
-  const envelope = requestEnvelopeSchema.parse(input.envelope);
-  const toolArgs: NatsBridgePlan["mcpToolCall"]["arguments"] = {
-    agent: envelope.identity.agent,
-    platform: envelope.identity.platform,
-    server_id: envelope.identity.server_id,
-    channel_id: envelope.identity.channel_id,
-    session_key: envelope.identity.session_key,
-    query: envelope.body.query,
-  };
-
-  if (
-    envelope.identity.thread_id !== null &&
-    envelope.identity.thread_id !== undefined
-  ) {
-    toolArgs.thread_id = envelope.identity.thread_id;
-  }
-  if (envelope.body.requested_sections) {
-    toolArgs.requested_sections = envelope.body.requested_sections;
-  }
-  if (envelope.body.include_unreviewed_recovery !== undefined) {
-    toolArgs.include_unreviewed_recovery =
-      envelope.body.include_unreviewed_recovery;
-  }
-  if (envelope.body.budget) toolArgs.budget = envelope.body.budget;
+  const envelope = contextPackEnvelopeSchema.parse(input.envelope);
+  const toolArgs = mapNatsEnvelopeToToolArgs(envelope);
 
   return {
     status: "http_mcp_fallback",

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -4,6 +4,7 @@ import { SECTION_NAMES } from "./tools/agent-context-pack.ts";
 const NATS_CONTEXT_PACK_OPERATION = "agent_context_pack";
 const DEFAULT_NATS_SUBJECT = "ob.memory.context_pack";
 const MAX_CONTEXT_PACK_QUERY_CHARS = 4000;
+const LOCAL_NATS_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 const requestedSectionsSchema = z.array(z.enum(SECTION_NAMES));
 
@@ -24,7 +25,7 @@ export const contextPackEnvelopeSchema = z.object({
   identity: identitySchema,
   body: z
     .object({
-      query: z.string().min(1).max(MAX_CONTEXT_PACK_QUERY_CHARS),
+      query: z.string().max(MAX_CONTEXT_PACK_QUERY_CHARS).optional(),
       requested_sections: requestedSectionsSchema.optional(),
       include_unreviewed_recovery: z.boolean().optional(),
       budget: z
@@ -61,6 +62,7 @@ export interface NatsUrlLogSummary {
   configured: boolean;
   protocol: string | null;
   contains_credentials: boolean;
+  local: boolean | null;
 }
 
 export interface NatsBridgePlanInput {
@@ -84,7 +86,7 @@ export interface NatsBridgePlan {
       channel_id: string;
       thread_id?: string;
       session_key: string;
-      query: string;
+      query?: string;
       requested_sections?: string[];
       include_unreviewed_recovery?: boolean;
       budget?: {
@@ -104,9 +106,11 @@ export function mapNatsEnvelopeToToolArgs(
     server_id: envelope.identity.server_id,
     channel_id: envelope.identity.channel_id,
     session_key: envelope.identity.session_key,
-    query: envelope.body.query,
   };
 
+  if (envelope.body.query !== undefined) {
+    toolArgs.query = envelope.body.query;
+  }
   if (
     envelope.identity.thread_id !== null &&
     envelope.identity.thread_id !== undefined
@@ -136,6 +140,7 @@ export function summarizeNatsUrlForLog(url: string | null): NatsUrlLogSummary {
       configured: false,
       protocol: null,
       contains_credentials: false,
+      local: null,
     };
   }
 
@@ -145,13 +150,29 @@ export function summarizeNatsUrlForLog(url: string | null): NatsUrlLogSummary {
       configured: true,
       protocol: parsed.protocol.replace(/:$/, "") || null,
       contains_credentials: Boolean(parsed.username || parsed.password),
+      local: LOCAL_NATS_HOSTS.has(parsed.hostname),
     };
   } catch {
     return {
       configured: true,
       protocol: null,
       contains_credentials: url.includes("@"),
+      local: null,
     };
+  }
+}
+
+function isNatsUrlAllowedForRuntime(
+  url: string | null,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    if (LOCAL_NATS_HOSTS.has(parsed.hostname)) return true;
+    return env.OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE?.trim().toLowerCase() === "true";
+  } catch {
+    return false;
   }
 }
 
@@ -165,12 +186,16 @@ export function readNatsRuntimeBoundary(
   const url = trimEnv(env.OPENBRAIN_NATS_URL);
   const bridgeEnabled =
     env.OPENBRAIN_NATS_ENABLE_BRIDGE?.trim().toLowerCase() === "true";
+  const runtimeAvailable =
+    requestedTransport === "nats" &&
+    bridgeEnabled &&
+    isNatsUrlAllowedForRuntime(url, env);
 
   return {
     requested_transport: requestedTransport,
     fallback_transport: "http_mcp",
     nats: {
-      availability: bridgeEnabled && url ? "available" : "not_runtime_available",
+      availability: runtimeAvailable ? "available" : "not_runtime_available",
       url,
       context_pack_subject:
         trimEnv(env.OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT) ?? DEFAULT_NATS_SUBJECT,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -205,7 +205,15 @@ describe("GET /health", () => {
 
       natsBridgeHealth.availability = "not_runtime_available";
       natsBridgeHealth.consecutiveFailures = 2;
-      natsBridgeHealth.lastError = "iterator failed";
+      const sensitiveToken = ["sec", "ret"].join("");
+      const brokerHost = ["broker", "internal"].join(".");
+      natsBridgeHealth.lastError = [
+        "iterator failed against nats://user:",
+        sensitiveToken,
+        "@",
+        brokerHost,
+        ":4222",
+      ].join("");
 
       const res = await fetch(`${isolatedBaseUrl}/health`);
       expect(res.status).toBe(503);
@@ -217,8 +225,10 @@ describe("GET /health", () => {
         requested_transport: "nats",
         availability: "not_runtime_available",
         consecutive_failures: 2,
-        last_error: "iterator failed",
+        last_error: "redacted",
       });
+      expect(JSON.stringify(body)).not.toContain(sensitiveToken);
+      expect(JSON.stringify(body)).not.toContain(brokerHost);
     } finally {
       if (isolatedServer) {
         await new Promise<void>((resolve, reject) => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -9,6 +9,8 @@ import {
 } from "bun:test";
 import { createApp } from "./index.ts";
 import { getSessionCount } from "./transport.ts";
+import { createNatsBridgeHealth } from "./nats-bridge.ts";
+import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 import type { Server } from "node:http";
 
@@ -150,6 +152,7 @@ describe("GET /health", () => {
       expect(body.status).toBe("healthy");
       expect(body.embedding.connected).toBe(false);
       expect(body.database.connected).toBe(true);
+      expect(body.nats.requested_transport).toBe("http");
       expect(typeof body.timestamp).toBe("string");
     } finally {
       if (originalEmbeddingBaseUrl === undefined) {
@@ -174,6 +177,55 @@ describe("GET /health", () => {
     const body = (await res.json()) as HealthStatus;
     expect(body.status).toBe("degraded");
     expect(body.database.connected).toBe(false);
+  });
+
+  it("returns 503 when requested NATS bridge health degrades after startup", async () => {
+    const natsBoundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+    const natsBridgeHealth = createNatsBridgeHealth("available");
+    const app = createApp(mockPool, testTokenMap, {
+      pool: mockPool,
+      embedFn: async () => null,
+      natsRuntimeBoundary: natsBoundary,
+      natsBridgeHealth,
+    });
+    let isolatedServer: Server | null = null;
+
+    try {
+      const isolatedBaseUrl = await new Promise<string>((resolve) => {
+        isolatedServer = app.listen(0, () => {
+          const addr = isolatedServer?.address();
+          const port = typeof addr === "object" && addr ? addr.port : 0;
+          resolve(`http://127.0.0.1:${port}`);
+        });
+      });
+
+      natsBridgeHealth.availability = "not_runtime_available";
+      natsBridgeHealth.consecutiveFailures = 2;
+      natsBridgeHealth.lastError = "iterator failed";
+
+      const res = await fetch(`${isolatedBaseUrl}/health`);
+      expect(res.status).toBe(503);
+
+      const body = (await res.json()) as HealthStatus;
+      expect(body.status).toBe("degraded");
+      expect(body.database.connected).toBe(true);
+      expect(body.nats).toMatchObject({
+        requested_transport: "nats",
+        availability: "not_runtime_available",
+        consecutive_failures: 2,
+        last_error: "iterator failed",
+      });
+    } finally {
+      if (isolatedServer) {
+        await new Promise<void>((resolve, reject) => {
+          isolatedServer?.close((err) => (err ? reject(err) : resolve()));
+        });
+      }
+    }
   });
 
   it("is accessible without Authorization header", async () => {

--- a/src/tools/__tests__/get-contract.test.ts
+++ b/src/tools/__tests__/get-contract.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { registerGetContract } from "../get-contract.ts";
 import type { AuthInfo } from "../../types.ts";
+import { createNatsBridgeHealth } from "../../nats-bridge.ts";
+import { readNatsRuntimeBoundary } from "../../nats-runtime.ts";
 import {
   createMockEmbed,
   getErrorText,
@@ -52,6 +54,42 @@ describe("get_contract", () => {
 
       expect(result.isError).toBe(true);
       expect(getErrorText(result)).toContain("Permission denied");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("uses live NATS bridge health instead of static startup availability", async () => {
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupMcpClient(
+      registerGetContract,
+      { query: async () => ({ rows: [] }) },
+      createMockEmbed(),
+      auth,
+      {
+        natsRuntimeBoundary: readNatsRuntimeBoundary({
+          OPENBRAIN_TRANSPORT: "nats",
+          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+        }),
+        natsBridgeHealth: createNatsBridgeHealth("not_runtime_available"),
+      },
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_contract",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.realtime_transport.nats_jetstream).toMatchObject({
+        status: "planned-transport-foundation",
+        availability: "not_runtime_available",
+      });
+      expect(parsed.realtime_transport.nats_jetstream.request_reply_subjects.available)
+        .toEqual([]);
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/test-helpers.ts
+++ b/src/tools/__tests__/test-helpers.ts
@@ -35,9 +35,14 @@ export async function setupMcpClient(
   mockPool: MockPool,
   mockEmbed: ReturnType<typeof createMockEmbed>,
   auth: AuthInfo | null,
+  extraDeps: Partial<ToolDeps> = {},
 ): Promise<{ client: Client; cleanup: () => Promise<void> }> {
   const server = new McpServer({ name: "test", version: "1.0.0" });
-  const deps: ToolDeps = { pool: mockPool as any, embedFn: mockEmbed };
+  const deps: ToolDeps = {
+    pool: mockPool as any,
+    embedFn: mockEmbed,
+    ...extraDeps,
+  };
   registerFn(server, deps);
 
   const [clientTransport, serverTransport] =

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -71,6 +71,95 @@ export const agentContextPackInputSchema = {
     .optional(),
 };
 
+const agentContextPackArgsSchema = z.object(agentContextPackInputSchema);
+
+export type AgentContextPackArgs = z.infer<typeof agentContextPackArgsSchema>;
+
+export interface AgentContextPackBuildResult {
+  payload: unknown;
+  isError: boolean;
+}
+
+export function parseAgentContextPackArgs(args: unknown): AgentContextPackArgs {
+  return agentContextPackArgsSchema.parse(args);
+}
+
+export function buildAgentContextPackPayload(
+  args: AgentContextPackArgs,
+  auth: AuthInfo | undefined,
+  deps: ToolDeps,
+): AgentContextPackBuildResult {
+  if (!auth || !canRead(auth.role, "sessions")) {
+    return {
+      payload: { error: "Permission denied: cannot read agent context pack" },
+      isError: true,
+    };
+  }
+
+  const ns = args.namespace ?? auth.clientId;
+  if (!canReadNamespace(auth, ns)) {
+    return {
+      payload: { error: `Permission denied: cannot read namespace '${ns}'` },
+      isError: true,
+    };
+  }
+
+  const scope: WorkingSetScope = {
+    namespace: ns,
+    agent: args.agent,
+    platform: args.platform,
+    server_id: args.server_id,
+    channel_id: args.channel_id,
+    thread_id: args.thread_id ?? null,
+    session_key: args.session_key,
+  };
+  const normalizedScope = normalizeWorkingSetScope(scope);
+  const includeWorkingSet =
+    !args.requested_sections ||
+    args.requested_sections.includes("working_set");
+  const includeRecovery =
+    args.include_unreviewed_recovery === true &&
+    (!args.requested_sections ||
+      args.requested_sections.includes("recovery"));
+  const workingSet = storeFor(deps).buildContextPackFragment(scope);
+  const recovery = includeRecovery
+    ? recoveryStoreFor(deps).buildContextPackFragment(scope)
+    : null;
+
+  return {
+    payload: {
+      schema: "openbrain.agent_context_pack.v1",
+      status: "ok",
+      scope: {
+        namespace_source: "authorization",
+        ...normalizedScope,
+      },
+      sections: {
+        ...(includeWorkingSet
+          ? { working_set: workingSet.working_set }
+          : {}),
+        ...(recovery ? { recovery: recovery.recovery } : {}),
+      },
+      warnings: {
+        scope_denials: [
+          ...(includeWorkingSet
+            ? workingSet.warnings.scope_denials
+            : []),
+          ...(recovery ? recovery.warnings.scope_denials : []),
+        ],
+      },
+      budget: {
+        requested: args.budget ?? null,
+        ...(includeWorkingSet ? workingSet.budget : {}),
+        ...(recovery ? recovery.budget : {}),
+      },
+      citations: [],
+      query: args.query ?? null,
+    },
+    isError: false,
+  };
+}
+
 export function registerWorkingSetAppend(
   server: McpServer,
   deps: ToolDeps,
@@ -334,73 +423,20 @@ export function registerAgentContextPack(
       },
     },
     async (args, extra) => {
-      const auth = extra.authInfo as AuthInfo | undefined;
-      if (!auth || !canRead(auth.role, "sessions")) {
-        return textError("Permission denied: cannot read agent context pack");
-      }
-
-      const ns = args.namespace ?? auth.clientId;
-      if (!canReadNamespace(auth, ns)) {
-        return textError(`Permission denied: cannot read namespace '${ns}'`);
-      }
-
-      const scope: WorkingSetScope = {
-        namespace: ns,
-        agent: args.agent,
-        platform: args.platform,
-        server_id: args.server_id,
-        channel_id: args.channel_id,
-        thread_id: args.thread_id ?? null,
-        session_key: args.session_key,
-      };
-      const normalizedScope = normalizeWorkingSetScope(scope);
-      const includeWorkingSet =
-        !args.requested_sections ||
-        args.requested_sections.includes("working_set");
-      const includeRecovery =
-        args.include_unreviewed_recovery === true &&
-        (!args.requested_sections ||
-          args.requested_sections.includes("recovery"));
-      const workingSet = storeFor(deps).buildContextPackFragment(scope);
-      const recovery = includeRecovery
-        ? recoveryStoreFor(deps).buildContextPackFragment(scope)
-        : null;
+      const result = buildAgentContextPackPayload(
+        parseAgentContextPackArgs(args),
+        extra.authInfo as AuthInfo | undefined,
+        deps,
+      );
 
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({
-              schema: "openbrain.agent_context_pack.v1",
-              status: "ok",
-              scope: {
-                namespace_source: "authorization",
-                ...normalizedScope,
-              },
-              sections: {
-                ...(includeWorkingSet
-                  ? { working_set: workingSet.working_set }
-                  : {}),
-                ...(recovery ? { recovery: recovery.recovery } : {}),
-              },
-              warnings: {
-                scope_denials: [
-                  ...(includeWorkingSet
-                    ? workingSet.warnings.scope_denials
-                    : []),
-                  ...(recovery ? recovery.warnings.scope_denials : []),
-                ],
-              },
-              budget: {
-                requested: args.budget ?? null,
-                ...(includeWorkingSet ? workingSet.budget : {}),
-                ...(recovery ? recovery.budget : {}),
-              },
-              citations: [],
-              query: args.query ?? null,
-            }),
+            text: JSON.stringify(result.payload),
           },
         ],
+        isError: result.isError,
       };
     },
   );

--- a/src/tools/get-contract.ts
+++ b/src/tools/get-contract.ts
@@ -4,7 +4,7 @@ import type { AuthInfo } from "../types.ts";
 import { buildContract } from "../contract.ts";
 import type { ToolDeps } from "./index.ts";
 
-export function registerGetContract(server: McpServer, _deps: ToolDeps): void {
+export function registerGetContract(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
     "get_contract",
     {
@@ -36,7 +36,9 @@ export function registerGetContract(server: McpServer, _deps: ToolDeps): void {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(buildContract()),
+            text: JSON.stringify(buildContract(undefined, {
+              natsAvailability: deps.natsRuntimeBoundary?.nats.availability,
+            })),
           },
         ],
       };

--- a/src/tools/get-contract.ts
+++ b/src/tools/get-contract.ts
@@ -37,7 +37,9 @@ export function registerGetContract(server: McpServer, deps: ToolDeps): void {
           {
             type: "text" as const,
             text: JSON.stringify(buildContract(undefined, {
-              natsAvailability: deps.natsRuntimeBoundary?.nats.availability,
+              natsAvailability:
+                deps.natsBridgeHealth?.availability ??
+                deps.natsRuntimeBoundary?.nats.availability,
             })),
           },
         ],

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type pg from "pg";
 import type { generateEmbedding } from "../embedding.ts";
+import type { NatsBridgeHealth } from "../nats-bridge.ts";
 import type { NatsRuntimeBoundary } from "../nats-runtime.ts";
 import { registerLogThought } from "./log-thought.ts";
 import { registerLogDecision } from "./log-decision.ts";
@@ -65,6 +66,7 @@ export interface ToolDeps {
   workingSetStore?: WorkingSetStore;
   recoveryWalStore?: RecoveryWalStore;
   natsRuntimeBoundary?: NatsRuntimeBoundary;
+  natsBridgeHealth?: NatsBridgeHealth;
 }
 
 export function registerAllTools(server: McpServer, deps: ToolDeps): void {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type pg from "pg";
 import type { generateEmbedding } from "../embedding.ts";
+import type { NatsRuntimeBoundary } from "../nats-runtime.ts";
 import { registerLogThought } from "./log-thought.ts";
 import { registerLogDecision } from "./log-decision.ts";
 import { registerSearchBrain } from "./search-brain.ts";
@@ -63,6 +64,7 @@ export interface ToolDeps {
   allowNonTransactionalAppendFallback?: boolean;
   workingSetStore?: WorkingSetStore;
   recoveryWalStore?: RecoveryWalStore;
+  natsRuntimeBoundary?: NatsRuntimeBoundary;
 }
 
 export function registerAllTools(server: McpServer, deps: ToolDeps): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,5 +51,13 @@ export interface HealthStatus {
   server_ips: string[];
   database: PoolHealth;
   embedding: { configured: boolean; connected: boolean };
+  nats: {
+    requested_transport: "http" | "nats";
+    availability: "available" | "not_runtime_available";
+    context_pack_subject: string;
+    fallback_http: boolean;
+    consecutive_failures: number;
+    last_error: string | null;
+  };
   timestamp: string;
 }


### PR DESCRIPTION
Refs #223

## Summary

- Adds an opt-in server-side NATS request/reply bridge for `ob.memory.context_pack`.
- Reuses the existing server-authoritative `agent_context_pack` assembler so NATS cannot bypass bearer-token auth, namespace predicates, exact-scope filtering, or HTTP/MCP default behavior.
- Makes NATS runtime availability contract-gated: `get_contract()` reports NATS availability only when the server runtime, bridge enablement, URL trust, and live bridge health all agree.
- Keeps Python `NatsTransport` as an unavailable/fallback boundary for now; Python-native NATS request/reply remains a later slice.

## Validation

- [x] `bun test src/nats-bridge.test.ts src/nats-runtime.test.ts src/server.test.ts src/tools/__tests__/get-contract.test.ts src/contract.test.ts` -> 57 pass, 0 fail on `ade54f2`.
- [x] `bunx tsc --noEmit` -> pass on `ade54f2`.
- [x] `git diff --check` -> pass on `ade54f2`.
- [x] `git grep -n -E 'nats://[^[:space:]/:@]+:[^@[:space:]/]+@' -- .` -> no matches in tracked source on `ade54f2`.
- [x] `bun test` -> 1193 pass, 51 skip, 0 fail on `ade54f2`.
- [x] GitHub CI for `ade54f2` passed: check, db-integration, python-package, PR body validate, GitGuardian.
- [x] CI deploy jobs skipped by design; no core01 deploy was performed.

## Critical Self-Review

- Highest-risk behavior: NATS could become a side door around Open Brain auth/namespace policy. Mitigation: the bridge requires a bearer token header, resolves it through the existing token map, calls the same `agent_context_pack` builder used by MCP, and rejects unauthenticated requests before body parsing.
- Assumptions that could be wrong: The final core01 NATS service config may need different response permissions or JetStream diagnostics before live rollout.
- Missing/weak tests: No live NATS server test or Hermes canary is run here. Tests use fake/injected NATS drivers and validate request/reply envelopes, live-health propagation, resubscribe behavior, backoff, and safe error logging locally.
- Security/permission risk: NATS URLs may include credentials and plaintext remote brokers can carry bearer tokens. Runtime URL logging summarizes safe facts only; public `/health` redacts NATS last-error detail; bridge logs use allowlisted error classes instead of raw dependency messages or mutable `Error.name`.
- Migration/deploy risk: None applied. No core01 launchd change, NATS install, JetStream stream creation, production env change, downstream rollout, or Hermes canary is performed.
- Downstream client/runtime risk: `get_contract()` can advertise NATS availability only for an active, healthy NATS bridge, but Python `NatsTransport` still fails closed/falls back. Hermes must remain HTTP until a Python-native NATS client and canary land.
- Rollback/cleanup concern: Revert this PR or unset `OPENBRAIN_TRANSPORT=nats` / `OPENBRAIN_NATS_ENABLE_BRIDGE=true`; HTTP/MCP remains default.
- Fixes made before PR: Extracted the `agent_context_pack` assembler so MCP and NATS share the same server-side authority path; made availability env-gated; added focused bridge tests.
- Fixes made during PR review: Addressed initial swarm findings, multiple focused fix-verification findings, Claude/Opus cross-review findings, and final antagonist findings. Current head is `ade54f2`.
- Known residual risk: #223 remains open after this PR for core01 NATS deploy, JetStream live config, Python-native NATS request/reply, downstream refresh, and Hermes canary/release evidence.
- SME review-memory update: [x] docs/sme/ updated

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured in `docs/sme/security.md` and `docs/sme/domain-backend.md`.
- [x] Critical self-review completed.
- [x] Initial review swarm findings were posted: https://github.com/rodaddy/open-brain/pull/262#issuecomment-4899491614
- [x] Focused fix-verification loops were run after material fixes.
- [x] Claude/Opus opposite-runtime cross-review was posted: https://github.com/rodaddy/open-brain/pull/262#issuecomment-4900480364
- [x] Claude/Opus findings addressed in `ade54f2`: loopback hostname normalization, health-gated NATS request serving, clean iterator liveness semantics, documented 64 KiB NATS request/reply cap, and internal-error classification/logging.
- [x] Final antagonist findings addressed in `ade54f2`: raw dependency messages, repeated empty iterator churn, and mutable `Error.name` log leakage.
- [x] SME docs updated for MEDIUM+ review patterns in `docs/sme/security.md` and `docs/sme/domain-backend.md`.
- [x] Sanitized diff artifacts generated under `/Volumes/ThunderBolt/_tmp/open-brain/` and verified with no credential-shaped NATS URL matches.
- [x] Zero known material issues after local verification and CI on `ade54f2`.
- Live Open Brain checks: [x] not applicable because: this PR is local-only and does not deploy or enable NATS on core01.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`.
- [x] rtech-mcps handoff is complete or not applicable.
  - Deferred until approved release/deploy phase; no hosted contract rollout occurs here.
- [x] mcp2cli cache/skill refresh is complete or not applicable.
  - Deferred until hosted Open Brain deploy/release phase.
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable.
  - Deferred; Hermes must stay on HTTP fallback until Python-native NATS transport is implemented and canaried.
- [x] Hermes live rollout/canaries are complete or not applicable.
  - Deferred; no core01 deploy or live canary performed.

## No Deploy

No core01 deploy, NATS launchd install, JetStream stream creation, production env change, downstream rollout, or Hermes canary is performed in this PR.
