### PR TITLE
fix(ci): run deploy dependencies on dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ env:
 jobs:
   check:
     runs-on: [self-hosted, Linux, rodaddy]
-    # Self-hosted runner: never execute untrusted fork code. Run on all pushes
-    # and on same-repo PRs only; fork PRs skip (a maintainer re-pushes the
-    # branch to this repo to test).
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Self-hosted runner: never execute untrusted fork code. Run on pushes,
+    # trusted workflow dispatches, and same-repo PRs only; fork PRs skip (a
+    # maintainer re-pushes the branch to this repo to test).
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       DB_HOST: 127.0.0.1
       DB_PORT: 5432
@@ -90,10 +90,10 @@ jobs:
   db-integration:
     runs-on: [self-hosted, Linux, rodaddy]
     # Docker-capable self-hosted runner: never execute untrusted fork code.
-    # Run on all pushes and on same-repo PRs only; fork PRs skip (a maintainer
-    # re-pushes the branch to this repo to test). `push` keeps this job alive
-    # on main so `deploy` (which needs it) still runs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Run on pushes, trusted workflow dispatches, and same-repo PRs only; fork
+    # PRs skip (a maintainer re-pushes the branch to this repo to test). Pushes
+    # and dispatches keep this job available to the deploy dependency chain.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       # 127.0.0.1 (not localhost): the ephemeral Postgres listens on the IPv4
       # loopback only; `localhost` can resolve to ::1.
@@ -197,7 +197,7 @@ jobs:
   python-package:
     runs-on: [self-hosted, Linux, rodaddy]
     # Self-hosted runner: same trusted-source gate as `check`/`db-integration`.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       PYTHON_VERSION: "3.13"
     defaults:


### PR DESCRIPTION
## Summary

- run `check`, `db-integration`, and `python-package` for trusted `workflow_dispatch` events
- unblock the documented `deploy_core01=true` front door, whose deploy job depends on all three
- keep fork PRs excluded from self-hosted runners

## Validation

- reproduced dispatch run 29672231486: all dependency jobs and deploy skipped
- actionlint parsed the workflow; only pre-existing custom self-hosted runner-label warnings remain
- `git diff --check` — passed

## Critical Self-Review

- Highest-risk behavior: enabling self-hosted jobs on manual dispatch; dispatch permission remains repository-controlled and no untrusted fork code is admitted.
- Assumptions that could be wrong: GitHub evaluates the explicit `workflow_dispatch` branch before the absent pull_request object; this is the same event discriminator used by the deploy job.
- Missing/weak tests: GitHub Actions conditions cannot be fully executed locally; the post-merge proof is a real dispatch that must run all dependency jobs and deploy.
- Security/permission risk: manual dispatch is trusted maintainer input and checks out the selected protected ref; fork PR behavior is unchanged.
- Migration/deploy risk: without this fix the documented deploy path is permanently skipped; with it the existing required dependency chain runs before core01.
- Downstream client/runtime risk: no Open Brain runtime or MCP behavior changes.
- Rollback/cleanup concern: reverting this commit restores the prior skipped-dispatch behavior; no host mutation happens until all dependencies pass.
- Fixes made before PR: changed all three deploy dependencies consistently and updated comments to match event behavior.
- Known residual risk: the real workflow-dispatch canary is required after merge.
- SME review-memory update: [ ] `docs/sme/` updated [x] not applicable because: this is a workflow event-condition correction with no new reusable runtime finding beyond the documented deployment front door.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below [x] not applicable because: this PR changes only whether validation/deploy jobs run; the real deployment canary follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)