### PR TITLE
feat(eval): add isolated live recall gate

### DIFF
--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -407,3 +407,50 @@ classifies as a denial regardless of array order.
   leading generic keyword AND over a bare HTTP status code?
 - Does a generic-only body still classify as non-denial (no over-broad
   promotion of every error to a denial)?
+
+## [2026-07-22] Per-run isolation namespaces must be non-reusable AND survive bounding
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #348 terminal audit, 2026-07-22 (issue #322 live recall gate)
+**Scope:** `eval/open-brain/live/config.ts` (`makeRunId`, `runNamespaces`,
+`boundRunId`), any per-run throwaway namespace/tenant derived from an
+operator-supplied id that is later truncated to a length bound
+**Status:** fixed-pre-merge
+
+### Pattern
+
+The gate isolates each run in a unique namespace so teardown can only touch this
+run's rows. Two ways that uniqueness silently collapsed:
+
+1. **Reusable explicit id.** `OPEN_BRAIN_LIVE_EVAL_RUN_ID` was returned verbatim
+   as the run id ("reproducible namespace"). Reusing it re-entered a prior run's
+   namespace — where a stranded prior seed still lived. The seed then upserted
+   (`ON CONFLICT`) onto that row and returned `merged: true`, which the seeder
+   adopted as a current-run creation (see the correctness seed-proof entry) and
+   would archive on teardown. A "reproducible" isolation namespace is a
+   contradiction: isolation requires non-reuse. Fix: the explicit id is now a
+   human-readable LABEL; a per-invocation crypto nonce is ALWAYS appended, so the
+   namespace can never be reused even with a fixed label.
+
+2. **Truncation-collision.** `runNamespaces` bounded the id with
+   `.slice(0, 80)`. A long label plus a trailing nonce puts the nonce PAST the
+   cut, so two runs sharing an 80-char prefix mapped to the SAME namespace — the
+   nonce that was supposed to guarantee uniqueness was thrown away by the length
+   bound. Fix: `boundRunId` keeps a truncated prefix and appends a deterministic
+   short hash of the FULL sanitized id, so distinct long ids stay distinct while
+   still fitting the bound. The hash is SHA-256 (pure/deterministic — no
+   Date.now/random), keeping the helper pinnable.
+
+### Review Questions
+
+- Does any "unique per run" identifier have a mode (explicit id, reused label,
+  fixed seed) where two invocations can produce the SAME value? For an isolation
+  boundary, the uniqueness source (nonce) must be mandatory and always mixed in.
+- Does a length/format bound (`slice`, hash-to-fixed-width, sanitize) run AFTER
+  the uniqueness suffix in a way that can DROP it? Two inputs sharing the bounded
+  prefix must still map to different outputs — bound with a hash of the full
+  input, not a prefix cut.
+- Is the collision case tested directly: two ids sharing the max-length prefix
+  (and a reused label across invocations) asserting distinct final namespaces?
+- If the boundary doubles as a destructive-teardown scope, does reuse let one
+  run's teardown touch another run's / a real namespace's rows?

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -368,3 +368,42 @@ row's `archived_at` stays NULL and the owning-namespace call succeeds
   with a paired owning-identity success proving the test is not vacuous?
 - Are all roles sharing the guarded branch parameterized, so a future
   role-specific branch cannot silently un-scope one of them?
+
+## [2026-07-22] Denial classification must win over generic keywords in a mixed error body
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #348 review swarm, 2026-07-22 (issue #322 live recall gate)
+**Scope:** `eval/open-brain/live/transport.ts` (`redactToolFailure`,
+`sanitizeThrownTransportError`), any content-free error classifier that picks a
+single keyword from an allowlist by first-match
+**Status:** fixed-pre-merge
+
+### Pattern
+
+The content-free redactor selected the error keyword with a single
+`KEYWORDS.find(kw => body.includes(kw))` over one flat array. Server error
+bodies routinely mix phrases — "invalid request: unauthorized for namespace",
+"invalid archive: forbidden" — and because `"invalid"` sat ahead of
+`"unauthorized"` / `"forbidden"` in the array, first-match returned the generic
+keyword and the label was classified as a NON-denial error. That silently
+weakens the two places denial classification matters: the isolation proof (a
+real permission denial mislabeled as a plain error is not counted as isolation
+proof) and a teardown/auth failure (a namespace/permission refusal read as a
+generic error loses its security meaning). Fixed by splitting the allowlist into
+denial keywords (`permission denied`, `not authenticated`, `unauthorized`,
+`forbidden`) matched FIRST, then generic keywords, so a mixed body always
+classifies as a denial regardless of array order.
+
+### Review Questions
+
+- Does any single-keyword error/label classifier depend on array ORDER to pick
+  the "right" keyword, when a real body can contain more than one match?
+- Are the security-relevant signals (denial / auth / permission) matched with
+  explicit precedence over generic ones (invalid / not-found / timeout), not by
+  incidental list position?
+- Is there a mixed-body test for BOTH the response-error path
+  (`redactToolFailure`) and the thrown-error path
+  (`sanitizeThrownTransportError`), asserting the denial keyword wins over a
+  leading generic keyword AND over a bare HTTP status code?
+- Does a generic-only body still classify as non-denial (no over-broad
+  promotion of every error to a denial)?

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -690,3 +690,124 @@ counted as clean teardown.
 - If the operation's response can be lost after a server-side commit, is that
   residual documented (a committed row can be stranded) rather than papered over
   with a broad query-shaped sweep that would violate mutation-safety?
+
+### Follow-up [2026-07-22, PR #348 terminal audit]: destructive success must bind returned identity/table
+
+The initial fix accepted `archived: true` alone. `archive_entry` actually
+returns `{id, table, archived: true}`, and `archived: true` does not say WHICH
+row was tombstoned. An echo for a different id/table, or a response missing them,
+would be credited as this record's cleanup while the real record stayed live.
+The terminal fix requires the returned `id`/`table` to EXACTLY match the
+requested record; anything else throws `archive_entry:identity-mismatch`
+(content-free). Extend the review question: for a destructive confirmed-success
+shape, is the confirmation BOUND to the requested record's identity/table, not
+just a bare `archived: true`? Tests must cover archived:true with a wrong id,
+wrong table, and missing id/table.
+
+## [2026-07-22] Unknown/foreign retrieval hits must fail closed, never drop before scoring
+
+**Severity:** MEDIUM (P1)
+**Source:** PR #348 terminal audit, 2026-07-22 (issue #322 live recall gate)
+**Scope:** `eval/open-brain/live/gate.ts` (`toFixtureRetrieval`), any scorer that
+maps live retrieval hits back to fixture/expected ids before computing metrics
+**Status:** fixed-pre-merge
+
+### Pattern
+
+`toFixtureRetrieval` mapped each hit's server id back to a fixture id and
+**silently skipped** any hit not in the seed map, and it never checked the hit's
+namespace at all. An unmapped or foreign-namespace hit therefore disappeared
+before scoring: ranks compressed (recall/MRR looked better than reality), a real
+cross-namespace leak left `namespace_leaks=0`, and the run could still reach
+PASS. Dropping an unaccountable hit is fail-OPEN. The fix validates EVERY hit
+before mapping — it must carry the EXACT bound primary namespace AND an id this
+run created (present in the seed map, which holds both primary and negative
+seeded ids) — and throws a content-free `LiveTransportError`
+(`search_brain:foreign-namespace` / `:unknown-hit`) otherwise, which defers to
+teardown and blocks PASS. A KNOWN negative-role id surfacing under the primary
+namespace is NOT a validation failure: it maps and flows to the scorer, which
+counts it as the namespace leak (that is how in-namespace leakage is scored).
+
+### Follow-up [2026-07-22, PR #348 terminal fix]: the parse boundary drops entries a layer earlier than the mapper
+
+`toFixtureRetrieval` only ever sees the hits `parseHits` (the transport parse
+boundary in `transport.ts`) chose to emit. `parseHits` was itself fail-OPEN: a
+non-array / invalid-JSON success body returned `[]` (conflating a malformed
+result set with a real empty read), and any non-object row or row lacking a
+string id was silently skipped. Those discarded raw results never reached the
+gate validator, so the gate-level fix above could not see them — the same
+rank-compression / hidden-leak hole, one layer up. Fix `parseHits` to fail
+closed: a success body MUST be a JSON array (`search_brain:malformed-results`
+otherwise) and EVERY entry MUST be an object with a non-empty string id
+(`search_brain:malformed-hit` otherwise). Keep namespace OPTIONAL at the parse
+boundary so a valid-but-namespace-less hit still reaches the gate and is
+classified there as `foreign-namespace` — moving the namespace check into
+`parseHits` would mask that distinct gate-level classification. The isolation
+probe (`attemptRead`) shares `parseHits`, so a malformed negative-namespace body
+throws instead of being misread as `hitCount: 0` (an empty allowed read).
+
+### Review Questions
+
+- Does a retrieval/scoring mapper `continue`/skip hits it cannot map? A skipped
+  hit compresses ranks and can hide a leak — validate and fail closed instead.
+- **Does the layer that PARSES the raw result set (before the mapper) also fail
+  closed?** A parser that returns `[]` for a non-array body, or skips a
+  non-object / idless row, drops the evidence before the mapper can validate it —
+  fix both the parse boundary and the mapper.
+- Is the retrieved row's namespace (or tenant/scope) checked to be EXACTLY the
+  one the query bound, so a row returned from outside the bound scope fails the
+  run rather than being scored or dropped?
+- Are the expected-but-present hits still returned alongside the bad one in the
+  test, proving the failure fires even when good data is also present (not just
+  on an all-bad result)?
+- Is the failure label content-free (no hit id, namespace value, or body)?
+- Do the read path (`search`) and the isolation-probe path (`attemptRead`) share
+  ONE parse boundary, so a malformed body cannot be misread as an empty allowed
+  read on the probe path?
+
+## [2026-07-22] Seed (create) proof must bind merged:false and the exact namespace
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #348 terminal audit, 2026-07-22 (issue #322 live recall gate)
+**Scope:** `eval/open-brain/live/transport.ts` (`OpenBrainLiveClient.logMemory`),
+any client that treats a `log_*` / upsert response as a fresh this-run creation
+it will later mutate
+**Status:** fixed-pre-merge
+
+### Pattern
+
+`log_thought` / `log_decision` return `{id, namespace, merged}` where
+`merged = !isNew` (src/tools/log-thought.ts, log-decision.ts): the tool upserts
+`ON CONFLICT (content_hash, namespace)`. The seeder ignored `merged` and
+defaulted a missing `namespace` to the requested one. In a REUSED namespace
+(see the adversarial reusable/truncated-run-id entry), a second run's seed
+upserts onto a prior run's stranded row and returns `merged: true` with the
+prior row's id — which the gate then adopted as a current-run creation and would
+archive on teardown, tombstoning a row this run did not create (and, symmetric,
+counting a prior row toward this run's scoring). The fix fails closed
+content-free unless the response proves a fresh create: `merged` present and
+`false`, a returned namespace EXACTLY equal to `opts.namespace` (no defaulting a
+missing/other namespace), and a present id. Labels: `:merged-upsert`,
+`:missing-merged`, `:namespace-mismatch`, `:missing-id`.
+
+### Review Questions
+
+- Does the create path assert the write actually CREATED a row (an explicit
+  `merged: false` / `created: true` / affected-rows signal), or does it treat any
+  2xx-shaped response as a new record it now owns?
+- For an upsert-backed "create", can a merged response onto a pre-existing row
+  be mistaken for this caller's row and later mutated/deleted?
+- Is the returned namespace/scope required to EXACTLY equal the requested one,
+  with no defaulting a missing field back to the request (which masks a write
+  that landed elsewhere)?
+- Is every rejection content-free (tool + reason), and is there a test for each
+  of merged:true, missing/non-boolean merged, wrong/absent namespace, missing id?
+
+### Note on canonicalization
+
+`log_thought` returns `canonicalNamespace(ns)` and `log_decision` returns raw
+`ns`. For the eval-live namespace (`eval-live-recall-<run-id>`),
+`canonicalNamespace` is a no-op (it only rewrites the shared namespace), so the
+exact-equality check is safe. A tool that seeds into the shared namespace would
+need to compare against the canonical form — check the tool's actual return
+transform before pinning exact-equality.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -646,3 +646,47 @@ restorable one.
 - Would the post-upgrade validation catch an out-of-order application, or do
   both paths converge to identical final sets (making the ordering bug
   invisible after the fact)?
+
+## [2026-07-22] Destructive-teardown success must fail closed on an unrecognized response shape
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #348 review swarm, 2026-07-22 (issue #322 live recall gate)
+**Scope:** `eval/open-brain/live/transport.ts` (`OpenBrainLiveClient.archive`),
+any client wrapper mapping a destructive tool's success body to a terminal
+"already gone / cleanup clean" outcome
+**Status:** fixed-pre-merge
+
+### Pattern
+
+`archive` mapped `archived === true` to `"archived"` and treated **every other
+success** as `"already_absent"`. That default is a false-pass: a shape drift, a
+differently-worded body, an empty body, or a success that did not actually
+tombstone the row all collapsed to "the row is gone", so teardown reported clean
+cleanup while a live record was stranded and the gate could still return PASS —
+the exact mutation-safety guarantee the per-record teardown exists to provide.
+For a destructive operation, only the tool's REAL success shapes are safe to
+accept. `archive_entry` (src/tools/archive-entry.ts) has exactly two:
+`{id, table, archived: true}` for a tombstoned row, and the EXACT plain-text
+body "Already archived or not found" (trimmed, case-insensitive) for the
+zero-row no-op. Accept only those — a structured `archived: false` (the server
+never emits it), a broad substring ("not found" / "no rows"), or the marker in
+mixed text are all rejected, because they could false-pass on unrelated output.
+Every other success throws a content-free `LiveTransportError`
+(`archive_entry:unrecognized-success`) so an ambiguous success can never be
+counted as clean teardown.
+
+### Review Questions
+
+- Does a wrapper over a destructive/idempotent tool have a catch-all branch that
+  maps *any* non-confirmed success to "already done / nothing to do"? That
+  branch fails OPEN — invert it to fail closed on unrecognized shapes.
+- Are the accepted positive shapes an explicit allowlist of the tool's REAL
+  success bodies (confirmed-success OR an EXACT absent marker, not a broad
+  substring), with everything else — including an invented `false` field or a
+  marker in mixed text — throwing?
+- Is the thrown label content-free (tool + marker), never the raw body — and is
+  there a test proving an unrecognized success (including an empty body and a
+  non-marker plain-text body) throws rather than silently passing?
+- If the operation's response can be lost after a server-side commit, is that
+  residual documented (a committed row can be stranded) rather than papered over
+  with a broad query-shaped sweep that would violate mutation-safety?

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -51,6 +51,103 @@ when the report is intended to be durable; otherwise write scratch reports under
   linked recall without calling hosted Open Brain.
 - Scale/performance: smoke latency is tracked against an expanded-corpus target.
 
+## Live Recall Gate (EVAL-1/2/3, issues #322-#324)
+
+The live gate is a single end-to-end command that seeds a unique throwaway
+namespace with a sealed synthetic corpus, runs recall queries through the real
+Open Brain MCP client, scores deterministic ranking metrics, applies versioned
+thresholds, proves namespace isolation with an explicit negative control, and
+tears down exactly this run's records. It is the live counterpart to the offline
+smoke suite and exercises the real contract, auth, and namespace boundary.
+
+```bash
+bun run eval:live
+bun run eval:live -- --json
+bun run eval:live -- --report /Volumes/ThunderBolt/_tmp/open-brain/live-recall.json
+```
+
+### Opt-in and required environment
+
+The gate is OFF by default so `bun test` and the offline eval never touch a
+hosted service. It runs only when explicitly opted in. Set these variable
+**names** in the environment (never paste token or URL values into the repo,
+logs, issues, or a report):
+
+Required:
+
+- `OPEN_BRAIN_LIVE_EVAL` — must equal `1` to enable the gate.
+- `OPEN_BRAIN_LIVE_EVAL_BASE_URL` — base URL of the target Open Brain server.
+- `OPEN_BRAIN_LIVE_EVAL_TOKEN` — bearer token with archive permission and
+  `X-Namespace` delegation authority (admin / ob-admin).
+
+Optional:
+
+- `OPEN_BRAIN_LIVE_EVAL_NEGATIVE_TOKEN` — a distinct token to also exercise
+  cross-token denial. Leave unset to use the same token; when set it must differ
+  from `OPEN_BRAIN_LIVE_EVAL_TOKEN`.
+- `OPEN_BRAIN_LIVE_EVAL_SEARCH_MODE` — one of `hybrid` (default), `vector`,
+  `keyword`.
+- `OPEN_BRAIN_LIVE_EVAL_TIMEOUT_MS` — positive integer per-request timeout.
+- `OPEN_BRAIN_LIVE_EVAL_RUN_ID` — explicit run id for a reproducible namespace;
+  otherwise a crypto-random suffix keeps repeated runs on the same commit from
+  colliding.
+
+### Same-token isolation semantics
+
+Isolation is a **real negative control**, not token inequality. Each caller
+binds its own `X-Namespace` header on every request (including the session
+`initialize`), so the token-sourced global role becomes header-bound to this
+run's exact namespace. The negative caller binds a distinct sibling namespace,
+so the **same** bearer token is a valid negative control — the header binding is
+what isolates, not a different credential. The gate proves isolation by having
+the primary caller attempt to read the negative namespace and requiring the
+server to **deny** it: an empty-but-successful read is not proof of denial and
+fails the gate. Supplying a distinct negative token additionally exercises
+cross-token denial but is never required.
+
+### Synthetic writes and cleanup
+
+Every seeded record comes from `fixtures/live-recall-v1.json`, which is sealed
+synthetic content invented for evaluation only — no real memory, secret, or
+token is ever written. The gate seeds under a per-run unique namespace pair and
+always tears down exactly the records it created, per record, through the
+namespace-scoped `archive_entry` tool (never a bulk or query-shaped delete), so
+it can only touch records it wrote. Teardown runs even when seeding or a query
+fails partway. A teardown that strands a record fails the gate — a cleanup
+failure can never silently become a PASS.
+
+### Thresholds, baseline receipt, and reports (#323)
+
+Pass thresholds are versioned in `thresholds.json` (recall@k, precision@k, MRR,
+max namespace leaks), never in test assertions; edit them there. The run emits a
+content-free structured baseline receipt (`schema: openbrain.live_recall_gate.v1`)
+carrying only fixture/thresholds ids, namespaces, seeded counts, metrics,
+per-probe scores, the negative-control proof, teardown tally, and the pass/fail
+verdict. No memory bodies or source content appear.
+
+Rather than committing a baseline artifact (which would pin a host- and
+provider-specific score into the repo and go stale), the baseline receipt is
+captured on demand via `--report <path>` (or `--json` to stdout). The controller
+owns the live run; the precise command to record a fresh baseline is:
+
+```bash
+OPEN_BRAIN_LIVE_EVAL=1 \
+OPEN_BRAIN_LIVE_EVAL_BASE_URL=<server-url> \
+OPEN_BRAIN_LIVE_EVAL_TOKEN=<admin-or-ob-admin-token> \
+bun run eval:live -- --report /Volumes/ThunderBolt/_tmp/open-brain/live-recall-baseline.json
+```
+
+Write reports to a scratch path under `/Volumes/ThunderBolt/_tmp` unless a
+durable, intentionally-pinned baseline path is chosen.
+
+### Exit statuses
+
+- `0` — all thresholds met, negative control denied, teardown clean (PASS).
+- `1` — the gate ran but failed a threshold, the isolation proof, or teardown.
+- `2` — a setup/transport error (missing env, unreachable server, seeding or
+  query failure). Error output is content-free: an error class + redacted label
+  only, never a raw remote message or response body.
+
 ## Next Expansion Points
 
 - Add a live Open Brain adapter that loads fixtures into an isolated namespace

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -88,9 +88,15 @@ Optional:
 - `OPEN_BRAIN_LIVE_EVAL_SEARCH_MODE` — one of `hybrid` (default), `vector`,
   `keyword`.
 - `OPEN_BRAIN_LIVE_EVAL_TIMEOUT_MS` — positive integer per-request timeout.
-- `OPEN_BRAIN_LIVE_EVAL_RUN_ID` — explicit run id for a reproducible namespace;
-  otherwise a crypto-random suffix keeps repeated runs on the same commit from
-  colliding.
+- `OPEN_BRAIN_LIVE_EVAL_RUN_ID` — an optional operator **label** for the run
+  (a human-readable prefix that shows up in the run's namespace for triage). It
+  is **not** a reusable namespace id: a per-invocation crypto nonce is always
+  appended, so setting the same label twice still produces two distinct
+  namespaces. Reusing a namespace would let a later run's seed upsert onto a
+  prior run's stranded row, so an explicit id can never yield a reproducible
+  namespace. When unset, the short commit is used as the label (still with the
+  appended nonce); when the label is long, the namespace is bounded with a
+  deterministic hash suffix that preserves uniqueness.
 
 ### Same-token isolation semantics
 
@@ -115,6 +121,34 @@ namespace-scoped `archive_entry` tool (never a bulk or query-shaped delete), so
 it can only touch records it wrote. Teardown runs even when seeding or a query
 fails partway. A teardown that strands a record fails the gate — a cleanup
 failure can never silently become a PASS.
+
+Every server response the gate depends on is bound to this run's exact identity
+and fails closed content-free (a redacted `tool:reason` label, never a body) on
+anything else:
+
+- **Seed (create) proof.** `log_thought` / `log_decision` must return
+  `merged: false` (a fresh row, not an upsert onto a pre-existing one) and a
+  namespace **exactly** equal to the one this run bound. A `merged: true`
+  upsert, a missing/non-boolean `merged`, a mismatched/absent namespace, or a
+  missing id fail the run. This stops a stranded prior seed in a reused
+  namespace from being adopted as a current-run creation and later archived as
+  though this run owned it.
+- **Retrieval-hit proof.** Validation is two-layered and neither layer ever
+  silently discards a raw result — dropping one would compress ranks and hide a
+  real leak while still reporting PASS. At the **transport boundary**
+  (`parseHits`), a successful search body must be a JSON array and every entry
+  must be an object with a non-empty string id; a non-array/invalid body
+  (`malformed-results`) or a non-object/idless entry (`malformed-hit`) fails the
+  run before scoring. Namespace stays optional here so the **gate** can then
+  enforce that every surviving hit carries the exact primary namespace **and** an
+  id this run created; a hit with a foreign/missing namespace
+  (`foreign-namespace`) or an unaccountable id (`unknown-hit`) fails the run. The
+  isolation probe (`attemptRead`) shares the same `parseHits` boundary, so a
+  malformed negative-namespace body cannot be misread as an empty allowed read.
+- **Archive proof.** A destructive archive success counts only when the server
+  returns `archived: true` **and** the returned `id`/`table` exactly match the
+  requested record. `archived: true` for a different or absent id/table fails
+  closed, so teardown cannot credit a row it did not actually tombstone.
 
 ### Thresholds, baseline receipt, and reports (#323)
 
@@ -157,9 +191,11 @@ The gate treats a seed/archive whose *response* is not received (a request
 timeout, a dropped connection after the server committed, or an ambiguous
 success body) as a failure — this is the correct default, because a destructive
 teardown must fail closed rather than assume a row is gone. `archive_entry`
-recognizes only two positive shapes: an explicit archived success or an explicit
-already-absent / not-found marker. Every other success response throws a
-content-free `LiveTransportError`, so teardown can never false-pass.
+recognizes only two positive shapes: an explicit archived success **bound to the
+requested `id`/`table`**, or the exact already-absent / not-found marker. Every
+other success response — an unrecognized body, or an `archived: true` for a
+different/absent id or table — throws a content-free `LiveTransportError`, so
+teardown can never false-pass on a row it did not actually tombstone.
 
 The residual is the write direction: if a `log_*` seed **commits server-side but
 the response is lost**, the gate never learns the server id, so teardown cannot

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -146,7 +146,46 @@ durable, intentionally-pinned baseline path is chosen.
 - `1` — the gate ran but failed a threshold, the isolation proof, or teardown.
 - `2` — a setup/transport error (missing env, unreachable server, seeding or
   query failure). Error output is content-free: an error class + redacted label
-  only, never a raw remote message or response body.
+  only, never a raw remote message or response body. When a deferred seed/query
+  failure also stranded records during teardown, the redacted error label
+  carries a `;teardown-failed=<n>` suffix (the integer count only — never a
+  record id or body) so the cleanup failure is not lost behind the setup error.
+
+### Residual risk: a commit that succeeds but times out on the response
+
+The gate treats a seed/archive whose *response* is not received (a request
+timeout, a dropped connection after the server committed, or an ambiguous
+success body) as a failure — this is the correct default, because a destructive
+teardown must fail closed rather than assume a row is gone. `archive_entry`
+recognizes only two positive shapes: an explicit archived success or an explicit
+already-absent / not-found marker. Every other success response throws a
+content-free `LiveTransportError`, so teardown can never false-pass.
+
+The residual is the write direction: if a `log_*` seed **commits server-side but
+the response is lost**, the gate never learns the server id, so teardown cannot
+archive that specific record. It is not silently counted as clean — the run
+fails (exit `2`, or a `teardown-failed` count if the loss happens during
+teardown) — but the committed row is left live under this run's unique
+throwaway namespace. The gate deliberately does **not** add a bulk or
+query-shaped delete to sweep it up: a query-shaped delete would be able to touch
+records the run did not create, which is exactly the mutation-safety property
+the per-record `archive_entry` teardown exists to guarantee. Broad cleanup is
+rejected by design.
+
+Because every run seeds under a **unique per-run namespace pair**
+(`eval-live-recall-<run-id>` and its `-negative` sibling), a stranded record is
+isolated to that one dead namespace and can never contaminate another run's
+scoring or a real memory namespace. Recovering a stranded record is therefore a
+bounded, operator-driven cleanup, not a gate responsibility:
+
+1. Identify the affected run id from the failed run's redacted receipt/output
+   (`namespace=eval-live-recall-<run-id>`). No id or body is needed.
+2. As an operator (not the gate), archive or delete exactly the records under
+   that unique namespace pair through the normal namespace-scoped admin tools.
+   Because the namespace is unique to the dead run, scoping cleanup to it cannot
+   touch any other run's or any real namespace's data.
+3. Never widen this into an automatic sweep inside the gate — the per-record,
+   namespace-scoped teardown is the only mutation the gate is allowed to make.
 
 ## Next Expansion Points
 

--- a/eval/open-brain/fixtures/live-recall-v1.json
+++ b/eval/open-brain/fixtures/live-recall-v1.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "fixture_id": "open-brain-live-recall-v1",
+  "description": "Sealed synthetic corpus for the live recall gate. All content is invented for evaluation only and carries no real memory, secret, or token. Primary-role entries are seeded and read under a per-run throwaway namespace; negative-role entries are seeded into a sibling namespace the query token cannot read and must never surface. Grades: 2 = directly on-topic, 1 = partially relevant, 0 = declared distractor.",
+  "corpus": [
+    {
+      "id": "grommet-torque-spec",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The zephyr grommet assembly must be torqued to forty-two newton meters using the calibrated torque wrench before the flange cap is fitted.",
+      "tags": ["zephyr", "grommet", "torque", "assembly"]
+    },
+    {
+      "id": "grommet-coating-note",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "Zephyr grommets receive a matte anodized coating so the assembly resists salt corrosion during coastal deployment.",
+      "tags": ["zephyr", "grommet", "coating", "corrosion"]
+    },
+    {
+      "id": "flange-cap-decision",
+      "table": "decisions",
+      "namespace_role": "primary",
+      "content": "We standardized on the hex flange cap for every zephyr grommet assembly because the square cap sheared under vibration load.",
+      "tags": ["zephyr", "flange", "cap", "vibration"]
+    },
+    {
+      "id": "quokka-migration-window",
+      "table": "decisions",
+      "namespace_role": "primary",
+      "content": "The quokka ledger migration runs only inside the Tuesday maintenance window so the reconciliation batch never overlaps the nightly export.",
+      "tags": ["quokka", "ledger", "migration", "maintenance"]
+    },
+    {
+      "id": "quokka-rollback-plan",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "If the quokka ledger migration fails midway the rollback restores the pre-window snapshot and replays the reconciliation batch from the checkpoint.",
+      "tags": ["quokka", "ledger", "rollback", "snapshot"]
+    },
+    {
+      "id": "solstice-cache-policy",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The solstice cache evicts entries after ninety seconds so a stale tariff lookup can never dominate the pricing response.",
+      "tags": ["solstice", "cache", "eviction", "pricing"]
+    },
+    {
+      "id": "distractor-torque-unrelated",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The barista torque test measures how much force the espresso tamper applies and has nothing to do with the zephyr grommet program.",
+      "tags": ["barista", "espresso", "tamper", "torque"]
+    },
+    {
+      "id": "distractor-migration-unrelated",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The seasonal bird migration study tracks quokka-shaped decoys across the estuary and is unrelated to any ledger system.",
+      "tags": ["estuary", "decoy", "migration", "study"]
+    },
+    {
+      "id": "negative-zephyr-secret-plan",
+      "table": "decisions",
+      "namespace_role": "negative",
+      "content": "Confidential competitor sourcing plan for zephyr grommet torque assemblies that lives in a private namespace the eval query token cannot read.",
+      "tags": ["zephyr", "grommet", "torque", "confidential"]
+    },
+    {
+      "id": "negative-quokka-secret-ledger",
+      "table": "thoughts",
+      "namespace_role": "negative",
+      "content": "Private quokka ledger migration credentials note that belongs to a namespace outside the eval token's read scope and must never be recalled.",
+      "tags": ["quokka", "ledger", "migration", "private"]
+    }
+  ],
+  "probes": [
+    {
+      "id": "probe-grommet-torque",
+      "query": "How much torque does the zephyr grommet assembly need and what cap is used?",
+      "relevant": [
+        { "id": "grommet-torque-spec", "grade": 2 },
+        { "id": "flange-cap-decision", "grade": 2 },
+        { "id": "grommet-coating-note", "grade": 1 }
+      ],
+      "forbidden_ids": ["negative-zephyr-secret-plan"]
+    },
+    {
+      "id": "probe-quokka-migration",
+      "query": "When does the quokka ledger migration run and how is it rolled back?",
+      "relevant": [
+        { "id": "quokka-migration-window", "grade": 2 },
+        { "id": "quokka-rollback-plan", "grade": 2 }
+      ],
+      "forbidden_ids": ["negative-quokka-secret-ledger"]
+    },
+    {
+      "id": "probe-solstice-cache",
+      "query": "What is the solstice cache eviction policy for tariff pricing lookups?",
+      "relevant": [
+        { "id": "solstice-cache-policy", "grade": 2 }
+      ],
+      "forbidden_ids": []
+    }
+  ]
+}

--- a/eval/open-brain/live/__tests__/config-fixture.test.ts
+++ b/eval/open-brain/live/__tests__/config-fixture.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseLiveFixture } from "../fixtures.ts";
+import { parseThresholds } from "../metrics.ts";
+import {
+  liveEvalEnabled,
+  loadLiveConfig,
+  makeRunId,
+  runNamespaces,
+} from "../config.ts";
+
+const SHIPPED_FIXTURE = JSON.parse(
+  readFileSync(
+    join(import.meta.dir, "../../fixtures/live-recall-v1.json"),
+    "utf8",
+  ),
+);
+const SHIPPED_THRESHOLDS = JSON.parse(
+  readFileSync(join(import.meta.dir, "../../thresholds.json"), "utf8"),
+);
+
+const BASE_ENV = {
+  OPEN_BRAIN_LIVE_EVAL: "1",
+  OPEN_BRAIN_LIVE_EVAL_BASE_URL: "http://127.0.0.1:3100",
+  OPEN_BRAIN_LIVE_EVAL_TOKEN: "primary-token",
+} as unknown as NodeJS.ProcessEnv;
+
+describe("live fixture validation", () => {
+  it("parses the shipped fixture and its probes", () => {
+    const fixture = parseLiveFixture(SHIPPED_FIXTURE);
+    expect(fixture.fixture_id).toBe("open-brain-live-recall-v1");
+    expect(fixture.probes.length).toBeGreaterThan(0);
+    expect(fixture.corpus.some((e) => e.namespace_role === "negative")).toBe(
+      true,
+    );
+  });
+
+  it("shipped thresholds apply to the shipped fixture", () => {
+    const fixture = parseLiveFixture(SHIPPED_FIXTURE);
+    const thresholds = parseThresholds(SHIPPED_THRESHOLDS);
+    expect(thresholds.applies_to_fixture_id).toBe(fixture.fixture_id);
+  });
+
+  it("shipped precision threshold is achievable given the fixture's relevant density", () => {
+    const fixture = parseLiveFixture(SHIPPED_FIXTURE);
+    const thresholds = parseThresholds(SHIPPED_THRESHOLDS);
+    // Best-case mean Precision@K = mean(relevant_count/top_k) must clear the bar,
+    // otherwise the gate can never pass no matter how good retrieval is.
+    const bestMeanPrecision =
+      fixture.probes
+        .map(
+          (p) =>
+            Math.min(
+              p.relevant.filter((r) => r.grade > 0).length,
+              thresholds.top_k,
+            ) / thresholds.top_k,
+        )
+        .reduce((a, b) => a + b, 0) / fixture.probes.length;
+    expect(bestMeanPrecision).toBeGreaterThanOrEqual(
+      thresholds.thresholds.min_precision_at_k,
+    );
+  });
+
+  it("rejects a probe that references an unknown relevant id", () => {
+    expect(() =>
+      parseLiveFixture({
+        schema_version: 1,
+        fixture_id: "bad",
+        description: "",
+        corpus: [
+          {
+            id: "a",
+            table: "thoughts",
+            namespace_role: "primary",
+            content: "a",
+            tags: [],
+          },
+        ],
+        probes: [
+          {
+            id: "p",
+            query: "q",
+            relevant: [{ id: "missing", grade: 1 }],
+            forbidden_ids: [],
+          },
+        ],
+      }),
+    ).toThrow(/unknown relevant id/);
+  });
+
+  it("rejects a forbidden id that is not a negative-role entry", () => {
+    expect(() =>
+      parseLiveFixture({
+        schema_version: 1,
+        fixture_id: "bad",
+        description: "",
+        corpus: [
+          {
+            id: "a",
+            table: "thoughts",
+            namespace_role: "primary",
+            content: "a",
+            tags: [],
+          },
+        ],
+        probes: [{ id: "p", query: "q", relevant: [], forbidden_ids: ["a"] }],
+      }),
+    ).toThrow(/must be a negative-role entry/);
+  });
+
+  it("rejects duplicate corpus ids", () => {
+    expect(() =>
+      parseLiveFixture({
+        schema_version: 1,
+        fixture_id: "dup",
+        description: "",
+        corpus: [
+          {
+            id: "a",
+            table: "thoughts",
+            namespace_role: "primary",
+            content: "a",
+            tags: [],
+          },
+          {
+            id: "a",
+            table: "thoughts",
+            namespace_role: "primary",
+            content: "a2",
+            tags: [],
+          },
+        ],
+        probes: [
+          {
+            id: "p",
+            query: "q",
+            relevant: [{ id: "a", grade: 1 }],
+            forbidden_ids: [],
+          },
+        ],
+      }),
+    ).toThrow(/duplicate corpus id/);
+  });
+});
+
+describe("live config validation", () => {
+  it("is disabled unless OPEN_BRAIN_LIVE_EVAL=1", () => {
+    expect(liveEvalEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(
+      liveEvalEnabled({ OPEN_BRAIN_LIVE_EVAL: "0" } as NodeJS.ProcessEnv),
+    ).toBe(false);
+    expect(liveEvalEnabled(BASE_ENV)).toBe(true);
+  });
+
+  it("throws when disabled", () => {
+    expect(() => loadLiveConfig("run1", {} as NodeJS.ProcessEnv)).toThrow(
+      /disabled/,
+    );
+  });
+
+  it("requires base URL and token", () => {
+    expect(() =>
+      loadLiveConfig("run1", {
+        OPEN_BRAIN_LIVE_EVAL: "1",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/BASE_URL/);
+    expect(() =>
+      loadLiveConfig("run1", {
+        OPEN_BRAIN_LIVE_EVAL: "1",
+        OPEN_BRAIN_LIVE_EVAL_BASE_URL: "http://127.0.0.1:3100",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/TOKEN/);
+  });
+
+  it("rejects a malformed base URL", () => {
+    expect(() =>
+      loadLiveConfig("run1", {
+        ...BASE_ENV,
+        OPEN_BRAIN_LIVE_EVAL_BASE_URL: "not a url",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/valid URL/);
+  });
+
+  it("rejects a negative token equal to the primary token when explicitly set", () => {
+    expect(() =>
+      loadLiveConfig("run1", {
+        ...BASE_ENV,
+        OPEN_BRAIN_LIVE_EVAL_NEGATIVE_TOKEN: "primary-token",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/must differ/);
+  });
+
+  it("defaults the negative token to the primary token (namespace binding is the isolation proof)", () => {
+    const config = loadLiveConfig("run-n", BASE_ENV);
+    // A real negative control is always available: same token, distinct
+    // negative namespace. Token inequality is NOT required for isolation.
+    expect(config.negativeToken).toBe("primary-token");
+    expect(config.negativeTokenIsDistinct).toBe(false);
+    expect(config.negativeNamespace).not.toBe(config.primaryNamespace);
+  });
+
+  it("accepts a distinct negative token and flags cross-token coverage", () => {
+    const config = loadLiveConfig("run-n2", {
+      ...BASE_ENV,
+      OPEN_BRAIN_LIVE_EVAL_NEGATIVE_TOKEN: "other-token",
+    } as NodeJS.ProcessEnv);
+    expect(config.negativeToken).toBe("other-token");
+    expect(config.negativeTokenIsDistinct).toBe(true);
+  });
+
+  it("rejects an invalid search mode and timeout", () => {
+    expect(() =>
+      loadLiveConfig("run1", {
+        ...BASE_ENV,
+        OPEN_BRAIN_LIVE_EVAL_SEARCH_MODE: "fuzzy",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/SEARCH_MODE/);
+    expect(() =>
+      loadLiveConfig("run1", {
+        ...BASE_ENV,
+        OPEN_BRAIN_LIVE_EVAL_TIMEOUT_MS: "-4",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/TIMEOUT_MS/);
+  });
+
+  it("derives a unique, isolated namespace pair per run id", () => {
+    const a = runNamespaces("commit-abc-123");
+    const b = runNamespaces("commit-xyz-999");
+    expect(a.primary).not.toBe(b.primary);
+    expect(a.negative).toBe(`${a.primary}-negative`);
+    expect(a.primary).not.toBe(a.negative);
+  });
+
+  it("sanitizes unsafe characters in the run id", () => {
+    const ns = runNamespaces("weird/../id name!");
+    expect(ns.primary).toMatch(/^eval-live-recall-[a-zA-Z0-9_-]+$/);
+  });
+
+  it("builds a valid config with defaults", () => {
+    const config = loadLiveConfig("run-7", BASE_ENV);
+    expect(config.baseUrl).toBe("http://127.0.0.1:3100");
+    expect(config.searchMode).toBe("hybrid");
+    expect(config.timeoutMs).toBeGreaterThan(0);
+    expect(config.negativeToken).toBe("primary-token");
+    expect(config.negativeTokenIsDistinct).toBe(false);
+    expect(config.primaryNamespace).toBe("eval-live-recall-run-7");
+  });
+});
+
+describe("run id uniqueness (crypto/operator, deterministic namespaces)", () => {
+  it("prefers an explicit operator run id for reproducibility", () => {
+    const id = makeRunId({
+      prefix: "commitpref",
+      randomHex: "deadbeef",
+      env: {
+        OPEN_BRAIN_LIVE_EVAL_RUN_ID: "operator-run-42",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(id).toBe("operator-run-42");
+  });
+
+  it("combines prefix + random suffix so repeated same-commit runs never collide", () => {
+    const a = makeRunId({
+      prefix: "abc123",
+      randomHex: "aaaa1111",
+      env: {} as NodeJS.ProcessEnv,
+    });
+    const b = makeRunId({
+      prefix: "abc123",
+      randomHex: "bbbb2222",
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(a).toBe("abc123-aaaa1111");
+    expect(b).toBe("abc123-bbbb2222");
+    expect(a).not.toBe(b);
+    // And the derived namespaces differ, so teardown never crosses runs.
+    expect(runNamespaces(a).primary).not.toBe(runNamespaces(b).primary);
+  });
+
+  it("throws when neither an operator id nor a random suffix is available", () => {
+    expect(() =>
+      makeRunId({
+        prefix: "abc",
+        randomHex: "   ",
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toThrow(/unique across runs/);
+  });
+
+  it("runNamespaces stays deterministic for a fixed run id", () => {
+    // No Date.now/random inside the helper: same input -> same output.
+    expect(runNamespaces("fixed-run")).toEqual(runNamespaces("fixed-run"));
+  });
+});

--- a/eval/open-brain/live/__tests__/config-fixture.test.ts
+++ b/eval/open-brain/live/__tests__/config-fixture.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { parseLiveFixture } from "../fixtures.ts";
 import { parseThresholds } from "../metrics.ts";
 import {
+  boundRunId,
   liveEvalEnabled,
   loadLiveConfig,
   makeRunId,
@@ -248,16 +249,31 @@ describe("live config validation", () => {
   });
 });
 
-describe("run id uniqueness (crypto/operator, deterministic namespaces)", () => {
-  it("prefers an explicit operator run id for reproducibility", () => {
-    const id = makeRunId({
+describe("run id uniqueness (crypto nonce always injected, operator id is a label)", () => {
+  it("treats an explicit operator run id as a LABEL and still appends the nonce", () => {
+    // The operator id is a human-readable prefix for triage, NOT a reusable
+    // namespace id: the nonce is always appended so two runs sharing the same
+    // label never enter the same namespace.
+    const a = makeRunId({
       prefix: "commitpref",
       randomHex: "deadbeef",
       env: {
         OPEN_BRAIN_LIVE_EVAL_RUN_ID: "operator-run-42",
       } as NodeJS.ProcessEnv,
     });
-    expect(id).toBe("operator-run-42");
+    expect(a).toBe("operator-run-42-deadbeef");
+
+    // Same label, different invocation nonce -> different id and namespace.
+    const b = makeRunId({
+      prefix: "commitpref",
+      randomHex: "cafef00d",
+      env: {
+        OPEN_BRAIN_LIVE_EVAL_RUN_ID: "operator-run-42",
+      } as NodeJS.ProcessEnv,
+    });
+    expect(b).toBe("operator-run-42-cafef00d");
+    expect(a).not.toBe(b);
+    expect(runNamespaces(a).primary).not.toBe(runNamespaces(b).primary);
   });
 
   it("combines prefix + random suffix so repeated same-commit runs never collide", () => {
@@ -278,18 +294,79 @@ describe("run id uniqueness (crypto/operator, deterministic namespaces)", () => 
     expect(runNamespaces(a).primary).not.toBe(runNamespaces(b).primary);
   });
 
-  it("throws when neither an operator id nor a random suffix is available", () => {
+  it("falls back to just the nonce when neither a label nor a prefix is present", () => {
+    const id = makeRunId({
+      prefix: "   ",
+      randomHex: "beadfeed",
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(id).toBe("beadfeed");
+  });
+
+  it("throws when the crypto random suffix is missing (uniqueness cannot be guaranteed)", () => {
     expect(() =>
       makeRunId({
         prefix: "abc",
         randomHex: "   ",
+        env: {
+          OPEN_BRAIN_LIVE_EVAL_RUN_ID: "operator-run-42",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toThrow(/unique across every invocation/);
+    // Even with a prefix but no operator id, a missing nonce still throws.
+    expect(() =>
+      makeRunId({
+        prefix: "abc",
+        randomHex: "",
         env: {} as NodeJS.ProcessEnv,
       }),
-    ).toThrow(/unique across runs/);
+    ).toThrow(/unique across every invocation/);
   });
 
   it("runNamespaces stays deterministic for a fixed run id", () => {
     // No Date.now/random inside the helper: same input -> same output.
     expect(runNamespaces("fixed-run")).toEqual(runNamespaces("fixed-run"));
+  });
+});
+
+describe("collision-safe bounding of long run ids", () => {
+  it("keeps ids at or under the safe length verbatim", () => {
+    const short = "a".repeat(80);
+    expect(boundRunId(short)).toBe(short);
+  });
+
+  it("preserves uniqueness for two long labels sharing an 80-char prefix", () => {
+    // The dangerous case the audit flagged: a long operator label suffixed with
+    // a per-invocation nonce. A naive slice(0,80) drops the nonce and both runs
+    // collide. Bounding must keep them distinct.
+    const shared = "operator-label-".padEnd(85, "x"); // > 80 chars, identical prefix
+    const a = `${shared}-aaaa1111`;
+    const b = `${shared}-bbbb2222`;
+    // Sanity: the first 80 characters are identical, so a naive slice collides.
+    expect(a.slice(0, 80)).toBe(b.slice(0, 80));
+    // But the bounded ids -- and therefore the namespaces -- differ.
+    expect(boundRunId(a)).not.toBe(boundRunId(b));
+    expect(runNamespaces(a).primary).not.toBe(runNamespaces(b).primary);
+    // And the primary namespace still fits the safe bound.
+    expect(boundRunId(a).length).toBeLessThanOrEqual(80);
+  });
+
+  it("is deterministic (same long id -> same bounded id, no Date.now/random)", () => {
+    const long = "z".repeat(120);
+    expect(boundRunId(long)).toBe(boundRunId(long));
+  });
+
+  it("full makeRunId + runNamespaces stays collision-free with a long reused label", () => {
+    const env = {
+      OPEN_BRAIN_LIVE_EVAL_RUN_ID: "x".repeat(100),
+    } as NodeJS.ProcessEnv;
+    const a = runNamespaces(
+      makeRunId({ prefix: "c", randomHex: "aaaa1111", env }),
+    );
+    const b = runNamespaces(
+      makeRunId({ prefix: "c", randomHex: "bbbb2222", env }),
+    );
+    expect(a.primary).not.toBe(b.primary);
+    expect(a.negative).not.toBe(b.negative);
   });
 });

--- a/eval/open-brain/live/__tests__/gate.test.ts
+++ b/eval/open-brain/live/__tests__/gate.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { runLiveGate, type GateClients } from "../gate.ts";
 import type { LiveEvalConfig } from "../config.ts";
-import { LiveTransportError, type OpenBrainLiveClient } from "../transport.ts";
+import {
+  LiveTransportError,
+  OpenBrainLiveClient,
+  type OpenBrainToolCaller,
+  type ToolCallResult,
+} from "../transport.ts";
 import type { LiveFixture, LiveThresholds, SearchHit } from "../types.ts";
 
 // Orchestrator tests for runLiveGate (issue #322 seeding/teardown + isolation
@@ -109,6 +114,14 @@ interface FakeOptions {
    * leaked negative id, to exercise leak counting via the retrieval mapping.
    */
   extraPrimaryHits?: string[];
+  /**
+   * Raw extra hits to append to the PRIMARY probe search result AFTER the
+   * mapped/seeded primary hits, used to exercise pre-mapping hit validation:
+   * a hit with a foreign/missing namespace, or an id this run never created.
+   * These are appended verbatim (no seed-map filtering) so the gate must react
+   * to them rather than silently drop them.
+   */
+  rawExtraPrimaryHits?: Array<{ id: string; namespace?: string }>;
 }
 
 interface FakeState {
@@ -163,7 +176,9 @@ function makeFakeClients(
         }
         const id = serverId(fixtureId);
         state.seeded.set(id, { table: o.table, namespace: o.namespace });
-        return { id, namespace: o.namespace };
+        // A fresh create: merged:false, matching the seed contract the real
+        // logMemory now enforces.
+        return { id, namespace: o.namespace, merged: false };
       },
       async search(o: { namespace: string }): Promise<SearchHit[]> {
         if (opts.searchThrows) {
@@ -178,13 +193,24 @@ function makeFakeClients(
           ...primaryFixtureIds,
           ...(opts.extraPrimaryHits ?? []),
         ];
-        return hitFixtureIds
+        const mapped: SearchHit[] = hitFixtureIds
           .filter((fid) => state.seeded.has(serverId(fid)))
           .map((fid) => ({
             id: serverId(fid),
             source_type: "thoughts",
             namespace: o.namespace,
           }));
+        // Append any raw (deliberately un-seeded / foreign-namespace) hits so a
+        // test can prove the gate validates EVERY hit before mapping instead of
+        // silently discarding an unaccountable one. The `namespace` key defaults
+        // to the searched namespace unless the test overrides it (including
+        // setting it undefined to model a hit with no namespace).
+        const raw: SearchHit[] = (opts.rawExtraPrimaryHits ?? []).map((h) => ({
+          id: h.id,
+          source_type: "thoughts",
+          namespace: "namespace" in h ? h.namespace : o.namespace,
+        }));
+        return [...mapped, ...raw];
       },
       async attemptRead(o: {
         namespace: string;
@@ -409,6 +435,50 @@ describe("runLiveGate negative-control (isolation) discipline", () => {
     assertContentFree(receipt);
   });
 
+  it("fails closed (content-free) on a foreign-namespace hit even with the expected hits present", async () => {
+    // The expected primary hits are returned first; a hit from a DIFFERENT
+    // namespace is appended. The gate must NOT drop it (which would compress
+    // ranks and hide the breach) -- it must fail the run closed. Teardown still
+    // archives the 3 seeded records.
+    const { outcome, state } = run(FIXTURE, {
+      rawExtraPrimaryHits: [{ id: "srv-foreign", namespace: "some-other-ns" }],
+    });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("search_brain:foreign-namespace");
+    // Content-free: the offending namespace value / id never appears.
+    expect(err.label).not.toContain("some-other-ns");
+    expect(err.label).not.toContain("srv-foreign");
+    // Teardown still ran for every seeded record.
+    expect(state.archived.length).toBe(3);
+  });
+
+  it("fails closed on a hit with NO namespace even with the expected hits present", async () => {
+    const { outcome, state } = run(FIXTURE, {
+      rawExtraPrimaryHits: [{ id: "srv-nons", namespace: undefined }],
+    });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    // A missing namespace is treated as foreign (not exactly the primary ns).
+    expect(err.label).toBe("search_brain:foreign-namespace");
+    expect(state.archived.length).toBe(3);
+  });
+
+  it("fails closed on an UNKNOWN same-namespace id even with the expected hits present", async () => {
+    // A hit carrying the correct primary namespace but an id this run never
+    // created is unaccountable: our seed map cannot map it, so we cannot know it
+    // is not a foreign row surfacing under our namespace. Fail closed rather than
+    // discard it (a discard would compress ranks and could hide a real leak).
+    const { outcome, state } = run(FIXTURE, {
+      rawExtraPrimaryHits: [{ id: "srv-unknown-1234" }], // defaults to primary ns
+    });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("search_brain:unknown-hit");
+    expect(err.label).not.toContain("srv-unknown-1234");
+    expect(state.archived.length).toBe(3);
+  });
+
   it("counts a leaked negative id in the primary result as a namespace leak and fails", async () => {
     // Inject the negative fixture id into the PRIMARY probe search result: the
     // gate must count it as a leak (max_namespace_leaks=0 -> fail).
@@ -455,5 +525,146 @@ describe("runLiveGate composite verdict", () => {
     // No seeding happened, so nothing to tear down.
     expect(state.seeded.size).toBe(0);
     expect(state.archived.length).toBe(0);
+  });
+});
+
+describe("runLiveGate through the REAL transport parseHits boundary", () => {
+  // The fakes above stub search at the OpenBrainLiveClient level, so they never
+  // exercise parseHits. This test wires a REAL primary OpenBrainLiveClient over a
+  // scripted tool caller, so the search body flows through the actual parseHits
+  // transport boundary and into the gate. It proves the end-to-end seam: a hit
+  // that is a valid object with a string id but NO namespace survives parseHits
+  // (namespace is optional there) and reaches the gate, which fails it closed as
+  // foreign-namespace -- not silently dropped at either layer.
+
+  /** Scripted tool caller: name -> queue of results, plus the standard close. */
+  function scriptedCaller(
+    script: Record<string, ToolCallResult[]>,
+  ): OpenBrainToolCaller {
+    const queues: Record<string, ToolCallResult[]> = {};
+    for (const [k, v] of Object.entries(script)) queues[k] = [...v];
+    return {
+      async callTool(name) {
+        const q = queues[name];
+        if (!q || q.length === 0) {
+          throw new Error(`scripted caller has no result for ${name}`);
+        }
+        return q.shift()!;
+      },
+      async close() {},
+    };
+  }
+
+  const ok = (data: string): ToolCallResult => ({
+    isError: false,
+    denied: false,
+    data,
+    errorLabel: "",
+  });
+
+  it("a valid namespace-less hit passes parseHits and fails at the gate as foreign-namespace", async () => {
+    const primaryNs = CONFIG.primaryNamespace;
+    // Seed responses: log_thought / log_decision return fresh creates under the
+    // primary namespace so the seed map is populated for prim-a and prim-b.
+    // The single probe search then returns the two seeded ids (with namespace)
+    // PLUS one valid hit that has a string id but NO namespace field.
+    const primary = new OpenBrainLiveClient(
+      scriptedCaller({
+        log_thought: [
+          ok(
+            JSON.stringify({
+              id: "srv-prim-a",
+              namespace: primaryNs,
+              merged: false,
+            }),
+          ),
+        ],
+        log_decision: [
+          ok(
+            JSON.stringify({
+              id: "srv-prim-b",
+              namespace: primaryNs,
+              merged: false,
+            }),
+          ),
+        ],
+        search_brain: [
+          ok(
+            JSON.stringify([
+              {
+                id: "srv-prim-a",
+                source_type: "thoughts",
+                namespace: primaryNs,
+              },
+              {
+                id: "srv-prim-b",
+                source_type: "decisions",
+                namespace: primaryNs,
+              },
+              // Valid object, string id, NO namespace: survives parseHits, then
+              // the gate must fail it closed as foreign-namespace.
+              { id: "srv-no-ns", source_type: "thoughts" },
+            ]),
+          ),
+        ],
+        // Teardown archives the two primary records (bound to id+table).
+        archive_entry: [
+          ok(
+            JSON.stringify({
+              id: "srv-prim-a",
+              table: "thoughts",
+              archived: true,
+            }),
+          ),
+          ok(
+            JSON.stringify({
+              id: "srv-prim-b",
+              table: "decisions",
+              archived: true,
+            }),
+          ),
+        ],
+      }),
+    );
+
+    // The negative client only needs to seed its one record and archive it; its
+    // namespace read is never reached because the primary search fails first.
+    const negative = new OpenBrainLiveClient(
+      scriptedCaller({
+        log_thought: [
+          ok(
+            JSON.stringify({
+              id: "srv-neg-secret",
+              namespace: CONFIG.negativeNamespace,
+              merged: false,
+            }),
+          ),
+        ],
+        archive_entry: [
+          ok(
+            JSON.stringify({
+              id: "srv-neg-secret",
+              table: "thoughts",
+              archived: true,
+            }),
+          ),
+        ],
+      }),
+    );
+
+    const err = await runLiveGate({
+      fixture: FIXTURE,
+      thresholds: THRESHOLDS,
+      config: CONFIG,
+      clients: { primary, negative },
+      commit: "testcommit",
+      generatedAt: "2026-07-22T00:00:00.000Z",
+    }).catch((e) => e as LiveTransportError);
+
+    expect(err).toBeInstanceOf(LiveTransportError);
+    // parseHits kept the namespace-less hit (namespace optional), so the gate --
+    // not the transport boundary -- classified it as foreign-namespace.
+    expect(err.label).toBe("search_brain:foreign-namespace");
+    expect(err.label).not.toContain("srv-no-ns");
   });
 });

--- a/eval/open-brain/live/__tests__/gate.test.ts
+++ b/eval/open-brain/live/__tests__/gate.test.ts
@@ -115,6 +115,8 @@ interface FakeState {
   seeded: Map<string, { table: string; namespace: string }>;
   archived: string[];
   closed: number;
+  /** Namespaces the PRIMARY caller's isolation probe (attemptRead) targeted. */
+  attemptReadNamespaces: string[];
 }
 
 /**
@@ -131,7 +133,12 @@ function makeFakeClients(
   clients: GateClients;
   state: FakeState;
 } {
-  const state: FakeState = { seeded: new Map(), archived: [], closed: 0 };
+  const state: FakeState = {
+    seeded: new Map(),
+    archived: [],
+    closed: 0,
+    attemptReadNamespaces: [],
+  };
   const serverId = (fixtureId: string) => `srv-${fixtureId}`;
 
   const seedFail = new Set(opts.seedFailFor ?? []);
@@ -179,7 +186,15 @@ function makeFakeClients(
             namespace: o.namespace,
           }));
       },
-      async attemptRead(): Promise<{ denied: boolean; hitCount: number }> {
+      async attemptRead(o: {
+        namespace: string;
+      }): Promise<{ denied: boolean; hitCount: number }> {
+        // Record the namespace the PRIMARY isolation probe targeted so a test can
+        // pin the live-proven call shape: the gate must probe the NEGATIVE
+        // namespace with the PRIMARY caller.
+        if (role === "primary") {
+          state.attemptReadNamespaces.push(o.namespace);
+        }
         switch (opts.negativeRead ?? "denied") {
           case "denied":
             return { denied: true, hitCount: 0 };
@@ -256,6 +271,14 @@ describe("runLiveGate happy path", () => {
     expect(receipt.negative_control.ran).toBe(true);
     expect(receipt.negative_control.denied).toBe(true);
     expect(receipt.negative_control.cross_token).toBe(false);
+    // The isolation probe used the PRIMARY caller against the NEGATIVE namespace
+    // -- pin the live-proven call shape so a future refactor cannot silently
+    // probe the primary namespace (which would prove nothing).
+    expect(state.attemptReadNamespaces.length).toBeGreaterThan(0);
+    for (const ns of state.attemptReadNamespaces) {
+      expect(ns).toBe(CONFIG.negativeNamespace);
+    }
+    expect(state.attemptReadNamespaces).not.toContain(CONFIG.primaryNamespace);
     // Teardown archived exactly the 3 seeded records, nothing stranded.
     expect(receipt.teardown).toEqual({
       attempted: 3,
@@ -298,6 +321,32 @@ describe("runLiveGate teardown discipline", () => {
     await expect(outcome).rejects.toThrow(LiveTransportError);
     // All 3 records were seeded before the query failed -> all 3 archived.
     expect(state.archived.length).toBe(3);
+  });
+
+  it("preserves the content-free teardown failed COUNT when the deferred error is rethrown", async () => {
+    // A query throws (deferred) AND one archive fails during teardown. The
+    // rethrown error must carry the stranded-record count (content-free) so the
+    // teardown failure is not lost behind the query error -- but never a record
+    // id, body, or raw error string.
+    const { outcome } = run(FIXTURE, {
+      searchThrows: true,
+      archiveFailFor: ["prim-a"],
+    });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    // Original redacted label preserved, teardown count appended.
+    expect(err.label).toBe("search_brain:timeout;teardown-failed=1");
+    expect(err.message).toBe("search_brain:timeout;teardown-failed=1");
+    // Content-free: no ids or bodies.
+    expect(err.label).not.toContain("srv-");
+    expect(err.label).not.toContain("body");
+  });
+
+  it("leaves the deferred error unchanged when teardown strands nothing", async () => {
+    const { outcome } = run(FIXTURE, { searchThrows: true });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    // No teardown failure -> label is untouched (no suffix).
+    expect(err.label).toBe("search_brain:timeout");
   });
 
   it("fails the gate (never PASS) when a teardown archive fails", async () => {

--- a/eval/open-brain/live/__tests__/gate.test.ts
+++ b/eval/open-brain/live/__tests__/gate.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from "bun:test";
+import { runLiveGate, type GateClients } from "../gate.ts";
+import type { LiveEvalConfig } from "../config.ts";
+import { LiveTransportError, type OpenBrainLiveClient } from "../transport.ts";
+import type { LiveFixture, LiveThresholds, SearchHit } from "../types.ts";
+
+// Orchestrator tests for runLiveGate (issue #322 seeding/teardown + isolation
+// regression, #324 composite gate). These drive a structural fake at the
+// OpenBrainLiveClient seam so no hosted server is touched. What they prove:
+//
+//  - Teardown ALWAYS runs and archives exactly the records this run seeded --
+//    even when seeding fails partway, when a query throws, or when a probe fails.
+//  - A cleanup (archive) failure can never turn an otherwise-passing run into
+//    PASS: teardownClean is a gate condition, not just a receipt field.
+//  - The negative-control isolation proof is mandatory: PASS requires an
+//    explicit denial. An allowed-but-empty negative read, an allowed non-empty
+//    read, and a thrown non-denial error each fail the gate.
+//  - Retrieved server ids are mapped back to fixture ids for scoring, and a
+//    leaked negative id is counted as a namespace leak.
+//  - thresholds that do not apply to the fixture throw before any live write.
+//
+// Everything the gate emits is content-free: only ids, namespaces, counts,
+// booleans, and scores. These tests also assert no memory body leaks into the
+// receipt.
+
+const CONFIG: LiveEvalConfig = {
+  baseUrl: "http://127.0.0.1:3100",
+  primaryToken: "primary-token",
+  negativeToken: "primary-token",
+  negativeTokenIsDistinct: false,
+  primaryNamespace: "eval-live-recall-run-test",
+  negativeNamespace: "eval-live-recall-run-test-negative",
+  searchMode: "hybrid",
+  timeoutMs: 1000,
+};
+
+const THRESHOLDS: LiveThresholds = {
+  schema_version: 1,
+  thresholds_id: "test-thresholds-v1",
+  applies_to_fixture_id: "test-fixture-v1",
+  top_k: 5,
+  thresholds: {
+    min_recall_at_k: 0.9,
+    min_precision_at_k: 0.3,
+    min_mrr: 0.8,
+    max_namespace_leaks: 0,
+  },
+};
+
+// A small fixture: two primary records relevant to one probe, one negative
+// record forbidden to that probe.
+const FIXTURE: LiveFixture = {
+  schema_version: 1,
+  fixture_id: "test-fixture-v1",
+  description: "test",
+  corpus: [
+    {
+      id: "prim-a",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "primary a body",
+      tags: ["t"],
+    },
+    {
+      id: "prim-b",
+      table: "decisions",
+      namespace_role: "primary",
+      content: "primary b body",
+      tags: ["t"],
+    },
+    {
+      id: "neg-secret",
+      table: "thoughts",
+      namespace_role: "negative",
+      content: "negative secret body that must never surface",
+      tags: ["t"],
+    },
+  ],
+  probes: [
+    {
+      id: "probe-1",
+      query: "find a and b",
+      relevant: [
+        { id: "prim-a", grade: 2 },
+        { id: "prim-b", grade: 2 },
+      ],
+      forbidden_ids: ["neg-secret"],
+    },
+  ],
+};
+
+interface FakeOptions {
+  /** Fixture ids whose seed should throw a transport error (partial seed). */
+  seedFailFor?: string[];
+  /** Throw on the primary search call. */
+  searchThrows?: boolean;
+  /** Fixture ids whose archive should throw (cleanup failure). */
+  archiveFailFor?: string[];
+  /**
+   * How the primary caller's read of the NEGATIVE namespace resolves:
+   *  - "denied": server denies the read (isolation proven).
+   *  - "empty": read is allowed but returns nothing (NOT proof).
+   *  - "leak": read is allowed and returns the negative record (breach).
+   *  - "throws": a non-denial transport error (proof could not be established).
+   */
+  negativeRead?: "denied" | "empty" | "leak" | "throws";
+  /**
+   * Extra fixture ids to inject into the PRIMARY probe search result, e.g. a
+   * leaked negative id, to exercise leak counting via the retrieval mapping.
+   */
+  extraPrimaryHits?: string[];
+}
+
+interface FakeState {
+  seeded: Map<string, { table: string; namespace: string }>;
+  archived: string[];
+  closed: number;
+}
+
+/**
+ * Build a pair of fake OpenBrainLiveClients (primary + negative) plus the shared
+ * state they mutate. The fakes model just enough server behavior for the gate:
+ * seeding assigns a stable server id ("srv-<fixtureId>"), primary search returns
+ * the seeded primary records (best-first) mapped through their server ids, and
+ * archive records the id. Negative-namespace behavior is driven by FakeOptions.
+ */
+function makeFakeClients(
+  fixture: LiveFixture,
+  opts: FakeOptions = {},
+): {
+  clients: GateClients;
+  state: FakeState;
+} {
+  const state: FakeState = { seeded: new Map(), archived: [], closed: 0 };
+  const serverId = (fixtureId: string) => `srv-${fixtureId}`;
+
+  const seedFail = new Set(opts.seedFailFor ?? []);
+  const archiveFail = new Set(opts.archiveFailFor ?? []);
+
+  // Reverse index: server id -> fixture id, for building search hits.
+  const byServerId = (id: string) => id.replace(/^srv-/, "");
+
+  function makeClient(role: "primary" | "negative"): OpenBrainLiveClient {
+    const fake = {
+      async logMemory(o: {
+        table: string;
+        content: string;
+        tags: string[];
+        namespace: string;
+      }) {
+        // Which fixture entry is this? Match by content (unique per entry).
+        const entry = fixture.corpus.find((c) => c.content === o.content);
+        const fixtureId = entry?.id ?? "unknown";
+        if (seedFail.has(fixtureId)) {
+          throw new LiveTransportError(`log:${fixtureId}:error`, false);
+        }
+        const id = serverId(fixtureId);
+        state.seeded.set(id, { table: o.table, namespace: o.namespace });
+        return { id, namespace: o.namespace };
+      },
+      async search(o: { namespace: string }): Promise<SearchHit[]> {
+        if (opts.searchThrows) {
+          throw new LiveTransportError("search_brain:timeout", false);
+        }
+        // Return the seeded PRIMARY records as ranked hits (best-first: a then b),
+        // plus any injected extra hits (e.g. a leaked negative id).
+        const primaryFixtureIds = fixture.corpus
+          .filter((c) => c.namespace_role === "primary")
+          .map((c) => c.id);
+        const hitFixtureIds = [
+          ...primaryFixtureIds,
+          ...(opts.extraPrimaryHits ?? []),
+        ];
+        return hitFixtureIds
+          .filter((fid) => state.seeded.has(serverId(fid)))
+          .map((fid) => ({
+            id: serverId(fid),
+            source_type: "thoughts",
+            namespace: o.namespace,
+          }));
+      },
+      async attemptRead(): Promise<{ denied: boolean; hitCount: number }> {
+        switch (opts.negativeRead ?? "denied") {
+          case "denied":
+            return { denied: true, hitCount: 0 };
+          case "empty":
+            return { denied: false, hitCount: 0 };
+          case "leak":
+            return { denied: false, hitCount: 1 };
+          case "throws":
+            throw new LiveTransportError("search_brain:timeout", false);
+        }
+      },
+      async archive(o: { table: string; id: string }) {
+        const fixtureId = byServerId(o.id);
+        if (archiveFail.has(fixtureId)) {
+          throw new LiveTransportError("archive_entry:error", false);
+        }
+        state.archived.push(o.id);
+        return state.seeded.has(o.id) ? "archived" : "already_absent";
+      },
+      async close() {
+        state.closed += 1;
+      },
+    };
+    return fake as unknown as OpenBrainLiveClient;
+  }
+
+  return {
+    clients: {
+      primary: makeClient("primary"),
+      negative: makeClient("negative"),
+    },
+    state,
+  };
+}
+
+function run(fixture: LiveFixture, opts: FakeOptions = {}) {
+  const { clients, state } = makeFakeClients(fixture, opts);
+  return {
+    outcome: runLiveGate({
+      fixture,
+      thresholds: THRESHOLDS,
+      config: CONFIG,
+      clients,
+      commit: "testcommit",
+      generatedAt: "2026-07-22T00:00:00.000Z",
+    }),
+    state,
+  };
+}
+
+/** Assert a receipt (serialized) carries no memory-body content. */
+function assertContentFree(receipt: unknown): void {
+  const json = JSON.stringify(receipt);
+  expect(json).not.toContain("body");
+  expect(json).not.toContain("secret");
+  expect(json).not.toContain("primary a body");
+  expect(json).not.toContain("must never surface");
+}
+
+describe("runLiveGate happy path", () => {
+  it("seeds, scores, proves isolation, tears down, and reports PASS", async () => {
+    const { outcome, state } = run(FIXTURE);
+    const { receipt, passed, scorecard } = await outcome;
+
+    expect(passed).toBe(true);
+    expect(scorecard.passed).toBe(true);
+    // Seeded counts split by role.
+    expect(receipt.seeded).toEqual({ primary: 2, negative: 1 });
+    // Metrics reflect both relevant primary records at ranks 1 and 2.
+    expect(receipt.metrics.recall_at_k).toBe(1);
+    expect(receipt.metrics.mrr).toBe(1);
+    expect(receipt.metrics.namespace_leaks).toBe(0);
+    // Negative control ran and denied.
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(true);
+    expect(receipt.negative_control.cross_token).toBe(false);
+    // Teardown archived exactly the 3 seeded records, nothing stranded.
+    expect(receipt.teardown).toEqual({
+      attempted: 3,
+      archived: 3,
+      already_absent: 0,
+      failed: 0,
+    });
+    expect(state.archived.sort()).toEqual(
+      ["srv-neg-secret", "srv-prim-a", "srv-prim-b"].sort(),
+    );
+    expect(receipt.failures).toEqual([]);
+    assertContentFree(receipt);
+  });
+
+  it("maps server ids back to fixture ids for citation/count scoring", async () => {
+    const { outcome } = run(FIXTURE);
+    const { receipt } = await outcome;
+    // The single probe found both relevant records: recall 1, precision 2/5.
+    const probe = receipt.probes.find((p) => p.probe_id === "probe-1");
+    expect(probe).toBeDefined();
+    expect(probe?.recall_at_k).toBe(1);
+    expect(probe?.precision_at_k).toBe(0.4);
+    expect(probe?.namespace_leaks).toBe(0);
+  });
+});
+
+describe("runLiveGate teardown discipline", () => {
+  it("tears down the records seeded so far when seeding fails partway", async () => {
+    // Fail seeding the negative record (last). prim-a + prim-b are already
+    // seeded and MUST be archived even though the run throws.
+    const { outcome, state } = run(FIXTURE, { seedFailFor: ["neg-secret"] });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    // The two successfully-seeded records were torn down; the failed one never
+    // got a server id, so it is not stranded.
+    expect(state.archived.sort()).toEqual(["srv-prim-a", "srv-prim-b"].sort());
+  });
+
+  it("tears down all seeded records when a query throws", async () => {
+    const { outcome, state } = run(FIXTURE, { searchThrows: true });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    // All 3 records were seeded before the query failed -> all 3 archived.
+    expect(state.archived.length).toBe(3);
+  });
+
+  it("fails the gate (never PASS) when a teardown archive fails", async () => {
+    // Everything else is clean, but archiving prim-a throws. The run must NOT
+    // report PASS -- a stranded record is a gate failure, not a silent success.
+    const { outcome } = run(FIXTURE, { archiveFailFor: ["prim-a"] });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.teardown.failed).toBe(1);
+    expect(receipt.teardown.archived).toBe(2);
+    expect(
+      receipt.failures.some((f) => f.includes("teardown failed to archive")),
+    ).toBe(true);
+    // Metrics still computed and content-free.
+    expect(receipt.metrics.recall_at_k).toBe(1);
+    assertContentFree(receipt);
+  });
+});
+
+describe("runLiveGate negative-control (isolation) discipline", () => {
+  it("fails when the negative read is allowed but empty (not a denial)", async () => {
+    const { outcome } = run(FIXTURE, { negativeRead: "empty" });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(
+      receipt.failures.some((f) => f.includes("negative-control not denied")),
+    ).toBe(true);
+  });
+
+  it("fails when the negative read leaks a record (allowed, non-empty)", async () => {
+    const { outcome } = run(FIXTURE, { negativeRead: "leak" });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(receipt.negative_control.observed_hit_count).toBe(1);
+    expect(
+      receipt.failures.some((f) => f.includes("negative-control not denied")),
+    ).toBe(true);
+  });
+
+  it("fails (content-free) and tears down when the negative read throws a non-denial error", async () => {
+    // A non-denial transport error during the isolation probe means the proof
+    // could not be established. probeNegativeControl catches it and reports
+    // denied=false with a redacted failure label, so the gate does NOT throw --
+    // it completes, tears down, and reports FAIL (isolation unproven).
+    const { outcome, state } = run(FIXTURE, { negativeRead: "throws" });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(false);
+    // The failure label is content-free (redacted transport label only).
+    expect(receipt.negative_control.failure).toContain(
+      "negative-control read failed",
+    );
+    expect(receipt.negative_control.failure).not.toContain("body");
+    // Teardown still ran for all seeded records.
+    expect(state.archived.length).toBe(3);
+    assertContentFree(receipt);
+  });
+
+  it("counts a leaked negative id in the primary result as a namespace leak and fails", async () => {
+    // Inject the negative fixture id into the PRIMARY probe search result: the
+    // gate must count it as a leak (max_namespace_leaks=0 -> fail).
+    const { outcome } = run(FIXTURE, { extraPrimaryHits: ["neg-secret"] });
+    const { receipt, passed, scorecard } = await outcome;
+    expect(receipt.metrics.namespace_leaks).toBe(1);
+    expect(scorecard.passed).toBe(false);
+    expect(passed).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("namespace_leaks"))).toBe(
+      true,
+    );
+    assertContentFree(receipt);
+  });
+});
+
+describe("runLiveGate composite verdict", () => {
+  it("requires clean teardown AND denial AND thresholds for PASS", async () => {
+    // Baseline PASS already proven above; here confirm no single failure mode
+    // slips through: a clean metrics + denial run with a stranded record fails.
+    const { outcome } = run(FIXTURE, { archiveFailFor: ["neg-secret"] });
+    const { passed, receipt } = await outcome;
+    expect(receipt.negative_control.denied).toBe(true);
+    expect(receipt.metrics.recall_at_k).toBe(1);
+    expect(receipt.teardown.failed).toBe(1);
+    // Even with metrics + isolation green, the stranded record blocks PASS.
+    expect(passed).toBe(false);
+  });
+
+  it("throws before any live write when thresholds do not apply to the fixture", async () => {
+    const { clients, state } = makeFakeClients(FIXTURE);
+    await expect(
+      runLiveGate({
+        fixture: FIXTURE,
+        thresholds: {
+          ...THRESHOLDS,
+          applies_to_fixture_id: "some-other-fixture",
+        },
+        config: CONFIG,
+        clients,
+        commit: "c",
+        generatedAt: "2026-07-22T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(/apply to fixture/);
+    // No seeding happened, so nothing to tear down.
+    expect(state.seeded.size).toBe(0);
+    expect(state.archived.length).toBe(0);
+  });
+});

--- a/eval/open-brain/live/__tests__/metrics.test.ts
+++ b/eval/open-brain/live/__tests__/metrics.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildScorecard,
+  namespaceLeaks,
+  parseThresholds,
+  precisionAtK,
+  recallAtK,
+  reciprocalRank,
+  scoreProbeMetric,
+} from "../metrics.ts";
+import { parseLiveFixture } from "../fixtures.ts";
+import type { LiveFixture, LiveThresholds } from "../types.ts";
+
+const FIXTURE: LiveFixture = parseLiveFixture({
+  schema_version: 1,
+  fixture_id: "known-rankings-v1",
+  description: "deterministic ranking test fixture",
+  corpus: [
+    {
+      id: "a",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "a",
+      tags: [],
+    },
+    {
+      id: "b",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "b",
+      tags: [],
+    },
+    {
+      id: "c",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "c",
+      tags: [],
+    },
+    {
+      id: "d",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "d distractor",
+      tags: [],
+    },
+    {
+      id: "neg",
+      table: "thoughts",
+      namespace_role: "negative",
+      content: "neg",
+      tags: [],
+    },
+  ],
+  probes: [
+    {
+      id: "p1",
+      query: "find a and b",
+      relevant: [
+        { id: "a", grade: 2 },
+        { id: "b", grade: 1 },
+      ],
+      forbidden_ids: ["neg"],
+    },
+    {
+      id: "p2",
+      query: "find c",
+      relevant: [{ id: "c", grade: 2 }],
+      forbidden_ids: ["neg"],
+    },
+  ],
+});
+
+const THRESHOLDS: LiveThresholds = parseThresholds({
+  schema_version: 1,
+  thresholds_id: "known-thresholds-v1",
+  applies_to_fixture_id: "known-rankings-v1",
+  top_k: 3,
+  thresholds: {
+    min_recall_at_k: 0.9,
+    min_precision_at_k: 0.3,
+    min_mrr: 0.8,
+    max_namespace_leaks: 0,
+  },
+});
+
+describe("deterministic ranking metrics", () => {
+  it("computes recall@k over a known ranked list", () => {
+    // relevant {a,b}; retrieved top-3 has a,d,b -> both relevant found
+    expect(recallAtK(["a", "d", "b"], ["a", "b"])).toBe(1);
+    // only a found -> 0.5
+    expect(recallAtK(["a", "d"], ["a", "b"])).toBe(0.5);
+    // none found -> 0
+    expect(recallAtK(["d", "e"], ["a", "b"])).toBe(0);
+    // no relevant items -> perfect recall by convention
+    expect(recallAtK([], [])).toBe(1);
+  });
+
+  it("computes precision@k with k as the denominator", () => {
+    // 2 relevant of top-3 slots -> 2/3
+    expect(precisionAtK(["a", "b", "d"], ["a", "b"], 3)).toBeCloseTo(2 / 3, 6);
+    // 1 relevant of top-3 -> 1/3
+    expect(precisionAtK(["a", "d", "e"], ["a", "b"], 3)).toBeCloseTo(1 / 3, 6);
+    // truncates to k even if more retrieved
+    expect(precisionAtK(["a", "b", "c", "d", "e"], ["a", "b", "c"], 2)).toBe(1);
+  });
+
+  it("computes reciprocal rank of the first relevant hit", () => {
+    expect(reciprocalRank(["a", "b"], ["a"])).toBe(1); // rank 1
+    expect(reciprocalRank(["d", "a"], ["a"])).toBe(0.5); // rank 2
+    expect(reciprocalRank(["d", "e"], ["a"])).toBe(0); // absent
+  });
+
+  it("counts namespace leaks over the full retrieved list", () => {
+    expect(namespaceLeaks(["a", "neg", "b"], ["neg"])).toBe(1);
+    expect(namespaceLeaks(["a", "b"], ["neg"])).toBe(0);
+    expect(namespaceLeaks(["a", "b"], [])).toBe(0);
+  });
+
+  it("scores a probe deterministically for a known ranking", () => {
+    const probe = FIXTURE.probes[0]!;
+    const metric = scoreProbeMetric(probe, ["a", "d", "b"], 3);
+    expect(metric).toEqual({
+      probe_id: "p1",
+      recall_at_k: 1,
+      precision_at_k: 2 / 3,
+      reciprocal_rank: 1,
+      namespace_leaks: 0,
+      retrieved_count: 3,
+      relevant_count: 2,
+    });
+  });
+
+  it("builds a passing scorecard for a perfect known retrieval", () => {
+    const scorecard = buildScorecard(FIXTURE, THRESHOLDS, {
+      p1: ["a", "b", "d"],
+      p2: ["c", "d"],
+    });
+    expect(scorecard.passed).toBe(true);
+    expect(scorecard.failures).toEqual([]);
+    expect(scorecard.recall_at_k).toBe(1);
+    expect(scorecard.mrr).toBe(1);
+    expect(scorecard.namespace_leaks).toBe(0);
+  });
+
+  it("fails the scorecard when recall/mrr fall below threshold (degraded retrieval)", () => {
+    // p1 returns only the distractor (no relevant), p2 returns nothing.
+    const scorecard = buildScorecard(FIXTURE, THRESHOLDS, {
+      p1: ["d"],
+      p2: [],
+    });
+    expect(scorecard.passed).toBe(false);
+    expect(scorecard.recall_at_k).toBeLessThan(0.9);
+    expect(scorecard.mrr).toBeLessThan(0.8);
+    expect(scorecard.failures.some((f) => f.startsWith("recall_at_k"))).toBe(
+      true,
+    );
+    expect(scorecard.failures.some((f) => f.startsWith("mrr"))).toBe(true);
+  });
+
+  it("fails the scorecard when a forbidden namespace record leaks", () => {
+    const scorecard = buildScorecard(FIXTURE, THRESHOLDS, {
+      p1: ["a", "b", "neg"],
+      p2: ["c"],
+    });
+    expect(scorecard.namespace_leaks).toBe(1);
+    expect(scorecard.passed).toBe(false);
+    expect(
+      scorecard.failures.some((f) => f.startsWith("namespace_leaks")),
+    ).toBe(true);
+  });
+
+  it("scores a missing probe as an empty (worst-case) retrieval", () => {
+    const scorecard = buildScorecard(FIXTURE, THRESHOLDS, { p1: ["a", "b"] });
+    const p2 = scorecard.probes.find((p) => p.probe_id === "p2");
+    expect(p2?.recall_at_k).toBe(0);
+    expect(p2?.reciprocal_rank).toBe(0);
+  });
+
+  it("rejects thresholds with out-of-range values", () => {
+    expect(() =>
+      parseThresholds({
+        schema_version: 1,
+        thresholds_id: "bad",
+        applies_to_fixture_id: "x",
+        top_k: 5,
+        thresholds: {
+          min_recall_at_k: 1.5,
+          min_precision_at_k: 0.3,
+          min_mrr: 0.8,
+          max_namespace_leaks: 0,
+        },
+      }),
+    ).toThrow();
+    expect(() =>
+      parseThresholds({
+        schema_version: 1,
+        thresholds_id: "bad",
+        applies_to_fixture_id: "x",
+        top_k: 0,
+        thresholds: {
+          min_recall_at_k: 0.9,
+          min_precision_at_k: 0.3,
+          min_mrr: 0.8,
+          max_namespace_leaks: 0,
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/eval/open-brain/live/__tests__/transport.test.ts
+++ b/eval/open-brain/live/__tests__/transport.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it } from "bun:test";
+import {
+  OpenBrainLiveClient,
+  LiveTransportError,
+  createMcpCaller,
+  isDenialLabel,
+  parseHits,
+  redactToolFailure,
+  sanitizeThrownTransportError,
+  type McpClientLike,
+  type OpenBrainToolCaller,
+  type ToolCallResult,
+} from "../transport.ts";
+
+// Behavior tests for the live transport wrapper. These target the redaction
+// boundary and the semantic client without touching a hosted server: every
+// failure must be reduced to a content-free label, denial must be modeled
+// distinctly from a generic error, and the primary recall path must never
+// swallow a denial (only the explicit isolation probe may).
+
+/** A scripted fake caller: each tool name maps to a queue of results. */
+function fakeCaller(
+  script: Record<string, ToolCallResult[]>,
+  log?: { calls: Array<{ name: string; args: Record<string, unknown> }> },
+): OpenBrainToolCaller {
+  const queues: Record<string, ToolCallResult[]> = {};
+  for (const [k, v] of Object.entries(script)) queues[k] = [...v];
+  return {
+    async callTool(name, args) {
+      log?.calls.push({ name, args });
+      const q = queues[name];
+      if (!q || q.length === 0) {
+        throw new Error(`fake caller has no scripted result for ${name}`);
+      }
+      return q.shift()!;
+    },
+    async close() {},
+  };
+}
+
+function ok(data: string): ToolCallResult {
+  return { isError: false, denied: false, data, errorLabel: "" };
+}
+function denied(label: string): ToolCallResult {
+  return { isError: true, denied: true, data: "", errorLabel: label };
+}
+function errored(label: string): ToolCallResult {
+  return { isError: true, denied: false, data: "", errorLabel: label };
+}
+
+describe("redactToolFailure (content-free error boundary)", () => {
+  it("emits a tool:reason label and never the raw body", () => {
+    const secretBody =
+      "Permission denied: cannot read namespace 'x' SECRET-TOKEN-abc123 memory body here";
+    const { errorLabel, denied: isDenied } = redactToolFailure(
+      "search_brain",
+      secretBody,
+    );
+    expect(errorLabel).toBe("search_brain:permission-denied");
+    expect(isDenied).toBe(true);
+    // The label must not carry any of the sensitive substrings.
+    expect(errorLabel).not.toContain("SECRET-TOKEN");
+    expect(errorLabel).not.toContain("memory body");
+    expect(errorLabel).not.toContain("namespace 'x'");
+  });
+
+  it("collapses an unknown error body to a bare tool:error label", () => {
+    const { errorLabel, denied: isDenied } = redactToolFailure(
+      "log_thought",
+      "Row 4831 content: my private grommet torque note leaked here",
+    );
+    expect(errorLabel).toBe("log_thought:error");
+    expect(isDenied).toBe(false);
+    expect(errorLabel).not.toContain("grommet");
+    expect(errorLabel).not.toContain("4831");
+  });
+
+  it("recognizes denial labels", () => {
+    expect(isDenialLabel("search_brain:permission-denied")).toBe(true);
+    expect(isDenialLabel("archive_entry:forbidden")).toBe(true);
+    expect(isDenialLabel("search_brain:not-found")).toBe(false);
+    expect(isDenialLabel("log_thought:error")).toBe(false);
+  });
+});
+
+describe("OpenBrainLiveClient.logMemory", () => {
+  it("returns the server id + namespace on success", async () => {
+    const log = {
+      calls: [] as Array<{ name: string; args: Record<string, unknown> }>,
+    };
+    const client = new OpenBrainLiveClient(
+      fakeCaller(
+        {
+          log_thought: [ok(JSON.stringify({ id: "srv-1", namespace: "ns-a" }))],
+        },
+        log,
+      ),
+    );
+    const res = await client.logMemory({
+      table: "thoughts",
+      content: "c",
+      tags: [],
+      namespace: "ns-a",
+    });
+    expect(res).toEqual({ id: "srv-1", namespace: "ns-a" });
+    expect(log.calls[0]?.args.namespace).toBe("ns-a");
+  });
+
+  it("throws a redacted LiveTransportError on failure (no raw body)", async () => {
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ log_decision: [errored("log_decision:error")] }),
+    );
+    await expect(
+      client.logMemory({
+        table: "decisions",
+        content: "c",
+        tags: [],
+        namespace: "n",
+      }),
+    ).rejects.toThrow(LiveTransportError);
+  });
+});
+
+describe("OpenBrainLiveClient.search (primary recall path)", () => {
+  it("parses ranked hits from a JSON array body", async () => {
+    const body = JSON.stringify([
+      { id: "a", source_type: "thoughts", namespace: "ns" },
+      { id: "b", source_type: "decisions" },
+    ]);
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [ok(body)] }),
+    );
+    const hits = await client.search({
+      query: "q",
+      namespace: "ns",
+      limit: 5,
+      searchMode: "hybrid",
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a", "b"]);
+  });
+
+  it("does NOT swallow a denial on the recall path -- it throws", async () => {
+    // A denial here means the primary token cannot read its own namespace,
+    // which is a misconfiguration and must fail loudly (content-free).
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [denied("search_brain:permission-denied")] }),
+    );
+    await expect(
+      client.search({
+        query: "q",
+        namespace: "ns",
+        limit: 5,
+        searchMode: "hybrid",
+      }),
+    ).rejects.toThrow(LiveTransportError);
+  });
+});
+
+describe("OpenBrainLiveClient.attemptRead (isolation probe)", () => {
+  it("reports denied=true when the server denies the read", async () => {
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [denied("search_brain:permission-denied")] }),
+    );
+    const res = await client.attemptRead({
+      query: "q",
+      namespace: "neg-ns",
+      limit: 5,
+      searchMode: "hybrid",
+    });
+    expect(res).toEqual({ denied: true, hitCount: 0 });
+  });
+
+  it("treats an empty successful read as NOT denied (no false isolation proof)", async () => {
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [ok("[]")] }),
+    );
+    const res = await client.attemptRead({
+      query: "q",
+      namespace: "neg-ns",
+      limit: 5,
+      searchMode: "hybrid",
+    });
+    // Empty + allowed is the dangerous case the gate must reject as proof.
+    expect(res.denied).toBe(false);
+    expect(res.hitCount).toBe(0);
+  });
+
+  it("reports a non-empty successful read as a leak (denied=false, hitCount>0)", async () => {
+    const body = JSON.stringify([{ id: "leak", source_type: "thoughts" }]);
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [ok(body)] }),
+    );
+    const res = await client.attemptRead({
+      query: "q",
+      namespace: "neg-ns",
+      limit: 5,
+      searchMode: "hybrid",
+    });
+    expect(res.denied).toBe(false);
+    expect(res.hitCount).toBe(1);
+  });
+
+  it("throws (not a false proof) on a non-denial transport error", async () => {
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [errored("search_brain:timeout")] }),
+    );
+    await expect(
+      client.attemptRead({
+        query: "q",
+        namespace: "neg",
+        limit: 5,
+        searchMode: "hybrid",
+      }),
+    ).rejects.toThrow(LiveTransportError);
+  });
+});
+
+describe("OpenBrainLiveClient.archive", () => {
+  it("maps archived=true to 'archived' and absent to 'already_absent'", async () => {
+    const c1 = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok(JSON.stringify({ archived: true }))] }),
+    );
+    expect(await c1.archive({ table: "thoughts", id: "x" })).toBe("archived");
+    const c2 = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok("Already archived or not found")] }),
+    );
+    expect(await c2.archive({ table: "thoughts", id: "y" })).toBe(
+      "already_absent",
+    );
+  });
+
+  it("throws a redacted LiveTransportError when archive errors", async () => {
+    const client = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [errored("archive_entry:error")] }),
+    );
+    await expect(
+      client.archive({ table: "thoughts", id: "z" }),
+    ).rejects.toThrow(LiveTransportError);
+  });
+});
+
+describe("parseHits", () => {
+  it("ignores rows without a string id and non-array bodies", () => {
+    expect(parseHits("not json")).toEqual([]);
+    expect(parseHits(JSON.stringify({ id: "a" }))).toEqual([]);
+    expect(
+      parseHits(
+        JSON.stringify([{ id: 1 }, { id: "ok", source_type: "t" }]),
+      ).map((h) => h.id),
+    ).toEqual(["ok"]);
+  });
+});
+
+describe("close delegates to the caller", () => {
+  it("calls the caller's close exactly once", async () => {
+    let closed = 0;
+    const caller: OpenBrainToolCaller = {
+      async callTool() {
+        return ok("{}");
+      },
+      async close() {
+        closed += 1;
+      },
+    };
+    const client = new OpenBrainLiveClient(caller);
+    await client.close();
+    expect(closed).toBe(1);
+  });
+});
+
+describe("sanitizeThrownTransportError (content-free thrown-error boundary)", () => {
+  // The SDK can throw an error whose .message carries the raw remote HTTP body,
+  // which may include a memory body or secret. The sanitizer must never surface
+  // the raw message -- only op + a known keyword / status / bare marker.
+  const secret =
+    "HTTP 500 body: Permission denied for SECRET-TOKEN-abc123, memory body 'grommet torque note' leaked";
+
+  it("keeps a known keyword and drops everything else", () => {
+    const err = sanitizeThrownTransportError("connect", new Error(secret));
+    expect(err).toBeInstanceOf(LiveTransportError);
+    // "permission denied" is a known keyword and wins over the status code.
+    expect(err.label).toBe("connect:permission-denied");
+    expect(err.denied).toBe(true);
+    expect(err.label).not.toContain("SECRET-TOKEN");
+    expect(err.label).not.toContain("grommet");
+    expect(err.label).not.toContain("500");
+    expect(err.message).toBe("connect:permission-denied");
+  });
+
+  it("names only an HTTP status when no keyword matches", () => {
+    const err = sanitizeThrownTransportError(
+      "search_brain",
+      new Error(
+        "Unexpected server response 503 body: private note contents here",
+      ),
+    );
+    expect(err.label).toBe("search_brain:http-503");
+    expect(err.denied).toBe(false);
+    expect(err.label).not.toContain("private note");
+  });
+
+  it("collapses an opaque error to <op>:transport-error", () => {
+    const err = sanitizeThrownTransportError(
+      "log_thought",
+      new Error("socket hang up while writing row 4831: grommet torque secret"),
+    );
+    expect(err.label).toBe("log_thought:transport-error");
+    expect(err.label).not.toContain("4831");
+    expect(err.label).not.toContain("grommet");
+  });
+
+  it("handles a non-Error throw without leaking its stringified body", () => {
+    const err = sanitizeThrownTransportError("close", {
+      toString: () => "raw object with SECRET-xyz inside",
+    });
+    expect(err.label).toBe("close:transport-error");
+    expect(err.label).not.toContain("SECRET-xyz");
+  });
+
+  it("passes an already-redacted LiveTransportError through unchanged", () => {
+    const original = new LiveTransportError(
+      "search_brain:permission-denied",
+      true,
+    );
+    expect(sanitizeThrownTransportError("connect", original)).toBe(original);
+  });
+});
+
+/** Build a fake McpClientLike whose methods throw or return scripted results. */
+function fakeMcpClient(behavior: {
+  connect?: () => Promise<void>;
+  callTool?: () => Promise<{ content?: unknown; isError?: boolean }>;
+  close?: () => Promise<void>;
+}): McpClientLike {
+  return {
+    async connect() {
+      if (behavior.connect) return behavior.connect();
+    },
+    async callTool() {
+      if (behavior.callTool) return behavior.callTool();
+      return { content: [{ type: "text", text: "{}" }], isError: false };
+    },
+    async close() {
+      if (behavior.close) return behavior.close();
+    },
+  };
+}
+
+describe("createMcpCaller (concrete boundary sanitization)", () => {
+  const baseOpts = {
+    baseUrl: "http://127.0.0.1:3100",
+    token: "tok",
+    namespace: "ns-x",
+    timeoutMs: 1000,
+  };
+
+  it("sanitizes a thrown connect error (no raw remote body)", async () => {
+    const promise = createMcpCaller({
+      ...baseOpts,
+      clientFactory: () => ({
+        client: fakeMcpClient({
+          connect: async () => {
+            throw new Error("HTTP 401 Unauthorized: token leaked-secret-xyz");
+          },
+        }),
+        transport: {},
+      }),
+    });
+    await expect(promise).rejects.toThrow(LiveTransportError);
+    await expect(promise).rejects.toThrow("connect:unauthorized");
+    await promise.catch((e) => {
+      expect((e as Error).message).not.toContain("leaked-secret-xyz");
+    });
+  });
+
+  it("sanitizes a thrown callTool error to a content-free label", async () => {
+    const caller = await createMcpCaller({
+      ...baseOpts,
+      clientFactory: () => ({
+        client: fakeMcpClient({
+          callTool: async () => {
+            throw new Error(
+              "stream broke: row body 'private grommet note' 500",
+            );
+          },
+        }),
+        transport: {},
+      }),
+    });
+    const call = caller.callTool("search_brain", { query: "q" });
+    await expect(call).rejects.toThrow(LiveTransportError);
+    await call.catch((e) => {
+      expect((e as LiveTransportError).label).toBe("search_brain:http-500");
+      expect((e as Error).message).not.toContain("grommet");
+    });
+  });
+
+  it("redacts a server isError body to a content-free label (not thrown)", async () => {
+    const caller = await createMcpCaller({
+      ...baseOpts,
+      clientFactory: () => ({
+        client: fakeMcpClient({
+          callTool: async () => ({
+            content: [
+              { type: "text", text: "Permission denied: secret body abc" },
+            ],
+            isError: true,
+          }),
+        }),
+        transport: {},
+      }),
+    });
+    const res = await caller.callTool("search_brain", { query: "q" });
+    expect(res.isError).toBe(true);
+    expect(res.denied).toBe(true);
+    expect(res.errorLabel).toBe("search_brain:permission-denied");
+    expect(res.data).toBe("");
+  });
+
+  it("returns the response body only on success, for structured parsing", async () => {
+    const body = JSON.stringify({ id: "srv-1", namespace: "ns-x" });
+    const caller = await createMcpCaller({
+      ...baseOpts,
+      clientFactory: () => ({
+        client: fakeMcpClient({
+          callTool: async () => ({
+            content: [{ type: "text", text: body }],
+            isError: false,
+          }),
+        }),
+        transport: {},
+      }),
+    });
+    const res = await caller.callTool("log_thought", { content: "c" });
+    expect(res.isError).toBe(false);
+    expect(res.data).toBe(body);
+    expect(res.errorLabel).toBe("");
+  });
+
+  it("sanitizes a thrown close error to a content-free label", async () => {
+    const caller = await createMcpCaller({
+      ...baseOpts,
+      clientFactory: () => ({
+        client: fakeMcpClient({
+          close: async () => {
+            throw new Error("close failed 503: leftover private body text");
+          },
+        }),
+        transport: {},
+      }),
+    });
+    const close = caller.close();
+    await expect(close).rejects.toThrow(LiveTransportError);
+    await close.catch((e) => {
+      expect((e as LiveTransportError).label).toBe("close:http-503");
+      expect((e as Error).message).not.toContain("private body");
+    });
+  });
+});

--- a/eval/open-brain/live/__tests__/transport.test.ts
+++ b/eval/open-brain/live/__tests__/transport.test.ts
@@ -127,14 +127,18 @@ describe("redactToolFailure (content-free error boundary)", () => {
 });
 
 describe("OpenBrainLiveClient.logMemory", () => {
-  it("returns the server id + namespace on success", async () => {
+  it("returns the server id + namespace on a fresh create (merged:false)", async () => {
     const log = {
       calls: [] as Array<{ name: string; args: Record<string, unknown> }>,
     };
     const client = new OpenBrainLiveClient(
       fakeCaller(
         {
-          log_thought: [ok(JSON.stringify({ id: "srv-1", namespace: "ns-a" }))],
+          log_thought: [
+            ok(
+              JSON.stringify({ id: "srv-1", namespace: "ns-a", merged: false }),
+            ),
+          ],
         },
         log,
       ),
@@ -145,7 +149,7 @@ describe("OpenBrainLiveClient.logMemory", () => {
       tags: [],
       namespace: "ns-a",
     });
-    expect(res).toEqual({ id: "srv-1", namespace: "ns-a" });
+    expect(res).toEqual({ id: "srv-1", namespace: "ns-a", merged: false });
     expect(log.calls[0]?.args.namespace).toBe("ns-a");
   });
 
@@ -161,6 +165,136 @@ describe("OpenBrainLiveClient.logMemory", () => {
         namespace: "n",
       }),
     ).rejects.toThrow(LiveTransportError);
+  });
+
+  it("FAILS CLOSED on a merged upsert (a stranded prior seed in a reused namespace)", async () => {
+    // A create must be merged:false. merged:true means the server upserted onto
+    // an EXISTING row -- a prior run's stranded seed in a reused namespace.
+    // Treating it as a this-run creation and later archiving it would tombstone a
+    // row this run did not create, so the seed must fail closed content-free.
+    const client = new OpenBrainLiveClient(
+      fakeCaller({
+        log_thought: [
+          ok(
+            JSON.stringify({
+              id: "srv-old",
+              namespace: "ns-a",
+              merged: true,
+            }),
+          ),
+        ],
+      }),
+    );
+    const err = await client
+      .logMemory({
+        table: "thoughts",
+        content: "c",
+        tags: [],
+        namespace: "ns-a",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("log_thought:merged-upsert");
+  });
+
+  it("FAILS CLOSED when `merged` is missing or not a boolean", async () => {
+    // No `merged` field at all: we cannot prove this was a fresh create.
+    const missing = new OpenBrainLiveClient(
+      fakeCaller({
+        log_decision: [ok(JSON.stringify({ id: "srv-1", namespace: "ns-a" }))],
+      }),
+    );
+    const missingErr = await missing
+      .logMemory({
+        table: "decisions",
+        content: "c",
+        tags: [],
+        namespace: "ns-a",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(missingErr).toBeInstanceOf(LiveTransportError);
+    expect(missingErr.label).toBe("log_decision:missing-merged");
+
+    // A non-boolean `merged` (string "false") is not a valid create signal.
+    const nonBool = new OpenBrainLiveClient(
+      fakeCaller({
+        log_thought: [
+          ok(
+            JSON.stringify({ id: "srv-1", namespace: "ns-a", merged: "false" }),
+          ),
+        ],
+      }),
+    );
+    const nonBoolErr = await nonBool
+      .logMemory({
+        table: "thoughts",
+        content: "c",
+        tags: [],
+        namespace: "ns-a",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(nonBoolErr.label).toBe("log_thought:missing-merged");
+  });
+
+  it("FAILS CLOSED when the returned namespace is not exactly the requested one", async () => {
+    // A row that landed in a different namespace (or a response with no
+    // namespace) is not where teardown/scoring were bound; do NOT default a
+    // missing namespace to the requested one.
+    const wrong = new OpenBrainLiveClient(
+      fakeCaller({
+        log_thought: [
+          ok(
+            JSON.stringify({
+              id: "srv-1",
+              namespace: "some-other-ns",
+              merged: false,
+            }),
+          ),
+        ],
+      }),
+    );
+    const wrongErr = await wrong
+      .logMemory({
+        table: "thoughts",
+        content: "c",
+        tags: [],
+        namespace: "ns-a",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(wrongErr).toBeInstanceOf(LiveTransportError);
+    expect(wrongErr.label).toBe("log_thought:namespace-mismatch");
+
+    const absent = new OpenBrainLiveClient(
+      fakeCaller({
+        log_decision: [ok(JSON.stringify({ id: "srv-1", merged: false }))],
+      }),
+    );
+    const absentErr = await absent
+      .logMemory({
+        table: "decisions",
+        content: "c",
+        tags: [],
+        namespace: "ns-a",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(absentErr.label).toBe("log_decision:namespace-mismatch");
+  });
+
+  it("still FAILS CLOSED on a missing id even when merged:false", async () => {
+    const client = new OpenBrainLiveClient(
+      fakeCaller({
+        log_thought: [ok(JSON.stringify({ namespace: "ns-a", merged: false }))],
+      }),
+    );
+    const err = await client
+      .logMemory({
+        table: "thoughts",
+        content: "c",
+        tags: [],
+        namespace: "ns-a",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(err.label).toBe("log_thought:missing-id");
   });
 });
 
@@ -256,12 +390,52 @@ describe("OpenBrainLiveClient.attemptRead (isolation probe)", () => {
       }),
     ).rejects.toThrow(LiveTransportError);
   });
+
+  it("FAILS CLOSED through the shared parseHits on a malformed successful body", async () => {
+    // The isolation probe shares parseHits with the primary search. A malformed
+    // (non-array) success body must NOT be read as hitCount:0 (an empty allowed
+    // read, which would look like a working boundary) -- it must throw, so
+    // probeNegativeControl reports the proof as unestablished rather than passing.
+    const nonArray = new OpenBrainLiveClient(
+      fakeCaller({ search_brain: [ok(JSON.stringify({ hits: [] }))] }),
+    );
+    const err = await nonArray
+      .attemptRead({
+        query: "q",
+        namespace: "neg",
+        limit: 5,
+        searchMode: "hybrid",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("search_brain:malformed-results");
+
+    // A malformed hit (missing id) on the probe path also fails closed.
+    const badHit = new OpenBrainLiveClient(
+      fakeCaller({
+        search_brain: [ok(JSON.stringify([{ source_type: "thoughts" }]))],
+      }),
+    );
+    const badHitErr = await badHit
+      .attemptRead({
+        query: "q",
+        namespace: "neg",
+        limit: 5,
+        searchMode: "hybrid",
+      })
+      .catch((e) => e as LiveTransportError);
+    expect(badHitErr.label).toBe("search_brain:malformed-hit");
+  });
 });
 
 describe("OpenBrainLiveClient.archive", () => {
-  it("maps archived=true to 'archived' and the EXACT absent marker to 'already_absent'", async () => {
+  it("maps archived=true (bound to the requested id/table) to 'archived' and the EXACT absent marker to 'already_absent'", async () => {
     const c1 = new OpenBrainLiveClient(
-      fakeCaller({ archive_entry: [ok(JSON.stringify({ archived: true }))] }),
+      fakeCaller({
+        archive_entry: [
+          ok(JSON.stringify({ id: "x", table: "thoughts", archived: true })),
+        ],
+      }),
     );
     expect(await c1.archive({ table: "thoughts", id: "x" })).toBe("archived");
     // The exact server no-op body (src/tools/archive-entry.ts).
@@ -293,6 +467,48 @@ describe("OpenBrainLiveClient.archive", () => {
       .catch((e) => e as LiveTransportError);
     expect(err).toBeInstanceOf(LiveTransportError);
     expect(err.label).toBe("archive_entry:unrecognized-success");
+  });
+
+  it("FAILS CLOSED on archived:true bound to a DIFFERENT id or table", async () => {
+    // archived:true says a row was tombstoned but not WHICH row. If the returned
+    // id/table do not exactly match this request, the server tombstoned some
+    // other row (or the response drifted); crediting it would leave OUR record
+    // live while teardown reports clean. Fail closed content-free.
+    const wrongId = new OpenBrainLiveClient(
+      fakeCaller({
+        archive_entry: [
+          ok(
+            JSON.stringify({ id: "other", table: "thoughts", archived: true }),
+          ),
+        ],
+      }),
+    );
+    const wrongIdErr = await wrongId
+      .archive({ table: "thoughts", id: "x" })
+      .catch((e) => e as LiveTransportError);
+    expect(wrongIdErr).toBeInstanceOf(LiveTransportError);
+    expect(wrongIdErr.label).toBe("archive_entry:identity-mismatch");
+
+    const wrongTable = new OpenBrainLiveClient(
+      fakeCaller({
+        archive_entry: [
+          ok(JSON.stringify({ id: "x", table: "decisions", archived: true })),
+        ],
+      }),
+    );
+    const wrongTableErr = await wrongTable
+      .archive({ table: "thoughts", id: "x" })
+      .catch((e) => e as LiveTransportError);
+    expect(wrongTableErr.label).toBe("archive_entry:identity-mismatch");
+
+    // archived:true with the id/table missing entirely is equally unbound.
+    const missing = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok(JSON.stringify({ archived: true }))] }),
+    );
+    const missingErr = await missing
+      .archive({ table: "thoughts", id: "x" })
+      .catch((e) => e as LiveTransportError);
+    expect(missingErr.label).toBe("archive_entry:identity-mismatch");
   });
 
   it("FAILS CLOSED (throws) on an unrecognized success shape -- never a false already_absent", async () => {
@@ -363,15 +579,115 @@ describe("OpenBrainLiveClient.archive", () => {
   });
 });
 
-describe("parseHits", () => {
-  it("ignores rows without a string id and non-array bodies", () => {
-    expect(parseHits("not json")).toEqual([]);
-    expect(parseHits(JSON.stringify({ id: "a" }))).toEqual([]);
-    expect(
-      parseHits(
-        JSON.stringify([{ id: 1 }, { id: "ok", source_type: "t" }]),
-      ).map((h) => h.id),
-    ).toEqual(["ok"]);
+describe("parseHits (fail-closed transport boundary)", () => {
+  // parseHits is the boundary every scored/probed hit passes through. A dropped
+  // raw result never reaches the gate-level validator (toFixtureRetrieval), so a
+  // malformed body or entry must FAIL CLOSED here, never be silently discarded --
+  // discarding would compress ranks or hide a foreign/malformed row before PASS.
+
+  it("FAILS CLOSED on a non-array success body (object) -- not an empty result", () => {
+    // The old behavior returned [] for a non-array body, conflating a malformed
+    // result set with a real empty read. It must now throw, content-free.
+    const err = (() => {
+      try {
+        parseHits(JSON.stringify({ id: "a" }));
+        return undefined;
+      } catch (e) {
+        return e as LiveTransportError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err?.label).toBe("search_brain:malformed-results");
+  });
+
+  it("FAILS CLOSED on a non-array success body (scalar)", () => {
+    expect(() => parseHits(JSON.stringify(42))).toThrow(LiveTransportError);
+    expect(() => parseHits(JSON.stringify("a string"))).toThrow(
+      LiveTransportError,
+    );
+  });
+
+  it("FAILS CLOSED on invalid JSON (content-free malformed-results)", () => {
+    const err = (() => {
+      try {
+        parseHits("not json {");
+        return undefined;
+      } catch (e) {
+        return e as LiveTransportError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err?.label).toBe("search_brain:malformed-results");
+    // Content-free: the raw body never appears in the label.
+    expect(err?.label).not.toContain("not json");
+  });
+
+  it("FAILS CLOSED on a non-object array entry -- never silently skipped", () => {
+    const err = (() => {
+      try {
+        parseHits(JSON.stringify([{ id: "ok" }, 7]));
+        return undefined;
+      } catch (e) {
+        return e as LiveTransportError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err?.label).toBe("search_brain:malformed-hit");
+  });
+
+  it("FAILS CLOSED on an entry with a missing / non-string id", () => {
+    const missing = (() => {
+      try {
+        parseHits(JSON.stringify([{ source_type: "t" }]));
+      } catch (e) {
+        return e as LiveTransportError;
+      }
+    })();
+    expect(missing?.label).toBe("search_brain:malformed-hit");
+
+    const nonString = (() => {
+      try {
+        parseHits(JSON.stringify([{ id: 1, source_type: "t" }]));
+      } catch (e) {
+        return e as LiveTransportError;
+      }
+    })();
+    expect(nonString?.label).toBe("search_brain:malformed-hit");
+  });
+
+  it("FAILS CLOSED on an entry with an EMPTY string id", () => {
+    const err = (() => {
+      try {
+        parseHits(JSON.stringify([{ id: "", source_type: "t" }]));
+      } catch (e) {
+        return e as LiveTransportError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err?.label).toBe("search_brain:malformed-hit");
+  });
+
+  it("preserves rank/order for valid rows and keeps namespace OPTIONAL", () => {
+    // Valid rows must survive in order; a valid row WITHOUT a namespace passes
+    // this boundary (it reaches gate.ts, which fails it as foreign-namespace) --
+    // requiring namespace here would mask that distinct gate-level classification.
+    const hits = parseHits(
+      JSON.stringify([
+        { id: "a", source_type: "thoughts", namespace: "ns" },
+        { id: "b", source_type: "decisions" }, // no namespace -> undefined, kept
+        { id: "c", source_type: "thoughts", namespace: "ns" },
+      ]),
+    );
+    expect(hits.map((h) => h.id)).toEqual(["a", "b", "c"]);
+    expect(hits[0]?.namespace).toBe("ns");
+    expect(hits[1]?.namespace).toBeUndefined();
+    expect(hits[2]?.namespace).toBe("ns");
+  });
+
+  it("returns an empty array for a genuinely empty result set", () => {
+    // An empty JSON array is a real "no hits" read, distinct from a malformed
+    // body -- it must NOT throw.
+    expect(parseHits("[]")).toEqual([]);
   });
 });
 

--- a/eval/open-brain/live/__tests__/transport.test.ts
+++ b/eval/open-brain/live/__tests__/transport.test.ts
@@ -81,6 +81,49 @@ describe("redactToolFailure (content-free error boundary)", () => {
     expect(isDenialLabel("search_brain:not-found")).toBe(false);
     expect(isDenialLabel("log_thought:error")).toBe(false);
   });
+
+  it("prioritizes a denial keyword over a generic one in a mixed body", () => {
+    // A body that mixes "invalid" with "unauthorized" must classify as a denial:
+    // the generic keyword appears first lexically, but denial precedence wins so
+    // the isolation proof / auth failure is never misread as a plain error.
+    const mixed = redactToolFailure(
+      "search_brain",
+      "Invalid request: unauthorized for namespace 'neg'",
+    );
+    expect(mixed.errorLabel).toBe("search_brain:unauthorized");
+    expect(mixed.denied).toBe(true);
+
+    const mixed2 = redactToolFailure(
+      "archive_entry",
+      "invalid archive: forbidden for this namespace",
+    );
+    expect(mixed2.errorLabel).toBe("archive_entry:forbidden");
+    expect(mixed2.denied).toBe(true);
+
+    // "permission denied" also wins over a leading "invalid".
+    const mixed3 = redactToolFailure(
+      "search_brain",
+      "invalid: permission denied reading namespace",
+    );
+    expect(mixed3.errorLabel).toBe("search_brain:permission-denied");
+    expect(mixed3.denied).toBe(true);
+  });
+
+  it("keeps a generic label when no denial keyword is present", () => {
+    const generic = redactToolFailure("log_thought", "invalid payload shape");
+    expect(generic.errorLabel).toBe("log_thought:invalid");
+    expect(generic.denied).toBe(false);
+  });
+
+  it("sanitizeThrownTransportError prioritizes a mixed-body denial keyword", () => {
+    const err = sanitizeThrownTransportError(
+      "connect",
+      new Error("HTTP 400 invalid request: forbidden token for namespace"),
+    );
+    // Denial keyword wins over both "invalid" and the status code.
+    expect(err.label).toBe("connect:forbidden");
+    expect(err.denied).toBe(true);
+  });
 });
 
 describe("OpenBrainLiveClient.logMemory", () => {
@@ -216,17 +259,98 @@ describe("OpenBrainLiveClient.attemptRead (isolation probe)", () => {
 });
 
 describe("OpenBrainLiveClient.archive", () => {
-  it("maps archived=true to 'archived' and absent to 'already_absent'", async () => {
+  it("maps archived=true to 'archived' and the EXACT absent marker to 'already_absent'", async () => {
     const c1 = new OpenBrainLiveClient(
       fakeCaller({ archive_entry: [ok(JSON.stringify({ archived: true }))] }),
     );
     expect(await c1.archive({ table: "thoughts", id: "x" })).toBe("archived");
+    // The exact server no-op body (src/tools/archive-entry.ts).
     const c2 = new OpenBrainLiveClient(
       fakeCaller({ archive_entry: [ok("Already archived or not found")] }),
     );
     expect(await c2.archive({ table: "thoughts", id: "y" })).toBe(
       "already_absent",
     );
+    // Trimmed + case-insensitive: whitespace/case variants of the exact marker
+    // still classify (the server body, tolerantly matched, nothing more).
+    const c3 = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok("  ALREADY archived or not found  ")] }),
+    );
+    expect(await c3.archive({ table: "thoughts", id: "z" })).toBe(
+      "already_absent",
+    );
+  });
+
+  it("FAILS CLOSED on a structured archived=false -- the server never emits it", async () => {
+    // archive_entry has exactly two success shapes: {archived:true} or the exact
+    // plain-text marker. A structured {archived:false} is an unrecognized shape
+    // and must fail closed, never a silent already_absent.
+    const c = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok(JSON.stringify({ archived: false }))] }),
+    );
+    const err = await c
+      .archive({ table: "thoughts", id: "y" })
+      .catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("archive_entry:unrecognized-success");
+  });
+
+  it("FAILS CLOSED (throws) on an unrecognized success shape -- never a false already_absent", async () => {
+    // The destructive-teardown hole: a success body that neither confirms an
+    // archive nor matches the already-absent marker must NOT be silently counted
+    // as clean cleanup. That would strand a live record while PASS is reported.
+    const ambiguous = new OpenBrainLiveClient(
+      fakeCaller({
+        archive_entry: [ok(JSON.stringify({ status: "queued", ok: true }))],
+      }),
+    );
+    const ambiguousErr = await ambiguous
+      .archive({ table: "thoughts", id: "z" })
+      .catch((e) => e as LiveTransportError);
+    expect(ambiguousErr).toBeInstanceOf(LiveTransportError);
+    // Content-free label: names the tool + a marker, never the raw body.
+    expect(ambiguousErr.label).toBe("archive_entry:unrecognized-success");
+
+    // An empty body is also ambiguous -> fail closed.
+    const empty = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok("")] }),
+    );
+    await expect(empty.archive({ table: "thoughts", id: "z" })).rejects.toThrow(
+      LiveTransportError,
+    );
+
+    // A non-JSON body that is NOT an absent marker is ambiguous -> fail closed.
+    const junk = new OpenBrainLiveClient(
+      fakeCaller({ archive_entry: [ok("row body: private grommet note")] }),
+    );
+    const junkErr = junk
+      .archive({ table: "thoughts", id: "z" })
+      .catch((e) => e as LiveTransportError);
+    const resolved = await junkErr;
+    expect(resolved).toBeInstanceOf(LiveTransportError);
+    expect(resolved.label).not.toContain("grommet");
+  });
+
+  it("FAILS CLOSED on partial / mixed-text markers -- only the exact marker passes", async () => {
+    // Under the exact-marker contract, a body that merely CONTAINS "not found"
+    // (or "no rows", or the marker embedded in incidental text) must NOT be
+    // treated as the absent no-op: it could false-pass on unrelated output.
+    const cases = [
+      "archive_entry: row not found (already tombstoned)", // marker embedded in mixed text
+      "not found", // partial substring of the marker
+      "no rows", // never a real archive_entry body
+      "Already archived or not found. extra tail", // exact marker + trailing text
+    ];
+    for (const body of cases) {
+      const c = new OpenBrainLiveClient(
+        fakeCaller({ archive_entry: [ok(body)] }),
+      );
+      const err = await c
+        .archive({ table: "thoughts", id: "y" })
+        .catch((e) => e as LiveTransportError);
+      expect(err).toBeInstanceOf(LiveTransportError);
+      expect(err.label).toBe("archive_entry:unrecognized-success");
+    }
   });
 
   it("throws a redacted LiveTransportError when archive errors", async () => {

--- a/eval/open-brain/live/config.ts
+++ b/eval/open-brain/live/config.ts
@@ -1,0 +1,197 @@
+// Env-gated configuration for the live recall gate.
+//
+// The gate is OFF unless OPEN_BRAIN_LIVE_EVAL=1 is set, so `bun test` and the
+// offline eval never touch a hosted service. When enabled, the gate needs a
+// base URL and a bearer token with archive permission AND X-Namespace
+// delegation authority (admin / ob-admin), so it can bind a per-run throwaway
+// namespace via the X-Namespace header.
+//
+// The isolation proof is a REAL negative control, not token inequality: the
+// negative session reads/writes a sibling namespace via a different X-Namespace
+// header. That header binding is what isolates it, so the SAME bearer token is
+// permitted for both sessions -- an optional distinct negative token is
+// accepted but never required. What is required is that a negative control can
+// always be constructed; there is no silent-skip path.
+//
+// A unique throwaway namespace is derived per run so concurrent or repeated
+// runs never collide and teardown only ever targets this run's records.
+
+export interface LiveEvalConfig {
+  baseUrl: string;
+  /** Token used to seed + read + archive the primary throwaway namespace. */
+  primaryToken: string;
+  /**
+   * Token used for the negative sibling namespace. Defaults to the primary
+   * token: isolation is proven by the distinct X-Namespace binding, not by a
+   * different token. An operator MAY supply a distinct token to also exercise
+   * cross-token denial, but it is never required and, when supplied, must
+   * differ from the primary token to be meaningful.
+   */
+  negativeToken: string;
+  /** True when the negative token is a distinct credential from the primary. */
+  negativeTokenIsDistinct: boolean;
+  /** Per-run unique primary namespace. */
+  primaryNamespace: string;
+  /** Per-run unique negative (unreadable-from-primary) sibling namespace. */
+  negativeNamespace: string;
+  /** Recall search mode; hybrid by default to exercise the full retriever. */
+  searchMode: "hybrid" | "vector" | "keyword";
+  /** Per-request timeout in milliseconds. */
+  timeoutMs: number;
+}
+
+/** True only when the operator has explicitly opted into live execution. */
+export function liveEvalEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.OPEN_BRAIN_LIVE_EVAL === "1";
+}
+
+/**
+ * Derive a unique per-run namespace pair from a run id. The run id is supplied
+ * by the caller; the gate constructs it at startup from an operator-provided
+ * run id or crypto randomness (see makeRunId), keeping this helper pure and
+ * deterministic so unit tests can pin it (no Date.now/random here).
+ */
+export function runNamespaces(runId: string): {
+  primary: string;
+  negative: string;
+} {
+  const safe = runId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 80);
+  if (safe.length === 0) {
+    throw new Error(
+      "live eval run id must contain at least one usable character",
+    );
+  }
+  return {
+    primary: `eval-live-recall-${safe}`,
+    negative: `eval-live-recall-${safe}-negative`,
+  };
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/**
+ * Build a per-run id that is unique across repeated runs on the same commit.
+ *
+ * Precedence:
+ *  1. An explicit operator run id (OPEN_BRAIN_LIVE_EVAL_RUN_ID) -- reproducible.
+ *  2. A crypto-random suffix combined with a caller-supplied prefix (e.g. the
+ *     short commit) so two runs of the same commit never collide.
+ *
+ * `randomHex` is injected so tests can assert the shape deterministically; the
+ * gate passes a crypto.randomUUID-derived value. This function itself never
+ * calls Date.now/Math.random, keeping runNamespaces deterministic under test.
+ */
+export function makeRunId(opts: {
+  prefix: string;
+  randomHex: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const env = opts.env ?? process.env;
+  const explicit = (env.OPEN_BRAIN_LIVE_EVAL_RUN_ID ?? "").trim();
+  if (explicit.length > 0) {
+    return explicit;
+  }
+  const suffix = opts.randomHex.trim();
+  if (suffix.length === 0) {
+    throw new Error(
+      "live eval run id needs an operator run id or a random suffix to stay unique across runs",
+    );
+  }
+  const prefix = opts.prefix.trim();
+  return prefix.length > 0 ? `${prefix}-${suffix}` : suffix;
+}
+
+/**
+ * Build and validate live config from the environment. Throws a precise,
+ * secret-free error naming the missing/invalid variable. `runId` is required so
+ * the namespace pair is stable for the lifetime of the run and reproducible in
+ * tests.
+ */
+export function loadLiveConfig(
+  runId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): LiveEvalConfig {
+  if (!liveEvalEnabled(env)) {
+    throw new Error(
+      "Live recall gate is disabled. Set OPEN_BRAIN_LIVE_EVAL=1 to run it.",
+    );
+  }
+
+  const baseUrl = (env.OPEN_BRAIN_LIVE_EVAL_BASE_URL ?? "").trim();
+  if (!baseUrl) {
+    throw new Error(
+      "OPEN_BRAIN_LIVE_EVAL_BASE_URL is required for the live gate",
+    );
+  }
+  try {
+    // Reject a malformed URL up front rather than deep in the transport.
+    // eslint-disable-next-line no-new
+    new URL(baseUrl);
+  } catch {
+    throw new Error("OPEN_BRAIN_LIVE_EVAL_BASE_URL is not a valid URL");
+  }
+
+  const primaryToken = (env.OPEN_BRAIN_LIVE_EVAL_TOKEN ?? "").trim();
+  if (!primaryToken) {
+    throw new Error("OPEN_BRAIN_LIVE_EVAL_TOKEN is required for the live gate");
+  }
+
+  // A real negative control is mandatory. It is provided by binding a distinct
+  // X-Namespace on the negative session, so the SAME bearer token is a valid
+  // negative control -- the header binding is the isolation proof, not token
+  // inequality. An operator MAY supply a distinct token to also cover
+  // cross-token denial; when supplied it must differ from the primary token
+  // (an identical token would be a no-op that hides a misconfiguration).
+  const negativeTokenRaw = (
+    env.OPEN_BRAIN_LIVE_EVAL_NEGATIVE_TOKEN ?? ""
+  ).trim();
+  let negativeToken = primaryToken;
+  let negativeTokenIsDistinct = false;
+  if (negativeTokenRaw.length > 0) {
+    if (negativeTokenRaw === primaryToken) {
+      throw new Error(
+        "OPEN_BRAIN_LIVE_EVAL_NEGATIVE_TOKEN, when set, must differ from OPEN_BRAIN_LIVE_EVAL_TOKEN; leave it unset to use the same token with a distinct negative namespace",
+      );
+    }
+    negativeToken = negativeTokenRaw;
+    negativeTokenIsDistinct = true;
+  }
+
+  const searchModeRaw = (
+    env.OPEN_BRAIN_LIVE_EVAL_SEARCH_MODE ?? "hybrid"
+  ).trim();
+  if (
+    searchModeRaw !== "hybrid" &&
+    searchModeRaw !== "vector" &&
+    searchModeRaw !== "keyword"
+  ) {
+    throw new Error(
+      "OPEN_BRAIN_LIVE_EVAL_SEARCH_MODE must be one of hybrid, vector, keyword",
+    );
+  }
+
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+  const timeoutRaw = env.OPEN_BRAIN_LIVE_EVAL_TIMEOUT_MS;
+  if (timeoutRaw !== undefined && timeoutRaw.trim() !== "") {
+    const parsed = Number.parseInt(timeoutRaw, 10);
+    if (Number.isNaN(parsed) || parsed < 1) {
+      throw new Error(
+        "OPEN_BRAIN_LIVE_EVAL_TIMEOUT_MS must be a positive integer",
+      );
+    }
+    timeoutMs = parsed;
+  }
+
+  const { primary, negative } = runNamespaces(runId);
+
+  return {
+    baseUrl,
+    primaryToken,
+    negativeToken,
+    negativeTokenIsDistinct,
+    primaryNamespace: primary,
+    negativeNamespace: negative,
+    searchMode: searchModeRaw,
+    timeoutMs,
+  };
+}

--- a/eval/open-brain/live/config.ts
+++ b/eval/open-brain/live/config.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 // Env-gated configuration for the live recall gate.
 //
 // The gate is OFF unless OPEN_BRAIN_LIVE_EVAL=1 is set, so `bun test` and the
@@ -45,22 +47,56 @@ export function liveEvalEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.OPEN_BRAIN_LIVE_EVAL === "1";
 }
 
+/** Max sanitized run-id length that is copied verbatim into a namespace. */
+const MAX_SAFE_RUN_ID_LEN = 80;
+/** Hex chars of the deterministic collision-suffix used when bounding. */
+const RUN_ID_HASH_LEN = 12;
+
+/**
+ * Bound a sanitized run id to a safe length WITHOUT losing uniqueness. A naive
+ * `.slice(0, N)` collides whenever two distinct run ids share their first N
+ * characters -- which is exactly what happens when a long operator label is
+ * suffixed with a per-invocation nonce: the nonce is past the cut and both runs
+ * enter the SAME namespace, where the second seed upserts onto the first run's
+ * stranded row.
+ *
+ * Instead, when the sanitized id exceeds the safe length, we keep a truncated
+ * prefix and append a deterministic short hash of the FULL sanitized id. Because
+ * the hash covers the whole input (including the trailing nonce), two ids that
+ * share only the first N characters produce different suffixes and therefore
+ * different namespaces. The hash is SHA-256 (pure/deterministic -- no
+ * Date.now/random), so this helper stays pinnable in tests.
+ */
+export function boundRunId(safe: string): string {
+  if (safe.length <= MAX_SAFE_RUN_ID_LEN) return safe;
+  const hash = createHash("sha256")
+    .update(safe)
+    .digest("hex")
+    .slice(0, RUN_ID_HASH_LEN);
+  // Reserve room for the "-<hash>" suffix so the bounded id still fits.
+  const prefixLen = MAX_SAFE_RUN_ID_LEN - RUN_ID_HASH_LEN - 1;
+  return `${safe.slice(0, prefixLen)}-${hash}`;
+}
+
 /**
  * Derive a unique per-run namespace pair from a run id. The run id is supplied
- * by the caller; the gate constructs it at startup from an operator-provided
- * run id or crypto randomness (see makeRunId), keeping this helper pure and
- * deterministic so unit tests can pin it (no Date.now/random here).
+ * by the caller; the gate constructs it at startup by combining an optional
+ * operator LABEL with a per-invocation crypto nonce (see makeRunId), keeping
+ * this helper pure and deterministic so unit tests can pin it (no
+ * Date.now/random here). Bounding preserves uniqueness: two run ids that share
+ * an 80-char prefix still map to distinct namespaces (see boundRunId).
  */
 export function runNamespaces(runId: string): {
   primary: string;
   negative: string;
 } {
-  const safe = runId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 80);
-  if (safe.length === 0) {
+  const sanitized = runId.replace(/[^a-zA-Z0-9_-]/g, "-");
+  if (sanitized.length === 0) {
     throw new Error(
       "live eval run id must contain at least one usable character",
     );
   }
+  const safe = boundRunId(sanitized);
   return {
     primary: `eval-live-recall-${safe}`,
     negative: `eval-live-recall-${safe}-negative`,
@@ -70,12 +106,18 @@ export function runNamespaces(runId: string): {
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 /**
- * Build a per-run id that is unique across repeated runs on the same commit.
+ * Build a per-run id that is unique across EVERY invocation, including repeated
+ * runs on the same commit and runs that reuse an operator-supplied label.
  *
- * Precedence:
- *  1. An explicit operator run id (OPEN_BRAIN_LIVE_EVAL_RUN_ID) -- reproducible.
- *  2. A crypto-random suffix combined with a caller-supplied prefix (e.g. the
- *     short commit) so two runs of the same commit never collide.
+ * The injected `randomHex` nonce is ALWAYS appended -- it is the only part of
+ * the id that guarantees uniqueness, so it is mandatory. The optional
+ * `OPEN_BRAIN_LIVE_EVAL_RUN_ID` is an operator LABEL (a human-readable prefix
+ * for triage), NOT a reusable namespace id: reusing a label would otherwise let
+ * two runs enter the same namespace, where the second seed upserts onto the
+ * first run's stranded row. The commit prefix is a fallback label. Precedence
+ * for the label is: explicit operator label > commit prefix > none.
+ *
+ * Shapes: `<label>-<nonce>`, `<prefix>-<nonce>`, or `<nonce>`.
  *
  * `randomHex` is injected so tests can assert the shape deterministically; the
  * gate passes a crypto.randomUUID-derived value. This function itself never
@@ -87,18 +129,17 @@ export function makeRunId(opts: {
   env?: NodeJS.ProcessEnv;
 }): string {
   const env = opts.env ?? process.env;
-  const explicit = (env.OPEN_BRAIN_LIVE_EVAL_RUN_ID ?? "").trim();
-  if (explicit.length > 0) {
-    return explicit;
-  }
-  const suffix = opts.randomHex.trim();
-  if (suffix.length === 0) {
+  const nonce = opts.randomHex.trim();
+  if (nonce.length === 0) {
+    // The nonce is the uniqueness guarantee; without it we cannot promise two
+    // invocations differ, so refuse rather than emit a reusable id.
     throw new Error(
-      "live eval run id needs an operator run id or a random suffix to stay unique across runs",
+      "live eval run id needs a crypto random suffix to stay unique across every invocation",
     );
   }
-  const prefix = opts.prefix.trim();
-  return prefix.length > 0 ? `${prefix}-${suffix}` : suffix;
+  const explicitLabel = (env.OPEN_BRAIN_LIVE_EVAL_RUN_ID ?? "").trim();
+  const label = explicitLabel.length > 0 ? explicitLabel : opts.prefix.trim();
+  return label.length > 0 ? `${label}-${nonce}` : nonce;
 }
 
 /**

--- a/eval/open-brain/live/fixtures.ts
+++ b/eval/open-brain/live/fixtures.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import type { LiveFixture } from "./types.ts";
+
+// Zod validation for the live recall fixture. Loading is fail-closed: a
+// malformed fixture aborts the gate before any live write happens.
+
+const gradedRelevanceSchema = z.object({
+  id: z.string().min(1),
+  grade: z.number().int().min(0),
+});
+
+const corpusEntrySchema = z.object({
+  id: z.string().min(1),
+  table: z.enum(["thoughts", "decisions"]),
+  namespace_role: z.enum(["primary", "negative"]),
+  content: z.string().min(1),
+  tags: z.array(z.string()),
+});
+
+const probeSchema = z.object({
+  id: z.string().min(1),
+  query: z.string().min(1),
+  relevant: z.array(gradedRelevanceSchema),
+  forbidden_ids: z.array(z.string()),
+});
+
+export const liveFixtureSchema: z.ZodType<LiveFixture> = z.object({
+  schema_version: z.literal(1),
+  fixture_id: z.string().min(1),
+  description: z.string(),
+  corpus: z.array(corpusEntrySchema).min(1),
+  probes: z.array(probeSchema).min(1),
+});
+
+/**
+ * Parse and structurally validate a live fixture, then check referential
+ * integrity: every id referenced by a probe (relevant or forbidden) must exist
+ * in the corpus, corpus ids are unique, and forbidden ids point at negative-role
+ * entries while relevant ids point at primary-role entries. Throws on any gap.
+ */
+export function parseLiveFixture(raw: unknown): LiveFixture {
+  const fixture = liveFixtureSchema.parse(raw);
+
+  const byId = new Map<string, (typeof fixture.corpus)[number]>();
+  for (const entry of fixture.corpus) {
+    if (byId.has(entry.id)) {
+      throw new Error(`duplicate corpus id: ${entry.id}`);
+    }
+    byId.set(entry.id, entry);
+  }
+
+  const probeIds = new Set<string>();
+  for (const probe of fixture.probes) {
+    if (probeIds.has(probe.id)) {
+      throw new Error(`duplicate probe id: ${probe.id}`);
+    }
+    probeIds.add(probe.id);
+
+    for (const rel of probe.relevant) {
+      const entry = byId.get(rel.id);
+      if (!entry) {
+        throw new Error(
+          `probe ${probe.id} references unknown relevant id ${rel.id}`,
+        );
+      }
+      if (entry.namespace_role !== "primary") {
+        throw new Error(
+          `probe ${probe.id} relevant id ${rel.id} must be a primary-role entry`,
+        );
+      }
+    }
+    for (const forbidden of probe.forbidden_ids) {
+      const entry = byId.get(forbidden);
+      if (!entry) {
+        throw new Error(
+          `probe ${probe.id} references unknown forbidden id ${forbidden}`,
+        );
+      }
+      if (entry.namespace_role !== "negative") {
+        throw new Error(
+          `probe ${probe.id} forbidden id ${forbidden} must be a negative-role entry`,
+        );
+      }
+    }
+  }
+
+  return fixture;
+}
+
+/** Load and validate a live fixture from disk. */
+export async function loadLiveFixture(path: string): Promise<LiveFixture> {
+  let raw: unknown;
+  try {
+    raw = await Bun.file(path).json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read live recall fixture ${path}: ${message}`);
+  }
+  try {
+    return parseLiveFixture(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid live recall fixture ${path}: ${message}`);
+  }
+}

--- a/eval/open-brain/live/gate.ts
+++ b/eval/open-brain/live/gate.ts
@@ -131,6 +131,30 @@ async function teardown(
 }
 
 /**
+ * Preserve the content-free teardown failed COUNT when a deferred seed/query
+ * error is rethrown after teardown. When nothing was stranded (failed === 0),
+ * the original error passes through unchanged. When records were stranded, a new
+ * LiveTransportError carries the original (already-redacted) label with a
+ * `;teardown-failed=<n>` suffix -- only the integer count, never a record id,
+ * body, or raw error string -- and preserves the original `denied` flag. A
+ * non-LiveTransportError is left untouched so we never widen an unknown error's
+ * content-free guarantees.
+ */
+export function withTeardownFailedCount(
+  error: unknown,
+  teardownFailed: number,
+): unknown {
+  if (teardownFailed <= 0) return error;
+  if (error instanceof LiveTransportError) {
+    return new LiveTransportError(
+      `${error.label};teardown-failed=${teardownFailed}`,
+      error.denied,
+    );
+  }
+  return error;
+}
+
+/**
  * Build the fixture-local retrieved-id list for one probe from live search hits.
  * Maps server ids back to fixture ids using the seed map, and appends any
  * forbidden (negative-namespace) server id that leaked so the metric can count
@@ -287,7 +311,11 @@ export async function runLiveGate(opts: RunGateOptions): Promise<GateOutcome> {
   const teardownTally = await teardown(seeded, clients);
 
   if (deferredError) {
-    throw deferredError;
+    // Re-raise the original (already content-free) seed/query error, but preserve
+    // the teardown failed COUNT so a partial-failure run that also stranded
+    // records does not silently lose that signal. Only the integer count is
+    // attached -- never a record id, body, or raw error string.
+    throw withTeardownFailedCount(deferredError, teardownTally.failed);
   }
 
   // --- Score + threshold ---

--- a/eval/open-brain/live/gate.ts
+++ b/eval/open-brain/live/gate.ts
@@ -1,6 +1,10 @@
 import type { LiveEvalConfig } from "./config.ts";
 import { buildScorecard } from "./metrics.ts";
-import { LiveTransportError, type OpenBrainLiveClient } from "./transport.ts";
+import {
+  LiveTransportError,
+  type OpenBrainLiveClient,
+  type SearchHit,
+} from "./transport.ts";
 import type {
   LiveCorpusEntry,
   LiveFixture,
@@ -156,18 +160,45 @@ export function withTeardownFailedCount(
 
 /**
  * Build the fixture-local retrieved-id list for one probe from live search hits.
- * Maps server ids back to fixture ids using the seed map, and appends any
- * forbidden (negative-namespace) server id that leaked so the metric can count
- * it. Preserves rank order.
+ *
+ * EVERY hit is validated before it is mapped: a hit is trustworthy only when it
+ * carries the EXACT primary namespace this run bound AND an id this run created
+ * (present in serverIdToFixtureId, which holds every seeded server id -- primary
+ * and negative). A hit that fails either check is NOT silently discarded:
+ * dropping an unmapped or foreign hit would compress the ranks, hide a real
+ * leak (leaving namespace_leaks=0), and let the run still reach PASS. Instead we
+ * fail the run closed, content-free -- naming only the failure class, never a
+ * hit id, namespace value, or body:
+ *
+ *  - a hit with no namespace, or a namespace that is not EXACTLY the primary
+ *    namespace, means the server returned a row from outside our bound
+ *    namespace (`:foreign-namespace`).
+ *  - a hit whose id this run did not create is an unknown row that our seed map
+ *    cannot account for (`:unknown-hit`).
+ *
+ * A KNOWN negative-role id that surfaces under the primary namespace is NOT a
+ * validation failure here: it maps to its fixture id and flows to the scorer,
+ * which counts it as a namespace leak (that is how in-namespace leakage is
+ * scored). Only genuinely unaccountable hits fail the run. Rank order is
+ * preserved for the survivors (which, on a clean run, is all of them).
  */
 function toFixtureRetrieval(
-  hits: { id: string }[],
+  hits: SearchHit[],
   serverIdToFixtureId: Map<string, string>,
+  primaryNamespace: string,
 ): string[] {
   const out: string[] = [];
   for (const hit of hits) {
+    if (hit.namespace !== primaryNamespace) {
+      // Missing or different namespace: a row from outside our bound namespace.
+      throw new LiveTransportError("search_brain:foreign-namespace", false);
+    }
     const fixtureId = serverIdToFixtureId.get(hit.id);
-    if (fixtureId) out.push(fixtureId);
+    if (!fixtureId) {
+      // A same-namespace id this run never created: unaccountable, fail closed.
+      throw new LiveTransportError("search_brain:unknown-hit", false);
+    }
+    out.push(fixtureId);
   }
   return out;
 }
@@ -291,7 +322,11 @@ export async function runLiveGate(opts: RunGateOptions): Promise<GateOutcome> {
         limit: thresholds.top_k,
         searchMode: config.searchMode,
       });
-      collected[probe.id] = toFixtureRetrieval(hits, serverIdToFixtureId);
+      collected[probe.id] = toFixtureRetrieval(
+        hits,
+        serverIdToFixtureId,
+        config.primaryNamespace,
+      );
     }
     retrievedByProbe = collected;
 

--- a/eval/open-brain/live/gate.ts
+++ b/eval/open-brain/live/gate.ts
@@ -1,0 +1,364 @@
+import type { LiveEvalConfig } from "./config.ts";
+import { buildScorecard } from "./metrics.ts";
+import { LiveTransportError, type OpenBrainLiveClient } from "./transport.ts";
+import type {
+  LiveCorpusEntry,
+  LiveFixture,
+  LiveGateReceipt,
+  LiveScorecard,
+  LiveThresholds,
+  NegativeControlProof,
+  SeededRecord,
+} from "./types.ts";
+
+// Live recall gate orchestrator.
+//
+// One run: seed a unique throwaway namespace (and a sibling negative namespace)
+// with the sealed synthetic fixture, run each recall probe under the primary
+// namespace, score deterministic ranking metrics, apply versioned thresholds,
+// and ALWAYS tear down exactly the records this run created -- even when a
+// probe or a threshold check fails partway through.
+//
+// Teardown is mutation-safe: it archives only server ids that this run created,
+// each under its own table, through the namespace-scoped archive_entry tool. It
+// never issues a bulk or query-shaped delete, so it cannot touch a record it
+// did not create.
+
+export interface GateClients {
+  /** Reads/writes/archives the primary throwaway namespace. */
+  primary: OpenBrainLiveClient;
+  /**
+   * Seeds/reads/archives the negative sibling namespace. This is a MANDATORY
+   * real negative control: it is bound to a distinct X-Namespace (optionally a
+   * distinct token too), so the primary caller must not be able to read what it
+   * writes. It is never optional -- the gate cannot prove isolation without it.
+   */
+  negative: OpenBrainLiveClient;
+}
+
+export interface RunGateOptions {
+  fixture: LiveFixture;
+  thresholds: LiveThresholds;
+  config: LiveEvalConfig;
+  clients: GateClients;
+  commit: string;
+  generatedAt: string;
+}
+
+export interface GateOutcome {
+  scorecard: LiveScorecard;
+  receipt: LiveGateReceipt;
+  /**
+   * Composite verdict. True only when scorecard thresholds are met AND the
+   * negative-control isolation proof ran and denied AND teardown stranded no
+   * seeded record. Never true on a metrics-only pass.
+   */
+  passed: boolean;
+}
+
+interface TeardownTally {
+  attempted: number;
+  archived: number;
+  already_absent: number;
+  failed: number;
+}
+
+/**
+ * Seed one entry with the owning client for its namespace role and record the
+ * resulting server id for scoring + teardown. Both the primary and negative
+ * clients always exist (the negative control is mandatory), so seeding never
+ * silently skips a corpus entry.
+ */
+async function seedEntry(
+  entry: LiveCorpusEntry,
+  config: LiveEvalConfig,
+  clients: GateClients,
+): Promise<SeededRecord> {
+  const isNegative = entry.namespace_role === "negative";
+  const client = isNegative ? clients.negative : clients.primary;
+  const namespace = isNegative
+    ? config.negativeNamespace
+    : config.primaryNamespace;
+
+  const result = await client.logMemory({
+    table: entry.table,
+    content: entry.content,
+    tags: entry.tags,
+    namespace,
+  });
+  return {
+    fixture_id: entry.id,
+    table: entry.table,
+    server_id: result.id,
+    namespace,
+    namespace_role: entry.namespace_role,
+  };
+}
+
+/**
+ * Archive every seeded record through its owning client, tolerating individual
+ * failures so one bad archive never strands the rest. Negative-namespace records
+ * are archived with the negative client (the only token that owns them).
+ */
+async function teardown(
+  seeded: SeededRecord[],
+  clients: GateClients,
+): Promise<TeardownTally> {
+  const tally: TeardownTally = {
+    attempted: 0,
+    archived: 0,
+    already_absent: 0,
+    failed: 0,
+  };
+  for (const record of seeded) {
+    const client =
+      record.namespace_role === "negative" ? clients.negative : clients.primary;
+    tally.attempted += 1;
+    try {
+      const outcome = await client.archive({
+        table: record.table,
+        id: record.server_id,
+      });
+      if (outcome === "archived") tally.archived += 1;
+      else tally.already_absent += 1;
+    } catch {
+      // Content-free: never surface the record body or an error string that
+      // could carry one. The count is the only signal the receipt needs.
+      tally.failed += 1;
+    }
+  }
+  return tally;
+}
+
+/**
+ * Build the fixture-local retrieved-id list for one probe from live search hits.
+ * Maps server ids back to fixture ids using the seed map, and appends any
+ * forbidden (negative-namespace) server id that leaked so the metric can count
+ * it. Preserves rank order.
+ */
+function toFixtureRetrieval(
+  hits: { id: string }[],
+  serverIdToFixtureId: Map<string, string>,
+): string[] {
+  const out: string[] = [];
+  for (const hit of hits) {
+    const fixtureId = serverIdToFixtureId.get(hit.id);
+    if (fixtureId) out.push(fixtureId);
+  }
+  return out;
+}
+
+/**
+ * Explicit negative-control proof. The PRIMARY caller attempts to read the
+ * NEGATIVE namespace (which the negative control seeded) and the server must
+ * DENY that read. An empty-but-successful read is NOT proof of denial -- the
+ * namespace being empty for the primary caller looks identical to a working
+ * isolation boundary, so we require an actual permission denial.
+ *
+ * The probe queries are the forbidden-bearing probe queries from the fixture,
+ * chosen because they are the ones most likely to surface the negative records
+ * if isolation were broken. Runs after seeding (records exist) and before
+ * teardown. Content-free: only booleans and counts, never hit bodies.
+ */
+async function probeNegativeControl(
+  fixture: LiveFixture,
+  config: LiveEvalConfig,
+  clients: GateClients,
+  topK: number,
+): Promise<NegativeControlProof> {
+  const proof: NegativeControlProof = {
+    ran: true,
+    denied: false,
+    observed_hit_count: 0,
+    cross_token: config.negativeTokenIsDistinct,
+  };
+
+  // Prefer probes that declare a forbidden (negative) id; fall back to all
+  // probes so the proof always exercises at least one read.
+  const withForbidden = fixture.probes.filter(
+    (p) => p.forbidden_ids.length > 0,
+  );
+  const probes = withForbidden.length > 0 ? withForbidden : fixture.probes;
+
+  let anyDenied = false;
+  let anyAllowed = false;
+  let totalHits = 0;
+  for (const probe of probes) {
+    let result;
+    try {
+      result = await clients.primary.attemptRead({
+        query: probe.query,
+        namespace: config.negativeNamespace,
+        limit: topK,
+        searchMode: config.searchMode,
+      });
+    } catch (error) {
+      // A non-denial transport error means we could not establish the proof.
+      const label =
+        error instanceof LiveTransportError
+          ? error.label
+          : "attempt-read-error";
+      proof.denied = false;
+      proof.failure = `negative-control read failed: ${label}`;
+      return proof;
+    }
+    if (result.denied) {
+      anyDenied = true;
+    } else {
+      anyAllowed = true;
+      totalHits += result.hitCount;
+    }
+  }
+
+  proof.observed_hit_count = totalHits;
+  // Isolation is proven ONLY when every read was denied and none was allowed.
+  proof.denied = anyDenied && !anyAllowed;
+  if (!proof.denied) {
+    proof.failure = anyAllowed
+      ? "primary caller was permitted to read the negative namespace"
+      : "no negative-namespace read was denied";
+  }
+  return proof;
+}
+
+/**
+ * Run the full gate. Seeding and querying failures are caught so teardown still
+ * runs; the thrown error (if any) is re-raised only AFTER teardown completes.
+ * PASS requires all three: scorecard thresholds met, the negative-control proof
+ * denied, and teardown left nothing behind.
+ */
+export async function runLiveGate(opts: RunGateOptions): Promise<GateOutcome> {
+  const { fixture, thresholds, config, clients, commit, generatedAt } = opts;
+
+  if (thresholds.applies_to_fixture_id !== fixture.fixture_id) {
+    throw new Error(
+      `thresholds ${thresholds.thresholds_id} apply to fixture ${thresholds.applies_to_fixture_id}, not ${fixture.fixture_id}`,
+    );
+  }
+
+  const seeded: SeededRecord[] = [];
+  const serverIdToFixtureId = new Map<string, string>();
+  let deferredError: unknown = null;
+  let retrievedByProbe: Record<string, string[]> = {};
+  // Default proof: did-not-run. Only replaced by a real probe result when
+  // seeding + querying complete without a deferred error.
+  let negativeControl: NegativeControlProof = {
+    ran: false,
+    denied: false,
+    observed_hit_count: 0,
+    cross_token: config.negativeTokenIsDistinct,
+    failure: "negative-control proof did not run",
+  };
+
+  try {
+    // --- Seed (both namespaces; negative control is mandatory) ---
+    for (const entry of fixture.corpus) {
+      const record = await seedEntry(entry, config, clients);
+      seeded.push(record);
+      serverIdToFixtureId.set(record.server_id, record.fixture_id);
+    }
+
+    // --- Query + collect fixture-local retrievals per probe ---
+    const collected: Record<string, string[]> = {};
+    for (const probe of fixture.probes) {
+      const hits = await clients.primary.search({
+        query: probe.query,
+        namespace: config.primaryNamespace,
+        limit: thresholds.top_k,
+        searchMode: config.searchMode,
+      });
+      collected[probe.id] = toFixtureRetrieval(hits, serverIdToFixtureId);
+    }
+    retrievedByProbe = collected;
+
+    // --- Explicit negative-control isolation proof (before teardown) ---
+    negativeControl = await probeNegativeControl(
+      fixture,
+      config,
+      clients,
+      thresholds.top_k,
+    );
+  } catch (error) {
+    // Defer: teardown must still run before we surface the failure.
+    deferredError = error;
+  }
+
+  // --- Teardown (always, even after a partial failure) ---
+  const teardownTally = await teardown(seeded, clients);
+
+  if (deferredError) {
+    throw deferredError;
+  }
+
+  // --- Score + threshold ---
+  const scorecard = buildScorecard(fixture, thresholds, retrievedByProbe);
+
+  const primarySeeded = seeded.filter(
+    (r) => r.namespace_role === "primary",
+  ).length;
+  const negativeSeeded = seeded.filter(
+    (r) => r.namespace_role === "negative",
+  ).length;
+
+  // Composite gate verdict. A metrics-only pass is never enough: the isolation
+  // proof must have denied, and teardown must have stranded nothing.
+  const teardownClean = teardownTally.failed === 0;
+  const gateFailures = [...scorecard.failures];
+  if (!negativeControl.ran) {
+    gateFailures.push(
+      `negative-control proof did not run: ${negativeControl.failure ?? "unknown"}`,
+    );
+  } else if (!negativeControl.denied) {
+    gateFailures.push(
+      `negative-control not denied: ${negativeControl.failure ?? "isolation not proven"}`,
+    );
+  }
+  if (!teardownClean) {
+    gateFailures.push(
+      `teardown failed to archive ${teardownTally.failed} of ${teardownTally.attempted} seeded records`,
+    );
+  }
+  const passed =
+    scorecard.passed &&
+    negativeControl.ran &&
+    negativeControl.denied &&
+    teardownClean;
+
+  const receipt: LiveGateReceipt = {
+    schema: "openbrain.live_recall_gate.v1",
+    generated_at: generatedAt,
+    commit,
+    fixture_id: fixture.fixture_id,
+    thresholds_id: thresholds.thresholds_id,
+    top_k: thresholds.top_k,
+    primary_namespace: config.primaryNamespace,
+    negative_namespace: config.negativeNamespace,
+    seeded: { primary: primarySeeded, negative: negativeSeeded },
+    metrics: {
+      recall_at_k: scorecard.recall_at_k,
+      precision_at_k: scorecard.precision_at_k,
+      mrr: scorecard.mrr,
+      namespace_leaks: scorecard.namespace_leaks,
+    },
+    thresholds: thresholds.thresholds,
+    probes: scorecard.probes.map((p) => ({
+      probe_id: p.probe_id,
+      recall_at_k: p.recall_at_k,
+      precision_at_k: p.precision_at_k,
+      reciprocal_rank: p.reciprocal_rank,
+      namespace_leaks: p.namespace_leaks,
+    })),
+    negative_control: {
+      ran: negativeControl.ran,
+      denied: negativeControl.denied,
+      observed_hit_count: negativeControl.observed_hit_count,
+      cross_token: negativeControl.cross_token,
+      failure: negativeControl.failure,
+    },
+    passed,
+    failures: gateFailures,
+    teardown: teardownTally,
+  };
+
+  return { scorecard, receipt, passed };
+}

--- a/eval/open-brain/live/metrics.ts
+++ b/eval/open-brain/live/metrics.ts
@@ -1,0 +1,205 @@
+import { z } from "zod";
+import type {
+  LiveFixture,
+  LiveProbe,
+  LiveScorecard,
+  LiveThresholds,
+  ProbeMetric,
+} from "./types.ts";
+
+// Deterministic ranking metrics for the live recall gate. Given a probe's
+// ranked list of retrieved fixture ids (top-k, best first), these produce
+// Recall@K, Precision@K, MRR, and a namespace-leak count with no randomness
+// and no dependence on wall-clock or embedding scores. Identical inputs always
+// produce identical outputs, which is what makes the gate reproducible.
+
+const thresholdsSchema: z.ZodType<LiveThresholds> = z.object({
+  schema_version: z.literal(1),
+  thresholds_id: z.string().min(1),
+  applies_to_fixture_id: z.string().min(1),
+  top_k: z.number().int().min(1),
+  thresholds: z.object({
+    min_recall_at_k: z.number().min(0).max(1),
+    min_precision_at_k: z.number().min(0).max(1),
+    min_mrr: z.number().min(0).max(1),
+    max_namespace_leaks: z.number().int().min(0),
+  }),
+  notes: z.string().optional(),
+});
+
+export function parseThresholds(raw: unknown): LiveThresholds {
+  return thresholdsSchema.parse(raw);
+}
+
+export async function loadThresholds(path: string): Promise<LiveThresholds> {
+  let raw: unknown;
+  try {
+    raw = await Bun.file(path).json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read thresholds ${path}: ${message}`);
+  }
+  try {
+    return parseThresholds(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid thresholds ${path}: ${message}`);
+  }
+}
+
+/** Fixture-local ids that count as relevant (graded > 0) for a probe. */
+export function relevantIdsFor(probe: LiveProbe): string[] {
+  return probe.relevant.filter((r) => r.grade > 0).map((r) => r.id);
+}
+
+/**
+ * Recall@K: fraction of relevant items that appear in the top-k retrieved list.
+ * By convention a probe with no relevant items has perfect recall (1).
+ */
+export function recallAtK(
+  retrievedTopK: string[],
+  relevantIds: string[],
+): number {
+  if (relevantIds.length === 0) return 1;
+  const retrieved = new Set(retrievedTopK);
+  const hits = relevantIds.filter((id) => retrieved.has(id)).length;
+  return hits / relevantIds.length;
+}
+
+/**
+ * Precision@K: fraction of the top-k retrieved list that is relevant, using k
+ * as the denominator (standard Precision@K). An empty retrieved list is 1 when
+ * nothing was relevant, else 0.
+ */
+export function precisionAtK(
+  retrievedTopK: string[],
+  relevantIds: string[],
+  k: number,
+): number {
+  if (relevantIds.length === 0) {
+    return retrievedTopK.length === 0 ? 1 : 0;
+  }
+  if (k <= 0) return 0;
+  const relevant = new Set(relevantIds);
+  const hits = retrievedTopK
+    .slice(0, k)
+    .filter((id) => relevant.has(id)).length;
+  return hits / k;
+}
+
+/**
+ * Reciprocal rank of the first relevant hit in the ranked list (1-indexed).
+ * 0 when no relevant item is retrieved.
+ */
+export function reciprocalRank(
+  retrievedRanked: string[],
+  relevantIds: string[],
+): number {
+  const relevant = new Set(relevantIds);
+  for (let i = 0; i < retrievedRanked.length; i++) {
+    const id = retrievedRanked[i];
+    if (id !== undefined && relevant.has(id)) {
+      return 1 / (i + 1);
+    }
+  }
+  return 0;
+}
+
+/** Count forbidden (out-of-namespace) ids that leaked into the retrieved list. */
+export function namespaceLeaks(
+  retrieved: string[],
+  forbiddenIds: string[],
+): number {
+  if (forbiddenIds.length === 0) return 0;
+  const forbidden = new Set(forbiddenIds);
+  return retrieved.filter((id) => forbidden.has(id)).length;
+}
+
+/** Score one probe against its ranked, top-k-truncated retrieved id list. */
+export function scoreProbeMetric(
+  probe: LiveProbe,
+  retrievedRanked: string[],
+  topK: number,
+): ProbeMetric {
+  const relevantIds = relevantIdsFor(probe);
+  const topK_ids = retrievedRanked.slice(0, topK);
+  return {
+    probe_id: probe.id,
+    recall_at_k: recallAtK(topK_ids, relevantIds),
+    precision_at_k: precisionAtK(topK_ids, relevantIds, topK),
+    reciprocal_rank: reciprocalRank(retrievedRanked, relevantIds),
+    // Leak check runs over the FULL retrieved list, not just top-k: any
+    // out-of-namespace record surfacing at all is an isolation breach.
+    namespace_leaks: namespaceLeaks(retrievedRanked, probe.forbidden_ids),
+    retrieved_count: retrievedRanked.length,
+    relevant_count: relevantIds.length,
+  };
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+/**
+ * Aggregate per-probe metrics into a scorecard and apply versioned thresholds.
+ * `retrievedByProbe` maps probe id -> the ranked fixture-id list observed for
+ * that probe. A missing probe is scored as an empty retrieval (worst case).
+ */
+export function buildScorecard(
+  fixture: LiveFixture,
+  thresholds: LiveThresholds,
+  retrievedByProbe: Record<string, string[]>,
+): LiveScorecard {
+  const topK = thresholds.top_k;
+  const probeMetrics = fixture.probes.map((probe) =>
+    scoreProbeMetric(probe, retrievedByProbe[probe.id] ?? [], topK),
+  );
+
+  const recall = round(mean(probeMetrics.map((p) => p.recall_at_k)));
+  const precision = round(mean(probeMetrics.map((p) => p.precision_at_k)));
+  const mrr = round(mean(probeMetrics.map((p) => p.reciprocal_rank)));
+  const leaks = probeMetrics.reduce((sum, p) => sum + p.namespace_leaks, 0);
+
+  const t = thresholds.thresholds;
+  const failures: string[] = [];
+  if (recall < t.min_recall_at_k) {
+    failures.push(`recall_at_k ${recall} below threshold ${t.min_recall_at_k}`);
+  }
+  if (precision < t.min_precision_at_k) {
+    failures.push(
+      `precision_at_k ${precision} below threshold ${t.min_precision_at_k}`,
+    );
+  }
+  if (mrr < t.min_mrr) {
+    failures.push(`mrr ${mrr} below threshold ${t.min_mrr}`);
+  }
+  if (leaks > t.max_namespace_leaks) {
+    failures.push(
+      `namespace_leaks ${leaks} above threshold ${t.max_namespace_leaks}`,
+    );
+  }
+
+  return {
+    fixture_id: fixture.fixture_id,
+    thresholds_id: thresholds.thresholds_id,
+    top_k: topK,
+    probes_total: probeMetrics.length,
+    recall_at_k: recall,
+    precision_at_k: precision,
+    mrr,
+    namespace_leaks: leaks,
+    passed: failures.length === 0,
+    failures,
+    probes: probeMetrics.map((p) => ({
+      ...p,
+      recall_at_k: round(p.recall_at_k),
+      precision_at_k: round(p.precision_at_k),
+      reciprocal_rank: round(p.reciprocal_rank),
+    })),
+  };
+}

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -49,7 +49,17 @@ export interface ToolCallResult {
 
 export interface LogMemoryResult {
   id: string;
+  /** The namespace the server reported the row was written to. */
   namespace: string;
+  /**
+   * The server's `merged` flag: false when this call CREATED a new row, true
+   * when it upserted onto an existing row (ON CONFLICT). The seeder requires
+   * `merged === false` so it can only ever count a fresh, this-run creation --
+   * a merged upsert means the record predates this run (a stranded prior seed in
+   * a reused namespace) and must never be treated as newly created and later
+   * archived as though this run owned it.
+   */
+  merged: boolean;
 }
 
 export interface SearchHit {
@@ -94,7 +104,26 @@ export class LiveTransportError extends Error {
 export class OpenBrainLiveClient {
   constructor(private readonly caller: OpenBrainToolCaller) {}
 
-  /** Seed one memory into a namespace, returning the server-assigned id. */
+  /**
+   * Seed one memory into a namespace, returning the server-assigned id.
+   *
+   * The seed is a CREATE: this run owns every record it later archives, so the
+   * response must prove a fresh row was created under the exact namespace we
+   * asked for. `log_thought`/`log_decision` return `{id, namespace, merged}`
+   * (src/tools/log-thought.ts, log-decision.ts). We fail closed content-free on
+   * any response that does not exactly match a create:
+   *
+   *  - missing/non-string `id` -> we never learned the server id, so teardown
+   *    could not archive this row (`:missing-id`).
+   *  - missing/non-boolean or `merged: true` -> the server upserted onto an
+   *    EXISTING row (a stranded prior seed in a reused namespace), so this is
+   *    not a this-run creation; archiving it later would tombstone a row this
+   *    run did not create (`:merged-upsert` / `:missing-merged`).
+   *  - a returned namespace that is not EXACTLY `opts.namespace` -> the row did
+   *    not land where we bound our teardown/scoring, so we must not treat it as
+   *    ours (`:namespace-mismatch`). We do NOT default a missing namespace to
+   *    the requested one: that would mask a server that wrote elsewhere.
+   */
   async logMemory(opts: {
     table: LiveMemoryTable;
     content: string;
@@ -121,13 +150,24 @@ export class OpenBrainLiveClient {
     }
     const parsed = safeJson(result.data);
     const id = typeof parsed?.id === "string" ? parsed.id : undefined;
-    const namespace =
-      typeof parsed?.namespace === "string" ? parsed.namespace : opts.namespace;
     if (!id) {
       // Content-free: name the tool, not the response body.
       throw new LiveTransportError(`${tool}:missing-id`, false);
     }
-    return { id, namespace };
+    // `merged` must be present and a boolean; a create is `merged === false`.
+    if (typeof parsed?.merged !== "boolean") {
+      throw new LiveTransportError(`${tool}:missing-merged`, false);
+    }
+    if (parsed.merged) {
+      // The server upserted onto a pre-existing row -- not a this-run creation.
+      throw new LiveTransportError(`${tool}:merged-upsert`, false);
+    }
+    // The returned namespace must EXACTLY equal the one we bound teardown/scoring
+    // to; no defaulting a missing/other namespace to the requested one.
+    if (parsed.namespace !== opts.namespace) {
+      throw new LiveTransportError(`${tool}:namespace-mismatch`, false);
+    }
+    return { id, namespace: opts.namespace, merged: false };
   }
 
   /**
@@ -201,9 +241,14 @@ export class OpenBrainLiveClient {
    * (src/tools/archive-entry.ts): a JSON object `{id, table, archived: true}`
    * for a row it tombstoned, and the EXACT plain-text body
    * "Already archived or not found" for the zero-row no-op. We recognize only
-   * those two -- `archived: true`, or that exact marker (trimmed,
-   * case-insensitive) -- and throw a content-free LiveTransportError for EVERY
-   * other success response.
+   * those two -- `archived: true` WITH the returned `id`/`table` exactly equal
+   * to the requested record, or that exact marker (trimmed, case-insensitive) --
+   * and throw a content-free LiveTransportError for EVERY other success response.
+   *
+   * The id/table binding matters because `archived: true` alone does not say
+   * WHICH row was tombstoned: an echo for a different id/table, or a response
+   * missing them, would otherwise be credited as this record's cleanup while the
+   * real record stays live. Binding returned identity closes that gap.
    *
    * We deliberately do NOT accept a structured `archived: false` (the server
    * never emits it), nor broad substrings like "not found" / "no rows", nor a
@@ -225,9 +270,21 @@ export class OpenBrainLiveClient {
       throw new LiveTransportError(result.errorLabel, result.denied);
     }
     const parsed = safeJson(result.data);
-    // Explicit archived success: the JSON object the server returns for a row
-    // it tombstoned. Only `archived: true` counts.
-    if (parsed?.archived === true) return "archived";
+    // Explicit archived success: the JSON object the server returns for a row it
+    // tombstoned is `{id, table, archived: true}` (src/tools/archive-entry.ts).
+    // A destructive success is only trustworthy when it is bound to the record
+    // we asked to archive: `archived: true` alone is not enough -- the returned
+    // `id` and `table` must EXACTLY match this request, or the server tombstoned
+    // some other row (a shape drift, a mismatched echo, or a response for a
+    // different record) and we must NOT count it as this record's cleanup.
+    if (parsed?.archived === true) {
+      if (parsed.id === opts.id && parsed.table === opts.table) {
+        return "archived";
+      }
+      // archived:true but for a different id/table (or missing them) -> fail
+      // closed content-free rather than credit this record as archived.
+      throw new LiveTransportError("archive_entry:identity-mismatch", false);
+    }
     // Exact already-absent no-op marker: the server returns the plain-text body
     // "Already archived or not found" (and nothing else) for the zero-row case.
     if (isAlreadyAbsentMarker(result.data)) return "already_absent";
@@ -243,24 +300,57 @@ export class OpenBrainLiveClient {
   }
 }
 
-/** Parse ranked search hits from a JSON array body. Never logs the body. */
+/**
+ * Parse ranked search hits from a JSON array body. Never logs the body.
+ *
+ * This is the transport boundary for every hit the gate scores or probes. It
+ * FAILS CLOSED content-free rather than silently dropping any entry, because a
+ * discarded raw result never reaches the gate-level validator (gate.ts
+ * `toFixtureRetrieval`) and so could compress rankings or hide a foreign /
+ * malformed result before PASS logic runs:
+ *
+ *  - a successful search body MUST be a JSON array. A non-array (object, scalar)
+ *    or invalid JSON is a malformed result set (`search_brain:malformed-results`)
+ *    -- NOT an empty result, which the old `return []` conflated with real
+ *    "no hits" and let a malformed body pass as a clean empty read.
+ *  - every array entry MUST be an object carrying a non-empty string `id`
+ *    (`search_brain:malformed-hit`). A non-object row, a missing id, or an empty
+ *    id is unaccountable at this boundary and must not be silently skipped.
+ *
+ * `namespace` stays OPTIONAL on purpose: a hit that is a valid object with a
+ * string id but no namespace passes THIS boundary and reaches gate.ts, which
+ * fails it specifically as `foreign-namespace`. Requiring namespace here would
+ * mask that distinct (and security-relevant) gate-level classification.
+ *
+ * Content-free: labels name only the tool + failure class, never a raw body,
+ * row, or id value.
+ */
 export function parseHits(text: string): SearchHit[] {
   const parsed = safeJsonArray(text);
-  if (!parsed) return [];
+  if (!parsed) {
+    // Non-array success body or invalid JSON: a malformed result set, not empty.
+    throw new LiveTransportError("search_brain:malformed-results", false);
+  }
   const hits: SearchHit[] = [];
   for (const row of parsed) {
-    if (row && typeof row === "object") {
-      const id = (row as Record<string, unknown>).id;
-      const sourceType = (row as Record<string, unknown>).source_type;
-      const namespace = (row as Record<string, unknown>).namespace;
-      if (typeof id === "string") {
-        hits.push({
-          id,
-          source_type: typeof sourceType === "string" ? sourceType : "",
-          namespace: typeof namespace === "string" ? namespace : undefined,
-        });
-      }
+    if (!row || typeof row !== "object") {
+      // A non-object array entry is unaccountable; never silently skip it.
+      throw new LiveTransportError("search_brain:malformed-hit", false);
     }
+    const id = (row as Record<string, unknown>).id;
+    if (typeof id !== "string" || id.length === 0) {
+      // Missing / non-string / empty id: cannot account for this hit.
+      throw new LiveTransportError("search_brain:malformed-hit", false);
+    }
+    const sourceType = (row as Record<string, unknown>).source_type;
+    const namespace = (row as Record<string, unknown>).namespace;
+    hits.push({
+      id,
+      source_type: typeof sourceType === "string" ? sourceType : "",
+      // Optional by design: a missing namespace reaches gate.ts, which fails it
+      // as foreign-namespace. Do NOT reject it here.
+      namespace: typeof namespace === "string" ? namespace : undefined,
+    });
   }
   return hits;
 }

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -1,0 +1,473 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { LiveMemoryTable } from "./types.ts";
+
+// Live transport for the recall gate.
+//
+// This talks to the real Open Brain server over its MCP streamable-HTTP
+// endpoint (`POST /mcp`) using the official MCP client. Every gate operation --
+// seeding a memory, running a recall search, and archiving a record -- is a
+// standard `tools/call`, so the gate exercises the exact contract, auth, and
+// namespace boundary that live agents hit. The MCP endpoint is used (not the
+// REST surface) because it uniformly exposes archive_entry, which the REST API
+// does not, and archive_entry is namespace-scoped -- the property that makes
+// teardown mutation-safe.
+
+/** Minimal tool interface so the gate can run against a fake in tests. */
+export interface OpenBrainToolCaller {
+  callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<ToolCallResult>;
+  close(): Promise<void>;
+}
+
+export interface ToolCallResult {
+  /** True when the server reported the call as an error. */
+  isError: boolean;
+  /**
+   * True when the server denied the call for permission/namespace reasons.
+   * Modeled distinctly from a generic error so the gate can require an explicit
+   * denial (isolation proof) without ever inspecting the raw error body.
+   */
+  denied: boolean;
+  /**
+   * On success: the raw response body text, from which the client parses only
+   * structured fields (ids, namespace) -- it is never logged or embedded in a
+   * receipt. Empty string on error, where the body is discarded at the
+   * redaction boundary so no memory body or secret can escape.
+   */
+  data: string;
+  /**
+   * A redacted, content-free label for a failed call: tool name plus, when the
+   * server surfaced them, an error class / status / reason keyword. NEVER the
+   * raw response text -- that could carry a memory body or secret. Empty string
+   * on success.
+   */
+  errorLabel: string;
+}
+
+export interface LogMemoryResult {
+  id: string;
+  namespace: string;
+}
+
+export interface SearchHit {
+  id: string;
+  source_type: string;
+  namespace?: string;
+}
+
+/**
+ * Result of an explicit isolation probe: an attempt by one caller to read a
+ * namespace it must not be able to read. `denied` is the only signal the gate
+ * trusts as proof of isolation; an empty-but-successful search is NOT denial.
+ * `hitCount` is retained so a "denied but non-empty" contradiction can be
+ * surfaced content-free. No hit ids or bodies are carried.
+ */
+export interface DenialProbeResult {
+  denied: boolean;
+  hitCount: number;
+}
+
+/**
+ * The public error surface for a live transport failure. Callers may log or
+ * embed `label` in a receipt; it is redacted to tool/class/status/reason
+ * keywords only and never contains raw response text.
+ */
+export class LiveTransportError extends Error {
+  readonly label: string;
+  readonly denied: boolean;
+  constructor(label: string, denied: boolean) {
+    super(label);
+    this.name = "LiveTransportError";
+    this.label = label;
+    this.denied = denied;
+  }
+}
+
+/**
+ * Semantic wrapper over an OpenBrainToolCaller. Keeps the gate orchestrator
+ * free of tool-name/argument details and response parsing, and is the seam the
+ * unit tests target with a fake caller.
+ */
+export class OpenBrainLiveClient {
+  constructor(private readonly caller: OpenBrainToolCaller) {}
+
+  /** Seed one memory into a namespace, returning the server-assigned id. */
+  async logMemory(opts: {
+    table: LiveMemoryTable;
+    content: string;
+    tags: string[];
+    namespace: string;
+  }): Promise<LogMemoryResult> {
+    const tool = opts.table === "decisions" ? "log_decision" : "log_thought";
+    const args: Record<string, unknown> =
+      opts.table === "decisions"
+        ? {
+            title: opts.content,
+            rationale: opts.content,
+            tags: opts.tags,
+            namespace: opts.namespace,
+          }
+        : {
+            content: opts.content,
+            tags: opts.tags,
+            namespace: opts.namespace,
+          };
+    const result = await this.caller.callTool(tool, args);
+    if (result.isError) {
+      throw new LiveTransportError(result.errorLabel, result.denied);
+    }
+    const parsed = safeJson(result.data);
+    const id = typeof parsed?.id === "string" ? parsed.id : undefined;
+    const namespace =
+      typeof parsed?.namespace === "string" ? parsed.namespace : opts.namespace;
+    if (!id) {
+      // Content-free: name the tool, not the response body.
+      throw new LiveTransportError(`${tool}:missing-id`, false);
+    }
+    return { id, namespace };
+  }
+
+  /**
+   * Run a recall search scoped to a namespace the caller is expected to be able
+   * to read. Returns ranked hits (best first). A permission-denied response is
+   * NOT swallowed here: this method is used for the primary recall scoring path,
+   * where a denial means the gate is misconfigured (primary token cannot read
+   * its own namespace) and must fail loudly, content-free. Use `attemptRead`
+   * for the isolation probe, where denial is the desired outcome.
+   */
+  async search(opts: {
+    query: string;
+    namespace: string;
+    limit: number;
+    searchMode: "hybrid" | "vector" | "keyword";
+  }): Promise<SearchHit[]> {
+    const result = await this.caller.callTool("search_brain", {
+      query: opts.query,
+      namespace: opts.namespace,
+      limit: opts.limit,
+      search_mode: opts.searchMode,
+    });
+    if (result.isError) {
+      throw new LiveTransportError(result.errorLabel, result.denied);
+    }
+    return parseHits(result.data);
+  }
+
+  /**
+   * Explicit isolation probe: attempt to read `namespace` and report whether the
+   * server denied the read. This is the ONLY method that treats a permission
+   * denial as a success signal, and it does so distinctly -- an empty but
+   * successful search is reported as `denied: false`, because "no results" is
+   * not proof of denial (the namespace could simply be empty for this caller).
+   *
+   * Never surfaces hit ids or bodies; only the boolean denial and a count.
+   */
+  async attemptRead(opts: {
+    query: string;
+    namespace: string;
+    limit: number;
+    searchMode: "hybrid" | "vector" | "keyword";
+  }): Promise<DenialProbeResult> {
+    const result = await this.caller.callTool("search_brain", {
+      query: opts.query,
+      namespace: opts.namespace,
+      limit: opts.limit,
+      search_mode: opts.searchMode,
+    });
+    if (result.isError) {
+      if (result.denied) {
+        return { denied: true, hitCount: 0 };
+      }
+      // A non-denial error (timeout, malformed request) is a real failure and
+      // must not be mistaken for isolation proof.
+      throw new LiveTransportError(result.errorLabel, false);
+    }
+    // Successful read of a namespace the caller should not reach: NOT denial.
+    return { denied: false, hitCount: parseHits(result.data).length };
+  }
+
+  /**
+   * Archive exactly one record by table + id. archive_entry is namespace-scoped
+   * server-side (it appends the caller's write-namespace predicate), so a token
+   * can only ever archive records it owns -- this is what makes per-record
+   * teardown mutation-safe. Returns "archived", "already_absent", or throws a
+   * redacted LiveTransportError.
+   */
+  async archive(opts: {
+    table: LiveMemoryTable;
+    id: string;
+  }): Promise<"archived" | "already_absent"> {
+    const result = await this.caller.callTool("archive_entry", {
+      table: opts.table,
+      id: opts.id,
+    });
+    if (result.isError) {
+      throw new LiveTransportError(result.errorLabel, result.denied);
+    }
+    const parsed = safeJson(result.data);
+    if (parsed?.archived === true) return "archived";
+    // The tool returns a plain-text "Already archived or not found" body when
+    // the row is absent or already tombstoned.
+    return "already_absent";
+  }
+
+  close(): Promise<void> {
+    return this.caller.close();
+  }
+}
+
+/** Parse ranked search hits from a JSON array body. Never logs the body. */
+export function parseHits(text: string): SearchHit[] {
+  const parsed = safeJsonArray(text);
+  if (!parsed) return [];
+  const hits: SearchHit[] = [];
+  for (const row of parsed) {
+    if (row && typeof row === "object") {
+      const id = (row as Record<string, unknown>).id;
+      const sourceType = (row as Record<string, unknown>).source_type;
+      const namespace = (row as Record<string, unknown>).namespace;
+      if (typeof id === "string") {
+        hits.push({
+          id,
+          source_type: typeof sourceType === "string" ? sourceType : "",
+          namespace: typeof namespace === "string" ? namespace : undefined,
+        });
+      }
+    }
+  }
+  return hits;
+}
+
+function safeJson(text: string): Record<string, unknown> | undefined {
+  try {
+    const value = JSON.parse(text);
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeJsonArray(text: string): unknown[] | undefined {
+  try {
+    const value = JSON.parse(text);
+    return Array.isArray(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Server error bodies the gate is willing to name in a content-free label. Only
+ * these known, non-sensitive tokens are ever copied out of a response; anything
+ * else collapses to "error", so a memory body or secret in the error text can
+ * never leak into a log or receipt.
+ */
+const REDACTED_ERROR_KEYWORDS: readonly string[] = [
+  "permission denied",
+  "not authenticated",
+  "invalid",
+  "not found",
+  "already archived",
+  "rate limit",
+  "timeout",
+  "unauthorized",
+  "forbidden",
+];
+
+/** True when the redacted error signal indicates a permission/namespace denial. */
+export function isDenialLabel(label: string): boolean {
+  return (
+    label.includes("permission-denied") ||
+    label.includes("unauthorized") ||
+    label.includes("forbidden") ||
+    label.includes("not-authenticated")
+  );
+}
+
+/**
+ * Reduce a failed tool call to a content-free label. Emits the tool name plus
+ * at most one matched known keyword (as a slug); the raw response text is never
+ * included. Returns { errorLabel, denied }.
+ */
+export function redactToolFailure(
+  toolName: string,
+  rawText: string,
+): { errorLabel: string; denied: boolean } {
+  const lower = rawText.toLowerCase();
+  const matched = REDACTED_ERROR_KEYWORDS.find((kw) => lower.includes(kw));
+  const slug = matched ? matched.replace(/\s+/g, "-") : "error";
+  const errorLabel = `${toolName}:${slug}`;
+  return { errorLabel, denied: isDenialLabel(errorLabel) };
+}
+
+/**
+ * Sanitize a THROWN transport-layer error (connect / callTool / close) into a
+ * content-free LiveTransportError. The MCP SDK can throw errors whose `.message`
+ * carries the raw remote HTTP body or response text -- which could include a
+ * memory body or secret -- so we NEVER surface `error.message` verbatim. We copy
+ * out only the operation name plus, if the message happens to contain one of the
+ * known non-sensitive keywords, that single keyword as a slug. Anything else
+ * collapses to `<op>:transport-error`. An HTTP status code (a bare number) is
+ * safe to name and helps triage, so we extract at most one 3-digit status.
+ *
+ * `op` is the transport operation (e.g. "connect", "close", or a tool name), not
+ * the raw error, so the label shape matches redactToolFailure's `<name>:<slug>`.
+ */
+export function sanitizeThrownTransportError(
+  op: string,
+  error: unknown,
+): LiveTransportError {
+  // Already redacted upstream: pass it through unchanged so we never re-wrap or
+  // accidentally widen a content-free label.
+  if (error instanceof LiveTransportError) {
+    return error;
+  }
+  const raw = error instanceof Error ? error.message : String(error);
+  const lower = raw.toLowerCase();
+  const matchedKeyword = REDACTED_ERROR_KEYWORDS.find((kw) =>
+    lower.includes(kw),
+  );
+  const statusMatch = /\b([1-5]\d{2})\b/.exec(raw);
+  let slug: string;
+  if (matchedKeyword) {
+    slug = matchedKeyword.replace(/\s+/g, "-");
+  } else if (statusMatch) {
+    slug = `http-${statusMatch[1]}`;
+  } else {
+    slug = "transport-error";
+  }
+  const errorLabel = `${op}:${slug}`;
+  return new LiveTransportError(errorLabel, isDenialLabel(errorLabel));
+}
+
+/**
+ * Concrete MCP-over-HTTP caller. One caller == one bearer token + one bound
+ * X-Namespace == one client session. The gate creates one caller per role
+ * (primary, negative), each pinned to the exact per-run namespace it owns.
+ *
+ * X-Namespace is sent on EVERY request (including the session-initializing
+ * `initialize`), which is what binds the token-sourced global role to this
+ * run's generated namespace. The server treats the delegated namespace as the
+ * effective clientId for both the write predicate and the read predicate, so
+ * two callers sharing one admin/ob-admin token but carrying different
+ * X-Namespace headers are genuinely isolated from each other -- token identity
+ * is NOT what proves isolation, the header-bound namespace is.
+ */
+/**
+ * Minimal surface of the MCP SDK client the caller depends on. Injected so unit
+ * tests can drive the redaction boundary (a thrown connect/callTool/close) with
+ * a fake that emits raw, secret-bearing errors -- proving nothing raw escapes --
+ * without standing up a hosted server.
+ */
+export interface McpClientLike {
+  connect(transport: unknown): Promise<void>;
+  callTool(
+    request: { name: string; arguments: Record<string, unknown> },
+    schema: undefined,
+    options: { timeout: number },
+  ): Promise<{ content?: unknown; isError?: boolean }>;
+  close(): Promise<void>;
+}
+
+/**
+ * Build the real SDK client + streamable-HTTP transport bound to a token and a
+ * per-request X-Namespace header. Factored out so createMcpCaller can accept an
+ * injected client in tests.
+ */
+export function defaultMcpClientFactory(opts: {
+  baseUrl: string;
+  token: string;
+  namespace: string;
+}): { client: McpClientLike; transport: unknown } {
+  const url = new URL("/mcp", opts.baseUrl);
+  const transport = new StreamableHTTPClientTransport(url, {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${opts.token}`,
+        "X-Namespace": opts.namespace,
+      },
+    },
+  });
+  const client = new Client({
+    name: "open-brain-live-recall-gate",
+    version: "1.0.0",
+  }) as unknown as McpClientLike;
+  return { client, transport };
+}
+
+export async function createMcpCaller(opts: {
+  baseUrl: string;
+  token: string;
+  /** Effective namespace to bind via the X-Namespace header on every request. */
+  namespace: string;
+  timeoutMs: number;
+  /** Injectable client factory; defaults to the real SDK client. Tests override. */
+  clientFactory?: (o: {
+    baseUrl: string;
+    token: string;
+    namespace: string;
+  }) => { client: McpClientLike; transport: unknown };
+}): Promise<OpenBrainToolCaller> {
+  const factory = opts.clientFactory ?? defaultMcpClientFactory;
+  const { client, transport } = factory({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    namespace: opts.namespace,
+  });
+
+  // connect() can throw an SDK error whose message carries the raw remote HTTP
+  // body. Sanitize at the boundary so no raw response text or secret escapes.
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    throw sanitizeThrownTransportError("connect", error);
+  }
+
+  return {
+    async callTool(name, args) {
+      let raw: { content?: unknown; isError?: boolean };
+      try {
+        raw = await client.callTool({ name, arguments: args }, undefined, {
+          timeout: opts.timeoutMs,
+        });
+      } catch (error) {
+        // A thrown callTool (network drop, HTTP error with a body, malformed
+        // response) is sanitized to a content-free label -- the raw error
+        // message is never surfaced to a script or log.
+        throw sanitizeThrownTransportError(name, error);
+      }
+      const content = Array.isArray(raw.content) ? raw.content : [];
+      const firstText = content.find(
+        (block): block is { type: "text"; text: string } =>
+          !!block &&
+          typeof block === "object" &&
+          (block as { type?: unknown }).type === "text" &&
+          typeof (block as { text?: unknown }).text === "string",
+      );
+      const text = firstText?.text ?? "";
+      if (raw.isError === true) {
+        // Redaction boundary: drop the raw body entirely, keep only a label.
+        const { errorLabel, denied } = redactToolFailure(name, text);
+        return { isError: true, denied, data: "", errorLabel };
+      }
+      // Success: carry the body forward for structured parsing only. Callers
+      // extract ids/namespace and never log it.
+      return { isError: false, denied: false, data: text, errorLabel: "" };
+    },
+    async close() {
+      // close() can also throw an SDK error carrying raw remote text. Sanitize
+      // it so a cleanup failure never leaks a body -- the gate's finally block
+      // already swallows this, but the message must be content-free if surfaced.
+      try {
+        await client.close();
+      } catch (error) {
+        throw sanitizeThrownTransportError("close", error);
+      }
+    },
+  };
+}

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -195,6 +195,23 @@ export class OpenBrainLiveClient {
    * can only ever archive records it owns -- this is what makes per-record
    * teardown mutation-safe. Returns "archived", "already_absent", or throws a
    * redacted LiveTransportError.
+   *
+   * A destructive teardown operation MUST fail closed on an ambiguous success.
+   * archive_entry has exactly two real successful response shapes on the server
+   * (src/tools/archive-entry.ts): a JSON object `{id, table, archived: true}`
+   * for a row it tombstoned, and the EXACT plain-text body
+   * "Already archived or not found" for the zero-row no-op. We recognize only
+   * those two -- `archived: true`, or that exact marker (trimmed,
+   * case-insensitive) -- and throw a content-free LiveTransportError for EVERY
+   * other success response.
+   *
+   * We deliberately do NOT accept a structured `archived: false` (the server
+   * never emits it), nor broad substrings like "not found" / "no rows", nor a
+   * marker embedded in mixed text: any of those could false-pass on unrelated
+   * output. Treating an unrecognized success as "already_absent" would let
+   * teardown false-pass -- a shape drift, a differently-worded body, or a
+   * success that did not actually tombstone the row would be silently counted
+   * as clean cleanup, stranding a live record while the gate reports PASS.
    */
   async archive(opts: {
     table: LiveMemoryTable;
@@ -208,10 +225,17 @@ export class OpenBrainLiveClient {
       throw new LiveTransportError(result.errorLabel, result.denied);
     }
     const parsed = safeJson(result.data);
+    // Explicit archived success: the JSON object the server returns for a row
+    // it tombstoned. Only `archived: true` counts.
     if (parsed?.archived === true) return "archived";
-    // The tool returns a plain-text "Already archived or not found" body when
-    // the row is absent or already tombstoned.
-    return "already_absent";
+    // Exact already-absent no-op marker: the server returns the plain-text body
+    // "Already archived or not found" (and nothing else) for the zero-row case.
+    if (isAlreadyAbsentMarker(result.data)) return "already_absent";
+    // Any other success shape -- a structured `archived: false`, a partial or
+    // mixed-text marker, "no rows", or an unknown body -- is ambiguous for a
+    // destructive operation: fail closed content-free rather than assume the
+    // row is gone.
+    throw new LiveTransportError("archive_entry:unrecognized-success", false);
   }
 
   close(): Promise<void> {
@@ -241,6 +265,25 @@ export function parseHits(text: string): SearchHit[] {
   return hits;
 }
 
+/**
+ * The exact plain-text no-op marker archive_entry returns for the zero-row case
+ * (src/tools/archive-entry.ts): "Already archived or not found", and nothing
+ * else. This is the ONLY non-structured success shape teardown treats as "the
+ * row is gone".
+ *
+ * Matching is EXACT (trimmed, case-insensitive) -- not substring -- on purpose:
+ * a destructive teardown must fail closed, so a partial phrase ("not found"),
+ * "no rows", or the marker embedded in incidental/mixed text must NOT classify,
+ * because any of those could false-pass on unrelated server output. Anything
+ * that is not exactly this marker fails closed at the caller. The raw text is
+ * never logged or returned -- only the boolean.
+ */
+const ARCHIVE_ABSENT_MARKER = "already archived or not found";
+
+function isAlreadyAbsentMarker(text: string): boolean {
+  return text.trim().toLowerCase() === ARCHIVE_ABSENT_MARKER;
+}
+
 function safeJson(text: string): Record<string, unknown> | undefined {
   try {
     const value = JSON.parse(text);
@@ -262,22 +305,53 @@ function safeJsonArray(text: string): unknown[] | undefined {
 }
 
 /**
- * Server error bodies the gate is willing to name in a content-free label. Only
- * these known, non-sensitive tokens are ever copied out of a response; anything
- * else collapses to "error", so a memory body or secret in the error text can
- * never leak into a log or receipt.
+ * Denial keywords: a permission/namespace/auth refusal. These are the security-
+ * relevant signals the isolation proof depends on, so they are classified FIRST,
+ * ahead of any generic error keyword. A server body can legitimately mix a
+ * denial phrase with a generic one (e.g. "invalid request: permission denied for
+ * namespace"); if a generic keyword like "invalid" were matched first, a real
+ * denial would be mislabeled as a non-denial error and the isolation proof (or a
+ * teardown auth failure) would be silently misread. Denial precedence closes
+ * that classification hole.
  */
-const REDACTED_ERROR_KEYWORDS: readonly string[] = [
+const DENIAL_ERROR_KEYWORDS: readonly string[] = [
   "permission denied",
   "not authenticated",
+  "unauthorized",
+  "forbidden",
+];
+
+/**
+ * Generic (non-denial) error bodies the gate is willing to name in a content-
+ * free label. Matched only AFTER the denial keywords above, so a mixed body that
+ * contains a denial phrase always classifies as a denial regardless of array
+ * order.
+ */
+const GENERIC_ERROR_KEYWORDS: readonly string[] = [
   "invalid",
   "not found",
   "already archived",
   "rate limit",
   "timeout",
-  "unauthorized",
-  "forbidden",
 ];
+
+/**
+ * The full allowlist of non-sensitive tokens the gate may copy out of a
+ * response is exactly DENIAL_ERROR_KEYWORDS followed by GENERIC_ERROR_KEYWORDS.
+ * Only these tokens are ever emitted; anything else collapses to a bare marker,
+ * so a memory body or secret in the error text can never leak into a log or
+ * receipt.
+ *
+ * Select the single keyword to name in a content-free label, prioritizing any
+ * denial keyword over every generic one so a mixed body classifies as a denial.
+ * Returns undefined when no known keyword is present.
+ */
+function matchRedactedKeyword(lower: string): string | undefined {
+  return (
+    DENIAL_ERROR_KEYWORDS.find((kw) => lower.includes(kw)) ??
+    GENERIC_ERROR_KEYWORDS.find((kw) => lower.includes(kw))
+  );
+}
 
 /** True when the redacted error signal indicates a permission/namespace denial. */
 export function isDenialLabel(label: string): boolean {
@@ -299,7 +373,7 @@ export function redactToolFailure(
   rawText: string,
 ): { errorLabel: string; denied: boolean } {
   const lower = rawText.toLowerCase();
-  const matched = REDACTED_ERROR_KEYWORDS.find((kw) => lower.includes(kw));
+  const matched = matchRedactedKeyword(lower);
   const slug = matched ? matched.replace(/\s+/g, "-") : "error";
   const errorLabel = `${toolName}:${slug}`;
   return { errorLabel, denied: isDenialLabel(errorLabel) };
@@ -329,9 +403,7 @@ export function sanitizeThrownTransportError(
   }
   const raw = error instanceof Error ? error.message : String(error);
   const lower = raw.toLowerCase();
-  const matchedKeyword = REDACTED_ERROR_KEYWORDS.find((kw) =>
-    lower.includes(kw),
-  );
+  const matchedKeyword = matchRedactedKeyword(lower);
   const statusMatch = /\b([1-5]\d{2})\b/.exec(raw);
   let slug: string;
   if (matchedKeyword) {

--- a/eval/open-brain/live/types.ts
+++ b/eval/open-brain/live/types.ts
@@ -1,0 +1,195 @@
+// Types for the live Open Brain recall gate (EVAL-1/2/3, issues #322-#324).
+//
+// The live gate seeds a unique throwaway namespace with a sealed synthetic
+// corpus, runs recall queries through the real Open Brain client/transport,
+// scores deterministic ranking metrics, compares against versioned thresholds,
+// and then tears down exactly the records this run created.
+//
+// Nothing in this module is allowed to carry a secret, token, or live memory
+// body off-box: fixtures are synthetic and receipts are content-free.
+
+/** Brain tables that can hold a durable memory the gate seeds and archives. */
+export type LiveMemoryTable = "thoughts" | "decisions";
+
+/**
+ * A single sealed synthetic memory to seed into the throwaway namespace.
+ *
+ * `id` is a fixture-local handle (NOT the server-assigned UUID). The seeder
+ * maps each fixture id to the UUID the server returns so scoring and teardown
+ * can talk about "the record the gate created for fixture id X".
+ *
+ * `namespace_role` decides which token seeds it:
+ *  - "primary": seeded and read under the primary throwaway namespace.
+ *  - "negative": seeded into a sibling namespace the query token cannot read;
+ *    it must never appear in a primary-namespace search result.
+ */
+export interface LiveCorpusEntry {
+  id: string;
+  table: LiveMemoryTable;
+  namespace_role: "primary" | "negative";
+  content: string;
+  tags: string[];
+}
+
+/**
+ * A graded relevance judgment for one expected memory under a probe.
+ * Grade 0 means "explicitly non-relevant" (a distractor that shares terms);
+ * higher grades are more relevant. Recall/precision treat grade > 0 as relevant.
+ */
+export interface GradedRelevance {
+  id: string;
+  grade: number;
+}
+
+/**
+ * A recall probe: a natural-language query plus the sealed expectation of which
+ * seeded records are relevant, at what grade, and any records that must NOT be
+ * returned (out-of-namespace negatives).
+ */
+export interface LiveProbe {
+  id: string;
+  query: string;
+  /** Graded relevance over fixture-local corpus ids. */
+  relevant: GradedRelevance[];
+  /**
+   * Fixture-local ids that must never appear in this probe's results.
+   * Populated with negative-namespace entries to prove isolation.
+   */
+  forbidden_ids: string[];
+}
+
+export interface LiveFixture {
+  schema_version: 1;
+  fixture_id: string;
+  description: string;
+  /** Table used for teardown iteration and search default. */
+  corpus: LiveCorpusEntry[];
+  probes: LiveProbe[];
+}
+
+/** Versioned pass thresholds (thresholds.json). */
+export interface LiveThresholds {
+  schema_version: 1;
+  thresholds_id: string;
+  applies_to_fixture_id: string;
+  top_k: number;
+  thresholds: {
+    min_recall_at_k: number;
+    min_precision_at_k: number;
+    min_mrr: number;
+    max_namespace_leaks: number;
+  };
+  notes?: string;
+}
+
+/** Per-probe deterministic scores over a ranked list of retrieved ids. */
+export interface ProbeMetric {
+  probe_id: string;
+  recall_at_k: number;
+  precision_at_k: number;
+  reciprocal_rank: number;
+  /** Count of forbidden (out-of-namespace) ids that leaked into results. */
+  namespace_leaks: number;
+  retrieved_count: number;
+  relevant_count: number;
+}
+
+/**
+ * Result of the explicit negative-control isolation probe: the primary caller
+ * attempts to read the negative namespace and the server must deny it. An empty
+ * successful read is NOT proof of denial and fails the gate.
+ */
+export interface NegativeControlProof {
+  /** True when a negative control was actually exercised this run. */
+  ran: boolean;
+  /** True when the primary caller's read of the negative namespace was denied. */
+  denied: boolean;
+  /**
+   * Hit count observed if the read unexpectedly succeeded; 0 on denial. Used to
+   * distinguish "denied" from "allowed but empty" content-free.
+   */
+  observed_hit_count: number;
+  /** True when a distinct negative token also exercised cross-token denial. */
+  cross_token: boolean;
+  /** Content-free reason the proof did not establish isolation, if any. */
+  failure?: string;
+}
+
+/** Aggregate metrics over all probes, plus the pass/fail verdict. */
+export interface LiveScorecard {
+  fixture_id: string;
+  thresholds_id: string;
+  top_k: number;
+  probes_total: number;
+  recall_at_k: number;
+  precision_at_k: number;
+  mrr: number;
+  namespace_leaks: number;
+  passed: boolean;
+  failures: string[];
+  probes: ProbeMetric[];
+}
+
+/**
+ * A resolved seeded record: the fixture handle, the table it lives in, the
+ * server-assigned UUID, and the exact physical namespace it was written to.
+ * Teardown only ever archives records described by this shape.
+ */
+export interface SeededRecord {
+  fixture_id: string;
+  table: LiveMemoryTable;
+  server_id: string;
+  namespace: string;
+  namespace_role: "primary" | "negative";
+}
+
+/** Content-free structured baseline receipt emitted by the gate. */
+export interface LiveGateReceipt {
+  schema: "openbrain.live_recall_gate.v1";
+  generated_at: string;
+  commit: string;
+  fixture_id: string;
+  thresholds_id: string;
+  top_k: number;
+  primary_namespace: string;
+  negative_namespace: string;
+  seeded: {
+    primary: number;
+    negative: number;
+  };
+  metrics: {
+    recall_at_k: number;
+    precision_at_k: number;
+    mrr: number;
+    namespace_leaks: number;
+  };
+  thresholds: LiveThresholds["thresholds"];
+  probes: Array<{
+    probe_id: string;
+    recall_at_k: number;
+    precision_at_k: number;
+    reciprocal_rank: number;
+    namespace_leaks: number;
+  }>;
+  /** Explicit negative-control isolation proof (primary read of negative ns). */
+  negative_control: {
+    ran: boolean;
+    denied: boolean;
+    observed_hit_count: number;
+    cross_token: boolean;
+    failure?: string;
+  };
+  /**
+   * Overall gate verdict. PASS requires ALL of: scorecard thresholds met, the
+   * negative-control proof ran and denied, and teardown left nothing behind
+   * (failed === 0). A metrics-only pass can never report PASS here.
+   */
+  passed: boolean;
+  failures: string[];
+  teardown: {
+    attempted: number;
+    archived: number;
+    already_absent: number;
+    failed: number;
+  };
+}

--- a/eval/open-brain/thresholds.json
+++ b/eval/open-brain/thresholds.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "thresholds_id": "open-brain-live-recall-thresholds-v1",
+  "applies_to_fixture_id": "open-brain-live-recall-v1",
+  "top_k": 5,
+  "thresholds": {
+    "min_recall_at_k": 0.9,
+    "min_precision_at_k": 0.3,
+    "min_mrr": 0.8,
+    "max_namespace_leaks": 0
+  },
+  "notes": "Versioned pass thresholds for the live recall gate. Edit here, never in test assertions. Metrics are the mean over probes at top_k. min_recall_at_k = mean fraction of graded-relevant records retrieved in top_k. min_precision_at_k uses top_k as the denominator (Precision@K), so its ceiling is bounded by relevant_count/top_k per probe; 0.3 reflects the open-brain-live-recall-v1 fixture in which probes carry 1-3 relevant records against top_k=5. min_mrr is the mean reciprocal rank of the first relevant hit and must stay high because the best record should lead. max_namespace_leaks must stay 0: any out-of-namespace record surfacing is an isolation breach, not a quality miss."
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "backfill": "bun run scripts/backfill.ts",
     "codex-memory-smoke": "bun run scripts/codex-memory-smoke.ts",
     "eval:memory": "bun run scripts/eval-open-brain-memory.ts",
+    "eval:live": "bun run scripts/eval-open-brain-live.ts",
     "import-kb": "bun run scripts/import-legacy-kb.ts",
     "promote:legacy-shared": "bun run scripts/promote-legacy-shared.ts",
     "promote:qmd-facts": "bun run scripts/promote-qmd-repo-facts.ts",

--- a/scripts/__tests__/eval-open-brain-live.test.ts
+++ b/scripts/__tests__/eval-open-brain-live.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+import { setUpGateClients } from "../eval-open-brain-live.ts";
+import type { CallerFactory } from "../eval-open-brain-live.ts";
+import { LiveTransportError } from "../../eval/open-brain/live/transport.ts";
+import type {
+  OpenBrainToolCaller,
+  ToolCallResult,
+} from "../../eval/open-brain/live/transport.ts";
+import type { LiveEvalConfig } from "../../eval/open-brain/live/config.ts";
+
+// Setup-lifecycle unit test for the live gate CLI (issue #322 fix delta). It
+// exercises setUpGateClients WITHOUT executing the CLI or touching a hosted
+// server, by injecting a fake caller factory. What it pins:
+//
+//  - When the negative caller's connect fails, the successfully-connected
+//    PRIMARY caller is CLOSED before the error propagates -- no live MCP session
+//    leaks on a setup failure.
+//  - The close is best-effort and content-free: a close that itself throws does
+//    not mask or widen the original connect error.
+//  - The happy path returns both clients with neither closed.
+
+const CONFIG: LiveEvalConfig = {
+  baseUrl: "http://127.0.0.1:3100",
+  primaryToken: "primary-token",
+  negativeToken: "primary-token",
+  negativeTokenIsDistinct: false,
+  primaryNamespace: "eval-live-recall-run-test",
+  negativeNamespace: "eval-live-recall-run-test-negative",
+  searchMode: "hybrid",
+  timeoutMs: 1000,
+};
+
+interface FakeCaller extends OpenBrainToolCaller {
+  namespace: string;
+  closes: number;
+}
+
+function makeFakeCaller(
+  namespace: string,
+  opts: { closeThrows?: boolean } = {},
+): FakeCaller {
+  const caller: FakeCaller = {
+    namespace,
+    closes: 0,
+    async callTool(): Promise<ToolCallResult> {
+      return { isError: false, denied: false, data: "{}", errorLabel: "" };
+    },
+    async close() {
+      caller.closes += 1;
+      if (opts.closeThrows) {
+        throw new Error("close failed 503: leftover private body text");
+      }
+    },
+  };
+  return caller;
+}
+
+describe("setUpGateClients lifecycle", () => {
+  it("closes the connected primary caller when the negative connect fails", async () => {
+    const primary = makeFakeCaller(CONFIG.primaryNamespace);
+    const connectError = new LiveTransportError("connect:unauthorized", true);
+    let primaryConnected = false;
+
+    const factory: CallerFactory = async (o) => {
+      if (o.namespace === CONFIG.primaryNamespace) {
+        primaryConnected = true;
+        return primary;
+      }
+      // Negative caller connect fails.
+      throw connectError;
+    };
+
+    await expect(setUpGateClients(CONFIG, factory)).rejects.toBe(connectError);
+    // The primary connected, so it must have been closed exactly once.
+    expect(primaryConnected).toBe(true);
+    expect(primary.closes).toBe(1);
+  });
+
+  it("does not mask the original connect error if the primary close itself throws", async () => {
+    const primary = makeFakeCaller(CONFIG.primaryNamespace, {
+      closeThrows: true,
+    });
+    const connectError = new LiveTransportError("connect:forbidden", true);
+
+    const factory: CallerFactory = async (o) => {
+      if (o.namespace === CONFIG.primaryNamespace) return primary;
+      throw connectError;
+    };
+
+    // The original connect error is surfaced, not the close error.
+    await expect(setUpGateClients(CONFIG, factory)).rejects.toBe(connectError);
+    expect(primary.closes).toBe(1);
+  });
+
+  it("returns both clients and closes neither on the happy path", async () => {
+    const primary = makeFakeCaller(CONFIG.primaryNamespace);
+    const negative = makeFakeCaller(CONFIG.negativeNamespace);
+    const factory: CallerFactory = async (o) =>
+      o.namespace === CONFIG.primaryNamespace ? primary : negative;
+
+    const clients = await setUpGateClients(CONFIG, factory);
+    expect(clients.primary).toBeDefined();
+    expect(clients.negative).toBeDefined();
+    expect(primary.closes).toBe(0);
+    expect(negative.closes).toBe(0);
+  });
+
+  it("propagates a primary connect failure without constructing a negative caller", async () => {
+    const primaryError = new LiveTransportError("connect:http-500", false);
+    let negativeAttempted = false;
+    const factory: CallerFactory = async (o) => {
+      if (o.namespace === CONFIG.primaryNamespace) throw primaryError;
+      negativeAttempted = true;
+      return makeFakeCaller(CONFIG.negativeNamespace);
+    };
+    await expect(setUpGateClients(CONFIG, factory)).rejects.toBe(primaryError);
+    expect(negativeAttempted).toBe(false);
+  });
+});

--- a/scripts/eval-open-brain-live.ts
+++ b/scripts/eval-open-brain-live.ts
@@ -13,10 +13,13 @@
 // No memory bodies, tokens, or secrets are ever printed.
 
 import { randomUUID } from "node:crypto";
+import type { LiveEvalConfig } from "../eval/open-brain/live/config.ts";
 import { loadLiveConfig, makeRunId } from "../eval/open-brain/live/config.ts";
 import { loadLiveFixture } from "../eval/open-brain/live/fixtures.ts";
 import { loadThresholds } from "../eval/open-brain/live/metrics.ts";
+import type { GateClients } from "../eval/open-brain/live/gate.ts";
 import { runLiveGate } from "../eval/open-brain/live/gate.ts";
+import type { OpenBrainToolCaller } from "../eval/open-brain/live/transport.ts";
 import {
   OpenBrainLiveClient,
   createMcpCaller,
@@ -24,6 +27,65 @@ import {
 
 const FIXTURE_PATH = "eval/open-brain/fixtures/live-recall-v1.json";
 const THRESHOLDS_PATH = "eval/open-brain/thresholds.json";
+
+/**
+ * Factory that connects one MCP caller for a (token, namespace) pair. Injected
+ * so the setup lifecycle (below) is unit-testable without a hosted server or the
+ * CLI: a fake factory can simulate a successful primary connect and a failing
+ * negative connect, proving the primary is closed and no caller leaks.
+ */
+export type CallerFactory = (opts: {
+  baseUrl: string;
+  token: string;
+  namespace: string;
+  timeoutMs: number;
+}) => Promise<OpenBrainToolCaller>;
+
+/**
+ * Connect the primary and negative callers in order, wrapping them in
+ * OpenBrainLiveClients. The negative control is mandatory, so BOTH callers must
+ * connect. If the primary connects but the negative connect fails, the
+ * successfully-connected primary caller is closed before the error propagates --
+ * otherwise a live MCP session (and its pool connection) would leak on every
+ * setup failure. The close is best-effort and content-free: a close failure
+ * never masks or widens the original connect error and never surfaces a raw
+ * remote body.
+ *
+ * Extracted from main() and exported purely so the lifecycle is exercisable in a
+ * unit test; the CLI path just calls it with the real createMcpCaller factory.
+ */
+export async function setUpGateClients(
+  config: LiveEvalConfig,
+  factory: CallerFactory = createMcpCaller,
+): Promise<GateClients> {
+  const primaryCaller = await factory({
+    baseUrl: config.baseUrl,
+    token: config.primaryToken,
+    namespace: config.primaryNamespace,
+    timeoutMs: config.timeoutMs,
+  });
+
+  let negativeCaller: OpenBrainToolCaller;
+  try {
+    negativeCaller = await factory({
+      baseUrl: config.baseUrl,
+      token: config.negativeToken,
+      namespace: config.negativeNamespace,
+      timeoutMs: config.timeoutMs,
+    });
+  } catch (error) {
+    // The primary already holds a live session; close it so a negative-connect
+    // failure does not strand it. Swallow the close outcome (content-free) so
+    // the original connect error is what the caller sees.
+    await primaryCaller.close().catch(() => {});
+    throw error;
+  }
+
+  return {
+    primary: new OpenBrainLiveClient(primaryCaller),
+    negative: new OpenBrainLiveClient(negativeCaller),
+  };
+}
 
 function argValue(name: string): string | undefined {
   const prefix = `--${name}=`;
@@ -68,24 +130,9 @@ async function main(): Promise<number> {
   // global role becomes header-bound to this run's exact namespace. The negative
   // caller is mandatory and binds the distinct negative namespace (optionally a
   // distinct token too), giving a real negative control even when both callers
-  // share one bearer token.
-  const primaryCaller = await createMcpCaller({
-    baseUrl: config.baseUrl,
-    token: config.primaryToken,
-    namespace: config.primaryNamespace,
-    timeoutMs: config.timeoutMs,
-  });
-  const negativeCaller = await createMcpCaller({
-    baseUrl: config.baseUrl,
-    token: config.negativeToken,
-    namespace: config.negativeNamespace,
-    timeoutMs: config.timeoutMs,
-  });
-
-  const clients = {
-    primary: new OpenBrainLiveClient(primaryCaller),
-    negative: new OpenBrainLiveClient(negativeCaller),
-  };
+  // share one bearer token. setUpGateClients closes the primary if the negative
+  // connect fails, so a setup failure never strands a live session.
+  const clients = await setUpGateClients(config);
 
   try {
     const outcome = await runLiveGate({
@@ -144,14 +191,19 @@ function printReceipt(
   console.log(lines.join("\n"));
 }
 
-main()
-  .then((code) => {
-    process.exitCode = code;
-  })
-  .catch((error) => {
-    // Content-free failure: name the error class + message only. The gate never
-    // constructs a message containing a memory body or secret.
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`Live recall gate error: ${message}`);
-    process.exitCode = 2;
-  });
+// Only auto-run as a CLI. When imported (e.g. by the setup-lifecycle unit test)
+// the module must NOT execute main() and touch config/env -- exporting the
+// lifecycle helper for test is the reason this guard exists.
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      // Content-free failure: name the error class + message only. The gate never
+      // constructs a message containing a memory body or secret.
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Live recall gate error: ${message}`);
+      process.exitCode = 2;
+    });
+}

--- a/scripts/eval-open-brain-live.ts
+++ b/scripts/eval-open-brain-live.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+// Single-command live recall gate (EVAL-3, issue #324).
+//
+//   bun run eval:live
+//
+// Requires opt-in: OPEN_BRAIN_LIVE_EVAL=1 plus base URL + token env vars (see
+// eval/open-brain/README.md). One invocation performs: seed a unique throwaway
+// namespace, run recall queries through the real Open Brain MCP client, score
+// deterministic ranking metrics, apply versioned thresholds, tear down exactly
+// this run's records, and exit nonzero below thresholds.
+//
+// Output is content-free: only ids, namespaces, labels, scores, and statuses.
+// No memory bodies, tokens, or secrets are ever printed.
+
+import { randomUUID } from "node:crypto";
+import { loadLiveConfig, makeRunId } from "../eval/open-brain/live/config.ts";
+import { loadLiveFixture } from "../eval/open-brain/live/fixtures.ts";
+import { loadThresholds } from "../eval/open-brain/live/metrics.ts";
+import { runLiveGate } from "../eval/open-brain/live/gate.ts";
+import {
+  OpenBrainLiveClient,
+  createMcpCaller,
+} from "../eval/open-brain/live/transport.ts";
+
+const FIXTURE_PATH = "eval/open-brain/fixtures/live-recall-v1.json";
+const THRESHOLDS_PATH = "eval/open-brain/thresholds.json";
+
+function argValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of Bun.argv.slice(2)) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  const index = Bun.argv.indexOf(`--${name}`);
+  const next = index >= 0 ? Bun.argv[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+async function gitCommit(): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    return code === 0 ? output.trim() : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+async function main(): Promise<number> {
+  const commit = await gitCommit();
+  // Unique across repeated runs of the same commit: an explicit operator run id
+  // (OPEN_BRAIN_LIVE_EVAL_RUN_ID) wins for reproducibility; otherwise a
+  // crypto-random suffix guarantees no collision. PID alone is NOT unique across
+  // sequential runs on one host, so it is not used as the sole source.
+  const runId = makeRunId({
+    prefix: commit.slice(0, 12),
+    randomHex: randomUUID().replace(/-/g, "").slice(0, 12),
+  });
+  const config = loadLiveConfig(runId);
+  const fixture = await loadLiveFixture(FIXTURE_PATH);
+  const thresholds = await loadThresholds(THRESHOLDS_PATH);
+  const generatedAt = new Date().toISOString();
+
+  // Each caller binds its OWN X-Namespace on every request, so the token-sourced
+  // global role becomes header-bound to this run's exact namespace. The negative
+  // caller is mandatory and binds the distinct negative namespace (optionally a
+  // distinct token too), giving a real negative control even when both callers
+  // share one bearer token.
+  const primaryCaller = await createMcpCaller({
+    baseUrl: config.baseUrl,
+    token: config.primaryToken,
+    namespace: config.primaryNamespace,
+    timeoutMs: config.timeoutMs,
+  });
+  const negativeCaller = await createMcpCaller({
+    baseUrl: config.baseUrl,
+    token: config.negativeToken,
+    namespace: config.negativeNamespace,
+    timeoutMs: config.timeoutMs,
+  });
+
+  const clients = {
+    primary: new OpenBrainLiveClient(primaryCaller),
+    negative: new OpenBrainLiveClient(negativeCaller),
+  };
+
+  try {
+    const outcome = await runLiveGate({
+      fixture,
+      thresholds,
+      config,
+      clients,
+      commit,
+      generatedAt,
+    });
+
+    const reportPath = argValue("report");
+    if (reportPath) {
+      await Bun.write(
+        reportPath,
+        `${JSON.stringify(outcome.receipt, null, 2)}\n`,
+      );
+    }
+
+    if (Bun.argv.includes("--json")) {
+      console.log(JSON.stringify(outcome.receipt, null, 2));
+    } else {
+      printReceipt(outcome.receipt);
+      if (reportPath) console.log(`\nWrote receipt: ${reportPath}`);
+    }
+
+    return outcome.passed ? 0 : 1;
+  } finally {
+    await clients.primary.close().catch(() => {});
+    await clients.negative.close().catch(() => {});
+  }
+}
+
+function printReceipt(
+  receipt: Awaited<ReturnType<typeof runLiveGate>>["receipt"],
+): void {
+  const verdict = receipt.passed ? "PASS" : "FAIL";
+  const lines = [
+    `Open Brain live recall gate: ${verdict}`,
+    `fixture=${receipt.fixture_id} thresholds=${receipt.thresholds_id} commit=${receipt.commit}`,
+    `namespace=${receipt.primary_namespace} (negative=${receipt.negative_namespace})`,
+    `seeded primary=${receipt.seeded.primary} negative=${receipt.seeded.negative}`,
+    `recall@${receipt.top_k}=${receipt.metrics.recall_at_k} precision@${receipt.top_k}=${receipt.metrics.precision_at_k} mrr=${receipt.metrics.mrr} namespace_leaks=${receipt.metrics.namespace_leaks}`,
+    `thresholds recall>=${receipt.thresholds.min_recall_at_k} precision>=${receipt.thresholds.min_precision_at_k} mrr>=${receipt.thresholds.min_mrr} leaks<=${receipt.thresholds.max_namespace_leaks}`,
+    `negative-control ran=${receipt.negative_control.ran} denied=${receipt.negative_control.denied} observed_hits=${receipt.negative_control.observed_hit_count} cross_token=${receipt.negative_control.cross_token}`,
+    `teardown attempted=${receipt.teardown.attempted} archived=${receipt.teardown.archived} already_absent=${receipt.teardown.already_absent} failed=${receipt.teardown.failed}`,
+  ];
+  for (const probe of receipt.probes) {
+    lines.push(
+      `- ${probe.probe_id}: recall=${probe.recall_at_k} precision=${probe.precision_at_k} rr=${probe.reciprocal_rank} leaks=${probe.namespace_leaks}`,
+    );
+  }
+  if (receipt.failures.length > 0) {
+    lines.push(`failures: ${receipt.failures.join("; ")}`);
+  }
+  console.log(lines.join("\n"));
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    // Content-free failure: name the error class + message only. The gate never
+    // constructs a message containing a memory body or secret.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Live recall gate error: ${message}`);
+    process.exitCode = 2;
+  });


### PR DESCRIPTION
## Summary

- add a sealed, versioned synthetic live-recall corpus with graded relevance and negative-namespace fixtures
- add deterministic recall@k, precision@k, MRR, namespace-leak scoring, and versioned thresholds
- add one opt-in MCP command that seeds unique namespaces, queries live retrieval, proves explicit namespace denial, emits a content-free receipt, and archives only records proven to be created by that invocation
- fail closed on malformed or foreign retrieval results, merged seed receipts, ambiguous archive outcomes, setup failures, and partial teardown

Closes #322
Closes #323
Closes #324

## Validation

- `bun test ./eval/open-brain/live/__tests__ ./scripts/__tests__/eval-open-brain-live.test.ts` — 101 pass, 0 fail
- `bun test` — 1620 pass, 74 skip, 0 fail
- `bunx tsc --noEmit` — passed
- `git diff --check` — passed
- exact-head CI at `eb8cf9f320c146a4060f3b74c558db6f797c120d` — check, contract-parity, db-integration, python-package, PR-body validation, and GitGuardian passed
- hosted hybrid baseline — PASS: recall@5 1.0, precision@5 0.4, MRR 1.0, namespace leaks 0, explicit denial, teardown 10/10
- deliberately degraded keyword mode — expected FAIL: recall/precision/MRR 0, isolation still denied, teardown 10/10
- restored hybrid mode — PASS with baseline metrics and clean teardown
- direct post-run database verification — 0 active eval thoughts and 0 active eval decisions
- live receipt: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5048757369

## Review Gate

Full tier completed. The five-lane initial swarm ran at pinned head `361bed5`; accepted findings were fixed at `044110a` and verified by two focused Opus lanes. The mandatory Terra-high opposite-runtime whole-PR audit then found one P1 and two P2 blockers; all were fixed at `eb8cf9f`, exact automation and CI passed, and two targeted Opus lanes returned TARGETED_ZERO_FINDINGS after the Terra companion failed to return a usable post-fix verdict at the adapter layer.

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:
- Initial findings: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5048768361
- Initial fixes: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5048931975
- Initial fix verification: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5048970134
- Terra terminal findings: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5049044929
- Terminal fixes: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5049245075
- Live Open Brain receipt: https://github.com/rodaddy/open-brain/pull/348#issuecomment-5048757369

## Downstream rollout

Not applicable. This PR adds repository-owned evaluation tooling and documentation; it does not change server MCP tool names, schemas, output shapes, auth/namespace semantics, Streamable HTTP server behavior, package exports, generated skills, or Hermes runtime behavior. The hosted evaluation run is issue validation, not a downstream contract rollout.

## Critical Self-Review

- Highest-risk behavior: teardown calls `archive_entry`; a namespace, ownership, or response mismatch could archive unrelated data or falsely report cleanup. The gate uses nonce-unique namespace pairs, accepts only fresh `merged:false` seeds under the exact requested namespace, validates every retrieval hit before scoring, archives only returned run-owned IDs through owning namespace-bound callers, and requires archive response identity to match the request.
- Assumptions that could be wrong: current hosted MCP response shapes and header-delegation semantics could drift. Every relevant success shape is now explicitly validated against current server source and unknown shapes fail closed rather than becoming PASS.
- Missing/weak tests: deterministic tests cover transport parsing, config uniqueness, seed ownership, scoring, isolation, setup cleanup, partial failures, and archive identity. Hosted baseline/degraded/restored runs prove current production behavior. The unavoidable response-loss-after-commit case cannot provide an ID for per-record teardown and remains documented.
- Security/permission risk: the command needs a global token capable of namespace delegation. It is opt-in, prints no token or memory body, binds `X-Namespace` on initialization and every call, sanitizes thrown/returned transport errors, and requires an actual permission denial rather than an empty successful read.
- Migration/deploy risk: no migration or runtime deployment change. The command writes sealed synthetic rows only during an explicit live run and attempts per-record teardown on every deferred failure path.
- Downstream client/runtime risk: no public contract or package behavior changes; mcp2cli/Hermes rollout is not applicable.
- Rollback/cleanup concern: remove the eval command/files to roll back. If a seed commits but its response is lost, the unknown server ID cannot be archived automatically; residue is bounded to the crypto-unique eval namespace and requires operator cleanup scoped to that namespace.
- Fixes made before PR: mandatory negative denial, exact header binding, nonce/hash-bounded run identities, malformed-hit fail-close, run-owned retrieval validation, fresh-seed proof, exact archive identity proof, denial precedence, partial setup cleanup, content-free teardown counts, SME updates, and hosted cleanup verification.
- Known residual risk: a seed request that commits server-side but loses its response can leave an untracked sealed synthetic record in the run's unique dead namespace. The run fails rather than reporting clean cleanup, and recovery deliberately avoids broad automatic deletion.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
