### PR TITLE
docs: compatibility matrix + enforced memory limits reference (#299, #300)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -455,6 +455,8 @@ lab HTTP endpoints such as `http://10.71.1.21:3100`.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — coding standards, development workflow, and infrastructure rules
 - [GLOSSARY.md](GLOSSARY.md) — domain terminology (tiers, warmth, dream cycles, etc.)
 - [docs/operator-audit-log.md](operator-audit-log.md) — MCP tool audit log schema, env controls, privacy guarantees, fail-open behavior
+- [docs/compatibility-matrix.md](compatibility-matrix.md) — supported client versions and Python/TS capability parity, rendered from the machine-enforced contract data
+- [docs/memory-limits.md](memory-limits.md) — enforced capacity/backpressure/degradation limits and their at-limit behavior
 
 ## License
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -18,8 +18,8 @@ declarations to it, and the deploy job cannot run without that gate passing.
 | Client surface | Runtime it serves | Minimum | Supported range | Enforced where |
 |---|---|---|---|---|
 | `openbrain-memory` (Python) | Claude direct provider (Development `_ob` adapter), Hermes Python runtime | 0.1.8 | `>=0.1.8 <1.0.0` | `get_contract` manifest + client `validate_required_memory_contract`; server `X-OB-Contract` tripwire |
-| `mcp2cli` | Codex durable memory (hosted daemon ct216), cc boxes, generated skills | 0.3.6 | `>=0.3.6 <1.0.0` | `get_contract` manifest; `X-OB-Contract` header forwarding on MCP paths |
-| `rtech-hermes-runtime` | Hermes live agents (Nagatha/Bilby/Skippy) | 0.1.0 | `>=0.1.0 <1.0.0` | `get_contract` manifest; fleet pins per `docs/downstream-rollout.md` |
+| `mcp2cli` | Codex durable memory (hosted daemon), cc boxes, generated skills | 0.3.6 | `>=0.3.6 <1.0.0` | `get_contract` manifest; `X-OB-Contract` header forwarding is expected from mcp2cli ≥0.3.6 (owned by the mcp2cli repo; verified live against core01 2026-07-21) |
+| `rtech-hermes-runtime` | Hermes live agents (inventory owned by the rtech-hermes repo) | 0.1.0 | `>=0.1.0 <1.0.0` | `get_contract` manifest; fleet pins per `docs/downstream-rollout.md` |
 
 Codex note: Codex is not itself a versioned Open Brain client. It reaches Open
 Brain through `mcp2cli`, which is the versioned, range-checked surface above.
@@ -44,8 +44,10 @@ From `contracts/memory/parity-manifest.json` (fixture-backed, CI-gated by
 
 The 12 fixtures in `contracts/memory/` are the runtime-neutral behavioral spec
 for both columns; `python/openbrain-memory/tests/test_contract_fixtures.py` is
-the Python fixture runner. The TS column flips to implemented via #312's
-fixture runner under `clients/ts/`.
+the Python fixture runner. The `(#312)` annotations and the `clients/ts/`
+landing path are doc-only forward references (the manifest records only
+`pending`; `contracts/parity-paths.txt` pre-wires `clients/ts/`) — update this
+page if #312 is re-scoped.
 
 ## Upgrade and deprecation policy
 
@@ -53,8 +55,10 @@ fixture runner under `clients/ts/`.
   validate on `get_contract` before lifecycle operations, and the rollout order
   in `docs/downstream-rollout.md` (steps 3-7) is the required fleet sequence.
 - `min_client_versions` only rises in a PR that also updates the parity
-  fixtures (`contract-declaration` fixture pins the live version), so CI fails
-  on any one-sided bump.
+  fixtures: the contract-declaration fixture pins `schema_hash`, and
+  `min_client_versions` is inside the hashed payload (only
+  `realtime_transport` is excluded from `schema_hash`), so any one-sided bump
+  changes the hash and fails CI.
 - Deprecating a client version = raising its minimum in `src/contract.ts`.
   There is no silent window: older clients fail contract validation loudly at
   session start, and the server logs drifted `X-OB-Contract` declarations.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,0 +1,70 @@
+# Client Compatibility Matrix
+
+Human-readable rendering of the machine-enforced compatibility data. The
+authoritative sources are `src/contract.ts` (`min_client_versions`,
+`compatible_client_ranges`) and `contracts/memory/parity-manifest.json`; if
+this page and those files disagree, the machine data wins. Update this page in
+the same PR whenever either source changes (the contract-parity pre-push hook
+watches `contracts/**`; treat `docs/compatibility-matrix.md` as part of that
+change set by convention).
+
+Live contract: `2026-07-17.memory-tools.v22` (`src/contract.ts`
+`CONTRACT_VERSION`), enforced end-to-end — clients validate the manifest before
+lifecycle operations, CI's `contract-parity` job binds in-tree client
+declarations to it, and the deploy job cannot run without that gate passing.
+
+## Supported client versions
+
+| Client surface | Runtime it serves | Minimum | Supported range | Enforced where |
+|---|---|---|---|---|
+| `openbrain-memory` (Python) | Claude direct provider (Development `_ob` adapter), Hermes Python runtime | 0.1.8 | `>=0.1.8 <1.0.0` | `get_contract` manifest + client `validate_required_memory_contract`; server `X-OB-Contract` tripwire |
+| `mcp2cli` | Codex durable memory (hosted daemon ct216), cc boxes, generated skills | 0.3.6 | `>=0.3.6 <1.0.0` | `get_contract` manifest; `X-OB-Contract` header forwarding on MCP paths |
+| `rtech-hermes-runtime` | Hermes live agents (Nagatha/Bilby/Skippy) | 0.1.0 | `>=0.1.0 <1.0.0` | `get_contract` manifest; fleet pins per `docs/downstream-rollout.md` |
+
+Codex note: Codex is not itself a versioned Open Brain client. It reaches Open
+Brain through `mcp2cli`, which is the versioned, range-checked surface above.
+There is no separately negotiated Codex contract; Codex compatibility is
+exactly mcp2cli compatibility plus the session-lifecycle directives in
+`docs/memory-contract.md`.
+
+## Capability parity (Python client vs TypeScript peer)
+
+From `contracts/memory/parity-manifest.json` (fixture-backed, CI-gated by
+`contracts/check-parity.ts`):
+
+| Capability | Python | TypeScript |
+|---|---|---|
+| contract-declaration | implemented | pending (#312) |
+| session-lifecycle | implemented | pending (#312) |
+| exact-scope-proof | implemented | pending (#312) |
+| spool-backpressure | implemented | pending (#312) |
+| redact-before-persist | implemented | pending (#312) |
+| auto-drain-allowlist | implemented | pending (#312) |
+| receipt-shapes | implemented | runtime-specific (bounded TS `error_category` enum is Development-adapter-owned) |
+
+The 12 fixtures in `contracts/memory/` are the runtime-neutral behavioral spec
+for both columns; `python/openbrain-memory/tests/test_contract_fixtures.py` is
+the Python fixture runner. The TS column flips to implemented via #312's
+fixture runner under `clients/ts/`.
+
+## Upgrade and deprecation policy
+
+- Contract bumps ship contract-first: server declares the new version, clients
+  validate on `get_contract` before lifecycle operations, and the rollout order
+  in `docs/downstream-rollout.md` (steps 3-7) is the required fleet sequence.
+- `min_client_versions` only rises in a PR that also updates the parity
+  fixtures (`contract-declaration` fixture pins the live version), so CI fails
+  on any one-sided bump.
+- Deprecating a client version = raising its minimum in `src/contract.ts`.
+  There is no silent window: older clients fail contract validation loudly at
+  session start, and the server logs drifted `X-OB-Contract` declarations.
+
+## What this matrix does not claim
+
+- No executable cross-runtime handoff tests exist yet (Claude→Codex,
+  Codex→Claude continuity on the same lane). Parity fixtures prove
+  same-contract behavior per runtime, not cross-runtime handoff. Tracked as
+  future work under the P2 program (#299 closure notes).
+- No mixed-version stateful upgrade/rollback fixtures; upgrade compatibility
+  is covered operationally by `docs/downstream-rollout.md` plus the
+  backup/restore program (#298).

--- a/docs/memory-limits.md
+++ b/docs/memory-limits.md
@@ -1,0 +1,61 @@
+# First-Class Memory: Capacity, Backpressure, and Degradation Limits
+
+Single reference for the limits that are enforced in code today, what happens
+at each limit, and which envelope items are deliberately deferred. Sources are
+cited per limit; if this page and the code disagree, the code wins and this
+page must be fixed in the same PR.
+
+Design rule (from #300 and the PR #305 incident): **capacity limits surface as
+backpressure or an observable receipt — never as silent loss of acknowledged
+data.** The one hard acceptance criterion — never silently drop an
+acknowledged checkpoint — is regression-tested
+(`python/openbrain-memory/tests/test_spool.py`, saturation tests fail on the
+old FIFO-eviction behavior).
+
+## Python client (openbrain-memory)
+
+| Limit | Value | At-limit behavior | Source |
+|---|---|---|---|
+| Distilled content size | 16 KiB (UTF-8 bytes) | `ValueError` before any transport call; nothing persisted | `_runtime_validation.py` `MAX_DISTILLED_CONTENT_BYTES` |
+| CLI JSON input | 64 KiB | Input rejected, error receipt, no partial parse | `cli.py` `MAX_JSON_INPUT_BYTES` |
+| Spool line cap | 1000 records | `SpoolFullError`; spool file byte-for-byte unchanged; caller receipt degrades (write reported non-durable) instead of silently evicting | `spool.py` `JsonlSpool(max_lines=1000)` |
+| Spool byte cap | 1,000,000 bytes | Same `SpoolFullError` backpressure; oversize single batch is `ValueError` | `spool.py` `JsonlSpool(max_bytes=1_000_000)` |
+| Spool payload redaction | always | Payloads pass `redact_value` before disk persistence | `spool.py` `_record_line` |
+| Replay concurrency | 1 (serialized) | Drain runs under the runtime operation lock on healthy operations only; failed/foreign/poison units are retained in place, never dropped | `runtime.py` `_drain_spool` (#309, #314) |
+| Queue observability | content-free | `SpoolStatus`: pending count, oldest/newest timestamps, per-operation counts, corrupted-line count — no payloads | `spool.py` `SpoolStatus` |
+
+Degraded-state ladder for a write when the provider is unhealthy:
+`SAVED` (direct) → `SPOOLED` (durable locally, replayed automatically on the
+next healthy operation) → `LOST` (spool saturated or unavailable; loudly
+reported in the receipt, never silent). Recovery is automatic: #309 auto-drain
+fires on every healthy direct recall and saved write; #314 replays units under
+their parked exact scope with namespace provenance.
+
+## Server (Bun/TypeScript)
+
+| Limit | Value | At-limit behavior | Source |
+|---|---|---|---|
+| Audit retention | 366 days max | Clamped; retention beyond cap rejected | `src/audit-log.ts` `MAX_RETENTION_DAYS` |
+| Audit write timeout | 5000 ms | Write abandoned; audit is fail-open by documented design on LAN-local infra (facts-only rows, no payloads) | `src/audit-log.ts` `MAX_WRITE_TIMEOUT_MS` |
+| Audit in-flight writes | 4 | Additional audit writes dropped while saturated (fail-open, intentional) | `src/audit-log.ts` `MAX_IN_FLIGHT_AUDIT_WRITES` |
+| Recovery WAL TTL | 24 h | Expired entries dropped from recovery view | `src/realtime/recovery-wal.ts` `DEFAULT_RECOVERY_WAL_BUDGET.ttl_ms` |
+| Recovery WAL sessions | 128 | Bounded; oldest-session eviction within the recovery (non-authoritative) view only | `recovery-wal.ts` `max_sessions` |
+| Recovery WAL items | 50/session, 2048 global | Bounded as above | `recovery-wal.ts` `max_items_per_session`, `max_global_items` |
+| Recovery WAL content | 8000 content / 2000 metadata / 1000 preview chars | Truncated at ingest | `recovery-wal.ts` budget fields |
+
+The recovery WAL is a bounded convenience view over durable lane data — its
+evictions never delete authoritative rows, so its caps are not a durability
+surface.
+
+## Deliberately deferred (safe because nothing at these envelopes can lose acknowledged data)
+
+- Concurrent multi-runtime load-test suite (Claude+Codex+Python on one lane) —
+  P2/P3 program work; correctness under concurrency is covered by the
+  operation lock, exact-scope proofs, and per-tool server tests, not by a
+  load harness.
+- Saturation alerting thresholds / unified degraded-state signal beyond
+  `SpoolStatus` and receipts — revisit with #296's drain receipts.
+- Receipt retention policy and backup storage/duration envelopes — owned by
+  the backup/restore program (#298).
+- Replay throughput limits beyond serialized-drain — no observed need at
+  current fleet size; revisit if drain latency ever shows up in receipts.

--- a/docs/memory-limits.md
+++ b/docs/memory-limits.md
@@ -18,30 +18,33 @@ old FIFO-eviction behavior).
 |---|---|---|---|
 | Distilled content size | 16 KiB (UTF-8 bytes) | `ValueError` before any transport call; nothing persisted | `_runtime_validation.py` `MAX_DISTILLED_CONTENT_BYTES` |
 | CLI JSON input | 64 KiB | Input rejected, error receipt, no partial parse | `cli.py` `MAX_JSON_INPUT_BYTES` |
-| Spool line cap | 1000 records | `SpoolFullError`; spool file byte-for-byte unchanged; caller receipt degrades (write reported non-durable) instead of silently evicting | `spool.py` `JsonlSpool(max_lines=1000)` |
-| Spool byte cap | 1,000,000 bytes | Same `SpoolFullError` backpressure; oversize single batch is `ValueError` | `spool.py` `JsonlSpool(max_bytes=1_000_000)` |
+| Spool line cap | 1000 records | `SpoolFullError` (a `ValueError` subclass); spool file byte-for-byte unchanged; caller receipt degrades (write reported non-durable) instead of silently evicting | `spool.py` `JsonlSpool(max_lines=1000)` |
+| Spool byte cap | 1,000,000 bytes | Same `SpoolFullError` backpressure at saturation; a single batch that can never fit raises plain `ValueError` | `spool.py` `JsonlSpool(max_bytes=1_000_000)` |
 | Spool payload redaction | always | Payloads pass `redact_value` before disk persistence | `spool.py` `_record_line` |
 | Replay concurrency | 1 (serialized) | Drain runs under the runtime operation lock on healthy operations only; failed/foreign/poison units are retained in place, never dropped | `runtime.py` `_drain_spool` (#309, #314) |
 | Queue observability | content-free | `SpoolStatus`: pending count, oldest/newest timestamps, per-operation counts, corrupted-line count — no payloads | `spool.py` `SpoolStatus` |
 
-Degraded-state ladder for a write when the provider is unhealthy:
-`SAVED` (direct) → `SPOOLED` (durable locally, replayed automatically on the
-next healthy operation) → `LOST` (spool saturated or unavailable; loudly
-reported in the receipt, never silent). Recovery is automatic: #309 auto-drain
-fires on every healthy direct recall and saved write; #314 replays units under
-their parked exact scope with namespace provenance.
+Write outcomes (`ReceiptStatus`, `runtime.py`): `SAVED` (direct write
+succeeded) → `SPOOLED` (durable locally, replayed automatically on the next
+healthy operation) → `FALLBACK` (delivered via a configured fallback route) →
+`FAILED`/`LOST` (loudly reported in the receipt, never silent; `LOST` includes
+spool-saturated). `DIRECT` is the recall-success status, not a write status.
+Recovery is automatic: #309 auto-drain fires on every healthy direct recall
+and saved write; #314 replays units under their parked exact scope with
+namespace provenance.
 
 ## Server (Bun/TypeScript)
 
 | Limit | Value | At-limit behavior | Source |
 |---|---|---|---|
-| Audit retention | 366 days max | Clamped; retention beyond cap rejected | `src/audit-log.ts` `MAX_RETENTION_DAYS` |
-| Audit write timeout | 5000 ms | Write abandoned; audit is fail-open by documented design on LAN-local infra (facts-only rows, no payloads) | `src/audit-log.ts` `MAX_WRITE_TIMEOUT_MS` |
-| Audit in-flight writes | 4 | Additional audit writes dropped while saturated (fail-open, intentional) | `src/audit-log.ts` `MAX_IN_FLIGHT_AUDIT_WRITES` |
+| Audit retention | configurable 1–366 days, default 30 | Out-of-range or non-numeric env values silently fall back to the default (30) — never clamped, never rejected; same fallback semantics for all audit config bounds | `src/audit-log.ts` `readBoundedInt`, `MAX_RETENTION_DAYS` |
+| Audit write timeout | default 1000 ms, configurable 50–5000 ms | Write abandoned at the configured timeout; out-of-range env falls back to 1000 ms; audit is fail-open by documented design on LAN-local infra (facts-only rows, no payloads) | `src/audit-log.ts` `DEFAULT_WRITE_TIMEOUT_MS`, `MAX_WRITE_TIMEOUT_MS` |
+| Audit in-flight writes | 4 | Audit writes are skipped while 4 are in flight **or whenever the DB pool has any waiters** — drops can occur below the cap under pool pressure (fail-open, intentional) | `src/audit-log.ts` `MAX_IN_FLIGHT_AUDIT_WRITES` |
 | Recovery WAL TTL | 24 h | Expired entries dropped from recovery view | `src/realtime/recovery-wal.ts` `DEFAULT_RECOVERY_WAL_BUDGET.ttl_ms` |
 | Recovery WAL sessions | 128 | Bounded; oldest-session eviction within the recovery (non-authoritative) view only | `recovery-wal.ts` `max_sessions` |
 | Recovery WAL items | 50/session, 2048 global | Bounded as above | `recovery-wal.ts` `max_items_per_session`, `max_global_items` |
-| Recovery WAL content | 8000 content / 2000 metadata / 1000 preview chars | Truncated at ingest | `recovery-wal.ts` budget fields |
+| Recovery WAL content | 8000 content / 2000 metadata chars | Oversize item **rejected at ingest** (`content_too_large` / `metadata_too_large`) — nothing stored | `recovery-wal.ts` append validation |
+| Recovery WAL preview | 1000 chars | Truncated (only the preview truncates; content/metadata reject) | `recovery-wal.ts` `max_preview_chars` |
 
 The recovery WAL is a bounded convenience view over durable lane data — its
 evictions never delete authoritative rows, so its caps are not a durability


### PR DESCRIPTION
Closes the definitional halves of #299 and #300 as scoped in their closure assessments.

**`docs/compatibility-matrix.md`** (#299): human-readable client × capability matrix rendered from the machine-enforced sources (`src/contract.ts` `min_client_versions`/`compatible_client_ranges`, `contracts/memory/parity-manifest.json`), with Codex mapped to its real versioned surface (mcp2cli ≥0.3.6), the upgrade/deprecation policy, and an explicit "what this matrix does not claim" section (no cross-runtime handoff tests, no mixed-version fixtures — named as deferred program work).

**`docs/memory-limits.md`** (#300): every enforced capacity/backpressure/degradation limit with value, at-limit behavior, and source citation — client distilled/CLI caps, spool line/byte caps with `SpoolFullError` backpressure (the issue's hard criterion, regression-tested since #305), serialized auto-drain, server audit budgets, recovery-WAL budgets — plus the degraded-state ladder (SAVED→SPOOLED→LOST, never silent) and the deliberately deferred envelope items (load harness, alerting thresholds, receipt retention → #298, replay throughput).

Both pages state that machine data wins on disagreement and must be updated in the same PR as their sources.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — docs-only; no code changed
- [x] Python package checks passed or are not applicable — not applicable (docs-only)
- [x] Live Open Brain smoke passed or is not applicable — not applicable (docs-only)

## Critical Self-Review

- Highest-risk behavior: stating limit values/file references that drift from code later; mitigated by "code wins" + same-PR update rule stated on both pages.
- Assumptions that could be wrong: every cited value was grepped from source this session (16KiB distilled, 64KiB CLI, 1000/1MB spool, 366d/5000ms/4 audit, WAL budget struct, v22 contract, 0.1.8/0.3.6/0.1.0 minimums).
- Missing/weak tests: none applicable — no behavior changed; the cited regression tests exist in test_spool.py.
- Security/permission risk: none; pages contain no secrets, tokens, or endpoints beyond the already-public LAN example line in README.
- Migration/deploy risk: none (docs-only).
- Downstream client/runtime risk: none; matrix documents existing enforcement, changes no contract surface.
- Rollback/cleanup concern: none — revert removes two doc files and two README index lines.
- Fixes made before PR: README Documentation section updated to index both pages.
- Known residual risk: the parity table duplicates parity-manifest.json state (ts: pending) and will need a one-line flip when #312 lands.
- SME review-memory update: [x] not applicable because: docs-only PR, no MEDIUM+ findings, no new review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: docs-only change with no runtime surface.

## Review swarm receipt

2-lane fable accuracy swarm (limits, matrix) on beae1f4 — every concrete claim checked against source. Findings, all fixed in ec80e50:

- **2 HIGH:** recovery-WAL content/metadata caps are ingest **rejection** (`content_too_large`/`metadata_too_large`), not truncation — only the preview truncates; audit retention uses fallback-to-default-30 semantics (`readBoundedInt`), never clamp/reject.
- **3 MEDIUM:** 5000 ms is the config ceiling, not the enforced timeout (default 1000 ms, range 50–5000); the write ladder was missing FALLBACK/FAILED and mislabeled SAVED as "direct"; audit writes also drop whenever the DB pool has waiters, below the in-flight cap.
- **4 LOW:** schema_hash (which covers min_client_versions) is the real one-sided-bump gate mechanism; mcp2cli header forwarding hedged as external-repo-owned; fleet agent names removed as rot-risk; #312 annotations marked doc-only forward references.
- **Verified clean:** all Python client limits, spool regression-test existence, all version pins/ranges, parity table vs manifest, CI/hook/tripwire claims, WAL non-authoritative claim.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — N/A (docs-only)
- [x] mcp2cli cache/skill refresh is complete or not applicable — N/A (docs-only)
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — N/A (docs-only)
- [x] Hermes live rollout/canaries are complete or not applicable — N/A (docs-only)

Notes/evidence:

- No MCP tool/schema/protocol or client-facing change; documentation of existing enforcement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
