### PR TITLE
feat(327): populate durable memory context section

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -904,3 +904,63 @@ missing/other namespace), and a present id. Labels: `:merged-upsert`,
 exact-equality check is safe. A tool that seeds into the shared namespace would
 need to compare against the canonical form — check the tool's actual return
 transform before pinning exact-equality.
+
+## [2026-07-22] Whole-pack trimming must reconcile section truth, not only retained items
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #353 / issue #327 Full-tier review
+**Scope:** `src/tools/agent-context-pack-budget.ts`, ranked context-pack sections
+**Status:** fixed-pre-merge
+
+### Pattern
+
+A whole-pack fitter can correctly drop low-priority items and citations while
+leaving the section envelope's own state stale. In PR #353, `durable_memory`
+reported `truncated: false` after ranked tail items were removed, and an empty
+retained envelope lacked a stable whole-pack empty reason. Counts and citations
+were correct, but the section still lied about whether the caller received the
+full result. The fix reconciles every trimmed return path: any dropped item sets
+`truncated: true`; an emptied-but-retained envelope reports
+`empty_reason: "whole_pack_budget"`; counts, citations, warnings, and serialized
+budget are rechecked after metadata changes.
+
+### Review Questions
+
+- When a pack-level fitter drops items, does it update the section's own
+  `truncated` and `empty_reason`, not only arrays and counts?
+- Are both partial-tail-drop and all-item-drop paths covered by tests that fail
+  against the old metadata behavior?
+- If reconciliation adds metadata, is the serialized pack measured again so the
+  fix cannot exceed the hard budget?
+- Do citations and warnings derive from the final retained item set?
+
+## [2026-07-22] Requested degraded sections and cited items need self-contained truth
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #353 / issue #327 Terra terminal audit
+**Scope:** `src/tools/agent-context-pack-durable-memory.ts`, context-pack section/citation contracts
+**Status:** fixed-pre-merge
+
+### Pattern
+
+A requested section that fails internally must not disappear into the same shape
+as an unrequested section. PR #353 initially omitted `durable_memory` when recall
+threw, leaving only a degraded warning; callers could not distinguish "not
+requested" from "requested but unavailable." It also put `source_ref` only on
+the separate citation even though each recalled item claimed item-level
+resolvability. The fix returns a truthful empty `recall_failed` envelope and
+builds one bounded `source_ref` per row, attaching the same value to both item and
+citation. Whole-pack trimming then prunes citations by retained `citation_id`,
+keeping an item/citation/source-ref bijection.
+
+### Review Questions
+
+- Does every explicitly requested degraded section return a stable empty envelope
+  with zero counts and a specific content-free reason, while an unrequested
+  section remains absent?
+- If an item contract promises `source_ref`, is it present on the item itself and
+  equal to the matching citation's reference?
+- After partial trim, all-item trim, or whole-section starvation, are there any
+  dangling citations or source refs?
+- Is duplicated item/citation provenance charged to the serialized hard budget,
+  and do higher-priority sections still survive unchanged?

--- a/src/tools/__tests__/agent-context-pack-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-budget.test.ts
@@ -189,7 +189,12 @@ describe("agent_context_pack whole-pack budget", () => {
       expect(contentChars(payload)).toBeLessThanOrEqual(contentBudget);
       expect(payload.budget.whole_pack).toMatchObject({
         content_char_limit: contentBudget,
-        allocation_order: ["working_set", "recovery", "durable_lane_context"],
+        allocation_order: [
+          "working_set",
+          "recovery",
+          "durable_lane_context",
+          "durable_memory",
+        ],
       });
     } finally {
       await cleanup();

--- a/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
@@ -195,6 +195,14 @@ describe("agent_context_pack durable_memory", () => {
         expect(citation.source_ref.source).toBe("brain");
         expect(citation.source_ref.id).toBe(item.id);
         expect(citation.source_ref.type).toBe(item.source_type);
+        // Every item carries its OWN bounded source_ref, not just a citation_id,
+        // and it is the same source_ref the citation exposes — the item is
+        // independently resolvable back to its brain record.
+        expect(item.source_ref).toBeDefined();
+        expect(item.source_ref).toEqual(citation.source_ref);
+        expect(item.source_ref.source).toBe("brain");
+        expect(item.source_ref.id).toBe(item.id);
+        expect(item.source_ref.type).toBe(item.source_type);
       }
       // No citation is emitted without a corresponding retained item.
       const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
@@ -434,6 +442,69 @@ describe("agent_context_pack durable_memory", () => {
     }
   });
 
+  it("preserves item.source_ref == citation.source_ref with no dangling refs after a partial whole-pack trim", async () => {
+    // After a partial trim, every surviving item must still carry its own
+    // source_ref, that source_ref must equal its citation's source_ref, and no
+    // citation (source_ref) may reference a dropped item — the item-carried
+    // source_ref must reconcile alongside the citation.
+    const records = Array.from({ length: 8 }, (_, index) =>
+      brainRecord({
+        id: `ref-${index}`,
+        source_type: "decisions",
+        content_preview: `ref-${index}:` + "D".repeat(800),
+        distance: 0.1 + index * 0.05,
+        fts_rank: 1 - index * 0.1,
+        usefulness: 1 - index * 0.05,
+        created_at: "2026-07-01T00:00:00Z",
+      }),
+    );
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "ref",
+          requested_sections: ["durable_memory"],
+          budget: { max_tokens: 900 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const section = payload.sections.durable_memory;
+      expect(section).toBeDefined();
+      // A genuine partial trim.
+      expect(section.items.length).toBeGreaterThan(0);
+      expect(section.items.length).toBeLessThan(8);
+
+      const citationById = new Map<string, any>(
+        payload.citations.map((c: any) => [c.id as string, c]),
+      );
+      // Every retained item has its own source_ref equal to its citation's.
+      for (const item of section.items) {
+        expect(item.source_ref).toBeDefined();
+        const citation = citationById.get(item.citation_id);
+        expect(citation).toBeDefined();
+        expect(item.source_ref).toEqual(citation.source_ref);
+        expect(item.source_ref.id).toBe(item.id);
+      }
+      // No dangling citation/source_ref: every citation maps to a retained item.
+      const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
+      expect(payload.citations.length).toBe(section.items.length);
+      for (const citation of payload.citations) {
+        expect(retainedIds.has(citation.id)).toBe(true);
+      }
+      // No dropped record's source_ref survives on any retained item.
+      const retainedRecordIds = new Set(section.items.map((i: any) => i.id));
+      for (const item of section.items) {
+        expect(retainedRecordIds.has(item.source_ref.id)).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("emits a zero-item durable_memory envelope with a truthful whole_pack_budget empty_reason when trimming empties it but the envelope still fits", async () => {
     // A single record whose serialized body cannot fit the surviving budget, but
     // where the empty durable_memory envelope (label/query/counters/empty_reason)
@@ -551,7 +622,12 @@ describe("agent_context_pack durable_memory", () => {
     }
   });
 
-  it("degrades a recall failure without leaking database errors", async () => {
+  it("emits a truthful recall_failed durable_memory envelope for an explicitly requested section without leaking database errors", async () => {
+    // When recall throws for an explicitly requested durable_memory section, the
+    // section is NOT omitted: a truthful empty envelope is emitted (items [],
+    // item_count 0, truncated false, empty_reason recall_failed) alongside the
+    // content-free degraded_sources warning and empty citations. This is distinct
+    // from an unrequested section (which is absent entirely).
     const auth: AuthInfo = { role: "admin", clientId: "rico" };
     const { client, cleanup } = await setupToolClient(auth, {
       query: async () => {
@@ -569,13 +645,66 @@ describe("agent_context_pack durable_memory", () => {
       });
       const payload = JSON.parse((pack.content as any)[0].text);
       expect(pack.isError).toBeFalsy();
-      expect(payload.sections.durable_memory).toBeUndefined();
+      const section = payload.sections.durable_memory;
+      // The requested section is present and truthful, not omitted.
+      expect(section).toBeDefined();
+      expect(section).toMatchObject({
+        label: "durable_memory",
+        namespace_scoped: true,
+        query: "durable",
+        empty_reason: "recall_failed",
+        item_count: 0,
+        truncated: false,
+      });
+      expect(section.items).toEqual([]);
+      expect(payload.citations).toEqual([]);
+      // The content-free degraded_sources warning is retained.
       expect(payload.warnings.degraded_sources).toContainEqual({
         source: "durable_memory",
         reason: "recall_failed",
       });
+      // No dependency/error detail leaks anywhere in the emitted pack — not the
+      // envelope, the warning, the citations, or the section body.
       expect(JSON.stringify(payload)).not.toContain("secret-host");
       expect(JSON.stringify(payload)).not.toContain("internal-detail");
+      expect(JSON.stringify(payload)).not.toContain("postgres");
+      // The only reason string anywhere is the stable, content-free recall_failed
+      // marker — no raw error message or dependency detail is carried through.
+      expect(section.empty_reason).toBe("recall_failed");
+      expect(JSON.stringify(payload)).not.toContain("Error");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("omits durable_memory entirely (no recall_failed envelope) when the section is not requested even if recall would fail", async () => {
+    // Behavior must stay distinct from "requested": an unrequested durable_memory
+    // section is absent from the pack. No recall runs, so no recall_failed
+    // envelope or degraded_sources warning is emitted for it.
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, {
+      query: async () => {
+        throw new Error("postgres://secret-host/internal-detail");
+      },
+    });
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["working_set"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      // Not requested => section absent, distinct from the empty recall_failed
+      // envelope emitted when it IS requested.
+      expect(payload.sections.durable_memory).toBeUndefined();
+      const degraded = payload.warnings.degraded_sources ?? [];
+      expect(degraded.some((d: any) => d.source === "durable_memory")).toBe(
+        false,
+      );
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthInfo } from "../../types.ts";
+import {
+  AGENT_CONTEXT_PACK_SCOPE as SCOPE,
+  setupAgentContextPackToolClient as setupToolClient,
+} from "./agent-context-pack-test-helpers.ts";
+
+/**
+ * The durable_memory section is a query-driven hybrid-RRF recall over the
+ * caller's readable durable brain records, isolated to the auth-derived
+ * namespace. These tests black-box the section through the MCP tool: they vary
+ * scope, query, budget, and role, and assert the observable envelope, citations,
+ * isolation predicate, and defined empty/degraded states — not the internal SQL
+ * shape beyond the namespace security boundary the issue requires proving.
+ */
+
+/**
+ * A mock pool that answers the hybrid search CTEs (vector + FTS) with a supplied
+ * set of brain records and records every query's params so isolation predicates
+ * can be asserted.
+ */
+function searchPool(
+  records: Array<Record<string, unknown>>,
+  captured: Array<{ sql: string; params?: unknown[] }> = [],
+) {
+  return {
+    pool: {
+      query: async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params });
+        // Vector CTE and FTS CTE both select from the brain tables; return the
+        // records for either search path so RRF has both lists to merge.
+        if (
+          sql.includes("query_embedding") ||
+          sql.includes("fts_query") ||
+          sql.includes("FROM ob_")
+        ) {
+          return { rows: records };
+        }
+        return { rows: [] };
+      },
+    },
+    captured,
+  };
+}
+
+function brainRecord(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    source_type: "decisions",
+    id: overrides.id ?? "dec-1",
+    namespace: "rico",
+    content_preview: "durable decision content",
+    tags: null,
+    created_by: "rico",
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-02T00:00:00Z",
+    usefulness: 0.9,
+    tier: "warm",
+    distance: 0.1,
+    fts_rank: 0.9,
+    ...overrides,
+  };
+}
+
+describe("agent_context_pack durable_memory", () => {
+  it("does not query or return durable_memory unless explicitly requested", async () => {
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool([brainRecord()], captured);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable decision",
+          requested_sections: ["working_set"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      expect(payload.sections.durable_memory).toBeUndefined();
+      expect(captured).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns a defined empty section with no_query reason when requested without a query", async () => {
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool([brainRecord()], captured);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section).toMatchObject({
+        label: "durable_memory",
+        namespace_scoped: true,
+        query: null,
+        empty_reason: "no_query",
+        item_count: 0,
+        truncated: false,
+      });
+      expect(section.items).toEqual([]);
+      expect(payload.citations).toEqual([]);
+      // No recall query is issued when there is no query.
+      expect(captured).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns a defined empty section with no_matches when the recall finds nothing", async () => {
+    const { pool } = searchPool([]);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "nothing matches this",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section).toMatchObject({
+        label: "durable_memory",
+        namespace_scoped: true,
+        query: "nothing matches this",
+        empty_reason: "no_matches",
+        item_count: 0,
+        truncated: false,
+      });
+      expect(section.items).toEqual([]);
+      expect(payload.citations).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("returns recalled records with a resolvable source_ref and matching citation on every item", async () => {
+    const records = [
+      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({
+        id: "th-1",
+        source_type: "thoughts",
+        content_preview: "a durable thought",
+      }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section.item_count).toBe(section.items.length);
+      expect(section.items.length).toBeGreaterThan(0);
+
+      // Every item carries a citation_id and every citation resolves back to a
+      // brain record with a source_ref (source/type/id) — the resolvability
+      // contract the issue requires on every item.
+      const citationIds = new Set(
+        payload.citations.map((c: any) => c.id as string),
+      );
+      for (const item of section.items) {
+        expect(typeof item.citation_id).toBe("string");
+        expect(citationIds.has(item.citation_id)).toBe(true);
+        const citation = payload.citations.find(
+          (c: any) => c.id === item.citation_id,
+        );
+        expect(citation.kind).toBe("brain_record");
+        expect(citation.source_ref).toBeDefined();
+        expect(citation.source_ref.source).toBe("brain");
+        expect(citation.source_ref.id).toBe(item.id);
+        expect(citation.source_ref.type).toBe(item.source_type);
+      }
+      // No citation is emitted without a corresponding retained item.
+      const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
+      for (const citation of payload.citations) {
+        expect(retainedIds.has(citation.id)).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("isolates recall to the auth-derived namespace for a token-scoped role", async () => {
+    // A token-sourced agent role reads only its own namespace plus shared. The
+    // recall must bind that namespace predicate on every search path — this is
+    // the isolation security boundary, enforced server-side.
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool([brainRecord()], captured);
+    const auth: AuthInfo = {
+      role: "agent",
+      clientId: "team-alpha",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const { namespace: _drop, ...unnamespacedScope } = SCOPE;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...unnamespacedScope,
+          // No explicit namespace: the auth-derived clientId is the boundary.
+          query: "durable",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      expect(pack.isError).toBeFalsy();
+      // Every issued search query binds a namespace predicate whose params
+      // include the caller's own namespace and never a foreign one.
+      expect(captured.length).toBeGreaterThan(0);
+      for (const q of captured) {
+        expect(q.sql).toContain("namespace");
+        const flat = (q.params ?? []).flat();
+        expect(flat).toContain("team-alpha");
+        expect(flat).not.toContain("rico");
+        expect(flat).not.toContain("other-tenant");
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("out-of-scope negative regression: a foreign-namespace record is never surfaced across the boundary", async () => {
+    // The DB layer is the authority. Simulate a leaky store that would return a
+    // foreign-namespace row: the section still binds the caller's namespace
+    // predicate, and the tool never widens the predicate to a foreign namespace.
+    // This fails on any change that drops or broadens the namespace binding.
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const auth: AuthInfo = {
+      role: "agent",
+      clientId: "tenant-a",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(auth, {
+      query: async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params });
+        return { rows: [] };
+      },
+    });
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          // An explicit foreign namespace is NOT authorized for a token role and
+          // must not be honored: the tool denies the section rather than reading
+          // across the boundary.
+          namespace: "tenant-b",
+          query: "secret",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      // The whole pack is denied at the namespace gate before any recall runs —
+      // no cross-namespace read is issued.
+      expect(pack.isError).toBe(true);
+      expect(JSON.stringify(payload)).toContain("Permission denied");
+      expect(captured).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("bounds the section to the whole-pack budget, dropping the lowest-ranked records first", async () => {
+    // RRF orders records best-first; under budget pressure the lowest-ranked
+    // (tail) records are shed while the highest-ranked head is preserved.
+    const records = Array.from({ length: 8 }, (_, index) =>
+      brainRecord({
+        id: `rank-${index}`,
+        source_type: "decisions",
+        content_preview: `rank-${index}:` + "D".repeat(800),
+        // Descending relevance so RRF keeps rank-0 first, rank-7 last.
+        distance: 0.1 + index * 0.05,
+        fts_rank: 1 - index * 0.1,
+        usefulness: 1 - index * 0.05,
+        created_at: "2026-07-01T00:00:00Z",
+      }),
+    );
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const maxTokens = 900;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "rank",
+          requested_sections: ["durable_memory"],
+          budget: { max_tokens: maxTokens },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const contentBudget = maxTokens * 4 - 1200;
+      const section = payload.sections.durable_memory;
+      expect(section).toBeDefined();
+      // A real trim happened: some but not all records survived.
+      expect(section.items.length).toBeGreaterThan(0);
+      expect(section.items.length).toBeLessThan(8);
+      // The serialized section stays within the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        contentBudget,
+      );
+      // The highest-ranked record survives; the lowest-ranked is shed.
+      const ids = section.items.map((i: any) => i.id);
+      expect(ids[0]).toBe("rank-0");
+      expect(ids).not.toContain("rank-7");
+      // Retained records are the highest-ranked contiguous prefix.
+      const retained = ids.map((id: string) =>
+        Number(/rank-(\d+)/.exec(id)![1]),
+      );
+      for (let k = 1; k < retained.length; k += 1) {
+        expect(retained[k]).toBe(retained[k - 1] + 1);
+      }
+      // item_count reconciles to retained items; citations never dangle.
+      expect(section.item_count).toBe(section.items.length);
+      const retainedCitationIds = new Set(
+        section.items.map((i: any) => i.citation_id),
+      );
+      for (const citation of payload.citations) {
+        expect(retainedCitationIds.has(citation.id)).toBe(true);
+      }
+      // Budget accounting reconciles to the retained content body.
+      const bodyChars = section.items.reduce(
+        (sum: number, i: any) => sum + (i.content ?? "").length,
+        0,
+      );
+      expect(payload.budget.durable_memory.content_chars_used).toBe(bodyChars);
+      // A whole-pack truncation marker names the trimmed section.
+      expect(payload.warnings.truncation).toContainEqual(
+        expect.objectContaining({
+          source: "durable_memory",
+          reason: "whole_pack_budget",
+        }),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("preserves higher-priority sections and allocates durable_memory last under one shared budget", async () => {
+    const records = Array.from({ length: 4 }, (_, index) =>
+      brainRecord({
+        id: `mem-${index}`,
+        content_preview: `mem-${index}:` + "M".repeat(800),
+      }),
+    );
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      // A modest working-set item that must survive whole; durable_memory is the
+      // lowest priority and absorbs the remaining pressure.
+      await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          kind: "task_state",
+          content: "keep-ws:" + "W".repeat(400),
+          trace_id: "ws-keep",
+        },
+      });
+
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "mem",
+          requested_sections: ["working_set", "durable_memory"],
+          budget: { max_tokens: 900 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const contentBudget = 900 * 4 - 1200;
+      // Highest-priority working_set survives whole.
+      expect(payload.sections.working_set.item_count).toBe(1);
+      expect(payload.sections.working_set.items[0].content).toContain(
+        "keep-ws",
+      );
+      // Whole serialized sections stay within the shared budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        contentBudget,
+      );
+      // durable_memory, not working_set, is the trimmed/starved source.
+      const wsMarker = payload.warnings.truncation.find(
+        (t: any) =>
+          t.source === "working_set" && t.reason === "whole_pack_budget",
+      );
+      expect(wsMarker).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("degrades a recall failure without leaking database errors", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, {
+      query: async () => {
+        throw new Error("postgres://secret-host/internal-detail");
+      },
+    });
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      expect(payload.sections.durable_memory).toBeUndefined();
+      expect(payload.warnings.degraded_sources).toContainEqual({
+        source: "durable_memory",
+        reason: "recall_failed",
+      });
+      expect(JSON.stringify(payload)).not.toContain("secret-host");
+      expect(JSON.stringify(payload)).not.toContain("internal-detail");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("multi-query determinism: identical inputs produce identical durable_memory allocation", async () => {
+    const records = Array.from({ length: 5 }, (_, index) =>
+      brainRecord({
+        id: `stable-${index}`,
+        content_preview: `stable-${index}:` + "S".repeat(700),
+        distance: 0.1 + index * 0.05,
+        fts_rank: 1 - index * 0.1,
+      }),
+    );
+    async function run() {
+      const { pool } = searchPool(records);
+      const auth: AuthInfo = { role: "admin", clientId: "rico" };
+      const { client, cleanup } = await setupToolClient(auth, pool);
+      try {
+        const pack = await client.callTool({
+          name: "agent_context_pack",
+          arguments: {
+            ...SCOPE,
+            query: "stable",
+            requested_sections: ["durable_memory"],
+            budget: { max_tokens: 900 },
+          },
+        });
+        return JSON.parse((pack.content as any)[0].text);
+      } finally {
+        await cleanup();
+      }
+    }
+    const first = await run();
+    const second = await run();
+    expect(first.sections.durable_memory.items.map((i: any) => i.id)).toEqual(
+      second.sections.durable_memory.items.map((i: any) => i.id),
+    );
+    expect(first.budget.durable_memory).toEqual(second.budget.durable_memory);
+    expect(first.warnings.truncation).toEqual(second.warnings.truncation);
+  });
+});

--- a/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
@@ -363,6 +363,140 @@ describe("agent_context_pack durable_memory", () => {
     }
   });
 
+  it("reconciles section.truncated to true when a partial whole-pack trim drops records", async () => {
+    // A partial trim (some records survive, some are dropped) must flip the
+    // section's own `truncated` flag to true — a stale false would tell the
+    // caller the recall was complete when the tail was actually shed. Counters,
+    // citations, and the whole-pack warning must stay consistent with the
+    // retained items.
+    const records = Array.from({ length: 8 }, (_, index) =>
+      brainRecord({
+        id: `trim-${index}`,
+        source_type: "decisions",
+        content_preview: `trim-${index}:` + "D".repeat(800),
+        distance: 0.1 + index * 0.05,
+        fts_rank: 1 - index * 0.1,
+        usefulness: 1 - index * 0.05,
+        created_at: "2026-07-01T00:00:00Z",
+      }),
+    );
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const maxTokens = 900;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "trim",
+          requested_sections: ["durable_memory"],
+          budget: { max_tokens: maxTokens },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const section = payload.sections.durable_memory;
+      expect(section).toBeDefined();
+      // A genuine partial trim: some but not all records survived.
+      expect(section.items.length).toBeGreaterThan(0);
+      expect(section.items.length).toBeLessThan(8);
+      // The section's own truncated flag reflects the drop — not a stale false.
+      expect(section.truncated).toBe(true);
+      // A partial trim retained records, so it is not marked empty.
+      expect(section.empty_reason).toBeUndefined();
+      // item_count reconciles to the retained items.
+      expect(section.item_count).toBe(section.items.length);
+      // Citations never dangle: every citation maps to a retained item and every
+      // retained item has a citation.
+      const retainedCitationIds = new Set(
+        section.items.map((i: any) => i.citation_id),
+      );
+      expect(payload.citations.length).toBe(section.items.length);
+      for (const citation of payload.citations) {
+        expect(retainedCitationIds.has(citation.id)).toBe(true);
+      }
+      for (const item of section.items) {
+        expect(typeof item.citation_id).toBe("string");
+      }
+      // The whole-pack truncation warning names the trimmed section.
+      expect(payload.warnings.truncation).toContainEqual(
+        expect.objectContaining({
+          source: "durable_memory",
+          reason: "whole_pack_budget",
+        }),
+      );
+      // Serialized sections stay within the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        maxTokens * 4 - 1200,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("emits a zero-item durable_memory envelope with a truthful whole_pack_budget empty_reason when trimming empties it but the envelope still fits", async () => {
+    // A single record whose serialized body cannot fit the surviving budget, but
+    // where the empty durable_memory envelope (label/query/counters/empty_reason)
+    // can. The retained list is trimmed to empty; the emitted envelope must state
+    // a stable empty_reason of whole_pack_budget rather than reporting no reason
+    // or claiming a complete-but-empty recall, and its truncated flag must be
+    // true with counts zeroed and no dangling citations.
+    const records = [
+      brainRecord({
+        id: "solo-1",
+        source_type: "decisions",
+        content_preview: "solo:" + "D".repeat(2000),
+      }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      // max_tokens 500 => 800-char whole-pack budget: too small for the ~2000-char
+      // record body, large enough for the empty envelope.
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "solo",
+          requested_sections: ["durable_memory"],
+          budget: { max_tokens: 500 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const budget = 500 * 4 - 1200;
+      const section = payload.sections.durable_memory;
+      // The empty envelope is preserved because it fits the surviving budget.
+      expect(section).toBeDefined();
+      expect(section.items).toEqual([]);
+      expect(section.item_count).toBe(0);
+      // Truthful empty state: the whole-pack budget starved the section, and the
+      // section reports it was truncated.
+      expect(section.empty_reason).toBe("whole_pack_budget");
+      expect(section.truncated).toBe(true);
+      // No citations reference a record that was not emitted.
+      expect(payload.citations).toEqual([]);
+      // The whole-pack truncation warning names the trimmed section.
+      expect(payload.warnings.truncation).toContainEqual(
+        expect.objectContaining({
+          source: "durable_memory",
+          reason: "whole_pack_budget",
+        }),
+      );
+      // The serialized sections object stays within the whole-pack budget.
+      expect(JSON.stringify(payload.sections).length).toBeLessThanOrEqual(
+        budget,
+      );
+      // Budget accounting reports zero content emitted, never more than the limit.
+      expect(payload.budget.durable_memory.content_chars_used).toBe(0);
+      expect(payload.budget.whole_pack.content_chars_used).toBeLessThanOrEqual(
+        payload.budget.whole_pack.content_char_limit,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("preserves higher-priority sections and allocates durable_memory last under one shared budget", async () => {
     const records = Array.from({ length: 4 }, (_, index) =>
       brainRecord({

--- a/src/tools/agent-context-pack-budget.ts
+++ b/src/tools/agent-context-pack-budget.ts
@@ -16,8 +16,10 @@ export const CHARS_PER_TOKEN = 4;
 /**
  * Deterministic whole-pack allocation order, highest value first. working_set
  * is the exact-scope hot active state, recovery is the explicit opt-in
- * interrupted-session trace, and durable_lane_context is the broader recallable
- * lane context. A lower-priority section is only assembled against whatever
+ * interrupted-session trace, durable_lane_context is the broader recallable
+ * lane context, and durable_memory is the query-driven hybrid recall over durable
+ * brain records — the lowest-priority section, allocated last against whatever
+ * budget survives. A lower-priority section is only assembled against whatever
  * pack budget the higher-priority sections leave behind, so one large section
  * cannot starve a higher-value one. This order is stable for identical inputs.
  */
@@ -25,6 +27,7 @@ export const CONTEXT_PACK_SECTION_PRIORITY = [
   "working_set",
   "recovery",
   "durable_lane_context",
+  "durable_memory",
 ] as const;
 
 /** Serialized size, in characters, of a section's content payload. */
@@ -246,4 +249,96 @@ export function fitItemSection<T extends { items: Array<{ id: string }> }>(
     (emptied as Record<keyof T, unknown>)[countKey] = 0;
   }
   return { section: emptied, truncated: true, starved: true };
+}
+
+export type DurableMemoryItem = { citation_id?: unknown; content?: unknown };
+export type DurableMemorySection = {
+  items?: DurableMemoryItem[];
+  item_count?: number;
+};
+
+/**
+ * Sum of durable-memory content-body characters (retained item content) for
+ * reconciling `budget.durable_memory.content_chars_used` to whatever survives
+ * the whole-pack re-fit.
+ */
+export function durableMemoryContentChars(
+  section: DurableMemorySection,
+): number {
+  let total = 0;
+  for (const item of section.items ?? []) {
+    if (typeof item.content === "string") total += item.content.length;
+  }
+  return total;
+}
+
+/**
+ * Fit a ranked item-bearing section (durable_memory) inside a remaining
+ * whole-pack char budget by dropping the LOWEST-ranked items first. Unlike the
+ * recency-ordered stores fit by {@link fitItemSection} (newest at the tail, drop
+ * the front), hybrid-RRF recall orders items highest-relevance-first, so the
+ * lowest-priority items live at the tail. Dropping the tail preserves the
+ * highest-ranked recall under budget pressure, matching the issue's
+ * "oldest/lowest-priority trimming" contract for a relevance-ordered section.
+ *
+ * The section is measured by its serialized length (`JSON.stringify`), so
+ * per-item metadata, ids, and wrappers are counted against the whole-pack
+ * budget. `item_count` is reconciled to the retained items so counters and
+ * citations stay consistent with the emitted content. A section is "starved"
+ * whenever no item body survives (items: []); the caller decides whether to
+ * emit the empty envelope or omit the section to hold the budget.
+ */
+export function fitRankedItemSection<
+  T extends { items: Array<{ citation_id?: unknown }> },
+>(
+  section: T,
+  countKeys: Array<keyof T>,
+  remainingChars: number,
+): { section: T; truncated: boolean; starved: boolean } {
+  if (serializedLength(section) <= remainingChars) {
+    return { section, truncated: false, starved: false };
+  }
+
+  // Drop the lowest-ranked item (last index) one at a time until the section
+  // fits or is emptied, preserving the highest-ranked head items.
+  const kept = [...section.items];
+  while (kept.length > 0) {
+    kept.pop();
+    const candidate = { ...section, items: kept } as T;
+    for (const countKey of countKeys) {
+      (candidate as Record<keyof T, unknown>)[countKey] = kept.length;
+    }
+    if (serializedLength(candidate) <= remainingChars) {
+      return {
+        section: candidate,
+        truncated: true,
+        starved: kept.length === 0,
+      };
+    }
+  }
+
+  const emptied = { ...section, items: [] as T["items"] } as T;
+  for (const countKey of countKeys) {
+    (emptied as Record<keyof T, unknown>)[countKey] = 0;
+  }
+  return { section: emptied, truncated: true, starved: true };
+}
+
+/**
+ * Keep only the citations whose durable-memory items survived the whole-pack
+ * re-fit, so citations never reference dropped records.
+ */
+export function reconcileDurableMemoryCitations(
+  citations: Array<Record<string, unknown>>,
+  keptItems: DurableMemoryItem[],
+): Array<Record<string, unknown>> {
+  const keptCitationIds = new Set(
+    keptItems
+      .map((item) => item.citation_id)
+      .filter((id): id is string => typeof id === "string"),
+  );
+  return citations.filter(
+    (citation) =>
+      typeof citation.id === "string" && keptCitationIds.has(citation.id),
+  );
 }

--- a/src/tools/agent-context-pack-budget.ts
+++ b/src/tools/agent-context-pack-budget.ts
@@ -284,9 +284,13 @@ export function durableMemoryContentChars(
  * The section is measured by its serialized length (`JSON.stringify`), so
  * per-item metadata, ids, and wrappers are counted against the whole-pack
  * budget. `item_count` is reconciled to the retained items so counters and
- * citations stay consistent with the emitted content. A section is "starved"
- * whenever no item body survives (items: []); the caller decides whether to
- * emit the empty envelope or omit the section to hold the budget.
+ * citations stay consistent with the emitted content. Whenever any item is
+ * dropped the section's own `truncated` flag is reconciled to `true` so it never
+ * reports a stale `false` while its content was trimmed. A section is "starved"
+ * whenever no item body survives (items: []); when trimming empties the retained
+ * list the section's `empty_reason` is stamped `whole_pack_budget` so the
+ * emitted empty envelope truthfully states why it holds no items, and the caller
+ * decides whether to emit that envelope or omit the section to hold the budget.
  */
 export function fitRankedItemSection<
   T extends { items: Array<{ citation_id?: unknown }> },
@@ -299,6 +303,18 @@ export function fitRankedItemSection<
     return { section, truncated: false, starved: false };
   }
 
+  // Reconcile a trimmed section to reflect that items were dropped: mark the
+  // section-level `truncated` flag, and when the retained list is emptied stamp a
+  // stable `empty_reason` so the empty envelope truthfully states the whole-pack
+  // budget starved it rather than reporting no reason.
+  const reconcile = (candidate: T): T => {
+    (candidate as Record<string, unknown>).truncated = true;
+    if ((candidate.items as unknown[]).length === 0) {
+      (candidate as Record<string, unknown>).empty_reason = "whole_pack_budget";
+    }
+    return candidate;
+  };
+
   // Drop the lowest-ranked item (last index) one at a time until the section
   // fits or is emptied, preserving the highest-ranked head items.
   const kept = [...section.items];
@@ -310,7 +326,7 @@ export function fitRankedItemSection<
     }
     if (serializedLength(candidate) <= remainingChars) {
       return {
-        section: candidate,
+        section: reconcile(candidate),
         truncated: true,
         starved: kept.length === 0,
       };
@@ -321,7 +337,7 @@ export function fitRankedItemSection<
   for (const countKey of countKeys) {
     (emptied as Record<keyof T, unknown>)[countKey] = 0;
   }
-  return { section: emptied, truncated: true, starved: true };
+  return { section: reconcile(emptied), truncated: true, starved: true };
 }
 
 /**

--- a/src/tools/agent-context-pack-durable-lane.ts
+++ b/src/tools/agent-context-pack-durable-lane.ts
@@ -200,7 +200,12 @@ async function openDurableLaneReader(
   };
 }
 
-function boundedText(
+/**
+ * Bound a text value to `maxChars`, reporting whether anything was dropped.
+ * Shared with the durable-memory loader ({@link ./agent-context-pack-durable-memory.ts})
+ * so both context-pack recall paths bound content the same way.
+ */
+export function boundedText(
   value: unknown,
   maxChars: number,
 ): {

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -1,0 +1,261 @@
+import type { ToolDeps } from "./index.ts";
+import type { AuthInfo } from "../types.ts";
+import type { AgentContextPackArgs } from "./agent-context-pack.ts";
+import { canRead } from "../permissions.ts";
+import { namespaceFilterFor } from "../read-policy.ts";
+import { ALL_TABLES } from "./table-constants.ts";
+import {
+  executeSearch,
+  type SearchRow,
+  type SearchTable,
+} from "./search-brain.ts";
+import { CONTEXT_PACK_ENVELOPE_CHAR_RESERVE } from "./agent-context-pack-durable-lane.ts";
+
+const DURABLE_MEMORY_MAX_CONTENT_CHARS = 8_000;
+const DURABLE_MEMORY_MAX_ITEMS = 8;
+const DURABLE_MEMORY_MAX_ITEM_CHARS = 1_000;
+
+/**
+ * Resolve the durable-memory content char budget.
+ *
+ * When the whole-pack allocator supplies an explicit `contentCharLimit`, the
+ * recall content is bounded by the pack-level allocation it was granted (still
+ * clamped by the durable-memory hard cap). Otherwise the historical per-section
+ * derivation from `budget.max_tokens` applies, preserving compatibility when no
+ * whole-pack allocation is in effect.
+ */
+function resolveDurableMemoryContentChars(
+  args: AgentContextPackArgs,
+  contentCharLimit: number | undefined,
+): number {
+  if (contentCharLimit !== undefined) {
+    return Math.max(
+      0,
+      Math.min(DURABLE_MEMORY_MAX_CONTENT_CHARS, contentCharLimit),
+    );
+  }
+  return Math.max(
+    0,
+    Math.min(
+      DURABLE_MEMORY_MAX_CONTENT_CHARS,
+      (args.budget?.max_tokens ?? 4000) * 4 -
+        CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+    ),
+  );
+}
+
+export type DurableMemoryContextFragment = {
+  section?: Record<string, unknown>;
+  scopeDenials: Array<Record<string, unknown>>;
+  truncation: Array<Record<string, unknown>>;
+  degradedSources: Array<Record<string, unknown>>;
+  budget: Record<string, unknown>;
+  citations: Array<Record<string, unknown>>;
+};
+
+function boundedText(
+  value: unknown,
+  maxChars: number,
+): { text: string | null; truncated: boolean } {
+  if (typeof value !== "string" || value.length === 0 || maxChars <= 0) {
+    return {
+      text: null,
+      truncated: typeof value === "string" && value.length > 0,
+    };
+  }
+  if (value.length <= maxChars) return { text: value, truncated: false };
+  return { text: value.slice(0, maxChars), truncated: true };
+}
+
+/**
+ * Build the `durable_memory` section: query-driven hybrid-RRF recall over the
+ * caller's readable durable brain records, isolated to the auth-derived
+ * namespace. This is distinct from `durable_lane_context`, which returns the
+ * exact seven-coordinate active lane. durable_memory answers "what durable
+ * records are relevant to this query" within the namespace security boundary.
+ *
+ * The section is only assembled when a `query` is supplied — recall has no
+ * meaning without one — and always returns a defined envelope (empty
+ * `items: []` with a reason when there is no query or no matching record), so a
+ * caller can distinguish "not requested" (section omitted) from "requested, no
+ * durable recall" (section present, empty).
+ *
+ * Every returned item carries a resolvable `source_ref` and a matching
+ * `citation_id`, and the citations list is built from the same source refs, so
+ * every emitted item is independently resolvable back to its brain record.
+ */
+export async function loadDurableMemoryContext(
+  args: AgentContextPackArgs,
+  auth: AuthInfo,
+  namespace: string,
+  deps: ToolDeps,
+  contentCharLimit?: number,
+): Promise<DurableMemoryContextFragment> {
+  const maxContentChars = resolveDurableMemoryContentChars(
+    args,
+    contentCharLimit,
+  );
+  const query = args.query?.trim() ?? "";
+
+  const emptyBudget = () => ({
+    content_char_limit: maxContentChars,
+    content_chars_used: 0,
+    max_items: DURABLE_MEMORY_MAX_ITEMS,
+    max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
+  });
+
+  // Recall requires a query. Return a defined empty section so the caller can
+  // tell "requested but no query" apart from "not requested".
+  if (query.length === 0) {
+    return {
+      section: {
+        label: "durable_memory",
+        namespace_scoped: true,
+        query: null,
+        empty_reason: "no_query",
+        items: [],
+        item_count: 0,
+        truncated: false,
+      },
+      scopeDenials: [],
+      truncation: [],
+      degradedSources: [],
+      budget: emptyBudget(),
+      citations: [],
+    };
+  }
+
+  const accessibleTables: SearchTable[] = ALL_TABLES.filter((table) =>
+    canRead(auth.role, table),
+  );
+  if (accessibleTables.length === 0) {
+    return {
+      section: {
+        label: "durable_memory",
+        namespace_scoped: true,
+        query,
+        empty_reason: "no_readable_tables",
+        items: [],
+        item_count: 0,
+        truncated: false,
+      },
+      scopeDenials: [
+        { source: "durable_memory", reasons: ["no_readable_tables"] },
+      ],
+      truncation: [],
+      degradedSources: [],
+      budget: emptyBudget(),
+      citations: [],
+    };
+  }
+
+  // Auth-derived namespace predicate is the isolation boundary. An explicit
+  // namespace arg was already authorized by the caller (canReadNamespace);
+  // otherwise fall back to the caller's own readable namespaces.
+  const namespaceFilter = args.namespace
+    ? namespaceFilterFor(auth, namespace)
+    : namespaceFilterFor(auth);
+
+  let rows: SearchRow[];
+  try {
+    rows = await executeSearch(
+      deps,
+      accessibleTables,
+      query,
+      DURABLE_MEMORY_MAX_ITEMS,
+      "hybrid",
+      undefined,
+      0,
+      namespaceFilter,
+      false,
+    );
+  } catch {
+    return {
+      scopeDenials: [],
+      truncation: [],
+      degradedSources: [{ source: "durable_memory", reason: "recall_failed" }],
+      budget: emptyBudget(),
+      citations: [],
+    };
+  }
+
+  let remainingChars = maxContentChars;
+  const items: Array<Record<string, unknown>> = [];
+  const citations: Array<Record<string, unknown>> = [];
+  let itemsTruncated = false;
+
+  for (const row of rows) {
+    const bounded = boundedText(
+      row.content_preview,
+      Math.min(DURABLE_MEMORY_MAX_ITEM_CHARS, remainingChars),
+    );
+    if (!bounded.text) {
+      if (
+        typeof row.content_preview === "string" &&
+        row.content_preview.length > 0
+      ) {
+        itemsTruncated = true;
+      }
+      break;
+    }
+    const citationId = `brain_record:${row.source_type}:${row.id}`;
+    items.push({
+      id: row.id,
+      source_type: row.source_type,
+      namespace: row.namespace ?? null,
+      content: bounded.text,
+      created_at: row.created_at,
+      updated_at: row.updated_at ?? null,
+      tier: row.tier ?? null,
+      citation_id: citationId,
+    });
+    citations.push({
+      id: citationId,
+      kind: "brain_record",
+      source_ref: row.source_ref ?? {
+        source: "brain",
+        type: row.source_type,
+        id: row.id,
+        namespace: row.namespace,
+        label: (row.content_preview ?? "").slice(0, 120),
+        preview: (row.content_preview ?? "").slice(0, 300),
+      },
+    });
+    remainingChars -= bounded.text.length;
+    if (bounded.truncated) itemsTruncated = true;
+  }
+  // Records beyond the ones whose bodies fit were dropped by the char budget.
+  if (items.length < rows.length) itemsTruncated = true;
+
+  const truncation: Array<Record<string, unknown>> = [];
+  if (itemsTruncated) {
+    truncation.push({
+      source: "durable_memory.items",
+      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
+      content_char_limit: maxContentChars,
+    });
+  }
+
+  return {
+    section: {
+      label: "durable_memory",
+      namespace_scoped: true,
+      query,
+      ...(items.length === 0 ? { empty_reason: "no_matches" } : {}),
+      items,
+      item_count: items.length,
+      truncated: truncation.length > 0,
+    },
+    scopeDenials: [],
+    truncation,
+    degradedSources: [],
+    budget: {
+      content_char_limit: maxContentChars,
+      content_chars_used: maxContentChars - remainingChars,
+      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
+    },
+    citations,
+  };
+}

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -155,7 +155,21 @@ export async function loadDurableMemoryContext(
       false,
     );
   } catch {
+    // Recall was explicitly requested for this section but the search failed.
+    // Return a truthful empty durable_memory envelope (not an omitted section) so
+    // the caller can tell "requested, recall failed" apart from "not requested".
+    // The degraded_sources warning stays content-free — no dependency/error
+    // detail is leaked into the envelope or the warning.
     return {
+      section: {
+        label: "durable_memory",
+        namespace_scoped: true,
+        query,
+        empty_reason: "recall_failed",
+        items: [],
+        item_count: 0,
+        truncated: false,
+      },
       scopeDenials: [],
       truncation: [],
       degradedSources: [{ source: "durable_memory", reason: "recall_failed" }],
@@ -184,6 +198,20 @@ export async function loadDurableMemoryContext(
       break;
     }
     const citationId = `brain_record:${row.source_type}:${row.id}`;
+    // Build the bounded source_ref once per row and attach the SAME object to
+    // both the item and its citation, so an item is independently resolvable back
+    // to its brain record without a citation lookup, and item.source_ref is
+    // identical to citation.source_ref. Citation reconciliation after whole-pack
+    // trimming keys off citation_id, so co-locating source_ref on the item keeps
+    // the two consistent through partial and full trims.
+    const sourceRef = row.source_ref ?? {
+      source: "brain",
+      type: row.source_type,
+      id: row.id,
+      namespace: row.namespace,
+      label: (row.content_preview ?? "").slice(0, 120),
+      preview: (row.content_preview ?? "").slice(0, 300),
+    };
     items.push({
       id: row.id,
       source_type: row.source_type,
@@ -193,18 +221,12 @@ export async function loadDurableMemoryContext(
       updated_at: row.updated_at ?? null,
       tier: row.tier ?? null,
       citation_id: citationId,
+      source_ref: sourceRef,
     });
     citations.push({
       id: citationId,
       kind: "brain_record",
-      source_ref: row.source_ref ?? {
-        source: "brain",
-        type: row.source_type,
-        id: row.id,
-        namespace: row.namespace,
-        label: (row.content_preview ?? "").slice(0, 120),
-        preview: (row.content_preview ?? "").slice(0, 300),
-      },
+      source_ref: sourceRef,
     });
     remainingChars -= bounded.text.length;
     if (bounded.truncated) itemsTruncated = true;

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -1,15 +1,14 @@
 import type { ToolDeps } from "./index.ts";
-import type { AuthInfo } from "../types.ts";
+import type { AuthInfo, Table } from "../types.ts";
 import type { AgentContextPackArgs } from "./agent-context-pack.ts";
 import { canRead } from "../permissions.ts";
 import { namespaceFilterFor } from "../read-policy.ts";
 import { ALL_TABLES } from "./table-constants.ts";
+import { executeSearch, type SearchRow } from "./search-brain.ts";
 import {
-  executeSearch,
-  type SearchRow,
-  type SearchTable,
-} from "./search-brain.ts";
-import { CONTEXT_PACK_ENVELOPE_CHAR_RESERVE } from "./agent-context-pack-durable-lane.ts";
+  CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+  boundedText,
+} from "./agent-context-pack-durable-lane.ts";
 
 const DURABLE_MEMORY_MAX_CONTENT_CHARS = 8_000;
 const DURABLE_MEMORY_MAX_ITEMS = 8;
@@ -52,20 +51,6 @@ export type DurableMemoryContextFragment = {
   budget: Record<string, unknown>;
   citations: Array<Record<string, unknown>>;
 };
-
-function boundedText(
-  value: unknown,
-  maxChars: number,
-): { text: string | null; truncated: boolean } {
-  if (typeof value !== "string" || value.length === 0 || maxChars <= 0) {
-    return {
-      text: null,
-      truncated: typeof value === "string" && value.length > 0,
-    };
-  }
-  if (value.length <= maxChars) return { text: value, truncated: false };
-  return { text: value.slice(0, maxChars), truncated: true };
-}
 
 /**
  * Build the `durable_memory` section: query-driven hybrid-RRF recall over the
@@ -125,7 +110,7 @@ export async function loadDurableMemoryContext(
     };
   }
 
-  const accessibleTables: SearchTable[] = ALL_TABLES.filter((table) =>
+  const accessibleTables: Table[] = ALL_TABLES.filter((table) =>
     canRead(auth.role, table),
   );
   if (accessibleTables.length === 0) {

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -332,8 +332,9 @@ export async function buildAgentContextPackPayload(
           serializedLength(durableLaneSection) -
           durableLaneFrame,
       );
-      // durable_lane_context is last in priority, so this only keeps the
-      // first-member invariant honest; no later section frames after it.
+      // durable_memory frames after durable_lane_context, so record that a
+      // member was admitted to keep the first-member framing invariant honest
+      // for the section that follows.
       firstSectionAdmitted = false;
       if (fitted.truncated) {
         wholePackTruncation.push({

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -20,15 +20,20 @@ import {
   CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
   loadDurableLaneContext,
 } from "./agent-context-pack-durable-lane.ts";
+import { loadDurableMemoryContext } from "./agent-context-pack-durable-memory.ts";
 import {
   CHARS_PER_TOKEN,
   CONTEXT_PACK_SECTION_PRIORITY,
   durableLaneContentChars,
+  durableMemoryContentChars,
   fitDurableLaneSection,
   fitItemSection,
+  fitRankedItemSection,
+  reconcileDurableMemoryCitations,
   sectionFrameCost,
   serializedLength,
   type DurableLaneSection,
+  type DurableMemorySection,
 } from "./agent-context-pack-budget.ts";
 
 export const SECTION_NAMES = [
@@ -148,6 +153,8 @@ export async function buildAgentContextPackPayload(
     (!args.requested_sections || args.requested_sections.includes("recovery"));
   const includeDurableLaneContext =
     args.requested_sections?.includes("durable_lane_context") === true;
+  const includeDurableMemory =
+    args.requested_sections?.includes("durable_memory") === true;
 
   // Total whole-pack char budget. Absent max_tokens => no whole-pack bound, and
   // every section keeps its historical independent per-section behavior.
@@ -364,10 +371,121 @@ export async function buildAgentContextPackPayload(
           : durableLaneContext.budget
       : durableLaneContext?.budget;
 
+  // durable_memory is the lowest-priority section: query-driven hybrid recall
+  // over the caller's readable durable brain records, isolated to the
+  // auth-derived namespace. It is assembled against whatever budget survives the
+  // higher-priority sections, seeded with a content limit and then re-fit against
+  // remainingChars by dropping the lowest-ranked (tail) records so the highest
+  // RRF-ranked recall is preserved under pressure. Counts, citations, and
+  // truncation are reconciled to whatever survives. Without a whole-pack budget
+  // the loader keeps its historical per-section derivation and no re-fit runs.
+  const durableMemoryFrame = sectionFrameCost(
+    "durable_memory",
+    firstSectionAdmitted,
+  );
+  const durableMemoryServingChars =
+    wholePackBudget === null
+      ? Number.POSITIVE_INFINITY
+      : Math.max(0, remainingChars - durableMemoryFrame);
+  const durableMemoryContentLimit =
+    wholePackBudget === null
+      ? undefined
+      : Number.isFinite(durableMemoryServingChars)
+        ? Math.floor(durableMemoryServingChars)
+        : undefined;
+  const durableMemoryContext = includeDurableMemory
+    ? await loadDurableMemoryContext(
+        args,
+        auth,
+        ns,
+        deps,
+        durableMemoryContentLimit,
+      )
+    : null;
+  let durableMemorySection = durableMemoryContext?.section ?? null;
+  let durableMemoryCitations = durableMemorySection
+    ? (durableMemoryContext?.citations ?? [])
+    : [];
+  let durableMemoryStarvedOut = false;
+  if (durableMemorySection && wholePackBudget !== null) {
+    const fitted = fitRankedItemSection(
+      durableMemorySection as {
+        items: Array<{ citation_id?: unknown }>;
+        item_count: number;
+      },
+      ["item_count"],
+      durableMemoryServingChars,
+    );
+    if (
+      fitted.starved &&
+      serializedLength(fitted.section) > durableMemoryServingChars
+    ) {
+      // Even the empty durable-memory envelope overflows the surviving budget:
+      // omit it and drop its citations so the whole pack stays within budget and
+      // no citation references an unemitted section. The starved truncation
+      // marker still signals that the requested section was dropped.
+      durableMemorySection = null;
+      durableMemoryCitations = [];
+      durableMemoryStarvedOut = true;
+      wholePackTruncation.push({
+        source: "durable_memory",
+        reason: "whole_pack_budget",
+        max_chars: wholePackBudget,
+        starved: true,
+      });
+    } else {
+      durableMemorySection = fitted.section;
+      durableMemoryCitations = reconcileDurableMemoryCitations(
+        durableMemoryCitations,
+        (durableMemorySection as DurableMemorySection).items ?? [],
+      );
+      remainingChars = Math.max(
+        0,
+        remainingChars -
+          serializedLength(durableMemorySection) -
+          durableMemoryFrame,
+      );
+      firstSectionAdmitted = false;
+      if (fitted.truncated) {
+        wholePackTruncation.push({
+          source: "durable_memory",
+          reason: "whole_pack_budget",
+          max_chars: wholePackBudget,
+        });
+      }
+    }
+  } else if (durableMemorySection) {
+    remainingChars = Math.max(
+      0,
+      remainingChars -
+        serializedLength(durableMemorySection) -
+        durableMemoryFrame,
+    );
+    firstSectionAdmitted = false;
+  }
+
+  // Reconcile durable_memory content_chars_used to the content that survived the
+  // whole-pack re-fit, mirroring the durable-lane reconciliation. Without a
+  // whole-pack budget the loader's own accounting is authoritative.
+  const durableMemoryBudget =
+    wholePackBudget !== null && durableMemoryContext?.budget
+      ? durableMemorySection
+        ? {
+            ...durableMemoryContext.budget,
+            content_chars_used: durableMemoryContentChars(
+              durableMemorySection as DurableMemorySection,
+            ),
+          }
+        : durableMemoryStarvedOut
+          ? { ...durableMemoryContext.budget, content_chars_used: 0 }
+          : durableMemoryContext.budget
+      : durableMemoryContext?.budget;
+
   const sections: Record<string, unknown> = {};
   if (workingSetSection) sections.working_set = workingSetSection;
   if (recoverySection) sections.recovery = recoverySection;
   if (durableLaneSection) sections.durable_lane_context = durableLaneSection;
+  if (durableMemorySection) sections.durable_memory = durableMemorySection;
 
   return {
     payload: {
@@ -383,10 +501,17 @@ export async function buildAgentContextPackPayload(
           ...(workingSet ? workingSet.warnings.scope_denials : []),
           ...(recovery ? recovery.warnings.scope_denials : []),
           ...(durableLaneContext?.scopeDenials ?? []),
+          ...(durableMemoryContext?.scopeDenials ?? []),
         ],
-        degraded_sources: durableLaneContext?.degradedSources ?? [],
+        degraded_sources: [
+          ...(durableLaneContext?.degradedSources ?? []),
+          ...(durableMemoryContext?.degradedSources ?? []),
+        ],
         truncation: [
           ...(durableLaneSection ? (durableLaneContext?.truncation ?? []) : []),
+          ...(durableMemorySection
+            ? (durableMemoryContext?.truncation ?? [])
+            : []),
           ...wholePackTruncation,
         ],
       },
@@ -407,8 +532,11 @@ export async function buildAgentContextPackPayload(
         ...(durableLaneSection || durableLaneContext
           ? { durable_lane_context: durableLaneBudget }
           : {}),
+        ...(durableMemorySection || durableMemoryContext
+          ? { durable_memory: durableMemoryBudget }
+          : {}),
       },
-      citations: durableCitations,
+      citations: [...durableCitations, ...durableMemoryCitations],
       query: args.query ?? null,
     },
     isError: false,

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -39,7 +39,7 @@ const LABEL_TO_TABLE: Record<string, Table> = Object.fromEntries(
 
 export type SearchMode = "hybrid" | "vector" | "keyword";
 type NamespaceFilter = string | string[];
-type SearchTable = Table | "entities";
+export type SearchTable = Table | "entities";
 export type { SourceScope };
 
 type ExecuteSearchOptions = {

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -39,7 +39,7 @@ const LABEL_TO_TABLE: Record<string, Table> = Object.fromEntries(
 
 export type SearchMode = "hybrid" | "vector" | "keyword";
 type NamespaceFilter = string | string[];
-export type SearchTable = Table | "entities";
+type SearchTable = Table | "entities";
 export type { SourceScope };
 
 type ExecuteSearchOptions = {


### PR DESCRIPTION
## Summary

Populates the existing `agent_context_pack` `durable_memory` section with namespace-authorized hybrid-RRF recall.

- reuses the existing `executeSearch` hybrid retrieval path
- returns `citation_id` and a bounded, matching `source_ref` on every item and citation
- denies unauthorized namespaces before issuing a search
- keeps seven-coordinate session-event recall in `durable_lane_context`
- makes `durable_memory` the lowest-priority whole-pack section
- drops lowest-ranked items first under budget pressure
- reconciles section truncation state, empty reasons, item counts, citations, budget usage, and warnings
- defines truthful no-query, no-match, no-readable-table, whole-pack-starved, and content-free `recall_failed` states

Implements #327; issue closure follows post-merge hosted rollout evidence.
Part of #325

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

Evidence:

- focused durable-memory tests: 14 passed
- full `src/tools`: 669 passed, 29 skipped, 0 failed
- `bunx tsc --noEmit`: passed
- `git diff --check`, formatting, and secret scan: passed
- Full-tier initial swarm completed; all findings fixed
- focused fix verification completed
- Terra opposite-runtime terminal audit completed; both findings fixed
- targeted post-terminal-fix verification: ZERO FINDINGS
- CI code, database integration, Python package, and contract-parity jobs passed on the prior code head; final docs-only SME commit is rerunning CI

## Critical Self-Review

- Highest-risk behavior: cross-namespace recall, stale section metadata after whole-pack trimming, or citations/source refs surviving after their items are removed.
- Assumptions that could be wrong: durable memories are namespace-scoped semantic records; seven-coordinate session scope remains owned by `durable_lane_context`.
- Missing/weak tests: hosted MCP behavior requires a post-merge core01 deployment and real `agent_context_pack` call before issue closure.
- Security/permission risk: explicit namespaces must not broaden the token's readable namespace set; auth-derived predicates are passed into both hybrid search legs.
- Migration/deploy risk: no schema migration; additive behavior in an existing context-pack section. Deployment is still required because server runtime code changes.
- Downstream client/runtime risk: additive existing-section behavior; standalone Python and eventual TypeScript clients can consume or ignore it. Direct Hermes integration is not in scope.
- Rollback/cleanup concern: revert the additive loader/wiring/allocation commits; no data migration rollback is required.
- Fixes made before PR: reconciled whole-pack `truncated`/empty state, corrected section-order/type/helper cleanup, returned truthful `recall_failed` envelopes, and co-located item/citation `source_ref`.
- Known residual risk: each item now serializes its provenance in both the item and citation, so very tight budgets may retain fewer low-ranked memories; hard-budget and priority tests cover current thresholds.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: hosted verification is a post-merge-only deployment step; issue #327 remains open until the core01 deploy and real changed-tool canary are recorded.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this implements the already-declared v22 `durable_memory` section on the TypeScript server; no standalone Python/TypeScript client source or cross-runtime adapter fixture changed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Hosted Open Brain deployment and a real `agent_context_pack` durable-memory call remain required after merge and before closing #327.
- rtech-mcps and mcp2cli schema/skill refresh are not applicable: tool name, input schema, declared section enum, wire protocol, auth headers, and contract version are unchanged.
- Direct Hermes integration and Hermes live canaries are not applicable under the approved standalone-client scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
