### PR TITLE
fix: #293-family memory hardening — spool redaction/backpressure, disclosure isolation slice, doctor audit probe, deploy labels

### DIFF
--- a/docs/downstream-rollout.md
+++ b/docs/downstream-rollout.md
@@ -40,7 +40,7 @@ If none of those apply, say so explicitly in the PR and release notes.
    - The script refuses unsupported refs, requires a manual-dispatch checkout to
      equal the current `origin/main` tip, stages the runtime, installs locked
      dependencies, bootstraps qmd when its script is present, runs migrations,
-     swaps the runtime, restarts `system/com.rico.open-brain`, and checks
+     swaps the runtime, restarts the `gui/<uid>/com.rico.open-brain` LaunchAgent (and, warn-only, `com.rico.open-brain-nats-worker`), and checks
      `http://127.0.0.1:3100/health`. After health passes it runs the Bun
      `search-all` test file. That test is regression coverage, not a live
      changed-tool smoke. On failed health the script restores the previous

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -511,3 +511,28 @@ Legacy lane upgrades are data migrations, not ordinary tool behavior. Mock pools
 **Status:** fixed in PR #294
 
 Before start, append, checkpoint, or wrap, a first-class runtime must validate the current live contract manifest rather than trust construction-time or stale cached compatibility. Compatibility must require exact `schema_version` and `schema_hash` agreement with the supported contract in addition to required-tool checks; a matching tool list does not make a differently hashed or versioned schema safe. Tests must mutate the advertised manifest between lifecycle calls and independently vary `schema_version` and `schema_hash`, proving an incompatible long-lived runtime is rejected before the operation.
+
+## [2026-07-20] Saturation handling must never silently drop acknowledged data
+
+**Severity:** HIGH
+**Source:** Issue #300, PR #305 (#293-family review)
+**Scope:** `python/openbrain-memory/src/openbrain_memory/spool.py`
+**Status:** active
+
+### Pattern
+
+`append_batch` FIFO-evicted previously-spooled groups to admit a new batch and
+then returned success — silently destroying records already acknowledged as
+`durable=True`/`SPOOLED`. Capacity limits must surface as backpressure
+(explicit rejection, e.g. `SpoolFullError`, with the store unchanged) or as an
+observable loss receipt — never as evict-then-return-success.
+
+### Review Questions
+
+- Under saturation, does any path drop already-acknowledged data and still
+  report success?
+- Is rejection all-or-nothing (store byte-for-byte unchanged on failure)?
+- Do tests cover both line-count and byte limits, and assert prior records
+  remain intact AND replayable after a rejected append?
+- Will a future replay/recovery consumer see the loss, or replay a queue that
+  already lost records?

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -434,3 +434,32 @@ Checking only that a required tool name exists lets an incompatible schema pass.
 **Status:** active
 
 Do not broaden a published lifecycle tool to rewrite non-null legacy coordinates without a contract/version rollout. A versioned migration must derive the canonical project/channel from the row's own stable key, require explicit legacy agent/source markers, keep threaded lanes out, accept only absent or already-canonical server/channel/project values, and leave unknown conflicts untouched. Require a real-Postgres migration test with JSON null, partial migration, idempotence, multiple namespaces, and preserved event history.
+
+## [2026-07-20] Silent caller-input rewriting instead of fail-closed conflict
+
+**Severity:** MEDIUM
+**Source:** Issue #297 export slice, PR #305 (#293-family review)
+**Scope:** `python/openbrain-memory/src/openbrain_memory/agent.py`,
+`src/agent-memory.ts`, `src/disclosure-bundle.ts`
+**Status:** active
+
+### Pattern
+
+`export_disclosure_bundle` silently OVERWROTE a caller-supplied lane
+sessionKey/agent/project with the active session's values. Silent rewriting
+hides caller bugs and spoofing attempts; identity/scope conflicts must fail
+closed with an explicit error, and outputs should carry an immutable
+session-derived isolation stamp. Also: a "server-side gate" finding can be
+stale if the path is a pure local formatter — verify a server round-trip
+actually exists before prescribing a server-side fix.
+
+### Review Questions
+
+- Where caller input overlaps session-derived identity, is a conflict an error
+  rather than a silent substitution?
+- Are supplied items carrying identity fields (session_key, agent, project,
+  namespace) validated against the export scope, with unverifiable fields
+  rejected?
+- Is the Python/TS behavior symmetric, with mirrored regression tests?
+- Does the fix location match where the data actually flows (client formatter
+  vs server tool)?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -41,6 +41,12 @@ Redacting the payload before calling Open Brain can silently persist legitimate
 memory content as `[REDACTED]`. Redacting before durable spool persistence can
 make replay unable to restore the original write.
 
+**2026-07-20 update (Issue #304, PR #305):** the spool half of this stance is
+superseded. The contract decision is that secrets never land on disk: the spool
+now redacts before persistence and replay deliberately replays the redacted
+form. The live-write half (successful live writes preserve caller content)
+remains active.
+
 ### Review Questions
 
 - Are live writes preserving caller content?
@@ -410,3 +416,28 @@ Validation may inspect a normalized copy for emptiness, bounds, or safety, but t
 **Status:** active
 
 A caller must not be able to relabel an arbitrary existing lane by presenting a new exact scope. Prefer a reviewed versioned database migration over silently broadening a published runtime tool contract. Automatic migration is permitted only for explicitly recognized legacy markers and canonical target coordinates derived from the same row's stable session key. The database predicate must constrain agent/source/server/channel/thread/project independently; unknown non-null conflicts remain untouched for operator review. Require live-Postgres tests for recognized and partial migration, idempotence, every coordinate conflict, namespace-independent row identity, and event-history preservation.
+
+## [2026-07-20] Client-side persistence paths must redact before disk
+
+**Severity:** HIGH
+**Source:** Issue #304, PR #305 (#293-family review)
+**Scope:** `python/openbrain-memory/src/openbrain_memory/spool.py`
+**Status:** active
+
+### Pattern
+
+The JSONL spool persisted `"payload": dict(payload)` raw to disk, with
+`redact_value` applied only to a diagnostic view — and a test explicitly
+asserted the secret WAS on disk. Any client-side persistence surface (spool,
+cache, export file) must apply redaction before the bytes hit disk, and replay
+must deliberately replay the redacted form rather than pretend raw fidelity.
+
+### Review Questions
+
+- Does every disk write of caller payloads pass through `redact_value` (or
+  equivalent) before serialization, not just before display?
+- Do tests assert the secret is absent from the RAW file content
+  (`path.read_text()`), not merely from a redacted accessor?
+- Is there a test locking the OPPOSITE (bad) behavior that should be flipped?
+- Do pre-fix artifacts on disk (written before the redaction change) get
+  retro-scrubbed or aged out, and is replay of old artifacts considered?

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -866,11 +866,17 @@ class AgentMemory:
         lane: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         self._require_session("export_disclosure_bundle")
+        session_key = cast(str, self.conversation_key)
         lane_payload: dict[str, Any] = dict(lane or {})
-        lane_payload["sessionKey"] = self.conversation_key
+        _validate_disclosure_lane_identity(
+            lane_payload,
+            session_key=session_key,
+            agent=self.agent,
+            project=self.project,
+        )
+        lane_payload["sessionKey"] = session_key
         lane_payload["agent"] = self.agent
-        if self.project is not None:
-            lane_payload["project"] = self.project
+        lane_payload["project"] = self.project
         event_payloads = [dict(item) for item in events or []]
         fact_payloads = [dict(item) for item in repo_facts or []]
         receipt_payloads = [dict(item) for item in receipts or []]
@@ -1273,6 +1279,9 @@ def _export_disclosure_bundle(
     repo_facts: list[dict[str, Any]],
     receipts: list[dict[str, Any]],
 ) -> dict[str, Any]:
+    _validate_disclosure_scope(lane, events, "event")
+    _validate_disclosure_scope(lane, repo_facts, "repo fact")
+    _validate_disclosure_scope(lane, receipts, "receipt")
     sorted_events = sorted(events, key=lambda item: (item["timestamp"], item["id"]))
     sorted_facts = sorted(repo_facts, key=lambda item: item["id"])
     sorted_receipts = sorted(
@@ -1285,6 +1294,11 @@ def _export_disclosure_bundle(
         sorted_receipts,
     )
     fact_paths = _concept_paths(sorted_facts)
+    isolation = {
+        "session_key": lane["sessionKey"],
+        "agent": lane.get("agent"),
+        "project": lane.get("project"),
+    }
     files = [
         {
             "path": "index.md",
@@ -1295,6 +1309,7 @@ def _export_disclosure_bundle(
                 sorted_receipts,
                 citations,
                 fact_paths,
+                isolation,
             ),
         },
         {"path": "log.md", "content": _render_disclosure_log(sorted_events)},
@@ -1318,7 +1333,7 @@ def _export_disclosure_bundle(
             },
         ]
     )
-    return {"profile": "okf-like", "files": files}
+    return {"profile": "okf-like", "isolation": isolation, "files": files}
 
 
 def _render_disclosure_index(
@@ -1328,6 +1343,7 @@ def _render_disclosure_index(
     receipts: list[dict[str, Any]],
     citations: list[dict[str, Any]],
     fact_paths: list[str],
+    isolation: Mapping[str, Any],
 ) -> str:
     title = lane.get("topic") or lane["sessionKey"]
     lines = [
@@ -1338,6 +1354,7 @@ def _render_disclosure_index(
                 "session_key": lane["sessionKey"],
                 "agent": lane.get("agent"),
                 "project": lane.get("project"),
+                "isolation": isolation,
                 "okf": _okf_metadata(lane.get("metadata")),
             }
         ),
@@ -1369,6 +1386,46 @@ def _render_disclosure_index(
     )
     lines.append("")
     return "\n".join(lines)
+
+
+def _validate_disclosure_lane_identity(
+    lane: Mapping[str, Any],
+    *,
+    session_key: str,
+    agent: str,
+    project: str | None,
+) -> None:
+    expected = {"sessionKey": session_key, "agent": agent, "project": project}
+    for identity_field, value in expected.items():
+        if identity_field in lane and lane[identity_field] != value:
+            raise ValueError(
+                f"disclosure bundle lane {identity_field} conflicts with active session"
+            )
+
+
+def _validate_disclosure_scope(
+    lane: Mapping[str, Any],
+    items: list[dict[str, Any]],
+    item_type: str,
+) -> None:
+    expected = {
+        "sessionKey": lane["sessionKey"],
+        "session_key": lane["sessionKey"],
+        "agent": lane.get("agent"),
+        "project": lane.get("project"),
+    }
+    for item in items:
+        if "namespace" in item:
+            raise ValueError(
+                f"cross-scope disclosure {item_type}: "
+                "namespace cannot be verified by the export lane"
+            )
+        for identity_field, value in expected.items():
+            if identity_field in item and item[identity_field] != value:
+                raise ValueError(
+                    f"cross-scope disclosure {item_type}: "
+                    f"{identity_field} does not match export lane"
+                )
 
 
 def _render_disclosure_log(events: list[dict[str, Any]]) -> str:

--- a/python/openbrain-memory/src/openbrain_memory/spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/spool.py
@@ -18,6 +18,10 @@ from .policy import idempotency_key, redact_value
 logger = logging.getLogger(__name__)
 
 
+class SpoolFullError(ValueError):
+    """Raised when an append would exceed spool capacity."""
+
+
 @dataclass(frozen=True)
 class SpoolRecord:
     idempotency_key: str
@@ -138,24 +142,17 @@ class JsonlSpool:
                 if self.path.exists()
                 else []
             )
-            existing_groups = self._line_groups(existing)
-            existing_line_count = sum(len(group) for group in existing_groups)
-            existing_bytes = sum(
-                len(line.encode("utf-8")) for group in existing_groups for line in group
-            )
-            while (
+            existing_line_count = len(existing)
+            existing_bytes = sum(len(line.encode("utf-8")) for line in existing)
+            if (
                 existing_line_count + len(batch_lines) > self.max_lines
                 or existing_bytes + batch_bytes > self.max_bytes
             ):
-                if not existing_groups:
-                    raise ValueError(
-                        "spool batch exceeds configured max_lines/max_bytes limits"
-                    )
-                evicted = existing_groups.pop(0)
-                existing_line_count -= len(evicted)
-                existing_bytes -= sum(len(line.encode("utf-8")) for line in evicted)
-            retained = [line for group in existing_groups for line in group]
-            self._write_lines([*retained, *batch_lines])
+                raise SpoolFullError(
+                    "spool is full; append would exceed configured "
+                    "max_lines/max_bytes limits"
+                )
+            self._write_lines([*existing, *batch_lines])
         finally:
             self._unlock(lock_fd)
         return safe_keys
@@ -174,7 +171,7 @@ class JsonlSpool:
         record = {
             "idempotency_key": key,
             "operation": operation,
-            "payload": dict(payload),
+            "payload": redact_value(dict(payload)),
             "created_at": created_at,
         }
         if group_id is not None:
@@ -182,12 +179,6 @@ class JsonlSpool:
             record["group_index"] = group_index
             record["group_size"] = group_size
         return json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
-
-    @classmethod
-    def _line_groups(cls, lines: list[str]) -> list[list[str]]:
-        return [
-            [line for _, line in group] for group in cls._group_indexed_lines(lines)
-        ]
 
     @classmethod
     def _group_indexed_lines(cls, lines: list[str]) -> list[list[tuple[int, str]]]:

--- a/python/openbrain-memory/tests/test_agent.py
+++ b/python/openbrain-memory/tests/test_agent.py
@@ -977,6 +977,11 @@ def test_export_disclosure_bundle_matches_ts_feature_shape():
     )
 
     assert bundle["profile"] == "okf-like"
+    assert bundle["isolation"] == {
+        "session_key": "conversation",
+        "agent": "bilby",
+        "project": "open-brain",
+    }
     files = {file["path"]: file["content"] for file in bundle["files"]}
     assert list(files) == [
         "index.md",
@@ -989,6 +994,10 @@ def test_export_disclosure_bundle_matches_ts_feature_shape():
     assert 'session_key: "conversation"' in files["index.md"]
     assert 'agent: "bilby"' in files["index.md"]
     assert 'project: "open-brain"' in files["index.md"]
+    assert (
+        'isolation: {"agent":"bilby","project":"open-brain",'
+        '"session_key":"conversation"}' in files["index.md"]
+    )
     assert 'okf: {"mode":"edge"}' in files["index.md"]
     assert files["log.md"].find("Hermes uses Python.") < files["log.md"].find(
         "Use Open Brain memory."
@@ -997,6 +1006,40 @@ def test_export_disclosure_bundle_matches_ts_feature_shape():
     assert "fact:fact-a:path" in files["citations.md"]
     assert "receipt:receipt-1" in files["citations.md"]
     assert '"status":"passed"' in files["receipts.md"]
+
+
+def test_export_disclosure_bundle_rejects_cross_scope_items():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+    memory.start_session("conversation")
+
+    for arguments in (
+        {
+            "events": [
+                {
+                    "id": "event-1",
+                    "type": "fact",
+                    "content": "Cross-scope event.",
+                    "timestamp": "2026-06-26T12:00:00Z",
+                    "session_key": "another-session",
+                }
+            ]
+        },
+        {"repo_facts": [{"agent": "another-agent"}]},
+        {"receipts": [{"project": "another-project"}]},
+        {"repo_facts": [{"namespace": "unverified-namespace"}]},
+    ):
+        with pytest.raises(ValueError, match="cross-scope disclosure"):
+            memory.export_disclosure_bundle(**arguments)
+
+
+def test_export_disclosure_bundle_rejects_conflicting_lane_identity():
+    client = FakeClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+    memory.start_session("conversation")
+
+    with pytest.raises(ValueError, match="lane sessionKey conflicts"):
+        memory.export_disclosure_bundle(lane={"sessionKey": "another-session"})
 
 
 def test_export_disclosure_bundle_matches_shared_golden_fixture():
@@ -1017,7 +1060,22 @@ def test_export_disclosure_bundle_matches_shared_golden_fixture():
 
     fixture_input = dict(fixture["input"])
     fixture_input["repo_facts"] = fixture_input.pop("repoFacts")
-    assert memory.export_disclosure_bundle(**fixture_input) == fixture["expected"]
+    expected = dict(fixture["expected"])
+    expected["isolation"] = {
+        "session_key": fixture["adapter"]["sessionKey"],
+        "agent": fixture["adapter"]["agent"],
+        "project": fixture["adapter"]["project"],
+    }
+    expected_files = [dict(file) for file in fixture["expected"]["files"]]
+    index = next(file for file in expected_files if file["path"] == "index.md")
+    index["content"] = index["content"].replace(
+        'project: "open-brain"\nokf:',
+        'project: "open-brain"\nisolation: '
+        '{"agent":"bilby","project":"open-brain","session_key":"fixture-session"}'
+        "\nokf:",
+    )
+    expected["files"] = expected_files
+    assert memory.export_disclosure_bundle(**fixture_input) == expected
 
 
 def test_public_facade_exports_quickstart_types():

--- a/python/openbrain-memory/tests/test_spool.py
+++ b/python/openbrain-memory/tests/test_spool.py
@@ -344,7 +344,11 @@ def test_spool_rejects_append_when_line_limit_is_full(tmp_path):
     ]
 
 
-def test_spool_rejects_append_when_byte_limit_is_full(tmp_path):
+def test_spool_rejects_append_when_byte_limit_is_full(tmp_path, monkeypatch):
+    # Freeze the persisted created_at timestamp: the JSON float's digit count
+    # otherwise varies between records, making the second line's byte length
+    # nondeterministic relative to the first.
+    monkeypatch.setattr("openbrain_memory.spool.time.time", lambda: 1_000_000.0)
     spool = JsonlSpool(tmp_path / "spool.jsonl")
     spool.append("one", {"content": "1"}, key="one")
     original = spool.path.read_bytes()

--- a/python/openbrain-memory/tests/test_spool.py
+++ b/python/openbrain-memory/tests/test_spool.py
@@ -19,6 +19,7 @@ from openbrain_memory import (
     SpoolRecord,
     replay_records,
 )
+from openbrain_memory.spool import SpoolFullError
 
 
 def token_sample(*parts: str) -> str:
@@ -266,9 +267,11 @@ def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tm
         retry_policy=RetryPolicy(attempts=2, backoff_seconds=0),
     )
 
+    secret = token_sample("super", "secret")
+
     with pytest.raises(ConnectionError):
         memory.remember_fact(
-            "token=" + token_sample("super", "secret"),
+            "token=" + secret,
             tags=["incident", "memory"],
         )
 
@@ -285,23 +288,32 @@ def test_failed_write_spools_replayable_payload_with_redacted_diagnostic_view(tm
     assert lock_mode == 0o600
     assert len(records) == 1
     assert records[0].operation == "log_thought"
-    assert records[0].payload == client.calls[0][1]
     assert records[0].payload["tags"] == [
         "fact",
         "incident",
         "memory",
         f"idempotency:{records[0].idempotency_key}",
     ]
-    assert token_sample("super", "secret") in str(records[0].payload)
-    assert token_sample("super", "secret") not in str(records[0].redacted_payload())
-    assert token_sample("super", "secret") not in str(
-        spool.redacted_records()[0].payload
-    )
+    assert secret not in spool.path.read_text(encoding="utf-8")
+    assert secret not in str(records[0].payload)
+    assert records[0].redacted_payload() == records[0].payload
+    assert spool.redacted_records()[0].payload == records[0].payload
     assert records[0].idempotency_key
     assert spool.replay(dispatch) == [{"ok": True}]
     assert replayed[0].operation == records[0].operation
     assert replayed[0].idempotency_key == records[0].idempotency_key
     assert replayed[0].payload == records[0].payload
+    assert secret not in str(replayed[0].payload)
+
+
+def test_spool_never_persists_secret_material_to_disk(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    secret = token_sample("hunt", "er2")
+
+    spool.append("log_thought", {"content": "password: " + secret}, key="one")
+
+    assert secret not in spool.path.read_text(encoding="utf-8")
+    assert secret not in str(spool.records()[0].payload)
 
 
 def test_live_write_payload_preserves_original_content():
@@ -314,14 +326,38 @@ def test_live_write_payload_preserves_original_content():
     assert "[REDACTED]" not in client.calls[0][1]["content"]
 
 
-def test_spool_trims_old_records_by_line_count(tmp_path):
+def test_spool_rejects_append_when_line_limit_is_full(tmp_path):
     spool = JsonlSpool(tmp_path / "spool.jsonl", max_lines=2)
 
     spool.append("one", {"content": "1"}, key="one")
     spool.append("two", {"content": "2"}, key="two")
-    spool.append("three", {"content": "3"}, key="three")
+    original = spool.path.read_bytes()
 
-    assert [record.operation for record in spool.records()] == ["two", "three"]
+    with pytest.raises(SpoolFullError, match="spool is full"):
+        spool.append("three", {"content": "3"}, key="three")
+
+    assert spool.path.read_bytes() == original
+    assert [record.operation for record in spool.records()] == ["one", "two"]
+    assert spool.replay(lambda record: {"operation": record.operation}) == [
+        {"operation": "one"},
+        {"operation": "two"},
+    ]
+
+
+def test_spool_rejects_append_when_byte_limit_is_full(tmp_path):
+    spool = JsonlSpool(tmp_path / "spool.jsonl")
+    spool.append("one", {"content": "1"}, key="one")
+    original = spool.path.read_bytes()
+    spool.max_bytes = len(original) * 2 - 1
+
+    with pytest.raises(SpoolFullError, match="spool is full"):
+        spool.append("two", {"content": "2"}, key="two")
+
+    assert spool.path.read_bytes() == original
+    assert [record.operation for record in spool.records()] == ["one"]
+    assert spool.replay(lambda record: {"operation": record.operation}) == [
+        {"operation": "one"}
+    ]
 
 
 def test_spool_replay_removes_successes_and_keeps_failures(tmp_path):
@@ -427,7 +463,7 @@ def test_spool_durability_failure_preserves_valid_file(tmp_path, failed_fsync):
     assert [record.idempotency_key for record in spool.records()] == ["existing-key"]
 
 
-def test_spool_later_append_evicts_whole_existing_batch(tmp_path):
+def test_spool_acknowledged_group_survives_saturation_attempt(tmp_path):
     spool = JsonlSpool(tmp_path / "spool.jsonl", max_lines=2)
     spool.append_batch(
         [
@@ -435,13 +471,26 @@ def test_spool_later_append_evicts_whole_existing_batch(tmp_path):
             ("session_wrap", {"session_key": "lane"}, "write-key"),
         ]
     )
+    original = spool.path.read_bytes()
+    returned = False
 
-    spool.append("new", {"content": "safe"}, key="new-key")
+    with pytest.raises(SpoolFullError, match="spool is full"):
+        spool.append("new", {"content": "safe"}, key="new-key")
+        returned = True
 
-    assert [record.idempotency_key for record in spool.records()] == ["new-key"]
+    assert returned is False
+    assert spool.path.read_bytes() == original
+    assert [record.idempotency_key for record in spool.records()] == [
+        "start-key",
+        "write-key",
+    ]
+    assert spool.replay(lambda record: {"key": record.idempotency_key}) == [
+        {"key": "start-key"},
+        {"key": "write-key"},
+    ]
 
 
-def test_spool_replay_preserves_batch_for_later_group_eviction(tmp_path):
+def test_spool_replay_preserves_batch_when_later_append_saturates(tmp_path):
     spool = JsonlSpool(tmp_path / "spool.jsonl", max_lines=3)
     spool.append("old", {"content": "safe"}, key="old-key")
     spool.append_batch(
@@ -472,11 +521,16 @@ def test_spool_replay_preserves_batch_for_later_group_eviction(tmp_path):
     ]
 
     spool.append("new-one", {"content": "1"}, key="new-one-key")
-    spool.append("new-two", {"content": "2"}, key="new-two-key")
+    original = spool.path.read_bytes()
 
+    with pytest.raises(SpoolFullError, match="spool is full"):
+        spool.append("new-two", {"content": "2"}, key="new-two-key")
+
+    assert spool.path.read_bytes() == original
     assert [record.idempotency_key for record in spool.records()] == [
+        "start-key",
+        "write-key",
         "new-one-key",
-        "new-two-key",
     ]
 
 
@@ -688,7 +742,7 @@ def test_spooled_operation_can_replay_through_real_client_method(tmp_path):
         (
             "log_thought",
             {
-                "content": secret,
+                "content": "[REDACTED]",
                 "tags": [
                     "fact",
                     "replay",
@@ -697,6 +751,7 @@ def test_spooled_operation_can_replay_through_real_client_method(tmp_path):
             },
         )
     ]
+    assert secret not in str(replay_client.calls)
 
 
 def test_replay_records_passes_full_record():

--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 RUNTIME_DIR="${RUNTIME_DIR:-/Volumes/ThunderBolt/open-brain/app}"
 ENV_FILE="${ENV_FILE:-/Users/rico/.config/open-brain/env}"
-SERVICE_LABEL="${SERVICE_LABEL:-system/com.rico.open-brain}"
+SERVICE_LABEL="${SERVICE_LABEL:-gui/$(id -u)/com.rico.open-brain}"
+NATS_WORKER_LABEL="${NATS_WORKER_LABEL:-gui/$(id -u)/com.rico.open-brain-nats-worker}"
 QMD_PATH_VALUE="${QMD_PATH_VALUE:-/Volumes/ThunderBolt/qmd/open-brain-qmd.ts}"
 BUN_BIN="${BUN_BIN:-}"
 STAGING_DIR="${STAGING_DIR:-${RUNTIME_DIR}.next}"
@@ -152,7 +153,10 @@ if [[ -d "$RUNTIME_DIR" ]]; then
 fi
 mv "$STAGING_DIR" "$RUNTIME_DIR"
 
-sudo launchctl kickstart -k "$SERVICE_LABEL"
+launchctl kickstart -k "$SERVICE_LABEL"
+if ! launchctl kickstart -k "$NATS_WORKER_LABEL"; then
+  echo "WARN: could not restart Open Brain NATS worker: $NATS_WORKER_LABEL" >&2
+fi
 
 if wait_for_health "Open Brain"; then
   "$BUN_BIN" test src/tools/__tests__/search-all.test.ts
@@ -163,7 +167,10 @@ fi
 if [[ -d "$PREVIOUS_DIR" ]]; then
   rm -rf "$RUNTIME_DIR"
   mv "$PREVIOUS_DIR" "$RUNTIME_DIR"
-  sudo launchctl kickstart -k "$SERVICE_LABEL"
+  launchctl kickstart -k "$SERVICE_LABEL"
+  if ! launchctl kickstart -k "$NATS_WORKER_LABEL"; then
+    echo "WARN: could not restart Open Brain NATS worker after rollback: $NATS_WORKER_LABEL" >&2
+  fi
 
   if wait_for_health "Open Brain rollback"; then
     echo "FATAL: Open Brain health check failed after deploy; previous runtime restored and passed health" >&2

--- a/src/__tests__/agent-memory.test.ts
+++ b/src/__tests__/agent-memory.test.ts
@@ -615,6 +615,11 @@ describe("AgentMemory TypeScript wrapper", () => {
     });
 
     expect(bundle.profile).toBe("okf-like");
+    expect(bundle.isolation).toEqual({
+      sessionKey: "session-disclosure",
+      agent: "codex",
+      project: undefined,
+    });
     expect(bundle.files.map((file) => file.path)).toEqual([
       "index.md",
       "log.md",
@@ -623,6 +628,9 @@ describe("AgentMemory TypeScript wrapper", () => {
       "receipts.md",
     ]);
     expect(bundle.files[0]!.content).toContain('"x_unknown_okf_key":"preserved"');
+    expect(bundle.files[0]!.content).toContain(
+      'isolation: {"agent":"codex","sessionKey":"session-disclosure"}',
+    );
     expect(bundle.files[1]!.content.indexOf("OKF is an edge")).toBeLessThan(
       bundle.files[1]!.content.indexOf("Generated report artifact"),
     );
@@ -645,9 +653,28 @@ describe("AgentMemory TypeScript wrapper", () => {
     });
     await memory.start({ sessionKey: disclosureGolden.adapter.sessionKey });
 
-    expect(memory.exportDisclosureBundle(disclosureGolden.input)).toEqual(
-      disclosureGolden.expected,
-    );
+    const expected = {
+      ...disclosureGolden.expected,
+      isolation: {
+        sessionKey: disclosureGolden.adapter.sessionKey,
+        agent: disclosureGolden.adapter.agent,
+        project: disclosureGolden.adapter.project,
+      },
+      files: disclosureGolden.expected.files.map((file) =>
+        file.path === "index.md"
+          ? {
+              ...file,
+              content: file.content.replace(
+                'project: "open-brain"\nokf:',
+                'project: "open-brain"\nisolation: '
+                  + '{"agent":"bilby","project":"open-brain","sessionKey":"fixture-session"}'
+                  + "\nokf:",
+              ),
+            }
+          : file,
+      ),
+    };
+    expect(memory.exportDisclosureBundle(disclosureGolden.input)).toEqual(expected);
   });
 
   it("makes disclosure concept paths stable and collision-resistant", async () => {
@@ -782,28 +809,93 @@ describe("AgentMemory TypeScript wrapper", () => {
     ).toHaveLength(0);
   });
 
-  it("keeps disclosure bundle identity bound to the active lane", async () => {
+  it("rejects conflicting disclosure bundle lane identity", async () => {
     const memory = new AgentMemory(new FakeTransport(), {
       agent: "codex",
       project: "open-brain",
     });
     await memory.start({ sessionKey: "real-session" });
 
-    const bundle = memory.exportDisclosureBundle({
-      lane: {
-        sessionKey: "spoofed-session",
-        agent: "spoofed-agent",
-        project: "spoofed-project",
-        topic: "Caller label is allowed",
+    expect(() =>
+      memory.exportDisclosureBundle({
+        lane: {
+          sessionKey: "spoofed-session",
+          agent: "spoofed-agent",
+          project: "spoofed-project",
+          topic: "Caller label is allowed",
+        },
+      }),
+    ).toThrow("disclosure bundle lane sessionKey conflicts with active session");
+  });
+
+  it("rejects cross-scope disclosure items and stamps untagged items from the active session", async () => {
+    const memory = new AgentMemory(new FakeTransport(), {
+      agent: "codex",
+      project: "open-brain",
+    });
+    await memory.start({ sessionKey: "real-session" });
+
+    for (const input of [
+      {
+        events: [
+          {
+            id: "event-1",
+            type: "fact",
+            content: "Cross-scope event.",
+            timestamp: "2026-06-26T12:00:00.000Z",
+            session_key: "spoofed-session",
+          },
+        ],
       },
+      { repoFacts: [{ id: "fact-1", subject: "Fact", fact: "Cross-scope.", agent: "spoofed" }] },
+      {
+        receipts: [
+          {
+            id: "receipt-1",
+            action: "validate",
+            timestamp: "2026-06-26T12:00:00.000Z",
+            project: "spoofed-project",
+          },
+        ],
+      },
+      {
+        repoFacts: [
+          { id: "fact-2", subject: "Fact", fact: "Unverified namespace.", namespace: "x" },
+        ],
+      },
+    ]) {
+      expect(() => memory.exportDisclosureBundle(input)).toThrow("cross-scope disclosure");
+    }
+
+    const bundle = memory.exportDisclosureBundle({
+      events: [
+        {
+          id: "event-1",
+          type: "fact",
+          content: "Untagged event.",
+          timestamp: "2026-06-26T12:00:00.000Z",
+        },
+      ],
+      repoFacts: [{ id: "fact-1", subject: "Fact", fact: "Untagged fact." }],
+      receipts: [
+        { id: "receipt-1", action: "validate", timestamp: "2026-06-26T12:00:00.000Z" },
+      ],
     });
     const index = bundle.files.find((file) => file.path === "index.md")!.content;
-    expect(index).toContain('session_key: "real-session"');
-    expect(index).toContain('agent: "codex"');
-    expect(index).toContain('project: "open-brain"');
-    expect(index).not.toContain("spoofed-session");
-    expect(index).not.toContain("spoofed-agent");
-    expect(index).not.toContain("spoofed-project");
+    expect(bundle.isolation).toEqual({
+      sessionKey: "real-session",
+      agent: "codex",
+      project: "open-brain",
+    });
+    expect(index).toContain(
+      'isolation: {"agent":"codex","project":"open-brain","sessionKey":"real-session"}',
+    );
+    expect(bundle.files.find((file) => file.path === "log.md")!.content).toContain(
+      "Untagged event.",
+    );
+    expect(bundle.files.find((file) => file.path === "receipts.md")!.content).toContain(
+      "validate",
+    );
   });
 
   it("feeds wrapper receipt/export evidence into the memory substrate eval shape", async () => {

--- a/src/agent-memory.ts
+++ b/src/agent-memory.ts
@@ -434,6 +434,11 @@ export class AgentMemory {
     lane?: Partial<DisclosureBundleInput["lane"]>;
   }): DisclosureBundle {
     this.requireSession("exportDisclosureBundle");
+    assertDisclosureLaneIdentity(input.lane, {
+      sessionKey: this.sessionKey,
+      agent: this.agent,
+      project: this.project,
+    });
     return exportDisclosureBundle({
       ...input,
       lane: {
@@ -487,6 +492,18 @@ export class AgentMemory {
 
   private requireSession(method: string): asserts this is this & { sessionKey: string } {
     if (!this.sessionKey) throw new Error(`${method} requires start() first`);
+  }
+}
+
+function assertDisclosureLaneIdentity(
+  lane: Partial<DisclosureBundleInput["lane"]> | undefined,
+  expected: Pick<DisclosureBundleInput["lane"], "sessionKey" | "agent" | "project">,
+): void {
+  if (!lane) return;
+  for (const field of ["sessionKey", "agent", "project"] as const) {
+    if (lane[field] !== undefined && lane[field] !== expected[field]) {
+      throw new Error(`disclosure bundle lane ${field} conflicts with active session`);
+    }
   }
 }
 

--- a/src/disclosure-bundle.ts
+++ b/src/disclosure-bundle.ts
@@ -6,7 +6,15 @@ export interface DisclosureCitation {
   sourceRef?: string;
 }
 
-export interface DisclosureEvent {
+interface DisclosureScopeIdentity {
+  sessionKey?: string;
+  session_key?: string;
+  agent?: string;
+  project?: string;
+  namespace?: string;
+}
+
+export interface DisclosureEvent extends DisclosureScopeIdentity {
   id: string;
   type: string;
   content: string;
@@ -19,7 +27,7 @@ export interface DisclosureEvent {
   metadata?: Record<string, unknown>;
 }
 
-export interface DisclosureRepoFact {
+export interface DisclosureRepoFact extends DisclosureScopeIdentity {
   id: string;
   subject: string;
   fact: string;
@@ -30,7 +38,7 @@ export interface DisclosureRepoFact {
   metadata?: Record<string, unknown>;
 }
 
-export interface DisclosureReceipt {
+export interface DisclosureReceipt extends DisclosureScopeIdentity {
   id: string;
   action: string;
   timestamp: string;
@@ -60,20 +68,37 @@ export interface DisclosureBundleFile {
 
 export interface DisclosureBundle {
   profile: "okf-like";
+  isolation: {
+    sessionKey: string;
+    agent?: string;
+    project?: string;
+  };
   files: DisclosureBundleFile[];
 }
 
 export function exportDisclosureBundle(input: DisclosureBundleInput): DisclosureBundle {
+  validateDisclosureScope(input.lane, input.events ?? [], "event");
+  validateDisclosureScope(input.lane, input.repoFacts ?? [], "repo fact");
+  validateDisclosureScope(input.lane, input.receipts ?? [], "receipt");
   const events = [...(input.events ?? [])].sort(byTimestampThenId);
   const facts = [...(input.repoFacts ?? [])].sort((a, b) => a.id.localeCompare(b.id));
   const receipts = [...(input.receipts ?? [])].sort(byTimestampThenId);
   const citations = collectCitations(events, facts, receipts);
   const factPaths = conceptPaths(facts);
+  const isolation = {
+    sessionKey: input.lane.sessionKey,
+    agent: input.lane.agent,
+    project: input.lane.project,
+  };
 
   return {
     profile: "okf-like",
+    isolation,
     files: [
-      { path: "index.md", content: renderIndex(input, events, facts, receipts, citations, factPaths) },
+      {
+        path: "index.md",
+        content: renderIndex(input, events, facts, receipts, citations, factPaths, isolation),
+      },
       { path: "log.md", content: renderLog(events) },
       ...facts.map((fact, index) => ({
         path: factPaths[index] ?? conceptPath(fact),
@@ -100,6 +125,7 @@ function renderIndex(
   receipts: DisclosureReceipt[],
   citations: DisclosureCitation[],
   factPaths: string[],
+  isolation: DisclosureBundle["isolation"],
 ): string {
   const title = input.lane.topic ?? input.lane.sessionKey;
   return [
@@ -109,6 +135,7 @@ function renderIndex(
       session_key: input.lane.sessionKey,
       agent: input.lane.agent,
       project: input.lane.project,
+      isolation,
       okf: okfMetadata(input.lane.metadata),
     }),
     `# ${title}`,
@@ -131,6 +158,31 @@ function renderIndex(
   ]
     .filter((line): line is string => line !== undefined)
     .join("\n");
+}
+
+function validateDisclosureScope(
+  lane: DisclosureBundleInput["lane"],
+  items: DisclosureScopeIdentity[],
+  itemType: string,
+): void {
+  const expected = {
+    sessionKey: lane.sessionKey,
+    session_key: lane.sessionKey,
+    agent: lane.agent,
+    project: lane.project,
+  };
+  for (const item of items) {
+    if ("namespace" in item) {
+      throw new Error(
+        `cross-scope disclosure ${itemType}: namespace cannot be verified by the export lane`,
+      );
+    }
+    for (const [field, value] of Object.entries(expected)) {
+      if (field in item && item[field as keyof DisclosureScopeIdentity] !== value) {
+        throw new Error(`cross-scope disclosure ${itemType}: ${field} does not match export lane`);
+      }
+    }
+  }
 }
 
 function conceptPaths(facts: DisclosureRepoFact[]): string[] {

--- a/src/operator-doctor.test.ts
+++ b/src/operator-doctor.test.ts
@@ -14,15 +14,25 @@ import { readNatsRuntimeBoundary } from "./nats-runtime.ts";
 const originalFetch = globalThis.fetch;
 const THIS_FILE = fileURLToPath(import.meta.url);
 
-function makePool(appliedFilenames: string[]) {
+function makePool(
+  appliedFilenames: string[],
+  auditProbe: "reachable" | "throws" = "reachable",
+  onAuditProbe?: () => void,
+) {
   return {
     totalCount: 1,
     idleCount: 1,
     waitingCount: 0,
-    query: async (sql: string) => {
+    query: async (query: string | { text: string }) => {
+      const sql = typeof query === "string" ? query : query.text;
       if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
       if (sql.includes("FROM _migrations")) {
         return { rows: appliedFilenames.map((filename) => ({ filename })) };
+      }
+      if (sql.includes("to_regclass")) {
+        onAuditProbe?.();
+        if (auditProbe === "throws") throw new Error("audit table unavailable");
+        return { rows: [{ table_name: "mcp_tool_audit_log" }] };
       }
       return { rows: [] };
     },
@@ -70,6 +80,7 @@ afterEach(() => {
   delete process.env.LOG_FILE;
   delete process.env.LOG_MAX_BYTES;
   delete process.env.LOG_MAX_FILES;
+  delete process.env.OPENBRAIN_MCP_AUDIT_ENABLED;
   resetOperatorDoctorCache();
 });
 
@@ -113,7 +124,7 @@ describe("operator doctor status", () => {
       request_logger: "enabled",
       file_log_configured: true,
       rotation_configured: true,
-      audit_storage: "not_available",
+      audit_storage: "available",
     });
     // QMD_PATH points at an existing file: binary presence only.
     expect(status.qmd).toEqual({
@@ -127,6 +138,39 @@ describe("operator doctor status", () => {
     expect(serialized).not.toContain(logPath);
     // The resolved qmd path must never appear in the payload.
     expect(serialized).not.toContain(THIS_FILE);
+  });
+
+  it("reports audit storage as available when audit is enabled and the table is reachable", async () => {
+    const status = await buildOperatorDoctorStatus(
+      makePool(["001_init.sql"]),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.log_audit.audit_storage).toBe("available");
+  });
+
+  it("reports audit storage as not available without probing when audit is disabled", async () => {
+    process.env.OPENBRAIN_MCP_AUDIT_ENABLED = "0";
+    let auditProbeCount = 0;
+
+    const status = await buildOperatorDoctorStatus(
+      makePool(["001_init.sql"], "reachable", () => {
+        auditProbeCount += 1;
+      }),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.log_audit.audit_storage).toBe("not_available");
+    expect(auditProbeCount).toBe(0);
+  });
+
+  it("reports audit storage as not available when the table probe throws", async () => {
+    const status = await buildOperatorDoctorStatus(
+      makePool(["001_init.sql"], "throws"),
+      readNatsRuntimeBoundary({}),
+    );
+
+    expect(status.log_audit.audit_storage).toBe("not_available");
   });
 
   it("resolves qmd via the same search_all resolution and reports missing binaries as unavailable", async () => {

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -12,6 +12,7 @@ import {
   EMBEDDING_MODEL,
 } from "./embedding.ts";
 import { checkPoolHealth } from "./db/pool.ts";
+import { readMcpAuditConfig } from "./audit-log.ts";
 import { resolveQmdPath } from "./qmd-path.ts";
 import type { NatsBridgeHealth } from "./nats-bridge.ts";
 import type { NatsRuntimeBoundary } from "./nats-runtime.ts";
@@ -203,6 +204,26 @@ async function readMigrationStatus(pool: pg.Pool): Promise<OperatorDoctorStatus[
   }
 }
 
+async function readAuditStorageStatus(
+  pool: pg.Pool,
+): Promise<OperatorDoctorStatus["log_audit"]["audit_storage"]> {
+  if (!readMcpAuditConfig().enabled) return "not_available";
+
+  const query: pg.QueryConfig<[string]> & { query_timeout: number } = {
+    text: "SELECT to_regclass($1) AS table_name",
+    values: ["mcp_tool_audit_log"],
+    query_timeout: OPTIONAL_TIMEOUT_MS,
+  };
+  const reachable = await withTimeout(
+    pool
+      .query(query)
+      .then(({ rows }) => rows[0]?.table_name != null)
+      .catch(() => false),
+    false,
+  );
+  return reachable ? "available" : "not_available";
+}
+
 async function checkEmbeddingAvailability(): Promise<boolean> {
   const baseUrl = embeddingBaseUrl();
   if (!baseUrl) return false;
@@ -236,12 +257,13 @@ export async function buildOperatorDoctorStatus(
   natsRuntimeBoundary: NatsRuntimeBoundary,
   natsBridgeHealth?: NatsBridgeHealth,
 ): Promise<OperatorDoctorStatus> {
-  const [database, migrations, embeddingAvailable, serviceVersion] =
+  const [database, migrations, embeddingAvailable, serviceVersion, auditStorage] =
     await Promise.all([
       checkPoolHealth(pool),
       readMigrationStatus(pool),
       checkEmbeddingAvailability(),
       readServiceVersion(),
+      readAuditStorageStatus(pool),
     ]);
   const qmd = checkQmdBinaryPresence();
 
@@ -312,7 +334,7 @@ export async function buildOperatorDoctorStatus(
       rotation_configured:
         fileLogConfigured &&
         (Boolean(process.env.LOG_MAX_BYTES) || Boolean(process.env.LOG_MAX_FILES)),
-      audit_storage: "not_available",
+      audit_storage: auditStorage,
     },
     optional_dependencies: {
       embedding_provider: embeddingDiagnostics.configured


### PR DESCRIPTION
## Summary

Verified-and-fixed pass over the #293-family review findings (handoff from session 29ed90f3). Every finding was independently re-derived from source before fixing.

| Issue | Verdict | Fix |
|---|---|---|
| #304 spool persists raw payloads | CONFIRMED (`spool.py` `_record_line`) | Redact via `redact_value` before serialization; replay deliberately replays the redacted form. Fixes #304 |
| #300 silent eviction of acknowledged records | CONFIRMED (`append_batch` while-loop) | Backpressure: full spool raises `SpoolFullError`, file left byte-for-byte unchanged. Addresses the "never silently drop an acknowledged checkpoint" criterion; broader #300 capacity work stays open. Refs #300 |
| #297 export has no server-side namespace/scope gate | PARTIALLY STALE — both exports are pure local formatters; **no server-side export path exists to gate** | Formatter-boundary slice, symmetric Python/TS: fail closed on conflicting lane identity and on cross-scope/namespace-tagged items; immutable session-derived isolation stamp (top-level + index frontmatter). Refs #297 |
| #287 deploy targets `system/` label with sudo | CONFIRMED | `gui/$(id -u)` labels, no sudo, warn-only nats-worker kickstart in deploy + rollback paths; rollout doc line updated. Fixes #287 |
| #281 doctor hardcodes `audit_storage` | CONFIRMED | Computed from `readMcpAuditConfig()` + bounded parameterized `to_regclass` probe, fail-open to `not_available`; value set unchanged, no `DOCTOR_CONTRACT_VERSION` bump. Fixes #281 |

One commit per fix. Built via a four-lane Claudex workflow (Sol ×3, Terra ×1, all codex companions, write-scoped, disjoint file ownership); controller diff-audited every lane before commit.

## Gates

- `bunx tsc --noEmit` clean; `bun test` 1346 pass / 0 fail (1410 across 101 files)
- `uv run mypy src/openbrain_memory` clean; `uv run ruff check src tests` clean; `uv run pytest -q` 344 passed / 5 skipped
- `shellcheck scripts/core01-deploy-local.sh` clean
- gitleaks over the tree: 14 findings, all pre-existing dummy fixtures (verified identical against the pre-change baseline; none introduced by this diff)

## Critical self-review

```text
Critical self-review:
- Highest-risk behavior: spool saturation semantics flip from evict-oldest to
  reject-newest. A full spool now surfaces an explicit SpoolFullError to the
  caller (as an error note on the failed write) instead of silently destroying
  previously-acknowledged records. Intended, but degraded environments will see
  more visible write failures.
- Assumptions that could be wrong: redact_value's pattern coverage defines what
  "secret" means — content it doesn't match still persists to the spool;
  disclosure items' agent/project fields are assumed to denote scope identity;
  to_regclass reachability is treated as "audit storage available" without
  proving INSERT permission.
- Missing/weak tests: no concurrent-append test at the exact capacity boundary;
  doctor "available" asserted against a fake pool, not live core01 (post-deploy
  verify listed below); deploy script covered by shellcheck only.
- Security/permission risk: disclosure export remains entirely client-side —
  this PR does NOT add a server-side gate because no server export path exists;
  runtime-level namespace/7-coordinate stamping is an explicit follow-up on #297.
- Migration/deploy risk: no migrations. Deploy-script change is exercised only
  by the next real dispatch/tag deploy; label values match the live install
  described in #287.
- Downstream client/runtime risk: SpoolFullError subclasses ValueError so
  existing handlers keep working; DisclosureBundle gains a required `isolation`
  key (additive for consumers of the value, breaking for TS code constructing
  the type); callers that previously passed mismatched lane identity got silent
  rewriting and now get an error.
- Rollback/cleanup concern: spool files written BEFORE this fix still contain
  raw payloads on disk; this PR does not retro-redact existing spool files, and
  replaying a pre-fix spool can still transmit previously-persisted raw
  content. Flagged on #304 as follow-up.
- Fixes made before PR: worker lanes validated green before handback; controller
  diff-audit found no material issue requiring rework; stale
  system/com.rico.open-brain reference in docs/downstream-rollout.md updated.
- Known residual risk: pattern-bounded redaction; pre-existing unredacted spool
  files; namespace unverifiable at the AgentMemory layer (rejected fail-closed
  rather than validated).
```

- SME review-memory update: [x] `docs/sme/` updated — promoted the #304 redact-before-disk, #300 acknowledged-data-saturation, and #297 fail-closed-identity patterns into security/correctness/gotcha lanes and superseded the spool half of the 2026-06-11 redaction stance (commit c8c8acf).

## Downstream rollout classification (docs/downstream-rollout.md)

Touched surfaces: `python/openbrain-memory` client behavior (spool semantics, export validation/shape) and TS client modules (`agent-memory.ts`, `disclosure-bundle.ts`); `operator-doctor` output value (computed instead of hardcoded — value set and schema unchanged).

Not touched: MCP tool names/input schemas/annotations/auth/error envelopes, transport/SSE/session behavior, DB migrations, generated skills.

- Step 1 (local verification): complete, evidence above.
- Step 2 (hosted verification): applicable for the doctor field and the deploy script — after merge, next `workflow_dispatch` deploy (or `v*` tag) exercises the fixed restart path; then verify live doctor reports `audit_storage: "available"`.
- Step 3 (rtech-mcps handoff): N/A — no registry/schema/secret-map change.
- Step 4 (mcp2cli cache/skill refresh): N/A — no tool schema change.
- Hermes/Python runtime: behavior-additive plus new fail-closed errors on inputs that were previously silently rewritten; picked up on next package refresh, no pinned-contract break identified. Live Hermes canary not required for this slice; flagged on #297 for the future runtime-level export wrapper.

Refs #293.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured in `docs/sme/` (commit c8c8acf)
- Live Open Brain checks: [x] not applicable because: no MCP tool/schema/transport surface changes pre-merge; the one hosted-visible change (doctor `audit_storage`) can only be exercised by the post-merge core01 deploy, which is scheduled in the rollout classification above.

Refs #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
