### PR TITLE
feat(344): schedule client-owned spool replay

### DIFF
--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -578,3 +578,31 @@ run's rows. Two ways that uniqueness silently collapsed:
   (and a reused label across invocations) asserting distinct final namespaces?
 - If the boundary doubles as a destructive-teardown scope, does reuse let one
   run's teardown touch another run's / a real namespace's rows?
+
+## [2026-07-22] Repeating scheduler loops must contain one-shot handler failures
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #355 / issue #344 Full-tier review
+**Scope:** `python/openbrain-memory/src/openbrain_memory/maintenance.py`
+**Status:** fixed-pre-merge
+
+### Pattern
+
+A scheduler can correctly re-raise handler exceptions from synchronous
+`run_once()` while accidentally letting the same exception escape its background
+loop. In PR #355, one raised handler unwound the daemon thread permanently, so
+all future scheduled replay beats disappeared; Python's default thread
+excepthook could also print the exception body to stderr. The fix catches only at
+the `_run_loop` boundary, after the content-free error status was logged, so the
+loop advances to the next interval while direct callers still receive the
+exception.
+
+### Review Questions
+
+- Does a repeating loop call a one-shot API that intentionally re-raises? If so,
+  is the exception contained at the loop boundary rather than killing the worker?
+- Do synchronous callers still observe the error after the background containment
+  fix?
+- Does a regression use a handler that raises once and then succeeds, proving a
+  later beat runs and the thread remains alive until explicit stop?
+- Can the thread excepthook or stderr expose the handler's exception message?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -678,3 +678,34 @@ Extra review question for this class:
 **Status:** fixed-pre-merge
 
 A public tool must not accept a caller-asserted digest as observed-content truth merely because it has SHA-256 shape. Keep source hashes behind a trusted collector path that hashes received bytes server-side; test that the public schema omits the field.
+
+## [2026-07-22] Replay failure logs must exclude traceback, path, and identity fields
+
+**Severity:** HIGH (P1)
+**Source:** PR #355 / issue #344 Terra terminal audit
+**Scope:** `python/openbrain-memory/src/openbrain_memory/spool.py`, `runtime.py`, scheduled replay/drain paths
+**Status:** fixed-pre-merge
+
+### Pattern
+
+A scheduler's own telemetry can be content-free while the reused replay path
+below it still leaks. PR #355 routed scheduled replay through the existing spool
+drain, whose dispatch-failure warning used `exc_info=True` and structured fields
+for the spool path, operation, and idempotency key; the outer drain catch also
+logged a traceback. `OpenBrainError` can carry a redacted-but-private server body,
+so background logs could expose replayed content even though the scheduler log
+itself emitted only status/counts. The fix uses stable category/status fields
+only and preserves retry, quarantine, disposition, and receipt behavior.
+
+### Review Questions
+
+- For every reused layer beneath a new content-free scheduler surface, do dispatch
+  and outer catch blocks avoid `exc_info`, raw exception messages, response
+  bodies, paths, keys, namespaces, and payload identifiers?
+- Does the leak test inject distinct private sentinels into the exception body,
+  spool path, and idempotency key, then inspect message, args, structured extras,
+  traceback state, and stderr?
+- Are retry counts, quarantine thresholds, `error_category`, dispositions, and
+  receipts unchanged after logging is reduced?
+- Are malformed-file corruption diagnostics adjudicated separately from provider
+  dispatch failures rather than silently treated as the same surface?

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -325,6 +325,18 @@ paths. The supported public surface is:
 - `FirstClassMemoryRuntime`, `RuntimeConfig`, `RuntimeScope`, `RuntimeOutput`,
   `RuntimeReceipt`, and `ReceiptStatus`.
 - `JsonlSpool`, `SpoolRecord`, `SpoolStatus`, and `replay_records`.
+- `MaintenanceRegistry`, `MaintenanceScheduler`, `MaintenanceHandler`,
+  `SpoolReplayMaintenanceHandler`, `MaintenanceRegistryError`, and
+  `SPOOL_REPLAY_JOB_KIND` -- an **explicit opt-in, client-local** maintenance
+  registry and in-process scheduler for running the runtime's spool
+  replay/quarantine flow (via `FirstClassMemoryRuntime.drain_spool_now()`) once,
+  on demand, or on a bounded interval. State scheduling is Python client
+  authority over a client-local JSONL spool: it does **not** depend on the
+  server TypeScript maintenance queue or any second job database, and nothing
+  runs in the background until `MaintenanceScheduler.start()` is called
+  explicitly. Each pass reuses the standalone drain unchanged, so exact-scope
+  replay, `REPLAYED`/`QUARANTINED` disposition, drain receipts, and content-free
+  observability are identical to the write/recall path.
 - `RetryPolicy` and `RetryExhaustedError`.
 - `redact_text()` and `redact_value()`.
 - `validate_required_memory_contract()` and `validate_contract_manifest()`.

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.13"
+version = "0.1.14"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -38,6 +38,14 @@ from .contract import (
     validate_required_memory_contract,
 )
 from .dream import DreamAction, DreamClient, DreamEngine, DreamPolicy, DreamRun
+from .maintenance import (
+    SPOOL_REPLAY_JOB_KIND,
+    MaintenanceHandler,
+    MaintenanceRegistry,
+    MaintenanceRegistryError,
+    MaintenanceScheduler,
+    SpoolReplayMaintenanceHandler,
+)
 from .policy import RetryExhaustedError, RetryPolicy, redact_text, redact_value
 from .runtime import (
     DrainReport,
@@ -80,6 +88,10 @@ __all__ = [
     "DreamEngine",
     "DreamPolicy",
     "DreamRun",
+    "MaintenanceHandler",
+    "MaintenanceRegistry",
+    "MaintenanceRegistryError",
+    "MaintenanceScheduler",
     "MemoryClient",
     "MemoryContext",
     "MemoryItem",
@@ -116,6 +128,8 @@ __all__ = [
     "RuntimeOutput",
     "RuntimeReceipt",
     "RuntimeScope",
+    "SPOOL_REPLAY_JOB_KIND",
+    "SpoolReplayMaintenanceHandler",
     "SpoolRecord",
     "SpoolReplayReport",
     "SpoolStatus",

--- a/python/openbrain-memory/src/openbrain_memory/maintenance.py
+++ b/python/openbrain-memory/src/openbrain_memory/maintenance.py
@@ -237,7 +237,16 @@ class MaintenanceScheduler:
         # returns True the instant ``stop`` is signalled, so a clean stop never
         # blocks for a full interval.
         while not self._stop.is_set():
-            self.tick(kind)
+            try:
+                self.tick(kind)
+            except Exception:
+                # ``_run_handler`` already logged this failure content-free and
+                # re-raised for a one-shot caller's own accounting. In the loop
+                # that re-raise would escape the daemon thread and stop every
+                # later beat; swallow it here so a transient handler failure
+                # cannot kill the scheduler. Nothing new is logged — the error
+                # was already recorded before it reached here.
+                pass
             if self._stop.wait(interval):
                 break
 

--- a/python/openbrain-memory/src/openbrain_memory/maintenance.py
+++ b/python/openbrain-memory/src/openbrain_memory/maintenance.py
@@ -1,0 +1,288 @@
+"""Idempotent maintenance handlers and an in-process scheduler (#344).
+
+The automatic spool replay/quarantine flow (#296/#317) runs inline after a
+successful direct write or recall. This module exposes that same flow as a
+registrable, idempotent maintenance handler, a small registry that maps a
+stable job ``kind`` to its handler, and an in-process scheduler that can run a
+registered handler once, on demand, or on a bounded interval — without
+inventing a second persistent job store.
+
+The handler is a thin wrapper: it calls
+``FirstClassMemoryRuntime.drain_spool_now``, which reuses the exact
+``_drain_spool`` path. Every invariant of the standalone path is therefore
+preserved unchanged — per-unit persisted exact scope, foreign-namespace and
+unprovable-scope retention, ``REPLAYED``/``QUARANTINED`` disposition,
+full-record namespace provenance, drain receipts, and content-free
+observability. No new quarantine categories are introduced.
+
+Durable work state is the spool file itself: a replayed unit leaves the spool
+within its pass, so a re-run drains only what remains and a settled spool is a
+no-op. The scheduler holds no job database of its own; it only owns the
+in-process concerns of not overlapping a run and stopping cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from .runtime import DrainReport, FirstClassMemoryRuntime
+
+logger = logging.getLogger(__name__)
+
+# Stable maintenance job kind for scheduled spool replay. Kept lowercase with
+# the same token shape the TS maintenance queue accepts for a job kind so a
+# cross-runtime scheduler can address this handler by a single identifier.
+SPOOL_REPLAY_JOB_KIND = "spool_replay"
+
+
+class MaintenanceHandler(Protocol):
+    """A registrable maintenance job.
+
+    ``kind`` is the stable identifier a registry and scheduler address the
+    handler by; ``run`` executes exactly one idempotent pass and returns a
+    content-free ``DrainReport`` (or ``None`` when there was nothing to do).
+    """
+
+    @property
+    def kind(self) -> str: ...
+
+    def run(self) -> DrainReport | None: ...
+
+
+@dataclass(frozen=True)
+class SpoolReplayMaintenanceHandler:
+    """Run the runtime's spool replay/quarantine flow as a maintenance job.
+
+    ``kind`` addresses this handler in a handler registry. ``run`` executes
+    one drain pass and returns the same content-free ``DrainReport`` the
+    standalone path produces (``None`` when nothing was pending or the drain
+    machinery itself failed).
+
+    Idempotent: replayed units are removed from the spool within the pass, so
+    running the handler twice over a settled spool drains only what remains and
+    the second run returns a zero-count report or ``None``. The handler holds no
+    per-run state; a scheduler may invoke it repeatedly and safely retry a
+    failed job. Any exception raised by ``run`` propagates to the scheduler for
+    that scheduler's own retry/dead-letter accounting; the drain itself never
+    raises (it returns ``None`` on internal failure), so ``run`` only raises if
+    the runtime handle is unusable.
+    """
+
+    runtime: FirstClassMemoryRuntime
+
+    @property
+    def kind(self) -> str:
+        return SPOOL_REPLAY_JOB_KIND
+
+    def run(self) -> DrainReport | None:
+        """Execute one idempotent spool replay pass."""
+        return self.runtime.drain_spool_now()
+
+
+class MaintenanceRegistryError(ValueError):
+    """Raised for a duplicate or unknown maintenance job kind."""
+
+
+class MaintenanceRegistry:
+    """Maps a stable job ``kind`` to the handler that services it.
+
+    Registration is deterministic: registering a kind that is already
+    registered raises, and resolving a kind that was never registered raises.
+    Both surface :class:`MaintenanceRegistryError` so a caller can tell a
+    routing mistake from a job failure. The registry owns no execution
+    concerns; it only answers "which handler runs this kind".
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, MaintenanceHandler] = {}
+
+    def register(self, handler: MaintenanceHandler) -> None:
+        """Register ``handler`` under its ``kind``; reject a duplicate kind."""
+        kind = handler.kind
+        if kind in self._handlers:
+            raise MaintenanceRegistryError(
+                f"maintenance kind is already registered: {kind}"
+            )
+        self._handlers[kind] = handler
+
+    def get(self, kind: str) -> MaintenanceHandler:
+        """Return the handler for ``kind``; reject an unknown kind."""
+        try:
+            return self._handlers[kind]
+        except KeyError as error:
+            raise MaintenanceRegistryError(
+                f"no maintenance handler registered for kind: {kind}"
+            ) from error
+
+    def kinds(self) -> frozenset[str]:
+        """Return the set of registered kinds."""
+        return frozenset(self._handlers)
+
+
+class MaintenanceScheduler:
+    """Run a registered maintenance handler once, on demand, or on a bounded
+    interval, in this process.
+
+    The spool file is the durable work state; the scheduler adds only two
+    in-process concerns:
+
+    * **No overlap.** ``run_once``/``tick`` take a non-blocking lock. If a run
+      is already in flight (including a background loop's run), the concurrent
+      caller returns ``None`` immediately rather than draining the same spool
+      twice at once.
+    * **Clean stop.** ``start`` spins a single daemon loop that calls ``tick``
+      and then waits on a stop event for ``interval`` seconds; ``stop`` sets the
+      event and joins the loop. There is no background thread unless ``start``
+      is called explicitly — construction and registration start nothing.
+
+    Telemetry is content-free by construction: only ``kind``, a status token,
+    elapsed milliseconds, and the drain's counts are logged. Records, paths,
+    payloads, and exception bodies are never logged here — a handler failure is
+    logged as ``status=error`` with no exception object.
+    """
+
+    def __init__(
+        self,
+        registry: MaintenanceRegistry,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._registry = registry
+        self._monotonic = monotonic
+        # Non-blocking guard: held for the duration of one handler run so an
+        # overlapping tick is suppressed instead of double-draining the spool.
+        self._run_lock = threading.Lock()
+        self._stop = threading.Event()
+        self._loop: threading.Thread | None = None
+        # Guards loop lifecycle (start/stop) against itself, not the run lock.
+        self._lifecycle_lock = threading.Lock()
+
+    def run_once(self, kind: str) -> DrainReport | None:
+        """Resolve ``kind`` and run it once if no run is already in flight.
+
+        Returns the handler's ``DrainReport`` (or ``None`` when it had nothing
+        to do), or ``None`` if a concurrent run holds the guard. Resolving an
+        unknown kind raises :class:`MaintenanceRegistryError` before any lock is
+        taken, so a routing mistake is never silently swallowed as a no-op.
+        """
+        handler = self._registry.get(kind)
+        if not self._run_lock.acquire(blocking=False):
+            logger.info(
+                "maintenance run suppressed: already in flight",
+                extra={"maintenance_kind": kind, "maintenance_status": "suppressed"},
+            )
+            return None
+        try:
+            return self._run_handler(handler)
+        finally:
+            self._run_lock.release()
+
+    def tick(self, kind: str) -> DrainReport | None:
+        """One scheduler beat: run ``kind`` once, suppressing overlap.
+
+        Identical to :meth:`run_once`; named separately so a caller's own
+        timer loop reads as a beat rather than a one-shot.
+        """
+        return self.run_once(kind)
+
+    def start(self, kind: str, *, interval: float) -> None:
+        """Start a single daemon loop that ticks ``kind`` every ``interval`` s.
+
+        Explicit opt-in only — nothing runs in the background until this is
+        called. ``interval`` must be > 0. Calling ``start`` while a loop is
+        already running raises; call :meth:`stop` first. The kind is resolved
+        eagerly so an unknown kind fails at ``start`` rather than silently in a
+        background thread.
+        """
+        if interval <= 0:
+            raise ValueError("interval must be > 0")
+        # Fail fast on an unknown kind before spawning the loop.
+        self._registry.get(kind)
+        with self._lifecycle_lock:
+            if self._loop is not None and self._loop.is_alive():
+                raise RuntimeError("maintenance scheduler is already running")
+            self._stop.clear()
+            loop = threading.Thread(
+                target=self._run_loop,
+                args=(kind, interval),
+                name=f"ob-maintenance-{kind}",
+                daemon=True,
+            )
+            self._loop = loop
+            loop.start()
+
+    def stop(self, *, timeout: float | None = None) -> None:
+        """Signal the loop to stop and join it; idempotent when not running."""
+        with self._lifecycle_lock:
+            loop = self._loop
+            self._stop.set()
+            if loop is not None:
+                loop.join(timeout)
+                if not loop.is_alive():
+                    self._loop = None
+
+    @property
+    def is_running(self) -> bool:
+        """True while a background loop thread is alive."""
+        loop = self._loop
+        return loop is not None and loop.is_alive()
+
+    def _run_loop(self, kind: str, interval: float) -> None:
+        # Tick immediately, then wait ``interval`` between beats. ``Event.wait``
+        # returns True the instant ``stop`` is signalled, so a clean stop never
+        # blocks for a full interval.
+        while not self._stop.is_set():
+            self.tick(kind)
+            if self._stop.wait(interval):
+                break
+
+    def _run_handler(self, handler: MaintenanceHandler) -> DrainReport | None:
+        kind = handler.kind
+        started = self._monotonic()
+        try:
+            report = handler.run()
+        except Exception:
+            elapsed_ms = self._elapsed_ms(started)
+            # Content-free: kind, status, timing only. No exception object, no
+            # message body — the drain itself never raises, so reaching here
+            # means the runtime handle was unusable.
+            logger.warning(
+                "maintenance run failed",
+                extra={
+                    "maintenance_kind": kind,
+                    "maintenance_status": "error",
+                    "maintenance_elapsed_ms": elapsed_ms,
+                },
+            )
+            raise
+        elapsed_ms = self._elapsed_ms(started)
+        self._log_result(kind, report, elapsed_ms)
+        return report
+
+    def _elapsed_ms(self, started: float) -> int:
+        return max(0, round((self._monotonic() - started) * 1000))
+
+    @staticmethod
+    def _log_result(
+        kind: str, report: DrainReport | None, elapsed_ms: int
+    ) -> None:
+        extra: dict[str, object] = {
+            "maintenance_kind": kind,
+            "maintenance_elapsed_ms": elapsed_ms,
+        }
+        if report is None:
+            extra["maintenance_status"] = "noop"
+        else:
+            # Counts only — never receipts, keys, operations, or payloads.
+            extra["maintenance_status"] = "ran"
+            extra["maintenance_attempted_units"] = report.attempted_units
+            extra["maintenance_replayed_units"] = report.replayed_units
+            extra["maintenance_failed_units"] = report.failed_units
+            extra["maintenance_quarantined_units"] = report.quarantined_units
+            extra["maintenance_retained_units"] = report.retained_units
+        logger.info("maintenance run complete", extra=extra)

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -492,6 +492,32 @@ class FirstClassMemoryRuntime:
         with self._operation_lock:
             self._router.close()
 
+    def drain_spool_now(self) -> DrainReport | None:
+        """Replay pending durable records on demand, outside a write/recall.
+
+        Scheduled or queued maintenance uses this to run the *same* spool
+        drain the write and recall paths trigger automatically after a
+        successful direct call: it reuses ``_drain_spool`` unchanged, so the
+        exact-scope replay, foreign-namespace/unprovable-scope retention,
+        ``REPLAYED``/``QUARANTINED`` semantics, full-record namespace
+        provenance, drain receipts, and content-free observability are
+        identical to the standalone path.
+
+        Idempotent by construction: a replayed unit is removed from the spool
+        in the same pass, so a re-run only drains what is still pending and a
+        fully-drained spool returns a zero-count report. Returns ``None`` when
+        there was nothing to drain or the drain machinery itself failed, and
+        the same content-free ``DrainReport`` otherwise (also stored on
+        ``last_drain_report``). The operation lock and per-operation state
+        reset mirror the write path so a concurrent write and a scheduled
+        drain never share a partial spool snapshot or stale router evidence.
+        """
+        with self._operation_lock:
+            self._router.reset()
+            if self._spool is not None:
+                self._spool.reset()
+            return self._drain_spool()
+
     def recall_context(
         self,
         query: str,

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -818,7 +818,15 @@ class FirstClassMemoryRuntime:
             self.last_drain_report = drain
             return drain
         except Exception:
-            logger.warning("Spool auto-drain failed", exc_info=True)
+            # Content-free background observability (#296): the raised error may
+            # be an OpenBrainError whose message/body carries redacted-but-
+            # private content, and a traceback exposes it. Log a stable status
+            # token only — no exception object/traceback, message, spool path,
+            # idempotency key, namespace, payload, or provider/server body.
+            logger.warning(
+                "Spool auto-drain failed",
+                extra={"spool_drain_status": "error"},
+            )
             return None
 
     def _build_drain_report(self, report: SpoolReplayReport) -> DrainReport:

--- a/python/openbrain-memory/src/openbrain_memory/spool.py
+++ b/python/openbrain-memory/src/openbrain_memory/spool.py
@@ -576,14 +576,18 @@ class JsonlSpool:
                     break
                 except Exception as dispatch_error:
                     error = dispatch_error
+                    # Content-free background observability (#296): a dispatch
+                    # failure carries the OpenBrainError message/body, which may
+                    # hold redacted-but-private content, and a traceback exposes
+                    # it. Log a stable status token only — never the exception
+                    # object/traceback, raw message, spool path, idempotency
+                    # key, namespace, payload, or provider/server body. Retry,
+                    # quarantine accounting, and the returned per-unit outcome
+                    # (which already carries the non-content class-name category)
+                    # are unchanged.
                     logger.warning(
-                        "Spool replay failed",
-                        extra={
-                            "spool_path": str(self.path),
-                            "spool_operation": record.operation,
-                            "spool_key": record.idempotency_key,
-                        },
-                        exc_info=True,
+                        "Spool replay dispatch failed",
+                        extra={"spool_replay_status": "failed"},
                     )
                     break
             if retained:

--- a/python/openbrain-memory/tests/_runtime_fakes.py
+++ b/python/openbrain-memory/tests/_runtime_fakes.py
@@ -251,6 +251,46 @@ class LaneAwareTransport:
         )
 
 
+class FailingReplayTransport(LaneAwareTransport):
+    """Fail one replay tool call with a sentinel-bearing error body.
+
+    Every other tool (including ``initialize``/``get_contract``) behaves
+    normally so the runtime reaches the drain, but the chosen replay operation
+    returns an MCP tool error whose text carries a non-secret private sentinel.
+    That surfaces as the dispatch failure the content-free replay/drain logs
+    must never leak.
+    """
+
+    def __init__(self, *, fail_tool: str, error_body: str) -> None:
+        super().__init__()
+        self.fail_tool = fail_tool
+        self.error_body = error_body
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        json_body: Mapping[str, Any],
+        timeout: float,
+    ) -> TransportResponse:
+        if json_body.get("method") == "tools/call":
+            params = json_body["params"]
+            if params.get("name") == self.fail_tool:
+                self.requests.append(
+                    {
+                        "url": url,
+                        "headers": dict(headers),
+                        "json": dict(json_body),
+                        "timeout": timeout,
+                    }
+                )
+                return self._tool_error(json_body["id"], self.error_body)
+        return super().post(
+            url, headers=headers, json_body=json_body, timeout=timeout
+        )
+
+
 class ForeignLaneTamperingTransport(LaneAwareTransport):
     """Echo one session's lane with a single tampered field to test replay proof."""
 

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -160,8 +160,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.13"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.13"
+    assert CURRENT_CLIENT_VERSION == "0.1.14"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.14"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.8 <1.0.0"
     )

--- a/python/openbrain-memory/tests/test_maintenance.py
+++ b/python/openbrain-memory/tests/test_maintenance.py
@@ -1,0 +1,570 @@
+"""Tests for the queued spool-replay maintenance handler (#344).
+
+The handler must run the *existing* spool replay/quarantine flow: the same
+``REPLAYED``/``QUARANTINED`` outcomes and drain receipts as the standalone
+auto-drain, each unit under its own persisted exact scope, with foreign
+namespace/scope provenance retained, content-free, and idempotent.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from openbrain_memory import (
+    SPOOL_REPLAY_JOB_KIND,
+    DrainReport,
+    FirstClassMemoryRuntime,
+    JsonlSpool,
+    MaintenanceHandler,
+    MaintenanceRegistry,
+    MaintenanceRegistryError,
+    MaintenanceScheduler,
+    ReceiptStatus,
+    SpoolReplayMaintenanceHandler,
+)
+from openbrain_memory._runtime_spool import PARKED_NAMESPACE_KEY
+
+from ._runtime_fakes import (
+    LaneAwareTransport,
+    runtime_config,
+    runtime_scope,
+    tool_calls,
+)
+from .test_runtime import _park_unit, _parked_unit_scope
+
+
+def _seed_replay_and_quarantine_fixture(spool: JsonlSpool) -> None:
+    """Seed one replayable unit and one unit that fails and quarantines.
+
+    ``quarantine_threshold`` is 1 on the spool under test, so the unsupported
+    operation fails its single replay attempt and quarantines in the same pass;
+    the valid ``session_start`` unit replays. This exercises both a ``REPLAYED``
+    and a ``QUARANTINED`` receipt in one drain.
+    """
+    scope = runtime_scope()
+    spool.append(
+        "unknown_operation",
+        {"value": "will fail and quarantine"},
+        key="poison-key",
+    )
+    spool.append(
+        "session_start",
+        {
+            **scope.start_metadata(),
+            "session_key": scope.session_key,
+            "agent": scope.agent,
+        },
+        key="valid-key",
+    )
+
+
+def _build_runtime(
+    spool: JsonlSpool, transport: LaneAwareTransport
+) -> FirstClassMemoryRuntime:
+    return FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+
+def test_handler_kind_is_the_stable_spool_replay_job_kind() -> None:
+    spool = JsonlSpool("/dev/null")
+    handler = SpoolReplayMaintenanceHandler(
+        _build_runtime(spool, LaneAwareTransport())
+    )
+    assert handler.kind == SPOOL_REPLAY_JOB_KIND == "spool_replay"
+
+
+def test_queued_drain_matches_standalone_outcomes_and_receipts(
+    tmp_path: Path,
+) -> None:
+    # Standalone path: the drain the write/recall path triggers automatically.
+    standalone_spool = JsonlSpool(
+        tmp_path / "standalone.jsonl", quarantine_threshold=1
+    )
+    _seed_replay_and_quarantine_fixture(standalone_spool)
+    standalone_runtime = _build_runtime(standalone_spool, LaneAwareTransport())
+    standalone = standalone_runtime.recall_context("Trigger standalone drain")
+
+    # Queued path: an identical fixture drained through the maintenance handler.
+    queued_spool = JsonlSpool(tmp_path / "queued.jsonl", quarantine_threshold=1)
+    _seed_replay_and_quarantine_fixture(queued_spool)
+    queued_runtime = _build_runtime(queued_spool, LaneAwareTransport())
+    queued_report = SpoolReplayMaintenanceHandler(queued_runtime).run()
+
+    assert standalone.receipt.status is ReceiptStatus.DIRECT
+    assert standalone.drain is not None
+    assert queued_report is not None
+    # Same REPLAYED and QUARANTINED outcomes and the same drain receipts.
+    assert queued_report.as_dict() == standalone.drain.as_dict()
+    # Concretely: one replayed unit and one quarantined unit in each path.
+    assert queued_report.replayed_units == 1
+    assert queued_report.quarantined_units == 1
+    replayed = [
+        receipt
+        for receipt in queued_report.receipts
+        if receipt.status is ReceiptStatus.REPLAYED
+    ]
+    quarantined = [
+        receipt
+        for receipt in queued_report.receipts
+        if receipt.status is ReceiptStatus.QUARANTINED
+    ]
+    assert [receipt.spool_key for receipt in replayed] == ["valid-key"]
+    assert [receipt.spool_key for receipt in quarantined] == ["poison-key"]
+
+
+def test_queued_drain_replays_unit_under_its_own_persisted_exact_scope(
+    tmp_path: Path,
+) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "queued.jsonl")
+    _park_unit(spool, parked, "Parked in another project")
+    transport = LaneAwareTransport()
+    runtime = _build_runtime(spool, transport)
+
+    report = SpoolReplayMaintenanceHandler(runtime).run()
+
+    assert report is not None
+    assert report.replayed_units == 1
+    assert spool.status().pending_count == 0
+    # The queued drain dispatched the parked unit under the scope it was parked
+    # with — not the replaying runtime's scope.
+    started = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "session_start"
+    ]
+    assert any(
+        arguments["session_key"] == parked.session_key
+        and arguments["channel_id"] == parked.channel_id
+        for arguments in started
+    )
+    appended = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "append_session_event"
+    ]
+    assert any(
+        arguments["content"] == "Parked in another project"
+        and arguments["channel_id"] == parked.channel_id
+        for arguments in appended
+    )
+
+
+def test_queued_drain_retains_unit_parked_under_another_namespace(
+    tmp_path: Path,
+) -> None:
+    parked = _parked_unit_scope()
+    spool = JsonlSpool(tmp_path / "queued.jsonl")
+    spool.append_batch(
+        [
+            (
+                "session_start",
+                {
+                    **parked.start_metadata(),
+                    "session_key": parked.session_key,
+                    "agent": parked.agent,
+                    PARKED_NAMESPACE_KEY: "other-namespace",
+                },
+                None,
+            ),
+            (
+                "append_session_event",
+                {
+                    **parked.start_metadata(),
+                    "session_key": parked.session_key,
+                    "agent": parked.agent,
+                    "content": "Parked by another namespace",
+                    "event_type": "fact",
+                    "source": parked.agent,
+                    "metadata": {"idempotency_key": "parked-other-namespace"},
+                },
+                None,
+            ),
+        ]
+    )
+    transport = LaneAwareTransport()
+    runtime = _build_runtime(spool, transport)
+
+    report = SpoolReplayMaintenanceHandler(runtime).run()
+
+    assert report is not None
+    # Foreign-namespace provenance is honored on the queued path exactly as on
+    # the standalone path: retained, never dispatched, still parked.
+    assert report.retained_units == 1
+    assert report.replayed_units == 0
+    assert [record.operation for record in spool.records()] == [
+        "session_start",
+        "append_session_event",
+    ]
+    dispatched_keys = [
+        call["params"]["arguments"].get("session_key")
+        for call in tool_calls(transport)
+        if call["params"]["name"] != "get_contract"
+    ]
+    assert parked.session_key not in dispatched_keys
+
+
+def test_queued_drain_is_idempotent_over_a_settled_spool(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "queued.jsonl", quarantine_threshold=1)
+    _seed_replay_and_quarantine_fixture(spool)
+    runtime = _build_runtime(spool, LaneAwareTransport())
+    handler = SpoolReplayMaintenanceHandler(runtime)
+
+    first = handler.run()
+    settled = spool.records()
+
+    second = handler.run()
+
+    assert first is not None
+    assert first.replayed_units == 1
+    assert first.quarantined_units == 1
+    # Replayed units left the spool; the quarantined unit is on the sidecar,
+    # not pending. A second pass has nothing to drain and is a no-op.
+    assert second is None
+    assert spool.status().pending_count == 0
+    # The settled spool is unchanged by the redundant second run.
+    assert [record.idempotency_key for record in spool.records()] == [
+        record.idempotency_key for record in settled
+    ]
+
+
+def test_queued_drain_receipts_are_content_free(tmp_path: Path) -> None:
+    spool = JsonlSpool(tmp_path / "queued.jsonl", quarantine_threshold=1)
+    _seed_replay_and_quarantine_fixture(spool)
+    runtime = _build_runtime(spool, LaneAwareTransport())
+
+    report = SpoolReplayMaintenanceHandler(runtime).run()
+
+    assert report is not None
+    allowed_receipt_keys = {
+        "schema",
+        "operation",
+        "status",
+        "durable",
+        "direct_attempted",
+        "fallback_attempted",
+        "spool_key",
+        "error",
+    }
+    for receipt in report.as_dict()["receipts"]:
+        assert set(receipt).issubset(allowed_receipt_keys)
+        # error carries only a class name (the failing unit), never a body.
+        assert receipt.get("error") in (None, "ValueError")
+
+
+# --- Registry -------------------------------------------------------------
+
+
+@dataclass
+class _RecordingHandler:
+    """A minimal handler that records how many times it ran.
+
+    Structurally satisfies :class:`MaintenanceHandler` (kind + run); used to
+    exercise the registry and scheduler without a real runtime or spool.
+    """
+
+    kind: str
+    report: DrainReport | None = None
+    calls: int = 0
+    barrier: threading.Event | None = None
+    released: threading.Event | None = None
+
+    def run(self) -> DrainReport | None:
+        self.calls += 1
+        if self.released is not None:
+            self.released.set()
+        if self.barrier is not None:
+            self.barrier.wait(2.0)
+        return self.report
+
+
+def _no_op_report() -> DrainReport:
+    return DrainReport(
+        attempted_units=0,
+        replayed_units=0,
+        replayed_records=0,
+        failed_units=0,
+        quarantined_units=0,
+        retained_units=0,
+    )
+
+
+def test_registry_resolves_registered_kind_to_its_handler() -> None:
+    handler: MaintenanceHandler = _RecordingHandler(SPOOL_REPLAY_JOB_KIND)
+    registry = MaintenanceRegistry()
+    registry.register(handler)
+
+    assert registry.get(SPOOL_REPLAY_JOB_KIND) is handler
+    assert registry.kinds() == frozenset({SPOOL_REPLAY_JOB_KIND})
+
+
+def test_registry_rejects_duplicate_kind() -> None:
+    registry = MaintenanceRegistry()
+    registry.register(_RecordingHandler(SPOOL_REPLAY_JOB_KIND))
+
+    with pytest.raises(MaintenanceRegistryError, match="already registered"):
+        registry.register(_RecordingHandler(SPOOL_REPLAY_JOB_KIND))
+
+
+def test_registry_rejects_unknown_kind() -> None:
+    registry = MaintenanceRegistry()
+
+    with pytest.raises(MaintenanceRegistryError, match="no maintenance handler"):
+        registry.get("never_registered")
+
+
+def test_spool_replay_handler_satisfies_the_handler_protocol(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "queued.jsonl")
+    handler: MaintenanceHandler = SpoolReplayMaintenanceHandler(
+        _build_runtime(spool, LaneAwareTransport())
+    )
+    registry = MaintenanceRegistry()
+    registry.register(handler)
+
+    assert registry.get(SPOOL_REPLAY_JOB_KIND).kind == SPOOL_REPLAY_JOB_KIND
+
+
+# --- Scheduler ------------------------------------------------------------
+
+
+def _replay_registry(runtime: FirstClassMemoryRuntime) -> MaintenanceRegistry:
+    registry = MaintenanceRegistry()
+    registry.register(SpoolReplayMaintenanceHandler(runtime))
+    return registry
+
+
+def test_scheduled_and_standalone_share_fixture_outcomes_and_receipts(
+    tmp_path: Path,
+) -> None:
+    # Standalone path: the drain the write/recall path triggers automatically.
+    standalone_spool = JsonlSpool(
+        tmp_path / "standalone.jsonl", quarantine_threshold=1
+    )
+    _seed_replay_and_quarantine_fixture(standalone_spool)
+    standalone_runtime = _build_runtime(standalone_spool, LaneAwareTransport())
+    standalone = standalone_runtime.recall_context("Trigger standalone drain")
+
+    # Scheduled path: identical fixture drained through the scheduler.
+    scheduled_spool = JsonlSpool(
+        tmp_path / "scheduled.jsonl", quarantine_threshold=1
+    )
+    _seed_replay_and_quarantine_fixture(scheduled_spool)
+    scheduled_runtime = _build_runtime(scheduled_spool, LaneAwareTransport())
+    scheduler = MaintenanceScheduler(_replay_registry(scheduled_runtime))
+    scheduled_report = scheduler.run_once(SPOOL_REPLAY_JOB_KIND)
+
+    assert standalone.drain is not None
+    assert scheduled_report is not None
+    # Same REPLAYED and QUARANTINED outcomes and the same drain receipts as the
+    # standalone auto-drain — the scheduler adds no behavior, only invocation.
+    assert scheduled_report.as_dict() == standalone.drain.as_dict()
+    assert scheduled_report.replayed_units == 1
+    assert scheduled_report.quarantined_units == 1
+
+
+def test_scheduler_run_once_unknown_kind_raises_before_running() -> None:
+    scheduler = MaintenanceScheduler(MaintenanceRegistry())
+
+    with pytest.raises(MaintenanceRegistryError, match="no maintenance handler"):
+        scheduler.run_once("never_registered")
+
+
+def test_scheduled_second_run_over_settled_spool_is_a_noop(
+    tmp_path: Path,
+) -> None:
+    spool = JsonlSpool(tmp_path / "scheduled.jsonl", quarantine_threshold=1)
+    _seed_replay_and_quarantine_fixture(spool)
+    runtime = _build_runtime(spool, LaneAwareTransport())
+    scheduler = MaintenanceScheduler(_replay_registry(runtime))
+
+    first = scheduler.run_once(SPOOL_REPLAY_JOB_KIND)
+    second = scheduler.tick(SPOOL_REPLAY_JOB_KIND)
+
+    assert first is not None
+    assert first.replayed_units == 1
+    assert first.quarantined_units == 1
+    # Replayed units left the spool; the settled spool is a no-op second pass.
+    assert second is None
+    assert spool.status().pending_count == 0
+
+
+def test_scheduler_suppresses_an_overlapping_tick() -> None:
+    # A run holds the guard on a barrier; a concurrent tick must be suppressed
+    # (return None) rather than run the handler a second time in parallel.
+    barrier = threading.Event()
+    released = threading.Event()
+    handler = _RecordingHandler(
+        "slow", report=_no_op_report(), barrier=barrier, released=released
+    )
+    registry = MaintenanceRegistry()
+    registry.register(handler)
+    scheduler = MaintenanceScheduler(registry)
+
+    holder: dict[str, DrainReport | None] = {}
+
+    def hold() -> None:
+        holder["result"] = scheduler.run_once("slow")
+
+    worker = threading.Thread(target=hold)
+    worker.start()
+    assert released.wait(2.0)  # first run is inside the guard
+
+    # Second tick while the first still holds the guard: suppressed no-op.
+    suppressed = scheduler.tick("slow")
+    assert suppressed is None
+    assert handler.calls == 1
+
+    barrier.set()
+    worker.join(2.0)
+    assert holder["result"] is handler.report
+    assert handler.calls == 1
+
+
+def test_scheduler_start_stop_lifecycle_runs_then_cleanly_stops() -> None:
+    ran = threading.Event()
+    handler = _RecordingHandler("loop", report=_no_op_report(), released=ran)
+    registry = MaintenanceRegistry()
+    registry.register(handler)
+    scheduler = MaintenanceScheduler(registry)
+
+    assert not scheduler.is_running
+    scheduler.start("loop", interval=3600.0)
+    assert ran.wait(2.0)  # the loop ticks immediately on start
+    assert scheduler.is_running
+
+    scheduler.stop(timeout=2.0)
+    assert not scheduler.is_running
+    # stop is idempotent when not running.
+    scheduler.stop(timeout=2.0)
+    assert handler.calls >= 1
+
+
+def test_scheduler_start_rejects_a_non_positive_interval() -> None:
+    registry = MaintenanceRegistry()
+    registry.register(_RecordingHandler("loop", report=_no_op_report()))
+    scheduler = MaintenanceScheduler(registry)
+
+    with pytest.raises(ValueError, match="interval must be > 0"):
+        scheduler.start("loop", interval=0.0)
+
+
+def test_scheduler_start_rejects_unknown_kind_before_spawning() -> None:
+    scheduler = MaintenanceScheduler(MaintenanceRegistry())
+
+    with pytest.raises(MaintenanceRegistryError, match="no maintenance handler"):
+        scheduler.start("never_registered", interval=3600.0)
+    assert not scheduler.is_running
+
+
+def test_scheduler_telemetry_is_content_free(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    spool = JsonlSpool(tmp_path / "scheduled.jsonl", quarantine_threshold=1)
+    _seed_replay_and_quarantine_fixture(spool)
+    runtime = _build_runtime(spool, LaneAwareTransport())
+    scheduler = MaintenanceScheduler(_replay_registry(runtime))
+
+    with caplog.at_level(logging.INFO, logger="openbrain_memory.maintenance"):
+        report = scheduler.run_once(SPOOL_REPLAY_JOB_KIND)
+
+    assert report is not None
+    records = [r for r in caplog.records if r.name == "openbrain_memory.maintenance"]
+    assert records
+    allowed_extra = {
+        "maintenance_kind",
+        "maintenance_status",
+        "maintenance_elapsed_ms",
+        "maintenance_attempted_units",
+        "maintenance_replayed_units",
+        "maintenance_failed_units",
+        "maintenance_quarantined_units",
+        "maintenance_retained_units",
+    }
+    # The seeded fixture parks the poison payload; assert it never leaks into a
+    # log message or structured field.
+    for record in records:
+        emitted = {
+            key for key in vars(record) if key.startswith("maintenance_")
+        }
+        assert emitted.issubset(allowed_extra)
+        assert record.args in (None, ())
+        assert "will fail and quarantine" not in record.getMessage()
+        assert getattr(record, "maintenance_kind") == SPOOL_REPLAY_JOB_KIND
+        assert str(spool.path) not in record.getMessage()
+
+
+def test_scheduler_logs_error_status_content_free_when_handler_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    @dataclass
+    class _RaisingHandler:
+        kind: str = "boom"
+
+        def run(self) -> DrainReport | None:
+            raise RuntimeError("runtime handle carrying a secret path is unusable")
+
+    registry = MaintenanceRegistry()
+    registry.register(_RaisingHandler())
+    scheduler = MaintenanceScheduler(registry)
+
+    with caplog.at_level(logging.WARNING, logger="openbrain_memory.maintenance"):
+        with pytest.raises(RuntimeError):
+            scheduler.run_once("boom")
+
+    records = [r for r in caplog.records if r.name == "openbrain_memory.maintenance"]
+    assert any(
+        getattr(record, "maintenance_status", None) == "error"
+        for record in records
+    )
+    for record in records:
+        # The exception body must never reach the log.
+        assert "secret path" not in record.getMessage()
+        assert record.exc_info is None
+
+
+# --- Mutation checks ------------------------------------------------------
+
+
+def test_mutation_scheduler_returning_noop_breaks_parity(
+    tmp_path: Path,
+) -> None:
+    """Guard: if the handler stopped draining (always None), the scheduled
+    parity and idempotency assertions must fail — proving those tests bind to
+    real drain results, not to any report shape.
+    """
+
+    @dataclass
+    class _NoopHandler:
+        kind: str = SPOOL_REPLAY_JOB_KIND
+
+        def run(self) -> DrainReport | None:
+            return None
+
+    spool = JsonlSpool(tmp_path / "standalone.jsonl", quarantine_threshold=1)
+    _seed_replay_and_quarantine_fixture(spool)
+    standalone = _build_runtime(spool, LaneAwareTransport()).recall_context(
+        "Trigger standalone drain"
+    )
+    assert standalone.drain is not None
+
+    registry = MaintenanceRegistry()
+    registry.register(_NoopHandler())
+    scheduler = MaintenanceScheduler(registry)
+    mutated = scheduler.run_once(SPOOL_REPLAY_JOB_KIND)
+
+    # The real handler returns a matching DrainReport; the mutant returns None.
+    assert mutated is None
+    assert mutated != standalone.drain

--- a/python/openbrain-memory/tests/test_maintenance.py
+++ b/python/openbrain-memory/tests/test_maintenance.py
@@ -535,6 +535,46 @@ def test_scheduler_logs_error_status_content_free_when_handler_raises(
         assert record.exc_info is None
 
 
+def test_scheduler_loop_survives_a_handler_that_raises_once(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A handler that raises on its first tick then succeeds. The loop must not
+    # die on the raise (later ticks still run) and the sentinel message must
+    # never reach stderr — the failure is logged content-free, not printed.
+    sentinel = "handler exploded carrying a secret path"
+    ran_again = threading.Event()
+
+    @dataclass
+    class _RaiseOnceHandler:
+        kind: str = "flaky"
+        calls: int = 0
+
+        def run(self) -> DrainReport | None:
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError(sentinel)
+            ran_again.set()
+            return None
+
+    handler = _RaiseOnceHandler()
+    registry = MaintenanceRegistry()
+    registry.register(handler)
+    scheduler = MaintenanceScheduler(registry)
+
+    try:
+        # A tiny interval so the second tick lands well within the wait.
+        scheduler.start("flaky", interval=0.01)
+        # The loop kept beating past the raise and reached a successful run.
+        assert ran_again.wait(2.0)
+        assert handler.calls >= 2
+        assert scheduler.is_running
+    finally:
+        scheduler.stop(timeout=2.0)
+
+    # The escaping exception never reached stderr as a daemon-thread traceback.
+    assert sentinel not in capsys.readouterr().err
+
+
 # --- Mutation checks ------------------------------------------------------
 
 

--- a/python/openbrain-memory/tests/test_maintenance.py
+++ b/python/openbrain-memory/tests/test_maintenance.py
@@ -30,6 +30,7 @@ from openbrain_memory import (
 from openbrain_memory._runtime_spool import PARKED_NAMESPACE_KEY
 
 from ._runtime_fakes import (
+    FailingReplayTransport,
     LaneAwareTransport,
     runtime_config,
     runtime_scope,
@@ -573,6 +574,60 @@ def test_scheduler_loop_survives_a_handler_that_raises_once(
 
     # The escaping exception never reached stderr as a daemon-thread traceback.
     assert sentinel not in capsys.readouterr().err
+
+
+def test_scheduled_drain_dispatch_failure_is_content_free(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A dispatch failure reached through the scheduler stays content-free.
+
+    Scheduled replay reuses the exact ``_drain_spool``/``replay_with_report``
+    path. When a replayed unit's direct dispatch fails, its provider error
+    body plus the spool path/key each carry a non-secret private sentinel;
+    none may reach any ``openbrain_memory`` log message, args, structured
+    extra, ``exc_info``, or stderr — while the drain still counts the failed
+    unit and leaves it pending.
+    """
+    body_sentinel = "PRIVATE-scheduled-provider-body"
+    path_sentinel = "private-scheduled-path"
+    key_sentinel = "private-scheduled-key"
+    spool = JsonlSpool(tmp_path / f"{path_sentinel}.jsonl")
+    spool.append("log_thought", {"content": "queued secret"}, key=key_sentinel)
+    transport = FailingReplayTransport(
+        fail_tool="log_thought", error_body=body_sentinel
+    )
+    runtime = _build_runtime(spool, transport)
+    scheduler = MaintenanceScheduler(_replay_registry(runtime))
+
+    with caplog.at_level(logging.DEBUG, logger="openbrain_memory"):
+        report = scheduler.run_once(SPOOL_REPLAY_JOB_KIND)
+
+    assert report is not None
+    assert report.failed_units == 1
+    assert report.replayed_units == 0
+    assert report.quarantined_units == 0
+    # The failed unit stayed pending with its retry counter incremented.
+    assert [record.idempotency_key for record in spool.records()] == [key_sentinel]
+    assert spool.status().retry_counts == {key_sentinel: 1}
+
+    records = [
+        r for r in caplog.records if r.name.startswith("openbrain_memory")
+    ]
+    assert records
+    for record in records:
+        for leaked in (body_sentinel, path_sentinel, key_sentinel):
+            assert leaked not in record.getMessage()
+            assert leaked not in str(record.args or "")
+            for value in vars(record).values():
+                assert leaked not in str(value)
+        assert record.exc_info is None
+
+    combined = capsys.readouterr()
+    for leaked in (body_sentinel, path_sentinel, key_sentinel):
+        assert leaked not in combined.err
+        assert leaked not in combined.out
 
 
 # --- Mutation checks ------------------------------------------------------

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -32,6 +33,7 @@ from openbrain_memory.cli import (
 
 from ._runtime_fakes import (
     ContextClient,
+    FailingReplayTransport,
     FakeRunner,
     FakeSpool,
     ForeignLaneTamperingTransport,
@@ -510,6 +512,118 @@ def test_spool_drain_retains_unknown_operation_and_replays_valid_unit(
     assert dispatched[-1] == "session_start"
     remaining = spool.records()
     assert [record.idempotency_key for record in remaining] == ["unknown-key"]
+
+
+def test_runtime_drain_dispatch_failure_logs_are_content_free(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A dispatch failure during ``_drain_spool`` must stay content-free.
+
+    The failing direct call carries a non-secret private sentinel in its error
+    body, and the spool path/key carry their own sentinels. None may reach any
+    ``openbrain_memory`` log message, log args, structured extra, ``exc_info``,
+    or stderr — while the drain report still counts the failed unit and the
+    unit stays pending for a later retry.
+    """
+    body_sentinel = "PRIVATE-provider-body-marker"
+    path_sentinel = "private-spool-path-marker"
+    key_sentinel = "private-spool-key-marker"
+    spool = JsonlSpool(tmp_path / f"{path_sentinel}.jsonl")
+    spool.append("log_thought", {"content": "queued secret"}, key=key_sentinel)
+    transport = FailingReplayTransport(
+        fail_tool="log_thought", error_body=body_sentinel
+    )
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+        spool=spool,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="openbrain_memory"):
+        recalled = runtime.recall_context("Trigger a failing drain")
+
+    # The direct recall itself succeeded, so a drain ran; the failing unit was
+    # counted and left pending for a later attempt (retry accounting intact).
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert recalled.drain is not None
+    assert recalled.drain.failed_units == 1
+    assert recalled.drain.replayed_units == 0
+    assert recalled.drain.quarantined_units == 0
+    assert [record.idempotency_key for record in spool.records()] == [key_sentinel]
+    assert spool.status().retry_counts == {key_sentinel: 1}
+
+    records = [
+        r for r in caplog.records if r.name.startswith("openbrain_memory")
+    ]
+    assert records  # the drain path did log
+    for record in records:
+        for leaked in (body_sentinel, path_sentinel, key_sentinel):
+            assert leaked not in record.getMessage()
+            assert leaked not in str(record.args or "")
+            for value in vars(record).values():
+                assert leaked not in str(value)
+        assert record.exc_info is None
+
+    combined = capsys.readouterr()
+    for leaked in (body_sentinel, path_sentinel, key_sentinel):
+        assert leaked not in combined.err
+        assert leaked not in combined.out
+
+
+def test_runtime_outer_drain_failure_log_is_content_free(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The outer ``_drain_spool`` catch must also stay content-free.
+
+    A failure of the drain *machinery* itself (outside per-record dispatch)
+    carries the sentinel in its exception body and traceback. The outer catch
+    must log a stable status token only — no exception object, message, or
+    path — and return ``None`` so the caller's own receipt is unchanged.
+    """
+    body_sentinel = "PRIVATE-outer-drain-body-marker"
+    path_sentinel = "private-outer-drain-path-marker"
+    spool = JsonlSpool(tmp_path / f"{path_sentinel}.jsonl")
+    spool.append("log_thought", {"content": "queued secret"}, key="outer-key")
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=LaneAwareTransport(),
+        spool=spool,
+    )
+
+    def boom(_dispatcher: object) -> None:
+        raise RuntimeError(body_sentinel)
+
+    with caplog.at_level(logging.DEBUG, logger="openbrain_memory"):
+        with patch.object(spool, "replay_with_report", side_effect=boom):
+            recalled = runtime.recall_context("Trigger an outer drain failure")
+
+    # The drain machinery failed, so no drain report is surfaced, but the
+    # direct recall itself is unaffected.
+    assert recalled.receipt.status is ReceiptStatus.DIRECT
+    assert recalled.drain is None
+
+    records = [
+        r for r in caplog.records if r.name.startswith("openbrain_memory")
+    ]
+    assert records
+    for record in records:
+        for leaked in (body_sentinel, path_sentinel):
+            assert leaked not in record.getMessage()
+            assert leaked not in str(record.args or "")
+            for value in vars(record).values():
+                assert leaked not in str(value)
+        assert record.exc_info is None
+
+    combined = capsys.readouterr()
+    for leaked in (body_sentinel, path_sentinel):
+        assert leaked not in combined.err
+        assert leaked not in combined.out
 
 
 def test_spool_drain_dispatches_every_allowlisted_operation(tmp_path: Path) -> None:

--- a/python/openbrain-memory/tests/test_spool.py
+++ b/python/openbrain-memory/tests/test_spool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import threading
 from typing import Any
@@ -871,6 +872,53 @@ def test_spool_quarantine_envelope_is_content_free_and_lines_are_redacted(tmp_pa
     assert restored["payload"] == {"content": "[REDACTED]"}
     mode = os.stat(spool.quarantine_path).st_mode & 0o777
     assert mode == 0o600
+
+
+def test_replay_dispatch_failure_log_is_content_free(tmp_path, caplog, capsys):
+    """A dispatch failure must log a stable status token only (#296/#344 P1).
+
+    The failing dispatcher's exception body, the spool path, and the
+    idempotency key all carry a non-secret private sentinel. None may reach the
+    log message, the log args, the structured extra, ``exc_info``, or stderr —
+    while the retry counter and returned outcome stay correct.
+    """
+    msg_sentinel = token_sample("PRIVATE-", "dispatch-body")
+    path_sentinel = token_sample("private-", "path-marker")
+    key_sentinel = token_sample("private-", "key-marker")
+    spool = JsonlSpool(tmp_path / f"{path_sentinel}.jsonl", quarantine_threshold=5)
+    spool.append("op", {"content": "secret payload"}, key=key_sentinel)
+
+    with caplog.at_level(logging.WARNING, logger="openbrain_memory.spool"):
+        report = spool.replay_with_report(
+            _always_fail(ConnectionError(msg_sentinel))
+        )
+
+    # The failure was accounted for and the returned outcome is unchanged: the
+    # class-name category survives, the raw body/path/key do not.
+    assert [outcome.status for outcome in report.outcomes] == ["failed"]
+    assert report.outcomes[0].consecutive_failures == 1
+    assert report.outcomes[0].error_category == "ConnectionError"
+    assert spool.status().retry_counts == {key_sentinel: 1}
+
+    records = [r for r in caplog.records if r.name == "openbrain_memory.spool"]
+    assert records  # the dispatch failure was logged
+    for record in records:
+        rendered = record.getMessage()
+        for leaked in (msg_sentinel, path_sentinel, key_sentinel):
+            assert leaked not in rendered
+            assert leaked not in str(record.args or "")
+            for value in vars(record).values():
+                assert leaked not in str(value)
+        assert record.exc_info is None
+        # Only the stable status token is allowed as structured context.
+        emitted = {key for key in vars(record) if key.startswith("spool_")}
+        assert emitted == {"spool_replay_status"}
+        assert record.spool_replay_status == "failed"
+
+    combined = capsys.readouterr()
+    for leaked in (msg_sentinel, path_sentinel, key_sentinel):
+        assert leaked not in combined.err
+        assert leaked not in combined.out
 
 
 def test_spool_poison_unit_never_blocks_valid_unit_replay(tmp_path):

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds explicit client-owned scheduling for the existing Python JSONL spool replay/quarantine flow and releases it as `openbrain-memory` 0.1.14.

- reuses the existing `_drain_spool` path through `drain_spool_now()`
- registers `spool_replay` in a typed Python maintenance registry
- provides explicit `run_once`/tick and opt-in interval start/stop lifecycle
- suppresses overlapping runs
- contains one-shot handler failures at the background-loop boundary while preserving synchronous re-raise behavior
- keeps the spool file as the only durable work state
- preserves per-unit persisted scope, quarantine/replay dispositions, provenance, and receipts
- emits content-free status/count/timing telemetry across scheduler, replay dispatch, and outer drain failure paths

Closes #344
Part of #342

## Architecture clarification

`retry_spool` is client authority and the JSONL spool is client-local. The #343 server-side TypeScript queue is a pattern reference, not a runtime dependency; it cannot reach client-local spool files. No cross-host control plane, second job database, or spool custody move is introduced.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence:

- focused maintenance/runtime/spool/contract/client tests: 247 passed
- full Python suite: 450 passed, 5 env-gated skips
- mypy: clean across 17 source files
- ruff: clean
- `uv sync --frozen` and lock check: clean
- 0.1.14 wheel and sdist built with matching metadata
- initial Full-tier five-lane review completed
- scheduler-loop finding fixed and mutation-verified
- Terra terminal audit completed; replay/drain logging finding fixed and mutation-verified
- focused post-terminal verification: ZERO FINDINGS
- rebased onto merged 0.1.13 before assigning 0.1.14

## Critical Self-Review

- Highest-risk behavior: concurrent ticks could replay the same parked unit twice, kill future scheduling after one exception, corrupt spool rewrite custody, or leak replayed content through background tracebacks.
- Assumptions that could be wrong: one in-process scheduler instance is sufficient for a client-local spool and cross-process coordination is intentionally unsupported.
- Missing/weak tests: no multi-process scheduler ownership test by design; in-process overlap, repeated ticks, stop, failure recovery, replay/quarantine, and content-free error paths are covered.
- Security/permission risk: replay stays under each record's persisted exact scope and park-time namespace provenance; foreign/unprovable scope stays parked with zero dispatch/accounting.
- Migration/deploy risk: no server/database migration; installable Python package moves from 0.1.13 to 0.1.14.
- Downstream client/runtime risk: Python-specific by custody design; TypeScript/server do not own this spool or scheduler.
- Rollback/cleanup concern: stop any explicitly started scheduler before reverting the exported maintenance API; the JSONL spool remains the durable work state.
- Fixes made before PR: added the registry/scheduler omitted by the first worker, contained daemon-loop exceptions, removed dispatch/drain traceback/path/key leakage, added sentinel leak regressions, and versioned/documented the stable public API.
- Known residual risk: a consumer that explicitly starts a scheduler and never calls `stop()` retains a daemon loop for process lifetime; daemon/thread semantics and clean stop are documented and tested.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a client-local spool/scheduler release using fake-transport and filesystem canaries; no hosted server code, schema, transport, auth, or namespace behavior changes.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `retry_spool` scheduling is Python client authority over a client-local JSONL spool; TypeScript/server do not own that custody.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- rtech-mcps and mcp2cli are not applicable: no server tool/schema/registry/generated-skill behavior changed.
- Direct Hermes integration and Hermes live canaries are not applicable under the approved standalone-client scope.
- Server `min_client_versions["openbrain-memory"]` intentionally remains 0.1.8 because the new maintenance API is optional and not server-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
