### PR TITLE
feat(nats): reconcile transport to fleet-bus + dedicated worker (closes #282, supersedes #283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
 Do not put qmd indexes, qmd models, Postgres data, or required production
 `node_modules` under `/Volumes/ThunderBolt/Development`.
 
+NATS transport rollout is separate from the HTTP deploy. The broker label is
+`com.rico.open-brain-nats`; the Open Brain NATS request/reply worker label is
+`com.rico.open-brain-nats-worker`. Keep HTTP workers in HTTP mode and follow
+[`docs/core01-nats-worker-runbook.md`](docs/core01-nats-worker-runbook.md)
+before installing or restarting the dedicated NATS worker service.
+
 qmd is a repo-knowledge compiler and optional deep lookup source. It is not a
 required distributed memory layer for Hermes or other agents. Required qmd-
 derived facts must be promoted into Open Brain; remote qmd access remains a

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -1,0 +1,157 @@
+# Core01 Dedicated NATS Worker Runbook
+
+Issue: #282.
+Status: runtime entrypoint and launchd shape exist; install only from a release
+that has passed the validation gate below.
+
+## Boundary
+
+The NATS bridge must run as a separate launchd service from the HTTP workers.
+HTTP workers stay in `OPENBRAIN_TRANSPORT=http` mode and keep serving `/health`
+on `3100`, `3101`, and `3102`. The NATS worker subscribes to
+`ob.memory.context_pack` and may fail or restart without taking HTTP health down.
+
+The broker and worker are separate services:
+
+| Component | Launchd label | Responsibility |
+| --- | --- | --- |
+| HTTP Open Brain | `com.rico.open-brain` | HTTP/MCP entrypoint and two HTTP workers. |
+| NATS broker | `com.rico.open-brain-nats` | Local NATS/JetStream server on `127.0.0.1:4222`. |
+| NATS Open Brain worker | `com.rico.open-brain-nats-worker` | Request/reply bridge for `ob.memory.context_pack`. |
+
+Do not put the NATS subscription path back into the HTTP launchd service. Broker
+restart, subscription failure, malformed NATS envelopes, or worker crash loops
+must be visible in NATS worker logs without degrading HTTP `/health`.
+
+## Files
+
+- launchd template:
+  `docs/deploy/com.rico.open-brain-nats-worker.plist.template`
+- runtime app:
+  `/Volumes/ThunderBolt/open-brain/app`
+- shared HTTP env:
+  `/Users/rico/.config/open-brain/env`
+- NATS worker env:
+  `/Users/rico/.config/open-brain/env.nats-worker`
+- logs:
+  `/Volumes/ThunderBolt/open-brain/logs/nats-worker.out.log`
+  and `/Volumes/ThunderBolt/open-brain/logs/nats-worker.err.log`
+
+The worker env should source or duplicate only the production settings required
+to execute Open Brain authority paths. Keep secrets in the env file or approved
+secret store; do not commit them.
+
+Minimum worker-specific values:
+
+```zsh
+OPENBRAIN_TRANSPORT=nats
+OPENBRAIN_NATS_ENABLE_BRIDGE=true
+OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
+OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
+OPENBRAIN_NATS_FALLBACK_HTTP=true
+OPEN_BRAIN_RUN_MIGRATIONS=0
+OPEN_BRAIN_WORKER_NAME=open-brain-nats-worker
+QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
+```
+
+HTTP worker env must stay in HTTP mode:
+
+```zsh
+OPENBRAIN_TRANSPORT=http
+OPENBRAIN_NATS_ENABLE_BRIDGE=false
+```
+
+## Install Gate
+
+Install the worker only after a release includes `scripts/run-nats-worker.ts`
+and tests for:
+
+- successful `ob.memory.context_pack` request/reply;
+- missing or invalid bearer auth;
+- malformed NATS envelope;
+- broker unavailable behavior;
+- HTTP health staying healthy while the NATS worker starts, stops, and restarts.
+
+If the entrypoint does not exist, stop at documentation and report that runtime
+work is still required. Do not patch around it in launchd with the HTTP server
+entrypoint.
+
+## Install Or Update
+
+Run these commands on core01 after the release gate in
+`docs/local-release-deploy-sop.md` has passed and the runtime app is staged at
+`/Volumes/ThunderBolt/open-brain/app`:
+
+```zsh
+sudo install -d -m 0755 /Volumes/ThunderBolt/open-brain/logs
+sudo cp \
+  /Volumes/ThunderBolt/open-brain/app/docs/deploy/com.rico.open-brain-nats-worker.plist.template \
+  /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chown root:wheel /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+```
+
+For updates after the service is already bootstrapped:
+
+```zsh
+sudo cp \
+  /Volumes/ThunderBolt/open-brain/app/docs/deploy/com.rico.open-brain-nats-worker.plist.template \
+  /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chown root:wheel /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo chmod 0644 /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+```
+
+## Verification
+
+Confirm the service shape:
+
+```zsh
+sudo launchctl print system/com.rico.open-brain
+sudo launchctl print system/com.rico.open-brain-nats
+sudo launchctl print system/com.rico.open-brain-nats-worker
+```
+
+Confirm HTTP health is independent:
+
+```zsh
+curl -fsS http://127.0.0.1:3100/health
+curl -fsS http://127.0.0.1:3101/health
+curl -fsS http://127.0.0.1:3102/health
+sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+curl -fsS http://127.0.0.1:3100/health
+curl -fsS http://127.0.0.1:3101/health
+curl -fsS http://127.0.0.1:3102/health
+```
+
+Confirm NATS request/reply with the release-owned smoke tool or approved client.
+The expected response envelope is:
+
+```json
+{
+  "schema": "openbrain.nats.response.v1",
+  "status": "ok"
+}
+```
+
+Record the command used, response status, HTTP health before and after worker
+restart, and any JetStream stream creation/defer evidence in the rollout
+receipt for #223 and #282.
+
+## Rollback
+
+Rollback of the NATS worker must not roll back PostgreSQL or HTTP workers.
+
+```zsh
+sudo launchctl bootout system/com.rico.open-brain-nats-worker
+curl -fsS http://127.0.0.1:3100/health
+curl -fsS http://127.0.0.1:3101/health
+curl -fsS http://127.0.0.1:3102/health
+```
+
+Preserve logs and JetStream state for inspection unless an explicit cleanup
+decision says only minimized metadata exists and the state can be removed. If
+the worker env carried credentials, rotate or remove them through the approved
+secret path.

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -8,8 +8,10 @@ that has passed the validation gate below.
 
 The NATS bridge must run as a separate launchd service from the HTTP workers.
 HTTP workers stay in `OPENBRAIN_TRANSPORT=http` mode and keep serving `/health`
-on `3100`, `3101`, and `3102`. The NATS worker subscribes to
-`ob.memory.context_pack` and may fail or restart without taking HTTP health down.
+on `3100`, `3101`, and `3102`. The NATS worker subscribes to the env-prefixed
+subject `{env}.ob.memory.context_pack` (e.g. `dev.ob.memory.context_pack`; env
+from `OPENBRAIN_NATS_ENV`) and may fail or restart without taking HTTP health
+down.
 
 The broker and worker are separate services:
 
@@ -17,11 +19,31 @@ The broker and worker are separate services:
 | --- | --- | --- |
 | HTTP Open Brain | `com.rico.open-brain` | HTTP/MCP entrypoint and two HTTP workers. |
 | NATS broker | `com.rico.open-brain-nats` | Local NATS/JetStream server on `127.0.0.1:4222`. |
-| NATS Open Brain worker | `com.rico.open-brain-nats-worker` | Request/reply bridge for `ob.memory.context_pack`. |
+| NATS Open Brain worker | `com.rico.open-brain-nats-worker` | Request/reply bridge for `{env}.ob.memory.context_pack`. |
 
 Do not put the NATS subscription path back into the HTTP launchd service. Broker
 restart, subscription failure, malformed NATS envelopes, or worker crash loops
 must be visible in NATS worker logs without degrading HTTP `/health`.
+
+## DEPLOYMENT PRECONDITION — message auth (READ BEFORE ENABLING)
+
+Enabling this worker with `OPENBRAIN_NATS_REQUIRE_AUTH` unset or `false` on any
+NATS bus reachable by untrusted publishers is a **cross-tenant read hole**: a
+publisher can forge `payload.namespace` or the envelope `from` and read **any**
+namespace. Auth-off is ONLY safe on a **fully-trusted local loopback bus**
+(`nats://127.0.0.1:4222`, no untrusted publishers).
+
+- **Local core01 broker (v1):** auth-off is acceptable because the bus is
+  loopback-only and no untrusted publisher can reach it.
+- **Fleet bus (CT274, `nats://10.71.20.74:4222`) or any shared/remote broker:**
+  you MUST set `OPENBRAIN_NATS_REQUIRE_AUTH=true` before enabling the worker.
+  With `REQUIRE_AUTH=true` the per-request bearer gate is on and the
+  `payload.namespace` override is force-disabled (mutually exclusive), so a
+  client can no longer forge a lane; the namespace is derived from the token.
+
+Treat this as a hard gate, not a footnote: do not point the worker at a
+non-loopback broker until `OPENBRAIN_NATS_REQUIRE_AUTH=true` is set in the worker
+env. namespace is an Open Brain security boundary.
 
 ## Files
 
@@ -49,7 +71,11 @@ source /Users/rico/.config/open-brain/env
 OPENBRAIN_TRANSPORT=nats
 OPENBRAIN_NATS_ENABLE_BRIDGE=true
 OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
-OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
+# Subject is built env-prefixed: {env}.ob.memory.context_pack. Set the env, not
+# a hand-pinned subject. Do NOT set OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT to the
+# legacy flat `ob.memory.context_pack` — clients publish the env-prefixed
+# subject and request/reply would hang.
+OPENBRAIN_NATS_ENV=dev
 OPENBRAIN_NATS_FALLBACK_HTTP=true
 OPEN_BRAIN_NATS_WORKER_HEALTH_PORT=3110
 OPEN_BRAIN_RUN_MIGRATIONS=0
@@ -69,7 +95,7 @@ OPENBRAIN_NATS_ENABLE_BRIDGE=false
 Install the worker only after a release includes `scripts/run-nats-worker.ts`
 and evidence for:
 
-- automated bridge tests for successful `ob.memory.context_pack` request/reply,
+- automated bridge tests for successful `{env}.ob.memory.context_pack` request/reply,
   missing or invalid bearer auth, malformed NATS envelopes, oversized payloads,
   and degraded bridge health;
 - automated worker tests for dedicated-worker boundary forcing, missing broker
@@ -149,26 +175,45 @@ curl -fsS http://127.0.0.1:3102/health
 ```
 
 Confirm NATS request/reply with the release-owned smoke tool or approved client.
-The expected response envelope is:
+Responses are fleet envelopes (compact UTF-8 JSON, wire key `from`, not `sender`)
+with `kind="context_pack_response"`, `from="open-brain"`, and `correlation_id`
+echoing the request `id`. The success reply is:
 
 ```json
 {
-  "schema": "openbrain.nats.response.v1",
-  "status": "ok"
+  "id": "<request id>",
+  "ts": "<ISO-8601 UTC>",
+  "from": "open-brain",
+  "kind": "context_pack_response",
+  "correlation_id": "<request id>",
+  "version": 1,
+  "payload": {
+    "status": "ok",
+    "operation": "agent_context_pack",
+    "namespace_source": "token|override|declared",
+    "body": { "...": "context pack" }
+  }
 }
 ```
 
-Expected error responses use the same response schema with `status: "error"`:
+Error replies use the same envelope with an error payload:
 
 ```json
 {
-  "schema": "openbrain.nats.response.v1",
-  "request_id": "uuid-or-null",
-  "status": "error",
-  "operation": "agent_context_pack",
-  "error": {
-    "code": "permission_denied|bad_request|payload_too_large|temporarily_unavailable|tool_error|internal_error",
-    "message": "redacted failure summary"
+  "id": "<request id or 'unknown'>",
+  "ts": "<ISO-8601 UTC>",
+  "from": "open-brain",
+  "kind": "context_pack_response",
+  "correlation_id": "<request id or null>",
+  "version": 1,
+  "payload": {
+    "status": "error",
+    "operation": "agent_context_pack",
+    "namespace_source": "token|override|declared|rejected|null",
+    "error": {
+      "code": "permission_denied|unroutable|bad_request|payload_too_large|temporarily_unavailable|tool_error|internal_error",
+      "message": "redacted failure summary"
+    }
   }
 }
 ```

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -37,18 +37,21 @@ must be visible in NATS worker logs without degrading HTTP `/health`.
   `/Volumes/ThunderBolt/open-brain/logs/nats-worker.out.log`
   and `/Volumes/ThunderBolt/open-brain/logs/nats-worker.err.log`
 
-The worker env should source or duplicate only the production settings required
-to execute Open Brain authority paths. Keep secrets in the env file or approved
-secret store; do not commit them.
+The worker env should source the shared production env and then set only
+worker-specific overrides. Keep secrets in the env file or approved secret
+store; do not commit them. The launchd template fails closed when this file is
+missing or unreadable.
 
-Minimum worker-specific values:
+Expected shape:
 
 ```zsh
+source /Users/rico/.config/open-brain/env
 OPENBRAIN_TRANSPORT=nats
 OPENBRAIN_NATS_ENABLE_BRIDGE=true
 OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
 OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
 OPENBRAIN_NATS_FALLBACK_HTTP=true
+OPEN_BRAIN_NATS_WORKER_HEALTH_PORT=3110
 OPEN_BRAIN_RUN_MIGRATIONS=0
 OPEN_BRAIN_WORKER_NAME=open-brain-nats-worker
 QMD_PATH=/Volumes/ThunderBolt/qmd/open-brain-qmd.ts
@@ -64,13 +67,16 @@ OPENBRAIN_NATS_ENABLE_BRIDGE=false
 ## Install Gate
 
 Install the worker only after a release includes `scripts/run-nats-worker.ts`
-and tests for:
+and evidence for:
 
-- successful `ob.memory.context_pack` request/reply;
-- missing or invalid bearer auth;
-- malformed NATS envelope;
-- broker unavailable behavior;
-- HTTP health staying healthy while the NATS worker starts, stops, and restarts.
+- automated bridge tests for successful `ob.memory.context_pack` request/reply,
+  missing or invalid bearer auth, malformed NATS envelopes, oversized payloads,
+  and degraded bridge health;
+- automated worker tests for dedicated-worker boundary forcing, missing broker
+  URL fail-closed behavior, subscription startup, shutdown cleanup, constant-time
+  bearer-token matching, and health-bind cleanup after bridge startup;
+- live release proof for broker unavailable behavior and HTTP health staying
+  healthy while the NATS worker starts, stops, and restarts.
 
 If the entrypoint does not exist, stop at documentation and report that runtime
 work is still required. Do not patch around it in launchd with the HTTP server
@@ -81,6 +87,16 @@ entrypoint.
 Run these commands on core01 after the release gate in
 `docs/local-release-deploy-sop.md` has passed and the runtime app is staged at
 `/Volumes/ThunderBolt/open-brain/app`:
+
+First create or validate the worker env file. It should be mode `0600`, source
+`/Users/rico/.config/open-brain/env`, and set the worker-specific overrides from
+the Files section above:
+
+```zsh
+sudo test -r /Users/rico/.config/open-brain/env
+sudo test -r /Users/rico/.config/open-brain/env.nats-worker
+/opt/homebrew/bin/bash -n /Users/rico/.config/open-brain/env.nats-worker
+```
 
 ```zsh
 sudo install -d -m 0755 /Volumes/ThunderBolt/open-brain/logs
@@ -93,7 +109,10 @@ sudo launchctl bootstrap system /Library/LaunchDaemons/com.rico.open-brain-nats-
 sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
 ```
 
-For updates after the service is already bootstrapped:
+For updates after the service is already bootstrapped, reload the launchd job
+definition. `kickstart` alone restarts the currently loaded definition and is
+not enough when `ProgramArguments`, environment, log paths, or resource limits
+changed:
 
 ```zsh
 sudo cp \
@@ -101,7 +120,10 @@ sudo cp \
   /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
 sudo chown root:wheel /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
 sudo chmod 0644 /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
+sudo launchctl bootout system/com.rico.open-brain-nats-worker
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.rico.open-brain-nats-worker.plist
 sudo launchctl kickstart -k system/com.rico.open-brain-nats-worker
+sudo launchctl print system/com.rico.open-brain-nats-worker
 ```
 
 ## Verification
@@ -135,6 +157,25 @@ The expected response envelope is:
   "status": "ok"
 }
 ```
+
+Expected error responses use the same response schema with `status: "error"`:
+
+```json
+{
+  "schema": "openbrain.nats.response.v1",
+  "request_id": "uuid-or-null",
+  "status": "error",
+  "operation": "agent_context_pack",
+  "error": {
+    "code": "permission_denied|bad_request|payload_too_large|temporarily_unavailable|tool_error|internal_error",
+    "message": "redacted failure summary"
+  }
+}
+```
+
+A missing reply inbox is not a successful request/reply smoke; inspect the NATS
+worker logs and `/health` for bridge request, subscription, shutdown, or close
+failures.
 
 Record the command used, response status, HTTP health before and after worker
 restart, and any JetStream stream creation/defer evidence in the rollout

--- a/docs/deploy/com.rico.open-brain-nats-worker.plist.template
+++ b/docs/deploy/com.rico.open-brain-nats-worker.plist.template
@@ -28,8 +28,13 @@
     <string>true</string>
     <key>OPENBRAIN_NATS_URL</key>
     <string>nats://127.0.0.1:4222</string>
-    <key>OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT</key>
-    <string>ob.memory.context_pack</string>
+    <!-- Subjects are env-prefixed via the fleet-bus builder:
+         {env}.ob.memory.context_pack. Set the env, NOT a hand-pinned subject.
+         Pinning OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack here
+         makes the worker subscribe to the legacy flat subject while clients now
+         publish dev.ob.memory.context_pack -> request/reply hangs. -->
+    <key>OPENBRAIN_NATS_ENV</key>
+    <string>dev</string>
     <key>OPENBRAIN_NATS_FALLBACK_HTTP</key>
     <string>true</string>
     <key>QMD_PATH</key>

--- a/docs/deploy/com.rico.open-brain-nats-worker.plist.template
+++ b/docs/deploy/com.rico.open-brain-nats-worker.plist.template
@@ -10,7 +10,7 @@
   <array>
     <string>/opt/homebrew/bin/bash</string>
     <string>-lc</string>
-    <string>set -a; source /Users/rico/.config/open-brain/env.nats-worker; set +a; cd /Volumes/ThunderBolt/open-brain/app; exec "${BUN_BIN:-bun}" run scripts/run-nats-worker.ts</string>
+    <string>set -euo pipefail; ENV_FILE=/Users/rico/.config/open-brain/env.nats-worker; test -r "$ENV_FILE"; set -a; source "$ENV_FILE"; set +a; cd /Volumes/ThunderBolt/open-brain/app; exec "${BUN_BIN:-bun}" run scripts/run-nats-worker.ts</string>
   </array>
 
   <key>WorkingDirectory</key>

--- a/docs/deploy/com.rico.open-brain-nats-worker.plist.template
+++ b/docs/deploy/com.rico.open-brain-nats-worker.plist.template
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.rico.open-brain-nats-worker</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>-lc</string>
+    <string>set -a; source /Users/rico/.config/open-brain/env.nats-worker; set +a; cd /Volumes/ThunderBolt/open-brain/app; exec "${BUN_BIN:-bun}" run scripts/run-nats-worker.ts</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Volumes/ThunderBolt/open-brain/app</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OPEN_BRAIN_WORKER_NAME</key>
+    <string>open-brain-nats-worker</string>
+    <key>OPEN_BRAIN_RUN_MIGRATIONS</key>
+    <string>0</string>
+    <key>OPENBRAIN_TRANSPORT</key>
+    <string>nats</string>
+    <key>OPENBRAIN_NATS_ENABLE_BRIDGE</key>
+    <string>true</string>
+    <key>OPENBRAIN_NATS_URL</key>
+    <string>nats://127.0.0.1:4222</string>
+    <key>OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT</key>
+    <string>ob.memory.context_pack</string>
+    <key>OPENBRAIN_NATS_FALLBACK_HTTP</key>
+    <string>true</string>
+    <key>QMD_PATH</key>
+    <string>/Volumes/ThunderBolt/qmd/open-brain-qmd.ts</string>
+  </dict>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Volumes/ThunderBolt/open-brain/logs/nats-worker.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Volumes/ThunderBolt/open-brain/logs/nats-worker.err.log</string>
+
+  <key>SoftResourceLimits</key>
+  <dict>
+    <key>NumberOfFiles</key>
+    <integer>4096</integer>
+  </dict>
+</dict>
+</plist>

--- a/docs/fleet-nats-integration.md
+++ b/docs/fleet-nats-integration.md
@@ -1,0 +1,142 @@
+# Fleet NATS Integration — Open Brain
+
+How the Hermes fleet adopts Open Brain's NATS request/reply transport, and how
+Open Brain moves from its local core01 broker to the shared fleet bus on CT274.
+
+This is the **paved road**: everything below is config, not code. The wire
+format, subject convention, and auth model are already reconciled to
+`rodaddy/fleet-bus`.
+
+## Current state (v1 — local, auth-off)
+
+Open Brain runs a dedicated NATS worker (`com.rico.open-brain-nats-worker`,
+`scripts/run-nats-worker.ts`) separate from the HTTP service, so a broker/
+subscription failure cannot take HTTP `/health` down. In v1 it points at a
+**local broker** on core01 and the message-auth gate is **off** (trusted local
+bus), matching fleet-bus's own bootstrapping stance.
+
+| Setting | v1 default | Meaning |
+|---|---|---|
+| `OPENBRAIN_NATS_URL` | `nats://127.0.0.1:4222` | Local core01 broker |
+| `OPENBRAIN_NATS_ENV` | `dev` | Subject env prefix — `{env}.ob.memory.context_pack` |
+| `OPENBRAIN_NATS_ENABLE_BRIDGE` | `true` | Worker runs the request/reply bridge |
+| `OPENBRAIN_NATS_REQUIRE_AUTH` | `false` | Message-auth gate OFF (local trust) |
+| `OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE` | `true` | `payload.namespace` may set the lane |
+
+> **HARD PRECONDITION — cross-tenant read hole.** Auth-off (`REQUIRE_AUTH`
+> unset/`false`) is ONLY safe on a **fully-trusted local loopback bus**. On any
+> bus reachable by untrusted publishers — including the fleet bus on CT274 — a
+> publisher can forge `payload.namespace` or the envelope `from` and read **any**
+> namespace. Before pointing the worker at a non-loopback broker you MUST set
+> `OPENBRAIN_NATS_REQUIRE_AUTH=true` (see the v2 flip below). This is a hard
+> deployment gate, not a footnote: namespace is an Open Brain security boundary.
+
+## Wire contract (what a fleet client must speak)
+
+Open Brain uses the shared fleet `Envelope` (compact UTF-8 JSON). The wire key is
+`from` (not `sender`); `version = 1`.
+
+**Request** — subject `{env}.ob.memory.context_pack`:
+
+```json
+{
+  "id": "<uuid>",
+  "ts": "<ISO-8601 UTC>",
+  "from": "<caller agent_id>",
+  "kind": "context_pack_request",
+  "correlation_id": "<uuid, echoed on the reply>",
+  "version": 1,
+  "payload": {
+    "operation": "agent_context_pack",
+    "identity": { "agent": "...", "platform": "...", "server_id": "...",
+                  "channel_id": "...", "session_key": "...", "thread_id": null },
+    "body": { "query": "...", "requested_sections": ["..."] },
+    "namespace": "<optional lane override>"
+  }
+}
+```
+
+**Response** — on the NATS reply inbox, `kind="context_pack_response"`,
+`from="open-brain"`, `correlation_id` = request `id`. `payload` carries
+`{ status, operation, namespace_source, body }` or `{ ..., error }`.
+
+`namespace_source` is stamped on every reply (a response-only field — never send
+it in a request): `token` (REQUIRE_AUTH: derived from the bearer token) |
+`override` (auth off: `payload.namespace` used) | `declared` (auth off: derived
+from the declared identity) | `rejected` (unroutable / auth missing). Use it to
+confirm your request landed in the lane you expected.
+
+### Lane binding (v1, auth off)
+
+1. `payload.namespace` present (and override allowed) → that lane
+   (`namespace_source: "override"`).
+2. else the lane is derived from the declared identity (`from` /
+   `payload.identity.agent`) → `namespace_source: "declared"`.
+3. else the request is **rejected** as unroutable — Open Brain never falls back
+   to a global or shared namespace.
+
+The declared/override namespace binds a **non-privileged** synthetic identity
+whose access is that one namespace only; it flows through the same server-side
+`canReadNamespace` check as every other request. There is no bypass.
+
+## Moving to the fleet bus (CT274) — the v2 flip
+
+The fleet NATS server ("honcho") runs on **CT274, `nats://10.71.20.74:4222`**
+(monitor `http://10.71.20.74:8223/connz` — note port **8223**, not 8222).
+
+To make Open Brain a real fleet participant, change **config only**:
+
+```bash
+# in /Users/rico/.config/open-brain/env.nats-worker on core01
+OPENBRAIN_NATS_URL=nats://10.71.20.74:4222   # join the fleet bus
+OPENBRAIN_NATS_ENV=prod                       # fleet env prefix (dev|prod)
+OPENBRAIN_NATS_REQUIRE_AUTH=true              # turn the bearer gate ON
+# OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE is force-disabled when REQUIRE_AUTH=true
+```
+
+Open Brain's remote-URL guard (`isNatsUrlAllowedForRuntime`) must allow the
+CT274 address; set `OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE=true` (the fleet bus is
+plain `nats://`, no TLS — consistent with fleet-bus convention).
+
+### Auth on the fleet bus
+
+Turning on `OPENBRAIN_NATS_REQUIRE_AUTH` re-enables Open Brain's per-request
+**bearer-token** auth (the same `AUTH_TOKEN_*` tokens every OB agent/user already
+holds — role tokens plus `AUTH_TOKEN_USER_<NAME>`). The token is sent as a NATS
+header (`authorization: Bearer <token>`), the namespace is derived from the
+token, and a client-supplied `payload.namespace` can no longer override it. This
+keeps Open Brain **stricter** than fleet-bus's trust-the-bus default, which is
+required because namespace is an Open Brain security boundary.
+
+fleet-bus's own perimeter is the NATS server's ACLs plus per-service NATS
+**connection** credentials. If CT274 enforces connection ACLs, Open Brain needs
+a per-service NATS credential (creds file / nkey / user-pass in the URL) to
+connect. As of this writing core01's OB env carries the app-level `AUTH_TOKEN_*`
+set but **no** NATS connection credential — provisioning that on CT274 is an
+infra step, tracked separately, and is the one piece that is not pure config.
+
+## Hermes client side
+
+- **Python:** `python/openbrain-memory` ships a `NatsTransport` +
+  `FleetNatsDriver`. It emits/validates this same fleet `Envelope`. It
+  optional-imports `fleet-nats` for byte-for-byte parity when the package is
+  installed (private monorepo, `git+ssh` with `#subdirectory=packages/fleet-nats`)
+  and mirrors the shape locally otherwise. Enable the `nats` extra for a live
+  driver: `pip install 'openbrain-memory[nats]'`.
+- **Per agent:** set the fleet env contract the client reads —
+  `FLEET_NATS_URL`, `FLEET_AGENT_ID=open-brain`, `FLEET_ENV` — then drive a
+  context-pack request/reply through the configured transport. Verify the agent
+  appears on the CT274 `/connz` probe and that a representative read returns
+  `namespace_source: "declared"` for the expected lane.
+
+Do not use TN01 / `10.71.1.11` as a control point. Roll agents through the
+standard update path (`ssh 10.71.1.71` → `/mnt/collab/agent-backups/rtech-hermes`
+→ `git pull --ff-only` → `scripts/update.sh`) once the server side is live.
+
+## Upstream follow-up
+
+fleet-bus's `fleet_nats/subjects.py` has no `ob_*` builder yet; Open Brain
+mirrors the `{env}.ob.memory.context_pack` convention in `src/nats-subjects.ts`
+(TS) and `nats_wire.py` (Python). File a `fleet-nats` issue to add an
+`ob_context_pack(env)` builder so subject construction has a single source of
+truth and the hand-maintained cross-language parity is retired.

--- a/docs/local-release-deploy-sop.md
+++ b/docs/local-release-deploy-sop.md
@@ -208,10 +208,12 @@ For contract-changing releases, complete the downstream steps in
 For releases that enable the dedicated NATS worker from issue #282, also follow
 `docs/core01-nats-worker-runbook.md`. The release is not complete until HTTP
 health is recorded before and after `com.rico.open-brain-nats-worker` restart,
-and a hosted NATS request/reply smoke returns an
-`openbrain.nats.response.v1` envelope. If the release does not include the NATS
-worker runtime entrypoint, leave the launchd template uninstalled and record the
-worker rollout as deferred.
+and a hosted NATS request/reply smoke returns a fleet `context_pack_response`
+envelope (`kind="context_pack_response"`, `from="open-brain"`, `correlation_id`
+echoing the request `id`) — see the runbook's Verification section and
+`docs/fleet-nats-integration.md` for the authoritative shape. If the release does
+not include the NATS worker runtime entrypoint, leave the launchd template
+uninstalled and record the worker rollout as deferred.
 
 ## Rollback
 

--- a/docs/local-release-deploy-sop.md
+++ b/docs/local-release-deploy-sop.md
@@ -205,6 +205,14 @@ mcp2cli open-brain search_all --params '{"query":"release smoke"}'
 For contract-changing releases, complete the downstream steps in
 `docs/downstream-rollout.md` before closing linked issues.
 
+For releases that enable the dedicated NATS worker from issue #282, also follow
+`docs/core01-nats-worker-runbook.md`. The release is not complete until HTTP
+health is recorded before and after `com.rico.open-brain-nats-worker` restart,
+and a hosted NATS request/reply smoke returns an
+`openbrain.nats.response.v1` envelope. If the release does not include the NATS
+worker runtime entrypoint, leave the launchd template uninstalled and record the
+worker rollout as deferred.
+
 ## Rollback
 
 The deploy script keeps the prior runtime at:

--- a/docs/nats-jetstream-foundation.md
+++ b/docs/nats-jetstream-foundation.md
@@ -42,7 +42,13 @@ Planned host:
 core01 Mac Mini, co-located with hosted Open Brain.
 
 Planned service:
-`com.rico.open-brain-nats` launchd service.
+`com.rico.open-brain-nats` launchd service for the broker.
+
+Dedicated Open Brain worker service:
+`com.rico.open-brain-nats-worker`, documented in
+`docs/core01-nats-worker-runbook.md`. This worker is separate from the HTTP
+launchd service and subscribes to NATS request/reply subjects without making
+HTTP `/health` depend on broker or subscription health.
 
 Planned config path:
 `/Volumes/ThunderBolt/open-brain/nats/nats-server.conf`.
@@ -251,10 +257,13 @@ availability only when explicitly enabled.
 - Constructor/config:
   `NatsTransport(url, context_pack_subject="ob.memory.context_pack",
   fallback_transport=UrllibTransport(...), timeout=...)`.
-- Server env:
+- Dedicated NATS worker env, not the HTTP worker env:
   `OPENBRAIN_TRANSPORT=nats`, `OPENBRAIN_NATS_ENABLE_BRIDGE=true`,
   `OPENBRAIN_NATS_URL`, `OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT`, and
   `OPENBRAIN_NATS_FALLBACK_HTTP=true`.
+- HTTP Open Brain workers must keep `OPENBRAIN_TRANSPORT=http` and
+  `OPENBRAIN_NATS_ENABLE_BRIDGE=false`, even when the same host has a local
+  broker and NATS worker.
 - Remote plaintext `nats://` broker URLs are not runtime-available by default.
   Use loopback/local NATS for local rollout, or set
   `OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE=true` only for an explicitly approved
@@ -305,7 +314,11 @@ Local-only validation for #223:
 Release validation, deferred until Rico approves deploy:
 
 - install NATS on core01 through the release SOP;
+- install or update `com.rico.open-brain-nats-worker` only after the runtime
+  entrypoint exists and the worker tests pass;
 - prove `/health` and monitoring endpoint locally on core01;
+- prove HTTP `/health` remains healthy while the NATS worker is started,
+  stopped, and restarted;
 - create streams with the documented limits;
 - run HTTP-vs-NATS parity tests for `agent_context_pack`;
 - run Hermes canary with HTTP fallback enabled;
@@ -318,8 +331,9 @@ Before NATS becomes the default path, rollback is to keep or restore
 the service and needs rollback:
 
 1. Set Hermes/Open Brain clients back to HTTP and confirm `/mcp` reads/writes.
-2. Stop or unload `com.rico.open-brain-nats`.
-3. Preserve the JetStream store for inspection unless an explicit cleanup
+2. Stop or unload `com.rico.open-brain-nats-worker`.
+3. Stop or unload `com.rico.open-brain-nats` if the broker itself is unsafe.
+4. Preserve the JetStream store for inspection unless an explicit cleanup
    decision says it contains only minimized metadata and can be deleted.
-4. Remove or rotate NATS credentials through the approved secret store.
-5. Leave PostgreSQL/Open Brain untouched; NATS streams are not memory authority.
+5. Remove or rotate NATS credentials through the approved secret store.
+6. Leave PostgreSQL/Open Brain untouched; NATS streams are not memory authority.

--- a/docs/nats-jetstream-foundation.md
+++ b/docs/nats-jetstream-foundation.md
@@ -145,6 +145,15 @@ audit once clients depend on them.
 
 ## Request Envelope
 
+> **Superseded wire shape.** The `openbrain.nats.request/response.v1` envelopes
+> shown in this section are the ORIGINAL #223 design shape. The shipped wire has
+> since been reconciled to the shared fleet-bus `Envelope` (compact JSON, wire
+> key `from`, `kind` = `context_pack_request` / `context_pack_response`,
+> top-level `payload.namespace`, subject `{env}.ob.memory.context_pack`). The
+> authoritative wire contract is `docs/fleet-nats-integration.md` and
+> `src/__fixtures__/nats-context-pack-wire.json`. The blocks below are retained
+> only for design history; do not implement against them.
+
 The request body is JSON and must be compatible with `agent_context_pack`
 request semantics. `query` is optional and bounded like the MCP tool input; the
 bridge must not require fields the MCP tool accepts as omitted.
@@ -291,7 +300,11 @@ Initial config should be explicit:
 OPENBRAIN_TRANSPORT=http
 OPENBRAIN_NATS_ENABLE_BRIDGE=false
 OPENBRAIN_NATS_URL=nats://127.0.0.1:4222
-OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT=ob.memory.context_pack
+# Subjects are env-prefixed via the fleet-bus builder
+# ({env}.ob.memory.context_pack). Set the env, NOT a hand-pinned subject —
+# pinning the legacy flat `ob.memory.context_pack` makes the worker subscribe to
+# a subject clients no longer publish, and request/reply hangs.
+OPENBRAIN_NATS_ENV=dev
 OPENBRAIN_NATS_FALLBACK_HTTP=true
 ```
 

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -220,6 +220,32 @@ outbids foreground work.
 - Do tests wedge the fake pool and prove foreground queries still get
   connections while audit writes shed load?
 
+## [2026-07-08] Auxiliary health bind failures must clean up started workers
+
+**Severity:** HIGH
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** dedicated worker entrypoints that start subscriptions/pools before a
+health or monitoring listener
+**Status:** fixed in PR #283
+
+### Pattern
+
+A worker can successfully start its core subscription and database pool, then
+throw while binding an auxiliary health endpoint. If that bind failure is
+outside the guarded startup path, launchd/systemd restarts the process while the
+startup path skips orderly bridge/pool cleanup. This turns a monitoring-port
+collision into a noisy worker restart loop.
+
+### Review Questions
+
+- Are pool creation, bridge/subscription startup, and health-server bind inside
+  one guarded startup path?
+- If a later startup step fails, are already-started subscriptions, health
+  servers, and pools closed before exit?
+- Does the worker log a redacted startup failure instead of a raw exception?
+- Is there a regression test where health bind throws after subscription startup
+  and cleanup still closes both bridge and pool?
+
 ## [2026-07-08] Reusing an output field with a new value distribution is a contract change
 
 **Severity:** MEDIUM

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -381,3 +381,27 @@ advertised floor, breaks the contract downstream consumers pin against.
   version when the contract requires lockstep?
 - Is the bump classified in `docs/downstream-rollout.md` terms before the PR is
   called complete?
+
+## [2026-07-08] Launchd updates must reload desired state, not only kickstart
+
+**Severity:** MEDIUM
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** launchd service templates and core01 deploy/runbook instructions
+**Status:** fixed in PR #283
+
+### Pattern
+
+Copying an updated plist and running `launchctl kickstart -k` can restart the
+currently loaded job definition without reloading changed `ProgramArguments`,
+environment, log paths, or resource limits. A deploy can look restarted while
+live launchd state still differs from the repo template.
+
+### Review Questions
+
+- For plist changes, does the update path boot out and bootstrap the service
+  before kickstart?
+- Does verification print the loaded job after bootstrap so desired state can be
+  compared to live state?
+- Does the launch command fail fast when its env file is missing or unreadable?
+- Does the runbook validate the env file before installing/restarting the
+  service, especially when the worker env sources a shared production env?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -219,3 +219,26 @@ not silently stop future request processing.
 - Does server shutdown isolate optional transport close failures from database
   and process cleanup?
 - Is shutdown bounded when an optional bridge can hang?
+
+## [2026-07-08] Operational runbooks must separate implemented tests from release proof
+
+**Severity:** MEDIUM
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** rollout/runbook docs for live service workers and transport bridges
+**Status:** fixed in PR #283
+
+### Pattern
+
+A runbook can accidentally overclaim readiness by saying "install after tests
+for X" when the PR only adds a subset of those tests and leaves some checks as
+release-time live proof. That trains future operators to treat aspirational
+checks as already covered and weakens the deploy gate.
+
+### Review Questions
+
+- Does the runbook distinguish automated tests already present from live
+  release proof still required on the host?
+- Does verification document both success and expected error envelopes?
+- Are no-reply, shutdown, and close failures described as log/health conditions
+  to inspect, not successful request/reply smokes?
+- Are PR comments and release notes explicit about what remains deferred?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -202,6 +202,33 @@ promotion -- the forward path and its reversal path diverged in authority.
 - Does the parity regression suite enumerate every gate (REST and MCP variants
   separately) rather than spot-checking one?
 
+## [2026-07-08] New bearer-auth transports must reuse constant-time token matching
+
+**Severity:** MEDIUM
+**Source:** PR #283 initial swarm for Issue #282
+**Scope:** NATS request/reply bridges, alternate transports, and any non-HTTP
+bearer-token auth path
+**Status:** fixed in PR #283
+
+### Pattern
+
+Adding a second bearer-auth surface can accidentally bypass HTTP middleware's
+constant-time token matching if it verifies tokens with direct `Map.get()` or
+another early-exit lookup. Even when the transport is local-first, the server
+auth semantics should match the HTTP path so timing and role behavior do not
+diverge.
+
+### Review Questions
+
+- Does the new transport call the same constant-time token matching helper as
+  HTTP auth?
+- Is there a regression test that would fail if the transport used direct token
+  lookup?
+- Do startup/shutdown logs avoid raw exception messages that may include
+  credential-bearing broker URLs or wrapped token material?
+- Does the health endpoint redact internal error detail while still exposing
+  machine-readable availability?
+
 ## [2026-07-06] Privileged source-scope predicates must match one source reference
 
 **Severity:** HIGH

--- a/scripts/run-nats-worker.test.ts
+++ b/scripts/run-nats-worker.test.ts
@@ -16,7 +16,7 @@ describe("startNatsWorkerProcess", () => {
     const runtime: NatsWorkerRuntime = {
       boundary: readNatsWorkerBoundary(env),
       health: createNatsBridgeHealth("available"),
-      subject: "ob.memory.context_pack",
+      subject: "dev.ob.memory.context_pack",
       close: async () => {
         runtimeClosed = true;
       },
@@ -66,7 +66,7 @@ describe("startNatsWorkerProcess", () => {
     const runtime: NatsWorkerRuntime = {
       boundary: readNatsWorkerBoundary(env),
       health: createNatsBridgeHealth("available"),
-      subject: "ob.memory.context_pack",
+      subject: "dev.ob.memory.context_pack",
       close: async () => {
         await new Promise(() => undefined);
       },
@@ -106,5 +106,30 @@ describe("safeWorkerError", () => {
     expect(
       safeWorkerError(new Error("nats://user:pass@broker.internal failed")),
     ).toEqual({ error_type: "Error" });
+  });
+
+  it("classifies by an instanceof allowlist, not the mutable err.name (#283)", () => {
+    // A hostile/mutable name that embeds a secret must NOT be surfaced.
+    const err = new Error("boom");
+    err.name = "NatsError nats://user:pass@broker.internal";
+    expect(safeWorkerError(err)).toEqual({ error_type: "Error" });
+
+    expect(safeWorkerError(new SyntaxError("x"))).toEqual({
+      error_type: "SyntaxError",
+    });
+    expect(safeWorkerError(new TypeError("x"))).toEqual({
+      error_type: "TypeError",
+    });
+    expect(safeWorkerError(new RangeError("x"))).toEqual({
+      error_type: "RangeError",
+    });
+    expect(
+      safeWorkerError(new AggregateError([new Error("a")], "agg")),
+    ).toEqual({ error_type: "AggregateError" });
+  });
+
+  it("reports typeof for non-Error throws", () => {
+    expect(safeWorkerError("just a string")).toEqual({ error_type: "string" });
+    expect(safeWorkerError(42)).toEqual({ error_type: "number" });
   });
 });

--- a/scripts/run-nats-worker.test.ts
+++ b/scripts/run-nats-worker.test.ts
@@ -54,6 +54,51 @@ describe("startNatsWorkerProcess", () => {
     expect(errorLogs.join("\n")).not.toContain("user:pass");
     expect(errorLogs.join("\n")).not.toContain("broker.internal");
   });
+
+  it("continues pool shutdown when bridge close times out", async () => {
+    const env = {
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "0",
+      OPEN_BRAIN_NATS_WORKER_SHUTDOWN_TIMEOUT_MS: "1",
+    };
+    let poolEnded = false;
+    const errorLogs: string[] = [];
+    const runtime: NatsWorkerRuntime = {
+      boundary: readNatsWorkerBoundary(env),
+      health: createNatsBridgeHealth("available"),
+      subject: "ob.memory.context_pack",
+      close: async () => {
+        await new Promise(() => undefined);
+      },
+    };
+
+    const processRuntime = await startNatsWorkerProcess({
+      env,
+      log: {
+        info: () => undefined,
+        error: (message, extra) => {
+          errorLogs.push(JSON.stringify({ message, extra }));
+        },
+      },
+      buildTokens: () =>
+        new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      createDbPool: () =>
+        ({
+          end: async () => {
+            poolEnded = true;
+          },
+        }) as any,
+      startWorker: async () => runtime,
+    });
+
+    await processRuntime.shutdown();
+
+    expect(poolEnded).toBe(true);
+    expect(errorLogs.join("\n")).toContain(
+      "Open Brain NATS worker bridge close failed",
+    );
+    expect(errorLogs.join("\n")).not.toContain("timed out");
+  });
 });
 
 describe("safeWorkerError", () => {

--- a/scripts/run-nats-worker.test.ts
+++ b/scripts/run-nats-worker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { createNatsBridgeHealth } from "../src/nats-bridge.ts";
+import { readNatsWorkerBoundary, type NatsWorkerRuntime } from "../src/nats-worker.ts";
+import { safeWorkerError, startNatsWorkerProcess } from "./run-nats-worker.ts";
+
+describe("startNatsWorkerProcess", () => {
+  it("closes the bridge and pool when health server bind fails after subscription startup", async () => {
+    const env = {
+      OPENBRAIN_NATS_URL: "nats://user:pass@127.0.0.1:4222",
+      OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "3110",
+    };
+    let runtimeClosed = false;
+    let poolEnded = false;
+    const infoLogs: string[] = [];
+    const errorLogs: string[] = [];
+    const runtime: NatsWorkerRuntime = {
+      boundary: readNatsWorkerBoundary(env),
+      health: createNatsBridgeHealth("available"),
+      subject: "ob.memory.context_pack",
+      close: async () => {
+        runtimeClosed = true;
+      },
+    };
+
+    await expect(
+      startNatsWorkerProcess({
+        env,
+        log: {
+          info: (message, extra) => {
+            infoLogs.push(JSON.stringify({ message, extra }));
+          },
+          error: (message, extra) => {
+            errorLogs.push(JSON.stringify({ message, extra }));
+          },
+        },
+        buildTokens: () =>
+          new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+        createDbPool: () =>
+          ({
+            end: async () => {
+              poolEnded = true;
+            },
+          }) as any,
+        startWorker: async () => runtime,
+        serve: (() => {
+          throw new Error("listen failed for nats://user:pass@broker.internal");
+        }) as any,
+      }),
+    ).rejects.toThrow("listen failed");
+
+    expect(runtimeClosed).toBe(true);
+    expect(poolEnded).toBe(true);
+    expect(infoLogs.join("\n")).not.toContain("Open Brain NATS worker started");
+    expect(errorLogs.join("\n")).not.toContain("user:pass");
+    expect(errorLogs.join("\n")).not.toContain("broker.internal");
+  });
+});
+
+describe("safeWorkerError", () => {
+  it("reports error type without leaking the message", () => {
+    expect(
+      safeWorkerError(new Error("nats://user:pass@broker.internal failed")),
+    ).toEqual({ error_type: "Error" });
+  });
+});

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env bun
+
+import { buildTokenMap } from "../src/auth.ts";
+import { createPool } from "../src/db/pool.ts";
+import { logger } from "../src/logger.ts";
+import {
+  natsWorkerLogSummary,
+  startNatsWorker,
+  type NatsWorkerRuntime,
+} from "../src/nats-worker.ts";
+
+const tokenMap = buildTokenMap(process.env as Record<string, string | undefined>);
+if (tokenMap.size === 0) {
+  logger.error("No auth tokens configured -- cannot start NATS worker");
+  process.exit(1);
+}
+
+const pool = createPool();
+let runtime: NatsWorkerRuntime;
+try {
+  runtime = await startNatsWorker({
+    env: process.env,
+    pool,
+    tokenMap,
+  });
+  logger.info("Open Brain NATS worker started", {
+    ...natsWorkerLogSummary(runtime.boundary),
+    availability: runtime.health.availability,
+  });
+} catch (err) {
+  logger.error("Open Brain NATS worker failed to start", {
+    error: err instanceof Error ? err.message : String(err),
+  });
+  await pool.end().catch(() => undefined);
+  process.exit(1);
+}
+
+const healthPort = Number.parseInt(
+  process.env.OPEN_BRAIN_NATS_WORKER_HEALTH_PORT ?? "3110",
+  10,
+);
+const healthServer =
+  Number.isFinite(healthPort) && healthPort > 0
+    ? Bun.serve({
+        port: healthPort,
+        fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname !== "/health") {
+            return Response.json({ error: "Not found" }, { status: 404 });
+          }
+          const healthy = runtime.health.availability === "available";
+          return Response.json(
+            {
+              status: healthy ? "healthy" : "degraded",
+              nats: {
+                availability: runtime.health.availability,
+                context_pack_subject:
+                  runtime.boundary.nats.context_pack_subject,
+                consecutive_failures: runtime.health.consecutiveFailures,
+                last_error: runtime.health.lastError ? "redacted" : null,
+              },
+              timestamp: new Date().toISOString(),
+            },
+            { status: healthy ? 200 : 503 },
+          );
+        },
+      })
+    : null;
+
+if (healthServer) {
+  logger.info("Open Brain NATS worker health server started", {
+    port: healthPort,
+  });
+}
+
+async function shutdown() {
+  logger.info("Shutting down Open Brain NATS worker");
+  healthServer?.stop(true);
+  try {
+    await runtime.close();
+  } catch (err) {
+    logger.error("Open Brain NATS worker bridge close failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    await pool.end();
+  } catch (err) {
+    logger.error("Open Brain NATS worker pool close failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    process.exit(0);
+  }
+}
+
+process.on("SIGTERM", () => {
+  void shutdown();
+});
+process.on("SIGINT", () => {
+  void shutdown();
+});
+
+await new Promise(() => undefined);

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -1,104 +1,193 @@
 #!/usr/bin/env bun
 
+import type pg from "pg";
 import { buildTokenMap } from "../src/auth.ts";
 import { createPool } from "../src/db/pool.ts";
 import { logger } from "../src/logger.ts";
 import {
   natsWorkerLogSummary,
+  readNatsWorkerBoundary,
   startNatsWorker,
   type NatsWorkerRuntime,
 } from "../src/nats-worker.ts";
+import type { AuthInfo } from "../src/types.ts";
 
-const tokenMap = buildTokenMap(process.env as Record<string, string | undefined>);
-if (tokenMap.size === 0) {
-  logger.error("No auth tokens configured -- cannot start NATS worker");
-  process.exit(1);
+type LoggerLike = Pick<typeof logger, "error" | "info">;
+type HealthServer = { stop(force?: boolean): void };
+type ServeFn = typeof Bun.serve;
+
+export interface NatsWorkerProcess {
+  runtime: NatsWorkerRuntime;
+  pool: pg.Pool;
+  healthServer: HealthServer | null;
+  shutdown(): Promise<void>;
 }
 
-const pool = createPool();
-let runtime: NatsWorkerRuntime;
-try {
-  runtime = await startNatsWorker({
-    env: process.env,
-    pool,
-    tokenMap,
-  });
-  logger.info("Open Brain NATS worker started", {
-    ...natsWorkerLogSummary(runtime.boundary),
-    availability: runtime.health.availability,
-  });
-} catch (err) {
-  logger.error("Open Brain NATS worker failed to start", {
-    error: err instanceof Error ? err.message : String(err),
-  });
-  await pool.end().catch(() => undefined);
-  process.exit(1);
+export interface StartNatsWorkerProcessOptions {
+  env: NodeJS.ProcessEnv;
+  log?: LoggerLike;
+  buildTokens?: typeof buildTokenMap;
+  createDbPool?: typeof createPool;
+  startWorker?: typeof startNatsWorker;
+  serve?: ServeFn;
 }
 
-const healthPort = Number.parseInt(
-  process.env.OPEN_BRAIN_NATS_WORKER_HEALTH_PORT ?? "3110",
-  10,
-);
-const healthServer =
-  Number.isFinite(healthPort) && healthPort > 0
-    ? Bun.serve({
-        port: healthPort,
-        fetch(request) {
-          const url = new URL(request.url);
-          if (url.pathname !== "/health") {
-            return Response.json({ error: "Not found" }, { status: 404 });
-          }
-          const healthy = runtime.health.availability === "available";
-          return Response.json(
-            {
-              status: healthy ? "healthy" : "degraded",
-              nats: {
-                availability: runtime.health.availability,
-                context_pack_subject:
-                  runtime.boundary.nats.context_pack_subject,
-                consecutive_failures: runtime.health.consecutiveFailures,
-                last_error: runtime.health.lastError ? "redacted" : null,
-              },
-              timestamp: new Date().toISOString(),
-            },
-            { status: healthy ? 200 : 503 },
-          );
-        },
-      })
-    : null;
+export function safeWorkerError(err: unknown): { error_type: string } {
+  if (err instanceof Error) return { error_type: err.name || "Error" };
+  return { error_type: typeof err };
+}
 
-if (healthServer) {
-  logger.info("Open Brain NATS worker health server started", {
+function healthPortFromEnv(env: NodeJS.ProcessEnv): number | null {
+  const healthPort = Number.parseInt(
+    env.OPEN_BRAIN_NATS_WORKER_HEALTH_PORT ?? "3110",
+    10,
+  );
+  return Number.isFinite(healthPort) && healthPort > 0 ? healthPort : null;
+}
+
+function startHealthServer(input: {
+  env: NodeJS.ProcessEnv;
+  runtime: NatsWorkerRuntime;
+  serve: ServeFn;
+}): HealthServer | null {
+  const healthPort = healthPortFromEnv(input.env);
+  if (!healthPort) return null;
+
+  return input.serve({
     port: healthPort,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname !== "/health") {
+        return Response.json({ error: "Not found" }, { status: 404 });
+      }
+      const healthy = input.runtime.health.availability === "available";
+      return Response.json(
+        {
+          status: healthy ? "healthy" : "degraded",
+          nats: {
+            availability: input.runtime.health.availability,
+            context_pack_subject: input.runtime.boundary.nats.context_pack_subject,
+            consecutive_failures: input.runtime.health.consecutiveFailures,
+            last_error: input.runtime.health.lastError ? "redacted" : null,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: healthy ? 200 : 503 },
+      );
+    },
   });
 }
 
-async function shutdown() {
-  logger.info("Shutting down Open Brain NATS worker");
-  healthServer?.stop(true);
+async function closeRuntime(
+  runtime: NatsWorkerRuntime | undefined,
+  log: LoggerLike,
+): Promise<void> {
+  if (!runtime) return;
   try {
     await runtime.close();
   } catch (err) {
-    logger.error("Open Brain NATS worker bridge close failed", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-  try {
-    await pool.end();
-  } catch (err) {
-    logger.error("Open Brain NATS worker pool close failed", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  } finally {
-    process.exit(0);
+    log.error("Open Brain NATS worker bridge close failed", safeWorkerError(err));
   }
 }
 
-process.on("SIGTERM", () => {
-  void shutdown();
-});
-process.on("SIGINT", () => {
-  void shutdown();
-});
+function closeHealthServer(
+  healthServer: HealthServer | null,
+  log: LoggerLike,
+): void {
+  if (!healthServer) return;
+  try {
+    healthServer.stop(true);
+  } catch (err) {
+    log.error(
+      "Open Brain NATS worker health server close failed",
+      safeWorkerError(err),
+    );
+  }
+}
 
-await new Promise(() => undefined);
+async function closePool(
+  pool: pg.Pool | undefined,
+  log: LoggerLike,
+): Promise<void> {
+  if (!pool) return;
+  try {
+    await pool.end();
+  } catch (err) {
+    log.error("Open Brain NATS worker pool close failed", safeWorkerError(err));
+  }
+}
+
+export async function startNatsWorkerProcess(
+  options: StartNatsWorkerProcessOptions,
+): Promise<NatsWorkerProcess> {
+  const log = options.log ?? logger;
+  const buildTokens = options.buildTokens ?? buildTokenMap;
+  const createDbPool = options.createDbPool ?? createPool;
+  const startWorker = options.startWorker ?? startNatsWorker;
+  const serve = options.serve ?? Bun.serve;
+  const env = options.env;
+
+  let pool: pg.Pool | undefined;
+  let runtime: NatsWorkerRuntime | undefined;
+  let healthServer: HealthServer | null = null;
+
+  try {
+    const tokenMap = buildTokens(env as Record<string, string | undefined>);
+    if (tokenMap.size === 0) {
+      throw new Error("No auth tokens configured");
+    }
+
+    pool = createDbPool();
+    runtime = await startWorker({
+      env,
+      pool,
+      tokenMap: tokenMap as Map<string, AuthInfo>,
+    });
+    healthServer = startHealthServer({ env, runtime, serve });
+    log.info("Open Brain NATS worker started", {
+      ...natsWorkerLogSummary(runtime.boundary),
+      availability: runtime.health.availability,
+      health_port: healthPortFromEnv(env),
+    });
+    return {
+      runtime,
+      pool,
+      healthServer,
+      shutdown: async () => {
+        log.info("Shutting down Open Brain NATS worker");
+        closeHealthServer(healthServer, log);
+        await closeRuntime(runtime, log);
+        await closePool(pool, log);
+      },
+    };
+  } catch (err) {
+    log.error("Open Brain NATS worker failed to start", {
+      ...safeWorkerError(err),
+      ...natsWorkerLogSummary(readNatsWorkerBoundary(env)),
+    });
+    closeHealthServer(healthServer, log);
+    await closeRuntime(runtime, log);
+    await closePool(pool, log);
+    throw err;
+  }
+}
+
+if (import.meta.main) {
+  try {
+    const processRuntime = await startNatsWorkerProcess({ env: process.env });
+    const shutdown = async () => {
+      await processRuntime.shutdown();
+      process.exit(0);
+    };
+    process.on("SIGTERM", () => {
+      void shutdown();
+    });
+    process.on("SIGINT", () => {
+      void shutdown();
+    });
+
+    await new Promise(() => undefined);
+  } catch {
+    process.exit(1);
+  }
+}

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -32,8 +32,16 @@ export interface StartNatsWorkerProcessOptions {
   serve?: ServeFn;
 }
 
+// Redaction: classify by an instanceof-allowlist returning STATIC strings,
+// matching safeErrorType in nats-bridge.ts. err.name is mutable/attacker-
+// influenced and err.message can embed a NATS url with credentials, so neither
+// is ever surfaced. (#283 low finding.)
 export function safeWorkerError(err: unknown): { error_type: string } {
-  if (err instanceof Error) return { error_type: err.name || "Error" };
+  if (err instanceof SyntaxError) return { error_type: "SyntaxError" };
+  if (err instanceof AggregateError) return { error_type: "AggregateError" };
+  if (err instanceof TypeError) return { error_type: "TypeError" };
+  if (err instanceof RangeError) return { error_type: "RangeError" };
+  if (err instanceof Error) return { error_type: "Error" };
   return { error_type: typeof err };
 }
 

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -45,6 +45,32 @@ function healthPortFromEnv(env: NodeJS.ProcessEnv): number | null {
   return Number.isFinite(healthPort) && healthPort > 0 ? healthPort : null;
 }
 
+function shutdownTimeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
+  const timeoutMs = Number.parseInt(
+    env.OPEN_BRAIN_NATS_WORKER_SHUTDOWN_TIMEOUT_MS ?? "5000",
+    10,
+  );
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 5000;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 function startHealthServer(input: {
   env: NodeJS.ProcessEnv;
   runtime: NatsWorkerRuntime;
@@ -81,10 +107,15 @@ function startHealthServer(input: {
 async function closeRuntime(
   runtime: NatsWorkerRuntime | undefined,
   log: LoggerLike,
+  timeoutMs: number,
 ): Promise<void> {
   if (!runtime) return;
   try {
-    await runtime.close();
+    await withTimeout(
+      runtime.close(),
+      timeoutMs,
+      "Open Brain NATS worker bridge close timed out",
+    );
   } catch (err) {
     log.error("Open Brain NATS worker bridge close failed", safeWorkerError(err));
   }
@@ -130,6 +161,7 @@ export async function startNatsWorkerProcess(
   let pool: pg.Pool | undefined;
   let runtime: NatsWorkerRuntime | undefined;
   let healthServer: HealthServer | null = null;
+  const shutdownTimeoutMs = shutdownTimeoutMsFromEnv(env);
 
   try {
     const tokenMap = buildTokens(env as Record<string, string | undefined>);
@@ -156,7 +188,7 @@ export async function startNatsWorkerProcess(
       shutdown: async () => {
         log.info("Shutting down Open Brain NATS worker");
         closeHealthServer(healthServer, log);
-        await closeRuntime(runtime, log);
+        await closeRuntime(runtime, log, shutdownTimeoutMs);
         await closePool(pool, log);
       },
     };
@@ -166,7 +198,7 @@ export async function startNatsWorkerProcess(
       ...natsWorkerLogSummary(readNatsWorkerBoundary(env)),
     });
     closeHealthServer(healthServer, log);
-    await closeRuntime(runtime, log);
+    await closeRuntime(runtime, log, shutdownTimeoutMs);
     await closePool(pool, log);
     throw err;
   }

--- a/scripts/run-two-worker.ts
+++ b/scripts/run-two-worker.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import { buildHttpWorkerEnv } from "./worker-env.ts";
+
 type WorkerConfig = {
   name: string;
   port: number;
@@ -44,13 +46,13 @@ const workers: WorkerConfig[] = Array.from({ length: workerCount }, (_, index) =
 
 const children = workers.map((worker) => {
   const child = Bun.spawn(["bun", "run", "src/index.ts"], {
-    env: {
-      ...process.env,
-      PORT: String(worker.port),
-      DB_POOL_MAX: poolMax,
-      OPEN_BRAIN_RUN_MIGRATIONS: worker.runMigrations ? "1" : "0",
-      OPEN_BRAIN_WORKER_NAME: worker.name,
-    },
+    env: buildHttpWorkerEnv({
+      baseEnv: process.env,
+      port: worker.port,
+      poolMax,
+      runMigrations: worker.runMigrations,
+      workerName: worker.name,
+    }),
     stdout: "inherit",
     stderr: "inherit",
   });

--- a/scripts/worker-env.test.ts
+++ b/scripts/worker-env.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { buildHttpWorkerEnv } from "./worker-env.ts";
+
+describe("buildHttpWorkerEnv", () => {
+  it("forces HTTP workers to stay off the NATS bridge even when shared env opts into NATS", () => {
+    const env = buildHttpWorkerEnv({
+      baseEnv: {
+        OPENBRAIN_TRANSPORT: "nats",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      },
+      port: 3101,
+      poolMax: "5",
+      runMigrations: true,
+      workerName: "open-brain-worker-1",
+    });
+
+    expect(env).toMatchObject({
+      PORT: "3101",
+      DB_POOL_MAX: "5",
+      OPEN_BRAIN_RUN_MIGRATIONS: "1",
+      OPEN_BRAIN_WORKER_NAME: "open-brain-worker-1",
+      OPENBRAIN_TRANSPORT: "http",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+  });
+});

--- a/scripts/worker-env.ts
+++ b/scripts/worker-env.ts
@@ -1,0 +1,19 @@
+type WorkerEnvInput = {
+  baseEnv: NodeJS.ProcessEnv;
+  port: number;
+  poolMax: string;
+  runMigrations: boolean;
+  workerName: string;
+};
+
+export function buildHttpWorkerEnv(input: WorkerEnvInput): NodeJS.ProcessEnv {
+  return {
+    ...input.baseEnv,
+    PORT: String(input.port),
+    DB_POOL_MAX: input.poolMax,
+    OPEN_BRAIN_RUN_MIGRATIONS: input.runMigrations ? "1" : "0",
+    OPEN_BRAIN_WORKER_NAME: input.workerName,
+    OPENBRAIN_TRANSPORT: "http",
+    OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+  };
+}

--- a/src/__fixtures__/nats-context-pack-wire.json
+++ b/src/__fixtures__/nats-context-pack-wire.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "SHARED cross-language wire fixture for the Open Brain NATS context-pack transport. TS (src/nats-runtime.ts) and Python (openbrain-memory nats_wire) MUST both round-trip against this file so the wire cannot drift. `wire` holds the EXACT canonical compact UTF-8 JSON bytes produced by the envelope serializer (fleet Envelope field order: id, ts, from, kind, payload, to, task_id, channel, topic, correlation_id, version). `envelope` is the same message as a structured object for constructing it. Do not reformat `wire`: it is a byte-for-byte contract.",
+  "envelope_field_order": ["id", "ts", "from", "kind", "payload", "to", "task_id", "channel", "topic", "correlation_id", "version"],
+  "request": {
+    "wire": "{\"id\":\"018f8b2c-0000-7000-8000-000000000abc\",\"ts\":\"2026-07-08T00:00:00.000Z\",\"from\":\"nagatha\",\"kind\":\"context_pack_request\",\"payload\":{\"operation\":\"agent_context_pack\",\"identity\":{\"agent\":\"nagatha\",\"platform\":\"discord\",\"server_id\":\"rodaddy-live\",\"channel_id\":\"open-brain\",\"thread_id\":null,\"session_key\":\"discord:rodaddy-live:open-brain:nagatha\"},\"body\":{\"query\":\"what is the current task state?\",\"requested_sections\":[\"working_set\"]},\"namespace\":\"rico\"},\"to\":null,\"task_id\":null,\"channel\":null,\"topic\":null,\"correlation_id\":\"018f8b2c-0000-7000-8000-000000000abc\",\"version\":1}",
+    "envelope": {
+      "id": "018f8b2c-0000-7000-8000-000000000abc",
+      "ts": "2026-07-08T00:00:00.000Z",
+      "from": "nagatha",
+      "kind": "context_pack_request",
+      "payload": {
+        "operation": "agent_context_pack",
+        "identity": {
+          "agent": "nagatha",
+          "platform": "discord",
+          "server_id": "rodaddy-live",
+          "channel_id": "open-brain",
+          "thread_id": null,
+          "session_key": "discord:rodaddy-live:open-brain:nagatha"
+        },
+        "body": {
+          "query": "what is the current task state?",
+          "requested_sections": ["working_set"]
+        },
+        "namespace": "rico"
+      },
+      "to": null,
+      "task_id": null,
+      "channel": null,
+      "topic": null,
+      "correlation_id": "018f8b2c-0000-7000-8000-000000000abc",
+      "version": 1
+    }
+  },
+  "response": {
+    "wire": "{\"id\":\"018f8b2c-0000-7000-8000-000000000abc\",\"ts\":\"2026-07-08T00:00:00.500Z\",\"from\":\"open-brain\",\"kind\":\"context_pack_response\",\"payload\":{\"status\":\"ok\",\"operation\":\"agent_context_pack\",\"namespace_source\":\"override\",\"body\":{\"schema\":\"openbrain.agent_context_pack.v1\",\"status\":\"ok\"}},\"to\":null,\"task_id\":null,\"channel\":null,\"topic\":null,\"correlation_id\":\"018f8b2c-0000-7000-8000-000000000abc\",\"version\":1}",
+    "envelope": {
+      "id": "018f8b2c-0000-7000-8000-000000000abc",
+      "ts": "2026-07-08T00:00:00.500Z",
+      "from": "open-brain",
+      "kind": "context_pack_response",
+      "payload": {
+        "status": "ok",
+        "operation": "agent_context_pack",
+        "namespace_source": "override",
+        "body": {
+          "schema": "openbrain.agent_context_pack.v1",
+          "status": "ok"
+        }
+      },
+      "to": null,
+      "task_id": null,
+      "channel": null,
+      "topic": null,
+      "correlation_id": "018f8b2c-0000-7000-8000-000000000abc",
+      "version": 1
+    }
+  }
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -79,6 +79,20 @@ export function verifyToken(provided: string, expected: string): boolean {
   return timingSafeEqual(a, b);
 }
 
+export function findAuthInfoForToken(
+  provided: string,
+  tokenMap: Map<string, AuthInfo>,
+): AuthInfo | null {
+  let matched: AuthInfo | null = null;
+  for (const [storedToken, authInfo] of tokenMap) {
+    if (verifyToken(provided, storedToken)) {
+      matched = authInfo;
+      // Don't break — iterate all tokens for constant-time behavior.
+    }
+  }
+  return matched;
+}
+
 export function authMiddleware(
   tokenMap: Map<string, AuthInfo>,
 ): (req: Request, res: Response, next: NextFunction) => void {
@@ -92,15 +106,7 @@ export function authMiddleware(
 
     const provided = authHeader.slice("Bearer ".length);
 
-    // Always iterate ALL tokens to avoid timing side-channel leaking
-    // which token (or whether any token) matched early vs late.
-    let matched: AuthInfo | null = null;
-    for (const [storedToken, authInfo] of tokenMap) {
-      if (verifyToken(provided, storedToken)) {
-        matched = authInfo;
-        // Don't break — iterate all tokens for constant-time
-      }
-    }
+    const matched = findAuthInfoForToken(provided, tokenMap);
 
     if (matched) {
       const namespace = headerValue(req.headers["x-namespace"]);

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -35,11 +35,11 @@ describe("Open Brain contract manifest", () => {
     ).toEqual({
       available: [],
       planned: [
-        "ob.memory.session_start",
-        "ob.memory.append_event",
-        "ob.memory.wrap",
-        "ob.memory.resolve",
-        "ob.health",
+        "{env}.ob.memory.session_start",
+        "{env}.ob.memory.append_event",
+        "{env}.ob.memory.wrap",
+        "{env}.ob.memory.resolve",
+        "{env}.ob.health",
       ],
     });
     expect(contract.realtime_transport.nats_jetstream.jetstream_streams).toEqual([
@@ -626,13 +626,13 @@ describe("Open Brain contract manifest", () => {
       status: "runtime-available",
       availability: "available",
       request_reply_subjects: {
-        available: ["ob.memory.context_pack"],
+        available: ["{env}.ob.memory.context_pack"],
         planned: [
-          "ob.memory.session_start",
-          "ob.memory.append_event",
-          "ob.memory.wrap",
-          "ob.memory.resolve",
-          "ob.health",
+          "{env}.ob.memory.session_start",
+          "{env}.ob.memory.append_event",
+          "{env}.ob.memory.wrap",
+          "{env}.ob.memory.resolve",
+          "{env}.ob.health",
         ],
       },
     });

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -38,14 +38,19 @@ export interface OpenBrainContract {
         monitoring_listen: "127.0.0.1:8222";
         jetstream_store_dir: "/Volumes/ThunderBolt/open-brain/nats/jetstream";
       };
+      // Subjects are env-prefixed via the fleet-bus builder convention
+      // (src/nats-subjects.ts obContextPackSubject). The `{env}.` template below
+      // is a documentation placeholder; the live subject substitutes the slugged
+      // OPENBRAIN_NATS_ENV value (default "dev"), e.g. dev.ob.memory.context_pack.
+      subject_convention: "env_prefixed_fleet_bus";
       request_reply_subjects: {
-        available: readonly ["ob.memory.context_pack"] | readonly [];
+        available: readonly ["{env}.ob.memory.context_pack"] | readonly [];
         planned: readonly [
-          "ob.memory.session_start",
-          "ob.memory.append_event",
-          "ob.memory.wrap",
-          "ob.memory.resolve",
-          "ob.health",
+          "{env}.ob.memory.session_start",
+          "{env}.ob.memory.append_event",
+          "{env}.ob.memory.wrap",
+          "{env}.ob.memory.resolve",
+          "{env}.ob.health",
         ];
       };
       jetstream_streams: readonly [
@@ -528,6 +533,11 @@ export function buildContract(
       namespace_boundary: "authorization" as const,
       session_required: true as const,
     },
+    // ADVISORY: realtime_transport is EXCLUDED from schema_hash
+    // (see requiredContractHashPayload — it destructures realtime_transport out
+    // before hashing). It is documentation of the NATS foundation, so its
+    // contents (subject shape, availability, streams) can change without a
+    // schema_hash bump or a contract-version break.
     realtime_transport: {
       nats_jetstream: {
         status: natsAvailability === "available"
@@ -543,16 +553,20 @@ export function buildContract(
           jetstream_store_dir:
             "/Volumes/ThunderBolt/open-brain/nats/jetstream" as const,
         },
+        // Env-prefixed subjects (fleet-bus convention). The advertised strings
+        // carry a `{env}.` template placeholder; the runtime substitutes the
+        // slugged OPENBRAIN_NATS_ENV value via obContextPackSubject(env).
+        subject_convention: "env_prefixed_fleet_bus" as const,
         request_reply_subjects: {
           available: natsAvailability === "available"
-            ? ["ob.memory.context_pack"] as const
+            ? ["{env}.ob.memory.context_pack"] as const
             : [] as const,
           planned: [
-            "ob.memory.session_start",
-            "ob.memory.append_event",
-            "ob.memory.wrap",
-            "ob.memory.resolve",
-            "ob.health",
+            "{env}.ob.memory.session_start",
+            "{env}.ob.memory.append_event",
+            "{env}.ob.memory.wrap",
+            "{env}.ob.memory.resolve",
+            "{env}.ob.health",
           ] as const,
         },
         jetstream_streams: [

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -142,6 +142,38 @@ describe("handleNatsContextPackMessage", () => {
     });
   });
 
+  it("uses constant-time token matching instead of direct map lookup", () => {
+    class NoDirectLookupTokenMap extends Map<string, AuthInfo> {
+      override get(_key: string): AuthInfo | undefined {
+        throw new Error("direct token lookup should not be used");
+      }
+    }
+
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: "ob.memory.context_pack",
+        data: data(baseEnvelope),
+        headers: { Authorization: "Bearer secret-token" },
+      },
+      boundary,
+      tokenMap: new NoDirectLookupTokenMap([
+        ["secret-token", { role: "admin", clientId: "rico" }],
+      ]),
+      deps: depsWithWorkingSet(),
+    }) as any;
+
+    expect(response).toMatchObject({
+      request_id: "req-123",
+      status: "ok",
+    });
+  });
+
   it("rejects oversized bodies before parsing", () => {
     const boundary = readNatsRuntimeBoundary({
       OPENBRAIN_TRANSPORT: "nats",

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -20,7 +20,6 @@ import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo } from "./types.ts";
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 
 const SUBJECT = "dev.ob.memory.context_pack";
 
@@ -87,23 +86,6 @@ function depsWithWorkingSet(namespace = scope.namespace): ToolDeps {
 
 function data(payload: unknown): Uint8Array {
   return encoder.encode(JSON.stringify(payload));
-}
-
-function decodeResponse(raw: Uint8Array): {
-  id: string;
-  from: string;
-  kind: string;
-  correlation_id: string | null;
-  payload: Record<string, any>;
-} {
-  const parsed = envelopeFromBytes(raw);
-  return {
-    id: parsed.id,
-    from: parsed.from,
-    kind: parsed.kind,
-    correlation_id: parsed.correlation_id,
-    payload: parsed.payload as Record<string, any>,
-  };
 }
 
 function localBoundary(extra: Record<string, string> = {}) {

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -7,7 +7,13 @@ import {
   type NatsRequestMessage,
 } from "./nats-bridge.ts";
 import { logger } from "./logger.ts";
-import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
+import {
+  envelopeFromBytes,
+  readNatsRuntimeBoundary,
+  REQUEST_KIND,
+  RESPONSE_FROM,
+  RESPONSE_KIND,
+} from "./nats-runtime.ts";
 import { WorkingSetStore } from "./realtime/working-set.ts";
 import { RecoveryWalStore } from "./realtime/recovery-wal.ts";
 import type { ToolDeps } from "./tools/index.ts";
@@ -15,6 +21,8 @@ import type { AuthInfo } from "./types.ts";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+
+const SUBJECT = "dev.ob.memory.context_pack";
 
 const scope = {
   namespace: "rico",
@@ -25,12 +33,9 @@ const scope = {
   session_key: "discord:rodaddy-live:open-brain:nagatha",
 };
 
-const baseEnvelope = {
-  schema: "openbrain.nats.request.v1",
+const requestPayload = {
   operation: "agent_context_pack",
-  request_id: "req-123",
   identity: {
-    namespace_source: "authorization",
     agent: scope.agent,
     platform: scope.platform,
     server_id: scope.server_id,
@@ -42,19 +47,35 @@ const baseEnvelope = {
     query: "what is the current task state?",
     requested_sections: ["working_set"],
   },
-  metadata: {
-    client: "openbrain-memory",
-    client_version: "0.1.0",
-    transport: "nats",
-  },
 } as const;
 
-function depsWithWorkingSet(): ToolDeps {
+function envelope(
+  overrides: {
+    id?: string;
+    from?: string;
+    payload?: Record<string, unknown>;
+    version?: number;
+  } = {},
+): Record<string, unknown> {
+  return {
+    id: overrides.id ?? "req-123",
+    ts: "2026-07-08T00:00:00.000Z",
+    from: overrides.from ?? scope.namespace,
+    kind: REQUEST_KIND,
+    payload: overrides.payload ?? requestPayload,
+    version: overrides.version ?? 1,
+  };
+}
+
+function depsWithWorkingSet(namespace = scope.namespace): ToolDeps {
   const workingSetStore = new WorkingSetStore();
-  workingSetStore.append(scope, {
-    kind: "current_intent",
-    content: "Finish #223 over NATS without changing HTTP default.",
-  });
+  workingSetStore.append(
+    { ...scope, namespace },
+    {
+      kind: "current_intent",
+      content: "Finish #223 over NATS without changing HTTP default.",
+    },
+  );
 
   return {
     pool: { query: async () => ({ rows: [] }) } as any,
@@ -66,6 +87,32 @@ function depsWithWorkingSet(): ToolDeps {
 
 function data(payload: unknown): Uint8Array {
   return encoder.encode(JSON.stringify(payload));
+}
+
+function decodeResponse(raw: Uint8Array): {
+  id: string;
+  from: string;
+  kind: string;
+  correlation_id: string | null;
+  payload: Record<string, any>;
+} {
+  const parsed = envelopeFromBytes(raw);
+  return {
+    id: parsed.id,
+    from: parsed.from,
+    kind: parsed.kind,
+    correlation_id: parsed.correlation_id,
+    payload: parsed.payload as Record<string, any>,
+  };
+}
+
+function localBoundary(extra: Record<string, string> = {}) {
+  return readNatsRuntimeBoundary({
+    OPENBRAIN_TRANSPORT: "nats",
+    OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+    OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    ...extra,
+  });
 }
 
 async function waitFor(
@@ -82,64 +129,169 @@ async function waitFor(
   }
 }
 
-describe("handleNatsContextPackMessage", () => {
-  it("returns the same agent_context_pack payload over an authorized NATS request", () => {
-    const tokenMap = new Map<string, AuthInfo>([
-      ["secret-token", { role: "admin", clientId: "rico" }],
-    ]);
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-    });
-
+describe("handleNatsContextPackMessage — response envelope", () => {
+  it("wraps the reply in a fleet context_pack_response envelope echoing the request id", () => {
     const response = handleNatsContextPackMessage({
-      message: {
-        subject: "ob.memory.context_pack",
-        data: data(baseEnvelope),
-        headers: { Authorization: "Bearer secret-token" },
-      },
-      boundary,
-      tokenMap,
+      message: { subject: SUBJECT, data: data(envelope()), headers: {} },
+      boundary: localBoundary(),
+      tokenMap: new Map(),
       deps: depsWithWorkingSet(),
-    }) as any;
-
-    expect(response).toMatchObject({
-      schema: "openbrain.nats.response.v1",
-      request_id: "req-123",
-      status: "ok",
-      operation: "agent_context_pack",
     });
-    expect(response.body.sections.working_set.items[0]).toMatchObject({
+
+    expect(response.kind).toBe(RESPONSE_KIND);
+    expect(response.from).toBe(RESPONSE_FROM);
+    expect(response.id).toBe("req-123");
+    expect(response.correlation_id).toBe("req-123");
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("ok");
+    expect(payload.operation).toBe("agent_context_pack");
+    expect(payload.namespace_source).toBe("declared");
+    expect(payload.body.sections.working_set.items[0]).toMatchObject({
       content: "Finish #223 over NATS without changing HTTP default.",
       label: "working_context",
     });
-    expect(response.body.warnings.scope_denials).toEqual([]);
   });
+});
 
-  it("rejects NATS requests that do not carry a bearer token", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-    });
-
+describe("handleNatsContextPackMessage — lane binding (auth off, local bus)", () => {
+  it("binds via explicit payload.namespace override when override is allowed", () => {
     const response = handleNatsContextPackMessage({
       message: {
-        subject: "ob.memory.context_pack",
-        data: data({ not: "valid-json-envelope" }),
+        subject: SUBJECT,
+        data: data(
+          envelope({
+            from: "someone-else",
+            payload: { ...requestPayload, namespace: "rico" },
+          }),
+        ),
         headers: {},
       },
-      boundary,
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+    });
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("ok");
+    expect(payload.namespace_source).toBe("override");
+    // The override namespace ("rico") — not the envelope from ("someone-else") —
+    // selected the working set.
+    expect(payload.body.sections.working_set.items[0].content).toContain(
+      "Finish #223",
+    );
+  });
+
+  it("binds via the declared identity (envelope from) when no override is given", () => {
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: SUBJECT,
+        data: data(envelope({ from: "rico" })),
+        headers: {},
+      },
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+    });
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("ok");
+    expect(payload.namespace_source).toBe("declared");
+  });
+
+  it("rejects as unroutable when no namespace can be derived", () => {
+    // Both the envelope from AND the identity agent must fail to normalise to a
+    // valid namespace token so nothing is routable. "@@@@" starts with a
+    // disallowed char, so it fails NAMESPACE_TOKEN_RE.
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: SUBJECT,
+        data: data(
+          envelope({
+            from: "@@@@",
+            payload: {
+              ...requestPayload,
+              identity: { ...requestPayload.identity, agent: "@@@@" },
+            },
+          }),
+        ),
+        headers: {},
+      },
+      boundary: localBoundary(),
       tokenMap: new Map(),
       deps: depsWithWorkingSet(),
-    }) as any;
-
-    expect(response).toMatchObject({
-      request_id: null,
-      status: "error",
-      error: { code: "permission_denied" },
     });
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.error.code).toBe("unroutable");
+    expect(payload.namespace_source).toBe("rejected");
+  });
+
+  it("ignores payload.namespace override when the override is disabled", () => {
+    // override disabled but auth still off -> falls to declared identity binding.
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: SUBJECT,
+        data: data(
+          envelope({
+            from: "rico",
+            payload: { ...requestPayload, namespace: "someone-else" },
+          }),
+        ),
+        headers: {},
+      },
+      boundary: localBoundary({ OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE: "false" }),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+    });
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("ok");
+    expect(payload.namespace_source).toBe("declared");
+  });
+});
+
+describe("handleNatsContextPackMessage — REQUIRE_AUTH interlock", () => {
+  const authBoundary = () => localBoundary({ OPENBRAIN_NATS_REQUIRE_AUTH: "true" });
+
+  it("requires a bearer token when REQUIRE_AUTH=true", () => {
+    const response = handleNatsContextPackMessage({
+      message: { subject: SUBJECT, data: data(envelope()), headers: {} },
+      boundary: authBoundary(),
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      deps: depsWithWorkingSet(),
+    });
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.error.code).toBe("permission_denied");
+    expect(payload.namespace_source).toBe("rejected");
+  });
+
+  it("uses the token-derived namespace and ignores a wire override when REQUIRE_AUTH=true", () => {
+    const response = handleNatsContextPackMessage({
+      message: {
+        subject: SUBJECT,
+        data: data(
+          // hostile client tries to override to a namespace it doesn't own
+          envelope({ from: "rico", payload: { ...requestPayload, namespace: "victim" } }),
+        ),
+        headers: { Authorization: "Bearer agent-token" },
+      },
+      boundary: authBoundary(),
+      // agent role -> clientId "rico" is the ONLY namespace it can read
+      tokenMap: new Map([["agent-token", { role: "agent", clientId: "rico" }]]),
+      deps: depsWithWorkingSet("rico"),
+    });
+
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("ok");
+    expect(payload.namespace_source).toBe("declared");
+    // Token namespace "rico" selected the working set, not "victim".
+    expect(payload.body.sections.working_set.items[0].content).toContain(
+      "Finish #223",
+    );
   });
 
   it("uses constant-time token matching instead of direct map lookup", () => {
@@ -149,116 +301,76 @@ describe("handleNatsContextPackMessage", () => {
       }
     }
 
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-    });
-
     const response = handleNatsContextPackMessage({
       message: {
-        subject: "ob.memory.context_pack",
-        data: data(baseEnvelope),
+        subject: SUBJECT,
+        data: data(envelope({ from: "rico" })),
         headers: { Authorization: "Bearer secret-token" },
       },
-      boundary,
+      boundary: authBoundary(),
       tokenMap: new NoDirectLookupTokenMap([
-        ["secret-token", { role: "admin", clientId: "rico" }],
+        ["secret-token", { role: "agent", clientId: "rico" }],
       ]),
-      deps: depsWithWorkingSet(),
-    }) as any;
-
-    expect(response).toMatchObject({
-      request_id: "req-123",
-      status: "ok",
+      deps: depsWithWorkingSet("rico"),
     });
+
+    expect((response.payload as Record<string, any>).status).toBe("ok");
   });
+});
 
+describe("handleNatsContextPackMessage — guards and redaction", () => {
   it("rejects oversized bodies before parsing", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-    });
-
     const response = handleNatsContextPackMessage({
       message: {
-        subject: "ob.memory.context_pack",
+        subject: SUBJECT,
         data: encoder.encode("x".repeat(65 * 1024)),
-        headers: { Authorization: "Bearer secret-token" },
+        headers: {},
       },
-      boundary,
-      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      boundary: localBoundary(),
+      tokenMap: new Map(),
       deps: depsWithWorkingSet(),
-    }) as any;
-
-    expect(response).toMatchObject({
-      request_id: null,
-      status: "error",
-      error: { code: "payload_too_large" },
     });
+
+    const payload = response.payload as Record<string, any>;
+    expect(response.id).toBe("unknown");
+    expect(payload.error.code).toBe("payload_too_large");
   });
 
   it("does not expose raw parser or schema errors to NATS callers", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    const response = handleNatsContextPackMessage({
+      message: { subject: SUBJECT, data: encoder.encode("{bad json"), headers: {} },
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet(),
     });
 
-    const response = handleNatsContextPackMessage({
-      message: {
-        subject: "ob.memory.context_pack",
-        data: encoder.encode("{bad json"),
-        headers: { Authorization: "Bearer secret-token" },
-      },
-      boundary,
-      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-      deps: depsWithWorkingSet(),
-    }) as any;
-
-    expect(response).toMatchObject({
-      request_id: null,
-      status: "error",
-      error: {
-        code: "bad_request",
-        message: "Invalid NATS context pack request",
-      },
+    const payload = response.payload as Record<string, any>;
+    expect(payload.error).toMatchObject({
+      code: "bad_request",
+      message: "Invalid NATS context pack request",
     });
   });
 
   it("returns unavailable when live bridge health is degraded", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-      OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-    });
     const health = createNatsBridgeHealth("not_runtime_available");
     health.lastError = "connection closed";
 
     const response = handleNatsContextPackMessage({
-      message: {
-        subject: "ob.memory.context_pack",
-        data: data(baseEnvelope),
-        headers: { Authorization: "Bearer secret-token" },
-      },
-      boundary,
-      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      message: { subject: SUBJECT, data: data(envelope()), headers: {} },
+      boundary: localBoundary(),
+      tokenMap: new Map(),
       deps: depsWithWorkingSet(),
       health,
-    }) as any;
+    });
 
-    expect(response).toMatchObject({
-      request_id: null,
-      status: "error",
-      error: {
-        code: "temporarily_unavailable",
-        message: "NATS bridge is not available",
-      },
+    const payload = response.payload as Record<string, any>;
+    expect(payload.error).toMatchObject({
+      code: "temporarily_unavailable",
+      message: "NATS bridge is not available",
     });
   });
 
-  it("logs internal handler failures without reporting them as bad requests", () => {
+  it("logs internal handler failures without leaking token/PII", () => {
     const loggedErrors: string[] = [];
     const originalError = logger.error;
     logger.error = (message, extra) => {
@@ -271,43 +383,28 @@ describe("handleNatsContextPackMessage", () => {
       const brokenWorkingSetStore = {
         buildContextPackFragment: () => {
           const err = new Error(
-            ["working set exploded for nats://", sensitiveToken, "@", sensitiveHost].join(
-              "",
-            ),
+            ["working set exploded for nats://", sensitiveToken, "@", sensitiveHost].join(""),
           );
-          err.name = ["NatsError nats://", sensitiveToken, "@", sensitiveHost].join(
-            "",
-          );
+          // Mutable err.name is deliberately set to a leaking value; the
+          // allowlist must NOT surface it.
+          err.name = ["NatsError nats://", sensitiveToken, "@", sensitiveHost].join("");
           throw err;
         },
       } as unknown as WorkingSetStore;
-      const response = handleNatsContextPackMessage({
-        message: {
-          subject: "ob.memory.context_pack",
-          data: data(baseEnvelope),
-          headers: { Authorization: "Bearer secret-token" },
-        },
-        boundary: readNatsRuntimeBoundary({
-          OPENBRAIN_TRANSPORT: "nats",
-          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-        }),
-        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-        deps: { ...depsWithWorkingSet(), workingSetStore: brokenWorkingSetStore },
-      }) as any;
 
-      expect(response).toMatchObject({
-        request_id: "req-123",
-        status: "error",
-        error: {
-          code: "internal_error",
-          message: "NATS context pack request failed",
-        },
+      const response = handleNatsContextPackMessage({
+        message: { subject: SUBJECT, data: data(envelope({ from: "rico" })), headers: {} },
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: { ...depsWithWorkingSet("rico"), workingSetStore: brokenWorkingSetStore },
+      });
+
+      const payload = response.payload as Record<string, any>;
+      expect(payload.error).toMatchObject({
+        code: "internal_error",
+        message: "NATS context pack request failed",
       });
       const joinedLogs = loggedErrors.join("\n");
-      expect(joinedLogs).toContain(
-        '"message":"NATS context-pack bridge request failed"',
-      );
       expect(joinedLogs).toContain('"error_type":"Error"');
       expect(joinedLogs).not.toContain(sensitiveToken);
       expect(joinedLogs).not.toContain(sensitiveHost);
@@ -325,8 +422,8 @@ describe("startNatsContextPackBridge", () => {
         subscribedSubject = subject;
         await handler({
           subject,
-          data: data(baseEnvelope),
-          headers: { authorization: "Bearer secret-token" },
+          data: data(envelope({ from: "rico" })),
+          headers: {},
           respond: () => undefined,
         } satisfies NatsRequestMessage);
         return { close: () => undefined };
@@ -335,21 +432,17 @@ describe("startNatsContextPackBridge", () => {
     };
 
     const runtime = await startNatsContextPackBridge({
-      boundary: readNatsRuntimeBoundary({
-        OPENBRAIN_TRANSPORT: "nats",
-        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-      }),
-      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-      deps: depsWithWorkingSet(),
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
       driver,
     });
 
     expect(runtime).toMatchObject({
-      subject: "ob.memory.context_pack",
+      subject: SUBJECT,
       availability: "available",
     });
-    expect(subscribedSubject).toBe("ob.memory.context_pack");
+    expect(subscribedSubject).toBe(SUBJECT);
     await runtime?.close();
   });
 
@@ -375,8 +468,8 @@ describe("startNatsContextPackBridge", () => {
         await expect(
           handler({
             subject,
-            data: data(baseEnvelope),
-            headers: { authorization: "Bearer secret-token" },
+            data: data(envelope({ from: "rico" })),
+            headers: {},
             respond: () => false,
           } satisfies NatsRequestMessage),
         ).rejects.toThrow("NATS request did not include a reply inbox");
@@ -386,13 +479,9 @@ describe("startNatsContextPackBridge", () => {
     };
 
     const runtime = await startNatsContextPackBridge({
-      boundary: readNatsRuntimeBoundary({
-        OPENBRAIN_TRANSPORT: "nats",
-        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-      }),
-      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-      deps: depsWithWorkingSet(),
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
       driver,
     });
 
@@ -410,13 +499,9 @@ describe("startNatsContextPackBridge", () => {
     };
 
     const runtime = await startNatsContextPackBridge({
-      boundary: readNatsRuntimeBoundary({
-        OPENBRAIN_TRANSPORT: "nats",
-        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-      }),
-      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-      deps: depsWithWorkingSet(),
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
       driver,
     });
 
@@ -426,7 +511,7 @@ describe("startNatsContextPackBridge", () => {
   });
 
   it("resubscribes the real NATS subscription loop after handler and iterator failures", async () => {
-    const responses: Array<{ request_id?: string; status?: string }> = [];
+    const responses: Array<{ correlation_id?: string | null; status?: string }> = [];
     const loggedErrors: string[] = [];
     const originalError = logger.error;
     logger.error = (message, extra) => {
@@ -435,30 +520,31 @@ describe("startNatsContextPackBridge", () => {
 
     try {
       const headers = {
-        keys: () => ["authorization"],
-        get: () => "Bearer secret-token",
+        keys: () => [] as string[],
+        get: () => "",
       };
-      const envelope = (requestId: string) => ({
-        ...baseEnvelope,
-        request_id: requestId,
-      });
+      const record = (payload: Uint8Array) => {
+        const parsed = envelopeFromBytes(payload);
+        responses.push({
+          correlation_id: parsed.correlation_id,
+          status: (parsed.payload as Record<string, any>).status,
+        });
+        return true;
+      };
       const firstSubscription = {
         unsubscribe: mock(() => {}),
         async *[Symbol.asyncIterator]() {
           yield {
-            subject: "ob.memory.context_pack",
-            data: data(envelope("req-no-reply")),
+            subject: SUBJECT,
+            data: data(envelope({ id: "req-no-reply", from: "rico" })),
             headers,
             respond: () => false,
           };
           yield {
-            subject: "ob.memory.context_pack",
-            data: data(envelope("req-before-resubscribe")),
+            subject: SUBJECT,
+            data: data(envelope({ id: "req-before-resubscribe", from: "rico" })),
             headers,
-            respond: (payload: Uint8Array) => {
-              responses.push(JSON.parse(decoder.decode(payload)));
-              return true;
-            },
+            respond: record,
           };
           throw new Error("subscription iterator failed");
         },
@@ -467,13 +553,10 @@ describe("startNatsContextPackBridge", () => {
         unsubscribe: mock(() => {}),
         async *[Symbol.asyncIterator]() {
           yield {
-            subject: "ob.memory.context_pack",
-            data: data(envelope("req-after-resubscribe")),
+            subject: SUBJECT,
+            data: data(envelope({ id: "req-after-resubscribe", from: "rico" })),
             headers,
-            respond: (payload: Uint8Array) => {
-              responses.push(JSON.parse(decoder.decode(payload)));
-              return true;
-            },
+            respond: record,
           };
         },
       };
@@ -485,48 +568,36 @@ describe("startNatsContextPackBridge", () => {
       const connection = {
         subscribe: mock(() => {
           subscribeCalls += 1;
-          if (subscribeCalls === 1) {
-            return firstSubscription;
-          }
-          if (subscribeCalls === 2) {
-            return secondSubscription;
-          }
+          if (subscribeCalls === 1) return firstSubscription;
+          if (subscribeCalls === 2) return secondSubscription;
           return fallbackSubscription;
         }),
         drain: mock(async () => {}),
       };
-      mock.module("nats", () => ({
-        connect: mock(async () => connection),
-      }));
+      mock.module("nats", () => ({ connect: mock(async () => connection) }));
 
       const runtime = await startNatsContextPackBridge({
-        boundary: readNatsRuntimeBoundary({
-          OPENBRAIN_TRANSPORT: "nats",
-          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-        }),
-        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-        deps: depsWithWorkingSet(),
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
       });
 
       await waitFor(
         () =>
-          responses.some(
-            (response) => response.request_id === "req-after-resubscribe",
-          ),
+          responses.some((r) => r.correlation_id === "req-after-resubscribe"),
         "NATS bridge to process a message after resubscribe",
       );
 
-      expect(connection.subscribe).toHaveBeenCalledWith("ob.memory.context_pack");
+      expect(connection.subscribe).toHaveBeenCalledWith(SUBJECT);
       expect(connection.subscribe.mock.calls.length).toBeGreaterThanOrEqual(2);
       expect(responses).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            request_id: "req-before-resubscribe",
+            correlation_id: "req-before-resubscribe",
             status: "ok",
           }),
           expect.objectContaining({
-            request_id: "req-after-resubscribe",
+            correlation_id: "req-after-resubscribe",
             status: "ok",
           }),
         ]),
@@ -548,11 +619,8 @@ describe("startNatsContextPackBridge", () => {
   });
 
   it("resubscribes after clean iterator completion without degrading health", async () => {
-    const responses: Array<{ request_id?: string; status?: string }> = [];
-    const headers = {
-      keys: () => ["authorization"],
-      get: () => "Bearer secret-token",
-    };
+    const responses: Array<{ correlation_id?: string | null; status?: string }> = [];
+    const headers = { keys: () => [] as string[], get: () => "" };
     const firstSubscription = {
       unsubscribe: mock(() => {}),
       async *[Symbol.asyncIterator]() {},
@@ -561,11 +629,15 @@ describe("startNatsContextPackBridge", () => {
       unsubscribe: mock(() => {}),
       async *[Symbol.asyncIterator]() {
         yield {
-          subject: "ob.memory.context_pack",
-          data: data({ ...baseEnvelope, request_id: "req-after-clean-end" }),
+          subject: SUBJECT,
+          data: data(envelope({ id: "req-after-clean-end", from: "rico" })),
           headers,
           respond: (payload: Uint8Array) => {
-            responses.push(JSON.parse(decoder.decode(payload)));
+            const parsed = envelopeFromBytes(payload);
+            responses.push({
+              correlation_id: parsed.correlation_id,
+              status: (parsed.payload as Record<string, any>).status,
+            });
             return true;
           },
         };
@@ -585,28 +657,19 @@ describe("startNatsContextPackBridge", () => {
       }),
       drain: mock(async () => {}),
     };
-    mock.module("nats", () => ({
-      connect: mock(async () => connection),
-    }));
+    mock.module("nats", () => ({ connect: mock(async () => connection) }));
     const health = createNatsBridgeHealth("available");
 
     try {
       const runtime = await startNatsContextPackBridge({
-        boundary: readNatsRuntimeBoundary({
-          OPENBRAIN_TRANSPORT: "nats",
-          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-        }),
-        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-        deps: depsWithWorkingSet(),
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
         health,
       });
 
       await waitFor(
-        () =>
-          responses.some(
-            (response) => response.request_id === "req-after-clean-end",
-          ),
+        () => responses.some((r) => r.correlation_id === "req-after-clean-end"),
         "NATS bridge to resubscribe after clean iterator completion",
       );
       expect(health).toMatchObject({
@@ -636,20 +699,14 @@ describe("startNatsContextPackBridge", () => {
       }),
       drain: mock(async () => {}),
     };
-    mock.module("nats", () => ({
-      connect: mock(async () => connection),
-    }));
+    mock.module("nats", () => ({ connect: mock(async () => connection) }));
     const health = createNatsBridgeHealth("available");
 
     try {
       const runtime = await startNatsContextPackBridge({
-        boundary: readNatsRuntimeBoundary({
-          OPENBRAIN_TRANSPORT: "nats",
-          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-        }),
-        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-        deps: depsWithWorkingSet(),
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
         health,
       });
 
@@ -695,19 +752,13 @@ describe("startNatsContextPackBridge", () => {
         }),
         drain: mock(async () => {}),
       };
-      mock.module("nats", () => ({
-        connect: mock(async () => connection),
-      }));
+      mock.module("nats", () => ({ connect: mock(async () => connection) }));
       const health = createNatsBridgeHealth("available");
 
       const runtime = await startNatsContextPackBridge({
-        boundary: readNatsRuntimeBoundary({
-          OPENBRAIN_TRANSPORT: "nats",
-          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-        }),
-        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-        deps: depsWithWorkingSet(),
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
         health,
       });
 
@@ -721,9 +772,6 @@ describe("startNatsContextPackBridge", () => {
       expect(health.availability).toBe("not_runtime_available");
       expect(health.lastError).toMatch(/^iterator failed /);
       expect(subscribeCalls - callsAfterSecondFailure).toBeLessThanOrEqual(1);
-      expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:Error",
-      );
       expect(loggedErrors).toContain(
         "NATS context-pack bridge subscription failed:Error",
       );
@@ -755,26 +803,18 @@ describe("startNatsContextPackBridge", () => {
       const connection = {
         subscribe: mock(() => {
           subscribeCalls += 1;
-          if (subscribeCalls === 1) {
-            return firstSubscription;
-          }
+          if (subscribeCalls === 1) return firstSubscription;
           throw new Error("connection closed");
         }),
         drain: mock(async () => {}),
       };
-      mock.module("nats", () => ({
-        connect: mock(async () => connection),
-      }));
+      mock.module("nats", () => ({ connect: mock(async () => connection) }));
       const health = createNatsBridgeHealth("available");
 
       const runtime = await startNatsContextPackBridge({
-        boundary: readNatsRuntimeBoundary({
-          OPENBRAIN_TRANSPORT: "nats",
-          OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
-          OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-        }),
-        tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
-        deps: depsWithWorkingSet(),
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
         health,
       });
 
@@ -793,9 +833,6 @@ describe("startNatsContextPackBridge", () => {
       });
       expect(callsAfterFailure).toBeGreaterThanOrEqual(2);
       expect(subscribeCalls - callsAfterFailure).toBeLessThanOrEqual(2);
-      expect(loggedErrors).toContain(
-        "NATS context-pack bridge subscription failed:Error",
-      );
       expect(loggedErrors).toContain(
         "NATS context-pack bridge subscription failed:Error",
       );

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -52,6 +52,7 @@ function envelope(
   overrides: {
     id?: string;
     from?: string;
+    kind?: string;
     payload?: Record<string, unknown>;
     version?: number;
   } = {},
@@ -60,7 +61,7 @@ function envelope(
     id: overrides.id ?? "req-123",
     ts: "2026-07-08T00:00:00.000Z",
     from: overrides.from ?? scope.namespace,
-    kind: REQUEST_KIND,
+    kind: overrides.kind ?? REQUEST_KIND,
     payload: overrides.payload ?? requestPayload,
     version: overrides.version ?? 1,
   };
@@ -133,6 +134,48 @@ describe("handleNatsContextPackMessage — response envelope", () => {
       content: "Finish #223 over NATS without changing HTTP default.",
       label: "working_context",
     });
+  });
+});
+
+describe("handleNatsContextPackMessage — inbound kind validation (codex-C5)", () => {
+  function expectBadRequestForKind(kind: string) {
+    const response = handleNatsContextPackMessage({
+      // A valid agent_context_pack payload on the subject, but the WRONG kind:
+      // must be rejected as bad_request before payload handling, so a reply or
+      // unrelated fleet message is never processed as a real request.
+      message: { subject: SUBJECT, data: data(envelope({ kind, from: "rico" })), headers: {} },
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+    });
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.error.code).toBe("bad_request");
+    // requestId is still echoed even though the kind was wrong.
+    expect(response.id).toBe("req-123");
+    expect(response.correlation_id).toBe("req-123");
+    return payload;
+  }
+
+  it("rejects a response-kind envelope replayed onto the request subject", () => {
+    expectBadRequestForKind(RESPONSE_KIND);
+  });
+
+  it("rejects an empty kind", () => {
+    // Empty kind is rejected by the envelope required-field guard (also bad_request).
+    const response = handleNatsContextPackMessage({
+      message: { subject: SUBJECT, data: data(envelope({ kind: "", from: "rico" })), headers: {} },
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+    });
+    const payload = response.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.error.code).toBe("bad_request");
+  });
+
+  it("rejects an unrelated kind", () => {
+    expectBadRequestForKind("dispatch");
   });
 });
 
@@ -269,7 +312,9 @@ describe("handleNatsContextPackMessage — REQUIRE_AUTH interlock", () => {
 
     const payload = response.payload as Record<string, any>;
     expect(payload.status).toBe("ok");
-    expect(payload.namespace_source).toBe("declared");
+    // Token-derived binding is stamped "token" — distinct from wire-derived
+    // "declared" (S2). A caller can tell auth was enforced.
+    expect(payload.namespace_source).toBe("token");
     // Token namespace "rico" selected the working set, not "victim".
     expect(payload.body.sections.working_set.items[0].content).toContain(
       "Finish #223",

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -8,13 +8,19 @@ import {
   parseAgentContextPackArgs,
 } from "./tools/agent-context-pack.ts";
 import type {
-  NatsBridgePlan,
-  NatsContextPackEnvelope,
+  FleetEnvelope,
+  NatsContextPackRequestPayload,
   NatsRuntimeBoundary,
 } from "./nats-runtime.ts";
 import {
-  contextPackEnvelopeSchema,
-  mapNatsEnvelopeToToolArgs,
+  buildEnvelope,
+  envelopeFromBytes,
+  envelopeToBytes,
+  EnvelopeError,
+  mapRequestPayloadToToolArgs,
+  requestPayloadSchema,
+  RESPONSE_FROM,
+  RESPONSE_KIND,
 } from "./nats-runtime.ts";
 
 export interface NatsRequestMessage {
@@ -69,12 +75,24 @@ export interface StartNatsContextPackBridgeOptions {
   health?: NatsBridgeHealth;
 }
 
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 const MAX_NATS_REQUEST_BYTES = 64 * 1024;
 const NATS_RESUBSCRIBE_INITIAL_DELAY_MS = 25;
 const NATS_RESUBSCRIBE_MAX_DELAY_MS = 1_000;
 const NATS_EMPTY_SUBSCRIPTION_DEGRADE_THRESHOLD = 2;
+
+// Role for the synthetic auth identity used on the trusted local bus when
+// REQUIRE_AUTH is off. `agent` is deliberately non-privileged: it can only read
+// its own namespace, so a declared/override namespace maps to exactly that
+// namespace and cannot reach "all" or another tenant's data.
+const LOCAL_BUS_ROLE = "agent" as const;
+
+/** How the request's namespace was bound, stamped on the response and logs. */
+export type NamespaceSource = "override" | "declared" | "rejected";
+
+// A namespace produced by a wire-declared identity/override must be a plausible
+// namespace token, not arbitrary text. Mirrors the delegated-id shape used by
+// the HTTP header-namespace path so the local bus cannot mint exotic namespaces.
+const NAMESPACE_TOKEN_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
 
 export function createNatsBridgeHealth(
   availability: NatsBridgeHealth["availability"] = "not_runtime_available",
@@ -110,7 +128,7 @@ export async function startNatsContextPackBridge(
       deps: options.deps,
       health,
     });
-    const responded = await message.respond(encoder.encode(JSON.stringify(response)));
+    const responded = await message.respond(envelopeToBytes(response));
     if (responded === false) {
       throw new Error("NATS request did not include a reply inbox");
     }
@@ -141,14 +159,94 @@ export async function startNatsContextPackBridge(
   };
 }
 
+interface LaneBinding {
+  auth: AuthInfo;
+  namespaceSource: NamespaceSource;
+}
+
+/**
+ * Resolve the auth identity + namespace binding for a request.
+ *
+ * REPO LAW: namespace is a security boundary. The override path exists ONLY on
+ * the trusted local bus with auth off. When REQUIRE_AUTH=true the boundary
+ * force-disables the override (require_auth and allow_namespace_override are
+ * mutually exclusive in readNatsRuntimeBoundary), so a client-supplied namespace
+ * can NEVER override the token-derived one.
+ *
+ * Resolution order:
+ *   (a) require_auth=true  -> a valid bearer is mandatory; the token's AuthInfo
+ *       governs; wire namespace is ignored. namespace_source is reported from
+ *       the token perspective as "declared" (token-derived).
+ *   (b) explicit payload.namespace AND override allowed -> use it ("override").
+ *   (c) else derive namespace from the declared identity -> "declared".
+ *   (d) else unroutable -> reject ("rejected"); NEVER fall through to a global
+ *       or shared namespace.
+ *
+ * Returns the rejection source on the error branch so it can still be stamped.
+ */
+function resolveLaneBinding(
+  payload: NatsContextPackRequestPayload,
+  envelope: FleetEnvelope,
+  boundary: NatsRuntimeBoundary,
+  auth: AuthInfo | null,
+): LaneBinding | { rejected: true } {
+  if (boundary.nats.require_auth) {
+    // Auth ON: the bearer-derived identity is authoritative. Override is already
+    // force-disabled at the boundary; we defensively ignore payload.namespace.
+    if (!auth) return { rejected: true };
+    return { auth, namespaceSource: "declared" };
+  }
+
+  // Auth OFF (trusted local bus). Bind a synthetic non-privileged identity to
+  // the resolved namespace so the server-side canReadNamespace check still runs
+  // and can only ever grant that one namespace.
+  if (payload.namespace && boundary.nats.allow_namespace_override) {
+    const ns = normalizeNamespaceToken(payload.namespace);
+    if (!ns) return { rejected: true };
+    return { auth: localBusAuth(ns), namespaceSource: "override" };
+  }
+
+  const declared = declaredNamespace(payload, envelope);
+  if (declared) {
+    return { auth: localBusAuth(declared), namespaceSource: "declared" };
+  }
+
+  return { rejected: true };
+}
+
+function localBusAuth(namespace: string): AuthInfo {
+  return { role: LOCAL_BUS_ROLE, clientId: namespace };
+}
+
+function normalizeNamespaceToken(value: string): string | null {
+  const trimmed = value.trim();
+  return NAMESPACE_TOKEN_RE.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Derive a namespace from the declared identity. Prefers the envelope `from`
+ * (the publisher id), then the payload identity agent, normalised to a valid
+ * namespace token. Returns null when nothing usable is declared.
+ */
+function declaredNamespace(
+  payload: NatsContextPackRequestPayload,
+  envelope: FleetEnvelope,
+): string | null {
+  return (
+    normalizeNamespaceToken(envelope.from) ??
+    normalizeNamespaceToken(payload.identity.agent)
+  );
+}
+
 export function handleNatsContextPackMessage(input: {
   message: Pick<NatsRequestMessage, "subject" | "data" | "headers">;
   boundary: NatsRuntimeBoundary;
   tokenMap: Map<string, AuthInfo>;
   deps: ToolDeps;
   health?: NatsBridgeHealth;
-}): unknown {
+}): FleetEnvelope {
   let requestId: string | null = null;
+  let namespaceSource: NamespaceSource | null = null;
 
   try {
     if (input.message.subject !== input.boundary.nats.context_pack_subject) {
@@ -157,60 +255,91 @@ export function handleNatsContextPackMessage(input: {
       );
     }
 
-    const auth = authFromHeaders(input.message.headers, input.tokenMap);
-    if (!auth) {
-      return natsError(requestId, "permission_denied", "Bearer token is required");
-    }
     if (input.message.data.byteLength > MAX_NATS_REQUEST_BYTES) {
-      return natsError(requestId, "payload_too_large", "NATS request body is too large");
+      return natsError(requestId, null, "payload_too_large", "NATS request body is too large");
     }
     if (input.health && input.health.availability !== "available") {
       return natsError(
         requestId,
+        null,
         "temporarily_unavailable",
         "NATS bridge is not available",
       );
     }
 
     const envelope = parseEnvelope(input.message.data);
-    requestId = envelope.request_id;
+    requestId = envelope.id;
+    const payload = requestPayloadSchema.parse(envelope.payload);
+
+    const auth = authFromHeaders(input.message.headers, input.tokenMap);
+    if (input.boundary.nats.require_auth && !auth) {
+      // Auth ON: a valid bearer is mandatory.
+      return natsError(requestId, "rejected", "permission_denied", "Bearer token is required");
+    }
+
+    const binding = resolveLaneBinding(payload, envelope, input.boundary, auth);
+    if ("rejected" in binding) {
+      namespaceSource = "rejected";
+      return natsError(
+        requestId,
+        "rejected",
+        "unroutable",
+        "Request could not be bound to a namespace",
+      );
+    }
+    namespaceSource = binding.namespaceSource;
 
     const result = buildAgentContextPackPayload(
-      parseAgentContextPackArgs(mapNatsEnvelopeToToolArgs(envelope)),
-      auth,
+      // On the override/declared local-bus path the synthetic auth.clientId IS
+      // the namespace, so tool args must NOT also carry a namespace (which would
+      // be a second, un-vetted source). On the require_auth path the token's own
+      // namespace governs and the wire namespace is dropped for the same reason.
+      parseAgentContextPackArgs(mapRequestPayloadToToolArgs(payload)),
+      binding.auth,
       input.deps,
     );
 
     if (result.isError) {
       return natsError(
         requestId,
+        namespaceSource,
         "tool_error",
         errorMessageFromPayload(result.payload),
       );
     }
 
-    return {
-      schema: "openbrain.nats.response.v1",
-      request_id: requestId,
+    return buildResponseEnvelope(requestId, {
       status: "ok",
       operation: "agent_context_pack",
+      namespace_source: namespaceSource,
       body: result.payload,
-    };
+    });
   } catch (err) {
     if (!isNatsRequestValidationError(err)) {
       logNatsRequestError(err, input.message.subject);
       return natsError(
         requestId,
+        namespaceSource,
         "internal_error",
         "NATS context pack request failed",
       );
     }
-    return natsError(requestId, "bad_request", "Invalid NATS context pack request");
+    return natsError(
+      requestId,
+      namespaceSource,
+      "bad_request",
+      "Invalid NATS context pack request",
+    );
   }
 }
 
-function parseEnvelope(data: Uint8Array): NatsContextPackEnvelope {
-  return contextPackEnvelopeSchema.parse(JSON.parse(decoder.decode(data)));
+function parseEnvelope(data: Uint8Array): FleetEnvelope {
+  return envelopeFromBytes(data, (version) => {
+    // Forward-compat: a newer producer's envelope is accepted but never silently.
+    logger.warn("NATS context-pack envelope version ahead of supported", {
+      version,
+    });
+  });
 }
 
 function authFromHeaders(
@@ -239,18 +368,35 @@ function errorMessageFromPayload(payload: unknown): string {
   return "NATS context pack request failed";
 }
 
+function buildResponseEnvelope(
+  requestId: string | null,
+  payload: Record<string, unknown>,
+): FleetEnvelope {
+  return buildEnvelope({
+    // A response to an unparseable request has no request id; use a stable
+    // placeholder so the envelope's non-empty id/from/kind invariant holds.
+    id: requestId ?? "unknown",
+    ts: new Date().toISOString(),
+    from: RESPONSE_FROM,
+    kind: RESPONSE_KIND,
+    // correlation_id echoes the request id so the caller can match reply->request.
+    correlation_id: requestId,
+    payload,
+  });
+}
+
 function natsError(
   requestId: string | null,
+  namespaceSource: NamespaceSource | null,
   code: string,
   message: string,
-): unknown {
-  return {
-    schema: "openbrain.nats.response.v1",
-    request_id: requestId,
+): FleetEnvelope {
+  return buildResponseEnvelope(requestId, {
     status: "error",
     operation: "agent_context_pack",
+    namespace_source: namespaceSource,
     error: { code, message },
-  };
+  });
 }
 
 async function createNatsJsDriver(
@@ -364,15 +510,22 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Redaction: return a STATIC allowlisted string, never err.name (mutable and
+// attacker-influenced) or err.message (may embed a NATS url with credentials).
 function safeErrorType(err: unknown): string {
   if (err instanceof SyntaxError) return "SyntaxError";
   if (err instanceof z.ZodError) return "ZodError";
+  if (err instanceof EnvelopeError) return "EnvelopeError";
   if (err instanceof Error) return "Error";
   return typeof err;
 }
 
 function isNatsRequestValidationError(err: unknown): boolean {
-  return err instanceof SyntaxError || err instanceof z.ZodError;
+  return (
+    err instanceof SyntaxError ||
+    err instanceof z.ZodError ||
+    err instanceof EnvelopeError
+  );
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -9,6 +9,7 @@ import {
 } from "./tools/agent-context-pack.ts";
 import type {
   FleetEnvelope,
+  NamespaceSource,
   NatsContextPackRequestPayload,
   NatsRuntimeBoundary,
 } from "./nats-runtime.ts";
@@ -18,6 +19,7 @@ import {
   envelopeToBytes,
   EnvelopeError,
   mapRequestPayloadToToolArgs,
+  REQUEST_KIND,
   requestPayloadSchema,
   RESPONSE_FROM,
   RESPONSE_KIND,
@@ -86,8 +88,9 @@ const NATS_EMPTY_SUBSCRIPTION_DEGRADE_THRESHOLD = 2;
 // namespace and cannot reach "all" or another tenant's data.
 const LOCAL_BUS_ROLE = "agent" as const;
 
-/** How the request's namespace was bound, stamped on the response and logs. */
-export type NamespaceSource = "override" | "declared" | "rejected";
+// NamespaceSource (the response-contract type) is owned by nats-runtime.ts; keep
+// a re-export so existing importers of it from this module still resolve.
+export type { NamespaceSource } from "./nats-runtime.ts";
 
 // A namespace produced by a wire-declared identity/override must be a plausible
 // namespace token, not arbitrary text. Mirrors the delegated-id shape used by
@@ -175,8 +178,8 @@ interface LaneBinding {
  *
  * Resolution order:
  *   (a) require_auth=true  -> a valid bearer is mandatory; the token's AuthInfo
- *       governs; wire namespace is ignored. namespace_source is reported from
- *       the token perspective as "declared" (token-derived).
+ *       governs; wire namespace is ignored. namespace_source is "token" so a
+ *       token-derived binding is distinguishable from a wire-derived one.
  *   (b) explicit payload.namespace AND override allowed -> use it ("override").
  *   (c) else derive namespace from the declared identity -> "declared".
  *   (d) else unroutable -> reject ("rejected"); NEVER fall through to a global
@@ -194,7 +197,7 @@ function resolveLaneBinding(
     // Auth ON: the bearer-derived identity is authoritative. Override is already
     // force-disabled at the boundary; we defensively ignore payload.namespace.
     if (!auth) return { rejected: true };
-    return { auth, namespaceSource: "declared" };
+    return { auth, namespaceSource: "token" };
   }
 
   // Auth OFF (trusted local bus). Bind a synthetic non-privileged identity to
@@ -269,6 +272,19 @@ export function handleNatsContextPackMessage(input: {
 
     const envelope = parseEnvelope(input.message.data);
     requestId = envelope.id;
+
+    // Reject any inbound envelope that is not a context_pack_request BEFORE we
+    // touch the payload. Without this, a reply envelope (context_pack_response)
+    // or an unrelated fleet message that happens to carry an agent_context_pack
+    // payload on this subject would be processed as a real request — a
+    // request/reply loop poisoning and scope hazard. EnvelopeError classifies as
+    // bad_request via isNatsRequestValidationError.
+    if (envelope.kind !== REQUEST_KIND) {
+      throw new EnvelopeError(
+        `NATS envelope kind '${envelope.kind}' is not '${REQUEST_KIND}'`,
+      );
+    }
+
     const payload = requestPayloadSchema.parse(envelope.payload);
 
     const auth = authFromHeaders(input.message.headers, input.tokenMap);

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -1,6 +1,7 @@
 import type { AuthInfo } from "./types.ts";
 import type { ToolDeps } from "./tools/index.ts";
 import { z } from "zod";
+import { findAuthInfoForToken } from "./auth.ts";
 import { logger } from "./logger.ts";
 import {
   buildAgentContextPackPayload,
@@ -223,7 +224,7 @@ function authFromHeaders(
     null;
   const match = /^Bearer\s+(.+)$/i.exec(raw ?? "");
   const token = match?.[1]?.trim();
-  return token ? tokenMap.get(token) ?? null : null;
+  return token ? findAuthInfoForToken(token, tokenMap) : null;
 }
 
 function errorMessageFromPayload(payload: unknown): string {

--- a/src/nats-runtime.test.ts
+++ b/src/nats-runtime.test.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from "bun:test";
 import {
+  buildEnvelope,
+  envelopeFromBytes,
+  envelopeToBytes,
+  EnvelopeError,
+  ENVELOPE_VERSION,
   planNatsContextPackBridge,
   readNatsRuntimeBoundary,
+  REQUEST_KIND,
+  resolveContextPackSubject,
   summarizeNatsUrlForLog,
 } from "./nats-runtime.ts";
 import { agentContextPackInputSchema } from "./tools/agent-context-pack.ts";
 
-const baseEnvelope = {
-  schema: "openbrain.nats.request.v1",
+const requestPayload = {
   operation: "agent_context_pack",
-  request_id: "req-123",
   identity: {
-    namespace_source: "authorization",
     agent: "nagatha",
     platform: "discord",
     server_id: "rodaddy-live",
@@ -25,15 +29,156 @@ const baseEnvelope = {
     include_unreviewed_recovery: true,
     budget: { max_tokens: 3500, max_latency_ms: 750 },
   },
-  metadata: {
-    client: "openbrain-memory",
-    client_version: "0.1.0",
-    transport: "nats",
-  },
 } as const;
 
+const baseEnvelope = {
+  id: "req-123",
+  ts: "2026-07-08T00:00:00.000Z",
+  from: "nagatha",
+  kind: REQUEST_KIND,
+  payload: requestPayload,
+  version: 1,
+} as const;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+describe("fleet envelope codec", () => {
+  it("round-trips through wire bytes with the 'from' key (not 'sender')", () => {
+    const envelope = buildEnvelope({
+      id: "m-1",
+      ts: "2026-07-08T00:00:00.000Z",
+      from: "nagatha",
+      kind: REQUEST_KIND,
+      payload: { operation: "agent_context_pack" },
+    });
+
+    const bytes = envelope ? envelopeToBytes(envelope) : new Uint8Array();
+    const wire = JSON.parse(decoder.decode(bytes));
+    expect(wire).toMatchObject({
+      id: "m-1",
+      from: "nagatha",
+      kind: REQUEST_KIND,
+      version: ENVELOPE_VERSION,
+    });
+    expect(wire).not.toHaveProperty("sender");
+
+    const parsed = envelopeFromBytes(bytes);
+    expect(parsed).toMatchObject({
+      id: "m-1",
+      from: "nagatha",
+      kind: REQUEST_KIND,
+      payload: { operation: "agent_context_pack" },
+      correlation_id: null,
+      version: ENVELOPE_VERSION,
+    });
+  });
+
+  it("emits compact JSON with no whitespace", () => {
+    const bytes = envelopeToBytes(buildEnvelope(baseEnvelope));
+    const text = decoder.decode(bytes);
+    expect(text).not.toContain(", ");
+    expect(text).not.toContain(": ");
+  });
+
+  it("warns but accepts a forward-compatible newer version", () => {
+    const wire = { ...baseEnvelope, version: 2 };
+    const warnings: number[] = [];
+    const parsed = envelopeFromBytes(
+      encoder.encode(JSON.stringify(wire)),
+      (v) => warnings.push(v),
+    );
+    expect(parsed.version).toBe(2);
+    expect(warnings).toEqual([2]);
+  });
+
+  it("rejects an empty id", () => {
+    expect(() =>
+      envelopeFromBytes(encoder.encode(JSON.stringify({ ...baseEnvelope, id: "" }))),
+    ).toThrow(EnvelopeError);
+  });
+
+  it("rejects a missing/null from", () => {
+    expect(() =>
+      envelopeFromBytes(
+        encoder.encode(JSON.stringify({ ...baseEnvelope, from: null })),
+      ),
+    ).toThrow(EnvelopeError);
+  });
+
+  it("rejects an empty kind", () => {
+    expect(() =>
+      envelopeFromBytes(
+        encoder.encode(JSON.stringify({ ...baseEnvelope, kind: "" })),
+      ),
+    ).toThrow(EnvelopeError);
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(() =>
+      envelopeFromBytes(
+        encoder.encode(JSON.stringify({ ...baseEnvelope, payload: [1, 2, 3] })),
+      ),
+    ).toThrow(/payload must be a JSON object/);
+  });
+
+  it("rejects a non-integer version rather than coercing it", () => {
+    expect(() =>
+      envelopeFromBytes(
+        encoder.encode(JSON.stringify({ ...baseEnvelope, version: "2" })),
+      ),
+    ).toThrow(/invalid version/);
+  });
+
+  it("rejects undecodable bytes", () => {
+    expect(() => envelopeFromBytes(encoder.encode("{bad json"))).toThrow(
+      EnvelopeError,
+    );
+  });
+
+  it("coerces non-string optional fields via _opt_str semantics", () => {
+    const parsed = envelopeFromBytes(
+      encoder.encode(JSON.stringify({ ...baseEnvelope, to: 123 })),
+    );
+    expect(parsed.to).toBe("123");
+  });
+
+  it("buildEnvelope rejects an empty from before it can be serialised", () => {
+    expect(() =>
+      buildEnvelope({ ...baseEnvelope, from: "" }),
+    ).toThrow(EnvelopeError);
+  });
+});
+
+describe("resolveContextPackSubject", () => {
+  it("defaults to the dev env-prefixed builder subject", () => {
+    expect(resolveContextPackSubject({})).toBe("dev.ob.memory.context_pack");
+  });
+
+  it("uses OPENBRAIN_NATS_ENV as the env prefix", () => {
+    expect(resolveContextPackSubject({ OPENBRAIN_NATS_ENV: "prod" })).toBe(
+      "prod.ob.memory.context_pack",
+    );
+  });
+
+  it("slugs the env token (lowercase, spaces/dots -> hyphens)", () => {
+    expect(
+      resolveContextPackSubject({ OPENBRAIN_NATS_ENV: "Staging Lab.1" }),
+    ).toBe("staging-lab-1.ob.memory.context_pack");
+  });
+
+  it("honours the explicit subject override escape hatch", () => {
+    expect(
+      resolveContextPackSubject({
+        OPENBRAIN_NATS_ENV: "prod",
+        OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT: "custom.subject",
+      }),
+    ).toBe("custom.subject");
+  });
+});
+
 describe("readNatsRuntimeBoundary", () => {
-  it("defaults to HTTP/MCP and the planned context-pack subject", () => {
+  it("defaults to HTTP/MCP, auth off, override allowed, env-prefixed subject", () => {
     const boundary = readNatsRuntimeBoundary({});
 
     expect(boundary).toEqual({
@@ -42,8 +187,10 @@ describe("readNatsRuntimeBoundary", () => {
       nats: {
         availability: "not_runtime_available",
         url: null,
-        context_pack_subject: "ob.memory.context_pack",
+        context_pack_subject: "dev.ob.memory.context_pack",
         fallback_http: true,
+        require_auth: false,
+        allow_namespace_override: true,
       },
     });
   });
@@ -52,7 +199,6 @@ describe("readNatsRuntimeBoundary", () => {
     const boundary = readNatsRuntimeBoundary({
       OPENBRAIN_TRANSPORT: "nats",
       OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
-      OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT: "ob.memory.context_pack",
       OPENBRAIN_NATS_FALLBACK_HTTP: "true",
     });
 
@@ -60,7 +206,7 @@ describe("readNatsRuntimeBoundary", () => {
     expect(boundary.nats).toMatchObject({
       availability: "not_runtime_available",
       url: "nats://127.0.0.1:4222",
-      context_pack_subject: "ob.memory.context_pack",
+      context_pack_subject: "dev.ob.memory.context_pack",
       fallback_http: true,
     });
   });
@@ -76,8 +222,28 @@ describe("readNatsRuntimeBoundary", () => {
     expect(boundary.nats).toMatchObject({
       availability: "available",
       url: "nats://127.0.0.1:4222",
-      context_pack_subject: "ob.memory.context_pack",
+      context_pack_subject: "dev.ob.memory.context_pack",
     });
+  });
+
+  it("REQUIRE_AUTH=true force-disables the namespace override (mutually exclusive)", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_NATS_REQUIRE_AUTH: "true",
+      // even if a caller tries to also enable override, auth wins
+      OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE: "true",
+    });
+
+    expect(boundary.nats.require_auth).toBe(true);
+    expect(boundary.nats.allow_namespace_override).toBe(false);
+  });
+
+  it("allows explicitly disabling the namespace override while auth stays off", () => {
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE: "false",
+    });
+
+    expect(boundary.nats.require_auth).toBe(false);
+    expect(boundary.nats.allow_namespace_override).toBe(false);
   });
 
   it("treats loopback NATS hostnames case-insensitively", () => {
@@ -145,14 +311,16 @@ describe("summarizeNatsUrlForLog", () => {
 });
 
 describe("planNatsContextPackBridge", () => {
-  it("maps the planned NATS envelope to the existing MCP tool call with HTTP fallback", () => {
+  const subject = "dev.ob.memory.context_pack";
+
+  it("maps the fleet envelope payload to the existing MCP tool call with HTTP fallback", () => {
     const boundary = readNatsRuntimeBoundary({
       OPENBRAIN_TRANSPORT: "nats",
       OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
     });
 
     const plan = planNatsContextPackBridge(boundary, {
-      subject: "ob.memory.context_pack",
+      subject,
       envelope: baseEnvelope,
       bearerToken: " bearer-token ",
     });
@@ -160,7 +328,7 @@ describe("planNatsContextPackBridge", () => {
     expect(plan).toEqual({
       status: "http_mcp_fallback",
       request_id: "req-123",
-      subject: "ob.memory.context_pack",
+      subject,
       operation: "agent_context_pack",
       bearerToken: "bearer-token",
       mcpToolCall: {
@@ -189,7 +357,7 @@ describe("planNatsContextPackBridge", () => {
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.context_pack",
+        subject,
         envelope: baseEnvelope,
         bearerToken: "token",
       }),
@@ -197,12 +365,10 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("keeps fallback tool arguments within the implemented agent_context_pack schema", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     const plan = planNatsContextPackBridge(boundary, {
-      subject: "ob.memory.context_pack",
+      subject,
       envelope: baseEnvelope,
       bearerToken: "token",
     });
@@ -215,17 +381,15 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("allows query to be omitted like the MCP agent_context_pack tool", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
-    const { body: _body, ...rest } = baseEnvelope;
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     const plan = planNatsContextPackBridge(boundary, {
-      subject: "ob.memory.context_pack",
+      subject,
       envelope: {
-        ...rest,
-        body: {
-          requested_sections: ["working_set"],
+        ...baseEnvelope,
+        payload: {
+          ...requestPayload,
+          body: { requested_sections: ["working_set"] },
         },
       },
       bearerToken: "token",
@@ -235,17 +399,15 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("preserves optional thread_id when the caller scoped the request to a thread", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     const plan = planNatsContextPackBridge(boundary, {
-      subject: "ob.memory.context_pack",
+      subject,
       envelope: {
         ...baseEnvelope,
-        identity: {
-          ...baseEnvelope.identity,
-          thread_id: "thread-7",
+        payload: {
+          ...requestPayload,
+          identity: { ...requestPayload.identity, thread_id: "thread-7" },
         },
       },
       bearerToken: "token",
@@ -255,13 +417,11 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("rejects fallback planning when no bearer token is available", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.context_pack",
+        subject,
         envelope: baseEnvelope,
         bearerToken: " ",
       }),
@@ -269,18 +429,16 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("rejects unsupported subjects before touching envelope contents", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.wrap",
+        subject: "dev.ob.memory.wrap",
         envelope: baseEnvelope,
         bearerToken: "token",
       }),
     ).toThrow(
-      "Unsupported NATS subject 'ob.memory.wrap'; expected 'ob.memory.context_pack'",
+      "Unsupported NATS subject 'dev.ob.memory.wrap'; expected 'dev.ob.memory.context_pack'",
     );
   });
 
@@ -292,7 +450,7 @@ describe("planNatsContextPackBridge", () => {
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.context_pack",
+        subject,
         envelope: baseEnvelope,
         bearerToken: "token",
       }),
@@ -300,16 +458,14 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("rejects non-context-pack operations so the bridge cannot widen scope silently", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.context_pack",
+        subject,
         envelope: {
           ...baseEnvelope,
-          operation: "session_wrap",
+          payload: { ...requestPayload, operation: "session_wrap" },
         },
         bearerToken: "token",
       }),
@@ -317,18 +473,19 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("rejects requested sections outside the current agent_context_pack contract", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.context_pack",
+        subject,
         envelope: {
           ...baseEnvelope,
-          body: {
-            ...baseEnvelope.body,
-            requested_sections: ["working_set", "unknown_section"],
+          payload: {
+            ...requestPayload,
+            body: {
+              ...requestPayload.body,
+              requested_sections: ["working_set", "unknown_section"],
+            },
           },
         },
         bearerToken: "token",
@@ -337,18 +494,16 @@ describe("planNatsContextPackBridge", () => {
   });
 
   it("rejects unsupported body fields before fallback planning", () => {
-    const boundary = readNatsRuntimeBoundary({
-      OPENBRAIN_TRANSPORT: "nats",
-    });
+    const boundary = readNatsRuntimeBoundary({ OPENBRAIN_TRANSPORT: "nats" });
 
     expect(() =>
       planNatsContextPackBridge(boundary, {
-        subject: "ob.memory.context_pack",
+        subject,
         envelope: {
           ...baseEnvelope,
-          body: {
-            ...baseEnvelope.body,
-            metadata: { route_name: "discord_reply" },
+          payload: {
+            ...requestPayload,
+            body: { ...requestPayload.body, metadata: { route_name: "x" } },
           },
         },
         bearerToken: "token",

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -19,7 +19,11 @@ import { obContextPackSubject } from "./nats-subjects.ts";
 //                               is "from" (NOT "sender"). Requests: the caller's
 //                               agent/client id. Responses: "open-brain".
 //     "kind":           string  (required, non-empty) — dispatch discriminator.
-//                               Requests:  "context_pack_request"
+//                               Requests:  "context_pack_request"  — the bridge
+//                               REJECTS any inbound envelope whose kind is not
+//                               "context_pack_request" as bad_request, before it
+//                               inspects the payload (so a reply or unrelated
+//                               fleet message on the subject is never processed).
 //                               Responses: "context_pack_response"
 //     "payload":        object  (required to be a JSON object; missing => {})
 //     "to":             string | null  (optional)
@@ -44,14 +48,22 @@ import { obContextPackSubject } from "./nats-subjects.ts";
 //                     (never overrides the token-derived namespace) once
 //                     OPENBRAIN_NATS_REQUIRE_AUTH=true. namespace IS a security
 //                     boundary — see nats-bridge.ts lane binding.
+//                     namespace_source is a RESPONSE-ONLY stamp; it MUST NOT
+//                     appear in the request wire.
 //   }
 //
 // RESPONSE payload:
 //   ok:    { "status": "ok",    "operation": "agent_context_pack",
-//            "namespace_source": "override"|"declared", "body": <context pack> }
+//            "namespace_source": "token"|"override"|"declared", "body": <pack> }
 //   error: { "status": "error", "operation": "agent_context_pack",
-//            "namespace_source": "override"|"declared"|"rejected"|null,
+//            "namespace_source": "token"|"override"|"declared"|"rejected"|null,
 //            "error": { "code": string, "message": string } }
+//   namespace_source values:
+//     "token"    — REQUIRE_AUTH=true: namespace derived from the bearer token.
+//     "override" — auth off: explicit payload.namespace override was used.
+//     "declared" — auth off: namespace derived from declared identity (from /
+//                  payload.identity.agent).
+//     "rejected" — request could not be bound to a namespace (or auth missing).
 //
 // SUBJECT: `{env}.ob.memory.context_pack`, built by obContextPackSubject(env)
 //   with env from OPENBRAIN_NATS_ENV (default "dev"). Env token is slugged
@@ -64,6 +76,16 @@ export const ENVELOPE_VERSION = 1;
 export const REQUEST_KIND = "context_pack_request";
 export const RESPONSE_KIND = "context_pack_response";
 export const RESPONSE_FROM = "open-brain";
+
+/**
+ * How the response's namespace was bound. RESPONSE-ONLY stamp — never present in
+ * the request wire.
+ *   "token"    — REQUIRE_AUTH=true: namespace derived from the bearer token.
+ *   "override" — auth off: explicit payload.namespace override was used.
+ *   "declared" — auth off: namespace derived from the declared identity.
+ *   "rejected" — request could not be bound to a namespace (or auth missing).
+ */
+export type NamespaceSource = "token" | "override" | "declared" | "rejected";
 
 const NATS_CONTEXT_PACK_OPERATION = "agent_context_pack";
 const DEFAULT_NATS_ENV = "dev";

--- a/src/nats-runtime.ts
+++ b/src/nats-runtime.ts
@@ -1,15 +1,81 @@
 import { z } from "zod";
 import { SECTION_NAMES } from "./tools/agent-context-pack.ts";
+import { obContextPackSubject } from "./nats-subjects.ts";
+
+// ============================================================================
+// CROSS-LANGUAGE WIRE CONTRACT (source of truth for the Python client lane)
+// ============================================================================
+//
+// Open Brain's NATS wire format is reconciled to the fleet-bus Envelope
+// (rodaddy/fleet-bus, `packages/fleet-nats/src/fleet_nats/envelope.py`). Any
+// client that speaks to the Open Brain NATS worker — including the separate
+// `python/openbrain-memory` lane — MUST match the shapes below.
+//
+// ENVELOPE (compact UTF-8 JSON; key order is not significant):
+//   {
+//     "id":             string  (required, non-empty) — unique message id
+//     "ts":             string  (required, non-empty) — ISO-8601 UTC timestamp
+//     "from":           string  (required, non-empty) — publisher id. Wire key
+//                               is "from" (NOT "sender"). Requests: the caller's
+//                               agent/client id. Responses: "open-brain".
+//     "kind":           string  (required, non-empty) — dispatch discriminator.
+//                               Requests:  "context_pack_request"
+//                               Responses: "context_pack_response"
+//     "payload":        object  (required to be a JSON object; missing => {})
+//     "to":             string | null  (optional)
+//     "task_id":        string | null  (optional)
+//     "channel":        string | null  (optional)
+//     "topic":          string | null  (optional)
+//     "correlation_id": string | null  (optional) — on a RESPONSE this ECHOES
+//                               the request envelope's "id".
+//     "version":        int     (default 1). version > 1 is accepted with a
+//                               warning (forward-compat), never silently.
+//   }
+//
+// REQUEST payload (validated by requestPayloadSchema, strict where noted):
+//   {
+//     "operation":  "agent_context_pack",
+//     "identity":   { agent, platform, server_id, channel_id, thread_id?,
+//                     session_key }  — same strictness as the HTTP MCP tool,
+//     "body":       { query?, requested_sections?, include_unreviewed_recovery?,
+//                     budget? }  (STRICT — unknown keys rejected),
+//     "namespace":  string?  — OPTIONAL client-declared namespace override. Only
+//                     honoured on the trusted local bus with auth off; ignored
+//                     (never overrides the token-derived namespace) once
+//                     OPENBRAIN_NATS_REQUIRE_AUTH=true. namespace IS a security
+//                     boundary — see nats-bridge.ts lane binding.
+//   }
+//
+// RESPONSE payload:
+//   ok:    { "status": "ok",    "operation": "agent_context_pack",
+//            "namespace_source": "override"|"declared", "body": <context pack> }
+//   error: { "status": "error", "operation": "agent_context_pack",
+//            "namespace_source": "override"|"declared"|"rejected"|null,
+//            "error": { "code": string, "message": string } }
+//
+// SUBJECT: `{env}.ob.memory.context_pack`, built by obContextPackSubject(env)
+//   with env from OPENBRAIN_NATS_ENV (default "dev"). Env token is slugged
+//   (lowercase, spaces/dots -> hyphens, empty throws). The
+//   OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT env var remains as an explicit escape
+//   hatch that overrides the builder output.
+// ============================================================================
+
+export const ENVELOPE_VERSION = 1;
+export const REQUEST_KIND = "context_pack_request";
+export const RESPONSE_KIND = "context_pack_response";
+export const RESPONSE_FROM = "open-brain";
 
 const NATS_CONTEXT_PACK_OPERATION = "agent_context_pack";
-const DEFAULT_NATS_SUBJECT = "ob.memory.context_pack";
+const DEFAULT_NATS_ENV = "dev";
 const MAX_CONTEXT_PACK_QUERY_CHARS = 4000;
 const LOCAL_NATS_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 const requestedSectionsSchema = z.array(z.enum(SECTION_NAMES));
 
+// Identity as declared by the caller. Kept exactly as strict as the pre-fleet
+// envelope identity, minus namespace_source (that is now derived server-side and
+// stamped on the response, not accepted from the wire).
 const identitySchema = z.object({
-  namespace_source: z.literal("authorization"),
   agent: z.string().min(1).max(200),
   platform: z.string().min(1).max(200),
   server_id: z.string().min(1).max(500),
@@ -18,34 +84,206 @@ const identitySchema = z.object({
   session_key: z.string().min(1).max(500),
 });
 
-export const contextPackEnvelopeSchema = z.object({
-  schema: z.literal("openbrain.nats.request.v1"),
+const requestBodySchema = z
+  .object({
+    query: z.string().max(MAX_CONTEXT_PACK_QUERY_CHARS).optional(),
+    requested_sections: requestedSectionsSchema.optional(),
+    include_unreviewed_recovery: z.boolean().optional(),
+    budget: z
+      .object({
+        max_tokens: z.number().int().min(100).max(20_000).optional(),
+        max_latency_ms: z.number().int().min(1).max(10_000).optional(),
+      })
+      .optional(),
+  })
+  .strict();
+
+// The request payload that lives INSIDE the fleet envelope's `payload` field.
+export const requestPayloadSchema = z.object({
   operation: z.literal(NATS_CONTEXT_PACK_OPERATION),
-  request_id: z.string().min(1).max(500),
   identity: identitySchema,
-  body: z
-    .object({
-      query: z.string().max(MAX_CONTEXT_PACK_QUERY_CHARS).optional(),
-      requested_sections: requestedSectionsSchema.optional(),
-      include_unreviewed_recovery: z.boolean().optional(),
-      budget: z
-        .object({
-          max_tokens: z.number().int().min(100).max(20_000).optional(),
-          max_latency_ms: z.number().int().min(1).max(10_000).optional(),
-        })
-        .optional(),
-    })
-    .strict(),
-  metadata: z.object({
-    client: z.string().min(1).max(200),
-    client_version: z.string().min(1).max(200),
-    transport: z.literal("nats"),
-    trace_id: z.string().max(500).optional(),
-    route_name: z.string().max(200).optional(),
-  }),
+  body: requestBodySchema,
+  namespace: z.string().min(1).max(500).optional(),
 });
 
-export type NatsContextPackEnvelope = z.infer<typeof contextPackEnvelopeSchema>;
+export type NatsContextPackRequestPayload = z.infer<typeof requestPayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// Fleet Envelope — TS mirror of fleet_nats.envelope.Envelope.
+// ---------------------------------------------------------------------------
+
+export interface FleetEnvelope {
+  id: string;
+  ts: string;
+  from: string;
+  kind: string;
+  payload: Record<string, unknown>;
+  to: string | null;
+  task_id: string | null;
+  channel: string | null;
+  topic: string | null;
+  correlation_id: string | null;
+  version: number;
+}
+
+/**
+ * Raised when envelope wire bytes are undecodable or miss required fields.
+ * Distinguishing this from Zod/Syntax errors lets the bridge classify a
+ * malformed message as a bad request without leaking parser internals.
+ */
+export class EnvelopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EnvelopeError";
+  }
+}
+
+function requireEnvelopeString(field: string, value: unknown): string {
+  // Mirror fleet's _require_str: a JSON null/missing/non-string required field
+  // must be rejected. String(None)->"None" would pass a naive non-empty check,
+  // so reject anything that is not already a non-empty string.
+  if (typeof value !== "string" || value.length === 0) {
+    throw new EnvelopeError(
+      `Envelope.fromBytes: required field '${field}' must be a non-empty string`,
+    );
+  }
+  return value;
+}
+
+function optEnvelopeString(value: unknown): string | null {
+  // Mirror fleet's _opt_str: null stays null; anything else is stringified so a
+  // numeric "to": 123 does not masquerade as a string downstream.
+  return value === null || value === undefined ? null : String(value);
+}
+
+export interface BuildEnvelopeInput {
+  id: string;
+  ts: string;
+  from: string;
+  kind: string;
+  payload?: Record<string, unknown>;
+  to?: string | null;
+  task_id?: string | null;
+  channel?: string | null;
+  topic?: string | null;
+  correlation_id?: string | null;
+  version?: number;
+}
+
+/**
+ * Construct a fleet envelope with caller-supplied id and timestamp. Mirrors
+ * fleet's Envelope.new + __post_init__ guards: id/from/kind must be non-empty.
+ */
+export function buildEnvelope(input: BuildEnvelopeInput): FleetEnvelope {
+  if (!input.id) throw new EnvelopeError("Envelope.id must be non-empty");
+  if (!input.from) throw new EnvelopeError("Envelope.from must be non-empty");
+  if (!input.kind) throw new EnvelopeError("Envelope.kind must be non-empty");
+  return {
+    id: input.id,
+    ts: input.ts,
+    from: input.from,
+    kind: input.kind,
+    payload: input.payload ?? {},
+    to: input.to ?? null,
+    task_id: input.task_id ?? null,
+    channel: input.channel ?? null,
+    topic: input.topic ?? null,
+    correlation_id: input.correlation_id ?? null,
+    version: input.version ?? ENVELOPE_VERSION,
+  };
+}
+
+/** Serialise an envelope to compact UTF-8 JSON wire bytes (fleet to_bytes). */
+export function envelopeToBytes(envelope: FleetEnvelope): Uint8Array {
+  const body = {
+    id: envelope.id,
+    ts: envelope.ts,
+    from: envelope.from,
+    kind: envelope.kind,
+    payload: envelope.payload,
+    to: envelope.to,
+    task_id: envelope.task_id,
+    channel: envelope.channel,
+    topic: envelope.topic,
+    correlation_id: envelope.correlation_id,
+    version: envelope.version,
+  };
+  return new TextEncoder().encode(JSON.stringify(body));
+}
+
+/**
+ * Parse a fleet envelope from wire bytes (fleet from_bytes).
+ *
+ * @param onVersionWarning Invoked when version > ENVELOPE_VERSION so the caller
+ *   controls how the forward-compat warning is surfaced (fleet logs a warning;
+ *   never fails closed, never accepts silently).
+ * @throws {EnvelopeError} On undecodable JSON, non-object body, non-object
+ *   payload, invalid version, or missing/empty required fields.
+ */
+export function envelopeFromBytes(
+  raw: Uint8Array,
+  onVersionWarning?: (version: number) => void,
+): FleetEnvelope {
+  let body: unknown;
+  try {
+    body = JSON.parse(new TextDecoder().decode(raw));
+  } catch (err) {
+    throw new EnvelopeError(
+      `Envelope.fromBytes: undecodable message: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new EnvelopeError("Envelope.fromBytes: message is not a JSON object");
+  }
+  const record = body as Record<string, unknown>;
+
+  // payload MUST be a JSON object. A list/str/number would satisfy decode but
+  // break every handler that reads payload.<key>. Reject it here so one
+  // malformed publisher cannot poison subscribers.
+  const rawPayload = record.payload;
+  let payload: Record<string, unknown>;
+  if (rawPayload === undefined || rawPayload === null) {
+    payload = {};
+  } else if (
+    typeof rawPayload === "object" &&
+    !Array.isArray(rawPayload)
+  ) {
+    payload = rawPayload as Record<string, unknown>;
+  } else {
+    throw new EnvelopeError(
+      `Envelope.fromBytes: payload must be a JSON object, got ${Array.isArray(rawPayload) ? "array" : typeof rawPayload}`,
+    );
+  }
+
+  // version must be an integer. A JSON null/string/float is rejected rather than
+  // coerced, so a malformed version can't slip past the forward-compat gate.
+  const rawVersion = record.version ?? ENVELOPE_VERSION;
+  if (typeof rawVersion !== "number" || !Number.isInteger(rawVersion)) {
+    throw new EnvelopeError(
+      `Envelope.fromBytes: invalid version ${JSON.stringify(rawVersion)}`,
+    );
+  }
+  const version = rawVersion;
+  if (version > ENVELOPE_VERSION) {
+    // Forward-compat: a newer producer may carry fields we drop or reinterpret.
+    // Warn but accept; never fail closed, never accept silently.
+    onVersionWarning?.(version);
+  }
+
+  return {
+    id: requireEnvelopeString("id", record.id),
+    ts: requireEnvelopeString("ts", record.ts),
+    from: requireEnvelopeString("from", record.from),
+    kind: requireEnvelopeString("kind", record.kind),
+    payload,
+    to: optEnvelopeString(record.to),
+    task_id: optEnvelopeString(record.task_id),
+    channel: optEnvelopeString(record.channel),
+    topic: optEnvelopeString(record.topic),
+    correlation_id: optEnvelopeString(record.correlation_id),
+    version,
+  };
+}
 
 export interface NatsRuntimeBoundary {
   requested_transport: "http" | "nats";
@@ -55,6 +293,8 @@ export interface NatsRuntimeBoundary {
     url: string | null;
     context_pack_subject: string;
     fallback_http: boolean;
+    require_auth: boolean;
+    allow_namespace_override: boolean;
   };
 }
 
@@ -97,34 +337,40 @@ export interface NatsBridgePlan {
   };
 }
 
-export function mapNatsEnvelopeToToolArgs(
-  envelope: NatsContextPackEnvelope,
+/**
+ * Map a validated request payload to agent_context_pack tool arguments.
+ * `namespace` is intentionally NOT mapped here — lane binding (nats-bridge.ts)
+ * decides whether a client-declared namespace may be used and passes it via the
+ * resolved AuthInfo/args, never straight from the wire.
+ */
+export function mapRequestPayloadToToolArgs(
+  payload: NatsContextPackRequestPayload,
 ): NatsBridgePlan["mcpToolCall"]["arguments"] {
   const toolArgs: NatsBridgePlan["mcpToolCall"]["arguments"] = {
-    agent: envelope.identity.agent,
-    platform: envelope.identity.platform,
-    server_id: envelope.identity.server_id,
-    channel_id: envelope.identity.channel_id,
-    session_key: envelope.identity.session_key,
+    agent: payload.identity.agent,
+    platform: payload.identity.platform,
+    server_id: payload.identity.server_id,
+    channel_id: payload.identity.channel_id,
+    session_key: payload.identity.session_key,
   };
 
-  if (envelope.body.query !== undefined) {
-    toolArgs.query = envelope.body.query;
+  if (payload.body.query !== undefined) {
+    toolArgs.query = payload.body.query;
   }
   if (
-    envelope.identity.thread_id !== null &&
-    envelope.identity.thread_id !== undefined
+    payload.identity.thread_id !== null &&
+    payload.identity.thread_id !== undefined
   ) {
-    toolArgs.thread_id = envelope.identity.thread_id;
+    toolArgs.thread_id = payload.identity.thread_id;
   }
-  if (envelope.body.requested_sections) {
-    toolArgs.requested_sections = envelope.body.requested_sections;
+  if (payload.body.requested_sections) {
+    toolArgs.requested_sections = payload.body.requested_sections;
   }
-  if (envelope.body.include_unreviewed_recovery !== undefined) {
+  if (payload.body.include_unreviewed_recovery !== undefined) {
     toolArgs.include_unreviewed_recovery =
-      envelope.body.include_unreviewed_recovery;
+      payload.body.include_unreviewed_recovery;
   }
-  if (envelope.body.budget) toolArgs.budget = envelope.body.budget;
+  if (payload.body.budget) toolArgs.budget = payload.body.budget;
 
   return toolArgs;
 }
@@ -193,6 +439,17 @@ export function isRequestedTransportDegraded(
   );
 }
 
+/**
+ * Resolve the default env-prefixed context-pack subject from OPENBRAIN_NATS_ENV,
+ * or the explicit OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT escape hatch when set.
+ */
+export function resolveContextPackSubject(env: NodeJS.ProcessEnv): string {
+  const override = trimEnv(env.OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT);
+  if (override) return override;
+  const natsEnv = trimEnv(env.OPENBRAIN_NATS_ENV) ?? DEFAULT_NATS_ENV;
+  return obContextPackSubject(natsEnv);
+}
+
 export function readNatsRuntimeBoundary(
   env: NodeJS.ProcessEnv,
 ): NatsRuntimeBoundary {
@@ -208,15 +465,25 @@ export function readNatsRuntimeBoundary(
     bridgeEnabled &&
     isNatsUrlAllowedForRuntime(url, env);
 
+  // Auth is OFF by default (trusted local bus). When REQUIRE_AUTH=true the
+  // bearer gate is re-enabled AND the namespace override is force-disabled:
+  // they are mutually exclusive. The override is a local-trust affordance only.
+  const requireAuth =
+    env.OPENBRAIN_NATS_REQUIRE_AUTH?.trim().toLowerCase() === "true";
+  const allowNamespaceOverride =
+    !requireAuth &&
+    env.OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE?.trim().toLowerCase() !== "false";
+
   return {
     requested_transport: requestedTransport,
     fallback_transport: "http_mcp",
     nats: {
       availability: runtimeAvailable ? "available" : "not_runtime_available",
       url,
-      context_pack_subject:
-        trimEnv(env.OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT) ?? DEFAULT_NATS_SUBJECT,
+      context_pack_subject: resolveContextPackSubject(env),
       fallback_http: env.OPENBRAIN_NATS_FALLBACK_HTTP?.trim().toLowerCase() !== "false",
+      require_auth: requireAuth,
+      allow_namespace_override: allowNamespaceOverride,
     },
   };
 }
@@ -244,12 +511,13 @@ export function planNatsContextPackBridge(
     throw new Error("Bearer token is required for NATS bridge fallback");
   }
 
-  const envelope = contextPackEnvelopeSchema.parse(input.envelope);
-  const toolArgs = mapNatsEnvelopeToToolArgs(envelope);
+  const envelope = envelopeFromEnvelopeInput(input.envelope);
+  const payload = requestPayloadSchema.parse(envelope.payload);
+  const toolArgs = mapRequestPayloadToToolArgs(payload);
 
   return {
     status: "http_mcp_fallback",
-    request_id: envelope.request_id,
+    request_id: envelope.id,
     subject: input.subject,
     operation: NATS_CONTEXT_PACK_OPERATION,
     bearerToken,
@@ -258,4 +526,13 @@ export function planNatsContextPackBridge(
       arguments: toolArgs,
     },
   };
+}
+
+/**
+ * Coerce a plain-object envelope (as passed to planNatsContextPackBridge) into a
+ * validated FleetEnvelope. Round-trips through the wire codec so plan-time
+ * validation is byte-identical to what the live bridge does with raw bytes.
+ */
+function envelopeFromEnvelopeInput(input: unknown): FleetEnvelope {
+  return envelopeFromBytes(new TextEncoder().encode(JSON.stringify(input)));
 }

--- a/src/nats-subjects.test.ts
+++ b/src/nats-subjects.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { obContextPackSubject, slugSubjectToken } from "./nats-subjects.ts";
+
+describe("slugSubjectToken", () => {
+  it("lowercases and collapses spaces and dots to hyphens (fleet _slug parity)", () => {
+    expect(slugSubjectToken("Staging Lab.1")).toBe("staging-lab-1");
+    expect(slugSubjectToken("PROD")).toBe("prod");
+  });
+
+  it("throws on a token that normalises to empty", () => {
+    expect(() => slugSubjectToken("   ")).toThrow(/normalises to empty/);
+    expect(() => slugSubjectToken("")).toThrow(/normalises to empty/);
+  });
+});
+
+describe("obContextPackSubject", () => {
+  it("builds the env-prefixed fleet subject", () => {
+    expect(obContextPackSubject("dev")).toBe("dev.ob.memory.context_pack");
+    expect(obContextPackSubject("prod")).toBe("prod.ob.memory.context_pack");
+  });
+
+  it("slugs the env token before use", () => {
+    expect(obContextPackSubject("Staging Lab")).toBe(
+      "staging-lab.ob.memory.context_pack",
+    );
+  });
+
+  it("throws when the env token is empty", () => {
+    expect(() => obContextPackSubject("  ")).toThrow(/normalises to empty/);
+  });
+});

--- a/src/nats-subjects.ts
+++ b/src/nats-subjects.ts
@@ -1,0 +1,49 @@
+// Subject-naming convention for the fleet bus, mirrored into TypeScript.
+//
+// This is the TS mirror of fleet-bus'
+// `packages/fleet-nats/src/fleet_nats/subjects.py` (rodaddy/fleet-bus).
+// fleet uses the live King convention `{env}.{domain}.{...}` — dot-delimited,
+// env-prefixed, hierarchical — and builds every subject through helpers so
+// nothing downstream hand-formats a subject string.
+//
+// Open Brain's context-pack subject slots into that tree as
+// `{env}.ob.memory.context_pack`. The `ob` domain is Open-Brain-owned.
+//
+// TODO(fleet-nats): file upstream issue to add ob_context_pack(env) builder in
+// fleet_nats/subjects.py; this TS mirror must stay in parity.
+
+/**
+ * Normalise a token for use in a subject (no dots or spaces).
+ *
+ * Matches fleet's `_slug`: lowercase, spaces and dots collapse to hyphens, and
+ * a token that normalises to empty (e.g. whitespace-only) throws — an empty
+ * token would silently produce an invalid NATS subject like `dev.ob..x` that
+ * the server rejects, losing the message far from the cause.
+ *
+ * @throws {Error} If the token normalises to an empty string.
+ */
+export function slugSubjectToken(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replaceAll(" ", "-")
+    .replaceAll(".", "-");
+  if (!slug) {
+    throw new Error(`subject token normalises to empty: ${JSON.stringify(value)}`);
+  }
+  return slug;
+}
+
+/**
+ * Subject for Open Brain's agent context-pack request/reply lane.
+ *
+ * Mirrors fleet's `{env}.{domain}.{...}` shape: `{env}.ob.memory.context_pack`.
+ * The env token is slugged (fleet convention); the fixed `ob.memory.context_pack`
+ * tail is a stable, already-normalised literal so it stays byte-identical to the
+ * pre-fleet flat subject minus the env prefix.
+ *
+ * @param env Environment prefix (e.g. "dev", "prod"). Slugged before use.
+ */
+export function obContextPackSubject(env: string): string {
+  return `${slugSubjectToken(env)}.ob.memory.context_pack`;
+}

--- a/src/nats-wire-fixture.test.ts
+++ b/src/nats-wire-fixture.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildEnvelope,
+  envelopeFromBytes,
+  envelopeToBytes,
+  REQUEST_KIND,
+  RESPONSE_FROM,
+  RESPONSE_KIND,
+} from "./nats-runtime.ts";
+import fixture from "./__fixtures__/nats-context-pack-wire.json" with { type: "json" };
+
+// Cross-language wire-parity guard. The fixture at
+// src/__fixtures__/nats-context-pack-wire.json is shared verbatim with the
+// Python (openbrain-memory) lane so the two implementations cannot drift. TS
+// must (a) serialize the canonical request to the EXACT bytes in `request.wire`
+// and (b) parse `response.wire` back to the canonical response envelope.
+
+const decoder = new TextDecoder();
+
+describe("shared NATS wire fixture — TS parity", () => {
+  it("serializes the canonical request to the exact fixture bytes ('from' key)", () => {
+    const env = fixture.request.envelope;
+    const built = buildEnvelope({
+      id: env.id,
+      ts: env.ts,
+      from: env.from,
+      kind: env.kind,
+      payload: env.payload,
+      to: env.to,
+      task_id: env.task_id,
+      channel: env.channel,
+      topic: env.topic,
+      correlation_id: env.correlation_id,
+      version: env.version,
+    });
+
+    const wire = decoder.decode(envelopeToBytes(built));
+    expect(wire).toBe(fixture.request.wire);
+    // Belt-and-suspenders: the wire uses "from", never "sender", and the request
+    // kind is the canonical discriminator.
+    expect(wire).toContain('"from":"nagatha"');
+    expect(wire).not.toContain('"sender"');
+    expect(env.kind).toBe(REQUEST_KIND);
+    // namespace override rides top-level payload.namespace.
+    expect(env.payload.namespace).toBe("rico");
+  });
+
+  it("round-trips the canonical request bytes back through the parser", () => {
+    const parsed = envelopeFromBytes(
+      new TextEncoder().encode(fixture.request.wire),
+    );
+    expect(parsed).toEqual(fixture.request.envelope as typeof parsed);
+    expect(parsed.kind).toBe(REQUEST_KIND);
+  });
+
+  it("parses the canonical response wire into the fixture response envelope", () => {
+    const parsed = envelopeFromBytes(
+      new TextEncoder().encode(fixture.response.wire),
+    );
+
+    expect(parsed).toEqual(fixture.response.envelope as typeof parsed);
+    expect(parsed.kind).toBe(RESPONSE_KIND);
+    expect(parsed.from).toBe(RESPONSE_FROM);
+    // correlation_id echoes the request id.
+    expect(parsed.correlation_id).toBe(fixture.request.envelope.id);
+    // namespace_source is a response-only stamp carried in the payload.
+    expect((parsed.payload as Record<string, unknown>).namespace_source).toBe(
+      "override",
+    );
+  });
+
+  it("re-serializes the canonical response to the exact fixture bytes", () => {
+    const env = fixture.response.envelope;
+    const built = buildEnvelope({
+      id: env.id,
+      ts: env.ts,
+      from: env.from,
+      kind: env.kind,
+      payload: env.payload,
+      to: env.to,
+      task_id: env.task_id,
+      channel: env.channel,
+      topic: env.topic,
+      correlation_id: env.correlation_id,
+      version: env.version,
+    });
+    expect(decoder.decode(envelopeToBytes(built))).toBe(fixture.response.wire);
+  });
+});

--- a/src/nats-worker.test.ts
+++ b/src/nats-worker.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import type { NatsBridgeDriver, NatsRequestMessage } from "./nats-bridge.ts";
+import { readNatsWorkerBoundary, startNatsWorker } from "./nats-worker.ts";
+
+function fakePool() {
+  return {
+    query: async () => ({ rows: [] }),
+    end: async () => undefined,
+  } as any;
+}
+
+function fakeDriver() {
+  const state: { subscribedSubject: string | null; closed: boolean } = {
+    subscribedSubject: null,
+    closed: false,
+  };
+  const driver: NatsBridgeDriver = {
+    subscribe: async (subject: string, _handler: (message: NatsRequestMessage) => Promise<void>) => {
+      state.subscribedSubject = subject;
+      return {
+        close: async () => {
+          state.closed = true;
+        },
+      };
+    },
+    close: async () => {
+      state.closed = true;
+    },
+  };
+  return { driver, state };
+}
+
+describe("readNatsWorkerBoundary", () => {
+  it("forces the dedicated worker into NATS mode without changing HTTP worker env", () => {
+    const boundary = readNatsWorkerBoundary({
+      OPENBRAIN_TRANSPORT: "http",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    });
+
+    expect(boundary).toMatchObject({
+      requested_transport: "nats",
+      nats: {
+        availability: "available",
+        url: "nats://127.0.0.1:4222",
+        context_pack_subject: "ob.memory.context_pack",
+      },
+    });
+  });
+
+  it("fails closed when no NATS URL is configured", () => {
+    const boundary = readNatsWorkerBoundary({});
+
+    expect(boundary).toMatchObject({
+      requested_transport: "nats",
+      nats: {
+        availability: "not_runtime_available",
+        url: null,
+      },
+    });
+  });
+});
+
+describe("startNatsWorker", () => {
+  it("starts only the NATS bridge subscription and exposes separate health", async () => {
+    const { driver, state } = fakeDriver();
+    const runtime = await startNatsWorker({
+      env: {
+        OPENBRAIN_TRANSPORT: "http",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+        OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      },
+      pool: fakePool(),
+      tokenMap: new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      driver,
+    });
+
+    expect(runtime.subject).toBe("ob.memory.context_pack");
+    expect(state.subscribedSubject).toBe("ob.memory.context_pack");
+    expect(runtime.health.availability).toBe("available");
+
+    await runtime.close();
+    expect(state.closed).toBe(true);
+  });
+
+  it("does not start when the broker URL is unavailable or disallowed", async () => {
+    await expect(
+      startNatsWorker({
+        env: {},
+        pool: fakePool(),
+        tokenMap: new Map(),
+      }),
+    ).rejects.toThrow("Dedicated NATS worker requires an allowed OPENBRAIN_NATS_URL");
+  });
+});

--- a/src/nats-worker.test.ts
+++ b/src/nats-worker.test.ts
@@ -43,7 +43,7 @@ describe("readNatsWorkerBoundary", () => {
       nats: {
         availability: "available",
         url: "nats://127.0.0.1:4222",
-        context_pack_subject: "ob.memory.context_pack",
+        context_pack_subject: "dev.ob.memory.context_pack",
       },
     });
   });
@@ -75,8 +75,8 @@ describe("startNatsWorker", () => {
       driver,
     });
 
-    expect(runtime.subject).toBe("ob.memory.context_pack");
-    expect(state.subscribedSubject).toBe("ob.memory.context_pack");
+    expect(runtime.subject).toBe("dev.ob.memory.context_pack");
+    expect(state.subscribedSubject).toBe("dev.ob.memory.context_pack");
     expect(runtime.health.availability).toBe("available");
 
     await runtime.close();

--- a/src/nats-worker.ts
+++ b/src/nats-worker.ts
@@ -1,6 +1,6 @@
 import type pg from "pg";
 import { generateEmbedding } from "./embedding.ts";
-import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth, type NatsBridgeRuntime } from "./nats-bridge.ts";
+import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth } from "./nats-bridge.ts";
 import { readNatsRuntimeBoundary, summarizeNatsUrlForLog, type NatsRuntimeBoundary } from "./nats-runtime.ts";
 import type { ToolDeps } from "./tools/index.ts";
 import type { AuthInfo } from "./types.ts";

--- a/src/nats-worker.ts
+++ b/src/nats-worker.ts
@@ -1,0 +1,75 @@
+import type pg from "pg";
+import { generateEmbedding } from "./embedding.ts";
+import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth, type NatsBridgeRuntime } from "./nats-bridge.ts";
+import { readNatsRuntimeBoundary, summarizeNatsUrlForLog, type NatsRuntimeBoundary } from "./nats-runtime.ts";
+import type { ToolDeps } from "./tools/index.ts";
+import type { AuthInfo } from "./types.ts";
+
+export interface StartNatsWorkerOptions {
+  env: NodeJS.ProcessEnv;
+  pool: pg.Pool;
+  tokenMap: Map<string, AuthInfo>;
+  driver?: NatsBridgeDriver;
+  deps?: Partial<ToolDeps>;
+}
+
+export interface NatsWorkerRuntime {
+  boundary: NatsRuntimeBoundary;
+  health: NatsBridgeHealth;
+  subject: string;
+  close(): Promise<void>;
+}
+
+export function readNatsWorkerBoundary(env: NodeJS.ProcessEnv): NatsRuntimeBoundary {
+  return readNatsRuntimeBoundary({
+    ...env,
+    OPENBRAIN_TRANSPORT: "nats",
+    OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+  });
+}
+
+export async function startNatsWorker(
+  options: StartNatsWorkerOptions,
+): Promise<NatsWorkerRuntime> {
+  const boundary = readNatsWorkerBoundary(options.env);
+  if (boundary.nats.availability !== "available") {
+    throw new Error(
+      "Dedicated NATS worker requires an allowed OPENBRAIN_NATS_URL",
+    );
+  }
+
+  const health = createNatsBridgeHealth("available");
+  const deps: ToolDeps = {
+    pool: options.pool,
+    embedFn: generateEmbedding,
+    ...options.deps,
+    natsRuntimeBoundary: boundary,
+    natsBridgeHealth: health,
+  };
+  const bridge = await startNatsContextPackBridge({
+    boundary,
+    tokenMap: options.tokenMap,
+    deps,
+    driver: options.driver,
+    health,
+  });
+  if (!bridge) {
+    throw new Error("Dedicated NATS worker did not start a bridge runtime");
+  }
+
+  return {
+    boundary,
+    health,
+    subject: bridge.subject,
+    close: async () => {
+      await bridge.close();
+    },
+  };
+}
+
+export function natsWorkerLogSummary(boundary: NatsRuntimeBoundary): object {
+  return {
+    subject: boundary.nats.context_pack_subject,
+    nats_url: summarizeNatsUrlForLog(boundary.nats.url),
+  };
+}


### PR DESCRIPTION
## Summary

Reconciles Open Brain's NATS request/reply transport (TS/Bun) to the
`rodaddy/fleet-bus` conventions, and supersedes/closes the dedicated-worker
work from #283 (this branch is built on `feat/282-dedicated-nats-worker` and
contains all of it).

Closes #282. Supersedes #283.

- **Fleet `Envelope`** wire format: `{ id, ts, from, kind, payload, ... , correlation_id, version }`, compact UTF-8 JSON, key `from` (not `sender`). Requests `kind="context_pack_request"`, responses `kind="context_pack_response"` with `correlation_id` echo.
- **Env-prefixed subject** `{env}.ob.memory.context_pack` via a `_slug`-parity builder (`src/nats-subjects.ts`); legacy flat subject unpinned from plist/runbook.
- **Lane binding (v1, auth off):** explicit top-level `payload.namespace` → `override`; else declared identity → `declared`; else `rejected` (never a silent global). `OPENBRAIN_NATS_REQUIRE_AUTH=true` re-enables the bearer gate and force-disables override; token-derived is stamped `token`.
- **Dedicated worker** (from #283) keeps HTTP `/health` isolated from NATS broker/subscription failures; `safeWorkerError` redaction hardened (instanceof allowlist).
- **Shared cross-language wire fixture** (`src/__fixtures__/nats-context-pack-wire.json`) that TS and the Python client both byte-validate against, so the wire cannot drift.
- Advisory contract manifest updated to advertise the env-prefixed subject (excluded from `schema_hash`; no v20 contract bump).

## Validation

- `bunx tsc --noEmit` → clean.
- `bun test` → **1317 pass, 54 skip, 0 fail**.
- Cross-language parity: TS serializer emits the fixture `request.wire` byte-for-byte; the Python client (PR for `lane/python-fleet-nats`) validates the byte-identical fixture (md5 `3aca6ba2…`).

## Gauntlet receipt

Critical → review-swarm (security/adversarial + gotcha/correctness, SME lanes injected) → codex `gpt-5.5` cross-model review → all findings fixed/waived.

- Findings: 2 BLOCKER, 2 HIGH, 3 MEDIUM, 3 low. Fixed: 8. Waived: 1 (shared-kb shadow — no privilege gain).
- `[codex/gpt-5.5]` caught both blockers (TS↔Python `kind` mismatch; override field-path mismatch) — end-to-end breakers no single-language review could see. Detail on #282.

## Downstream classification

Runtime/transport-facing. Local + hosted (core01) verification apply and are complete/planned in this run. mcp2cli/rtech-hermes live rollout deferred: NATS is opt-in, not default; the fleet cutover (CT274) is documented in `docs/fleet-nats-integration.md` as a config-only v2 flip gated on `REQUIRE_AUTH=true`.

## Critical Self-Review

- Highest-risk behavior: namespace/lane binding on the auth-off local bus — a caller-declared identity or `payload.namespace` selects the lane. Mitigated: binds a non-privileged synthetic identity through the same server-side `canReadNamespace` check; `NAMESPACE_TOKEN_RE` bounds the token; reject-on-unroutable never falls to a global namespace; runbook states auth-off-on-untrusted-bus as a hard cross-tenant-read precondition.
- Assumptions that could be wrong: that the core01 NATS broker is a trusted loopback bus with no untrusted publishers. Documented as a deployment precondition; the fleet cutover requires `REQUIRE_AUTH=true`.
- Missing/weak tests: no live-broker integration test in CI (fake driver + the shared wire fixture cover the contract); live request/reply is a deploy-time smoke.
- Security/permission risk: bearer auth is off by default in v1 (intentional, local trust); namespace remains a server-enforced boundary; logs/errors redact token/PII/URL via instanceof allowlist.
- Migration/deploy risk: no DB migration. Deploy risk is worker startup + env separation on core01; legacy-subject pin removed so the worker subscribes to the fleet subject.
- Downstream client/runtime risk: breaking NATS wire change vs the prior `openbrain.nats.*.v1` shape, but that surface is advisory (excluded from `schema_hash`) and NATS is opt-in; Python client lands in lockstep; HTTP transport unchanged.
- Rollback/cleanup concern: unload only `com.rico.open-brain-nats-worker`; HTTP/Postgres untouched.
- Fixes made before PR: all 8 gauntlet findings (2 blocker, 2 high, 3 medium, 1 low) fixed; shared wire fixture added to prevent recurrence.
- Known residual risk: cross-language parity is fixture-locked but hand-maintained (no automated TS↔Python check beyond the shared fixture); upstream `fleet-nats` `ob_context_pack` builder not yet filed.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured: 2 blocker + 2 high + 3 medium fixed, posted to #282
- Live Open Brain checks: [x] linked below

Live checks: core01 deploy + NATS request/reply smoke run post-merge in this goal run; receipt to follow on #282.
