### PR TITLE
feat: add privacy-safe MCP audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Five core tables, all with 768-dimensional halfvec embeddings and HNSW indexes:
 - **projects** — named projects with status and metadata
 - **sessions** — session summaries with blockers, next steps, and key decisions
 
-Supporting tables: `entry_access_log` (usage tracking), `discarded_entries` (archive staging), `_migrations`.
+Supporting tables: `entry_access_log` (usage tracking), `discarded_entries` (archive staging), `mcp_tool_audit_log` (privacy-safe MCP tool audit — see [docs/operator-audit-log.md](docs/operator-audit-log.md)), `_migrations`.
 
 ## Search
 
@@ -448,6 +448,7 @@ lab HTTP endpoints such as `http://10.71.1.21:3100`.
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — coding standards, development workflow, and infrastructure rules
 - [GLOSSARY.md](GLOSSARY.md) — domain terminology (tiers, warmth, dream cycles, etc.)
+- [docs/operator-audit-log.md](docs/operator-audit-log.md) — MCP tool audit log schema, env controls, privacy guarantees, fail-open behavior
 
 ## License
 

--- a/docs/operator-audit-log.md
+++ b/docs/operator-audit-log.md
@@ -1,8 +1,11 @@
 # MCP Tool Audit Log (Operator Guide)
 
-Open Brain records a privacy-safe audit row for every MCP tool call handled by
-the server (issue #269). The log answers "who called which tool, when, with
-what outcome and rough payload shape" without ever persisting request content.
+Open Brain records a privacy-safe audit row for every tool call dispatched
+through the MCP server, i.e. tools registered via `registerTool` and reached
+over the HTTP `/mcp` transport (issue #269). Calls that bypass the MCP server
+-- notably the NATS-bridge runtime paths -- are **not** covered by this log.
+The log answers "who called which tool, when, with what outcome and rough
+payload shape" without ever persisting request content.
 
 Implementation: `src/audit-log.ts`. Schema:
 `src/db/migrations/022_mcp_tool_audit_log.sql`.
@@ -22,8 +25,8 @@ Implementation: `src/audit-log.ts`. Schema:
 | `caller_agent_id` | `TEXT` | Agent id from auth context. |
 | `namespace_source` | `TEXT` | How the namespace was resolved (e.g. `header`). |
 | `declared_parameter_keys` | `JSONB` | Sorted, de-duplicated key names from the tool's **declared** input schema only. |
-| `unknown_parameter_count` | `INTEGER` | Count of argument keys not in the declared schema. The unknown key names themselves are never stored. |
-| `payload_size_bucket` | `TEXT` | Coarse size bucket of the JSON-serialized arguments (`0b`, `le_128b`, `le_512b`, `le_1kb`, `le_4kb`, `le_16kb`, `le_64kb`, `le_256kb`, `le_1mb`, `gt_1mb`). |
+| `unknown_parameter_count` | `INTEGER` | Count of **raw** request argument keys not in the declared schema, measured before Zod validation strips undeclared keys. The unknown key names themselves are never stored. If a request carries more than 256 argument keys, per-key comparison is skipped and the total raw key count is recorded instead. |
+| `payload_size_bucket` | `TEXT` | Coarse size bucket of the JSON-serialized **raw** request arguments, measured before Zod validation strips undeclared keys (`0b`, `le_128b`, `le_512b`, `le_1kb`, `le_4kb`, `le_16kb`, `le_64kb`, `le_256kb`, `le_1mb`, `gt_1mb`). The sentinel `unknown` is recorded when the arguments cannot be JSON-serialized (never conflated with `0b`). |
 
 ## Privacy Guarantees
 
@@ -59,9 +62,19 @@ Audit logging never blocks or fails user-facing tool calls:
   tool result (or original exception) is returned to the caller unchanged.
 - Slow inserts are bounded by `OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS`
   (`mcp_tool_audit_write_timeout` warning on breach).
-- Retention cleanup failures are caught and logged as
-  `mcp_tool_audit_cleanup_failed` and retried on a later write.
+- At most 16 audit inserts may be in flight against the pool at once. Beyond
+  that (for example under sustained database slowness), further audit writes
+  are skipped entirely and logged as `mcp_tool_audit_write_skipped`, so
+  detached audit writes can never hold every pool connection and starve real
+  tool queries.
+- Retention cleanup fires detached after a successful insert and never runs
+  inside the request-latency window. Failures are caught and logged as
+  `mcp_tool_audit_cleanup_failed` and retried on a later write. The cleanup
+  clock is process-scoped per pool, so per-session MCP server construction
+  does not re-trigger the retention DELETE.
+- Audit warning log lines carry only the error `code`/`name` (for example the
+  Postgres error code), never the raw error message.
 
 The trade-off is deliberate: availability of the memory tools wins over audit
-completeness. Watch the three warning events above if you need to detect audit
+completeness. Watch the four warning events above if you need to detect audit
 gaps.

--- a/docs/operator-audit-log.md
+++ b/docs/operator-audit-log.md
@@ -4,6 +4,9 @@ Open Brain records a privacy-safe audit row for every tool call dispatched
 through the MCP server, i.e. tools registered via `registerTool` and reached
 over the HTTP `/mcp` transport (issue #269). Calls that bypass the MCP server
 -- notably the NATS-bridge runtime paths -- are **not** covered by this log.
+Calls that fail input validation for a **registered** tool are audited with
+status `validation_error`; calls naming an **unknown tool** are rejected by
+the SDK above any repo-owned hook and produce no audit row (known limitation).
 The log answers "who called which tool, when, with what outcome and rough
 payload shape" without ever persisting request content.
 
@@ -17,16 +20,16 @@ Implementation: `src/audit-log.ts`. Schema:
 | `id` | `BIGSERIAL` | Row id. |
 | `created_at` | `TIMESTAMPTZ` | Insert time (`NOW()` default). Retention and both indexes key on this. |
 | `operation` | `TEXT` | MCP tool name (e.g. `log_thought`). |
-| `status` | `TEXT` | `success`, `error` (tool returned `isError: true`), or `exception` (handler threw). |
-| `duration_ms` | `INTEGER` | Handler duration, rounded, never negative. |
-| `caller_role` | `TEXT` | Auth-derived role (`admin`, `agent`, ...), or `NULL` if absent. |
+| `status` | `TEXT` | `success`, `error` (tool returned `isError: true`), `exception` (handler threw), or `validation_error` (request rejected by input validation before reaching the handler). |
+| `duration_ms` | `INTEGER` | Handler duration, rounded, never negative. For `validation_error` rows this is the validation duration. |
+| `caller_role` | `TEXT` | Auth-derived role (`admin`, `agent`, ...), or `NULL` if absent. All caller fields are `NULL` on `validation_error` rows: the validation hook runs before the SDK exposes any auth context. |
 | `caller_client_id` | `TEXT` | Effective client id from auth context. |
 | `caller_token_client_id` | `TEXT` | Client id bound to the bearer token. |
 | `caller_agent_id` | `TEXT` | Agent id from auth context. |
 | `namespace_source` | `TEXT` | How the namespace was resolved (e.g. `header`). |
 | `declared_parameter_keys` | `JSONB` | Sorted, de-duplicated key names from the tool's **declared** input schema only. |
 | `unknown_parameter_count` | `INTEGER` | Count of **raw** request argument keys not in the declared schema, measured before Zod validation strips undeclared keys. The unknown key names themselves are never stored. If a request carries more than 256 argument keys, per-key comparison is skipped and the total raw key count is recorded instead. |
-| `payload_size_bucket` | `TEXT` | Coarse size bucket of the JSON-serialized **raw** request arguments, measured before Zod validation strips undeclared keys (`0b`, `le_128b`, `le_512b`, `le_1kb`, `le_4kb`, `le_16kb`, `le_64kb`, `le_256kb`, `le_1mb`, `gt_1mb`). The sentinel `unknown` is recorded when the arguments cannot be JSON-serialized (never conflated with `0b`). |
+| `payload_size_bucket` | `TEXT` | Coarse size bucket of the **raw** request arguments, measured before Zod validation strips undeclared keys (`0b`, `le_128b`, `le_512b`, `le_1kb`, `le_4kb`, `le_16kb`, `le_64kb`, `le_256kb`, `le_1mb`, `gt_1mb`). The size is an approximation from a bounded traversal (string lengths plus structural overhead, with an early exit into `gt_1mb`), not an exact serialization -- the request path never materializes a full JSON copy of the arguments. The sentinel `unknown` is recorded when the arguments cannot be JSON-serialized (never conflated with `0b`). |
 
 ## Privacy Guarantees
 
@@ -44,8 +47,10 @@ bucketed rather than exact to avoid a size side channel on short secrets.
 
 ## Environment Controls
 
-All variables are read at server start (`readMcpAuditConfig`). Out-of-range or
-non-integer values fall back to the default.
+All variables are read at server start (`readMcpAuditConfig`). Values must be
+plain base-10 integers (digits only); anything else -- including `1.5`,
+`1000ms`, or padded whitespace -- and out-of-range values fall back to the
+default.
 
 | Variable | Default | Bounds | Effect |
 |----------|---------|--------|--------|
@@ -62,11 +67,11 @@ Audit logging never blocks or fails user-facing tool calls:
   tool result (or original exception) is returned to the caller unchanged.
 - Slow inserts are bounded by `OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS`
   (`mcp_tool_audit_write_timeout` warning on breach).
-- At most 16 audit inserts may be in flight against the pool at once. Beyond
-  that (for example under sustained database slowness), further audit writes
-  are skipped entirely and logged as `mcp_tool_audit_write_skipped`, so
-  detached audit writes can never hold every pool connection and starve real
-  tool queries.
+- At most 4 audit inserts may be in flight against the pool at once (kept
+  well below the pool size), and audit writes are also skipped whenever the
+  pool reports waiting clients. In both cases the write is skipped entirely
+  and logged as `mcp_tool_audit_write_skipped`, so audit writes can never
+  hold every pool connection and starve real tool queries.
 - Retention cleanup fires detached after a successful insert and never runs
   inside the request-latency window. Failures are caught and logged as
   `mcp_tool_audit_cleanup_failed` and retried on a later write. The cleanup

--- a/docs/operator-audit-log.md
+++ b/docs/operator-audit-log.md
@@ -1,0 +1,67 @@
+# MCP Tool Audit Log (Operator Guide)
+
+Open Brain records a privacy-safe audit row for every MCP tool call handled by
+the server (issue #269). The log answers "who called which tool, when, with
+what outcome and rough payload shape" without ever persisting request content.
+
+Implementation: `src/audit-log.ts`. Schema:
+`src/db/migrations/022_mcp_tool_audit_log.sql`.
+
+## Table: `mcp_tool_audit_log`
+
+| Column | Type | Meaning |
+|--------|------|---------|
+| `id` | `BIGSERIAL` | Row id. |
+| `created_at` | `TIMESTAMPTZ` | Insert time (`NOW()` default). Retention and both indexes key on this. |
+| `operation` | `TEXT` | MCP tool name (e.g. `log_thought`). |
+| `status` | `TEXT` | `success`, `error` (tool returned `isError: true`), or `exception` (handler threw). |
+| `duration_ms` | `INTEGER` | Handler duration, rounded, never negative. |
+| `caller_role` | `TEXT` | Auth-derived role (`admin`, `agent`, ...), or `NULL` if absent. |
+| `caller_client_id` | `TEXT` | Effective client id from auth context. |
+| `caller_token_client_id` | `TEXT` | Client id bound to the bearer token. |
+| `caller_agent_id` | `TEXT` | Agent id from auth context. |
+| `namespace_source` | `TEXT` | How the namespace was resolved (e.g. `header`). |
+| `declared_parameter_keys` | `JSONB` | Sorted, de-duplicated key names from the tool's **declared** input schema only. |
+| `unknown_parameter_count` | `INTEGER` | Count of argument keys not in the declared schema. The unknown key names themselves are never stored. |
+| `payload_size_bucket` | `TEXT` | Coarse size bucket of the JSON-serialized arguments (`0b`, `le_128b`, `le_512b`, `le_1kb`, `le_4kb`, `le_16kb`, `le_64kb`, `le_256kb`, `le_1mb`, `gt_1mb`). |
+
+## Privacy Guarantees
+
+The audit path persists operation metadata only. It never stores:
+
+- raw request bodies or parameter values
+- prompt or content text
+- file paths, headers, tokens, or credential values
+- unknown/undeclared argument key names (only their count)
+
+Parameter key names are recorded only when they come from the tool's declared
+input schema, so an attacker-controlled key (for example a path or a secret
+used as a key) is reduced to `unknown_parameter_count`. Payload size is
+bucketed rather than exact to avoid a size side channel on short secrets.
+
+## Environment Controls
+
+All variables are read at server start (`readMcpAuditConfig`). Out-of-range or
+non-integer values fall back to the default.
+
+| Variable | Default | Bounds | Effect |
+|----------|---------|--------|--------|
+| `OPENBRAIN_MCP_AUDIT_ENABLED` | enabled | set to `0` to disable | Any value other than `0` (including unset) leaves auditing on. When disabled, the wrapper is not installed and no audit SQL runs. |
+| `OPENBRAIN_MCP_AUDIT_RETENTION_DAYS` | `30` | `1`-`366` | Rows older than this many days are deleted by the periodic cleanup. |
+| `OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS` | `3600000` (1h) | `60000`-`86400000` | Minimum time between retention cleanup attempts. Cleanup is piggybacked on audit writes; a failed cleanup does not advance the interval clock and is retried on the next write. |
+| `OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS` | `1000` | `50`-`5000` | Upper bound on how long a tool response waits for its audit insert. On timeout the call proceeds and `mcp_tool_audit_write_timeout` is logged; the insert may still complete in the background. |
+
+## Failure Behavior (Fail Open)
+
+Audit logging never blocks or fails user-facing tool calls:
+
+- Insert failures are caught and logged as `mcp_tool_audit_write_failed`; the
+  tool result (or original exception) is returned to the caller unchanged.
+- Slow inserts are bounded by `OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS`
+  (`mcp_tool_audit_write_timeout` warning on breach).
+- Retention cleanup failures are caught and logged as
+  `mcp_tool_audit_cleanup_failed` and retried on a later write.
+
+The trade-off is deliberate: availability of the memory tools wins over audit
+completeness. Watch the three warning events above if you need to detect audit
+gaps.

--- a/src/audit-log.test.ts
+++ b/src/audit-log.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  declaredParameterKeys,
+  payloadSizeBucket,
+  readMcpAuditConfig,
+  summarizeMcpAudit,
+} from "./audit-log.ts";
+
+describe("MCP audit log privacy helpers", () => {
+  test("summarizes declared keys and counts unknown keys without storing unknown names", () => {
+    const summary = summarizeMcpAudit({
+      operation: "log_thought",
+      status: "success",
+      durationMs: 12.4,
+      auth: {
+        role: "admin",
+        clientId: "delegated",
+        tokenClientId: "rico",
+        agentId: "worker-269",
+        namespaceSource: "header",
+      },
+      declaredKeys: ["content", "tags", "namespace"],
+      args: {
+        content: "do not persist this prompt body",
+        tags: ["secret-token-shaped-value"],
+        namespace: "delegated",
+        "/Users/rico/private.txt": "do not persist attacker key",
+        api_key: "sk-live-secret-shaped-value",
+      },
+    });
+
+    expect(summary).toMatchObject({
+      operation: "log_thought",
+      status: "success",
+      durationMs: 12,
+      callerRole: "admin",
+      callerClientId: "delegated",
+      callerTokenClientId: "rico",
+      callerAgentId: "worker-269",
+      namespaceSource: "header",
+      declaredParameterKeys: ["content", "namespace", "tags"],
+      unknownParameterCount: 2,
+    });
+    expect(JSON.stringify(summary)).not.toContain("do not persist");
+    expect(JSON.stringify(summary)).not.toContain("/Users/rico");
+    expect(JSON.stringify(summary)).not.toContain("api_key");
+    expect(JSON.stringify(summary)).not.toContain("sk-live");
+  });
+
+  test("extracts declared keys from the repo's registerTool inputSchema shape", () => {
+    expect(
+      declaredParameterKeys({
+        zeta: {},
+        alpha: {},
+        namespace: {},
+      }),
+    ).toEqual(["alpha", "namespace", "zeta"]);
+  });
+
+  test("buckets payload size instead of returning exact bytes", () => {
+    expect(payloadSizeBucket({ q: "x" })).toBe("le_128b");
+    expect(payloadSizeBucket({ q: "x".repeat(900) })).toBe("le_1kb");
+    expect(payloadSizeBucket({ q: "x".repeat(5000) })).toBe("le_16kb");
+  });
+
+  test("supports disable and retention env controls", () => {
+    expect(
+      readMcpAuditConfig({
+        OPENBRAIN_MCP_AUDIT_ENABLED: "0",
+        OPENBRAIN_MCP_AUDIT_RETENTION_DAYS: "14",
+        OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS: "60000",
+      }),
+    ).toEqual({
+      enabled: false,
+      retentionDays: 14,
+      cleanupIntervalMs: 60000,
+    });
+  });
+});

--- a/src/audit-log.test.ts
+++ b/src/audit-log.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  captureArgsFacts,
   declaredParameterKeys,
   payloadSizeBucket,
   readMcpAuditConfig,
@@ -62,6 +63,68 @@ describe("MCP audit log privacy helpers", () => {
     expect(payloadSizeBucket({ q: "x" })).toBe("le_128b");
     expect(payloadSizeBucket({ q: "x".repeat(900) })).toBe("le_1kb");
     expect(payloadSizeBucket({ q: "x".repeat(5000) })).toBe("le_16kb");
+  });
+
+  test("un-serializable payloads bucket as unknown, not 0b", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(payloadSizeBucket(circular)).toBe("unknown");
+    expect(payloadSizeBucket({ big: 1n })).toBe("unknown");
+    expect(payloadSizeBucket(() => "not json")).toBe("unknown");
+  });
+
+  test("clamps non-finite durations to zero instead of violating the CHECK", () => {
+    for (const durationMs of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      const summary = summarizeMcpAudit({
+        operation: "log_thought",
+        status: "success",
+        durationMs,
+        declaredKeys: ["content"],
+        args: { content: "x" },
+      });
+      expect(summary.durationMs).toBe(0);
+    }
+  });
+
+  test("prefers raw-args capture over parsed (stripped) args", () => {
+    const summary = summarizeMcpAudit({
+      operation: "log_thought",
+      status: "success",
+      durationMs: 1,
+      declaredKeys: ["content"],
+      // Parsed view after Zod stripped the undeclared key.
+      args: { content: "short" },
+      // Raw view captured by the validation hook before stripping.
+      rawArgs: captureArgsFacts({
+        content: "short",
+        undeclared_probe: "x".repeat(5000),
+      }),
+    });
+    expect(summary.unknownParameterCount).toBe(1);
+    expect(summary.payloadSizeBucket).toBe("le_16kb");
+  });
+
+  test("caps per-key unknown scanning on adversarially wide payloads", () => {
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 300; i += 1) wide[`k${i}`] = "v";
+    const facts = captureArgsFacts(wide);
+    expect(facts.rawKeys).toBeNull();
+    expect(facts.rawKeyCount).toBe(300);
+
+    const summary = summarizeMcpAudit({
+      operation: "log_thought",
+      status: "success",
+      durationMs: 1,
+      declaredKeys: ["k0"],
+      args: wide,
+      rawArgs: facts,
+    });
+    // Over the cap every raw key counts as unknown; no per-key comparison.
+    expect(summary.unknownParameterCount).toBe(300);
   });
 
   test("supports disable and retention env controls", () => {

--- a/src/audit-log.test.ts
+++ b/src/audit-log.test.ts
@@ -3,6 +3,7 @@ import {
   declaredParameterKeys,
   payloadSizeBucket,
   readMcpAuditConfig,
+  recordMcpAudit,
   summarizeMcpAudit,
 } from "./audit-log.ts";
 
@@ -74,6 +75,61 @@ describe("MCP audit log privacy helpers", () => {
       enabled: false,
       retentionDays: 14,
       cleanupIntervalMs: 60000,
+      writeTimeoutMs: 1000,
     });
+  });
+
+  test("retries retention cleanup after a failed cleanup attempt", async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = [];
+    let deleteAttempts = 0;
+    const pool = {
+      query: async (sql: string, params: unknown[] = []) => {
+        calls.push({ sql, params });
+        if (sql.trimStart().startsWith("DELETE FROM mcp_tool_audit_log")) {
+          deleteAttempts += 1;
+          if (deleteAttempts === 1) {
+            throw new Error("temporary cleanup outage");
+          }
+        }
+        return { rows: [] };
+      },
+    };
+    const config = {
+      enabled: true,
+      retentionDays: 30,
+      cleanupIntervalMs: 0,
+      writeTimeoutMs: 1000,
+    };
+    const state = { lastCleanupAt: 0 };
+    const summary = summarizeMcpAudit({
+      operation: "log_thought",
+      status: "success",
+      durationMs: 1,
+      declaredKeys: ["content"],
+      args: { content: "private text" },
+    });
+
+    await recordMcpAudit(
+      { pool: pool as never, now: () => new Date(1000) },
+      config,
+      state,
+      summary,
+    );
+    expect(deleteAttempts).toBe(1);
+    expect(state.lastCleanupAt).toBe(0);
+
+    await recordMcpAudit(
+      { pool: pool as never, now: () => new Date(2000) },
+      config,
+      state,
+      summary,
+    );
+    expect(deleteAttempts).toBe(2);
+    expect(state.lastCleanupAt).toBe(2000);
+    expect(
+      calls.filter((call) =>
+        call.sql.trimStart().startsWith("INSERT INTO mcp_tool_audit_log"),
+      ),
+    ).toHaveLength(2);
   });
 });

--- a/src/audit-log.test.ts
+++ b/src/audit-log.test.ts
@@ -142,6 +142,32 @@ describe("MCP audit log privacy helpers", () => {
     });
   });
 
+  test("non-integer env values fall back instead of being coerced", () => {
+    // parseInt would accept "1.5" (-> 1) and "60000ms" (-> 60000); the strict
+    // digits-only rule must reject both and use the defaults.
+    expect(
+      readMcpAuditConfig({
+        OPENBRAIN_MCP_AUDIT_RETENTION_DAYS: "1.5",
+        OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS: "60000ms",
+        OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS: " 500 ",
+      }),
+    ).toEqual({
+      enabled: true,
+      retentionDays: 30,
+      cleanupIntervalMs: 3600000,
+      writeTimeoutMs: 1000,
+    });
+  });
+
+  test("large payloads hit the top bucket via early exit, without full serialization", () => {
+    expect(
+      payloadSizeBucket({ content: "x".repeat(2 * 1024 * 1024) }),
+    ).toBe("gt_1mb");
+    expect(
+      payloadSizeBucket({ items: Array.from({ length: 3_000_000 }, () => 1) }),
+    ).toBe("gt_1mb");
+  });
+
   test("retries retention cleanup after a failed cleanup attempt", async () => {
     const calls: Array<{ sql: string; params: unknown[] }> = [];
     let deleteAttempts = 0;

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -13,10 +13,14 @@ const MAX_WRITE_TIMEOUT_MS = 5000;
 // payloads. Above this, every raw key is counted as unknown without any
 // per-key set membership work.
 const MAX_UNKNOWN_KEY_SCAN = 256;
-// Cap on detached audit INSERTs still running against the pool. Beyond it,
-// audit writes are skipped (fail open) so a slow database cannot let audit
-// writes hold every pool connection and starve real tool queries.
-const MAX_IN_FLIGHT_AUDIT_WRITES = 16;
+// Cap on detached audit INSERTs still running against the pool. Kept well
+// below the default pool size (10) so hung audit writes can never occupy the
+// whole shared pool; beyond it audit writes are skipped (fail open) so a slow
+// database cannot let audit writes starve real tool queries.
+const MAX_IN_FLIGHT_AUDIT_WRITES = 4;
+// Early-exit boundary for the payload size estimator: once the running
+// estimate passes the top bucket boundary there is nothing left to learn.
+const SIZE_ESTIMATE_EARLY_EXIT_BYTES = 1024 * 1024;
 const auditInstalledServers = new WeakSet<McpServer>();
 
 export interface McpAuditConfig {
@@ -34,7 +38,7 @@ export interface McpAuditDeps {
 
 export interface McpAuditSummary {
   operation: string;
-  status: "success" | "error" | "exception";
+  status: "success" | "error" | "exception" | "validation_error";
   durationMs: number;
   callerRole: string | null;
   callerClientId: string | null;
@@ -121,6 +125,12 @@ function takeRawArgsAuditCapture(
 
 type RegisterTool = McpServer["registerTool"];
 
+type ToolInputValidator = (
+  tool: unknown,
+  args: unknown,
+  toolName: string,
+) => Promise<unknown>;
+
 export function readMcpAuditConfig(
   env: Record<string, string | undefined> = process.env,
 ): McpAuditConfig {
@@ -154,6 +164,9 @@ function readBoundedInt(
   fallback: number,
 ): number {
   if (raw === undefined) return fallback;
+  // Strict base-10 digits only: parseInt would silently accept "1.5" (-> 1)
+  // and "1000ms" (-> 1000), contradicting the documented fallback behavior.
+  if (!/^[0-9]+$/.test(raw)) return fallback;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
     return fallback;
@@ -172,11 +185,10 @@ function ownKeys(value: unknown): string[] {
 }
 
 export function payloadSizeBucket(input: unknown): string {
-  const json = safeStringify(input);
-  // Un-serializable payloads get a distinct sentinel so "couldn't measure"
+  const bytes = estimateJsonBytes(input);
+  // Un-measurable payloads get a distinct sentinel so "couldn't measure"
   // is never conflated with "empty".
-  if (json === null) return "unknown";
-  const bytes = Buffer.byteLength(json, "utf8");
+  if (bytes === null) return "unknown";
   if (bytes === 0) return "0b";
   if (bytes <= 128) return "le_128b";
   if (bytes <= 512) return "le_512b";
@@ -189,14 +201,71 @@ export function payloadSizeBucket(input: unknown): string {
   return "gt_1mb";
 }
 
-function safeStringify(input: unknown): string | null {
-  try {
-    const json = JSON.stringify(input ?? null);
-    // JSON.stringify returns undefined for lone unserializable values.
-    return json === undefined ? null : json;
-  } catch {
-    return null;
+// Approximates the JSON-serialized byte size of a value WITHOUT materializing
+// the JSON string, so the request path never builds a full copy of an
+// unbounded content string just to bucket it. String cost is code-unit length
+// plus quotes plus a ~6% escaping/multi-byte fudge; containers add structural
+// overhead. Traversal exits early once the running total passes the top
+// bucket boundary. Returns null for values JSON.stringify could not serialize
+// (a cycle, a BigInt anywhere, or a lone non-JSON value), which buckets as
+// "unknown". Buckets are coarse by design; the estimate only needs to land in
+// the right order of magnitude.
+function estimateJsonBytes(input: unknown): number | null {
+  const top = input ?? null;
+  if (typeof top === "function" || typeof top === "symbol") return null;
+  // Raw MCP arguments are transport-parsed JSON (always trees), so an object
+  // seen twice can only mean a cycle in practice.
+  const seen = new Set<object>();
+  const stack: unknown[] = [top];
+  let total = 0;
+  while (stack.length > 0) {
+    if (total > SIZE_ESTIMATE_EARLY_EXIT_BYTES) return total;
+    const value = stack.pop();
+    if (value === null || value === undefined) {
+      total += 4;
+      continue;
+    }
+    switch (typeof value) {
+      case "string":
+        total += value.length + 2 + (value.length >> 4);
+        break;
+      case "number":
+        total += Number.isFinite(value) ? String(value).length : 4;
+        break;
+      case "boolean":
+        total += value ? 4 : 5;
+        break;
+      case "bigint":
+        // JSON.stringify throws on BigInt anywhere in the value.
+        return null;
+      case "object": {
+        if (seen.has(value as object)) return null;
+        seen.add(value as object);
+        if (Array.isArray(value)) {
+          // Brackets plus one comma per element; element bytes are counted
+          // up front so an adversarially long array trips the early exit
+          // before its members are pushed.
+          total += 2 + value.length;
+          if (total > SIZE_ESTIMATE_EARLY_EXIT_BYTES) return total;
+          for (const item of value) stack.push(item);
+        } else {
+          const entries = Object.entries(value as Record<string, unknown>);
+          total += 2 + entries.length;
+          if (total > SIZE_ESTIMATE_EARLY_EXIT_BYTES) return total;
+          for (const [key, item] of entries) {
+            total += key.length + 3;
+            stack.push(item);
+          }
+        }
+        break;
+      }
+      default:
+        // Nested function/symbol: JSON omits the member (object) or emits
+        // null (array); either way the contribution is negligible.
+        break;
+    }
   }
+  return total;
 }
 
 export function summarizeMcpAudit(input: {
@@ -245,6 +314,44 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
   rawArgsCaptureEnabled = true;
 
   const state = sharedAuditState(deps.pool);
+  // Declared keys per tool name, populated by the registerTool wrapper below
+  // and reused by the validation-failure audit path (which only has the tool
+  // name and the SDK's compiled schema object).
+  const declaredKeysByTool = new Map<string, string[]>();
+
+  // Validation failures never reach the tool handler, so the most
+  // security-relevant probes (undeclared keys plus an invalid payload) would
+  // otherwise leave no audit row. Wrap the server's validateToolInput hook to
+  // record them with status "validation_error". The SDK invokes this hook as
+  // validateToolInput(tool, request.params.arguments, toolName) with no
+  // request extra, so no auth context exists at this layer: caller fields
+  // stay null by construction. Unknown-tool-name calls are rejected above any
+  // repo-owned hook and remain unaudited (documented limitation).
+  const validatorHost = server as unknown as {
+    validateToolInput?: ToolInputValidator;
+  };
+  if (typeof validatorHost.validateToolInput === "function") {
+    const originalValidate = validatorHost.validateToolInput.bind(
+      server,
+    ) as ToolInputValidator;
+    validatorHost.validateToolInput = async (tool, args, toolName) => {
+      const started = Date.now();
+      try {
+        return await originalValidate(tool, args, toolName);
+      } catch (err) {
+        await writeMcpAuditWithTimeout(deps, config, state, summarizeMcpAudit({
+          operation: toolName,
+          status: "validation_error",
+          durationMs: Date.now() - started,
+          declaredKeys: declaredKeysByTool.get(toolName) ?? [],
+          args,
+          rawArgs: captureArgsFacts(args),
+        }));
+        throw err;
+      }
+    };
+  }
+
   const original = server.registerTool.bind(server) as RegisterTool;
   server.registerTool = ((name: string, configOrDescription: unknown, cb?: unknown) => {
     if (typeof cb !== "function") {
@@ -259,6 +366,7 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
       (configOrDescription as { inputSchema?: unknown } | undefined)
         ?.inputSchema,
     );
+    declaredKeysByTool.set(name, declaredKeys);
     const callback = cb as (args: unknown, extra: unknown) => unknown;
     const wrapped = async (args: unknown, extra: unknown) => {
       const started = Date.now();
@@ -313,11 +421,19 @@ async function writeMcpAuditWithTimeout(
   state: SharedMcpAuditState,
   summary: McpAuditSummary,
 ): Promise<void> {
-  if (state.inFlightWrites >= MAX_IN_FLIGHT_AUDIT_WRITES) {
+  // Never compete with real tool queries for connections: skip when the pool
+  // already has waiters, or when too many audit writes are still in flight.
+  const waitingCount =
+    (deps.pool as { waitingCount?: number }).waitingCount ?? 0;
+  if (
+    state.inFlightWrites >= MAX_IN_FLIGHT_AUDIT_WRITES ||
+    waitingCount > 0
+  ) {
     logger.warn("mcp_tool_audit_write_skipped", {
       operation: summary.operation,
       status: summary.status,
       inFlightWrites: state.inFlightWrites,
+      waitingCount,
     });
     return;
   }

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -5,12 +5,17 @@ import { logger } from "./logger.ts";
 
 const DEFAULT_RETENTION_DAYS = 30;
 const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+const DEFAULT_WRITE_TIMEOUT_MS = 1000;
 const MAX_RETENTION_DAYS = 366;
+const MIN_WRITE_TIMEOUT_MS = 50;
+const MAX_WRITE_TIMEOUT_MS = 5000;
+const auditInstalledServers = new WeakSet<McpServer>();
 
 export interface McpAuditConfig {
   enabled: boolean;
   retentionDays: number;
   cleanupIntervalMs: number;
+  writeTimeoutMs: number;
 }
 
 export interface McpAuditDeps {
@@ -33,9 +38,11 @@ export interface McpAuditSummary {
   payloadSizeBucket: string;
 }
 
-type RegisterTool = McpServer["registerTool"];
+export interface McpAuditState {
+  lastCleanupAt: number;
+}
 
-let lastCleanupAt = 0;
+type RegisterTool = McpServer["registerTool"];
 
 export function readMcpAuditConfig(
   env: Record<string, string | undefined> = process.env,
@@ -53,6 +60,12 @@ export function readMcpAuditConfig(
       60_000,
       24 * 60 * 60 * 1000,
       DEFAULT_CLEANUP_INTERVAL_MS,
+    ),
+    writeTimeoutMs: readBoundedInt(
+      env.OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS,
+      MIN_WRITE_TIMEOUT_MS,
+      MAX_WRITE_TIMEOUT_MS,
+      DEFAULT_WRITE_TIMEOUT_MS,
     ),
   };
 }
@@ -136,7 +149,10 @@ export function summarizeMcpAudit(input: {
 export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
   const config = deps.config ?? readMcpAuditConfig();
   if (!config.enabled) return;
+  if (auditInstalledServers.has(server)) return;
+  auditInstalledServers.add(server);
 
+  const state: McpAuditState = { lastCleanupAt: 0 };
   const original = server.registerTool.bind(server) as RegisterTool;
   server.registerTool = ((name: string, configOrDescription: unknown, cb?: unknown) => {
     if (typeof cb !== "function") {
@@ -158,7 +174,7 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
       try {
         const result = await callback(args, extra);
         const status = isToolError(result) ? "error" : "success";
-        void writeMcpAudit(deps, config, summarizeMcpAudit({
+        await writeMcpAuditWithTimeout(deps, config, state, summarizeMcpAudit({
           operation: name,
           status,
           durationMs: Date.now() - started,
@@ -168,7 +184,7 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
         }));
         return result;
       } catch (err) {
-        void writeMcpAudit(deps, config, summarizeMcpAudit({
+        await writeMcpAuditWithTimeout(deps, config, state, summarizeMcpAudit({
           operation: name,
           status: "exception",
           durationMs: Date.now() - started,
@@ -196,13 +212,38 @@ function isToolError(result: unknown): boolean {
   );
 }
 
-async function writeMcpAudit(
+async function writeMcpAuditWithTimeout(
   deps: McpAuditDeps,
   config: McpAuditConfig,
+  state: McpAuditState,
+  summary: McpAuditSummary,
+): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const write = recordMcpAudit(deps, config, state, summary);
+  const timed = new Promise<"timeout">((resolve) => {
+    timeout = setTimeout(() => resolve("timeout"), config.writeTimeoutMs);
+  });
+  const outcome = await Promise.race([
+    write.then(() => "written" as const),
+    timed,
+  ]);
+  if (timeout) clearTimeout(timeout);
+  if (outcome === "timeout") {
+    logger.warn("mcp_tool_audit_write_timeout", {
+      operation: summary.operation,
+      status: summary.status,
+      timeoutMs: config.writeTimeoutMs,
+    });
+  }
+}
+
+export async function recordMcpAudit(
+  deps: McpAuditDeps,
+  config: McpAuditConfig,
+  state: McpAuditState,
   summary: McpAuditSummary,
 ): Promise<void> {
   try {
-    maybeCleanupAuditLog(deps, config);
     await deps.pool.query(
       `INSERT INTO mcp_tool_audit_log (
         operation,
@@ -231,6 +272,7 @@ async function writeMcpAudit(
         summary.payloadSizeBucket,
       ],
     );
+    await maybeCleanupAuditLog(deps, config, state);
   } catch (err) {
     logger.warn("mcp_tool_audit_write_failed", {
       operation: summary.operation,
@@ -243,16 +285,19 @@ async function writeMcpAudit(
 function maybeCleanupAuditLog(
   deps: McpAuditDeps,
   config: McpAuditConfig,
-): void {
+  state: McpAuditState,
+): Promise<void> {
   const now = (deps.now ?? (() => new Date()))().getTime();
-  if (now - lastCleanupAt < config.cleanupIntervalMs) return;
-  lastCleanupAt = now;
-  void deps.pool
+  if (now - state.lastCleanupAt < config.cleanupIntervalMs) return Promise.resolve();
+  return deps.pool
     .query(
       `DELETE FROM mcp_tool_audit_log
        WHERE created_at < NOW() - ($1::int * INTERVAL '1 day')`,
       [config.retentionDays],
     )
+    .then(() => {
+      state.lastCleanupAt = now;
+    })
     .catch((err: unknown) => {
       logger.warn("mcp_tool_audit_cleanup_failed", {
         error: err instanceof Error ? err.message : String(err),

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -9,6 +9,14 @@ const DEFAULT_WRITE_TIMEOUT_MS = 1000;
 const MAX_RETENTION_DAYS = 366;
 const MIN_WRITE_TIMEOUT_MS = 50;
 const MAX_WRITE_TIMEOUT_MS = 5000;
+// Bound for per-key unknown-parameter comparison on adversarially wide
+// payloads. Above this, every raw key is counted as unknown without any
+// per-key set membership work.
+const MAX_UNKNOWN_KEY_SCAN = 256;
+// Cap on detached audit INSERTs still running against the pool. Beyond it,
+// audit writes are skipped (fail open) so a slow database cannot let audit
+// writes hold every pool connection and starve real tool queries.
+const MAX_IN_FLIGHT_AUDIT_WRITES = 16;
 const auditInstalledServers = new WeakSet<McpServer>();
 
 export interface McpAuditConfig {
@@ -40,6 +48,75 @@ export interface McpAuditSummary {
 
 export interface McpAuditState {
   lastCleanupAt: number;
+  cleanupInFlight?: boolean;
+}
+
+interface SharedMcpAuditState extends McpAuditState {
+  inFlightWrites: number;
+}
+
+// Facts about the RAW (pre-Zod-validation) request arguments, captured before
+// the SDK strips undeclared keys. Held only in process memory (never
+// persisted); rawKeys is null when the request exceeds MAX_UNKNOWN_KEY_SCAN.
+export interface RawArgsAuditCapture {
+  rawKeyCount: number;
+  rawKeys: string[] | null;
+  payloadSizeBucket: string;
+}
+
+// Cleanup/backpressure state is process-scoped and keyed by pool so per-session
+// server construction (serverFactory in src/index.ts) shares one retention
+// clock and one in-flight budget, while tests with separate pools stay
+// isolated.
+const sharedStateByPool = new WeakMap<object, SharedMcpAuditState>();
+
+function sharedAuditState(pool: pg.Pool): SharedMcpAuditState {
+  let state = sharedStateByPool.get(pool);
+  if (!state) {
+    state = { lastCleanupAt: 0, inFlightWrites: 0 };
+    sharedStateByPool.set(pool, state);
+  }
+  return state;
+}
+
+// Raw-args metrics ride from the repo-owned validation hook
+// (validateToolInputWithSummary) to the audit wrapper keyed by the identity of
+// the parsed-data object: the SDK dispatch passes validateToolInput's return
+// value to the tool handler unchanged (node_modules/@modelcontextprotocol/sdk
+// dist mcp.js: `const args = await this.validateToolInput(...)` then
+// `executeToolHandler(tool, args, extra)` -> `handler(args, extra)`).
+const rawArgsCaptureByParsed = new WeakMap<object, RawArgsAuditCapture>();
+
+// The validation hook is installed unconditionally (createBrainServer), but
+// raw-args measurement should only cost anything once auditing is actually
+// installed for this process.
+let rawArgsCaptureEnabled = false;
+
+export function captureArgsFacts(args: unknown): RawArgsAuditCapture {
+  const keys = ownKeys(args);
+  return {
+    rawKeyCount: keys.length,
+    rawKeys: keys.length > MAX_UNKNOWN_KEY_SCAN ? null : keys,
+    payloadSizeBucket: payloadSizeBucket(args),
+  };
+}
+
+export function captureRawArgsForAudit(
+  rawArgs: unknown,
+  parsedData: unknown,
+): void {
+  if (!rawArgsCaptureEnabled) return;
+  if (!parsedData || typeof parsedData !== "object") return;
+  rawArgsCaptureByParsed.set(parsedData as object, captureArgsFacts(rawArgs));
+}
+
+function takeRawArgsAuditCapture(
+  parsedArgs: unknown,
+): RawArgsAuditCapture | undefined {
+  if (!parsedArgs || typeof parsedArgs !== "object") return undefined;
+  const capture = rawArgsCaptureByParsed.get(parsedArgs as object);
+  if (capture) rawArgsCaptureByParsed.delete(parsedArgs as object);
+  return capture;
 }
 
 type RegisterTool = McpServer["registerTool"];
@@ -96,6 +173,9 @@ function ownKeys(value: unknown): string[] {
 
 export function payloadSizeBucket(input: unknown): string {
   const json = safeStringify(input);
+  // Un-serializable payloads get a distinct sentinel so "couldn't measure"
+  // is never conflated with "empty".
+  if (json === null) return "unknown";
   const bytes = Buffer.byteLength(json, "utf8");
   if (bytes === 0) return "0b";
   if (bytes <= 128) return "le_128b";
@@ -109,11 +189,13 @@ export function payloadSizeBucket(input: unknown): string {
   return "gt_1mb";
 }
 
-function safeStringify(input: unknown): string {
+function safeStringify(input: unknown): string | null {
   try {
-    return JSON.stringify(input ?? null);
+    const json = JSON.stringify(input ?? null);
+    // JSON.stringify returns undefined for lone unserializable values.
+    return json === undefined ? null : json;
   } catch {
-    return "";
+    return null;
   }
 }
 
@@ -124,17 +206,26 @@ export function summarizeMcpAudit(input: {
   auth?: AuthInfo;
   declaredKeys: string[];
   args: unknown;
+  // Raw pre-validation facts from the validation hook; when absent (paths
+  // that bypass validateToolInputWithSummary) the parsed args are measured.
+  rawArgs?: RawArgsAuditCapture;
 }): McpAuditSummary {
   const declared = [...new Set(input.declaredKeys)].sort();
   const declaredSet = new Set(declared);
-  const unknownParameterCount = ownKeys(input.args).filter(
-    (key) => !declaredSet.has(key),
-  ).length;
+  const facts = input.rawArgs ?? captureArgsFacts(input.args);
+  // Over the scan cap, per-key comparison is skipped and every raw key counts
+  // as unknown (rawKeys is null); such requests are adversarial by shape.
+  const unknownParameterCount =
+    facts.rawKeys === null
+      ? facts.rawKeyCount
+      : facts.rawKeys.filter((key) => !declaredSet.has(key)).length;
 
   return {
     operation: input.operation,
     status: input.status,
-    durationMs: Math.max(0, Math.round(input.durationMs)),
+    durationMs: Number.isFinite(input.durationMs)
+      ? Math.max(0, Math.round(input.durationMs))
+      : 0,
     callerRole: input.auth?.role ?? null,
     callerClientId: input.auth?.clientId ?? null,
     callerTokenClientId: input.auth?.tokenClientId ?? null,
@@ -142,7 +233,7 @@ export function summarizeMcpAudit(input: {
     namespaceSource: input.auth?.namespaceSource ?? null,
     declaredParameterKeys: declared,
     unknownParameterCount,
-    payloadSizeBucket: payloadSizeBucket(input.args),
+    payloadSizeBucket: facts.payloadSizeBucket,
   };
 }
 
@@ -151,8 +242,9 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
   if (!config.enabled) return;
   if (auditInstalledServers.has(server)) return;
   auditInstalledServers.add(server);
+  rawArgsCaptureEnabled = true;
 
-  const state: McpAuditState = { lastCleanupAt: 0 };
+  const state = sharedAuditState(deps.pool);
   const original = server.registerTool.bind(server) as RegisterTool;
   server.registerTool = ((name: string, configOrDescription: unknown, cb?: unknown) => {
     if (typeof cb !== "function") {
@@ -171,6 +263,7 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
     const wrapped = async (args: unknown, extra: unknown) => {
       const started = Date.now();
       const auth = (extra as { authInfo?: AuthInfo } | undefined)?.authInfo;
+      const rawArgs = takeRawArgsAuditCapture(args);
       try {
         const result = await callback(args, extra);
         const status = isToolError(result) ? "error" : "success";
@@ -181,6 +274,7 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
           auth,
           declaredKeys,
           args,
+          rawArgs,
         }));
         return result;
       } catch (err) {
@@ -191,6 +285,7 @@ export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
           auth,
           declaredKeys,
           args,
+          rawArgs,
         }));
         throw err;
       }
@@ -215,11 +310,29 @@ function isToolError(result: unknown): boolean {
 async function writeMcpAuditWithTimeout(
   deps: McpAuditDeps,
   config: McpAuditConfig,
-  state: McpAuditState,
+  state: SharedMcpAuditState,
   summary: McpAuditSummary,
 ): Promise<void> {
+  if (state.inFlightWrites >= MAX_IN_FLIGHT_AUDIT_WRITES) {
+    logger.warn("mcp_tool_audit_write_skipped", {
+      operation: summary.operation,
+      status: summary.status,
+      inFlightWrites: state.inFlightWrites,
+    });
+    return;
+  }
+  state.inFlightWrites += 1;
+  // insertMcpAudit never rejects (it catches and logs), so finally/then are
+  // safe to chain without another catch.
+  const write = insertMcpAudit(deps, summary).finally(() => {
+    state.inFlightWrites -= 1;
+  });
+  // Retention cleanup fires detached after the INSERT settles; it never
+  // participates in the response-latency race and catches its own errors.
+  void write.then((inserted) => {
+    if (inserted) return maybeCleanupAuditLog(deps, config, state);
+  });
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const write = recordMcpAudit(deps, config, state, summary);
   const timed = new Promise<"timeout">((resolve) => {
     timeout = setTimeout(() => resolve("timeout"), config.writeTimeoutMs);
   });
@@ -243,6 +356,14 @@ export async function recordMcpAudit(
   state: McpAuditState,
   summary: McpAuditSummary,
 ): Promise<void> {
+  const inserted = await insertMcpAudit(deps, summary);
+  if (inserted) await maybeCleanupAuditLog(deps, config, state);
+}
+
+async function insertMcpAudit(
+  deps: McpAuditDeps,
+  summary: McpAuditSummary,
+): Promise<boolean> {
   try {
     await deps.pool.query(
       `INSERT INTO mcp_tool_audit_log (
@@ -272,14 +393,28 @@ export async function recordMcpAudit(
         summary.payloadSizeBucket,
       ],
     );
-    await maybeCleanupAuditLog(deps, config, state);
+    return true;
   } catch (err) {
     logger.warn("mcp_tool_audit_write_failed", {
       operation: summary.operation,
       status: summary.status,
-      error: err instanceof Error ? err.message : String(err),
+      error: auditErrorLabel(err),
     });
+    return false;
   }
+}
+
+// Audit warn lines log the error code/name only, never the raw message, so a
+// driver/db error string can never smuggle payload or credential text into
+// logs.
+function auditErrorLabel(err: unknown): string {
+  if (err && typeof err === "object") {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "string" && code.length > 0) return code;
+    const name = (err as { name?: unknown }).name;
+    if (typeof name === "string" && name.length > 0) return name;
+  }
+  return "unknown_error";
 }
 
 function maybeCleanupAuditLog(
@@ -289,6 +424,11 @@ function maybeCleanupAuditLog(
 ): Promise<void> {
   const now = (deps.now ?? (() => new Date()))().getTime();
   if (now - state.lastCleanupAt < config.cleanupIntervalMs) return Promise.resolve();
+  // Single-flight: detached triggers can race within the interval before
+  // lastCleanupAt advances; only one DELETE may run at a time. A failed
+  // cleanup does not advance the clock, so it is retried on a later write.
+  if (state.cleanupInFlight) return Promise.resolve();
+  state.cleanupInFlight = true;
   return deps.pool
     .query(
       `DELETE FROM mcp_tool_audit_log
@@ -300,7 +440,10 @@ function maybeCleanupAuditLog(
     })
     .catch((err: unknown) => {
       logger.warn("mcp_tool_audit_cleanup_failed", {
-        error: err instanceof Error ? err.message : String(err),
+        error: auditErrorLabel(err),
       });
+    })
+    .finally(() => {
+      state.cleanupInFlight = false;
     });
 }

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -1,0 +1,261 @@
+import type pg from "pg";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthInfo } from "./types.ts";
+import { logger } from "./logger.ts";
+
+const DEFAULT_RETENTION_DAYS = 30;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+const MAX_RETENTION_DAYS = 366;
+
+export interface McpAuditConfig {
+  enabled: boolean;
+  retentionDays: number;
+  cleanupIntervalMs: number;
+}
+
+export interface McpAuditDeps {
+  pool: pg.Pool;
+  config?: McpAuditConfig;
+  now?: () => Date;
+}
+
+export interface McpAuditSummary {
+  operation: string;
+  status: "success" | "error" | "exception";
+  durationMs: number;
+  callerRole: string | null;
+  callerClientId: string | null;
+  callerTokenClientId: string | null;
+  callerAgentId: string | null;
+  namespaceSource: string | null;
+  declaredParameterKeys: string[];
+  unknownParameterCount: number;
+  payloadSizeBucket: string;
+}
+
+type RegisterTool = McpServer["registerTool"];
+
+let lastCleanupAt = 0;
+
+export function readMcpAuditConfig(
+  env: Record<string, string | undefined> = process.env,
+): McpAuditConfig {
+  return {
+    enabled: env.OPENBRAIN_MCP_AUDIT_ENABLED !== "0",
+    retentionDays: readBoundedInt(
+      env.OPENBRAIN_MCP_AUDIT_RETENTION_DAYS,
+      1,
+      MAX_RETENTION_DAYS,
+      DEFAULT_RETENTION_DAYS,
+    ),
+    cleanupIntervalMs: readBoundedInt(
+      env.OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS,
+      60_000,
+      24 * 60 * 60 * 1000,
+      DEFAULT_CLEANUP_INTERVAL_MS,
+    ),
+  };
+}
+
+function readBoundedInt(
+  raw: string | undefined,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export function declaredParameterKeys(inputSchema: unknown): string[] {
+  if (!inputSchema || typeof inputSchema !== "object") return [];
+  return Object.keys(inputSchema as Record<string, unknown>).sort();
+}
+
+function ownKeys(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  return Object.keys(value as Record<string, unknown>);
+}
+
+export function payloadSizeBucket(input: unknown): string {
+  const json = safeStringify(input);
+  const bytes = Buffer.byteLength(json, "utf8");
+  if (bytes === 0) return "0b";
+  if (bytes <= 128) return "le_128b";
+  if (bytes <= 512) return "le_512b";
+  if (bytes <= 1024) return "le_1kb";
+  if (bytes <= 4096) return "le_4kb";
+  if (bytes <= 16 * 1024) return "le_16kb";
+  if (bytes <= 64 * 1024) return "le_64kb";
+  if (bytes <= 256 * 1024) return "le_256kb";
+  if (bytes <= 1024 * 1024) return "le_1mb";
+  return "gt_1mb";
+}
+
+function safeStringify(input: unknown): string {
+  try {
+    return JSON.stringify(input ?? null);
+  } catch {
+    return "";
+  }
+}
+
+export function summarizeMcpAudit(input: {
+  operation: string;
+  status: McpAuditSummary["status"];
+  durationMs: number;
+  auth?: AuthInfo;
+  declaredKeys: string[];
+  args: unknown;
+}): McpAuditSummary {
+  const declared = [...new Set(input.declaredKeys)].sort();
+  const declaredSet = new Set(declared);
+  const unknownParameterCount = ownKeys(input.args).filter(
+    (key) => !declaredSet.has(key),
+  ).length;
+
+  return {
+    operation: input.operation,
+    status: input.status,
+    durationMs: Math.max(0, Math.round(input.durationMs)),
+    callerRole: input.auth?.role ?? null,
+    callerClientId: input.auth?.clientId ?? null,
+    callerTokenClientId: input.auth?.tokenClientId ?? null,
+    callerAgentId: input.auth?.agentId ?? null,
+    namespaceSource: input.auth?.namespaceSource ?? null,
+    declaredParameterKeys: declared,
+    unknownParameterCount,
+    payloadSizeBucket: payloadSizeBucket(input.args),
+  };
+}
+
+export function installMcpAudit(server: McpServer, deps: McpAuditDeps): void {
+  const config = deps.config ?? readMcpAuditConfig();
+  if (!config.enabled) return;
+
+  const original = server.registerTool.bind(server) as RegisterTool;
+  server.registerTool = ((name: string, configOrDescription: unknown, cb?: unknown) => {
+    if (typeof cb !== "function") {
+      return (original as unknown as (...args: unknown[]) => unknown)(
+        name,
+        configOrDescription,
+        cb,
+      );
+    }
+
+    const declaredKeys = declaredParameterKeys(
+      (configOrDescription as { inputSchema?: unknown } | undefined)
+        ?.inputSchema,
+    );
+    const callback = cb as (args: unknown, extra: unknown) => unknown;
+    const wrapped = async (args: unknown, extra: unknown) => {
+      const started = Date.now();
+      const auth = (extra as { authInfo?: AuthInfo } | undefined)?.authInfo;
+      try {
+        const result = await callback(args, extra);
+        const status = isToolError(result) ? "error" : "success";
+        void writeMcpAudit(deps, config, summarizeMcpAudit({
+          operation: name,
+          status,
+          durationMs: Date.now() - started,
+          auth,
+          declaredKeys,
+          args,
+        }));
+        return result;
+      } catch (err) {
+        void writeMcpAudit(deps, config, summarizeMcpAudit({
+          operation: name,
+          status: "exception",
+          durationMs: Date.now() - started,
+          auth,
+          declaredKeys,
+          args,
+        }));
+        throw err;
+      }
+    };
+
+    return (original as unknown as (...args: unknown[]) => unknown)(
+      name,
+      configOrDescription,
+      wrapped,
+    );
+  }) as RegisterTool;
+}
+
+function isToolError(result: unknown): boolean {
+  return Boolean(
+    result &&
+      typeof result === "object" &&
+      (result as { isError?: unknown }).isError === true,
+  );
+}
+
+async function writeMcpAudit(
+  deps: McpAuditDeps,
+  config: McpAuditConfig,
+  summary: McpAuditSummary,
+): Promise<void> {
+  try {
+    maybeCleanupAuditLog(deps, config);
+    await deps.pool.query(
+      `INSERT INTO mcp_tool_audit_log (
+        operation,
+        status,
+        duration_ms,
+        caller_role,
+        caller_client_id,
+        caller_token_client_id,
+        caller_agent_id,
+        namespace_source,
+        declared_parameter_keys,
+        unknown_parameter_count,
+        payload_size_bucket
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11)`,
+      [
+        summary.operation,
+        summary.status,
+        summary.durationMs,
+        summary.callerRole,
+        summary.callerClientId,
+        summary.callerTokenClientId,
+        summary.callerAgentId,
+        summary.namespaceSource,
+        JSON.stringify(summary.declaredParameterKeys),
+        summary.unknownParameterCount,
+        summary.payloadSizeBucket,
+      ],
+    );
+  } catch (err) {
+    logger.warn("mcp_tool_audit_write_failed", {
+      operation: summary.operation,
+      status: summary.status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function maybeCleanupAuditLog(
+  deps: McpAuditDeps,
+  config: McpAuditConfig,
+): void {
+  const now = (deps.now ?? (() => new Date()))().getTime();
+  if (now - lastCleanupAt < config.cleanupIntervalMs) return;
+  lastCleanupAt = now;
+  void deps.pool
+    .query(
+      `DELETE FROM mcp_tool_audit_log
+       WHERE created_at < NOW() - ($1::int * INTERVAL '1 day')`,
+      [config.retentionDays],
+    )
+    .catch((err: unknown) => {
+      logger.warn("mcp_tool_audit_cleanup_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}

--- a/src/db/migrations/022_mcp_tool_audit_log.sql
+++ b/src/db/migrations/022_mcp_tool_audit_log.sql
@@ -1,0 +1,25 @@
+-- Privacy-safe MCP tool request audit log.
+-- This table records operation metadata only: no request bodies, raw
+-- parameter values, prompt text, file paths, headers, or unknown key names.
+
+CREATE TABLE IF NOT EXISTS mcp_tool_audit_log (
+  id BIGSERIAL PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  operation TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('success', 'error', 'exception')),
+  duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+  caller_role TEXT,
+  caller_client_id TEXT,
+  caller_token_client_id TEXT,
+  caller_agent_id TEXT,
+  namespace_source TEXT,
+  declared_parameter_keys JSONB NOT NULL DEFAULT '[]'::jsonb,
+  unknown_parameter_count INTEGER NOT NULL DEFAULT 0 CHECK (unknown_parameter_count >= 0),
+  payload_size_bucket TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_audit_log_created_at
+  ON mcp_tool_audit_log(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_audit_log_operation_created_at
+  ON mcp_tool_audit_log(operation, created_at DESC);

--- a/src/db/migrations/022_mcp_tool_audit_log.sql
+++ b/src/db/migrations/022_mcp_tool_audit_log.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS mcp_tool_audit_log (
   id BIGSERIAL PRIMARY KEY,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   operation TEXT NOT NULL,
-  status TEXT NOT NULL CHECK (status IN ('success', 'error', 'exception')),
+  status TEXT NOT NULL CHECK (status IN ('success', 'error', 'exception', 'validation_error')),
   duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
   caller_role TEXT,
   caller_client_id TEXT,

--- a/src/tools/__tests__/mcp-audit-log.test.ts
+++ b/src/tools/__tests__/mcp-audit-log.test.ts
@@ -2,18 +2,37 @@ import { describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createBrainServer } from "../../server.ts";
+import { installMcpAudit } from "../../audit-log.ts";
 import { registerAllTools } from "../index.ts";
 import type { AuthInfo } from "../../types.ts";
 
-function auditPool(options: { failAudit?: boolean } = {}) {
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function auditPool(options: {
+  failAudit?: boolean;
+  deferAuditInsert?: Promise<{ rows: unknown[] }>;
+} = {}) {
   const calls: Array<{ sql: string; params: unknown[] }> = [];
   return {
     calls,
     pool: {
       query: async (sql: string, params: unknown[] = []) => {
         calls.push({ sql, params });
-        if (sql.includes("mcp_tool_audit_log")) {
+        const statement = sql.trimStart();
+        if (statement.startsWith("INSERT INTO mcp_tool_audit_log")) {
           if (options.failAudit) throw new Error("audit table unavailable");
+          if (options.deferAuditInsert) return options.deferAuditInsert;
+          return { rows: [] };
+        }
+        if (statement.startsWith("DELETE FROM mcp_tool_audit_log")) {
           return { rows: [] };
         }
         if (sql.includes("INSERT INTO thoughts")) {
@@ -29,8 +48,22 @@ async function setupClient(input: {
   auth: AuthInfo;
   pool: ReturnType<typeof auditPool>["pool"];
   auditEnabled?: boolean;
+  preinstallAuditTimes?: number;
+  writeTimeoutMs?: number;
 }) {
+  const writeTimeoutMs = input.writeTimeoutMs ?? 1000;
   const server = createBrainServer();
+  for (let i = 0; i < (input.preinstallAuditTimes ?? 0); i += 1) {
+    installMcpAudit(server, {
+      pool: input.pool as any,
+      config: {
+        enabled: true,
+        retentionDays: 30,
+        cleanupIntervalMs: 60_000,
+        writeTimeoutMs,
+      },
+    });
+  }
   registerAllTools(server, {
     pool: input.pool as any,
     embedFn: async () => null,
@@ -38,6 +71,7 @@ async function setupClient(input: {
       enabled: input.auditEnabled ?? true,
       retentionDays: 30,
       cleanupIntervalMs: 60_000,
+      writeTimeoutMs,
     },
   });
   const [clientTransport, serverTransport] =
@@ -122,6 +156,54 @@ describe("MCP tool audit logging", () => {
       });
       expect(result.isError).toBeFalsy();
     } finally {
+      await cleanup();
+    }
+  });
+
+  test("installing the audit wrapper twice records one audit row per call", async () => {
+    const store = auditPool();
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      preinstallAuditTimes: 2,
+      auth: { role: "admin", clientId: "rico" },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: { content: "logged once" },
+      });
+      expect(result.isError).toBeFalsy();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      await cleanup();
+    }
+
+    const inserts = store.calls.filter((call) =>
+      call.sql.includes("INSERT INTO mcp_tool_audit_log"),
+    );
+    expect(inserts).toHaveLength(1);
+  });
+
+  test("slow audit writes are bounded by the write timeout", async () => {
+    const insert = deferred<{ rows: unknown[] }>();
+    const store = auditPool({ deferAuditInsert: insert.promise });
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      writeTimeoutMs: 50,
+      auth: { role: "admin", clientId: "rico" },
+    });
+
+    try {
+      // Without the bounded write timeout this call would never resolve,
+      // because the audit insert promise stays pending.
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: { content: "audit insert hangs" },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      insert.resolve({ rows: [] });
       await cleanup();
     }
   });

--- a/src/tools/__tests__/mcp-audit-log.test.ts
+++ b/src/tools/__tests__/mcp-audit-log.test.ts
@@ -135,11 +135,50 @@ describe("MCP tool audit logging", () => {
       "worker-269",
       "header",
       JSON.stringify(["content", "namespace", "source_refs", "tags"]),
+      // All argument keys are declared, so the RAW-args unknown count is 0.
       0,
-      expect.stringMatching(/^le_|^gt_|^0b$/),
+      // Bucket of the RAW request arguments (~100 bytes of JSON).
+      "le_128b",
     ]);
     expect(JSON.stringify(insert?.params)).not.toContain("raw prompt text");
     expect(JSON.stringify(insert?.params)).not.toContain("token-shaped-secret");
+  });
+
+  test("counts undeclared keys and buckets raw payload size before Zod stripping", async () => {
+    const store = auditPool();
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      auth: { role: "agent", clientId: "rico" },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: {
+          content: "small declared value",
+          // Undeclared key with a large value: Zod strips it before the tool
+          // handler runs, so only the raw-args capture can see it.
+          undeclared_probe_key: "x".repeat(5000),
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      await cleanup();
+    }
+
+    const insert = store.calls.find((call) =>
+      call.sql.includes("INSERT INTO mcp_tool_audit_log"),
+    );
+    expect(insert).toBeDefined();
+    // unknown_parameter_count reflects the RAW request arguments.
+    expect(insert?.params[9]).toBe(1);
+    // payload_size_bucket reflects the RAW ~5KB payload, not the post-strip
+    // ~50-byte parsed args (which would bucket as le_128b).
+    expect(insert?.params[10]).toBe("le_16kb");
+    expect(JSON.stringify(insert?.params)).not.toContain(
+      "undeclared_probe_key",
+    );
   });
 
   test("audit write failures fail open for user-facing tool calls", async () => {
@@ -183,6 +222,77 @@ describe("MCP tool audit logging", () => {
       call.sql.includes("INSERT INTO mcp_tool_audit_log"),
     );
     expect(inserts).toHaveLength(1);
+  });
+
+  test("shares the retention cleanup clock across sessions on one pool", async () => {
+    const store = auditPool();
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    // Two installMcpAudit calls on two separate server instances (fresh
+    // server per MCP session, as in src/index.ts serverFactory) sharing one
+    // pool must share one cleanup interval clock.
+    const sessionOne = await setupClient({ pool: store.pool, auth });
+    const sessionTwo = await setupClient({ pool: store.pool, auth });
+
+    const countDeletes = () =>
+      store.calls.filter((call) =>
+        call.sql.trimStart().startsWith("DELETE FROM mcp_tool_audit_log"),
+      ).length;
+
+    try {
+      const first = await sessionOne.client.callTool({
+        name: "log_thought",
+        arguments: { content: "session one call" },
+      });
+      expect(first.isError).toBeFalsy();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(countDeletes()).toBe(1);
+
+      const second = await sessionTwo.client.callTool({
+        name: "log_thought",
+        arguments: { content: "session two call" },
+      });
+      expect(second.isError).toBeFalsy();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Second session's first call must NOT re-trigger the retention DELETE
+      // within the cleanup interval.
+      expect(countDeletes()).toBe(1);
+    } finally {
+      await sessionOne.cleanup();
+      await sessionTwo.cleanup();
+    }
+  });
+
+  test("skips audit writes above the in-flight cap instead of queueing", async () => {
+    const insert = deferred<{ rows: unknown[] }>();
+    const store = auditPool({ deferAuditInsert: insert.promise });
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      writeTimeoutMs: 50,
+      auth: { role: "admin", clientId: "rico" },
+    });
+
+    try {
+      // Audit INSERTs never resolve, so in-flight writes accumulate until the
+      // cap (16); the remaining calls must skip their audit write entirely
+      // while still succeeding for the caller.
+      const results = await Promise.all(
+        Array.from({ length: 20 }, (_, index) =>
+          client.callTool({
+            name: "log_thought",
+            arguments: { content: `call ${index}` },
+          }),
+        ),
+      );
+      for (const result of results) expect(result.isError).toBeFalsy();
+    } finally {
+      insert.resolve({ rows: [] });
+      await cleanup();
+    }
+
+    const inserts = store.calls.filter((call) =>
+      call.sql.includes("INSERT INTO mcp_tool_audit_log"),
+    );
+    expect(inserts).toHaveLength(16);
   });
 
   test("slow audit writes are bounded by the write timeout", async () => {

--- a/src/tools/__tests__/mcp-audit-log.test.ts
+++ b/src/tools/__tests__/mcp-audit-log.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createBrainServer } from "../../server.ts";
+import { registerAllTools } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+function auditPool(options: { failAudit?: boolean } = {}) {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  return {
+    calls,
+    pool: {
+      query: async (sql: string, params: unknown[] = []) => {
+        calls.push({ sql, params });
+        if (sql.includes("mcp_tool_audit_log")) {
+          if (options.failAudit) throw new Error("audit table unavailable");
+          return { rows: [] };
+        }
+        if (sql.includes("INSERT INTO thoughts")) {
+          return { rows: [{ id: "audit-test-id", is_new: true, source_refs: [] }] };
+        }
+        return { rows: [] };
+      },
+    },
+  };
+}
+
+async function setupClient(input: {
+  auth: AuthInfo;
+  pool: ReturnType<typeof auditPool>["pool"];
+  auditEnabled?: boolean;
+}) {
+  const server = createBrainServer();
+  registerAllTools(server, {
+    pool: input.pool as any,
+    embedFn: async () => null,
+    mcpAuditConfig: {
+      enabled: input.auditEnabled ?? true,
+      retentionDays: 30,
+      cleanupIntervalMs: 60_000,
+    },
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: any, options?: any) =>
+    originalSend(message, { ...options, authInfo: input.auth });
+
+  const client = new Client({ name: "audit-test", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("MCP tool audit logging", () => {
+  test("records safe metadata for a successful tool call", async () => {
+    const store = auditPool();
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      auth: {
+        role: "admin",
+        clientId: "delegated",
+        tokenClientId: "rico",
+        agentId: "worker-269",
+        namespaceSource: "header",
+      },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: {
+          content: "raw prompt text must not be audited",
+          tags: ["token-shaped-secret"],
+          namespace: "delegated",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      await cleanup();
+    }
+
+    const insert = store.calls.find((call) =>
+      call.sql.includes("INSERT INTO mcp_tool_audit_log"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert?.params).toEqual([
+      "log_thought",
+      "success",
+      expect.any(Number),
+      "admin",
+      "delegated",
+      "rico",
+      "worker-269",
+      "header",
+      JSON.stringify(["content", "namespace", "source_refs", "tags"]),
+      0,
+      expect.stringMatching(/^le_|^gt_|^0b$/),
+    ]);
+    expect(JSON.stringify(insert?.params)).not.toContain("raw prompt text");
+    expect(JSON.stringify(insert?.params)).not.toContain("token-shaped-secret");
+  });
+
+  test("audit write failures fail open for user-facing tool calls", async () => {
+    const store = auditPool({ failAudit: true });
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      auth: { role: "admin", clientId: "rico" },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: { content: "still succeeds" },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("disable control suppresses audit writes", async () => {
+    const store = auditPool();
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      auditEnabled: false,
+      auth: { role: "admin", clientId: "rico" },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: { content: "not audited" },
+      });
+      expect(result.isError).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+
+    expect(
+      store.calls.some((call) => call.sql.includes("mcp_tool_audit_log")),
+    ).toBe(false);
+  });
+});

--- a/src/tools/__tests__/mcp-audit-log.test.ts
+++ b/src/tools/__tests__/mcp-audit-log.test.ts
@@ -273,8 +273,8 @@ describe("MCP tool audit logging", () => {
 
     try {
       // Audit INSERTs never resolve, so in-flight writes accumulate until the
-      // cap (16); the remaining calls must skip their audit write entirely
-      // while still succeeding for the caller.
+      // cap (4, kept below the pool size); the remaining calls must skip
+      // their audit write entirely while still succeeding for the caller.
       const results = await Promise.all(
         Array.from({ length: 20 }, (_, index) =>
           client.callTool({
@@ -292,7 +292,88 @@ describe("MCP tool audit logging", () => {
     const inserts = store.calls.filter((call) =>
       call.sql.includes("INSERT INTO mcp_tool_audit_log"),
     );
-    expect(inserts).toHaveLength(16);
+    expect(inserts).toHaveLength(4);
+  });
+
+  test("skips audit writes while the pool has waiting clients", async () => {
+    const store = auditPool();
+    (store.pool as { waitingCount?: number }).waitingCount = 2;
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      auth: { role: "admin", clientId: "rico" },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: { content: "pool is saturated" },
+      });
+      expect(result.isError).toBeFalsy();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      await cleanup();
+    }
+
+    expect(
+      store.calls.some((call) =>
+        call.sql.includes("INSERT INTO mcp_tool_audit_log"),
+      ),
+    ).toBe(false);
+  });
+
+  test("audits Zod validation failures as validation_error without raw values", async () => {
+    const store = auditPool();
+    const { client, cleanup } = await setupClient({
+      pool: store.pool,
+      auth: {
+        role: "admin",
+        clientId: "delegated",
+        tokenClientId: "rico",
+        agentId: "worker-269",
+        namespaceSource: "header",
+      },
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "log_thought",
+        arguments: {
+          // Invalid type for a declared key plus an undeclared probe key:
+          // this call fails Zod validation and never reaches the handler.
+          content: 987654,
+          undeclared_probe_key: "secret-shaped-value",
+        },
+      });
+      // The caller still gets the normal validation error result.
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain(
+        "Input validation error",
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      await cleanup();
+    }
+
+    const insert = store.calls.find((call) =>
+      call.sql.includes("INSERT INTO mcp_tool_audit_log"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert?.params[0]).toBe("log_thought");
+    expect(insert?.params[1]).toBe("validation_error");
+    // No auth context exists at the validation hook layer (the SDK calls it
+    // without request extra), so caller fields are null even though the
+    // transport carried authInfo.
+    expect(insert?.params[3]).toBeNull();
+    expect(insert?.params[4]).toBeNull();
+    expect(insert?.params[5]).toBeNull();
+    expect(insert?.params[6]).toBeNull();
+    expect(insert?.params[7]).toBeNull();
+    // Raw-args facts: the undeclared probe key is counted, never named.
+    expect(insert?.params[9]).toBe(1);
+    const persisted = JSON.stringify(insert?.params);
+    expect(persisted).not.toContain("undeclared_probe_key");
+    expect(persisted).not.toContain("secret-shaped-value");
+    expect(persisted).not.toContain("987654");
   });
 
   test("slow audit writes are bounded by the write timeout", async () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -58,6 +58,7 @@ import {
 } from "./agent-context-pack.ts";
 import { WorkingSetStore } from "../realtime/working-set.ts";
 import { RecoveryWalStore } from "../realtime/recovery-wal.ts";
+import { installMcpAudit, type McpAuditConfig } from "../audit-log.ts";
 
 export interface ToolDeps {
   pool: pg.Pool;
@@ -67,6 +68,7 @@ export interface ToolDeps {
   recoveryWalStore?: RecoveryWalStore;
   natsRuntimeBoundary?: NatsRuntimeBoundary;
   natsBridgeHealth?: NatsBridgeHealth;
+  mcpAuditConfig?: McpAuditConfig;
 }
 
 export function registerAllTools(server: McpServer, deps: ToolDeps): void {
@@ -79,6 +81,11 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
         walPath: process.env.OPENBRAIN_RECOVERY_WAL_PATH ?? null,
       }),
   };
+
+  installMcpAudit(server, {
+    pool: toolDeps.pool,
+    config: toolDeps.mcpAuditConfig,
+  });
 
   registerLogThought(server, toolDeps);
   registerLogDecision(server, toolDeps);

--- a/src/validation-errors.ts
+++ b/src/validation-errors.ts
@@ -5,6 +5,7 @@ import {
   safeParseAsync,
 } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { captureRawArgsForAudit } from "./audit-log.ts";
 
 export interface ValidationFieldIssue {
   field: string;
@@ -115,5 +116,10 @@ export async function validateToolInputWithSummary(
       formatValidationSummary(summary),
     );
   }
+  // This hook is the only repo-owned layer that still sees the RAW
+  // request.params.arguments (Zod strips undeclared keys from parsed data).
+  // Capture raw-args audit facts keyed by the parsed-data object, which the
+  // SDK hands unchanged to the tool handler where the audit wrapper runs.
+  captureRawArgsForAudit(args, parseResult.data);
   return parseResult.data;
 }


### PR DESCRIPTION
## Summary

- add privacy-safe MCP/tool audit summaries for registered tool calls
- persist only operation metadata: status, duration, caller identity, namespace source, declared parameter keys, unknown parameter count, and coarse payload size bucket
- add a fail-open audit writer with retention cleanup and disable/retention environment controls
- add migration `022_mcp_tool_audit_log.sql` plus focused privacy and protocol tests

Closes #269.

## Validation

Re-run at head `4df18f0` (hardening: bounded audit write timeout, cleanup retry state, double-install guard, operator docs):

- `bun test src/audit-log.test.ts src/tools/__tests__/mcp-audit-log.test.ts src/tools/__tests__/protocol.test.ts` - PASS, 26 pass / 0 fail (71 expect calls)
- `bunx tsc --noEmit` - PASS
- `bun test` - PASS, 1215 pass / 54 skip / 0 fail (1269 tests across 88 files)
- `git diff --check` - PASS
- `git diff --cached --check` - PASS before commit

## Critical self-review

- Highest-risk behavior: audit logging could accidentally persist raw prompts, values, secrets, file paths, or attacker-controlled unknown key names.
- Assumptions that could be wrong: declared parameter key names are acceptable metadata because they come from registered tool schemas, not caller payloads.
- Missing/weak tests: no live database migration smoke was run; migration is covered by SQL review and local test fakes rather than a live Postgres apply.
- Security/permission risk: caller identity fields are operational metadata; request bodies and values are deliberately omitted. Unknown caller key names are counted, not stored.
- Migration\/deploy risk: adds table `mcp_tool_audit_log`. Note: migration 022 was amended in place during review (status CHECK gained 'validation_error'); envs that applied the earlier branch version need the constraint re-added or table dropped — main\/prod never ran 022; deploy/release must run migrations through the normal release tag path.
- Downstream client/runtime risk: no MCP tool contract, input schema, output shape, Python client, or transport behavior changes. Operators may see new audit rows only after release/deploy.
- Rollback/cleanup concern: rollback removes the table wiring and tests; a DB rollback would leave an unused audit table unless explicitly dropped in a later migration.
- Fixes made before PR: added fail-open write behavior, disable control, retention cleanup, payload bucketing, and tests proving raw values and unknown key names are not persisted.
- Known residual risk: hosted migration/live smoke is intentionally deferred until the approved release tag/deploy phase.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding has been produced yet; PR remains draft until review swarm completes.

## Downstream rollout classification

Checked `docs/downstream-rollout.md`.

- Applies partially because this PR adds a database migration that affects runtime/operator behavior.
- Does not change public MCP tool names, tool schemas, output envelopes, streamable HTTP behavior, Python client behavior, generated skills, or Hermes call shapes.
- Local Open Brain verification is complete.
- Hosted Open Brain deploy, live DB migration, mcp2cli refresh, rtech-mcps handoff, rtech-hermes changes, Hermes rollout, and live canaries are not run in this PR. They remain release-phase work after merge, via the approved v* release tag path.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured: no review swarm has run yet; PR remains draft until standard review completes.
- [ ] Initial review swarm complete
- [ ] Material findings fixed or explicitly deferred
- [ ] Fix verification complete
- [ ] CI passed for this PR head
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is local-first sprint work; no core01 deploy or live DB mutation is approved for this PR.

## No deploy / release note

No core01 deploy is performed by this PR. The sprint remains local branches, PRs, and CI first. After the sprint issues are merged and verified, the release step is a v* tag.