### PR TITLE
feat: add operator doctor/status surface

### DIFF
--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -44,7 +44,7 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-07-06.memory-tools.v19"
+CURRENT_CONTRACT_VERSION = "2026-07-08.memory-tools.v20"
 COMPATIBLE_CONTRACT_VERSIONS = (CURRENT_CONTRACT_VERSION,)
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
@@ -57,6 +57,7 @@ REQUIRED_CONTRACT_TOOLS = (
     "lane_upsert",
     "list_repo_facts",
     "log_thought",
+    "operator_doctor",
     "recovery_wal_append",
     "recovery_wal_mark",
     "search_all",
@@ -90,6 +91,7 @@ CURRENT_TOOL_HELP: Mapping[str, str] = {
     "list_entities": "List graph entities by type, name, or namespace.",
     "list_repo_facts": "Read curated qmd-derived repository facts.",
     "log_thought": "Write a durable thought or observation to Open Brain.",
+    "operator_doctor": "Read privileged Open Brain operator doctor/status JSON.",
     "recovery_wal_append": (
         "Append exact-scope quarantined recovery evidence, not durable memory."
     ),
@@ -1027,6 +1029,9 @@ class OpenBrainClient:
 
     def get_contract(self, **arguments: Any) -> JSON:
         return self.call_tool("get_contract", arguments)
+
+    def operator_doctor(self, **arguments: Any) -> JSON:
+        return self.call_tool("operator_doctor", arguments)
 
     def get_stats(self, **arguments: Any) -> JSON:
         return self.call_tool("get_stats", arguments)

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -1407,6 +1407,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
         "find_duplicates",
         "find_person",
         "get_contract",
+        "operator_doctor",
         "get_entry",
         "resolve_entry",
         "get_entity",
@@ -1453,7 +1454,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-07-06.memory-tools.v19"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-08.memory-tools.v20"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -11,7 +11,7 @@ from openbrain_memory import (
     validate_required_memory_contract,
 )
 
-CURRENT_CLIENT_VERSION = "0.1.4"
+CURRENT_CLIENT_VERSION = "0.1.6"
 
 
 def safe_string_display(value: str) -> str:
@@ -32,7 +32,7 @@ def representative_contract_manifest() -> dict:
             "rtech-hermes-runtime": "0.1.0",
         },
         "compatible_client_ranges": {
-            "openbrain-memory": ">=0.1.4 <1.0.0",
+            "openbrain-memory": ">=0.1.6 <1.0.0",
             "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
         },
         "transport": {
@@ -246,7 +246,7 @@ def test_validate_contract_manifest_reports_min_client_version_failure():
         f"{safe_string_display(CURRENT_CLIENT_VERSION)}",
         "openbrain-memory "
         f"{safe_string_display('0.0.9')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.4 <1.0.0')}",
+        f"{safe_string_display('>=0.1.6 <1.0.0')}",
     )
 
 
@@ -259,7 +259,7 @@ def test_validate_contract_manifest_reports_compatible_range_failure():
     assert result.reasons == (
         "openbrain-memory "
         f"{safe_string_display('1.0.0')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.4 <1.0.0')}",
+        f"{safe_string_display('>=0.1.6 <1.0.0')}",
     )
 
 

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -19,6 +19,14 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     input_schema: {},
     output_shape: "OpenBrainContract JSON text payload",
   },
+  operator_doctor: {
+    version: 1,
+    input_schema: {},
+    output_shape:
+      "privileged operator doctor/status JSON text payload with stable " +
+      "runtime, database, migrations, optional provider, transport, and " +
+      "log/audit health fields; secrets and raw paths are redacted/omitted",
+  },
   working_set_append: {
     version: 1,
     input_schema: {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,7 +13,7 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "45224e3f2ae54daf2c2c3706340e6610879f8a98fe29af77b5cf0b3e98ae48b9",
+      "240112d2dbe4d203731a2889c56f089f279963e6b1cf08cc7a1881c2368345a7",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
     expect(contract.transport.namespace_boundary).toBe("authorization");
@@ -497,7 +497,7 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-07-06.memory-tools.v19");
+    expect(contract.contract_version).toBe("2026-07-08.memory-tools.v20");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,9 +13,13 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "240112d2dbe4d203731a2889c56f089f279963e6b1cf08cc7a1881c2368345a7",
+      "4df9c742add84e2bbc3495a9baad8f103ee191a82518ea43c754a7fbb961bb48",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
+    expect(contract.min_client_versions["openbrain-memory"]).toBe("0.1.6");
+    expect(contract.compatible_client_ranges["openbrain-memory"]).toBe(
+      ">=0.1.6 <1.0.0",
+    );
     expect(contract.transport.namespace_boundary).toBe("authorization");
     expect(contract.realtime_transport.nats_jetstream).toMatchObject({
       status: "planned-transport-foundation",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-07-06.memory-tools.v19";
+export const CONTRACT_VERSION = "2026-07-08.memory-tools.v20";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -252,6 +252,15 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
     version: 1,
     kind: "tool",
     description: "Read the canonical Open Brain public contract manifest.",
+  },
+  {
+    name: "operator_doctor",
+    version: 1,
+    kind: "tool",
+    description:
+      "Read privileged operator doctor/status JSON for runtime, database, " +
+      "migrations, optional providers, transport, and log/audit health. " +
+      "Requires admin or ob-admin auth and never returns secrets or raw paths.",
   },
   {
     name: "get_entry",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -513,12 +513,12 @@ export function buildContract(
     contract_scope: "required_openbrain_memory_contract" as const,
     schema_version: CONTRACT_SCHEMA_VERSION,
     min_client_versions: {
-      "openbrain-memory": "0.1.4",
+      "openbrain-memory": "0.1.6",
       "rtech-hermes-runtime": "0.1.0",
       mcp2cli: "0.3.6",
     },
     compatible_client_ranges: {
-      "openbrain-memory": ">=0.1.4 <1.0.0",
+      "openbrain-memory": ">=0.1.6 <1.0.0",
       "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
       mcp2cli: ">=0.3.6 <1.0.0",
     },

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -218,6 +218,31 @@ export function __setEmbeddingWatchdogRestartSpawnerForTests(
   restartProcessSpawner = spawner;
 }
 
+export function getEmbeddingProviderDiagnostics(): {
+  configured: boolean;
+  model: string;
+  dimensions: number;
+  last_failure_code: EmbeddingError["code"] | null;
+  consecutive_restartable_failures: number;
+  restart_configured: boolean;
+  restart_in_flight: boolean;
+  last_restart_at: string | null;
+} {
+  return {
+    configured: Boolean(embeddingBaseUrl()),
+    model: EMBEDDING_MODEL,
+    dimensions: EMBEDDING_DIMENSIONS,
+    last_failure_code: lastFailureCode,
+    consecutive_restartable_failures: consecutiveRestartableFailures,
+    restart_configured: Boolean(process.env.EMBEDDING_WATCHDOG_RESTART_SCRIPT),
+    restart_in_flight: watchdogRestartInFlight,
+    last_restart_at:
+      lastWatchdogRestartAt > 0
+        ? new Date(lastWatchdogRestartAt).toISOString()
+        : null,
+  };
+}
+
 function embeddingFailure(error: EmbeddingError): EmbeddingResult {
   recordWatchdogFailure(error);
   return { embedding: null, error };

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -248,12 +248,12 @@ function embeddingFailure(error: EmbeddingError): EmbeddingResult {
   return { embedding: null, error };
 }
 
-function embeddingBaseUrl(explicitUrl?: string): string | undefined {
+export function embeddingBaseUrl(explicitUrl?: string): string | undefined {
   const raw = explicitUrl ?? process.env.EMBEDDING_BASE_URL;
   return raw?.replace(/\/+$/, "");
 }
 
-function embeddingApiKey(): string | undefined {
+export function embeddingApiKey(): string | undefined {
   return process.env.EMBEDDING_API_KEY;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./nats-bridge.ts";
 import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
+import { buildOperatorDoctorStatus } from "./operator-doctor.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
 
@@ -130,6 +131,31 @@ export function createApp(
   const auth = authMiddleware(tokenMap);
 
   // REST API -- no MCP handshake required
+  app.get(
+    "/api/v1/operator/doctor",
+    auth,
+    async (req: Request, res: Response) => {
+      const authInfo = (req as Request & { auth?: AuthInfo }).auth;
+      if (authInfo?.role !== "admin" && authInfo?.role !== "ob-admin") {
+        res
+          .status(403)
+          .json({ error: "Permission denied: admin or ob-admin role required" });
+        return;
+      }
+      try {
+        const status = await buildOperatorDoctorStatus(
+          pool,
+          natsRuntimeBoundary,
+          toolDeps.natsBridgeHealth,
+        );
+        res.status(200).json(status);
+      } catch {
+        // Never surface raw error messages (they can carry paths or env
+        // detail); the doctor payload itself is the diagnostic surface.
+        res.status(500).json({ error: "operator doctor status unavailable" });
+      }
+    },
+  );
   app.use("/api/v1", auth, createRestRouter(toolDeps));
   app.use("/api/v1", auth, createPromotionRouter(toolDeps));
   app.use(

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { requestLogger } from "./middleware/request-logger.ts";
 import { createRestRouter } from "./rest-api.ts";
 import { createPromotionRouter } from "./rest-promotion.ts";
 import {
+  isRequestedTransportDegraded,
   readNatsRuntimeBoundary,
   summarizeNatsUrlForLog,
 } from "./nats-runtime.ts";
@@ -24,7 +25,7 @@ import {
 } from "./nats-bridge.ts";
 import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
-import { buildOperatorDoctorStatus } from "./operator-doctor.ts";
+import { canReadDoctor, getOperatorDoctorStatus } from "./operator-doctor.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
 
@@ -100,9 +101,10 @@ export function createApp(
     const natsAvailability =
       toolDeps.natsBridgeHealth?.availability ??
       natsRuntimeBoundary.nats.availability;
-    const natsDegraded =
-      natsRuntimeBoundary.requested_transport === "nats" &&
-      natsAvailability !== "available";
+    const natsDegraded = isRequestedTransportDegraded(
+      natsRuntimeBoundary,
+      natsAvailability,
+    );
     const status: HealthStatus = {
       status: dbHealth.connected && !natsDegraded ? "healthy" : "degraded",
       server_ip: ips[0] ?? "unknown",
@@ -136,19 +138,21 @@ export function createApp(
     auth,
     async (req: Request, res: Response) => {
       const authInfo = (req as Request & { auth?: AuthInfo }).auth;
-      if (authInfo?.role !== "admin" && authInfo?.role !== "ob-admin") {
+      if (!canReadDoctor(authInfo)) {
         res
           .status(403)
           .json({ error: "Permission denied: admin or ob-admin role required" });
         return;
       }
       try {
-        const status = await buildOperatorDoctorStatus(
+        const status = await getOperatorDoctorStatus(
           pool,
           natsRuntimeBoundary,
           toolDeps.natsBridgeHealth,
         );
-        res.status(200).json(status);
+        // Mirror /health: monitoring that alarms on status code must see a
+        // non-200 whenever the body is not fully healthy.
+        res.status(status.status === "healthy" ? 200 : 503).json(status);
       } catch {
         // Never surface raw error messages (they can carry paths or env
         // detail); the doctor payload itself is the diagnostic surface.

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -180,6 +180,19 @@ function normalizeNatsHostname(hostname: string): string {
   return hostname.toLowerCase();
 }
 
+// Shared "requested transport is degraded" predicate. Consumed by both
+// GET /health and the operator doctor so their degradation logic cannot
+// diverge: degraded means NATS was explicitly requested but the runtime
+// bridge is not available.
+export function isRequestedTransportDegraded(
+  boundary: NatsRuntimeBoundary,
+  availability: NatsRuntimeBoundary["nats"]["availability"],
+): boolean {
+  return (
+    boundary.requested_transport === "nats" && availability !== "available"
+  );
+}
+
 export function readNatsRuntimeBoundary(
   env: NodeJS.ProcessEnv,
 ): NatsRuntimeBoundary {

--- a/src/operator-doctor.test.ts
+++ b/src/operator-doctor.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { buildOperatorDoctorStatus } from "./operator-doctor.ts";
+import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
+
+const originalFetch = globalThis.fetch;
+
+function makePool(appliedFilenames: string[]) {
+  return {
+    totalCount: 1,
+    idleCount: 1,
+    waitingCount: 0,
+    query: async (sql: string) => {
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      if (sql.includes("FROM _migrations")) {
+        return { rows: appliedFilenames.map((filename) => ({ filename })) };
+      }
+      return { rows: [] };
+    },
+  } as any;
+}
+
+function makePoolWithUnknownMigrations() {
+  return {
+    totalCount: 1,
+    idleCount: 1,
+    waitingCount: 0,
+    query: async (sql: string) => {
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      if (sql.includes("FROM _migrations")) throw new Error("not available");
+      return { rows: [] };
+    },
+  } as any;
+}
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).fetch = originalFetch;
+  delete process.env.EMBEDDING_BASE_URL;
+  delete process.env.EMBEDDING_API_KEY;
+  delete process.env.QMD_PATH;
+  delete process.env.LOG_FILE;
+  delete process.env.LOG_MAX_BYTES;
+  delete process.env.LOG_MAX_FILES;
+});
+
+describe("operator doctor status", () => {
+  it("returns stable privileged JSON without raw env values or sensitive paths", async () => {
+    const secret = "doctor-secret-token";
+    const embeddingHost = "embedding.internal";
+    const logPath = "/sensitive/open-brain.log";
+    process.env.EMBEDDING_BASE_URL = `http://${embeddingHost}:8791/v1`;
+    process.env.EMBEDDING_API_KEY = secret;
+    process.env.LOG_FILE = logPath;
+    process.env.LOG_MAX_BYTES = "1000";
+
+    (globalThis as Record<string, unknown>).fetch = (
+      input: string | URL | globalThis.Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      expect(url).toContain("/models");
+      expect(init?.headers).toMatchObject({ Authorization: `Bearer ${secret}` });
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    };
+
+    const status = await buildOperatorDoctorStatus(
+      makePool(["001_init.sql"]),
+      readNatsRuntimeBoundary({}),
+    );
+    const serialized = JSON.stringify(status);
+
+    expect(status.contract_version).toBe("2026-07-08.operator-doctor.v1");
+    expect(status.runtime.contract_version).toBe("2026-07-08.memory-tools.v20");
+    expect(status.database.connected).toBe(true);
+    expect(status.embedding_provider).toMatchObject({
+      configured: true,
+      available: true,
+    });
+    expect(status.log_audit).toMatchObject({
+      request_logger: "enabled",
+      file_log_configured: true,
+      rotation_configured: true,
+      audit_storage: "not_available",
+    });
+    expect(status.qmd.status).toBe("not_configured");
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain(embeddingHost);
+    expect(serialized).not.toContain(logPath);
+  });
+
+  it("bounds optional dependency failures without making the service unhealthy", async () => {
+    process.env.EMBEDDING_BASE_URL = "http://embedding.internal:8791/v1";
+    (globalThis as Record<string, unknown>).fetch = () =>
+      Promise.reject(new Error("connection refused"));
+
+    const status = await buildOperatorDoctorStatus(
+      makePoolWithUnknownMigrations(),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.status).toBe("healthy");
+    expect(status.migrations.status).toBe("unknown");
+    expect(status.embedding_provider.available).toBe(false);
+    expect(status.optional_dependencies.embedding_provider).toBe("unavailable");
+  });
+
+  it("reports pending migrations as degraded operator status", async () => {
+    const status = await buildOperatorDoctorStatus(
+      makePool([]),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.status).toBe("degraded");
+    expect(status.migrations.status).toBe("pending");
+    expect(status.migrations.pending_count).toBeGreaterThan(0);
+    expect(status.migrations.latest_expected).toMatch(/\.sql$/);
+  });
+});

--- a/src/operator-doctor.test.ts
+++ b/src/operator-doctor.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   DOCTOR_CONTRACT_VERSION,
@@ -38,6 +40,13 @@ function makePoolWithUnknownMigrations() {
       return { rows: [] };
     },
   } as any;
+}
+
+// Pool that reports every on-disk migration as applied: migrations "current".
+async function makeCurrentPool() {
+  const migrationsDir = join(dirname(THIS_FILE), "db", "migrations");
+  const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql"));
+  return makePool(files);
 }
 
 function makeDownPool() {
@@ -117,10 +126,11 @@ describe("operator doctor status", () => {
   });
 
   it("resolves qmd via the same search_all resolution and reports missing binaries as unavailable", async () => {
+    delete process.env.EMBEDDING_BASE_URL;
     process.env.QMD_PATH = "/nonexistent/qmd-entrypoint.ts";
 
     const status = await buildOperatorDoctorStatus(
-      makePoolWithUnknownMigrations(),
+      await makeCurrentPool(),
       readNatsRuntimeBoundary({}),
     );
 
@@ -152,20 +162,51 @@ describe("operator doctor status", () => {
     );
   });
 
-  it("bounds optional dependency failures without making the service unhealthy", async () => {
+  it("degrades (never unhealthy) when a configured embedding provider is unavailable", async () => {
     process.env.EMBEDDING_BASE_URL = "http://embedding.internal:8791/v1";
     (globalThis as Record<string, unknown>).fetch = () =>
       Promise.reject(new Error("connection refused"));
+
+    const status = await buildOperatorDoctorStatus(
+      await makeCurrentPool(),
+      readNatsRuntimeBoundary({}),
+    );
+
+    // Configured-but-down embedding hard-fails vector search: degraded,
+    // but never unhealthy -- that tier is reserved for DB failure.
+    expect(status.status).toBe("degraded");
+    expect(status.database.connected).toBe(true);
+    expect(status.migrations.status).toBe("current");
+    expect(status.embedding_provider.available).toBe(false);
+    expect(status.optional_dependencies.embedding_provider).toBe("unavailable");
+  });
+
+  it("stays healthy when the embedding provider is simply not configured", async () => {
+    delete process.env.EMBEDDING_BASE_URL;
+
+    const status = await buildOperatorDoctorStatus(
+      await makeCurrentPool(),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.status).toBe("healthy");
+    expect(status.embedding_provider.configured).toBe(false);
+    expect(status.optional_dependencies.embedding_provider).toBe("not_configured");
+  });
+
+  it("degrades when the DB is connected but migration state is unknown", async () => {
+    delete process.env.EMBEDDING_BASE_URL;
 
     const status = await buildOperatorDoctorStatus(
       makePoolWithUnknownMigrations(),
       readNatsRuntimeBoundary({}),
     );
 
-    expect(status.status).toBe("healthy");
+    // Unknown migration state on a connected DB is an unverified or broken
+    // schema, not a healthy service.
+    expect(status.status).toBe("degraded");
+    expect(status.database.connected).toBe(true);
     expect(status.migrations.status).toBe("unknown");
-    expect(status.embedding_provider.available).toBe(false);
-    expect(status.optional_dependencies.embedding_provider).toBe("unavailable");
   });
 
   it("reports pending migrations as degraded operator status", async () => {

--- a/src/operator-doctor.test.ts
+++ b/src/operator-doctor.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { buildOperatorDoctorStatus } from "./operator-doctor.ts";
+import { fileURLToPath } from "node:url";
+import {
+  DOCTOR_CONTRACT_VERSION,
+  buildOperatorDoctorStatus,
+  canReadDoctor,
+  getOperatorDoctorStatus,
+  resetOperatorDoctorCache,
+} from "./operator-doctor.ts";
 import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 
 const originalFetch = globalThis.fetch;
+const THIS_FILE = fileURLToPath(import.meta.url);
 
 function makePool(appliedFilenames: string[]) {
   return {
@@ -32,6 +40,17 @@ function makePoolWithUnknownMigrations() {
   } as any;
 }
 
+function makeDownPool() {
+  return {
+    totalCount: 0,
+    idleCount: 0,
+    waitingCount: 0,
+    query: async () => {
+      throw new Error("connection refused");
+    },
+  } as any;
+}
+
 afterEach(() => {
   (globalThis as Record<string, unknown>).fetch = originalFetch;
   delete process.env.EMBEDDING_BASE_URL;
@@ -40,6 +59,7 @@ afterEach(() => {
   delete process.env.LOG_FILE;
   delete process.env.LOG_MAX_BYTES;
   delete process.env.LOG_MAX_FILES;
+  resetOperatorDoctorCache();
 });
 
 describe("operator doctor status", () => {
@@ -51,6 +71,7 @@ describe("operator doctor status", () => {
     process.env.EMBEDDING_API_KEY = secret;
     process.env.LOG_FILE = logPath;
     process.env.LOG_MAX_BYTES = "1000";
+    process.env.QMD_PATH = THIS_FILE;
 
     (globalThis as Record<string, unknown>).fetch = (
       input: string | URL | globalThis.Request,
@@ -68,7 +89,7 @@ describe("operator doctor status", () => {
     );
     const serialized = JSON.stringify(status);
 
-    expect(status.contract_version).toBe("2026-07-08.operator-doctor.v1");
+    expect(status.contract_version).toBe("2026-07-08.operator-doctor.v2");
     expect(status.runtime.contract_version).toBe("2026-07-08.memory-tools.v20");
     expect(status.database.connected).toBe(true);
     expect(status.embedding_provider).toMatchObject({
@@ -81,10 +102,54 @@ describe("operator doctor status", () => {
       rotation_configured: true,
       audit_storage: "not_available",
     });
-    expect(status.qmd.status).toBe("not_configured");
+    // QMD_PATH points at an existing file: binary presence only.
+    expect(status.qmd).toEqual({
+      configured: true,
+      path_source: "env",
+      available: true,
+      status: "available",
+    });
     expect(serialized).not.toContain(secret);
     expect(serialized).not.toContain(embeddingHost);
     expect(serialized).not.toContain(logPath);
+    // The resolved qmd path must never appear in the payload.
+    expect(serialized).not.toContain(THIS_FILE);
+  });
+
+  it("resolves qmd via the same search_all resolution and reports missing binaries as unavailable", async () => {
+    process.env.QMD_PATH = "/nonexistent/qmd-entrypoint.ts";
+
+    const status = await buildOperatorDoctorStatus(
+      makePoolWithUnknownMigrations(),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.qmd).toEqual({
+      configured: true,
+      path_source: "env",
+      available: false,
+      status: "unavailable",
+    });
+    expect(status.optional_dependencies.qmd).toBe("unavailable");
+    // qmd is an optional dependency: presence/absence never changes the tier.
+    expect(status.status).toBe("healthy");
+    expect(JSON.stringify(status)).not.toContain("/nonexistent/qmd-entrypoint.ts");
+  });
+
+  it("falls back to the shared default qmd path when QMD_PATH is unset", async () => {
+    delete process.env.QMD_PATH;
+
+    const status = await buildOperatorDoctorStatus(
+      makePool(["001_init.sql"]),
+      readNatsRuntimeBoundary({}),
+    );
+
+    // Unset env is NOT "not configured": search_all runs the default path.
+    expect(status.qmd.configured).toBe(true);
+    expect(status.qmd.path_source).toBe("default");
+    expect(status.qmd.status).toBe(
+      status.qmd.available ? "available" : "unavailable",
+    );
   });
 
   it("bounds optional dependency failures without making the service unhealthy", async () => {
@@ -113,5 +178,187 @@ describe("operator doctor status", () => {
     expect(status.migrations.status).toBe("pending");
     expect(status.migrations.pending_count).toBeGreaterThan(0);
     expect(status.migrations.latest_expected).toMatch(/\.sql$/);
+  });
+
+  it("reports a hard database failure as unhealthy, distinct from degraded", async () => {
+    const status = await buildOperatorDoctorStatus(
+      makeDownPool(),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.status).toBe("unhealthy");
+    expect(status.database.connected).toBe(false);
+  });
+
+  it("locks the exact doctor payload shape to DOCTOR_CONTRACT_VERSION", async () => {
+    // ANY field addition or removal in this payload (top-level or per
+    // section) requires bumping DOCTOR_CONTRACT_VERSION in
+    // src/operator-doctor.ts. Update the version literal and these field
+    // sets together, never one without the other.
+    expect(DOCTOR_CONTRACT_VERSION).toBe("2026-07-08.operator-doctor.v2");
+
+    const status = await buildOperatorDoctorStatus(
+      makePool(["001_init.sql"]),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(Object.keys(status).sort()).toEqual([
+      "contract_version",
+      "database",
+      "embedding_provider",
+      "generated_at",
+      "log_audit",
+      "migrations",
+      "optional_dependencies",
+      "qmd",
+      "runtime",
+      "status",
+      "transport",
+    ]);
+    expect(Object.keys(status.runtime).sort()).toEqual([
+      "contract_schema_version",
+      "contract_version",
+      "node_env",
+      "service",
+      "version",
+    ]);
+    expect(Object.keys(status.database).sort()).toEqual([
+      "connected",
+      "idle",
+      "total",
+      "waiting",
+    ]);
+    expect(Object.keys(status.migrations).sort()).toEqual([
+      "applied_count",
+      "expected_count",
+      "latest_applied",
+      "latest_expected",
+      "pending_count",
+      "status",
+    ]);
+    expect(Object.keys(status.embedding_provider).sort()).toEqual([
+      "available",
+      "configured",
+      "dimensions",
+      "model",
+      "recent_failures",
+    ]);
+    expect(Object.keys(status.embedding_provider.recent_failures).sort()).toEqual([
+      "consecutive_restartable_failures",
+      "last_failure_code",
+      "last_restart_at",
+      "restart_configured",
+      "restart_in_flight",
+    ]);
+    expect(Object.keys(status.qmd).sort()).toEqual([
+      "available",
+      "configured",
+      "path_source",
+      "status",
+    ]);
+    expect(Object.keys(status.transport).sort()).toEqual([
+      "availability",
+      "consecutive_failures",
+      "fallback_http",
+      "last_error",
+      "mode",
+    ]);
+    expect(Object.keys(status.log_audit).sort()).toEqual([
+      "audit_storage",
+      "file_log_configured",
+      "request_logger",
+      "rotation_configured",
+    ]);
+    expect(Object.keys(status.optional_dependencies).sort()).toEqual([
+      "embedding_provider",
+      "qmd",
+    ]);
+  });
+});
+
+describe("operator doctor cache", () => {
+  it("shares one probe cycle across concurrent callers (single-flight)", async () => {
+    resetOperatorDoctorCache();
+    let probeCycles = 0;
+    const pool = {
+      totalCount: 1,
+      idleCount: 1,
+      waitingCount: 0,
+      query: async (sql: string) => {
+        if (sql.trim() === "SELECT 1") {
+          probeCycles += 1;
+          // Keep the build in flight long enough for the second caller to
+          // arrive while the first is still building.
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          return { rows: [{ ok: 1 }] };
+        }
+        if (sql.includes("FROM _migrations")) {
+          return { rows: [{ filename: "001_init.sql" }] };
+        }
+        return { rows: [] };
+      },
+    } as any;
+    const boundary = readNatsRuntimeBoundary({});
+
+    const [first, second] = await Promise.all([
+      getOperatorDoctorStatus(pool, boundary),
+      getOperatorDoctorStatus(pool, boundary),
+    ]);
+
+    expect(probeCycles).toBe(1);
+    expect(first).toBe(second);
+  });
+
+  it("serves cached results within the TTL and rebuilds after expiry", async () => {
+    resetOperatorDoctorCache();
+    let probeCycles = 0;
+    const pool = {
+      totalCount: 1,
+      idleCount: 1,
+      waitingCount: 0,
+      query: async (sql: string) => {
+        if (sql.trim() === "SELECT 1") probeCycles += 1;
+        if (sql.includes("FROM _migrations")) {
+          return { rows: [{ filename: "001_init.sql" }] };
+        }
+        return { rows: [{ ok: 1 }] };
+      },
+    } as any;
+    const boundary = readNatsRuntimeBoundary({});
+    let clock = 0;
+    const options = { ttlMs: 5_000, now: () => clock };
+
+    const first = await getOperatorDoctorStatus(pool, boundary, undefined, options);
+    clock = 4_999;
+    const cached = await getOperatorDoctorStatus(pool, boundary, undefined, options);
+    expect(probeCycles).toBe(1);
+    expect(cached).toBe(first);
+
+    clock = 5_001;
+    const rebuilt = await getOperatorDoctorStatus(pool, boundary, undefined, options);
+    expect(probeCycles).toBe(2);
+    expect(rebuilt).not.toBe(first);
+  });
+
+  it("rebuilds immediately after resetOperatorDoctorCache", async () => {
+    resetOperatorDoctorCache();
+    const boundary = readNatsRuntimeBoundary({});
+    const first = await getOperatorDoctorStatus(makePool(["001_init.sql"]), boundary);
+    resetOperatorDoctorCache();
+    const second = await getOperatorDoctorStatus(makeDownPool(), boundary);
+
+    expect(first.status).toBe("degraded");
+    expect(second.status).toBe("unhealthy");
+    expect(second).not.toBe(first);
+  });
+});
+
+describe("canReadDoctor", () => {
+  it("permits only admin and ob-admin roles", () => {
+    expect(canReadDoctor({ role: "admin", clientId: "a" } as any)).toBe(true);
+    expect(canReadDoctor({ role: "ob-admin", clientId: "b" } as any)).toBe(true);
+    expect(canReadDoctor({ role: "agent", clientId: "c" } as any)).toBe(false);
+    expect(canReadDoctor({ role: "readonly", clientId: "d" } as any)).toBe(false);
+    expect(canReadDoctor(undefined)).toBe(false);
   });
 });

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -5,13 +6,17 @@ import type pg from "pg";
 import { CONTRACT_VERSION, CONTRACT_SCHEMA_VERSION } from "./contract.ts";
 import {
   getEmbeddingProviderDiagnostics,
+  embeddingBaseUrl,
+  embeddingApiKey,
   EMBEDDING_DIMENSIONS,
   EMBEDDING_MODEL,
 } from "./embedding.ts";
 import { checkPoolHealth } from "./db/pool.ts";
+import { resolveQmdPath } from "./qmd-path.ts";
 import type { NatsBridgeHealth } from "./nats-bridge.ts";
 import type { NatsRuntimeBoundary } from "./nats-runtime.ts";
-import type { PoolHealth } from "./types.ts";
+import { isRequestedTransportDegraded } from "./nats-runtime.ts";
+import type { AuthInfo, PoolHealth } from "./types.ts";
 
 const MIGRATIONS_DIR = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -19,8 +24,11 @@ const MIGRATIONS_DIR = join(
   "migrations",
 );
 
-const DOCTOR_CONTRACT_VERSION = "2026-07-08.operator-doctor.v1";
+// Any field addition/removal in OperatorDoctorStatus requires bumping this
+// version. src/operator-doctor.test.ts locks the exact payload shape.
+export const DOCTOR_CONTRACT_VERSION = "2026-07-08.operator-doctor.v2";
 const OPTIONAL_TIMEOUT_MS = 2_000;
+const DOCTOR_CACHE_TTL_MS = 5_000;
 
 let cachedServiceVersion: string | null = null;
 
@@ -40,8 +48,18 @@ async function readServiceVersion(): Promise<string> {
   return cachedServiceVersion;
 }
 
+// Shared privileged-read predicate for the doctor surface. Consumed by both
+// the MCP tool (src/tools/operator-doctor.ts) and the REST route
+// (src/index.ts) so the gates cannot diverge.
+export function canReadDoctor(auth: AuthInfo | undefined): boolean {
+  return auth?.role === "admin" || auth?.role === "ob-admin";
+}
+
 export interface OperatorDoctorStatus {
-  status: "healthy" | "degraded";
+  // unhealthy: the database is unreachable (hard failure).
+  // degraded: pending migrations, or the requested transport is unavailable.
+  // Optional dependencies (embedding provider, qmd) affect neither tier.
+  status: "healthy" | "degraded" | "unhealthy";
   contract_version: string;
   generated_at: string;
   runtime: {
@@ -74,9 +92,16 @@ export interface OperatorDoctorStatus {
     };
   };
   qmd: {
+    // The qmd path always resolves (QMD_PATH env override or the built-in
+    // default used by search_all), so configured is true whenever a path
+    // resolution source exists.
     configured: boolean;
-    available: boolean | null;
-    status: "available" | "unavailable" | "not_configured";
+    path_source: "env" | "default";
+    // available means the qmd entrypoint file exists at the resolved path --
+    // binary presence only, NOT qmd search health. The raw path is never
+    // included in the payload.
+    available: boolean;
+    status: "available" | "unavailable";
   };
   transport: {
     mode: "http" | "nats";
@@ -93,7 +118,7 @@ export interface OperatorDoctorStatus {
   };
   optional_dependencies: {
     embedding_provider: "available" | "unavailable" | "not_configured";
-    qmd: "available" | "unavailable" | "not_configured";
+    qmd: "available" | "unavailable";
   };
 }
 
@@ -102,6 +127,10 @@ async function withTimeout<T>(
   fallback: T,
   timeoutMs = OPTIONAL_TIMEOUT_MS,
 ): Promise<T> {
+  // Absorb late rejections: if the timeout wins the race, a subsequent
+  // rejection of the abandoned task must not surface as an unhandled
+  // rejection.
+  task.catch(() => {});
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
@@ -172,40 +201,31 @@ async function readMigrationStatus(pool: pg.Pool): Promise<OperatorDoctorStatus[
 }
 
 async function checkEmbeddingAvailability(): Promise<boolean> {
-  const baseUrl = process.env.EMBEDDING_BASE_URL?.replace(/\/+$/, "");
+  const baseUrl = embeddingBaseUrl();
   if (!baseUrl) return false;
   const headers: Record<string, string> = {};
-  if (process.env.EMBEDDING_API_KEY) {
-    headers.Authorization = `Bearer ${process.env.EMBEDDING_API_KEY}`;
-  }
+  const apiKey = embeddingApiKey();
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
   return withTimeout(probeUrl(`${baseUrl}/models`, headers), false);
 }
 
-async function checkQmdAvailability(): Promise<boolean | null> {
-  if (!process.env.QMD_PATH) return null;
+// Availability = the qmd entrypoint file exists at the same resolved path
+// search_all executes (src/qmd-path.ts). This proves binary presence only;
+// it does not exercise qmd search health.
+function checkQmdBinaryPresence(): OperatorDoctorStatus["qmd"] {
+  const resolved = resolveQmdPath();
+  let available = false;
   try {
-    const proc = Bun.spawn(["bun", process.env.QMD_PATH, "--help"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const result = await withTimeout(
-      (async () => {
-        await new Response(proc.stdout).text();
-        await new Response(proc.stderr).text();
-        return (await proc.exited) === 0;
-      })(),
-      false,
-    );
-    if (!result) proc.kill();
-    return result;
+    available = existsSync(resolved.path);
   } catch {
-    return false;
+    available = false;
   }
-}
-
-function qmdStatus(available: boolean | null): "available" | "unavailable" | "not_configured" {
-  if (available === null) return "not_configured";
-  return available ? "available" : "unavailable";
+  return {
+    configured: true,
+    path_source: resolved.source,
+    available,
+    status: available ? "available" : "unavailable",
+  };
 }
 
 export async function buildOperatorDoctorStatus(
@@ -213,25 +233,27 @@ export async function buildOperatorDoctorStatus(
   natsRuntimeBoundary: NatsRuntimeBoundary,
   natsBridgeHealth?: NatsBridgeHealth,
 ): Promise<OperatorDoctorStatus> {
-  const [database, migrations, embeddingAvailable, qmdAvailable, serviceVersion] =
+  const [database, migrations, embeddingAvailable, serviceVersion] =
     await Promise.all([
       checkPoolHealth(pool),
       readMigrationStatus(pool),
       checkEmbeddingAvailability(),
-      checkQmdAvailability(),
       readServiceVersion(),
     ]);
+  const qmd = checkQmdBinaryPresence();
 
   const embeddingDiagnostics = getEmbeddingProviderDiagnostics();
   const transportAvailability =
     natsBridgeHealth?.availability ?? natsRuntimeBoundary.nats.availability;
-  const transportDegraded =
-    natsRuntimeBoundary.requested_transport === "nats" &&
-    transportAvailability !== "available";
-  const status =
-    database.connected && migrations.status !== "pending" && !transportDegraded
-      ? "healthy"
-      : "degraded";
+  const transportDegraded = isRequestedTransportDegraded(
+    natsRuntimeBoundary,
+    transportAvailability,
+  );
+  const status: OperatorDoctorStatus["status"] = !database.connected
+    ? "unhealthy"
+    : migrations.status === "pending" || transportDegraded
+      ? "degraded"
+      : "healthy";
   const fileLogConfigured = Boolean(process.env.LOG_FILE?.trim());
 
   return {
@@ -266,11 +288,7 @@ export async function buildOperatorDoctorStatus(
         last_restart_at: embeddingDiagnostics.last_restart_at,
       },
     },
-    qmd: {
-      configured: qmdAvailable !== null,
-      available: qmdAvailable,
-      status: qmdStatus(qmdAvailable),
-    },
+    qmd,
     transport: {
       mode: natsRuntimeBoundary.requested_transport,
       availability: transportAvailability,
@@ -292,7 +310,61 @@ export async function buildOperatorDoctorStatus(
           ? "available"
           : "unavailable"
         : "not_configured",
-      qmd: qmdStatus(qmdAvailable),
+      qmd: qmd.status,
     },
   };
+}
+
+// --- Single-flight + short-TTL cache -----------------------------------
+//
+// Every doctor build fans out DB scans and an outbound embedding probe;
+// without a cache, a polling dashboard or looping token amplifies probes
+// during the exact incident being diagnosed. All callers (REST route and
+// MCP tool) go through getOperatorDoctorStatus: concurrent callers share
+// one in-flight build, and results are served from cache within the TTL.
+
+interface DoctorCacheEntry {
+  value: OperatorDoctorStatus;
+  expiresAt: number;
+}
+
+export interface OperatorDoctorCacheOptions {
+  ttlMs?: number;
+  now?: () => number;
+}
+
+let doctorCache: DoctorCacheEntry | null = null;
+let doctorInFlight: Promise<OperatorDoctorStatus> | null = null;
+
+export function resetOperatorDoctorCache(): void {
+  doctorCache = null;
+  doctorInFlight = null;
+}
+
+export async function getOperatorDoctorStatus(
+  pool: pg.Pool,
+  natsRuntimeBoundary: NatsRuntimeBoundary,
+  natsBridgeHealth?: NatsBridgeHealth,
+  options: OperatorDoctorCacheOptions = {},
+): Promise<OperatorDoctorStatus> {
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? DOCTOR_CACHE_TTL_MS;
+  if (doctorCache && now() < doctorCache.expiresAt) {
+    return doctorCache.value;
+  }
+  if (doctorInFlight) return doctorInFlight;
+  const build = buildOperatorDoctorStatus(
+    pool,
+    natsRuntimeBoundary,
+    natsBridgeHealth,
+  )
+    .then((value) => {
+      doctorCache = { value, expiresAt: now() + ttlMs };
+      return value;
+    })
+    .finally(() => {
+      doctorInFlight = null;
+    });
+  doctorInFlight = build;
+  return build;
 }

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -57,8 +57,11 @@ export function canReadDoctor(auth: AuthInfo | undefined): boolean {
 
 export interface OperatorDoctorStatus {
   // unhealthy: the database is unreachable (hard failure).
-  // degraded: pending migrations, or the requested transport is unavailable.
-  // Optional dependencies (embedding provider, qmd) affect neither tier.
+  // degraded: DB is connected but migrations are not verified current
+  //   (pending OR unknown), the requested transport is unavailable, or a
+  //   CONFIGURED embedding provider is unavailable.
+  // Neutral: an unconfigured embedding provider and qmd availability never
+  //   affect the tier (issue #270 optional-dep rule).
   status: "healthy" | "degraded" | "unhealthy";
   contract_version: string;
   generated_at: string;
@@ -249,9 +252,16 @@ export async function buildOperatorDoctorStatus(
     natsRuntimeBoundary,
     transportAvailability,
   );
+  // Migrations not verified current (pending OR unknown) with a connected
+  // DB means an unverified or broken schema: degraded, never silently
+  // healthy. A configured-but-unavailable embedding provider hard-fails
+  // vector search: degraded. An unconfigured provider and qmd stay neutral.
+  const migrationsDegraded = migrations.status !== "current";
+  const embeddingDegraded =
+    embeddingDiagnostics.configured && !embeddingAvailable;
   const status: OperatorDoctorStatus["status"] = !database.connected
     ? "unhealthy"
-    : migrations.status === "pending" || transportDegraded
+    : migrationsDegraded || transportDegraded || embeddingDegraded
       ? "degraded"
       : "healthy";
   const fileLogConfigured = Boolean(process.env.LOG_FILE?.trim());

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -1,0 +1,298 @@
+import { readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type pg from "pg";
+import { CONTRACT_VERSION, CONTRACT_SCHEMA_VERSION } from "./contract.ts";
+import {
+  getEmbeddingProviderDiagnostics,
+  EMBEDDING_DIMENSIONS,
+  EMBEDDING_MODEL,
+} from "./embedding.ts";
+import { checkPoolHealth } from "./db/pool.ts";
+import type { NatsBridgeHealth } from "./nats-bridge.ts";
+import type { NatsRuntimeBoundary } from "./nats-runtime.ts";
+import type { PoolHealth } from "./types.ts";
+
+const MIGRATIONS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "db",
+  "migrations",
+);
+
+const DOCTOR_CONTRACT_VERSION = "2026-07-08.operator-doctor.v1";
+const OPTIONAL_TIMEOUT_MS = 2_000;
+
+let cachedServiceVersion: string | null = null;
+
+async function readServiceVersion(): Promise<string> {
+  if (cachedServiceVersion !== null) return cachedServiceVersion;
+  try {
+    const pkg = (await Bun.file(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"),
+    ).json()) as { version?: unknown };
+    cachedServiceVersion =
+      typeof pkg.version === "string" && pkg.version.length > 0
+        ? pkg.version
+        : (process.env.npm_package_version ?? "unknown");
+  } catch {
+    cachedServiceVersion = process.env.npm_package_version ?? "unknown";
+  }
+  return cachedServiceVersion;
+}
+
+export interface OperatorDoctorStatus {
+  status: "healthy" | "degraded";
+  contract_version: string;
+  generated_at: string;
+  runtime: {
+    service: "open-brain";
+    version: string;
+    contract_version: string;
+    contract_schema_version: number;
+    node_env: "production" | "development" | "test" | "unknown";
+  };
+  database: PoolHealth;
+  migrations: {
+    status: "current" | "pending" | "unknown";
+    applied_count: number | null;
+    expected_count: number;
+    pending_count: number | null;
+    latest_applied: string | null;
+    latest_expected: string | null;
+  };
+  embedding_provider: {
+    configured: boolean;
+    available: boolean;
+    model: string;
+    dimensions: number;
+    recent_failures: {
+      last_failure_code: string | null;
+      consecutive_restartable_failures: number;
+      restart_configured: boolean;
+      restart_in_flight: boolean;
+      last_restart_at: string | null;
+    };
+  };
+  qmd: {
+    configured: boolean;
+    available: boolean | null;
+    status: "available" | "unavailable" | "not_configured";
+  };
+  transport: {
+    mode: "http" | "nats";
+    availability: "available" | "not_runtime_available";
+    fallback_http: boolean;
+    consecutive_failures: number;
+    last_error: "redacted" | null;
+  };
+  log_audit: {
+    request_logger: "enabled";
+    file_log_configured: boolean;
+    rotation_configured: boolean;
+    audit_storage: "available" | "not_available";
+  };
+  optional_dependencies: {
+    embedding_provider: "available" | "unavailable" | "not_configured";
+    qmd: "available" | "unavailable" | "not_configured";
+  };
+}
+
+async function withTimeout<T>(
+  task: Promise<T>,
+  fallback: T,
+  timeoutMs = OPTIONAL_TIMEOUT_MS,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(fallback), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function probeUrl(url: string, headers: Record<string, string>): Promise<boolean> {
+  try {
+    const resp = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(OPTIONAL_TIMEOUT_MS),
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function readMigrationStatus(pool: pg.Pool): Promise<OperatorDoctorStatus["migrations"]> {
+  let files: string[];
+  try {
+    files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith(".sql")).sort();
+  } catch {
+    // Never let a filesystem error propagate: thrown messages can carry raw
+    // paths into MCP tool error text or Express error pages.
+    return {
+      status: "unknown",
+      applied_count: null,
+      expected_count: 0,
+      pending_count: null,
+      latest_applied: null,
+      latest_expected: null,
+    };
+  }
+  const latestExpected = files.at(-1) ?? null;
+  try {
+    const { rows } = await pool.query(
+      "SELECT filename FROM _migrations ORDER BY filename",
+    );
+    const applied = rows.map((row) => String(row.filename));
+    const appliedSet = new Set(applied);
+    const pending = files.filter((file) => !appliedSet.has(file));
+    return {
+      status: pending.length === 0 ? "current" : "pending",
+      applied_count: applied.length,
+      expected_count: files.length,
+      pending_count: pending.length,
+      latest_applied: applied.at(-1) ?? null,
+      latest_expected: latestExpected,
+    };
+  } catch {
+    return {
+      status: "unknown",
+      applied_count: null,
+      expected_count: files.length,
+      pending_count: null,
+      latest_applied: null,
+      latest_expected: latestExpected,
+    };
+  }
+}
+
+async function checkEmbeddingAvailability(): Promise<boolean> {
+  const baseUrl = process.env.EMBEDDING_BASE_URL?.replace(/\/+$/, "");
+  if (!baseUrl) return false;
+  const headers: Record<string, string> = {};
+  if (process.env.EMBEDDING_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.EMBEDDING_API_KEY}`;
+  }
+  return withTimeout(probeUrl(`${baseUrl}/models`, headers), false);
+}
+
+async function checkQmdAvailability(): Promise<boolean | null> {
+  if (!process.env.QMD_PATH) return null;
+  try {
+    const proc = Bun.spawn(["bun", process.env.QMD_PATH, "--help"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const result = await withTimeout(
+      (async () => {
+        await new Response(proc.stdout).text();
+        await new Response(proc.stderr).text();
+        return (await proc.exited) === 0;
+      })(),
+      false,
+    );
+    if (!result) proc.kill();
+    return result;
+  } catch {
+    return false;
+  }
+}
+
+function qmdStatus(available: boolean | null): "available" | "unavailable" | "not_configured" {
+  if (available === null) return "not_configured";
+  return available ? "available" : "unavailable";
+}
+
+export async function buildOperatorDoctorStatus(
+  pool: pg.Pool,
+  natsRuntimeBoundary: NatsRuntimeBoundary,
+  natsBridgeHealth?: NatsBridgeHealth,
+): Promise<OperatorDoctorStatus> {
+  const [database, migrations, embeddingAvailable, qmdAvailable, serviceVersion] =
+    await Promise.all([
+      checkPoolHealth(pool),
+      readMigrationStatus(pool),
+      checkEmbeddingAvailability(),
+      checkQmdAvailability(),
+      readServiceVersion(),
+    ]);
+
+  const embeddingDiagnostics = getEmbeddingProviderDiagnostics();
+  const transportAvailability =
+    natsBridgeHealth?.availability ?? natsRuntimeBoundary.nats.availability;
+  const transportDegraded =
+    natsRuntimeBoundary.requested_transport === "nats" &&
+    transportAvailability !== "available";
+  const status =
+    database.connected && migrations.status !== "pending" && !transportDegraded
+      ? "healthy"
+      : "degraded";
+  const fileLogConfigured = Boolean(process.env.LOG_FILE?.trim());
+
+  return {
+    status,
+    contract_version: DOCTOR_CONTRACT_VERSION,
+    generated_at: new Date().toISOString(),
+    runtime: {
+      service: "open-brain",
+      version: serviceVersion,
+      contract_version: CONTRACT_VERSION,
+      contract_schema_version: CONTRACT_SCHEMA_VERSION,
+      node_env:
+        process.env.NODE_ENV === "production" ||
+        process.env.NODE_ENV === "development" ||
+        process.env.NODE_ENV === "test"
+          ? process.env.NODE_ENV
+          : "unknown",
+    },
+    database,
+    migrations,
+    embedding_provider: {
+      configured: embeddingDiagnostics.configured,
+      available: embeddingAvailable,
+      model: EMBEDDING_MODEL,
+      dimensions: EMBEDDING_DIMENSIONS,
+      recent_failures: {
+        last_failure_code: embeddingDiagnostics.last_failure_code,
+        consecutive_restartable_failures:
+          embeddingDiagnostics.consecutive_restartable_failures,
+        restart_configured: embeddingDiagnostics.restart_configured,
+        restart_in_flight: embeddingDiagnostics.restart_in_flight,
+        last_restart_at: embeddingDiagnostics.last_restart_at,
+      },
+    },
+    qmd: {
+      configured: qmdAvailable !== null,
+      available: qmdAvailable,
+      status: qmdStatus(qmdAvailable),
+    },
+    transport: {
+      mode: natsRuntimeBoundary.requested_transport,
+      availability: transportAvailability,
+      fallback_http: natsRuntimeBoundary.nats.fallback_http,
+      consecutive_failures: natsBridgeHealth?.consecutiveFailures ?? 0,
+      last_error: natsBridgeHealth?.lastError ? "redacted" : null,
+    },
+    log_audit: {
+      request_logger: "enabled",
+      file_log_configured: fileLogConfigured,
+      rotation_configured:
+        fileLogConfigured &&
+        (Boolean(process.env.LOG_MAX_BYTES) || Boolean(process.env.LOG_MAX_FILES)),
+      audit_storage: "not_available",
+    },
+    optional_dependencies: {
+      embedding_provider: embeddingDiagnostics.configured
+        ? embeddingAvailable
+          ? "available"
+          : "unavailable"
+        : "not_configured",
+      qmd: qmdStatus(qmdAvailable),
+    },
+  };
+}

--- a/src/qmd-path.ts
+++ b/src/qmd-path.ts
@@ -1,0 +1,23 @@
+// Single source of truth for qmd entrypoint path resolution.
+//
+// Both the real qmd caller (src/tools/search-all.ts) and the operator doctor
+// (src/operator-doctor.ts) MUST consume resolveQmdPath() so their view of the
+// qmd binary location can never diverge. The default matches the documented
+// prod layout on core01.
+export const DEFAULT_QMD_PATH = "/opt/qmd/src/qmd.ts";
+
+export interface ResolvedQmdPath {
+  path: string;
+  source: "env" | "default";
+}
+
+export function resolveQmdPath(
+  env: Record<string, string | undefined> = process.env,
+): ResolvedQmdPath {
+  // Mirror the historical `process.env.QMD_PATH ?? DEFAULT_QMD_PATH` exactly
+  // (no trimming) so search_all behavior is unchanged.
+  if (env.QMD_PATH === undefined) {
+    return { path: DEFAULT_QMD_PATH, source: "default" };
+  }
+  return { path: env.QMD_PATH, source: "env" };
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -10,6 +10,7 @@ import {
 import { createApp } from "./index.ts";
 import { getSessionCount } from "./transport.ts";
 import { createNatsBridgeHealth } from "./nats-bridge.ts";
+import { resetOperatorDoctorCache } from "./operator-doctor.ts";
 import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 import type { Server } from "node:http";
@@ -246,6 +247,13 @@ describe("GET /health", () => {
 });
 
 describe("GET /api/v1/operator/doctor", () => {
+  beforeEach(() => {
+    resetOperatorDoctorCache();
+  });
+  afterEach(() => {
+    resetOperatorDoctorCache();
+  });
+
   it("requires auth", async () => {
     const res = await fetch(`${baseUrl}/api/v1/operator/doctor`);
     expect(res.status).toBe(401);
@@ -270,9 +278,9 @@ describe("GET /api/v1/operator/doctor", () => {
     process.env.LOG_FILE = logPath;
     mockPool.query = async (sql: string) => {
       if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
-      if (sql.includes("FROM _migrations")) {
-        return { rows: [{ filename: "001_init.sql" }] };
-      }
+      // Unknown migration state keeps the doctor healthy so this test can
+      // pin the 200 path; the degraded/unhealthy 503 paths are pinned below.
+      if (sql.includes("FROM _migrations")) throw new Error("not available");
       return { rows: [] };
     };
     (globalThis as Record<string, unknown>).fetch = (
@@ -295,12 +303,14 @@ describe("GET /api/v1/operator/doctor", () => {
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
+        status: string;
         contract_version: string;
         runtime: { contract_version: string };
         embedding_provider: { available: boolean };
       };
       const serialized = JSON.stringify(body);
-      expect(body.contract_version).toBe("2026-07-08.operator-doctor.v1");
+      expect(body.status).toBe("healthy");
+      expect(body.contract_version).toBe("2026-07-08.operator-doctor.v2");
       expect(body.runtime.contract_version).toBe("2026-07-08.memory-tools.v20");
       expect(body.embedding_provider.available).toBe(true);
       expect(serialized).not.toContain(secret);
@@ -313,6 +323,53 @@ describe("GET /api/v1/operator/doctor", () => {
       else process.env.EMBEDDING_API_KEY = originalEmbeddingApiKey;
       if (originalLogFile === undefined) delete process.env.LOG_FILE;
       else process.env.LOG_FILE = originalLogFile;
+    }
+  });
+
+  it("returns 503 when the doctor reports degraded (pending migrations)", async () => {
+    const originalEmbeddingBaseUrl = process.env.EMBEDDING_BASE_URL;
+    delete process.env.EMBEDDING_BASE_URL;
+    mockPool.query = async (sql: string) => {
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      // No migrations applied: everything on disk is pending.
+      if (sql.includes("FROM _migrations")) return { rows: [] };
+      return { rows: [] };
+    };
+
+    try {
+      const res = await fetch(`${baseUrl}/api/v1/operator/doctor`, {
+        headers: { Authorization: "Bearer test-token-123" },
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("degraded");
+    } finally {
+      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
+    }
+  });
+
+  it("returns 503 when the doctor reports unhealthy (database down)", async () => {
+    const originalEmbeddingBaseUrl = process.env.EMBEDDING_BASE_URL;
+    delete process.env.EMBEDDING_BASE_URL;
+    mockPool.query = async () => {
+      throw new Error("connection refused");
+    };
+
+    try {
+      const res = await fetch(`${baseUrl}/api/v1/operator/doctor`, {
+        headers: { Authorization: "Bearer test-token-123" },
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as {
+        status: string;
+        database: { connected: boolean };
+      };
+      expect(body.status).toBe("unhealthy");
+      expect(body.database.connected).toBe(false);
+    } finally {
+      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
     }
   });
 });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -11,6 +11,9 @@ import { createApp } from "./index.ts";
 import { getSessionCount } from "./transport.ts";
 import { createNatsBridgeHealth } from "./nats-bridge.ts";
 import { resetOperatorDoctorCache } from "./operator-doctor.ts";
+import { readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 import type { AuthInfo, HealthStatus } from "./types.ts";
 import type { Server } from "node:http";
@@ -276,11 +279,22 @@ describe("GET /api/v1/operator/doctor", () => {
     process.env.EMBEDDING_BASE_URL = `http://${embeddingHost}:8791/v1`;
     process.env.EMBEDDING_API_KEY = secret;
     process.env.LOG_FILE = logPath;
+    // All on-disk migrations applied: migrations "current" keeps the doctor
+    // healthy so this test can pin the 200 path; the degraded/unhealthy 503
+    // paths are pinned below.
+    const migrationsDir = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "db",
+      "migrations",
+    );
+    const allMigrations = (await readdir(migrationsDir)).filter((f) =>
+      f.endsWith(".sql"),
+    );
     mockPool.query = async (sql: string) => {
       if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
-      // Unknown migration state keeps the doctor healthy so this test can
-      // pin the 200 path; the degraded/unhealthy 503 paths are pinned below.
-      if (sql.includes("FROM _migrations")) throw new Error("not available");
+      if (sql.includes("FROM _migrations")) {
+        return { rows: allMigrations.map((filename) => ({ filename })) };
+      }
       return { rows: [] };
     };
     (globalThis as Record<string, unknown>).fetch = (
@@ -343,6 +357,35 @@ describe("GET /api/v1/operator/doctor", () => {
       expect(res.status).toBe(503);
       const body = (await res.json()) as { status: string };
       expect(body.status).toBe("degraded");
+    } finally {
+      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
+    }
+  });
+
+  it("returns 503 when the DB is connected but migration state is unknown", async () => {
+    const originalEmbeddingBaseUrl = process.env.EMBEDDING_BASE_URL;
+    delete process.env.EMBEDDING_BASE_URL;
+    mockPool.query = async (sql: string) => {
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      // Connected DB, but the _migrations ledger is missing/unreadable.
+      if (sql.includes("FROM _migrations")) throw new Error("not available");
+      return { rows: [] };
+    };
+
+    try {
+      const res = await fetch(`${baseUrl}/api/v1/operator/doctor`, {
+        headers: { Authorization: "Bearer test-token-123" },
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as {
+        status: string;
+        database: { connected: boolean };
+        migrations: { status: string };
+      };
+      expect(body.status).toBe("degraded");
+      expect(body.database.connected).toBe(true);
+      expect(body.migrations.status).toBe("unknown");
     } finally {
       if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
       else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -245,6 +245,78 @@ describe("GET /health", () => {
   });
 });
 
+describe("GET /api/v1/operator/doctor", () => {
+  it("requires auth", async () => {
+    const res = await fetch(`${baseUrl}/api/v1/operator/doctor`);
+    expect(res.status).toBe(401);
+  });
+
+  it("requires admin or ob-admin auth", async () => {
+    const res = await fetch(`${baseUrl}/api/v1/operator/doctor`, {
+      headers: { Authorization: "Bearer agent-token-123" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns privileged doctor JSON without secret or path disclosure", async () => {
+    const originalEmbeddingBaseUrl = process.env.EMBEDDING_BASE_URL;
+    const originalEmbeddingApiKey = process.env.EMBEDDING_API_KEY;
+    const originalLogFile = process.env.LOG_FILE;
+    const secret = "doctor-rest-secret";
+    const embeddingHost = "doctor-provider.internal";
+    const logPath = "/sensitive/open-brain.log";
+    process.env.EMBEDDING_BASE_URL = `http://${embeddingHost}:8791/v1`;
+    process.env.EMBEDDING_API_KEY = secret;
+    process.env.LOG_FILE = logPath;
+    mockPool.query = async (sql: string) => {
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      if (sql.includes("FROM _migrations")) {
+        return { rows: [{ filename: "001_init.sql" }] };
+      }
+      return { rows: [] };
+    };
+    (globalThis as Record<string, unknown>).fetch = (
+      input: string | URL | globalThis.Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/models") && !url.includes("127.0.0.1")) {
+        expect(init?.headers).toMatchObject({
+          Authorization: `Bearer ${secret}`,
+        });
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }
+      return originalFetch(input, init);
+    };
+
+    try {
+      const res = await fetch(`${baseUrl}/api/v1/operator/doctor`, {
+        headers: { Authorization: "Bearer test-token-123" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        contract_version: string;
+        runtime: { contract_version: string };
+        embedding_provider: { available: boolean };
+      };
+      const serialized = JSON.stringify(body);
+      expect(body.contract_version).toBe("2026-07-08.operator-doctor.v1");
+      expect(body.runtime.contract_version).toBe("2026-07-08.memory-tools.v20");
+      expect(body.embedding_provider.available).toBe(true);
+      expect(serialized).not.toContain(secret);
+      expect(serialized).not.toContain(embeddingHost);
+      expect(serialized).not.toContain(logPath);
+    } finally {
+      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
+      if (originalEmbeddingApiKey === undefined) delete process.env.EMBEDDING_API_KEY;
+      else process.env.EMBEDDING_API_KEY = originalEmbeddingApiKey;
+      if (originalLogFile === undefined) delete process.env.LOG_FILE;
+      else process.env.LOG_FILE = originalLogFile;
+    }
+  });
+});
+
 describe("POST /mcp", () => {
   it("returns 401 without Authorization header", async () => {
     const res = await fetch(`${baseUrl}/mcp`, {

--- a/src/tools/__tests__/operator-doctor.test.ts
+++ b/src/tools/__tests__/operator-doctor.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { registerOperatorDoctor } from "../operator-doctor.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  getErrorText,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+function makePool() {
+  return {
+    query: async (sql: string) => {
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      if (sql.includes("FROM _migrations")) {
+        return { rows: [{ filename: "001_init.sql" }] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+describe("operator_doctor", () => {
+  it("allows admin clients to read doctor status", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "operator" };
+    const { client, cleanup } = await setupMcpClient(
+      registerOperatorDoctor,
+      makePool(),
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "operator_doctor",
+        arguments: {},
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.contract_version).toBe("2026-07-08.operator-doctor.v1");
+      expect(parsed.runtime.service).toBe("open-brain");
+      expect(parsed.database.connected).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies non-privileged clients", async () => {
+    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const { client, cleanup } = await setupMcpClient(
+      registerOperatorDoctor,
+      makePool(),
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "operator_doctor",
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("admin or ob-admin role required");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/operator-doctor.test.ts
+++ b/src/tools/__tests__/operator-doctor.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { registerOperatorDoctor } from "../operator-doctor.ts";
+import { resetOperatorDoctorCache } from "../../operator-doctor.ts";
 import type { AuthInfo } from "../../types.ts";
 import {
   createMockEmbed,
@@ -21,6 +22,13 @@ function makePool() {
 }
 
 describe("operator_doctor", () => {
+  beforeEach(() => {
+    resetOperatorDoctorCache();
+  });
+  afterEach(() => {
+    resetOperatorDoctorCache();
+  });
+
   it("allows admin clients to read doctor status", async () => {
     const auth: AuthInfo = { role: "admin", clientId: "operator" };
     const { client, cleanup } = await setupMcpClient(
@@ -37,7 +45,7 @@ describe("operator_doctor", () => {
       });
       expect(result.isError).toBeFalsy();
       const parsed = parseToolResult(result);
-      expect(parsed.contract_version).toBe("2026-07-08.operator-doctor.v1");
+      expect(parsed.contract_version).toBe("2026-07-08.operator-doctor.v2");
       expect(parsed.runtime.service).toBe("open-brain");
       expect(parsed.database.connected).toBe(true);
     } finally {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -49,6 +49,7 @@ import { registerScanNamespace } from "./scan-namespace.ts";
 import { registerTierLane } from "./tier-lane.ts";
 import { registerPromoteShared } from "./promote-shared.ts";
 import { registerGetContract } from "./get-contract.ts";
+import { registerOperatorDoctor } from "./operator-doctor.ts";
 import { registerListRepoFacts, registerUpsertRepoFact } from "./repo-facts.ts";
 import {
   registerAgentContextPack,
@@ -130,6 +131,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerRecoveryWalMark(server, toolDeps);
   registerAgentContextPack(server, toolDeps);
   registerGetContract(server, toolDeps);
+  registerOperatorDoctor(server, toolDeps);
   registerUpsertRepoFact(server, toolDeps);
   registerListRepoFacts(server, toolDeps);
 }

--- a/src/tools/operator-doctor.ts
+++ b/src/tools/operator-doctor.ts
@@ -1,12 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AuthInfo } from "../types.ts";
-import { buildOperatorDoctorStatus } from "../operator-doctor.ts";
+import { canReadDoctor, getOperatorDoctorStatus } from "../operator-doctor.ts";
 import { readNatsRuntimeBoundary } from "../nats-runtime.ts";
 import type { ToolDeps } from "./index.ts";
-
-function canReadDoctor(auth: AuthInfo | undefined): boolean {
-  return auth?.role === "admin" || auth?.role === "ob-admin";
-}
 
 export function registerOperatorDoctor(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
@@ -37,7 +33,7 @@ export function registerOperatorDoctor(server: McpServer, deps: ToolDeps): void 
       }
 
       try {
-        const status = await buildOperatorDoctorStatus(
+        const status = await getOperatorDoctorStatus(
           deps.pool,
           deps.natsRuntimeBoundary ?? readNatsRuntimeBoundary(process.env),
           deps.natsBridgeHealth,

--- a/src/tools/operator-doctor.ts
+++ b/src/tools/operator-doctor.ts
@@ -1,0 +1,68 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthInfo } from "../types.ts";
+import { buildOperatorDoctorStatus } from "../operator-doctor.ts";
+import { readNatsRuntimeBoundary } from "../nats-runtime.ts";
+import type { ToolDeps } from "./index.ts";
+
+function canReadDoctor(auth: AuthInfo | undefined): boolean {
+  return auth?.role === "admin" || auth?.role === "ob-admin";
+}
+
+export function registerOperatorDoctor(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "operator_doctor",
+    {
+      description:
+        "Return privileged operator doctor/status JSON without secrets or raw paths.",
+      inputSchema: {},
+      annotations: {
+        title: "Operator Doctor",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (_args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!canReadDoctor(auth)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: admin or ob-admin role required",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      try {
+        const status = await buildOperatorDoctorStatus(
+          deps.pool,
+          deps.natsRuntimeBoundary ?? readNatsRuntimeBoundary(process.env),
+          deps.natsBridgeHealth,
+        );
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(status),
+            },
+          ],
+        };
+      } catch {
+        // Never surface raw error messages (they can carry paths or env
+        // detail) through MCP tool error text.
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "operator doctor status unavailable",
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -18,6 +18,7 @@ import {
   type SourceRef,
 } from "./search-brain.ts";
 import { isSharedNamespace } from "../shared-namespace.ts";
+import { resolveQmdPath } from "../qmd-path.ts";
 import {
   sourceScopeAuthorizationError,
   sourceScopeSchema,
@@ -59,8 +60,6 @@ interface QmdDocument {
   collection?: string;
 }
 
-const QMD_PATH = process.env.QMD_PATH ?? "/opt/qmd/src/qmd.ts";
-
 const QMD_TIMEOUT_MS = 10_000;
 
 async function searchQmd(
@@ -69,9 +68,11 @@ async function searchQmd(
   collection?: string,
 ): Promise<UnifiedResult[]> {
   try {
+    // Shared resolution with the operator doctor (src/qmd-path.ts) so the
+    // doctor's availability report can never diverge from the real caller.
     const qmdArgs = [
       "bun",
-      QMD_PATH,
+      resolveQmdPath().path,
       "search",
       query,
       "--json",


### PR DESCRIPTION
## Summary

- add a privileged operator doctor/status surface with stable machine-readable JSON covering runtime version, contract version, DB connectivity, migration status, embedding provider availability plus recent degraded failures, qmd availability when configured, transport mode/availability, and log/audit health
- REST `GET /api/v1/operator/doctor` behind the auth middleware plus a server-side admin/ob-admin role check (401 unauthenticated, 403 non-privileged); public `/health` stays minimal and unchanged
- MCP tool `operator_doctor` with the same server-side role gate; both surfaces return a generic error envelope on failure so raw error messages (which can carry paths or env detail) never reach a client
- optional-dependency failures (embedding provider, qmd) are fail-open: they mark the dependency unavailable but never make the service unhealthy; overall status degrades only on DB disconnect, pending migrations, or requested-NATS-transport unavailability
- no secrets, raw env values, or filesystem paths in any output field, proven by explicit non-containment tests on the serialized payload
- contract bump to `2026-07-08.memory-tools.v20` adding the `operator_doctor` capability and tool contract; schema hash updated in lockstep
- Python client: contract pin bump, `operator_doctor` first-class wrapper, required-tool and help coverage

Closes #270

## Validation

- `bun test src/operator-doctor.test.ts src/tools/__tests__/operator-doctor.test.ts src/server.test.ts src/contract.test.ts src/tools/__tests__/get-contract.test.ts` - PASS, 31 pass / 0 fail (255 expect() calls)
- `bunx tsc --noEmit` - PASS
- `bun test` - PASS, 1213 pass / 54 skip / 0 fail (1267 tests, 88 files)
- `git diff --check` - PASS (and `git diff --cached --check` before commit)
- Python client (`python/openbrain-memory`):
  - `uv sync` - PASS
  - `uv run pytest -q` - PASS, 225 passed / 5 skipped
  - `uv run mypy src/openbrain_memory` - PASS, no issues in 8 source files
  - `uv run ruff check src tests` - PASS, all checks passed

## Critical self-review

- Highest-risk behavior: the doctor payload leaking secrets, raw env values, or filesystem paths (directly or via error paths). Mitigated by allowlisted output fields only, `last_error: "redacted"`, migration readdir failure fully caught, and generic catch envelopes on both the REST handler and the MCP tool; tests assert the serialized payload does not contain the embedding API key, embedding host, or log file path.
- Assumptions that could be wrong: that admin/ob-admin is the correct privilege boundary for the doctor (readonly/agent/discord/n8n are denied); that probing `EMBEDDING_BASE_URL/models` and `bun $QMD_PATH --help` are faithful availability proxies for the real call paths; that DB + migrations + requested-transport are the right inputs to overall healthy/degraded.
- Missing/weak tests: no live smoke against hosted core01 (deferred to release path); qmd availability probe is exercised only via the not_configured branch in unit tests, not with a real qmd binary; the readdir-failure fallback branch is covered by review rather than a dedicated test.
- Security/permission risk: new privileged surface. Auth is enforced server-side twice on REST (auth middleware, then role check) and server-side in the MCP tool handler via `extra.authInfo`; no client-side checks are relied on. No SQL takes caller input (fixed `SELECT filename FROM _migrations`).
- Migration/deploy risk: none - no migrations, no schema changes, no deploy from this PR. Contract version bump requires the normal release/rollout path for downstream consumers.
- Downstream client/runtime risk: contract bump to v20 adds `operator_doctor` as a required contract tool in the Python client; downstream pin refresh (mcp2cli schema cache, generated skills, rtech-hermes) is required at release, per the rollout section below.
- Rollback/cleanup concern: revert removes the endpoint, tool, contract entry, and client wrapper cleanly; a reverted server with clients pinned to v20 would fail contract validation until client pins are reverted too.
- Fixes made before PR: (1) wrapped the migrations-directory `readdir` in try/catch so a filesystem error cannot leak a raw path through MCP error text or Express error pages; (2) `runtime.version` now reads package.json (cached) instead of relying on `npm_package_version`, which is unset when launchd runs bun directly; (3) added defensive catch envelopes to both the REST handler and MCP tool so unexpected errors return a generic message.
- Known residual risk: `qmd.configured` tracks explicit `QMD_PATH` while `search_all` falls back to a default path (`/opt/qmd/src/qmd.ts`); the doctor can report `not_configured` on a host where search still probes the default. Doctor contract version string is dated 2026-07-08 to match the memory-tools v20 bump.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding has been produced yet; PR remains draft until the review swarm completes.

## Downstream rollout classification

Checked `docs/downstream-rollout.md`. Rollout applies: this PR changes the public contract (new MCP tool `operator_doctor`, contract version bump to `2026-07-08.memory-tools.v20`, schema hash change) and `python/openbrain-memory` client behavior (contract pin, required tools, new wrapper).

- Open Brain local verification is complete (server tests, typecheck, full suite, Python package tests above).
- Hosted Open Brain deploy, mcp2cli schema cache invalidation and generated-skill refresh, rtech-mcps handoff, rtech-hermes runtime/plugin check, Hermes live rollout, and live agent canaries are NOT run in this PR. They are deferred to the release `v*` tag path after merge, consistent with the local-first sprint flow. The mcp2cli stale-schema-cache known issue (mcp2cli#58) applies at that point because this is a contract bump.
- No generated skill content under `skill/` is touched here; skill regeneration happens as part of the deferred mcp2cli refresh.
- **Rollout ordering (load-bearing):** hosted Open Brain MUST deploy contract v20 (`2026-07-08.memory-tools.v20`) BEFORE the openbrain-memory 0.1.6 client is published or rolled out to mcp2cli/Hermes. A published v20-pinned 0.1.6 client hard-rejects a v19 server (exact contract-version pin plus the required `operator_doctor` tool), so client-first rollout is a hard outage for every consumer. Server deploys first; client publish/roll follows.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured: no review swarm has run yet; PR remains draft until standard review completes.
- [ ] Initial review swarm complete
- [ ] Material findings fixed or explicitly deferred
- [ ] Fix verification complete
- [ ] CI passed for this PR head
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is local-first sprint work; no core01 deploy or live DB mutation is approved for this PR.

## No deploy / release note

No core01 deploy is performed by this PR. The doctor surface, contract bump, and Python client changes ship to the hosted service and downstream consumers only via the normal `v*` release tag path after merge and verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

