### PR TITLE
feat(memory): add transcript citation recall contract

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -231,6 +231,24 @@ renders. `content_length` and `content_truncated` describe the readable compact
 projection used for `content_preview`; callers that need every raw stored column
 should follow `fetch_path` with `render: "full"`.
 
+### Transcript Citation Contract
+
+`append_session_event` may store a memory/summary with `transcript_ref`, an
+optional inline `transcript`, and optional `occurred_at`. A supplied transcript
+(including an empty transcript) or occurred time requires `transcript_ref`.
+`transcript_ref` is a durable host-neutral `collab/...` path with canonical
+alphanumeric-starting segments containing only alphanumerics, `.`, `_`, and
+`-`; absolute, host, backslash, colon, empty, `.` and `..` segments are
+rejected. The event's `source` is the cited speaker/agent.
+
+Use `citation_recall` with the readable session-event UUID to return the fact,
+conversation ref, speaker, date, and the stored exchange. Its bounded
+`before`/`after` context comes from neighboring transcript-bearing events in
+the same lane and conversation ref; callers may explicitly raise
+`context_limit` or `max_transcript_chars` within the server bounds. Existing
+events without a transcript ref remain readable and return
+`citation.status: "source_not_stored"`; callers must not infer a source.
+
 ### OKF Compatibility Hooks
 
 Open Brain does not implement OKF as its storage model. Treat OKF as an edge

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -271,3 +271,12 @@ downstream rollout gate even though the schema is untouched.
 - Was the change classified under `docs/downstream-rollout.md` as
   client-visible despite having no schema diff?
 - Do tests assert the emitted values stay inside the documented range?
+
+## [2026-07-13] Duplicate facts must not silently discard new citation evidence
+
+**Severity:** MEDIUM
+**Source:** Issue #288 Full-tier antagonist review
+**Scope:** append_session_event dedupe and citation recall
+**Status:** fixed in issue #288 implementation
+
+Content-hash dedupe can turn citation backfill into a false success. When an existing event lacks or differs from supplied citation fields, return an explicit citation-not-stored error instead of claiming a harmless duplicate.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -466,3 +466,12 @@ healthy instead of degrading the rollup.
   to healthy?
 - Do tests cover each subsystem failing alone and assert both body state and
   HTTP code?
+
+## [2026-07-13] Citation expansion flags require real remaining evidence
+
+**Severity:** MEDIUM
+**Source:** Issue #288 Full-tier initial review
+**Scope:** citation recall bounds and response truth
+**Status:** fixed in issue #288 implementation
+
+A bounded citation response must not hardcode `expandable`. Query one extra neighbor and derive it from unseen rows or transcript truncation; tests must cover both true and false cases.

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -405,3 +405,12 @@ live launchd state still differs from the repo template.
 - Does the launch command fail fast when its env file is missing or unreadable?
 - Does the runbook validate the env file before installing/restarting the
   service, especially when the worker env sources a shared production env?
+
+## [2026-07-13] Joined event chronology must stay database-owned and fully ordered
+
+**Severity:** HIGH
+**Source:** Issue #288 Full-tier review and focused verification
+**Scope:** transcript citation migration and neighbor SQL
+**Status:** fixed in issue #288 implementation
+
+Do not round-trip PostgreSQL timestamps through millisecond JS dates for tuple boundaries. Compare against the target row in SQL, qualify every projected column, apply direction to every ORDER BY term, and make constraint creation retry-idempotent.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -380,3 +380,12 @@ making the diagnostic lie in exactly the failure cases it exists for.
 - If the consumer's default changes, does the probe change with it by
   construction, or only by convention?
 - Do tests pin probe resolution and consumer resolution to the same value?
+
+## [2026-07-13] Required-tool changes must bump every client compatibility fixture
+
+**Severity:** HIGH
+**Source:** Issue #288 Full-tier gotcha and fix verification
+**Scope:** public contract plus openbrain-memory package
+**Status:** fixed in issue #288 implementation
+
+Adding a required tool while retaining the released client version makes the manifest lie. Bump the package, minimum/range, lockfile, server assertions, and Python contract fixtures together; search expected error strings for the retired range too.

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -383,3 +383,12 @@ inject a pg-like error carrying a secret-looking message, capture
 - Does the PR touch audit-logging code? If so, REQUIRE the focused
   logger-redaction test described above -- it does not exist yet, and
   code-review verification from PR #275 does not protect against reverts.
+
+## [2026-07-13] Inline transcript storage is a credential boundary
+
+**Severity:** MEDIUM
+**Source:** Issue #288 Full-tier security review
+**Scope:** append_session_event transcript citations
+**Status:** fixed in issue #288 implementation
+
+Transcript payloads require the same synchronous secret rejection as other durable evidence. References use canonical host-neutral segments, empty transcript still requires a ref, and DB-error logs expose only allowlisted labels.

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -52,7 +52,7 @@ def _resolve_package_version(pyproject: Path | None = None) -> str:
 
 
 PACKAGE_VERSION = _resolve_package_version()
-CURRENT_CONTRACT_VERSION = "2026-07-08.memory-tools.v20"
+CURRENT_CONTRACT_VERSION = "2026-07-13.memory-tools.v21"
 COMPATIBLE_CONTRACT_VERSIONS = (CURRENT_CONTRACT_VERSION,)
 REQUIRED_CONTRACT_TOOLS = (
     "append_session_event",
@@ -74,9 +74,13 @@ REQUIRED_CONTRACT_TOOLS = (
     "session_wrap",
     "upsert_repo_fact",
     "working_set_append",
+    "citation_recall",
 )
 CURRENT_TOOL_HELP: Mapping[str, str] = {
     "append_session_event": "Append a durable event to a session lane journal.",
+    "citation_recall": (
+        "Return stored transcript citation evidence for a session event."
+    ),
     "agent_context_pack": (
         "Build a scoped context pack with working context and explicit "
         "quarantined recovery."
@@ -1218,6 +1222,9 @@ class OpenBrainClient:
 
     def append_session_event(self, **arguments: Any) -> JSON:
         return self.call_tool("append_session_event", arguments)
+
+    def citation_recall(self, **arguments: Any) -> JSON:
+        return self.call_tool("citation_recall", arguments)
 
     def archive_entry(self, **arguments: Any) -> JSON:
         return self.call_tool("archive_entry", arguments)

--- a/python/openbrain-memory/tests/test_client.py
+++ b/python/openbrain-memory/tests/test_client.py
@@ -1781,6 +1781,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
         "access_report",
         "adjacent_context",
         "append_session_event",
+        "citation_recall",
         "agent_context_pack",
         "archive_entity",
         "archive_entry",
@@ -1840,7 +1841,7 @@ def test_all_registered_tool_wrappers_call_matching_tool_names():
 
 
 def test_required_contract_tools_have_first_class_wrappers_and_help():
-    assert CURRENT_CONTRACT_VERSION == "2026-07-08.memory-tools.v20"
+    assert CURRENT_CONTRACT_VERSION == "2026-07-13.memory-tools.v21"
     assert set(REQUIRED_CONTRACT_TOOLS) <= set(CURRENT_TOOL_HELP)
 
     for tool_name in REQUIRED_CONTRACT_TOOLS:

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -11,7 +11,7 @@ from openbrain_memory import (
     validate_required_memory_contract,
 )
 
-CURRENT_CLIENT_VERSION = "0.1.6"
+CURRENT_CLIENT_VERSION = "0.1.7"
 
 
 def safe_string_display(value: str) -> str:
@@ -32,7 +32,7 @@ def representative_contract_manifest() -> dict:
             "rtech-hermes-runtime": "0.1.0",
         },
         "compatible_client_ranges": {
-            "openbrain-memory": ">=0.1.6 <1.0.0",
+            "openbrain-memory": ">=0.1.7 <1.0.0",
             "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
         },
         "transport": {
@@ -246,7 +246,7 @@ def test_validate_contract_manifest_reports_min_client_version_failure():
         f"{safe_string_display(CURRENT_CLIENT_VERSION)}",
         "openbrain-memory "
         f"{safe_string_display('0.0.9')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.6 <1.0.0')}",
+        f"{safe_string_display('>=0.1.7 <1.0.0')}",
     )
 
 
@@ -259,7 +259,7 @@ def test_validate_contract_manifest_reports_compatible_range_failure():
     assert result.reasons == (
         "openbrain-memory "
         f"{safe_string_display('1.0.0')} does not satisfy compatible range "
-        f"{safe_string_display('>=0.1.6 <1.0.0')}",
+        f"{safe_string_display('>=0.1.7 <1.0.0')}",
     )
 
 

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/src/contract-schemas.ts
+++ b/src/contract-schemas.ts
@@ -2,10 +2,7 @@ import {
   REPO_FACT_METADATA_CONTRACT,
   REPO_FACT_VALIDATION_CONTRACT,
 } from "./tools/repo-facts.ts";
-import {
-  SOURCE_REFS_CONTRACT,
-  SOURCE_SCOPE_CONTRACT,
-} from "./source-refs.ts";
+import { SOURCE_REFS_CONTRACT, SOURCE_SCOPE_CONTRACT } from "./source-refs.ts";
 
 export interface ToolContract {
   version: number;
@@ -39,9 +36,24 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "the server enforces write authority before accepting RAM working context.",
       },
       agent: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      platform: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      server_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
-      channel_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      platform: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 200,
+      },
+      server_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
+      channel_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
       thread_id: {
         type: "string",
         required: false,
@@ -84,7 +96,12 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         type: "object",
         required: false,
         fields: {
-          table: { type: "string", required: true, minLength: 1, maxLength: 100 },
+          table: {
+            type: "string",
+            required: true,
+            minLength: 1,
+            maxLength: 100,
+          },
           id: { type: "string", required: true, minLength: 1, maxLength: 200 },
         },
       },
@@ -112,9 +129,24 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "server enforces read authority before returning any scoped context.",
       },
       agent: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      platform: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      server_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
-      channel_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      platform: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 200,
+      },
+      server_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
+      channel_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
       thread_id: { type: "string", required: false, maxLength: 500 },
       session_key: {
         type: "string",
@@ -183,9 +215,24 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "server enforces write authority before accepting recovery WAL records.",
       },
       agent: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      platform: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      server_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
-      channel_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      platform: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 200,
+      },
+      server_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
+      channel_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
       thread_id: { type: "string", required: false, maxLength: 500 },
       session_key: {
         type: "string",
@@ -239,9 +286,24 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "server enforces write authority before marking recovery WAL records.",
       },
       agent: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      platform: { type: "string", required: true, minLength: 1, maxLength: 200 },
-      server_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
-      channel_id: { type: "string", required: true, minLength: 1, maxLength: 500 },
+      platform: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 200,
+      },
+      server_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
+      channel_id: {
+        type: "string",
+        required: true,
+        minLength: 1,
+        maxLength: 500,
+      },
       thread_id: { type: "string", required: false, maxLength: 500 },
       session_key: {
         type: "string",
@@ -291,7 +353,13 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       table: {
         type: "enum",
         required: true,
-        values: ["thoughts", "decisions", "relationships", "projects", "sessions"],
+        values: [
+          "thoughts",
+          "decisions",
+          "relationships",
+          "projects",
+          "sessions",
+        ],
         description:
           "Readable table containing the target row. Use the plural table " +
           "name derived from search result source_type.",
@@ -334,7 +402,13 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       table: {
         type: "enum",
         required: true,
-        values: ["thoughts", "decisions", "relationships", "projects", "sessions"],
+        values: [
+          "thoughts",
+          "decisions",
+          "relationships",
+          "projects",
+          "sessions",
+        ],
         description:
           "Readable source table containing the oversized row to decompose.",
       },
@@ -587,7 +661,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     output_shape: "session lane plus recent events JSON text payload",
   },
   session_context: {
-    version: 2,
+    version: 3,
     input_schema: {
       session_key: {
         type: "string",
@@ -658,7 +732,49 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
           "warm, cold. Omit to include all tiers.",
       },
     },
-    output_shape: "session lane plus recent events JSON text payload",
+    output_shape:
+      "session lane plus recent events JSON text payload; events may include " +
+      "transcript_ref, transcript, and occurred_at citation fields",
+  },
+  citation_recall: {
+    version: 1,
+    input_schema: {
+      event_id: {
+        type: "string",
+        required: true,
+        format: "uuid",
+        description: "Readable session event UUID to cite.",
+      },
+      namespace: {
+        type: "string",
+        required: false,
+        maxLength: 500,
+        description:
+          "Memory partition to read. Defaults to the auth-derived namespace and is enforced server-side.",
+      },
+      context_limit: {
+        type: "integer",
+        required: false,
+        min: 0,
+        max: 10,
+        default: 2,
+        description:
+          "Neighboring transcript exchanges returned before and after the cited event.",
+      },
+      max_transcript_chars: {
+        type: "integer",
+        required: false,
+        min: 100,
+        max: 50000,
+        default: 2000,
+        description:
+          "Maximum characters from each returned source exchange; raise explicitly to expand context.",
+      },
+    },
+    output_shape:
+      "citation JSON text payload with fact and either citation.status=stored " +
+      "(host-neutral conversation_ref, speaker, date, optional transcript, bounded before/after context) " +
+      "or citation.status=source_not_stored for legacy evidence-less events",
   },
   lane_upsert: {
     version: 2,
@@ -717,22 +833,19 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         type: "string",
         required: false,
         maxLength: 500,
-        description:
-          "Originating thread id within the channel, when threaded.",
+        description: "Originating thread id within the channel, when threaded.",
       },
       project: {
         type: "string",
         required: false,
         maxLength: 500,
-        description:
-          "Project the lane belongs to, for scoping and filtering.",
+        description: "Project the lane belongs to, for scoping and filtering.",
       },
       topic: {
         type: "string",
         required: false,
         maxLength: 500,
-        description:
-          "Short human-readable subject for the lane.",
+        description: "Short human-readable subject for the lane.",
       },
       current_context_md: {
         type: "string",
@@ -791,8 +904,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       channel_id: {
         type: "string",
         required: false,
-        description:
-          "Filter to lanes from this originating chat channel.",
+        description: "Filter to lanes from this originating chat channel.",
       },
       status: {
         type: "enum",
@@ -816,7 +928,7 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
     output_shape: "session lane array JSON text payload",
   },
   append_session_event: {
-    version: 6,
+    version: 7,
     input_schema: {
       session_key: {
         type: "string",
@@ -944,6 +1056,28 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         description:
           "Path or URI to a produced/referenced artifact (file, doc, URL). " +
           "Set especially for artifact events so the output can be located.",
+      },
+      transcript_ref: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        maxLength: 2000,
+        description:
+          "Host-neutral source conversation reference. Must use collab/... and must not contain /Volumes/ or /mnt/ host paths.",
+      },
+      transcript: {
+        type: "string",
+        required: false,
+        maxLength: 50000,
+        description:
+          "Optional inline exchange from transcript_ref. transcript_ref is required when this is supplied.",
+      },
+      occurred_at: {
+        type: "string",
+        required: false,
+        format: "date-time",
+        description:
+          "ISO 8601 timestamp with timezone for the cited exchange. transcript_ref is required when this is supplied.",
       },
       importance: {
         type: "enum",
@@ -1094,8 +1228,8 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
       },
     },
     output_shape:
-      "session event JSON text payload with lane_created, writer_identity, " +
-      "token_identity, delegated_agent_id, and namespace_source provenance " +
+      "session event JSON text payload with lane_created, transcript_ref when supplied, " +
+      "writer_identity, token_identity, delegated_agent_id, and namespace_source provenance " +
       "fields; sync share_candidate rejections include share_candidate_rejected " +
       "and reject_detail {category, matched_kind, span_count, redaction_hint, " +
       "resubmittable, resubmit_attempt, max_resubmit_attempts, optional " +
@@ -1204,29 +1338,25 @@ export const TOOL_CONTRACTS: Record<string, ToolContract> = {
         type: "string",
         required: false,
         maxLength: 300,
-        description:
-          "Filter to facts derived from this qmd collection.",
+        description: "Filter to facts derived from this qmd collection.",
       },
       path: {
         type: "string",
         required: false,
         maxLength: 1000,
-        description:
-          "Filter to facts about this repo-relative file path.",
+        description: "Filter to facts about this repo-relative file path.",
       },
       fact_type: {
         type: "enum",
         required: false,
         values: REPO_FACT_METADATA_CONTRACT.fact_type.values,
-        description:
-          "Filter to one fact category. Omit to return all types.",
+        description: "Filter to one fact category. Omit to return all types.",
       },
       subject: {
         type: "string",
         required: false,
         maxLength: 500,
-        description:
-          "Filter to facts whose subject/symbol matches this value.",
+        description: "Filter to facts whose subject/symbol matches this value.",
       },
       limit: {
         type: "integer",

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -13,12 +13,12 @@ describe("Open Brain contract manifest", () => {
     expect(contract.contract_scope).toBe("required_openbrain_memory_contract");
     expect(contract.schema_hash).toMatch(/^[0-9a-f]{64}$/);
     expect(contract.schema_hash).toBe(
-      "4df9c742add84e2bbc3495a9baad8f103ee191a82518ea43c754a7fbb961bb48",
+      "a744dddbbe4ea3f3330f5ce23c7178cd66cedd0dbb25d1a809f0cbbbd8d403d1",
     );
     expect(contract.min_client_versions.mcp2cli).toBe("0.3.6");
-    expect(contract.min_client_versions["openbrain-memory"]).toBe("0.1.6");
+    expect(contract.min_client_versions["openbrain-memory"]).toBe("0.1.7");
     expect(contract.compatible_client_ranges["openbrain-memory"]).toBe(
-      ">=0.1.6 <1.0.0",
+      ">=0.1.7 <1.0.0",
     );
     expect(contract.transport.namespace_boundary).toBe("authorization");
     expect(contract.realtime_transport.nats_jetstream).toMatchObject({
@@ -42,7 +42,9 @@ describe("Open Brain contract manifest", () => {
         "{env}.ob.health",
       ],
     });
-    expect(contract.realtime_transport.nats_jetstream.jetstream_streams).toEqual([
+    expect(
+      contract.realtime_transport.nats_jetstream.jetstream_streams,
+    ).toEqual([
       "OB_AGENT_TRACE",
       "OB_CONTEXT_PACK_REQUESTS",
       "OB_CONTEXT_PACK_AUDIT",
@@ -322,18 +324,10 @@ describe("Open Brain contract manifest", () => {
     expect(recoveryWalAppend).toBeDefined();
     expect(recoveryWalMark).toBeDefined();
     expect(agentContextPack).toBeDefined();
-    expect(workingSetAppend?.output_shape).toContain(
-      "RAM-only",
-    );
-    expect(agentContextPack?.output_shape).toContain(
-      "explicit recovery",
-    );
-    expect(recoveryWalAppend?.output_shape).toContain(
-      "not_searchable_recall",
-    );
-    expect(recoveryWalMark?.output_shape).toContain(
-      "not_searchable_recall",
-    );
+    expect(workingSetAppend?.output_shape).toContain("RAM-only");
+    expect(agentContextPack?.output_shape).toContain("explicit recovery");
+    expect(recoveryWalAppend?.output_shape).toContain("not_searchable_recall");
+    expect(recoveryWalMark?.output_shape).toContain("not_searchable_recall");
     expect((workingSetAppend?.input_schema as any).durable_ref).toEqual({
       type: "object",
       required: false,
@@ -373,7 +367,13 @@ describe("Open Brain contract manifest", () => {
     expect((getEntry?.input_schema as any).table).toEqual({
       type: "enum",
       required: true,
-      values: ["thoughts", "decisions", "relationships", "projects", "sessions"],
+      values: [
+        "thoughts",
+        "decisions",
+        "relationships",
+        "projects",
+        "sessions",
+      ],
       description:
         "Readable table containing the target row. Use the plural table " +
         "name derived from search result source_type.",
@@ -395,9 +395,24 @@ describe("Open Brain contract manifest", () => {
       default: 500,
     });
     expect((getEntry?.input_schema as any).source_scope.fields).toMatchObject({
-      client_id: { type: "string", required: false, minLength: 1, maxLength: 300 },
-      matter_id: { type: "string", required: false, minLength: 1, maxLength: 300 },
-      document_id: { type: "string", required: false, minLength: 1, maxLength: 500 },
+      client_id: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        maxLength: 300,
+      },
+      matter_id: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        maxLength: 300,
+      },
+      document_id: {
+        type: "string",
+        required: false,
+        minLength: 1,
+        maxLength: 500,
+      },
       path: { type: "string", required: false, minLength: 1, maxLength: 1000 },
       dms_id: { type: "string", required: false, minLength: 1, maxLength: 500 },
     });
@@ -427,7 +442,9 @@ describe("Open Brain contract manifest", () => {
       required: false,
       values: ["write_replacements"],
     });
-    expect(decomposeEntry?.output_shape).toContain("without source-row mutation");
+    expect(decomposeEntry?.output_shape).toContain(
+      "without source-row mutation",
+    );
     const resolveEntry = contract.tool_contracts.resolve_entry;
     expect(resolveEntry).toBeDefined();
     expect(resolveEntry?.version).toBe(1);
@@ -457,7 +474,9 @@ describe("Open Brain contract manifest", () => {
       "warm",
       "cold",
     ]);
-    expect((searchAll?.input_schema as any).source_scope.fields.path).toMatchObject({
+    expect(
+      (searchAll?.input_schema as any).source_scope.fields.path,
+    ).toMatchObject({
       type: "string",
       required: false,
       minLength: 1,
@@ -469,9 +488,9 @@ describe("Open Brain contract manifest", () => {
     expect((laneUpsert?.input_schema as any).current_context_md.maxLength).toBe(
       100000,
     );
-    expect((laneUpsert?.input_schema as any).metadata.propertyNames.maxLength).toBe(
-      100,
-    );
+    expect(
+      (laneUpsert?.input_schema as any).metadata.propertyNames.maxLength,
+    ).toBe(100);
     const laneLoad = contract.tool_contracts.lane_load;
     expect(laneLoad).toBeDefined();
     expect((laneLoad?.input_schema as any).status.default).toBe("active");
@@ -501,11 +520,11 @@ describe("Open Brain contract manifest", () => {
     // contract so a future TS/Python divergence fails here, in lockstep with
     // python/openbrain-memory CURRENT_CONTRACT_VERSION.
     const contract = buildContract("2026-06-18T00:00:00.000Z");
-    expect(contract.contract_version).toBe("2026-07-08.memory-tools.v20");
+    expect(contract.contract_version).toBe("2026-07-13.memory-tools.v21");
 
     const appendEvent = contract.tool_contracts.append_session_event;
     expect(appendEvent).toBeDefined();
-    expect(appendEvent?.version).toBe(6);
+    expect(appendEvent?.version).toBe(7);
     expect(appendEvent?.output_shape).toContain("writer_identity");
     expect(appendEvent?.output_shape).toContain("token_identity");
     expect(appendEvent?.output_shape).toContain("delegated_agent_id");
@@ -520,8 +539,12 @@ describe("Open Brain contract manifest", () => {
     expect(appendInput.create_if_missing.description).toContain(
       "first-write realtime agent scopes",
     );
-    expect(appendInput.agent.description).toContain("validate against an existing lane");
-    expect(appendInput.platform.description).toContain("Stored as the lane source");
+    expect(appendInput.agent.description).toContain(
+      "validate against an existing lane",
+    );
+    expect(appendInput.platform.description).toContain(
+      "Stored as the lane source",
+    );
     expect(appendInput.server_id.description).toContain("exact realtime scope");
     expect(appendInput.channel_id.description).toContain(
       "validate against an existing lane",
@@ -560,10 +583,12 @@ describe("Open Brain contract manifest", () => {
       "memory_lifecycle_action=nominate_shared",
     );
     expect(shareCandidate.description.toLowerCase()).toContain("secret");
-    expect(appendInput.metadata.fields.sanitized_resubmit_of.type).toBe("string");
-    expect(appendInput.metadata.fields.sanitized_resubmit_of.description).toContain(
-      "reject_detail.resubmit_metadata",
+    expect(appendInput.metadata.fields.sanitized_resubmit_of.type).toBe(
+      "string",
     );
+    expect(
+      appendInput.metadata.fields.sanitized_resubmit_of.description,
+    ).toContain("reject_detail.resubmit_metadata");
     expect(appendInput.metadata.fields.sanitized_resubmit_attempt.type).toBe(
       "integer",
     );
@@ -598,7 +623,8 @@ describe("Open Brain contract manifest", () => {
           request_reply_subjects: {
             ...base.realtime_transport.nats_jetstream.request_reply_subjects,
             planned: [
-              ...base.realtime_transport.nats_jetstream.request_reply_subjects.planned,
+              ...base.realtime_transport.nats_jetstream.request_reply_subjects
+                .planned,
               "ob.memory.experimental",
             ],
           } as unknown as typeof base.realtime_transport.nats_jetstream.request_reply_subjects,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { TOOL_CONTRACTS } from "./contract-schemas.ts";
 
-export const CONTRACT_VERSION = "2026-07-08.memory-tools.v20";
+export const CONTRACT_VERSION = "2026-07-13.memory-tools.v21";
 export const CONTRACT_SCHEMA_VERSION = 1;
 
 export interface ContractCapability {
@@ -79,7 +79,13 @@ export interface OpenBrainContract {
         "tags",
         "timestamp",
       ];
-      export_surfaces: readonly ["concept", "index", "log", "citations", "receipts"];
+      export_surfaces: readonly [
+        "concept",
+        "index",
+        "log",
+        "citations",
+        "receipts",
+      ];
     };
   };
   agent_memory_adapter: {
@@ -344,7 +350,7 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "session_context",
-    version: 2,
+    version: 3,
     kind: "tool",
     description:
       "Read a session lane's current state and recent events without creating " +
@@ -372,13 +378,22 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "append_session_event",
-    version: 5,
+    version: 6,
     kind: "tool",
     description:
       "Append one durable, typed event (fact, decision, blocker, action, etc.) " +
       "to a session lane's journal. This is the main way to record what happened " +
       "during a session so it survives and can be recalled later. Supports " +
       "first-write lane creation with create_if_missing for realtime agents.",
+  },
+  {
+    name: "citation_recall",
+    version: 1,
+    kind: "tool",
+    description:
+      "Read a session event's stored host-neutral transcript citation and " +
+      "bounded neighboring exchanges, or explicitly report source_not_stored " +
+      "for legacy evidence-less events.",
   },
   {
     name: "session_wrap",
@@ -398,9 +413,10 @@ export const CONTRACT_CAPABILITIES: ContractCapability[] = [
   },
   {
     name: "session_lanes",
-    version: 1,
+    version: 2,
     kind: "schema",
-    description: "Durable session lanes, events, context, and wraps.",
+    description:
+      "Durable session lanes, events, context, wraps, and host-neutral transcript citations.",
   },
   {
     name: "agent_context_pack",
@@ -491,7 +507,10 @@ export function stableJson(value: unknown): string {
 
 function requiredContractHashPayload(
   payload: Omit<OpenBrainContract, "generated_at" | "schema_hash">,
-): Omit<OpenBrainContract, "generated_at" | "schema_hash" | "realtime_transport"> {
+): Omit<
+  OpenBrainContract,
+  "generated_at" | "schema_hash" | "realtime_transport"
+> {
   const { realtime_transport: _advisoryRealtimeTransport, ...requiredPayload } =
     payload;
   return requiredPayload;
@@ -518,12 +537,12 @@ export function buildContract(
     contract_scope: "required_openbrain_memory_contract" as const,
     schema_version: CONTRACT_SCHEMA_VERSION,
     min_client_versions: {
-      "openbrain-memory": "0.1.6",
+      "openbrain-memory": "0.1.7",
       "rtech-hermes-runtime": "0.1.0",
       mcp2cli: "0.3.6",
     },
     compatible_client_ranges: {
-      "openbrain-memory": ">=0.1.6 <1.0.0",
+      "openbrain-memory": ">=0.1.7 <1.0.0",
       "rtech-hermes-runtime": ">=0.1.0 <1.0.0",
       mcp2cli: ">=0.3.6 <1.0.0",
     },
@@ -540,9 +559,10 @@ export function buildContract(
     // schema_hash bump or a contract-version break.
     realtime_transport: {
       nats_jetstream: {
-        status: natsAvailability === "available"
-          ? "runtime-available" as const
-          : "planned-transport-foundation" as const,
+        status:
+          natsAvailability === "available"
+            ? ("runtime-available" as const)
+            : ("planned-transport-foundation" as const),
         availability: natsAvailability,
         parent_issue: 223 as const,
         contract_doc: "docs/nats-jetstream-foundation.md" as const,
@@ -558,9 +578,10 @@ export function buildContract(
         // slugged OPENBRAIN_NATS_ENV value via obContextPackSubject(env).
         subject_convention: "env_prefixed_fleet_bus" as const,
         request_reply_subjects: {
-          available: natsAvailability === "available"
-            ? ["{env}.ob.memory.context_pack"] as const
-            : [] as const,
+          available:
+            natsAvailability === "available"
+              ? (["{env}.ob.memory.context_pack"] as const)
+              : ([] as const),
           planned: [
             "{env}.ob.memory.session_start",
             "{env}.ob.memory.append_event",
@@ -595,7 +616,13 @@ export function buildContract(
           "tags",
           "timestamp",
         ] as const,
-        export_surfaces: ["concept", "index", "log", "citations", "receipts"] as const,
+        export_surfaces: [
+          "concept",
+          "index",
+          "log",
+          "citations",
+          "receipts",
+        ] as const,
       },
     },
     agent_memory_adapter: {
@@ -747,8 +774,7 @@ export function buildContract(
         status: "local-quarantine-boundary" as const,
         parent_issue: 221 as const,
         implementation: "src/realtime/recovery-wal.ts" as const,
-        storage:
-          "env_configured_file_wal_with_in_memory_fallback" as const,
+        storage: "env_configured_file_wal_with_in_memory_fallback" as const,
         availability: "mcp_tool_available" as const,
         item_label: "quarantined_recovery" as const,
         not_durable_memory: true as const,

--- a/src/db/migrations/023_session_event_transcript_citations.sql
+++ b/src/db/migrations/023_session_event_transcript_citations.sql
@@ -1,0 +1,44 @@
+-- Migration 023: Host-neutral transcript citations for session events (#288)
+-- A journal event can retain a durable conversation reference and an optional
+-- captured exchange. The reference is deliberately host-neutral so callers do
+-- not persist workstation-specific /Volumes or /mnt locations.
+
+ALTER TABLE ob_session_events
+  ADD COLUMN IF NOT EXISTS transcript_ref TEXT,
+  ADD COLUMN IF NOT EXISTS transcript TEXT,
+  ADD COLUMN IF NOT EXISTS occurred_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ob_session_events_transcript_ref_host_neutral'
+      AND conrelid = 'ob_session_events'::regclass
+  ) THEN
+    ALTER TABLE ob_session_events
+      ADD CONSTRAINT ob_session_events_transcript_ref_host_neutral
+      CHECK (
+        transcript_ref IS NULL
+        OR transcript_ref ~ '^collab/[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*$'
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ob_session_events_transcript_citation_ref_required'
+      AND conrelid = 'ob_session_events'::regclass
+  ) THEN
+    ALTER TABLE ob_session_events
+      ADD CONSTRAINT ob_session_events_transcript_citation_ref_required
+      CHECK (
+        (transcript IS NULL AND occurred_at IS NULL)
+        OR transcript_ref IS NOT NULL
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_session_events_transcript_ref
+  ON ob_session_events (lane_id, transcript_ref, created_at, id)
+  WHERE transcript_ref IS NOT NULL;

--- a/src/operator-doctor.test.ts
+++ b/src/operator-doctor.test.ts
@@ -45,7 +45,9 @@ function makePoolWithUnknownMigrations() {
 // Pool that reports every on-disk migration as applied: migrations "current".
 async function makeCurrentPool() {
   const migrationsDir = join(dirname(THIS_FILE), "db", "migrations");
-  const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql"));
+  const files = (await readdir(migrationsDir)).filter((f) =>
+    f.endsWith(".sql"),
+  );
   return makePool(files);
 }
 
@@ -88,7 +90,9 @@ describe("operator doctor status", () => {
     ) => {
       const url = typeof input === "string" ? input : input.toString();
       expect(url).toContain("/models");
-      expect(init?.headers).toMatchObject({ Authorization: `Bearer ${secret}` });
+      expect(init?.headers).toMatchObject({
+        Authorization: `Bearer ${secret}`,
+      });
       return Promise.resolve(new Response("{}", { status: 200 }));
     };
 
@@ -99,7 +103,7 @@ describe("operator doctor status", () => {
     const serialized = JSON.stringify(status);
 
     expect(status.contract_version).toBe("2026-07-08.operator-doctor.v2");
-    expect(status.runtime.contract_version).toBe("2026-07-08.memory-tools.v20");
+    expect(status.runtime.contract_version).toBe("2026-07-13.memory-tools.v21");
     expect(status.database.connected).toBe(true);
     expect(status.embedding_provider).toMatchObject({
       configured: true,
@@ -143,7 +147,9 @@ describe("operator doctor status", () => {
     expect(status.optional_dependencies.qmd).toBe("unavailable");
     // qmd is an optional dependency: presence/absence never changes the tier.
     expect(status.status).toBe("healthy");
-    expect(JSON.stringify(status)).not.toContain("/nonexistent/qmd-entrypoint.ts");
+    expect(JSON.stringify(status)).not.toContain(
+      "/nonexistent/qmd-entrypoint.ts",
+    );
   });
 
   it("falls back to the shared default qmd path when QMD_PATH is unset", async () => {
@@ -191,7 +197,9 @@ describe("operator doctor status", () => {
 
     expect(status.status).toBe("healthy");
     expect(status.embedding_provider.configured).toBe(false);
-    expect(status.optional_dependencies.embedding_provider).toBe("not_configured");
+    expect(status.optional_dependencies.embedding_provider).toBe(
+      "not_configured",
+    );
   });
 
   it("degrades when the DB is connected but migration state is unknown", async () => {
@@ -284,7 +292,9 @@ describe("operator doctor status", () => {
       "model",
       "recent_failures",
     ]);
-    expect(Object.keys(status.embedding_provider.recent_failures).sort()).toEqual([
+    expect(
+      Object.keys(status.embedding_provider.recent_failures).sort(),
+    ).toEqual([
       "consecutive_restartable_failures",
       "last_failure_code",
       "last_restart_at",
@@ -369,14 +379,29 @@ describe("operator doctor cache", () => {
     let clock = 0;
     const options = { ttlMs: 5_000, now: () => clock };
 
-    const first = await getOperatorDoctorStatus(pool, boundary, undefined, options);
+    const first = await getOperatorDoctorStatus(
+      pool,
+      boundary,
+      undefined,
+      options,
+    );
     clock = 4_999;
-    const cached = await getOperatorDoctorStatus(pool, boundary, undefined, options);
+    const cached = await getOperatorDoctorStatus(
+      pool,
+      boundary,
+      undefined,
+      options,
+    );
     expect(probeCycles).toBe(1);
     expect(cached).toBe(first);
 
     clock = 5_001;
-    const rebuilt = await getOperatorDoctorStatus(pool, boundary, undefined, options);
+    const rebuilt = await getOperatorDoctorStatus(
+      pool,
+      boundary,
+      undefined,
+      options,
+    );
     expect(probeCycles).toBe(2);
     expect(rebuilt).not.toBe(first);
   });
@@ -384,7 +409,10 @@ describe("operator doctor cache", () => {
   it("rebuilds immediately after resetOperatorDoctorCache", async () => {
     resetOperatorDoctorCache();
     const boundary = readNatsRuntimeBoundary({});
-    const first = await getOperatorDoctorStatus(makePool(["001_init.sql"]), boundary);
+    const first = await getOperatorDoctorStatus(
+      makePool(["001_init.sql"]),
+      boundary,
+    );
     resetOperatorDoctorCache();
     const second = await getOperatorDoctorStatus(makeDownPool(), boundary);
 
@@ -397,9 +425,13 @@ describe("operator doctor cache", () => {
 describe("canReadDoctor", () => {
   it("permits only admin and ob-admin roles", () => {
     expect(canReadDoctor({ role: "admin", clientId: "a" } as any)).toBe(true);
-    expect(canReadDoctor({ role: "ob-admin", clientId: "b" } as any)).toBe(true);
+    expect(canReadDoctor({ role: "ob-admin", clientId: "b" } as any)).toBe(
+      true,
+    );
     expect(canReadDoctor({ role: "agent", clientId: "c" } as any)).toBe(false);
-    expect(canReadDoctor({ role: "readonly", clientId: "d" } as any)).toBe(false);
+    expect(canReadDoctor({ role: "readonly", clientId: "d" } as any)).toBe(
+      false,
+    );
     expect(canReadDoctor(undefined)).toBe(false);
   });
 });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -325,15 +325,17 @@ describe("GET /api/v1/operator/doctor", () => {
       const serialized = JSON.stringify(body);
       expect(body.status).toBe("healthy");
       expect(body.contract_version).toBe("2026-07-08.operator-doctor.v2");
-      expect(body.runtime.contract_version).toBe("2026-07-08.memory-tools.v20");
+      expect(body.runtime.contract_version).toBe("2026-07-13.memory-tools.v21");
       expect(body.embedding_provider.available).toBe(true);
       expect(serialized).not.toContain(secret);
       expect(serialized).not.toContain(embeddingHost);
       expect(serialized).not.toContain(logPath);
     } finally {
-      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      if (originalEmbeddingBaseUrl === undefined)
+        delete process.env.EMBEDDING_BASE_URL;
       else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
-      if (originalEmbeddingApiKey === undefined) delete process.env.EMBEDDING_API_KEY;
+      if (originalEmbeddingApiKey === undefined)
+        delete process.env.EMBEDDING_API_KEY;
       else process.env.EMBEDDING_API_KEY = originalEmbeddingApiKey;
       if (originalLogFile === undefined) delete process.env.LOG_FILE;
       else process.env.LOG_FILE = originalLogFile;
@@ -358,7 +360,8 @@ describe("GET /api/v1/operator/doctor", () => {
       const body = (await res.json()) as { status: string };
       expect(body.status).toBe("degraded");
     } finally {
-      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      if (originalEmbeddingBaseUrl === undefined)
+        delete process.env.EMBEDDING_BASE_URL;
       else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
     }
   });
@@ -387,7 +390,8 @@ describe("GET /api/v1/operator/doctor", () => {
       expect(body.database.connected).toBe(true);
       expect(body.migrations.status).toBe("unknown");
     } finally {
-      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      if (originalEmbeddingBaseUrl === undefined)
+        delete process.env.EMBEDDING_BASE_URL;
       else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
     }
   });
@@ -411,7 +415,8 @@ describe("GET /api/v1/operator/doctor", () => {
       expect(body.status).toBe("unhealthy");
       expect(body.database.connected).toBe(false);
     } finally {
-      if (originalEmbeddingBaseUrl === undefined) delete process.env.EMBEDDING_BASE_URL;
+      if (originalEmbeddingBaseUrl === undefined)
+        delete process.env.EMBEDDING_BASE_URL;
       else process.env.EMBEDDING_BASE_URL = originalEmbeddingBaseUrl;
     }
   });
@@ -469,7 +474,8 @@ describe("POST /mcp", () => {
 
   it("returns retryable session-cap diagnostics when initialize is over cap", async () => {
     const originalMax = process.env.OPEN_BRAIN_MAX_SESSIONS;
-    const originalRetryAfter = process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS;
+    const originalRetryAfter =
+      process.env.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS;
     const seed = await fetch(`${baseUrl}/mcp`, {
       method: "POST",
       headers: {

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -299,10 +299,14 @@ describe("append_session_event", () => {
       },
     };
     const auth: AuthInfo = { role: "agent", clientId: "nagatha" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth, async (text) => {
-      captured.embedInputs.push(text);
-      return Array(768).fill(0.1);
-    });
+    const { client, cleanup } = await setupToolClient(
+      mockPool,
+      auth,
+      async (text) => {
+        captured.embedInputs.push(text);
+        return Array(768).fill(0.1);
+      },
+    );
 
     try {
       const result = await client.callTool({
@@ -1203,12 +1207,14 @@ describe("append_session_event", () => {
             ],
           };
         }
-        // INSERT INTO ob_session_events — $7 (index 6) is the metadata JSON.
-        if (params && typeof params[6] === "string") {
-          captured.metadata = JSON.parse(params[6]);
-          captured.createdBy = params[11] ?? null;
+        // INSERT INTO ob_session_events — $10 (index 9) is the metadata JSON.
+        if (params && typeof params[9] === "string") {
+          captured.metadata = JSON.parse(params[9]);
+          captured.createdBy = params[14] ?? null;
         }
-        return { rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }] };
+        return {
+          rows: [{ id: "event-uuid-1", created_at: "2026-06-08T10:00:00Z" }],
+        };
       },
     };
     return pool;
@@ -1424,7 +1430,9 @@ describe("append_session_event", () => {
       // Persisted metadata: nomination stripped, audit marker stamped.
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
-      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
+      expect(
+        mockPool.captured.metadata!.memory_lifecycle_action,
+      ).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
         "reject-secret",
       );
@@ -1433,7 +1441,7 @@ describe("append_session_event", () => {
     }
   });
 
-  it("treats string \"true\" nomination like boolean true (matches async SQL truthiness)", async () => {
+  it('treats string "true" nomination like boolean true (matches async SQL truthiness)', async () => {
     // The async promoter nominates on `metadata->>'share_candidate' = 'true'`,
     // which matches a JSON string "true". If the sync gate only accepted boolean
     // true, a mistyped nomination would skip the inline secret check yet still
@@ -1467,7 +1475,9 @@ describe("append_session_event", () => {
         },
       });
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
-      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
+      expect(
+        mockPool.captured.metadata!.memory_lifecycle_action,
+      ).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
         "reject-secret",
       );
@@ -1509,7 +1519,9 @@ describe("append_session_event", () => {
 
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
-      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
+      expect(
+        mockPool.captured.metadata!.memory_lifecycle_action,
+      ).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBe(
         "reject-private",
       );
@@ -1743,7 +1755,9 @@ describe("append_session_event", () => {
       // must treat this as inert candidate state.
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBe(true);
-      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
+      expect(
+        mockPool.captured.metadata!.memory_lifecycle_action,
+      ).toBeUndefined();
       expect(mockPool.captured.metadata!.share_rejected_sync).toBeUndefined();
     } finally {
       await cleanup();
@@ -1767,7 +1781,8 @@ describe("append_session_event", () => {
             share_candidate: true,
             memory_lifecycle_action: "nominate_shared",
             candidate_type: "shared_kb_nomination",
-            candidate_reason: "Reviewed fact is safe to nominate for shared-kb.",
+            candidate_reason:
+              "Reviewed fact is safe to nominate for shared-kb.",
           },
         },
       });
@@ -1802,8 +1817,7 @@ describe("append_session_event", () => {
         arguments: {
           session_key: "test",
           event_type: "fact",
-          content:
-            "Secret nomination contains key " + "sk-" + "b".repeat(20),
+          content: "Secret nomination contains key " + "sk-" + "b".repeat(20),
           metadata: {
             share_candidate: true,
             memory_lifecycle_action: "nominate_shared",
@@ -1822,7 +1836,9 @@ describe("append_session_event", () => {
       expect(parsed.share_candidate_rejected).toBe("reject-secret");
       expect(mockPool.captured.metadata).not.toBeNull();
       expect(mockPool.captured.metadata!.share_candidate).toBeUndefined();
-      expect(mockPool.captured.metadata!.memory_lifecycle_action).toBeUndefined();
+      expect(
+        mockPool.captured.metadata!.memory_lifecycle_action,
+      ).toBeUndefined();
       expect(mockPool.captured.metadata!.candidate_type).toBeUndefined();
       expect(mockPool.captured.metadata!.candidate_reason).toBeUndefined();
       expect(mockPool.captured.metadata!.candidate_confidence).toBeUndefined();
@@ -1884,9 +1900,7 @@ describe("append_session_event", () => {
             memory_lifecycle_action: "candidate",
             candidate_type: "negative_example",
             candidate_reason: "Evidence refs should not persist secrets.",
-            evidence_refs: [
-              { note: "token=" + "sk-" + "c".repeat(20) },
-            ],
+            evidence_refs: [{ note: "token=" + "sk-" + "c".repeat(20) }],
           },
         },
       });
@@ -2026,6 +2040,202 @@ describe("append_session_event", () => {
       expect(result.isError).toBe(true);
       expect((result.content as any)[0].text).toContain("connection refused");
       expect((result.content as any)[0].text).toContain("Database error");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("persists a host-neutral transcript citation with the event", async () => {
+    let insertParams: unknown[] | undefined;
+    const mockPool = {
+      query: async (sql: string, params?: unknown[]) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
+        }
+        insertParams = params;
+        return {
+          rows: [{ id: "event-uuid-1", created_at: "2026-07-13T12:00:00Z" }],
+        };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "capture:288",
+          event_type: "decision",
+          content: "Use durable transcript citations.",
+          source: "rico",
+          transcript_ref: "collab/open-brain/conversations/288",
+          transcript:
+            "Rico: preserve the source conversation with the decision.",
+          occurred_at: "2026-07-13T11:59:00Z",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(JSON.parse((result.content as any)[0].text).transcript_ref).toBe(
+        "collab/open-brain/conversations/288",
+      );
+      expect(insertParams?.slice(5, 8)).toEqual([
+        "collab/open-brain/conversations/288",
+        "Rico: preserve the source conversation with the decision.",
+        "2026-07-13T11:59:00Z",
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects host-specific transcript references before any database write", async () => {
+    let queryCount = 0;
+    const mockPool = {
+      query: async () => {
+        queryCount += 1;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "capture:288",
+          event_type: "decision",
+          content: "This must not write.",
+          transcript_ref: "/Volumes/ThunderBolt/transcripts/288.jsonl",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse((result.content as any)[0].text);
+      expect(parsed.error).toBe("scope_validation");
+      expect(parsed.message).toContain("canonical host-neutral collab");
+      expect(queryCount).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("requires transcript_ref for an empty transcript and rejects noncanonical segments", async () => {
+    let queryCount = 0;
+    const mockPool = {
+      query: async () => {
+        queryCount += 1;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const emptyTranscript = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "capture:288",
+          event_type: "decision",
+          content: "This must not write.",
+          transcript: "",
+        },
+      });
+      const noncanonicalRef = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "capture:288",
+          event_type: "decision",
+          content: "This also must not write.",
+          transcript_ref: "collab/open-brain/../conversations",
+        },
+      });
+
+      expect(
+        JSON.parse((emptyTranscript.content as any)[0].text).message,
+      ).toContain("transcript_ref is required");
+      expect(
+        JSON.parse((noncanonicalRef.content as any)[0].text).message,
+      ).toContain("canonical host-neutral");
+      expect(emptyTranscript.isError).toBe(true);
+      expect(noncanonicalRef.isError).toBe(true);
+      expect(queryCount).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects credential-like transcript material before any database write", async () => {
+    let queryCount = 0;
+    const mockPool = {
+      query: async () => {
+        queryCount += 1;
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+    const syntheticCredential = ["api", "key"].join("_") + ": synthetic-value";
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "capture:288",
+          event_type: "decision",
+          content: "This fact is safe, but its source exchange is not.",
+          transcript_ref: "collab/open-brain/conversations/288",
+          transcript: `Rico: ${syntheticCredential}`,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse((result.content as any)[0].text).message).toContain(
+        "credential-like material",
+      );
+      expect(queryCount).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reports when a duplicate cannot retain newly supplied citation fields", async () => {
+    const mockPool = {
+      query: async (sql: string) => {
+        if (sql.includes("ob_session_lanes")) {
+          return { rows: [{ id: "lane-uuid-1", status: "active" }] };
+        }
+        if (sql.includes("citation_matches")) {
+          return {
+            rows: [{ id: "existing-event-uuid", citation_matches: false }],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
+    const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+    try {
+      const result = await client.callTool({
+        name: "append_session_event",
+        arguments: {
+          session_key: "capture:288",
+          event_type: "decision",
+          content: "A deduplicated fact.",
+          transcript_ref: "collab/open-brain/conversations/288",
+          transcript: "Rico: cite this exchange.",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.parse((result.content as any)[0].text)).toMatchObject({
+        error: "citation_not_stored",
+        duplicate: true,
+        existing_event_id: "existing-event-uuid",
+      });
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/citation-recall.test.ts
+++ b/src/tools/__tests__/citation-recall.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "bun:test";
+import { registerCitationRecall } from "../citation-recall.ts";
+import {
+  createMockEmbed,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const EVENT_ID = "2f9a936b-1dc5-4fd0-8efb-d9778a68fc4d";
+const BEFORE_ID = "16e2dfdf-e343-4e03-88c2-93b43a12f9ec";
+const AFTER_ID = "c8f64cd3-13c8-43f5-a228-4ba1dc5ae06e";
+
+type MockCitationEvent = {
+  id: string;
+  lane_id: string;
+  session_key: string;
+  event_type: string;
+  content: string;
+  source: string | null;
+  transcript_ref: string | null;
+  transcript: string | null;
+  occurred_at: string | null;
+  created_at: string;
+  created_by: string;
+};
+
+const TARGET: MockCitationEvent = {
+  id: EVENT_ID,
+  lane_id: "lane-288",
+  session_key: "capture:288",
+  event_type: "decision",
+  content: "Store a durable transcript citation with each memory.",
+  source: "rico",
+  transcript_ref: "collab/open-brain/conversations/288",
+  transcript: "Rico: the fact needs its original exchange.",
+  occurred_at: "2026-07-13T11:59:00Z",
+  created_at: "2026-07-13T12:00:00Z",
+  created_by: "skippy",
+};
+
+function citationPool(target = TARGET) {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params });
+      if (sql.includes("JOIN ob_session_lanes")) return { rows: [target] };
+      if (sql.includes("ORDER BY") && sql.includes("DESC")) {
+        return {
+          rows: [
+            {
+              ...TARGET,
+              id: BEFORE_ID,
+              transcript: "Skippy: cite the original discussion.",
+              created_at: "2026-07-13T11:58:00Z",
+            },
+          ],
+        };
+      }
+      return {
+        rows: [
+          {
+            ...TARGET,
+            id: AFTER_ID,
+            transcript: "Rico: include adjacent context too.",
+            created_at: "2026-07-13T12:01:00Z",
+          },
+        ],
+      };
+    },
+  };
+  return { pool, calls };
+}
+
+describe("citation_recall", () => {
+  it("returns a stored citation and bounded neighboring transcript exchanges", async () => {
+    const { pool, calls } = citationPool();
+    const auth: AuthInfo = { role: "readonly", clientId: "skippy" };
+    const { client, cleanup } = await setupMcpClient(
+      registerCitationRecall,
+      pool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "citation_recall",
+        arguments: { event_id: EVENT_ID, max_transcript_chars: 100 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result)).toEqual({
+        event_id: EVENT_ID,
+        fact: TARGET.content,
+        citation: {
+          status: "stored",
+          conversation_ref: TARGET.transcript_ref,
+          speaker: "rico",
+          date: "2026-07-13T11:59:00.000Z",
+          transcript: TARGET.transcript,
+          transcript_length: TARGET.transcript!.length,
+          transcript_truncated: false,
+        },
+        context: {
+          before: [
+            expect.objectContaining({ event_id: BEFORE_ID, speaker: "rico" }),
+          ],
+          after: [
+            expect.objectContaining({ event_id: AFTER_ID, speaker: "rico" }),
+          ],
+          expandable: false,
+        },
+      });
+      expect(calls[0]?.params).toEqual(["skippy", EVENT_ID]);
+      expect(calls[1]?.params).toEqual([
+        TARGET.lane_id,
+        TARGET.transcript_ref,
+        EVENT_ID,
+        3,
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("uses source occurrence order and database-owned microsecond target values", async () => {
+    const target = {
+      ...TARGET,
+      // The source event may arrive late; created_at must not decide its place.
+      occurred_at: "2026-07-13T11:59:00.123456Z",
+      created_at: "2026-07-13T12:10:00.000000Z",
+    };
+    const { pool, calls } = citationPool(target);
+    const auth: AuthInfo = { role: "readonly", clientId: "skippy" };
+    const { client, cleanup } = await setupMcpClient(
+      registerCitationRecall,
+      pool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "citation_recall",
+        arguments: { event_id: EVENT_ID },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const beforeSql = calls[1]?.sql ?? "";
+      expect(beforeSql).toContain(
+        "JOIN ob_session_events target ON target.id = $3::uuid",
+      );
+      expect(beforeSql).toContain(
+        "candidate.occurred_at, candidate.created_at",
+      );
+      expect(beforeSql).not.toContain("\n  occurred_at");
+      expect(beforeSql).toContain(
+        "candidate.occurred_at, candidate.created_at) DESC, candidate.created_at DESC, candidate.id DESC",
+      );
+      expect(beforeSql).toContain(
+        "COALESCE(candidate.occurred_at, candidate.created_at)",
+      );
+      expect(beforeSql).toContain("target.occurred_at, target.created_at");
+      expect(beforeSql).not.toContain("$3::timestamptz");
+      expect(calls[1]?.params).toEqual([
+        target.lane_id,
+        target.transcript_ref,
+        EVENT_ID,
+        3,
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("marks context expandable only when truncation or unseen neighbors exist", async () => {
+    const { pool } = citationPool();
+    const auth: AuthInfo = { role: "readonly", clientId: "skippy" };
+    const { client, cleanup } = await setupMcpClient(
+      registerCitationRecall,
+      pool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "citation_recall",
+        arguments: { event_id: EVENT_ID, context_limit: 0 },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result)).toMatchObject({
+        context: { before: [], after: [], expandable: true },
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reports source_not_stored for a readable legacy memory", async () => {
+    const { pool } = citationPool({
+      ...TARGET,
+      transcript_ref: null,
+      transcript: null,
+      occurred_at: null,
+    });
+    const auth: AuthInfo = { role: "readonly", clientId: "skippy" };
+    const { client, cleanup } = await setupMcpClient(
+      registerCitationRecall,
+      pool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "citation_recall",
+        arguments: { event_id: EVENT_ID },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(parseToolResult(result)).toMatchObject({
+        fact: TARGET.content,
+        citation: { status: "source_not_stored", conversation_ref: null },
+        context: { before: [], after: [], expandable: false },
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("enforces the requested namespace before querying citation evidence", async () => {
+    const { pool, calls } = citationPool();
+    const auth: AuthInfo = { role: "agent", clientId: "skippy" };
+    const { client, cleanup } = await setupMcpClient(
+      registerCitationRecall,
+      pool,
+      createMockEmbed(),
+      auth,
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "citation_recall",
+        arguments: { event_id: EVENT_ID, namespace: "other-agent" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Permission denied");
+      expect(calls).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/append-session-event.ts
+++ b/src/tools/append-session-event.ts
@@ -22,7 +22,8 @@ type AppendErrorClass =
   | "auth_denied"
   | "scope_validation"
   | "unsupported_operation"
-  | "conflict_retry";
+  | "conflict_retry"
+  | "citation_not_stored";
 
 function appendSessionEventError(
   errorClass: AppendErrorClass,
@@ -411,7 +412,8 @@ WHERE namespace = $1 AND session_key = $2`,
         {
           session_key: args.session_key,
           namespace: args.namespace,
-          remedy: "Call session_start first or retry append_session_event with create_if_missing=true.",
+          remedy:
+            "Call session_start first or retry append_session_event with create_if_missing=true.",
         },
       ),
     };
@@ -525,7 +527,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function hasShareCandidate(metadata: Record<string, unknown>): boolean {
-  return metadata.share_candidate === true || metadata.share_candidate === "true";
+  return (
+    metadata.share_candidate === true || metadata.share_candidate === "true"
+  );
 }
 
 function validateMemoryLifecycleMetadata(
@@ -721,7 +725,8 @@ function writerProvenance(auth: AuthInfo): {
   return {
     writer_identity: auth.clientId,
     token_identity: auth.tokenClientId ?? auth.clientId,
-    delegated_agent_id: namespaceSource === "header" ? (auth.agentId ?? null) : null,
+    delegated_agent_id:
+      namespaceSource === "header" ? (auth.agentId ?? null) : null,
     namespace_source: namespaceSource,
   };
 }
@@ -749,6 +754,27 @@ function appendWriterProvenance(
       },
     },
   };
+}
+
+function transcriptCitationValidationError(args: {
+  transcript_ref?: string;
+  transcript?: string;
+  occurred_at?: string;
+}): string | undefined {
+  const citationPayloadSupplied =
+    args.transcript !== undefined || args.occurred_at !== undefined;
+  if (!args.transcript_ref && citationPayloadSupplied) {
+    return "transcript_ref is required when transcript or occurred_at is supplied";
+  }
+  if (!args.transcript_ref) return undefined;
+  if (
+    !/^collab\/[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/.test(
+      args.transcript_ref,
+    )
+  ) {
+    return "transcript_ref must use canonical host-neutral collab/... path segments";
+  }
+  return undefined;
 }
 
 export function registerAppendSessionEvent(
@@ -787,7 +813,9 @@ export function registerAppendSessionEvent(
           .string()
           .max(500)
           .optional()
-          .describe("Agent identity for first-write lane creation and scope checks"),
+          .describe(
+            "Agent identity for first-write lane creation and scope checks",
+          ),
         platform: z
           .string()
           .max(500)
@@ -819,7 +847,9 @@ export function registerAppendSessionEvent(
           .string()
           .max(500)
           .optional()
-          .describe("Human-readable lane topic to set when first-write creates the lane"),
+          .describe(
+            "Human-readable lane topic to set when first-write creates the lane",
+          ),
         event_type: z
           .enum(EVENT_TYPES)
           .describe(
@@ -840,6 +870,27 @@ export function registerAppendSessionEvent(
           .max(2000)
           .optional()
           .describe("Path to related artifact (file, URL, etc.)"),
+        transcript_ref: z
+          .string()
+          .trim()
+          .min(1)
+          .max(2000)
+          .optional()
+          .describe(
+            "Host-neutral source conversation reference (collab/...); never use /Volumes or /mnt paths",
+          ),
+        transcript: z
+          .string()
+          .max(50_000)
+          .optional()
+          .describe("Optional inline source exchange captured with the event"),
+        occurred_at: z
+          .string()
+          .datetime({ offset: true })
+          .optional()
+          .describe(
+            "When the cited exchange occurred (ISO 8601 with timezone)",
+          ),
         importance: z
           .enum(IMPORTANCE_LEVELS)
           .optional()
@@ -892,11 +943,33 @@ export function registerAppendSessionEvent(
       }
       const importance = args.importance ?? "warm";
       const provenance = writerProvenance(auth);
-      const lifecycleError = validateMemoryLifecycleMetadata(args.metadata ?? {});
+      const lifecycleError = validateMemoryLifecycleMetadata(
+        args.metadata ?? {},
+      );
       if (lifecycleError) {
         return appendSessionEventError(
           "scope_validation",
           lifecycleError,
+          false,
+          { session_key: args.session_key, namespace: ns },
+        );
+      }
+      const citationError = transcriptCitationValidationError(args);
+      if (citationError) {
+        return appendSessionEventError(
+          "scope_validation",
+          citationError,
+          false,
+          {
+            session_key: args.session_key,
+            namespace: ns,
+          },
+        );
+      }
+      if (args.transcript !== undefined && containsSecret(args.transcript)) {
+        return appendSessionEventError(
+          "scope_validation",
+          "transcript must not contain credential-like material",
           false,
           { session_key: args.session_key, namespace: ns },
         );
@@ -1011,9 +1084,10 @@ export function registerAppendSessionEvent(
 
             const { rows } = await db.query(
               `INSERT INTO ob_session_events
-             (lane_id, event_type, content, source, artifact_path, importance,
-              metadata, embedding, content_hash, embedded_at, embedding_model, created_by)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+             (lane_id, event_type, content, source, artifact_path, transcript_ref,
+              transcript, occurred_at, importance, metadata, embedding, content_hash,
+              embedded_at, embedding_model, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
            ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL DO NOTHING
            RETURNING id, created_at`,
               [
@@ -1022,6 +1096,9 @@ export function registerAppendSessionEvent(
                 args.content,
                 args.source ?? null,
                 args.artifact_path ?? null,
+                args.transcript_ref ?? null,
+                args.transcript ?? null,
+                args.occurred_at ?? null,
                 importance,
                 JSON.stringify(metadata),
                 eventEmbedding.embeddingVal,
@@ -1033,6 +1110,44 @@ export function registerAppendSessionEvent(
             );
 
             if (rows.length === 0) {
+              const citationSupplied =
+                args.transcript_ref !== undefined ||
+                args.transcript !== undefined ||
+                args.occurred_at !== undefined;
+              if (citationSupplied) {
+                const { rows: existingRows } = await db.query<{
+                  id: string;
+                  citation_matches: boolean;
+                }>(
+                  `SELECT id,
+                    transcript_ref IS NOT DISTINCT FROM $3::text
+                    AND transcript IS NOT DISTINCT FROM $4::text
+                    AND occurred_at IS NOT DISTINCT FROM $5::timestamptz
+                      AS citation_matches
+FROM ob_session_events
+WHERE lane_id = $1 AND content_hash = $2`,
+                  [
+                    laneId,
+                    eventEmbedding.contentHashValue,
+                    args.transcript_ref ?? null,
+                    args.transcript ?? null,
+                    args.occurred_at ?? null,
+                  ],
+                );
+                const existing = existingRows[0];
+                if (!existing || !existing.citation_matches) {
+                  return appendSessionEventError(
+                    "citation_not_stored",
+                    "Duplicate content exists but the supplied citation was not stored",
+                    false,
+                    {
+                      duplicate: true,
+                      existing_event_id: existing?.id ?? null,
+                      ...provenance,
+                    },
+                  );
+                }
+              }
               return {
                 content: [
                   {
@@ -1055,6 +1170,7 @@ export function registerAppendSessionEvent(
               event_type: args.event_type,
               importance,
               created_at: rows[0].created_at,
+              transcript_ref: args.transcript_ref ?? null,
               ...provenance,
               // Surface the sync nomination outcome so a contract-driven agent
               // learns its share_candidate was refused (and why) without polling.
@@ -1099,7 +1215,11 @@ export function registerAppendSessionEvent(
           await fillAcceptedLaneEmbedding(deps, acceptedLaneForEmbedding, args);
         }
         if (acceptedEventForEmbedding) {
-          await fillAcceptedEventEmbedding(deps, acceptedEventForEmbedding, args);
+          await fillAcceptedEventEmbedding(
+            deps,
+            acceptedEventForEmbedding,
+            args,
+          );
         }
 
         return response;

--- a/src/tools/citation-recall.ts
+++ b/src/tools/citation-recall.ts
@@ -1,0 +1,296 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canRead } from "../permissions.ts";
+import { canReadNamespace } from "../read-policy.ts";
+import type { AuthInfo } from "../types.ts";
+import type { ToolDeps } from "./index.ts";
+import { logger } from "../logger.ts";
+
+type CitationEventRow = {
+  id: string;
+  event_type: string;
+  content: string;
+  source: string | null;
+  transcript_ref: string | null;
+  transcript: string | null;
+  occurred_at: string | Date | null;
+  created_at: string | Date;
+  created_by: string;
+  lane_id: string;
+  session_key: string;
+};
+
+function iso(value: string | Date | null): string | null {
+  if (value === null) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function transcriptProjection(row: CitationEventRow, maxChars: number) {
+  const transcript = row.transcript;
+  const transcriptLength = transcript?.length ?? 0;
+  return {
+    event_id: row.id,
+    event_type: row.event_type,
+    speaker: row.source ?? row.created_by,
+    date: iso(row.occurred_at) ?? iso(row.created_at),
+    transcript: transcript?.slice(0, maxChars) ?? null,
+    transcript_length: transcriptLength,
+    transcript_truncated: transcriptLength > maxChars,
+  };
+}
+
+const EVENT_COLUMNS = `id, event_type, content, source, transcript_ref, transcript,
+  occurred_at, created_at, created_by`;
+const TARGET_EVENT_COLUMNS = `e.id, e.event_type, e.content, e.source, e.transcript_ref,
+  e.transcript, e.occurred_at, e.created_at, e.created_by`;
+const CANDIDATE_EVENT_COLUMNS =
+  `candidate.id, candidate.event_type, candidate.content, candidate.source, ` +
+  `candidate.transcript_ref, candidate.transcript, candidate.occurred_at, ` +
+  `candidate.created_at, candidate.created_by`;
+const SAFE_DB_ERROR_CODES = new Set([
+  "22001",
+  "22P02",
+  "23503",
+  "23505",
+  "42P01",
+  "57014",
+]);
+const SAFE_DB_ERROR_NAMES = new Set(["Error", "PostgresError"]);
+
+function citationRecallDbErrorLabel(err: unknown): string {
+  if (!err || typeof err !== "object") return "unknown";
+  const candidate = err as { code?: unknown; name?: unknown };
+  if (
+    typeof candidate.code === "string" &&
+    SAFE_DB_ERROR_CODES.has(candidate.code)
+  ) {
+    return candidate.code;
+  }
+  if (
+    typeof candidate.name === "string" &&
+    SAFE_DB_ERROR_NAMES.has(candidate.name)
+  ) {
+    return candidate.name;
+  }
+  return "unknown";
+}
+
+export function registerCitationRecall(
+  server: McpServer,
+  deps: ToolDeps,
+): void {
+  server.registerTool(
+    "citation_recall",
+    {
+      description:
+        "Return citation evidence for one readable session event. Stored citations include a host-neutral conversation ref, speaker, date, optional transcript, and bounded neighboring exchanges; legacy events explicitly report source_not_stored.",
+      inputSchema: {
+        event_id: z.string().uuid().describe("Session event UUID to cite"),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        context_limit: z
+          .number()
+          .int()
+          .min(0)
+          .max(10)
+          .optional()
+          .describe(
+            "Neighboring transcript exchanges to return on each side (default 2)",
+          ),
+        max_transcript_chars: z
+          .number()
+          .int()
+          .min(100)
+          .max(50_000)
+          .optional()
+          .describe(
+            "Maximum characters for each returned transcript exchange (default 2000)",
+          ),
+      },
+      annotations: {
+        title: "Citation Recall",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+      if (!auth || !canRead(auth.role, "sessions")) {
+        logger.warn("citation_recall_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Permission denied: cannot recall citations",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const namespace = args.namespace ?? auth.clientId;
+      if (!canReadNamespace(auth, namespace)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: cannot read namespace '${namespace}'`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const contextLimit = args.context_limit ?? 2;
+      const maxTranscriptChars = args.max_transcript_chars ?? 2_000;
+      try {
+        const { rows } = await deps.pool.query<CitationEventRow>(
+          `SELECT ${TARGET_EVENT_COLUMNS}, e.lane_id, l.session_key
+FROM ob_session_events e
+JOIN ob_session_lanes l ON l.id = e.lane_id
+WHERE l.namespace = $1 AND e.id = $2`,
+          [namespace, args.event_id],
+        );
+        const event = rows[0];
+        if (!event) {
+          return {
+            content: [
+              { type: "text" as const, text: "Citation event not found" },
+            ],
+            isError: true,
+          };
+        }
+
+        if (!event.transcript_ref) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  event_id: event.id,
+                  fact: event.content,
+                  citation: {
+                    status: "source_not_stored",
+                    conversation_ref: null,
+                    date: null,
+                    speaker: null,
+                    transcript: null,
+                  },
+                  context: { before: [], after: [], expandable: false },
+                }),
+              },
+            ],
+          };
+        }
+
+        const contextParams = [
+          event.lane_id,
+          event.transcript_ref,
+          event.id,
+          contextLimit + 1,
+        ];
+        const sourceOrder =
+          "COALESCE(candidate.occurred_at, candidate.created_at), candidate.created_at, candidate.id";
+        const sourceOrderDescending =
+          "COALESCE(candidate.occurred_at, candidate.created_at) DESC, " +
+          "candidate.created_at DESC, candidate.id DESC";
+        const contextTarget = `FROM ob_session_events candidate
+JOIN ob_session_events target ON target.id = $3::uuid
+WHERE candidate.lane_id = $1
+  AND candidate.transcript_ref = $2
+  AND candidate.transcript IS NOT NULL`;
+        const beforePromise = deps.pool.query<CitationEventRow>(
+          `SELECT ${CANDIDATE_EVENT_COLUMNS}
+${contextTarget}
+  AND (${sourceOrder}) < (
+    COALESCE(target.occurred_at, target.created_at), target.created_at, target.id
+  )
+ORDER BY ${sourceOrderDescending}
+LIMIT $4`,
+          contextParams,
+        );
+        const afterPromise = deps.pool.query<CitationEventRow>(
+          `SELECT ${CANDIDATE_EVENT_COLUMNS}
+${contextTarget}
+  AND (${sourceOrder}) > (
+    COALESCE(target.occurred_at, target.created_at), target.created_at, target.id
+  )
+ORDER BY ${sourceOrder} ASC
+LIMIT $4`,
+          contextParams,
+        );
+        const [beforeResult, afterResult] = await Promise.all([
+          beforePromise,
+          afterPromise,
+        ]);
+        const before = beforeResult.rows
+          .slice(0, contextLimit)
+          .reverse()
+          .map((row) => transcriptProjection(row, maxTranscriptChars));
+        const after = afterResult.rows
+          .slice(0, contextLimit)
+          .map((row) => transcriptProjection(row, maxTranscriptChars));
+        const transcriptTruncated =
+          (event.transcript?.length ?? 0) > maxTranscriptChars;
+        const contextTruncated =
+          before.some((row) => row.transcript_truncated) ||
+          after.some((row) => row.transcript_truncated);
+
+        const result = {
+          event_id: event.id,
+          fact: event.content,
+          citation: {
+            status: "stored",
+            conversation_ref: event.transcript_ref,
+            speaker: event.source ?? event.created_by,
+            date: iso(event.occurred_at) ?? iso(event.created_at),
+            transcript: event.transcript?.slice(0, maxTranscriptChars) ?? null,
+            transcript_length: event.transcript?.length ?? 0,
+            transcript_truncated: transcriptTruncated,
+          },
+          context: {
+            before,
+            after,
+            expandable:
+              transcriptTruncated ||
+              contextTruncated ||
+              beforeResult.rows.length > contextLimit ||
+              afterResult.rows.length > contextLimit,
+          },
+        };
+        logger.info("citation_recall_ok", {
+          event_id: event.id,
+          namespace,
+          context_before: result.context.before.length,
+          context_after: result.context.after.length,
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result) }],
+        };
+      } catch (err) {
+        logger.error("citation_recall_db_error", {
+          event_id: args.event_id,
+          namespace,
+          error_label: citationRecallDbErrorLabel(err),
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Database error during citation recall",
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -32,6 +32,7 @@ import { registerTierRecommendations } from "./tier-recommendations.ts";
 import { registerLaneUpsert } from "./lane-upsert.ts";
 import { registerLaneLoad } from "./lane-load.ts";
 import { registerAppendSessionEvent } from "./append-session-event.ts";
+import { registerCitationRecall } from "./citation-recall.ts";
 import { registerSessionContext } from "./session-context.ts";
 import { registerSessionStart } from "./session-start.ts";
 import { registerSessionWrap } from "./session-wrap.ts";
@@ -117,6 +118,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerLaneUpsert(server, toolDeps);
   registerLaneLoad(server, toolDeps);
   registerAppendSessionEvent(server, toolDeps);
+  registerCitationRecall(server, toolDeps);
   registerSessionContext(server, toolDeps);
   registerSessionStart(server, toolDeps);
   registerSessionWrap(server, toolDeps);

--- a/src/tools/session-context.ts
+++ b/src/tools/session-context.ts
@@ -193,7 +193,7 @@ LIMIT 1`;
           eventParams.push(eventLimit);
 
           const eventSql = `SELECT id, event_type, content, source, artifact_path,
-  importance, metadata, created_at, created_by
+  transcript_ref, transcript, occurred_at, importance, metadata, created_at, created_by
 FROM ob_session_events
 WHERE ${eventConditions.join(" AND ")}
 ORDER BY created_at DESC

--- a/src/tools/session-start.ts
+++ b/src/tools/session-start.ts
@@ -10,7 +10,7 @@ const LANE_COLUMNS = `id, session_key, namespace, status, agent, project, topic,
   current_context_md, metadata, created_at, updated_at, ended_at`;
 
 const EVENT_COLUMNS = `id, event_type, content, source, artifact_path,
-  importance, metadata, created_at, created_by`;
+  transcript_ref, transcript, occurred_at, importance, metadata, created_at, created_by`;
 
 export function registerSessionStart(server: McpServer, deps: ToolDeps): void {
   server.registerTool(


### PR DESCRIPTION
Closes #288.

## Summary

- extends `append_session_event` with host-neutral transcript citations
- adds migration 023 and namespace-scoped `citation_recall`
- returns explicit `source_not_stored` for legacy events
- adds bounded source-ordered neighboring context
- bumps contract to v21 and `openbrain-memory` to 0.1.7
- updates Python wrapper, contract docs, and review SME knowledge

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence: `bunx tsc --noEmit`; `bun test` (1327 pass, 54 skip, 0 fail); `uv run pytest -q tests/test_contract.py tests/test_client.py` (108 pass); `uv run mypy src/openbrain_memory`; `uv run ruff check src tests`; `git diff --check`.

## Critical Self-Review

- Highest-risk behavior: namespace-scoped citation reads and migration correctness
- Assumptions that could be wrong: PostgreSQL timestamp/order semantics and duplicate-content behavior
- Missing/weak tests: live PostgreSQL migration tests remain env-gated; focused SQL-shape and MCP-dispatch regressions cover the new paths
- Security/permission risk: transcript storage can leak credentials; synchronous secret rejection and auth-derived namespace predicates are enforced
- Migration/deploy risk: migration 023 changes a live table; constraint creation is retry-idempotent
- Downstream client/runtime risk: public contract changes to v21; Python minimum is 0.1.7
- Rollback/cleanup concern: deploy must take normal DB/runtime backups before migration
- Fixes made before PR: all five-lane findings plus focused fix-verifier findings were fixed
- Known residual risk: hosted deploy and downstream cache/client refresh are required after merge
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: PR validation does not deploy; hosted proof is a post-merge rollout gate.

Full tier receipt: one five-lane initial swarm, one coupled fixer, two focused fix-verification lanes, one final targeted verifier, and a CLEAN Claude Opus-high whole-PR audit on exact head `309ef69`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- After merge: deploy Open Brain, prove contract v21 and citation calls live, refresh mcp2cli schema caches/generated skill, and complete applicable Hermes/client canaries.
