### PR TITLE
chore(python): bump openbrain-memory to 0.1.9 for provider re-pin

### DIFF
--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.8"
+version = "0.1.9"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -160,8 +160,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.8"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.8"
+    assert CURRENT_CLIENT_VERSION == "0.1.9"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.9"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.8 <1.0.0"
     )

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Version-only bump of the Python client package `openbrain-memory` 0.1.8 → 0.1.9 so the #293-family client fixes merged in #305 (spool redact-before-persist #304, `SpoolFullError` backpressure #300, disclosure fail-closed isolation slice #297) ship in a distinct, pinnable wheel version. The consumer is the Claude direct-provider install (`~/.local/share/openbrain-memory`), whose adapter pins exact wheel version + RECORD hashes and therefore needs a new version to re-pin against.

Changes: `pyproject.toml` version, `uv.lock` version stanza, and the two contract-test assertions that track the current package version (`CURRENT_CLIENT_VERSION` and the fixture-derived manifest min). Server-side `min_client_versions`/`compatible_client_ranges` in `src/contract.ts` are intentionally unchanged (0.1.9 satisfies `>=0.1.8 <1.0.0`).

## Gates

- `uv run pytest -q`: 344 passed / 5 skipped
- `uv run mypy src/openbrain_memory`: clean
- `uv run ruff check src tests`: clean
- No TS changes; server contract untouched.

## Critical self-review

- Highest-risk behavior: none functional — version metadata only; the risk is a consumer pinned to `==0.1.8` breaking, and the only known exact-pin consumer (the Claude direct-provider adapter) is being re-pinned deliberately as the point of this bump.
- Assumptions that could be wrong: assumed no other consumer pins `openbrain-memory==0.1.8` exactly; server ranges (`>=0.1.8 <1.0.0`) verified to admit 0.1.9.
- Missing/weak tests: no new tests — existing contract tests already validate current-version handling and were updated to track 0.1.9.
- Security/permission risk: none — no code paths changed in this PR.
- Migration/deploy risk: none — no migrations, no server behavior change; hosted deploy not required for this bump.
- Downstream client/runtime risk: consumers resolving by range are unaffected; the direct-provider re-pin to 0.1.9 happens in the Development repo flow after this merges.
- Rollback/cleanup concern: reverting is a version-string revert; no persisted-state implications.
- Fixes made before PR: updated the fixture-derived manifest-min assertion that tracks the package version (caught by the contract test on first run).
- Known residual risk: none beyond the exact-pin consumer coordination noted above.
- SME review-memory update: [x] not applicable because: version-metadata-only change with no reviewable behavior pattern; the behavioral patterns from this family were already captured in `docs/sme/` by #305.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured — none arose; behavioral findings from this family were captured in `docs/sme/` under #305
- Live Open Brain checks: [x] not applicable because: no server-side or hosted-visible change; the wheel build + provider re-pin validation happens in the Development-repo flow that consumes this version.

Refs #293, #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
