### PR TITLE
feat(326): enforce whole-pack context budget for agent_context_pack

### DIFF
--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -337,9 +337,14 @@ When `budget.max_tokens` is set, the envelope carries:
 }
 ```
 
-`content_char_limit` is the derived whole-pack character budget,
-`content_chars_used` is the portion of that budget consumed by the emitted
-sections (never greater than `content_char_limit`), and `allocation_order` is the
+`content_char_limit` is the derived whole-pack serialized-section limit: the
+`max_tokens * 4` minus `1200`-reserve budget, but never below `2` because
+`JSON.stringify(payload.sections)` always emits at least the irreducible empty
+object `{}` (2 characters). At tiny budgets that clamp the member budget to zero,
+`content_char_limit` is therefore `2` and no section member is admitted, yet the
+declared limit still bounds the serialized `sections` object with no slack.
+`content_chars_used` is the portion of that budget consumed by emitted section
+members (never greater than `content_char_limit`), and `allocation_order` is the
 fixed priority order above. Every section that is trimmed, starved, or omitted by
 the whole-pack budget adds a `whole_pack_budget` entry to `warnings.truncation`.
 

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -292,12 +292,19 @@ runtime-available sections today; sections added by later issues (for example
 **Serialized section accounting.** The budget bounds the *serialized* size of the
 emitted `sections` object — `JSON.stringify(payload.sections)` — not merely the
 summed per-section content bodies. The enclosing `{}` of the `sections` object is
-reserved once, and each retained section additionally charges its own framing
-(its quoted key plus one delimiter) against the running budget. Item-bearing
-sections (`working_set`, `recovery`) and the durable-lane section are each fitted
-by their full serialized length, so per-item wrappers, ids, lane metadata, event
-wrappers, and citation ids all count against the whole-pack budget rather than
-being allowed to overshoot it.
+reserved once, and each retained section additionally charges its own object
+framing against the running budget. That framing is position-aware, matching how
+JSON writes object members (`{"a":…,"b":…}`): the **first** admitted section
+charges only its quoted key plus the colon (`"key":`), and each **subsequent**
+admitted section additionally charges the one leading comma that separates it from
+the previous member. "First" tracks actual admission, so a starved-out or omitted
+candidate never consumes the comma-free first-member slot — the next admitted
+section still frames as the first. (Charging a comma for the first member would
+overcount one character and could falsely truncate content sitting on the exact
+boundary.) Item-bearing sections (`working_set`, `recovery`) and the durable-lane
+section are each fitted by their full serialized length, so per-item wrappers,
+ids, lane metadata, event wrappers, and citation ids all count against the
+whole-pack budget rather than being allowed to overshoot it.
 
 **Recency-preserving trim.** Both stores order items oldest-first, and store
 trimming removes the oldest (index 0), so the newest highest-value items live at

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -264,6 +264,85 @@ never overwrite an asserted coordinate, concurrent conflicts fail closed, and a
 fully asserted null thread remains unthreaded. A fresh checkpoint/wrap is
 therefore immediately recallable through this section.
 
+### Whole-Pack Budget Boundary
+
+When the request sets `budget.max_tokens`, the pack enforces one shared
+whole-pack character budget across the assembled sections instead of letting
+each section spend its own independent per-section cap. The budget is derived
+as `max_tokens * 4` serialized characters (`CHARS_PER_TOKEN = 4`) minus a fixed
+`1200`-character envelope reserve for the surrounding response frame, clamped at
+zero. Absent `max_tokens`, there is no whole-pack bound and every section keeps
+its historical independent per-section behavior; `budget.whole_pack` is then
+omitted entirely.
+
+Sections are allocated in a fixed, deterministic priority order — highest value
+first:
+
+1. `working_set` — exact-scope hot active state;
+2. `recovery` — explicit opt-in interrupted-session trace;
+3. `durable_lane_context` — broader recallable exact-scope lane context.
+
+Each lower-priority section is only fitted against whatever whole-pack budget the
+higher-priority sections leave behind, so a large low-priority section can never
+starve a higher-value one. This order is stable for identical inputs and is
+echoed back in `budget.whole_pack.allocation_order`. It matches the three
+runtime-available sections today; sections added by later issues (for example
+`#327`-`#329`) are not yet wired into this allocation order.
+
+**Serialized section accounting.** The budget bounds the *serialized* size of the
+emitted `sections` object — `JSON.stringify(payload.sections)` — not merely the
+summed per-section content bodies. The enclosing `{}` of the `sections` object is
+reserved once, and each retained section additionally charges its own framing
+(its quoted key plus one delimiter) against the running budget. Item-bearing
+sections (`working_set`, `recovery`) and the durable-lane section are each fitted
+by their full serialized length, so per-item wrappers, ids, lane metadata, event
+wrappers, and citation ids all count against the whole-pack budget rather than
+being allowed to overshoot it.
+
+**Recency-preserving trim.** Both stores order items oldest-first, and store
+trimming removes the oldest (index 0), so the newest highest-value items live at
+the tail. Whole-pack pressure matches that recency ordering: it drops the oldest
+items/events first and preserves the newest suffix. For `working_set` the
+retained `item_count` is reconciled to the surviving items; for `recovery` both
+`item_count` and `pending_count` are reconciled to the surviving items; for
+`durable_lane_context` the oldest events are dropped first (then the checkpoint
+is trimmed), `event_count`/`truncated` are reconciled, and citations for dropped
+events are removed so no citation references unemitted evidence.
+
+**Starvation and omission.** A requested item-bearing section that is fully
+starved (all item bodies dropped) keeps its defined empty envelope
+(`items: []`, counts `0`) only when that empty envelope still fits the surviving
+budget, so the caller still receives its scope/budget/counter shape. If even the
+empty envelope would overflow the whole-pack budget, the section is omitted
+entirely — the hard "sections never exceed the budget" contract wins over
+envelope-shape preservation. In either case a `warnings.truncation` marker of
+`{ "source": <section>, "reason": "whole_pack_budget", "starved": true }` is
+recorded so the caller knows the requested section was fully dropped rather than
+silently absent. A durable-lane section that is starved out reports
+`budget.durable_lane_context.content_chars_used = 0` and drops its lane/event
+citations, and its loader-derived per-section truncation markers are suppressed
+so no marker references an unemitted section.
+
+When `budget.max_tokens` is set, the envelope carries:
+
+```json
+{
+  "budget": {
+    "whole_pack": {
+      "content_char_limit": 14800,
+      "content_chars_used": 9213,
+      "allocation_order": ["working_set", "recovery", "durable_lane_context"]
+    }
+  }
+}
+```
+
+`content_char_limit` is the derived whole-pack character budget,
+`content_chars_used` is the portion of that budget consumed by the emitted
+sections (never greater than `content_char_limit`), and `allocation_order` is the
+fixed priority order above. Every section that is trimmed, starved, or omitted by
+the whole-pack budget adds a `whole_pack_budget` entry to `warnings.truncation`.
+
 `warnings`, `budget`, and `citations` are always-present top-level envelope
 fields, not section members. They are mirrored by
 `get_contract().agent_context_pack.envelope_fields` and cannot be toggled

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -368,3 +368,34 @@ row's `archived_at` stays NULL and the owning-namespace call succeeds
   with a paired owning-identity success proving the test is not vacuous?
 - Are all roles sharing the guarded branch parameterized, so a future
   role-specific branch cannot silently un-scope one of them?
+
+## [2026-07-22] Declared budget limits must admit their own irreducible framing
+
+**Severity:** P3 (LOW)
+**Source:** PR #349 / Issue #326 confirmed finding
+**Scope:** `src/tools/agent-context-pack.ts` whole-pack budget derivation
+**Status:** active — fixed regression in
+`src/tools/__tests__/agent-context-pack-budget.test.ts`
+
+### Pattern
+
+`agent_context_pack` reported `budget.whole_pack.content_char_limit` as the raw
+member budget (`max_tokens * 4 - 1200`, clamped to 0). But
+`JSON.stringify(payload.sections)` is irreducibly `"{}"` (2 chars) even when
+every section is omitted, so for `max_tokens <= 300` (budget clamps to 0) the
+contract "content_char_limit bounds the serialized sections object" was violated:
+`2 <= 0` is false. Two omit tests masked it with `+ 2` slack instead of asserting
+the true invariant. The declared serialized-section limit must account for the
+irreducible empty object (floor of 2) while still leaving zero characters for
+section members at those tiny budgets, and `content_chars_used` must stay
+truthful and `<= content_char_limit`.
+
+### Review Questions
+
+- Does a declared serialized-size limit account for the container's irreducible
+  framing (e.g. the `{}` an empty object always serializes to), or does a clamp
+  to zero leave the limit below what `JSON.stringify` can ever emit?
+- Do budget/limit tests assert `serialized.length <= limit` with NO additive
+  slack, so a limit that is genuinely too small cannot pass?
+- At the smallest budgets, is the member allocation still zero even though the
+  declared limit is raised to the framing floor?

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -399,3 +399,57 @@ truthful and `<= content_char_limit`.
   slack, so a limit that is genuinely too small cannot pass?
 - At the smallest budgets, is the member allocation still zero even though the
   declared limit is raised to the framing floor?
+
+## [2026-07-22] Per-member object framing must be position-aware, not uniform
+
+**Severity:** P2 (MEDIUM)
+**Source:** PR #349 / Issue #326 Terra terminal-audit finding
+**Scope:** `src/tools/agent-context-pack-budget.ts` `sectionFrameCost`,
+`src/tools/agent-context-pack.ts` whole-pack section allocation
+**Status:** active — fixed regression in
+`src/tools/__tests__/agent-context-pack-budget.test.ts`
+
+### Pattern
+
+The whole-pack allocator reserved the enclosing `{}` once (2 chars) up front,
+then charged `sectionFrameCost = key.length + 3 + 1` — a comma — for **every**
+admitted section. But JSON writes object members as `"key":<body>` joined by a
+single `,` *between* adjacent members: the FIRST member has no leading comma.
+Charging a comma for the first admitted member overcounted exactly one character,
+so content whose serialized section sat on the exact whole-pack boundary was
+falsely truncated. Reproduction: a single small working-set item whose unbounded
+serialized `sections` length equals the limit exactly (e.g. 804 chars, the budget
+for `max_tokens=501`) was dropped even though it fit.
+
+The fix makes framing position-aware:
+- the **first** admitted member charges `key.length + 3` (quoted key + colon,
+  no comma);
+- each **subsequent** admitted member charges `key.length + 3 + 1` (add one
+  comma).
+
+Crucially, "first" tracks whether any earlier candidate was *actually admitted* —
+a starved-out or omitted candidate must not consume the comma-free first-member
+slot, so the next admitted section still frames as the first. This is distinct
+from the [zero-floor entry above](#2026-07-22-declared-budget-limits-must-admit-their-own-irreducible-framing):
+that one is about the *container's* irreducible `{}` floor; this one is about
+*per-member* delimiter accounting between members inside the container.
+
+**Fixed invariant:** for any admitted set of sections, the running budget spent
+equals `2 (outer braces) + Σ member framing + Σ member bodies`, where member
+framing is `key.length + 3` for the first admitted member and `key.length + 3 + 1`
+for each subsequent one — i.e. exactly `JSON.stringify(sections).length`. Content
+that fits the limit exactly is retained; nothing is dropped by an off-by-one
+delimiter overcharge.
+
+### Review Questions
+
+- When a helper charges "framing" or "delimiter" cost per collection member, is
+  the cost position-sensitive (first member has no separator) or does it
+  uniformly charge a separator that the first element never pays?
+- Does a "first member" flag flip only on *actual admission*, so a starved,
+  omitted, or absent earlier candidate cannot steal the separator-free slot from
+  a later admitted one?
+- Is there an exact-boundary regression (serialized length == limit, no additive
+  slack) proving content on the limit is retained, not truncated?
+- Is the framing accounting validated against real `JSON.stringify` output for
+  single-member and multi-member objects, not just an asserted formula?

--- a/src/tools/__tests__/agent-context-pack-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-budget.test.ts
@@ -1,0 +1,885 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthInfo } from "../../types.ts";
+import {
+  AGENT_CONTEXT_PACK_SCOPE as SCOPE,
+  setupAgentContextPackToolClient as setupToolClient,
+} from "./agent-context-pack-test-helpers.ts";
+
+const AUTH: AuthInfo = { role: "admin", clientId: "rico" };
+
+/**
+ * Sum of retained section *content* characters — working-set item bodies plus
+ * durable lane current-context and event bodies. This is the quantity the
+ * whole-pack budget bounds; per-section serialized metadata is covered by the
+ * envelope reserve, matching the durable-lane section's own budget model.
+ */
+function contentChars(payload: any): number {
+  let total = 0;
+  const ws = payload.sections.working_set;
+  if (ws) {
+    for (const item of ws.items) total += (item.content ?? "").length;
+  }
+  const durable = payload.sections.durable_lane_context;
+  if (durable) {
+    total += (durable.lane.current_context_md ?? "").length;
+    for (const event of durable.events ?? [])
+      total += (event.content ?? "").length;
+  }
+  const recovery = payload.sections.recovery;
+  if (recovery) {
+    for (const item of recovery.items)
+      total += (item.content_preview ?? "").length;
+  }
+  return total;
+}
+
+const durableLane = {
+  id: "lane-budget-1",
+  session_key: SCOPE.session_key,
+  status: "active",
+  agent: SCOPE.agent,
+  source: SCOPE.platform,
+  channel_id: SCOPE.channel_id,
+  thread_id: null,
+  project: "open-brain",
+  topic: "whole pack budget",
+  current_context_md: "C".repeat(9000),
+  updated_at: "2026-07-17T18:00:00Z",
+};
+
+// event-0 is oldest, event-7 newest (ascending created_at).
+const durableEvents = Array.from({ length: 8 }, (_, index) => ({
+  id: `event-${index}`,
+  event_type: "fact",
+  content: `event-${index}:` + "E".repeat(900),
+  source: "shared",
+  importance: "warm",
+  artifact_path: null,
+  transcript_ref: `collab/open-brain/conversations/${index}`,
+  occurred_at: null,
+  created_at: `2026-07-17T17:00:0${index}Z`,
+}));
+
+function durablePool() {
+  return {
+    query: async (sql: string) => {
+      if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
+        return { rows: [durableLane] };
+      }
+      if (sql.includes("FROM ob_session_events")) {
+        // Real SQL selects newest-first (created_at DESC); mirror that so the
+        // loader's chronological reverse() lands the newest event at the tail,
+        // matching the production ordering the whole-pack re-fit relies on.
+        return { rows: [...durableEvents].reverse() };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+async function appendWorkingItem(
+  client: any,
+  content: string,
+  extra: Record<string, unknown> = {},
+) {
+  return client.callTool({
+    name: "working_set_append",
+    arguments: {
+      ...SCOPE,
+      kind: "task_state",
+      content,
+      ...extra,
+    },
+  });
+}
+
+async function appendRecoveryItem(
+  client: any,
+  content: string,
+  extra: Record<string, unknown> = {},
+) {
+  return client.callTool({
+    name: "recovery_wal_append",
+    arguments: {
+      ...SCOPE,
+      content,
+      ...extra,
+    },
+  });
+}
+
+describe("agent_context_pack whole-pack budget", () => {
+  it("bounds total serialized section content below the configured token budget", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      // Fill working set with several items and request a durable lane whose
+      // 9000-char context alone would blow past the budget.
+      for (let i = 0; i < 6; i += 1) {
+        await appendWorkingItem(client, `item-${i}:` + "W".repeat(300));
+      }
+
+      const maxTokens = 1000;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set", "durable_lane_context"],
+          budget: { max_tokens: maxTokens },
+        },
+      });
+
+      expect(pack.isError).toBeFalsy();
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // Content budget is max_tokens * 4 minus the envelope reserve (1200).
+      const contentBudget = maxTokens * 4 - 1200;
+      // Retained content never exceeds the whole-pack budget, even though the
+      // durable context alone (9000 chars) would.
+      expect(contentChars(payload)).toBeLessThanOrEqual(contentBudget);
+      expect(payload.budget.whole_pack).toMatchObject({
+        content_char_limit: contentBudget,
+        allocation_order: ["working_set", "recovery", "durable_lane_context"],
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves the highest-priority section and starves the lowest under pressure", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      // One modest working-set item that fits comfortably.
+      await appendWorkingItem(client, "keep-me:" + "W".repeat(400), {
+        trace_id: "trace-keep",
+      });
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          // Budget large enough for the whole working set but not the 9000-char
+          // durable context on top of it (max_tokens 700 => 1600 content chars).
+          requested_sections: ["working_set", "durable_lane_context"],
+          budget: { max_tokens: 700 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // Highest-priority working_set survives whole.
+      expect(payload.sections.working_set.item_count).toBe(1);
+      expect(payload.sections.working_set.items[0].content).toContain(
+        "keep-me",
+      );
+      // Durable lane is present but its content is bounded by the leftover
+      // budget rather than its own independent 6000-char default cap.
+      const durable = payload.sections.durable_lane_context;
+      if (durable) {
+        const contextLen = durable.lane.current_context_md?.length ?? 0;
+        expect(contextLen).toBeLessThan(6000);
+      }
+      // Total retained content within budget.
+      expect(contentChars(payload)).toBeLessThanOrEqual(700 * 4 - 1200);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("produces identical allocation and truncation for repeated identical inputs", async () => {
+    async function run() {
+      const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+      try {
+        for (let i = 0; i < 5; i += 1) {
+          await appendWorkingItem(client, `stable-${i}:` + "W".repeat(1500));
+        }
+        const pack = await client.callTool({
+          name: "agent_context_pack",
+          arguments: {
+            ...SCOPE,
+            requested_sections: ["working_set", "durable_lane_context"],
+            budget: { max_tokens: 900 },
+          },
+        });
+        return JSON.parse((pack.content as any)[0].text);
+      } finally {
+        await cleanup();
+      }
+    }
+
+    const first = await run();
+    const second = await run();
+    // Timestamps in durable events are fixed; the only volatile fields are the
+    // working-set item ids and created/expires timestamps, so compare the
+    // allocation-relevant shape.
+    expect(first.sections.working_set.item_count).toBe(
+      second.sections.working_set.item_count,
+    );
+    expect(first.sections.working_set.items.map((i: any) => i.content)).toEqual(
+      second.sections.working_set.items.map((i: any) => i.content),
+    );
+    expect(first.budget.whole_pack).toEqual(second.budget.whole_pack);
+    expect(first.warnings.truncation).toEqual(second.warnings.truncation);
+    expect(Boolean(first.sections.durable_lane_context)).toBe(
+      Boolean(second.sections.durable_lane_context),
+    );
+  });
+
+  it("records whole-pack truncation and never emits citations for dropped events", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      // Working set consumes nearly the whole budget so durable events are cut.
+      for (let i = 0; i < 4; i += 1) {
+        await appendWorkingItem(client, `big-${i}:` + "W".repeat(3500));
+      }
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set", "durable_lane_context"],
+          budget: { max_tokens: 1200 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // Every emitted event citation must correspond to an event still present
+      // in the durable section — no citation for truncated evidence.
+      const durable = payload.sections.durable_lane_context;
+      const retainedEventCitationIds = new Set(
+        (durable?.events ?? []).map((e: any) => e.citation_id),
+      );
+      const eventCitations = payload.citations.filter(
+        (c: any) => c.kind === "session_event",
+      );
+      for (const citation of eventCitations) {
+        expect(retainedEventCitationIds.has(citation.id)).toBe(true);
+      }
+      // Whole-pack truncation is declared when a section is trimmed.
+      const anyWholePack = payload.warnings.truncation.some(
+        (t: any) => t.reason === "whole_pack_budget",
+      );
+      const durableTruncated = Boolean(durable?.truncated);
+      expect(anyWholePack || durableTruncated).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("under pressure preserves the newest items and drops the oldest", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // Items append oldest-first: drop-0 is the oldest, drop-7 the newest.
+      // The store itself trims the oldest (index 0) under pressure, so the
+      // whole-pack budget must do the same: keep the newest, shed the oldest.
+      for (let i = 0; i < 8; i += 1) {
+        await appendWorkingItem(client, `drop-${i}:` + "W".repeat(400), {
+          trace_id: `trace-${i}`,
+        });
+      }
+
+      // max_tokens 900 => 2400 content chars: several ~400-char items fit, not all.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+          budget: { max_tokens: 900 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const items = payload.sections.working_set.items;
+      // item_count reflects retained content, not the full store.
+      expect(payload.sections.working_set.item_count).toBe(items.length);
+      expect(items.length).toBeGreaterThan(0);
+      expect(items.length).toBeLessThan(8);
+      // Serialized section — not merely content-body chars — stays within budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        900 * 4 - 1200,
+      );
+      expect(contentChars(payload)).toBeLessThanOrEqual(900 * 4 - 1200);
+      // The oldest item (drop-0) is shed; the newest (drop-7) is preserved.
+      const contents = items.map((i: any) => i.content);
+      expect(contents.some((c: string) => c.includes("drop-0"))).toBe(false);
+      expect(items[items.length - 1].content).toContain("drop-7");
+      // Retained items are exactly the newest contiguous suffix of the store.
+      const retainedIndices = contents.map((c: string) =>
+        Number(/drop-(\d+):/.exec(c)![1]),
+      );
+      for (let k = 1; k < retainedIndices.length; k += 1) {
+        expect(retainedIndices[k]).toBe(retainedIndices[k - 1] + 1);
+      }
+      expect(retainedIndices[retainedIndices.length - 1]).toBe(7);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("omits a fully-starved working-set section whose empty envelope exceeds the budget", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // A single item far larger than the whole-pack budget can hold.
+      await appendWorkingItem(client, "huge:" + "W".repeat(3900));
+
+      // max_tokens 100 => 400 - 1200 clamps to a 0-char whole-pack budget. Even
+      // the empty working_set envelope (label/scope/budget/counters) serializes
+      // to hundreds of chars, so it cannot be emitted without breaking the hard
+      // "sections never exceed budget" contract: the section is omitted.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+          budget: { max_tokens: 100 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // The section is omitted rather than emitted with an over-budget envelope.
+      expect(payload.sections.working_set).toBeUndefined();
+      // The whole serialized sections object stays within the whole-pack budget
+      // (0 chars here) — an empty object.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        Math.max(0, 100 * 4 - 1200) + 2,
+      );
+      // Truncation still records the fully-starved requested section so the
+      // caller knows it was dropped rather than silently absent.
+      const starved = payload.warnings.truncation.find(
+        (t: any) =>
+          t.source === "working_set" && t.reason === "whole_pack_budget",
+      );
+      expect(starved).toBeDefined();
+      expect(starved.starved).toBe(true);
+      // whole_pack accounting never claims more content used than the limit.
+      expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
+        payload.budget.whole_pack.content_char_limit,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps a fully-starved working-set envelope when it still fits the budget", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // One item whose body cannot fit, but where the empty envelope can. The
+      // envelope serializes to roughly ~450-500 chars, so a whole-pack budget
+      // comfortably above that but below the item body keeps the empty shape.
+      await appendWorkingItem(client, "huge:" + "W".repeat(3000));
+
+      // max_tokens 500 => 2000 - 1200 = 800-char whole-pack budget: too small for
+      // the ~3000-char item body, large enough for the empty envelope.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+          budget: { max_tokens: 500 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const budget = 500 * 4 - 1200;
+      // The empty envelope is preserved because it fits the surviving budget.
+      expect(payload.sections.working_set).toBeDefined();
+      expect(payload.sections.working_set.items).toEqual([]);
+      expect(payload.sections.working_set.item_count).toBe(0);
+      expect(payload.sections.working_set.label).toBe("working_context");
+      // And the serialized sections still respect the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        budget,
+      );
+      const starved = payload.warnings.truncation.find(
+        (t: any) =>
+          t.source === "working_set" && t.reason === "whole_pack_budget",
+      );
+      expect(starved).toBeDefined();
+      expect(starved.starved).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("bounds the serialized durable-lane section, not just its content body", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      // A budget that, after content trimming, still leaves durable-lane
+      // metadata + event wrappers as the dominant serialized cost.
+      const maxTokens = 800;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["durable_lane_context"],
+          budget: { max_tokens: maxTokens },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const contentBudget = maxTokens * 4 - 1200;
+      // The *serialized* durable-lane section (metadata, event wrappers, and
+      // citation ids included) fits within the whole-pack budget — it does not
+      // overshoot just because the raw content body was under the limit.
+      const durable = payload.sections.durable_lane_context;
+      if (durable) {
+        expect(JSON.stringify(durable).length).toBeLessThanOrEqual(
+          contentBudget,
+        );
+      }
+      // And the whole serialized sections object stays within budget too.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        contentBudget,
+      );
+      // Every emitted event citation still corresponds to a retained event.
+      const retained = new Set(
+        (durable?.events ?? []).map((e: any) => e.citation_id),
+      );
+      for (const citation of payload.citations.filter(
+        (c: any) => c.kind === "session_event",
+      )) {
+        expect(retained.has(citation.id)).toBe(true);
+      }
+      // Reconciled content_chars_used matches the retained content body.
+      if (durable) {
+        expect(payload.budget.durable_lane_context.content_chars_used).toBe(
+          contentChars(payload),
+        );
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("drops the oldest durable-lane events first under whole-pack pressure", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      // Consume most of the budget with working-set items so only a couple of
+      // durable events can survive. Events are chronological ascending, so
+      // event-7 is newest and event-0 oldest.
+      for (let i = 0; i < 2; i += 1) {
+        await appendWorkingItem(client, `ws-${i}:` + "W".repeat(1000));
+      }
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set", "durable_lane_context"],
+          budget: { max_tokens: 900 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const durable = payload.sections.durable_lane_context;
+      if (durable && durable.events.length > 0) {
+        const ids = durable.events.map((e: any) => e.id);
+        // Retained events are the newest suffix: the last retained id is the
+        // newest available event, and the oldest (event-0) is not retained
+        // unless all events fit.
+        expect(ids[ids.length - 1]).toBe("event-7");
+        if (ids.length < 8) {
+          expect(ids).not.toContain("event-0");
+        }
+        expect(durable.event_count).toBe(durable.events.length);
+      }
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        900 * 4 - 1200,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("omits the durable-lane section entirely when even its empty envelope exceeds the surviving budget", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      // A small working-set item is retained (highest priority), consuming enough
+      // budget that the durable-lane section — whose empty lane-metadata envelope
+      // is still ~400 chars — cannot fit the sliver that survives.
+      await appendWorkingItem(client, "a:" + "W".repeat(100));
+
+      // max_tokens 550 => 1000-char whole-pack budget: the ~900-char retained
+      // working-set section leaves under ~100 chars, too little for the durable
+      // envelope, which is dropped rather than emitted over budget.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set", "durable_lane_context"],
+          budget: { max_tokens: 550 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const budget = 550 * 4 - 1200;
+      // Highest-priority working_set is retained whole.
+      expect(payload.sections.working_set).toBeDefined();
+      expect(payload.sections.working_set.item_count).toBe(1);
+      // Durable-lane section is omitted rather than emitted over budget.
+      expect(payload.sections.durable_lane_context).toBeUndefined();
+      // The whole serialized sections object stays within the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        budget,
+      );
+      // No dangling citations reference the dropped section — neither the lane
+      // citation nor any event citation survives.
+      expect(
+        payload.citations.filter((c: any) => c.kind === "session_lane"),
+      ).toEqual([]);
+      expect(
+        payload.citations.filter((c: any) => c.kind === "session_event"),
+      ).toEqual([]);
+      // The reconciled durable budget reports zero content emitted, not the
+      // loader's pre-refit selection.
+      expect(payload.budget.durable_lane_context.content_chars_used).toBe(0);
+      // A starved truncation marker signals the requested section was dropped.
+      const starved = payload.warnings.truncation.find(
+        (t: any) =>
+          t.source === "durable_lane_context" &&
+          t.reason === "whole_pack_budget",
+      );
+      expect(starved).toBeDefined();
+      expect(starved.starved).toBe(true);
+      // The loader's own per-section truncation markers are suppressed for the
+      // dropped section (no orphan durable_lane_context.* markers).
+      const orphanLoaderMarkers = payload.warnings.truncation.filter(
+        (t: any) =>
+          typeof t.source === "string" &&
+          t.source.startsWith("durable_lane_context."),
+      );
+      expect(orphanLoaderMarkers).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("still honors max_latency_ms degradation under a whole-pack budget", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => {
+        throw new Error("budgeted reads must use a checked-out client");
+      },
+      connect: () => new Promise(() => undefined),
+    });
+    try {
+      const startedAt = performance.now();
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["durable_lane_context"],
+          budget: { max_tokens: 800, max_latency_ms: 25 },
+        },
+      });
+      const elapsedMs = performance.now() - startedAt;
+
+      expect(pack.isError).toBeFalsy();
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(payload.sections.durable_lane_context).toBeUndefined();
+      expect(payload.warnings.degraded_sources).toEqual([
+        { source: "durable_lane_context", reason: "database_unavailable" },
+      ]);
+      expect(elapsedMs).toBeLessThan(250);
+      // Envelope still advertises the whole-pack budget even when the section
+      // degraded.
+      expect(payload.budget.whole_pack.content_char_limit).toBe(800 * 4 - 1200);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("denies exact-scope durable lane under a whole-pack budget without querying events", async () => {
+    const queries: string[] = [];
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async (sql: string) => {
+        queries.push(sql);
+        return { rows: [] };
+      },
+    });
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          channel_id: "wrong-channel",
+          requested_sections: ["durable_lane_context"],
+          budget: { max_tokens: 1000 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(payload.sections.durable_lane_context).toBeUndefined();
+      expect(payload.warnings.scope_denials).toContainEqual({
+        source: "durable_lane_context",
+        reasons: ["exact_scope"],
+      });
+      expect(payload.citations).toEqual([]);
+      expect(queries).toHaveLength(1);
+      expect(queries[0]).not.toContain("ob_session_events");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves per-section behavior and omits whole-pack budget when no budget is set", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, durablePool());
+    try {
+      await appendWorkingItem(client, "compat:" + "W".repeat(3000));
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set", "durable_lane_context"],
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // No whole-pack budget entry when max_tokens is absent.
+      expect(payload.budget.whole_pack).toBeUndefined();
+      expect(payload.budget.requested).toBeNull();
+      // Working set retains its full item.
+      expect(payload.sections.working_set.item_count).toBe(1);
+      // Durable lane uses its historical per-section 12000-char default.
+      expect(payload.budget.durable_lane_context.content_char_limit).toBe(
+        12000,
+      );
+      // No whole-pack truncation markers when unbounded.
+      expect(
+        payload.warnings.truncation.every(
+          (t: any) => t.reason !== "whole_pack_budget",
+        ),
+      ).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe("agent_context_pack whole-pack budget: recovery section", () => {
+  it("trims the recovery section to the newest items and reconciles both item_count and pending_count", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // Recovery items append oldest-first: rec-0 is oldest, rec-5 newest. The
+      // WAL store itself trims the oldest (splice(0, …)) under budget pressure,
+      // so the whole-pack re-fit must match that recency ordering — drop the
+      // oldest, keep the newest suffix.
+      for (let i = 0; i < 6; i += 1) {
+        await appendRecoveryItem(client, `rec-${i}:` + "R".repeat(400), {
+          trace_id: `rw-trace-${i}`,
+        });
+      }
+
+      // max_tokens 950 => 2600-char whole-pack budget: several ~740-char
+      // serialized recovery items fit, not all six.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          include_unreviewed_recovery: true,
+          requested_sections: ["recovery"],
+          budget: { max_tokens: 950 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const recovery = payload.sections.recovery;
+      const contentBudget = 950 * 4 - 1200;
+      expect(recovery).toBeDefined();
+      // A real trim happened: some but not all items survived.
+      expect(recovery.items.length).toBeGreaterThan(0);
+      expect(recovery.items.length).toBeLessThan(6);
+      // BOTH counters are reconciled to the retained items, not left at the
+      // full store count. fitItemSection is called with both count keys, so a
+      // regression that reconciled only item_count would leave pending_count
+      // overstated here.
+      expect(recovery.item_count).toBe(recovery.items.length);
+      expect(recovery.pending_count).toBe(recovery.items.length);
+      // Serialized section — not merely content-body chars — stays within the
+      // whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        contentBudget,
+      );
+      expect(contentChars(payload)).toBeLessThanOrEqual(contentBudget);
+      // The oldest (rec-0) is shed; the newest (rec-5) is preserved at the tail.
+      const previews = recovery.items.map((i: any) => i.content_preview);
+      expect(previews.some((c: string) => c.startsWith("rec-0:"))).toBe(false);
+      expect(
+        recovery.items[recovery.items.length - 1].content_preview,
+      ).toContain("rec-5");
+      // Retained items are exactly the newest contiguous suffix of the store.
+      const retainedIndices = previews.map((c: string) =>
+        Number(/rec-(\d+):/.exec(c)![1]),
+      );
+      for (let k = 1; k < retainedIndices.length; k += 1) {
+        expect(retainedIndices[k]).toBe(retainedIndices[k - 1] + 1);
+      }
+      expect(retainedIndices[retainedIndices.length - 1]).toBe(5);
+      // A whole-pack truncation marker names the trimmed recovery section.
+      const marker = payload.warnings.truncation.find(
+        (t: any) => t.source === "recovery" && t.reason === "whole_pack_budget",
+      );
+      expect(marker).toBeDefined();
+      // whole_pack accounting never claims more content used than the limit.
+      expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
+        payload.budget.whole_pack.content_char_limit,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("keeps a fully-starved recovery envelope with both counts zeroed when the envelope still fits", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // One recovery item whose serialized body cannot fit, but where the empty
+      // recovery envelope (~706 chars for this scope) can.
+      await appendRecoveryItem(client, "solo:" + "R".repeat(400));
+
+      // max_tokens 480 => 720-char whole-pack budget: too small for the ~740-char
+      // serialized item, large enough for the empty envelope.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          include_unreviewed_recovery: true,
+          requested_sections: ["recovery"],
+          budget: { max_tokens: 480 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const contentBudget = 480 * 4 - 1200;
+      const recovery = payload.sections.recovery;
+      // The empty envelope is preserved because it fits the surviving budget.
+      expect(recovery).toBeDefined();
+      expect(recovery.items).toEqual([]);
+      // Both counters are reconciled to zero when the section is starved empty.
+      expect(recovery.item_count).toBe(0);
+      expect(recovery.pending_count).toBe(0);
+      expect(recovery.label).toBe("quarantined_recovery");
+      // The serialized sections still respect the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        contentBudget,
+      );
+      const starved = payload.warnings.truncation.find(
+        (t: any) => t.source === "recovery" && t.reason === "whole_pack_budget",
+      );
+      expect(starved).toBeDefined();
+      expect(starved.starved).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("omits a fully-starved recovery section whose empty envelope exceeds the budget, still recording the starved marker", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      await appendRecoveryItem(client, "solo:" + "R".repeat(400));
+
+      // max_tokens 450 => 600-char whole-pack budget: below even the empty
+      // recovery envelope (~693 chars), so the section is omitted rather than
+      // emitted over budget.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          include_unreviewed_recovery: true,
+          requested_sections: ["recovery"],
+          budget: { max_tokens: 450 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const budget = 450 * 4 - 1200;
+      // The section is omitted rather than emitted with an over-budget envelope.
+      expect(payload.sections.recovery).toBeUndefined();
+      // The whole serialized sections object stays within the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        budget + 2,
+      );
+      // Truncation still records the fully-starved requested section so the
+      // caller knows it was dropped rather than silently absent.
+      const starved = payload.warnings.truncation.find(
+        (t: any) => t.source === "recovery" && t.reason === "whole_pack_budget",
+      );
+      expect(starved).toBeDefined();
+      expect(starved.starved).toBe(true);
+      // whole_pack accounting never claims more content used than the limit.
+      expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
+        payload.budget.whole_pack.content_char_limit,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves higher-priority working_set whole while trimming recovery under one shared budget", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // working_set is higher priority than recovery in the allocation order, so
+      // the modest working-set item survives whole while recovery absorbs the
+      // remaining pressure.
+      await appendWorkingItem(client, "keep-ws:" + "W".repeat(400), {
+        trace_id: "ws-keep",
+      });
+      for (let i = 0; i < 4; i += 1) {
+        await appendRecoveryItem(client, `rec-${i}:` + "R".repeat(400));
+      }
+
+      // max_tokens 950 => 2600-char budget: the ~900-char working-set section
+      // survives whole, and recovery is starved to its empty envelope in the
+      // sliver that remains.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          include_unreviewed_recovery: true,
+          requested_sections: ["working_set", "recovery"],
+          budget: { max_tokens: 950 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const contentBudget = 950 * 4 - 1200;
+      // Highest-priority working_set survives whole.
+      expect(payload.sections.working_set.item_count).toBe(1);
+      expect(payload.sections.working_set.items[0].content).toContain(
+        "keep-ws",
+      );
+      // Recovery is present but starved to zero content by the leftover budget,
+      // with both counters reconciled.
+      const recovery = payload.sections.recovery;
+      if (recovery) {
+        expect(recovery.item_count).toBe(recovery.items.length);
+        expect(recovery.pending_count).toBe(recovery.items.length);
+      }
+      // The whole serialized sections object stays within the shared budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        contentBudget,
+      );
+      // Recovery is the trimmed/starved source, not working_set.
+      const recoveryMarker = payload.warnings.truncation.find(
+        (t: any) => t.source === "recovery" && t.reason === "whole_pack_budget",
+      );
+      expect(recoveryMarker).toBeDefined();
+      const workingSetMarker = payload.warnings.truncation.find(
+        (t: any) =>
+          t.source === "working_set" && t.reason === "whole_pack_budget",
+      );
+      expect(workingSetMarker).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/agent-context-pack-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-budget.test.ts
@@ -4,8 +4,60 @@ import {
   AGENT_CONTEXT_PACK_SCOPE as SCOPE,
   setupAgentContextPackToolClient as setupToolClient,
 } from "./agent-context-pack-test-helpers.ts";
+import { sectionFrameCost } from "../agent-context-pack-budget.ts";
 
 const AUTH: AuthInfo = { role: "admin", clientId: "rico" };
+
+describe("sectionFrameCost object framing", () => {
+  it("charges no delimiter for the first admitted member", () => {
+    // The first member of `{...}` is written as `"key":<body>` with no comma —
+    // the outer braces are reserved separately. Framing is exactly the quoted
+    // key plus the colon: '"' + key + '"' + ':' === key.length + 3.
+    expect(sectionFrameCost("working_set", true)).toBe(
+      "working_set".length + 3,
+    );
+    expect(sectionFrameCost("recovery", true)).toBe("recovery".length + 3);
+    expect(sectionFrameCost("durable_lane_context", true)).toBe(
+      "durable_lane_context".length + 3,
+    );
+  });
+
+  it("charges exactly one comma for each subsequent admitted member", () => {
+    // Each member after the first is written as `,"key":<body>` — one leading
+    // comma on top of the quoted key and colon.
+    expect(sectionFrameCost("working_set", false)).toBe(
+      "working_set".length + 3 + 1,
+    );
+    expect(sectionFrameCost("recovery", false)).toBe("recovery".length + 3 + 1);
+    expect(sectionFrameCost("durable_lane_context", false)).toBe(
+      "durable_lane_context".length + 3 + 1,
+    );
+  });
+
+  it("matches the literal JSON framing of a two-member sections object", () => {
+    // Ground the helper against real JSON.stringify output: the framing a member
+    // adds beyond its own serialized body equals sectionFrameCost.
+    const bodyA = { x: 1 };
+    const bodyB = { y: 2 };
+    const twoMember = JSON.stringify({ working_set: bodyA, recovery: bodyB });
+    // Outer braces (2) + first-member framing + firstBody + second-member
+    // framing + secondBody === full serialized length.
+    const firstFrame = sectionFrameCost("working_set", true);
+    const secondFrame = sectionFrameCost("recovery", false);
+    const total =
+      2 +
+      firstFrame +
+      JSON.stringify(bodyA).length +
+      secondFrame +
+      JSON.stringify(bodyB).length;
+    expect(total).toBe(twoMember.length);
+    // A single-member object frames with only the first (comma-free) cost.
+    const oneMember = JSON.stringify({ working_set: bodyA });
+    expect(2 + firstFrame + JSON.stringify(bodyA).length).toBe(
+      oneMember.length,
+    );
+  });
+});
 
 /**
  * Sum of retained section *content* characters — working-set item bodies plus
@@ -401,6 +453,72 @@ describe("agent_context_pack whole-pack budget", () => {
       expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
         payload.budget.whole_pack.content_char_limit,
       );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("retains exact-boundary working-set content when the unbounded sections length equals the limit (#326 terminal)", async () => {
+    // Terminal-audit reproduction: outer `{}` is reserved once, but the prior
+    // sectionFrameCost charged a comma for EVERY admitted member — including the
+    // first, which has no comma. That overcharged one char and falsely truncated
+    // content sitting exactly on the boundary.
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // A single small working-set item sized so the UNBOUNDED serialized
+      // sections length lands exactly on the budget boundary (804 chars).
+      await appendWorkingItem(client, "WXY");
+
+      // First measure the UNBOUNDED serialized sections length for this exact
+      // single-item working_set section.
+      const unbounded = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+        },
+      });
+      const unboundedPayload = JSON.parse((unbounded.content as any)[0].text);
+      const unboundedLen = JSON.stringify(unboundedPayload.sections).length;
+      // Terminal fixture: this exact single-item working_set section serializes
+      // to 804 chars unbounded, which is exactly the budget for max_tokens 501
+      // (501 * 4 - 1200 = 804). Anchor the fixture so the boundary is exact, not
+      // approximate — the item sits precisely on the limit with no slack.
+      expect(unboundedLen).toBe(804);
+      expect(501 * 4 - 1200).toBe(804);
+
+      // Now request exactly that budget. The item fits with NO slack: the outer
+      // braces plus first-member framing (no comma) plus the item body equal the
+      // limit precisely. The old one-comma overcharge dropped the item here.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+          budget: { max_tokens: 501 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const budget = 501 * 4 - 1200;
+      // The item survives — exact-boundary content is not falsely truncated.
+      expect(payload.sections.working_set).toBeDefined();
+      expect(payload.sections.working_set.item_count).toBe(1);
+      expect(payload.sections.working_set.items[0].content).toBe("WXY");
+      // Serialized sections is identical to the unbounded shape and exactly at
+      // the limit — no slack, no overshoot.
+      expect(JSON.stringify(payload.sections).length).toBe(budget);
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        budget,
+      );
+      // No whole-pack truncation marker: nothing was dropped.
+      expect(
+        payload.warnings.truncation.some(
+          (t: any) => t.reason === "whole_pack_budget",
+        ),
+      ).toBe(false);
     } finally {
       await cleanup();
     }
@@ -923,6 +1041,187 @@ describe("agent_context_pack whole-pack budget: recovery section", () => {
           t.source === "working_set" && t.reason === "whole_pack_budget",
       );
       expect(workingSetMarker).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+describe("agent_context_pack whole-pack budget: first-member framing (#326 terminal)", () => {
+  // Measure the unbounded serialized `sections` length, then set max_tokens so
+  // the whole-pack budget equals it exactly, and assert the content survives at
+  // the boundary. The first admitted member frames as `"key":<body>` with no
+  // comma, so a section on the exact limit must NOT be falsely truncated. This
+  // exercises the same defect for recovery-first and durable-lane-first as the
+  // working_set reproduction does, including the combination where an earlier
+  // requested section is omitted and a later one becomes the first member.
+  // Grow `content` by trailing padding until the recovery-only section's
+  // unbounded serialized length lands exactly on a reachable budget boundary
+  // (budget = max_tokens * 4 - 1200 can only hit multiples of 4). Returns the
+  // padded content, that exact length, and the integer max_tokens that makes the
+  // whole-pack budget equal it. This yields a genuine exact-boundary fixture for
+  // any section without hardcoding envelope internals.
+  async function recoveryExactBoundaryFixture(client: any) {
+    for (let pad = 0; pad < 8; pad += 1) {
+      const content = "REC" + "r".repeat(pad);
+      // Fresh client per probe so the store holds exactly one item.
+      const probe = await setupToolClient(AUTH, {
+        query: async () => ({ rows: [] }),
+      });
+      try {
+        await appendRecoveryItem(probe.client, content);
+        const unbounded = await probe.client.callTool({
+          name: "agent_context_pack",
+          arguments: {
+            ...SCOPE,
+            include_unreviewed_recovery: true,
+            requested_sections: ["recovery"],
+          },
+        });
+        const payload = JSON.parse((unbounded.content as any)[0].text);
+        const len = JSON.stringify(payload.sections).length;
+        if ((len + 1200) % 4 === 0) {
+          return { content, len, tokens: (len + 1200) / 4 };
+        }
+      } finally {
+        await probe.cleanup();
+      }
+    }
+    throw new Error("no exact-boundary recovery fixture found within padding");
+  }
+
+  it("frames recovery as the first admitted member at the exact boundary when working_set is absent", async () => {
+    // Derive an exact-boundary recovery-only fixture, then assert the item
+    // survives at that boundary. recovery is the only requested section, so it
+    // is the first (comma-free) member; the old +1 comma overcharge dropped it.
+    const fixtureClient = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    let fixture: { content: string; len: number; tokens: number };
+    try {
+      fixture = await recoveryExactBoundaryFixture(fixtureClient.client);
+    } finally {
+      await fixtureClient.cleanup();
+    }
+
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      await appendRecoveryItem(client, fixture.content);
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          include_unreviewed_recovery: true,
+          requested_sections: ["recovery"],
+          budget: { max_tokens: fixture.tokens },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // Recovery item survives at the exact boundary — no false truncation.
+      expect(payload.sections.recovery).toBeDefined();
+      expect(payload.sections.recovery.item_count).toBe(1);
+      expect(payload.sections.recovery.items[0].content_preview).toContain(
+        fixture.content,
+      );
+      // Serialized sections equals the unbounded length and exactly the budget.
+      expect(JSON.stringify(payload.sections).length).toBe(fixture.len);
+      expect(JSON.stringify(payload.sections).length).toBe(
+        fixture.tokens * 4 - 1200,
+      );
+      expect(
+        payload.warnings.truncation.some(
+          (t: any) => t.reason === "whole_pack_budget",
+        ),
+      ).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("frames a starved first member comma-free and charges the second member exactly one comma at the boundary", async () => {
+    // Combination case: working_set is requested with a body far too large to
+    // retain, so it collapses to its empty envelope and is admitted as the
+    // FIRST member (comma-free). recovery is admitted as the SECOND member and
+    // MUST be charged exactly one leading comma. Land the two-member sections
+    // object on an exact reachable budget and assert both survive with no slack:
+    // the old code overcharged the first member's comma, and any regression that
+    // dropped or mischarged the second member's comma would break the boundary.
+    async function twoMemberBoundaryFixture() {
+      for (let pad = 0; pad < 8; pad += 1) {
+        const recContent = "REC" + "r".repeat(pad);
+        const probe = await setupToolClient(AUTH, {
+          query: async () => ({ rows: [] }),
+        });
+        try {
+          await appendWorkingItem(probe.client, "hugews:" + "W".repeat(4000));
+          await appendRecoveryItem(probe.client, recContent);
+          // A budget comfortably above the two-member shape so nothing trims;
+          // we only need the untrimmed two-member serialized length.
+          const r = await probe.client.callTool({
+            name: "agent_context_pack",
+            arguments: {
+              ...SCOPE,
+              include_unreviewed_recovery: true,
+              requested_sections: ["working_set", "recovery"],
+              budget: { max_tokens: 5000 },
+            },
+          });
+          const p = JSON.parse((r.content as any)[0].text);
+          // Require the untrimmed shape: WS empty first member + recovery item.
+          if (
+            p.sections.working_set &&
+            p.sections.working_set.items.length === 0 &&
+            p.sections.recovery &&
+            p.sections.recovery.items.length === 1
+          ) {
+            const len = JSON.stringify(p.sections).length;
+            if ((len + 1200) % 4 === 0) {
+              return { recContent, len, tokens: (len + 1200) / 4 };
+            }
+          }
+        } finally {
+          await probe.cleanup();
+        }
+      }
+      throw new Error("no exact-boundary two-member fixture found");
+    }
+
+    const fixture = await twoMemberBoundaryFixture();
+
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      await appendWorkingItem(client, "hugews:" + "W".repeat(4000));
+      await appendRecoveryItem(client, fixture.recContent);
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          include_unreviewed_recovery: true,
+          requested_sections: ["working_set", "recovery"],
+          budget: { max_tokens: fixture.tokens },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // working_set is the empty first member (comma-free); recovery is the
+      // second member (one comma) and its item survives at the exact boundary.
+      expect(payload.sections.working_set).toBeDefined();
+      expect(payload.sections.working_set.items).toEqual([]);
+      expect(payload.sections.recovery).toBeDefined();
+      expect(payload.sections.recovery.item_count).toBe(1);
+      expect(payload.sections.recovery.items[0].content_preview).toContain(
+        fixture.recContent,
+      );
+      // Serialized two-member sections equals the fixture length and exactly the
+      // budget — first member comma-free, second member one comma, no slack.
+      expect(JSON.stringify(payload.sections).length).toBe(fixture.len);
+      expect(JSON.stringify(payload.sections).length).toBe(
+        fixture.tokens * 4 - 1200,
+      );
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/agent-context-pack-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-budget.test.ts
@@ -339,10 +339,10 @@ describe("agent_context_pack whole-pack budget", () => {
       const payload = JSON.parse((pack.content as any)[0].text);
       // The section is omitted rather than emitted with an over-budget envelope.
       expect(payload.sections.working_set).toBeUndefined();
-      // The whole serialized sections object stays within the whole-pack budget
-      // (0 chars here) — an empty object.
+      // The serialized sections object is exactly the irreducible empty object
+      // "{}" (2 chars), and the declared limit accounts for it with no slack.
       expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
-        Math.max(0, 100 * 4 - 1200) + 2,
+        payload.budget.whole_pack.content_char_limit,
       );
       // Truncation still records the fully-starved requested section so the
       // caller knows it was dropped rather than silently absent.
@@ -353,6 +353,51 @@ describe("agent_context_pack whole-pack budget", () => {
       expect(starved).toBeDefined();
       expect(starved.starved).toBe(true);
       // whole_pack accounting never claims more content used than the limit.
+      expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
+        payload.budget.whole_pack.content_char_limit,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("declares a content_char_limit that admits the irreducible empty '{}' at a zero-member budget (#326)", async () => {
+    const { client, cleanup } = await setupToolClient(AUTH, {
+      query: async () => ({ rows: [] }),
+    });
+    try {
+      // A single item that cannot fit, forcing the section to be omitted so the
+      // serialized sections collapse to the irreducible empty object "{}".
+      await appendWorkingItem(client, "huge:" + "W".repeat(3900));
+
+      // max_tokens 100 => 400 - 1200 clamps the member budget to 0. The serialized
+      // sections object is still "{}" (2 chars), so the declared limit must admit
+      // those two irreducible chars while leaving zero for section members.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["working_set"],
+          budget: { max_tokens: 100 },
+        },
+      });
+
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(payload.sections.working_set).toBeUndefined();
+      // The serialized sections is exactly "{}".
+      const serialized = JSON.stringify(payload.sections);
+      expect(serialized).toBe("{}");
+      // The declared whole-pack limit bounds the serialized sections object with
+      // NO slack: this fails on the old head where content_char_limit was 0 while
+      // JSON.stringify(payload.sections) is 2.
+      expect(serialized.length).toBeLessThanOrEqual(
+        payload.budget.whole_pack.content_char_limit,
+      );
+      // The limit accounts for the irreducible two-char empty object.
+      expect(payload.budget.whole_pack.content_char_limit).toBe(2);
+      // Zero characters were available for section members at this tiny budget.
+      expect(payload.budget.whole_pack.content_chars_used).toBe(0);
+      // content_chars_used stays truthful and within the declared limit.
       expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
         payload.budget.whole_pack.content_char_limit,
       );
@@ -799,12 +844,12 @@ describe("agent_context_pack whole-pack budget: recovery section", () => {
       });
 
       const payload = JSON.parse((pack.content as any)[0].text);
-      const budget = 450 * 4 - 1200;
       // The section is omitted rather than emitted with an over-budget envelope.
       expect(payload.sections.recovery).toBeUndefined();
-      // The whole serialized sections object stays within the whole-pack budget.
+      // The serialized sections object is exactly the irreducible empty object
+      // "{}" (2 chars), and the declared limit accounts for it with no slack.
       expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
-        budget + 2,
+        payload.budget.whole_pack.content_char_limit,
       );
       // Truncation still records the fully-starved requested section so the
       // caller knows it was dropped rather than silently absent.

--- a/src/tools/__tests__/agent-context-pack-durable-lane.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-lane.test.ts
@@ -72,7 +72,9 @@ describe("agent_context_pack durable lane context", () => {
           return { rows: [lane] };
         }
         if (sql.includes("FROM ob_session_events")) {
-          return { rows: events.slice(0, 8) };
+          // Real SQL selects newest-first (created_at DESC); mirror it so the
+          // loader's chronological reverse() lands the newest event at the tail.
+          return { rows: [...events].reverse().slice(0, 8) };
         }
         return { rows: [] };
       },
@@ -91,25 +93,41 @@ describe("agent_context_pack durable lane context", () => {
       expect(pack.isError).toBeFalsy();
       const payload = JSON.parse((pack.content as any)[0].text);
       const durable = payload.sections.durable_lane_context;
+      // The whole-pack budget bounds the *serialized* section, so under a 10800
+      // whole-pack budget the loader's 5-event content selection is re-fit down
+      // to the newest events whose serialized wrappers also fit. Newest events
+      // are preserved; the oldest are dropped.
       expect(durable).toMatchObject({
         label: "durable_lane_context",
         exact_scope_required: true,
-        event_count: 5,
+        event_count: 3,
         truncated: true,
       });
+      expect(durable.events.map((e: any) => e.id)).toEqual([
+        "event-7",
+        "event-8",
+        "event-9",
+      ]);
       expect(durable.lane.current_context_md).toHaveLength(6000);
-      expect(durable.events).toHaveLength(5);
-      expect(durable.events.every((event: any) => event.content.length <= 1000)).toBe(true);
+      expect(
+        durable.events.every((event: any) => event.content.length <= 1000),
+      ).toBe(true);
+      // The whole serialized section stays within the whole-pack budget.
+      expect(JSON.stringify(durable).length).toBeLessThanOrEqual(
+        3000 * 4 - 1200,
+      );
       expect(JSON.stringify(durable)).not.toContain("RAW TRANSCRIPT");
       expect(JSON.stringify(durable)).not.toContain("RAW TOOL OUTPUT");
       expect(JSON.stringify(durable)).not.toContain("must not escape");
       expect(payload.warnings.truncation).not.toEqual([]);
+      // content_chars_used is reconciled to the retained content body (checkpoint
+      // 6000 + 3 events x 1000), not the loader's pre-refit selection.
       expect(payload.budget.durable_lane_context).toMatchObject({
-        content_char_limit: 10800,
-        content_chars_used: 10800,
+        content_chars_used: 9000,
         max_events: 8,
       });
-      expect(payload.citations).toHaveLength(6);
+      // One lane citation plus one per retained event, none for dropped events.
+      expect(payload.citations).toHaveLength(4);
 
       expect(queries[0]!.sql).toContain("WHERE namespace = $1");
       expect(queries[0]!.sql).toContain("AND session_key = $2");
@@ -117,7 +135,9 @@ describe("agent_context_pack durable lane context", () => {
       expect(queries[0]!.sql).toContain("AND source = $4");
       expect(queries[0]!.sql).toContain("metadata->>'server_id' = $5");
       expect(queries[0]!.sql).toContain("AND channel_id = $6");
-      expect(queries[0]!.sql).toContain("thread_id IS NOT DISTINCT FROM $7::text");
+      expect(queries[0]!.sql).toContain(
+        "thread_id IS NOT DISTINCT FROM $7::text",
+      );
       expect(queries[0]!.params).toEqual([
         "rico",
         SCOPE.session_key,
@@ -475,7 +495,9 @@ describe("agent_context_pack durable lane context", () => {
             setTimeout(resolve, statementTimeoutMs + 2),
           );
           activeQueries -= 1;
-          throw new Error("canceling statement due to statement timeout secret-detail");
+          throw new Error(
+            "canceling statement due to statement timeout secret-detail",
+          );
         }
         return { rows: [] };
       },
@@ -523,7 +545,6 @@ describe("agent_context_pack durable lane context", () => {
       await cleanup();
     }
   });
-
 });
 
 const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
@@ -626,8 +647,10 @@ dbDescribe("agent_context_pack durable lane reads (live Postgres)", () => {
           (event: Record<string, unknown>) => event.id,
         ),
       ).toEqual(
-        Array.from({ length: 8 }, (_, index) =>
-          `00000000-0000-0000-0000-${String(index + 2).padStart(12, "0")}`,
+        Array.from(
+          { length: 8 },
+          (_, index) =>
+            `00000000-0000-0000-0000-${String(index + 2).padStart(12, "0")}`,
         ),
       );
       expect(payload.sections.durable_lane_context).toMatchObject({
@@ -645,7 +668,9 @@ dbDescribe("agent_context_pack durable lane reads (live Postgres)", () => {
     try {
       await insertLane();
       await blocker.query("BEGIN");
-      await blocker.query("LOCK TABLE ob_session_events IN ACCESS EXCLUSIVE MODE");
+      await blocker.query(
+        "LOCK TABLE ob_session_events IN ACCESS EXCLUSIVE MODE",
+      );
 
       const startedAt = performance.now();
       const pack = await callLivePack(50);

--- a/src/tools/agent-context-pack-budget.ts
+++ b/src/tools/agent-context-pack-budget.ts
@@ -35,16 +35,28 @@ export function serializedLength(value: unknown): number {
 
 /**
  * Serialized framing a section adds to the enclosing `sections` object beyond
- * its own body: the quoted key, the `:` separator, and one `,`/`}` delimiter
- * (`{"key":<body>}` / `,"key":<body>`). Counting this against the whole-pack
- * budget keeps `JSON.stringify(payload.sections)` — not merely the summed
- * per-section bodies — within the declared budget. The outer `{}` (2 chars for
- * an empty object, otherwise the leading `{` and trailing `}` replace two of
- * the per-section delimiters) is reserved once up front.
+ * its own body. The outer `{}` is reserved once up front (2 chars). Within
+ * those braces JSON writes members as `"key":<body>` joined by a single `,`
+ * between adjacent members — so in `{"a":1,"b":2}` member `a` is framed by just
+ * `"a":` (the `"`, key, `"`, `:` = keyLen + 3) and member `b` by a leading comma
+ * plus `"b":` (keyLen + 3 + 1).
+ *
+ * The framing therefore depends on member position, not just the key:
+ * - the FIRST admitted member charges `keyLen + 3` (quoted key + colon only);
+ * - each SUBSEQUENT admitted member charges `keyLen + 3 + 1` (add one comma).
+ *
+ * Charging a comma for the first member (the prior behavior) overcounted one
+ * character and could falsely truncate content that fit at the exact boundary.
+ * `isFirstAdmitted` MUST reflect whether any earlier candidate was actually
+ * admitted — a starved or omitted candidate does not consume the first-member
+ * slot, so the next admitted section still frames as the first.
  */
-export function sectionFrameCost(key: string): number {
-  // "key": plus one delimiter character.
-  return key.length + 3 + 1;
+export function sectionFrameCost(
+  key: string,
+  isFirstAdmitted: boolean,
+): number {
+  // '"' + key + '"' + ':' = key.length + 3, plus one ',' for non-first members.
+  return key.length + 3 + (isFirstAdmitted ? 0 : 1);
 }
 
 export type DurableLaneEvent = { content?: unknown; citation_id?: unknown };

--- a/src/tools/agent-context-pack-budget.ts
+++ b/src/tools/agent-context-pack-budget.ts
@@ -1,0 +1,237 @@
+/**
+ * Whole-pack budget allocation and section-fitting helpers for
+ * `agent_context_pack`. These are pure, store-agnostic functions that fit each
+ * assembled section inside a shared serialized-character budget in a fixed
+ * priority order, plus the narrow shared types/constants they operate on.
+ * Registration and tool behavior live in `agent-context-pack.ts`.
+ */
+
+/**
+ * Approximate serialized characters per token. Kept in sync with the
+ * durable-lane accounting so the whole-pack char budget derived here matches
+ * the per-section content accounting the durable-lane loader reuses.
+ */
+export const CHARS_PER_TOKEN = 4;
+
+/**
+ * Deterministic whole-pack allocation order, highest value first. working_set
+ * is the exact-scope hot active state, recovery is the explicit opt-in
+ * interrupted-session trace, and durable_lane_context is the broader recallable
+ * lane context. A lower-priority section is only assembled against whatever
+ * pack budget the higher-priority sections leave behind, so one large section
+ * cannot starve a higher-value one. This order is stable for identical inputs.
+ */
+export const CONTEXT_PACK_SECTION_PRIORITY = [
+  "working_set",
+  "recovery",
+  "durable_lane_context",
+] as const;
+
+/** Serialized size, in characters, of a section's content payload. */
+export function serializedLength(value: unknown): number {
+  if (value === undefined) return 0;
+  return JSON.stringify(value).length;
+}
+
+/**
+ * Serialized framing a section adds to the enclosing `sections` object beyond
+ * its own body: the quoted key, the `:` separator, and one `,`/`}` delimiter
+ * (`{"key":<body>}` / `,"key":<body>`). Counting this against the whole-pack
+ * budget keeps `JSON.stringify(payload.sections)` — not merely the summed
+ * per-section bodies — within the declared budget. The outer `{}` (2 chars for
+ * an empty object, otherwise the leading `{` and trailing `}` replace two of
+ * the per-section delimiters) is reserved once up front.
+ */
+export function sectionFrameCost(key: string): number {
+  // "key": plus one delimiter character.
+  return key.length + 3 + 1;
+}
+
+export type DurableLaneEvent = { content?: unknown; citation_id?: unknown };
+export type DurableLaneSection = {
+  lane?: { current_context_md?: unknown };
+  events?: DurableLaneEvent[];
+  event_count?: number;
+  truncated?: boolean;
+};
+
+/**
+ * Sum of durable-lane content-body characters (checkpoint + retained event
+ * bodies) for reconciling `budget.durable_lane_context.content_chars_used` to
+ * whatever survives the whole-pack re-fit.
+ */
+export function durableLaneContentChars(section: DurableLaneSection): number {
+  const context =
+    typeof section.lane?.current_context_md === "string"
+      ? section.lane.current_context_md.length
+      : 0;
+  let events = 0;
+  for (const event of section.events ?? []) {
+    if (typeof event.content === "string") events += event.content.length;
+  }
+  return context + events;
+}
+
+/**
+ * Fit a loaded durable-lane section inside the remaining whole-pack budget by
+ * its *serialized* size, not its content-body total. The loader already bounds
+ * raw content chars, but the serialized section additionally carries lane
+ * metadata, per-event wrappers, and citation ids that must be counted against
+ * the surviving whole-pack budget. Events are chronological oldest-first (the
+ * loader fetches newest-first then reverses), so trailing entries are the
+ * newest highest-value ones; drop the oldest (front) first, then trim the
+ * checkpoint, so the freshest lane evidence is preserved under pressure.
+ *
+ * Citations for dropped events are removed so no citation references evidence
+ * that is no longer present, and `event_count`/`truncated` are reconciled to
+ * the retained events.
+ */
+export function fitDurableLaneSection(
+  section: Record<string, unknown>,
+  citations: Array<Record<string, unknown>>,
+  remainingChars: number,
+): {
+  section: Record<string, unknown>;
+  citations: Array<Record<string, unknown>>;
+  truncated: boolean;
+} {
+  if (serializedLength(section) <= remainingChars) {
+    return { section, citations, truncated: false };
+  }
+
+  const events = Array.isArray(section.events)
+    ? [...(section.events as DurableLaneEvent[])]
+    : [];
+  const lane =
+    section.lane && typeof section.lane === "object"
+      ? { ...(section.lane as Record<string, unknown>) }
+      : undefined;
+
+  const rebuild = (
+    keptEvents: DurableLaneEvent[],
+    contextMd: unknown,
+  ): Record<string, unknown> => {
+    const next: Record<string, unknown> = {
+      ...section,
+      events: keptEvents,
+      event_count: keptEvents.length,
+    };
+    if (lane) next.lane = { ...lane, current_context_md: contextMd };
+    next.truncated = true;
+    return next;
+  };
+
+  let contextMd = lane?.current_context_md ?? null;
+
+  // Drop the oldest event (index 0) until the serialized section fits.
+  const kept = [...events];
+  while (kept.length > 0) {
+    kept.shift();
+    if (serializedLength(rebuild(kept, contextMd)) <= remainingChars) {
+      return {
+        section: rebuild(kept, contextMd),
+        citations: reconcileDurableCitations(citations, kept),
+        truncated: true,
+      };
+    }
+  }
+
+  // No events left: shrink the checkpoint text until the section fits, or empty
+  // it entirely.
+  if (typeof contextMd === "string" && contextMd.length > 0) {
+    let low = 0;
+    let high = contextMd.length;
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      const candidate = rebuild([], contextMd.slice(0, mid));
+      if (serializedLength(candidate) <= remainingChars) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+    contextMd = low > 0 ? (contextMd as string).slice(0, low) : null;
+  }
+
+  return {
+    section: rebuild([], contextMd),
+    citations: reconcileDurableCitations(citations, []),
+    truncated: true,
+  };
+}
+
+/**
+ * Keep the lane citation and only the event citations whose events survived the
+ * whole-pack re-fit, so citations never reference dropped evidence.
+ */
+export function reconcileDurableCitations(
+  citations: Array<Record<string, unknown>>,
+  keptEvents: DurableLaneEvent[],
+): Array<Record<string, unknown>> {
+  const keptEventCitationIds = new Set(
+    keptEvents
+      .map((event) => event.citation_id)
+      .filter((id): id is string => typeof id === "string"),
+  );
+  return citations.filter((citation) => {
+    if (citation.kind === "session_event") {
+      return (
+        typeof citation.id === "string" && keptEventCitationIds.has(citation.id)
+      );
+    }
+    return true;
+  });
+}
+
+/**
+ * Deterministically fit an item-bearing section (working_set/recovery) inside a
+ * remaining whole-pack char budget by dropping the oldest items until the
+ * serialized section fits. Both stores order items oldest-first: `append`
+ * pushes the newest item to the end, and store trimming removes index 0
+ * (`splice(0, …)` / `shift()`), so the newest highest-value items live at the
+ * tail. Whole-pack pressure must match that recency ordering — drop from the
+ * front (oldest) and preserve the newest — so the enforced budget never
+ * sacrifices the freshest working state to keep stale entries.
+ *
+ * The section is measured by its serialized length (`JSON.stringify`), not by
+ * summed content-body characters, so metadata, ids, and per-item wrappers are
+ * counted against the whole-pack section budget rather than allowed to
+ * overshoot it. Counts are reconciled to the retained items so citations and
+ * counters stay consistent with the emitted content.
+ */
+export function fitItemSection<T extends { items: Array<{ id: string }> }>(
+  section: T,
+  countKeys: Array<keyof T>,
+  remainingChars: number,
+): { section: T; truncated: boolean; starved: boolean } {
+  if (serializedLength(section) <= remainingChars) {
+    return { section, truncated: false, starved: false };
+  }
+
+  // Drop the oldest item (index 0) one at a time until the section fits or is
+  // emptied, preserving the newest tail items. A section is "starved" whenever
+  // no item body survives (items: []), whether it fit only once empty or was
+  // exhausted — the empty envelope may still exceed remainingChars, so the
+  // caller decides whether to emit it or omit the section to hold the budget.
+  const kept = [...section.items];
+  while (kept.length > 0) {
+    kept.shift();
+    const candidate = { ...section, items: kept } as T;
+    for (const countKey of countKeys) {
+      (candidate as Record<keyof T, unknown>)[countKey] = kept.length;
+    }
+    if (serializedLength(candidate) <= remainingChars) {
+      return {
+        section: candidate,
+        truncated: true,
+        starved: kept.length === 0,
+      };
+    }
+  }
+
+  const emptied = { ...section, items: [] as T["items"] } as T;
+  for (const countKey of countKeys) {
+    (emptied as Record<keyof T, unknown>)[countKey] = 0;
+  }
+  return { section: emptied, truncated: true, starved: true };
+}

--- a/src/tools/agent-context-pack-durable-lane.ts
+++ b/src/tools/agent-context-pack-durable-lane.ts
@@ -6,7 +6,36 @@ const DURABLE_LANE_MAX_CONTENT_CHARS = 12_000;
 const DURABLE_LANE_MAX_CONTEXT_CHARS = 6_000;
 const DURABLE_LANE_MAX_EVENTS = 8;
 const DURABLE_LANE_MAX_EVENT_CHARS = 1_000;
-const CONTEXT_PACK_ENVELOPE_CHAR_RESERVE = 1_200;
+export const CONTEXT_PACK_ENVELOPE_CHAR_RESERVE = 1_200;
+
+/**
+ * Resolve the durable-lane content char budget.
+ *
+ * When the whole-pack allocator supplies an explicit `contentCharLimit`, the
+ * lane content is bounded by the pack-level allocation it was granted (still
+ * clamped by the durable-lane hard cap). Otherwise the historical per-section
+ * derivation from `budget.max_tokens` applies, preserving compatibility when no
+ * whole-pack allocation is in effect.
+ */
+function resolveDurableLaneContentChars(
+  args: AgentContextPackArgs,
+  contentCharLimit: number | undefined,
+): number {
+  if (contentCharLimit !== undefined) {
+    return Math.max(
+      0,
+      Math.min(DURABLE_LANE_MAX_CONTENT_CHARS, contentCharLimit),
+    );
+  }
+  return Math.max(
+    0,
+    Math.min(
+      DURABLE_LANE_MAX_CONTENT_CHARS,
+      (args.budget?.max_tokens ?? 4000) * 4 -
+        CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+    ),
+  );
+}
 
 type DurableLaneContextFragment = {
   section?: Record<string, unknown>;
@@ -118,9 +147,10 @@ async function openDurableLaneReader(
   let released = false;
   let unsafeError: Error | undefined;
   const markUnsafe = (error: unknown) => {
-    unsafeError = error instanceof Error
-      ? error
-      : new Error("durable lane context client is unsafe");
+    unsafeError =
+      error instanceof Error
+        ? error
+        : new Error("durable lane context client is unsafe");
   };
   const release = () => {
     if (released) return;
@@ -144,10 +174,9 @@ async function openDurableLaneReader(
   try {
     await query("BEGIN READ ONLY");
     transactionOpen = true;
-    await query(
-      "SELECT set_config('statement_timeout', $1, true)",
-      [`${remainingLatencyMs(startedAt, maxLatencyMs)}ms`],
-    );
+    await query("SELECT set_config('statement_timeout', $1, true)", [
+      `${remainingLatencyMs(startedAt, maxLatencyMs)}ms`,
+    ]);
   } catch (error) {
     markUnsafe(error);
     release();
@@ -171,12 +200,18 @@ async function openDurableLaneReader(
   };
 }
 
-function boundedText(value: unknown, maxChars: number): {
+function boundedText(
+  value: unknown,
+  maxChars: number,
+): {
   text: string | null;
   truncated: boolean;
 } {
   if (typeof value !== "string" || value.length === 0 || maxChars <= 0) {
-    return { text: null, truncated: typeof value === "string" && value.length > 0 };
+    return {
+      text: null,
+      truncated: typeof value === "string" && value.length > 0,
+    };
   }
   if (value.length <= maxChars) return { text: value, truncated: false };
   return { text: value.slice(0, maxChars), truncated: true };
@@ -186,14 +221,11 @@ export async function loadDurableLaneContext(
   args: AgentContextPackArgs,
   namespace: string,
   deps: ToolDeps,
+  contentCharLimit?: number,
 ): Promise<DurableLaneContextFragment> {
-  const maxContentChars = Math.max(
-    0,
-    Math.min(
-      DURABLE_LANE_MAX_CONTENT_CHARS,
-      (args.budget?.max_tokens ?? 4000) * 4 -
-        CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
-    ),
+  const maxContentChars = resolveDurableLaneContentChars(
+    args,
+    contentCharLimit,
   );
   const scopeParams = [
     namespace,

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -16,7 +16,20 @@ import {
   RecoveryWalStore,
 } from "../realtime/recovery-wal.ts";
 import type { ToolDeps } from "./index.ts";
-import { loadDurableLaneContext } from "./agent-context-pack-durable-lane.ts";
+import {
+  CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+  loadDurableLaneContext,
+} from "./agent-context-pack-durable-lane.ts";
+import {
+  CHARS_PER_TOKEN,
+  CONTEXT_PACK_SECTION_PRIORITY,
+  durableLaneContentChars,
+  fitDurableLaneSection,
+  fitItemSection,
+  sectionFrameCost,
+  serializedLength,
+  type DurableLaneSection,
+} from "./agent-context-pack-budget.ts";
 
 export const SECTION_NAMES = [
   "working_set",
@@ -49,11 +62,7 @@ export const scopeInputSchema = {
     .max(500)
     .optional()
     .describe("Optional thread id; missing means unthreaded only"),
-  session_key: z
-    .string()
-    .min(1)
-    .max(500)
-    .describe("Stable active-session key"),
+  session_key: z.string().min(1).max(500).describe("Stable active-session key"),
 };
 
 export const agentContextPackInputSchema = {
@@ -90,6 +99,18 @@ export function parseAgentContextPackArgs(args: unknown): AgentContextPackArgs {
   return agentContextPackArgsSchema.parse(args);
 }
 
+// Whole-pack budget allocation/fitting helpers and their shared
+// types/constants (CHARS_PER_TOKEN, CONTEXT_PACK_SECTION_PRIORITY,
+// serializedLength, sectionFrameCost, fitItemSection, fitDurableLaneSection,
+// durableLaneContentChars, DurableLaneSection) live in
+// ./agent-context-pack-budget.ts and are imported above.
+
+/**
+ * Re-exported for backward compatibility with callers that imported the
+ * whole-pack allocation order from this module.
+ */
+export { CONTEXT_PACK_SECTION_PRIORITY };
+
 export async function buildAgentContextPackPayload(
   args: AgentContextPackArgs,
   auth: AuthInfo | undefined,
@@ -121,21 +142,209 @@ export async function buildAgentContextPackPayload(
   };
   const normalizedScope = normalizeWorkingSetScope(scope);
   const includeWorkingSet =
-    !args.requested_sections ||
-    args.requested_sections.includes("working_set");
+    !args.requested_sections || args.requested_sections.includes("working_set");
   const includeRecovery =
     args.include_unreviewed_recovery === true &&
-    (!args.requested_sections ||
-      args.requested_sections.includes("recovery"));
+    (!args.requested_sections || args.requested_sections.includes("recovery"));
   const includeDurableLaneContext =
     args.requested_sections?.includes("durable_lane_context") === true;
-  const workingSet = storeFor(deps).buildContextPackFragment(scope);
+
+  // Total whole-pack char budget. Absent max_tokens => no whole-pack bound, and
+  // every section keeps its historical independent per-section behavior.
+  const wholePackBudget =
+    args.budget?.max_tokens !== undefined
+      ? Math.max(
+          0,
+          args.budget.max_tokens * CHARS_PER_TOKEN -
+            CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+        )
+      : null;
+  // Reserve the enclosing `{}` of the serialized `sections` object once, so the
+  // running budget bounds JSON.stringify(payload.sections), not just the summed
+  // section bodies. Each retained section additionally charges its own framing
+  // (quoted key + delimiter) via sectionFrameCost.
+  let remainingChars =
+    wholePackBudget !== null
+      ? Math.max(0, wholePackBudget - 2)
+      : Number.POSITIVE_INFINITY;
+  const wholePackTruncation: Array<Record<string, unknown>> = [];
+
+  const workingSet = includeWorkingSet
+    ? storeFor(deps).buildContextPackFragment(scope)
+    : null;
   const recovery = includeRecovery
     ? recoveryStoreFor(deps).buildContextPackFragment(scope)
     : null;
+
+  // Allocate in fixed priority order. Each section only sees the serialized
+  // budget that higher-priority sections leave behind, so a large low-priority
+  // section can never starve a higher-value one.
+  //
+  // A requested item-bearing section that is fully starved keeps its defined
+  // empty envelope (items: [], count 0) *only when that envelope fits the
+  // surviving budget*, so the caller still gets its scope/budget/counter shape.
+  // If even the empty envelope would overflow the whole-pack budget, the section
+  // is omitted entirely — the hard "sections never exceed the budget" contract
+  // wins over envelope-shape preservation — and a `starved` truncation marker is
+  // still recorded so the caller knows the requested section was fully dropped.
+  let workingSetSection = workingSet?.working_set ?? null;
+  if (workingSetSection) {
+    const frame = sectionFrameCost("working_set");
+    const serving = Math.max(0, remainingChars - frame);
+    const fitted = fitItemSection(workingSetSection, ["item_count"], serving);
+    if (fitted.starved && serializedLength(fitted.section) > serving) {
+      // Empty envelope does not fit: omit the section to hold the budget.
+      workingSetSection = null;
+    } else {
+      workingSetSection = fitted.section;
+      remainingChars = Math.max(
+        0,
+        remainingChars - serializedLength(fitted.section) - frame,
+      );
+    }
+    if (fitted.truncated) {
+      wholePackTruncation.push({
+        source: "working_set",
+        reason: "whole_pack_budget",
+        max_chars: wholePackBudget,
+        ...(fitted.starved ? { starved: true } : {}),
+      });
+    }
+  }
+
+  let recoverySection = recovery?.recovery ?? null;
+  if (recoverySection) {
+    const frame = sectionFrameCost("recovery");
+    const serving = Math.max(0, remainingChars - frame);
+    const fitted = fitItemSection(
+      recoverySection,
+      ["item_count", "pending_count"],
+      serving,
+    );
+    if (fitted.starved && serializedLength(fitted.section) > serving) {
+      recoverySection = null;
+    } else {
+      recoverySection = fitted.section;
+      remainingChars = Math.max(
+        0,
+        remainingChars - serializedLength(fitted.section) - frame,
+      );
+    }
+    if (fitted.truncated) {
+      wholePackTruncation.push({
+        source: "recovery",
+        reason: "whole_pack_budget",
+        max_chars: wholePackBudget,
+        ...(fitted.starved ? { starved: true } : {}),
+      });
+    }
+  }
+
+  // durable_lane_context content is bounded by the pack budget that survives the
+  // higher-priority sections. The loader trims raw content chars, but its
+  // serialized section also carries lane metadata, per-event wrappers, and
+  // citation ids. To keep the *serialized* section — not merely its content
+  // body — within the surviving whole-pack budget, seed the loader with a
+  // content limit and then re-fit the returned section against remainingChars,
+  // dropping the oldest events and finally trimming the checkpoint until the
+  // serialized section fits. Counts, citations, and truncation are reconciled
+  // to whatever survives. When there is no whole-pack budget the loader keeps
+  // its historical per-section derivation and no re-fit runs.
+  const durableLaneFrame = sectionFrameCost("durable_lane_context");
+  const durableLaneServingChars =
+    wholePackBudget === null
+      ? Number.POSITIVE_INFINITY
+      : Math.max(0, remainingChars - durableLaneFrame);
+  const durableLaneContentLimit =
+    wholePackBudget === null
+      ? undefined
+      : Number.isFinite(durableLaneServingChars)
+        ? Math.floor(durableLaneServingChars)
+        : undefined;
   const durableLaneContext = includeDurableLaneContext
-    ? await loadDurableLaneContext(args, ns, deps)
+    ? await loadDurableLaneContext(args, ns, deps, durableLaneContentLimit)
     : null;
+  let durableLaneSection = durableLaneContext?.section ?? null;
+  let durableCitations = durableLaneSection
+    ? (durableLaneContext?.citations ?? [])
+    : [];
+  // True only when a loaded durable-lane section is dropped by the whole-pack
+  // re-fit (its trimmed envelope still overflowed the surviving budget), so the
+  // reconciled budget can report zero content emitted rather than the loader's
+  // pre-refit selection.
+  let durableLaneStarvedOut = false;
+  if (durableLaneSection && wholePackBudget !== null) {
+    const fitted = fitDurableLaneSection(
+      durableLaneSection,
+      durableCitations,
+      durableLaneServingChars,
+    );
+    if (
+      fitted.truncated &&
+      serializedLength(fitted.section) > durableLaneServingChars
+    ) {
+      // Even the trimmed (possibly empty) durable-lane section overflows the
+      // surviving budget: omit it and drop its citations so the whole pack stays
+      // within budget and no citation references an unemitted section. The
+      // starved truncation marker still signals that the requested section was
+      // dropped.
+      durableLaneSection = null;
+      durableCitations = [];
+      durableLaneStarvedOut = true;
+      wholePackTruncation.push({
+        source: "durable_lane_context",
+        reason: "whole_pack_budget",
+        max_chars: wholePackBudget,
+        starved: true,
+      });
+    } else {
+      durableLaneSection = fitted.section;
+      durableCitations = fitted.citations;
+      remainingChars = Math.max(
+        0,
+        remainingChars -
+          serializedLength(durableLaneSection) -
+          durableLaneFrame,
+      );
+      if (fitted.truncated) {
+        wholePackTruncation.push({
+          source: "durable_lane_context",
+          reason: "whole_pack_budget",
+          max_chars: wholePackBudget,
+        });
+      }
+    }
+  } else if (durableLaneSection) {
+    remainingChars = Math.max(
+      0,
+      remainingChars - serializedLength(durableLaneSection) - durableLaneFrame,
+    );
+  }
+
+  // Reconcile the durable-lane budget's content_chars_used to the content that
+  // actually survived the whole-pack re-fit. When the section survives, count its
+  // retained content body. When it was starved out entirely, report zero content
+  // emitted so the budget never claims usage for an unemitted section. Without a
+  // whole-pack budget the loader's own accounting is authoritative and passes
+  // through unchanged.
+  const durableLaneBudget =
+    wholePackBudget !== null && durableLaneContext?.budget
+      ? durableLaneSection
+        ? {
+            ...durableLaneContext.budget,
+            content_chars_used: durableLaneContentChars(
+              durableLaneSection as DurableLaneSection,
+            ),
+          }
+        : durableLaneStarvedOut
+          ? { ...durableLaneContext.budget, content_chars_used: 0 }
+          : durableLaneContext.budget
+      : durableLaneContext?.budget;
+
+  const sections: Record<string, unknown> = {};
+  if (workingSetSection) sections.working_set = workingSetSection;
+  if (recoverySection) sections.recovery = recoverySection;
+  if (durableLaneSection) sections.durable_lane_context = durableLaneSection;
 
   return {
     payload: {
@@ -145,35 +354,38 @@ export async function buildAgentContextPackPayload(
         namespace_source: "authorization",
         ...normalizedScope,
       },
-      sections: {
-        ...(includeWorkingSet
-          ? { working_set: workingSet.working_set }
-          : {}),
-        ...(recovery ? { recovery: recovery.recovery } : {}),
-        ...(durableLaneContext?.section
-          ? { durable_lane_context: durableLaneContext.section }
-          : {}),
-      },
+      sections,
       warnings: {
         scope_denials: [
-          ...(includeWorkingSet
-            ? workingSet.warnings.scope_denials
-            : []),
+          ...(workingSet ? workingSet.warnings.scope_denials : []),
           ...(recovery ? recovery.warnings.scope_denials : []),
           ...(durableLaneContext?.scopeDenials ?? []),
         ],
         degraded_sources: durableLaneContext?.degradedSources ?? [],
-        truncation: durableLaneContext?.truncation ?? [],
+        truncation: [
+          ...(durableLaneSection ? (durableLaneContext?.truncation ?? []) : []),
+          ...wholePackTruncation,
+        ],
       },
       budget: {
         requested: args.budget ?? null,
-        ...(includeWorkingSet ? workingSet.budget : {}),
+        ...(wholePackBudget !== null
+          ? {
+              whole_pack: {
+                content_char_limit: wholePackBudget,
+                content_chars_used:
+                  wholePackBudget - Math.max(0, remainingChars),
+                allocation_order: [...CONTEXT_PACK_SECTION_PRIORITY],
+              },
+            }
+          : {}),
+        ...(workingSet ? workingSet.budget : {}),
         ...(recovery ? recovery.budget : {}),
-        ...(durableLaneContext
-          ? { durable_lane_context: durableLaneContext.budget }
+        ...(durableLaneSection || durableLaneContext
+          ? { durable_lane_context: durableLaneBudget }
           : {}),
       },
-      citations: durableLaneContext?.citations ?? [],
+      citations: durableCitations,
       query: args.query ?? null,
     },
     isError: false,
@@ -227,27 +439,32 @@ export function registerWorkingSetAppend(
       const ns = args.namespace ?? auth.clientId;
       const nsCheck = canWriteNamespace(auth, ns);
       if (!nsCheck.allowed) {
-        return textError(nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`);
+        return textError(
+          nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`,
+        );
       }
 
-      const result = storeFor(deps).append({
-        namespace: ns,
-        agent: args.agent,
-        platform: args.platform,
-        server_id: args.server_id,
-        channel_id: args.channel_id,
-        thread_id: args.thread_id ?? null,
-        session_key: args.session_key,
-      }, {
-        kind: args.kind,
-        content: args.content,
-        confidence: args.confidence,
-        stale_at: args.stale_at ?? null,
-        trace_id: args.trace_id ?? null,
-        source_ref: args.source_ref ?? null,
-        durable_ref: args.durable_ref ?? null,
-        metadata: args.metadata,
-      });
+      const result = storeFor(deps).append(
+        {
+          namespace: ns,
+          agent: args.agent,
+          platform: args.platform,
+          server_id: args.server_id,
+          channel_id: args.channel_id,
+          thread_id: args.thread_id ?? null,
+          session_key: args.session_key,
+        },
+        {
+          kind: args.kind,
+          content: args.content,
+          confidence: args.confidence,
+          stale_at: args.stale_at ?? null,
+          trace_id: args.trace_id ?? null,
+          source_ref: args.source_ref ?? null,
+          durable_ref: args.durable_ref ?? null,
+          metadata: args.metadata,
+        },
+      );
 
       return {
         content: [
@@ -307,24 +524,29 @@ export function registerRecoveryWalAppend(
       const ns = args.namespace ?? auth.clientId;
       const nsCheck = canWriteNamespace(auth, ns);
       if (!nsCheck.allowed) {
-        return textError(nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`);
+        return textError(
+          nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`,
+        );
       }
 
-      const result = recoveryStoreFor(deps).append({
-        namespace: ns,
-        agent: args.agent,
-        platform: args.platform,
-        server_id: args.server_id,
-        channel_id: args.channel_id,
-        thread_id: args.thread_id ?? null,
-        session_key: args.session_key,
-      }, {
-        content: args.content,
-        status: args.status,
-        trace_id: args.trace_id ?? null,
-        source_ref: args.source_ref ?? null,
-        metadata: args.metadata,
-      });
+      const result = recoveryStoreFor(deps).append(
+        {
+          namespace: ns,
+          agent: args.agent,
+          platform: args.platform,
+          server_id: args.server_id,
+          channel_id: args.channel_id,
+          thread_id: args.thread_id ?? null,
+          session_key: args.session_key,
+        },
+        {
+          content: args.content,
+          status: args.status,
+          trace_id: args.trace_id ?? null,
+          source_ref: args.source_ref ?? null,
+          metadata: args.metadata,
+        },
+      );
 
       return {
         content: [
@@ -383,7 +605,9 @@ export function registerRecoveryWalMark(
       const ns = args.namespace ?? auth.clientId;
       const nsCheck = canWriteNamespace(auth, ns);
       if (!nsCheck.allowed) {
-        return textError(nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`);
+        return textError(
+          nsCheck.reason ?? `Permission denied: cannot write namespace '${ns}'`,
+        );
       }
 
       const result = recoveryStoreFor(deps).mark(

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -159,6 +159,14 @@ export async function buildAgentContextPackPayload(
             CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
         )
       : null;
+  // The declared serialized-section limit must always admit the irreducible
+  // two-character empty object `{}`, which JSON.stringify(payload.sections)
+  // emits even when every section is omitted. At tiny budgets wholePackBudget
+  // clamps to 0, but "{}" is 2 chars, so the reported limit is raised to that
+  // floor; section *members* still get zero of it (remainingChars below), so no
+  // section body is ever admitted at those budgets.
+  const wholePackSerializedLimit =
+    wholePackBudget !== null ? Math.max(2, wholePackBudget) : null;
   // Reserve the enclosing `{}` of the serialized `sections` object once, so the
   // running budget bounds JSON.stringify(payload.sections), not just the summed
   // section bodies. Each retained section additionally charges its own framing
@@ -372,7 +380,7 @@ export async function buildAgentContextPackPayload(
         ...(wholePackBudget !== null
           ? {
               whole_pack: {
-                content_char_limit: wholePackBudget,
+                content_char_limit: wholePackSerializedLimit,
                 content_chars_used:
                   wholePackBudget - Math.max(0, remainingChars),
                 allocation_order: [...CONTEXT_PACK_SECTION_PRIORITY],

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -175,6 +175,11 @@ export async function buildAgentContextPackPayload(
     wholePackBudget !== null
       ? Math.max(0, wholePackBudget - 2)
       : Number.POSITIVE_INFINITY;
+  // Object framing is position-sensitive: the first admitted member costs only
+  // `"key":<body>`, each subsequent member adds one leading `,`. This flips to
+  // false the moment a section is actually admitted, so a starved/omitted
+  // candidate never consumes the first-member (comma-free) slot.
+  let firstSectionAdmitted = true;
   const wholePackTruncation: Array<Record<string, unknown>> = [];
 
   const workingSet = includeWorkingSet
@@ -197,11 +202,12 @@ export async function buildAgentContextPackPayload(
   // still recorded so the caller knows the requested section was fully dropped.
   let workingSetSection = workingSet?.working_set ?? null;
   if (workingSetSection) {
-    const frame = sectionFrameCost("working_set");
+    const frame = sectionFrameCost("working_set", firstSectionAdmitted);
     const serving = Math.max(0, remainingChars - frame);
     const fitted = fitItemSection(workingSetSection, ["item_count"], serving);
     if (fitted.starved && serializedLength(fitted.section) > serving) {
-      // Empty envelope does not fit: omit the section to hold the budget.
+      // Empty envelope does not fit: omit the section to hold the budget. It is
+      // not admitted, so the first-member slot stays available for a later one.
       workingSetSection = null;
     } else {
       workingSetSection = fitted.section;
@@ -209,6 +215,7 @@ export async function buildAgentContextPackPayload(
         0,
         remainingChars - serializedLength(fitted.section) - frame,
       );
+      firstSectionAdmitted = false;
     }
     if (fitted.truncated) {
       wholePackTruncation.push({
@@ -222,7 +229,7 @@ export async function buildAgentContextPackPayload(
 
   let recoverySection = recovery?.recovery ?? null;
   if (recoverySection) {
-    const frame = sectionFrameCost("recovery");
+    const frame = sectionFrameCost("recovery", firstSectionAdmitted);
     const serving = Math.max(0, remainingChars - frame);
     const fitted = fitItemSection(
       recoverySection,
@@ -237,6 +244,7 @@ export async function buildAgentContextPackPayload(
         0,
         remainingChars - serializedLength(fitted.section) - frame,
       );
+      firstSectionAdmitted = false;
     }
     if (fitted.truncated) {
       wholePackTruncation.push({
@@ -258,7 +266,10 @@ export async function buildAgentContextPackPayload(
   // serialized section fits. Counts, citations, and truncation are reconciled
   // to whatever survives. When there is no whole-pack budget the loader keeps
   // its historical per-section derivation and no re-fit runs.
-  const durableLaneFrame = sectionFrameCost("durable_lane_context");
+  const durableLaneFrame = sectionFrameCost(
+    "durable_lane_context",
+    firstSectionAdmitted,
+  );
   const durableLaneServingChars =
     wholePackBudget === null
       ? Number.POSITIVE_INFINITY
@@ -314,6 +325,9 @@ export async function buildAgentContextPackPayload(
           serializedLength(durableLaneSection) -
           durableLaneFrame,
       );
+      // durable_lane_context is last in priority, so this only keeps the
+      // first-member invariant honest; no later section frames after it.
+      firstSectionAdmitted = false;
       if (fitted.truncated) {
         wholePackTruncation.push({
           source: "durable_lane_context",
@@ -327,6 +341,7 @@ export async function buildAgentContextPackPayload(
       0,
       remainingChars - serializedLength(durableLaneSection) - durableLaneFrame,
     );
+    firstSectionAdmitted = false;
   }
 
   // Reconcile the durable-lane budget's content_chars_used to the content that


### PR DESCRIPTION
## Summary

Adds a shared whole-pack serialized-character budget to `agent_context_pack` when callers set `budget.max_tokens`.

- allocates in fixed priority order: `working_set` → `recovery` → `durable_lane_context`
- measures serialized section cost rather than only body text
- trims oldest items/events first so the newest working context survives
- reconciles item, pending, event, and citation counts after trimming
- keeps a starved empty envelope only when it fits; otherwise omits the section and emits content-free starvation metadata
- preserves historical behavior when `max_tokens` is absent
- extracts pure fitting logic into `agent-context-pack-budget.ts`
- documents `budget.whole_pack`, `allocation_order`, serialized accounting, and starvation semantics

Refs #326

## Validation

- focused budget/durable/recovery tests — 25 pass, 3 env-gated skip, 0 fail
- full `src/tools/` suite — 645 pass, 29 skip, 0 fail
- `bunx tsc --noEmit` — passed
- `git diff --check` — passed
- working tree clean at `50771e5164367d43a39d8c3b48e45195ad329512`

## Review Gate

Full tier: this changes public `agent_context_pack` output and budget behavior. Review covers serialized accounting, priority/starvation, recency, count/citation reconciliation, exact-scope preservation, documentation truth, and downstream compatibility.

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the PR is a local contract candidate; hosted and downstream verification remain pending before closure.

## Downstream rollout

Applicable and pending. This adds `budget.whole_pack`, `allocation_order`, and `whole_pack_budget` truncation markers to the public `agent_context_pack` output when `max_tokens` is set. Before issue closure, complete or explicitly disposition the applicable rtech-mcps, mcp2cli/generated-skill, rtech-hermes, hosted Open Brain, and live Hermes canary steps from `docs/downstream-rollout.md`.

## Critical Self-Review

- Highest-risk behavior: serialized fitting could exceed the declared boundary or discard newest/high-value state. Tests assert serialized section bounds, fixed priority, oldest-first trim, starvation behavior, and survivor citation/count reconciliation.
- Assumptions that could be wrong: `CHARS_PER_TOKEN=4` is approximate; store ordering must place newest items at the tail before oldest-first trim; the fixed 1200-character envelope reserve must remain conservative as the envelope evolves.
- Missing/weak tests: three-section simultaneous pressure is covered through focused pairwise and starvation cases rather than every section trimming in one scenario; true tokenizer variance is not modeled.
- Security/permission risk: no auth or namespace predicate changes. Exact-scope denial remains server-side and is regression-tested under budget pressure; helpers are pure and store-agnostic.
- Migration/deploy risk: no migration or service startup change. Hosted activation is still required because the public MCP output behavior changes.
- Downstream client/runtime risk: real and pending. Consumers that snapshot exact section presence, citations, counts, or budget fields may observe additive fields and deterministic trimming when `max_tokens` is used.
- Rollback/cleanup concern: single-commit revert; no persisted state. Callers without `max_tokens` remain on the previous behavior.
- Fixes made before PR: corrected recency behavior, serialized rather than body-only accounting, empty-envelope starvation, durable citation reconciliation, file-size split, recovery count reconciliation tests, and contract documentation.
- Known residual risk: token approximation and envelope-growth reserve; downstream rollout has not yet been completed.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review finding has surfaced yet; MEDIUM+ patterns will be captured after the review cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

