### PR TITLE
fix(343): repair lease_expired constraint on upgraded databases

### DIFF
--- a/src/db/migrations/028_maintenance_jobs_lease_expired_compat.sql
+++ b/src/db/migrations/028_maintenance_jobs_lease_expired_compat.sql
@@ -1,0 +1,28 @@
+-- Migration 028: repair the maintenance_jobs.last_error_category CHECK on
+-- databases upgraded across the migration-026 revision that added
+-- 'lease_expired'.
+--
+-- Migration 026 uses CREATE TABLE IF NOT EXISTS. A database that applied an
+-- earlier revision of 026 — before 'lease_expired' was added to the inline
+-- last_error_category CHECK — keeps its stale constraint: re-running 026 is a
+-- no-op on the existing table, so the enum is never widened. The queue's
+-- expired-lease dead-letter path then stores 'lease_expired' and the write
+-- fails on those upgraded databases while a freshly created database (which
+-- got the current 026 body) succeeds.
+--
+-- This migration re-derives the constraint to the canonical 026 allow-list so
+-- upgraded and fresh databases converge. It only widens the accepted set, so
+-- every previously stored last_error_category value remains valid — no data is
+-- rewritten or lost. It is additive and idempotent: dropping IF EXISTS and
+-- re-adding the same named constraint is safe to re-run and safe on a database
+-- that already has the current definition.
+
+ALTER TABLE maintenance_jobs
+  DROP CONSTRAINT IF EXISTS maintenance_jobs_last_error_category_check;
+
+ALTER TABLE maintenance_jobs
+  ADD CONSTRAINT maintenance_jobs_last_error_category_check
+  CHECK (last_error_category IN (
+    'syntax_error', 'type_error', 'range_error', 'error', 'non_error',
+    'unsupported_job_kind', 'lease_expired'
+  ));

--- a/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
+++ b/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
@@ -22,6 +22,7 @@ const namespace = "test-migration-028-lease-compat";
 // disturb the shared maintenance_jobs table while Bun runs test files in
 // parallel. Chosen once, never derived from anything mutable.
 const TEST_SCHEMA = "ob_test_mig028_lease_compat";
+const TEST_SCHEMA_LOCK = 28_028;
 
 // The canonical last_error_category allow-list minus the value that a
 // database upgraded across an earlier revision of migration 026 is missing.
@@ -130,6 +131,9 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
 
   beforeAll(async () => {
     await client.connect();
+    // Duplicate CI workflows can share one PostgreSQL database. Hold a
+    // session-scoped lock so their fixed test schema cannot be dropped mid-run.
+    await client.query("SELECT pg_advisory_lock($1)", [TEST_SCHEMA_LOCK]);
     // Own an isolated schema. Everything below runs against it via search_path,
     // so migration 026/028 SQL exercises the exact real DDL without mutating
     // public.maintenance_jobs (which parallel test files may depend on). public
@@ -160,9 +164,16 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
   });
 
   afterAll(async () => {
-    // Drop the whole test-owned schema; public was never modified.
-    await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
-    await client.end();
+    try {
+      // Drop the whole test-owned schema; public was never modified.
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    } finally {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1)", [TEST_SCHEMA_LOCK]);
+      } finally {
+        await client.end();
+      }
+    }
   });
 
   it("rejects lease_expired before the migration and accepts it after — proving the upgrade repair", async () => {

--- a/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
+++ b/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const migration026Url = new URL("026_maintenance_queue.sql", import.meta.url);
+const migration028Url = new URL(
+  "028_maintenance_jobs_lease_expired_compat.sql",
+  import.meta.url,
+);
+const namespace = "test-migration-028-lease-compat";
+
+// The canonical last_error_category allow-list minus the value that a
+// database upgraded across an earlier revision of migration 026 is missing.
+// Modelling the pre-'lease_expired' constraint is how we reproduce the
+// upgrade-path defect: migration 026 is CREATE TABLE IF NOT EXISTS, so a
+// database that already has the table keeps its stale inline CHECK.
+const PRE_LEASE_EXPIRED_CATEGORIES = [
+  "syntax_error",
+  "type_error",
+  "range_error",
+  "error",
+  "non_error",
+  "unsupported_job_kind",
+] as const;
+
+const CONSTRAINT_NAME = "maintenance_jobs_last_error_category_check";
+
+dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+      namespace,
+    ]);
+  }
+
+  async function applyMigration026(): Promise<void> {
+    await pool.query(await Bun.file(migration026Url).text());
+  }
+
+  async function applyMigration028(): Promise<void> {
+    await pool.query(await Bun.file(migration028Url).text());
+  }
+
+  // Rewind the persisted constraint to the shape a database that applied an
+  // earlier revision of 026 (before 'lease_expired') carries forward, so the
+  // regression proves the real upgrade path rather than the fresh-DB path.
+  async function installPreLeaseExpiredConstraint(): Promise<void> {
+    // A CHECK constraint definition is DDL and cannot be parameterized, so the
+    // fixture list is inlined from the const above (SQL string literals).
+    const inList = PRE_LEASE_EXPIRED_CATEGORIES.map((c) => `'${c}'`).join(", ");
+    await pool.query(
+      `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
+    );
+    await pool.query(
+      `ALTER TABLE maintenance_jobs
+         ADD CONSTRAINT ${CONSTRAINT_NAME}
+         CHECK (last_error_category IN (${inList}))`,
+    );
+  }
+
+  async function insertWithCategory(
+    idempotencyKey: string,
+    category: string | null,
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO maintenance_jobs
+         (job_kind, job_version, idempotency_key, namespace, last_error_category)
+       VALUES ($1, 1, $2, $3, $4)`,
+      ["maintenance.test", idempotencyKey, namespace, category],
+    );
+  }
+
+  beforeEach(async () => {
+    // Ensure the table exists (idempotent), then model an upgraded database.
+    await applyMigration026();
+    await cleanup();
+    await installPreLeaseExpiredConstraint();
+  });
+  afterAll(async () => {
+    await cleanup();
+    // Leave the table in the canonical (repaired) state for reuse.
+    await applyMigration028();
+    await pool.end();
+  });
+
+  it("rejects lease_expired before the migration and accepts it after — proving the upgrade repair", async () => {
+    // Precondition: the upgrade-path defect is real on the old constraint.
+    await expect(
+      insertWithCategory("028-before", "lease_expired"),
+    ).rejects.toThrow(/last_error_category/);
+
+    await applyMigration028();
+
+    // After the repair, the queue's dead-letter category is accepted.
+    await insertWithCategory("028-after", "lease_expired");
+    const { rows } = await pool.query(
+      `SELECT last_error_category FROM maintenance_jobs
+        WHERE namespace = $1 AND idempotency_key = $2`,
+      [namespace, "028-after"],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].last_error_category).toBe("lease_expired");
+  });
+
+  it("preserves every previously allowed category and still rejects unknown values", async () => {
+    // Seed one row per pre-existing category under the old constraint so the
+    // repair must validate real persisted rows, proving no data loss.
+    for (const category of PRE_LEASE_EXPIRED_CATEGORIES) {
+      await insertWithCategory(`028-preserve-${category}`, category);
+    }
+    await insertWithCategory("028-preserve-null", null);
+
+    await applyMigration028();
+
+    const { rows } = await pool.query(
+      `SELECT idempotency_key, last_error_category FROM maintenance_jobs
+        WHERE namespace = $1
+        ORDER BY idempotency_key`,
+      [namespace],
+    );
+    const persisted = new Map(
+      rows.map((r) => [r.idempotency_key as string, r.last_error_category]),
+    );
+    for (const category of PRE_LEASE_EXPIRED_CATEGORIES) {
+      expect(persisted.get(`028-preserve-${category}`)).toBe(category);
+    }
+    expect(persisted.get("028-preserve-null")).toBeNull();
+
+    // The repaired constraint still enforces the allow-list.
+    await expect(
+      insertWithCategory("028-preserve-bogus", "not_a_real_category"),
+    ).rejects.toThrow(/last_error_category/);
+  });
+
+  it("is idempotent — re-running the repair leaves the constraint intact", async () => {
+    await applyMigration028();
+    await applyMigration028();
+
+    await insertWithCategory("028-idempotent", "lease_expired");
+    const { rows } = await pool.query(
+      `SELECT count(*)::int AS n FROM maintenance_jobs
+        WHERE namespace = $1 AND idempotency_key = $2`,
+      [namespace, "028-idempotent"],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+});

--- a/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
+++ b/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
@@ -1,5 +1,12 @@
-import { afterAll, beforeEach, describe, expect, it } from "bun:test";
-import { Pool } from "pg";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import { Client } from "pg";
 
 const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
 const dbDescribe = DB_URL ? describe : describe.skip;
@@ -9,6 +16,12 @@ const migration028Url = new URL(
   import.meta.url,
 );
 const namespace = "test-migration-028-lease-compat";
+
+// Fixed, code-owned identifier for the isolated test schema. Migration 026/028
+// SQL is applied verbatim here (never against public) so this file cannot
+// disturb the shared maintenance_jobs table while Bun runs test files in
+// parallel. Chosen once, never derived from anything mutable.
+const TEST_SCHEMA = "ob_test_mig028_lease_compat";
 
 // The canonical last_error_category allow-list minus the value that a
 // database upgraded across an earlier revision of migration 026 is missing.
@@ -26,34 +39,77 @@ const PRE_LEASE_EXPIRED_CATEGORIES = [
 
 const CONSTRAINT_NAME = "maintenance_jobs_last_error_category_check";
 
-dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-
-  async function cleanup(): Promise<void> {
-    await pool.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
-      namespace,
-    ]);
+// Narrowly extract the last_error_category CHECK allow-list from a migration's
+// SQL text. This is a targeted regex over the exact shape both migrations use —
+// `last_error_category IN ( 'a', 'b', ... )` — not a general SQL parser. It
+// backs the drift guard so a future addition to 026's set that is not mirrored
+// into 028 fails loudly.
+function extractLastErrorCategorySet(sql: string): Set<string> {
+  const match = sql.match(
+    /last_error_category\s+(?:TEXT\s+)?(?:CHECK\s*\()?\s*IN\s*\(([^)]*)\)/i,
+  );
+  if (!match) {
+    throw new Error(
+      "could not locate a `last_error_category IN (...)` list in the migration SQL",
+    );
   }
+  const values = [...match[1]!.matchAll(/'([^']*)'/g)].map((m) => m[1]!);
+  if (values.length === 0) {
+    throw new Error(
+      "found a `last_error_category IN (...)` list but it contained no quoted values",
+    );
+  }
+  return new Set(values);
+}
+
+// Drift guard — runs without a database. Proves migration 028's repaired CHECK
+// accepts exactly the set migration 026 currently defines, so a future value
+// added to 026 cannot silently be omitted from the 028 upgrade repair.
+describe("028 / 026 last_error_category allow-lists stay in sync", () => {
+  it("028's repaired accepted-value set equals 026's current accepted-value set", async () => {
+    const set026 = extractLastErrorCategorySet(
+      await Bun.file(migration026Url).text(),
+    );
+    const set028 = extractLastErrorCategorySet(
+      await Bun.file(migration028Url).text(),
+    );
+    // Compare as sorted arrays for a readable diff on failure.
+    expect([...set028].sort()).toEqual([...set026].sort());
+  });
+});
+
+dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
+  // A dedicated Client (not a Pool) so the schema-scoping search_path set once
+  // at connect time holds for every query in this file. A Pool hands out
+  // arbitrary connections, which would let a query leak back to public.
+  const client = new Client({ connectionString: DB_URL });
 
   async function applyMigration026(): Promise<void> {
-    await pool.query(await Bun.file(migration026Url).text());
+    await client.query(await Bun.file(migration026Url).text());
   }
 
   async function applyMigration028(): Promise<void> {
-    await pool.query(await Bun.file(migration028Url).text());
+    await client.query(await Bun.file(migration028Url).text());
+  }
+
+  async function cleanup(): Promise<void> {
+    await client.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+      namespace,
+    ]);
   }
 
   // Rewind the persisted constraint to the shape a database that applied an
   // earlier revision of 026 (before 'lease_expired') carries forward, so the
   // regression proves the real upgrade path rather than the fresh-DB path.
+  // Scoped to the test schema by search_path — public is never touched.
   async function installPreLeaseExpiredConstraint(): Promise<void> {
     // A CHECK constraint definition is DDL and cannot be parameterized, so the
     // fixture list is inlined from the const above (SQL string literals).
     const inList = PRE_LEASE_EXPIRED_CATEGORIES.map((c) => `'${c}'`).join(", ");
-    await pool.query(
+    await client.query(
       `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
     );
-    await pool.query(
+    await client.query(
       `ALTER TABLE maintenance_jobs
          ADD CONSTRAINT ${CONSTRAINT_NAME}
          CHECK (last_error_category IN (${inList}))`,
@@ -64,7 +120,7 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
     idempotencyKey: string,
     category: string | null,
   ): Promise<void> {
-    await pool.query(
+    await client.query(
       `INSERT INTO maintenance_jobs
          (job_kind, job_version, idempotency_key, namespace, last_error_category)
        VALUES ($1, 1, $2, $3, $4)`,
@@ -72,17 +128,41 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
     );
   }
 
+  beforeAll(async () => {
+    await client.connect();
+    // Own an isolated schema. Everything below runs against it via search_path,
+    // so migration 026/028 SQL exercises the exact real DDL without mutating
+    // public.maintenance_jobs (which parallel test files may depend on). public
+    // stays on the path only so core resolution (e.g. gen_random_uuid) works;
+    // maintenance_jobs resolves to the test schema because it is listed first.
+    await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+    await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+    // Migration 026 creates a trigger that calls update_updated_at(); provide
+    // it inside the isolated schema so 026 applies self-contained, without
+    // depending on the full base migration chain (which needs pgvector).
+    await client.query(
+      `CREATE OR REPLACE FUNCTION ${TEST_SCHEMA}.update_updated_at()
+         RETURNS TRIGGER AS $$
+         BEGIN
+           NEW.updated_at = NOW();
+           RETURN NEW;
+         END;
+         $$ LANGUAGE plpgsql`,
+    );
+  });
+
   beforeEach(async () => {
     // Ensure the table exists (idempotent), then model an upgraded database.
     await applyMigration026();
     await cleanup();
     await installPreLeaseExpiredConstraint();
   });
+
   afterAll(async () => {
-    await cleanup();
-    // Leave the table in the canonical (repaired) state for reuse.
-    await applyMigration028();
-    await pool.end();
+    // Drop the whole test-owned schema; public was never modified.
+    await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    await client.end();
   });
 
   it("rejects lease_expired before the migration and accepts it after — proving the upgrade repair", async () => {
@@ -95,7 +175,7 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
 
     // After the repair, the queue's dead-letter category is accepted.
     await insertWithCategory("028-after", "lease_expired");
-    const { rows } = await pool.query(
+    const { rows } = await client.query(
       `SELECT last_error_category FROM maintenance_jobs
         WHERE namespace = $1 AND idempotency_key = $2`,
       [namespace, "028-after"],
@@ -114,7 +194,7 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
 
     await applyMigration028();
 
-    const { rows } = await pool.query(
+    const { rows } = await client.query(
       `SELECT idempotency_key, last_error_category FROM maintenance_jobs
         WHERE namespace = $1
         ORDER BY idempotency_key`,
@@ -139,7 +219,7 @@ dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
     await applyMigration028();
 
     await insertWithCategory("028-idempotent", "lease_expired");
-    const { rows } = await pool.query(
+    const { rows } = await client.query(
       `SELECT count(*)::int AS n FROM maintenance_jobs
         WHERE namespace = $1 AND idempotency_key = $2`,
       [namespace, "028-idempotent"],


### PR DESCRIPTION
## Summary

Repairs the upgrade path for the maintenance queue migration introduced by PR #350.

- adds additive migration `028_maintenance_jobs_lease_expired_compat.sql`
- rebuilds the persisted `maintenance_jobs_last_error_category_check` so databases that applied the earlier migration-026 body accept `lease_expired`
- preserves all previously accepted categories and continues rejecting unknown categories
- adds a real-PostgreSQL regression that reproduces the stale constraint before the repair, proves the repair, and checks idempotency

The defect was exposed by PR #351 exact-head CI: the persistent test database had already recorded migration 026 before `lease_expired` was added to that file, so the filename-only migration ledger skipped the edited body. Fresh db-integration databases passed, while the upgraded persistent database correctly failed.

Refs #343

## Validation

- focused migration 028 regression on PostgreSQL 18: 4 pass, 0 fail
- focused migration and maintenance queue suite on PostgreSQL 18: 27 pass, 0 fail
- negative control with migration 028 omitting `lease_expired`: drift guard and repair assertions fail as expected
- duplicate exact-head CI runs: `check`, `db-integration`, Python, contract-parity, PR-body validation, and GitGuardian all passed
- `bunx tsc --noEmit`: passed
- `git diff --check`: passed
- branch and remote head: `95e8360a874a2bb28d6905e9e747ee401a14d71b`

## Review Gate

Full tier: this changes a PostgreSQL schema migration and repairs behavior on already-upgraded databases.

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- [x] Initial five-lane review complete
- [x] Findings fixed and focused verification complete
- [x] Opposite-runtime terminal audit complete
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this PR is a local migration compatibility fix and core01 must remain untouched until the local chain is green

## Downstream rollout

No separate client/runtime rollout. This does not change MCP tools, schemas, transport, client packages, or agent-facing guidance. It must merge before PR #351 is refreshed and merged. Any later core01 deployment remains governed by the combined #326/#337 rollout gate.

## Critical Self-Review

- Highest-risk behavior: dropping and rebuilding the CHECK could reject existing rows or accidentally broaden the category set. The change only widens the prior allowlist by `lease_expired`; the regression seeds every old category and proves unknown values remain rejected.
- Assumptions that could be wrong: PostgreSQL retains the auto-generated inline constraint name `maintenance_jobs_last_error_category_check`. The exact failing CI annotation names that constraint, and migration 026 deterministically creates it under that name.
- Missing/weak tests: the regression is PostgreSQL-gated and does not run without `OPENBRAIN_TEST_DATABASE_URL`; CI db-integration supplies the real database boundary.
- Security/permission risk: none beyond normal migration execution privileges; no auth, namespace, content, or role semantics change.
- Migration/deploy risk: databases with a renamed out-of-band constraint are not a repo-produced state. Normal old-026 and current-026 databases converge to the same constraint. Migration 028 is independent of PR #351's migration 027.
- Downstream client/runtime risk: none; no public contract or package surface changes.
- Rollback/cleanup concern: reverting after application leaves the widened CHECK in place because migrations are forward-only; restoring the stale constraint would reintroduce the defect and is not a safe rollback.
- Fixes made before PR: used an additive migration instead of editing migration 026 again; added an old-schema upgrade regression and negative control. Review fixes isolated the test in a dedicated schema, serialized duplicate workflows with a session advisory lock, and added a 026/028 allowlist drift guard.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new MEDIUM+ review pattern has been confirmed yet; any finding from the active review will be captured before readiness.
- Known residual risk: the migration runner still tracks filenames without checksums, so future edits to applied migration files can cause the same class of drift. That broader hardening is outside this narrow repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
