### PR TITLE
feat: expose graph-expanded evidence in brain_answer and search_all

### DIFF
--- a/src/tools/__tests__/graph-evidence-consumers.test.ts
+++ b/src/tools/__tests__/graph-evidence-consumers.test.ts
@@ -182,7 +182,7 @@ function graphEntriesFor(
   );
 }
 
-function searchRow(entry: FixtureEntry) {
+function searchRow(entry: FixtureEntry, ftsRank = 1) {
   return {
     source_type: entry.source_type,
     id: entry.id,
@@ -195,7 +195,7 @@ function searchRow(entry: FixtureEntry) {
     tier: "warm",
     usefulness: 0.5,
     access_count: 0,
-    fts_rank: 1,
+    fts_rank: ftsRank,
     distance: null,
   };
 }
@@ -207,7 +207,10 @@ type GraphPoolStats = {
   totalQueries: number;
 };
 
-function graphAwarePool(): { pool: { query: (...args: any[]) => Promise<{ rows: any[] }> }; stats: GraphPoolStats } {
+function graphAwarePool(options?: {
+  /** fts_rank stamped on graph-hydrated rows (raw link weight in prod). */
+  graphFtsRank?: number;
+}): { pool: { query: (...args: any[]) => Promise<{ rows: any[] }> }; stats: GraphPoolStats } {
   const stats: GraphPoolStats = {
     graphCalls: 0,
     graphNamespaceParams: [],
@@ -231,7 +234,7 @@ function graphAwarePool(): { pool: { query: (...args: any[]) => Promise<{ rows: 
             String(params[0] ?? ""),
             String(params[1] ?? ""),
             namespaceList(params[3]),
-          ).map(searchRow),
+          ).map((entry) => searchRow(entry, options?.graphFtsRank ?? 1)),
         };
       }
       // vector, fts, and explicit-link lookups return nothing so every hit
@@ -500,6 +503,75 @@ describe("brain_answer graph-expanded evidence (#268)", () => {
       await cleanup();
     }
   });
+
+  it("clamps graph-row scores derived from link weight > 1 into [0,1] (finding 1)", async () => {
+    const { pool, stats } = graphAwarePool({ graphFtsRank: 2.5 });
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "What depends on Alpha?", namespace: READER_NS },
+        }),
+      );
+      expect(stats.graphCalls).toBe(1);
+      expect(parsed.citations).toHaveLength(1);
+      expect(parsed.citations[0].score).toBeLessThanOrEqual(1);
+      expect(parsed.citations[0].score).toBeGreaterThanOrEqual(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("still cites graph evidence when the embedding provider is down (finding 2)", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(null),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "What depends on Alpha?", namespace: READER_NS },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(stats.graphCalls).toBe(1);
+      expect(parsed.citations).toHaveLength(1);
+      expect(parsed.citations[0].source_ref.id).toBe("graph-target");
+      expect(parsed.answer).toContain("schema freeze decision");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps the graph arm dark for non-relational queries (finding 3)", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "deploy readiness notes", namespace: READER_NS },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(stats.graphCalls).toBe(0);
+      expect(stats.totalQueries).toBeGreaterThan(0);
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -720,6 +792,90 @@ describe("search_all graph-expanded evidence (#268)", () => {
       const parsed = parseToolResult(result);
       expect(parsed.brain_hits).toBe(0);
       expect(stats.graphCalls).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("clamps graph-row scores derived from link weight > 1 into [0,1] (finding 1)", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool({ graphFtsRank: 2.5 });
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "search_all",
+          arguments: {
+            query: "What depends on Alpha?",
+            namespace: READER_NS,
+            sources: "brain",
+          },
+        }),
+      );
+      expect(stats.graphCalls).toBe(1);
+      expect(parsed.brain_hits).toBe(1);
+      expect(parsed.results[0].id).toBe("graph-target");
+      expect(parsed.results[0].score).toBeLessThanOrEqual(1);
+      expect(parsed.results[0].score).toBeGreaterThanOrEqual(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("still surfaces graph evidence when the embedding provider is down (finding 2)", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(null),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "search_all",
+        arguments: {
+          query: "What depends on Alpha?",
+          namespace: READER_NS,
+          sources: "brain",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(stats.graphCalls).toBe(1);
+      expect(parsed.brain_hits).toBe(1);
+      expect(parsed.results[0].id).toBe("graph-target");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps the graph arm dark for non-relational queries (finding 3)", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "search_all",
+        arguments: {
+          query: "deploy readiness notes",
+          namespace: READER_NS,
+          sources: "brain",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(stats.graphCalls).toBe(0);
+      expect(stats.totalQueries).toBeGreaterThan(0);
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/graph-evidence-consumers.test.ts
+++ b/src/tools/__tests__/graph-evidence-consumers.test.ts
@@ -1,0 +1,727 @@
+/**
+ * #268: graph-expanded evidence at the consumer surfaces.
+ *
+ * brain_answer and search_all inherit search_brain's relational graph arm
+ * (#267/PR #274) instead of running their own traversal. These tests prove,
+ * at the consumer surface, that graph-hydrated rows are cited with normal
+ * Open Brain source refs, that the auth-derived namespace predicate reaches
+ * the graph SQL, that unreadable and archived targets never surface, that
+ * brain_answer still reports gaps instead of fabricating from edges, and
+ * that search_all's qmd federation stays decoupled and fail-open.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { registerBrainAnswer } from "../brain-answer.ts";
+import { registerSearchAll } from "../search-all.ts";
+import type { AuthInfo } from "../../types.ts";
+import {
+  createMockEmbed,
+  parseToolResult,
+  getErrorText,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Fixture: two namespaces, one archived seed, one archived link
+// ---------------------------------------------------------------------------
+
+type SourceType = "thought" | "decision";
+
+type FixtureEntry = {
+  id: string;
+  source_type: SourceType;
+  namespace: string;
+  text: string;
+  created_at: string;
+  archived_at?: string | null;
+};
+
+type FixtureEntity = {
+  id: string;
+  namespace: string;
+  name: string;
+  archived_at?: string | null;
+};
+
+type FixtureLink = {
+  namespace: string;
+  from_type: SourceType;
+  from_id: string;
+  to_entity: string;
+  relation: string;
+  archived_at?: string | null;
+};
+
+const READER_NS = "agent-a";
+const PRIVATE_NS = "agent-b";
+
+const entries: FixtureEntry[] = [
+  {
+    id: "graph-target",
+    source_type: "thought",
+    namespace: READER_NS,
+    text: "Deploy gate depends on the schema freeze decision.",
+    created_at: "2026-06-01T00:00:00Z",
+  },
+  {
+    id: "stale-target",
+    source_type: "decision",
+    namespace: READER_NS,
+    text: "Legacy pipeline decision predates the current rollout policy.",
+    created_at: "2020-01-01T00:00:00Z",
+  },
+  {
+    id: "private-target",
+    source_type: "thought",
+    namespace: PRIVATE_NS,
+    text: "Private namespace target must never surface for agent-a.",
+    created_at: "2026-06-01T00:00:00Z",
+  },
+  {
+    id: "archived-link-target",
+    source_type: "thought",
+    namespace: READER_NS,
+    text: "Archived link target must not hydrate.",
+    created_at: "2026-06-01T00:00:00Z",
+  },
+  {
+    id: "archived-entity-target",
+    source_type: "thought",
+    namespace: READER_NS,
+    text: "Archived entity target must not hydrate.",
+    created_at: "2026-06-01T00:00:00Z",
+  },
+];
+
+const entities: FixtureEntity[] = [
+  { id: "entity-alpha", namespace: READER_NS, name: "Alpha" },
+  { id: "entity-legacy", namespace: READER_NS, name: "Legacy" },
+  { id: "entity-private", namespace: PRIVATE_NS, name: "Private" },
+  {
+    id: "entity-archived",
+    namespace: READER_NS,
+    name: "Archived",
+    archived_at: "2026-07-01T00:00:00Z",
+  },
+];
+
+const links: FixtureLink[] = [
+  {
+    namespace: READER_NS,
+    from_type: "thought",
+    from_id: "graph-target",
+    to_entity: "entity-alpha",
+    relation: "depends_on",
+  },
+  {
+    namespace: READER_NS,
+    from_type: "decision",
+    from_id: "stale-target",
+    to_entity: "entity-legacy",
+    relation: "depends_on",
+  },
+  {
+    namespace: PRIVATE_NS,
+    from_type: "thought",
+    from_id: "private-target",
+    to_entity: "entity-private",
+    relation: "mentions",
+  },
+  {
+    namespace: READER_NS,
+    from_type: "thought",
+    from_id: "archived-link-target",
+    to_entity: "entity-alpha",
+    relation: "mentions",
+    archived_at: "2026-07-01T00:00:00Z",
+  },
+  {
+    namespace: READER_NS,
+    from_type: "thought",
+    from_id: "archived-entity-target",
+    to_entity: "entity-archived",
+    relation: "mentions",
+  },
+];
+
+function namespaceList(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+  return typeof value === "string" ? [value] : undefined;
+}
+
+function graphEntriesFor(
+  seedName: string,
+  relation: string,
+  readableNamespaces: string[] | undefined,
+): FixtureEntry[] {
+  const readable = (namespace: string) =>
+    readableNamespaces === undefined || readableNamespaces.includes(namespace);
+  const seed = entities.find(
+    (entity) =>
+      !entity.archived_at &&
+      readable(entity.namespace) &&
+      entity.name.toLowerCase() === seedName.toLowerCase(),
+  );
+  if (!seed) return [];
+  const linkedIds = links
+    .filter(
+      (link) =>
+        !link.archived_at &&
+        link.namespace === seed.namespace &&
+        link.relation === relation &&
+        link.to_entity === seed.id,
+    )
+    .map((link) => `${link.from_type}:${link.from_id}`);
+  return entries.filter(
+    (entry) =>
+      !entry.archived_at &&
+      entry.namespace === seed.namespace &&
+      linkedIds.includes(`${entry.source_type}:${entry.id}`),
+  );
+}
+
+function searchRow(entry: FixtureEntry) {
+  return {
+    source_type: entry.source_type,
+    id: entry.id,
+    namespace: entry.namespace,
+    content_preview: entry.text,
+    tags: [],
+    created_by: "test",
+    created_at: entry.created_at,
+    updated_at: entry.created_at,
+    tier: "warm",
+    usefulness: 0.5,
+    access_count: 0,
+    fts_rank: 1,
+    distance: null,
+  };
+}
+
+type GraphPoolStats = {
+  graphCalls: number;
+  graphNamespaceParams: unknown[];
+  writeQueries: string[];
+  totalQueries: number;
+};
+
+function graphAwarePool(): { pool: { query: (...args: any[]) => Promise<{ rows: any[] }> }; stats: GraphPoolStats } {
+  const stats: GraphPoolStats = {
+    graphCalls: 0,
+    graphNamespaceParams: [],
+    writeQueries: [],
+    totalQueries: 0,
+  };
+  const pool = {
+    query: async (...args: any[]) => {
+      const [sql, params = []] = args;
+      const text = String(sql);
+      stats.totalQueries += 1;
+      if (/^\s*(UPDATE|INSERT)/i.test(text)) {
+        stats.writeQueries.push(text);
+        return { rows: [] };
+      }
+      if (text.includes("relational_graph_seed")) {
+        stats.graphCalls += 1;
+        stats.graphNamespaceParams.push(params[3]);
+        return {
+          rows: graphEntriesFor(
+            String(params[0] ?? ""),
+            String(params[1] ?? ""),
+            namespaceList(params[3]),
+          ).map(searchRow),
+        };
+      }
+      // vector, fts, and explicit-link lookups return nothing so every hit
+      // below is attributable to the graph arm alone.
+      return { rows: [] };
+    },
+  };
+  return { pool, stats };
+}
+
+const readerAuth: AuthInfo = { role: "agent", clientId: READER_NS };
+
+// ---------------------------------------------------------------------------
+// qmd spawn mocking (same convention as search-all.test.ts)
+// ---------------------------------------------------------------------------
+
+const originalSpawn = Bun.spawn;
+
+function mockBunSpawn(exitCode: number, stdout: string, stderr = "") {
+  (Bun as any).spawn = () => {
+    const encoder = new TextEncoder();
+    return {
+      stdout: new ReadableStream({
+        start(c) {
+          c.enqueue(encoder.encode(stdout));
+          c.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(c) {
+          c.enqueue(encoder.encode(stderr));
+          c.close();
+        },
+      }),
+      exited: Promise.resolve(exitCode),
+    };
+  };
+}
+
+function restoreBunSpawn() {
+  (Bun as any).spawn = originalSpawn;
+}
+
+// ---------------------------------------------------------------------------
+// brain_answer
+// ---------------------------------------------------------------------------
+
+describe("brain_answer graph-expanded evidence (#268)", () => {
+  it("cites graph-expanded evidence with normal Open Brain source refs", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "What depends on Alpha?", namespace: READER_NS },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.evidence_count).toBe(1);
+      expect(parsed.answer).toContain("[1]");
+      expect(parsed.answer).toContain("schema freeze decision");
+      expect(parsed.citations).toHaveLength(1);
+      expect(parsed.citations[0].source_ref).toMatchObject({
+        source: "brain",
+        type: "thought",
+        id: "graph-target",
+        namespace: READER_NS,
+      });
+      expect(parsed.citations[0].excerpt).toContain("Deploy gate depends on");
+      expect(stats.graphCalls).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not expose link-path metadata in citations", async () => {
+    const { pool } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "What depends on Alpha?", namespace: READER_NS },
+        }),
+      );
+      expect(Object.keys(parsed.citations[0]).sort()).toEqual([
+        "excerpt",
+        "index",
+        "score",
+        "source_ref",
+        "stale",
+      ]);
+      const serialized = JSON.stringify(parsed);
+      expect(serialized).not.toContain("explicit_links");
+      expect(serialized).not.toContain("entity-alpha");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reports a gap instead of fabricating when the graph arm finds nothing", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "What depends on Ghost?", namespace: READER_NS },
+        }),
+      );
+      expect(parsed.answer).toBeNull();
+      expect(parsed.citations).toEqual([]);
+      expect(parsed.known_gaps[0]).toContain("No readable Open Brain evidence");
+      expect(stats.graphCalls).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("flags stale graph-cited evidence instead of hiding age", async () => {
+    const { pool } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: {
+            query: "What depends on Legacy?",
+            namespace: READER_NS,
+            max_age_days: 30,
+          },
+        }),
+      );
+      expect(parsed.citations).toHaveLength(1);
+      expect(parsed.citations[0].source_ref.id).toBe("stale-target");
+      expect(parsed.citations[0].stale).toBe(true);
+      expect(parsed.uncertainty.join(" ")).toContain("older than 30 days");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unreadable namespace filters before any graph retrieval", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "What mentions Private?", namespace: PRIVATE_NS },
+      });
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("namespace read access denied");
+      expect(stats.graphCalls).toBe(0);
+      expect(stats.totalQueries).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("passes the auth-derived namespace predicate into the graph SQL and hydrates nothing unreadable", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "What mentions Private?" },
+        }),
+      );
+      expect(stats.graphCalls).toBe(1);
+      const namespaces = namespaceList(stats.graphNamespaceParams[0]);
+      expect(namespaces).toBeDefined();
+      expect(namespaces).toContain(READER_NS);
+      expect(namespaces).not.toContain(PRIVATE_NS);
+      expect(parsed.answer).toBeNull();
+      expect(parsed.citations).toEqual([]);
+      expect(JSON.stringify(parsed)).not.toContain("private-target");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("excludes archived links and archived entities from graph-cited evidence", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const viaArchivedLink = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "What mentions Alpha?", namespace: READER_NS },
+        }),
+      );
+      expect(viaArchivedLink.citations).toEqual([]);
+      expect(JSON.stringify(viaArchivedLink)).not.toContain(
+        "archived-link-target",
+      );
+
+      const viaArchivedEntity = parseToolResult(
+        await client.callTool({
+          name: "brain_answer",
+          arguments: { query: "What mentions Archived?", namespace: READER_NS },
+        }),
+      );
+      expect(viaArchivedEntity.citations).toEqual([]);
+      expect(JSON.stringify(viaArchivedEntity)).not.toContain(
+        "archived-entity-target",
+      );
+      expect(stats.graphCalls).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("performs no tracking writes when graph evidence is cited", async () => {
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "What depends on Alpha?", namespace: READER_NS },
+      });
+      expect(result.isError).toBeFalsy();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(stats.writeQueries).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search_all
+// ---------------------------------------------------------------------------
+
+describe("search_all graph-expanded evidence (#268)", () => {
+  afterEach(restoreBunSpawn);
+
+  it("surfaces graph-expanded brain evidence with normal source refs", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "search_all",
+        arguments: {
+          query: "What depends on Alpha?",
+          namespace: READER_NS,
+          sources: "brain",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.brain_hits).toBe(1);
+      expect(parsed.results[0].source).toBe("brain");
+      expect(parsed.results[0].type).toBe("thought");
+      expect(parsed.results[0].id).toBe("graph-target");
+      expect(parsed.results[0].source_ref).toMatchObject({
+        source: "brain",
+        type: "thought",
+        id: "graph-target",
+        namespace: READER_NS,
+      });
+      expect(stats.graphCalls).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("stays stable and keeps graph evidence when qmd is unavailable", async () => {
+    mockBunSpawn(1, "", "qmd crashed");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "search_all",
+        arguments: {
+          query: "What depends on Alpha?",
+          namespace: READER_NS,
+          sources: "all",
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.brain_hits).toBe(1);
+      expect(parsed.qmd_hits).toBe(0);
+      expect(parsed.results[0].id).toBe("graph-target");
+      expect(stats.graphCalls).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps qmd federation decoupled from graph retrieval", async () => {
+    mockBunSpawn(
+      0,
+      JSON.stringify([{ path: "/doc.md", content: "qmd hit", score: 0.9 }]),
+    );
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "search_all",
+          arguments: { query: "What depends on Alpha?", sources: "qmd" },
+        }),
+      );
+      expect(parsed.qmd_hits).toBe(1);
+      expect(parsed.brain_hits).toBe(0);
+      expect(stats.graphCalls).toBe(0);
+      expect(stats.totalQueries).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies unreadable namespace filters before any graph retrieval", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "search_all",
+        arguments: { query: "What mentions Private?", namespace: PRIVATE_NS },
+      });
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toContain("namespace read access denied");
+      expect(stats.graphCalls).toBe(0);
+      expect(stats.totalQueries).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("passes the auth-derived namespace predicate into the graph SQL and leaks nothing unreadable", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const parsed = parseToolResult(
+        await client.callTool({
+          name: "search_all",
+          arguments: { query: "What mentions Private?", sources: "brain" },
+        }),
+      );
+      expect(stats.graphCalls).toBe(1);
+      const namespaces = namespaceList(stats.graphNamespaceParams[0]);
+      expect(namespaces).toBeDefined();
+      expect(namespaces).toContain(READER_NS);
+      expect(namespaces).not.toContain(PRIVATE_NS);
+      expect(parsed.brain_hits).toBe(0);
+      expect(JSON.stringify(parsed)).not.toContain("private-target");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("excludes archived links and archived entities from graph results", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const viaArchivedLink = parseToolResult(
+        await client.callTool({
+          name: "search_all",
+          arguments: {
+            query: "What mentions Alpha?",
+            namespace: READER_NS,
+            sources: "brain",
+          },
+        }),
+      );
+      expect(viaArchivedLink.brain_hits).toBe(0);
+      expect(JSON.stringify(viaArchivedLink)).not.toContain(
+        "archived-link-target",
+      );
+
+      const viaArchivedEntity = parseToolResult(
+        await client.callTool({
+          name: "search_all",
+          arguments: {
+            query: "What mentions Archived?",
+            namespace: READER_NS,
+            sources: "brain",
+          },
+        }),
+      );
+      expect(viaArchivedEntity.brain_hits).toBe(0);
+      expect(JSON.stringify(viaArchivedEntity)).not.toContain(
+        "archived-entity-target",
+      );
+      expect(stats.graphCalls).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not run graph SQL when source_scope is set", async () => {
+    mockBunSpawn(1, "");
+    const { pool, stats } = graphAwarePool();
+    const { client, cleanup } = await setupMcpClient(
+      registerSearchAll,
+      pool,
+      createMockEmbed(),
+      { role: "admin", clientId: "admin" },
+    );
+    try {
+      const result = await client.callTool({
+        name: "search_all",
+        arguments: {
+          query: "What depends on Alpha?",
+          sources: "brain",
+          source_scope: { client_id: "acme" },
+        },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.brain_hits).toBe(0);
+      expect(stats.graphCalls).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/graph-evidence-consumers.test.ts
+++ b/src/tools/__tests__/graph-evidence-consumers.test.ts
@@ -210,6 +210,9 @@ type GraphPoolStats = {
 function graphAwarePool(options?: {
   /** fts_rank stamped on graph-hydrated rows (raw link weight in prod). */
   graphFtsRank?: number;
+  /** Rows returned by the ordinary (non-graph) retrieval arms, with a
+   * caller-controlled cosine distance (may exceed 1 or be non-finite). */
+  vectorRows?: Array<{ entry: FixtureEntry; distance: number }>;
 }): { pool: { query: (...args: any[]) => Promise<{ rows: any[] }> }; stats: GraphPoolStats } {
   const stats: GraphPoolStats = {
     graphCalls: 0,
@@ -237,8 +240,19 @@ function graphAwarePool(options?: {
           ).map((entry) => searchRow(entry, options?.graphFtsRank ?? 1)),
         };
       }
-      // vector, fts, and explicit-link lookups return nothing so every hit
-      // below is attributable to the graph arm alone.
+      // Unless vectorRows is provided, vector, fts, and explicit-link
+      // lookups return nothing so every hit below is attributable to the
+      // graph arm alone. (executeSearch dedupes by source_type:id, so
+      // returning the same rows from multiple arms is safe.)
+      if (options?.vectorRows?.length) {
+        return {
+          rows: options.vectorRows.map(({ entry, distance }) => ({
+            ...searchRow(entry),
+            fts_rank: null,
+            distance,
+          })),
+        };
+      }
       return { rows: [] };
     },
   };
@@ -528,6 +542,65 @@ describe("brain_answer graph-expanded evidence (#268)", () => {
     }
   });
 
+  it("clamps vector-row scores when cosine distance exceeds 1 and guards non-finite (codex finding 1)", async () => {
+    const { pool, stats } = graphAwarePool({
+      vectorRows: [
+        {
+          entry: {
+            id: "vector-far",
+            source_type: "thought",
+            namespace: READER_NS,
+            text: "Vector row beyond unit cosine distance.",
+            created_at: "2026-06-01T00:00:00Z",
+          },
+          distance: 1.3,
+        },
+        {
+          entry: {
+            id: "vector-nan",
+            source_type: "thought",
+            namespace: READER_NS,
+            text: "Vector row with a non-finite distance.",
+            created_at: "2026-06-01T00:00:00Z",
+          },
+          distance: Number.NaN,
+        },
+      ],
+    });
+    const { client, cleanup } = await setupMcpClient(
+      registerBrainAnswer,
+      pool,
+      createMockEmbed(),
+      readerAuth,
+    );
+    try {
+      const result = await client.callTool({
+        name: "brain_answer",
+        arguments: { query: "deploy readiness notes", namespace: READER_NS },
+      });
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(stats.graphCalls).toBe(0);
+      expect(parsed.citations.length).toBeGreaterThan(0);
+      for (const citation of parsed.citations as Array<{ score: number }>) {
+        expect(Number.isFinite(citation.score)).toBe(true);
+        expect(citation.score).toBeGreaterThanOrEqual(0);
+        expect(citation.score).toBeLessThanOrEqual(1);
+      }
+      const far = (
+        parsed.citations as Array<{
+          score: number;
+          source_ref: { id: string };
+        }>
+      ).find((citation) => citation.source_ref.id === "vector-far");
+      expect(far).toBeDefined();
+      // 1 - 1.3 = -0.3 without the clamp.
+      expect(far!.score).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("still cites graph evidence when the embedding provider is down (finding 2)", async () => {
     const { pool, stats } = graphAwarePool();
     const { client, cleanup } = await setupMcpClient(
@@ -797,7 +870,7 @@ describe("search_all graph-expanded evidence (#268)", () => {
     }
   });
 
-  it("clamps graph-row scores derived from link weight > 1 into [0,1] (finding 1)", async () => {
+  it("emits the [0,1] RRF-derived score, never raw link weight > 1 (findings 1-2)", async () => {
     mockBunSpawn(1, "");
     const { pool, stats } = graphAwarePool({ graphFtsRank: 2.5 });
     const { client, cleanup } = await setupMcpClient(
@@ -820,8 +893,13 @@ describe("search_all graph-expanded evidence (#268)", () => {
       expect(stats.graphCalls).toBe(1);
       expect(parsed.brain_hits).toBe(1);
       expect(parsed.results[0].id).toBe("graph-target");
-      expect(parsed.results[0].score).toBeLessThanOrEqual(1);
+      // search_all's operative [0,1] mechanism is the RRF overwrite at the
+      // tool boundary: a rank-1 warm brain row emits exactly
+      // 1/(RRF_K + 1) = 1/61 (tier boost 0), NOT the raw 2.5 link weight.
+      // If the overwrite is ever removed and raw scores leak, this fails.
+      expect(parsed.results[0].score).toBeCloseTo(1 / 61, 10);
       expect(parsed.results[0].score).toBeGreaterThanOrEqual(0);
+      expect(parsed.results[0].score).toBeLessThanOrEqual(1);
     } finally {
       await cleanup();
     }

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -37,7 +37,13 @@ interface Evidence {
 }
 
 function scoreFor(row: SearchRow): number {
-  return row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5);
+  // fts_rank is not guaranteed to be [0,1]: graph-hydrated rows carry raw
+  // link weight (GREATEST(l.weight, 0), unbounded above) and ts_rank_cd is
+  // only typically <1. Clamp at the consumer boundary so the emitted score
+  // stays a [0,1] relevance value (#268 review finding 1).
+  return row.distance != null
+    ? 1 - row.distance
+    : Math.min(1, Math.max(0, row.fts_rank ?? 0.5));
 }
 
 function excerptFor(row: SearchRow): string | null {

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -36,14 +36,20 @@ interface Evidence {
   source_ref: SourceRef;
 }
 
+// Neither raw input is guaranteed to be [0,1]: graph-hydrated rows carry raw
+// link weight (GREATEST(l.weight, 0), unbounded above) as fts_rank, ts_rank_cd
+// is only typically <1, and cosine distance can exceed 1 (making 1 - distance
+// negative). Clamp the final computed score at the consumer boundary so the
+// emitted score stays a finite [0,1] relevance value (#268 review findings).
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
 function scoreFor(row: SearchRow): number {
-  // fts_rank is not guaranteed to be [0,1]: graph-hydrated rows carry raw
-  // link weight (GREATEST(l.weight, 0), unbounded above) and ts_rank_cd is
-  // only typically <1. Clamp at the consumer boundary so the emitted score
-  // stays a [0,1] relevance value (#268 review finding 1).
-  return row.distance != null
-    ? 1 - row.distance
-    : Math.min(1, Math.max(0, row.fts_rank ?? 0.5));
+  return clampScore(
+    row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
+  );
 }
 
 function excerptFor(row: SearchRow): string | null {

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -228,6 +228,10 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
 
       let rows: SearchRow[];
       try {
+        // #268: inherit search_brain's graph-expanded retrieval arm. Graph
+        // candidates hydrate into normal SearchRows with standard source_refs,
+        // so extractive/cited answer behavior is unchanged; namespace and
+        // archived predicates are enforced inside the shared arm (#267).
         rows =
           typeof namespace === "string" && isSharedNamespace(namespace)
             ? await executeSearchWithSharedFallback(
@@ -241,6 +245,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
                 namespace,
                 false,
                 sourceScope,
+                { enableGraph: true },
               )
             : await executeSearchWithScopedSharedFallback(
                 deps,
@@ -253,6 +258,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
                 namespace,
                 false,
                 sourceScope,
+                { enableGraph: true },
               );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -334,6 +334,9 @@ async function searchOB(
 
   let rows: SearchRow[];
   try {
+    // #268: inherit search_brain's graph-expanded retrieval arm on the brain
+    // side only. qmd federation stays separate and fail-open; the graph arm
+    // never runs on qmd paths and is skipped entirely under source_scope.
     rows =
       typeof namespace === "string" && isSharedNamespace(namespace)
         ? await executeSearchWithSharedFallback(
@@ -347,6 +350,7 @@ async function searchOB(
             namespace,
             false,
             sourceScope,
+            { enableGraph: true },
           )
         : await executeSearchWithScopedSharedFallback(
             deps,
@@ -359,6 +363,7 @@ async function searchOB(
             namespace,
             false,
             sourceScope,
+            { enableGraph: true },
           );
   } catch (err) {
     logger.warn("searchOB_failed", {

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -380,13 +380,13 @@ async function searchOB(
       source: "brain" as const,
       type: row.source_type,
       content: preview.slice(0, 300),
-      // fts_rank is not guaranteed to be [0,1]: graph-hydrated rows carry
-      // raw link weight (unbounded above). Clamp so the emitted score stays
-      // a [0,1] relevance value (#268 review finding 1).
-      score:
-        row.distance != null
-          ? 1 - row.distance
-          : Math.min(1, Math.max(0, row.fts_rank ?? 0.5)),
+      // Pre-RRF score only: the tool handler always overwrites `score` with
+      // the RRF value before emitting (see the final `.map` in the handler),
+      // which is structurally finite and within [0,1] (Math.max(0, ...)
+      // lower bound; upper bound 1/(RRF_K+1) + max tier boost 0.3). Raw
+      // distance/fts_rank (including graph link weight > 1) therefore never
+      // reaches the tool output (#268 review findings).
+      score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
       source_ref: row.source_ref ?? {
         source: "brain" as const,
         type: row.source_type,

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -380,7 +380,13 @@ async function searchOB(
       source: "brain" as const,
       type: row.source_type,
       content: preview.slice(0, 300),
-      score: row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
+      // fts_rank is not guaranteed to be [0,1]: graph-hydrated rows carry
+      // raw link weight (unbounded above). Clamp so the emitted score stays
+      // a [0,1] relevance value (#268 review finding 1).
+      score:
+        row.distance != null
+          ? 1 - row.distance
+          : Math.min(1, Math.max(0, row.fts_rank ?? 0.5)),
       source_ref: row.source_ref ?? {
         source: "brain" as const,
         type: row.source_type,


### PR DESCRIPTION
## Summary

- expose graph-expanded evidence in `brain_answer` and `search_all` by inheriting `search_brain`'s relational graph retrieval arm (#267 / PR #274) — both consumers now pass `{ enableGraph: true }` to the shared retrieval helpers; no second traversal is built
- graph candidates hydrate into normal `SearchRow`s with standard Open Brain source refs, so `brain_answer` stays extractive/cited and keeps its gap/staleness/conflict reporting, and `search_all`'s `UnifiedResult` output shape is unchanged
- qmd federation stays separate and fail-open: the graph arm runs only on the brain side of `search_all`, and remains disabled entirely under `source_scope`
- add `src/tools/__tests__/graph-evidence-consumers.test.ts` with 15 consumer-surface tests

Closes #268.

## Design decision: default inheritance, not opt-in

The sprint spec allowed a consumer-surface opt-in flag only if default inheritance would silently change cited answer behavior or downstream contracts. From the actual code, it does not:

- Graph rows are hydrated real rows (thoughts/decisions/projects/sessions) run through `withSourceRefs`, identical in shape to vector/FTS rows. `brain_answer` cites them extractively through the same `Citation` path; nothing is synthesized from edges, and rows lacking preview/citation metadata are still skipped with a gap.
- No input schema, output shape, error envelope, or `get_contract` change. `CONTRACT_VERSION` and `src/contract*.ts` are untouched; the Python client pin is unaffected.
- The arm activates only for deterministic relational query patterns ("what depends on X?" etc.); all other queries are byte-identical in behavior. It is already skipped under `source_scope` inside `executeSearch`.
- Link-path metadata is NOT exposed at either consumer surface: `brain_answer` citations contain only `{index, source_ref, excerpt, score, stale}`, and both consumers pass `includeLinks: false`, so graph rows carry no `explicit_links`. A test pins the citation key set.
- Namespace read policy is enforced server-side exactly as in `search_brain`: `canReadNamespace` denial before retrieval, and the auth-derived `namespaceFilterFor` value is the same parameter the graph seed/traversal SQL binds on every hop (`l.namespace = seed.namespace`, target `namespace = l.namespace`, `archived_at IS NULL` on links, entities, and hydrated rows). Tests assert the graph SQL receives the auth-derived namespace list at the consumer surface.

An opt-in flag would have required a new input schema field (a real contract change with downstream rollout cost) to guard against a change that alters no shapes — worse than the default.

## Validation

- `bunx tsc --noEmit` - PASS
- `bun test src/tools/__tests__/graph-evidence-consumers.test.ts` - PASS, 15 pass / 0 fail (71 expect calls)
- `bun test` (full suite, mandatory for shared retrieval changes) - PASS, 1220 pass / 54 skip / 0 fail (1274 tests, 87 files)
- `git diff --check` - PASS
- `git diff --cached --check` - PASS before commit

## Critical self-review

Critical self-review:
- Highest-risk behavior: graph-hydrated rows entering the cited-answer path could leak cross-namespace or archived content if the shared arm's predicates were ever bypassed; mitigated because both consumers reuse the exact #267 arm (no new SQL), and consumer-surface tests assert the auth-derived namespace parameter reaches the graph query and unreadable/archived targets never surface.
- Assumptions that could be wrong: that the PR #274 arm's SQL predicates are correct (proven by its live-Postgres predicate test, which this PR relies on rather than re-proving); that no consumer depends on brain_answer/search_all returning strictly vector/FTS-ranked rows for relational-pattern queries.
- Missing/weak tests: consumer tests use a graph-aware mock pool (same convention as PR #274's unit tests); no new live-Postgres test at the consumer surface — the live predicate proof lives in search-brain-relational-retrieval.test.ts and the SQL is shared, not duplicated.
- Security/permission risk: namespace denial happens before any pool query (asserted); graph SQL binds the auth-derived namespace filter; link-path metadata is not exposed (citation key set pinned by test).
- Migration/deploy risk: none — no migrations, no schema, no env changes.
- Downstream client/runtime risk: no MCP tool names, input schemas, output shapes, annotations, auth semantics, or error envelopes change; retrieval ranking for relational-pattern queries improves, which is the issue's intent. Python client untouched.
- Rollback/cleanup concern: revert is two `{ enableGraph: true }` arguments plus one test file; no state to clean up.
- Fixes made before PR: none needed beyond the initial implementation; typecheck and full suite passed first run.
- Known residual risk: relational-pattern queries in brain_answer/search_all now weight graph candidates (3x RRF) ahead of lexical matches; if a deployed workflow depended on the old ordering for those exact phrasings, results reorder. Judged acceptable and intended per #268.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no review swarm has produced a MEDIUM+ finding yet; PR remains draft until review completes.

## Downstream rollout classification

Checked `docs/downstream-rollout.md`.

- Does not apply: no MCP tool names, input schemas, output shapes, annotations, auth/namespace semantics, or error envelopes change; no transport, migration, `python/openbrain-memory`, or generated-skill changes. `get_contract` and `CONTRACT_VERSION` are untouched.
- The change is server-internal retrieval behavior (which rows the existing tools return for relational-pattern queries). rtech-mcps, mcp2cli schema refresh, rtech-hermes, and Hermes canary steps are not applicable.
- Value-distribution note: relational-phrased queries now include graph-sourced rows whose `score` derives from clamped link weight (bounded to [0,1]) rather than vector distance; no schema change.
- Hosted deploy/live smoke remains release-phase work via the normal v* tag path; not performed by this PR.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured: no review swarm has run yet; PR remains draft until standard review completes.
- [ ] Initial review swarm complete
- [ ] Material findings fixed or explicitly deferred
- [ ] Fix verification complete
- [ ] CI passed for this PR head
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is local-first sprint work; no core01 deploy or live DB mutation is approved for this PR.

## No deploy / release note

No core01 deploy is performed by this PR. The sprint remains local branches, PRs, and CI first. After the sprint issues are merged and verified, the release step is a v* tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
