### PR TITLE
feat(346): derive namespace-scoped graph knowledge

### DIFF
--- a/docs/graph-derivation.md
+++ b/docs/graph-derivation.md
@@ -1,0 +1,58 @@
+# Graph derivation from approved sources
+
+Deterministic, server-side derivation of the entity/link graph from approved
+source items, driven through the durable maintenance queue. Issue #346
+(MAINT-4).
+
+- `src/graph-derivation.ts` — the primitive `deriveGraphFromMetadata`:
+  content-hash idempotent (new / unchanged / changed), cross-namespace-rejecting,
+  self-link-guarded, with defense-in-depth namespace re-verification on every
+  persisted row. It derives into the source's **exact** namespace so the existing
+  `search_all` / `brain_answer` graph arm consumes the result with no contract
+  change. It runs and adds no migration.
+- `src/graph-derivation-handler.ts` — selection sweep + enqueue + the registered
+  `graph.derive` handler (`selectSourcesNeedingDerivation` /
+  `enqueueGraphDerivationJobs` / `makeGraphDerivationHandler`), with a
+  source-snapshot guard and terminal-vs-retryable failure classification.
+
+## Server-owned runtime and the terminal dead-letter path
+
+The handler is composed into the live server's maintenance runner by
+`src/maintenance-bootstrap.ts` (started from `src/index.ts`), alongside the #345
+`embedding.repair` handler. `composeMaintenanceHandlers` builds one handler map —
+no second bootstrap or framework — and registers `graph.derive` under a
+**deliberate, server-owned global maintenance identity** (`MAINTENANCE_GRAPH_AUTH`:
+`ob-admin`, `namespaceSource: "token"`). That identity grants only the
+cross-namespace *write capability* one runner needs; it is **not** the authority.
+The authority is the persisted job payload's namespace, which the handler
+re-checks with `canWriteNamespace` and re-validates against the live source row
+(the snapshot guard) before deriving. The handler **cannot be registered without
+a clear auth identity** — a missing role/clientId throws at startup (fail closed).
+
+**Terminal (non-retryable) failures dead-letter immediately.** When the source
+drifts out from under a job (revoked approval, retired, deleted, content
+re-observed, stale revision, malformed payload, cross-namespace endpoint), the
+handler throws `GraphDerivationTerminalError`, which **extends the queue-owned
+`MaintenanceTerminalError`** marker. The `MaintenanceQueueRunner` identifies that
+type at dispatch and passes an explicit `terminal` flag into
+`MaintenanceQueue.fail`, which dead-letters the job on that exact attempt —
+regardless of remaining retry budget — recording the content-free `terminal`
+category (distinct from `error` and `lease_expired`). Ordinary errors (transient
+DB failures) keep the persisted bounded backoff/retry policy verbatim. The queue
+owns the marker; the handler depends on the queue, never the reverse.
+
+The `terminal` category is added to the `maintenance_jobs.last_error_category`
+CHECK by migration 029 (a named re-derive mirroring the 028 `lease_expired`
+compat migration) plus the fresh inline 026/028 bodies, so fresh and
+already-upgraded databases converge.
+
+## No automatic recurrence — enqueue is an explicit bounded producer
+
+The maintenance queue has **no recurrence primitive**: the runner only claims
+and dispatches jobs that are already enqueued. Registering `graph.derive` makes
+the server able to *run* graph jobs; it does **not** make derivation automatic or
+continuous. `enqueueGraphDerivationJobs` is the only, explicit, bounded producer
+(namespace-scoped selection + one idempotent job per changed source, bound to
+`source id + content hash`). Sweeps must be driven by an operator or a future
+scheduler (**#347**). There is no automatic continuous derivation, and the
+bootstrap enqueues nothing.

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -606,3 +606,49 @@ exception.
 - Does a regression use a handler that raises once and then succeeds, proving a
   later beat runs and the thread remains alive until explicit stop?
 - Can the thread excepthook or stderr expose the handler's exception message?
+
+## [2026-07-22] Registering a maintenance handler is not "continuous derivation"; a server-owned identity is not a namespace bypass
+
+**Severity:** MEDIUM
+**Source:** Issue #346 (MAINT-4), graph-derivation bootstrap wiring
+**Scope:** `src/maintenance-bootstrap.ts`, `src/graph-derivation-handler.ts`,
+any handler registered under a server-owned global maintenance identity
+**Status:** active
+
+### Pattern
+
+Two adversarial traps in wiring a maintenance handler into the production
+bootstrap:
+
+1. **Phantom recurrence.** The maintenance queue has no recurrence primitive —
+   the runner only claims and dispatches *already-enqueued* jobs. Registering
+   `graph.derive` makes the server able to *run* graph jobs; it does NOT make
+   derivation automatic or continuous. Claiming otherwise ("graph is now kept up
+   to date automatically") is false: with no producer calling
+   `enqueueGraphDerivationJobs`, the queue stays empty forever. The explicit,
+   bounded producer must stay the only enqueue path, and docs must say an
+   operator / a future scheduler (#347) has to drive sweeps.
+2. **Identity as a bypass.** A server-owned global maintenance identity
+   (`ob-admin`, token-sourced) is needed so one runner can derive into whatever
+   namespace a claimed job carries. The trap is treating that identity as the
+   authority: it must grant only the cross-namespace *write capability*, while
+   the persisted job payload's namespace stays the exact authority — re-checked
+   via `canWriteNamespace` AND re-validated against the live source row inside
+   the handler. A `header`-sourced identity would wrongly pin every write to one
+   clientId namespace; a handler that trusted the identity instead of the
+   per-job guard could derive into a namespace the job never authorized.
+
+### Review Questions
+
+- Does any doc/PR claim automatic/continuous derivation when the queue has no
+  recurrence primitive and nothing enqueues sweeps? Is the explicit bounded
+  producer preserved and documented as the required trigger?
+- Can the handler be registered WITHOUT a clear auth identity (missing
+  role/clientId)? It must fail closed at startup, not dispatch under an ambiguous
+  identity — is there a test asserting the throw?
+- Is the maintenance identity token-sourced (can serve cross-namespace jobs), and
+  is the per-job namespace still the authority (re-checked against the live
+  source), so the identity grants capability, not a guard bypass?
+- Does the bootstrap compose handlers into one map without inventing a second
+  bootstrap/framework, and is there a test proving BOTH existing and new kinds
+  dispatch to their own handlers (not `unsupported_job_kind`)?

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -652,3 +652,40 @@ bootstrap:
 - Does the bootstrap compose handlers into one map without inventing a second
   bootstrap/framework, and is there a test proving BOTH existing and new kinds
   dispatch to their own handlers (not `unsupported_job_kind`)?
+
+## [2026-07-23] Active queue handlers must renew leases before reclaim can win
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #358 exact-head terminal audit (issue #346)
+**Scope:** `src/maintenance-queue.ts`, long-running or lock-waiting maintenance handlers
+**Status:** fixed-pre-merge
+
+### Pattern
+
+A claimed job had a bounded lease but no heartbeat. A live graph handler could
+wait on a source-row lock or execute enough statements to cross the 30-second
+window. Another runner could then reclaim the job repeatedly and eventually mark
+it `lease_expired`, while the original handler still committed valid graph state
+but could no longer complete its stale queue token. The durable graph and queue
+receipt contradicted each other, and the current hash could suppress repair.
+
+### Rule
+
+The queue runner renews each active lease at a bounded cadence under the immutable
+claimed job ID and lease token. Renewal calls never overlap, stop on lost
+ownership, and are cleared and awaited before complete/fail so a heartbeat cannot
+race a terminal transition. The lease duration itself remains bounded; ownership
+is extended only while the live handler is tracked. Real-PostgreSQL coverage must
+hold a handler across multiple short lease windows while a competing queue tries
+to reclaim it, then prove one attempt completes without dead-lettering.
+
+### Review Questions
+
+- Can a valid handler exceed its lease through work or lock contention without a
+  renewal path?
+- Is renewal guarded by the immutable claimed ID/token rather than a handler-
+  mutable job object?
+- Can heartbeat calls overlap, outlive completion/failure, or keep renewing after
+  ownership is lost?
+- Does a real-database test cross multiple lease windows with a competing claimer
+  and prove attempts stay at one and the row finishes succeeded?

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1141,3 +1141,39 @@ first terminal write fails on upgraded databases.
 - Is a NEW `last_error_category` value added to BOTH the fresh inline CHECK and a
   named re-derive migration for already-upgraded DBs, with a drift-guard test?
 - Is the failure log content-free (stable category only, never the reason text)?
+
+## [2026-07-23] Snapshot validation and derived writes must share one locked transaction
+
+**Severity:** HIGH (P1)
+**Source:** PR #358 opposite-runtime terminal audit (issue #346)
+**Scope:** `src/graph-derivation-handler.ts`, multi-statement maintenance derivations
+**Status:** fixed-pre-merge
+
+### Pattern
+
+The graph handler validated a source snapshot, then stamped the final derivation
+hash and wrote nodes, links, and stale-edge pruning in independent statements.
+A later transient failure could leave the completed hash with an incomplete graph;
+a retry then returned `unchanged` and never repaired it. The same gap let an old
+job pass its snapshot check, pause, and overwrite a newer derivation after the
+source advanced.
+
+### Rule
+
+Lock and revalidate the authoritative source row with `SELECT ... FOR UPDATE`,
+then run the entire derived write set on the same checked-out client and in the
+same transaction. Commit the source proof, final hash, nodes, links, and pruning
+as one unit; rollback all of them on any error. This serializes source updates
+with derivation so an old job either finishes before the source advances or sees
+drift and terminal-stops after the newer revision commits.
+
+### Review Questions
+
+- Can a final hash/status stamp commit before any later derived write or prune?
+- Do snapshot validation and every derived mutation use one transaction/client?
+- Is the source row locked so concurrent source updates cannot invalidate the
+  snapshot between validation and commit?
+- Does a real-PostgreSQL fault-injection test prove a mid-derivation failure leaves
+  no partial hash, nodes, or links and that retry converges?
+- Does a deterministic old/new interleaving test prove the newer snapshot remains
+  final and an obsolete job cannot overwrite it?

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1210,6 +1210,16 @@ rename-to-existing-title against real PostgreSQL.
 - Does a real-PostgreSQL regression cover both duplicate-title creation and a
   rename onto an existing title?
 
+### Follow-up: display state must refresh independently of structural derivation
+
+A collision-safe name is incomplete if the unchanged short-circuit ignores a
+pure title rename. The derivation hash intentionally covers the node set, not the
+human label, so the `unchanged` path must separately compare and refresh the
+stored name plus `metadata.display_name`. Production callers must pass the full
+label to the primitive and bound only the indexed storage name; slicing upstream
+silently destroys the supposedly preserved display value. Tests need a pure
+rename with identical topics/people and a label longer than the storage limit.
+
 ## [2026-07-23] Maintenance handlers must reject unsupported job versions before parsing
 
 **Severity:** MEDIUM (P2)

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1177,3 +1177,63 @@ drift and terminal-stops after the newer revision commits.
   no partial hash, nodes, or links and that retry converges?
 - Does a deterministic old/new interleaving test prove the newer snapshot remains
   final and an obsolete job cannot overwrite it?
+
+## [2026-07-23] Canonical anchor identity must also satisfy display-name uniqueness
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #358 exact-head terminal audit (issue #346)
+**Scope:** `src/graph-derivation.ts`, entity tables with independent canonical-id and display-name unique indexes
+**Status:** fixed-pre-merge
+
+### Pattern
+
+An anchor upsert correctly arbitrated on stable `canonical_id`, but the table also
+enforced live uniqueness on `(namespace, entity_type, lower(name))`. Two distinct
+source IDs with the same title therefore missed the canonical conflict and failed
+on the name index with deterministic `23505`; a rename onto a sibling title failed
+the same way.
+
+### Rule
+
+When one row is constrained by independent identity indexes, the stored values
+must satisfy all of them. Keep the human label readable, append the stable
+canonical identity to form a bounded collision-safe storage name, and preserve
+the complete display label separately. Prove same-title creation and
+rename-to-existing-title against real PostgreSQL.
+
+### Review Questions
+
+- Does an upsert arbitrate one unique index while another applicable index can
+  still reject the proposed row?
+- Can two stable IDs legitimately share a human title, and if so is the stored
+  name deterministic, readable, bounded, and collision-safe?
+- Does a real-PostgreSQL regression cover both duplicate-title creation and a
+  rename onto an existing title?
+
+## [2026-07-23] Maintenance handlers must reject unsupported job versions before parsing
+
+**Severity:** MEDIUM (P2)
+**Source:** PR #358 exact-head terminal audit (issue #346)
+**Scope:** `src/graph-derivation-handler.ts`, versioned maintenance payloads
+**Status:** fixed-pre-merge
+
+### Pattern
+
+`graph.derive` enqueue stamped a payload version, but its handler validated only
+the payload shape. A future-version payload that remained structurally compatible
+could execute under an older deployment after rollback, applying obsolete
+semantics instead of failing closed.
+
+### Rule
+
+Every versioned handler checks the exact job version before payload parsing or any
+read/write. Unsupported older or newer versions are permanent input failures and
+must use the queue-owned terminal path. Tests cover current-version dispatch plus
+both version directions.
+
+### Review Questions
+
+- Is the enqueued version checked by the handler, or merely persisted?
+- Does the guard run before payload parsing and database access?
+- Do older and future versions terminal-stop immediately while the exact current
+  version still dispatches?

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1090,3 +1090,54 @@ allocator to trim.
 - If a downstream allocator can also stamp an `empty_reason`, is the ownership
   boundary explicit so the loader-owned and allocator-owned reasons cannot
   overwrite each other in the wrong case?
+
+## [2026-07-22] A "non-retryable" classification is inert unless the queue honors it
+
+**Severity:** MEDIUM
+**Source:** Issue #346 (MAINT-4), graph-derivation queue integration
+**Scope:** `src/maintenance-queue.ts` (`fail`, runner dispatch), any handler that
+throws a terminal/non-retryable error
+**Status:** active
+
+### Pattern
+
+The graph-derivation handler classified drift (revoked approval, retired,
+content re-observed, stale revision) as a `GraphDerivationTerminalError` — but
+the class was only a plain `Error`, and `MaintenanceQueue.fail` dead-lettered
+solely on `attempts >= max_attempts`. So a "terminal" failure was correctly
+*named* yet still burned the full bounded-retry budget (N backoff attempts)
+before dead-lettering. A classification that no code branches on is a comment,
+not behavior. The mirror of this on the write side is equally easy to miss: a
+handler must not be able to force an *immediate* dead-letter for a genuinely
+retryable failure either — the terminal decision has to be a distinct,
+queue-owned signal, not something derivable from a handler-mutable field.
+
+### Rule
+
+When a handler can declare a failure non-retryable, the queue must (1) own the
+marker type at its own boundary (handlers depend on the queue, never the
+reverse — a handler's terminal subclass `extends` the queue marker so the queue
+imports nothing from the handler), (2) identify it by *type* at the dispatch
+boundary and pass an explicit `terminal` flag into `fail`, and (3) fork the
+persisted-row UPDATE so a terminal failure dead-letters on THIS attempt
+regardless of remaining budget, while an ordinary error keeps the exact bounded
+backoff/retry policy. Derive the decision from the durable row + the flag, never
+from the handler-supplied job object. Store a distinct content-free category
+(`terminal`) so dead-letter analysis can tell a policy-driven immediate
+dead-letter apart from retry-exhaustion and expired-lease. If the category is
+CHECK-constrained, ship the migration (fresh inline + a named re-derive for
+already-upgraded DBs, mirroring the `lease_expired` compat migration) or the
+first terminal write fails on upgraded databases.
+
+### Review Questions
+
+- Is the terminal/non-retryable error a queue-owned type the handler extends, or
+  a bare `Error` the queue can't distinguish from a retryable one?
+- Does `fail` actually branch on a terminal signal, or only on
+  `attempts >= max_attempts`? Is there a test with `attempts < max_attempts`
+  proving dead-letter-on-attempt-1 for terminal AND bounded retry for ordinary?
+- Is the terminal decision derived from the durable row + an explicit flag, not
+  from a handler-mutable `job` field a handler could set to force a dead-letter?
+- Is a NEW `last_error_category` value added to BOTH the fresh inline CHECK and a
+  named re-derive migration for already-upgraded DBs, with a drift-guard test?
+- Is the failure log content-free (stable category only, never the reason text)?

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -471,3 +471,52 @@ draining `active`, so no leased row is ever dropped on the floor.
 - Is there a deterministic test with a claim that resolves *after* stop begins,
   asserting the handler runs, complete/fail is invoked, and stop does not
   resolve until that work drains?
+
+## [2026-07-22] A server-owned maintenance identity must satisfy the shared-kb promoter convention to write shared-kb
+
+**Severity:** P1
+**Source:** PR #358 review swarm; issue #346 (MAINT-4)
+**Scope:** `src/maintenance-bootstrap.ts` `MAINTENANCE_GRAPH_AUTH`, `src/namespace-policy.ts` `canWriteNamespace` / `isPromoterIdentity`
+**Status:** fixed
+
+### Pattern
+
+`canWriteNamespace` gates writes to the shared namespace (`shared-kb`) behind
+`isPromoterIdentity`, which grants ONLY: `role === "promoter"`, or an
+`admin`/`ob-admin` token whose `tokenClientId ?? clientId` is in
+`PROMOTER_CLIENT_IDS` (`openbrain-promoter`, `hermes-promoter`). A global
+`ob-admin` alone does NOT clear this gate — being ob-admin makes an identity
+globally writable *everywhere except* shared-kb.
+
+`MAINTENANCE_GRAPH_AUTH` shipped as `{ role: "ob-admin", clientId:
+"open-brain-maintenance" }`. It could write every per-tenant namespace, so every
+handler unit test (which uses per-tenant namespaces) passed — but a claimed
+`graph.derive` job whose payload namespace was `shared-kb` failed
+`canWriteNamespace` inside the handler and threw `GraphDerivationTerminalError`,
+so the queue *terminal-dead-lettered* it (not a retryable backoff). Shared-kb
+graph derivation was silently, permanently broken with green tests.
+
+The fix is the smallest existing-policy-compatible one: add
+`tokenClientId: "openbrain-promoter"` to the identity so it satisfies the
+EXISTING promoter convention. `clientId` stays the maintenance label used for
+logging/provenance; only `isPromoterIdentity` reads `tokenClientId`. This grants
+the shared-kb write capability narrowly — it does NOT weaken `canWriteNamespace`
+globally and adds no bypass: the per-job namespace check, the source-snapshot
+guard, and frozen-namespace rejection (`collab`) all still apply to this
+identity.
+
+### Review Questions
+
+- Does any server-owned/maintenance identity that may derive/promote/write into
+  `shared-kb` actually pass `isPromoterIdentity` (promoter role, or
+  `tokenClientId ?? clientId` in `PROMOTER_CLIENT_IDS`)? Being `ob-admin` is not
+  enough for shared-kb.
+- Do the handler/authorization tests exercise a `shared-kb` (canonical AND
+  physical) job through the PRODUCTION-composed identity, not just synthetic
+  per-tenant namespaces that mask the shared-kb gate?
+- Does the shared-kb grant stay scoped: is the same identity still rejected
+  pre-read for frozen namespaces, and does it still fail closed on a missing job
+  namespace and honor the source-snapshot guard?
+- Would the regression fail on the pre-fix identity with the exact "shared-kb
+  writes require the openbrain-promoter or hermes-promoter service identity"
+  terminal reason?

--- a/src/db/migrations/026_maintenance_queue.sql
+++ b/src/db/migrations/026_maintenance_queue.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS maintenance_jobs (
   backoff_max_ms      INTEGER NOT NULL DEFAULT 300000 CHECK (backoff_max_ms >= backoff_base_ms),
   last_error_category TEXT CHECK (last_error_category IN (
     'syntax_error', 'type_error', 'range_error', 'error', 'non_error',
-    'unsupported_job_kind', 'lease_expired'
+    'unsupported_job_kind', 'lease_expired', 'terminal'
   )),
   terminal_at         TIMESTAMPTZ,
   dead_lettered_at    TIMESTAMPTZ,

--- a/src/db/migrations/028_maintenance_jobs_lease_expired_compat.sql
+++ b/src/db/migrations/028_maintenance_jobs_lease_expired_compat.sql
@@ -24,5 +24,5 @@ ALTER TABLE maintenance_jobs
   ADD CONSTRAINT maintenance_jobs_last_error_category_check
   CHECK (last_error_category IN (
     'syntax_error', 'type_error', 'range_error', 'error', 'non_error',
-    'unsupported_job_kind', 'lease_expired'
+    'unsupported_job_kind', 'lease_expired', 'terminal'
   ));

--- a/src/db/migrations/029_maintenance_jobs_terminal_category.sql
+++ b/src/db/migrations/029_maintenance_jobs_terminal_category.sql
@@ -1,0 +1,34 @@
+-- Migration 029: widen the maintenance_jobs.last_error_category CHECK to accept
+-- the queue-owned 'terminal' category (#346).
+--
+-- Background mirrors migration 028. A handler can now declare a failure
+-- non-retryable by throwing the queue-owned MaintenanceTerminalError; the queue
+-- dead-letters that job on the failing attempt and records the content-free
+-- category 'terminal', distinct from 'error' (unclassified retryable) and
+-- 'lease_expired' (expired lease past its attempt budget) so dead-letter
+-- analysis can tell a policy-driven immediate dead-letter apart.
+--
+-- Migration 026 (CREATE TABLE IF NOT EXISTS) and 028 (drop/re-add the named
+-- constraint) both already carry 'terminal' in their current bodies, so a fresh
+-- database converges through them. A database that already applied 026 and 028
+-- before 'terminal' was introduced keeps its stale constraint: neither 026 nor
+-- 028 re-runs once recorded in _migrations, so the enum is never widened and the
+-- terminal dead-letter write would fail. This migration re-derives the named
+-- constraint to the canonical allow-list so upgraded and fresh databases
+-- converge.
+--
+-- It only widens the accepted set, so every previously stored
+-- last_error_category value remains valid — no data is rewritten or lost. It is
+-- additive and idempotent: dropping IF EXISTS and re-adding the same named
+-- constraint is safe to re-run and safe on a database that already has the
+-- current definition.
+
+ALTER TABLE maintenance_jobs
+  DROP CONSTRAINT IF EXISTS maintenance_jobs_last_error_category_check;
+
+ALTER TABLE maintenance_jobs
+  ADD CONSTRAINT maintenance_jobs_last_error_category_check
+  CHECK (last_error_category IN (
+    'syntax_error', 'type_error', 'range_error', 'error', 'non_error',
+    'unsupported_job_kind', 'lease_expired', 'terminal'
+  ));

--- a/src/db/migrations/029_maintenance_jobs_terminal_category.test.ts
+++ b/src/db/migrations/029_maintenance_jobs_terminal_category.test.ts
@@ -1,0 +1,225 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import { Client } from "pg";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const migration026Url = new URL("026_maintenance_queue.sql", import.meta.url);
+const migration029Url = new URL(
+  "029_maintenance_jobs_terminal_category.sql",
+  import.meta.url,
+);
+const namespace = "test-migration-029-terminal";
+
+// Fixed, code-owned identifier for the isolated test schema so this file never
+// disturbs the shared maintenance_jobs table while Bun runs test files in
+// parallel. Chosen once, never derived from anything mutable.
+const TEST_SCHEMA = "ob_test_mig029_terminal";
+const TEST_SCHEMA_LOCK = 29_029;
+
+// The canonical last_error_category allow-list minus the value a database
+// upgraded across an earlier revision of 026/028 is missing: 'terminal'. This
+// models the pre-'terminal' constraint so the regression reproduces the real
+// upgrade-path defect the same way 028's test models the pre-'lease_expired'
+// constraint.
+const PRE_TERMINAL_CATEGORIES = [
+  "syntax_error",
+  "type_error",
+  "range_error",
+  "error",
+  "non_error",
+  "unsupported_job_kind",
+  "lease_expired",
+] as const;
+
+const CONSTRAINT_NAME = "maintenance_jobs_last_error_category_check";
+
+// Narrowly extract the last_error_category CHECK allow-list from a migration's
+// SQL text — the same targeted regex the 028 test uses, not a general parser.
+function extractLastErrorCategorySet(sql: string): Set<string> {
+  const match = sql.match(
+    /last_error_category\s+(?:TEXT\s+)?(?:CHECK\s*\()?\s*IN\s*\(([^)]*)\)/i,
+  );
+  if (!match) {
+    throw new Error(
+      "could not locate a `last_error_category IN (...)` list in the migration SQL",
+    );
+  }
+  const values = [...match[1]!.matchAll(/'([^']*)'/g)].map((m) => m[1]!);
+  if (values.length === 0) {
+    throw new Error(
+      "found a `last_error_category IN (...)` list but it contained no quoted values",
+    );
+  }
+  return new Set(values);
+}
+
+// Drift guard — runs without a database. Proves migration 029's repaired CHECK
+// accepts exactly the set migration 026 currently defines, so a future value
+// added to 026 cannot silently be omitted from the 029 upgrade repair.
+describe("029 / 026 last_error_category allow-lists stay in sync", () => {
+  it("029's repaired accepted-value set equals 026's current accepted-value set", async () => {
+    const set026 = extractLastErrorCategorySet(
+      await Bun.file(migration026Url).text(),
+    );
+    const set029 = extractLastErrorCategorySet(
+      await Bun.file(migration029Url).text(),
+    );
+    expect([...set029].sort()).toEqual([...set026].sort());
+  });
+
+  it("026's current allow-list includes 'terminal'", async () => {
+    const set026 = extractLastErrorCategorySet(
+      await Bun.file(migration026Url).text(),
+    );
+    expect(set026.has("terminal")).toBe(true);
+  });
+});
+
+dbDescribe(
+  "029 maintenance_jobs terminal category compat (live Postgres)",
+  () => {
+    const client = new Client({ connectionString: DB_URL });
+
+    async function applyMigration026(): Promise<void> {
+      await client.query(await Bun.file(migration026Url).text());
+    }
+
+    async function applyMigration029(): Promise<void> {
+      await client.query(await Bun.file(migration029Url).text());
+    }
+
+    async function cleanup(): Promise<void> {
+      await client.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+        namespace,
+      ]);
+    }
+
+    // Rewind the persisted constraint to the shape a database that applied an
+    // earlier revision of 026/028 (before 'terminal') carries forward, so the
+    // regression proves the real upgrade path rather than the fresh-DB path.
+    async function installPreTerminalConstraint(): Promise<void> {
+      const inList = PRE_TERMINAL_CATEGORIES.map((c) => `'${c}'`).join(", ");
+      await client.query(
+        `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
+      );
+      await client.query(
+        `ALTER TABLE maintenance_jobs
+         ADD CONSTRAINT ${CONSTRAINT_NAME}
+         CHECK (last_error_category IN (${inList}))`,
+      );
+    }
+
+    async function insertWithCategory(
+      idempotencyKey: string,
+      category: string | null,
+    ): Promise<void> {
+      await client.query(
+        `INSERT INTO maintenance_jobs
+         (job_kind, job_version, idempotency_key, namespace, last_error_category)
+       VALUES ($1, 1, $2, $3, $4)`,
+        ["maintenance.test", idempotencyKey, namespace, category],
+      );
+    }
+
+    beforeAll(async () => {
+      await client.connect();
+      await client.query("SELECT pg_advisory_lock($1)", [TEST_SCHEMA_LOCK]);
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+      await client.query(
+        `CREATE OR REPLACE FUNCTION ${TEST_SCHEMA}.update_updated_at()
+         RETURNS TRIGGER AS $$
+         BEGIN
+           NEW.updated_at = NOW();
+           RETURN NEW;
+         END;
+         $$ LANGUAGE plpgsql`,
+      );
+    });
+
+    beforeEach(async () => {
+      await applyMigration026();
+      await cleanup();
+      await installPreTerminalConstraint();
+    });
+
+    afterAll(async () => {
+      try {
+        await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      } finally {
+        try {
+          await client.query("SELECT pg_advisory_unlock($1)", [
+            TEST_SCHEMA_LOCK,
+          ]);
+        } finally {
+          await client.end();
+        }
+      }
+    });
+
+    it("rejects terminal before the migration and accepts it after — proving the upgrade repair", async () => {
+      await expect(
+        insertWithCategory("029-before", "terminal"),
+      ).rejects.toThrow(/last_error_category/);
+
+      await applyMigration029();
+
+      await insertWithCategory("029-after", "terminal");
+      const { rows } = await client.query(
+        `SELECT last_error_category FROM maintenance_jobs
+        WHERE namespace = $1 AND idempotency_key = $2`,
+        [namespace, "029-after"],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].last_error_category).toBe("terminal");
+    });
+
+    it("preserves every previously allowed category and still rejects unknown values", async () => {
+      for (const category of PRE_TERMINAL_CATEGORIES) {
+        await insertWithCategory(`029-preserve-${category}`, category);
+      }
+      await insertWithCategory("029-preserve-null", null);
+
+      await applyMigration029();
+
+      const { rows } = await client.query(
+        `SELECT idempotency_key, last_error_category FROM maintenance_jobs
+        WHERE namespace = $1
+        ORDER BY idempotency_key`,
+        [namespace],
+      );
+      const persisted = new Map(
+        rows.map((r) => [r.idempotency_key as string, r.last_error_category]),
+      );
+      for (const category of PRE_TERMINAL_CATEGORIES) {
+        expect(persisted.get(`029-preserve-${category}`)).toBe(category);
+      }
+      expect(persisted.get("029-preserve-null")).toBeNull();
+
+      await expect(
+        insertWithCategory("029-preserve-bogus", "not_a_real_category"),
+      ).rejects.toThrow(/last_error_category/);
+    });
+
+    it("is idempotent — re-running the repair leaves the constraint intact", async () => {
+      await applyMigration029();
+      await applyMigration029();
+
+      await insertWithCategory("029-idempotent", "terminal");
+      const { rows } = await client.query(
+        `SELECT count(*)::int AS n FROM maintenance_jobs
+        WHERE namespace = $1 AND idempotency_key = $2`,
+        [namespace, "029-idempotent"],
+      );
+      expect(rows[0].n).toBe(1);
+    });
+  },
+);

--- a/src/graph-derivation-handler.live.test.ts
+++ b/src/graph-derivation-handler.live.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import {
   GRAPH_DERIVATION_JOB_KIND,
+  GraphDerivationTerminalError,
   SOURCE_ANCHOR_ENTITY_TYPE,
   makeGraphDerivationHandler,
   selectSourcesNeedingDerivation,
@@ -407,5 +408,363 @@ dbDescribe("graph derivation maintenance integration (live Postgres)", () => {
       [[ns, otherNs]],
     );
     expect(crossing.rows[0].n).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mutation-sensitive regressions for the coupled P1 atomicity findings.
+  //
+  // These are the tests the pre-fix code fails: they mutate real graph state
+  // through a real failure/race, not a hand-modeled fake. Finding A: a failure
+  // AFTER the anchor/hash mutation but BEFORE completion must roll the whole
+  // derivation back — no partial hash/nodes/links — so a retry converges rather
+  // than being falsely short-circuited by a completed hash. Finding B: an old
+  // job must never overwrite a newer committed graph; the FOR UPDATE snapshot
+  // guard serializes it so it either runs before the source advances or observes
+  // drift and terminal-stops.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Wrap a pool so the client it hands out throws exactly once, on the first
+   * statement whose SQL contains `failOn`. Everything else — including
+   * BEGIN/COMMIT/ROLLBACK and every other statement — passes straight through to
+   * a real checked-out client, so the transaction the handler opens is genuine
+   * and the injected failure lands mid-derivation on real Postgres state. This
+   * injects the failure without touching production code: the handler still runs
+   * its own BEGIN/guard/derive/COMMIT; we only make one inner statement fail.
+   *
+   * Two harness-safety rules the override MUST honor, or it corrupts the shared
+   * `pool` for every later query in the suite:
+   *  - Forward ALL arguments verbatim (`...args`), so the callback form
+   *    `client.query(text, values, cb)` that `pool.query()` uses internally
+   *    still resolves. An override that only accepts `(sql, params)` and returns
+   *    a Promise silently drops the callback, and every later `pool.query()` on
+   *    the reused connection hangs forever.
+   *  - Restore the pristine `query` when the client is released back to the
+   *    pool. The client we mutate is a POOLED connection; leaving the override
+   *    on it poisons whatever code checks it out next.
+   */
+  function poolFailingAfter(
+    real: Pool,
+    failOn: string,
+  ): Pick<Pool, "connect"> & { armed: boolean } {
+    const wrapper = {
+      armed: true,
+      connect: async () => {
+        const client = await real.connect();
+        const realQuery = client.query.bind(client);
+        const realRelease = client.release.bind(client);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).query = ((...args: unknown[]) => {
+          const sql = args[0];
+          if (wrapper.armed && String(sql).includes(failOn)) {
+            wrapper.armed = false;
+            throw new Error("injected mid-derivation failure");
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (realQuery as any)(...args);
+        }) as never;
+        // Un-patch on release so the pooled connection returns to the pool with
+        // its original query/release, never the failure-injecting override.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).release = ((...args: unknown[]) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (client as any).query = realQuery;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (client as any).release = realRelease;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (realRelease as any)(...args);
+        }) as never;
+        return client;
+      },
+    };
+    return wrapper as Pick<Pool, "connect"> & { armed: boolean };
+  }
+
+  it("rollback atomicity: a failure after the hash stamp leaves no partial graph, and retry converges", async () => {
+    const src = await insertSource(ns, { external_id: "rollback-src" });
+
+    // Inject a failure on the stale-edge prune UPDATE — the LAST derivation
+    // statement, which runs AFTER the anchor upsert has already stamped both the
+    // derivation_hash and the content_hash and after every term node + mentions
+    // edge has been inserted. Pre-fix (statements auto-committed on the pool),
+    // those writes would survive and the stamped hash would falsely short-
+    // circuit the retry. With the fix they all live in one transaction.
+    const failingPool = poolFailingAfter(
+      pool,
+      "UPDATE ob_links\n        SET archived_at = NOW()",
+    );
+    const failingHandler = makeGraphDerivationHandler({
+      pool: failingPool as unknown as Pool,
+      auth,
+    });
+
+    await expect(
+      failingHandler(
+        jobFor(
+          {
+            source_id: src.id,
+            source_kind: "git",
+            external_id: src.external_id,
+            content_hash: hashA,
+            revision: src.revision,
+            metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+          },
+          ns,
+        ),
+      ),
+    ).rejects.toThrow("injected mid-derivation failure");
+
+    // ROLLBACK proof: nothing landed. No anchor, no term nodes, no edges — and
+    // crucially NO stamped hash for a retry to short-circuit past.
+    const entitiesAfterFail = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+      [ns],
+    );
+    expect(entitiesAfterFail.rows[0].n).toBe(0);
+    const linksAfterFail = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1",
+      [ns],
+    );
+    expect(linksAfterFail.rows[0].n).toBe(0);
+    const anchorAfterFail = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3`,
+      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+    );
+    expect(anchorAfterFail.rows[0].n).toBe(0);
+    // The source is still selectable (never derived), proving no partial hash.
+    const stillNeeded = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(stillNeeded.length).toBe(1);
+    expect(stillNeeded[0]!.id).toBe(src.id);
+
+    // Retry on the healthy pool: the derivation now converges fully.
+    const handler = makeGraphDerivationHandler({ pool, auth });
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: src.revision,
+          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+        },
+        ns,
+      ),
+    );
+    const entitiesAfterRetry = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+      [ns],
+    );
+    // anchor + 2 topics + 1 person = 4 nodes; 3 mentions edges.
+    expect(entitiesAfterRetry.rows[0].n).toBe(4);
+    const linksAfterRetry = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1 AND relation = 'mentions'",
+      [ns],
+    );
+    expect(linksAfterRetry.rows[0].n).toBe(3);
+    const anchorAfterRetry = await pool.query(
+      `SELECT metadata ->> 'content_hash' AS content_hash
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+    );
+    expect(anchorAfterRetry.rows[0].content_hash).toBe(hashA);
+    // Fully converged now: no longer selectable.
+    const afterRetrySelect = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(afterRetrySelect.length).toBe(0);
+  });
+
+  it("serialized interleave: an old job cannot overwrite a newer committed graph and terminal-stops on drift", async () => {
+    // The source starts at revision R / hash A. The registry then advances it to
+    // revision R+1 / hash B (new bytes AND new terms). A fresh job for (B, R+1)
+    // derives the newer graph. The OLD job for (A, R) — still in the queue — must
+    // never overwrite that newer graph: its FOR UPDATE guard re-reads the live
+    // row under the (A, R) predicate, matches zero rows, and terminal-stops.
+    const src = await insertSource(ns, { external_id: "interleave-src" });
+    const oldRevision = src.revision;
+    const handler = makeGraphDerivationHandler({ pool, auth });
+
+    // Old job runs first and commits the A-graph (one topic: "OldTopic").
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: oldRevision,
+          metadata: { topics: ["OldTopic"], people: [] },
+        },
+        ns,
+      ),
+    );
+
+    // The registry observes new content and advances the source (hash + revision
+    // bump, exactly as source-registry.ts does on a content change).
+    const bumped = await pool.query(
+      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+        WHERE id = $2 AND namespace = $3 RETURNING revision`,
+      [hashB, src.id, ns],
+    );
+    const newRevision = bumped.rows[0].revision as number;
+
+    // A fresh job for the newer snapshot derives the B-graph ("NewTopic").
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashB,
+          revision: newRevision,
+          metadata: { topics: ["NewTopic"], people: [] },
+        },
+        ns,
+      ),
+    );
+
+    // The graph now reflects the NEWER snapshot: anchor stamped hashB, a live
+    // anchor->NewTopic edge, and the stale anchor->OldTopic edge pruned.
+    async function graphState() {
+      const anchor = await pool.query(
+        `SELECT id, metadata ->> 'content_hash' AS content_hash,
+                metadata ->> 'derivation_hash' AS derivation_hash
+           FROM ob_entities
+          WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+            AND archived_at IS NULL`,
+        [
+          ns,
+          SOURCE_ANCHOR_ENTITY_TYPE,
+          `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`,
+        ],
+      );
+      const liveTopics = await pool.query(
+        `SELECT e.name
+           FROM ob_links l
+           JOIN ob_entities e ON e.id = l.to_id
+          WHERE l.namespace = $1 AND l.from_id = $2 AND l.relation = 'mentions'
+            AND l.archived_at IS NULL
+          ORDER BY e.name`,
+        [ns, anchor.rows[0].id],
+      );
+      return {
+        contentHash: anchor.rows[0].content_hash as string,
+        derivationHash: anchor.rows[0].derivation_hash as string,
+        liveTopics: liveTopics.rows.map((r) => r.name as string),
+      };
+    }
+    const newer = await graphState();
+    expect(newer.contentHash).toBe(hashB);
+    expect(newer.liveTopics).toEqual(["NewTopic"]);
+
+    // Now replay the OLD job for (A, R). It is obsolete: the live row is (B, R+1).
+    // The FOR UPDATE snapshot guard matches zero rows -> terminal-stop. It must
+    // NOT overwrite the newer graph or re-stamp the old hash.
+    await expect(
+      handler(
+        jobFor(
+          {
+            source_id: src.id,
+            source_kind: "git",
+            external_id: src.external_id,
+            content_hash: hashA,
+            revision: oldRevision,
+            metadata: { topics: ["OldTopic"], people: [] },
+          },
+          ns,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+
+    // The committed graph is UNCHANGED — still the newer B-snapshot. No stale
+    // overwrite: the anchor still stamps hashB and OldTopic did not revive.
+    const afterOldReplay = await graphState();
+    expect(afterOldReplay.contentHash).toBe(hashB);
+    expect(afterOldReplay.derivationHash).toBe(newer.derivationHash);
+    expect(afterOldReplay.liveTopics).toEqual(["NewTopic"]);
+
+    // Finally, prove the serialization comes from the HANDLER'S OWN guard, not a
+    // hand-taken lock: while a real handler derivation is mid-transaction (its
+    // FOR UPDATE guard holding the source row), a competing registry UPDATE on
+    // that same row must BLOCK until the handler commits. Pre-fix — no
+    // transaction, no FOR UPDATE — the competing UPDATE would proceed
+    // immediately and advance the snapshot out from under the in-flight job.
+    //
+    // We slow the handler's transaction from the inside by delaying its first
+    // derivation write (the anchor upsert), which runs AFTER the FOR UPDATE
+    // guard has locked the row and BEFORE COMMIT. That widens the window during
+    // which the row lock is held so the race is observable deterministically.
+    const src2 = await insertSource(ns, {
+      external_id: "lock-serialize-src",
+      title: "lock serialization source",
+    });
+    let updateResolved = false;
+    const slowPool = {
+      connect: async () => {
+        const client = await pool.connect();
+        const realQuery = client.query.bind(client);
+        const realRelease = client.release.bind(client);
+        let delayed = false;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).query = (async (...args: unknown[]) => {
+          // Delay once, on the first anchor upsert — inside the transaction,
+          // after the guard's FOR UPDATE has taken the row lock.
+          if (!delayed && String(args[0]).includes("INSERT INTO ob_entities")) {
+            delayed = true;
+            await new Promise((r) => setTimeout(r, 300));
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (realQuery as any)(...args);
+        }) as never;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).release = ((...a: unknown[]) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (client as any).query = realQuery;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (client as any).release = realRelease;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (realRelease as any)(...a);
+        }) as never;
+        return client;
+      },
+    };
+    const slowHandler = makeGraphDerivationHandler({
+      pool: slowPool as unknown as Pool,
+      auth,
+    });
+    const derivation = slowHandler(
+      jobFor(
+        {
+          source_id: src2.id,
+          source_kind: "git",
+          external_id: src2.external_id,
+          content_hash: hashA,
+          revision: src2.revision,
+          metadata: { topics: ["LockTopic"], people: [] },
+        },
+        ns,
+      ),
+    );
+    // Let the handler reach its in-transaction delay (guard row lock held).
+    await new Promise((r) => setTimeout(r, 100));
+    // A competing registry update on the locked row must BLOCK, not proceed.
+    const competing = pool
+      .query(
+        `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+          WHERE id = $2 AND namespace = $3`,
+        [hashB, src2.id, ns],
+      )
+      .then(() => {
+        updateResolved = true;
+      });
+    // Still inside the handler's transaction: the competing UPDATE is blocked.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(updateResolved).toBe(false);
+    // Handler commits and releases the lock; the competing update now completes.
+    await derivation;
+    await competing;
+    expect(updateResolved).toBe(true);
   });
 });

--- a/src/graph-derivation-handler.live.test.ts
+++ b/src/graph-derivation-handler.live.test.ts
@@ -1,0 +1,411 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import {
+  GRAPH_DERIVATION_JOB_KIND,
+  SOURCE_ANCHOR_ENTITY_TYPE,
+  makeGraphDerivationHandler,
+  selectSourcesNeedingDerivation,
+  type GraphDerivationPayload,
+} from "./graph-derivation-handler.ts";
+import { type MaintenanceJob } from "./maintenance-queue.ts";
+import type { AuthInfo } from "./types.ts";
+
+/**
+ * Live-Postgres regression for the #346 maintenance integration.
+ *
+ * The in-memory FakeSourcePool in graph-derivation-handler.test.ts models the
+ * selection join and snapshot guard by hand. This suite proves the NOVEL SQL
+ * against the REAL schema and REAL partial-index arbitration:
+ *   - selectSourcesNeedingDerivation()'s ob_sources ⋈ ob_entities anchor join,
+ *     including the `IS DISTINCT FROM` new/unchanged/changed comparison and the
+ *     approved+active+hash-shaped filter,
+ *   - the handler's snapshot guard against a live ob_sources row,
+ *   - end-to-end derivation into the real ob_entities / ob_links graph, and
+ *   - the anchor content_hash stamp that makes selection converge (unchanged →
+ *     empty sweep) and reruns idempotent.
+ *
+ * Env-gated exactly like the other live suites: skipped unless
+ * OPENBRAIN_TEST_DATABASE_URL points at a migrated database.
+ */
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("graph derivation maintenance integration (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-graph-derivation-maint";
+  const otherNs = "test-graph-derivation-maint-other";
+  const auth: AuthInfo = {
+    role: "admin",
+    clientId: "test-graph-derivation-maint",
+    namespaceSource: "token",
+  };
+
+  const hashA = "a".repeat(64);
+  const hashB = "b".repeat(64);
+
+  async function cleanup(): Promise<void> {
+    for (const namespace of [ns, otherNs]) {
+      await pool.query("DELETE FROM ob_links WHERE namespace = $1", [
+        namespace,
+      ]);
+      await pool.query("DELETE FROM ob_entities WHERE namespace = $1", [
+        namespace,
+      ]);
+      await pool.query("DELETE FROM ob_sources WHERE namespace = $1", [
+        namespace,
+      ]);
+    }
+  }
+
+  async function insertSource(
+    namespace: string,
+    over: Partial<{
+      approval_state: string;
+      lifecycle_state: string;
+      content_hash: string | null;
+      title: string | null;
+      external_id: string;
+    }> = {},
+  ): Promise<{ id: string; revision: number; external_id: string }> {
+    const externalId = over.external_id ?? `ext-${namespace}`;
+    const { rows } = await pool.query(
+      `INSERT INTO ob_sources
+         (namespace, source_kind, external_id, title,
+          approval_state, lifecycle_state, content_hash, created_by)
+       VALUES ($1, 'git', $2, $3, $4, $5, $6, 'tester')
+       RETURNING id, revision, external_id`,
+      [
+        namespace,
+        externalId,
+        over.title ?? "release plan",
+        over.approval_state ?? "approved",
+        over.lifecycle_state ?? "active",
+        over.content_hash === undefined ? hashA : over.content_hash,
+      ],
+    );
+    return {
+      id: rows[0].id as string,
+      revision: rows[0].revision as number,
+      external_id: rows[0].external_id as string,
+    };
+  }
+
+  function jobFor(
+    payload: GraphDerivationPayload,
+    namespace: string,
+  ): MaintenanceJob {
+    return {
+      id: "job-live",
+      kind: GRAPH_DERIVATION_JOB_KIND,
+      version: 1,
+      payload: payload as unknown as Record<string, unknown>,
+      idempotencyKey: "k",
+      state: "running",
+      runAfter: new Date("2026-07-22T12:00:00.000Z"),
+      leaseToken: "00000000-0000-4000-8000-000000000009",
+      leaseUntil: new Date("2026-07-22T12:00:30.000Z"),
+      attempts: 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_000,
+      backoffMaxMs: 4_000,
+      lastErrorCategory: null,
+      terminalAt: null,
+      deadLetteredAt: null,
+      namespace,
+      provenance: null,
+      createdAt: new Date("2026-07-22T12:00:00.000Z"),
+      updatedAt: new Date("2026-07-22T12:00:00.000Z"),
+    };
+  }
+
+  beforeEach(cleanup);
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("selects a new approved source, skips pending/retired/foreign, derives, then no-ops", async () => {
+    const newSource = await insertSource(ns, { external_id: "new-src" });
+    await insertSource(ns, {
+      external_id: "pending-src",
+      approval_state: "pending",
+    });
+    await insertSource(ns, {
+      external_id: "retired-src",
+      lifecycle_state: "retired",
+    });
+    await insertSource(ns, { external_id: "nohash-src", content_hash: null });
+    await insertSource(otherNs, { external_id: "foreign-src" });
+
+    // Namespace-scoped selection: only the one new, approved, active, hashed
+    // source in `ns` is returned.
+    const selected = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(selected.length).toBe(1);
+    expect(selected[0]!.id).toBe(newSource.id);
+    expect(selected[0]!.derived_content_hash).toBeNull();
+
+    // Derive it via the handler.
+    const handler = makeGraphDerivationHandler({ pool, auth });
+    await handler(
+      jobFor(
+        {
+          source_id: newSource.id,
+          source_kind: "git",
+          external_id: newSource.external_id,
+          content_hash: hashA,
+          revision: newSource.revision,
+          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+        },
+        ns,
+      ),
+    );
+
+    // The anchor entity exists, stamped with the content hash.
+    const anchor = await pool.query(
+      `SELECT metadata ->> 'content_hash' AS content_hash
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [
+        ns,
+        SOURCE_ANCHOR_ENTITY_TYPE,
+        `${SOURCE_ANCHOR_ENTITY_TYPE}:${newSource.id}`,
+      ],
+    );
+    expect(anchor.rows.length).toBe(1);
+    expect(anchor.rows[0].content_hash).toBe(hashA);
+
+    // 3 term entities (2 topics + 1 person) + anchor, and 3 mentions edges.
+    const terms = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+      [ns],
+    );
+    expect(terms.rows[0].n).toBe(4);
+    const edges = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1 AND relation = 'mentions'",
+      [ns],
+    );
+    expect(edges.rows[0].n).toBe(3);
+
+    // Unchanged now: selection returns nothing for this source.
+    const afterSelect = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(afterSelect.length).toBe(0);
+
+    // Rerun the exact job: converges, no duplicate nodes/edges.
+    await handler(
+      jobFor(
+        {
+          source_id: newSource.id,
+          source_kind: "git",
+          external_id: newSource.external_id,
+          content_hash: hashA,
+          revision: newSource.revision,
+          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+        },
+        ns,
+      ),
+    );
+    const termsAfter = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+      [ns],
+    );
+    expect(termsAfter.rows[0].n).toBe(4);
+    const edgesAfter = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1",
+      [ns],
+    );
+    expect(edgesAfter.rows[0].n).toBe(3);
+  });
+
+  it("changed content hash is re-selected and derived without duplicating the anchor", async () => {
+    const src = await insertSource(ns, { external_id: "changing-src" });
+    const handler = makeGraphDerivationHandler({ pool, auth });
+
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: src.revision,
+          metadata: { topics: ["Migrations"], people: [] },
+        },
+        ns,
+      ),
+    );
+
+    // Observe new content: bump the source's content_hash (and revision, as the
+    // registry would). It becomes selectable again as `changed`.
+    const bumped = await pool.query(
+      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+        WHERE id = $2 AND namespace = $3
+        RETURNING revision`,
+      [hashB, src.id, ns],
+    );
+    const newRevision = bumped.rows[0].revision as number;
+
+    const selected = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(selected.length).toBe(1);
+    expect(selected[0]!.derived_content_hash).toBe(hashA);
+
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashB,
+          revision: newRevision,
+          metadata: { topics: ["Migrations", "pgvector"], people: [] },
+        },
+        ns,
+      ),
+    );
+
+    // Exactly one anchor row (renamed/updated in place), stamped with hashB.
+    const anchor = await pool.query(
+      `SELECT COUNT(*)::int AS n, MAX(metadata ->> 'content_hash') AS content_hash
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+    );
+    expect(anchor.rows[0].n).toBe(1);
+    expect(anchor.rows[0].content_hash).toBe(hashB);
+  });
+
+  it("changed bytes but identical terms still converges (content_hash stamp refreshes)", async () => {
+    // The corner case the in-memory sentinel guards, proven live: a source's
+    // bytes change (new content_hash + revision) while its extracted terms stay
+    // identical, so the derivation node set — and thus derivation_hash — is
+    // unchanged. The run takes the primitive's `unchanged` node path but MUST
+    // refresh the anchor's stamped content_hash, or the source is re-selected on
+    // every sweep forever.
+    const src = await insertSource(ns, { external_id: "same-terms-src" });
+    const handler = makeGraphDerivationHandler({ pool, auth });
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: src.revision,
+          metadata: { topics: ["Migrations"], people: [] },
+        },
+        ns,
+      ),
+    );
+
+    // Bump ONLY the content hash + revision; keep the same extracted terms.
+    const bumped = await pool.query(
+      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+        WHERE id = $2 AND namespace = $3 RETURNING revision`,
+      [hashB, src.id, ns],
+    );
+    const newRevision = bumped.rows[0].revision as number;
+
+    // Selectable as changed (source hash B <> stamped hash A).
+    const selectedBefore = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(selectedBefore.length).toBe(1);
+    expect(selectedBefore[0]!.derived_content_hash).toBe(hashA);
+
+    await handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashB,
+          revision: newRevision,
+          metadata: { topics: ["Migrations"], people: [] },
+        },
+        ns,
+      ),
+    );
+
+    // The anchor's stamped content_hash advanced to B even though the node set
+    // (and derivation_hash) never changed. The sweep now skips this source.
+    const anchor = await pool.query(
+      `SELECT metadata ->> 'content_hash' AS content_hash
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+    );
+    expect(anchor.rows[0].content_hash).toBe(hashB);
+    const selectedAfter = await selectSourcesNeedingDerivation(pool, [ns]);
+    expect(selectedAfter.length).toBe(0);
+  });
+
+  it("snapshot guard: a stale-revision job derives nothing against the live row", async () => {
+    const src = await insertSource(ns, { external_id: "stale-src" });
+    const handler = makeGraphDerivationHandler({ pool, auth });
+    await expect(
+      handler(
+        jobFor(
+          {
+            source_id: src.id,
+            source_kind: "git",
+            external_id: src.external_id,
+            content_hash: hashA,
+            revision: src.revision + 99,
+          },
+          ns,
+        ),
+      ),
+    ).rejects.toThrow();
+
+    // Nothing derived: no anchor entity was written.
+    const anchor = await pool.query(
+      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+      [ns],
+    );
+    expect(anchor.rows[0].n).toBe(0);
+  });
+
+  it("no derived edge crosses the namespace boundary", async () => {
+    const here = await insertSource(ns, { external_id: "iso-here" });
+    const there = await insertSource(otherNs, { external_id: "iso-there" });
+    const handler = makeGraphDerivationHandler({ pool, auth });
+    await handler(
+      jobFor(
+        {
+          source_id: here.id,
+          source_kind: "git",
+          external_id: here.external_id,
+          content_hash: hashA,
+          revision: here.revision,
+          metadata: { topics: ["Shared Topic"], people: [] },
+        },
+        ns,
+      ),
+    );
+    await handler(
+      jobFor(
+        {
+          source_id: there.id,
+          source_kind: "git",
+          external_id: there.external_id,
+          content_hash: hashA,
+          revision: there.revision,
+          metadata: { topics: ["Shared Topic"], people: [] },
+        },
+        otherNs,
+      ),
+    );
+
+    // Every edge sits entirely within one namespace on both endpoints.
+    const crossing = await pool.query(
+      `SELECT COUNT(*)::int AS n
+         FROM ob_links l
+         JOIN ob_entities f ON f.id = l.from_id
+         JOIN ob_entities t ON t.id = l.to_id
+        WHERE l.namespace = ANY($1::text[])
+          AND (f.namespace <> l.namespace OR t.namespace <> l.namespace)`,
+      [[ns, otherNs]],
+    );
+    expect(crossing.rows[0].n).toBe(0);
+  });
+});

--- a/src/graph-derivation-handler.test.ts
+++ b/src/graph-derivation-handler.test.ts
@@ -14,8 +14,11 @@ import {
   type SourceNeedingDerivation,
 } from "./graph-derivation-handler.ts";
 import {
+  MaintenanceQueueRunner,
+  isMaintenanceTerminalError,
   type EnqueueMaintenanceJob,
   type MaintenanceJob,
+  type MaintenanceQueuePort,
 } from "./maintenance-queue.ts";
 import { logger } from "./logger.ts";
 import type { AuthInfo } from "./types.ts";
@@ -363,11 +366,12 @@ function makeSource(over: Partial<FakeSource> = {}): FakeSource {
 function jobFor(
   payload: GraphDerivationPayload,
   namespace: string | null,
+  version: number = GRAPH_DERIVATION_JOB_VERSION,
 ): MaintenanceJob {
   return {
     id: "job-1",
     kind: GRAPH_DERIVATION_JOB_KIND,
-    version: GRAPH_DERIVATION_JOB_VERSION,
+    version,
     payload: payload as unknown as Record<string, unknown>,
     idempotencyKey: "k",
     state: "running",
@@ -607,6 +611,117 @@ describe("makeGraphDerivationHandler", () => {
     // After the first run, the source is no longer selectable (hash derived).
     const stillNeeded = await selectSourcesNeedingDerivation(pool, ["team-kb"]);
     expect(stillNeeded.length).toBe(0);
+  });
+
+  it("exact current version succeeds and derives", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    // The canonical current version drives the full derivation.
+    await handler(
+      jobFor(payloadFor(s), s.namespace, GRAPH_DERIVATION_JOB_VERSION),
+    );
+    expect(
+      pool.calls.some((c) => c.sql.includes("INSERT INTO ob_entities")),
+    ).toBe(true);
+    const anchor = pool.anchors.find(
+      (a) => a.canonical_id === `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+    );
+    expect(anchor?.content_hash).toBe(s.content_hash);
+  });
+
+  it("future job version is TERMINAL, rejected before any payload parse or SQL", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await expect(
+      handler(
+        jobFor(payloadFor(s), s.namespace, GRAPH_DERIVATION_JOB_VERSION + 1),
+      ),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+    // Rejected before the payload parse and before the snapshot read: no SQL.
+    expect(pool.calls.length).toBe(0);
+  });
+
+  it("older job version is TERMINAL, rejected before any payload parse or SQL", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await expect(
+      handler(
+        jobFor(payloadFor(s), s.namespace, GRAPH_DERIVATION_JOB_VERSION - 1),
+      ),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+    expect(pool.calls.length).toBe(0);
+  });
+
+  it("version gate runs BEFORE payload parse: a foreign-version job with a malformed payload is still terminal", async () => {
+    // The version check must not depend on a parseable payload. A future-version
+    // job whose body would ALSO fail the strict schema must still be rejected on
+    // the version, proving the gate precedes the parse (order matters: a future
+    // contract may legitimately carry fields the current strict schema rejects).
+    const pool = new FakeSourcePool();
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    const bad = jobFor(
+      { source_id: "not-a-uuid" } as unknown as GraphDerivationPayload,
+      "team-kb",
+      GRAPH_DERIVATION_JOB_VERSION + 5,
+    );
+    await expect(handler(bad)).rejects.toBeInstanceOf(
+      GraphDerivationTerminalError,
+    );
+    expect(pool.calls.length).toBe(0);
+  });
+
+  it("runner classification: a foreign-version job dead-letters as terminal on attempt 1", async () => {
+    // End-to-end through the real runner: a version-mismatch throw from the
+    // handler is the queue-owned non-retryable marker, so the runner classifies
+    // it terminal and fail() dead-letters immediately (category 'terminal'),
+    // rather than scheduling a bounded retry that could never succeed.
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+
+    const failCalls: Array<{ category?: string; terminal?: boolean }> = [];
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [
+        jobFor(payloadFor(s), s.namespace, GRAPH_DERIVATION_JOB_VERSION + 1),
+      ],
+      complete: async () => true,
+      fail: async (input) => {
+        failCalls.push({ category: input.category, terminal: input.terminal });
+        return jobFor(payloadFor(s), s.namespace);
+      },
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([[GRAPH_DERIVATION_JOB_KIND, handler]]),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+
+    await runner.runOnce();
+    expect(failCalls).toHaveLength(1);
+    expect(failCalls[0]?.terminal).toBe(true);
+    expect(failCalls[0]?.category).toBe("terminal");
+  });
+
+  it("the version-mismatch error is the queue-owned terminal marker (runner recognizes it)", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    try {
+      await handler(
+        jobFor(payloadFor(s), s.namespace, GRAPH_DERIVATION_JOB_VERSION + 2),
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(isMaintenanceTerminalError(err)).toBe(true);
+    }
   });
 
   it("snapshot guard — stale revision is TERMINAL", async () => {

--- a/src/graph-derivation-handler.test.ts
+++ b/src/graph-derivation-handler.test.ts
@@ -98,6 +98,37 @@ class FakeSourcePool {
     return `00000000-0000-4000-8000-${String(this.seq).padStart(12, "0")}`;
   }
 
+  // The handler now runs the snapshot guard + derivation inside one transaction
+  // on a checked-out client. connect() hands back a client whose query delegates
+  // to THIS fake (shared state) so every statement — including the FOR UPDATE
+  // guard and the primitive's writes — hits the same in-memory tables, and whose
+  // BEGIN/COMMIT/ROLLBACK are recognized no-ops. It dispatches through
+  // `this.query` on every call (not a captured reference) so a test that
+  // monkeypatches pool.query mid-run still sees its override on the client too.
+  released = 0;
+  connect: any = async () => {
+    const self = this;
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: (async (sql: string, params: unknown[] = []) => {
+        const text = String(sql).trim();
+        if (
+          text === "BEGIN" ||
+          text === "COMMIT" ||
+          text === "ROLLBACK" ||
+          text.startsWith("ROLLBACK")
+        ) {
+          self.calls.push({ sql, params });
+          return { rows: [] };
+        }
+        return self.query(sql, params);
+      }) as any,
+      release: () => {
+        self.released += 1;
+      },
+    };
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   query: any = (async (sql: string, params: unknown[] = []) => {
     this.calls.push({ sql, params });

--- a/src/graph-derivation-handler.test.ts
+++ b/src/graph-derivation-handler.test.ts
@@ -283,6 +283,15 @@ class FakeSourcePool {
       const ns = params[3] as string;
       return { rows: [{ id: this.nextId(), is_new: true, namespace: ns }] };
     }
+    // Stale-edge prune (#346). This handler-level fake does not model link
+    // identity — these tests exercise the handler's snapshot/convergence path,
+    // not edge pruning — so a prune sweep finds nothing stale and archives zero.
+    if (
+      text.includes("UPDATE ob_links") &&
+      text.includes("SET archived_at = NOW()")
+    ) {
+      return { rows: [] };
+    }
 
     throw new Error(`unexpected sql: ${text.slice(0, 60)}`);
   }) as any;

--- a/src/graph-derivation-handler.test.ts
+++ b/src/graph-derivation-handler.test.ts
@@ -1,0 +1,730 @@
+import { describe, expect, it } from "bun:test";
+import {
+  GRAPH_DERIVATION_JOB_KIND,
+  GRAPH_DERIVATION_JOB_VERSION,
+  GraphDerivationTerminalError,
+  SOURCE_ANCHOR_ENTITY_TYPE,
+  buildGraphDerivationEnqueue,
+  enqueueGraphDerivationJobs,
+  graphDerivationPayloadSchema,
+  makeGraphDerivationHandler,
+  selectSourcesNeedingDerivation,
+  type GraphDerivationEnqueuePort,
+  type GraphDerivationPayload,
+  type SourceNeedingDerivation,
+} from "./graph-derivation-handler.ts";
+import {
+  type EnqueueMaintenanceJob,
+  type MaintenanceJob,
+} from "./maintenance-queue.ts";
+import { logger } from "./logger.ts";
+import type { AuthInfo } from "./types.ts";
+
+/**
+ * Capture every field the handler hands the logger during `fn`, then restore
+ * the real logger. Backs the content-free sentinel: a successful handler run
+ * must emit only the stable source_kind category, the derivation status, and
+ * structural counts — never a namespace value, a content/derivation hash, a
+ * source id, a title, or an external id.
+ */
+async function captureLoggerFields(
+  fn: () => Promise<void>,
+): Promise<Record<string, unknown>[]> {
+  const captured: Record<string, unknown>[] = [];
+  const original = {
+    info: logger.info,
+    debug: logger.debug,
+    warn: logger.warn,
+    error: logger.error,
+  };
+  const record = (extra?: Record<string, unknown>) => {
+    if (extra) captured.push(extra);
+  };
+  logger.info = (_m, extra) => record(extra);
+  logger.debug = (_m, extra) => record(extra);
+  logger.warn = (_m, extra) => record(extra);
+  logger.error = (_m, extra) => record(extra);
+  try {
+    await fn();
+  } finally {
+    logger.info = original.info;
+    logger.debug = original.debug;
+    logger.warn = original.warn;
+    logger.error = original.error;
+  }
+  return captured;
+}
+
+// ---------------------------------------------------------------------------
+// A small in-memory pool that models the two tables the integration reads:
+// ob_sources (the selection + snapshot-guard surface) and ob_entities (the
+// anchor the derivation stamps / the selection join reads). It is deliberately
+// simple: enough to exercise the exact WHERE/JOIN semantics the selection and
+// snapshot guard rely on, plus record calls for shape assertions. The graph
+// writes themselves are covered by graph-derivation.test.ts against a richer
+// fake and the live-Postgres suite; here we assert the INTEGRATION contract.
+// ---------------------------------------------------------------------------
+
+interface FakeSource {
+  id: string;
+  namespace: string;
+  source_kind: string;
+  external_id: string;
+  title: string | null;
+  approval_state: string;
+  lifecycle_state: string;
+  content_hash: string | null;
+  revision: number;
+  updated_at: string;
+}
+
+interface FakeAnchor {
+  namespace: string;
+  entity_type: string;
+  canonical_id: string;
+  content_hash: string | null;
+  derivation_hash: string | null;
+  archived_at: string | null;
+}
+
+class FakeSourcePool {
+  sources: FakeSource[] = [];
+  anchors: FakeAnchor[] = [];
+  calls: Array<{ sql: string; params: unknown[] }> = [];
+  private seq = 0;
+
+  private nextId(): string {
+    this.seq += 1;
+    return `00000000-0000-4000-8000-${String(this.seq).padStart(12, "0")}`;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: any = (async (sql: string, params: unknown[] = []) => {
+    this.calls.push({ sql, params });
+    const text = String(sql);
+
+    // --- selection sweep (SELECT ... FROM ob_sources s LEFT JOIN ob_entities anchor)
+    if (text.includes("LEFT JOIN ob_entities anchor")) {
+      const anchorType = params[0] as string;
+      // Optional namespace predicate: present iff the SQL binds a text[] param.
+      const nsList = text.includes("s.namespace = ANY(")
+        ? (params[1] as string[])
+        : undefined;
+      const rows = this.sources
+        .filter(
+          (s) =>
+            s.approval_state === "approved" &&
+            s.lifecycle_state === "active" &&
+            s.content_hash !== null &&
+            /^[0-9a-f]{64}$/.test(s.content_hash) &&
+            (nsList === undefined || nsList.includes(s.namespace)),
+        )
+        .map((s) => {
+          const anchor = this.anchors.find(
+            (a) =>
+              a.namespace === s.namespace &&
+              a.entity_type === anchorType &&
+              a.canonical_id === `${anchorType}:${s.id}` &&
+              a.archived_at === null,
+          );
+          return {
+            ...s,
+            derived_content_hash: anchor ? anchor.content_hash : null,
+            _anchorMissing: anchor === undefined,
+          };
+        })
+        // WHERE: anchor missing OR anchor hash IS DISTINCT FROM s.content_hash
+        .filter(
+          (r) => r._anchorMissing || r.derived_content_hash !== r.content_hash,
+        )
+        .sort((a, b) =>
+          a.updated_at < b.updated_at
+            ? -1
+            : a.updated_at > b.updated_at
+              ? 1
+              : 0,
+        )
+        .map((r) => ({
+          id: r.id,
+          namespace: r.namespace,
+          source_kind: r.source_kind,
+          external_id: r.external_id,
+          content_hash: r.content_hash,
+          revision: r.revision,
+          derived_content_hash: r.derived_content_hash,
+        }));
+      return { rows };
+    }
+
+    // --- snapshot guard (SELECT title FROM ob_sources WHERE id=..revision=..)
+    if (text.includes("SELECT title") && text.includes("FROM ob_sources")) {
+      const [id, ns, kind, externalId, hash, revision] = params as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        number,
+      ];
+      const match = this.sources.find(
+        (s) =>
+          s.id === id &&
+          s.namespace === ns &&
+          s.source_kind === kind &&
+          s.external_id === externalId &&
+          s.content_hash === hash &&
+          s.revision === revision &&
+          s.approval_state === "approved" &&
+          s.lifecycle_state === "active",
+      );
+      return { rows: match ? [{ title: match.title }] : [] };
+    }
+
+    // --- graph derivation primitive queries (prior-hash read + upserts).
+    // Model just enough: the prior-hash SELECT returns the anchor's stamped
+    // hash; entity/link INSERTs return a fresh-namespace row and stamp the
+    // anchor. This lets the handler exercise the real primitive end to end.
+    if (text.includes("SELECT metadata ->> 'derivation_hash'")) {
+      const [ns, type, canonical] = params as [string, string, string];
+      const anchor = this.anchors.find(
+        (a) =>
+          a.namespace === ns &&
+          a.entity_type === type &&
+          a.canonical_id === canonical &&
+          a.archived_at === null,
+      );
+      if (!anchor) return { rows: [] };
+      // The real SELECT reads both hash keys; the fake tracks content_hash and
+      // the derivation_hash it stamped, so an unchanged rerun short-circuits.
+      return {
+        rows: [
+          {
+            derivation_hash: anchor.derivation_hash ?? null,
+            content_hash: anchor.content_hash ?? null,
+          },
+        ],
+      };
+    }
+    // Content-hash refresh on the unchanged path (metadata || $4::jsonb).
+    if (
+      text.includes("UPDATE ob_entities") &&
+      text.includes("metadata || $4::jsonb")
+    ) {
+      const [ns, type, canonical, patch] = params as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const anchor = this.anchors.find(
+        (a) =>
+          a.namespace === ns &&
+          a.entity_type === type &&
+          a.canonical_id === canonical &&
+          a.archived_at === null,
+      );
+      if (anchor) {
+        const parsed = JSON.parse(patch) as { content_hash?: string };
+        if (parsed.content_hash !== undefined) {
+          anchor.content_hash = parsed.content_hash;
+        }
+      }
+      return { rows: [] };
+    }
+    if (text.includes("INSERT INTO ob_entities")) {
+      const [type, , canonical, ns, meta] = params as [
+        string,
+        string,
+        string,
+        string,
+        string?,
+      ];
+      // Anchor upsert carries a metadata param ($5::jsonb); derived terms don't.
+      if (text.includes("$5::jsonb") && typeof meta === "string") {
+        const parsedMeta = JSON.parse(meta) as {
+          derivation_hash?: string;
+          content_hash?: string;
+        };
+        const existing = this.anchors.find(
+          (a) =>
+            a.namespace === ns &&
+            a.entity_type === type &&
+            a.canonical_id === canonical,
+        );
+        // The primitive stamps content_hash and derivation_hash directly in the
+        // $5::jsonb metadata bind — read them straight from the parsed param.
+        if (existing) {
+          existing.content_hash =
+            parsedMeta.content_hash ?? existing.content_hash;
+          existing.derivation_hash =
+            parsedMeta.derivation_hash ?? existing.derivation_hash;
+          return {
+            rows: [
+              { id: this.anchorId(existing), is_new: false, namespace: ns },
+            ],
+          };
+        }
+        const anchor: FakeAnchor = {
+          namespace: ns,
+          entity_type: type,
+          canonical_id: canonical,
+          content_hash: parsedMeta.content_hash ?? null,
+          derivation_hash: parsedMeta.derivation_hash ?? null,
+          archived_at: null,
+        };
+        this.anchors.push(anchor);
+        return {
+          rows: [{ id: this.anchorId(anchor), is_new: true, namespace: ns }],
+        };
+      }
+      return { rows: [{ id: this.nextId(), is_new: true, namespace: ns }] };
+    }
+    if (text.includes("INSERT INTO ob_links")) {
+      const ns = params[3] as string;
+      return { rows: [{ id: this.nextId(), is_new: true, namespace: ns }] };
+    }
+
+    throw new Error(`unexpected sql: ${text.slice(0, 60)}`);
+  }) as any;
+
+  private anchorIds = new Map<FakeAnchor, string>();
+  private anchorId(anchor: FakeAnchor): string {
+    let id = this.anchorIds.get(anchor);
+    if (!id) {
+      id = this.nextId();
+      this.anchorIds.set(anchor, id);
+    }
+    return id;
+  }
+}
+
+const auth: AuthInfo = {
+  role: "admin",
+  clientId: "maintenance",
+  namespaceSource: "token",
+};
+
+function makeSource(over: Partial<FakeSource> = {}): FakeSource {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    namespace: "team-kb",
+    source_kind: "git",
+    external_id: "https://example.invalid/repo.git",
+    title: "release plan",
+    approval_state: "approved",
+    lifecycle_state: "active",
+    content_hash: "a".repeat(64),
+    revision: 3,
+    updated_at: "2026-07-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function jobFor(
+  payload: GraphDerivationPayload,
+  namespace: string | null,
+): MaintenanceJob {
+  return {
+    id: "job-1",
+    kind: GRAPH_DERIVATION_JOB_KIND,
+    version: GRAPH_DERIVATION_JOB_VERSION,
+    payload: payload as unknown as Record<string, unknown>,
+    idempotencyKey: "k",
+    state: "running",
+    runAfter: new Date("2026-07-22T12:00:00.000Z"),
+    leaseToken: "00000000-0000-4000-8000-000000000001",
+    leaseUntil: new Date("2026-07-22T12:00:30.000Z"),
+    attempts: 1,
+    maxAttempts: 3,
+    backoffBaseMs: 1_000,
+    backoffMaxMs: 4_000,
+    lastErrorCategory: null,
+    terminalAt: null,
+    deadLetteredAt: null,
+    namespace,
+    provenance: null,
+    createdAt: new Date("2026-07-22T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-22T12:00:00.000Z"),
+  };
+}
+
+function payloadFor(
+  source: FakeSource,
+  over: Partial<GraphDerivationPayload> = {},
+): GraphDerivationPayload {
+  return {
+    source_id: source.id,
+    source_kind: source.source_kind as GraphDerivationPayload["source_kind"],
+    external_id: source.external_id,
+    content_hash: source.content_hash as string,
+    revision: source.revision,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// selection: new / unchanged / changed by content hash
+// ---------------------------------------------------------------------------
+
+describe("selectSourcesNeedingDerivation", () => {
+  it("new: an approved+active source with no anchor is selected", async () => {
+    const pool = new FakeSourcePool();
+    pool.sources.push(makeSource());
+    const rows = await selectSourcesNeedingDerivation(pool, ["team-kb"]);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.derived_content_hash).toBeNull();
+    expect(rows[0]!.content_hash).toBe("a".repeat(64));
+  });
+
+  it("unchanged: an anchor already derived for this hash is NOT selected", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    pool.anchors.push({
+      namespace: s.namespace,
+      entity_type: SOURCE_ANCHOR_ENTITY_TYPE,
+      canonical_id: `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+      content_hash: s.content_hash,
+      derivation_hash: "deadbeef",
+      archived_at: null,
+    });
+    const rows = await selectSourcesNeedingDerivation(pool, ["team-kb"]);
+    expect(rows.length).toBe(0);
+  });
+
+  it("changed: an anchor derived for a DIFFERENT hash is selected", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ content_hash: "b".repeat(64) });
+    pool.sources.push(s);
+    pool.anchors.push({
+      namespace: s.namespace,
+      entity_type: SOURCE_ANCHOR_ENTITY_TYPE,
+      canonical_id: `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+      content_hash: "a".repeat(64),
+      derivation_hash: "deadbeef",
+      archived_at: null,
+    });
+    const rows = await selectSourcesNeedingDerivation(pool, ["team-kb"]);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.derived_content_hash).toBe("a".repeat(64));
+  });
+
+  it("skips pending/retired sources and sources without a well-formed hash", async () => {
+    const pool = new FakeSourcePool();
+    pool.sources.push(
+      makeSource({
+        id: "22222222-2222-4222-8222-222222222222",
+        approval_state: "pending",
+      }),
+      makeSource({
+        id: "33333333-3333-4333-8333-333333333333",
+        lifecycle_state: "retired",
+      }),
+      makeSource({
+        id: "44444444-4444-4444-8444-444444444444",
+        content_hash: null,
+      }),
+      makeSource({
+        id: "55555555-5555-4555-8555-555555555555",
+        content_hash: "not-a-hash",
+      }),
+    );
+    const rows = await selectSourcesNeedingDerivation(pool, ["team-kb"]);
+    expect(rows.length).toBe(0);
+  });
+
+  it("cross-namespace negative: the writable-namespace predicate is bound as a param", async () => {
+    const pool = new FakeSourcePool();
+    pool.sources.push(makeSource({ namespace: "team-kb" }));
+    // A caller writable only in a foreign namespace selects nothing.
+    const rows = await selectSourcesNeedingDerivation(pool, ["other-team"]);
+    expect(rows.length).toBe(0);
+    // The predicate is a bound text[] param, never interpolated.
+    const call = pool.calls.at(-1)!;
+    expect(call.sql).toContain("s.namespace = ANY(");
+    expect(call.params).toContainEqual(["other-team"]);
+  });
+
+  it("bounds the limit to the hard cap", async () => {
+    const pool = new FakeSourcePool();
+    await selectSourcesNeedingDerivation(pool, undefined, 10_000);
+    const call = pool.calls.at(-1)!;
+    // Limit is a bound param (last param); never interpolated as a literal.
+    expect(call.params.at(-1)).toBe(256);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enqueue: idempotency key binds source id + content hash
+// ---------------------------------------------------------------------------
+
+describe("buildGraphDerivationEnqueue", () => {
+  const source: SourceNeedingDerivation = {
+    id: "11111111-1111-4111-8111-111111111111",
+    namespace: "team-kb",
+    source_kind: "git",
+    external_id: "repo",
+    content_hash: "a".repeat(64),
+    revision: 2,
+    derived_content_hash: null,
+  };
+
+  it("binds kind, version, namespace, and a content-hash idempotency key", () => {
+    const e = buildGraphDerivationEnqueue(source);
+    expect(e.kind).toBe(GRAPH_DERIVATION_JOB_KIND);
+    expect(e.version).toBe(GRAPH_DERIVATION_JOB_VERSION);
+    expect(e.scope?.namespace).toBe("team-kb");
+    expect(e.idempotencyKey).toBe(
+      `${GRAPH_DERIVATION_JOB_KIND}:${source.id}:${"a".repeat(64)}`,
+    );
+    // Payload validates against the strict schema and is content-free.
+    const parsed = graphDerivationPayloadSchema.safeParse(e.payload);
+    expect(parsed.success).toBe(true);
+  });
+
+  it("a changed hash yields a DIFFERENT idempotency key (fresh job)", () => {
+    const a = buildGraphDerivationEnqueue(source);
+    const b = buildGraphDerivationEnqueue({
+      ...source,
+      content_hash: "b".repeat(64),
+    });
+    expect(a.idempotencyKey).not.toBe(b.idempotencyKey);
+  });
+
+  it("carries already-extracted metadata, dropping empty arrays", () => {
+    const e = buildGraphDerivationEnqueue(source, {
+      topics: ["Migrations"],
+      people: [],
+    });
+    const parsed = graphDerivationPayloadSchema.parse(e.payload);
+    expect(parsed.metadata?.topics).toEqual(["Migrations"]);
+    expect(parsed.metadata?.people).toBeUndefined();
+  });
+});
+
+describe("enqueueGraphDerivationJobs", () => {
+  it("selects and enqueues one bounded job per source, resolving metadata outside the queue", async () => {
+    const pool = new FakeSourcePool();
+    pool.sources.push(
+      makeSource({ id: "11111111-1111-4111-8111-111111111111" }),
+      makeSource({
+        id: "22222222-2222-4222-8222-222222222222",
+        updated_at: "2026-07-02T00:00:00.000Z",
+      }),
+    );
+    const enqueued: EnqueueMaintenanceJob[] = [];
+    const queue: GraphDerivationEnqueuePort = {
+      enqueue: async (input) => {
+        enqueued.push(input);
+        return { id: `mj-${enqueued.length}` } as unknown as MaintenanceJob;
+      },
+    };
+    let resolveCalls = 0;
+    const jobs = await enqueueGraphDerivationJobs(pool, queue, ["team-kb"], {
+      resolveMetadata: (s) => {
+        resolveCalls += 1;
+        return { topics: [`topic-${s.id.slice(0, 8)}`], people: [] };
+      },
+    });
+    expect(jobs.length).toBe(2);
+    expect(enqueued.length).toBe(2);
+    expect(resolveCalls).toBe(2);
+    expect(enqueued[0]!.kind).toBe(GRAPH_DERIVATION_JOB_KIND);
+    expect(enqueued[0]!.scope?.namespace).toBe("team-kb");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handler: registration/call shape, snapshot guard, terminal vs retryable
+// ---------------------------------------------------------------------------
+
+describe("makeGraphDerivationHandler", () => {
+  it("registration/call shape: returns a MaintenanceJobHandler invoked per job", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    // A handler is a single-arg async function; the runner calls handler(job).
+    await handler(jobFor(payloadFor(s), s.namespace));
+    // It exercised the primitive: prior-hash read + anchor upsert happened.
+    expect(pool.calls.some((c) => c.sql.includes("SELECT title"))).toBe(true);
+    expect(
+      pool.calls.some((c) => c.sql.includes("INSERT INTO ob_entities")),
+    ).toBe(true);
+    // The anchor now records the derived content hash: a second run no-ops.
+    const anchor = pool.anchors.find(
+      (a) => a.canonical_id === `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+    );
+    expect(anchor?.content_hash).toBe(s.content_hash);
+  });
+
+  it("idempotent rerun: a second run for the same hash converges without new selection", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await handler(jobFor(payloadFor(s), s.namespace));
+    // After the first run, the source is no longer selectable (hash derived).
+    const stillNeeded = await selectSourcesNeedingDerivation(pool, ["team-kb"]);
+    expect(stillNeeded.length).toBe(0);
+  });
+
+  it("snapshot guard — stale revision is TERMINAL", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ revision: 5 });
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    // The job was enqueued at revision 4; the live row is revision 5.
+    await expect(
+      handler(jobFor(payloadFor(s, { revision: 4 }), s.namespace)),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+  });
+
+  it("snapshot guard — changed content hash is TERMINAL (obsolete job)", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ content_hash: "b".repeat(64) });
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await expect(
+      handler(
+        jobFor(payloadFor(s, { content_hash: "a".repeat(64) }), s.namespace),
+      ),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+  });
+
+  it("snapshot guard — revoked approval is TERMINAL", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ approval_state: "rejected" });
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await expect(
+      handler(jobFor(payloadFor(s), s.namespace)),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+  });
+
+  it("missing namespace on the job is TERMINAL", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await expect(handler(jobFor(payloadFor(s), null))).rejects.toBeInstanceOf(
+      GraphDerivationTerminalError,
+    );
+  });
+
+  it("malformed payload is TERMINAL", async () => {
+    const pool = new FakeSourcePool();
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    const bad = jobFor(
+      { source_id: "not-a-uuid" } as unknown as GraphDerivationPayload,
+      "team-kb",
+    );
+    await expect(handler(bad)).rejects.toBeInstanceOf(
+      GraphDerivationTerminalError,
+    );
+    // Fail-closed: no source read, no graph write attempted.
+    expect(pool.calls.length).toBe(0);
+  });
+
+  it("cross-namespace negative: an identity that cannot write the job namespace is TERMINAL, no reads", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ namespace: "tenant-b" });
+    pool.sources.push(s);
+    const readonly: AuthInfo = { role: "readonly", clientId: "viewer" };
+    const handler = makeGraphDerivationHandler({
+      pool: pool as never,
+      auth: readonly,
+    });
+    await expect(
+      handler(jobFor(payloadFor(s), "tenant-b")),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+    // Rejected before the snapshot read: no SQL issued.
+    expect(pool.calls.length).toBe(0);
+  });
+
+  it("cross-namespace negative: header identity cannot derive into a foreign namespace", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ namespace: "tenant-b" });
+    pool.sources.push(s);
+    const delegated: AuthInfo = {
+      role: "agent",
+      clientId: "tenant-a",
+      namespaceSource: "header",
+    };
+    const handler = makeGraphDerivationHandler({
+      pool: pool as never,
+      auth: delegated,
+    });
+    await expect(
+      handler(jobFor(payloadFor(s), "tenant-b")),
+    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+    expect(pool.calls.length).toBe(0);
+  });
+
+  it("transient DB error is RETRYABLE (rethrown, not terminal)", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource();
+    pool.sources.push(s);
+    // Make the snapshot-guard read fail transiently.
+    const original = pool.query;
+    let failed = false;
+    pool.query = (async (sql: string, params: unknown[] = []) => {
+      if (String(sql).includes("SELECT title") && !failed) {
+        failed = true;
+        throw new Error("connection reset");
+      }
+      return original(sql, params);
+    }) as never;
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    await expect(handler(jobFor(payloadFor(s), s.namespace))).rejects.toThrow(
+      "connection reset",
+    );
+    // A retryable error is NOT the terminal subclass.
+    try {
+      await handler(jobFor(payloadFor(s), s.namespace));
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(GraphDerivationTerminalError);
+    }
+  });
+
+  it("content-free: the handler never surfaces the source title in its thrown terminal reason", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ title: "SECRET-PROJECT-CODENAME", revision: 9 });
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    try {
+      await handler(jobFor(payloadFor(s, { revision: 1 }), s.namespace));
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(String((err as Error).message)).not.toContain(
+        "SECRET-PROJECT-CODENAME",
+      );
+    }
+  });
+
+  it("content-free logs: a successful handler run logs no namespace, hash, id, title, or external id", async () => {
+    const pool = new FakeSourcePool();
+    const s = makeSource({ title: "SECRET-PROJECT-CODENAME" });
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+    const fields = await captureLoggerFields(async () => {
+      await handler(jobFor(payloadFor(s), s.namespace));
+    });
+    // The handler_ok line (and the primitive's own ok line) WAS emitted.
+    expect(fields.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(fields);
+    expect(serialized).not.toContain("team-kb"); // namespace value
+    expect(serialized).not.toContain(s.content_hash as string); // content hash
+    expect(serialized).not.toContain(s.id); // source / anchor id
+    expect(serialized).not.toContain("SECRET-PROJECT-CODENAME"); // title
+    expect(serialized).not.toContain(s.external_id); // external id
+    // No 64-char sha256 hex (content_hash OR derivation_hash) in any field.
+    for (const entry of fields) {
+      for (const value of Object.values(entry)) {
+        if (typeof value === "string") {
+          expect(value).not.toMatch(/^[0-9a-f]{64}$/);
+        }
+      }
+    }
+  });
+});

--- a/src/graph-derivation-handler.test.ts
+++ b/src/graph-derivation-handler.test.ts
@@ -85,6 +85,8 @@ interface FakeAnchor {
   namespace: string;
   entity_type: string;
   canonical_id: string;
+  name: string;
+  display_name: string | null;
   content_hash: string | null;
   derivation_hash: string | null;
   archived_at: string | null;
@@ -218,7 +220,7 @@ class FakeSourcePool {
     // Model just enough: the prior-hash SELECT returns the anchor's stamped
     // hash; entity/link INSERTs return a fresh-namespace row and stamp the
     // anchor. This lets the handler exercise the real primitive end to end.
-    if (text.includes("SELECT metadata ->> 'derivation_hash'")) {
+    if (text.includes("metadata ->> 'derivation_hash' AS derivation_hash")) {
       const [ns, type, canonical] = params as [string, string, string];
       const anchor = this.anchors.find(
         (a) =>
@@ -233,18 +235,21 @@ class FakeSourcePool {
       return {
         rows: [
           {
+            name: anchor.name,
+            display_name: anchor.display_name,
             derivation_hash: anchor.derivation_hash ?? null,
             content_hash: anchor.content_hash ?? null,
           },
         ],
       };
     }
-    // Content-hash refresh on the unchanged path (metadata || $4::jsonb).
+    // Display/content refresh on the unchanged derivation path.
     if (
       text.includes("UPDATE ob_entities") &&
-      text.includes("metadata || $4::jsonb")
+      text.includes("metadata = metadata || $5::jsonb")
     ) {
-      const [ns, type, canonical, patch] = params as [
+      const [ns, type, canonical, name, patch] = params as [
+        string,
         string,
         string,
         string,
@@ -258,7 +263,12 @@ class FakeSourcePool {
           a.archived_at === null,
       );
       if (anchor) {
-        const parsed = JSON.parse(patch) as { content_hash?: string };
+        const parsed = JSON.parse(patch) as {
+          content_hash?: string;
+          display_name?: string;
+        };
+        anchor.name = name;
+        anchor.display_name = parsed.display_name ?? anchor.display_name;
         if (parsed.content_hash !== undefined) {
           anchor.content_hash = parsed.content_hash;
         }
@@ -266,7 +276,7 @@ class FakeSourcePool {
       return { rows: [] };
     }
     if (text.includes("INSERT INTO ob_entities")) {
-      const [type, , canonical, ns, meta] = params as [
+      const [type, name, canonical, ns, meta] = params as [
         string,
         string,
         string,
@@ -278,6 +288,7 @@ class FakeSourcePool {
         const parsedMeta = JSON.parse(meta) as {
           derivation_hash?: string;
           content_hash?: string;
+          display_name?: string;
         };
         const existing = this.anchors.find(
           (a) =>
@@ -288,6 +299,9 @@ class FakeSourcePool {
         // The primitive stamps content_hash and derivation_hash directly in the
         // $5::jsonb metadata bind — read them straight from the parsed param.
         if (existing) {
+          existing.name = name;
+          existing.display_name =
+            parsedMeta.display_name ?? existing.display_name;
           existing.content_hash =
             parsedMeta.content_hash ?? existing.content_hash;
           existing.derivation_hash =
@@ -302,6 +316,8 @@ class FakeSourcePool {
           namespace: ns,
           entity_type: type,
           canonical_id: canonical,
+          name,
+          display_name: parsedMeta.display_name ?? null,
           content_hash: parsedMeta.content_hash ?? null,
           derivation_hash: parsedMeta.derivation_hash ?? null,
           archived_at: null,
@@ -428,6 +444,8 @@ describe("selectSourcesNeedingDerivation", () => {
       namespace: s.namespace,
       entity_type: SOURCE_ANCHOR_ENTITY_TYPE,
       canonical_id: `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+      name: `source:${s.id}`,
+      display_name: s.title,
       content_hash: s.content_hash,
       derivation_hash: "deadbeef",
       archived_at: null,
@@ -444,6 +462,8 @@ describe("selectSourcesNeedingDerivation", () => {
       namespace: s.namespace,
       entity_type: SOURCE_ANCHOR_ENTITY_TYPE,
       canonical_id: `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+      name: `source:${s.id}`,
+      display_name: s.title,
       content_hash: "a".repeat(64),
       derivation_hash: "deadbeef",
       archived_at: null,
@@ -629,6 +649,25 @@ describe("makeGraphDerivationHandler", () => {
       (a) => a.canonical_id === `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
     );
     expect(anchor?.content_hash).toBe(s.content_hash);
+  });
+
+  it("preserves the complete source title while bounding only the stored entity name", async () => {
+    const pool = new FakeSourcePool();
+    const title = Array.from({ length: 40 }, () => "Long source title").join(
+      " ",
+    );
+    const s = makeSource({ title });
+    pool.sources.push(s);
+    const handler = makeGraphDerivationHandler({ pool: pool as never, auth });
+
+    await handler(jobFor(payloadFor(s), s.namespace));
+
+    const anchor = pool.anchors.find(
+      (a) => a.canonical_id === `${SOURCE_ANCHOR_ENTITY_TYPE}:${s.id}`,
+    );
+    expect(anchor?.display_name).toBe(title);
+    expect(anchor?.name.length).toBeLessThanOrEqual(500);
+    expect(anchor?.name.endsWith(`[source:${s.id}]`)).toBe(true);
   });
 
   it("future job version is TERMINAL, rejected before any payload parse or SQL", async () => {

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -345,6 +345,9 @@ interface GraphDerivationHandlerDeps {
  * there is no automatic continuous derivation.
  *
  * On each run it:
+ *  0. Rejects any job.version other than GRAPH_DERIVATION_JOB_VERSION BEFORE
+ *     parsing the payload — a foreign-version job carries a payload under a
+ *     different contract and is terminal (a retry cannot change the version).
  *  1. Validates the payload shape (a malformed payload is terminal — a retry
  *     cannot fix it).
  *  2. Confirms the job's namespace is writable by the handler identity, and
@@ -390,6 +393,22 @@ export function makeGraphDerivationHandler(
   deps: GraphDerivationHandlerDeps,
 ): MaintenanceJobHandler {
   return async (job: MaintenanceJob): Promise<void> => {
+    // Version gate FIRST, before any payload parsing. A job whose version is not
+    // the exact contract version this handler implements carries a payload under
+    // a DIFFERENT (future or older) contract; parsing it against the current
+    // strict schema is meaningless — a future payload could add fields the strict
+    // schema rejects, and an older payload could parse yet mean something else.
+    // A retry cannot change a job's stamped version, so a mismatch is terminal:
+    // dead-letter immediately rather than derive from a foreign contract. The
+    // producer (buildGraphDerivationEnqueue) always stamps GRAPH_DERIVATION_JOB_
+    // VERSION; a mismatch means a cross-version enqueue that this handler build
+    // must not process. Content-free: only the stable category leaves the server.
+    if (job.version !== GRAPH_DERIVATION_JOB_VERSION) {
+      throw new GraphDerivationTerminalError(
+        "graph derivation job version is not supported by this handler",
+      );
+    }
+
     const parsed = graphDerivationPayloadSchema.safeParse(job.payload);
     if (!parsed.success) {
       // A structurally invalid payload can never succeed on retry.

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -19,6 +19,7 @@ import {
   type SourceKind,
 } from "./source-registry.ts";
 import {
+  MaintenanceTerminalError,
   type EnqueueMaintenanceJob,
   type MaintenanceJob,
   type MaintenanceJobHandler,
@@ -300,20 +301,15 @@ export async function enqueueGraphDerivationJobs(
  * disposition is to dead-letter it immediately rather than burn the retry
  * budget.
  *
- * Current truth (do not overstate): this is only a NON-RETRYABLE SIGNAL. The
- * maintenance queue (maintenance-queue.ts) does not yet special-case this
- * subclass — a thrown Error still follows the generic attempts>=max_attempts
- * retry-then-dead-letter path, so today this error merely exhausts retries
- * before dead-lettering rather than short-circuiting to it. Immediate
- * dead-lettering awaits generic queue support (a terminal/non-retryable
- * category the `fail()` path honors), which lands with this handler's queue
- * registration (rebase onto #356). Until then this handler is intentionally
- * NOT registered in maintenance-queue.ts / src/index.ts; the subclass exists so
- * that once the queue can distinguish terminal from retryable failures, the
- * wrapper can map it to immediate dead-letter without any content leaving the
- * server.
+ * This extends the queue-owned {@link MaintenanceTerminalError} marker, so the
+ * generic MaintenanceQueueRunner recognizes it by type and MaintenanceQueue.fail
+ * dead-letters the job on this exact attempt (category `terminal`) instead of
+ * scheduling a bounded backoff retry to the attempt bound. The dependency points
+ * the right way — this handler imports the queue's marker; the queue imports
+ * nothing from this handler. Content leaves the server on neither path: the
+ * category is a stable enum value and the runner's failure log is content-free.
  */
-export class GraphDerivationTerminalError extends Error {
+export class GraphDerivationTerminalError extends MaintenanceTerminalError {
   constructor(reason: string) {
     super(reason);
     this.name = "GraphDerivationTerminalError";

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -1,0 +1,486 @@
+import { z } from "zod";
+import type pg from "pg";
+import { logger } from "./logger.ts";
+import { canWriteNamespace } from "./namespace-policy.ts";
+import { physicalNamespace } from "./shared-namespace.ts";
+import type { AuthInfo } from "./types.ts";
+import { extractMetadata } from "./extraction.ts";
+import {
+  CrossNamespaceEndpointError,
+  deriveGraphFromMetadata,
+  type DerivationMetadata,
+  type DerivationReceipt,
+  type GraphDerivationPool,
+} from "./graph-derivation.ts";
+import {
+  SOURCE_CONTENT_HASH_VERSION,
+  SOURCE_REGISTRY_TABLE,
+  SOURCE_KINDS,
+  type SourceKind,
+} from "./source-registry.ts";
+import {
+  type EnqueueMaintenanceJob,
+  type MaintenanceJob,
+  type MaintenanceJobHandler,
+} from "./maintenance-queue.ts";
+
+/**
+ * Maintenance integration for graph derivation (#346 / MAINT-4).
+ *
+ * This is the concrete maintenance-queue handler #342 calls out and #343 left
+ * unimplemented: it identifies approved, new-or-changed source items by their
+ * canonical content hash, and drives the deterministic graph derivation
+ * primitive (graph-derivation.ts) into the source's exact namespace so the
+ * existing search_all / brain_answer graph arm can consume the result without a
+ * contract change.
+ *
+ * Responsibility split (intentionally narrow):
+ *  - selectSourcesNeedingDerivation(): read-only, namespace-scoped selection of
+ *    approved+active ob_sources whose observed content_hash has not yet been
+ *    derived into the graph (new) or differs from the last derived hash
+ *    (changed). Unchanged hashes are never selected — they no-op at the source.
+ *  - enqueueGraphDerivationJobs(): turns each selected source into one bounded
+ *    maintenance job whose idempotency key binds (source id + content hash), so
+ *    a re-scan of an unchanged source is a queue no-op and a changed hash is a
+ *    distinct fresh job. Selection and extraction stay OUTSIDE any queue lock.
+ *  - graphDerivationHandler(): the registered handler. It re-reads the source
+ *    under a snapshot guard (the payload's content_hash + revision must still
+ *    match the live approved+active row), runs bounded metadata extraction, and
+ *    calls deriveGraphFromMetadata. The primitive's own content-hash check makes
+ *    a redundant run converge without duplicate nodes/edges.
+ *
+ * Non-goals honored here: no MCP tool surface, no Dream planning or prompt
+ * placement changes, no SOURCE-1 re-implementation (extraction is reused), and
+ * no ranking changes. Receipts and logs are content-free (ids, counts, hashes,
+ * status only).
+ */
+
+/** The job kind this handler registers under. Matches the queue's kind regex. */
+export const GRAPH_DERIVATION_JOB_KIND = "graph.derive" as const;
+/** Payload contract version. Bump only on an incompatible payload change. */
+export const GRAPH_DERIVATION_JOB_VERSION = 1 as const;
+/** The anchor entity_type every derived source graph hangs from. */
+export const SOURCE_ANCHOR_ENTITY_TYPE = "source" as const;
+
+// Upper bound on how many sources one selection/enqueue sweep considers. The
+// scheduler sweeps repeatedly; a single sweep must not scan or enqueue the whole
+// table unbounded.
+const MAX_SELECT_LIMIT = 256;
+const DEFAULT_SELECT_LIMIT = 100;
+
+// The stored content_hash / derivation payload hashes are lowercase sha256 hex.
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+/**
+ * A source that needs (re-)derivation: its last-observed content_hash differs
+ * from the derivation hash already stamped on its anchor entity. Content-free:
+ * identity, hashes, and revision only — never a title or body.
+ */
+export interface SourceNeedingDerivation {
+  id: string;
+  namespace: string;
+  source_kind: SourceKind;
+  external_id: string;
+  content_hash: string;
+  revision: number;
+  /** The derivation hash currently on the anchor, if any (absent => new). */
+  derived_content_hash: string | null;
+}
+
+/**
+ * Namespace-scoped, read-only selection of approved+active sources whose
+ * observed content_hash has not been derived into the graph, or has changed
+ * since the last derivation.
+ *
+ * The auth-derived namespace predicate is mandatory. `namespaces === undefined`
+ * (a token-sourced global admin/ob-admin) selects across namespaces; every
+ * other identity is constrained to its writable namespace set. A source is
+ * eligible only when it is approved AND active AND carries a well-formed
+ * content_hash, mirroring the ingestion-eligibility gate in source-registry.ts.
+ *
+ * "Needs derivation" is decided by comparing the source's content_hash to the
+ * `content_hash` recorded in its anchor entity's metadata (the derivation
+ * handler stamps this on every successful run). A missing anchor (never
+ * derived) is `new`; a differing recorded hash is `changed`; an equal recorded
+ * hash is filtered out in SQL and never selected. The comparison lives in the
+ * WHERE clause so an unchanged corpus produces an empty sweep with no work.
+ */
+export async function selectSourcesNeedingDerivation(
+  pool: Pick<pg.Pool, "query">,
+  writableNamespaces: string[] | undefined,
+  limit = DEFAULT_SELECT_LIMIT,
+): Promise<SourceNeedingDerivation[]> {
+  const boundedLimit = Math.min(
+    Math.max(Math.trunc(limit), 1),
+    MAX_SELECT_LIMIT,
+  );
+
+  const params: unknown[] = [SOURCE_ANCHOR_ENTITY_TYPE];
+  let namespacePredicate = "";
+  if (writableNamespaces !== undefined) {
+    // Auth-derived namespace predicate. Constrain both the source scan and the
+    // anchor join to the caller's writable namespace set; never widen.
+    params.push(writableNamespaces);
+    namespacePredicate = ` AND s.namespace = ANY($${params.length}::text[])`;
+  }
+  params.push(boundedLimit);
+  const limitParam = `$${params.length}`;
+
+  // The anchor's canonical id is stable: '<entity_type>:<source id>' — matching
+  // the handler's anchorCanonical below. The LEFT JOIN pulls the last derived
+  // content_hash from the anchor entity's metadata (same namespace only), and
+  // the WHERE keeps only sources whose observed hash is absent from the anchor
+  // (new) or differs from it (changed). Parameterized throughout; the only
+  // interpolated identifiers are the table-name constants (allowlisted).
+  const { rows } = await pool.query(
+    `SELECT s.id, s.namespace, s.source_kind, s.external_id,
+            s.content_hash, s.revision,
+            anchor.metadata ->> 'content_hash' AS derived_content_hash
+       FROM ${SOURCE_REGISTRY_TABLE} s
+       LEFT JOIN ob_entities anchor
+         ON anchor.namespace = s.namespace
+        AND anchor.entity_type = $1
+        AND anchor.canonical_id = $1 || ':' || s.id::text
+        AND anchor.archived_at IS NULL
+      WHERE s.approval_state = 'approved'
+        AND s.lifecycle_state = 'active'
+        AND s.content_hash IS NOT NULL
+        AND s.content_hash ~ '^[0-9a-f]{64}$'
+        AND (
+          anchor.id IS NULL
+          OR anchor.metadata ->> 'content_hash' IS DISTINCT FROM s.content_hash
+        )${namespacePredicate}
+      ORDER BY s.updated_at ASC, s.id ASC
+      LIMIT ${limitParam}`,
+    params,
+  );
+
+  return rows.map((row) => ({
+    id: row.id as string,
+    namespace: row.namespace as string,
+    source_kind: row.source_kind as SourceKind,
+    external_id: row.external_id as string,
+    content_hash: row.content_hash as string,
+    revision: row.revision as number,
+    derived_content_hash: (row.derived_content_hash as string | null) ?? null,
+  }));
+}
+
+/**
+ * The already-extracted metadata a collector observed for one source. Optional:
+ * when absent, the handler runs the deterministic extractor over the source's
+ * label so a source still produces its stable anchor node. Never a body.
+ */
+const derivationMetadataSchema = z
+  .object({
+    topics: z.array(z.string()).max(200).optional(),
+    people: z.array(z.string()).max(200).optional(),
+  })
+  .strict();
+
+/**
+ * The bounded job payload. Content-free: source identity, the observed content
+ * hash + revision (the snapshot guard), and optionally already-extracted
+ * structural metadata (topics/people). No body, no free text.
+ */
+export const graphDerivationPayloadSchema = z
+  .object({
+    source_id: z.string().uuid(),
+    source_kind: z.enum(SOURCE_KINDS),
+    external_id: z.string().trim().min(1).max(1000),
+    content_hash: z.string().regex(SHA256_HEX_RE),
+    revision: z.number().int().min(1),
+    metadata: derivationMetadataSchema.optional(),
+  })
+  .strict();
+
+export type GraphDerivationPayload = z.infer<
+  typeof graphDerivationPayloadSchema
+>;
+
+/**
+ * Build one bounded enqueue request for a selected source. The idempotency key
+ * binds source id + content hash: a re-scan of an unchanged source resolves to
+ * the SAME key (queue DO NOTHING no-op), while a changed content hash is a
+ * distinct key and therefore a fresh job. The namespace and a content-free
+ * provenance ride along so a handler run is namespace-scoped end to end.
+ */
+export function buildGraphDerivationEnqueue(
+  source: SourceNeedingDerivation,
+  metadata?: DerivationMetadata,
+): EnqueueMaintenanceJob {
+  const payload: GraphDerivationPayload = {
+    source_id: source.id,
+    source_kind: source.source_kind,
+    external_id: source.external_id,
+    content_hash: source.content_hash,
+    revision: source.revision,
+    ...(metadata ? { metadata: prunedMetadata(metadata) } : {}),
+  };
+  return {
+    kind: GRAPH_DERIVATION_JOB_KIND,
+    version: GRAPH_DERIVATION_JOB_VERSION,
+    payload: payload as unknown as Record<string, unknown>,
+    // Distinct per (source, observed content). A changed hash => new job; an
+    // unchanged re-enqueue => queue no-op. Bounded well under the 256-char cap.
+    idempotencyKey: `${GRAPH_DERIVATION_JOB_KIND}:${source.id}:${source.content_hash}`,
+    scope: {
+      namespace: source.namespace,
+      provenance: {
+        hash_version: SOURCE_CONTENT_HASH_VERSION,
+      },
+    },
+  };
+}
+
+// Drop empty term arrays so the payload stays minimal and stable.
+function prunedMetadata(metadata: DerivationMetadata): DerivationMetadata {
+  const out: DerivationMetadata = {};
+  if (metadata.topics && metadata.topics.length > 0)
+    out.topics = metadata.topics;
+  if (metadata.people && metadata.people.length > 0)
+    out.people = metadata.people;
+  return out;
+}
+
+/**
+ * Queue interface this integration needs, kept minimal so the enqueue path is
+ * injectable in tests without the concrete MaintenanceQueue.
+ */
+export interface GraphDerivationEnqueuePort {
+  enqueue(input: EnqueueMaintenanceJob): Promise<MaintenanceJob>;
+}
+
+/**
+ * Selection + enqueue sweep. Reads the sources needing derivation (namespace
+ * scoped) and enqueues one bounded job each. Optionally a metadata resolver
+ * supplies already-extracted topics/people per source (the collector seam);
+ * when omitted, the job carries no metadata and the handler falls back to the
+ * deterministic extractor. Both selection and metadata resolution happen here,
+ * OUTSIDE any queue lock. Returns the enqueued jobs. Content-free logging only.
+ */
+export async function enqueueGraphDerivationJobs(
+  pool: Pick<pg.Pool, "query">,
+  queue: GraphDerivationEnqueuePort,
+  writableNamespaces: string[] | undefined,
+  options: {
+    limit?: number;
+    resolveMetadata?: (
+      source: SourceNeedingDerivation,
+    ) =>
+      Promise<DerivationMetadata | undefined> | DerivationMetadata | undefined;
+  } = {},
+): Promise<MaintenanceJob[]> {
+  const sources = await selectSourcesNeedingDerivation(
+    pool,
+    writableNamespaces,
+    options.limit,
+  );
+  const enqueued: MaintenanceJob[] = [];
+  for (const source of sources) {
+    const metadata = options.resolveMetadata
+      ? await options.resolveMetadata(source)
+      : undefined;
+    const job = await queue.enqueue(
+      buildGraphDerivationEnqueue(source, metadata),
+    );
+    enqueued.push(job);
+  }
+  logger.info("graph_derivation_enqueue_sweep", {
+    selected: sources.length,
+    enqueued: enqueued.length,
+  });
+  return enqueued;
+}
+
+/**
+ * A terminal (non-retryable) handler failure. The source drifted out from under
+ * the job (revoked approval, retired, deleted, content re-observed, or a stale
+ * revision), so retrying the SAME payload can never succeed — it must
+ * dead-letter immediately rather than burn the retry budget. The queue maps a
+ * plain thrown Error to a retryable category; this subclass lets the wrapper
+ * distinguish the two without any content leaving the server.
+ */
+export class GraphDerivationTerminalError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "GraphDerivationTerminalError";
+  }
+}
+
+interface GraphDerivationHandlerDeps {
+  pool: GraphDerivationPool & Pick<pg.Pool, "query">;
+  /**
+   * The server identity the handler derives under. Must be able to write the
+   * job's namespace; deriveGraphFromMetadata re-checks this too. A maintenance
+   * bootstrap supplies a token-sourced admin/ob-admin identity.
+   */
+  auth: AuthInfo;
+}
+
+/**
+ * Build the registered handler for GRAPH_DERIVATION_JOB_KIND. The returned
+ * function is the MaintenanceJobHandler the runner invokes per claimed job.
+ *
+ * On each run it:
+ *  1. Validates the payload shape (a malformed payload is terminal — a retry
+ *     cannot fix it).
+ *  2. Confirms the job's namespace is writable by the handler identity, and
+ *     that it matches the source's own namespace (defense in depth against a
+ *     payload whose namespace was tampered with; both are cross-checked).
+ *  3. Re-reads the live source row under a snapshot guard: it must still be
+ *     approved + active in the job namespace AND carry the exact content_hash
+ *     and revision the job was enqueued for. Any drift is terminal — the world
+ *     moved on and this exact unit of work is obsolete.
+ *  4. Derives the graph from the (already-extracted) metadata, or from a
+ *     deterministic extraction over the source label when the payload carried
+ *     none. The primitive's content-hash short-circuit makes a redundant run a
+ *     no-op; a changed hash converges without duplicate nodes/edges.
+ */
+export function makeGraphDerivationHandler(
+  deps: GraphDerivationHandlerDeps,
+): MaintenanceJobHandler {
+  return async (job: MaintenanceJob): Promise<void> => {
+    const parsed = graphDerivationPayloadSchema.safeParse(job.payload);
+    if (!parsed.success) {
+      // A structurally invalid payload can never succeed on retry.
+      throw new GraphDerivationTerminalError(
+        "graph derivation payload invalid",
+      );
+    }
+    const payload = parsed.data;
+
+    // The job's own namespace is the ONLY namespace this run may touch. The
+    // queue stored it; a null namespace is a mis-enqueued job (terminal).
+    if (job.namespace === null) {
+      throw new GraphDerivationTerminalError(
+        "graph derivation job is missing its namespace",
+      );
+    }
+    const namespace = physicalNamespace(job.namespace);
+
+    const nsCheck = canWriteNamespace(deps.auth, namespace);
+    if (!nsCheck.allowed) {
+      // The handler identity cannot write this namespace. Terminal: another
+      // retry with the same identity cannot change the authorization outcome.
+      throw new GraphDerivationTerminalError(
+        `graph derivation namespace not writable: ${nsCheck.reason}`,
+      );
+    }
+
+    // Snapshot guard: re-read the live source, namespace-bound by id, and prove
+    // it is still an approved+active ingestion target at the exact revision and
+    // content hash the job was enqueued for. This is the source-snapshot guard:
+    // a stale job (content re-observed, approval revoked, retired, deleted, or a
+    // revision bump) resolves to zero rows and terminates without deriving from
+    // an obsolete snapshot.
+    const guarded = await deps.pool.query(
+      `SELECT title
+         FROM ${SOURCE_REGISTRY_TABLE}
+        WHERE id = $1
+          AND namespace = $2
+          AND source_kind = $3
+          AND external_id = $4
+          AND content_hash = $5
+          AND revision = $6
+          AND approval_state = 'approved'
+          AND lifecycle_state = 'active'`,
+      [
+        payload.source_id,
+        namespace,
+        payload.source_kind,
+        payload.external_id,
+        payload.content_hash,
+        payload.revision,
+      ],
+    );
+    if (guarded.rows.length === 0) {
+      throw new GraphDerivationTerminalError(
+        "source snapshot changed since enqueue; derivation obsolete",
+      );
+    }
+    const title: string | null =
+      (guarded.rows[0].title as string | null) ?? null;
+
+    // Resolve the metadata to derive from. The already-extracted metadata the
+    // collector observed rides in the payload; when absent, run the
+    // deterministic (zero-network) extractor over the source label so the
+    // source still yields its stable anchor node. Extraction runs OUTSIDE any
+    // queue lock — the job is already leased, not holding a row lock.
+    const metadata = await resolveDerivationMetadata(payload, title);
+
+    // The anchor label names the anchor entity node. Prefer the source title;
+    // fall back to the external id so an untitled source still names its anchor.
+    const anchorName = (
+      title && title.trim().length > 0 ? title : payload.external_id
+    ).slice(0, 500);
+
+    let receipt: DerivationReceipt;
+    try {
+      receipt = await deriveGraphFromMetadata(deps.pool, deps.auth, {
+        anchorType: SOURCE_ANCHOR_ENTITY_TYPE,
+        anchorId: payload.source_id,
+        anchorName,
+        namespace,
+        metadata,
+        // Stamp the source snapshot digest on the anchor so the selection sweep
+        // can read it back and skip this source until its content_hash changes.
+        // The guard above already proved this hash matches the live source row.
+        anchorContentHash: payload.content_hash,
+      });
+    } catch (err) {
+      if (err instanceof CrossNamespaceEndpointError) {
+        // An isolation breach or an un-writable namespace is terminal: the same
+        // payload will breach again. Surface content-free and dead-letter.
+        throw new GraphDerivationTerminalError(
+          "graph derivation rejected a cross-namespace endpoint",
+        );
+      }
+      // Any other error (e.g. a transient DB failure) is retryable: rethrow so
+      // the queue schedules a bounded backoff retry.
+      throw err;
+    }
+
+    // Content-free: only the stable source_kind category, the derivation
+    // status, and structural counts. No namespace value, no content_hash /
+    // derivation_hash value, no source id — the maintenance queue's own
+    // completion log already carries the (content-free) job_id / job_kind.
+    logger.info("graph_derivation_handler_ok", {
+      source_kind: payload.source_kind,
+      status: receipt.status,
+      entities_upserted: receipt.entities_upserted,
+      entities_new: receipt.entities_new,
+      links_upserted: receipt.links_upserted,
+      links_new: receipt.links_new,
+    });
+  };
+}
+
+/**
+ * Turn the payload (and optionally the source label) into the derivation
+ * metadata. Already-extracted topics/people from the collector are used as-is;
+ * absent metadata falls back to the deterministic extractor over the label,
+ * which never networks and never logs content. The derivation primitive only
+ * consumes topics/people, so action_items/dates are intentionally dropped here.
+ */
+async function resolveDerivationMetadata(
+  payload: GraphDerivationPayload,
+  title: string | null,
+): Promise<DerivationMetadata> {
+  if (payload.metadata) {
+    return prunedMetadata({
+      topics: payload.metadata.topics ?? [],
+      people: payload.metadata.people ?? [],
+    });
+  }
+  if (title && title.trim().length > 0) {
+    const extracted = await extractMetadata(title);
+    if (extracted) {
+      return prunedMetadata({
+        topics: extracted.topics,
+        people: extracted.people,
+      });
+    }
+  }
+  return {};
+}

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -296,10 +296,22 @@ export async function enqueueGraphDerivationJobs(
 /**
  * A terminal (non-retryable) handler failure. The source drifted out from under
  * the job (revoked approval, retired, deleted, content re-observed, or a stale
- * revision), so retrying the SAME payload can never succeed — it must
- * dead-letter immediately rather than burn the retry budget. The queue maps a
- * plain thrown Error to a retryable category; this subclass lets the wrapper
- * distinguish the two without any content leaving the server.
+ * revision), so retrying the SAME payload can never succeed — the correct
+ * disposition is to dead-letter it immediately rather than burn the retry
+ * budget.
+ *
+ * Current truth (do not overstate): this is only a NON-RETRYABLE SIGNAL. The
+ * maintenance queue (maintenance-queue.ts) does not yet special-case this
+ * subclass — a thrown Error still follows the generic attempts>=max_attempts
+ * retry-then-dead-letter path, so today this error merely exhausts retries
+ * before dead-lettering rather than short-circuiting to it. Immediate
+ * dead-lettering awaits generic queue support (a terminal/non-retryable
+ * category the `fail()` path honors), which lands with this handler's queue
+ * registration (rebase onto #356). Until then this handler is intentionally
+ * NOT registered in maintenance-queue.ts / src/index.ts; the subclass exists so
+ * that once the queue can distinguish terminal from retryable failures, the
+ * wrapper can map it to immediate dead-letter without any content leaving the
+ * server.
  */
 export class GraphDerivationTerminalError extends Error {
   constructor(reason: string) {
@@ -319,8 +331,10 @@ interface GraphDerivationHandlerDeps {
 }
 
 /**
- * Build the registered handler for GRAPH_DERIVATION_JOB_KIND. The returned
- * function is the MaintenanceJobHandler the runner invokes per claimed job.
+ * Build the handler for GRAPH_DERIVATION_JOB_KIND. The returned function is the
+ * MaintenanceJobHandler the runner will invoke per claimed job once the queue
+ * registration lands (rebase onto #356); it is intentionally not yet wired into
+ * maintenance-queue.ts / src/index.ts.
  *
  * On each run it:
  *  1. Validates the payload shape (a malformed payload is terminal — a retry
@@ -452,6 +466,7 @@ export function makeGraphDerivationHandler(
       entities_new: receipt.entities_new,
       links_upserted: receipt.links_upserted,
       links_new: receipt.links_new,
+      links_archived: receipt.links_archived,
     });
   };
 }

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -317,7 +317,15 @@ export class GraphDerivationTerminalError extends MaintenanceTerminalError {
 }
 
 interface GraphDerivationHandlerDeps {
-  pool: GraphDerivationPool & Pick<pg.Pool, "query">;
+  /**
+   * The pool the handler checks a client out of. `connect` is required (not just
+   * `query`) because the handler runs the snapshot guard and the whole graph
+   * derivation inside ONE transaction on ONE checked-out client — see the
+   * transaction-ownership contract on {@link makeGraphDerivationHandler}. `query`
+   * is retained for callers that still hand a bare pool; the handler only uses
+   * `connect`.
+   */
+  pool: GraphDerivationPool & Pick<pg.Pool, "query" | "connect">;
   /**
    * The server identity the handler derives under. Must be able to write the
    * job's namespace; deriveGraphFromMetadata re-checks this too. A maintenance
@@ -342,14 +350,41 @@ interface GraphDerivationHandlerDeps {
  *  2. Confirms the job's namespace is writable by the handler identity, and
  *     that it matches the source's own namespace (defense in depth against a
  *     payload whose namespace was tampered with; both are cross-checked).
- *  3. Re-reads the live source row under a snapshot guard: it must still be
- *     approved + active in the job namespace AND carry the exact content_hash
- *     and revision the job was enqueued for. Any drift is terminal — the world
- *     moved on and this exact unit of work is obsolete.
- *  4. Derives the graph from the (already-extracted) metadata, or from a
- *     deterministic extraction over the source label when the payload carried
- *     none. The primitive's content-hash short-circuit makes a redundant run a
- *     no-op; a changed hash converges without duplicate nodes/edges.
+ *  3. Opens ONE database transaction on ONE checked-out client and, inside it,
+ *     re-reads the live source row under a snapshot guard that ALSO locks it
+ *     (`SELECT ... FOR UPDATE`): the row must still be approved + active in the
+ *     job namespace AND carry the exact content_hash and revision the job was
+ *     enqueued for. Any drift is terminal — the world moved on and this exact
+ *     unit of work is obsolete.
+ *  4. In the SAME transaction and on the SAME client, derives the graph from
+ *     the (already-extracted) metadata, or from a deterministic extraction over
+ *     the source label when the payload carried none. The primitive's
+ *     content-hash short-circuit makes a redundant run a no-op; a changed hash
+ *     converges without duplicate nodes/edges.
+ *  5. COMMITs. Any error — the guard, extraction, or any derivation write —
+ *     ROLLs BACK every graph mutation AND the anchor hash stamp together, so a
+ *     transient failure never leaves a partial graph with a completed hash that
+ *     a retry would falsely short-circuit past.
+ *
+ * Transaction ownership (the fix for the coupled P1 atomicity findings):
+ *  - The HANDLER owns the transaction boundary. It checks out the client, runs
+ *    BEGIN, holds the source-row lock, calls the derivation primitive on that
+ *    client, and runs COMMIT/ROLLBACK. deriveGraphFromMetadata does NOT open a
+ *    transaction of its own — it runs every statement through the `query` of
+ *    whatever client/pool it is handed, so handing it this client enlists all
+ *    of its writes (anchor+hash, entities, links, stale-edge prune) in the one
+ *    transaction. The primitive stays a reusable, transaction-agnostic
+ *    primitive and its unit-test injectability is unchanged (a fake pool with a
+ *    `query` still drives it directly).
+ *  - The `SELECT ... FOR UPDATE` in step 3 serializes concurrent derivations
+ *    for one source AND against the source registry's own row updates. An OLDER
+ *    job that already holds the lock finishes and commits before the source can
+ *    advance (the registry UPDATE blocks on the lock), so a later fresh-hash job
+ *    runs after it; a job that starts AFTER a newer revision committed re-reads
+ *    under its stale content_hash/revision predicate, matches zero rows, and
+ *    terminal-stops. An obsolete job therefore can never overwrite a newer
+ *    committed graph, and the succeeded current-hash queue key never blocks a
+ *    genuine repair because a rolled-back failure stamps no hash at all.
  */
 export function makeGraphDerivationHandler(
   deps: GraphDerivationHandlerDeps,
@@ -382,56 +417,77 @@ export function makeGraphDerivationHandler(
       );
     }
 
-    // Snapshot guard: re-read the live source, namespace-bound by id, and prove
-    // it is still an approved+active ingestion target at the exact revision and
-    // content hash the job was enqueued for. This is the source-snapshot guard:
-    // a stale job (content re-observed, approval revoked, retired, deleted, or a
-    // revision bump) resolves to zero rows and terminates without deriving from
-    // an obsolete snapshot.
-    const guarded = await deps.pool.query(
-      `SELECT title
-         FROM ${SOURCE_REGISTRY_TABLE}
-        WHERE id = $1
-          AND namespace = $2
-          AND source_kind = $3
-          AND external_id = $4
-          AND content_hash = $5
-          AND revision = $6
-          AND approval_state = 'approved'
-          AND lifecycle_state = 'active'`,
-      [
-        payload.source_id,
-        namespace,
-        payload.source_kind,
-        payload.external_id,
-        payload.content_hash,
-        payload.revision,
-      ],
-    );
-    if (guarded.rows.length === 0) {
-      throw new GraphDerivationTerminalError(
-        "source snapshot changed since enqueue; derivation obsolete",
-      );
-    }
-    const title: string | null =
-      (guarded.rows[0].title as string | null) ?? null;
-
-    // Resolve the metadata to derive from. The already-extracted metadata the
-    // collector observed rides in the payload; when absent, run the
-    // deterministic (zero-network) extractor over the source label so the
-    // source still yields its stable anchor node. Extraction runs OUTSIDE any
-    // queue lock — the job is already leased, not holding a row lock.
-    const metadata = await resolveDerivationMetadata(payload, title);
-
-    // The anchor label names the anchor entity node. Prefer the source title;
-    // fall back to the external id so an untitled source still names its anchor.
-    const anchorName = (
-      title && title.trim().length > 0 ? title : payload.external_id
-    ).slice(0, 500);
-
+    // Everything from here — the snapshot guard, the source-row lock, and the
+    // full graph derivation (anchor+hash, entities, links, stale-edge prune) —
+    // runs inside ONE transaction on ONE client. deps.pool.connect() hands us a
+    // dedicated client; deriveGraphFromMetadata runs its statements through this
+    // client's `query`, so its writes are enlisted in this transaction and roll
+    // back atomically with the guard on any error. The handler owns COMMIT and
+    // ROLLBACK; the primitive stays transaction-agnostic (see the ownership note
+    // on makeGraphDerivationHandler).
+    const client = await deps.pool.connect();
     let receipt: DerivationReceipt;
     try {
-      receipt = await deriveGraphFromMetadata(deps.pool, deps.auth, {
+      await client.query("BEGIN");
+
+      // Snapshot guard + row lock: re-read the live source, namespace-bound by
+      // id, and prove it is still an approved+active ingestion target at the
+      // exact revision and content hash the job was enqueued for. FOR UPDATE
+      // locks the matched row FOR THE LIFE OF THIS TRANSACTION, which is what
+      // serializes concurrent/racing derivations and the registry's own source
+      // updates: a stale job (content re-observed, approval revoked, retired,
+      // deleted, or a revision bump) resolves to zero rows and terminates
+      // without deriving from an obsolete snapshot; a newer source revision
+      // cannot commit over us while we hold the lock, and a job that starts
+      // after a newer revision committed sees zero rows here and stops. The
+      // predicate is unchanged from the pre-fix read — only FOR UPDATE is added.
+      const guarded = await client.query(
+        `SELECT title
+           FROM ${SOURCE_REGISTRY_TABLE}
+          WHERE id = $1
+            AND namespace = $2
+            AND source_kind = $3
+            AND external_id = $4
+            AND content_hash = $5
+            AND revision = $6
+            AND approval_state = 'approved'
+            AND lifecycle_state = 'active'
+          FOR UPDATE`,
+        [
+          payload.source_id,
+          namespace,
+          payload.source_kind,
+          payload.external_id,
+          payload.content_hash,
+          payload.revision,
+        ],
+      );
+      if (guarded.rows.length === 0) {
+        throw new GraphDerivationTerminalError(
+          "source snapshot changed since enqueue; derivation obsolete",
+        );
+      }
+      const title: string | null =
+        (guarded.rows[0].title as string | null) ?? null;
+
+      // Resolve the metadata to derive from. The already-extracted metadata the
+      // collector observed rides in the payload; when absent, run the
+      // deterministic (zero-network) extractor over the source label so the
+      // source still yields its stable anchor node. Extraction is CPU-only and
+      // networkless; running it while the source row is locked keeps the derive
+      // atomic with the guard without any external wait inside the transaction.
+      const metadata = await resolveDerivationMetadata(payload, title);
+
+      // The anchor label names the anchor entity node. Prefer the source title;
+      // fall back to the external id so an untitled source still names its anchor.
+      const anchorName = (
+        title && title.trim().length > 0 ? title : payload.external_id
+      ).slice(0, 500);
+
+      // Derive on the SAME client, INSIDE this transaction. Every anchor/hash,
+      // entity, link, and prune write the primitive issues is now part of the
+      // atomic unit below and rolls back together on any failure.
+      receipt = await deriveGraphFromMetadata(client, deps.auth, {
         anchorType: SOURCE_ANCHOR_ENTITY_TYPE,
         anchorId: payload.source_id,
         anchorName,
@@ -439,10 +495,16 @@ export function makeGraphDerivationHandler(
         metadata,
         // Stamp the source snapshot digest on the anchor so the selection sweep
         // can read it back and skip this source until its content_hash changes.
-        // The guard above already proved this hash matches the live source row.
+        // The guard above already proved this hash matches the locked source row.
         anchorContentHash: payload.content_hash,
       });
+
+      await client.query("COMMIT");
     } catch (err) {
+      // Roll back the entire unit: any mutation the primitive made — including
+      // the anchor hash stamp — is undone, so a transient later failure leaves
+      // NO partial graph and NO stamped hash for a retry to short-circuit past.
+      await client.query("ROLLBACK").catch(() => undefined);
       if (err instanceof CrossNamespaceEndpointError) {
         // An isolation breach or an un-writable namespace is terminal: the same
         // payload will breach again. Surface content-free and dead-letter.
@@ -450,9 +512,12 @@ export function makeGraphDerivationHandler(
           "graph derivation rejected a cross-namespace endpoint",
         );
       }
-      // Any other error (e.g. a transient DB failure) is retryable: rethrow so
-      // the queue schedules a bounded backoff retry.
+      // A GraphDerivationTerminalError (e.g. the snapshot guard above) stays
+      // terminal; any other error (e.g. a transient DB failure) stays retryable
+      // — both simply propagate after the rollback.
       throw err;
+    } finally {
+      client.release();
     }
 
     // Content-free: only the stable source_kind category, the derivation

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -328,9 +328,13 @@ interface GraphDerivationHandlerDeps {
 
 /**
  * Build the handler for GRAPH_DERIVATION_JOB_KIND. The returned function is the
- * MaintenanceJobHandler the runner will invoke per claimed job once the queue
- * registration lands (rebase onto #356); it is intentionally not yet wired into
- * maintenance-queue.ts / src/index.ts.
+ * MaintenanceJobHandler the runner invokes per claimed job. It is registered by
+ * composeMaintenanceHandlers (maintenance-bootstrap.ts) and dispatched by the
+ * runner started in startMaintenanceQueue — the queue/index wiring is present.
+ * graph.derive jobs are produced only by the explicit, bounded
+ * enqueueGraphDerivationJobs producer (an operator or the future #347
+ * scheduler); the bootstrap enqueues nothing and defines no recurring sweep, so
+ * there is no automatic continuous derivation.
  *
  * On each run it:
  *  1. Validates the payload shape (a malformed payload is terminal — a retry

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -499,9 +499,8 @@ export function makeGraphDerivationHandler(
 
       // The anchor label names the anchor entity node. Prefer the source title;
       // fall back to the external id so an untitled source still names its anchor.
-      const anchorName = (
-        title && title.trim().length > 0 ? title : payload.external_id
-      ).slice(0, 500);
+      const anchorName =
+        title && title.trim().length > 0 ? title : payload.external_id;
 
       // Derive on the SAME client, INSIDE this transaction. Every anchor/hash,
       // entity, link, and prune write the primitive issues is now part of the

--- a/src/graph-derivation.live.test.ts
+++ b/src/graph-derivation.live.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { deriveGraphFromMetadata } from "./graph-derivation.ts";
+import type { AuthInfo } from "./types.ts";
+
+/**
+ * Live-Postgres regression for the #346 P2 anchor-rename bug.
+ *
+ * The in-memory FakeGraph in graph-derivation.test.ts models both partial-unique
+ * indexes by hand. This suite proves the fix against the REAL schema and REAL
+ * partial-index arbitration: ob_entities carries
+ *   idx_ob_entities_canonical    (namespace, entity_type, canonical_id)
+ *     WHERE canonical_id IS NOT NULL AND archived_at IS NULL
+ *   idx_ob_entities_lookup_unique(namespace, entity_type, lower(name))
+ *     WHERE archived_at IS NULL
+ * A rename of the same anchor (stable canonical id, new display name) must be a
+ * safe in-place UPDATE and must not raise a 23505 on the canonical index.
+ *
+ * Env-gated exactly like search-brain-relational-retrieval.test.ts: skipped
+ * unless OPENBRAIN_TEST_DATABASE_URL points at a migrated database.
+ */
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-graph-derivation-rename";
+  const anchorType = "thought";
+  const anchorId = "aa000000-0000-4000-8000-000000000346";
+  const anchorCanonical = `${anchorType}:${anchorId}`;
+  const auth: AuthInfo = {
+    role: "admin",
+    clientId: "test-graph-derivation",
+    namespaceSource: "token",
+  };
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM ob_links WHERE namespace = $1", [ns]);
+    await pool.query("DELETE FROM ob_entities WHERE namespace = $1", [ns]);
+  }
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("renames the anchor in place without violating the canonical unique index", async () => {
+    await cleanup();
+
+    // First derivation: create the anchor under its original display name.
+    const first = await deriveGraphFromMetadata(
+      { query: pool.query.bind(pool) },
+      auth,
+      {
+        anchorType,
+        anchorId,
+        anchorName: "release plan",
+        namespace: ns,
+        metadata: { topics: ["Migrations"], people: [] },
+      },
+    );
+    expect(first.status).toBe("new");
+
+    const beforeRes = await pool.query(
+      `SELECT id, name FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, anchorType, anchorCanonical],
+    );
+    expect(beforeRes.rows.length).toBe(1);
+    const anchorIdBefore: string = beforeRes.rows[0].id;
+    expect(beforeRes.rows[0].name).toBe("release plan");
+
+    // Second derivation: SAME anchor (same canonical id), NEW display name, plus
+    // a new term so the run takes the write path (a pure rename with identical
+    // metadata short-circuits to `unchanged`). Pre-fix this raised
+    // "duplicate key value violates unique constraint idx_ob_entities_canonical".
+    const renamed = await deriveGraphFromMetadata(
+      { query: pool.query.bind(pool) },
+      auth,
+      {
+        anchorType,
+        anchorId,
+        anchorName: "Release Plan v2",
+        namespace: ns,
+        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+      },
+    );
+    expect(renamed.status).toBe("changed");
+
+    // The canonical index still points at exactly one active row — the SAME id,
+    // renamed in place. No duplicate anchor row, no unique violation.
+    const afterRes = await pool.query(
+      `SELECT id, name FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, anchorType, anchorCanonical],
+    );
+    expect(afterRes.rows.length).toBe(1);
+    expect(afterRes.rows[0].id).toBe(anchorIdBefore);
+    expect(afterRes.rows[0].name).toBe("Release Plan v2");
+
+    // Re-running the exact same (renamed) input is idempotent and content-free.
+    const again = await deriveGraphFromMetadata(
+      { query: pool.query.bind(pool) },
+      auth,
+      {
+        anchorType,
+        anchorId,
+        anchorName: "Release Plan v2",
+        namespace: ns,
+        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+      },
+    );
+    expect(again.status).toBe("unchanged");
+    expect(JSON.stringify(again)).not.toContain("Release Plan");
+  });
+});

--- a/src/graph-derivation.live.test.ts
+++ b/src/graph-derivation.live.test.ts
@@ -116,3 +116,149 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
     expect(JSON.stringify(again)).not.toContain("Release Plan");
   });
 });
+
+/**
+ * Live-Postgres regression for the #346 stale-edge convergence bug.
+ *
+ * When an anchor's derived term set shrinks, the dropped term's anchor->term
+ * `mentions` edge must be soft-deleted (archived_at set) so the search-brain
+ * graph join (which filters archived_at IS NULL) stops returning it, while the
+ * SHARED term entity node is left intact. A rerun of the shrunk set is a no-op.
+ * Proven against the real partial-unique index and the real UPDATE semantics.
+ */
+dbDescribe("deriveGraphFromMetadata stale-edge prune (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const ns = "test-graph-derivation-prune";
+  const anchorType = "thought";
+  const anchorId = "bb000000-0000-4000-8000-000000000346";
+  const anchorCanonical = `${anchorType}:${anchorId}`;
+  const auth: AuthInfo = {
+    role: "admin",
+    clientId: "test-graph-derivation",
+    namespaceSource: "token",
+  };
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM ob_links WHERE namespace = $1", [ns]);
+    await pool.query("DELETE FROM ob_entities WHERE namespace = $1", [ns]);
+  }
+
+  async function anchorEntityId(): Promise<string> {
+    const res = await pool.query(
+      `SELECT id FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, anchorType, anchorCanonical],
+    );
+    return res.rows[0].id as string;
+  }
+
+  async function topicId(name: string): Promise<string | undefined> {
+    const res = await pool.query(
+      `SELECT id FROM ob_entities
+        WHERE namespace = $1 AND entity_type = 'topic' AND lower(name) = lower($2)
+          AND archived_at IS NULL`,
+      [ns, name],
+    );
+    return res.rows[0]?.id as string | undefined;
+  }
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("archives the dropped term's edge, keeps the shared node, and no-ops on rerun", async () => {
+    await cleanup();
+
+    // Initial: topics [migrations, indexing] -> two live anchor->term edges.
+    const first = await deriveGraphFromMetadata(
+      { query: pool.query.bind(pool) },
+      auth,
+      {
+        anchorType,
+        anchorId,
+        anchorName: "release plan",
+        namespace: ns,
+        metadata: { topics: ["migrations", "indexing"], people: [] },
+      },
+    );
+    expect(first.status).toBe("new");
+    expect(first.links_new).toBe(2);
+    expect(first.links_archived).toBe(0);
+
+    const anchor = await anchorEntityId();
+    const indexingId = await topicId("indexing");
+    expect(indexingId).toBeDefined();
+
+    const liveBefore = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM ob_links
+        WHERE namespace = $1 AND from_id = $2 AND relation = 'mentions'
+          AND archived_at IS NULL`,
+      [ns, anchor],
+    );
+    expect(liveBefore.rows[0].n).toBe(2);
+
+    // Changed: topics [migrations] -> the indexing edge is now stale.
+    const changed = await deriveGraphFromMetadata(
+      { query: pool.query.bind(pool) },
+      auth,
+      {
+        anchorType,
+        anchorId,
+        anchorName: "release plan",
+        namespace: ns,
+        metadata: { topics: ["migrations"], people: [] },
+      },
+    );
+    expect(changed.status).toBe("changed");
+    expect(changed.links_archived).toBe(1);
+
+    // The anchor->indexing edge is now archived (not hard-deleted).
+    const staleEdge = await pool.query(
+      `SELECT archived_at FROM ob_links
+        WHERE namespace = $1 AND from_id = $2 AND to_id = $3
+          AND relation = 'mentions'`,
+      [ns, anchor, indexingId],
+    );
+    expect(staleEdge.rows.length).toBe(1);
+    expect(staleEdge.rows[0].archived_at).not.toBeNull();
+
+    // Exactly one live edge remains (anchor->migrations).
+    const liveAfter = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM ob_links
+        WHERE namespace = $1 AND from_id = $2 AND relation = 'mentions'
+          AND archived_at IS NULL`,
+      [ns, anchor],
+    );
+    expect(liveAfter.rows[0].n).toBe(1);
+
+    // The SHARED "indexing" entity node is untouched — only the link was pruned.
+    const indexingStillLive = await topicId("indexing");
+    expect(indexingStillLive).toBe(indexingId);
+
+    // Rerun the SAME shrunk set: unchanged content, nothing new to prune.
+    const again = await deriveGraphFromMetadata(
+      { query: pool.query.bind(pool) },
+      auth,
+      {
+        anchorType,
+        anchorId,
+        anchorName: "release plan",
+        namespace: ns,
+        metadata: { topics: ["migrations"], people: [] },
+      },
+    );
+    expect(again.status).toBe("unchanged");
+    expect(again.links_archived).toBe(0);
+
+    // Still exactly one live edge; the archived edge did not revive.
+    const liveFinal = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM ob_links
+        WHERE namespace = $1 AND from_id = $2 AND relation = 'mentions'
+          AND archived_at IS NULL`,
+      [ns, anchor],
+    );
+    expect(liveFinal.rows[0].n).toBe(1);
+  });
+});

--- a/src/graph-derivation.live.test.ts
+++ b/src/graph-derivation.live.test.ts
@@ -62,14 +62,16 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
     expect(first.status).toBe("new");
 
     const beforeRes = await pool.query(
-      `SELECT id, name FROM ob_entities
+      `SELECT id, name, metadata ->> 'display_name' AS display_name
+         FROM ob_entities
         WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
           AND archived_at IS NULL`,
       [ns, anchorType, anchorCanonical],
     );
     expect(beforeRes.rows.length).toBe(1);
     const anchorIdBefore: string = beforeRes.rows[0].id;
-    expect(beforeRes.rows[0].name).toBe("release plan");
+    expect(beforeRes.rows[0].name).toBe(`release plan [${anchorCanonical}]`);
+    expect(beforeRes.rows[0].display_name).toBe("release plan");
 
     // Second derivation: SAME anchor (same canonical id), NEW display name, plus
     // a new term so the run takes the write path (a pure rename with identical
@@ -91,14 +93,16 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
     // The canonical index still points at exactly one active row — the SAME id,
     // renamed in place. No duplicate anchor row, no unique violation.
     const afterRes = await pool.query(
-      `SELECT id, name FROM ob_entities
+      `SELECT id, name, metadata ->> 'display_name' AS display_name
+         FROM ob_entities
         WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
           AND archived_at IS NULL`,
       [ns, anchorType, anchorCanonical],
     );
     expect(afterRes.rows.length).toBe(1);
     expect(afterRes.rows[0].id).toBe(anchorIdBefore);
-    expect(afterRes.rows[0].name).toBe("Release Plan v2");
+    expect(afterRes.rows[0].name).toBe(`Release Plan v2 [${anchorCanonical}]`);
+    expect(afterRes.rows[0].display_name).toBe("Release Plan v2");
 
     // Re-running the exact same (renamed) input is idempotent and content-free.
     const again = await deriveGraphFromMetadata(
@@ -116,6 +120,143 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
     expect(JSON.stringify(again)).not.toContain("Release Plan");
   });
 });
+
+/**
+ * Live-Postgres regression for the #346 P2 duplicate-source-title collision.
+ *
+ * Two DISTINCT source anchors (distinct canonical ids) that share the same human
+ * display title must both persist. Against the REAL idx_ob_entities_lookup_unique
+ * (namespace, entity_type, lower(name)), storing the human title as the row name
+ * makes the second anchor's INSERT raise a 23505 on that index (the canonical
+ * upsert never arbitrates lower(name)). The fix stores a canonical-derived name
+ * so lower(name) is unique exactly where canonical_id is, and preserves the
+ * shared label in metadata.display_name.
+ */
+dbDescribe(
+  "deriveGraphFromMetadata duplicate source titles (live Postgres)",
+  () => {
+    const pool = new Pool({ connectionString: DB_URL });
+    const ns = "test-graph-derivation-dup-title";
+    const anchorType = "source";
+    const idA = "cc000000-0000-4000-8000-0000000003a1";
+    const idB = "cc000000-0000-4000-8000-0000000003b2";
+    const auth: AuthInfo = {
+      role: "admin",
+      clientId: "test-graph-derivation",
+      namespaceSource: "token",
+    };
+
+    async function cleanup(): Promise<void> {
+      await pool.query("DELETE FROM ob_links WHERE namespace = $1", [ns]);
+      await pool.query("DELETE FROM ob_entities WHERE namespace = $1", [ns]);
+    }
+
+    afterAll(async () => {
+      await cleanup();
+      await pool.end();
+    });
+
+    it("stores two same-titled anchors without a lower(name) unique violation", async () => {
+      await cleanup();
+      const sharedTitle = "Q3 Release Plan";
+
+      // First anchor: title T under canonical source:idA.
+      const a = await deriveGraphFromMetadata(
+        { query: pool.query.bind(pool) },
+        auth,
+        {
+          anchorType,
+          anchorId: idA,
+          anchorName: sharedTitle,
+          namespace: ns,
+          metadata: { topics: ["Migrations"], people: [] },
+        },
+      );
+      expect(a.status).toBe("new");
+
+      // Second anchor: SAME title T under a DIFFERENT canonical source:idB.
+      // Pre-fix this raised "duplicate key value violates unique constraint
+      // idx_ob_entities_lookup_unique".
+      const b = await deriveGraphFromMetadata(
+        { query: pool.query.bind(pool) },
+        auth,
+        {
+          anchorType,
+          anchorId: idB,
+          anchorName: sharedTitle,
+          namespace: ns,
+          metadata: { topics: ["Migrations"], people: [] },
+        },
+      );
+      expect(b.status).toBe("new");
+
+      // Both anchors persist as distinct active rows, each preserving the label.
+      const anchors = await pool.query(
+        `SELECT canonical_id, name, metadata ->> 'display_name' AS display_name
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2
+          AND canonical_id = ANY($3::text[]) AND archived_at IS NULL
+        ORDER BY canonical_id`,
+        [ns, anchorType, [`${anchorType}:${idA}`, `${anchorType}:${idB}`]],
+      );
+      expect(anchors.rows.length).toBe(2);
+      for (const row of anchors.rows) {
+        expect(row.display_name).toBe(sharedTitle);
+      }
+      // Stored names differ (canonical-derived), so lower(name) never collided.
+      expect(anchors.rows[0].name).not.toBe(anchors.rows[1].name);
+    });
+
+    it("renames an anchor onto a sibling's title without a lower(name) collision", async () => {
+      await cleanup();
+
+      await deriveGraphFromMetadata({ query: pool.query.bind(pool) }, auth, {
+        anchorType,
+        anchorId: idA,
+        anchorName: "Existing Title",
+        namespace: ns,
+        metadata: { topics: ["Migrations"], people: [] },
+      });
+      await deriveGraphFromMetadata({ query: pool.query.bind(pool) }, auth, {
+        anchorType,
+        anchorId: idB,
+        anchorName: "Different Title",
+        namespace: ns,
+        metadata: { topics: ["Migrations"], people: [] },
+      });
+
+      // Rename B onto A's exact title, adding a term so the run takes the write
+      // path. Pre-fix the rename would set name = "Existing Title" and collide
+      // with A's row on lower(name).
+      const renamed = await deriveGraphFromMetadata(
+        { query: pool.query.bind(pool) },
+        auth,
+        {
+          anchorType,
+          anchorId: idB,
+          anchorName: "Existing Title",
+          namespace: ns,
+          metadata: { topics: ["Migrations", "pgvector"], people: [] },
+        },
+      );
+      expect(renamed.status).toBe("changed");
+
+      const anchors = await pool.query(
+        `SELECT canonical_id, metadata ->> 'display_name' AS display_name
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2
+          AND canonical_id = ANY($3::text[]) AND archived_at IS NULL
+        ORDER BY canonical_id`,
+        [ns, anchorType, [`${anchorType}:${idA}`, `${anchorType}:${idB}`]],
+      );
+      // Two distinct anchor rows, both now titled "Existing Title" via display_name.
+      expect(anchors.rows.length).toBe(2);
+      for (const row of anchors.rows) {
+        expect(row.display_name).toBe("Existing Title");
+      }
+    });
+  },
+);
 
 /**
  * Live-Postgres regression for the #346 stale-edge convergence bug.

--- a/src/graph-derivation.live.test.ts
+++ b/src/graph-derivation.live.test.ts
@@ -73,10 +73,9 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
     expect(beforeRes.rows[0].name).toBe(`release plan [${anchorCanonical}]`);
     expect(beforeRes.rows[0].display_name).toBe("release plan");
 
-    // Second derivation: SAME anchor (same canonical id), NEW display name, plus
-    // a new term so the run takes the write path (a pure rename with identical
-    // metadata short-circuits to `unchanged`). Pre-fix this raised
-    // "duplicate key value violates unique constraint idx_ob_entities_canonical".
+    // Second derivation: SAME anchor and derived terms, NEW display name only.
+    // The derivation remains structurally `unchanged`, but the anchor's readable
+    // storage name and exact display_name must still refresh in place.
     const renamed = await deriveGraphFromMetadata(
       { query: pool.query.bind(pool) },
       auth,
@@ -85,10 +84,10 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
         anchorId,
         anchorName: "Release Plan v2",
         namespace: ns,
-        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+        metadata: { topics: ["Migrations"], people: [] },
       },
     );
-    expect(renamed.status).toBe("changed");
+    expect(renamed.status).toBe("unchanged");
 
     // The canonical index still points at exactly one active row — the SAME id,
     // renamed in place. No duplicate anchor row, no unique violation.
@@ -113,7 +112,7 @@ dbDescribe("deriveGraphFromMetadata anchor rename (live Postgres)", () => {
         anchorId,
         anchorName: "Release Plan v2",
         namespace: ns,
-        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+        metadata: { topics: ["Migrations"], people: [] },
       },
     );
     expect(again.status).toBe("unchanged");

--- a/src/graph-derivation.test.ts
+++ b/src/graph-derivation.test.ts
@@ -139,7 +139,7 @@ class FakeGraph implements GraphDerivationPool {
     this.calls.push({ sql, params });
     const text = String(sql);
 
-    if (text.includes("SELECT metadata ->> 'derivation_hash'")) {
+    if (text.includes("metadata ->> 'derivation_hash' AS derivation_hash")) {
       const [ns, type, canonical] = params as [string, string, string];
       const found = this.byCanonical(ns, type, canonical);
       if (!found) return { rows: [] } as any;
@@ -148,6 +148,8 @@ class FakeGraph implements GraphDerivationPool {
       return {
         rows: [
           {
+            name: found.name,
+            display_name: found.metadata["display_name"] ?? null,
             derivation_hash: found.metadata["derivation_hash"] ?? null,
             content_hash: found.metadata["content_hash"] ?? null,
           },
@@ -155,14 +157,14 @@ class FakeGraph implements GraphDerivationPool {
       } as any;
     }
 
-    // Content-hash refresh on the unchanged path: metadata || $4::jsonb merges
-    // the new content_hash into the addressed anchor row without touching the
-    // node/edge set. Mirrors the partial-index-scoped UPDATE.
+    // Anchor refresh on the unchanged derivation path: update the collision-safe
+    // storage name plus display/content metadata without touching nodes or edges.
     if (
       text.includes("UPDATE ob_entities") &&
-      text.includes("metadata || $4::jsonb")
+      text.includes("metadata = metadata || $5::jsonb")
     ) {
-      const [ns, type, canonical, patch] = params as [
+      const [ns, type, canonical, name, patch] = params as [
+        string,
         string,
         string,
         string,
@@ -170,6 +172,7 @@ class FakeGraph implements GraphDerivationPool {
       ];
       const row = this.byCanonical(ns, type, canonical);
       if (row) {
+        row.name = name;
         row.metadata = {
           ...row.metadata,
           ...(JSON.parse(patch) as Record<string, unknown>),
@@ -363,7 +366,7 @@ describe("deriveGraphFromMetadata", () => {
     // Only the prior-hash SELECT ran; no INSERTs after the short-circuit.
     expect(g.calls.length).toBe(callsAfterFirst + 1);
     expect(g.calls.at(-1)?.sql).toContain(
-      "SELECT metadata ->> 'derivation_hash'",
+      "metadata ->> 'derivation_hash' AS derivation_hash",
     );
   });
 
@@ -449,6 +452,34 @@ describe("deriveGraphFromMetadata", () => {
     // not duplicate — it was renamed in place.
     expect(g.rows.length).toBe(rowCountBefore + 1);
     expect(after.metadata["derivation_hash"]).toBe(renamed.derivation_hash);
+  });
+
+  it("pure anchor rename refreshes display state even when derived terms are unchanged", async () => {
+    const g = new FakeGraph();
+    const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
+
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorName: "Original Title",
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+
+    const renamed = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorName: "Renamed Only",
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+
+    expect(renamed.status).toBe("unchanged");
+    const anchor = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    expect(anchor.name).toBe(`Renamed Only [${anchorCanonical}]`);
+    expect(anchor.metadata["display_name"]).toBe("Renamed Only");
   });
 
   it("duplicate source titles: two distinct anchors with the same display title coexist (no lower(name) collision)", async () => {
@@ -960,7 +991,7 @@ describe("deriveGraphFromMetadata", () => {
     // Exactly one extra call: the prior-hash SELECT. No stamp UPDATE.
     expect(g.calls.length).toBe(callsAfterFirst + 1);
     expect(g.calls.at(-1)?.sql).toContain(
-      "SELECT metadata ->> 'derivation_hash'",
+      "metadata ->> 'derivation_hash' AS derivation_hash",
     );
   });
 

--- a/src/graph-derivation.test.ts
+++ b/src/graph-derivation.test.ts
@@ -415,7 +415,10 @@ describe("deriveGraphFromMetadata", () => {
     const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
     const before = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
     const anchorIdBefore = before.id;
-    expect(before.name).toBe("release plan");
+    // The stored name keeps the human label readable and appends the stable
+    // canonical identity so lower(name) remains collision-safe.
+    expect(before.name).toBe(`release plan [${anchorCanonical}]`);
+    expect(before.metadata["display_name"]).toBe("release plan");
     const rowCountBefore = g.rows.length;
 
     // Re-derive the SAME anchor (same canonical id) under a NEW display name.
@@ -435,14 +438,123 @@ describe("deriveGraphFromMetadata", () => {
     );
 
     expect(renamed.status).toBe("changed");
-    // The anchor row was UPDATED in place (same id), not duplicated.
+    // The anchor row was UPDATED in place (same id), not duplicated. Both the
+    // readable prefix and metadata display label follow the rename while the
+    // canonical suffix keeps the stored name unique.
     const after = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
     expect(after.id).toBe(anchorIdBefore);
-    expect(after.name).toBe("Release Plan v2");
+    expect(after.name).toBe(`Release Plan v2 [${anchorCanonical}]`);
+    expect(after.metadata["display_name"]).toBe("Release Plan v2");
     // Exactly one new row appeared: the added "pgvector" term. The anchor did
     // not duplicate — it was renamed in place.
     expect(g.rows.length).toBe(rowCountBefore + 1);
     expect(after.metadata["derivation_hash"]).toBe(renamed.derivation_hash);
+  });
+
+  it("duplicate source titles: two distinct anchors with the same display title coexist (no lower(name) collision)", async () => {
+    // Regression for #346 P2. Two DISTINCT source anchors (distinct canonical
+    // ids source:<id1> / source:<id2>) that share the same human display title
+    // must both persist. Pre-fix the stored `name` WAS the title, so the second
+    // anchor found no canonical conflict, attempted an INSERT, and collided on
+    // idx_ob_entities_lookup_unique (namespace, entity_type, lower(name)) — a
+    // 23505 that threw the whole derivation. The fix stores anchorStorageName
+    // (canonical-derived), so lower(name) is unique exactly where canonical_id
+    // is; the shared title lives in metadata.display_name on each anchor.
+    const g = new FakeGraph();
+    const sharedTitle = "Q3 Release Plan";
+    const idA = "aaaaaaaa-1111-4111-8111-111111111111";
+    const idB = "bbbbbbbb-2222-4222-8222-222222222222";
+
+    const a = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorType: "source",
+        anchorId: idA,
+        anchorName: sharedTitle,
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+    // The second source shares the exact title but is a different canonical id.
+    // Pre-fix this call threw FakeUniqueViolation("idx_ob_entities_lookup_unique").
+    const b = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorType: "source",
+        anchorId: idB,
+        anchorName: sharedTitle,
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+    expect(a.status).toBe("new");
+    expect(b.status).toBe("new");
+
+    const anchorA = g.rows.find((r) => r.canonical_id === `source:${idA}`)!;
+    const anchorB = g.rows.find((r) => r.canonical_id === `source:${idB}`)!;
+    // Two distinct anchor rows survive; their stored names differ (canonical-
+    // derived) so lower(name) never collides, and both preserve the shared label.
+    expect(anchorA.id).not.toBe(anchorB.id);
+    expect(anchorA.name).not.toBe(anchorB.name);
+    expect(anchorA.name).toBe(`${sharedTitle} [source:${idA}]`);
+    expect(anchorB.name).toBe(`${sharedTitle} [source:${idB}]`);
+    expect(anchorA.metadata["display_name"]).toBe(sharedTitle);
+    expect(anchorB.metadata["display_name"]).toBe(sharedTitle);
+  });
+
+  it("rename-to-existing-title: renaming an anchor onto a sibling's display title does not collide", async () => {
+    // Regression for #346 P2. Anchor B is renamed so its display title becomes
+    // IDENTICAL to anchor A's, on a run that also changes B's term set (the
+    // realistic write-path trigger). Pre-fix the stored name would become the
+    // title and collide with A on lower(name); with the fix the stored name is
+    // canonical-derived and stable, so the rename is a clean in-place UPDATE and
+    // only display_name converges on the shared label.
+    const g = new FakeGraph();
+    const idA = "aaaaaaaa-3333-4333-8333-333333333333";
+    const idB = "bbbbbbbb-4444-4444-8444-444444444444";
+
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorType: "source",
+        anchorId: idA,
+        anchorName: "Existing Title",
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorType: "source",
+        anchorId: idB,
+        anchorName: "Different Title",
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+
+    // Rename B onto A's title, adding a term so the run takes the write path.
+    const renamed = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorType: "source",
+        anchorId: idB,
+        anchorName: "Existing Title",
+        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+      }),
+    );
+    expect(renamed.status).toBe("changed");
+
+    const anchorA = g.rows.find((r) => r.canonical_id === `source:${idA}`)!;
+    const anchorB = g.rows.find((r) => r.canonical_id === `source:${idB}`)!;
+    // Both anchors now carry the SAME display title, yet remain distinct rows
+    // with distinct stored names — no lower(name) collision on the rename.
+    expect(anchorA.metadata["display_name"]).toBe("Existing Title");
+    expect(anchorB.metadata["display_name"]).toBe("Existing Title");
+    expect(anchorA.id).not.toBe(anchorB.id);
+    expect(anchorB.name).toBe(`Existing Title [source:${idB}]`);
   });
 
   it("anchor rename: the old lower(name)-only arbiter would raise a canonical unique violation", async () => {

--- a/src/graph-derivation.test.ts
+++ b/src/graph-derivation.test.ts
@@ -1,0 +1,767 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CrossNamespaceEndpointError,
+  deriveGraphFromMetadata,
+  type DeriveGraphInput,
+  type GraphDerivationPool,
+} from "./graph-derivation.ts";
+import { logger } from "./logger.ts";
+import type { AuthInfo } from "./types.ts";
+
+/**
+ * Capture every field the primitive hands the logger during `fn`, then restore
+ * the real logger. Used by the content-free sentinel tests: the derivation
+ * primitive must never emit a namespace value, a content/derivation hash value,
+ * an anchor id, or any extracted term through observability. Only stable
+ * categories (anchor_type / status) and structural counts may leave the server.
+ */
+async function captureLoggerFields(
+  fn: () => Promise<void>,
+): Promise<Record<string, unknown>[]> {
+  const captured: Record<string, unknown>[] = [];
+  const original = {
+    info: logger.info,
+    debug: logger.debug,
+    warn: logger.warn,
+    error: logger.error,
+  };
+  const record = (extra?: Record<string, unknown>) => {
+    if (extra) captured.push(extra);
+  };
+  logger.info = (_m, extra) => record(extra);
+  logger.debug = (_m, extra) => record(extra);
+  logger.warn = (_m, extra) => record(extra);
+  logger.error = (_m, extra) => record(extra);
+  try {
+    await fn();
+  } finally {
+    logger.info = original.info;
+    logger.debug = original.debug;
+    logger.warn = original.warn;
+    logger.error = original.error;
+  }
+  return captured;
+}
+
+/** Postgres-style unique-violation surfaced when an unarbitrated index collides. */
+class FakeUniqueViolation extends Error {
+  code = "23505";
+  constructor(public constraint: string) {
+    super(`duplicate key value violates unique constraint "${constraint}"`);
+    this.name = "FakeUniqueViolation";
+  }
+}
+
+interface FakeEntityRow {
+  id: string;
+  namespace: string;
+  entity_type: string;
+  name: string;
+  canonical_id: string | null;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Realistic in-memory stand-in for the ob_entities / ob_links graph.
+ *
+ * It models the graph as a flat row set and honors BOTH partial-unique indexes
+ * migration 017 defines on ob_entities, not just one:
+ *   - idx_ob_entities_lookup_unique (namespace, entity_type, lower(name))
+ *     WHERE archived_at IS NULL
+ *   - idx_ob_entities_canonical    (namespace, entity_type, canonical_id)
+ *     WHERE canonical_id IS NOT NULL AND archived_at IS NULL
+ * plus the (namespace, from,to,relation) link identity, all scoped to a single
+ * namespace. An INSERT resolves the row addressed by its declared ON CONFLICT
+ * arbiter; if the resulting row would collide on the OTHER unique index, that is
+ * an UNARBITRATED violation and throws a 23505 exactly as Postgres would. This
+ * is what lets the rename regression below observe the canonical-index breach
+ * that a name-only fake would silently swallow. `is_new` mirrors `(xmax = 0)`.
+ */
+class FakeGraph implements GraphDerivationPool {
+  rows: FakeEntityRow[] = [];
+  links = new Map<string, { id: string; namespace: string }>();
+  calls: Array<{ sql: string; params: unknown[] }> = [];
+  private seq = 0;
+
+  private nextId(prefix: string): string {
+    this.seq += 1;
+    const n = String(this.seq).padStart(12, "0");
+    return `00000000-0000-4000-8000-${n}` + prefix.slice(0, 0);
+  }
+
+  /** Active row matching the lower(name) partial-unique index, if any. */
+  private byName(
+    ns: string,
+    type: string,
+    name: string,
+  ): FakeEntityRow | undefined {
+    return this.rows.find(
+      (r) =>
+        r.namespace === ns &&
+        r.entity_type === type &&
+        r.name.toLowerCase() === name.toLowerCase(),
+    );
+  }
+
+  /** Active row matching the canonical_id partial-unique index, if any. */
+  private byCanonical(
+    ns: string,
+    type: string,
+    canonical: string,
+  ): FakeEntityRow | undefined {
+    return this.rows.find(
+      (r) =>
+        r.namespace === ns &&
+        r.entity_type === type &&
+        r.canonical_id === canonical,
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: GraphDerivationPool["query"] = (async (
+    sql: string,
+    params: unknown[] = [],
+  ) => {
+    this.calls.push({ sql, params });
+    const text = String(sql);
+
+    if (text.includes("SELECT metadata ->> 'derivation_hash'")) {
+      const [ns, type, canonical] = params as [string, string, string];
+      const found = this.byCanonical(ns, type, canonical);
+      if (!found) return { rows: [] } as any;
+      // Mirror the real SELECT: both hash keys read from the anchor metadata.
+      // A jsonb ->> of an absent key is NULL, surfaced here as null.
+      return {
+        rows: [
+          {
+            derivation_hash: found.metadata["derivation_hash"] ?? null,
+            content_hash: found.metadata["content_hash"] ?? null,
+          },
+        ],
+      } as any;
+    }
+
+    // Content-hash refresh on the unchanged path: metadata || $4::jsonb merges
+    // the new content_hash into the addressed anchor row without touching the
+    // node/edge set. Mirrors the partial-index-scoped UPDATE.
+    if (
+      text.includes("UPDATE ob_entities") &&
+      text.includes("metadata || $4::jsonb")
+    ) {
+      const [ns, type, canonical, patch] = params as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const row = this.byCanonical(ns, type, canonical);
+      if (row) {
+        row.metadata = {
+          ...row.metadata,
+          ...(JSON.parse(patch) as Record<string, unknown>),
+        };
+      }
+      return { rows: [] } as any;
+    }
+
+    if (text.includes("INSERT INTO ob_entities")) {
+      const [type, name, canonical, ns] = params as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      // The anchor INSERT binds metadata as $5::jsonb; the derived-entity INSERT
+      // uses an inline '{}'::jsonb literal and has no metadata param. Detect by
+      // the SQL shape so we read the right slot.
+      const meta = text.includes("$5::jsonb")
+        ? (JSON.parse(params[4] as string) as Record<string, unknown>)
+        : {};
+      // Which partial-unique index does this INSERT arbitrate on?
+      const arbitratesCanonical = text.includes(
+        "ON CONFLICT (namespace, entity_type, canonical_id)",
+      );
+      const conflictRow = arbitratesCanonical
+        ? this.byCanonical(ns, type, canonical)
+        : this.byName(ns, type, name);
+
+      if (conflictRow) {
+        // DO UPDATE on the arbitrated row. The anchor upsert sets name = EXCLUDED.name;
+        // the derived-term upsert leaves name as-is. Then re-check the OTHER index.
+        if (arbitratesCanonical) conflictRow.name = name;
+        conflictRow.metadata = { ...conflictRow.metadata, ...meta };
+        // Post-update: the updated row must not collide with a DIFFERENT active row
+        // on either unique index (mirrors a real UPDATE hitting the other constraint).
+        const nameClash = this.byName(ns, type, conflictRow.name);
+        if (nameClash && nameClash !== conflictRow) {
+          throw new FakeUniqueViolation("idx_ob_entities_lookup_unique");
+        }
+        return {
+          rows: [
+            {
+              id: conflictRow.id,
+              is_new: false,
+              namespace: conflictRow.namespace,
+            },
+          ],
+        } as any;
+      }
+
+      // No arbitrated conflict -> INSERT. Postgres still enforces the OTHER
+      // partial-unique index; a colliding row there is an unarbitrated violation.
+      const canonicalClash = this.byCanonical(ns, type, canonical);
+      if (canonicalClash) {
+        throw new FakeUniqueViolation("idx_ob_entities_canonical");
+      }
+      const nameClash = this.byName(ns, type, name);
+      if (nameClash) {
+        throw new FakeUniqueViolation("idx_ob_entities_lookup_unique");
+      }
+      const id = this.nextId("e");
+      this.rows.push({
+        id,
+        namespace: ns,
+        entity_type: type,
+        name,
+        canonical_id: canonical,
+        metadata: meta,
+      });
+      return { rows: [{ id, is_new: true, namespace: ns }] } as any;
+    }
+
+    if (text.includes("INSERT INTO ob_links")) {
+      const [fromId, toId, relation, ns] = params as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const key = `${ns}|entity|${fromId}|entity|${toId}|${relation}`;
+      const existing = this.links.get(key);
+      if (existing) {
+        return {
+          rows: [
+            { id: existing.id, is_new: false, namespace: existing.namespace },
+          ],
+        } as any;
+      }
+      const id = this.nextId("l");
+      this.links.set(key, { id, namespace: ns });
+      return { rows: [{ id, is_new: true, namespace: ns }] } as any;
+    }
+
+    throw new Error(`unexpected sql: ${text.slice(0, 60)}`);
+  }) as any;
+}
+
+const auth: AuthInfo = {
+  role: "admin",
+  clientId: "skippy",
+  namespaceSource: "token",
+};
+
+function baseInput(
+  overrides: Partial<DeriveGraphInput> = {},
+): DeriveGraphInput {
+  return {
+    anchorType: "thought",
+    anchorId: "11111111-1111-4111-8111-111111111111",
+    anchorName: "release plan",
+    namespace: "team-kb",
+    metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+    ...overrides,
+  };
+}
+
+describe("deriveGraphFromMetadata", () => {
+  it("status=new: derives anchor + entities + edges on first run", async () => {
+    const g = new FakeGraph();
+    const receipt = await deriveGraphFromMetadata(g, auth, baseInput());
+
+    expect(receipt.status).toBe("new");
+    expect(receipt.previous_hash).toBeUndefined();
+    // anchor + 2 topics + 1 person = 4 entity upserts, all new.
+    expect(receipt.entities_upserted).toBe(4);
+    expect(receipt.entities_new).toBe(4);
+    // 3 anchor->term edges.
+    expect(receipt.links_upserted).toBe(3);
+    expect(receipt.links_new).toBe(3);
+    // content-free: no topic/person/anchor text in the receipt.
+    expect(JSON.stringify(receipt)).not.toContain("Migrations");
+    expect(JSON.stringify(receipt)).not.toContain("Rico");
+    expect(JSON.stringify(receipt)).not.toContain("release plan");
+  });
+
+  it("status=unchanged: identical metadata re-run skips all writes (idempotent)", async () => {
+    const g = new FakeGraph();
+    await deriveGraphFromMetadata(g, auth, baseInput());
+    const callsAfterFirst = g.calls.length;
+
+    const receipt = await deriveGraphFromMetadata(g, auth, baseInput());
+    expect(receipt.status).toBe("unchanged");
+    expect(receipt.entities_upserted).toBe(0);
+    expect(receipt.links_upserted).toBe(0);
+    // Only the prior-hash SELECT ran; no INSERTs after the short-circuit.
+    expect(g.calls.length).toBe(callsAfterFirst + 1);
+    expect(g.calls.at(-1)?.sql).toContain(
+      "SELECT metadata ->> 'derivation_hash'",
+    );
+  });
+
+  it("rerun is graph-stable: forced re-derive with identical content adds no duplicates", async () => {
+    const g = new FakeGraph();
+    const first = await deriveGraphFromMetadata(g, auth, baseInput());
+    // Simulate a stale prior derivation (e.g. an older hash version) so the
+    // next run takes the "changed" branch even though the content is identical.
+    // The anchor is addressed by its stable canonical id, not its display name.
+    const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
+    const anchorRow = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    anchorRow.metadata = { derivation_hash: "stale-prior-hash" };
+    const second = await deriveGraphFromMetadata(g, auth, baseInput());
+
+    expect(second.status).toBe("changed");
+    expect(second.previous_hash).toBe("stale-prior-hash");
+    // Content is unchanged, so the re-derivation hash equals the first run's.
+    expect(second.derivation_hash).toBe(first.derivation_hash);
+    // Re-derivation upserts the same 4 entities / 3 links but none are new.
+    expect(second.entities_upserted).toBe(4);
+    expect(second.entities_new).toBe(0);
+    expect(second.links_upserted).toBe(3);
+    expect(second.links_new).toBe(0);
+    // Graph size unchanged: no duplicate nodes or edges appeared.
+    expect(g.links.size).toBe(3);
+  });
+
+  it("anchor rename: stable canonical id survives a display-name change without a unique violation", async () => {
+    // Regression for #346 P2. The anchor's identity is its canonical id
+    // (anchorType:anchorId), which is stable across runs, while the display name
+    // can change (the thought was retitled). ob_entities carries two partial-
+    // unique indexes and the anchor row must stay unique under BOTH:
+    //   idx_ob_entities_canonical    (namespace, entity_type, canonical_id)
+    //   idx_ob_entities_lookup_unique(namespace, entity_type, lower(name))
+    // Arbitrating the anchor upsert on lower(name) would find no match after a
+    // rename, attempt an INSERT, and violate the canonical index (23505). We
+    // arbitrate on the canonical index so the rename is an in-place UPDATE.
+    const g = new FakeGraph();
+    const first = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorName: "release plan",
+        metadata: { topics: ["Migrations"], people: [] },
+      }),
+    );
+    expect(first.status).toBe("new");
+
+    const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
+    const before = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    const anchorIdBefore = before.id;
+    expect(before.name).toBe("release plan");
+    const rowCountBefore = g.rows.length;
+
+    // Re-derive the SAME anchor (same canonical id) under a NEW display name.
+    // A pure rename with identical metadata short-circuits to `unchanged` (name
+    // is not part of the derivation hash), so the collision only manifests on a
+    // run that is ALSO a content change — the realistic P2 trigger. We add a
+    // term so the run takes the write path. The fake throws a FakeUniqueViolation
+    // on any unarbitrated index collision, so this resolving cleanly is the proof
+    // the canonical arbiter is correct.
+    const renamed = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorName: "Release Plan v2",
+        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+      }),
+    );
+
+    expect(renamed.status).toBe("changed");
+    // The anchor row was UPDATED in place (same id), not duplicated.
+    const after = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    expect(after.id).toBe(anchorIdBefore);
+    expect(after.name).toBe("Release Plan v2");
+    // Exactly one new row appeared: the added "pgvector" term. The anchor did
+    // not duplicate — it was renamed in place.
+    expect(g.rows.length).toBe(rowCountBefore + 1);
+    expect(after.metadata["derivation_hash"]).toBe(renamed.derivation_hash);
+  });
+
+  it("anchor rename: the old lower(name)-only arbiter would raise a canonical unique violation", async () => {
+    // Proves the fake genuinely models the canonical index the fix targets: an
+    // INSERT that arbitrates ONLY on lower(name) (the pre-fix anchor shape) hits
+    // idx_ob_entities_canonical when the same canonical id already exists under a
+    // different name. This test fails on the OLD behavior and documents the exact
+    // constraint the fix avoids.
+    const g = new FakeGraph();
+    const ns = "team-kb";
+    const type = "thought";
+    const canonical = "thought:renamed-anchor";
+
+    // Seed an active anchor row via the canonical-arbiter upsert (the fixed shape).
+    await g.query(
+      `INSERT INTO ob_entities
+         (entity_type, name, canonical_id, namespace, metadata, created_by)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+       ON CONFLICT (namespace, entity_type, canonical_id)
+       WHERE canonical_id IS NOT NULL AND archived_at IS NULL
+       DO UPDATE SET name = EXCLUDED.name, metadata = ob_entities.metadata || EXCLUDED.metadata,
+         archived_at = NULL, updated_at = NOW()
+       RETURNING id, (xmax = 0) AS is_new, namespace`,
+      [type, "Old Name", canonical, ns, "{}", "skippy"],
+    );
+
+    // Now replay the PRE-FIX anchor upsert: same canonical id, a new name, but
+    // arbitrating on lower(name). No name match -> INSERT -> canonical collision.
+    await expect(
+      g.query(
+        `INSERT INTO ob_entities
+           (entity_type, name, canonical_id, namespace, metadata, created_by)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+         ON CONFLICT (namespace, entity_type, lower(name))
+         WHERE archived_at IS NULL
+         DO UPDATE SET canonical_id = COALESCE(EXCLUDED.canonical_id, ob_entities.canonical_id),
+           metadata = ob_entities.metadata || EXCLUDED.metadata, archived_at = NULL, updated_at = NOW()
+         RETURNING id, (xmax = 0) AS is_new, namespace`,
+        [type, "New Name", canonical, ns, "{}", "skippy"],
+      ),
+    ).rejects.toThrow("idx_ob_entities_canonical");
+  });
+
+  it("status=changed: new metadata term adds a node and reports previous hash", async () => {
+    const g = new FakeGraph();
+    const first = await deriveGraphFromMetadata(g, auth, baseInput());
+
+    const changed = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        metadata: {
+          topics: ["Migrations", "pgvector", "halfvec"],
+          people: ["Rico"],
+        },
+      }),
+    );
+    expect(changed.status).toBe("changed");
+    expect(changed.previous_hash).toBe(first.derivation_hash);
+    expect(changed.derivation_hash).not.toBe(first.derivation_hash);
+    // anchor + 3 topics + 1 person = 5; only the "halfvec" node is new.
+    expect(changed.entities_upserted).toBe(5);
+    expect(changed.entities_new).toBe(1);
+    expect(changed.links_new).toBe(1);
+  });
+
+  it("case-insensitive identity: 'Rico' and 'rico' collapse to one node", async () => {
+    const g = new FakeGraph();
+    const receipt = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        metadata: { topics: [], people: ["Rico", "rico", " RICO "] },
+      }),
+    );
+    // anchor + 1 person node.
+    expect(receipt.entities_upserted).toBe(2);
+    expect(receipt.links_upserted).toBe(1);
+  });
+
+  it("SQL predicate: every persisted write binds namespace as a parameter", async () => {
+    const g = new FakeGraph();
+    await deriveGraphFromMetadata(g, auth, baseInput());
+
+    const writes = g.calls.filter((c) => c.sql.includes("INSERT INTO ob_"));
+    expect(writes.length).toBeGreaterThan(0);
+    for (const call of writes) {
+      // Namespace-scoped conflict target on the exact partial-unique indexes.
+      if (call.sql.includes("ob_entities")) {
+        // The anchor upsert (identified by its $5::jsonb metadata bind) arbitrates
+        // on the canonical partial-unique index so a rename is a safe UPDATE and
+        // never violates idx_ob_entities_canonical. Derived-term upserts arbitrate
+        // on lower(name) since their canonical is name-derived.
+        if (call.sql.includes("$5::jsonb")) {
+          expect(call.sql).toContain(
+            "ON CONFLICT (namespace, entity_type, canonical_id)",
+          );
+          expect(call.sql).toContain(
+            "WHERE canonical_id IS NOT NULL AND archived_at IS NULL",
+          );
+        } else {
+          expect(call.sql).toContain(
+            "ON CONFLICT (namespace, entity_type, lower(name))",
+          );
+          expect(call.sql).toContain("WHERE archived_at IS NULL");
+        }
+      } else {
+        expect(call.sql).toContain(
+          "ON CONFLICT (namespace, from_type, from_id, to_type, to_id, relation)",
+        );
+      }
+      // namespace value is passed as a bound param, never interpolated.
+      expect(call.params).toContain("team-kb");
+    }
+  });
+
+  it("cross-namespace negative: unwritable namespace is rejected before any write", async () => {
+    const g = new FakeGraph();
+    const readonly: AuthInfo = { role: "readonly", clientId: "viewer" };
+    await expect(
+      deriveGraphFromMetadata(g, readonly, baseInput({ namespace: "team-kb" })),
+    ).rejects.toBeInstanceOf(CrossNamespaceEndpointError);
+    // No SQL issued at all — fail-closed before touching the graph.
+    expect(g.calls.length).toBe(0);
+  });
+
+  it("cross-namespace negative: header-bound identity cannot derive into a foreign namespace", async () => {
+    const g = new FakeGraph();
+    const delegated: AuthInfo = {
+      role: "agent",
+      clientId: "tenant-a",
+      namespaceSource: "header",
+    };
+    await expect(
+      deriveGraphFromMetadata(
+        g,
+        delegated,
+        baseInput({ namespace: "tenant-b" }),
+      ),
+    ).rejects.toBeInstanceOf(CrossNamespaceEndpointError);
+    expect(g.calls.length).toBe(0);
+  });
+
+  it("cross-namespace negative: a row persisted under a foreign namespace aborts", async () => {
+    const g = new FakeGraph();
+    // Simulate schema drift: the entity INSERT returns a different namespace.
+    const originalQuery = g.query;
+    g.query = (async (sql: string, params: unknown[] = []) => {
+      const res = await originalQuery(sql, params);
+      if (String(sql).includes("INSERT INTO ob_entities")) {
+        return { rows: [{ ...res.rows[0], namespace: "evil-ns" }] } as any;
+      }
+      return res;
+    }) as any;
+
+    await expect(
+      deriveGraphFromMetadata(g, auth, baseInput()),
+    ).rejects.toBeInstanceOf(CrossNamespaceEndpointError);
+  });
+
+  it("graph-search regression: derived edges match the relationalGraphSearch join shape", async () => {
+    // The existing search-brain relational-graph join (tools/search-brain.ts)
+    // seeds on an ob_entities row, then joins ob_links with:
+    //   l.namespace = seed.namespace AND l.relation = $2 AND l.archived_at IS NULL
+    //   AND l.from_id = seed.id (outbound direction)
+    // then joins the target entity in the SAME namespace. This asserts every
+    // edge we persist satisfies that join so derived edges stay retrievable and
+    // never leak across the namespace boundary the join relies on.
+    const g = new FakeGraph();
+    await deriveGraphFromMetadata(g, auth, baseInput());
+
+    const linkWrites = g.calls.filter((c) =>
+      c.sql.includes("INSERT INTO ob_links"),
+    );
+    expect(linkWrites.length).toBe(3);
+
+    const anchorInsert = g.calls.find(
+      (c) =>
+        c.sql.includes("INSERT INTO ob_entities") &&
+        c.sql.includes("$5::jsonb"),
+    );
+    const anchorId = "00000000-0000-4000-8000-000000000001"; // first minted id
+
+    for (const call of linkWrites) {
+      const [fromId, toId, relation, ns] = call.params as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      // Outbound from the anchor seed, same namespace on both endpoints.
+      expect(fromId).toBe(anchorId);
+      expect(ns).toBe("team-kb");
+      // relation is the value the join filters on ($2); it is a bound param.
+      expect(relation).toBe("mentions");
+      // Endpoints are entity nodes (the join hydrates ob_entities targets).
+      expect(call.sql).toContain("VALUES ('entity', $1, 'entity', $2,");
+      // No self-edge (would violate the CHECK and the seed<>target join).
+      expect(fromId).not.toBe(toId);
+    }
+    // The seed row the join matches on is the anchor entity, namespace-scoped.
+    expect(anchorInsert?.params).toContain("team-kb");
+    // Every target term was persisted in the derivation namespace, so the
+    // target-entity same-namespace join can reach it.
+    for (const row of g.rows) {
+      if (row.namespace !== "team-kb") {
+        throw new Error(
+          `entity persisted outside derivation namespace: ${row.namespace}`,
+        );
+      }
+    }
+  });
+
+  it("stamps anchorContentHash on the anchor so the maintenance sweep can converge", async () => {
+    // Regression: the maintenance selection compares a source's content_hash to
+    // the value stamped on its anchor. If the primitive never stamped it, the
+    // sweep would re-select the same source forever. Assert the write path
+    // records content_hash (distinct from derivation_hash) on the anchor row.
+    const g = new FakeGraph();
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ anchorContentHash: "c".repeat(64) }),
+    );
+    const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
+    const anchor = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    expect(anchor.metadata["content_hash"]).toBe("c".repeat(64));
+    // derivation_hash and content_hash are distinct keys, distinct values.
+    expect(anchor.metadata["derivation_hash"]).not.toBe("c".repeat(64));
+  });
+
+  it("unchanged terms but changed source bytes: refreshes the stamped content_hash", async () => {
+    // The convergence corner case: a source's bytes change (new content_hash)
+    // while its extracted terms stay identical (same derivation_hash). The run
+    // takes the `unchanged` node path but MUST refresh the anchor content_hash,
+    // or the sweep re-selects this source on every pass.
+    const g = new FakeGraph();
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ anchorContentHash: "a".repeat(64) }),
+    );
+    const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
+    const anchor = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    expect(anchor.metadata["content_hash"]).toBe("a".repeat(64));
+    const callsAfterFirst = g.calls.length;
+
+    // Same metadata (=> same derivation_hash, `unchanged`), new content hash.
+    const receipt = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ anchorContentHash: "b".repeat(64) }),
+    );
+    expect(receipt.status).toBe("unchanged");
+    // No node/edge INSERTs — only the prior-hash SELECT and the stamp UPDATE.
+    expect(receipt.entities_upserted).toBe(0);
+    expect(receipt.links_upserted).toBe(0);
+    expect(g.calls.length).toBe(callsAfterFirst + 2);
+    expect(g.calls.at(-1)?.sql).toContain("UPDATE ob_entities");
+    // The stamp now reflects the new source bytes; the sweep will skip it.
+    expect(anchor.metadata["content_hash"]).toBe("b".repeat(64));
+    // derivation_hash is untouched (terms unchanged).
+    expect(receipt.derivation_hash).toBe(
+      anchor.metadata["derivation_hash"] as string,
+    );
+  });
+
+  it("unchanged terms AND unchanged source bytes: a true no-op, no stamp UPDATE", async () => {
+    // When neither terms nor bytes changed, the unchanged path must not issue a
+    // superfluous UPDATE — the whole point of the content-hash short-circuit.
+    const g = new FakeGraph();
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ anchorContentHash: "a".repeat(64) }),
+    );
+    const callsAfterFirst = g.calls.length;
+    const receipt = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ anchorContentHash: "a".repeat(64) }),
+    );
+    expect(receipt.status).toBe("unchanged");
+    // Exactly one extra call: the prior-hash SELECT. No stamp UPDATE.
+    expect(g.calls.length).toBe(callsAfterFirst + 1);
+    expect(g.calls.at(-1)?.sql).toContain(
+      "SELECT metadata ->> 'derivation_hash'",
+    );
+  });
+
+  it("content-free: anchorContentHash never leaks source text into the receipt", async () => {
+    const g = new FakeGraph();
+    const receipt = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorContentHash: "d".repeat(64),
+        metadata: { topics: ["Migrations"], people: ["Rico"] },
+      }),
+    );
+    const serialized = JSON.stringify(receipt);
+    expect(serialized).not.toContain("Migrations");
+    expect(serialized).not.toContain("Rico");
+    expect(serialized).not.toContain("release plan");
+  });
+
+  it("empty metadata: derives only the anchor node, no edges", async () => {
+    const g = new FakeGraph();
+    const receipt = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ metadata: {} }),
+    );
+    expect(receipt.status).toBe("new");
+    expect(receipt.entities_upserted).toBe(1);
+    expect(receipt.links_upserted).toBe(0);
+  });
+
+  it("content-free logs: a new/changed derivation never logs namespace, hash, id, or terms", async () => {
+    const g = new FakeGraph();
+    const sensitiveHash = "c".repeat(64);
+    const fields = await captureLoggerFields(async () => {
+      await deriveGraphFromMetadata(
+        g,
+        auth,
+        baseInput({ anchorContentHash: sensitiveHash }),
+      );
+    });
+    // Something WAS logged (the graph_derivation_ok line) so the assertion is real.
+    expect(fields.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(fields);
+    // Namespace value, both hash notions, the anchor id, and every extracted
+    // term are all forbidden in observability.
+    expect(serialized).not.toContain("team-kb");
+    expect(serialized).not.toContain(sensitiveHash);
+    expect(serialized).not.toContain("11111111-1111-4111-8111-111111111111");
+    expect(serialized).not.toContain("Migrations");
+    expect(serialized).not.toContain("pgvector");
+    expect(serialized).not.toContain("Rico");
+    expect(serialized).not.toContain("release plan");
+    // A derivation_hash is a 64-char lowercase sha256 hex; none may appear in
+    // any logged field, regardless of which hash it is.
+    for (const entry of fields) {
+      for (const value of Object.values(entry)) {
+        if (typeof value === "string") {
+          expect(value).not.toMatch(/^[0-9a-f]{64}$/);
+        }
+      }
+    }
+  });
+
+  it("content-free logs: an unchanged short-circuit never logs namespace or hash", async () => {
+    const g = new FakeGraph();
+    const sensitiveHash = "e".repeat(64);
+    // Prime the anchor so the second run takes the unchanged path.
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ anchorContentHash: sensitiveHash }),
+    );
+    const fields = await captureLoggerFields(async () => {
+      const receipt = await deriveGraphFromMetadata(
+        g,
+        auth,
+        baseInput({ anchorContentHash: sensitiveHash }),
+      );
+      expect(receipt.status).toBe("unchanged");
+    });
+    const serialized = JSON.stringify(fields);
+    expect(serialized).not.toContain("team-kb");
+    expect(serialized).not.toContain(sensitiveHash);
+    expect(serialized).not.toContain("11111111-1111-4111-8111-111111111111");
+    for (const entry of fields) {
+      for (const value of Object.values(entry)) {
+        if (typeof value === "string") {
+          expect(value).not.toMatch(/^[0-9a-f]{64}$/);
+        }
+      }
+    }
+  });
+});

--- a/src/graph-derivation.test.ts
+++ b/src/graph-derivation.test.ts
@@ -79,7 +79,21 @@ interface FakeEntityRow {
  */
 class FakeGraph implements GraphDerivationPool {
   rows: FakeEntityRow[] = [];
-  links = new Map<string, { id: string; namespace: string }>();
+  // Link rows keyed by the (namespace, from, to, relation) live identity. The
+  // stored value carries archived state so the prune UPDATE (soft-delete) and
+  // the partial-unique WHERE archived_at IS NULL revive-on-conflict are both
+  // observable, exactly like the real ob_links table under migration 017.
+  links = new Map<
+    string,
+    {
+      id: string;
+      namespace: string;
+      from_id: string;
+      to_id: string;
+      relation: string;
+      archived: boolean;
+    }
+  >();
   calls: Array<{ sql: string; params: unknown[] }> = [];
   private seq = 0;
 
@@ -239,6 +253,12 @@ class FakeGraph implements GraphDerivationPool {
       const key = `${ns}|entity|${fromId}|entity|${toId}|${relation}`;
       const existing = this.links.get(key);
       if (existing) {
+        // The ON CONFLICT ... WHERE archived_at IS NULL arbiter only matches a
+        // LIVE edge. A previously-archived edge with the same identity is not
+        // seen by the partial index, so the DO UPDATE revives it (archived_at =
+        // NULL) — modeled here by clearing the archived flag. `xmax = 0` on a
+        // conflict-resolved row is false either way (not a fresh insert).
+        existing.archived = false;
         return {
           rows: [
             { id: existing.id, is_new: false, namespace: existing.namespace },
@@ -246,8 +266,47 @@ class FakeGraph implements GraphDerivationPool {
         } as any;
       }
       const id = this.nextId("l");
-      this.links.set(key, { id, namespace: ns });
+      this.links.set(key, {
+        id,
+        namespace: ns,
+        from_id: fromId,
+        to_id: toId,
+        relation,
+        archived: false,
+      });
       return { rows: [{ id, is_new: true, namespace: ns }] } as any;
+    }
+
+    // Stale-edge prune (#346): soft-delete this anchor's live `mentions` edges
+    // whose target dropped out of the derived set. Scoped by exact namespace +
+    // anchor identity (from_type/from_id) + relation; the surviving-target list
+    // is a bound uuid[] compared with NOT (to_id = ANY(...)). Returns the rows
+    // it archived so the primitive can count and same-namespace-verify them.
+    if (
+      text.includes("UPDATE ob_links") &&
+      text.includes("SET archived_at = NOW()")
+    ) {
+      const [ns, fromId, relation, survivors] = params as [
+        string,
+        string,
+        string,
+        string[],
+      ];
+      const keep = new Set(survivors);
+      const archived: Array<{ namespace: string }> = [];
+      for (const link of this.links.values()) {
+        if (
+          link.namespace === ns &&
+          link.from_id === fromId &&
+          link.relation === relation &&
+          !link.archived &&
+          !keep.has(link.to_id)
+        ) {
+          link.archived = true;
+          archived.push({ namespace: link.namespace });
+        }
+      }
+      return { rows: archived } as any;
     }
 
     throw new Error(`unexpected sql: ${text.slice(0, 60)}`);
@@ -448,6 +507,125 @@ describe("deriveGraphFromMetadata", () => {
     expect(changed.entities_upserted).toBe(5);
     expect(changed.entities_new).toBe(1);
     expect(changed.links_new).toBe(1);
+  });
+
+  it("stale-edge prune: a dropped term's anchor->term edge is archived and stays gone on rerun", async () => {
+    // Regression for #346 stale-edge convergence. Initial derivation has two
+    // topics; the second derivation drops one. The dropped topic's ENTITY NODE
+    // is shared and must survive (another anchor may reference it), but the
+    // obsolete anchor->term `mentions` EDGE must be soft-deleted so the
+    // search-brain graph join (archived_at IS NULL) stops returning it. A third
+    // derivation with the same shrunk set must be a no-op — nothing new to prune.
+    const g = new FakeGraph();
+    const anchorCanonical = "thought:11111111-1111-4111-8111-111111111111";
+
+    // Initial: topics [migrations, indexing] -> 2 live anchor->term edges.
+    const first = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        metadata: { topics: ["migrations", "indexing"], people: [] },
+      }),
+    );
+    expect(first.status).toBe("new");
+    expect(first.links_new).toBe(2);
+    expect(first.links_archived).toBe(0);
+
+    const anchorRow = g.rows.find((r) => r.canonical_id === anchorCanonical)!;
+    const indexingRow = g.rows.find(
+      (r) => r.entity_type === "topic" && r.name === "indexing",
+    )!;
+    const indexingKey = `team-kb|entity|${anchorRow.id}|entity|${indexingRow.id}|mentions`;
+    // Both edges start live.
+    expect([...g.links.values()].filter((l) => !l.archived).length).toBe(2);
+    expect(g.links.get(indexingKey)?.archived).toBe(false);
+
+    // Changed: topics [migrations] -> the indexing edge is now stale.
+    const changed = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ metadata: { topics: ["migrations"], people: [] } }),
+    );
+    expect(changed.status).toBe("changed");
+    // Exactly one edge archived: anchor->indexing. The migrations edge stays.
+    expect(changed.links_archived).toBe(1);
+    // The shared "indexing" ENTITY NODE is NOT archived — only the link is.
+    expect(
+      g.rows.find((r) => r.entity_type === "topic" && r.name === "indexing"),
+    ).toBeDefined();
+    // The stale edge is no longer live; the migrations edge still is.
+    expect(g.links.get(indexingKey)?.archived).toBe(true);
+    expect([...g.links.values()].filter((l) => !l.archived).length).toBe(1);
+
+    // Rerun the SAME shrunk set: unchanged content => no re-prune, no re-derive.
+    const again = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ metadata: { topics: ["migrations"], people: [] } }),
+    );
+    expect(again.status).toBe("unchanged");
+    expect(again.links_archived).toBe(0);
+    // Still exactly one live edge; the archived indexing edge did not revive.
+    expect([...g.links.values()].filter((l) => !l.archived).length).toBe(1);
+    expect(g.links.get(indexingKey)?.archived).toBe(true);
+  });
+
+  it("stale-edge prune: only THIS anchor's edges are touched, never a sibling anchor's", async () => {
+    // The prune predicate is scoped by from_id = the derived anchor's entity id.
+    // A different anchor that also mentions the dropped term must keep its edge
+    // live: the prune deactivates obsolete anchor->term links for one anchor
+    // only, never a shared node or a sibling anchor's edge.
+    const g = new FakeGraph();
+    const otherAnchorId = "22222222-2222-4222-8222-222222222222";
+
+    // Anchor A and Anchor B both mention "indexing".
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        metadata: { topics: ["migrations", "indexing"], people: [] },
+      }),
+    );
+    await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({
+        anchorId: otherAnchorId,
+        // A distinct display name: two anchor entities of the same type cannot
+        // share (namespace, entity_type, lower(name)) under the lookup index.
+        anchorName: "sibling plan",
+        metadata: { topics: ["indexing"], people: [] },
+      }),
+    );
+    const liveBefore = [...g.links.values()].filter((l) => !l.archived).length;
+    expect(liveBefore).toBe(3); // A->migrations, A->indexing, B->indexing
+
+    // Anchor A drops "indexing". Only A->indexing is archived; B->indexing lives.
+    const anchorA = g.rows.find(
+      (r) => r.canonical_id === "thought:11111111-1111-4111-8111-111111111111",
+    )!;
+    const anchorB = g.rows.find(
+      (r) => r.canonical_id === `thought:${otherAnchorId}`,
+    )!;
+    const indexingRow = g.rows.find(
+      (r) => r.entity_type === "topic" && r.name === "indexing",
+    )!;
+
+    const changed = await deriveGraphFromMetadata(
+      g,
+      auth,
+      baseInput({ metadata: { topics: ["migrations"], people: [] } }),
+    );
+    expect(changed.links_archived).toBe(1);
+
+    const aIndexing = g.links.get(
+      `team-kb|entity|${anchorA.id}|entity|${indexingRow.id}|mentions`,
+    );
+    const bIndexing = g.links.get(
+      `team-kb|entity|${anchorB.id}|entity|${indexingRow.id}|mentions`,
+    );
+    expect(aIndexing?.archived).toBe(true);
+    expect(bIndexing?.archived).toBe(false);
   });
 
   it("case-insensitive identity: 'Rico' and 'rico' collapse to one node", async () => {

--- a/src/graph-derivation.ts
+++ b/src/graph-derivation.ts
@@ -93,6 +93,12 @@ export interface DerivationReceipt {
   entities_new: number;
   links_upserted: number;
   links_new: number;
+  /**
+   * Count of previously-live anchor->term `mentions` edges soft-deleted this run
+   * because their target dropped out of the derived term set. Always 0 on `new`
+   * and `unchanged`; only a `changed` derivation whose term set shrank prunes.
+   */
+  links_archived: number;
 }
 
 export class CrossNamespaceEndpointError extends Error {
@@ -278,6 +284,7 @@ export async function deriveGraphFromMetadata(
       entities_new: 0,
       links_upserted: 0,
       links_new: 0,
+      links_archived: 0,
     };
   }
 
@@ -342,6 +349,15 @@ export async function deriveGraphFromMetadata(
   let entitiesNew = anchorNode.is_new ? 1 : 0;
   let linksUpserted = 0;
   let linksNew = 0;
+  let linksArchived = 0;
+
+  // The entity ids this derivation keeps a live anchor->term edge to. Any live
+  // `mentions` edge FROM this anchor to an id NOT in this set is a stale edge
+  // left behind by a prior derivation whose term set has since shrunk; step 4
+  // archives exactly those. The anchor's own id is included defensively so the
+  // self-link guard below can never let the prune touch a (nonexistent) self
+  // edge.
+  const liveTargetIds = new Set<string>([anchorEntityId]);
 
   // 3) Upsert each derived node and its anchor->node edge. Every write is
   //    parameterized and namespace-bound; every returned row's namespace is
@@ -392,7 +408,42 @@ export async function deriveGraphFromMetadata(
     assertSameNamespace(link.namespace, namespace, "derived link");
     linksUpserted += 1;
     if (link.is_new) linksNew += 1;
+    liveTargetIds.add(nodeId);
   }
+
+  // 4) Prune obsolete anchor->term edges. A `changed` derivation whose term set
+  //    shrank (e.g. topics [migrations,indexing] -> [migrations]) leaves the
+  //    dropped term's `mentions` edge live, so the search-brain graph join keeps
+  //    returning it. Archive (soft-delete) every live edge FROM this exact
+  //    anchor node under this exact namespace whose target is no longer in the
+  //    current derived set. We deactivate only the obsolete anchor->term LINK —
+  //    the shared term entity node is left untouched (another anchor may still
+  //    reference it, and it upserts back into the live set on its own).
+  //
+  //    Scoped by the exact namespace + anchor-identity predicates
+  //    (from_type = 'entity' AND from_id = the anchor entity id) and the
+  //    ANCHOR_RELATION, so no other anchor's edges and no cross-namespace edge
+  //    can ever be touched. Fully parameterized; NOT (... = ANY($n)) keeps the
+  //    surviving-target list a bound array, never interpolated. `archived_at IS
+  //    NULL` in the predicate makes a rerun with no newly-stale edges a no-op.
+  const pruneRes = await pool.query(
+    `UPDATE ob_links
+        SET archived_at = NOW(), updated_at = NOW()
+      WHERE namespace = $1
+        AND from_type = 'entity'
+        AND from_id = $2
+        AND relation = $3
+        AND archived_at IS NULL
+        AND NOT (to_id = ANY($4::uuid[]))
+      RETURNING namespace`,
+    [namespace, anchorEntityId, ANCHOR_RELATION, [...liveTargetIds]],
+  );
+  for (const row of pruneRes.rows) {
+    // Defense in depth: a soft-deleted edge must belong to the derivation
+    // namespace, mirroring the same-namespace guard on every persisted write.
+    assertSameNamespace(row.namespace, namespace, "pruned link");
+  }
+  linksArchived = pruneRes.rows.length;
 
   // Content-free: only the stable anchor_type category, the status, and
   // structural counts. No namespace value, no derivation_hash value, no ids.
@@ -403,6 +454,7 @@ export async function deriveGraphFromMetadata(
     entities_new: entitiesNew,
     links_upserted: linksUpserted,
     links_new: linksNew,
+    links_archived: linksArchived,
   });
 
   return {
@@ -416,6 +468,7 @@ export async function deriveGraphFromMetadata(
     entities_new: entitiesNew,
     links_upserted: linksUpserted,
     links_new: linksNew,
+    links_archived: linksArchived,
   };
 }
 

--- a/src/graph-derivation.ts
+++ b/src/graph-derivation.ts
@@ -188,6 +188,19 @@ function derivationHash(
  * metadata. Content-hash idempotent, namespace-bound, cross-namespace-rejecting,
  * content-free receipt. Throws CrossNamespaceEndpointError on isolation breach
  * and rethrows DB errors to the caller (no partial receipt on failure).
+ *
+ * Transaction-agnostic: this primitive opens NO transaction of its own. It runs
+ * every statement — the prior-hash read, the anchor upsert that stamps the
+ * derivation/content hash, the entity+link upserts, and the stale-edge prune —
+ * through the `query` of whatever `pool` it is handed, in call order. Hand it a
+ * bare pool and each statement auto-commits independently (fine for a
+ * durable-memory anchor with no cross-statement atomicity need, and what the
+ * unit tests inject). Hand it a checked-out client that is mid-transaction — as
+ * the maintenance handler does under its source-row lock — and ALL of these
+ * writes, including the hash stamp, become part of that caller's transaction and
+ * roll back together on any error. The caller owns BEGIN/COMMIT/ROLLBACK; this
+ * primitive never touches them, which is why passing a client (whose surface is
+ * a superset of GraphDerivationPool) needs no signature change.
  */
 export async function deriveGraphFromMetadata(
   pool: GraphDerivationPool,

--- a/src/graph-derivation.ts
+++ b/src/graph-derivation.ts
@@ -1,0 +1,438 @@
+import type pg from "pg";
+import { createHash } from "node:crypto";
+import { logger } from "./logger.ts";
+import { canWriteNamespace } from "./namespace-policy.ts";
+import type { AuthInfo, LinkRelation } from "./types.ts";
+
+/**
+ * Standalone, server-side graph-derivation maintenance primitive (#346).
+ *
+ * Turns already-extracted, structured metadata for one durable-memory anchor
+ * into deterministic entity nodes and edges in the existing ob_entities /
+ * ob_links graph. It is intentionally *not* wired to the maintenance queue
+ * (#343), *not* exposed as an MCP tool, and does *not* re-run SOURCE-1
+ * extraction (#337). Callers hand it metadata that some other stage already
+ * produced; this primitive owns only the deterministic derivation + persistence.
+ *
+ * Invariants (see docs/sme and the graph-search join in tools/search-brain.ts):
+ *  - Everything lives in a single namespace. The graph-traversal join requires
+ *    l.namespace = seed.namespace and target.namespace = l.namespace, so a
+ *    cross-namespace endpoint is both unreachable AND an isolation breach.
+ *    We reject any such derivation up front.
+ *  - ob_entities enforces TWO partial-unique indexes (migration 017), both
+ *    WHERE archived_at IS NULL: idx_ob_entities_lookup_unique on
+ *    (namespace, entity_type, lower(name)) and idx_ob_entities_canonical on
+ *    (namespace, entity_type, canonical_id) WHERE canonical_id IS NOT NULL.
+ *    Derived terms whose canonical id is name-derived upsert on lower(name)
+ *    (the upsert-entity.ts shape). The anchor, whose canonical id is stable
+ *    (anchorType:anchorId) but whose display name may change, upserts on the
+ *    canonical index so a rename is a safe in-place UPDATE and never violates
+ *    the other index (see step 2). Links are unique on
+ *    (namespace, from_type, from_id, to_type, to_id, relation) WHERE
+ *    archived_at IS NULL (the link-entities.ts shape).
+ *  - Idempotent: identical metadata re-run is detected via a content hash stored
+ *    on the anchor node and short-circuits to an `unchanged` receipt.
+ *  - Receipts are content-free: counts, status, and hashes only. No topic,
+ *    person, or anchor text ever leaves the server through this primitive.
+ */
+
+/** Minimal pool surface this primitive needs; keeps tests injectable. */
+export interface GraphDerivationPool {
+  query: pg.Pool["query"];
+}
+
+/**
+ * Structured, already-extracted metadata for a single anchor. This mirrors the
+ * shape produced by the extraction stage (see extraction.ts ExtractedMetadata)
+ * but is passed in — we do not extract here.
+ */
+export interface DerivationMetadata {
+  topics?: string[];
+  people?: string[];
+}
+
+export interface DeriveGraphInput {
+  /** The durable-memory row this graph is derived from (thought/decision/...). */
+  anchorType: string;
+  /** The anchor row UUID. */
+  anchorId: string;
+  /** Human-readable anchor label, used only to name the anchor entity node. */
+  anchorName: string;
+  /** Target namespace for every derived node and edge. */
+  namespace: string;
+  /** Already-extracted structured metadata. */
+  metadata: DerivationMetadata;
+  /**
+   * Optional upstream source content hash (a lowercase sha256 hex digest) to
+   * stamp on the anchor node's metadata as `content_hash`. This is distinct
+   * from the derivation_hash (which is computed over the derived node set): it
+   * records WHICH source snapshot this anchor was last derived from, so the
+   * maintenance selection sweep can compare a source's observed content_hash to
+   * the last-derived one and skip unchanged sources. Absent when the caller has
+   * no source-content notion (e.g. a durable-memory anchor).
+   */
+  anchorContentHash?: string;
+}
+
+export type DerivationStatus = "new" | "changed" | "unchanged";
+
+/**
+ * Content-free receipt. Contains no topic/person/anchor text — only structural
+ * counts, the derivation content hash, and status.
+ */
+export interface DerivationReceipt {
+  status: DerivationStatus;
+  namespace: string;
+  anchor_type: string;
+  anchor_id: string;
+  /** sha256 over the normalized derivation payload. */
+  derivation_hash: string;
+  /** Prior hash on the anchor node, if any (present on `changed`). */
+  previous_hash?: string;
+  entities_upserted: number;
+  entities_new: number;
+  links_upserted: number;
+  links_new: number;
+}
+
+export class CrossNamespaceEndpointError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "CrossNamespaceEndpointError";
+  }
+}
+
+const TOPIC_ENTITY_TYPE = "topic";
+const PERSON_ENTITY_TYPE = "person";
+const ANCHOR_RELATION: LinkRelation = "mentions";
+const MAX_TERMS = 200;
+
+interface DerivedEntity {
+  entity_type: string;
+  /** Display name (identity is namespace + entity_type + lower(name)). */
+  name: string;
+  /** Stable canonical id, e.g. "topic:migrations". */
+  canonical_id: string;
+}
+
+/**
+ * Normalize one extracted term to a stable identity. Deterministic: trims,
+ * collapses internal whitespace, lowercases the canonical id. The display name
+ * preserves the first-seen casing; identity dedup is case-insensitive so
+ * "Rico" and "rico" collapse to one node.
+ */
+function normalizeTerm(entityType: string, raw: string): DerivedEntity | null {
+  const name = raw.trim().replace(/\s+/g, " ");
+  if (name.length === 0) return null;
+  const canonical = `${entityType}:${name.toLowerCase()}`;
+  return { entity_type: entityType, name, canonical_id: canonical };
+}
+
+/**
+ * Deterministically build the node set from metadata. Dedups by canonical id
+ * (case-insensitive) and sorts by canonical id so identical input always
+ * produces the same ordered derivation regardless of extraction ordering.
+ */
+function deriveEntities(metadata: DerivationMetadata): DerivedEntity[] {
+  const byCanonical = new Map<string, DerivedEntity>();
+  const add = (entityType: string, terms: string[] | undefined) => {
+    for (const raw of (terms ?? []).slice(0, MAX_TERMS)) {
+      const entity = normalizeTerm(entityType, raw);
+      if (!entity) continue;
+      if (!byCanonical.has(entity.canonical_id)) {
+        byCanonical.set(entity.canonical_id, entity);
+      }
+    }
+  };
+  add(TOPIC_ENTITY_TYPE, metadata.topics);
+  add(PERSON_ENTITY_TYPE, metadata.people);
+  return [...byCanonical.values()].sort((a, b) =>
+    a.canonical_id < b.canonical_id
+      ? -1
+      : a.canonical_id > b.canonical_id
+        ? 1
+        : 0,
+  );
+}
+
+/**
+ * Deterministic content hash over the derivation payload. Only structural
+ * derivation inputs feed the hash (namespace, anchor identity, ordered node
+ * identities). Re-running with identical metadata yields the same hash, which
+ * is how we detect unchanged content and skip re-persistence.
+ */
+function derivationHash(
+  namespace: string,
+  anchorType: string,
+  anchorId: string,
+  entities: DerivedEntity[],
+): string {
+  const payload = JSON.stringify({
+    v: 1,
+    namespace,
+    anchor_type: anchorType,
+    anchor_id: anchorId,
+    entities: entities.map((e) => [e.entity_type, e.canonical_id]),
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+/**
+ * Derive and persist the entity/link graph for one anchor's structured
+ * metadata. Content-hash idempotent, namespace-bound, cross-namespace-rejecting,
+ * content-free receipt. Throws CrossNamespaceEndpointError on isolation breach
+ * and rethrows DB errors to the caller (no partial receipt on failure).
+ */
+export async function deriveGraphFromMetadata(
+  pool: GraphDerivationPool,
+  auth: AuthInfo,
+  input: DeriveGraphInput,
+): Promise<DerivationReceipt> {
+  const {
+    anchorType,
+    anchorId,
+    anchorName,
+    namespace,
+    metadata,
+    anchorContentHash,
+  } = input;
+
+  // Server-side namespace-write gate. The derivation namespace is the ONLY
+  // namespace any node or edge may touch; a caller who cannot write it cannot
+  // derive into it.
+  const nsCheck = canWriteNamespace(auth, namespace);
+  if (!nsCheck.allowed) {
+    throw new CrossNamespaceEndpointError(
+      `derivation namespace '${namespace}' not writable: ${nsCheck.reason}`,
+    );
+  }
+
+  const anchorLabel = anchorName.trim().replace(/\s+/g, " ");
+  if (anchorLabel.length === 0) {
+    throw new Error("anchorName is required to name the anchor entity node");
+  }
+
+  const entities = deriveEntities(metadata);
+  const hash = derivationHash(namespace, anchorType, anchorId, entities);
+
+  const anchorCanonical = `${anchorType}:${anchorId}`;
+
+  // 1) Read the anchor node's prior derivation + content hashes (namespace-
+  //    bound). If the derivation is unchanged we skip the node/edge writes, but
+  //    we still refresh the anchor's stamped content_hash when it drifted: a
+  //    source can change its bytes (new content_hash) while its extracted terms
+  //    stay identical (same derivation_hash). Without refreshing the stamp, the
+  //    maintenance selection sweep — which compares the source content_hash to
+  //    the anchor's stamped content_hash — would re-select that source forever.
+  const prior = await pool.query(
+    `SELECT metadata ->> 'derivation_hash' AS derivation_hash,
+            metadata ->> 'content_hash'    AS content_hash
+       FROM ob_entities
+      WHERE namespace = $1
+        AND entity_type = $2
+        AND canonical_id = $3
+        AND archived_at IS NULL`,
+    [namespace, anchorType, anchorCanonical],
+  );
+  const previousHash: string | undefined =
+    prior.rows[0]?.derivation_hash ?? undefined;
+  const previousContentHash: string | undefined =
+    prior.rows[0]?.content_hash ?? undefined;
+
+  if (previousHash === hash) {
+    // The derived node set is unchanged. Only touch the anchor when the caller
+    // supplied a content_hash that differs from the stamped one (a source-bytes
+    // change with identical extracted terms); otherwise this is a true no-op.
+    if (
+      anchorContentHash !== undefined &&
+      anchorContentHash !== previousContentHash
+    ) {
+      await pool.query(
+        `UPDATE ob_entities
+            SET metadata = metadata || $4::jsonb, updated_at = NOW()
+          WHERE namespace = $1
+            AND entity_type = $2
+            AND canonical_id = $3
+            AND archived_at IS NULL`,
+        [
+          namespace,
+          anchorType,
+          anchorCanonical,
+          JSON.stringify({ content_hash: anchorContentHash }),
+        ],
+      );
+    }
+    // Content-free: no namespace value, no derivation_hash value, no anchor id.
+    // Only the stable anchor_type category and the status leave the server.
+    logger.debug("graph_derivation_unchanged", {
+      anchor_type: anchorType,
+      status: "unchanged",
+    });
+    return {
+      status: "unchanged",
+      namespace,
+      anchor_type: anchorType,
+      anchor_id: anchorId,
+      derivation_hash: hash,
+      entities_upserted: 0,
+      entities_new: 0,
+      links_upserted: 0,
+      links_new: 0,
+    };
+  }
+
+  const status: DerivationStatus =
+    previousHash === undefined ? "new" : "changed";
+
+  // 2) Upsert the anchor entity, stamping the new derivation hash into its
+  //    metadata so the next run can detect unchanged content. All parameters;
+  //    namespace is a bound value, never interpolated.
+  //
+  //    The anchor's identity is its stable canonical id (anchorType:anchorId),
+  //    NOT its display name — a thought/decision can be renamed while pointing
+  //    at the same anchor row. ob_entities carries two partial-unique indexes
+  //    that both apply here: idx_ob_entities_canonical
+  //    (namespace, entity_type, canonical_id) WHERE canonical_id IS NOT NULL
+  //    AND archived_at IS NULL, and idx_ob_entities_lookup_unique
+  //    (namespace, entity_type, lower(name)) WHERE archived_at IS NULL. If we
+  //    arbitrated on lower(name) (as the derived-term upsert does), a rename
+  //    would find no lower(name) match, attempt an INSERT, and violate the
+  //    canonical index that ON CONFLICT never mentioned — throwing the whole
+  //    derivation. Arbitrating on the canonical index resolves the anchor by
+  //    its stable identity and updates the display name in place, so a rename
+  //    is a safe UPDATE. (Migration 017 makes the canonical index partial on
+  //    archived_at IS NULL, matching this arbiter exactly.)
+  // Stamp both hashes on the anchor. `derivation_hash` (over the derived node
+  // set) drives the primitive's own unchanged short-circuit; `content_hash`
+  // (the upstream source snapshot digest, when the caller supplies one) is what
+  // the maintenance selection sweep reads back to decide new/unchanged/changed.
+  // The metadata `||` merge below preserves any content_hash a prior run
+  // stamped, so a caller that omits it never clears a previously-recorded one.
+  const anchorMeta = JSON.stringify(
+    anchorContentHash === undefined
+      ? { derivation_hash: hash }
+      : { derivation_hash: hash, content_hash: anchorContentHash },
+  );
+  const anchorRow = await pool.query(
+    `INSERT INTO ob_entities
+       (entity_type, name, canonical_id, namespace, metadata, created_by)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+     ON CONFLICT (namespace, entity_type, canonical_id)
+     WHERE canonical_id IS NOT NULL AND archived_at IS NULL
+     DO UPDATE SET
+       name = EXCLUDED.name,
+       metadata = ob_entities.metadata || EXCLUDED.metadata,
+       archived_at = NULL,
+       updated_at = NOW()
+     RETURNING id, (xmax = 0) AS is_new, namespace`,
+    [
+      anchorType,
+      anchorLabel,
+      anchorCanonical,
+      namespace,
+      anchorMeta,
+      auth.clientId,
+    ],
+  );
+  const anchorNode = anchorRow.rows[0];
+  assertSameNamespace(anchorNode.namespace, namespace, "anchor");
+
+  const anchorEntityId: string = anchorNode.id;
+  let entitiesUpserted = 1;
+  let entitiesNew = anchorNode.is_new ? 1 : 0;
+  let linksUpserted = 0;
+  let linksNew = 0;
+
+  // 3) Upsert each derived node and its anchor->node edge. Every write is
+  //    parameterized and namespace-bound; every returned row's namespace is
+  //    re-verified against the derivation namespace as defense in depth.
+  for (const entity of entities) {
+    const nodeRow = await pool.query(
+      `INSERT INTO ob_entities
+         (entity_type, name, canonical_id, namespace, metadata, created_by)
+       VALUES ($1, $2, $3, $4, '{}'::jsonb, $5)
+       ON CONFLICT (namespace, entity_type, lower(name))
+       WHERE archived_at IS NULL
+       DO UPDATE SET
+         canonical_id = COALESCE(EXCLUDED.canonical_id, ob_entities.canonical_id),
+         archived_at = NULL,
+         updated_at = NOW()
+       RETURNING id, (xmax = 0) AS is_new, namespace`,
+      [
+        entity.entity_type,
+        entity.name,
+        entity.canonical_id,
+        namespace,
+        auth.clientId,
+      ],
+    );
+    const node = nodeRow.rows[0];
+    assertSameNamespace(node.namespace, namespace, "derived entity");
+    entitiesUpserted += 1;
+    if (node.is_new) entitiesNew += 1;
+
+    const nodeId: string = node.id;
+    // Self-link guard: an anchor that is itself a derived term would violate the
+    // ob_links CHECK (from_type <> to_type OR from_id <> to_id). Skip it.
+    if (anchorEntityId === nodeId) continue;
+
+    const linkRow = await pool.query(
+      `INSERT INTO ob_links
+         (from_type, from_id, to_type, to_id, relation, weight, namespace, metadata, created_by)
+       VALUES ('entity', $1, 'entity', $2, $3, 1.0, $4, '{}'::jsonb, $5)
+       ON CONFLICT (namespace, from_type, from_id, to_type, to_id, relation)
+       WHERE archived_at IS NULL
+       DO UPDATE SET
+         archived_at = NULL,
+         updated_at = NOW()
+       RETURNING id, (xmax = 0) AS is_new, namespace`,
+      [anchorEntityId, nodeId, ANCHOR_RELATION, namespace, auth.clientId],
+    );
+    const link = linkRow.rows[0];
+    assertSameNamespace(link.namespace, namespace, "derived link");
+    linksUpserted += 1;
+    if (link.is_new) linksNew += 1;
+  }
+
+  // Content-free: only the stable anchor_type category, the status, and
+  // structural counts. No namespace value, no derivation_hash value, no ids.
+  logger.info("graph_derivation_ok", {
+    anchor_type: anchorType,
+    status,
+    entities_upserted: entitiesUpserted,
+    entities_new: entitiesNew,
+    links_upserted: linksUpserted,
+    links_new: linksNew,
+  });
+
+  return {
+    status,
+    namespace,
+    anchor_type: anchorType,
+    anchor_id: anchorId,
+    derivation_hash: hash,
+    previous_hash: previousHash,
+    entities_upserted: entitiesUpserted,
+    entities_new: entitiesNew,
+    links_upserted: linksUpserted,
+    links_new: linksNew,
+  };
+}
+
+/**
+ * Defense in depth: the SQL already binds namespace as a parameter, but we
+ * re-verify every persisted row's returned namespace matches the derivation
+ * namespace so a schema drift (e.g. a default or trigger rewriting namespace)
+ * can never let a cross-namespace endpoint slip through undetected.
+ */
+function assertSameNamespace(
+  returned: unknown,
+  expected: string,
+  what: string,
+): void {
+  if (returned !== expected) {
+    throw new CrossNamespaceEndpointError(
+      `${what} persisted into namespace '${String(returned)}' but derivation namespace is '${expected}'`,
+    );
+  }
+}

--- a/src/graph-derivation.ts
+++ b/src/graph-derivation.ts
@@ -113,9 +113,8 @@ const PERSON_ENTITY_TYPE = "person";
 const ANCHOR_RELATION: LinkRelation = "mentions";
 const MAX_TERMS = 200;
 // The existing ob_entities.name length bound this primitive honors on every
-// stored name (the handler slices anchorName to the same width upstream). Both
-// the deterministic anchor storage name and any derived term name stay within
-// it; the human anchor label is preserved verbatim in metadata, unsliced.
+// stored name. The deterministic anchor storage name and every derived term stay
+// within it; the complete human anchor label is preserved separately in metadata.
 const MAX_ENTITY_NAME = 500;
 
 /**
@@ -265,6 +264,7 @@ export async function deriveGraphFromMetadata(
   const hash = derivationHash(namespace, anchorType, anchorId, entities);
 
   const anchorCanonical = `${anchorType}:${anchorId}`;
+  const anchorStoredName = anchorStorageName(anchorCanonical, anchorLabel);
 
   // 1) Read the anchor node's prior derivation + content hashes (namespace-
   //    bound). If the derivation is unchanged we skip the node/edge writes, but
@@ -274,7 +274,9 @@ export async function deriveGraphFromMetadata(
   //    maintenance selection sweep — which compares the source content_hash to
   //    the anchor's stamped content_hash — would re-select that source forever.
   const prior = await pool.query(
-    `SELECT metadata ->> 'derivation_hash' AS derivation_hash,
+    `SELECT name,
+            metadata ->> 'display_name'    AS display_name,
+            metadata ->> 'derivation_hash' AS derivation_hash,
             metadata ->> 'content_hash'    AS content_hash
        FROM ob_entities
       WHERE namespace = $1
@@ -287,18 +289,33 @@ export async function deriveGraphFromMetadata(
     prior.rows[0]?.derivation_hash ?? undefined;
   const previousContentHash: string | undefined =
     prior.rows[0]?.content_hash ?? undefined;
+  const previousStoredName: string | undefined =
+    prior.rows[0]?.name ?? undefined;
+  const previousDisplayName: string | undefined =
+    prior.rows[0]?.display_name ?? undefined;
 
   if (previousHash === hash) {
-    // The derived node set is unchanged. Only touch the anchor when the caller
-    // supplied a content_hash that differs from the stamped one (a source-bytes
-    // change with identical extracted terms); otherwise this is a true no-op.
-    if (
+    // The derived node set is unchanged, but source bytes and the human label are
+    // independent anchor state. Refresh either when it drifted so a pure title
+    // rename does not leave stale graph display data behind.
+    const contentHashChanged =
       anchorContentHash !== undefined &&
-      anchorContentHash !== previousContentHash
-    ) {
+      anchorContentHash !== previousContentHash;
+    const nameChanged =
+      anchorStoredName !== previousStoredName ||
+      anchorLabel !== previousDisplayName;
+    if (contentHashChanged || nameChanged) {
+      const metadataPatch: Record<string, string> = {
+        display_name: anchorLabel,
+      };
+      if (anchorContentHash !== undefined) {
+        metadataPatch.content_hash = anchorContentHash;
+      }
       await pool.query(
         `UPDATE ob_entities
-            SET metadata = metadata || $4::jsonb, updated_at = NOW()
+            SET name = $4,
+                metadata = metadata || $5::jsonb,
+                updated_at = NOW()
           WHERE namespace = $1
             AND entity_type = $2
             AND canonical_id = $3
@@ -307,7 +324,8 @@ export async function deriveGraphFromMetadata(
           namespace,
           anchorType,
           anchorCanonical,
-          JSON.stringify({ content_hash: anchorContentHash }),
+          anchorStoredName,
+          JSON.stringify(metadataPatch),
         ],
       );
     }
@@ -381,7 +399,6 @@ export async function deriveGraphFromMetadata(
   // Same-titled anchors therefore hold distinct lower(name) keys, while the
   // canonical upsert still resolves a rename to a safe in-place UPDATE. The full
   // unbounded human label rides in metadata above.
-  const anchorStoredName = anchorStorageName(anchorCanonical, anchorLabel);
   const anchorRow = await pool.query(
     `INSERT INTO ob_entities
        (entity_type, name, canonical_id, namespace, metadata, created_by)

--- a/src/graph-derivation.ts
+++ b/src/graph-derivation.ts
@@ -112,6 +112,36 @@ const TOPIC_ENTITY_TYPE = "topic";
 const PERSON_ENTITY_TYPE = "person";
 const ANCHOR_RELATION: LinkRelation = "mentions";
 const MAX_TERMS = 200;
+// The existing ob_entities.name length bound this primitive honors on every
+// stored name (the handler slices anchorName to the same width upstream). Both
+// the deterministic anchor storage name and any derived term name stay within
+// it; the human anchor label is preserved verbatim in metadata, unsliced.
+const MAX_ENTITY_NAME = 500;
+
+/**
+ * The deterministic, collision-safe storage name for an anchor entity.
+ *
+ * The anchor's IDENTITY is its stable canonical id (anchorType:anchorId), and the
+ * anchor upsert arbitrates on idx_ob_entities_canonical. But ob_entities ALSO
+ * enforces idx_ob_entities_lookup_unique (namespace, entity_type, lower(name)),
+ * which the canonical upsert never mentions. If the stored `name` were the human
+ * label, two DISTINCT anchors (distinct canonical ids) that happen to share a
+ * display title would resolve to no canonical conflict, attempt an INSERT, and
+ * collide on lower(name) — an unarbitrated 23505 that throws the whole
+ * derivation (#346 P2). Appending the stable canonical id to a bounded human
+ * label makes lower(name) unique exactly where canonical_id is unique, so two
+ * same-titled sources coexist without reducing graph displays to opaque ids. The
+ * complete human label is also preserved in metadata.display_name (see anchor
+ * upsert). The readable prefix is shortened as needed to honor MAX_ENTITY_NAME.
+ */
+function anchorStorageName(canonicalId: string, displayName: string): string {
+  const suffix = ` [${canonicalId}]`;
+  const prefixLimit = Math.max(MAX_ENTITY_NAME - suffix.length, 0);
+  return `${displayName.slice(0, prefixLimit)}${suffix}`.slice(
+    0,
+    MAX_ENTITY_NAME,
+  );
+}
 
 interface DerivedEntity {
   entity_type: string;
@@ -319,20 +349,39 @@ export async function deriveGraphFromMetadata(
   //    would find no lower(name) match, attempt an INSERT, and violate the
   //    canonical index that ON CONFLICT never mentioned — throwing the whole
   //    derivation. Arbitrating on the canonical index resolves the anchor by
-  //    its stable identity and updates the display name in place, so a rename
-  //    is a safe UPDATE. (Migration 017 makes the canonical index partial on
-  //    archived_at IS NULL, matching this arbiter exactly.)
-  // Stamp both hashes on the anchor. `derivation_hash` (over the derived node
-  // set) drives the primitive's own unchanged short-circuit; `content_hash`
-  // (the upstream source snapshot digest, when the caller supplies one) is what
-  // the maintenance selection sweep reads back to decide new/unchanged/changed.
-  // The metadata `||` merge below preserves any content_hash a prior run
-  // stamped, so a caller that omits it never clears a previously-recorded one.
+  //    its stable identity, so a rename is a safe in-place UPDATE. (Migration
+  //    017 makes the canonical index partial on archived_at IS NULL, matching
+  //    this arbiter exactly.)
+  //
+  //    The stored `name` is anchorStorageName(canonical, label): a readable,
+  //    bounded human-label prefix plus the stable canonical id. This closes the
+  //    #346 P2 lower(name) collision: two DISTINCT anchors that share a display
+  //    title still get distinct stored names. The complete human label is also
+  //    preserved in metadata.display_name and overwritten in place on a rename.
+  // Stamp both hashes AND the human display label on the anchor. `derivation_hash`
+  // (over the derived node set) drives the primitive's own unchanged short-circuit;
+  // `content_hash` (the upstream source snapshot digest, when the caller supplies
+  // one) is what the maintenance selection sweep reads back to decide
+  // new/unchanged/changed. `display_name` preserves the human anchor label
+  // verbatim now that the STORED name is the deterministic, collision-safe
+  // anchorStorageName (see below): the label is no longer the row's `name`, so it
+  // must live somewhere retrievable. The metadata `||` merge below preserves any
+  // content_hash a prior run stamped, so a caller that omits it never clears a
+  // previously-recorded one; a rename overwrites only display_name in place.
   const anchorMeta = JSON.stringify(
     anchorContentHash === undefined
-      ? { derivation_hash: hash }
-      : { derivation_hash: hash, content_hash: anchorContentHash },
+      ? { derivation_hash: hash, display_name: anchorLabel }
+      : {
+          derivation_hash: hash,
+          content_hash: anchorContentHash,
+          display_name: anchorLabel,
+        },
   );
+  // The stored name includes the stable canonical id after a readable label.
+  // Same-titled anchors therefore hold distinct lower(name) keys, while the
+  // canonical upsert still resolves a rename to a safe in-place UPDATE. The full
+  // unbounded human label rides in metadata above.
+  const anchorStoredName = anchorStorageName(anchorCanonical, anchorLabel);
   const anchorRow = await pool.query(
     `INSERT INTO ob_entities
        (entity_type, name, canonical_id, namespace, metadata, created_by)
@@ -347,7 +396,7 @@ export async function deriveGraphFromMetadata(
      RETURNING id, (xmax = 0) AS is_new, namespace`,
     [
       anchorType,
-      anchorLabel,
+      anchorStoredName,
       anchorCanonical,
       namespace,
       anchorMeta,

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,11 +145,9 @@ export function createApp(
     async (req: Request, res: Response) => {
       const authInfo = (req as Request & { auth?: AuthInfo }).auth;
       if (!canReadDoctor(authInfo)) {
-        res
-          .status(403)
-          .json({
-            error: "Permission denied: admin or ob-admin role required",
-          });
+        res.status(403).json({
+          error: "Permission denied: admin or ob-admin role required",
+        });
         return;
       }
       try {
@@ -350,7 +348,7 @@ if (import.meta.main) {
   if (maintenanceQueueEnabled()) {
     maintenance = startMaintenanceQueue({ pool, logger });
     logger.info("maintenance queue started", {
-      handlers: "embedding.repair",
+      handlers: "embedding.repair,graph.derive",
     });
   } else {
     logger.info("maintenance queue disabled", {

--- a/src/maintenance-bootstrap.test.ts
+++ b/src/maintenance-bootstrap.test.ts
@@ -18,13 +18,20 @@ import { describe, it, expect, mock } from "bun:test";
 import {
   startMaintenanceQueue,
   maintenanceQueueEnabled,
+  composeMaintenanceHandlers,
+  MAINTENANCE_GRAPH_AUTH,
 } from "./maintenance-bootstrap.ts";
 import {
   EMBEDDING_REPAIR_JOB_KIND,
   EMBEDDING_REPAIR_JOB_VERSION,
 } from "./embedding-repair-handler.ts";
+import {
+  GRAPH_DERIVATION_JOB_KIND,
+  GRAPH_DERIVATION_JOB_VERSION,
+} from "./graph-derivation-handler.ts";
 import type { MaintenanceQueueLogger } from "./maintenance-queue.ts";
 import type { EmbedWithMetaFn } from "./embedding-repair.ts";
+import type { AuthInfo } from "./types.ts";
 
 const silentLogger: MaintenanceQueueLogger = {
   info: () => {},
@@ -47,9 +54,12 @@ function jobRow() {
   const now = new Date("2026-07-22T12:00:00.000Z");
   return {
     id: "job-boot-1",
-    job_kind: EMBEDDING_REPAIR_JOB_KIND,
+    job_kind: EMBEDDING_REPAIR_JOB_KIND as string,
     job_version: EMBEDDING_REPAIR_JOB_VERSION,
-    payload: { table: "thoughts", scope: { global: true } },
+    payload: { table: "thoughts", scope: { global: true } } as Record<
+      string,
+      unknown
+    >,
     idempotency_key: "boot-k",
     state: "running",
     run_after: now,
@@ -62,27 +72,55 @@ function jobRow() {
     last_error_category: null,
     terminal_at: null,
     dead_lettered_at: null,
-    namespace: null,
+    namespace: null as string | null,
     provenance: null,
     created_at: now,
     updated_at: now,
   };
 }
 
+/** A leased graph.derive job row. The payload is intentionally schema-INVALID
+ * (missing every required field) so the graph handler dispatches, throws its
+ * GraphDerivationTerminalError, and the runner fails it as `terminal` — proving
+ * the handler was actually reached WITHOUT needing to fake the full derivation
+ * SQL. A dispatch to no handler would fail as `unsupported_job_kind` instead. */
+function graphJobRow() {
+  const base = jobRow();
+  return {
+    ...base,
+    id: "job-graph-1",
+    job_kind: GRAPH_DERIVATION_JOB_KIND,
+    job_version: GRAPH_DERIVATION_JOB_VERSION,
+    // Schema-invalid on purpose (missing every required field).
+    payload: {} as Record<string, unknown>,
+    idempotency_key: "boot-graph-k",
+    namespace: "some-ns" as string | null,
+  };
+}
+
 /**
- * Fake pool emulating exactly the SQL the MaintenanceQueue + handler issue:
+ * Fake pool emulating exactly the SQL the MaintenanceQueue + handlers issue:
  *  - claimDueJobs(): pool.connect() -> BEGIN, the claim CTE (returns `claimRows`
  *    ONCE, then nothing so a second tick claims no work), COMMIT, release().
- *  - the handler's repair SELECT -> empty (no stale rows -> convergent no-op).
+ *  - the embedding handler's repair SELECT -> empty (convergent no-op).
+ *  - the fail UPDATE -> rowCount 1, capturing the category param ($4).
  *  - complete(): UPDATE ... state='succeeded' -> rowCount 1.
  */
-function fakePool(claimRows: ReturnType<typeof jobRow>[]) {
+type FakeJobRow = ReturnType<typeof jobRow>;
+
+function fakePool(claimRows: FakeJobRow[]) {
   let claimed = false;
   const completeCalls: unknown[][] = [];
+  const failCategories: Array<string | null> = [];
 
   const runQuery = async (sql: string, params: unknown[] = []) => {
     if (/state\s*=\s*'succeeded'/i.test(sql)) {
       completeCalls.push(params);
+      return { rows: [], rowCount: 1 };
+    }
+    // The fail UPDATE forks on CASE and records last_error_category = $4.
+    if (/UPDATE\s+maintenance_jobs[\s\S]*state\s*=\s*CASE/i.test(sql)) {
+      failCategories.push((params?.[3] as string) ?? null);
       return { rows: [], rowCount: 1 };
     }
     // The claim CTE ends in an UPDATE ... SET state='running' ... RETURNING.
@@ -91,7 +129,8 @@ function fakePool(claimRows: ReturnType<typeof jobRow>[]) {
       claimed = true;
       return { rows: claimRows, rowCount: claimRows.length };
     }
-    // The handler's stale-selection SELECT: no stale rows -> a true no-op repair.
+    // Any handler SELECT: no rows (embedding: no stale; graph: never reaches it
+    // because the invalid-payload guard throws terminal first).
     if (/^\s*SELECT/i.test(sql)) return { rows: [], rowCount: 0 };
     // BEGIN / COMMIT / ROLLBACK and any other statement.
     return { rows: [], rowCount: 0 };
@@ -103,7 +142,7 @@ function fakePool(claimRows: ReturnType<typeof jobRow>[]) {
     connect: mock(async () => client),
     end: mock(async () => {}),
   };
-  return { pool: pool as any, client, completeCalls };
+  return { pool: pool as any, client, completeCalls, failCategories };
 }
 
 describe("startMaintenanceQueue wiring", () => {
@@ -156,11 +195,11 @@ describe("startMaintenanceQueue wiring", () => {
     expect(completeCalls[0]?.[0]).toBe("job-boot-1");
   });
 
-  it("throws for an unknown kind — proves ONLY embedding.repair is registered", async () => {
+  it("throws for an unknown kind — proves only registered kinds are handled", async () => {
     // A job of an unregistered kind must be failed as unsupported_job_kind, not
     // silently handled. We assert the runner claimed+failed it (no complete).
     const wrong = { ...jobRow(), job_kind: "not.a.real.kind" };
-    const { pool, completeCalls } = fakePool([wrong]);
+    const { pool, completeCalls, failCategories } = fakePool([wrong]);
     const rt = startMaintenanceQueue({
       pool,
       logger: silentLogger,
@@ -171,6 +210,79 @@ describe("startMaintenanceQueue wiring", () => {
     await rt.stop();
     // Unsupported kind -> failed, never completed.
     expect(completeCalls.length).toBe(0);
+    expect(failCategories).toEqual(["unsupported_job_kind"]);
+  });
+
+  it("dispatches BOTH embedding.repair (complete) and graph.derive (its own handler)", async () => {
+    // Seed one of each kind. The embedding job SELECTs no stale rows and
+    // completes. The graph job carries a schema-invalid payload, so the
+    // graph-derivation handler runs and throws its terminal error — the runner
+    // fails it as `terminal`. Both outcomes are handler-specific: an unregistered
+    // graph.derive would instead fail as `unsupported_job_kind`.
+    const { pool, completeCalls, failCategories } = fakePool([
+      jobRow(),
+      graphJobRow(),
+    ]);
+    const rt = startMaintenanceQueue({
+      pool,
+      logger: silentLogger,
+      embedFn: stubEmbed,
+      autoStart: false,
+    });
+    await rt.runner.runOnce();
+    await rt.stop();
+
+    // embedding.repair reached completion.
+    expect(completeCalls.map((c) => c[0])).toContain("job-boot-1");
+    // graph.derive was dispatched to ITS handler (terminal), not unsupported.
+    expect(failCategories).toContain("terminal");
+    expect(failCategories).not.toContain("unsupported_job_kind");
+  });
+});
+
+describe("composeMaintenanceHandlers", () => {
+  const fakeDbPool = { query: async () => ({ rows: [], rowCount: 0 }) } as any;
+
+  it("registers both embedding.repair and graph.derive under their kinds", () => {
+    const handlers = composeMaintenanceHandlers({
+      pool: fakeDbPool,
+      logger: silentLogger,
+      embedFn: stubEmbed,
+      graphAuth: MAINTENANCE_GRAPH_AUTH,
+    });
+    expect(handlers.has(EMBEDDING_REPAIR_JOB_KIND)).toBe(true);
+    expect(handlers.has(GRAPH_DERIVATION_JOB_KIND)).toBe(true);
+    expect(handlers.size).toBe(2);
+  });
+
+  it("refuses to register without a clear auth identity (fail closed)", () => {
+    const noRole = { clientId: "x" } as unknown as AuthInfo;
+    const noClient = { role: "ob-admin" } as unknown as AuthInfo;
+    expect(() =>
+      composeMaintenanceHandlers({
+        pool: fakeDbPool,
+        logger: silentLogger,
+        embedFn: stubEmbed,
+        graphAuth: noRole,
+      }),
+    ).toThrow(/auth identity/);
+    expect(() =>
+      composeMaintenanceHandlers({
+        pool: fakeDbPool,
+        logger: silentLogger,
+        embedFn: stubEmbed,
+        graphAuth: noClient,
+      }),
+    ).toThrow(/auth identity/);
+  });
+
+  it("the default maintenance identity is a token-sourced global admin", () => {
+    // Token-sourced (not header-pinned) so it can serve jobs across namespaces;
+    // ob-admin so it can write the derived namespace. The per-job namespace and
+    // source-snapshot guards inside the handler remain the actual authority.
+    expect(MAINTENANCE_GRAPH_AUTH.namespaceSource).toBe("token");
+    expect(MAINTENANCE_GRAPH_AUTH.role).toBe("ob-admin");
+    expect(MAINTENANCE_GRAPH_AUTH.clientId.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/maintenance-bootstrap.test.ts
+++ b/src/maintenance-bootstrap.test.ts
@@ -322,7 +322,8 @@ describe("MAINTENANCE_GRAPH_AUTH shared-kb authorization (#358 finding 1)", () =
       sqls.push(sql);
       return { rows: [], rowCount: 0 };
     };
-    return { pool: { query } as any, sqls };
+    const connect = async () => ({ query, release: () => undefined });
+    return { pool: { query, connect } as any, sqls };
   }
 
   /** The production-composed graph.derive handler under the real default id. */

--- a/src/maintenance-bootstrap.test.ts
+++ b/src/maintenance-bootstrap.test.ts
@@ -28,10 +28,15 @@ import {
 import {
   GRAPH_DERIVATION_JOB_KIND,
   GRAPH_DERIVATION_JOB_VERSION,
+  GraphDerivationTerminalError,
 } from "./graph-derivation-handler.ts";
-import type { MaintenanceQueueLogger } from "./maintenance-queue.ts";
+import type {
+  MaintenanceJob,
+  MaintenanceQueueLogger,
+} from "./maintenance-queue.ts";
 import type { EmbedWithMetaFn } from "./embedding-repair.ts";
 import type { AuthInfo } from "./types.ts";
+import { sharedNamespaceConfig } from "./shared-namespace.ts";
 
 const silentLogger: MaintenanceQueueLogger = {
   info: () => {},
@@ -283,6 +288,140 @@ describe("composeMaintenanceHandlers", () => {
     expect(MAINTENANCE_GRAPH_AUTH.namespaceSource).toBe("token");
     expect(MAINTENANCE_GRAPH_AUTH.role).toBe("ob-admin");
     expect(MAINTENANCE_GRAPH_AUTH.clientId.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Regression for #358 finding 1 (P1): the PRODUCTION-composed graph.derive
+ * handler must authorize and dispatch a shared-kb job, because
+ * MAINTENANCE_GRAPH_AUTH now satisfies the existing shared-kb promoter
+ * convention (tokenClientId ∈ PROMOTER_CLIENT_IDS). Before the fix, ob-admin
+ * without a promoter tokenClientId failed canWriteNamespace for the shared
+ * namespace, so every shared-kb graph.derive job terminal-dead-lettered.
+ *
+ * The handler under test is pulled from composeMaintenanceHandlers with the real
+ * default identity — no synthetic auth — so this exercises exactly what the
+ * server wires. Proof of "authorization passed, dispatch reached": the handler
+ * gets PAST canWriteNamespace and issues the snapshot-guard SELECT; with an
+ * empty source table that guard then throws the SNAPSHOT terminal reason, which
+ * is a distinct signal from the pre-read authorization rejection. Foreign
+ * namespace authority remains guarded: the same production identity is still
+ * rejected pre-read for a frozen namespace, and the promoter grant never
+ * bypasses the per-job namespace/source guards.
+ */
+describe("MAINTENANCE_GRAPH_AUTH shared-kb authorization (#358 finding 1)", () => {
+  const SHARED_NS = sharedNamespaceConfig().physicalSharedNamespace;
+  const VALID_SOURCE_ID = "44444444-4444-4444-8444-444444444444";
+
+  /** A fake pool that records every SQL statement and returns no rows for the
+   * snapshot-guard SELECT (empty source table) so the handler terminates there
+   * — AFTER passing authorization. */
+  function recordingPool() {
+    const sqls: string[] = [];
+    const query = async (sql: string) => {
+      sqls.push(sql);
+      return { rows: [], rowCount: 0 };
+    };
+    return { pool: { query } as any, sqls };
+  }
+
+  /** The production-composed graph.derive handler under the real default id. */
+  function productionGraphHandler(pool: any) {
+    const handlers = composeMaintenanceHandlers({
+      pool,
+      logger: silentLogger,
+      embedFn: stubEmbed,
+      graphAuth: MAINTENANCE_GRAPH_AUTH,
+    });
+    const handler = handlers.get(GRAPH_DERIVATION_JOB_KIND);
+    if (!handler) throw new Error("graph.derive handler not registered");
+    return handler;
+  }
+
+  function graphJob(namespace: string | null): MaintenanceJob {
+    const now = new Date("2026-07-22T12:00:00.000Z");
+    return {
+      id: "job-shared-1",
+      kind: GRAPH_DERIVATION_JOB_KIND,
+      version: GRAPH_DERIVATION_JOB_VERSION,
+      payload: {
+        source_id: VALID_SOURCE_ID,
+        source_kind: "git",
+        external_id: "https://example.invalid/repo.git",
+        content_hash: "a".repeat(64),
+        revision: 3,
+      },
+      idempotencyKey: "k-shared",
+      state: "running",
+      runAfter: now,
+      leaseToken: "00000000-0000-4000-8000-000000000001",
+      leaseUntil: new Date("2026-07-22T12:00:30.000Z"),
+      attempts: 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_000,
+      backoffMaxMs: 4_000,
+      lastErrorCategory: null,
+      terminalAt: null,
+      deadLetteredAt: null,
+      namespace,
+      provenance: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  it("a shared-kb job PASSES authorization and reaches snapshot dispatch", async () => {
+    const { pool, sqls } = recordingPool();
+    const handler = productionGraphHandler(pool);
+
+    // The empty source table makes the snapshot guard the terminal cause. The
+    // point is WHICH terminal cause: it must be the post-auth snapshot guard,
+    // proving canWriteNamespace(MAINTENANCE_GRAPH_AUTH, shared-kb) allowed.
+    let thrown: unknown;
+    try {
+      await handler(graphJob(SHARED_NS));
+      throw new Error("expected the snapshot guard to terminate this job");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(GraphDerivationTerminalError);
+    // Authorization passed: the reason is the snapshot guard, NOT "not writable".
+    expect(String((thrown as Error).message)).toContain("snapshot changed");
+    expect(String((thrown as Error).message)).not.toContain("not writable");
+    // Dispatch reached the DB: the snapshot-guard SELECT was actually issued.
+    expect(sqls.some((s) => s.includes("SELECT title"))).toBe(true);
+  });
+
+  it("the canonical shared alias also passes authorization to snapshot dispatch", async () => {
+    const canonical = sharedNamespaceConfig().canonicalSharedNamespace;
+    const { pool, sqls } = recordingPool();
+    const handler = productionGraphHandler(pool);
+    await expect(handler(graphJob(canonical))).rejects.toThrow(
+      "snapshot changed",
+    );
+    expect(sqls.some((s) => s.includes("SELECT title"))).toBe(true);
+  });
+
+  it("foreign namespace authority stays guarded: a frozen namespace is rejected pre-read", async () => {
+    // Even the promoter-conventioned maintenance identity cannot write a frozen
+    // snapshot namespace; it is rejected before any source read. Proof the grant
+    // is scoped to shared-kb and does not blanket-open canWriteNamespace.
+    const { pool, sqls } = recordingPool();
+    const handler = productionGraphHandler(pool);
+    await expect(handler(graphJob("collab"))).rejects.toBeInstanceOf(
+      GraphDerivationTerminalError,
+    );
+    // Rejected before the snapshot read: no SELECT issued.
+    expect(sqls.some((s) => s.includes("SELECT title"))).toBe(false);
+  });
+
+  it("still fails closed on a missing job namespace (no bypass introduced)", async () => {
+    const { pool, sqls } = recordingPool();
+    const handler = productionGraphHandler(pool);
+    await expect(handler(graphJob(null))).rejects.toBeInstanceOf(
+      GraphDerivationTerminalError,
+    );
+    expect(sqls.some((s) => s.includes("SELECT title"))).toBe(false);
   });
 });
 

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -58,12 +58,23 @@ import {
  *
  * `namespaceSource: "token"` is required: a "header"-sourced identity would pin
  * every write to a single clientId namespace and could not serve jobs across
- * namespaces. The clientId is a fixed, non-secret label used only for logging
- * and the promoter-convention check (which this identity intentionally is not).
+ * namespaces.
+ *
+ * `tokenClientId: "openbrain-promoter"` satisfies the EXISTING shared-kb write
+ * convention (namespace-policy.ts: canWriteNamespace gates shared-kb writes on
+ * isPromoterIdentity, which recognizes an admin/ob-admin token whose
+ * `tokenClientId ?? clientId` is in PROMOTER_CLIENT_IDS). Without it, a claimed
+ * shared-kb graph.derive job fails canWriteNamespace and terminal-dead-letters,
+ * even though ob-admin holds global maintenance capability everywhere else. The
+ * `clientId` stays the fixed maintenance label used for logging/provenance; only
+ * the promoter-convention check reads `tokenClientId`, so this narrowly grants
+ * the shared-kb write capability without weakening canWriteNamespace or adding a
+ * bypass — the per-job namespace and source-snapshot guards remain the authority.
  */
 export const MAINTENANCE_GRAPH_AUTH: AuthInfo = {
   role: "ob-admin",
   clientId: "open-brain-maintenance",
+  tokenClientId: "openbrain-promoter",
   namespaceSource: "token",
 };
 

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -6,11 +6,19 @@
  * an enqueued `embedding.repair` job could never actually run in production.
  *
  * `startMaintenanceQueue` constructs the durable `MaintenanceQueue` over the real
- * pool, registers the embedding-repair handler with the real embed provider and a
- * content-free logger, and starts the runner's bounded automatic polling. The
- * returned handle exposes `stop()`, which the server's shutdown path awaits before
- * `pool.end()` so in-flight jobs drain (their leases are honored) instead of being
- * stranded mid-run.
+ * pool, composes the server-owned handler map (embedding-repair #345 +
+ * graph-derivation #346, the latter under an explicit global maintenance
+ * identity) with the real embed provider and a content-free logger, and starts
+ * the runner's bounded automatic polling. The returned handle exposes `stop()`,
+ * which the server's shutdown path awaits before `pool.end()` so in-flight jobs
+ * drain (their leases are honored) instead of being stranded mid-run.
+ *
+ * The bootstrap enqueues nothing and defines no recurring sweep: the maintenance
+ * queue has no recurrence primitive. graph.derive jobs are produced only by the
+ * explicit, bounded `enqueueGraphDerivationJobs` producer, which an operator or
+ * a future scheduler (#347) must call. This bootstrap only DISPATCHES claimed
+ * graph.derive jobs; it never invents or schedules them, and there is no
+ * automatic continuous derivation.
  *
  * #343 invariants preserved verbatim — this only wires them, it changes none:
  *  - Bounded concurrency: the runner clamps to [1, MAX_CONCURRENCY].
@@ -25,12 +33,39 @@
 import type pg from "pg";
 import { generateEmbeddingWithMetadata } from "./embedding.ts";
 import type { EmbedWithMetaFn } from "./embedding-repair.ts";
+import type { AuthInfo } from "./types.ts";
 import {
   MaintenanceQueue,
   MaintenanceQueueRunner,
+  type MaintenanceJobHandler,
   type MaintenanceQueueLogger,
 } from "./maintenance-queue.ts";
 import { buildEmbeddingRepairHandlers } from "./embedding-repair-handler.ts";
+import {
+  GRAPH_DERIVATION_JOB_KIND,
+  makeGraphDerivationHandler,
+} from "./graph-derivation-handler.ts";
+
+/**
+ * The deliberate, server-owned identity the graph-derivation handler derives
+ * under. It is a global maintenance identity (ob-admin, token-sourced) so the
+ * handler can write into whatever namespace a claimed job carries — but it is
+ * NOT the namespace authority: the persisted job payload's namespace remains the
+ * exact authority, and the handler re-checks canWriteNamespace against it AND
+ * re-validates it against the live source row before deriving. This identity
+ * only grants the cross-namespace write capability a maintenance sweep needs; it
+ * grants no bypass of the per-job namespace/source guards.
+ *
+ * `namespaceSource: "token"` is required: a "header"-sourced identity would pin
+ * every write to a single clientId namespace and could not serve jobs across
+ * namespaces. The clientId is a fixed, non-secret label used only for logging
+ * and the promoter-convention check (which this identity intentionally is not).
+ */
+export const MAINTENANCE_GRAPH_AUTH: AuthInfo = {
+  role: "ob-admin",
+  clientId: "open-brain-maintenance",
+  namespaceSource: "token",
+};
 
 /**
  * Runtime handle for the started maintenance queue. `stop()` halts polling and
@@ -56,6 +91,55 @@ export interface StartMaintenanceQueueOptions {
   leaseMs?: number;
   /** Start automatic polling immediately (default true). Set false to wire without polling. */
   autoStart?: boolean;
+  /**
+   * The server-owned identity the graph-derivation handler derives under.
+   * Defaults to {@link MAINTENANCE_GRAPH_AUTH}. Injectable for tests; must carry
+   * a concrete role/clientId — a handler cannot be registered without a clear
+   * auth identity (see composeMaintenanceHandlers).
+   */
+  graphAuth?: AuthInfo;
+}
+
+/**
+ * Compose the server-owned maintenance handler map without a second bootstrap or
+ * framework: start from the #345 embedding-repair map and register the #346
+ * graph-derivation handler under its kind. Both handlers share the runner's
+ * content-free logger and the same pool.
+ *
+ * The graph handler CANNOT be registered without a clear auth identity: a
+ * missing role or clientId throws before any handler is built, so a mis-wired
+ * bootstrap fails closed at startup instead of dispatching graph jobs under an
+ * ambiguous identity. The identity grants only the cross-namespace write
+ * capability the sweep needs; the per-job namespace and source-snapshot guards
+ * inside the handler remain the authority.
+ */
+export function composeMaintenanceHandlers(input: {
+  pool: pg.Pool;
+  logger: MaintenanceQueueLogger;
+  embedFn: EmbedWithMetaFn;
+  graphAuth: AuthInfo;
+}): ReadonlyMap<string, MaintenanceJobHandler> {
+  if (!input.graphAuth.role || !input.graphAuth.clientId) {
+    throw new Error(
+      "maintenance bootstrap requires a graph-derivation auth identity with a role and clientId",
+    );
+  }
+
+  const handlers = new Map<string, MaintenanceJobHandler>(
+    buildEmbeddingRepairHandlers({
+      db: input.pool,
+      logger: input.logger,
+      embedFn: input.embedFn,
+    }),
+  );
+  handlers.set(
+    GRAPH_DERIVATION_JOB_KIND,
+    makeGraphDerivationHandler({
+      pool: input.pool,
+      auth: input.graphAuth,
+    }),
+  );
+  return handlers;
 }
 
 /**
@@ -96,12 +180,16 @@ export function startMaintenanceQueue(
   options: StartMaintenanceQueueOptions,
 ): MaintenanceRuntime {
   const queue = new MaintenanceQueue(options.pool);
-  const handlers = buildEmbeddingRepairHandlers({
-    db: options.pool,
+  // Compose the server-owned handler map: embedding.repair (#345) +
+  // graph.derive (#346), the latter under an explicit global maintenance
+  // identity. currentModel / embeddingUrl are intentionally omitted from the
+  // embedding handler: it defaults to the configured EMBEDDING_MODEL and
+  // endpoint, matching the live write path.
+  const handlers = composeMaintenanceHandlers({
+    pool: options.pool,
     logger: options.logger,
     embedFn: options.embedFn ?? generateEmbeddingWithMetadata,
-    // currentModel / embeddingUrl intentionally omitted: the handler defaults to
-    // the configured EMBEDDING_MODEL and endpoint, matching the live write path.
+    graphAuth: options.graphAuth ?? MAINTENANCE_GRAPH_AUTH,
   });
 
   const runner = new MaintenanceQueueRunner({

--- a/src/maintenance-queue.pg.test.ts
+++ b/src/maintenance-queue.pg.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Live-Postgres regression for the queue-owned terminal (non-retryable)
+ * dead-letter path (#346), exercised against the real maintenance_jobs schema,
+ * the real CHECK constraint on last_error_category, and the real CASE forks in
+ * MaintenanceQueue.fail.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo convention); skips when unset so a
+ * DB-less CI job passes while the db-integration job runs it against Postgres.
+ *
+ * The two facts proven end to end:
+ *  1. A terminal handler failure dead-letters on attempt 1 — before the retry
+ *     bound — recording the content-free `terminal` category, with no backoff
+ *     reschedule.
+ *  2. An ordinary (non-terminal) failure on the same fresh job keeps its bounded
+ *     retry: it goes back to `queued`, schedules a future run_after, and does NOT
+ *     dead-letter until attempts reach max_attempts.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import type { Pool } from "pg";
+import { runMigrations } from "./db/migrate.ts";
+import {
+  MaintenanceQueue,
+  MaintenanceTerminalError,
+  type MaintenanceJob,
+} from "./maintenance-queue.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+// Every job this suite enqueues shares this idempotency-key prefix so cleanup
+// deletes exactly the queue rows this suite owns and nothing else.
+const JOB_KEY_PREFIX = "lane346-queue-";
+
+dbDescribe("maintenance queue terminal dead-letter (live Postgres)", () => {
+  let pool: Pool;
+  let queue: MaintenanceQueue;
+
+  beforeAll(async () => {
+    const { Pool } = await import("pg");
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    queue = new MaintenanceQueue(pool);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    await pool.query(
+      "DELETE FROM maintenance_jobs WHERE idempotency_key LIKE $1",
+      [`${JOB_KEY_PREFIX}%`],
+    );
+  }
+
+  beforeEach(cleanup);
+
+  /** Enqueue one bounded test job and claim it so it is running at attempts=1. */
+  async function enqueueAndClaim(key: string): Promise<MaintenanceJob> {
+    await queue.enqueue({
+      kind: "maintenance.test",
+      version: 1,
+      payload: { unit: key },
+      idempotencyKey: `${JOB_KEY_PREFIX}${key}`,
+      retry: { maxAttempts: 3, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+    });
+    const claimed = await queue.claimDueJobs({ limit: 10, leaseMs: 30_000 });
+    const job = claimed.find(
+      (j) => j.idempotencyKey === `${JOB_KEY_PREFIX}${key}`,
+    );
+    if (!job) throw new Error("test job was not claimed");
+    return job;
+  }
+
+  async function readRow(id: string) {
+    const { rows } = await pool.query(
+      `SELECT state, attempts, last_error_category, terminal_at,
+              dead_lettered_at, run_after
+         FROM maintenance_jobs WHERE id = $1`,
+      [id],
+    );
+    return rows[0];
+  }
+
+  it("dead-letters a terminal failure on attempt 1, before the retry bound", async () => {
+    const job = await enqueueAndClaim("terminal-1");
+    expect(job.attempts).toBe(1);
+    expect(job.maxAttempts).toBe(3);
+
+    const failed = await queue.fail({
+      job,
+      error: new MaintenanceTerminalError("private terminal reason"),
+      terminal: true,
+    });
+
+    // Returned + persisted: immediate dead-letter despite attempts (1) < max (3).
+    expect(failed?.state).toBe("dead_letter");
+    const row = await readRow(job.id);
+    expect(row.state).toBe("dead_letter");
+    expect(row.attempts).toBe(1);
+    expect(row.last_error_category).toBe("terminal");
+    expect(row.terminal_at).not.toBeNull();
+    expect(row.dead_lettered_at).not.toBeNull();
+  });
+
+  it("keeps bounded retry for an ordinary failure on the same fresh job", async () => {
+    const job = await enqueueAndClaim("retry-1");
+    expect(job.attempts).toBe(1);
+
+    const before = Date.now();
+    const failed = await queue.fail({
+      job,
+      error: new Error("transient blip"),
+    });
+
+    // Non-terminal: back to queued with a scheduled backoff, not dead-lettered.
+    expect(failed?.state).toBe("queued");
+    const row = await readRow(job.id);
+    expect(row.state).toBe("queued");
+    expect(row.attempts).toBe(1);
+    expect(row.last_error_category).toBe("error");
+    expect(row.terminal_at).toBeNull();
+    expect(row.dead_lettered_at).toBeNull();
+    // Backoff scheduled a future run_after (base 1s from now).
+    expect(new Date(row.run_after).getTime()).toBeGreaterThan(before);
+  });
+
+  it("subclassed terminal marker also dead-letters immediately (queue owns the type)", async () => {
+    class HandlerTerminal extends MaintenanceTerminalError {}
+    const job = await enqueueAndClaim("terminal-subclass");
+
+    // The runner derives terminal/category from the thrown type; here we assert
+    // the same category the runner would pass for a subclass reaches the row.
+    const failed = await queue.fail({
+      job,
+      error: new HandlerTerminal("subclass reason"),
+      terminal: true,
+      category: "terminal",
+    });
+    expect(failed?.state).toBe("dead_letter");
+    const row = await readRow(job.id);
+    expect(row.last_error_category).toBe("terminal");
+  });
+});

--- a/src/maintenance-queue.pg.test.ts
+++ b/src/maintenance-queue.pg.test.ts
@@ -27,6 +27,7 @@ import type { Pool } from "pg";
 import { runMigrations } from "./db/migrate.ts";
 import {
   MaintenanceQueue,
+  MaintenanceQueueRunner,
   MaintenanceTerminalError,
   type MaintenanceJob,
 } from "./maintenance-queue.ts";
@@ -149,5 +150,89 @@ dbDescribe("maintenance queue terminal dead-letter (live Postgres)", () => {
     expect(failed?.state).toBe("dead_letter");
     const row = await readRow(job.id);
     expect(row.last_error_category).toBe("terminal");
+  });
+
+  it("renews a live handler lease across competing claim windows", async () => {
+    await queue.enqueue({
+      kind: "maintenance.heartbeat-test",
+      version: 1,
+      payload: { unit: "lease-renew" },
+      idempotencyKey: `${JOB_KEY_PREFIX}lease-renew`,
+      retry: { maxAttempts: 3, backoffBaseMs: 10, backoffMaxMs: 40 },
+    });
+
+    let handlerStartedResolve!: () => void;
+    const handlerStarted = new Promise<void>((resolve) => {
+      handlerStartedResolve = resolve;
+    });
+    let releaseHandler!: () => void;
+    const handlerBlocked = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const logger = { info: () => {}, warn: () => {}, error: () => {} };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.heartbeat-test",
+          async () => {
+            handlerStartedResolve();
+            await handlerBlocked;
+          },
+        ],
+      ]),
+      logger,
+      concurrency: 1,
+      leaseMs: 100,
+      leaseRenewMs: 20,
+    });
+
+    await runner.runOnce();
+    await handlerStarted;
+
+    const { rows: initialRows } = await pool.query(
+      `SELECT id, lease_until, attempts
+         FROM maintenance_jobs
+        WHERE idempotency_key = $1`,
+      [`${JOB_KEY_PREFIX}lease-renew`],
+    );
+    const jobId: string = initialRows[0].id;
+    const initialLeaseUntil = new Date(initialRows[0].lease_until).getTime();
+    expect(initialRows[0].attempts).toBe(1);
+
+    // Cross several original lease windows. A second queue instance repeatedly
+    // attempts to reclaim due work; the live runner's heartbeat must keep this
+    // exact job unavailable without incrementing its attempt count.
+    const competitor = new MaintenanceQueue(pool);
+    for (let i = 0; i < 3; i += 1) {
+      await Bun.sleep(120);
+      const claimed = await competitor.claimDueJobs({
+        limit: 10,
+        leaseMs: 100,
+      });
+      expect(claimed.some((candidate) => candidate.id === jobId)).toBe(false);
+    }
+
+    const { rows: heldRows } = await pool.query(
+      `SELECT state, lease_until, attempts, dead_lettered_at
+         FROM maintenance_jobs
+        WHERE id = $1`,
+      [jobId],
+    );
+    expect(heldRows[0].state).toBe("running");
+    expect(heldRows[0].attempts).toBe(1);
+    expect(heldRows[0].dead_lettered_at).toBeNull();
+    expect(new Date(heldRows[0].lease_until).getTime()).toBeGreaterThan(
+      initialLeaseUntil,
+    );
+
+    releaseHandler();
+    await runner.stop();
+
+    const completed = await readRow(jobId);
+    expect(completed.state).toBe("succeeded");
+    expect(completed.attempts).toBe(1);
+    expect(completed.last_error_category).toBeNull();
+    expect(completed.dead_lettered_at).toBeNull();
   });
 });

--- a/src/maintenance-queue.test.ts
+++ b/src/maintenance-queue.test.ts
@@ -186,6 +186,219 @@ describe("maintenance queue runner", () => {
     expect(handlerRan).toBe(false);
   });
 
+  it("renews a held lease on cadence while the handler runs, then stops after completion", async () => {
+    // Regression for the #346 lease-renewal finding. A handler that blocks past
+    // several lease windows must have its lease renewed under the immutable
+    // (id, lease token) so a competing claim can never reclaim/dead-letter it.
+    const renewCalls: Array<{ id: string; token: string; leaseMs: number }> =
+      [];
+    let releaseHandler: (() => void) | undefined;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      renew: async (id, token, leaseMs) => {
+        renewCalls.push({ id, token, leaseMs });
+        return true; // still owned.
+      },
+      complete: async () => true,
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () =>
+            new Promise<void>((resolve) => {
+              releaseHandler = resolve;
+            }),
+        ],
+      ]),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      // Tiny windows so several renewals land during the test deterministically.
+      leaseMs: 30,
+      leaseRenewMs: 10,
+    });
+
+    await runner.runOnce();
+    // Let the handler block across multiple heartbeat intervals.
+    await new Promise((r) => setTimeout(r, 55));
+    expect(renewCalls.length).toBeGreaterThanOrEqual(3);
+    // Every renewal used the IMMUTABLE claim id + minted lease token, and the
+    // durable lease window (leaseMs), never a handler-mutable value.
+    for (const call of renewCalls) {
+      expect(call.id).toBe("job-1");
+      expect(call.token).toBe("00000000-0000-4000-8000-000000000001");
+      expect(call.leaseMs).toBe(30);
+    }
+
+    // Complete the handler; the heartbeat must stop — no further renewals.
+    const before = renewCalls.length;
+    releaseHandler?.();
+    await runner.stop();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(renewCalls.length).toBe(before);
+  });
+
+  it("stops renewing the moment a stale token loses the lease (content-free)", async () => {
+    // renew() returning false means the lease was reclaimed/rotated: the
+    // heartbeat must stop immediately rather than spin, and log content-free.
+    const logs: string[] = [];
+    let renewCalls = 0;
+    let releaseHandler: (() => void) | undefined;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      renew: async () => {
+        renewCalls += 1;
+        return false; // lease lost on the very first renewal.
+      },
+      complete: async () => true,
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () =>
+            new Promise<void>((resolve) => {
+              releaseHandler = resolve;
+            }),
+        ],
+      ]),
+      logger: {
+        info: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        warn: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        error: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+      },
+      leaseMs: 30,
+      leaseRenewMs: 10,
+    });
+
+    await runner.runOnce();
+    await new Promise((r) => setTimeout(r, 55));
+    // A lost lease stops the heartbeat after the first renewal; it does not spin.
+    expect(renewCalls).toBe(1);
+    releaseHandler?.();
+    await runner.stop();
+    // Content-free: the lost-lease warning carries only ids/kind + a stable
+    // status token; never the payload text.
+    expect(logs.join("\n")).toContain('"status":"lease_lost"');
+    expect(logs.join("\n")).not.toContain("must never reach logs");
+  });
+
+  it("never overlaps renewal calls even when renew is slower than the cadence", async () => {
+    // The overlap guard: a renew that outlasts the heartbeat interval must not
+    // stack a second concurrent renew. Peak in-flight renewals stays 1.
+    let inFlight = 0;
+    let peak = 0;
+    let releaseHandler: (() => void) | undefined;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      renew: async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        // Renew takes ~25ms — longer than the 10ms cadence, so ticks pile up
+        // behind it and would overlap without the guard.
+        await new Promise((r) => setTimeout(r, 25));
+        inFlight -= 1;
+        return true;
+      },
+      complete: async () => true,
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () =>
+            new Promise<void>((resolve) => {
+              releaseHandler = resolve;
+            }),
+        ],
+      ]),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      leaseMs: 60,
+      leaseRenewMs: 10,
+    });
+
+    await runner.runOnce();
+    await new Promise((r) => setTimeout(r, 90));
+    expect(peak).toBe(1);
+    releaseHandler?.();
+    await runner.stop();
+  });
+
+  it("awaits an in-flight renewal before completing (no renew races complete)", async () => {
+    // stop() on the heartbeat must await any renewal already in flight so it
+    // cannot land concurrently with (or after) the complete UPDATE. We record
+    // the ORDER of the last renew finishing vs complete starting.
+    const order: string[] = [];
+    let completeSeen = false;
+    let renewFinishedBeforeComplete = true;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      renew: async () => {
+        await new Promise((r) => setTimeout(r, 20));
+        order.push("renew_done");
+        if (completeSeen) renewFinishedBeforeComplete = false;
+        return true;
+      },
+      complete: async () => {
+        completeSeen = true;
+        order.push("complete");
+        return true;
+      },
+      fail: async () => null,
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          // Handler finishes right as a renew is mid-flight.
+          async () => {
+            await new Promise((r) => setTimeout(r, 12));
+          },
+        ],
+      ]),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      leaseMs: 30,
+      leaseRenewMs: 10,
+    });
+
+    await runner.runOnce();
+    await runner.stop();
+    // complete never fired before an in-flight renew resolved.
+    expect(renewFinishedBeforeComplete).toBe(true);
+  });
+
+  it("does not renew a job whose handler is unsupported (no heartbeat, immediate fail)", async () => {
+    let renewCalls = 0;
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      renew: async () => {
+        renewCalls += 1;
+        return true;
+      },
+      complete: async () => true,
+      fail: async () => job({ state: "dead_letter" }),
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([["some.other.kind", async () => undefined]]),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      leaseMs: 30,
+      leaseRenewMs: 10,
+    });
+    await runner.runOnce();
+    await new Promise((r) => setTimeout(r, 40));
+    expect(renewCalls).toBe(0);
+  });
+
   it("stores unsupported_job_kind as its own category, not non_error", async () => {
     const failCalls: Array<{ error: unknown; category?: string }> = [];
     const logs: string[] = [];

--- a/src/maintenance-queue.test.ts
+++ b/src/maintenance-queue.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   MaintenanceQueue,
   MaintenanceQueueRunner,
+  MaintenanceTerminalError,
+  isMaintenanceTerminalError,
   maintenanceBackoffMs,
   safeMaintenanceErrorCategory,
   type MaintenanceJob,
@@ -255,6 +257,85 @@ describe("maintenance queue runner", () => {
     expect(logs.join("\n")).toContain('"error_category":"type_error"');
   });
 
+  it("routes a MaintenanceTerminalError to fail() as terminal, category 'terminal'", async () => {
+    const failCalls: Array<{ category?: string; terminal?: boolean }> = [];
+    const logs: string[] = [];
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      complete: async () => true,
+      fail: async (input) => {
+        failCalls.push({ category: input.category, terminal: input.terminal });
+        // The queue dead-letters immediately for a terminal failure.
+        return job({ state: "dead_letter", lastErrorCategory: "terminal" });
+      },
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            throw new MaintenanceTerminalError("private terminal reason text");
+          },
+        ],
+      ]),
+      logger: {
+        info: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        warn: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+        error: (message, fields) =>
+          logs.push(JSON.stringify({ message, fields })),
+      },
+    });
+
+    await runner.runOnce();
+    expect(failCalls).toHaveLength(1);
+    expect(failCalls[0]?.terminal).toBe(true);
+    expect(failCalls[0]?.category).toBe("terminal");
+    // Content-free: the terminal category is logged; the reason text is not.
+    expect(logs.join("\n")).toContain('"error_category":"terminal"');
+    expect(logs.join("\n")).not.toContain("private terminal reason text");
+    expect(logs.join("\n")).toContain('"status":"dead_letter"');
+  });
+
+  it("routes an ordinary error to fail() as non-terminal (bounded retry preserved)", async () => {
+    const failCalls: Array<{ category?: string; terminal?: boolean }> = [];
+    const queue: MaintenanceQueuePort = {
+      claimDueJobs: async () => [job()],
+      complete: async () => true,
+      fail: async (input) => {
+        failCalls.push({ category: input.category, terminal: input.terminal });
+        return job({ state: "queued" });
+      },
+    };
+    const runner = new MaintenanceQueueRunner({
+      queue,
+      handlers: new Map([
+        [
+          "maintenance.test",
+          async () => {
+            throw new Error("transient DB blip");
+          },
+        ],
+      ]),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+
+    await runner.runOnce();
+    expect(failCalls).toHaveLength(1);
+    // An ordinary error is NOT terminal: the queue keeps the bounded-retry path.
+    expect(failCalls[0]?.terminal).toBe(false);
+    expect(failCalls[0]?.category).toBe("error");
+  });
+
+  it("classifies a MaintenanceTerminalError subclass as terminal", () => {
+    class HandlerTerminal extends MaintenanceTerminalError {}
+    expect(isMaintenanceTerminalError(new HandlerTerminal("x"))).toBe(true);
+    expect(isMaintenanceTerminalError(new Error("x"))).toBe(false);
+    expect(isMaintenanceTerminalError("unsupported_job_kind")).toBe(false);
+  });
+
   it("contains persistence failures as content-free runner errors", async () => {
     const logs: string[] = [];
     const queue: MaintenanceQueuePort = {
@@ -400,5 +481,85 @@ describe("maintenance queue retry policy", () => {
     expect(safeMaintenanceErrorCategory("private error text")).toBe(
       "non_error",
     );
+  });
+});
+
+// A fake pool that captures the params of the fail UPDATE and echoes a row so
+// MaintenanceQueue.fail resolves. It proves the terminal flag reaches SQL as the
+// 5th positional param and picks the category, WITHOUT a live database. The
+// exact dead-letter/queued row transition on a real CHECK/CASE is proven by the
+// live-Postgres test in maintenance-queue.pg.test.ts.
+function captureFailPool() {
+  const failParams: unknown[][] = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []) => {
+      if (/UPDATE\s+maintenance_jobs[\s\S]*state\s*=\s*CASE/i.test(sql)) {
+        failParams.push(params);
+      }
+      // Echo a minimal running->transition row so toJob() succeeds.
+      return {
+        rows: [
+          {
+            id: "job-1",
+            job_kind: "maintenance.test",
+            job_version: 1,
+            payload: {},
+            idempotency_key: "once",
+            state: "dead_letter",
+            run_after: new Date("2026-07-22T12:00:00.000Z"),
+            lease_token: null,
+            lease_until: null,
+            attempts: 1,
+            max_attempts: 3,
+            backoff_base_ms: 1_000,
+            backoff_max_ms: 4_000,
+            last_error_category: (params?.[3] as string) ?? null,
+            terminal_at: new Date("2026-07-22T12:00:01.000Z"),
+            dead_lettered_at: new Date("2026-07-22T12:00:01.000Z"),
+            namespace: null,
+            provenance: null,
+            created_at: new Date("2026-07-22T12:00:00.000Z"),
+            updated_at: new Date("2026-07-22T12:00:01.000Z"),
+          },
+        ],
+        rowCount: 1,
+      };
+    },
+    connect: async () => {
+      throw new Error("fail() must not open a transaction");
+    },
+  };
+  return { pool: pool as never, failParams };
+}
+
+describe("maintenance queue fail() terminal short-circuit", () => {
+  it("passes terminal=true and category 'terminal' to the fail UPDATE", async () => {
+    const { pool, failParams } = captureFailPool();
+    const queue = new MaintenanceQueue(pool);
+    // A job with retry budget remaining (attempts 1 < max 3): only the terminal
+    // flag can force an immediate dead-letter, not the attempt bound.
+    const failed = await queue.fail({
+      job: job({ attempts: 1, maxAttempts: 3 }),
+      error: new MaintenanceTerminalError("private terminal text"),
+      category: "terminal",
+      terminal: true,
+    });
+    expect(failParams).toHaveLength(1);
+    // $4 = category, $5 = terminal flag.
+    expect(failParams[0]?.[3]).toBe("terminal");
+    expect(failParams[0]?.[4]).toBe(true);
+    expect(failed?.state).toBe("dead_letter");
+  });
+
+  it("passes terminal=false for an ordinary error (bounded retry preserved)", async () => {
+    const { pool, failParams } = captureFailPool();
+    const queue = new MaintenanceQueue(pool);
+    await queue.fail({
+      job: job({ attempts: 1, maxAttempts: 3 }),
+      error: new Error("transient text"),
+    });
+    expect(failParams).toHaveLength(1);
+    expect(failParams[0]?.[3]).toBe("error");
+    expect(failParams[0]?.[4]).toBe(false);
   });
 });

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -4,6 +4,10 @@ const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_BACKOFF_BASE_MS = 1_000;
 const DEFAULT_BACKOFF_MAX_MS = 300_000;
 const MAX_CONCURRENCY = 16;
+// A held lease is renewed every leaseMs / LEASE_RENEW_DIVISOR while its handler
+// runs, so a renewal always lands with a safe margin before the deadline. Three
+// gives two renewal opportunities per lease window before expiry.
+const LEASE_RENEW_DIVISOR = 3;
 // Upper bound on a single direct claim. The scheduled runner never asks for
 // more than its available concurrency, but a direct caller must not be able to
 // drain or lock the whole table in one statement.
@@ -112,6 +116,25 @@ export interface ClaimMaintenanceJobs {
 
 export interface MaintenanceQueuePort {
   claimDueJobs(input: ClaimMaintenanceJobs): Promise<MaintenanceJob[]>;
+  /**
+   * Extend a still-owned running lease. Guarded by the immutable (id, lease
+   * token) the claim minted: it advances lease_until to now + leaseMs ONLY while
+   * the row is still `running` under that exact token. A job whose lease was
+   * already reclaimed, completed, failed, or dead-lettered no longer matches the
+   * token guard, so renewal is a safe no-op that returns false — the runner then
+   * knows it no longer owns the job. The new lease_until is derived here from the
+   * durable row + the passed leaseMs, never from any handler-mutable state.
+   *
+   * Optional on the port so a minimal/legacy queue fake need not implement it;
+   * the runner heartbeats only when a queue provides `renew`. The concrete
+   * MaintenanceQueue always implements it.
+   */
+  renew?(
+    jobId: string,
+    leaseToken: string,
+    leaseMs: number,
+    now?: Date,
+  ): Promise<boolean>;
   complete(jobId: string, leaseToken: string, now?: Date): Promise<boolean>;
   fail(input: {
     job: MaintenanceJob;
@@ -452,6 +475,32 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
     }
   }
 
+  async renew(
+    jobId: string,
+    leaseToken: string,
+    leaseMs: number,
+    now = new Date(),
+  ): Promise<boolean> {
+    assertPositiveInteger(leaseMs, "lease duration");
+    // Advance the lease under the same stale-lease guard `complete`/`fail` use:
+    // the row must still be `running` under this exact minted token. If a
+    // concurrent claim already reclaimed the row (state changed or token
+    // rotated) the guard matches nothing and this is a no-op returning false.
+    // lease_until is recomputed from the durable NOW() + leaseMs, so a renewal
+    // can only ever push the deadline forward for a lease we still own. The
+    // maintenance_jobs_lease_shape CHECK is preserved: a running row keeps a
+    // non-null lease_token and lease_until throughout.
+    const renewed = await this.pool.query(
+      `UPDATE maintenance_jobs
+          SET lease_until = $3::timestamptz + ($4 * interval '1 millisecond')
+        WHERE id = $1
+          AND state = 'running'
+          AND lease_token = $2::uuid`,
+      [jobId, leaseToken, now, leaseMs],
+    );
+    return (renewed.rowCount ?? 0) === 1;
+  }
+
   async complete(
     jobId: string,
     leaseToken: string,
@@ -556,6 +605,14 @@ export interface MaintenanceQueueRunnerOptions {
   concurrency?: number;
   pollIntervalMs?: number;
   leaseMs?: number;
+  /**
+   * Heartbeat cadence for renewing a held lease WHILE its handler runs. Defaults
+   * to leaseMs / LEASE_RENEW_DIVISOR (a fraction of the lease window) so a renew
+   * always lands well before the deadline. Clamped to [1, leaseMs - 1] so a
+   * renew never coincides with or trails expiry. Injectable for tests that drive
+   * multiple short lease windows deterministically.
+   */
+  leaseRenewMs?: number;
   now?: () => Date;
 }
 
@@ -568,6 +625,7 @@ export class MaintenanceQueueRunner {
   private readonly concurrency: number;
   private readonly pollIntervalMs: number;
   private readonly leaseMs: number;
+  private readonly leaseRenewMs: number;
   private readonly now: () => Date;
   private readonly active = new Set<Promise<void>>();
   private interval: ReturnType<typeof setInterval> | null = null;
@@ -581,6 +639,18 @@ export class MaintenanceQueueRunner {
     );
     this.pollIntervalMs = Math.max(options.pollIntervalMs ?? 5_000, 1);
     this.leaseMs = Math.max(options.leaseMs ?? 30_000, 1);
+    // Heartbeat cadence: renew at a fraction of the lease window so a renewal
+    // always lands before the deadline, and clamp to [1, leaseMs - 1] so it can
+    // never sit at or past expiry. With the default 30s lease this renews every
+    // 10s. This is a CADENCE, not a longer lease — leaseMs itself is unchanged.
+    const renewDefault = Math.max(
+      Math.floor(this.leaseMs / LEASE_RENEW_DIVISOR),
+      1,
+    );
+    this.leaseRenewMs = Math.min(
+      Math.max(options.leaseRenewMs ?? renewDefault, 1),
+      Math.max(this.leaseMs - 1, 1),
+    );
     this.now = options.now ?? (() => new Date());
   }
 
@@ -669,8 +739,22 @@ export class MaintenanceQueueRunner {
       return;
     }
 
+    // Renew this lease on a heartbeat WHILE the handler runs, so a handler that
+    // blocks on a long/contended transaction past the lease window is not
+    // reclaimed or dead-lettered out from under its live owner. The heartbeat is
+    // bound to the immutable claim (id + minted lease token), so a handler that
+    // mutated job.id/job.leaseToken cannot redirect it. It is cleared and awaited
+    // BEFORE complete/fail below so no renewal races the terminal transition, and
+    // drained again in stop() via `active`.
+    // null when this queue/claim cannot heartbeat (no renew capability or no
+    // lease token). We only await stop() when a heartbeat actually started, so a
+    // queue without renewal keeps its exact pre-existing execute timing.
+    const heartbeat = this.startHeartbeat(claim);
     try {
       await handler(job);
+      // Stop and await the heartbeat before completing: a renewal must never run
+      // concurrently with (or after) the complete UPDATE on the same row.
+      if (heartbeat) await heartbeat.stop();
       const completed = await this.options.queue.complete(
         claim.id,
         claim.leaseToken!,
@@ -683,8 +767,95 @@ export class MaintenanceQueueRunner {
         duration_ms: this.now().getTime() - startedAt,
       });
     } catch (error) {
+      // Same ordering on the failure path: quiesce the heartbeat before fail().
+      if (heartbeat) await heartbeat.stop();
       await this.fail(job, claim, error, startedAt);
     }
+  }
+
+  /**
+   * Start a lease-renewal heartbeat for one claimed job and return a handle whose
+   * `stop()` clears the timer and awaits any in-flight renewal. The heartbeat:
+   *  - renews under the IMMUTABLE claim (id + minted lease token), never a
+   *    handler-mutable field, so it addresses exactly the row the claim leased;
+   *  - NEVER overlaps its own renewal: a `renewing` guard skips a tick while the
+   *    previous renew is still awaiting, so a slow DB cannot stack renew calls;
+   *  - stops heartbeating the moment it observes it no longer owns the lease
+   *    (renew returned false — reclaimed/completed/failed elsewhere), or a renew
+   *    threw, so a lost lease does not spin; and
+   *  - logs content-free only (job id/kind + a stable status token), never the
+   *    payload, error message, or lease values.
+   */
+  private startHeartbeat(claim: {
+    id: string;
+    kind: string;
+    leaseToken: string | null;
+  }): { stop(): Promise<void> } | null {
+    // A null lease token means the claim carried no lease to renew (defensive;
+    // claimDueJobs always mints one for a running row). And a queue without a
+    // `renew` capability cannot heartbeat. Either way: no heartbeat at all.
+    const renew = this.options.queue.renew;
+    if (claim.leaseToken === null || typeof renew !== "function") {
+      return null;
+    }
+    const leaseToken = claim.leaseToken;
+    let inFlight: Promise<void> | null = null;
+    let stopped = false;
+
+    const renewOnce = async (): Promise<void> => {
+      // Overlap guard: a previous renew is still awaiting; skip this tick.
+      if (inFlight || stopped) return;
+      const run = (async () => {
+        try {
+          const held = await renew.call(
+            this.options.queue,
+            claim.id,
+            leaseToken,
+            this.leaseMs,
+            this.now(),
+          );
+          if (!held) {
+            // We no longer own the lease (reclaimed/completed/failed elsewhere).
+            // Stop heartbeating; the terminal transition is owned elsewhere.
+            stopped = true;
+            if (timer) clearInterval(timer);
+            this.options.logger.warn("maintenance queue lease renewal lost", {
+              job_id: claim.id,
+              job_kind: claim.kind,
+              status: "lease_lost",
+            });
+          }
+        } catch (error) {
+          // A transient renewal failure is contained content-free. Do not crash
+          // the run; the next tick retries, or the lease simply expires.
+          this.options.logger.error("maintenance queue lease renewal failed", {
+            job_id: claim.id,
+            job_kind: claim.kind,
+            error_category: safeMaintenanceErrorCategory(error),
+          });
+        }
+      })();
+      inFlight = run;
+      try {
+        await run;
+      } finally {
+        inFlight = null;
+      }
+    };
+
+    const timer: ReturnType<typeof setInterval> | null = setInterval(() => {
+      void renewOnce();
+    }, this.leaseRenewMs);
+
+    return {
+      stop: async (): Promise<void> => {
+        stopped = true;
+        if (timer) clearInterval(timer);
+        // Await any renewal already in flight so it can never land concurrently
+        // with (or after) the complete/fail UPDATE the caller runs next.
+        if (inFlight) await inFlight;
+      },
+    };
   }
 
   private async fail(

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -25,7 +25,42 @@ export type MaintenanceErrorCategory =
   // Terminal signal for a running lease that expired after the job already
   // consumed all of its execution attempts. Content-free and distinct from any
   // handler-thrown error so dead-letter analysis can tell the two apart.
-  | "lease_expired";
+  | "lease_expired"
+  // A handler declared its own failure non-retryable by throwing a
+  // MaintenanceTerminalError (below). The job dead-letters on this exact
+  // attempt regardless of remaining retry budget. Distinct from `error` and
+  // `lease_expired` so dead-letter analysis can tell a policy-driven immediate
+  // dead-letter from a retry-exhaustion or an expired lease. Content-free.
+  | "terminal";
+
+/**
+ * Queue-owned generic marker for a handler failure that is NON-RETRYABLE.
+ *
+ * A handler throws this (or a subclass) to tell the queue that retrying the
+ * SAME job payload can never succeed, so the queue must dead-letter it on this
+ * exact attempt instead of scheduling a bounded backoff retry to the attempt
+ * bound. This marker lives at the queue boundary on purpose: handlers depend on
+ * the queue, never the reverse, so a handler's own terminal-error subclass can
+ * extend this without the queue importing anything from the handler.
+ *
+ * Everything else (transient DB failures, provider outages, unclassified
+ * errors) stays retryable and follows the persisted attempts>=max_attempts
+ * retry-then-dead-letter policy. Only an explicit throw of this type opts a
+ * failure into immediate dead-lettering.
+ */
+export class MaintenanceTerminalError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "MaintenanceTerminalError";
+  }
+}
+
+/** True when a thrown value is the queue's non-retryable terminal marker. */
+export function isMaintenanceTerminalError(
+  error: unknown,
+): error is MaintenanceTerminalError {
+  return error instanceof MaintenanceTerminalError;
+}
 
 export interface MaintenanceJob {
   id: string;
@@ -86,6 +121,11 @@ export interface MaintenanceQueuePort {
     // unsupported-job-kind sentinel, which is not a thrown Error). When unset,
     // the category is derived from `error`.
     category?: MaintenanceErrorCategory;
+    // When true, the failure is non-retryable: the job dead-letters on this
+    // attempt regardless of remaining retry budget (see MaintenanceQueue.fail).
+    // The runner sets this from a MaintenanceTerminalError; ordinary errors
+    // leave it unset and follow the persisted bounded-retry policy.
+    terminal?: boolean;
     now?: Date;
   }): Promise<MaintenanceJob | null>;
 }
@@ -436,11 +476,18 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
     job: MaintenanceJob;
     error: unknown;
     category?: MaintenanceErrorCategory;
+    terminal?: boolean;
     now?: Date;
   }): Promise<MaintenanceJob | null> {
     const now = input.now ?? new Date();
+    // A non-retryable failure dead-letters on this attempt regardless of
+    // remaining retry budget. The flag is derived from a MaintenanceTerminalError
+    // at the runner boundary, never from the caller-supplied `input.job` fields;
+    // it forces the dead-letter branch below without touching backoff math.
+    const terminal = input.terminal === true;
     const errorCategory =
-      input.category ?? safeMaintenanceErrorCategory(input.error);
+      input.category ??
+      (terminal ? "terminal" : safeMaintenanceErrorCategory(input.error));
     // The terminal decision and the retry schedule are derived from the durable
     // row, never from the caller-supplied `input.job` retry fields. A registered
     // handler receives the same job object it is failing and could mutate
@@ -456,11 +503,19 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
     // clamped to [0, 30], and the result is capped at backoff_max_ms. attempts
     // is bounded [0, 25] and the exponent [0, 30], so 2 ^ exponent stays within
     // numeric range with no overflow.
+    //
+    // The dead-letter branch fires when the row has exhausted its bounded retry
+    // budget (attempts >= max_attempts) OR the caller flagged the failure
+    // terminal ($5). A terminal failure short-circuits to dead_letter on this
+    // attempt without consulting attempts/max_attempts and without scheduling a
+    // backoff retry; an ordinary failure keeps the persisted bounded-retry
+    // policy verbatim. The stale-lease guard (state='running' AND lease_token)
+    // and content-free category are preserved on both paths.
     const failed = await this.pool.query<MaintenanceJobRow>(
       `UPDATE maintenance_jobs
-          SET state = CASE WHEN attempts >= max_attempts
+          SET state = CASE WHEN $5::boolean OR attempts >= max_attempts
                            THEN 'dead_letter' ELSE 'queued' END,
-              run_after = CASE WHEN attempts >= max_attempts
+              run_after = CASE WHEN $5::boolean OR attempts >= max_attempts
                                THEN run_after
                                ELSE $3::timestamptz + (
                                  LEAST(
@@ -472,15 +527,15 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
               lease_token = NULL,
               lease_until = NULL,
               last_error_category = $4,
-              terminal_at = CASE WHEN attempts >= max_attempts
+              terminal_at = CASE WHEN $5::boolean OR attempts >= max_attempts
                                  THEN $3::timestamptz ELSE NULL END,
-              dead_lettered_at = CASE WHEN attempts >= max_attempts
+              dead_lettered_at = CASE WHEN $5::boolean OR attempts >= max_attempts
                                       THEN $3::timestamptz ELSE NULL END
         WHERE id = $1
           AND state = 'running'
           AND lease_token = $2::uuid
        RETURNING ${JOB_COLUMNS}`,
-      [input.job.id, input.job.leaseToken, now, errorCategory],
+      [input.job.id, input.job.leaseToken, now, errorCategory, terminal],
     );
     return failed.rows[0] ? toJob(failed.rows[0]) : null;
   }
@@ -638,10 +693,18 @@ export class MaintenanceQueueRunner {
     error: unknown,
     startedAt: number,
   ): Promise<void> {
+    // A handler that threw the queue-owned non-retryable marker opts this
+    // failure into immediate dead-lettering: the queue skips the bounded-retry
+    // schedule and dead-letters on this attempt. The classification is made
+    // here from the thrown value's TYPE, not from any handler import — the
+    // marker lives on the queue and a handler's own subclass extends it.
+    const terminal = isMaintenanceTerminalError(error);
     const errorCategory =
       error === "unsupported_job_kind"
         ? "unsupported_job_kind"
-        : safeMaintenanceErrorCategory(error);
+        : terminal
+          ? "terminal"
+          : safeMaintenanceErrorCategory(error);
     try {
       // Pass the immutable claim id/leaseToken as the lease-token guard so a
       // handler that mutated job.id/job.leaseToken cannot redirect the fail
@@ -651,6 +714,7 @@ export class MaintenanceQueueRunner {
         job: { ...job, id: claim.id, leaseToken: claim.leaseToken },
         error,
         category: errorCategory,
+        terminal,
         now: this.now(),
       });
       this.options.logger.warn("maintenance queue job failed", {


### PR DESCRIPTION
## Summary

Adds idempotent, namespace-scoped graph derivation for approved source records and registers it with the existing durable maintenance queue.

- reuses the existing metadata extraction boundary rather than reimplementing SOURCE-1
- derives deterministic anchor/topic/person entities and `mentions` links
- skips unchanged derivation hashes and converges changed content without duplicate nodes or links
- archives obsolete anchor-to-term links while preserving shared term entities
- guards writes with exact namespace and source snapshot predicates
- registers `graph.derive` beside `embedding.repair` in the existing production bootstrap
- adds queue-owned immediate terminal dead-letter handling for permanent job failures
- upgrades fresh and existing maintenance-queue constraints to accept the content-free `terminal` category
- keeps sweep production explicit: operators or #347 enqueue bounded graph jobs; this PR does not invent recurrence

Closes #346
Part of #342

## Verification

- focused exact-head suite: 91 passed, 5 env-gated skips, 0 failed
- real PostgreSQL exact-head suites: 15 passed, 0 failed — including rollback/retry convergence, locked old/new snapshot serialization, duplicate-title/pure-rename behavior, and multi-window lease renewal against a competing claimer
- `bunx tsc --noEmit`: passed
- `git diff --check origin/main...HEAD`: passed
- correctness/domain review: ZERO FINDINGS
- security/adversarial review: ZERO FINDINGS
- opposite-runtime terminal audit and targeted fix verification: zero surviving P0-P2 findings on `269db79061e91b55747e060e5ce434501dac76f0`

## Critical Self-Review

- Highest-risk behavior: a global maintenance identity could be mistaken for namespace authority, stale source content could be committed after extraction, or changed derivations could leave obsolete graph edges live.
- Assumptions that could be wrong: approved source rows retain stable source identity and revision/content-hash snapshots; the existing graph consumer continues to interpret `entity` + `mentions` as documented.
- Missing/weak tests: no production-size corpus soak; bounded unit and real-PostgreSQL tests cover new/changed/unchanged, pruning, replay, snapshot drift, namespace negatives, and queue dispatch.
- Security/permission risk: the server-owned `ob-admin` identity grants maintenance capability only; the persisted job namespace remains authoritative and is checked at selection, handler, primitive, snapshot, and write boundaries.
- Migration/deploy risk: migration 029 re-derives the queue error-category CHECK for upgraded databases, while migrations 026/028 include `terminal` for fresh installs; startup now registers an additional inert handler but enqueues no graph work.
- Downstream client/runtime risk: no MCP tool/schema, transport, Python client, TypeScript client, prompt-placement, search-ranking, or Hermes integration contract changes.
- Rollback/cleanup concern: revert the bootstrap/queue integration and graph modules; graph entities/links already derived remain namespace-scoped and can be archived by a separate explicit maintenance action if required.
- Fixes made before PR: content-bearing log fields were removed; changed derivations now prune stale anchor links; queue terminal markers are honored immediately rather than merely classified; migration upgrade compatibility and production bootstrap dispatch were added; snapshot validation, metadata resolution, all graph writes, pruning, and hash stamping now share one locked transaction so partial failures roll back and stale jobs cannot overwrite newer graphs; source-anchor names are collision-safe while exact display labels survive pure renames; unsupported job versions terminal-stop before parsing; active handlers renew immutable-token leases across long runs.
- Known residual risk: graph derivation is not continuously scheduled. `enqueueGraphDerivationJobs` must be called by an operator or future #347 scheduling work.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: hosted activation and maintenance dispatch canary occur only after merge, before issue closure.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is internal maintenance execution with no MCP/client schema or wrapper change.

## Downstream Rollout

- [x] Checked `docs/downstream-rollout.md`
- rtech-mcps / mcp2cli regeneration: not applicable — no public tool/schema/protocol change
- Python and TypeScript standalone clients: unaffected
- Direct Hermes integration and Hermes canaries: outside approved scope
- Hosted Open Brain deploy and a safe maintenance dispatch canary remain post-merge closure gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)


