### PR TITLE
test: add relational retrieval eval gate

### DIFF
--- a/docs/plan-3f-gbrain-sprint.md
+++ b/docs/plan-3f-gbrain-sprint.md
@@ -1,6 +1,6 @@
 # Plan 3F: gbrain-Informed Graph Retrieval Sprint
 
-Updated: 2026-07-07.
+Updated: 2026-07-08T00:12Z.
 
 ## Critical Read
 
@@ -25,6 +25,14 @@ Confirmed live state when this plan was created:
     evidence. Do not close #223 from this sprint.
   - PR #264 was checked after the sprint was created and is not part of this
     sprint.
+
+Current execution update, 2026-07-08T00:12Z:
+
+- Planning PR #272 merged as `a838735`.
+- Project #8 has #266 in review/fix loop for the relational retrieval eval gate
+  on PR #273.
+- #267 remains Todo and must not be marked ready until #266 proof exists.
+- #223 remains open and Blocked.
 
 Critical correction:
 

--- a/scripts/assert-db-tests-ran.test.ts
+++ b/scripts/assert-db-tests-ran.test.ts
@@ -44,7 +44,7 @@ describe("assert-db-tests-ran anti-skip guard", () => {
   it("passes when every required live-Postgres suite executed cleanly", () => {
     const result = evaluateJunit(wrap(allSuitesGreen()));
     expect(result.errors).toEqual([]);
-    expect(result.executedLiveTestcases).toBe(17);
+    expect(result.executedLiveTestcases).toBe(18);
   });
 
   it("fails when a required suite is missing entirely", () => {
@@ -181,7 +181,7 @@ describe("assert-db-tests-ran anti-skip guard", () => {
     }).join("\n");
 
     const result = evaluateJunit(wrap(suites));
-    expect(result.executedLiveTestcases).toBe(17);
+    expect(result.executedLiveTestcases).toBe(18);
     expect(
       result.errors.some((e) =>
         e.includes(

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -35,11 +35,15 @@ export const REQUIRED_SUITES: ReadonlyArray<{ name: string; minTests: number }> 
       minTests: 4,
     },
     { name: "runSharedPromoter cursor-stall fix (live Postgres)", minTests: 8 },
+    {
+      name: "search_brain relational retrieval eval fixture (live Postgres)",
+      minTests: 1,
+    },
   ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
 // independent of the per-suite breakdown above.
-export const MIN_TOTAL_LIVE_TESTCASES = 17;
+export const MIN_TOTAL_LIVE_TESTCASES = 18;
 
 export interface SuiteStats {
   tests: number;

--- a/specs/plan-3f-gbrain-sprint.html
+++ b/specs/plan-3f-gbrain-sprint.html
@@ -209,8 +209,8 @@
       <summary>Metadata</summary>
       <dl>
         <dt>created</dt><dd>2026-07-07T22:19:50Z</dd>
-        <dt>modified</dt><dd>2026-07-07T22:19:50Z, 2026-07-07T22:45:00Z</dd>
-        <dt>commits</dt><dd>base 80450e3, branch docs/plan3f-gbrain-sprint pending</dd>
+        <dt>modified</dt><dd>2026-07-07T22:19:50Z, 2026-07-07T22:45:00Z, 2026-07-07T23:20:00Z, 2026-07-08T00:12:00Z</dd>
+        <dt>commits</dt><dd>base a838735, branch feat/266-relational-retrieval-eval active</dd>
         <dt>agent name</dt><dd>codex</dd>
         <dt>session id</dt><dd>019f30e7-61d0-7d52-a491-1699760f2cea</dd>
         <dt>back refs</dt><dd>GitHub issue #265, child issues #266 #267 #268 #269 #270 #271, issue #223 non-closure gate, gbrain audit thread</dd>
@@ -229,6 +229,9 @@
     <p>This plan turns the gbrain audit into a sprint that Open Brain can actually land. The useful idea is not a new graph database or a visual graph UI. It is retrieval-time typed-edge recall: parse relational questions, resolve seed entities, traverse existing Open Brain links, hydrate graph evidence into normal search rows, and prove the change with no-regression tests.</p>
     <div class="callout">
       <strong>Board snapshot at plan creation:</strong> #265 is In Progress; #266, #267, #269, and #270 are Todo; #268 and #271 are Backlog; #223 is Blocked and must stay open until the separate fleet-bus/NATS rollout has parity and canary proof. Verify Project #8 live before acting; the board is the current source of truth.
+    </div>
+    <div class="callout">
+      <strong>Current execution update, 2026-07-08T00:12Z:</strong> planning PR #272 merged as a838735. Project #8 now has #266 in review/fix loop for PR #273, the relational retrieval eval gate; #267 remains Todo and is not ready until #266 proof exists. #223 is still open and Blocked.
     </div>
   </section>
 
@@ -259,7 +262,7 @@
         </tr>
         <tr>
           <td><a href="https://github.com/rodaddy/open-brain/issues/266">#266</a></td>
-          <td>Todo</td>
+          <td>In Review / Fixes In Progress</td>
           <td>Relational retrieval eval and no-regression fixtures</td>
           <td>Must pass before #267 readiness</td>
         </tr>
@@ -356,7 +359,7 @@
       </ul>
       <h4>2.2 Testing Strategy</h4>
       <ul class="checklist">
-        <li><code class="status">[]</code><code>bun test tests/search-brain-relational-retrieval.test.ts</code> - proves relational lift and normal-query no-regression via the #266 fixture file.</li>
+        <li><code class="status">[]</code><code>bun test src/tools/__tests__/search-brain-relational-retrieval.test.ts</code> - proves relational lift and normal-query no-regression via the #266 fixture file.</li>
         <li><code class="status">[]</code><code>bun test tests/search-brain-namespace.test.ts</code> - proves namespace/read-policy denial via search namespace regression tests.</li>
         <li><code class="status">[]</code><code>bunx tsc --noEmit</code> - proves TypeScript contracts still compile via the repo compiler.</li>
       </ul>
@@ -377,7 +380,7 @@
       <h4>3.2 Testing Strategy</h4>
       <ul class="checklist">
         <li><code class="status">[]</code><code>bun test tests/search-brain-graph-arm.test.ts</code> - proves parser, seed resolution, traversal, hydration, fusion, and fail-open behavior via focused graph-arm tests.</li>
-        <li><code class="status">[]</code><code>bun test tests/search-brain-relational-retrieval.test.ts</code> - proves #267 passes the #266 eval gate via graph-on fixture results.</li>
+        <li><code class="status">[]</code><code>bun test src/tools/__tests__/search-brain-relational-retrieval.test.ts</code> - proves #267 passes the #266 eval gate via graph-on fixture results.</li>
         <li><code class="status">[]</code><code>bun test</code> - proves no shared retrieval regression via the full Bun suite.</li>
       </ul>
       <div class="loop">If #267 is split from #266, #267 stays blocked until #266 is merged and passing.</div>

--- a/specs/plan-3f-gbrain-sprint.verify.sh
+++ b/specs/plan-3f-gbrain-sprint.verify.sh
@@ -75,7 +75,7 @@ fi
 
 check "#223 remains open" zsh -c 'test "$(gh issue view 223 --repo rodaddy/open-brain --json state --jq .state)" = "OPEN"'
 check "#265 remains open while sprint runs" zsh -c 'test "$(gh issue view 265 --repo rodaddy/open-brain --json state --jq .state)" = "OPEN"'
-check "#266 relational retrieval eval tests pass" bun test tests/search-brain-relational-retrieval.test.ts
+check "#266 relational retrieval eval tests pass" bun test src/tools/__tests__/search-brain-relational-retrieval.test.ts
 check "#267 graph arm tests pass" bun test tests/search-brain-graph-arm.test.ts
 check "#269 audit log tests pass" bun test tests/tool-audit-log.test.ts
 check "#270 doctor status tests pass" bun test tests/doctor-status.test.ts

--- a/src/tools/__tests__/search-brain-relational-retrieval.test.ts
+++ b/src/tools/__tests__/search-brain-relational-retrieval.test.ts
@@ -1,0 +1,695 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { registerSearchBrain } from "../search-brain.ts";
+import { LINK_RELATIONS } from "../table-constants.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+type SourceType = "thought" | "decision" | "session" | "project";
+
+type FixtureEntry = {
+  id: string;
+  source_type: SourceType;
+  namespace: string;
+  text: string;
+  archived_at?: string | null;
+};
+
+type FixtureEntity = {
+  id: string;
+  namespace: string;
+  name: string;
+  entity_type: string;
+  archived_at?: string | null;
+};
+
+type FixtureLink = {
+  id: string;
+  namespace: string;
+  from_type: "entity" | SourceType;
+  from_id: string;
+  to_type: "entity" | SourceType;
+  to_id: string;
+  relation: string;
+  archived_at?: string | null;
+};
+
+type RelationalQuestion = {
+  id: string;
+  question: string;
+  namespace: string;
+  seed: string;
+  relation: string;
+  expected_id: string;
+  expected_type: SourceType;
+};
+
+const entries: FixtureEntry[] = [
+  {
+    id: "thought-deploy-readiness",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Readiness packet confirms the release train passed local checks.",
+  },
+  {
+    id: "decision-schema-v11",
+    source_type: "decision",
+    namespace: "shared-kb",
+    text: "Schema v11 remains the selected contract after downstream review.",
+  },
+  {
+    id: "session-worker-handoff",
+    source_type: "session",
+    namespace: "shared-kb",
+    text: "Worker handoff captured exact validation evidence for the canary.",
+  },
+  {
+    id: "project-promoter-cleanup",
+    source_type: "project",
+    namespace: "shared-kb",
+    text: "Promoter cleanup project owns stale collab migration follow-through.",
+  },
+  {
+    id: "thought-auth-boundary",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Auth boundary note names server-side namespace predicates as mandatory.",
+  },
+  {
+    id: "decision-qmd-fallback",
+    source_type: "decision",
+    namespace: "shared-kb",
+    text: "QMD fallback stays separate from Open Brain graph evidence.",
+  },
+  {
+    id: "session-review-gauntlet",
+    source_type: "session",
+    namespace: "shared-kb",
+    text: "Review gauntlet receipt lists SME and antagonist verification lanes.",
+  },
+  {
+    id: "thought-hot-memory-defer",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Hot memory prompt placement is deferred until exact-scope tests exist.",
+  },
+  {
+    id: "decision-nats-gate",
+    source_type: "decision",
+    namespace: "shared-kb",
+    text: "NATS rollout gate remains outside the graph retrieval sprint.",
+  },
+  {
+    id: "session-archive-safety",
+    source_type: "session",
+    namespace: "shared-kb",
+    text: "Archive safety session excludes soft-deleted graph nodes from answers.",
+  },
+  {
+    id: "thought-db-owner",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Database owner repair requires backup proof before migration retry.",
+  },
+  {
+    id: "project-docs-site",
+    source_type: "project",
+    namespace: "shared-kb",
+    text: "Docs site project keeps source HTML in specs and published HTML in collab sites.",
+  },
+  {
+    id: "decision-python-floor",
+    source_type: "decision",
+    namespace: "shared-kb",
+    text: "Python package floor moves to 3.13 for fleet bus compatibility.",
+  },
+  {
+    id: "thought-redaction-superset",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Redaction superset adds bare token and high entropy detectors.",
+  },
+  {
+    id: "session-canary-proof",
+    source_type: "session",
+    namespace: "shared-kb",
+    text: "Canary proof records contract version, tool list, and hosted health.",
+  },
+  {
+    id: "decision-shared-kb",
+    source_type: "decision",
+    namespace: "shared-kb",
+    text: "Shared knowledge canonical namespace remains shared-kb.",
+  },
+  {
+    id: "thought-mcp-cache",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "MCP schema cache refresh is required after contract deployment.",
+  },
+  {
+    id: "project-dreamengine",
+    source_type: "project",
+    namespace: "shared-kb",
+    text: "DreamEngine decomposition tracks oversized entries for later splitting.",
+  },
+  {
+    id: "session-agent-context",
+    source_type: "session",
+    namespace: "shared-kb",
+    text: "Agent context contract preserves citations and unpromoted working state.",
+  },
+  {
+    id: "thought-rollback-note",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Rollback note names runtime previous path and launchd restart boundary.",
+  },
+  {
+    id: "private-leak-target",
+    source_type: "thought",
+    namespace: "private-agent",
+    text: "Private agent target must never hydrate through shared-kb graph search.",
+  },
+  {
+    id: "archived-link-target",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Archived link target should be invisible to relational traversal.",
+  },
+  {
+    id: "archived-entity-target",
+    source_type: "thought",
+    namespace: "shared-kb",
+    text: "Archived entity target should be invisible to relational traversal.",
+  },
+];
+
+const entities: FixtureEntity[] = [
+  { id: "entity-alpha", namespace: "shared-kb", entity_type: "issue", name: "Alpha" },
+  { id: "entity-bravo", namespace: "shared-kb", entity_type: "issue", name: "Bravo" },
+  { id: "entity-charlie", namespace: "shared-kb", entity_type: "issue", name: "Charlie" },
+  { id: "entity-delta", namespace: "shared-kb", entity_type: "issue", name: "Delta" },
+  { id: "entity-echo", namespace: "shared-kb", entity_type: "issue", name: "Echo" },
+  { id: "entity-foxtrot", namespace: "shared-kb", entity_type: "issue", name: "Foxtrot" },
+  { id: "entity-golf", namespace: "shared-kb", entity_type: "issue", name: "Golf" },
+  { id: "entity-hotel", namespace: "shared-kb", entity_type: "issue", name: "Hotel" },
+  { id: "entity-india", namespace: "shared-kb", entity_type: "issue", name: "India" },
+  { id: "entity-juliet", namespace: "shared-kb", entity_type: "issue", name: "Juliet" },
+  { id: "entity-kilo", namespace: "shared-kb", entity_type: "issue", name: "Kilo" },
+  { id: "entity-lima", namespace: "shared-kb", entity_type: "issue", name: "Lima" },
+  { id: "entity-mike", namespace: "shared-kb", entity_type: "issue", name: "Mike" },
+  { id: "entity-november", namespace: "shared-kb", entity_type: "issue", name: "November" },
+  { id: "entity-oscar", namespace: "shared-kb", entity_type: "issue", name: "Oscar" },
+  { id: "entity-papa", namespace: "shared-kb", entity_type: "issue", name: "Papa" },
+  { id: "entity-quebec", namespace: "shared-kb", entity_type: "issue", name: "Quebec" },
+  { id: "entity-romeo", namespace: "shared-kb", entity_type: "issue", name: "Romeo" },
+  { id: "entity-sierra", namespace: "shared-kb", entity_type: "issue", name: "Sierra" },
+  { id: "entity-tango", namespace: "shared-kb", entity_type: "issue", name: "Tango" },
+  { id: "entity-private", namespace: "private-agent", entity_type: "issue", name: "Private" },
+  {
+    id: "entity-archived",
+    namespace: "shared-kb",
+    entity_type: "issue",
+    name: "Archived",
+    archived_at: "2026-07-01T00:00:00Z",
+  },
+];
+
+const relationalQuestionRows = [
+  ["q01", "What depends on Alpha?", "Alpha", "depends_on", "thought-deploy-readiness", "thought"],
+  ["q02", "What is blocked by Bravo?", "Bravo", "blocked_by", "decision-schema-v11", "decision"],
+  ["q03", "What was implemented by Charlie?", "Charlie", "implemented_by", "session-worker-handoff", "session"],
+  ["q04", "What was decided by Delta?", "Delta", "decided_by", "project-promoter-cleanup", "project"],
+  ["q05", "What supersedes Echo?", "Echo", "supersedes", "thought-auth-boundary", "thought"],
+  ["q06", "What duplicates Foxtrot?", "Foxtrot", "duplicates", "decision-qmd-fallback", "decision"],
+  ["q07", "What contradicts Golf?", "Golf", "contradicts", "session-review-gauntlet", "session"],
+  ["q08", "What mentions Hotel?", "Hotel", "mentions", "thought-hot-memory-defer", "thought"],
+  ["q09", "What relates to India?", "India", "relates_to", "decision-nats-gate", "decision"],
+  ["q10", "What depends on Juliet?", "Juliet", "depends_on", "session-archive-safety", "session"],
+  ["q11", "What is blocked by Kilo?", "Kilo", "blocked_by", "thought-db-owner", "thought"],
+  ["q12", "What was implemented by Lima?", "Lima", "implemented_by", "project-docs-site", "project"],
+  ["q13", "What was decided by Mike?", "Mike", "decided_by", "decision-python-floor", "decision"],
+  ["q14", "What supersedes November?", "November", "supersedes", "thought-redaction-superset", "thought"],
+  ["q15", "What duplicates Oscar?", "Oscar", "duplicates", "session-canary-proof", "session"],
+  ["q16", "What contradicts Papa?", "Papa", "contradicts", "decision-shared-kb", "decision"],
+  ["q17", "What mentions Quebec?", "Quebec", "mentions", "thought-mcp-cache", "thought"],
+  ["q18", "What relates to Romeo?", "Romeo", "relates_to", "project-dreamengine", "project"],
+  ["q19", "What depends on Sierra?", "Sierra", "depends_on", "session-agent-context", "session"],
+  ["q20", "What is blocked by Tango?", "Tango", "blocked_by", "thought-rollback-note", "thought"],
+] satisfies Array<[string, string, string, string, string, SourceType]>;
+
+const relationalQuestions: RelationalQuestion[] = relationalQuestionRows.map(
+  ([id, question, seed, relation, expected_id, expected_type]) => ({
+  id,
+  question,
+  namespace: "shared-kb",
+  seed,
+  relation,
+  expected_id,
+  expected_type,
+}),
+);
+
+const links: FixtureLink[] = [
+  ...relationalQuestions.map((question, index) => ({
+    id: `link-${index + 1}`,
+    namespace: question.namespace,
+    from_type: "entity" as const,
+    from_id: `entity-${question.seed.toLowerCase()}`,
+    to_type: question.expected_type,
+    to_id: question.expected_id,
+    relation: question.relation,
+  })),
+  {
+    id: "link-private-leak",
+    namespace: "private-agent",
+    from_type: "entity",
+    from_id: "entity-private",
+    to_type: "thought",
+    to_id: "private-leak-target",
+    relation: "mentions",
+  },
+  {
+    id: "link-archived-link",
+    namespace: "shared-kb",
+    from_type: "entity",
+    from_id: "entity-alpha",
+    to_type: "thought",
+    to_id: "archived-link-target",
+    relation: "mentions",
+    archived_at: "2026-07-01T00:00:00Z",
+  },
+  {
+    id: "link-archived-entity",
+    namespace: "shared-kb",
+    from_type: "entity",
+    from_id: "entity-archived",
+    to_type: "thought",
+    to_id: "archived-entity-target",
+    relation: "mentions",
+  },
+];
+
+const RELATION_PATTERN =
+  /what\s+(?:is\s+)?(?:was\s+)?(?<relation>depends on|blocked by|implemented by|decided by|supersedes|duplicates|contradicts|mentions|relates to)\s+(?<seed>[a-z]+)\??/i;
+
+const relationAliases: Record<string, string> = {
+  "depends on": "depends_on",
+  "blocked by": "blocked_by",
+  "implemented by": "implemented_by",
+  "decided by": "decided_by",
+  supersedes: "supersedes",
+  duplicates: "duplicates",
+  contradicts: "contradicts",
+  mentions: "mentions",
+  "relates to": "relates_to",
+};
+
+const BASELINE_STOPWORDS = new Set([
+  "what",
+  "is",
+  "was",
+  "by",
+  "on",
+  "to",
+  "depends",
+  "blocked",
+  "implemented",
+  "decided",
+  "supersedes",
+  "duplicates",
+  "contradicts",
+  "mentions",
+  "relates",
+]);
+
+function keywordBaseline(query: string, readableNamespaces = ["shared-kb"]): FixtureEntry[] {
+  const terms = query
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((term) => term.length > 2 && !BASELINE_STOPWORDS.has(term));
+  return entries.filter(
+    (entry) =>
+      !entry.archived_at &&
+      readableNamespaces.includes(entry.namespace) &&
+      terms.some((term) => entry.text.toLowerCase().includes(term)),
+  );
+}
+
+function graphOracle(query: string, readableNamespaces = ["shared-kb"]): FixtureEntry[] {
+  const parsed = RELATION_PATTERN.exec(query)?.groups;
+  if (!parsed) return keywordBaseline(query, readableNamespaces);
+  if (!parsed.relation || !parsed.seed) return [];
+  const relation = relationAliases[parsed.relation.toLowerCase()];
+  const seedName = parsed.seed.toLowerCase();
+  const seed = entities.find(
+    (entity) =>
+      !entity.archived_at &&
+      readableNamespaces.includes(entity.namespace) &&
+      entity.name.toLowerCase() === seedName,
+  );
+  if (!seed || !relation) return [];
+  const linkedIds = links
+    .filter(
+      (link) =>
+        !link.archived_at &&
+        link.namespace === seed.namespace &&
+        readableNamespaces.includes(link.namespace) &&
+        link.from_type === "entity" &&
+        link.from_id === seed.id &&
+        link.relation === relation,
+    )
+    .map((link) => `${link.to_type}:${link.to_id}`);
+  return entries.filter(
+    (entry) =>
+      !entry.archived_at &&
+      readableNamespaces.includes(entry.namespace) &&
+      linkedIds.includes(`${entry.source_type}:${entry.id}`),
+  );
+}
+
+function recall(
+  questions: RelationalQuestion[],
+  search: (query: string, readableNamespaces?: string[]) => FixtureEntry[],
+): number {
+  const hits = questions.filter((question) =>
+    search(question.question, [question.namespace]).some(
+      (entry) => entry.id === question.expected_id,
+    ),
+  ).length;
+  return hits / questions.length;
+}
+
+describe("search_brain relational retrieval eval fixture", () => {
+  it("defines at least 20 Open Brain-native relational questions", () => {
+    expect(relationalQuestions).toHaveLength(20);
+    expect(new Set(relationalQuestions.map((question) => question.id)).size).toBe(20);
+    expect(new Set(relationalQuestions.map((question) => question.relation))).toEqual(
+      new Set([
+        "depends_on",
+        "blocked_by",
+        "implemented_by",
+        "decided_by",
+        "supersedes",
+        "duplicates",
+        "contradicts",
+        "mentions",
+        "relates_to",
+      ]),
+    );
+    for (const question of relationalQuestions) {
+      expect(LINK_RELATIONS).toContain(question.relation as any);
+    }
+  });
+
+  it("proves the target graph oracle has material lift over graph-off baseline", () => {
+    expect(recall(relationalQuestions, keywordBaseline)).toBe(0);
+    expect(recall(relationalQuestions, graphOracle)).toBe(1);
+  });
+
+  it("proves current search_brain graph-off behavior cannot recover relational-only answers", async () => {
+    const pool = {
+      query: async (...args: any[]) => {
+        const [sql] = args;
+        if (String(sql).includes("FROM ob_links")) return { rows: [] };
+        return {
+          rows: keywordBaseline(String(args[1]?.[0] ?? "")).map((entry) => ({
+            source_type: entry.source_type,
+            id: entry.id,
+            namespace: entry.namespace,
+            content_preview: entry.text,
+            tags: [],
+            created_by: "test",
+            created_at: "2026-01-01T00:00:00Z",
+            usefulness: 0,
+            fts_rank: 1,
+          })),
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "agent", clientId: "shared-kb" };
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchBrain,
+      pool,
+      createMockEmbed(null),
+      auth,
+    );
+    try {
+      const recovered = [];
+      for (const question of relationalQuestions) {
+        const result = await client.callTool({
+          name: "search_brain",
+          arguments: {
+            query: question.question,
+            namespace: question.namespace,
+            search_mode: "keyword",
+            limit: 10,
+          },
+        });
+        expect(result.isError).toBeFalsy();
+        recovered.push(
+          parseToolResult(result).some(
+            (entry: { id: string }) => entry.id === question.expected_id,
+          ),
+        );
+      }
+      expect(recovered.every(Boolean)).toBe(false);
+      expect(recovered.filter(Boolean)).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it.todo(
+    "search_brain graph arm returns relational fixture answers through the real tool",
+    () => {},
+  );
+
+  it("keeps non-relational query behavior unchanged", () => {
+    const query = "schema v11 downstream review";
+    expect(graphOracle(query).map((entry) => entry.id)).toEqual(
+      keywordBaseline(query).map((entry) => entry.id),
+    );
+  });
+
+  it("excludes unreadable namespaces from graph hydration", () => {
+    expect(graphOracle("What mentions Private?", ["shared-kb"])).toEqual([]);
+    expect(graphOracle("What mentions Private?", ["private-agent"]).map((entry) => entry.id)).toEqual([
+      "private-leak-target",
+    ]);
+  });
+
+  it("excludes archived links and archived seed entities", () => {
+    expect(graphOracle("What mentions Alpha?").map((entry) => entry.id)).not.toContain(
+      "archived-link-target",
+    );
+    expect(graphOracle("What mentions Archived?").map((entry) => entry.id)).not.toContain(
+      "archived-entity-target",
+    );
+  });
+});
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("search_brain relational retrieval eval fixture (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-relational-retrieval-eval";
+  const privateNs = `${ns}-private`;
+
+  afterAll(async () => {
+    await cleanupDbFixture();
+    await pool.end();
+  });
+
+  async function cleanupDbFixture(): Promise<void> {
+    await pool.query("DELETE FROM ob_links WHERE namespace = ANY($1::text[])", [
+      [ns, privateNs],
+    ]);
+    await pool.query("DELETE FROM ob_entities WHERE namespace = ANY($1::text[])", [
+      [ns, privateNs],
+    ]);
+    await pool.query("DELETE FROM decisions WHERE namespace = ANY($1::text[])", [
+      [ns, privateNs],
+    ]);
+    await pool.query("DELETE FROM projects WHERE namespace = ANY($1::text[])", [
+      [ns, privateNs],
+    ]);
+    await pool.query("DELETE FROM sessions WHERE namespace = ANY($1::text[])", [
+      [ns, privateNs],
+    ]);
+    await pool.query("DELETE FROM thoughts WHERE namespace = ANY($1::text[])", [
+      [ns, privateNs],
+    ]);
+  }
+
+  async function seedDbFixture(): Promise<void> {
+    await cleanupDbFixture();
+    await pool.query(
+      `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
+       VALUES
+         ('10000000-0000-4000-8000-000000000001', 'DB relational target visible only through active graph link', $1, 'test', 'rr-db-visible'),
+         ('10000000-0000-4000-8000-000000000002', 'DB private target must not leak', $2, 'test', 'rr-db-private'),
+         ('10000000-0000-4000-8000-000000000003', 'DB archived link target must not hydrate', $1, 'test', 'rr-db-archived-link'),
+         ('10000000-0000-4000-8000-000000000004', 'DB archived entity target must not hydrate', $1, 'test', 'rr-db-archived-entity')`,
+      [ns, privateNs],
+    );
+    await pool.query(
+      `INSERT INTO decisions (id, title, rationale, namespace, created_by, content_hash)
+       VALUES ('11000000-0000-4000-8000-000000000001', 'DB decision target', 'Hydrated by graph relation only', $1, 'test', 'rr-db-decision')`,
+      [ns],
+    );
+    await pool.query(
+      `INSERT INTO projects (id, name, description, namespace, created_by, content_hash)
+       VALUES ('12000000-0000-4000-8000-000000000001', 'DB project target', 'Hydrated by graph relation only', $1, 'test', 'rr-db-project')`,
+      [ns],
+    );
+    await pool.query(
+      `INSERT INTO sessions (id, project, summary, namespace, created_by, content_hash)
+       VALUES ('13000000-0000-4000-8000-000000000001', 'DB session target', 'Hydrated by graph relation only', $1, 'test', 'rr-db-session')`,
+      [ns],
+    );
+    await pool.query(
+      `INSERT INTO ob_entities (id, entity_type, name, namespace, created_by, archived_at)
+       VALUES
+         ('20000000-0000-4000-8000-000000000001', 'issue', 'VisibleSeed', $1, 'test', NULL),
+         ('20000000-0000-4000-8000-000000000002', 'issue', 'PrivateSeed', $2, 'test', NULL),
+         ('20000000-0000-4000-8000-000000000003', 'issue', 'ArchivedSeed', $1, 'test', '2026-07-01T00:00:00Z'::timestamptz)`,
+      [ns, privateNs],
+    );
+    await pool.query(
+      `INSERT INTO ob_links
+         (id, from_type, from_id, to_type, to_id, relation, namespace, created_by, archived_at)
+       VALUES
+         ('30000000-0000-4000-8000-000000000001', 'entity', '20000000-0000-4000-8000-000000000001', 'thought', '10000000-0000-4000-8000-000000000001', 'depends_on', $1, 'test', NULL),
+         ('30000000-0000-4000-8000-000000000002', 'entity', '20000000-0000-4000-8000-000000000002', 'thought', '10000000-0000-4000-8000-000000000002', 'depends_on', $2, 'test', NULL),
+         ('30000000-0000-4000-8000-000000000003', 'entity', '20000000-0000-4000-8000-000000000001', 'thought', '10000000-0000-4000-8000-000000000003', 'mentions', $1, 'test', '2026-07-01T00:00:00Z'::timestamptz),
+         ('30000000-0000-4000-8000-000000000004', 'entity', '20000000-0000-4000-8000-000000000003', 'thought', '10000000-0000-4000-8000-000000000004', 'mentions', $1, 'test', NULL),
+         ('30000000-0000-4000-8000-000000000005', 'entity', '20000000-0000-4000-8000-000000000001', 'decision', '11000000-0000-4000-8000-000000000001', 'decided_by', $1, 'test', NULL),
+         ('30000000-0000-4000-8000-000000000006', 'entity', '20000000-0000-4000-8000-000000000001', 'project', '12000000-0000-4000-8000-000000000001', 'implemented_by', $1, 'test', NULL),
+         ('30000000-0000-4000-8000-000000000007', 'entity', '20000000-0000-4000-8000-000000000001', 'session', '13000000-0000-4000-8000-000000000001', 'blocked_by', $1, 'test', NULL)`,
+      [ns, privateNs],
+    );
+  }
+
+  async function relationalDbCandidates(
+    seedName: string,
+    relation: string,
+    readableNamespaces: string[],
+  ): Promise<Array<{ source_type: string; id: string }>> {
+    const { rows } = await pool.query<{ source_type: string; id: string }>(
+      `WITH seed AS (
+         SELECT id, namespace
+         FROM ob_entities
+         WHERE lower(name) = lower($1)
+           AND namespace = ANY($3::text[])
+           AND archived_at IS NULL
+       )
+       SELECT source_type, id
+       FROM (
+         SELECT 'thought' AS source_type, t.id::text AS id
+         FROM seed s
+         JOIN ob_links l
+           ON l.from_type = 'entity'
+          AND l.from_id = s.id
+          AND l.namespace = s.namespace
+          AND l.relation = $2
+          AND l.archived_at IS NULL
+         JOIN thoughts t
+           ON l.to_type = 'thought'
+          AND t.id = l.to_id
+          AND t.namespace = l.namespace
+          AND t.archived_at IS NULL
+         WHERE l.namespace = ANY($3::text[])
+         UNION ALL
+         SELECT 'decision' AS source_type, d.id::text AS id
+         FROM seed s
+         JOIN ob_links l
+           ON l.from_type = 'entity'
+          AND l.from_id = s.id
+          AND l.namespace = s.namespace
+          AND l.relation = $2
+          AND l.archived_at IS NULL
+         JOIN decisions d
+           ON l.to_type = 'decision'
+          AND d.id = l.to_id
+          AND d.namespace = l.namespace
+          AND d.archived_at IS NULL
+         WHERE l.namespace = ANY($3::text[])
+         UNION ALL
+         SELECT 'project' AS source_type, p.id::text AS id
+         FROM seed s
+         JOIN ob_links l
+           ON l.from_type = 'entity'
+          AND l.from_id = s.id
+          AND l.namespace = s.namespace
+          AND l.relation = $2
+          AND l.archived_at IS NULL
+         JOIN projects p
+           ON l.to_type = 'project'
+          AND p.id = l.to_id
+          AND p.namespace = l.namespace
+          AND p.archived_at IS NULL
+         WHERE l.namespace = ANY($3::text[])
+         UNION ALL
+         SELECT 'session' AS source_type, se.id::text AS id
+         FROM seed s
+         JOIN ob_links l
+           ON l.from_type = 'entity'
+          AND l.from_id = s.id
+          AND l.namespace = s.namespace
+          AND l.relation = $2
+          AND l.archived_at IS NULL
+         JOIN sessions se
+           ON l.to_type = 'session'
+          AND se.id = l.to_id
+          AND se.namespace = l.namespace
+          AND se.archived_at IS NULL
+         WHERE l.namespace = ANY($3::text[])
+       ) hydrated
+       ORDER BY source_type, id`,
+      [seedName, relation, readableNamespaces],
+    );
+    return rows;
+  }
+
+  it("proves real graph predicates enforce namespace and archived lifecycle", async () => {
+    await seedDbFixture();
+    try {
+      await expect(relationalDbCandidates("VisibleSeed", "depends_on", [ns]))
+        .resolves.toEqual([
+          { source_type: "thought", id: "10000000-0000-4000-8000-000000000001" },
+        ]);
+      await expect(relationalDbCandidates("PrivateSeed", "depends_on", [ns]))
+        .resolves.toEqual([]);
+      await expect(relationalDbCandidates("PrivateSeed", "depends_on", [privateNs]))
+        .resolves.toEqual([
+          { source_type: "thought", id: "10000000-0000-4000-8000-000000000002" },
+        ]);
+      await expect(relationalDbCandidates("VisibleSeed", "mentions", [ns]))
+        .resolves.toEqual([]);
+      await expect(relationalDbCandidates("ArchivedSeed", "mentions", [ns]))
+        .resolves.toEqual([]);
+      await expect(relationalDbCandidates("VisibleSeed", "decided_by", [ns]))
+        .resolves.toEqual([
+          { source_type: "decision", id: "11000000-0000-4000-8000-000000000001" },
+        ]);
+      await expect(relationalDbCandidates("VisibleSeed", "implemented_by", [ns]))
+        .resolves.toEqual([
+          { source_type: "project", id: "12000000-0000-4000-8000-000000000001" },
+        ]);
+      await expect(relationalDbCandidates("VisibleSeed", "blocked_by", [ns]))
+        .resolves.toEqual([
+          { source_type: "session", id: "13000000-0000-4000-8000-000000000001" },
+        ]);
+    } finally {
+      await cleanupDbFixture();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a deterministic relational retrieval eval fixture for issue #266 with 20 Open Brain-native relational questions.
- Proves the target graph oracle has material lift over graph-off keyword baseline while preserving non-relational behavior.
- Adds a real `search_brain` MCP-tool graph-off guard proving current keyword behavior cannot recover relational-only answers.
- Covers unreadable namespace exclusion and archived link/entity exclusion in the default infra-free test.
- Adds an `OPENBRAIN_TEST_DATABASE_URL`-gated Postgres predicate test over real `ob_entities`, `ob_links`, `thoughts`, `decisions`, `projects`, and `sessions`.
- Registers the new live Postgres suite in the CI anti-skip guard so DB coverage cannot silently skip.
- Updates the Plan 3F markdown, verifier command, tracked HTML source, and finished collab HTML status for the issue #266 branch.

Closes #266.

## Validation

- `bun install --frozen-lockfile`
- `bun test src/tools/__tests__/search-brain-relational-retrieval.test.ts scripts/assert-db-tests-ran.test.ts` -> 14 pass, 2 skipped DB-gated locally because `OPENBRAIN_TEST_DATABASE_URL` is unset, 1 todo for the #267 graph-on real-tool assertion.
- `bun test src/tools/__tests__/search-brain.test.ts src/tools/__tests__/search-brain-relational-retrieval.test.ts` -> 46 pass, 2 skipped, 1 todo.
- `bunx tsc --noEmit`
- `git diff --check`
- `specs/plan-3f-gbrain-sprint.verify.sh --artifact-only` -> PASS, including repo source vs finished collab site byte comparisons.
- CI `db-integration` anti-skip guard -> PASS with 22 live-Postgres testcases across 6 required suites, including `search_brain relational retrieval eval fixture (live Postgres): 1 tests`.

## Review / Fix Verification

- Initial correctness and adversarial review found blockers around false-comfort oracle coverage, CI anti-skip coverage, cross-source DB fixture breadth, and stale Plan 3F HTML status.
- Fixes landed in commit `7673624`.
- Focused SME/correctness fix verification: no material issues.
- Focused adversarial fix verification: no material issues.
- Known residual risk is intentionally scoped to #267: the graph-on real-tool assertion remains `it.todo` until the graph-powered `search_brain` arm exists.

## Deploy / Downstream

No core01 deploy, live DB mutation, hosted NATS setup, fleet-bus rollout, or Hermes canary. NATS issue 223 remains open and outside this sprint slice.

Downstream rollout classification: not applicable for runtime rollout because this PR adds tests/eval fixtures and planning/status docs only. It does not change MCP contracts, server runtime behavior, Python client behavior, transport behavior, auth, namespace semantics, or hosted Open Brain behavior.

## Critical Self-Review

- Highest-risk behavior: the eval could become a false comfort if it tests only an in-memory oracle instead of the real tool boundary. Fixed by adding a real `search_brain` graph-off guard; #267 still owns graph-on real-tool pass.
- Assumptions that could be wrong: the DB-gated SQL shape may need adjustment when #267 implements the production graph arm.
- Missing/weak tests: local shell does not run the DB-gated section because `OPENBRAIN_TEST_DATABASE_URL` is unset; CI db-integration proves the suite runs against ephemeral Postgres.
- Security/permission risk: namespace leakage is covered in both fixture logic and DB-gated predicates; no production auth behavior changes.
- Migration/deploy risk: none; no migration or deploy path changes.
- Downstream client/runtime risk: none for runtime behavior; #267 remains the implementation gate before consumers see graph retrieval.
- Rollback/cleanup concern: revert this PR to remove the eval fixture and plan-status updates; no data cleanup required.
- Fixes made before PR: corrected fixture content so graph-off recall is zero, added real-tool graph-off guard, added DB-gated predicate coverage across target tables, registered the live suite in CI anti-skip guard, corrected verifier/test paths, and synced the collab HTML copy.
- Known residual risk: #267 still must wire the real graph retrieval arm into `search_brain` and pass this eval before readiness.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no recurring MEDIUM+ review pattern was found; the blockers were fixed in this PR and documented in the PR comments.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured in PR review/fix-verification comments
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a test/eval/docs PR only and does not change hosted Open Brain runtime behavior.
