### PR TITLE
feat(332): drive recall with bounded turn concepts

### DIFF
--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -333,9 +333,20 @@ paths. The supported public surface is:
 - `CURRENT_CONTRACT_VERSION`, `CURRENT_CONTRACT_SCHEMA_VERSION`,
   `CURRENT_CONTRACT_SCHEMA_HASH`, `REQUIRED_CONTRACT_TOOLS`, `CURRENT_TOOL_HELP`,
   and `PACKAGE_VERSION`.
+- `extract_turn_concepts()`, `TurnConcepts`, and `DEFAULT_MAX_KEYS` -- the
+  deterministic per-turn concept/entity key extractor that `AgentMemory.recall()`
+  uses to augment the recall query with salient keys from the current turn.
 
 The wheel includes a `py.typed` marker so typed consumers can rely on the
 package's inline annotations.
+
+Per-turn concept extraction is a **Python-only client convenience today**. It is
+a zero-network, deterministic tokenizer/normalizer over the caller-supplied turn
+text; it drives recall for the current turn only and is never persisted as
+durable memory. A standalone TypeScript counterpart is **deferred** to the later
+client phase -- no TypeScript module implements this pass today, so there is no
+existing counterpart to mirror. It carries **no Hermes dependency or Hermes
+rollout requirement**.
 
 ### Versioning and Contract Pinning
 

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.12"
+version = "0.1.13"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -68,8 +68,6 @@ from .turn_concepts import (
     DEFAULT_MAX_KEYS,
     TurnConcepts,
     extract_turn_concepts,
-    normalized_tokens,
-    verbatim_tokens,
 )
 
 __all__ = [
@@ -77,8 +75,6 @@ __all__ = [
     "DEFAULT_MAX_KEYS",
     "TurnConcepts",
     "extract_turn_concepts",
-    "normalized_tokens",
-    "verbatim_tokens",
     "DreamAction",
     "DreamClient",
     "DreamEngine",

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -64,9 +64,21 @@ from .spool import (
     SpoolUnitRetained,
     replay_records,
 )
+from .turn_concepts import (
+    DEFAULT_MAX_KEYS,
+    TurnConcepts,
+    extract_turn_concepts,
+    normalized_tokens,
+    verbatim_tokens,
+)
 
 __all__ = [
     "AgentMemory",
+    "DEFAULT_MAX_KEYS",
+    "TurnConcepts",
+    "extract_turn_concepts",
+    "normalized_tokens",
+    "verbatim_tokens",
     "DreamAction",
     "DreamClient",
     "DreamEngine",

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
@@ -15,6 +16,21 @@ from .policy import (
     idempotency_key,
     with_retry,
 )
+from .turn_concepts import (
+    TurnConcepts,
+    extract_turn_concepts,
+    verbatim_tokens,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cap on how many extracted keys may be appended to the derived recall query, on
+# top of the original turn text (which is always kept in full). Applied AFTER
+# dropping keys already textually represented in the query and after
+# case-insensitive dedupe, so the derived query length is bounded regardless of
+# how many keys the turn produced. Keys are appended in extraction order
+# (entities before concepts), first-seen wins.
+DERIVED_QUERY_MAX_KEYS = 8
 
 EVENT_TYPES = {
     "fact",
@@ -163,12 +179,20 @@ class MemoryItem:
 
 @dataclass(frozen=True)
 class MemoryContext:
+    # ``query`` is the ORIGINAL user input, verbatim -- never the internally
+    # derived recall query. The keys extracted from it drive this turn's recall
+    # via that derived query (see AgentMemory.recall), not by mutating this field.
     query: str
     items: tuple[MemoryItem, ...]
     text: str
     raw: Mapping[str, Any]
     session: JSON | None = None
     answer: JSON | None = None
+    # Bounded, normalized entity/concept keys extracted deterministically from
+    # the current turn's query at the recall-request boundary (OB #332). Exposed
+    # as structured output for the caller; they drove this turn's derived recall
+    # query internally. NOT durable memory -- the caller must not persist them.
+    concepts: TurnConcepts = field(default_factory=TurnConcepts)
 
     def as_prompt_text(self) -> str:
         return self.text
@@ -219,8 +243,21 @@ class AgentMemory:
     ) -> MemoryContext:
         effective_limit = self._effective_limit(limit)
         sources = _sources(include_decisions, include_facts)
+        # Deterministic per-turn concept/entity extraction at the recall-request
+        # boundary (OB #332). The keys are computed here, surfaced on the returned
+        # MemoryContext as structured output, AND folded into a single derived
+        # recall query so they actually drive this turn's retrieval. The derived
+        # query is original text plus only the keys not already represented in it
+        # (see _derive_recall_query); the caller's auth-derived namespace, scope,
+        # session, and sources are untouched, and no key is added as a payload
+        # field or persisted as a memory.
+        concepts = extract_turn_concepts(query)
+        recall_query = _derive_recall_query(query, concepts)
+        # Content-free telemetry: counts and category names only, never the raw
+        # turn text and never an extracted key.
+        logger.debug("turn_concepts_extracted", extra=concepts.telemetry())
         payload = {
-            "query": query,
+            "query": recall_query,
             "limit": effective_limit,
         }
         if sources:
@@ -237,7 +274,7 @@ class AgentMemory:
         )
         raw = self.client.search_all(**payload)
         answer = (
-            self.client.brain_answer(query=query, limit=effective_limit)
+            self.client.brain_answer(query=recall_query, limit=effective_limit)
             if include_answer
             else None
         )
@@ -250,6 +287,7 @@ class AgentMemory:
             raw=raw_mapping if include_raw else {},
             session=cast(JSON | None, session),
             answer=cast(JSON | None, answer),
+            concepts=concepts,
         )
 
     def load_session_context(
@@ -1000,6 +1038,44 @@ class AgentMemory:
                 except Exception as spool_error:
                     error.add_note(f"Failed to spool {operation}: {spool_error}")
             raise
+
+
+def _derive_recall_query(query: str, concepts: TurnConcepts) -> str:
+    """Fold extracted keys into one bounded derived recall query (OB #332).
+
+    Deterministic and zero-network. The result is the original ``query`` text
+    verbatim, followed by only the extracted keys whose exact normalized form is
+    NOT already a verbatim token of the query. Extracted keys are always
+    lowercased and identifier-normalized, so a key like ``open-brain`` or ``api``
+    is appended even when the query said ``Open-Brain`` or ``API`` -- the
+    normalized form is a new representation and is what should drive retrieval --
+    while a key already present in that exact form (``handle`` in ``handle``) is
+    not re-appended. Extractor dedupe plus this guard mean a repeated or
+    case-equivalent key contributes at most one appended token. Appended keys are
+    capped at ``DERIVED_QUERY_MAX_KEYS`` in extraction order (entities before
+    concepts), so the derived query cannot bloat regardless of turn length.
+
+    The original query is always kept in full and represented first, so recall
+    never loses the user's exact wording. When no key adds a new normalized form
+    the derived query is exactly the original query. This changes only the recall
+    *query* -- never the caller's namespace, scope, sources, or session.
+    """
+    represented = set(verbatim_tokens(query))
+    appended: list[str] = []
+    for key in concepts.keys:
+        if len(appended) >= DERIVED_QUERY_MAX_KEYS:
+            break
+        if key in represented:
+            continue
+        # Guard against re-appending a key already emitted (extractor dedupes
+        # its own output, but stay defensive so a key never repeats here).
+        represented.add(key)
+        appended.append(key)
+    if not appended:
+        return query
+    if not query:
+        return " ".join(appended)
+    return f"{query} {' '.join(appended)}"
 
 
 def _coerce_policy(policy: MemoryPolicy | Mapping[str, Any] | None) -> MemoryPolicy:

--- a/python/openbrain-memory/src/openbrain_memory/turn_concepts.py
+++ b/python/openbrain-memory/src/openbrain_memory/turn_concepts.py
@@ -5,12 +5,16 @@ brain does not: the exact text of *this* turn. This module turns that text into 
 small, normalized, bounded set of salient **entity** and **concept** keys that can
 drive recall for the turn.
 
+This is currently a standalone Python client convenience. A TypeScript
+counterpart is future work tracked for the later client phase; no existing
+TypeScript module implements this pass today, so nothing here mirrors an
+existing counterpart.
+
 Design constraints (issue #332, REFLEX-1):
 
 - Deterministic and zero-network. The same input always yields the same keys; no
   model, provider, or network call participates. This is a pure tokenizer +
-  normalizer over the caller-supplied string, mirroring the deterministic
-  structural pass in the TypeScript ``src/extraction.ts``.
+  normalizer over the caller-supplied string.
 - Bounded. A configured maximum caps the number of emitted keys per category, so
   adversarial or verbose input cannot inflate an unbounded key list.
 - Normalized and stable. Equivalent spellings collapse to one key
@@ -28,6 +32,7 @@ Design constraints (issue #332, REFLEX-1):
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass, field
 
 # Default cap on emitted keys *per category* (entities, concepts). Applied AFTER
@@ -45,16 +50,25 @@ MIN_CONCEPT_LENGTH = 3
 # unbroken token cannot smuggle a large substring of the turn into a key.
 MAX_KEY_LENGTH = 64
 
-# Tokenizer: a "word" is a run of letters/digits, optionally joined internally by
-# a single ``-``, ``_``, ``.`` or ``/`` (so ``open-brain``, ``agent_memory``,
-# ``v1.2`` and ``src/extraction`` survive as one token). Anchored to word
-# boundaries; punctuation between tokens is a separator, never part of a key.
-_TOKEN_RE = re.compile(r"[A-Za-z0-9]+(?:[-_./][A-Za-z0-9]+)*")
+# Tokenizer: a "word" is a run of Unicode letters/digits, optionally joined
+# internally by a single ``-``, ``_``, ``.`` or ``/`` (so ``open-brain``,
+# ``agent_memory``, ``v1.2`` and ``src/tokenizer`` survive as one token). The
+# atom class ``[^\W_]`` is the Unicode word set minus underscore -- i.e. any
+# letter or digit in any script (accented Latin ``café``, Cyrillic ``Москва``,
+# CJK ``日本語``, digits) -- so tokenization is not ASCII-only. ``re.UNICODE`` is
+# the default for ``str`` patterns; it is set explicitly here as documentation.
+#
+# Because every atom must contain at least one letter/digit, a run of pure
+# punctuation, a bare separator, or a standalone combining mark can never form a
+# token: punctuation-only and combining-mark garbage keys are impossible by
+# construction. Anchored to letter/digit runs; anything between tokens is a
+# separator, never part of a key.
+_TOKEN_RE = re.compile(r"[^\W_]+(?:[-_./][^\W_]+)*", re.UNICODE)
 
 # Entity classification is casing-independent so equivalent inputs are stable: a
 # token is an entity ONLY when it carries an internal separator (``-``, ``_``,
 # ``.`` or ``/``) -- the identifier-shaped tokens like ``open-brain``,
-# ``agent_memory``, ``v1.2`` or ``src/extraction``. Leading/mixed *case* is
+# ``agent_memory``, ``v1.2`` or ``src/tokenizer``. Leading/mixed *case* is
 # deliberately NOT used as an entity signal: "API"/"api" or sentence-initial
 # capitalization would otherwise flip a key's category between equivalent turns,
 # which breaks normalization stability. Ordinary words -- capitalized or not --
@@ -116,7 +130,7 @@ class TurnConcepts:
     """Bounded normalized keys extracted from one turn.
 
     ``entities`` are identifier-shaped keys -- tokens carrying an internal
-    separator (``open-brain``, ``agent_memory``, ``src/extraction``, ``v1.2``).
+    separator (``open-brain``, ``agent_memory``, ``src/tokenizer``, ``v1.2``).
     ``concepts`` are ordinary content keys. Both are lowercased (so equivalent
     inputs are stable regardless of casing), order-preserving, internally
     deduped, and capped at ``max_keys``.
@@ -160,40 +174,64 @@ class TurnConcepts:
         }
 
 
-def normalized_tokens(text: str) -> frozenset[str]:
-    """Return the set of normalized (bounded, casefolded) tokens in ``text``.
-
-    Uses the exact same tokenizer and normalization as ``extract_turn_concepts``
-    so a caller can test whether an extracted key's *normalized* form appears in
-    another string without re-implementing tokenization and risking a mismatch.
-    Deterministic and zero-network.
-    """
-    if not text:
-        return frozenset()
-    return frozenset(
-        _bound_key(match.group(0)).casefold() for match in _TOKEN_RE.finditer(text)
-    )
-
-
 def verbatim_tokens(text: str) -> frozenset[str]:
-    """Return the set of raw (bounded, case-preserving) tokens in ``text``.
+    """Return the set of raw (Unicode-normalized, bounded) tokens in ``text``.
 
-    Same tokenizer and length bound as ``extract_turn_concepts`` but WITHOUT
-    casefolding. A caller uses this to decide whether an extracted key -- which
-    is always lowercased -- is already represented in the original text in its
-    exact normalized form. A query token like ``API`` or ``Open-Brain`` is not a
-    verbatim match for the key ``api``/``open-brain``, so the normalized key is a
-    genuinely new representation worth surfacing. Deterministic and zero-network.
+    Same tokenizer, Unicode NFC normalization, and length bound as
+    ``extract_turn_concepts`` but WITHOUT casefolding. A caller uses this to
+    decide whether an extracted key -- which is always casefolded -- is already
+    represented in the original text in its exact normalized form. A query token
+    like ``API`` or ``Open-Brain`` is not a verbatim match for the key
+    ``api``/``open-brain``, so the normalized key is a genuinely new
+    representation worth surfacing. NFC normalization means an accented token
+    written in decomposed form (``e`` + combining acute) matches the same token
+    written composed (``é``). Deterministic and zero-network.
     """
     if not text:
         return frozenset()
     return frozenset(
-        _bound_key(match.group(0)) for match in _TOKEN_RE.finditer(text)
+        _verbatim_key(match.group(0)) for match in _TOKEN_RE.finditer(_nfc(text))
     )
+
+
+def _nfc(text: str) -> str:
+    """NFC-normalize the whole input BEFORE tokenizing.
+
+    Combining marks (U+0301 and friends) are not word characters, so the
+    tokenizer would otherwise break an atom at a base letter and silently drop a
+    trailing combining mark -- turning decomposed ``cafe`` + combining acute into
+    the key ``cafe`` instead of ``café``. Composing the text first means the
+    accented letter is a single word code point that survives tokenization, so
+    composed and decomposed spellings yield the same key and no bare combining
+    mark can leak into a key or a derived recall fragment.
+    """
+    return unicodedata.normalize("NFC", text)
 
 
 def _is_entity_token(token: str) -> bool:
     return bool(_SEPARATOR_RE.search(token))
+
+
+def _verbatim_key(token: str) -> str:
+    """Length-bound a token, preserving its casing.
+
+    The input text is already NFC-normalized before tokenization (see ``_nfc``),
+    so bounding is all that remains; it is applied last so ``MAX_KEY_LENGTH``
+    counts code points of the emitted key.
+    """
+    return _bound_key(token)
+
+
+def _casefold_key(token: str) -> str:
+    """Casefold and length-bound a token.
+
+    The input text is already NFC-normalized before tokenization (see ``_nfc``),
+    giving stable caseless equivalence across composed and decomposed accented
+    spellings. Casefold output is re-composed to NFC so casing folds that emit
+    combining sequences still yield a stable, composed key; bounding is applied
+    last so ``MAX_KEY_LENGTH`` counts code points of the final normalized key.
+    """
+    return _bound_key(unicodedata.normalize("NFC", token.casefold()))
 
 
 def _bound_key(token: str) -> str:
@@ -232,8 +270,8 @@ def extract_turn_concepts(
     dropped_concepts = 0
 
     if text:
-        for match in _TOKEN_RE.finditer(text):
-            lowered = _bound_key(match.group(0)).casefold()
+        for match in _TOKEN_RE.finditer(_nfc(text)):
+            lowered = _casefold_key(match.group(0))
             if _is_entity_token(lowered):
                 # Entity (identifier-shaped) keys are lowercased and deduped, so
                 # "Open-Brain" and "open-brain" collapse to one stable key.

--- a/python/openbrain-memory/src/openbrain_memory/turn_concepts.py
+++ b/python/openbrain-memory/src/openbrain_memory/turn_concepts.py
@@ -1,0 +1,274 @@
+"""Deterministic, bounded per-turn concept/entity key extraction (OB #332).
+
+At the current-turn recall-request boundary the caller has one thing the durable
+brain does not: the exact text of *this* turn. This module turns that text into a
+small, normalized, bounded set of salient **entity** and **concept** keys that can
+drive recall for the turn.
+
+Design constraints (issue #332, REFLEX-1):
+
+- Deterministic and zero-network. The same input always yields the same keys; no
+  model, provider, or network call participates. This is a pure tokenizer +
+  normalizer over the caller-supplied string, mirroring the deterministic
+  structural pass in the TypeScript ``src/extraction.ts``.
+- Bounded. A configured maximum caps the number of emitted keys per category, so
+  adversarial or verbose input cannot inflate an unbounded key list.
+- Normalized and stable. Equivalent spellings collapse to one key
+  (case-insensitive, first spelling wins), so "the API" and "API" and "api"
+  produce one concept key, and repeated entities are counted once.
+- Never persisted. These keys drive recall for the current turn only. Nothing
+  here writes durable memory; the caller must not persist the returned keys as
+  memories.
+- Content-free telemetry. ``TurnConcepts.telemetry()`` emits only counts and
+  category names -- never the raw turn text and never an extracted key -- so an
+  observability sink can record extraction behavior without leaking private
+  turn content.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Default cap on emitted keys *per category* (entities, concepts). Applied AFTER
+# normalize + dedupe so the emitted list is always bounded regardless of input
+# length. Kept modest: these keys drive a single turn's recall, not a corpus.
+DEFAULT_MAX_KEYS = 16
+
+# A token must be at least this many characters to be considered a concept key.
+# Short function words ("a", "to", "is") carry no recall signal and are dropped
+# below this threshold; entity keys (proper-noun-shaped) bypass it so a short
+# capitalized name like "OB" or "AI" still surfaces as an entity.
+MIN_CONCEPT_LENGTH = 3
+
+# Hard cap on the character length of any single normalized key, so one giant
+# unbroken token cannot smuggle a large substring of the turn into a key.
+MAX_KEY_LENGTH = 64
+
+# Tokenizer: a "word" is a run of letters/digits, optionally joined internally by
+# a single ``-``, ``_``, ``.`` or ``/`` (so ``open-brain``, ``agent_memory``,
+# ``v1.2`` and ``src/extraction`` survive as one token). Anchored to word
+# boundaries; punctuation between tokens is a separator, never part of a key.
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+(?:[-_./][A-Za-z0-9]+)*")
+
+# Entity classification is casing-independent so equivalent inputs are stable: a
+# token is an entity ONLY when it carries an internal separator (``-``, ``_``,
+# ``.`` or ``/``) -- the identifier-shaped tokens like ``open-brain``,
+# ``agent_memory``, ``v1.2`` or ``src/extraction``. Leading/mixed *case* is
+# deliberately NOT used as an entity signal: "API"/"api" or sentence-initial
+# capitalization would otherwise flip a key's category between equivalent turns,
+# which breaks normalization stability. Ordinary words -- capitalized or not --
+# are concept keys, always lowercased. The separator survives casefold, so
+# "Open-Brain" and "open-brain" classify identically and normalize to one key.
+_SEPARATOR_RE = re.compile(r"[-_./]")
+
+# Deterministic, tiny stopword set. Kept intentionally small and closed: it only
+# removes the highest-frequency English function words that are pure noise as
+# recall keys. It is NOT a semantic filter and never touches entity-shaped
+# tokens. Frozen so the set is stable across processes and releases.
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "are",
+        "but",
+        "not",
+        "you",
+        "with",
+        "this",
+        "that",
+        "have",
+        "from",
+        "they",
+        "will",
+        "would",
+        "there",
+        "their",
+        "what",
+        "about",
+        "which",
+        "when",
+        "your",
+        "were",
+        "been",
+        "than",
+        "then",
+        "them",
+        "these",
+        "some",
+        "into",
+        "could",
+        "should",
+        "please",
+        "just",
+        "like",
+        "how",
+        "can",
+        "get",
+        "got",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TurnConcepts:
+    """Bounded normalized keys extracted from one turn.
+
+    ``entities`` are identifier-shaped keys -- tokens carrying an internal
+    separator (``open-brain``, ``agent_memory``, ``src/extraction``, ``v1.2``).
+    ``concepts`` are ordinary content keys. Both are lowercased (so equivalent
+    inputs are stable regardless of casing), order-preserving, internally
+    deduped, and capped at ``max_keys``.
+
+    ``truncated`` is True when either category hit ``max_keys`` and additional
+    distinct keys were dropped, so a caller can tell a bounded emission from an
+    exhaustive one. ``max_keys`` records the cap that produced this result.
+
+    Nothing here is durable memory. These keys drive the current turn's recall
+    and must not be persisted as memories.
+    """
+
+    entities: tuple[str, ...] = ()
+    concepts: tuple[str, ...] = ()
+    truncated: bool = False
+    max_keys: int = DEFAULT_MAX_KEYS
+    _dropped_entities: int = field(default=0, repr=False)
+    _dropped_concepts: int = field(default=0, repr=False)
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        """Entities followed by concepts as a single ordered key list."""
+        return self.entities + self.concepts
+
+    def telemetry(self) -> dict[str, int | bool | list[str]]:
+        """Content-free observability envelope.
+
+        Emits ONLY counts, category names, and the configured bound -- never the
+        raw turn text and never an extracted key. Safe to hand to any logger or
+        metrics sink without leaking private turn content.
+        """
+        return {
+            "categories": ["entities", "concepts"],
+            "entity_count": len(self.entities),
+            "concept_count": len(self.concepts),
+            "key_count": len(self.entities) + len(self.concepts),
+            "dropped_entities": self._dropped_entities,
+            "dropped_concepts": self._dropped_concepts,
+            "truncated": self.truncated,
+            "max_keys": self.max_keys,
+        }
+
+
+def normalized_tokens(text: str) -> frozenset[str]:
+    """Return the set of normalized (bounded, casefolded) tokens in ``text``.
+
+    Uses the exact same tokenizer and normalization as ``extract_turn_concepts``
+    so a caller can test whether an extracted key's *normalized* form appears in
+    another string without re-implementing tokenization and risking a mismatch.
+    Deterministic and zero-network.
+    """
+    if not text:
+        return frozenset()
+    return frozenset(
+        _bound_key(match.group(0)).casefold() for match in _TOKEN_RE.finditer(text)
+    )
+
+
+def verbatim_tokens(text: str) -> frozenset[str]:
+    """Return the set of raw (bounded, case-preserving) tokens in ``text``.
+
+    Same tokenizer and length bound as ``extract_turn_concepts`` but WITHOUT
+    casefolding. A caller uses this to decide whether an extracted key -- which
+    is always lowercased -- is already represented in the original text in its
+    exact normalized form. A query token like ``API`` or ``Open-Brain`` is not a
+    verbatim match for the key ``api``/``open-brain``, so the normalized key is a
+    genuinely new representation worth surfacing. Deterministic and zero-network.
+    """
+    if not text:
+        return frozenset()
+    return frozenset(
+        _bound_key(match.group(0)) for match in _TOKEN_RE.finditer(text)
+    )
+
+
+def _is_entity_token(token: str) -> bool:
+    return bool(_SEPARATOR_RE.search(token))
+
+
+def _bound_key(token: str) -> str:
+    return token if len(token) <= MAX_KEY_LENGTH else token[:MAX_KEY_LENGTH]
+
+
+def extract_turn_concepts(
+    text: str,
+    *,
+    max_keys: int = DEFAULT_MAX_KEYS,
+) -> TurnConcepts:
+    """Extract bounded, normalized entity/concept keys from one turn of text.
+
+    Deterministic and zero-network: the same ``text`` always yields the same
+    result. Entities are identifier-shaped tokens (an internal
+    ``-``/``_``/``.``/``/`` separator); everything else is a concept. Every key
+    is lowercased. Both categories are:
+
+    - deduped case-insensitively (so repeated entities count once and equivalent
+      spellings -- "API"/"api", "Open-Brain"/"open-brain" -- collapse to one key),
+    - order-preserving (first occurrence order in the turn),
+    - capped at ``max_keys`` per category, with any further distinct keys dropped
+      and ``truncated`` set.
+
+    Empty or whitespace-only input yields an empty result (no keys, not
+    truncated). ``max_keys`` must be >= 1.
+    """
+    if max_keys < 1:
+        raise ValueError("max_keys must be >= 1")
+
+    entities: list[str] = []
+    concepts: list[str] = []
+    seen_entities: set[str] = set()
+    seen_concepts: set[str] = set()
+    dropped_entities = 0
+    dropped_concepts = 0
+
+    if text:
+        for match in _TOKEN_RE.finditer(text):
+            lowered = _bound_key(match.group(0)).casefold()
+            if _is_entity_token(lowered):
+                # Entity (identifier-shaped) keys are lowercased and deduped, so
+                # "Open-Brain" and "open-brain" collapse to one stable key.
+                if lowered in seen_entities:
+                    continue
+                if len(entities) >= max_keys:
+                    dropped_entities += 1
+                    continue
+                seen_entities.add(lowered)
+                entities.append(lowered)
+                continue
+
+            # Concept tokens: drop stopwords and sub-threshold tokens. Pure-digit
+            # tokens carry no concept signal on their own and are dropped here;
+            # identifier-shaped digit tokens (e.g. "v1", "sha256") are letters+
+            # digits and survive.
+            if len(lowered) < MIN_CONCEPT_LENGTH:
+                continue
+            if lowered in _STOPWORDS:
+                continue
+            if lowered.isdigit():
+                continue
+            if lowered in seen_concepts:
+                continue
+            if len(concepts) >= max_keys:
+                dropped_concepts += 1
+                continue
+            seen_concepts.add(lowered)
+            concepts.append(lowered)
+
+    return TurnConcepts(
+        entities=tuple(entities),
+        concepts=tuple(concepts),
+        truncated=dropped_entities > 0 or dropped_concepts > 0,
+        max_keys=max_keys,
+        _dropped_entities=dropped_entities,
+        _dropped_concepts=dropped_concepts,
+    )

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -160,8 +160,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.12"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.12"
+    assert CURRENT_CLIENT_VERSION == "0.1.13"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.13"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.8 <1.0.0"
     )

--- a/python/openbrain-memory/tests/test_turn_concepts.py
+++ b/python/openbrain-memory/tests/test_turn_concepts.py
@@ -1,0 +1,384 @@
+"""Tests for deterministic per-turn concept/entity extraction (OB #332)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from openbrain_memory import (
+    DEFAULT_MAX_KEYS,
+    AgentMemory,
+    TurnConcepts,
+    extract_turn_concepts,
+    normalized_tokens,
+    verbatim_tokens,
+)
+from openbrain_memory.agent import DERIVED_QUERY_MAX_KEYS, _derive_recall_query
+
+
+class _RecordingClient:
+    """Minimal fake client recording every downstream call for scope assertions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.search_payload: dict[str, Any] = {"results": []}
+
+    def search_all(self, **payload: Any) -> dict[str, Any]:
+        self.calls.append(("search_all", payload))
+        return self.search_payload
+
+    def session_context(self, **payload: Any) -> dict[str, Any]:
+        self.calls.append(("session_context", payload))
+        return {"tool": "session_context", "arguments": payload}
+
+    def brain_answer(self, **payload: Any) -> dict[str, Any]:
+        self.calls.append(("brain_answer", payload))
+        return {"tool": "brain_answer", "arguments": payload}
+
+
+# ---------------------------------------------------------------------------
+# Pure extractor behavior
+# ---------------------------------------------------------------------------
+
+
+def test_representative_turn_emits_entities_and_concepts() -> None:
+    result = extract_turn_concepts(
+        "Rico asked how the open-brain recall boundary handles the durable memory "
+        "namespace for the agent_memory module."
+    )
+    # Identifier-shaped tokens (internal separator) land in entities, lowercased.
+    assert "open-brain" in result.entities
+    assert "agent_memory" in result.entities
+    # Ordinary content words -- capitalized or not -- land in concepts, lowercased.
+    assert "rico" in result.concepts
+    assert "recall" in result.concepts
+    assert "boundary" in result.concepts
+    assert "durable" in result.concepts
+    assert "namespace" in result.concepts
+    # Stopwords and sub-threshold tokens are dropped from concepts.
+    assert "the" not in result.concepts
+    assert "how" not in result.concepts
+
+
+def test_empty_input_yields_empty_result() -> None:
+    for text in ("", "   ", "\n\t  "):
+        result = extract_turn_concepts(text)
+        assert result.entities == ()
+        assert result.concepts == ()
+        assert result.keys == ()
+        assert result.truncated is False
+
+
+def test_repeated_entities_counted_once_order_preserved() -> None:
+    result = extract_turn_concepts(
+        "Open-Brain then open-brain again, and OPEN-BRAIN once more; "
+        "agent_memory agent_memory."
+    )
+    # Case-insensitive dedupe: one lowercased key per distinct entity.
+    assert result.entities.count("open-brain") == 1
+    assert result.entities.count("agent_memory") == 1
+    # First-occurrence order is preserved.
+    assert result.entities.index("open-brain") < result.entities.index("agent_memory")
+
+
+def test_repeated_concepts_counted_once() -> None:
+    result = extract_turn_concepts("recall recall RECALL boundary boundary")
+    assert result.concepts.count("recall") == 1
+    assert result.concepts.count("boundary") == 1
+
+
+def test_normalization_stability_equivalent_inputs() -> None:
+    # Casing and surrounding punctuation/whitespace do not change the keys.
+    a = extract_turn_concepts("The API handles Recall.")
+    b = extract_turn_concepts("the   api,  handles ...  recall!!!")
+    c = extract_turn_concepts("\tTHE api\nHANDLES recall")
+    assert a.concepts == b.concepts == c.concepts
+    # And extraction is deterministic across repeated calls.
+    again = extract_turn_concepts("The API handles Recall.")
+    assert again.entities == a.entities
+    assert again.concepts == a.concepts
+
+
+def test_configured_maximum_bounds_each_category() -> None:
+    # Ten distinct entity-shaped (separator) tokens and ten distinct concepts.
+    entities = " ".join(f"ent-{i}" for i in range(10))
+    concepts = " ".join(f"concept{i}" for i in range(10))
+    result = extract_turn_concepts(f"{entities} {concepts}", max_keys=3)
+    assert len(result.entities) == 3
+    assert len(result.concepts) == 3
+    assert result.max_keys == 3
+    assert result.truncated is True
+    # The kept keys are the first-seen ones (order-preserving cap).
+    assert result.entities == ("ent-0", "ent-1", "ent-2")
+    assert result.concepts == ("concept0", "concept1", "concept2")
+
+
+def test_default_maximum_applied_when_unspecified() -> None:
+    concepts = " ".join(f"concept{i}" for i in range(DEFAULT_MAX_KEYS + 5))
+    result = extract_turn_concepts(concepts)
+    assert len(result.concepts) == DEFAULT_MAX_KEYS
+    assert result.truncated is True
+
+
+def test_max_keys_must_be_positive() -> None:
+    with pytest.raises(ValueError):
+        extract_turn_concepts("anything", max_keys=0)
+
+
+def test_single_giant_token_is_length_bounded() -> None:
+    huge = "z" * 500
+    result = extract_turn_concepts(huge)
+    assert len(result.concepts) == 1
+    assert len(result.concepts[0]) <= 64
+
+
+def test_pure_digit_tokens_are_dropped_from_concepts() -> None:
+    result = extract_turn_concepts("meeting 2026 about budget 42")
+    assert "2026" not in result.concepts
+    assert "42" not in result.concepts
+    assert "meeting" in result.concepts
+    assert "budget" in result.concepts
+
+
+# ---------------------------------------------------------------------------
+# Content-free telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_excludes_raw_text_and_keys() -> None:
+    text = "SecretProject reticulates splines for Rico"
+    result = extract_turn_concepts(text)
+    telemetry = result.telemetry()
+    serialized = repr(telemetry)
+    # No raw turn substring leaks.
+    assert "reticulates" not in serialized
+    assert "splines" not in serialized
+    # No extracted key leaks into telemetry.
+    for key in result.keys:
+        assert key not in serialized
+    # Only counts, category names, and the bound are present.
+    assert telemetry["categories"] == ["entities", "concepts"]
+    assert telemetry["entity_count"] == len(result.entities)
+    assert telemetry["concept_count"] == len(result.concepts)
+    assert telemetry["key_count"] == len(result.keys)
+    assert isinstance(telemetry["truncated"], bool)
+    assert telemetry["max_keys"] == result.max_keys
+
+
+def test_telemetry_reports_dropped_counts_on_truncation() -> None:
+    result = extract_turn_concepts(
+        " ".join(f"concept{i}" for i in range(10)), max_keys=4
+    )
+    telemetry = result.telemetry()
+    assert telemetry["concept_count"] == 4
+    assert telemetry["dropped_concepts"] == 6
+    assert telemetry["truncated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Derived recall query: extracted keys actually drive retrieval
+# ---------------------------------------------------------------------------
+#
+# Every extracted key comes FROM a query token, so "not already represented"
+# means: the key's exact normalized (lowercased, identifier-joined) form is not
+# already a verbatim token of the query. A query saying "API"/"Open-Brain"
+# surfaces the normalized keys "api"/"open-brain" -- a new representation that
+# drives recall -- while a token already in that exact lowercase form is not
+# re-appended.
+
+
+def test_derived_query_appends_normalized_form_of_cased_tokens() -> None:
+    query = "How does the API handle Recall for Open-Brain?"
+    concepts = extract_turn_concepts(query)
+    derived = _derive_recall_query(query, concepts)
+
+    # Original text kept verbatim and first.
+    assert derived.startswith(query)
+    suffix = derived[len(query) :]
+    # The lowercased normalized keys for the cased query tokens are appended.
+    assert "api" in suffix
+    assert "recall" in suffix
+    assert "open-brain" in suffix
+    # A token already lowercase-verbatim in the query ("does", "handle", "for")
+    # is not re-appended.
+    assert "does" not in suffix
+    assert "handle" not in suffix
+
+
+def test_derived_query_is_original_when_all_keys_already_verbatim() -> None:
+    # Every content token is already lowercase in the query, so its normalized
+    # key equals a verbatim query token and nothing new is appended.
+    query = "recall durable namespace boundary handle"
+    concepts = extract_turn_concepts(query)
+    derived = _derive_recall_query(query, concepts)
+    assert derived == query
+
+
+def test_derived_query_does_not_bloat_on_repeats_or_case() -> None:
+    # The same salient token appears many times in mixed casing, but never in
+    # its exact lowercase form; the extractor dedupes to one normalized key so
+    # the derived query appends it at most once.
+    query = "Explain the API, the Api, and the API again"
+    concepts = extract_turn_concepts(query)
+    derived = _derive_recall_query(query, concepts)
+    suffix = derived[len(query) :]
+    assert suffix.count("api") == 1
+
+
+def test_derived_query_appended_keys_are_bounded() -> None:
+    # Many distinct cased tokens all yield novel normalized keys; the number of
+    # keys folded onto the original query is capped at DERIVED_QUERY_MAX_KEYS.
+    tokens = " ".join(f"Ent{i}Word" for i in range(DERIVED_QUERY_MAX_KEYS + 6))
+    concepts = extract_turn_concepts(tokens, max_keys=DERIVED_QUERY_MAX_KEYS + 6)
+    assert len(concepts.keys) > DERIVED_QUERY_MAX_KEYS
+    derived = _derive_recall_query(tokens, concepts)
+    # The derived query is the original followed by exactly the bounded number of
+    # appended key tokens.
+    assert derived.startswith(tokens + " ")
+    appended = derived[len(tokens) + 1 :].split()
+    assert len(appended) == DERIVED_QUERY_MAX_KEYS
+    # And every appended token is one of the extracted keys.
+    assert set(appended).issubset(set(concepts.keys))
+
+
+def test_derived_query_keeps_original_verbatim_and_first() -> None:
+    query = "Explain the API for Rico"
+    concepts = extract_turn_concepts(query)
+    derived = _derive_recall_query(query, concepts)
+    assert derived == query or derived.startswith(query + " ")
+    assert query in derived
+
+
+def test_derived_query_empty_original_falls_back_to_keys() -> None:
+    concepts = extract_turn_concepts("Vault-Secret Reticulate")
+    derived = _derive_recall_query("", concepts)
+    assert "vault-secret" in derived
+    assert "reticulate" in derived
+
+
+def test_token_helpers_agree_up_to_casing() -> None:
+    text = "The API drives Open-Brain Recall"
+    verbatim = verbatim_tokens(text)
+    normalized = normalized_tokens(text)
+    # Verbatim preserves the source casing; normalized casefolds each token.
+    assert "API" in verbatim
+    assert "Open-Brain" in verbatim
+    assert "api" in normalized
+    assert "open-brain" in normalized
+    # Same token set once casefolded, so the only difference is case.
+    assert {token.casefold() for token in verbatim} == normalized
+    assert verbatim_tokens("") == frozenset()
+    assert normalized_tokens("") == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Recall-boundary wiring: derived query drives recall, scope unchanged,
+# no persistence, content-free logs
+# ---------------------------------------------------------------------------
+
+
+def test_recall_drives_search_with_derived_query_keeping_scope() -> None:
+    client = _RecordingClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    # Cased/identifier tokens ("Open-Brain", "Namespace") surface normalized keys
+    # the raw query does not contain verbatim, so they drive the derived query.
+    original = "How does Recall handle the durable Namespace in Open-Brain?"
+    context = memory.recall(original)
+
+    name, payload = client.calls[-1]
+    assert name == "search_all"
+    # The request payload keeps exactly its query/limit/sources shape: keys are
+    # folded into the query string, never added as separate payload fields, and
+    # never persisted.
+    assert set(payload) == {"query", "limit", "sources"}
+    assert "concepts" not in payload
+    assert "entities" not in payload
+    assert "keys" not in payload
+
+    # The derived query actually drives retrieval: original text is represented
+    # in full AND the normalized keys are present, so recall differs from a bare
+    # original-query request.
+    assert original in payload["query"]
+    assert payload["query"] != original
+    assert "open-brain" in payload["query"]
+    assert "namespace" in payload["query"]
+
+    # MemoryContext.query stays the ORIGINAL input; concepts are structured out
+    # and not merged into the stored query.
+    assert context.query == original
+    assert isinstance(context.concepts, TurnConcepts)
+    assert "open-brain" in context.concepts.entities
+    assert "durable" in context.concepts.concepts
+    assert "namespace" in context.concepts.concepts
+
+
+def test_recall_answer_uses_same_derived_query() -> None:
+    client = _RecordingClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+
+    original = "Recall the durable Namespace via Open-Brain"
+    memory.recall(original, include_answer=True)
+
+    search = next(p for n, p in client.calls if n == "search_all")
+    answer = next(p for n, p in client.calls if n == "brain_answer")
+    # search_all and brain_answer receive the exact same derived query.
+    assert answer["query"] == search["query"]
+    assert original in answer["query"]
+    assert "open-brain" in answer["query"]
+
+
+def test_recall_session_and_namespace_behavior_unchanged() -> None:
+    client = _RecordingClient()
+    memory = AgentMemory(client, agent="bilby", project="open-brain")
+    memory.conversation_key = "sess-123"
+
+    memory.recall("Recall the Namespace now", include_session=True)
+
+    session_calls = [p for n, p in client.calls if n == "session_context"]
+    assert len(session_calls) == 1
+    # Session context is loaded under the caller's exact session key; the derived
+    # query does not leak into or alter session/namespace scoping.
+    assert session_calls[0]["session_key"] == "sess-123"
+    # No namespace field is fabricated onto the search payload.
+    search = next(p for n, p in client.calls if n == "search_all")
+    assert "namespace" not in search
+
+
+def test_recall_never_calls_a_write_path() -> None:
+    client = _RecordingClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    memory.recall("remember that OpenBrain is durable")
+
+    # Only read-side calls happen; no session_start / log / promote / candidate
+    # write is triggered by extraction or query derivation.
+    called = {name for name, _ in client.calls}
+    assert called == {"search_all"}
+
+
+def test_recall_telemetry_log_is_content_free(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _RecordingClient()
+    memory = AgentMemory(client, agent="bilby")
+
+    with caplog.at_level(logging.DEBUG, logger="openbrain_memory.agent"):
+        memory.recall("Rico wants OpenBrain to reticulate splines now")
+
+    turn_records = [
+        r for r in caplog.records if r.getMessage() == "turn_concepts_extracted"
+    ]
+    assert turn_records, "expected a turn_concepts_extracted telemetry record"
+    record = turn_records[-1]
+    # The record carries only content-free telemetry fields; the raw turn text
+    # and extracted keys never reach the log.
+    assert getattr(record, "categories", None) == ["entities", "concepts"]
+    assert isinstance(getattr(record, "entity_count"), int)
+    assert isinstance(getattr(record, "concept_count"), int)
+    for leak in ("reticulate", "splines", "Rico", "OpenBrain"):
+        assert leak not in record.getMessage()
+        for value in vars(record).values():
+            assert not (isinstance(value, str) and leak in value)

--- a/python/openbrain-memory/tests/test_turn_concepts.py
+++ b/python/openbrain-memory/tests/test_turn_concepts.py
@@ -12,10 +12,18 @@ from openbrain_memory import (
     AgentMemory,
     TurnConcepts,
     extract_turn_concepts,
-    normalized_tokens,
-    verbatim_tokens,
 )
 from openbrain_memory.agent import DERIVED_QUERY_MAX_KEYS, _derive_recall_query
+from openbrain_memory.turn_concepts import verbatim_tokens
+
+# Combining acute / grave, written as escapes so the test source stays ASCII and
+# unambiguous about exactly which code points are fed to the extractor.
+_COMBINING_ACUTE = "́"
+_COMBINING_GRAVE = "̀"
+_CAFE_COMPOSED = "café"  # 'e-acute' precomposed (NFC)
+_CAFE_DECOMPOSED = "cafe" + _COMBINING_ACUTE  # 'e' + combining acute (NFD)
+_MOSKVA = "Москва"  # Cyrillic "Москва"
+_NIHONGO = "日本語"  # CJK "日本語"
 
 
 class _RecordingClient:
@@ -143,6 +151,82 @@ def test_pure_digit_tokens_are_dropped_from_concepts() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Unicode-aware tokenization
+# ---------------------------------------------------------------------------
+
+
+def test_accented_latin_survives_as_concept_keys() -> None:
+    # Accented Latin letters are word characters; the tokens survive intact and
+    # are casefolded, not stripped down to ASCII.
+    result = extract_turn_concepts(
+        f"Le {_CAFE_COMPOSED} and my résumé were both ready"
+    )
+    assert _CAFE_COMPOSED in result.concepts
+    assert "résumé" in result.concepts
+
+
+def test_cyrillic_and_cjk_survive() -> None:
+    # Cyrillic and CJK scripts tokenize as ordinary content words.
+    result = extract_turn_concepts(
+        f"The city {_MOSKVA} and the language {_NIHONGO} matter"
+    )
+    # Cyrillic is casefolded (Москва -> москва).
+    assert _MOSKVA.casefold() in result.concepts
+    # CJK has no case; the token passes the >=3 code-point concept threshold.
+    assert _NIHONGO in result.concepts
+
+
+def test_normalization_equivalence_composed_and_decomposed() -> None:
+    # "cafe" precomposed (U+00E9) and decomposed (e + U+0301 combining acute) are
+    # the same word; NFC normalization collapses them to one stable key.
+    assert _CAFE_COMPOSED != _CAFE_DECOMPOSED  # genuinely distinct code points
+    composed = extract_turn_concepts(f"{_CAFE_COMPOSED} recall")
+    decomposed = extract_turn_concepts(f"{_CAFE_DECOMPOSED} recall")
+    assert composed.concepts == decomposed.concepts
+    # The key is stored in composed (NFC) form regardless of input spelling.
+    assert _CAFE_COMPOSED in composed.concepts
+    for key in composed.concepts + decomposed.concepts:
+        assert _COMBINING_ACUTE not in key  # no bare combining mark in any key
+
+
+def test_punctuation_and_combining_marks_do_not_form_keys() -> None:
+    # A run of pure punctuation, bare separators, and standalone combining marks
+    # (with no base letter) can never become a token, so no garbage key appears.
+    text = f"--- ... /// ??? {_COMBINING_ACUTE}{_COMBINING_GRAVE} !!! recall"
+    result = extract_turn_concepts(text)
+    assert result.entities == ()
+    # Only the real word survives.
+    assert result.concepts == ("recall",)
+
+
+def test_mixed_separator_identifier_is_one_entity_key() -> None:
+    # A single identifier joining atoms with several of the allowed separators
+    # tokenizes as ONE key, not fragments; the whole path survives intact.
+    result = extract_turn_concepts("see src/openbrain_memory/turn-concepts.v2 now")
+    assert "src/openbrain_memory/turn-concepts.v2" in result.entities
+    # It is not split into mangled sub-fragments.
+    assert "src" not in result.concepts
+    assert "turn" not in result.concepts
+
+
+def test_large_input_is_linear_and_bounded() -> None:
+    # A large, varied Unicode input must extract in linear time and stay bounded
+    # by max_keys per category -- no pathological backtracking or unbounded keys.
+    chunk = (
+        f"{_CAFE_COMPOSED} {_MOSKVA} {_NIHONGO} open-brain agent_memory "
+        "recall boundary namespace "
+    )
+    big = chunk * 5000  # ~300k characters
+    result = extract_turn_concepts(big)
+    assert len(result.entities) <= DEFAULT_MAX_KEYS
+    assert len(result.concepts) <= DEFAULT_MAX_KEYS
+    # Distinct salient tokens are still surfaced from the repeated content.
+    assert _CAFE_COMPOSED in result.concepts
+    assert _MOSKVA.casefold() in result.concepts
+    assert "open-brain" in result.entities
+
+
+# ---------------------------------------------------------------------------
 # Content-free telemetry
 # ---------------------------------------------------------------------------
 
@@ -227,6 +311,24 @@ def test_derived_query_does_not_bloat_on_repeats_or_case() -> None:
     assert suffix.count("api") == 1
 
 
+def test_derived_query_appends_clean_unicode_keys_not_mangled_fragments() -> None:
+    # A cased accented token and a cased Cyrillic token surface normalized keys
+    # not present verbatim; the derived query appends exactly those clean tokens
+    # (NFC, casefolded) and never a bare combining mark or punctuation fragment.
+    query = f"About {_CAFE_COMPOSED.capitalize()} in {_MOSKVA}!!!"
+    concepts = extract_turn_concepts(query)
+    derived = _derive_recall_query(query, concepts)
+    suffix = derived[len(query) :]
+    assert _CAFE_COMPOSED in suffix
+    assert _MOSKVA.casefold() in suffix
+    # No stray combining mark or separator/punctuation-only fragment is appended.
+    assert _COMBINING_ACUTE not in suffix
+    for appended in suffix.split():
+        assert extract_turn_concepts(appended).keys, (
+            f"appended fragment {appended!r} is not a clean extractable key"
+        )
+
+
 def test_derived_query_appended_keys_are_bounded() -> None:
     # Many distinct cased tokens all yield novel normalized keys; the number of
     # keys folded onto the original query is capped at DERIVED_QUERY_MAX_KEYS.
@@ -258,19 +360,20 @@ def test_derived_query_empty_original_falls_back_to_keys() -> None:
     assert "reticulate" in derived
 
 
-def test_token_helpers_agree_up_to_casing() -> None:
+def test_verbatim_tokens_preserve_casing_and_normalize_unicode() -> None:
     text = "The API drives Open-Brain Recall"
     verbatim = verbatim_tokens(text)
-    normalized = normalized_tokens(text)
-    # Verbatim preserves the source casing; normalized casefolds each token.
+    # Verbatim preserves the exact source casing of each token.
     assert "API" in verbatim
     assert "Open-Brain" in verbatim
-    assert "api" in normalized
-    assert "open-brain" in normalized
-    # Same token set once casefolded, so the only difference is case.
-    assert {token.casefold() for token in verbatim} == normalized
+    assert "The" in verbatim
+    # A casefolded extracted key ("api") is NOT a verbatim token of a cased query,
+    # which is exactly why _derive_recall_query treats it as a new representation.
+    assert "api" not in verbatim
+    assert "open-brain" not in verbatim
     assert verbatim_tokens("") == frozenset()
-    assert normalized_tokens("") == frozenset()
+    # NFC normalization: a decomposed accented token matches the composed form.
+    assert verbatim_tokens(_CAFE_DECOMPOSED) == frozenset({_CAFE_COMPOSED})
 
 
 # ---------------------------------------------------------------------------

--- a/python/openbrain-memory/tests/test_turn_concepts.py
+++ b/python/openbrain-memory/tests/test_turn_concepts.py
@@ -24,6 +24,13 @@ _CAFE_COMPOSED = "café"  # 'e-acute' precomposed (NFC)
 _CAFE_DECOMPOSED = "cafe" + _COMBINING_ACUTE  # 'e' + combining acute (NFD)
 _MOSKVA = "Москва"  # Cyrillic "Москва"
 _NIHONGO = "日本語"  # CJK "日本語"
+# German sharp-s: an uppercase form whose casefold expands where lower() does not.
+# "STRASSE".casefold() == "straße".casefold() == "strasse", but
+# "straße".lower() == "straße" (unchanged). This is the canonical case where
+# casefold and lower diverge, so it pins the dedupe/normalized-key contract to
+# casefold specifically.
+_STRASSE_UPPER = "STRASSE"
+_STRASSE_SHARP = "straße"  # 'stra' + U+00DF (ß) + 'e'
 
 
 class _RecordingClient:
@@ -174,6 +181,49 @@ def test_cyrillic_and_cjk_survive() -> None:
     assert _MOSKVA.casefold() in result.concepts
     # CJK has no case; the token passes the >=3 code-point concept threshold.
     assert _NIHONGO in result.concepts
+
+
+def test_casefold_not_lower_folds_expanding_sharp_s() -> None:
+    # Regression: the normalized dedupe key MUST use casefold, not lower.
+    # "STRASSE" and "straße" are the same word; casefold expands both to
+    # "strasse", so they dedupe to ONE concept key. A lower()-based key would
+    # leave "straße" un-expanded ("straße" != "strasse"), so the two spellings
+    # would survive as TWO distinct concept keys -- this test fails on that
+    # mutant. Both spellings are >=3 chars, separator-free (concepts, not
+    # entities), non-stopword, and non-digit, so nothing else can drop them.
+    assert _STRASSE_UPPER.casefold() == _STRASSE_SHARP.casefold() == "strasse"
+    assert _STRASSE_SHARP.lower() != "strasse"  # lower() would NOT fold ß
+
+    result = extract_turn_concepts(f"Rico noted {_STRASSE_UPPER} and {_STRASSE_SHARP}")
+    # Exactly one casefolded key, in composed/expanded form -- no ß survives.
+    assert result.concepts.count("strasse") == 1
+    assert _STRASSE_SHARP not in result.concepts
+    assert _STRASSE_UPPER.lower() not in [c for c in result.concepts if c != "strasse"]
+
+
+def test_derived_query_folds_sharp_s_verbatim_original_key_appended() -> None:
+    # The documented derived-query contract under an expanding casefold: the
+    # original query stays verbatim and first, and the single normalized recall
+    # key ("strasse") -- which is not a verbatim token of a query spelled with
+    # "STRASSE"/"straße" -- is appended exactly once. A lower()-based key would
+    # dedupe to two keys and could append a bare-ß fragment, breaking both the
+    # single-append bound and the "clean normalized key" guarantee.
+    query = f"Rico noted {_STRASSE_UPPER} and {_STRASSE_SHARP} today"
+    concepts = extract_turn_concepts(query)
+    derived = _derive_recall_query(query, concepts)
+
+    # Original preserved verbatim and first; recall key appended after it.
+    assert derived.startswith(query + " ")
+    assert query in derived
+    suffix = derived[len(query) :]
+    assert suffix.count("strasse") == 1
+    # The un-expanded sharp-s spelling never leaks into the appended keys.
+    assert _STRASSE_SHARP not in suffix
+    # Every appended fragment is a clean, re-extractable key (no garbage).
+    for appended in suffix.split():
+        assert extract_turn_concepts(appended).keys, (
+            f"appended fragment {appended!r} is not a clean extractable key"
+        )
 
 
 def test_normalization_equivalence_composed_and_decomposed() -> None:

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds deterministic, bounded per-turn entity/concept extraction to the standalone Python client and uses the derived keys to drive recall.

- preserves the original query while appending at most eight normalized keys not already represented
- sends the same derived query to `search_all` and optional `brain_answer`
- keeps `MemoryContext.query` as the original input and exposes structured concepts separately
- supports NFC-normalized accented Latin, Cyrillic, CJK, and the documented `-_./` identifier separators
- retains namespace/session/source payload behavior
- never persists extracted keys
- emits count/category telemetry only, without raw text or keys
- releases the public behavior and root exports as `openbrain-memory` 0.1.13

Closes #332
Part of #331

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence:

- focused turn-concept + contract tests: 62 passed
- full Python suite: 425 passed, 5 env-gated skips
- mypy: clean across 16 source files
- ruff: clean
- `uv sync --frozen` and `uv lock --check`: clean
- 0.1.13 wheel and sdist built with matching metadata
- lower-vs-casefold mutation is killed by the sharp-s regression
- initial Full-tier review, focused verification, Terra terminal audit, and targeted terminal-fix verification completed

## Critical Self-Review

- Highest-risk behavior: derived keys could leak through logs, replace the original query, or make search/answer use different queries.
- Assumptions that could be wrong: separator-shaped tokens are useful entity signals; a uniform three-code-point minimum is appropriate across scripts.
- Missing/weak tests: live retrieval-quality deltas are not measured here; deterministic transport call shape and failure behavior are covered locally.
- Security/permission risk: current-turn private text remains inside the existing authenticated recall path; telemetry contains counts/categories only and extracted keys are not persisted.
- Migration/deploy risk: no database migration or server deployment; installable Python artifact moves from 0.1.12 to 0.1.13.
- Downstream client/runtime risk: standalone Python behavior only; standalone TypeScript parity is deferred. Server MCP schema, wire contract, auth, and namespace behavior are unchanged.
- Rollback/cleanup concern: revert the extractor exports/recall wiring and the 0.1.13 artifact commit before publishing.
- Fixes made before PR: corrected the first worker version that extracted keys without using them; added Unicode/NFC behavior, trimmed unused public helpers, added mutation-killing casefold coverage, documented the public API, and bumped the package version.
- Known residual risk: heuristic quality is unit-tested but not benchmarked against a live corpus; CJK terms shorter than three code points follow the same threshold as other scripts.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: existing active Python client versioning and cross-runtime parity entries already cover the review patterns; this PR introduced no new MEDIUM+ review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: client-only recall-query augmentation uses existing server tools and does not change hosted server code, schema, transport, auth, or namespace behavior.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: per-turn concept extraction and derived recall-query augmentation are standalone Python client conveniences; TypeScript parity is explicitly deferred to the later standalone TS client phase.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- rtech-mcps and mcp2cli are not applicable: no server tool/schema/registry/generated-skill behavior changed.
- Direct Hermes integration and live canaries are not applicable; this is a runtime-neutral standalone Python client release and Hermes is outside the approved scope.
- The server compatibility floor intentionally remains `openbrain-memory >=0.1.8 <1.0.0`; the new convenience is optional, not server-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
