### PR TITLE
docs(glossary): add envelope vs contract; fix stray q# header

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,12 +1,16 @@
-q# Glossary
+# Glossary
 
 Project-specific terminology for Open Brain. All agents and contributors use these definitions.
+
+The cross-repo transport terms **envelope** and **contract** are canonical in `_DOCS/GLOSSARY.md`; the rows below are Open Brain's view of them.
 
 ## Domain Terms
 
 | Term | Definition | NOT This |
 |------|-----------|----------|
 | **Brain** | The collective knowledge store -- all five domain tables (thoughts, decisions, relationships, projects, sessions) accessed as a unified system. | A single table or the database host. |
+| **contract** | **What OB and its callers agree to exchange.** OB's message format -- the `agent_context_pack` request/response semantics (scope, `requested_sections`, the returned sections/pointers/warnings). It rides *inside* the fleet-bus envelope's `data` slot; OB owns and enforces it on both sides (in OB's own runtime), independent of how the bytes travel. | The fleet-bus envelope/transport (that's fleet-bus's job, not OB's); the NATS connection; the four-slot `Payload` shape (that carries the contract, it is not the contract). |
+| **envelope** | **fleet-bus transport.** The wire frame the bus uses to route/dedupe/auth/deliver a message; its body is four slots (`header · data · extras · footer`) and the bus treats that body as opaque. OB's **contract** rides in the `data` slot. Owned by fleet-bus, not OB. See `_DOCS/GLOSSARY.md` and `fleet-bus/docs/contracts/C6-envelope-vs-message-body.md`. | OB's message semantics; the memory payload itself; something OB defines. |
 | **Curation** | The automated process of detecting and handling duplicates, stale entries, and vague content via LLM-as-judge; runs via `scripts/curate.ts`. | Manual review or deletion of records. |
 | **Decision** | A recorded choice with a required `title` and `rationale`, plus optional `alternatives` and `context`; stored in the `decisions` table. | Any loosely noted choice; decisions must capture why and what alternatives were considered. |
 | **Entry** | Any single row in any of the five brain tables; the generic term used in tools like `archive_entry`, `update_entry`, and `rate_entry`. | A specific table record; use the table name when precision matters. |


### PR DESCRIPTION
## Summary

- Adds `envelope` and `contract` to OB's glossary and fixes the stray `q#` header typo. OB is a fleet-bus actor; the two message-layer terms were being conflated. Defines OB's view of the canonical pair (source of truth: `_DOCS/GLOSSARY.md`, rodaddy/development#12): **envelope** = fleet-bus transport frame (owned by fleet-bus, not OB); **contract** = OB's own `agent_context_pack` request/response format, riding *inside* the envelope's `data` slot, owned and enforced by OB. Docs-only.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — N/A, docs-only change to `GLOSSARY.md`; no code/schema touched.
- [x] Python package checks passed or are not applicable — not applicable (no Python touched).
- [x] Live Open Brain smoke passed or is not applicable — not applicable (no runtime behavior changed).

## Critical Self-Review

- Highest-risk behavior: None — a Markdown glossary edit; no code path, tool, or query is affected.
- Assumptions that could be wrong: That the canonical definitions land in rodaddy/development#12 as written; this PR references that as source of truth.
- Missing/weak tests: N/A — documentation has no test surface.
- Security/permission risk: None — no secrets, no auth, no permission logic; text only.
- Migration/deploy risk: None — no migration, no deploy artifact.
- Downstream client/runtime risk: None — no client or runtime consumes `GLOSSARY.md`.
- Rollback/cleanup concern: Trivial — revert the single-file commit.
- Fixes made before PR: Fixed the stray `q#` at the top of the file while editing.
- Known residual risk: The `docs/` reorg on an unrelated in-flight branch (`fix/openbrain-memory-redaction-superset`) moves `GLOSSARY.md` → `docs/GLOSSARY.md`; if that merges first, this edit may need a trivial path rebase. Flagged, not blocking.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no reviewable behavior/decision, pure terminology definition.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: docs-only, no runtime surface.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Pure glossary/terminology change; nothing downstream consumes this file.