### PR TITLE
fix(python): scope-aware spool drain — replay parked units under their own exact scope

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -547,3 +547,30 @@ observable loss receipt — never as evict-then-return-success.
 - Fixture discovery without an expected-id set lets the fixture corpus silently shrink; the manifest must pin the exact fixture-id set and the validator must fail on missing OR extra fixtures.
 - CI's contract-parity change detection fell back to `HEAD^` on zero/empty push `before` SHAs, checking a narrower range than the pre-push hook; derive the base from the merge-base with `origin/main` instead.
 - Empty-string checks alone accept placeholder runtime-specific reasons (`n/a`, `na`, `none`, `todo`, `tbd`); reason validation must reject the placeholder set case-insensitively in both the PR-body gate and the manifest validator.
+
+## [2026-07-21] Instance-state validation latches need reset tests, not just resets
+
+**Severity:** MEDIUM
+**Source:** PR #314 (open-brain#310 scope-aware drain) review swarm 2026-07-21
+**Scope:** `python/openbrain-memory/src/openbrain_memory/runtime.py` (`_replay_scope`, `_drain_spool`)
+**Status:** fixed-pre-merge
+
+### Pattern
+
+`_drain_spool` latches `self._replay_scope` so replayed `session_start` results
+validate against the parked unit's scope. The `finally` reset was correct, but
+no test failed when it was deleted — the entire suite stayed green while the
+regression (stale foreign scope failing every subsequent live `session_start`,
+degrading all writes to SPOOLED) went undetected. Any instance-state latch that
+changes validation behavior needs a test that exercises the *next* operation
+after the latch should have cleared, and the test should be mutation-verified
+(delete the reset, watch the test fail) before it counts as coverage.
+
+### Review Questions
+
+- Does any instance attribute temporarily change validation/dispatch behavior?
+  If so, is there a test asserting the behavior *after* the temporary window?
+- Was the guard test proven against the mutant (reset removed → test fails with
+  the predicted failure mode)?
+- Is the latch also reset per iteration inside loops, so later items cannot
+  inherit a stale value if new code paths skip the tail reset?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -501,3 +501,32 @@ shipped artifact, per-sha cache dirs, deterministic probe receipts.
   access to the code doing the defending? If yes — wrong trust boundary, reject.
 - Does the accident-class equivalent (stale cache, wrong file, partial write)
   already fail closed via hash + probe? Then the TOCTOU add-on is theater.
+
+## [2026-07-21] Spooled records replayed under config authority need origin provenance
+
+**Severity:** MEDIUM
+**Source:** PR #314 (open-brain#310 scope-aware drain) review swarm 2026-07-21
+**Scope:** `python/openbrain-memory/src/openbrain_memory/_runtime_spool.py`, `runtime.py` `_drain_spool`
+**Status:** fixed-pre-merge
+
+### Pattern
+
+Scope-aware drain rebuilds lane coordinates from the spooled record but binds
+the namespace to the *draining* runtime's auth config. When two runtimes with
+different namespaces share one spool file, a unit parked under namespace A
+would drain into namespace B — a silent cross-namespace transplant. Any record
+persisted under one authority and replayed under another must carry provenance
+of the authority it was parked under (here: client-internal
+`_parked_namespace`, stamped at append, stripped before dispatch, mismatch →
+retain with zero live dispatches). Namespace isolation is a security boundary;
+"the config decides at replay time" is not enough when the config can differ
+from the one that accepted the write.
+
+### Review Questions
+
+- Can a persisted-then-replayed record cross an auth/namespace boundary because
+  replay-time config differs from park-time config?
+- Is the provenance marker client-internal (stripped before any server
+  dispatch) so it never widens the wire contract?
+- On mismatch, is the unit retained with *zero* dispatches (no wasted live
+  call, no partial replay)?

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.10"
+version = "0.1.11"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/_runtime_spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_spool.py
@@ -8,12 +8,17 @@ from typing import Any, cast
 from ._runtime_router import safe_error
 from .agent import MemorySpool
 
+# Client-internal provenance key stamped on spooled session_start payloads and
+# stripped before dispatch; it never reaches the server.
+PARKED_NAMESPACE_KEY = "_parked_namespace"
+
 
 class TrackingSpool:
     """Own ordered prerequisite/requested-write spooling for one runtime."""
 
-    def __init__(self, spool: MemorySpool) -> None:
+    def __init__(self, spool: MemorySpool, *, namespace: str | None = None) -> None:
         self.spool = spool
+        self.namespace = namespace
         self.last_key: str | None = None
         self.last_operation: str | None = None
         self.last_error: str | None = None
@@ -35,7 +40,13 @@ class TrackingSpool:
     ) -> str:
         """Defer lane setup until it can be atomically paired with the write."""
         if operation == "session_start":
-            self.pending_start = (operation, dict(payload), key)
+            parked = dict(payload)
+            if self.namespace is not None:
+                # Namespace provenance: a shared spool file replayed by a
+                # runtime configured for another namespace must retain this
+                # unit instead of silently transplanting its lane content.
+                parked[PARKED_NAMESPACE_KEY] = self.namespace
+            self.pending_start = (operation, parked, key)
             self.last_operation = operation
             return key or "pending-session-start"
         try:

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -23,7 +23,7 @@ from ._runtime_router import (
     safe_error,
     safe_text,
 )
-from ._runtime_spool import TrackingSpool
+from ._runtime_spool import PARKED_NAMESPACE_KEY, TrackingSpool
 from ._runtime_validation import (
     bounded_int as _bounded_int,
 )
@@ -413,7 +413,11 @@ class FirstClassMemoryRuntime:
         configured_spool = spool
         if configured_spool is None and config.spool_path is not None:
             configured_spool = JsonlSpool(config.spool_path)
-        self._spool = TrackingSpool(configured_spool) if configured_spool else None
+        self._spool = (
+            TrackingSpool(configured_spool, namespace=config.namespace)
+            if configured_spool
+            else None
+        )
         self._memory = AgentMemory(
             cast(MemoryClient, self._router),
             agent=scope.agent,
@@ -674,19 +678,35 @@ class FirstClassMemoryRuntime:
                 return
 
             def dispatch(record: SpoolRecord) -> JSON:
+                # Reset per record so no later record or unit can inherit a
+                # stale scope if scope-validated replay operations are added.
+                self._replay_scope = None
                 if record.operation not in _REPLAYABLE_SPOOL_OPERATIONS:
                     raise ValueError(
                         f"Unsupported spooled operation: {record.operation}"
                     )
+                payload = dict(record.payload)
                 if record.operation == "session_start":
+                    # A unit parked by a runtime configured for another
+                    # namespace must stay parked: draining it here would
+                    # silently transplant its lane content into this
+                    # runtime's namespace.
+                    parked_namespace = payload.pop(PARKED_NAMESPACE_KEY, None)
+                    if (
+                        parked_namespace is not None
+                        and parked_namespace != self.config.namespace
+                    ):
+                        raise ValueError(
+                            "spooled unit parked under a different namespace"
+                        )
                     # Validate the replayed lane against the scope the unit was
                     # parked under, not the runtime's current scope, so units
                     # from another project drain instead of re-failing forever
                     # (#310). The namespace stays bound to this runtime's auth
                     # config; only the lane coordinates come from the record.
-                    self._replay_scope = _spooled_start_scope(record.payload)
+                    self._replay_scope = _spooled_start_scope(payload)
                 method = getattr(self._router, record.operation)
-                return cast(JSON, method(**record.payload))
+                return cast(JSON, method(**payload))
 
             try:
                 with self._router.direct_only():

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -120,6 +120,23 @@ _REPLAYABLE_SPOOL_OPERATIONS = frozenset(
 )
 
 
+def _spooled_start_scope(payload: Mapping[str, Any]) -> RuntimeScope:
+    """Rebuild the exact scope a spooled session_start unit was parked under."""
+    try:
+        return RuntimeScope(
+            agent=payload["agent"],
+            platform=payload["platform"],
+            server_id=payload["server_id"],
+            channel_id=payload["channel_id"],
+            session_key=payload["session_key"],
+            thread_id=payload.get("thread_id"),
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(
+            "spooled session_start record does not carry a complete exact scope"
+        ) from error
+
+
 class ReceiptStatus(StrEnum):
     """Observable outcome of one runtime lifecycle operation."""
 
@@ -359,6 +376,9 @@ class FirstClassMemoryRuntime:
         self.scope = scope
         self._owns_client = client is None
         self._operation_lock = threading.RLock()
+        # Set only while draining a spooled unit parked under another scope;
+        # session_start replay results validate against this instead of scope.
+        self._replay_scope: RuntimeScope | None = None
         direct = client
         setup_error: BaseException | None = None
         if direct is None:
@@ -658,11 +678,21 @@ class FirstClassMemoryRuntime:
                     raise ValueError(
                         f"Unsupported spooled operation: {record.operation}"
                     )
+                if record.operation == "session_start":
+                    # Validate the replayed lane against the scope the unit was
+                    # parked under, not the runtime's current scope, so units
+                    # from another project drain instead of re-failing forever
+                    # (#310). The namespace stays bound to this runtime's auth
+                    # config; only the lane coordinates come from the record.
+                    self._replay_scope = _spooled_start_scope(record.payload)
                 method = getattr(self._router, record.operation)
                 return cast(JSON, method(**record.payload))
 
-            with self._router.direct_only():
-                spool.replay(dispatch)
+            try:
+                with self._router.direct_only():
+                    spool.replay(dispatch)
+            finally:
+                self._replay_scope = None
         except Exception:
             logger.warning("Spool auto-drain failed", exc_info=True)
 
@@ -681,7 +711,12 @@ class FirstClassMemoryRuntime:
     def _validate_direct_result(self, tool: str, result: Any) -> None:
         try:
             if tool == "session_start":
-                _validate_started_lane(result, self.config.namespace, self.scope)
+                scope = (
+                    self._replay_scope
+                    if self._replay_scope is not None
+                    else self.scope
+                )
+                _validate_started_lane(result, self.config.namespace, scope)
             elif tool == "agent_context_pack":
                 _validate_context_pack_scope(result, self.config.namespace, self.scope)
         except ValueError as error:

--- a/python/openbrain-memory/tests/_runtime_fakes.py
+++ b/python/openbrain-memory/tests/_runtime_fakes.py
@@ -251,6 +251,27 @@ class LaneAwareTransport:
         )
 
 
+class ForeignLaneTamperingTransport(LaneAwareTransport):
+    """Echo one session's lane with a hijacked channel_id to test replay proof."""
+
+    def __init__(self, tampered_session_key: str) -> None:
+        super().__init__()
+        self.tampered_session_key = tampered_session_key
+
+    def _tool_result(  # type: ignore[override]
+        self,
+        request_id: int,
+        body: Mapping[str, Any],
+    ) -> TransportResponse:
+        lane = body.get("lane") if isinstance(body, Mapping) else None
+        if (
+            isinstance(lane, Mapping)
+            and lane.get("session_key") == self.tampered_session_key
+        ):
+            body = {**body, "lane": {**lane, "channel_id": "hijacked-channel"}}
+        return LaneAwareTransport._tool_result(request_id, body)
+
+
 class StartThenFailClient:
     def __init__(self, *, fail_start: bool = False) -> None:
         self.fail_start = fail_start

--- a/python/openbrain-memory/tests/_runtime_fakes.py
+++ b/python/openbrain-memory/tests/_runtime_fakes.py
@@ -252,11 +252,19 @@ class LaneAwareTransport:
 
 
 class ForeignLaneTamperingTransport(LaneAwareTransport):
-    """Echo one session's lane with a hijacked channel_id to test replay proof."""
+    """Echo one session's lane with a single tampered field to test replay proof."""
 
-    def __init__(self, tampered_session_key: str) -> None:
+    def __init__(
+        self,
+        tampered_session_key: str,
+        *,
+        field: str = "channel_id",
+        value: Any = "hijacked-channel",
+    ) -> None:
         super().__init__()
         self.tampered_session_key = tampered_session_key
+        self.field = field
+        self.value = value
 
     def _tool_result(  # type: ignore[override]
         self,
@@ -268,7 +276,15 @@ class ForeignLaneTamperingTransport(LaneAwareTransport):
             isinstance(lane, Mapping)
             and lane.get("session_key") == self.tampered_session_key
         ):
-            body = {**body, "lane": {**lane, "channel_id": "hijacked-channel"}}
+            tampered = dict(lane)
+            if self.field == "metadata.server_id":
+                metadata = tampered.get("metadata")
+                nested = dict(metadata) if isinstance(metadata, Mapping) else {}
+                nested["server_id"] = self.value
+                tampered["metadata"] = nested
+            else:
+                tampered[self.field] = self.value
+            body = {**body, "lane": tampered}
         return LaneAwareTransport._tool_result(request_id, body)
 
 

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -160,8 +160,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.10"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.10"
+    assert CURRENT_CLIENT_VERSION == "0.1.11"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.11"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.8 <1.0.0"
     )

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 import openbrain_memory.__main__ as main_module
 import openbrain_memory.runtime as runtime_module
 from openbrain_memory import (
@@ -20,6 +22,7 @@ from openbrain_memory import (
     RuntimeConfig,
     RuntimeScope,
 )
+from openbrain_memory._runtime_spool import PARKED_NAMESPACE_KEY
 from openbrain_memory.cli import (
     MAX_JSON_INPUT_BYTES,
     encode_json_output,
@@ -720,6 +723,159 @@ def test_spool_drain_retains_start_record_missing_scope_coordinates(
         if call["params"]["name"] == "session_start"
     ]
     assert "other-repo/session-9" not in started_keys
+
+
+def test_live_write_after_foreign_unit_drain_validates_against_own_scope(
+    tmp_path: Path,
+) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    _park_unit(spool, parked, "Parked in another project")
+    transport = LaneAwareTransport()
+    scope = runtime_scope()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        scope,
+        transport=transport,
+        spool=spool,
+    )
+
+    recalled = runtime.recall_context("Drains the foreign unit")
+    saved = runtime.capture_distilled("Live write after the drain")
+
+    # A stale replay scope leaking past the drain would make this live
+    # session_start validate against the parked scope and fail.
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    assert spool.status().pending_count == 0
+    started = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "session_start"
+    ]
+    assert started[-1]["session_key"] == scope.session_key
+    assert started[-1]["channel_id"] == scope.channel_id
+
+
+def test_spool_drain_retains_unit_parked_under_another_namespace(
+    tmp_path: Path,
+) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    spool.append_batch(
+        [
+            (
+                "session_start",
+                {
+                    **parked.start_metadata(),
+                    "session_key": parked.session_key,
+                    "agent": parked.agent,
+                    PARKED_NAMESPACE_KEY: "other-namespace",
+                },
+                None,
+            ),
+            (
+                "append_session_event",
+                {
+                    **parked.start_metadata(),
+                    "session_key": parked.session_key,
+                    "agent": parked.agent,
+                    "content": "Parked by another namespace",
+                    "event_type": "fact",
+                    "source": parked.agent,
+                    "metadata": {"idempotency_key": "parked-other-namespace"},
+                },
+                None,
+            ),
+        ]
+    )
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    saved = runtime.capture_distilled("Healthy current-scope write")
+
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    # The unit was parked by a runtime bound to another namespace: retained,
+    # with no live dispatch for any of its records.
+    assert [record.operation for record in spool.records()] == [
+        "session_start",
+        "append_session_event",
+    ]
+    dispatched_keys = [
+        call["params"]["arguments"].get("session_key")
+        for call in tool_calls(transport)
+        if call["params"]["name"] != "get_contract"
+    ]
+    assert parked.session_key not in dispatched_keys
+
+
+def test_runtime_parked_start_record_carries_parking_namespace(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        client=StartThenFailClient(fail_start=True),
+        spool=spool,
+    )
+
+    queued = runtime.capture_distilled("Parked by this runtime")
+
+    assert queued.receipt.status is ReceiptStatus.SPOOLED
+    records = spool.records()
+    assert records[0].operation == "session_start"
+    assert records[0].payload[PARKED_NAMESPACE_KEY] == "bilby"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("agent", "hijacked-agent"),
+        ("source", "hijacked-source"),
+        ("thread_id", "hijacked-thread"),
+        ("namespace", "hijacked-namespace"),
+        ("metadata.server_id", "hijacked-guild"),
+    ],
+)
+def test_spool_drain_rejects_any_tampered_lane_field_for_parked_scope(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    _park_unit(spool, parked, "Must stay parked")
+    transport = ForeignLaneTamperingTransport(
+        parked.session_key, field=field, value=value
+    )
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    saved = runtime.capture_distilled("Healthy current-scope write")
+
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    assert [record.operation for record in spool.records()] == [
+        "session_start",
+        "append_session_event",
+    ]
+    appended = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "append_session_event"
+    ]
+    assert all(
+        arguments["content"] != "Must stay parked" for arguments in appended
+    )
 
 
 def test_spool_replay_failure_keeps_unit_without_changing_outer_receipt(

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -31,6 +31,7 @@ from ._runtime_fakes import (
     ContextClient,
     FakeRunner,
     FakeSpool,
+    ForeignLaneTamperingTransport,
     LaneAwareTransport,
     StartThenFailClient,
     WriteResultClient,
@@ -566,6 +567,159 @@ def test_spool_drain_dispatches_every_allowlisted_operation(tmp_path: Path) -> N
     assert recalled.receipt.status is ReceiptStatus.DIRECT
     assert dispatched[1:] == [operation for operation, _payload in records]
     assert spool.status().pending_count == 0
+
+
+def _parked_unit_scope() -> RuntimeScope:
+    return RuntimeScope(
+        agent="bilby",
+        platform="discord",
+        server_id="guild-9",
+        channel_id="channel-parked",
+        session_key="other-repo/session-9",
+    )
+
+
+def _park_unit(spool: JsonlSpool, scope: RuntimeScope, content: str) -> None:
+    spool.append_batch(
+        [
+            (
+                "session_start",
+                {
+                    **scope.start_metadata(),
+                    "session_key": scope.session_key,
+                    "agent": scope.agent,
+                },
+                None,
+            ),
+            (
+                "append_session_event",
+                {
+                    **scope.start_metadata(),
+                    "session_key": scope.session_key,
+                    "agent": scope.agent,
+                    "content": content,
+                    "event_type": "fact",
+                    "source": scope.agent,
+                    "metadata": {"idempotency_key": f"parked-{content}"},
+                },
+                None,
+            ),
+        ]
+    )
+
+
+def test_spool_drain_replays_unit_parked_under_another_scope(tmp_path: Path) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    _park_unit(spool, parked, "Parked in another project")
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    saved = runtime.capture_distilled("Recovery trigger in current project")
+
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    assert spool.status().pending_count == 0
+    started = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "session_start"
+    ]
+    assert any(
+        arguments["session_key"] == parked.session_key
+        and arguments["channel_id"] == parked.channel_id
+        for arguments in started
+    )
+    appended = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "append_session_event"
+    ]
+    assert any(
+        arguments["content"] == "Parked in another project"
+        and arguments["channel_id"] == parked.channel_id
+        for arguments in appended
+    )
+
+
+def test_spool_drain_rejects_tampered_lane_echo_for_parked_scope(
+    tmp_path: Path,
+) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    _park_unit(spool, parked, "Must stay parked")
+    transport = ForeignLaneTamperingTransport(parked.session_key)
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    saved = runtime.capture_distilled("Healthy current-scope write")
+
+    assert saved.receipt.status is ReceiptStatus.SAVED
+    # The replayed lane echo failed the parked unit's exact-scope proof, so the
+    # unit stays parked and its write never dispatched.
+    assert [record.operation for record in spool.records()] == [
+        "session_start",
+        "append_session_event",
+    ]
+    appended = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "append_session_event"
+    ]
+    assert all(
+        arguments["content"] != "Must stay parked" for arguments in appended
+    )
+
+
+def test_spool_drain_retains_start_record_missing_scope_coordinates(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "runtime-spool.jsonl")
+    spool.append(
+        "session_start",
+        {"session_key": "other-repo/session-9", "agent": "bilby"},
+        key="incomplete-start",
+    )
+    scope = runtime_scope()
+    spool.append(
+        "session_start",
+        {
+            **scope.start_metadata(),
+            "session_key": scope.session_key,
+            "agent": scope.agent,
+        },
+        key="valid-start",
+    )
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        scope,
+        transport=transport,
+        spool=spool,
+    )
+
+    recalled = runtime.recall_context("Drain what can be proven")
+
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    # The incomplete record cannot prove a parked scope: retained, and never
+    # dispatched as a wasted live session_start.
+    assert [record.idempotency_key for record in spool.records()] == [
+        "incomplete-start"
+    ]
+    started_keys = [
+        call["params"]["arguments"].get("session_key")
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "session_start"
+    ]
+    assert "other-repo/session-9" not in started_keys
 
 
 def test_spool_replay_failure_keeps_unit_without_changing_outer_receipt(

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #310. Auto-drain now replays each parked unit under the exact scope it was parked with, instead of validating every replayed `session_start` against the runtime's *current* scope — which made units parked in project A re-fail (with a wasted live dispatch each time) on every healthy operation in project B, forever.

**Change (client-local, `FirstClassMemoryRuntime`):**
- `_drain_spool` rebuilds a `RuntimeScope` from each spooled `session_start` record's own payload (`agent/platform/server_id/channel_id/session_key/thread_id` — all already recorded) and validates the lane echo against *that* scope. Namespace stays bound to the runtime's auth config — only lane coordinates come from the record, so no isolation boundary moves.
- A tampered/mismatched lane echo still fails the exact-scope proof and retains the unit (regression-tested with a tampering fake transport).
- A spooled start record missing scope coordinates is retained without any wasted live dispatch.
- Package version 0.1.11.

**Tests (fake transport, per repo standard):** cross-scope unit drains on a healthy current-scope write with the parked coordinates proven in the dispatched calls; tampered lane echo for the parked scope → unit retained, its write never dispatched; incomplete scope record → retained with zero dispatches; all existing drain/replay ordering tests unchanged and passing.

**Gates (post swarm-fix, eab2bbc):** `uv run pytest` 373 passed / 5 skipped; `uv run mypy src/openbrain_memory` clean; `uv run ruff check src tests` clean.

**Downstream rollout classification (docs/downstream-rollout.md):** client-behavior bugfix — no MCP tool/schema/protocol or receipt change; contract v22 untouched (min client stays 0.1.8, fleet pins unaffected). Applicable rollout = wheel 0.1.11 build + Development adapter pin bump + re-activation on the Macs; rtech-mcps/mcp2cli/Hermes runtime steps not applicable.

## Contract Parity
- Contract parity: [x] runtime-specific because: client-local replay validation ordering only — no request shape, receipt schema, or contract capability change.

## Critical self-review
- Highest-risk behavior: deriving validation scope from spool-file content. Bounded: same-user 0600 file, namespace still auth-config-bound, and a forged record can only target scopes the bearer token already reaches — identical power to a normal write.
- Assumptions that could be wrong: every legitimately-spooled `session_start` payload carries the full coordinate set (it does — `start_session` builds it; incomplete records fail closed to retention).
- Missing/weak tests: no live multi-project drain test in CI (env-gated canary planned at rollout; the 2026-07-21 core01/local observations are the field repro).
- Security/permission risk: none new — exact-scope proof still enforced per replayed unit; tamper test proves it.
- Migration/deploy risk: none — spool format unchanged, replay of existing parked units just starts succeeding.
- Downstream client/runtime risk: none — receipts/contract unchanged; fleet can stay on 0.1.10.
- Rollback/cleanup concern: revert restores current-scope-only draining; parked units return to waiting for scope-matched operations (today's behavior).
- Fixes made before PR: contract test version pins updated with the 0.1.11 bump.
- Known residual risk: `_replay_scope` is instance state guarded by the operation lock; a future concurrent-drain refactor must keep it per-drain (noted in code comment).
- SME review-memory update: [x] `docs/sme/` updated (b8e4d2c: correctness latch-reset pattern, security spool-provenance pattern)

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` (both swarm MEDIUMs, commit b8e4d2c)
- Live Open Brain checks: [x] not applicable because: client-only replay change validated by the fake-transport suite; live receipts land with the 0.1.11 wheel activation rollout recorded on #310 closure.

Fresh-context review swarm complete — receipt below (gotcha-agent lane run, mandatory for `python/openbrain-memory/`).

## Review swarm receipt

Fresh-context swarm (SME-injected lanes: correctness, adversarial, quality, security, domain-backend, gotcha-agent) on head b30b0f4. Findings and dispositions, all fixed in eab2bbc:

- **MEDIUM (correctness):** no test guarded the `_replay_scope` finally-reset — deleting it left every test green while a stale foreign scope would fail all subsequent live `session_start`s, degrading writes to SPOOLED. **Fixed:** `test_live_write_after_foreign_unit_drain_validates_against_own_scope`; mutation-verified (both resets removed → test fails with exactly the predicted SPOOLED + scope-proof error, restored → green).
- **MEDIUM (security):** runtimes with different namespaces sharing one spool file could transplant a unit's lane content across namespaces (records carried no namespace provenance). **Fixed:** `TrackingSpool` stamps client-internal `_parked_namespace` on parked `session_start` payloads; drain strips it before dispatch and retains units whose parked namespace differs from the runtime's config namespace (zero live dispatches). Tests: provenance stamp asserted on runtime-parked records; mismatched-namespace unit retained.
- **LOW:** `_replay_scope` now also resets per record at dispatch top (stale-latch trap if future replayable ops become scope-validated).
- **LOW:** tampered-lane-echo test parameterized over `agent`, `source`, `thread_id`, `namespace`, `metadata.server_id` (channel_id already covered).
- **Gotcha lane:** clean; empirically confirmed the tamper test depends on the runtime validator (neutered-validator experiment flipped it to failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
