### PR TITLE
fix(migration): normalize recognized legacy lanes

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -494,6 +494,15 @@ Every lifecycle writer must establish the complete exact-scope coordinate set be
 
 Required-tool presence is insufficient when the tool contract itself evolves. Compatibility must parse and compare each required tool's semantic version against the supported range, fail closed on malformed or incompatible versions, and test older, newer, malformed, and missing version declarations.
 
+## [2026-07-18] Exact-scope upgrades need real-Postgres conflict and history tests
+
+**Severity:** HIGH
+**Source:** Issues #295/#297, Claude first-class memory rollout
+**Scope:** `src/db/migrations/025_normalize_legacy_development_lanes.sql` and its live-Postgres test
+**Status:** active
+
+Legacy lane upgrades are data migrations, not ordinary tool behavior. Mock pools cannot prove PostgreSQL JSONB handling, case normalization, conflict predicates, idempotence, or preservation of existing lane IDs and events. Every changed upgrade predicate needs an env-gated real-pool test covering recognized and partially canonical shapes, repeated application, JSON null, unknown agent/source, server/channel/thread/project conflicts, multiple namespaces, and event-history continuity.
+
 ## [2026-07-17] First-class lifecycle runtimes must gate on the live manifest
 
 **Severity:** HIGH

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -425,3 +425,12 @@ Validation can reject content but must not normalize accepted caller payloads. U
 **Status:** fixed in PR #294; recurrence of #82 contract drift
 
 Checking only that a required tool name exists lets an incompatible schema pass. Parse the advertised tool version, enforce the supported semantic range, fail closed on malformed declarations, and cover missing, older, newer, and malformed versions in fixtures.
+
+## [2026-07-18] Legacy-lane repair can become a scope takeover
+
+**Severity:** HIGH
+**Source:** Issues #295/#297, Claude first-class memory rollout
+**Scope:** versioned exact-scope lane migrations
+**Status:** active
+
+Do not broaden a published lifecycle tool to rewrite non-null legacy coordinates without a contract/version rollout. A versioned migration must derive the canonical project/channel from the row's own stable key, require explicit legacy agent/source markers, keep threaded lanes out, accept only absent or already-canonical server/channel/project values, and leave unknown conflicts untouched. Require a real-Postgres migration test with JSON null, partial migration, idempotence, multiple namespaces, and preserved event history.

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -401,3 +401,12 @@ Transcript payloads require the same synchronous secret rejection as other durab
 **Status:** fixed in PR #294
 
 Validation may inspect a normalized copy for emptiness, bounds, or safety, but the accepted durable payload must remain byte-for-byte caller content. Trimming or rewriting during validation silently changes memory evidence and can make live and replayed writes disagree. Regression tests must use leading/trailing whitespace and sensitive-looking legitimate text and assert exact persisted and replayed content.
+
+## [2026-07-18] Legacy exact-scope migration must be an atomic allowlisted CAS
+
+**Severity:** HIGH
+**Source:** Issues #295/#297, Claude first-class memory rollout
+**Scope:** versioned lane migrations, replay, and restore paths
+**Status:** active
+
+A caller must not be able to relabel an arbitrary existing lane by presenting a new exact scope. Prefer a reviewed versioned database migration over silently broadening a published runtime tool contract. Automatic migration is permitted only for explicitly recognized legacy markers and canonical target coordinates derived from the same row's stable session key. The database predicate must constrain agent/source/server/channel/thread/project independently; unknown non-null conflicts remain untouched for operator review. Require live-Postgres tests for recognized and partial migration, idempotence, every coordinate conflict, namespace-independent row identity, and event-history preservation.

--- a/src/db/migrations/025_normalize_legacy_development_lanes.sql
+++ b/src/db/migrations/025_normalize_legacy_development_lanes.sql
@@ -1,0 +1,44 @@
+-- Normalize the allowlisted pre-v22 local Development lane shape without
+-- broadening session_start's public exact-scope contract. Unknown conflicts are
+-- intentionally left unchanged for explicit operator review.
+WITH candidates AS (
+  SELECT
+    id,
+    substring(session_key FROM 5) AS canonical_project
+  FROM ob_session_lanes
+  WHERE session_key ~ '^dev:.+$'
+    AND (
+      agent = 'shared-session-finalizer'
+      OR source = 'local-runtime'
+    )
+    AND agent IN ('shared-session-finalizer', 'shared')
+    AND (source IS NULL OR source IN ('local-runtime', 'development'))
+    AND thread_id IS NULL
+    AND (
+      metadata = 'null'::jsonb
+      OR (
+        jsonb_typeof(metadata) = 'object'
+        AND (metadata->>'server_id' IS NULL OR metadata->>'server_id' = 'local')
+      )
+    )
+    AND (
+      channel_id IS NULL
+      OR channel_id = substring(session_key FROM 5)
+    )
+    AND (
+      project IS NULL
+      OR lower(project) = lower(substring(session_key FROM 5))
+    )
+)
+UPDATE ob_session_lanes AS lane
+SET agent = 'shared',
+    source = 'development',
+    project = candidates.canonical_project,
+    channel_id = candidates.canonical_project,
+    metadata = CASE
+      WHEN lane.metadata = 'null'::jsonb
+        THEN jsonb_build_object('server_id', 'local')
+      ELSE jsonb_set(lane.metadata, '{server_id}', '"local"'::jsonb, true)
+    END
+FROM candidates
+WHERE lane.id = candidates.id;

--- a/src/db/migrations/025_normalize_legacy_development_lanes.test.ts
+++ b/src/db/migrations/025_normalize_legacy_development_lanes.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const migrationUrl = new URL("025_normalize_legacy_development_lanes.sql", import.meta.url);
+
+dbDescribe("025 normalize legacy Development lanes (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const namespaces = [
+    "test-migration-025-local",
+    "test-migration-025-foreign",
+  ];
+
+  async function cleanup(): Promise<void> {
+    await pool.query(
+      `DELETE FROM ob_session_events WHERE lane_id IN
+         (SELECT id FROM ob_session_lanes WHERE namespace = ANY($1::text[]))`,
+      [namespaces],
+    );
+    await pool.query(
+      "DELETE FROM ob_session_lanes WHERE namespace = ANY($1::text[])",
+      [namespaces],
+    );
+  }
+
+  async function seedLane(
+    slug: string,
+    overrides: Record<string, unknown> = {},
+    namespace = namespaces[0]!,
+  ): Promise<string> {
+    const lane = {
+      agent: "shared-session-finalizer",
+      source: "local-runtime",
+      project: slug,
+      channel_id: null,
+      thread_id: null,
+      metadata: {},
+      ...overrides,
+    };
+    const { rows } = await pool.query(
+      `INSERT INTO ob_session_lanes
+         (session_key, namespace, status, agent, source, project, channel_id,
+          thread_id, metadata, created_by)
+       VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $2)
+       RETURNING id`,
+      [
+        `dev:${slug}`,
+        namespace,
+        lane.agent,
+        lane.source,
+        lane.project,
+        lane.channel_id,
+        lane.thread_id,
+        JSON.stringify(lane.metadata),
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  async function runMigration(): Promise<void> {
+    await pool.query(await Bun.file(migrationUrl).text());
+  }
+
+  beforeEach(cleanup);
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("normalizes only recognized legacy and partial shapes while preserving identity and history", async () => {
+    const accepted = [
+      { slug: "legacy", overrides: {} },
+      {
+        slug: "partial",
+        overrides: {
+          agent: "shared",
+          channel_id: "partial",
+          metadata: { server_id: "local", retained: true },
+        },
+      },
+      { slug: "null-project", overrides: { project: null } },
+      { slug: "json-null", overrides: { metadata: null } },
+      { slug: "CaseProject", overrides: { project: "caseproject" } },
+      {
+        slug: "foreign",
+        overrides: { source: null },
+        namespace: namespaces[1]!,
+      },
+    ];
+    const acceptedIds = new Map<string, string>();
+    for (const item of accepted) {
+      acceptedIds.set(
+        `${item.namespace ?? namespaces[0]}:${item.slug}`,
+        await seedLane(item.slug, item.overrides, item.namespace),
+      );
+    }
+    const historyLaneId = acceptedIds.get(`${namespaces[0]}:legacy`)!;
+    await pool.query(
+      `INSERT INTO ob_session_events
+         (lane_id, event_type, content, created_by)
+       VALUES ($1, 'decision', 'preserved history', $2)`,
+      [historyLaneId, namespaces[0]],
+    );
+
+    await runMigration();
+    await runMigration();
+
+    for (const item of accepted) {
+      const namespace = item.namespace ?? namespaces[0]!;
+      const { rows } = await pool.query(
+        `SELECT id, agent, source, project, channel_id, thread_id, metadata
+           FROM ob_session_lanes
+          WHERE namespace = $1 AND session_key = $2`,
+        [namespace, `dev:${item.slug}`],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: acceptedIds.get(`${namespace}:${item.slug}`),
+        agent: "shared",
+        source: "development",
+        project: item.slug,
+        channel_id: item.slug,
+        thread_id: null,
+      });
+      expect(rows[0].metadata.server_id).toBe("local");
+    }
+
+    const { rows: partialRows } = await pool.query(
+      `SELECT metadata FROM ob_session_lanes
+        WHERE namespace = $1 AND session_key = 'dev:partial'`,
+      [namespaces[0]],
+    );
+    expect(partialRows[0].metadata).toEqual({
+      retained: true,
+      server_id: "local",
+    });
+    const { rows: eventRows } = await pool.query(
+      "SELECT id FROM ob_session_events WHERE lane_id = $1",
+      [historyLaneId],
+    );
+    expect(eventRows).toHaveLength(1);
+  });
+
+  it("leaves unknown or conflicting lane shapes byte-for-byte unchanged", async () => {
+    const rejected = [
+      { slug: "bad-agent", overrides: { agent: "unknown-finalizer" } },
+      { slug: "bad-source", overrides: { source: "unknown-runtime" } },
+      { slug: "bad-server", overrides: { metadata: { server_id: "other" } } },
+      { slug: "bad-channel", overrides: { channel_id: "other" } },
+      { slug: "bad-thread", overrides: { thread_id: "thread" } },
+      { slug: "bad-project", overrides: { project: "other" } },
+      { slug: "bad-metadata", overrides: { metadata: "scalar" } },
+    ];
+    const before = new Map<string, Record<string, unknown>>();
+    for (const item of rejected) {
+      await seedLane(item.slug, item.overrides);
+      const { rows } = await pool.query(
+        `SELECT id, agent, source, project, channel_id, thread_id, metadata
+           FROM ob_session_lanes
+          WHERE namespace = $1 AND session_key = $2`,
+        [namespaces[0], `dev:${item.slug}`],
+      );
+      before.set(item.slug, rows[0]);
+    }
+
+    await runMigration();
+
+    for (const item of rejected) {
+      const { rows } = await pool.query(
+        `SELECT id, agent, source, project, channel_id, thread_id, metadata
+           FROM ob_session_lanes
+          WHERE namespace = $1 AND session_key = $2`,
+        [namespaces[0], `dev:${item.slug}`],
+      );
+      expect(rows).toEqual([before.get(item.slug)]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add versioned migration 025 for the explicitly recognized pre-v22 local Development lane shape
- derive canonical project/channel from each row's unchanged `dev:<repo>` session key and normalize only legacy/partially canonical agent-source markers
- accept absent or already-canonical server/channel/project values, JSON null metadata, and case-distinct legacy project spelling
- leave unknown agent/source, server/channel/thread/project, and scalar-metadata conflicts untouched for operator review
- preserve lane IDs, namespaces, and event history; keep the published `session_start` v2 behavior and v22 schema hash unchanged
- add real-PostgreSQL migration, conflict, idempotence, namespace, JSONB, and history tests plus SME guidance

Closes #295
Related: #297, #293

## Validation

- `bun test` — 1342 passed, 64 skipped, 0 failed
- live PostgreSQL migration 025 suite — 2 passed, 0 failed, 27 assertions
- `tsc --noEmit` — passed
- `git diff --check` — passed
- gitleaks commit scan — no leaks

## Initial review findings and fixes

The five-lane GPT-5.6-Sol review found six material findings on the original lazy `session_start` rewrite: public v22 contract drift, partial-coordinate rejection, JSON-null failure, a weak cross-namespace test, case-distinct project rejection, and failure to populate null project for Python validation. The fix replaced the runtime rewrite entirely with versioned migration 025. The migration handles the safe partial/JSON-null/case/null-project states, tests multiple namespaces through the real database, and leaves public tool/schema behavior unchanged.

## Downstream rollout

No MCP tool schema, public contract hash/version, transport, or package API changed. rtech-mcps/mcp2cli schema regeneration is not applicable. Deployment must run migration 025 and then validate the direct Claude provider against the canonical Development lane.

## Critical Self-Review

- Highest-risk behavior: a deploy migration rewrites non-null legacy lane coordinates; eligibility requires explicit legacy agent/source markers plus a `dev:<repo>` key, unthreaded scope, and only absent/already-canonical server/channel/project values.
- Assumptions that could be wrong: the recognized legacy family is local Development-only and canonical project/channel spelling is the session-key suffix; all other shapes intentionally remain unchanged.
- Missing/weak tests: the live suite covers full and partial legacy shapes, null project, JSON null, case normalization, multiple namespaces, repeat idempotence, every known conflict, preserved row IDs, and event history; it does not inventory unknown production shapes.
- Security/permission risk: no caller gains a relabeling surface and `session_start` remains fail-closed; the migration operates row-by-row without crossing IDs or namespaces.
- Migration/deploy risk: migration 025 is global and irreversible by automatic down-migration, but idempotent and narrowly allowlisted; rollback of code does not reintroduce legacy coordinates.
- Downstream client/runtime risk: the public v22 manifest, schema hash, tool version, and response shapes are unchanged, avoiding a forced package/client rollout.
- Rollback/cleanup concern: already-normalized rows intentionally remain canonical; unknown/conflicting rows remain available for explicit review rather than partial mutation.
- Fixes made before PR: replaced the reviewed lazy runtime rewrite after six P1/P2 findings, added JSONB/partial/case/null-project handling, strengthened namespace/history tests, and moved the rule into migration/SME docs.
- Known residual risk: any additional legitimate legacy marker family requires a separate explicit migration and live-Postgres proof.
- SME review-memory update: [x] `docs/sme/` updated [ ] not applicable because: -

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below [ ] not applicable because: -

Live check: `OPENBRAIN_TEST_DATABASE_URL=<redacted> bun test src/db/migrations/025_normalize_legacy_development_lanes.test.ts` — 2 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)