### PR TITLE
fix(memory): allow case-distinct session lane hashes

### DIFF
--- a/src/db/migrations/024_session_lane_content_hash_nonunique.sql
+++ b/src/db/migrations/024_session_lane_content_hash_nonunique.sql
@@ -1,0 +1,10 @@
+-- Migration 024: session lane hashes are search metadata, not identity
+-- Lane identity is the case-sensitive (namespace, session_key) constraint.
+-- contentHash normalizes case, so a unique hash index rejects valid lanes such
+-- as dev:rTech-audit and dev:rtech-audit when they share a topic.
+
+DROP INDEX IF EXISTS idx_session_lanes_content_hash;
+
+CREATE INDEX IF NOT EXISTS idx_session_lanes_content_hash
+  ON ob_session_lanes (content_hash, namespace)
+  WHERE content_hash IS NOT NULL;

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -2502,7 +2502,19 @@ dbDescribe("append_session_event create_if_missing (live Postgres)", () => {
         [ns, ["dev:rTech-audit", "dev:rtech-audit"]],
       );
       expect(rows).toHaveLength(2);
-      expect(rows[0].content_hash).toBe(rows[1].content_hash);
+      const expectedHash = contentHash(
+        "dev:rTech-audit|Shared development session memory",
+      );
+      expect(expectedHash).toBe(
+        contentHash("dev:rtech-audit|Shared development session memory"),
+      );
+      expect(rows.map((row) => row.session_key).sort()).toEqual(
+        ["dev:rTech-audit", "dev:rtech-audit"].sort(),
+      );
+      expect(rows.map((row) => row.content_hash)).toEqual([
+        expectedHash,
+        expectedHash,
+      ]);
     } finally {
       await cleanupNs();
     }

--- a/src/tools/__tests__/append-session-event.test.ts
+++ b/src/tools/__tests__/append-session-event.test.ts
@@ -2469,6 +2469,45 @@ dbDescribe("append_session_event create_if_missing (live Postgres)", () => {
     }
   });
 
+  it("allows case-distinct session keys with the same normalized lane hash", async () => {
+    await cleanupNs();
+    try {
+      const base = {
+        create_if_missing: true,
+        agent: "shared-session-finalizer",
+        platform: "local-runtime",
+        project: "rtech-audit",
+        topic: "Shared development session memory",
+        event_type: "handoff",
+      };
+      const first = await callAppend({
+        ...base,
+        session_key: "dev:rTech-audit",
+        content: "mixed-case project session",
+      });
+      expect(first.isError).toBeFalsy();
+
+      const second = await callAppend({
+        ...base,
+        session_key: "dev:rtech-audit",
+        content: "lower-case project session",
+      });
+      expect(second.isError).toBeFalsy();
+
+      const { rows } = await pool.query(
+        `SELECT session_key, content_hash
+           FROM ob_session_lanes
+          WHERE namespace=$1 AND session_key = ANY($2::text[])
+          ORDER BY session_key`,
+        [ns, ["dev:rTech-audit", "dev:rtech-audit"]],
+      );
+      expect(rows).toHaveLength(2);
+      expect(rows[0].content_hash).toBe(rows[1].content_hash);
+    } finally {
+      await cleanupNs();
+    }
+  });
+
   it("denies a scoped append that conflicts with the real stored lane scope", async () => {
     await cleanupNs();
     try {


### PR DESCRIPTION
## Summary

- convert the session-lane content-hash index from unique to non-unique
- preserve `(namespace, session_key)` as the canonical case-sensitive lane identity
- add a real-Postgres regression for the exact `dev:rTech-audit` / `dev:rtech-audit` collision

## Root cause

`contentHash()` lowercases text before hashing. Two valid case-distinct session keys with the same topic therefore receive the same lane hash, while the database treats their `(namespace, session_key)` identities as distinct. The redundant unique hash index rejected the second lane and blocked Development's session-history backfill.

## Validation

- `bunx tsc --noEmit` — passed
- focused live-Postgres regression is included and will run in CI where `OPENBRAIN_TEST_DATABASE_URL` is configured
- local focused invocation loaded successfully but skipped the Postgres-gated test because this workstation does not expose that test URL

## Downstream rollout

Applicable only to hosted Open Brain because this is a database migration affecting runtime behavior. No MCP tool name, input schema, output shape, auth rule, client contract, or generated skill changes. rtech-mcps, mcp2cli schema refresh, rtech-hermes code changes, and Hermes agent rollout are not applicable. Hosted migration plus an exact append/backfill canary are required before closure.

## Critical self-review

- Highest-risk behavior: changing a uniqueness constraint on session-lane search metadata
- Assumptions that could be wrong: another caller may rely on hash uniqueness; source search found no such caller, while `(namespace, session_key)` is the documented identity constraint
- Missing/weak tests: local Postgres integration is unavailable; CI owns the real database execution
- Security/permission risk: none; namespace and session-key identity constraints are unchanged
- Migration/deploy risk: index replacement briefly takes a table lock during migration; table is small and rollback can recreate the prior unique index only after resolving duplicates
- Downstream client/runtime risk: no public contract shape changes
- Rollback/cleanup concern: new legitimate duplicate hashes prevent blindly restoring the old unique index
- Fixes made before PR: regression uses the exact case-normalized collision shape found in production
- Known residual risk: hosted deploy and backfill canary remain required
- SME review-memory update: [x] not applicable because: the finding was specific to this new regression and does not add a reusable reviewer pattern

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: migration deployment and hosted proof run only after merge and remain required before issue closure

Supports rodaddy/development#4 and follows up rodaddy/open-brain#288.
