### PR TITLE
feat(python): auto-drain durable spool replay on healthy direct operations

### DIFF
--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/_runtime_router.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_router.py
@@ -61,6 +61,14 @@ class DirectClient(Protocol):
 
     def append_session_event(self, **arguments: Any) -> JSON: ...
 
+    def lane_upsert(self, **arguments: Any) -> JSON: ...
+
+    def upsert_repo_fact(self, **arguments: Any) -> JSON: ...
+
+    def log_thought(self, **arguments: Any) -> JSON: ...
+
+    def log_decision(self, **arguments: Any) -> JSON: ...
+
     def session_wrap(self, **arguments: Any) -> JSON: ...
 
     def agent_context_pack(self, **arguments: Any) -> JSON: ...
@@ -194,7 +202,7 @@ class Mcp2CliFallback:
 
 
 class RuntimeClientRouter:
-    """Route only the four tools owned by the first-class runtime."""
+    """Route first-class runtime calls and direct durable-record replays."""
 
     def __init__(
         self,
@@ -210,6 +218,7 @@ class RuntimeClientRouter:
         self.direct_result_validator = direct_result_validator
         self.state = CallState()
         self._queue_only = False
+        self._direct_only = False
 
     def reset(self) -> None:
         """Reset evidence for one public runtime operation."""
@@ -225,11 +234,33 @@ class RuntimeClientRouter:
         finally:
             self._queue_only = previous
 
+    @contextmanager
+    def direct_only(self) -> Iterator[None]:
+        """Disable fallback while replaying records from the durable spool."""
+        previous = self._direct_only
+        self._direct_only = True
+        try:
+            yield
+        finally:
+            self._direct_only = previous
+
     def session_start(self, **arguments: Any) -> JSON:
         return self._call("session_start", arguments)
 
     def append_session_event(self, **arguments: Any) -> JSON:
         return self._call("append_session_event", arguments)
+
+    def lane_upsert(self, **arguments: Any) -> JSON:
+        return self._call("lane_upsert", arguments)
+
+    def upsert_repo_fact(self, **arguments: Any) -> JSON:
+        return self._call("upsert_repo_fact", arguments)
+
+    def log_thought(self, **arguments: Any) -> JSON:
+        return self._call("log_thought", arguments)
+
+    def log_decision(self, **arguments: Any) -> JSON:
+        return self._call("log_decision", arguments)
 
     def session_wrap(self, **arguments: Any) -> JSON:
         return self._call("session_wrap", arguments)
@@ -279,17 +310,16 @@ class RuntimeClientRouter:
         if self.direct is not None:
             try:
                 self._ensure_direct_contract(timeout=timeout)
-                method = {
-                    "session_start": self.direct.session_start,
-                    "append_session_event": self.direct.append_session_event,
-                    "session_wrap": self.direct.session_wrap,
-                    "agent_context_pack": self.direct.agent_context_pack,
-                }[tool]
+                method = getattr(self.direct, tool, None)
+                if not callable(method):
+                    raise RuntimeCallError(
+                        f"direct client does not implement {tool}"
+                    )
                 original_timeout = self.direct.timeout
                 if timeout is not None:
                     self.direct.timeout = min(original_timeout, timeout)
                 try:
-                    result = method(**dict(arguments))
+                    result = cast(JSON, method(**dict(arguments)))
                 finally:
                     self.direct.timeout = original_timeout
                 _verify_direct_result(tool, result)
@@ -300,7 +330,7 @@ class RuntimeClientRouter:
                 return result
             except Exception as error:
                 direct_error = error
-        if self.fallback is not None:
+        if self.fallback is not None and not self._direct_only:
             self.state.fallback_attempted = True
             try:
                 result = self.fallback.call(tool, arguments, timeout=timeout)

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from collections.abc import Callable, Mapping, Sequence
@@ -71,7 +72,9 @@ from .agent import (
 )
 from .client import JSON, OpenBrainClient, Transport
 from .policy import redact_value
-from .spool import JsonlSpool
+from .spool import JsonlSpool, SpoolRecord
+
+logger = logging.getLogger(__name__)
 
 MAX_DISTILLED_CONTENT_BYTES = _runtime_validation.MAX_DISTILLED_CONTENT_BYTES
 _CONFIG_KEYS = {
@@ -104,6 +107,17 @@ _CONTEXT_PACK_SECTIONS = {
     "repo_facts",
     "working_set",
 }
+_REPLAYABLE_SPOOL_OPERATIONS = frozenset(
+    {
+        "session_start",
+        "lane_upsert",
+        "upsert_repo_fact",
+        "append_session_event",
+        "log_thought",
+        "log_decision",
+        "session_wrap",
+    }
+)
 
 
 class ReceiptStatus(StrEnum):
@@ -464,10 +478,13 @@ class FirstClassMemoryRuntime:
                 if self._router.state.path is not None
                 else ReceiptStatus.FAILED
             )
-            return RuntimeOutput(
+            output = RuntimeOutput(
                 receipt=self._receipt("recall", status, durable=False),
                 context=result,
             )
+            if status is ReceiptStatus.DIRECT:
+                self._drain_spool()
+            return output
         except Exception as error:
             return RuntimeOutput(
                 receipt=self._receipt(
@@ -572,10 +589,13 @@ class FirstClassMemoryRuntime:
                 if self._router.state.path == ReceiptStatus.FALLBACK.value
                 else ReceiptStatus.SAVED
             )
-            return RuntimeOutput(
+            output = RuntimeOutput(
                 receipt=self._receipt(operation, receipt_status, durable=True),
                 result=result,
             )
+            if receipt_status is ReceiptStatus.SAVED:
+                self._drain_spool()
+            return output
         except ValueError as error:
             return RuntimeOutput(
                 receipt=self._receipt(
@@ -621,6 +641,30 @@ class FirstClassMemoryRuntime:
                     error=lost_error,
                 )
             )
+
+    def _drain_spool(self) -> None:
+        """Replay pending durable records after direct connectivity recovers."""
+        try:
+            if self._spool is None:
+                return
+            spool = self._spool.spool
+            if not isinstance(spool, JsonlSpool):
+                return
+            if spool.status().pending_count <= 0:
+                return
+
+            def dispatch(record: SpoolRecord) -> JSON:
+                if record.operation not in _REPLAYABLE_SPOOL_OPERATIONS:
+                    raise ValueError(
+                        f"Unsupported spooled operation: {record.operation}"
+                    )
+                method = getattr(self._router, record.operation)
+                return cast(JSON, method(**record.payload))
+
+            with self._router.direct_only():
+                spool.replay(dispatch)
+        except Exception:
+            logger.warning("Spool auto-drain failed", exc_info=True)
 
     def _queue_requested_write(self, call: Callable[[], JSON]) -> BaseException:
         previous_key = self._memory.conversation_key

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -160,8 +160,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.9"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.9"
+    assert CURRENT_CLIENT_VERSION == "0.1.10"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.10"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.8 <1.0.0"
     )

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -417,6 +417,204 @@ def test_failed_lane_start_jsonl_spool_persists_ordered_replay_pair(
     assert records[1].payload["content"] == distilled
 
 
+def test_successful_direct_write_drains_spooled_unit_in_order(tmp_path: Path) -> None:
+    transport = LaneAwareTransport(fail_session_start=True)
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    queued = runtime.capture_distilled("Queued capture")
+    transport.fail_session_start = False
+    saved = runtime.capture_distilled("Recovery trigger")
+
+    calls = [
+        call["params"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] != "get_contract"
+    ]
+    assert queued.receipt.status is ReceiptStatus.SPOOLED
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    assert [call["name"] for call in calls[-2:]] == [
+        "session_start",
+        "append_session_event",
+    ]
+    assert calls[-1]["arguments"]["content"] == "Queued capture"
+    assert spool.status().pending_count == 0
+    assert spool.path.read_text(encoding="utf-8") == ""
+
+
+def test_successful_direct_recall_drains_spooled_unit_in_order(tmp_path: Path) -> None:
+    transport = LaneAwareTransport(fail_session_start=True)
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    queued = runtime.capture_distilled("Queued before recall")
+    transport.fail_session_start = False
+    recalled = runtime.recall_context("Connectivity restored")
+
+    calls = [
+        call["params"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] != "get_contract"
+    ]
+    assert queued.receipt.status is ReceiptStatus.SPOOLED
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert [call["name"] for call in calls[-2:]] == [
+        "session_start",
+        "append_session_event",
+    ]
+    assert calls[-1]["arguments"]["content"] == "Queued before recall"
+    assert spool.status().pending_count == 0
+
+
+def test_spool_drain_retains_unknown_operation_and_replays_valid_unit(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    spool.append("unknown_operation", {"value": "must stay"}, key="unknown-key")
+    spool.append(
+        "session_start",
+        {
+            **runtime_scope().start_metadata(),
+            "session_key": runtime_scope().session_key,
+            "agent": runtime_scope().agent,
+        },
+        key="valid-key",
+    )
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    recalled = runtime.recall_context("Drain valid records")
+
+    dispatched = [call["params"]["name"] for call in tool_calls(transport)]
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert "unknown_operation" not in dispatched
+    assert dispatched[-1] == "session_start"
+    remaining = spool.records()
+    assert [record.idempotency_key for record in remaining] == ["unknown-key"]
+
+
+def test_spool_drain_dispatches_every_allowlisted_operation(tmp_path: Path) -> None:
+    scope = runtime_scope()
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    records = [
+        (
+            "session_start",
+            {
+                **scope.start_metadata(),
+                "session_key": scope.session_key,
+                "agent": scope.agent,
+            },
+        ),
+        ("lane_upsert", {"session_key": scope.session_key}),
+        ("upsert_repo_fact", {"metadata": {"fact": "queued"}}),
+        (
+            "append_session_event",
+            {
+                **scope.start_metadata(),
+                "session_key": scope.session_key,
+                "agent": scope.agent,
+                "content": "Queued event",
+                "event_type": "fact",
+                "source": scope.agent,
+                "metadata": {"idempotency_key": "allowed-append"},
+            },
+        ),
+        ("log_thought", {"content": "Queued thought"}),
+        ("log_decision", {"content": "Queued decision"}),
+        (
+            "session_wrap",
+            {
+                **scope.start_metadata(),
+                "session_key": scope.session_key,
+                "agent": scope.agent,
+                "summary": "Queued wrap",
+            },
+        ),
+    ]
+    for index, (operation, payload) in enumerate(records):
+        spool.append(operation, payload, key=f"allowed-{index}")
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        scope,
+        transport=transport,
+        spool=spool,
+    )
+
+    recalled = runtime.recall_context("Drain allowlisted records")
+
+    dispatched = [
+        call["params"]["name"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] != "get_contract"
+    ]
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert dispatched[1:] == [operation for operation, _payload in records]
+    assert spool.status().pending_count == 0
+
+
+def test_spool_replay_failure_keeps_unit_without_changing_outer_receipt(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    spool.append(
+        "append_session_event",
+        {
+            **runtime_scope().start_metadata(),
+            "session_key": runtime_scope().session_key,
+            "agent": runtime_scope().agent,
+            "content": "Queued event",
+            "event_type": "fact",
+            "source": runtime_scope().agent,
+            "metadata": {"idempotency_key": "failed-key"},
+        },
+        key="failed-key",
+    )
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=LaneAwareTransport(),
+        spool=spool,
+    )
+
+    recalled = runtime.recall_context("Outer operation succeeds")
+
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert [record.idempotency_key for record in spool.records()] == ["failed-key"]
+
+
+def test_corrupt_spool_never_raises_out_of_capture_or_recall(tmp_path: Path) -> None:
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    spool.path.write_bytes(b"\xff\xfe")
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=LaneAwareTransport(),
+        spool=spool,
+    )
+
+    saved = runtime.capture_distilled("Direct write survives corrupt spool")
+    recalled = runtime.recall_context("Direct recall survives corrupt spool")
+
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+
+
 def test_failed_lane_start_batch_failure_leaves_no_orphaned_prerequisite() -> None:
     spool = FakeSpool(fail=True)
     runtime = FirstClassMemoryRuntime(

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes #307: `Spool.replay()` had no production caller, so records written as `spooled, durable` never drained. The runtime now opportunistically replays pending spool units after any successful direct operation — end of a successful direct write (`_write_locked`, receipt SAVED) and end of a successful direct recall (`_recall_context`, status DIRECT) — under the already-held operation lock.

Mechanics:

- Dispatcher validates each record against the exact spooled-operation allowlist (`session_start`, `lane_upsert`, `upsert_repo_fact`, `append_session_event`, `log_thought`, `log_decision`, `session_wrap`) and dispatches via the router's direct client path with `**record.payload`. Unknown operations raise inside the dispatcher so `JsonlSpool.replay` keeps that unit on disk.
- New `RuntimeClientRouter.direct_only()` context disables mcp2cli fallback during replay — durable records only ever replay over the verified direct path. Router also gains the four missing direct methods (`lane_upsert`, `upsert_repo_fact`, `log_thought`, `log_decision`) so every spooled operation is dispatchable.
- Drain never raises out of the outer operation: the whole drain is wrapped, unexpected errors log a warning and leave records on disk. Receipt shape is unchanged — no new fields.
- Replay does not re-enter `AgentMemory._call_write`, so a failing replay cannot re-spool or loop.
- Version bumped 0.1.9 → 0.1.10 (pyproject, uv.lock, contract-test assertions), giving the hash-pinned Claude provider install a distinct wheel to re-pin against.

Built via a Claudex workflow lane (Sol-high codex companion, write-scoped, isolated worktree); controller independently diff-audited the lane and re-ran all gates.

## Gates

- `uv run pytest -q`: 350 passed / 5 skipped (6 new drain tests: drain-after-write, drain-after-recall, unknown-operation retained, replay failure keeps unit + outer receipt unchanged, corrupt spool never raises, full allowlist dispatch)
- `uv run mypy src/openbrain_memory`: clean
- `uv run ruff check src tests`: clean
- No TS/server changes in this PR.

## Critical self-review

- Highest-risk behavior: replay dispatches previously-failed writes automatically on the next healthy operation — a burst of parked records lands on the server at once. Bounded by spool caps (max_lines/max_bytes) and unit ordering; SpoolFullError semantics from #300 unchanged.
- Assumptions that could be wrong: assumed every spooled record was produced by `_call_write` with kwargs-shaped payloads (enforced by allowlist + dispatcher raising on anything else); assumed replaying `session_start` prerequisites is idempotent server-side (it is the same lane-establishment call every session already makes).
- Missing/weak tests: no live-server replay test in this PR (covered in the rollout validation on core01, which has 5 real parked units); no concurrency test replaying while another process appends (file lock in `replay()` snapshots under flock, pre-existing behavior).
- Security/permission risk: replay goes only over the direct authenticated client with `direct_only()` explicitly disabling fallback; the operation allowlist prevents a tampered spool file from steering the client into arbitrary method calls.
- Migration/deploy risk: none server-side. Client-side, pre-0.1.9 spool files may contain unredacted payloads (known #304 residual); draining them transmits that content to the server over the normal authenticated path — delivery, not disclosure.
- Downstream client/runtime risk: additive behavior; receipt shape unchanged, so the pinned Claude adapter needs only the version/hash re-pin (Development-side, queued). Hermes/mcp2cli unaffected — no tool schema or transport change.
- Rollback/cleanup concern: reverting restores never-drains behavior; no persisted-state migration either way.
- Fixes made before PR: controller audit found no material rework; version-assertion updates were part of the lane.
- Known residual risk: drain is opportunistic — a client that only ever fails direct writes still never drains (needs a healthy moment); acceptable, matches #307's design intent.
- SME review-memory update: [x] not applicable because: this PR implements the previously-captured #300/#304 patterns' delivery path; no new MEDIUM+ review finding arose. The #307 never-drains gap itself is tracked as the issue this PR fixes.

## Downstream rollout classification (docs/downstream-rollout.md)

Touched surfaces: `python/openbrain-memory` client behavior only (spool drain on healthy operations; router direct-method surface). Not touched: MCP tool names/schemas/annotations, auth, transport/SSE, DB migrations, generated skills, server code.

- Step 1 (local verification): complete, gates above.
- Step 2 (hosted verification): N/A server-side; client rollout validation happens via the Development provider re-pin (0.1.10) with a live drain check on core01's parked spool units.
- Step 3 (rtech-mcps handoff): N/A — no registry/schema/secret-map change.
- Step 4 (mcp2cli cache/skill refresh): N/A — no tool schema change.
- Hermes/Python runtime: additive; next package refresh picks it up, no pinned-contract break.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured — none arose; existing `docs/sme/` patterns (#300 saturation, #304 redact-before-persist) already cover this family
- Live Open Brain checks: [x] not applicable because: no server-side change; the live check is the core01 drain validation in the Development-side 0.1.10 rollout that consumes this wheel.

Refs #307, #300, #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
