### PR TITLE
feat(343): add durable maintenance queue substrate

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -646,3 +646,40 @@ restorable one.
 - Would the post-upgrade validation catch an out-of-order application, or do
   both paths converge to identical final sets (making the ordering bug
   invisible after the fact)?
+
+## [2026-07-22] A retry bound must terminate the expiry-reclaim path, not just the fail() path
+
+**Severity:** P2
+**Source:** PR #350 / issue #343 review swarm, 2026-07-22
+**Scope:** `src/maintenance-queue.ts` `claimDueJobs` expired-lease reclaim
+**Status:** fixed
+
+### Pattern
+
+`claimDueJobs` reclaimed *every* expired `running` row and incremented
+`attempts` unconditionally, while only the explicit `fail()` path honored
+`max_attempts`. A handler that keeps blowing its lease (hang/crash, never
+calling complete/fail) was therefore reclaimed and re-executed forever, past
+its bound — the retry cap was enforced on one exit but not the other. The fix
+terminates in the same claim statement: an expired running row whose
+already-consumed execution attempts (`attempts`, which counts leases) have
+reached `max_attempts` is dead-lettered instead of reclaimed — lease cleared,
+`terminal_at`/`dead_lettered_at` stamped, a content-free `lease_expired`
+category stored — and is excluded from `RETURNING` so the runner never treats
+it as claimed. `attempts` is left at the number of leases actually consumed,
+never inflated past `max_attempts` by the sweep. Rows with budget remaining
+still reclaim normally.
+
+### Review Questions
+
+- Does every path that consumes an attempt (explicit failure AND lease-expiry
+  reclaim) enforce the same `max_attempts` bound, or can one path retry past
+  it?
+- When a bounded row terminates, is it moved to a real terminal state that
+  satisfies every migration CHECK (lease cleared, terminal/dead-letter
+  timestamps set, valid category) — or merely left un-selected and stuck
+  `running`?
+- Does the counter that gates the bound keep a stable meaning (executions
+  consumed) across both paths, or does the reclaim path inflate it?
+- Is there a real-database regression that fails on the pre-fix code by proving
+  the exhausted row cannot be reclaimed again?

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -683,3 +683,60 @@ still reclaim normally.
   consumed) across both paths, or does the reclaim path inflate it?
 - Is there a real-database regression that fails on the pre-fix code by proving
   the exhausted row cannot be reclaimed again?
+
+## [2026-07-22] The state-machine transition must derive from the durable row, not the caller's job object
+
+**Severity:** P2
+**Source:** PR #350 / issue #343 Terra terminal audit, 2026-07-22
+**Scope:** `src/maintenance-queue.ts` `MaintenanceQueue.fail`, `MaintenanceQueueRunner.execute/fail`
+**Status:** fixed
+
+### Pattern
+
+`fail()` decided the terminal state (`attempts >= $3`) and the retry schedule
+(`nextRunAfter = now + maintenanceBackoffMs(input.job)`) from the caller-supplied
+`input.job` retry fields — `maxAttempts`, `attempts`, `backoffBaseMs`,
+`backoffMaxMs`. The runner hands the **same** `MaintenanceJob` object to the
+registered handler (`handler(job)`), so a handler could mutate those fields
+before throwing and thereby override the persisted policy: inflate
+`maxAttempts` to dodge the terminal bound (dead-letter → indefinite requeue),
+or shrink `backoffBaseMs`/`backoffMaxMs` to collapse the schedule. The durable
+row's policy was authoritative on disk but ignored by the transition.
+
+The fix moves the whole decision to the persisted columns inside the
+lease-token-guarded UPDATE: terminal state is `attempts >= max_attempts`, and
+`run_after` is computed in SQL from the row's own `attempts`, `backoff_base_ms`,
+`backoff_max_ms` — `now + LEAST(backoff_base_ms * 2 ^ LEAST(GREATEST(attempts-1,
+0), 30), backoff_max_ms)` — mirroring `maintenanceBackoffMs()` exactly (first
+retry uses base, exponent bounded, cap preserved). No caller-supplied
+retry-policy value reaches the transition; `input.job` is used only for the
+id + lease-token guard, which `claimDueJobs` minted. The runner additionally
+captures immutable claim identity (`id`, `kind`, `leaseToken`) before invoking
+the handler and binds `complete`/`fail` to it, so handler mutation of
+`job.id`/`job.leaseToken` cannot redirect the guard to another row or make the
+regression vacuous. Content-free category and stale-lease no-op semantics are
+unchanged. See also [2026-07-22] retry-bound-must-terminate-the-expiry-reclaim
+above — both paths now honor `max_attempts` from the row, not from any object.
+
+### Rule
+
+A durable state-machine transition (terminal decision, next-run time, any
+policy gate) must be derived from persisted row columns inside the guarded
+UPDATE — never from a mutable in-memory object that untrusted or handler code
+holds a reference to. The passed object may supply only opaque identity used in
+the WHERE guard (here id + lease token), and even that identity should be
+snapshotted before handler code runs.
+
+### Review Questions
+
+- Does a state transition read retry/policy values from a caller-passed object,
+  or from the row's own columns? If the same object is handed to a handler that
+  runs before the transition, mutation of those fields silently rewrites policy.
+- Is the terminal bound and the schedule computed in SQL over persisted columns,
+  or in JS over the input job? A JS computation over the input is caller-owned.
+- Is the claim identity used in the lease-token guard snapshotted before handler
+  code runs, so mutation of `id`/`leaseToken` cannot redirect or void the guard?
+- Does a real-database regression enqueue a known policy, mutate the retry
+  fields via the handler (or the returned job) before failing, and prove the
+  persisted row still dead-letters/schedules per the durable policy — failing on
+  the pre-fix code?

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -438,3 +438,36 @@ Do not round-trip PostgreSQL timestamps through millisecond JS dates for tuple b
 **Status:** fixed in PR #294
 
 A bounded context query must fetch one extra row before truncating so omission flags are truthful, use a total order such as `(created_at, id)` in both selection and returned chronology, and keep timestamp comparison database-owned. PostgreSQL ordering boundaries must not round-trip through millisecond-precision `Date` values, which can collapse distinct timestamps and skip or duplicate rows. The request budget must cover pool acquisition as well as query execution: race `pool.connect()` against the remaining deadline, and if acquisition resolves after timeout, release that late client immediately so the pool does not leak capacity. Every acquired-client query, including `BEGIN`, transaction-local timeout setup, reads, commit, and rollback, must carry pg's per-query `query_timeout`; never bootstrap it with an unbounded session `SET`. Keep PostgreSQL `statement_timeout` transaction-local for server-side read cancellation, and discard a client after a timed-out or protocol-uncertain query rather than queueing cleanup behind it. Tests must cover sub-millisecond timestamps, timestamp ties, exactly-at-limit versus over-limit results, a saturated pool with late acquisition, a concretely wedged transaction start, per-query timeout configuration, and no session `SET`/`RESET`.
+
+## [2026-07-22] Shutdown must not abandon rows a claim leased while stop() ran
+
+**Severity:** P2
+**Source:** PR #350 / issue #343 review swarm, 2026-07-22
+**Scope:** `src/maintenance-queue.ts` `MaintenanceQueueRunner` tick/stop lifecycle
+**Status:** fixed
+
+### Pattern
+
+`stop()` could flip `stopping` while a `claimDueJobs` call was in flight. The
+claim then committed — leasing rows to this runner in the database — but the
+dispatch loop's mid-iteration `if (this.stopping) return` abandoned them: no
+handler ran, `complete()`/`fail()` was never called, and the rows sat
+`running` with a live lease, outside `active`, so `stop()` (which only waits on
+`active`) resolved without draining them. They stayed stuck until lease expiry.
+The lease-boundary rule for a claim-then-dispatch runner: refuse to *begin* a
+new claim once stopping is observed (a claim mutates durable state), but treat
+every row returned by a claim already in flight as owned work — dispatch and
+track each in `active`, and have `stop()` await the in-flight tick before
+draining `active`, so no leased row is ever dropped on the floor.
+
+### Review Questions
+
+- Can a shutdown flag be observed *between* a claim committing its leases and
+  those jobs being tracked, leaving leased rows dispatched by neither path?
+- Is the stop guard placed before the state-mutating claim (correct) or in the
+  post-claim dispatch loop (drops already-leased work)?
+- Does `stop()` await the in-flight tick so its claim's jobs land in the
+  tracked set before the drain wait begins?
+- Is there a deterministic test with a claim that resolves *after* stop begins,
+  asserting the handler runs, complete/fail is invoked, and stop does not
+  resolve until that work drains?

--- a/src/db/migrations/026_maintenance_queue.sql
+++ b/src/db/migrations/026_maintenance_queue.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS maintenance_jobs (
   backoff_max_ms      INTEGER NOT NULL DEFAULT 300000 CHECK (backoff_max_ms >= backoff_base_ms),
   last_error_category TEXT CHECK (last_error_category IN (
     'syntax_error', 'type_error', 'range_error', 'error', 'non_error',
-    'unsupported_job_kind'
+    'unsupported_job_kind', 'lease_expired'
   )),
   terminal_at         TIMESTAMPTZ,
   dead_lettered_at    TIMESTAMPTZ,

--- a/src/db/migrations/026_maintenance_queue.sql
+++ b/src/db/migrations/026_maintenance_queue.sql
@@ -1,0 +1,65 @@
+-- Durable, server-owned maintenance queue. Jobs are intentionally not exposed
+-- through MCP: each future handler owns its own authorization and scope rules.
+CREATE TABLE IF NOT EXISTS maintenance_jobs (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_kind            TEXT NOT NULL CHECK (job_kind ~ '^[a-z][a-z0-9_.-]{0,127}$'),
+  job_version         INTEGER NOT NULL CHECK (job_version > 0),
+  payload             JSONB NOT NULL DEFAULT '{}'::jsonb
+                        CHECK (jsonb_typeof(payload) = 'object'),
+  idempotency_key     TEXT NOT NULL CHECK (length(idempotency_key) BETWEEN 1 AND 256),
+  state               TEXT NOT NULL DEFAULT 'queued'
+                        CHECK (state IN ('queued', 'running', 'succeeded', 'dead_letter')),
+  run_after           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  lease_token         UUID,
+  lease_until         TIMESTAMPTZ,
+  attempts            INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  max_attempts        INTEGER NOT NULL DEFAULT 3 CHECK (max_attempts BETWEEN 1 AND 25),
+  backoff_base_ms     INTEGER NOT NULL DEFAULT 1000 CHECK (backoff_base_ms > 0),
+  backoff_max_ms      INTEGER NOT NULL DEFAULT 300000 CHECK (backoff_max_ms >= backoff_base_ms),
+  last_error_category TEXT CHECK (last_error_category IN (
+    'syntax_error', 'type_error', 'range_error', 'error', 'non_error',
+    'unsupported_job_kind'
+  )),
+  terminal_at         TIMESTAMPTZ,
+  dead_lettered_at    TIMESTAMPTZ,
+  namespace           TEXT,
+  provenance          JSONB CHECK (provenance IS NULL OR jsonb_typeof(provenance) = 'object'),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT maintenance_jobs_unique_kind_idempotency UNIQUE (job_kind, idempotency_key),
+  CONSTRAINT maintenance_jobs_lease_shape CHECK (
+    (state = 'running' AND lease_token IS NOT NULL AND lease_until IS NOT NULL)
+    OR (state <> 'running' AND lease_token IS NULL AND lease_until IS NULL)
+  ),
+  CONSTRAINT maintenance_jobs_terminal_shape CHECK (
+    (state IN ('succeeded', 'dead_letter') AND terminal_at IS NOT NULL)
+    OR (state IN ('queued', 'running') AND terminal_at IS NULL)
+  ),
+  CONSTRAINT maintenance_jobs_dead_letter_shape CHECK (
+    (state = 'dead_letter' AND dead_lettered_at IS NOT NULL)
+    OR (state <> 'dead_letter' AND dead_lettered_at IS NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_due
+  ON maintenance_jobs (run_after, created_at, id)
+  WHERE state = 'queued';
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_expired_lease
+  ON maintenance_jobs (lease_until, id)
+  WHERE state = 'running';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_trigger
+     WHERE tgname = 'trg_maintenance_jobs_updated_at'
+       AND tgrelid = 'maintenance_jobs'::regclass
+  ) THEN
+    CREATE TRIGGER trg_maintenance_jobs_updated_at
+      BEFORE UPDATE ON maintenance_jobs
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  END IF;
+END;
+$$;

--- a/src/db/migrations/026_maintenance_queue.test.ts
+++ b/src/db/migrations/026_maintenance_queue.test.ts
@@ -1,0 +1,245 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import type { Pool } from "pg";
+import { MaintenanceQueue } from "../../maintenance-queue.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const migrationUrl = new URL("026_maintenance_queue.sql", import.meta.url);
+const namespace = "test-maintenance-queue-026";
+
+dbDescribe("026 maintenance queue (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const { Pool } = await import("pg");
+    pool = new Pool({ connectionString: DB_URL });
+  });
+
+  async function migrate(): Promise<void> {
+    await pool.query(await Bun.file(migrationUrl).text());
+  }
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+      namespace,
+    ]);
+  }
+
+  function queue(): MaintenanceQueue {
+    return new MaintenanceQueue(pool);
+  }
+
+  async function enqueue(
+    input: Partial<Parameters<MaintenanceQueue["enqueue"]>[0]> = {},
+  ) {
+    return queue().enqueue({
+      kind: "maintenance.test",
+      version: 1,
+      payload: {},
+      idempotencyKey: crypto.randomUUID(),
+      scope: { namespace },
+      // Default to a far-past run_after so tests that claim with a fixed
+      // deterministic `now` see the job as due, instead of racing the DB's NOW().
+      runAfter: new Date("2000-01-01T00:00:00.000Z"),
+      ...input,
+    });
+  }
+
+  beforeEach(async () => {
+    await migrate();
+    await cleanup();
+  });
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("enforces live migration constraints and idempotent enqueue", async () => {
+    const first = await enqueue({
+      idempotencyKey: "same-key",
+      payload: { a: 1 },
+    });
+    // Identical semantics (key order aside) is a safe idempotent replay.
+    const second = await enqueue({
+      idempotencyKey: "same-key",
+      payload: { a: 1 },
+    });
+    expect(second.id).toBe(first.id);
+
+    // Reusing the key with a divergent payload must be rejected content-free,
+    // not silently return the stale job under the old contract.
+    await expect(
+      enqueue({ idempotencyKey: "same-key", payload: { a: 2 } }),
+    ).rejects.toThrow("divergent job semantics");
+    // Divergent retry semantics under the same key must also be rejected.
+    await expect(
+      enqueue({
+        idempotencyKey: "same-key",
+        payload: { a: 1 },
+        retry: { maxAttempts: 5 },
+      }),
+    ).rejects.toThrow("divergent job semantics");
+
+    const { rows } = await pool.query<{ conname: string }>(
+      `SELECT conname
+         FROM pg_constraint
+        WHERE conrelid = 'maintenance_jobs'::regclass`,
+    );
+    expect(rows.map((row) => row.conname)).toContain(
+      "maintenance_jobs_unique_kind_idempotency",
+    );
+    expect(rows.map((row) => row.conname)).toContain(
+      "maintenance_jobs_lease_shape",
+    );
+    expect(rows.map((row) => row.conname)).toContain(
+      "maintenance_jobs_terminal_shape",
+    );
+  });
+
+  it("persists the caller-forced terminal category (unsupported kind is not non_error)", async () => {
+    await enqueue({ idempotencyKey: "unsupported", retry: { maxAttempts: 1 } });
+    const [claimed] = await queue().claimDueJobs({
+      limit: 1,
+      now: new Date(),
+      leaseMs: 60_000,
+    });
+    const dead = await queue().fail({
+      job: claimed!,
+      error: "unsupported_job_kind",
+      category: "unsupported_job_kind",
+    });
+    expect(dead?.state).toBe("dead_letter");
+    // Old behavior stored non_error because the sentinel is a plain string.
+    expect(dead?.lastErrorCategory).toBe("unsupported_job_kind");
+    const { rows } = await pool.query<{ last_error_category: string }>(
+      "SELECT last_error_category FROM maintenance_jobs WHERE id = $1",
+      [claimed!.id],
+    );
+    expect(rows[0]?.last_error_category).toBe("unsupported_job_kind");
+  });
+
+  it("rejects an out-of-bounds direct claim limit before touching the table", async () => {
+    await expect(
+      queue().claimDueJobs({ limit: 1_000, now: new Date(), leaseMs: 60_000 }),
+    ).rejects.toThrow("claim limit exceeds the bound");
+  });
+
+  it("rejects an invalid namespace token content-free", async () => {
+    await expect(
+      enqueue({
+        idempotencyKey: "bad-ns",
+        scope: { namespace: "not a valid namespace!" },
+      }),
+    ).rejects.toThrow("namespace is invalid");
+  });
+
+  it("allows only one concurrent runner to claim a due job", async () => {
+    await enqueue({ idempotencyKey: "single-claim" });
+    const now = new Date();
+    const [first, second] = await Promise.all([
+      queue().claimDueJobs({ limit: 1, now, leaseMs: 60_000 }),
+      queue().claimDueJobs({ limit: 1, now, leaseMs: 60_000 }),
+    ]);
+    expect(first.length + second.length).toBe(1);
+  });
+
+  it("does not steal an unexpired lease, reclaims an expired one, and rejects stale completion", async () => {
+    await enqueue({ idempotencyKey: "leases" });
+    const now = new Date("2026-07-22T12:00:00.000Z");
+    const [first] = await queue().claimDueJobs({
+      limit: 1,
+      now,
+      leaseMs: 1_000,
+    });
+    expect(first).toBeDefined();
+    expect(
+      await queue().claimDueJobs({
+        limit: 1,
+        now: new Date(now.getTime() + 999),
+        leaseMs: 1_000,
+      }),
+    ).toHaveLength(0);
+
+    const [reclaimed] = await queue().claimDueJobs({
+      limit: 1,
+      now: new Date(now.getTime() + 1_000),
+      leaseMs: 1_000,
+    });
+    expect(reclaimed?.id).toBe(first?.id);
+    expect(reclaimed?.attempts).toBe(2);
+    expect(
+      await queue().complete(
+        first!.id,
+        first!.leaseToken!,
+        new Date(now.getTime() + 1_001),
+      ),
+    ).toBe(false);
+    expect(
+      await queue().complete(
+        reclaimed!.id,
+        reclaimed!.leaseToken!,
+        new Date(now.getTime() + 1_001),
+      ),
+    ).toBe(true);
+  });
+
+  it("retries at a deterministic time, dead-letters terminal attempts, and recovers after a restart", async () => {
+    const now = new Date("2026-07-22T13:00:00.000Z");
+    await enqueue({
+      idempotencyKey: "retry",
+      retry: { maxAttempts: 2, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+    });
+    const [first] = await queue().claimDueJobs({
+      limit: 1,
+      now,
+      leaseMs: 1_000,
+    });
+    const retry = await queue().fail({
+      job: first!,
+      error: new TypeError("content must not persist"),
+      now,
+    });
+    expect(retry).toMatchObject({
+      state: "queued",
+      lastErrorCategory: "type_error",
+    });
+    expect(retry?.runAfter.toISOString()).toBe("2026-07-22T13:00:01.000Z");
+
+    const [second] = await queue().claimDueJobs({
+      limit: 1,
+      now: retry!.runAfter,
+      leaseMs: 1_000,
+    });
+    const deadLetter = await queue().fail({
+      job: second!,
+      error: new Error("still private"),
+      now: retry!.runAfter,
+    });
+    expect(deadLetter?.state).toBe("dead_letter");
+    expect(deadLetter?.terminalAt).toBeInstanceOf(Date);
+    expect(deadLetter?.deadLetteredAt).toBeInstanceOf(Date);
+
+    const recovered = await enqueue({ idempotencyKey: "restart" });
+    const [beforeRestart] = await queue().claimDueJobs({
+      limit: 1,
+      now,
+      leaseMs: 1_000,
+    });
+    expect(beforeRestart?.id).toBe(recovered.id);
+    const restartedQueue = new MaintenanceQueue(pool);
+    const [afterRestart] = await restartedQueue.claimDueJobs({
+      limit: 1,
+      now: new Date(now.getTime() + 1_000),
+      leaseMs: 1_000,
+    });
+    expect(afterRestart?.id).toBe(recovered.id);
+    expect(afterRestart?.attempts).toBe(2);
+  });
+});

--- a/src/db/migrations/026_maintenance_queue.test.ts
+++ b/src/db/migrations/026_maintenance_queue.test.ts
@@ -190,6 +190,93 @@ dbDescribe("026 maintenance queue (live Postgres)", () => {
     ).toBe(true);
   });
 
+  it("dead-letters an expired lease once its execution attempts are exhausted, not reclaims it forever", async () => {
+    // maxAttempts=1: exactly one handler execution is allowed. The claim below
+    // consumes it (attempts 0 -> 1). The lease then expires without a
+    // complete()/fail(), simulating a handler that hung or crashed.
+    await enqueue({
+      idempotencyKey: "expired-bound",
+      retry: { maxAttempts: 1 },
+    });
+    const now = new Date("2026-07-22T14:00:00.000Z");
+    const [first] = await queue().claimDueJobs({
+      limit: 1,
+      now,
+      leaseMs: 1_000,
+    });
+    expect(first).toBeDefined();
+    expect(first?.attempts).toBe(1);
+
+    // Old behavior: the expired running row is reclaimed unconditionally,
+    // attempts -> 2, state stays running, and it is returned as a fresh claim —
+    // a second handler execution past the maxAttempts=1 bound. The bounded
+    // behavior returns nothing and terminates the row instead.
+    const afterExpiry = new Date(now.getTime() + 1_000);
+    const reclaimed = await queue().claimDueJobs({
+      limit: 1,
+      now: afterExpiry,
+      leaseMs: 1_000,
+    });
+    expect(reclaimed).toHaveLength(0);
+
+    const { rows } = await pool.query<{
+      state: string;
+      attempts: number;
+      lease_token: string | null;
+      lease_until: string | null;
+      last_error_category: string | null;
+      terminal_at: string | null;
+      dead_lettered_at: string | null;
+    }>(
+      `SELECT state, attempts, lease_token, lease_until, last_error_category,
+              terminal_at, dead_lettered_at
+         FROM maintenance_jobs WHERE id = $1`,
+      [first!.id],
+    );
+    const row = rows[0];
+    expect(row?.state).toBe("dead_letter");
+    // attempts stays at the number of execution leases actually consumed (1),
+    // never inflated past max_attempts by the expiry sweep.
+    expect(row?.attempts).toBe(1);
+    expect(row?.lease_token).toBeNull();
+    expect(row?.lease_until).toBeNull();
+    expect(row?.last_error_category).toBe("lease_expired");
+    expect(row?.terminal_at).not.toBeNull();
+    expect(row?.dead_lettered_at).not.toBeNull();
+
+    // The terminated row cannot be reclaimed again on any later sweep.
+    const laterSweep = await queue().claimDueJobs({
+      limit: 1,
+      now: new Date(now.getTime() + 10_000),
+      leaseMs: 1_000,
+    });
+    expect(laterSweep).toHaveLength(0);
+  });
+
+  it("still reclaims an expired lease that has execution attempts remaining", async () => {
+    // maxAttempts=3: after one claim (attempts 1) an expired lease has budget,
+    // so the bounded sweep must still reclaim it rather than dead-letter it.
+    await enqueue({
+      idempotencyKey: "expired-with-budget",
+      retry: { maxAttempts: 3 },
+    });
+    const now = new Date("2026-07-22T15:00:00.000Z");
+    const [first] = await queue().claimDueJobs({
+      limit: 1,
+      now,
+      leaseMs: 1_000,
+    });
+    expect(first?.attempts).toBe(1);
+    const [reclaimed] = await queue().claimDueJobs({
+      limit: 1,
+      now: new Date(now.getTime() + 1_000),
+      leaseMs: 1_000,
+    });
+    expect(reclaimed?.id).toBe(first?.id);
+    expect(reclaimed?.attempts).toBe(2);
+    expect(reclaimed?.state).toBe("running");
+  });
+
   it("retries at a deterministic time, dead-letters terminal attempts, and recovers after a restart", async () => {
     const now = new Date("2026-07-22T13:00:00.000Z");
     await enqueue({

--- a/src/db/migrations/026_maintenance_queue.test.ts
+++ b/src/db/migrations/026_maintenance_queue.test.ts
@@ -7,7 +7,12 @@ import {
   it,
 } from "bun:test";
 import type { Pool } from "pg";
-import { MaintenanceQueue } from "../../maintenance-queue.ts";
+import {
+  MaintenanceQueue,
+  MaintenanceQueueRunner,
+  type MaintenanceJob,
+  type MaintenanceJobHandler,
+} from "../../maintenance-queue.ts";
 
 const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
 const dbDescribe = DB_URL ? describe : describe.skip;
@@ -328,5 +333,164 @@ dbDescribe("026 maintenance queue (live Postgres)", () => {
     });
     expect(afterRestart?.id).toBe(recovered.id);
     expect(afterRestart?.attempts).toBe(2);
+  });
+
+  // Drive the real runner over the real queue with a handler that mutates the
+  // job's durable retry fields before throwing. The terminal decision and the
+  // retry schedule must come from the persisted row, not the mutated object, so
+  // no caller-supplied retry-policy value can decide the transition.
+  function runnerFor(
+    handlers: Record<string, MaintenanceJobHandler>,
+    fixedNow: Date,
+  ): MaintenanceQueueRunner {
+    return new MaintenanceQueueRunner({
+      queue: queue(),
+      handlers: new Map(Object.entries(handlers)),
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+      concurrency: 1,
+      leaseMs: 60_000,
+      now: () => fixedNow,
+    });
+  }
+
+  it("dead-letters at attempt 1 when a handler inflates maxAttempts/backoff before throwing", async () => {
+    // maxAttempts=1: exactly one execution is allowed, so a first failure must
+    // dead-letter. The handler tries to buy itself more attempts and a larger
+    // backoff by mutating the job it was handed. The durable row's max_attempts
+    // must still terminate it — the caller cannot override the terminal bound.
+    const created = await enqueue({
+      idempotencyKey: "mutating-terminal",
+      retry: { maxAttempts: 1, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+    });
+    const fixedNow = new Date("2026-07-22T16:00:00.000Z");
+    let observed: MaintenanceJob | undefined;
+    const runner = runnerFor(
+      {
+        "maintenance.test": async (job) => {
+          observed = job;
+          // Handler mutates the in-memory retry policy, then throws.
+          job.maxAttempts = 99;
+          job.backoffBaseMs = 1;
+          job.backoffMaxMs = 1;
+          job.attempts = 0;
+          throw new Error("handler blew up after tampering with retry policy");
+        },
+      },
+      fixedNow,
+    );
+    await runner.runOnce();
+    await runner.stop();
+
+    expect(observed?.id).toBe(created.id);
+    const { rows } = await pool.query<{
+      state: string;
+      attempts: number;
+      max_attempts: number;
+      run_after: string;
+      lease_token: string | null;
+      terminal_at: string | null;
+      dead_lettered_at: string | null;
+    }>(
+      `SELECT state, attempts, max_attempts, run_after, lease_token,
+              terminal_at, dead_lettered_at
+         FROM maintenance_jobs WHERE id = $1`,
+      [created.id],
+    );
+    const row = rows[0];
+    // Persisted policy wins: one execution consumed, terminal at attempt 1.
+    expect(row?.state).toBe("dead_letter");
+    expect(row?.attempts).toBe(1);
+    expect(row?.max_attempts).toBe(1);
+    expect(row?.lease_token).toBeNull();
+    expect(row?.terminal_at).not.toBeNull();
+    expect(row?.dead_lettered_at).not.toBeNull();
+
+    // No requeue: the terminated row is never claimed again.
+    const later = await queue().claimDueJobs({
+      limit: 1,
+      now: new Date(fixedNow.getTime() + 60_000),
+      leaseMs: 1_000,
+    });
+    expect(later).toHaveLength(0);
+  });
+
+  it("schedules the next retry from the persisted backoff, not a handler-mutated one", async () => {
+    // maxAttempts=3 leaves budget after the first failure, so the row requeues.
+    // The handler shrinks backoff_base/max on the object before throwing; the
+    // persisted schedule (base 2000ms at attempt 1) must be used, so run_after
+    // is now + 2000ms, not now + 1ms.
+    const created = await enqueue({
+      idempotencyKey: "mutating-schedule",
+      retry: { maxAttempts: 3, backoffBaseMs: 2_000, backoffMaxMs: 8_000 },
+    });
+    const fixedNow = new Date("2026-07-22T17:00:00.000Z");
+    const runner = runnerFor(
+      {
+        "maintenance.test": async (job) => {
+          job.backoffBaseMs = 1;
+          job.backoffMaxMs = 1;
+          job.maxAttempts = 25;
+          throw new Error("handler blew up after shrinking its own backoff");
+        },
+      },
+      fixedNow,
+    );
+    await runner.runOnce();
+    await runner.stop();
+
+    const { rows } = await pool.query<{
+      state: string;
+      attempts: number;
+      run_after: string;
+    }>(
+      "SELECT state, attempts, run_after FROM maintenance_jobs WHERE id = $1",
+      [created.id],
+    );
+    const row = rows[0];
+    expect(row?.state).toBe("queued");
+    expect(row?.attempts).toBe(1);
+    // First retry uses the persisted base (2000ms), capped exponent semantics
+    // unchanged. A handler-mutated 1ms backoff would have scheduled +1ms.
+    expect(new Date(row!.run_after).toISOString()).toBe(
+      "2026-07-22T17:00:02.000Z",
+    );
+  });
+
+  it("fail() derives the transition from the durable row when the passed job is tampered", async () => {
+    // Direct-queue proof independent of the runner: claim, then tamper the
+    // returned job's retry fields exactly as a handler holding the reference
+    // could, and fail it. maxAttempts=1 on the row must still dead-letter.
+    const created = await enqueue({
+      idempotencyKey: "direct-tamper",
+      retry: { maxAttempts: 1, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+    });
+    const now = new Date("2026-07-22T18:00:00.000Z");
+    const [claimed] = await queue().claimDueJobs({
+      limit: 1,
+      now,
+      leaseMs: 60_000,
+    });
+    expect(claimed?.attempts).toBe(1);
+    // Tamper every retry-policy field the old code read from the object.
+    claimed!.maxAttempts = 99;
+    claimed!.attempts = 0;
+    claimed!.backoffBaseMs = 1;
+    claimed!.backoffMaxMs = 1;
+    const result = await queue().fail({
+      job: claimed!,
+      error: new Error("still private"),
+      now,
+    });
+    expect(result?.state).toBe("dead_letter");
+    const { rows } = await pool.query<{ state: string; attempts: number }>(
+      "SELECT state, attempts FROM maintenance_jobs WHERE id = $1",
+      [created.id],
+    );
+    expect(rows[0]?.state).toBe("dead_letter");
+    expect(rows[0]?.attempts).toBe(1);
   });
 });

--- a/src/maintenance-queue.test.ts
+++ b/src/maintenance-queue.test.ts
@@ -83,6 +83,107 @@ describe("maintenance queue runner", () => {
     expect(stopped).toBe(true);
   });
 
+  it("dispatches and drains a claim already in flight when stop() begins", async () => {
+    // The claim resolves only after stop() has flipped `stopping`. The old
+    // mid-loop `if (this.stopping) return` abandoned every job the in-flight
+    // claim returned: the handler never ran, complete()/fail() was never
+    // invoked, and the leased rows were left stranded outside `active`.
+    let resolveClaim: ((jobs: MaintenanceJob[]) => void) | undefined;
+    let handlerRan = false;
+    let completeCalled = false;
+    const claimStarted = Promise.withResolvers<void>();
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: () => {
+        claimStarted.resolve();
+        return new Promise<MaintenanceJob[]>((resolve) => {
+          resolveClaim = resolve;
+        });
+      },
+      complete: async () => {
+        completeCalled = true;
+        return true;
+      },
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            handlerRan = true;
+          },
+        ],
+      ]),
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+      concurrency: 1,
+    });
+
+    const tick = runner.runOnce();
+    // Wait until the claim is genuinely in flight before beginning shutdown.
+    await claimStarted.promise;
+
+    const stopping = runner.stop();
+    let stopResolved = false;
+    void stopping.then(() => {
+      stopResolved = true;
+    });
+    // Let stop() run up to its await; the leased jobs are not yet delivered.
+    await Promise.resolve();
+    expect(stopResolved).toBe(false);
+    expect(handlerRan).toBe(false);
+
+    // The claim commits its lease after stop began. Every returned job must be
+    // dispatched, executed, and completed; stop() must not resolve before that.
+    resolveClaim?.([job()]);
+    await tick;
+    await stopping;
+    expect(handlerRan).toBe(true);
+    expect(completeCalled).toBe(true);
+    expect(stopResolved).toBe(true);
+  });
+
+  it("does not begin a new claim once stopping is observed", async () => {
+    // A tick that starts after stop() has flipped `stopping` must not lease any
+    // new rows: no claim, no handler, immediate drain.
+    let claimCalls = 0;
+    let handlerRan = false;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => {
+        claimCalls += 1;
+        return [job()];
+      },
+      complete: async () => true,
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            handlerRan = true;
+          },
+        ],
+      ]),
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+      concurrency: 1,
+    });
+
+    await runner.stop();
+    await runner.runOnce();
+    expect(claimCalls).toBe(0);
+    expect(handlerRan).toBe(false);
+  });
+
   it("stores unsupported_job_kind as its own category, not non_error", async () => {
     const failCalls: Array<{ error: unknown; category?: string }> = [];
     const logs: string[] = [];

--- a/src/maintenance-queue.test.ts
+++ b/src/maintenance-queue.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MaintenanceQueue,
+  MaintenanceQueueRunner,
+  maintenanceBackoffMs,
+  safeMaintenanceErrorCategory,
+  type MaintenanceJob,
+  type MaintenanceJobState,
+  type MaintenanceQueuePort,
+} from "./maintenance-queue.ts";
+
+function job(overrides: Partial<MaintenanceJob> = {}): MaintenanceJob {
+  return {
+    id: "job-1",
+    kind: "maintenance.test",
+    version: 1,
+    payload: { private: "must never reach logs" },
+    idempotencyKey: "once",
+    state: "running",
+    runAfter: new Date("2026-07-22T12:00:00.000Z"),
+    leaseToken: "00000000-0000-4000-8000-000000000001",
+    leaseUntil: new Date("2026-07-22T12:00:30.000Z"),
+    attempts: 1,
+    maxAttempts: 3,
+    backoffBaseMs: 1_000,
+    backoffMaxMs: 4_000,
+    lastErrorCategory: null,
+    terminalAt: null,
+    deadLetteredAt: null,
+    namespace: null,
+    provenance: null,
+    createdAt: new Date("2026-07-22T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-22T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("maintenance queue runner", () => {
+  it("bounds dispatch and waits for in-flight work during shutdown", async () => {
+    let resolveHandler: (() => void) | undefined;
+    let concurrent = 0;
+    let peakConcurrent = 0;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job(), job({ id: "job-2" })],
+      complete: async () => true,
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            concurrent += 1;
+            peakConcurrent = Math.max(peakConcurrent, concurrent);
+            await new Promise<void>((resolve) => {
+              resolveHandler = resolve;
+            });
+            concurrent -= 1;
+          },
+        ],
+      ]),
+      logger: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+      concurrency: 1,
+    });
+
+    await runner.runOnce();
+    const stopping = runner.stop();
+    let stopped = false;
+    void stopping.then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(peakConcurrent).toBe(1);
+    expect(stopped).toBe(false);
+
+    resolveHandler?.();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
+  it("stores unsupported_job_kind as its own category, not non_error", async () => {
+    const failCalls: Array<{ error: unknown; category?: string }> = [];
+    const logs: string[] = [];
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      complete: async () => true,
+      fail: async (input) => {
+        failCalls.push({ error: input.error, category: input.category });
+        return job({
+          state: "dead_letter",
+          lastErrorCategory: input.category ?? null,
+        });
+      },
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      // No handler registered for the claimed job's kind.
+      handlers: new Map([["some.other.kind", async () => undefined]]),
+      logger: {
+        info: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        warn: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        error: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+      },
+    });
+
+    await runner.runOnce();
+    // Old behavior: fail() received the raw string and derived "non_error" for storage.
+    expect(failCalls).toHaveLength(1);
+    expect(failCalls[0]?.category).toBe("unsupported_job_kind");
+    expect(logs.join("\n")).toContain(
+      '"error_category":"unsupported_job_kind"',
+    );
+    expect(logs.join("\n")).not.toContain('"error_category":"non_error"');
+  });
+
+  it("keeps runner logs content-free and categorizes failures without messages", async () => {
+    const logs: string[] = [];
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      complete: async () => true,
+      fail: async () => job({ state: "queued" }),
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            throw new TypeError("secret payload text");
+          },
+        ],
+      ]),
+      logger: {
+        info: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        warn: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        error: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+      },
+    });
+
+    await runner.runOnce();
+    expect(logs.join("\n")).not.toContain("secret payload text");
+    expect(logs.join("\n")).not.toContain("must never reach logs");
+    expect(logs.join("\n")).toContain('"error_category":"type_error"');
+  });
+
+  it("contains persistence failures as content-free runner errors", async () => {
+    const logs: string[] = [];
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      complete: async () => true,
+      fail: async () => {
+        throw new Error("failed to store private payload text");
+      },
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            throw new Error("private handler text");
+          },
+        ],
+      ]),
+      logger: {
+        info: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        warn: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        error: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+      },
+    });
+
+    await runner.runOnce();
+    expect(logs.join("\n")).toContain(
+      "maintenance queue failure recording failed",
+    );
+    expect(logs.join("\n")).not.toContain("private payload text");
+    expect(logs.join("\n")).not.toContain("private handler text");
+  });
+});
+
+function storedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "existing-1",
+    job_kind: "maintenance.test",
+    job_version: 1,
+    payload: { a: 1 },
+    idempotency_key: "dup",
+    state: "queued" as MaintenanceJobState,
+    run_after: new Date("2026-07-22T12:00:00.000Z"),
+    lease_token: null,
+    lease_until: null,
+    attempts: 0,
+    max_attempts: 3,
+    backoff_base_ms: 1_000,
+    backoff_max_ms: 300_000,
+    last_error_category: null,
+    terminal_at: null,
+    dead_lettered_at: null,
+    namespace: null,
+    provenance: null,
+    created_at: new Date("2026-07-22T12:00:00.000Z"),
+    updated_at: new Date("2026-07-22T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+// Fake pool: INSERT ... ON CONFLICT DO NOTHING returns no row, SELECT returns
+// the pre-existing job. Lets us exercise the conflict path without Postgres.
+function conflictPool(existing: Record<string, unknown>) {
+  return {
+    query: async (sql: string) => {
+      if (/^\s*INSERT/i.test(sql)) return { rows: [], rowCount: 0 };
+      if (/^\s*SELECT/i.test(sql)) return { rows: [existing], rowCount: 1 };
+      throw new Error("unexpected query");
+    },
+    connect: async () => {
+      throw new Error("connect not expected");
+    },
+  };
+}
+
+describe("maintenance queue enqueue idempotency", () => {
+  const base = {
+    kind: "maintenance.test",
+    version: 1,
+    payload: { a: 1 },
+    idempotencyKey: "dup",
+  };
+
+  it("returns the existing job when semantics match, key order aside", async () => {
+    const queue = new MaintenanceQueue(conflictPool(storedRow()) as never);
+    const result = await queue.enqueue({ ...base, payload: { a: 1 } });
+    expect(result.id).toBe("existing-1");
+  });
+
+  it("rejects a reused key with a divergent payload content-free", async () => {
+    const queue = new MaintenanceQueue(conflictPool(storedRow()) as never);
+    await expect(queue.enqueue({ ...base, payload: { a: 2 } })).rejects.toThrow(
+      "divergent job semantics",
+    );
+  });
+
+  it("rejects a reused key with divergent version, retry, or scope", async () => {
+    const queue = new MaintenanceQueue(conflictPool(storedRow()) as never);
+    await expect(queue.enqueue({ ...base, version: 2 })).rejects.toThrow(
+      "divergent job semantics",
+    );
+    const q2 = new MaintenanceQueue(conflictPool(storedRow()) as never);
+    await expect(
+      q2.enqueue({ ...base, retry: { maxAttempts: 9 } }),
+    ).rejects.toThrow("divergent job semantics");
+    const q3 = new MaintenanceQueue(conflictPool(storedRow()) as never);
+    await expect(
+      q3.enqueue({ ...base, scope: { namespace: "other-ns" } }),
+    ).rejects.toThrow("divergent job semantics");
+  });
+
+  it("rejects an invalid namespace and an out-of-bounds claim limit before querying", async () => {
+    const noQuery = {
+      query: async () => {
+        throw new Error("must not query on validation failure");
+      },
+      connect: async () => {
+        throw new Error("must not connect on validation failure");
+      },
+    };
+    const queue = new MaintenanceQueue(noQuery as never);
+    await expect(
+      queue.enqueue({ ...base, scope: { namespace: "bad ns!" } }),
+    ).rejects.toThrow("namespace is invalid");
+    await expect(
+      queue.claimDueJobs({ limit: 100_000, leaseMs: 1_000 }),
+    ).rejects.toThrow("claim limit exceeds the bound");
+  });
+});
+
+describe("maintenance queue retry policy", () => {
+  it("uses deterministic capped exponential backoff and safe categories", () => {
+    expect(maintenanceBackoffMs(job({ attempts: 1 }))).toBe(1_000);
+    expect(maintenanceBackoffMs(job({ attempts: 3 }))).toBe(4_000);
+    expect(maintenanceBackoffMs(job({ attempts: 9 }))).toBe(4_000);
+    expect(safeMaintenanceErrorCategory(new Error("private error text"))).toBe(
+      "error",
+    );
+    expect(safeMaintenanceErrorCategory("private error text")).toBe(
+      "non_error",
+    );
+  });
+});

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -441,30 +441,46 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
     const now = input.now ?? new Date();
     const errorCategory =
       input.category ?? safeMaintenanceErrorCategory(input.error);
-    const nextRunAfter = new Date(
-      now.getTime() + maintenanceBackoffMs(input.job),
-    );
+    // The terminal decision and the retry schedule are derived from the durable
+    // row, never from the caller-supplied `input.job` retry fields. A registered
+    // handler receives the same job object it is failing and could mutate
+    // maxAttempts/backoff before throwing; deriving the transition from
+    // `input.job.maxAttempts`/`backoffBaseMs`/`backoffMaxMs` would let that
+    // mutation override the persisted policy and bypass the terminal bound.
+    // `attempts`, `max_attempts`, `backoff_base_ms`, and `backoff_max_ms` below
+    // are the row's own columns; `input.job` is used only for the lease-token
+    // guard (id + lease_token), which claimDueJobs minted and no handler owns.
+    //
+    // The SQL backoff mirrors maintenanceBackoffMs() exactly: the first retry
+    // (attempts = 1) uses backoff_base_ms, the exponent is (attempts - 1)
+    // clamped to [0, 30], and the result is capped at backoff_max_ms. attempts
+    // is bounded [0, 25] and the exponent [0, 30], so 2 ^ exponent stays within
+    // numeric range with no overflow.
     const failed = await this.pool.query<MaintenanceJobRow>(
       `UPDATE maintenance_jobs
-          SET state = CASE WHEN attempts >= $3 THEN 'dead_letter' ELSE 'queued' END,
-              run_after = CASE WHEN attempts >= $3 THEN run_after ELSE $4::timestamptz END,
+          SET state = CASE WHEN attempts >= max_attempts
+                           THEN 'dead_letter' ELSE 'queued' END,
+              run_after = CASE WHEN attempts >= max_attempts
+                               THEN run_after
+                               ELSE $3::timestamptz + (
+                                 LEAST(
+                                   backoff_base_ms::numeric
+                                     * (2 ^ LEAST(GREATEST(attempts - 1, 0), 30)),
+                                   backoff_max_ms::numeric
+                                 ) * interval '1 millisecond'
+                               ) END,
               lease_token = NULL,
               lease_until = NULL,
-              last_error_category = $5,
-              terminal_at = CASE WHEN attempts >= $3 THEN $6::timestamptz ELSE NULL END,
-              dead_lettered_at = CASE WHEN attempts >= $3 THEN $6::timestamptz ELSE NULL END
+              last_error_category = $4,
+              terminal_at = CASE WHEN attempts >= max_attempts
+                                 THEN $3::timestamptz ELSE NULL END,
+              dead_lettered_at = CASE WHEN attempts >= max_attempts
+                                      THEN $3::timestamptz ELSE NULL END
         WHERE id = $1
           AND state = 'running'
           AND lease_token = $2::uuid
        RETURNING ${JOB_COLUMNS}`,
-      [
-        input.job.id,
-        input.job.leaseToken,
-        input.job.maxAttempts,
-        nextRunAfter,
-        errorCategory,
-        now,
-      ],
+      [input.job.id, input.job.leaseToken, now, errorCategory],
     );
     return failed.rows[0] ? toJob(failed.rows[0]) : null;
   }
@@ -581,32 +597,44 @@ export class MaintenanceQueueRunner {
 
   private async execute(job: MaintenanceJob): Promise<void> {
     const startedAt = this.now().getTime();
-    const handler = this.options.handlers.get(job.kind);
+    // Capture the claim identity before the handler runs. The handler receives
+    // the same `job` object and may mutate it (deliberately or accidentally);
+    // the lease-token guard and completion call shape must bind to the id/kind
+    // and lease token claimDueJobs actually minted, not to whatever the handler
+    // left on the object. The durable row remains the retry-policy authority
+    // (see MaintenanceQueue.fail); this only keeps the row we address stable.
+    const claim = {
+      id: job.id,
+      kind: job.kind,
+      leaseToken: job.leaseToken,
+    };
+    const handler = this.options.handlers.get(claim.kind);
     if (!handler) {
-      await this.fail(job, "unsupported_job_kind", startedAt);
+      await this.fail(job, claim, "unsupported_job_kind", startedAt);
       return;
     }
 
     try {
       await handler(job);
       const completed = await this.options.queue.complete(
-        job.id,
-        job.leaseToken!,
+        claim.id,
+        claim.leaseToken!,
         this.now(),
       );
       this.options.logger.info("maintenance queue job completed", {
-        job_id: job.id,
-        job_kind: job.kind,
+        job_id: claim.id,
+        job_kind: claim.kind,
         status: completed ? "succeeded" : "stale_lease",
         duration_ms: this.now().getTime() - startedAt,
       });
     } catch (error) {
-      await this.fail(job, error, startedAt);
+      await this.fail(job, claim, error, startedAt);
     }
   }
 
   private async fail(
     job: MaintenanceJob,
+    claim: { id: string; kind: string; leaseToken: string | null },
     error: unknown,
     startedAt: number,
   ): Promise<void> {
@@ -615,23 +643,27 @@ export class MaintenanceQueueRunner {
         ? "unsupported_job_kind"
         : safeMaintenanceErrorCategory(error);
     try {
+      // Pass the immutable claim id/leaseToken as the lease-token guard so a
+      // handler that mutated job.id/job.leaseToken cannot redirect the fail
+      // UPDATE to a different row or make it a no-op. The retry-policy fields
+      // this UPDATE consults come from the durable row, not this object.
       const failed = await this.options.queue.fail({
-        job,
+        job: { ...job, id: claim.id, leaseToken: claim.leaseToken },
         error,
         category: errorCategory,
         now: this.now(),
       });
       this.options.logger.warn("maintenance queue job failed", {
-        job_id: job.id,
-        job_kind: job.kind,
+        job_id: claim.id,
+        job_kind: claim.kind,
         status: failed?.state ?? "stale_lease",
         error_category: errorCategory,
         duration_ms: this.now().getTime() - startedAt,
       });
     } catch (recordingError) {
       this.options.logger.error("maintenance queue failure recording failed", {
-        job_id: job.id,
-        job_kind: job.kind,
+        job_id: claim.id,
+        job_kind: claim.kind,
         error_category: safeMaintenanceErrorCategory(recordingError),
         duration_ms: this.now().getTime() - startedAt,
       });

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -21,7 +21,11 @@ export type MaintenanceErrorCategory =
   | "range_error"
   | "error"
   | "non_error"
-  | "unsupported_job_kind";
+  | "unsupported_job_kind"
+  // Terminal signal for a running lease that expired after the job already
+  // consumed all of its execution attempts. Content-free and distinct from any
+  // handler-thrown error so dead-letter analysis can tell the two apart.
+  | "lease_expired";
 
 export interface MaintenanceJob {
   id: string;
@@ -349,23 +353,52 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
 
     try {
       await client.query("BEGIN");
+      // A queued-due row and an expired running row are both eligible, but an
+      // expired running row whose already-consumed execution attempts have
+      // reached max_attempts must terminate, not be reclaimed for another
+      // handler run — otherwise a job that keeps blowing its lease is retried
+      // forever, past its bound. `attempts` counts execution leases: a running
+      // row already ran `attempts` handler executions, so attempts >= max means
+      // no budget is left. Such rows dead-letter in the same statement (clearing
+      // the lease, stamping terminal/dead-letter timestamps, and recording the
+      // content-free `lease_expired` category) and are excluded from RETURNING
+      // so the runner never treats a terminated job as claimed.
       const claimed = await client.query<MaintenanceJobRow>(
         `WITH eligible AS (
-           SELECT id
+           SELECT id, state, attempts, max_attempts
              FROM maintenance_jobs
             WHERE (state = 'queued' AND run_after <= $1)
                OR (state = 'running' AND lease_until <= $1)
             ORDER BY run_after, created_at, id
             FOR UPDATE SKIP LOCKED
             LIMIT $2
+         ),
+         reclaim AS (
+           SELECT id FROM eligible
+            WHERE state = 'queued' OR attempts < max_attempts
+         ),
+         expire AS (
+           SELECT id FROM eligible
+            WHERE state = 'running' AND attempts >= max_attempts
+         ),
+         dead AS (
+           UPDATE maintenance_jobs AS job
+              SET state = 'dead_letter',
+                  lease_token = NULL,
+                  lease_until = NULL,
+                  last_error_category = 'lease_expired',
+                  terminal_at = $1,
+                  dead_lettered_at = $1
+             FROM expire
+            WHERE job.id = expire.id
          )
          UPDATE maintenance_jobs AS job
             SET state = 'running',
                 lease_token = $3::uuid,
                 lease_until = $1 + ($4 * interval '1 millisecond'),
                 attempts = job.attempts + 1
-           FROM eligible
-          WHERE job.id = eligible.id
+           FROM reclaim
+          WHERE job.id = reclaim.id
          RETURNING ${jobColumns("job")}`,
         [now, input.limit, leaseToken, input.leaseMs],
       );
@@ -512,6 +545,13 @@ export class MaintenanceQueueRunner {
   }
 
   private async tick(): Promise<void> {
+    // Never begin a new claim once shutdown has started: a claim leases rows in
+    // the database, so starting one during stop would strand freshly-leased
+    // jobs. But a claim already in flight when stop() flips this flag has (or
+    // will) commit its leases, so every job it returns must still be dispatched
+    // and tracked in `active` below — stop() waits on `active`, and abandoning a
+    // leased job here would leave it stuck running until its lease expired.
+    if (this.stopping) return;
     const available = this.concurrency - this.active.size;
     if (available <= 0) return;
 
@@ -529,8 +569,10 @@ export class MaintenanceQueueRunner {
       return;
     }
 
+    // No mid-loop stopping guard: these rows are already leased to this runner,
+    // so each one is dispatched and tracked even if stop() began after the
+    // claim committed.
     for (const job of jobs.slice(0, available)) {
-      if (this.stopping) return;
       let active: Promise<void>;
       active = this.execute(job).finally(() => this.active.delete(active));
       this.active.add(active);

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -1,0 +1,598 @@
+import type pg from "pg";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_BASE_MS = 1_000;
+const DEFAULT_BACKOFF_MAX_MS = 300_000;
+const MAX_CONCURRENCY = 16;
+// Upper bound on a single direct claim. The scheduled runner never asks for
+// more than its available concurrency, but a direct caller must not be able to
+// drain or lock the whole table in one statement.
+const MAX_CLAIM_LIMIT = 256;
+// Namespace token shape, mirroring the delegated-id/header-namespace path used
+// elsewhere so the queue cannot mint exotic namespaces. Queue mechanics never
+// infer a namespace; this only validates one a caller opts into.
+const NAMESPACE_TOKEN_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
+export type MaintenanceJobState =
+  "queued" | "running" | "succeeded" | "dead_letter";
+export type MaintenanceErrorCategory =
+  | "syntax_error"
+  | "type_error"
+  | "range_error"
+  | "error"
+  | "non_error"
+  | "unsupported_job_kind";
+
+export interface MaintenanceJob {
+  id: string;
+  kind: string;
+  version: number;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+  state: MaintenanceJobState;
+  runAfter: Date;
+  leaseToken: string | null;
+  leaseUntil: Date | null;
+  attempts: number;
+  maxAttempts: number;
+  backoffBaseMs: number;
+  backoffMaxMs: number;
+  lastErrorCategory: MaintenanceErrorCategory | null;
+  terminalAt: Date | null;
+  deadLetteredAt: Date | null;
+  namespace: string | null;
+  provenance: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface EnqueueMaintenanceJob {
+  kind: string;
+  version: number;
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+  runAfter?: Date;
+  retry?: {
+    maxAttempts?: number;
+    backoffBaseMs?: number;
+    backoffMaxMs?: number;
+  };
+  // These are deliberately opt-in. Future job contracts decide whether they
+  // require a namespace/provenance; queue mechanics never infer either value.
+  scope?: {
+    namespace?: string;
+    provenance?: Record<string, unknown>;
+  };
+}
+
+export interface ClaimMaintenanceJobs {
+  limit: number;
+  now?: Date;
+  leaseMs: number;
+}
+
+export interface MaintenanceQueuePort {
+  claimDueJobs(input: ClaimMaintenanceJobs): Promise<MaintenanceJob[]>;
+  complete(jobId: string, leaseToken: string, now?: Date): Promise<boolean>;
+  fail(input: {
+    job: MaintenanceJob;
+    error: unknown;
+    // When set, the stored terminal/retry category is forced to this value so
+    // persistence matches what the caller categorizes and logs (e.g. the
+    // unsupported-job-kind sentinel, which is not a thrown Error). When unset,
+    // the category is derived from `error`.
+    category?: MaintenanceErrorCategory;
+    now?: Date;
+  }): Promise<MaintenanceJob | null>;
+}
+
+interface MaintenanceJobRow {
+  id: string;
+  job_kind: string;
+  job_version: number;
+  payload: Record<string, unknown>;
+  idempotency_key: string;
+  state: MaintenanceJobState;
+  run_after: Date | string;
+  lease_token: string | null;
+  lease_until: Date | string | null;
+  attempts: number;
+  max_attempts: number;
+  backoff_base_ms: number;
+  backoff_max_ms: number;
+  last_error_category: MaintenanceErrorCategory | null;
+  terminal_at: Date | string | null;
+  dead_lettered_at: Date | string | null;
+  namespace: string | null;
+  provenance: Record<string, unknown> | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+const JOB_COLUMN_NAMES = [
+  "id",
+  "job_kind",
+  "job_version",
+  "payload",
+  "idempotency_key",
+  "state",
+  "run_after",
+  "lease_token",
+  "lease_until",
+  "attempts",
+  "max_attempts",
+  "backoff_base_ms",
+  "backoff_max_ms",
+  "last_error_category",
+  "terminal_at",
+  "dead_lettered_at",
+  "namespace",
+  "provenance",
+  "created_at",
+  "updated_at",
+] as const;
+
+const JOB_COLUMNS = JOB_COLUMN_NAMES.join(", ");
+
+// Same column set qualified by a table alias. Required in the claim statement,
+// whose CTE join exposes `id` on both `maintenance_jobs` and `eligible`, making
+// an unqualified RETURNING list ambiguous.
+function jobColumns(alias: string): string {
+  return JOB_COLUMN_NAMES.map((column) => `${alias}.${column}`).join(", ");
+}
+
+function toDate(value: Date | string | null): Date | null {
+  return value === null ? null : new Date(value);
+}
+
+function toJob(row: MaintenanceJobRow): MaintenanceJob {
+  return {
+    id: row.id,
+    kind: row.job_kind,
+    version: row.job_version,
+    payload: row.payload,
+    idempotencyKey: row.idempotency_key,
+    state: row.state,
+    runAfter: new Date(row.run_after),
+    leaseToken: row.lease_token,
+    leaseUntil: toDate(row.lease_until),
+    attempts: row.attempts,
+    maxAttempts: row.max_attempts,
+    backoffBaseMs: row.backoff_base_ms,
+    backoffMaxMs: row.backoff_max_ms,
+    lastErrorCategory: row.last_error_category,
+    terminalAt: toDate(row.terminal_at),
+    deadLetteredAt: toDate(row.dead_lettered_at),
+    namespace: row.namespace,
+    provenance: row.provenance,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+function assertPositiveInteger(value: number, field: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`maintenance queue ${field} must be a positive integer`);
+  }
+}
+
+function assertObject(
+  value: unknown,
+  field: string,
+): asserts value is Record<string, unknown> {
+  if (!value || Array.isArray(value) || typeof value !== "object") {
+    throw new Error(`maintenance queue ${field} must be an object`);
+  }
+}
+
+function validateEnqueue(input: EnqueueMaintenanceJob): Required<
+  Pick<EnqueueMaintenanceJob, "kind" | "version" | "payload" | "idempotencyKey">
+> & {
+  runAfter: Date;
+  maxAttempts: number;
+  backoffBaseMs: number;
+  backoffMaxMs: number;
+  namespace: string | null;
+  provenance: Record<string, unknown> | null;
+} {
+  if (!/^[a-z][a-z0-9_.-]{0,127}$/.test(input.kind)) {
+    throw new Error("maintenance queue job kind is invalid");
+  }
+  if (input.idempotencyKey.length === 0 || input.idempotencyKey.length > 256) {
+    throw new Error("maintenance queue idempotency key is invalid");
+  }
+  assertPositiveInteger(input.version, "job version");
+  assertObject(input.payload, "payload");
+
+  const maxAttempts = input.retry?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const backoffBaseMs = input.retry?.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
+  const backoffMaxMs = input.retry?.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
+  assertPositiveInteger(maxAttempts, "max attempts");
+  assertPositiveInteger(backoffBaseMs, "backoff base");
+  assertPositiveInteger(backoffMaxMs, "backoff maximum");
+  if (maxAttempts > 25 || backoffMaxMs < backoffBaseMs) {
+    throw new Error("maintenance queue retry policy is invalid");
+  }
+  if (input.scope?.provenance !== undefined) {
+    assertObject(input.scope.provenance, "provenance");
+  }
+  if (
+    input.scope?.namespace !== undefined &&
+    !NAMESPACE_TOKEN_RE.test(input.scope.namespace)
+  ) {
+    throw new Error("maintenance queue namespace is invalid");
+  }
+
+  return {
+    kind: input.kind,
+    version: input.version,
+    payload: input.payload,
+    idempotencyKey: input.idempotencyKey,
+    runAfter: input.runAfter ?? new Date(),
+    maxAttempts,
+    backoffBaseMs,
+    backoffMaxMs,
+    namespace: input.scope?.namespace ?? null,
+    provenance: input.scope?.provenance ?? null,
+  };
+}
+
+// Order-independent structural equality for JSONB-shaped values so that two
+// payloads differing only in key order are not treated as divergent.
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.fromEntries(
+        Object.entries(val as Record<string, unknown>).sort(([a], [b]) =>
+          a < b ? -1 : a > b ? 1 : 0,
+        ),
+      );
+    }
+    return val;
+  });
+}
+
+type ValidatedEnqueue = ReturnType<typeof validateEnqueue>;
+
+function enqueueSemanticsDiverge(
+  requested: ValidatedEnqueue,
+  existing: MaintenanceJob,
+): boolean {
+  return (
+    requested.version !== existing.version ||
+    requested.maxAttempts !== existing.maxAttempts ||
+    requested.backoffBaseMs !== existing.backoffBaseMs ||
+    requested.backoffMaxMs !== existing.backoffMaxMs ||
+    requested.namespace !== existing.namespace ||
+    canonicalJson(requested.payload) !== canonicalJson(existing.payload) ||
+    canonicalJson(requested.provenance) !== canonicalJson(existing.provenance)
+  );
+}
+
+export function safeMaintenanceErrorCategory(
+  error: unknown,
+): MaintenanceErrorCategory {
+  if (error instanceof SyntaxError) return "syntax_error";
+  if (error instanceof TypeError) return "type_error";
+  if (error instanceof RangeError) return "range_error";
+  if (error instanceof Error) return "error";
+  return "non_error";
+}
+
+export function maintenanceBackoffMs(
+  job: Pick<MaintenanceJob, "attempts" | "backoffBaseMs" | "backoffMaxMs">,
+): number {
+  const exponent = Math.min(Math.max(job.attempts - 1, 0), 30);
+  return Math.min(job.backoffBaseMs * 2 ** exponent, job.backoffMaxMs);
+}
+
+export class MaintenanceQueue implements MaintenanceQueuePort {
+  constructor(private readonly pool: Pick<pg.Pool, "query" | "connect">) {}
+
+  async enqueue(input: EnqueueMaintenanceJob): Promise<MaintenanceJob> {
+    const job = validateEnqueue(input);
+    const inserted = await this.pool.query<MaintenanceJobRow>(
+      `INSERT INTO maintenance_jobs (
+         job_kind, job_version, payload, idempotency_key, run_after,
+         max_attempts, backoff_base_ms, backoff_max_ms, namespace, provenance
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       ON CONFLICT (job_kind, idempotency_key) DO NOTHING
+       RETURNING ${JOB_COLUMNS}`,
+      [
+        job.kind,
+        job.version,
+        JSON.stringify(job.payload),
+        job.idempotencyKey,
+        job.runAfter,
+        job.maxAttempts,
+        job.backoffBaseMs,
+        job.backoffMaxMs,
+        job.namespace,
+        job.provenance === null ? null : JSON.stringify(job.provenance),
+      ],
+    );
+    if (inserted.rows[0]) return toJob(inserted.rows[0]);
+
+    const existing = await this.pool.query<MaintenanceJobRow>(
+      `SELECT ${JOB_COLUMNS}
+         FROM maintenance_jobs
+        WHERE job_kind = $1 AND idempotency_key = $2`,
+      [job.kind, job.idempotencyKey],
+    );
+    const existingRow = existing.rows[0];
+    if (!existingRow) {
+      throw new Error("maintenance queue idempotency lookup failed");
+    }
+    const existingJob = toJob(existingRow);
+    // Idempotent replay is safe only when the reused (kind, idempotency_key)
+    // carries identical semantics. Any divergence in version, payload, scope, or
+    // retry policy means the caller expects *different* work under an already-used
+    // key; return the stale job and it silently runs the old contract. Reject
+    // content-free — the divergence itself is the signal, not the payload values.
+    if (enqueueSemanticsDiverge(job, existingJob)) {
+      throw new Error(
+        "maintenance queue idempotency key reused with divergent job semantics",
+      );
+    }
+    return existingJob;
+  }
+
+  async claimDueJobs(input: ClaimMaintenanceJobs): Promise<MaintenanceJob[]> {
+    assertPositiveInteger(input.limit, "claim limit");
+    if (input.limit > MAX_CLAIM_LIMIT) {
+      throw new Error("maintenance queue claim limit exceeds the bound");
+    }
+    assertPositiveInteger(input.leaseMs, "lease duration");
+    const now = input.now ?? new Date();
+    const client = await this.pool.connect();
+    const leaseToken = crypto.randomUUID();
+
+    try {
+      await client.query("BEGIN");
+      const claimed = await client.query<MaintenanceJobRow>(
+        `WITH eligible AS (
+           SELECT id
+             FROM maintenance_jobs
+            WHERE (state = 'queued' AND run_after <= $1)
+               OR (state = 'running' AND lease_until <= $1)
+            ORDER BY run_after, created_at, id
+            FOR UPDATE SKIP LOCKED
+            LIMIT $2
+         )
+         UPDATE maintenance_jobs AS job
+            SET state = 'running',
+                lease_token = $3::uuid,
+                lease_until = $1 + ($4 * interval '1 millisecond'),
+                attempts = job.attempts + 1
+           FROM eligible
+          WHERE job.id = eligible.id
+         RETURNING ${jobColumns("job")}`,
+        [now, input.limit, leaseToken, input.leaseMs],
+      );
+      await client.query("COMMIT");
+      return claimed.rows.map(toJob);
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async complete(
+    jobId: string,
+    leaseToken: string,
+    now = new Date(),
+  ): Promise<boolean> {
+    const completed = await this.pool.query(
+      `UPDATE maintenance_jobs
+          SET state = 'succeeded',
+              lease_token = NULL,
+              lease_until = NULL,
+              last_error_category = NULL,
+              terminal_at = $3
+        WHERE id = $1
+          AND state = 'running'
+          AND lease_token = $2::uuid`,
+      [jobId, leaseToken, now],
+    );
+    return (completed.rowCount ?? 0) === 1;
+  }
+
+  async fail(input: {
+    job: MaintenanceJob;
+    error: unknown;
+    category?: MaintenanceErrorCategory;
+    now?: Date;
+  }): Promise<MaintenanceJob | null> {
+    const now = input.now ?? new Date();
+    const errorCategory =
+      input.category ?? safeMaintenanceErrorCategory(input.error);
+    const nextRunAfter = new Date(
+      now.getTime() + maintenanceBackoffMs(input.job),
+    );
+    const failed = await this.pool.query<MaintenanceJobRow>(
+      `UPDATE maintenance_jobs
+          SET state = CASE WHEN attempts >= $3 THEN 'dead_letter' ELSE 'queued' END,
+              run_after = CASE WHEN attempts >= $3 THEN run_after ELSE $4::timestamptz END,
+              lease_token = NULL,
+              lease_until = NULL,
+              last_error_category = $5,
+              terminal_at = CASE WHEN attempts >= $3 THEN $6::timestamptz ELSE NULL END,
+              dead_lettered_at = CASE WHEN attempts >= $3 THEN $6::timestamptz ELSE NULL END
+        WHERE id = $1
+          AND state = 'running'
+          AND lease_token = $2::uuid
+       RETURNING ${JOB_COLUMNS}`,
+      [
+        input.job.id,
+        input.job.leaseToken,
+        input.job.maxAttempts,
+        nextRunAfter,
+        errorCategory,
+        now,
+      ],
+    );
+    return failed.rows[0] ? toJob(failed.rows[0]) : null;
+  }
+}
+
+export interface MaintenanceQueueLogger {
+  info(message: string, fields: Record<string, string | number>): void;
+  warn(message: string, fields: Record<string, string | number>): void;
+  error(message: string, fields: Record<string, string | number>): void;
+}
+
+export type MaintenanceJobHandler = (job: MaintenanceJob) => Promise<void>;
+
+export interface MaintenanceQueueRunnerOptions {
+  queue: MaintenanceQueuePort;
+  handlers: ReadonlyMap<string, MaintenanceJobHandler>;
+  logger: MaintenanceQueueLogger;
+  concurrency?: number;
+  pollIntervalMs?: number;
+  leaseMs?: number;
+  now?: () => Date;
+}
+
+/**
+ * Private lifecycle runner for a future server-owned maintenance bootstrap.
+ * Do not start it until concrete handlers are registered. The bootstrap must
+ * await runner.stop() before calling pool.end() during shutdown.
+ */
+export class MaintenanceQueueRunner {
+  private readonly concurrency: number;
+  private readonly pollIntervalMs: number;
+  private readonly leaseMs: number;
+  private readonly now: () => Date;
+  private readonly active = new Set<Promise<void>>();
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private tickPromise: Promise<void> | null = null;
+  private stopping = false;
+
+  constructor(private readonly options: MaintenanceQueueRunnerOptions) {
+    this.concurrency = Math.min(
+      Math.max(options.concurrency ?? 2, 1),
+      MAX_CONCURRENCY,
+    );
+    this.pollIntervalMs = Math.max(options.pollIntervalMs ?? 5_000, 1);
+    this.leaseMs = Math.max(options.leaseMs ?? 30_000, 1);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  start(): void {
+    if (this.options.handlers.size === 0) {
+      throw new Error("maintenance queue runner requires a registered handler");
+    }
+    if (this.interval || this.stopping) return;
+    void this.runOnce();
+    this.interval = setInterval(() => {
+      void this.runOnce();
+    }, this.pollIntervalMs);
+  }
+
+  async runOnce(): Promise<void> {
+    if (this.stopping || this.tickPromise) return this.tickPromise ?? undefined;
+    this.tickPromise = this.tick();
+    try {
+      await this.tickPromise;
+    } finally {
+      this.tickPromise = null;
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+    await this.tickPromise;
+    while (this.active.size > 0) {
+      await Promise.all([...this.active]);
+    }
+  }
+
+  private async tick(): Promise<void> {
+    const available = this.concurrency - this.active.size;
+    if (available <= 0) return;
+
+    let jobs: MaintenanceJob[];
+    try {
+      jobs = await this.options.queue.claimDueJobs({
+        limit: available,
+        now: this.now(),
+        leaseMs: this.leaseMs,
+      });
+    } catch (error) {
+      this.options.logger.error("maintenance queue claim failed", {
+        error_category: safeMaintenanceErrorCategory(error),
+      });
+      return;
+    }
+
+    for (const job of jobs.slice(0, available)) {
+      if (this.stopping) return;
+      let active: Promise<void>;
+      active = this.execute(job).finally(() => this.active.delete(active));
+      this.active.add(active);
+    }
+  }
+
+  private async execute(job: MaintenanceJob): Promise<void> {
+    const startedAt = this.now().getTime();
+    const handler = this.options.handlers.get(job.kind);
+    if (!handler) {
+      await this.fail(job, "unsupported_job_kind", startedAt);
+      return;
+    }
+
+    try {
+      await handler(job);
+      const completed = await this.options.queue.complete(
+        job.id,
+        job.leaseToken!,
+        this.now(),
+      );
+      this.options.logger.info("maintenance queue job completed", {
+        job_id: job.id,
+        job_kind: job.kind,
+        status: completed ? "succeeded" : "stale_lease",
+        duration_ms: this.now().getTime() - startedAt,
+      });
+    } catch (error) {
+      await this.fail(job, error, startedAt);
+    }
+  }
+
+  private async fail(
+    job: MaintenanceJob,
+    error: unknown,
+    startedAt: number,
+  ): Promise<void> {
+    const errorCategory =
+      error === "unsupported_job_kind"
+        ? "unsupported_job_kind"
+        : safeMaintenanceErrorCategory(error);
+    try {
+      const failed = await this.options.queue.fail({
+        job,
+        error,
+        category: errorCategory,
+        now: this.now(),
+      });
+      this.options.logger.warn("maintenance queue job failed", {
+        job_id: job.id,
+        job_kind: job.kind,
+        status: failed?.state ?? "stale_lease",
+        error_category: errorCategory,
+        duration_ms: this.now().getTime() - startedAt,
+      });
+    } catch (recordingError) {
+      this.options.logger.error("maintenance queue failure recording failed", {
+        job_id: job.id,
+        job_kind: job.kind,
+        error_category: safeMaintenanceErrorCategory(recordingError),
+        duration_ms: this.now().getTime() - startedAt,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a durable, server-owned maintenance queue substrate for issue #343.

- migration `026_maintenance_queue.sql` adds the `maintenance_jobs` state machine, lease/terminal/dead-letter constraints, idempotency uniqueness, due/expired-lease indexes, and updated-at trigger
- `MaintenanceQueue` provides content-free divergent-idempotency rejection, atomic `FOR UPDATE SKIP LOCKED` claims, lease-bound complete/fail, deterministic capped backoff, and dead-lettering
- `MaintenanceQueueRunner` provides bounded concurrency, no overlapping ticks, drain-on-stop, and content-free logs
- the substrate is intentionally dormant: no bootstrap start, no registered handlers, no MCP or client export

Closes #343

## Validation

- focused fake queue tests — 9 pass, 0 fail
- real PostgreSQL 18.4 + pgvector proof — 27 migrations applied; 9 DB-gated maintenance queue tests pass, 0 fail, 0 skip
- `bunx tsc --noEmit` — passed
- `git diff --check` — passed
- working tree clean at `4af5e632b3d883e85c7684958b99334292b8cc70`

## Review Gate

Full tier: schema migration, idempotency, concurrent claiming, leases, retry/backoff, dead-letter transitions, and dormant-runner lifecycle require the five specialist lanes plus opposite-runtime terminal audit.

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the queue is dormant and unexported; real PostgreSQL migration/behavior tests provide the applicable live proof.

## Downstream rollout

Not applicable. No MCP tool/schema/transport, Python client, package export, generated skill, Hermes runtime, or live agent behavior changes. The table and runner are internal and unreachable until a future handler/bootstrap PR.

## Critical Self-Review

- Highest-risk behavior: atomic claim/reclaim under `FOR UPDATE SKIP LOCKED`, lease-token ownership, and attempts-to-dead-letter transitions could double-run or lose work. Real PG18 tests cover single claim, non-steal, expiry reclaim, stale completion rejection, retry, dead-letter, and restart recovery.
- Assumptions that could be wrong: claim-time attempt increment aligns with fail-time terminal comparison; `update_updated_at()` exists before migration 026; future handlers will supply their own authorization and exact namespace contracts.
- Missing/weak tests: direct hand-written invalid rows are not tested against every CHECK constraint; no real bootstrap/handler exists by design, so runner integration remains future work.
- Security/permission risk: no exposed auth surface. Namespace is explicit and validated; the queue never infers it. SQL is parameterized and direct claim/concurrency limits are bounded.
- Migration/deploy risk: additive table only, migration is idempotent and applied successfully in a fresh PG18 chain. No server startup behavior changes.
- Downstream client/runtime risk: none; the substrate is dormant, unexported, and not contract-visible.
- Rollback/cleanup concern: revert and drop `maintenance_jobs`; no existing table or data is modified and no runner can hold a live lease because bootstrap is absent.
- Fixes made before PR: divergent idempotency semantics, unsupported-handler error category, claim bounds, namespace validation, ambiguous SQL qualification, timestamp parameter casts, and real PostgreSQL verification.
- Known residual risk: future handler/bootstrap integration must re-review auth, namespace scope, shutdown, and operational backpressure; deterministic backoff has no jitter.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review pattern has surfaced yet; MEDIUM+ findings will be captured after the review cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
