### PR TITLE
Add dedicated Open Brain NATS worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
 Do not put qmd indexes, qmd models, Postgres data, or required production
 `node_modules` under `/Volumes/ThunderBolt/Development`.
 
+NATS transport rollout is separate from the HTTP deploy. The broker label is
+`com.rico.open-brain-nats`; the Open Brain NATS request/reply worker label is
+`com.rico.open-brain-nats-worker`. Keep HTTP workers in HTTP mode and follow
+[`docs/core01-nats-worker-runbook.md`](docs/core01-nats-worker-runbook.md)
+before installing or restarting the dedicated NATS worker service.
+
 qmd is a repo-knowledge compiler and optional deep lookup source. It is not a
 required distributed memory layer for Hermes or other agents. Required qmd-
 derived facts must be promoted into Open Brain; remote qmd access remains a

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -1,0 +1,157 @@
+# Core01 Dedicated NATS Worker Runbook
+
+Issue: #282.
+Status: runtime entrypoint and launchd shape exist; install only from a release
+that has passed the validation gate below.
+
+## Boundary
+
+The NATS bridge must run as a separate launchd service from the HTTP workers.
+HTTP workers stay in `OPENBRAIN_TRANSPORT=http` mode and keep serving `/health`
+on `3100`, `3101`, and `3102`. The NATS worker subscribes to
+`ob.memory.context_pack` and may fail or restart without taking HTTP health down.
+
+The broker and worker are separate services:
+
+| Component | Launchd label | Responsibility |
+| --- | --- | --- |
+| HTTP Open Brain | `com.rico.open-brain` | HTTP/MCP entrypoint and two HTTP workers. |
+| NATS broker | `com.rico.open-brain-nats` | Local NATS/JetStream server on `127.0.0.1:4222`. |
+| NATS Open Brain worker | `com.rico.open-brain-nats-worker` | Request/reply bridge for `ob.memory.context_pack`. |
+
+Do not put the NATS subscription path back into the HTTP launchd service. Broker
+restart, subscription failure, malformed NATS envelopes, or worker crash loops
+must be visible in NATS worker logs without degrading HTTP `/health`.
+
+## Files
+
+- launchd template:
+  `docs/deploy/com.rico.open-brain-nats-worker.plist.template`
+- runtime app:
+  `/Volumes/ThunderBolt/open-brain/app`
+- shared HTTP env:
+  `/Users/rico/.config/open-brain/env`
+- NATS worker env:
+  `/Users/rico/.config/open-brain/env.nats-worker`
+- logs:
+  `/Volumes/ThunderBolt/open-brain/logs/nats-worker.out.log`
+  and `/Volumes/ThunderBolt/open-brain/logs/nats-worker.err.log`
+
+The worker env should source or duplicate only the production settings required
+to execute Open Brain authority paths. Keep secrets in the env file or approved
+secret store; do not commit them.
+
+Minimum worker-specific values:
+
+```zsh
+OPENBRAIN_TRANSPORT=nats
+OPENBRAIN_NATS_ENABLE_BRIDGE=true
+OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
+OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
+OPENBRAIN_NATS_FALLBACK_HTTP=true
+OPEN_BRAIN_RUN_MIGRATIONS=0
+OPEN_BRAIN_WORKER_NAME=open-brain-nats-worker
+QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
+```
+
+HTTP worker env must stay in HTTP mode:
+
+```zsh
+OPENBRAIN_TRANSPORT=http
+OPENBRAIN_NATS_ENABLE_BRIDGE=false
+```
+
+## Install Gate
+
+Install the worker only after a release includes `scripts/run-nats-worker.ts`
+and tests for:
+
+- successful `ob.memory.context_pack` request/reply;
+- missing or invalid bearer auth;
+- malformed NATS envelope;
+- broker unavailable behavior;
+- HTTP health staying healthy while the NATS worker starts, stops, and restarts.
+
+If the entrypoint does not exist, stop at documentation and report that runtime
+work is still required. Do not patch around it in launchd with the HTTP server
+entrypoint.
+
+## Install Or Update
+
+Run these commands on core01 after the release gate in
+`docs/local-release-deploy-sop.md` has passed and the runtime app is staged at
+`/Volumes/ThunderBolt/open-brain/app`:
+
+```zsh
+sudo install -d -m 0755 /Volumes/ThunderBolt/open-brain/logs
+sudo cp \
+  /Volumes/ThunderBolt/open-brain/app/docs/deploy/com.rico.open-brain-nats-worker.plist.template \
+  /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chown root:wheel /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+```
+
+For updates after the service is already bootstrapped:
+
+```zsh
+sudo cp \
+  /Volumes/ThunderBolt/open-brain/app/docs/deploy/com.rico.open-brain-nats-worker.plist.template \
+  /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chown root:wheel /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+```
+
+## Verification
+
+Confirm the service shape:
+
+```zsh
+sudo launchctl print system/com.rico.open-brain
+sudo launchctl print system/com.rico.open-brain-nats
+sudo launchctl print system/com.rico.open-brain-nats-worker
+```
+
+Confirm HTTP health is independent:
+
+```zsh
+curl -fsS http://127.0.0.1:3100/health
+curl -fsS http://127.0.0.1:3101/health
+curl -fsS http://127.0.0.1:3102/health
+sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+curl -fsS http://127.0.0.1:3100/health
+curl -fsS http://127.0.0.1:3101/health
+curl -fsS http://127.0.0.1:3102/health
+```
+
+Confirm NATS request/reply with the release-owned smoke tool or approved client.
+The expected response envelope is:
+
+```json
+{
+  "schema": "openbrain.nats.response.v1",
+  "status": "ok"
+}
+```
+
+Record the command used, response status, HTTP health before and after worker
+restart, and any JetStream stream creation/defer evidence in the rollout
+receipt for #223 and #282.
+
+## Rollback
+
+Rollback of the NATS worker must not roll back PostgreSQL or HTTP workers.
+
+```zsh
+sudo launchctl bootout system/com.rico.open-brain-nats-worker
+curl -fsS http://127.0.0.1:3100/health
+curl -fsS http://127.0.0.1:3101/health
+curl -fsS http://127.0.0.1:3102/health
+```
+
+Preserve logs and JetStream state for inspection unless an explicit cleanup
+decision says only minimized metadata exists and the state can be removed. If
+the worker env carried credentials, rotate or remove them through the approved
+secret path.

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -37,18 +37,21 @@ must be visible in NATS worker logs without degrading HTTP `/health`.
   `/Volumes/ThunderBolt/open-brain/logs/nats-worker.out.log`
   and `/Volumes/ThunderBolt/open-brain/logs/nats-worker.err.log`
 
-The worker env should source or duplicate only the production settings required
-to execute Open Brain authority paths. Keep secrets in the env file or approved
-secret store; do not commit them.
+The worker env should source the shared production env and then set only
+worker-specific overrides. Keep secrets in the env file or approved secret
+store; do not commit them. The launchd template fails closed when this file is
+missing or unreadable.
 
-Minimum worker-specific values:
+Expected shape:
 
 ```zsh
+source /Users/rico/.config/open-brain/env
 OPENBRAIN_TRANSPORT=nats
 OPENBRAIN_NATS_ENABLE_BRIDGE=true
 OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
 OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
 OPENBRAIN_NATS_FALLBACK_HTTP=true
+OPEN_BRAIN_NATS_WORKER_HEALTH_PORT=3110
 OPEN_BRAIN_RUN_MIGRATIONS=0
 OPEN_BRAIN_WORKER_NAME=open-brain-nats-worker
 QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
@@ -64,13 +67,16 @@ OPENBRAIN_NATS_ENABLE_BRIDGE=false
 ## Install Gate
 
 Install the worker only after a release includes `scripts/run-nats-worker.ts`
-and tests for:
+and evidence for:
 
-- successful `ob.memory.context_pack` request/reply;
-- missing or invalid bearer auth;
-- malformed NATS envelope;
-- broker unavailable behavior;
-- HTTP health staying healthy while the NATS worker starts, stops, and restarts.
+- automated bridge tests for successful `ob.memory.context_pack` request/reply,
+  missing or invalid bearer auth, malformed NATS envelopes, oversized payloads,
+  and degraded bridge health;
+- automated worker tests for dedicated-worker boundary forcing, missing broker
+  URL fail-closed behavior, subscription startup, shutdown cleanup, constant-time
+  bearer-token matching, and health-bind cleanup after bridge startup;
+- live release proof for broker unavailable behavior and HTTP health staying
+  healthy while the NATS worker starts, stops, and restarts.
 
 If the entrypoint does not exist, stop at documentation and report that runtime
 work is still required. Do not patch around it in launchd with the HTTP server
@@ -81,6 +87,16 @@ entrypoint.
 Run these commands on core01 after the release gate in
 `docs/local-release-deploy-sop.md` has passed and the runtime app is staged at
 `/Volumes/ThunderBolt/open-brain/app`:
+
+First create or validate the worker env file. It should be mode `0600`, source
+`/Users/rico/.config/open-brain/env`, and set the worker-specific overrides from
+the Files section above:
+
+```zsh
+sudo test -r /Users/rico/.config/open-brain/env
+sudo test -r /Users/rico/.config/open-brain/env.nats-worker
+/opt/homebrew/bin/bash -n /Users/rico/.config/open-brain/env.nats-worker
+```
 
 ```zsh
 sudo install -d -m 0755 /Volumes/ThunderBolt/open-brain/logs
@@ -93,7 +109,10 @@ sudo launchctl bootstrap system /Library/LaunchDaemons/com.rico.open-brain-nats-
 sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
 ```
 
-For updates after the service is already bootstrapped:
+For updates after the service is already bootstrapped, reload the launchd job
+definition. `kickstart` alone restarts the currently loaded definition and is
+not enough when `ProgramArguments`, environment, log paths, or resource limits
+changed:
 
 ```zsh
 sudo cp \
@@ -101,7 +120,10 @@ sudo cp \
   /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
 sudo chown root:wheel /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
 sudo chmod 0644 /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl bootout system/com.rico.open-brain-nats-worker
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
 sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+sudo launchctl print system/com.rico.open-brain-nats-worker
 ```
 
 ## Verification
@@ -135,6 +157,25 @@ The expected response envelope is:
   "status": "ok"
 }
 ```
+
+Expected error responses use the same response schema with `status: "error"`:
+
+```json
+{
+  "schema": "openbrain.nats.response.v1",
+  "request_id": "uuid-or-null",
+  "status": "error",
+  "operation": "agent_context_pack",
+  "error": {
+    "code": "permission_denied|bad_request|payload_too_large|temporarily_unavailable|tool_error|internal_error",
+    "message": "redacted failure summary"
+  }
+}
+```
+
+A missing reply inbox is not a successful request/reply smoke; inspect the NATS
+worker logs and `/health` for bridge request, subscription, shutdown, or close
+failures.
 
 Record the command used, response status, HTTP health before and after worker
 restart, and any JetStream stream creation/defer evidence in the rollout

--- a/docs/deploy/com.rico.open-brain-nats-worker.plist.template
+++ b/docs/deploy/com.rico.open-brain-nats-worker.plist.template
@@ -10,7 +10,7 @@
   <array>
     <string>/opt/homebrew/bin/bash</string>
     <string>-lc</string>
-    <string>set -a; source /Users/rico/.config/open-brain/env.nats-worker; set +a; cd /Volumes/ThunderBolt/open-brain/app; exec "${BUN_BIN:-bun}" run scripts/run-nats-worker.ts</string>
+    <string>set -euo pipefail; ENV_FILE=/Users/rico/.config/open-brain/env.nats-worker; test -r "$ENV_FILE"; set -a; source "$ENV_FILE"; set +a; cd /Volumes/ThunderBolt/open-brain/app; exec "${BUN_BIN:-bun}" run scripts/run-nats-worker.ts</string>
   </array>
 
   <key>WorkingDirectory</key>

--- a/docs/deploy/com.rico.open-brain-nats-worker.plist.template
+++ b/docs/deploy/com.rico.open-brain-nats-worker.plist.template
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.rico.open-brain-nats-worker</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>-lc</string>
+    <string>set -a; source /Users/rico/.config/open-brain/env.nats-worker; set +a; cd /Volumes/ThunderBolt/open-brain/app; exec "${BUN_BIN:-bun}" run scripts/run-nats-worker.ts</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Volumes/ThunderBolt/open-brain/app</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OPEN_BRAIN_WORKER_NAME</key>
+    <string>open-brain-nats-worker</string>
+    <key>OPEN_BRAIN_RUN_MIGRATIONS</key>
+    <string>0</string>
+    <key>OPENBRAIN_TRANSPORT</key>
+    <string>nats</string>
+    <key>OPENBRAIN_NATS_ENABLE_BRIDGE</key>
+    <string>true</string>
+    <key>OPENBRAIN_NATS_URL</key>
+    <string>nats://127.0.0.1:4222</string>
+    <key>OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT</key>
+    <string>ob.memory.context_pack</string>
+    <key>OPENBRAIN_NATS_FALLBACK_HTTP</key>
+    <string>true</string>
+    <key>QMD_PATH</key>
+    <string>/Volumes/ThunderBolt/qmd/open-brain-qmd.ts</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Volumes/ThunderBolt/open-brain/logs/nats-worker.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Volumes/ThunderBolt/open-brain/logs/nats-worker.err.log</string>
+
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+</dict>
+</plist>

--- a/docs/local-release-deploy-sop.md
+++ b/docs/local-release-deploy-sop.md
@@ -205,6 +205,14 @@ mcp2cli open-brain search_all --params '{"query":"release smoke"}'
 For contract-changing releases, complete the downstream steps in
 `docs/downstream-rollout.md` before closing linked issues.
 
+For releases that enable the dedicated NATS worker from issue #282, also follow
+`docs/core01-nats-worker-runbook.md`. The release is not complete until HTTP
+health is recorded before and after `com.rico.open-brain-nats-worker` restart,
+and a hosted NATS request/reply smoke returns an
+`openbrain.nats.response.v1` envelope. If the release does not include the NATS
+worker runtime entrypoint, leave the launchd template uninstalled and record the
+worker rollout as deferred.
+
 ## Rollback
 
 The deploy script keeps the prior runtime at:

--- a/docs/nats-jetstream-foundation.md
+++ b/docs/nats-jetstream-foundation.md
@@ -42,7 +42,13 @@ Planned host:
 core01 Mac Mini, co-located with hosted Open Brain.
 
 Planned service:
-`com.rico.open-brain-nats` launchd service.
+`com.rico.open-brain-nats` launchd service for the broker.
+
+Dedicated Open Brain worker service:
+`com.rico.open-brain-nats-worker`, documented in
+`docs/core01-nats-worker-runbook.md`. This worker is separate from the HTTP
+launchd service and subscribes to NATS request/reply subjects without making
+HTTP `/health` depend on broker or subscription health.
 
 Planned config path:
 `/Volumes/ThunderBolt/open-brain/nats/nats-server.conf`.
@@ -251,10 +257,13 @@ availability only when explicitly enabled.
 - Constructor/config:
   `NatsTransport(url, context_pack_subject="ob.memory.context_pack",
   fallback_transport=UrllibTransport(...), timeout=...)`.
-- Server env:
+- Dedicated NATS worker env, not the HTTP worker env:
   `OPENBRAIN_TRANSPORT=nats`, `OPENBRAIN_NATS_ENABLE_BRIDGE=true`,
   `OPENBRAIN_NATS_URL`, `OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT`, and
   `OPENBRAIN_NATS_FALLBACK_HTTP=true`.
+- HTTP Open Brain workers must keep `OPENBRAIN_TRANSPORT=http` and
+  `OPENBRAIN_NATS_ENABLE_BRIDGE=false`, even when the same host has a local
+  broker and NATS worker.
 - Remote plaintext `nats://` broker URLs are not runtime-available by default.
   Use loopback/local NATS for local rollout, or set
   `OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE=true` only for an explicitly approved
@@ -305,7 +314,11 @@ Local-only validation for #223:
 Release validation, deferred until Rico approves deploy:
 
 - install NATS on core01 through the release SOP;
+- install or update `com.rico.open-brain-nats-worker` only after the runtime
+  entrypoint exists and the worker tests pass;
 - prove `/health` and monitoring endpoint locally on core01;
+- prove HTTP `/health` remains healthy while the NATS worker is started,
+  stopped, and restarted;
 - create streams with the documented limits;
 - run HTTP-vs-NATS parity tests for `agent_context_pack`;
 - run Hermes canary with HTTP fallback enabled;
@@ -318,8 +331,9 @@ Before NATS becomes the default path, rollback is to keep or restore
 the service and needs rollback:
 
 1. Set Hermes/Open Brain clients back to HTTP and confirm `/mcp` reads/writes.
-2. Stop or unload `com.rico.open-brain-nats`.
-3. Preserve the JetStream store for inspection unless an explicit cleanup
+2. Stop or unload `com.rico.open-brain-nats-worker`.
+3. Stop or unload `com.rico.open-brain-nats` if the broker itself is unsafe.
+4. Preserve the JetStream store for inspection unless an explicit cleanup
    decision says it contains only minimized metadata and can be deleted.
-4. Remove or rotate NATS credentials through the approved secret store.
-5. Leave PostgreSQL/Open Brain untouched; NATS streams are not memory authority.
+5. Remove or rotate NATS credentials through the approved secret store.
+6. Leave PostgreSQL/Open Brain untouched; NATS streams are not memory authority.

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -220,6 +220,32 @@ outbids foreground work.
 - Do tests wedge the fake pool and prove foreground queries still get
   connections while audit writes shed load?
 
+## [2026-07-08] Auxiliary health bind failures must clean up started workers
+
+**Severity:** HIGH
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** dedicated worker entrypoints that start subscriptions/pools before a
+health or monitoring listener
+**Status:** fixed in PR #283
+
+### Pattern
+
+A worker can successfully start its core subscription and database pool, then
+throw while binding an auxiliary health endpoint. If that bind failure is
+outside the guarded startup path, launchd/systemd restarts the process while the
+startup path skips orderly bridge/pool cleanup. This turns a monitoring-port
+collision into a noisy worker restart loop.
+
+### Review Questions
+
+- Are pool creation, bridge/subscription startup, and health-server bind inside
+  one guarded startup path?
+- If a later startup step fails, are already-started subscriptions, health
+  servers, and pools closed before exit?
+- Does the worker log a redacted startup failure instead of a raw exception?
+- Is there a regression test where health bind throws after subscription startup
+  and cleanup still closes both bridge and pool?
+
 ## [2026-07-08] Reusing an output field with a new value distribution is a contract change
 
 **Severity:** MEDIUM

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -381,3 +381,27 @@ advertised floor, breaks the contract downstream consumers pin against.
   version when the contract requires lockstep?
 - Is the bump classified in `docs/downstream-rollout.md` terms before the PR is
   called complete?
+
+## [2026-07-08] Launchd updates must reload desired state, not only kickstart
+
+**Severity:** MEDIUM
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** launchd service templates and core01 deploy/runbook instructions
+**Status:** fixed in PR #283
+
+### Pattern
+
+Copying an updated plist and running `launchctl kickstart -k` can restart the
+currently loaded job definition without reloading changed `ProgramArguments`,
+environment, log paths, or resource limits. A deploy can look restarted while
+live launchd state still differs from the repo template.
+
+### Review Questions
+
+- For plist changes, does the update path boot out and bootstrap the service
+  before kickstart?
+- Does verification print the loaded job after bootstrap so desired state can be
+  compared to live state?
+- Does the launch command fail fast when its env file is missing or unreadable?
+- Does the runbook validate the env file before installing/restarting the
+  service, especially when the worker env sources a shared production env?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -219,3 +219,26 @@ not silently stop future request processing.
 - Does server shutdown isolate optional transport close failures from database
   and process cleanup?
 - Is shutdown bounded when an optional bridge can hang?
+
+## [2026-07-08] Operational runbooks must separate implemented tests from release proof
+
+**Severity:** MEDIUM
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** rollout/runbook docs for live service workers and transport bridges
+**Status:** fixed in PR #283
+
+### Pattern
+
+A runbook can accidentally overclaim readiness by saying "install after tests
+for X" when the PR only adds a subset of those tests and leaves some checks as
+release-time live proof. That trains future operators to treat aspirational
+checks as already covered and weakens the deploy gate.
+
+### Review Questions
+
+- Does the runbook distinguish automated tests already present from live
+  release proof still required on the host?
+- Does verification document both success and expected error envelopes?
+- Are no-reply, shutdown, and close failures described as log/health conditions
+  to inspect, not successful request/reply smokes?
+- Are PR comments and release notes explicit about what remains deferred?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -202,6 +202,33 @@ promotion -- the forward path and its reversal path diverged in authority.
 - Does the parity regression suite enumerate every gate (REST and MCP variants
   separately) rather than spot-checking one?
 
+## [2026-07-08] New bearer-auth transports must reuse constant-time token matching
+
+**Severity:** MEDIUM
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** NATS request/reply bridges, alternate transports, and any non-HTTP
+bearer-token auth path
+**Status:** fixed in PR #283
+
+### Pattern
+
+Adding a second bearer-auth surface can accidentally bypass HTTP middleware's
+constant-time token matching if it verifies tokens with direct `Map.get()` or
+another early-exit lookup. Even when the transport is local-first, the server
+auth semantics should match the HTTP path so timing and role behavior do not
+diverge.
+
+### Review Questions
+
+- Does the new transport call the same constant-time token matching helper as
+  HTTP auth?
+- Is there a regression test that would fail if the transport used direct token
+  lookup?
+- Do startup/shutdown logs avoid raw exception messages that may include
+  credential-bearing broker URLs or wrapped token material?
+- Does the health endpoint redact internal error detail while still exposing
+  machine-readable availability?
+
 ## [2026-07-06] Privileged source-scope predicates must match one source reference
 
 **Severity:** HIGH

--- a/scripts/run-nats-worker.test.ts
+++ b/scripts/run-nats-worker.test.ts
@@ -54,6 +54,51 @@ describe("startNatsWorkerProcess", () => {
     expect(errorLogs.join("\n")).not.toContain("user:pass");
     expect(errorLogs.join("\n")).not.toContain("broker.internal");
   });
+
+  it("continues pool shutdown when bridge close times out", async () => {
+    const env = {
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "0",
+      OPEN_BRAIN_NATS_WORKER_SHUTDOWN_TIMEOUT_MS: "1",
+    };
+    let poolEnded = false;
+    const errorLogs: string[] = [];
+    const runtime: NatsWorkerRuntime = {
+      boundary: readNatsWorkerBoundary(env),
+      health: createNatsBridgeHealth("available"),
+      subject: "ob.memory.context_pack",
+      close: async () => {
+        await new Promise(() => undefined);
+      },
+    };
+
+    const processRuntime = await startNatsWorkerProcess({
+      env,
+      log: {
+        info: () => undefined,
+        error: (message, extra) => {
+          errorLogs.push(JSON.stringify({ message, extra }));
+        },
+      },
+      buildTokens: () =>
+        new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      createDbPool: () =>
+        ({
+          end: async () => {
+            poolEnded = true;
+          },
+        }) as any,
+      startWorker: async () => runtime,
+    });
+
+    await processRuntime.shutdown();
+
+    expect(poolEnded).toBe(true);
+    expect(errorLogs.join("\n")).toContain(
+      "Open Brain NATS worker bridge close failed",
+    );
+    expect(errorLogs.join("\n")).not.toContain("timed out");
+  });
 });
 
 describe("safeWorkerError", () => {

--- a/scripts/run-nats-worker.test.ts
+++ b/scripts/run-nats-worker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { createNatsBridgeHealth } from "../src/nats-bridge.ts";
+import { readNatsWorkerBoundary, type NatsWorkerRuntime } from "../src/nats-worker.ts";
+import { safeWorkerError, startNatsWorkerProcess } from "./run-nats-worker.ts";
+
+describe("startNatsWorkerProcess", () => {
+  it("closes the bridge and pool when health server bind fails after subscription startup", async () => {
+    const env = {
+      OPENBRAIN_NATS_URL: "nats://user:pass@127.0.0.1:4222",
+      OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "3110",
+    };
+    let runtimeClosed = false;
+    let poolEnded = false;
+    const infoLogs: string[] = [];
+    const errorLogs: string[] = [];
+    const runtime: NatsWorkerRuntime = {
+      boundary: readNatsWorkerBoundary(env),
+      health: createNatsBridgeHealth("available"),
+      subject: "ob.memory.context_pack",
+      close: async () => {
+        runtimeClosed = true;
+      },
+    };
+
+    await expect(
+      startNatsWorkerProcess({
+        env,
+        log: {
+          info: (message, extra) => {
+            infoLogs.push(JSON.stringify({ message, extra }));
+          },
+          error: (message, extra) => {
+            errorLogs.push(JSON.stringify({ message, extra }));
+          },
+        },
+        buildTokens: () =>
+          new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        createDbPool: () =>
+          ({
+            end: async () => {
+              poolEnded = true;
+            },
+          }) as any,
+        startWorker: async () => runtime,
+        serve: (() => {
+          throw new Error("listen failed for nats://user:pass@broker.internal");
+        }) as any,
+      }),
+    ).rejects.toThrow("listen failed");
+
+    expect(runtimeClosed).toBe(true);
+    expect(poolEnded).toBe(true);
+    expect(infoLogs.join("\n")).not.toContain("Open Brain NATS worker started");
+    expect(errorLogs.join("\n")).not.toContain("user:pass");
+    expect(errorLogs.join("\n")).not.toContain("broker.internal");
+  });
+});
+
+describe("safeWorkerError", () => {
+  it("reports error type without leaking the message", () => {
+    expect(
+      safeWorkerError(new Error("nats://user:pass@broker.internal failed")),
+    ).toEqual({ error_type: "Error" });
+  });
+});

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env bun
+
+import { buildTokenMap } from "../src/auth.ts";
+import { createPool } from "../src/db/pool.ts";
+import { logger } from "../src/logger.ts";
+import {
+  natsWorkerLogSummary,
+  startNatsWorker,
+  type NatsWorkerRuntime,
+} from "../src/nats-worker.ts";
+
+const tokenMap = buildTokenMap(process.env as Record<string, string | undefined>);
+if (tokenMap.size === 0) {
+  logger.error("No auth tokens configured -- cannot start NATS worker");
+  process.exit(1);
+}
+
+const pool = createPool();
+let runtime: NatsWorkerRuntime;
+try {
+  runtime = await startNatsWorker({
+    env: process.env,
+    pool,
+    tokenMap,
+  });
+  logger.info("Open Brain NATS worker started", {
+    ...natsWorkerLogSummary(runtime.boundary),
+    availability: runtime.health.availability,
+  });
+} catch (err) {
+  logger.error("Open Brain NATS worker failed to start", {
+    error: err instanceof Error ? err.message : String(err),
+  });
+  await pool.end().catch(() => undefined);
+  process.exit(1);
+}
+
+const healthPort = Number.parseInt(
+  process.env.OPEN_BRAIN_NATS_WORKER_HEALTH_PORT ?? "3110",
+  10,
+);
+const healthServer =
+  Number.isFinite(healthPort) && healthPort > 0
+    ? Bun.serve({
+        port: healthPort,
+        fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname !== "/health") {
+            return Response.json({ error: "Not found" }, { status: 404 });
+          }
+          const healthy = runtime.health.availability === "available";
+          return Response.json(
+            {
+              status: healthy ? "healthy" : "degraded",
+              nats: {
+                availability: runtime.health.availability,
+                context_pack_subject:
+                  runtime.boundary.nats.context_pack_subject,
+                consecutive_failures: runtime.health.consecutiveFailures,
+                last_error: runtime.health.lastError ? "redacted" : null,
+              },
+              timestamp: new Date().toISOString(),
+            },
+            { status: healthy ? 200 : 503 },
+          );
+        },
+      })
+    : null;
+
+if (healthServer) {
+  logger.info("Open Brain NATS worker health server started", {
+    port: healthPort,
+  });
+}
+
+async function shutdown() {
+  logger.info("Shutting down Open Brain NATS worker");
+  healthServer?.stop(true);
+  try {
+    await runtime.close();
+  } catch (err) {
+    logger.error("Open Brain NATS worker bridge close failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    await pool.end();
+  } catch (err) {
+    logger.error("Open Brain NATS worker pool close failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    process.exit(0);
+  }
+}
+
+process.on("SIGTERM", () => {
+  void shutdown();
+});
+process.on("SIGINT", () => {
+  void shutdown();
+});
+
+await new Promise(() => undefined);

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -1,104 +1,193 @@
 #!/usr/bin/env bun
 
+import type pg from "pg";
 import { buildTokenMap } from "../src/auth.ts";
 import { createPool } from "../src/db/pool.ts";
 import { logger } from "../src/logger.ts";
 import {
   natsWorkerLogSummary,
+  readNatsWorkerBoundary,
   startNatsWorker,
   type NatsWorkerRuntime,
 } from "../src/nats-worker.ts";
+import type { AuthInfo } from "../src/types.ts";
 
-const tokenMap = buildTokenMap(process.env as Record<string, string | undefined>);
-if (tokenMap.size === 0) {
-  logger.error("No auth tokens configured -- cannot start NATS worker");
-  process.exit(1);
+type LoggerLike = Pick<typeof logger, "error" | "info">;
+type HealthServer = { stop(force?: boolean): void };
+type ServeFn = typeof Bun.serve;
+
+export interface NatsWorkerProcess {
+  runtime: NatsWorkerRuntime;
+  pool: pg.Pool;
+  healthServer: HealthServer | null;
+  shutdown(): Promise<void>;
 }
 
-const pool = createPool();
-let runtime: NatsWorkerRuntime;
-try {
-  runtime = await startNatsWorker({
-    env: process.env,
-    pool,
-    tokenMap,
-  });
-  logger.info("Open Brain NATS worker started", {
-    ...natsWorkerLogSummary(runtime.boundary),
-    availability: runtime.health.availability,
-  });
-} catch (err) {
-  logger.error("Open Brain NATS worker failed to start", {
-    error: err instanceof Error ? err.message : String(err),
-  });
-  await pool.end().catch(() => undefined);
-  process.exit(1);
+export interface StartNatsWorkerProcessOptions {
+  env: NodeJS.ProcessEnv;
+  log?: LoggerLike;
+  buildTokens?: typeof buildTokenMap;
+  createDbPool?: typeof createPool;
+  startWorker?: typeof startNatsWorker;
+  serve?: ServeFn;
 }
 
-const healthPort = Number.parseInt(
-  process.env.OPEN_BRAIN_NATS_WORKER_HEALTH_PORT ?? "3110",
-  10,
-);
-const healthServer =
-  Number.isFinite(healthPort) && healthPort > 0
-    ? Bun.serve({
-        port: healthPort,
-        fetch(request) {
-          const url = new URL(request.url);
-          if (url.pathname !== "/health") {
-            return Response.json({ error: "Not found" }, { status: 404 });
-          }
-          const healthy = runtime.health.availability === "available";
-          return Response.json(
-            {
-              status: healthy ? "healthy" : "degraded",
-              nats: {
-                availability: runtime.health.availability,
-                context_pack_subject:
-                  runtime.boundary.nats.context_pack_subject,
-                consecutive_failures: runtime.health.consecutiveFailures,
-                last_error: runtime.health.lastError ? "redacted" : null,
-              },
-              timestamp: new Date().toISOString(),
-            },
-            { status: healthy ? 200 : 503 },
-          );
-        },
-      })
-    : null;
+export function safeWorkerError(err: unknown): { error_type: string } {
+  if (err instanceof Error) return { error_type: err.name || "Error" };
+  return { error_type: typeof err };
+}
 
-if (healthServer) {
-  logger.info("Open Brain NATS worker health server started", {
+function healthPortFromEnv(env: NodeJS.ProcessEnv): number | null {
+  const healthPort = Number.parseInt(
+    env.OPEN_BRAIN_NATS_WORKER_HEALTH_PORT ?? "3110",
+    10,
+  );
+  return Number.isFinite(healthPort) && healthPort > 0 ? healthPort : null;
+}
+
+function startHealthServer(input: {
+  env: NodeJS.ProcessEnv;
+  runtime: NatsWorkerRuntime;
+  serve: ServeFn;
+}): HealthServer | null {
+  const healthPort = healthPortFromEnv(input.env);
+  if (!healthPort) return null;
+
+  return input.serve({
     port: healthPort,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname !== "/health") {
+        return Response.json({ error: "Not found" }, { status: 404 });
+      }
+      const healthy = input.runtime.health.availability === "available";
+      return Response.json(
+        {
+          status: healthy ? "healthy" : "degraded",
+          nats: {
+            availability: input.runtime.health.availability,
+            context_pack_subject: input.runtime.boundary.nats.context_pack_subject,
+            consecutive_failures: input.runtime.health.consecutiveFailures,
+            last_error: input.runtime.health.lastError ? "redacted" : null,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: healthy ? 200 : 503 },
+      );
+    },
   });
 }
 
-async function shutdown() {
-  logger.info("Shutting down Open Brain NATS worker");
-  healthServer?.stop(true);
+async function closeRuntime(
+  runtime: NatsWorkerRuntime | undefined,
+  log: LoggerLike,
+): Promise<void> {
+  if (!runtime) return;
   try {
     await runtime.close();
   } catch (err) {
-    logger.error("Open Brain NATS worker bridge close failed", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-  try {
-    await pool.end();
-  } catch (err) {
-    logger.error("Open Brain NATS worker pool close failed", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  } finally {
-    process.exit(0);
+    log.error("Open Brain NATS worker bridge close failed", safeWorkerError(err));
   }
 }
 
-process.on("SIGTERM", () => {
-  void shutdown();
-});
-process.on("SIGINT", () => {
-  void shutdown();
-});
+function closeHealthServer(
+  healthServer: HealthServer | null,
+  log: LoggerLike,
+): void {
+  if (!healthServer) return;
+  try {
+    healthServer.stop(true);
+  } catch (err) {
+    log.error(
+      "Open Brain NATS worker health server close failed",
+      safeWorkerError(err),
+    );
+  }
+}
 
-await new Promise(() => undefined);
+async function closePool(
+  pool: pg.Pool | undefined,
+  log: LoggerLike,
+): Promise<void> {
+  if (!pool) return;
+  try {
+    await pool.end();
+  } catch (err) {
+    log.error("Open Brain NATS worker pool close failed", safeWorkerError(err));
+  }
+}
+
+export async function startNatsWorkerProcess(
+  options: StartNatsWorkerProcessOptions,
+): Promise<NatsWorkerProcess> {
+  const log = options.log ?? logger;
+  const buildTokens = options.buildTokens ?? buildTokenMap;
+  const createDbPool = options.createDbPool ?? createPool;
+  const startWorker = options.startWorker ?? startNatsWorker;
+  const serve = options.serve ?? Bun.serve;
+  const env = options.env;
+
+  let pool: pg.Pool | undefined;
+  let runtime: NatsWorkerRuntime | undefined;
+  let healthServer: HealthServer | null = null;
+
+  try {
+    const tokenMap = buildTokens(env as Record<string, string | undefined>);
+    if (tokenMap.size === 0) {
+      throw new Error("No auth tokens configured");
+    }
+
+    pool = createDbPool();
+    runtime = await startWorker({
+      env,
+      pool,
+      tokenMap: tokenMap as Map<string, AuthInfo>,
+    });
+    healthServer = startHealthServer({ env, runtime, serve });
+    log.info("Open Brain NATS worker started", {
+      ...natsWorkerLogSummary(runtime.boundary),
+      availability: runtime.health.availability,
+      health_port: healthPortFromEnv(env),
+    });
+    return {
+      runtime,
+      pool,
+      healthServer,
+      shutdown: async () => {
+        log.info("Shutting down Open Brain NATS worker");
+        closeHealthServer(healthServer, log);
+        await closeRuntime(runtime, log);
+        await closePool(pool, log);
+      },
+    };
+  } catch (err) {
+    log.error("Open Brain NATS worker failed to start", {
+      ...safeWorkerError(err),
+      ...natsWorkerLogSummary(readNatsWorkerBoundary(env)),
+    });
+    closeHealthServer(healthServer, log);
+    await closeRuntime(runtime, log);
+    await closePool(pool, log);
+    throw err;
+  }
+}
+
+if (import.meta.main) {
+  try {
+    const processRuntime = await startNatsWorkerProcess({ env: process.env });
+    const shutdown = async () => {
+      await processRuntime.shutdown();
+      process.exit(0);
+    };
+    process.on("SIGTERM", () => {
+      void shutdown();
+    });
+    process.on("SIGINT", () => {
+      void shutdown();
+    });
+
+    await new Promise(() => undefined);
+  } catch {
+    process.exit(1);
+  }
+}

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -45,6 +45,32 @@ function healthPortFromEnv(env: NodeJS.ProcessEnv): number | null {
   return Number.isFinite(healthPort) && healthPort > 0 ? healthPort : null;
 }
 
+function shutdownTimeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
+  const timeoutMs = Number.parseInt(
+    env.OPEN_BRAIN_NATS_WORKER_SHUTDOWN_TIMEOUT_MS ?? "5000",
+    10,
+  );
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 5000;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 function startHealthServer(input: {
   env: NodeJS.ProcessEnv;
   runtime: NatsWorkerRuntime;
@@ -81,10 +107,15 @@ function startHealthServer(input: {
 async function closeRuntime(
   runtime: NatsWorkerRuntime | undefined,
   log: LoggerLike,
+  timeoutMs: number,
 ): Promise<void> {
   if (!runtime) return;
   try {
-    await runtime.close();
+    await withTimeout(
+      runtime.close(),
+      timeoutMs,
+      "Open Brain NATS worker bridge close timed out",
+    );
   } catch (err) {
     log.error("Open Brain NATS worker bridge close failed", safeWorkerError(err));
   }
@@ -130,6 +161,7 @@ export async function startNatsWorkerProcess(
   let pool: pg.Pool | undefined;
   let runtime: NatsWorkerRuntime | undefined;
   let healthServer: HealthServer | null = null;
+  const shutdownTimeoutMs = shutdownTimeoutMsFromEnv(env);
 
   try {
     const tokenMap = buildTokens(env as Record<string, string | undefined>);
@@ -156,7 +188,7 @@ export async function startNatsWorkerProcess(
       shutdown: async () => {
         log.info("Shutting down Open Brain NATS worker");
         closeHealthServer(healthServer, log);
-        await closeRuntime(runtime, log);
+        await closeRuntime(runtime, log, shutdownTimeoutMs);
         await closePool(pool, log);
       },
     };
@@ -166,7 +198,7 @@ export async function startNatsWorkerProcess(
       ...natsWorkerLogSummary(readNatsWorkerBoundary(env)),
     });
     closeHealthServer(healthServer, log);
-    await closeRuntime(runtime, log);
+    await closeRuntime(runtime, log, shutdownTimeoutMs);
     await closePool(pool, log);
     throw err;
   }

--- a/scripts/run-two-worker.ts
+++ b/scripts/run-two-worker.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import { buildHttpWorkerEnv } from "./worker-env.ts";
+
 type WorkerConfig = {
   name: string;
   port: number;
@@ -44,13 +46,13 @@ const workers: WorkerConfig[] = Array.from({ length: workerCount }, (_, index) =
 
 const children = workers.map((worker) => {
   const child = Bun.spawn(["bun", "run", "src/index.ts"], {
-    env: {
-      ...process.env,
-      PORT: String(worker.port),
-      DB_POOL_MAX: poolMax,
-      OPEN_BRAIN_RUN_MIGRATIONS: worker.runMigrations ? "1" : "0",
-      OPEN_BRAIN_WORKER_NAME: worker.name,
-    },
+    env: buildHttpWorkerEnv({
+      baseEnv: process.env,
+      port: worker.port,
+      poolMax,
+      runMigrations: worker.runMigrations,
+      workerName: worker.name,
+    }),
     stdout: "inherit",
     stderr: "inherit",
   });

--- a/scripts/worker-env.test.ts
+++ b/scripts/worker-env.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { buildHttpWorkerEnv } from "./worker-env.ts";
+
+describe("buildHttpWorkerEnv", () => {
+  it("forces HTTP workers to stay off the NATS bridge even when shared env opts into NATS", () => {
+    const env = buildHttpWorkerEnv({
+      baseEnv: {
+        OPENBRAIN_TRANSPORT: "nats",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      },
+      port: 3101,
+      poolMax: "5",
+      runMigrations: true,
+      workerName: "open-brain-worker-1",
+    });
+
+    expect(env).toMatchObject({
+      PORT: "3101",
+      DB_POOL_MAX: "5",
+      OPEN_BRAIN_RUN_MIGRATIONS: "1",
+      OPEN_BRAIN_WORKER_NAME: "open-brain-worker-1",
+      OPENBRAIN_TRANSPORT: "http",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+  });
+});

--- a/scripts/worker-env.ts
+++ b/scripts/worker-env.ts
@@ -1,0 +1,19 @@
+type WorkerEnvInput = {
+  baseEnv: NodeJS.ProcessEnv;
+  port: number;
+  poolMax: string;
+  runMigrations: boolean;
+  workerName: string;
+};
+
+export function buildHttpWorkerEnv(input: WorkerEnvInput): NodeJS.ProcessEnv {
+  return {
+    ...input.baseEnv,
+    PORT: String(input.port),
+    DB_POOL_MAX: input.poolMax,
+    OPEN_BRAIN_RUN_MIGRATIONS: input.runMigrations ? "1" : "0",
+    OPEN_BRAIN_WORKER_NAME: input.workerName,
+    OPENBRAIN_TRANSPORT: "http",
+    OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+  };
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -79,6 +79,20 @@ export function verifyToken(provided: string, expected: string): boolean {
   return timingSafeEqual(a, b);
 }
 
+export function findAuthInfoForToken(
+  provided: string,
+  tokenMap: Map<string, AuthInfo>,
+): AuthInfo | null {
+  let matched: AuthInfo | null = null;
+  for (const [storedToken, authInfo] of tokenMap) {
+    if (verifyToken(provided, storedToken)) {
+      matched = authInfo;
+      // Don't break — iterate all tokens for constant-time behavior.
+    }
+  }
+  return matched;
+}
+
 export function authMiddleware(
   tokenMap: Map<string, AuthInfo>,
 ): (req: Request, res: Response, next: NextFunction) => void {
@@ -92,15 +106,7 @@ export function authMiddleware(
 
     const provided = authHeader.slice("Bearer ".length);
 
-    // Always iterate ALL tokens to avoid timing side-channel leaking
-    // which token (or whether any token) matched early vs late.
-    let matched: AuthInfo | null = null;
-    for (const [storedToken, authInfo] of tokenMap) {
-      if (verifyToken(provided, storedToken)) {
-        matched = authInfo;
-        // Don't break — iterate all tokens for constant-time
-      }
-    }
+    const matched = findAuthInfoForToken(provided, tokenMap);
 
     if (matched) {
       const namespace = headerValue(req.headers["x-namespace"]);

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -142,6 +142,38 @@ describe("handleNatsContextPackMessage", () => {
     });
   });
 
+  it("uses constant-time token matching instead of direct map lookup", () => {
+    class NoDirectLookupTokenMap extends Map<string, AuthInfo> {
+      override get(_key: string): AuthInfo | undefined {
+        throw new Error("direct token lookup should not be used");
+      }
+    }
+
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        headers: { Authorization: "Bearer secret-token" },
+      },
+      boundary,
+      tokenMap: new NoDirectLookupTokenMap([
+        ["secret-token", { role: "admin", clientId: "rico" }],
+      ]),
+      deps: depsWithWorkingSet(),
+    }) as any;
+
+    expect(response).toMatchObject({
+      request_id: "req-123",
+      status: "ok",
+    });
+  });
+
   it("rejects oversized bodies before parsing", () => {
     const boundary = readNatsRuntimeBoundary({
       OPENBRAIN_TRANSPORT: "nats",

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -1,6 +1,7 @@
 import type { AuthInfo } from "./types.ts";
 import type { ToolDeps } from "./tools/index.ts";
 import { z } from "zod";
+import { findAuthInfoForToken } from "./auth.ts";
 import { logger } from "./logger.ts";
 import {
   buildAgentContextPackPayload,
@@ -223,7 +224,7 @@ function authFromHeaders(
     null;
   const match = /^Bearer\s+(.+)$/i.exec(raw ?? "");
   const token = match?.[1]?.trim();
-  return token ? tokenMap.get(token) ?? null : null;
+  return token ? findAuthInfoForToken(token, tokenMap) : null;
 }
 
 function errorMessageFromPayload(payload: unknown): string {

--- a/src/nats-worker.test.ts
+++ b/src/nats-worker.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import type { NatsBridgeDriver, NatsRequestMessage } from "./nats-bridge.ts";
+import { readNatsWorkerBoundary, startNatsWorker } from "./nats-worker.ts";
+
+function fakePool() {
+  return {
+    query: async () => ({ rows: [] }),
+    end: async () => undefined,
+  } as any;
+}
+
+function fakeDriver() {
+  const state: { subscribedSubject: string | null; closed: boolean } = {
+    subscribedSubject: null,
+    closed: false,
+  };
+  const driver: NatsBridgeDriver = {
+    subscribe: async (subject: string, _handler: (message: NatsRequestMessage) => Promise<void>) => {
+      state.subscribedSubject = subject;
+      return {
+        close: async () => {
+          state.closed = true;
+        },
+      };
+    },
+    close: async () => {
+      state.closed = true;
+    },
+  };
+  return { driver, state };
+}
+
+describe("readNatsWorkerBoundary", () => {
+  it("forces the dedicated worker into NATS mode without changing HTTP worker env", () => {
+    const boundary = readNatsWorkerBoundary({
+      OPENBRAIN_TRANSPORT: "http",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    expect(boundary).toMatchObject({
+      requested_transport: "nats",
+      nats: {
+        availability: "available",
+        url: "nats://127.0.0.1:4222",
+        context_pack_subject: "ob.memory.context_pack",
+      },
+    });
+  });
+
+  it("fails closed when no NATS URL is configured", () => {
+    const boundary = readNatsWorkerBoundary({});
+
+    expect(boundary).toMatchObject({
+      requested_transport: "nats",
+      nats: {
+        availability: "not_runtime_available",
+        url: null,
+      },
+    });
+  });
+});
+
+describe("startNatsWorker", () => {
+  it("starts only the NATS bridge subscription and exposes separate health", async () => {
+    const { driver, state } = fakeDriver();
+    const runtime = await startNatsWorker({
+      env: {
+        OPENBRAIN_TRANSPORT: "http",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      },
+      pool: fakePool(),
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      driver,
+    });
+
+    expect(runtime.subject).toBe("ob.memory.context_pack");
+    expect(state.subscribedSubject).toBe("ob.memory.context_pack");
+    expect(runtime.health.availability).toBe("available");
+
+    await runtime.close();
+    expect(state.closed).toBe(true);
+  });
+
+  it("does not start when the broker URL is unavailable or disallowed", async () => {
+    await expect(
+      startNatsWorker({
+        env: {},
+        pool: fakePool(),
+        tokenMap: new Map(),
+      }),
+    ).rejects.toThrow("Dedicated NATS worker requires an allowed OPENBRAIN_NATS_URL");
+  });
+});

--- a/src/nats-worker.ts
+++ b/src/nats-worker.ts
@@ -1,6 +1,6 @@
 import type pg from "pg";
 import { generateEmbedding } from "./embedding.ts";
-import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth, type NatsBridgeRuntime } from "./nats-bridge.ts";
+import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth } from "./nats-bridge.ts";
 import { readNatsRuntimeBoundary, summarizeNatsUrlForLog, type NatsRuntimeBoundary } from "./nats-runtime.ts";
 import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo } from "./types.ts";

--- a/src/nats-worker.ts
+++ b/src/nats-worker.ts
@@ -1,0 +1,75 @@
+import type pg from "pg";
+import { generateEmbedding } from "./embedding.ts";
+import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth, type NatsBridgeRuntime } from "./nats-bridge.ts";
+import { readNatsRuntimeBoundary, summarizeNatsUrlForLog, type NatsRuntimeBoundary } from "./nats-runtime.ts";
+import type { ToolDeps } from "./tools/index.ts";
+import type { AuthInfo } from "./types.ts";
+
+export interface StartNatsWorkerOptions {
+  env: NodeJS.ProcessEnv;
+  pool: pg.Pool;
+  tokenMap: Map<string, AuthInfo>;
+  driver?: NatsBridgeDriver;
+  deps?: Partial<ToolDeps>;
+}
+
+export interface NatsWorkerRuntime {
+  boundary: NatsRuntimeBoundary;
+  health: NatsBridgeHealth;
+  subject: string;
+  close(): Promise<void>;
+}
+
+export function readNatsWorkerBoundary(env: NodeJS.ProcessEnv): NatsRuntimeBoundary {
+  return readNatsRuntimeBoundary({
+    ...env,
+    OPENBRAIN_TRANSPORT: "nats",
+    OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+  });
+}
+
+export async function startNatsWorker(
+  options: StartNatsWorkerOptions,
+): Promise<NatsWorkerRuntime> {
+  const boundary = readNatsWorkerBoundary(options.env);
+  if (boundary.nats.availability !== "available") {
+    throw new Error(
+      "Dedicated NATS worker requires an allowed OPENBRAIN_NATS_URL",
+    );
+  }
+
+  const health = createNatsBridgeHealth("available");
+  const deps: ToolDeps = {
+    pool: options.pool,
+    embedFn: generateEmbedding,
+    ...options.deps,
+    natsRuntimeBoundary: boundary,
+    natsBridgeHealth: health,
+  };
+  const bridge = await startNatsContextPackBridge({
+    boundary,
+    tokenMap: options.tokenMap,
+    deps,
+    driver: options.driver,
+    health,
+  });
+  if (!bridge) {
+    throw new Error("Dedicated NATS worker did not start a bridge runtime");
+  }
+
+  return {
+    boundary,
+    health,
+    subject: bridge.subject,
+    close: async () => {
+      await bridge.close();
+    },
+  };
+}
+
+export function natsWorkerLogSummary(boundary: NatsRuntimeBoundary): object {
+  return {
+    subject: boundary.nats.context_pack_subject,
+    nats_url: summarizeNatsUrlForLog(boundary.nats.url),
+  };
+}


### PR DESCRIPTION
## Summary

Refs #282 and #223.

- Adds a dedicated `scripts/run-nats-worker.ts` entrypoint for the Open Brain NATS request/reply bridge.
- Keeps HTTP workers isolated by forcing `run-two-worker.ts` children into `OPENBRAIN_TRANSPORT=http` and `OPENBRAIN_NATS_ENABLE_BRIDGE=false`, even if shared host env includes NATS settings.
- Adds a launchd template and core01 runbook for `com.rico.open-brain-nats-worker` so broker/listener failures do not take HTTP `/health` down.
- Updates NATS foundation and release SOP docs to make the NATS worker a separate rollout step from the HTTP service.

## Validation

- `bunx tsc --noEmit`
- `bun test src/nats-worker.test.ts scripts/worker-env.test.ts src/nats-bridge.test.ts src/nats-runtime.test.ts src/server.test.ts src/tools/__tests__/get-contract.test.ts`
- `bun test` (`1281 pass`, `54 skip`, `0 fail`)
- `plutil -lint docs/deploy/com.rico.open-brain-nats-worker.plist.template`
- `git diff --check`

## Downstream Rollout Classification

Applies: this is runtime/transport-facing NATS infrastructure. This PR is code and deploy-shape only.

- Open Brain local verification: complete, see validation above.
- Hosted Open Brain/core01 deploy: deferred to the release SOP after merge.
- `com.rico.open-brain-nats-worker` install: deferred until release staging on core01.
- NATS request/reply live smoke: deferred until the worker is installed from a release.
- rtech-mcps registry/secret-map handoff: not changed in this PR.
- mcp2cli/generated skill refresh: not required by this PR unless a later release changes public contract/schema.
- rtech-hermes runtime/plugin and live canaries: deferred until hosted NATS availability is canaried and clients explicitly opt in.

## Critical self-review

- Highest-risk behavior: accidentally coupling HTTP worker health to NATS broker/subscription state. Mitigation: HTTP launcher now forces HTTP mode and disables the bridge for every HTTP child worker; the NATS bridge runs through a separate entrypoint.
- Assumptions that could be wrong: launchd env sourcing shape may need adjustment on core01 if `/Users/rico/.config/open-brain/env.nats-worker` differs from the template assumptions.
- Missing/weak tests: no live broker integration test in CI; current tests use fake driver and existing bridge unit coverage. Live request/reply proof remains a release/deploy gate.
- Security/permission risk: bearer token authorization still gates NATS messages; launchd template and docs do not commit credentials. NATS credentials and Open Brain auth tokens must stay in env/secret storage.
- Migration/deploy risk: no DB migration. Deploy risk is service-startup and env separation on core01; rollback is booting out only `com.rico.open-brain-nats-worker`.
- Downstream client/runtime risk: NATS is not made default for HTTP, mcp2cli, or Hermes. Downstream rollout remains explicit and deferred.
- Rollback/cleanup concern: if the worker loops, unload only the NATS worker launchd label and leave HTTP/Postgres untouched.
- Fixes made before PR: corrected runbook/foundation wording so `OPENBRAIN_TRANSPORT=nats` is documented as dedicated worker env, not HTTP worker env; addressed initial swarm findings for startup cleanup, launchd reload, env fail-fast, constant-time NATS auth, redacted worker logs, runbook evidence boundaries, and bounded shutdown cleanup.
- Known residual risk: core01 is not a full NATS participant until this is merged, released, installed, and live-smoked through the NATS subject.
- SME review-memory update: [x] `docs/sme/` updated [ ] not applicable because: -

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Open Brain process correction persisted:

- Lane: `open-brain:issue-282:nats-worker`
- Event: `7df791b1-cec3-4a6e-91ff-91cb2277b069`
- Read-back: `lane_load` returned lane `0d2bcb73-29bb-4851-91f2-b6a33822b35c` in namespace `rico`.
