### PR TITLE
feat(333): suppress explicitly supplied prior context

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1035,3 +1035,58 @@ hash.
   and its `content_hash` is preserved? Both must fail on the pre-fix code.
 - Were parallel expectations updated (e.g. `embedding-targets.test.ts`) — a
   reference asserting the old raw-order fold is itself a latent regression.
+
+## [2026-07-22] Empty-envelope `empty_reason` must reconcile with the counters that produced it
+
+**Severity:** MEDIUM
+**Source:** PR #359 (P2), fix `fix(333)`; #333 prior-context suppression
+**Scope:** `src/tools/agent-context-pack-durable-memory.ts`, any section that emits both an `empty_reason` and content-free counters
+**Status:** active
+
+### Pattern
+
+A section that emits a zero-item envelope AND separate counters (here
+`prior_context_suppression: {recalled, suppressed, net_new, emitted}`) can put
+the two in direct contradiction. `durable_memory` derived `empty_reason` from
+only two causes — `all_suppressed` (all recalled rows were prior context) vs
+`no_matches` (recall found nothing) — and missed a third: a record survived
+suppression (`net_new > 0`) but produced no emittable body (null / empty-string
+`content_preview`, or the char budget was too small for even the first body).
+That case fell through to `no_matches`, so the envelope claimed recall found
+nothing while `net_new > 0`, `emitted = 0`, and `truncated = true` all said a
+net-new match existed and was dropped. The counters were correct; the reason
+lied about them.
+
+The truthful fix adds a distinct, content-free reason (`content_unavailable`)
+and derives `empty_reason` in the only order that reads correctly:
+`net_new > 0` → `content_unavailable`; else recalled-and-all-suppressed →
+`all_suppressed`; else → `no_matches`. `net_new` is tested first so a
+net-new-but-unemittable section can never be mislabeled. The distinction is
+kept truthful without inventing a body: the reason is derived from the same
+counters the envelope already exposes, not from re-reading content.
+
+Note the boundary split: the section loader owns the *genuine* empty reasons
+(no data / all-suppressed / content-free); the whole-pack allocator separately
+stamps `whole_pack_budget` only when its own re-fit trims a non-empty body to
+empty. The two never collide because the content-free case emits no body for the
+allocator to trim.
+
+### Review Questions
+
+- Does a zero-item / empty envelope carry an `empty_reason` AND separate
+  counters? Do all counter combinations map to a distinct, truthful reason, or
+  can a real state (e.g. `net_new > 0, emitted = 0`) fall through to a reason
+  that contradicts the counters?
+- Is the reason derived from the counters/state the envelope already exposes,
+  or re-derived from a narrower predicate that misses a case?
+- Are the empty-reason branches ordered so the most specific truthful cause wins
+  (net-new-but-unemittable before "no matches")?
+- Is there a regression for the null AND empty-string content case proving the
+  reason, `truncated`, the counters, and empty citations together — and does it
+  fail on the pre-fix code (received the wrong reason)?
+- Is there a no-over-suppression guard proving an unemittable record does not
+  hide or starve a sibling record that IS emittable (something emitted ⇒ no
+  content-free empty reason)?
+- If a downstream allocator can also stamp an `empty_reason`, is the ownership
+  boundary explicit so the loader-owned and allocator-owned reasons cannot
+  overwrite each other in the wrong case?

--- a/src/prior-context-suppression.test.ts
+++ b/src/prior-context-suppression.test.ts
@@ -1,0 +1,517 @@
+import { describe, expect, it } from "bun:test";
+import {
+  canonicalSourceRefKey,
+  scopeQueryPredicate,
+  suppressPriorContext,
+  suppressReferencedRecords,
+  type RecallScope,
+  type RecalledItem,
+} from "./prior-context-suppression.ts";
+
+const scope: RecallScope = {
+  namespace: "acme",
+  agent: "skippy",
+  platform: "discord",
+  server_id: "guild-1",
+  channel_id: "chan-1",
+  thread_id: "thread-1",
+  session_key: "sess-1",
+};
+
+function item(
+  identity: RecalledItem["identity"],
+  payload: unknown = { note: "opaque" },
+  namespace = scope.namespace,
+): RecalledItem {
+  return { namespace, identity, payload };
+}
+
+describe("prior-context suppression", () => {
+  it("suppresses items whose canonical id is in prior context", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: ["deploy"],
+      recalled: [
+        item({ canonical_id: "session_event:1" }),
+        item({ canonical_id: "session_event:2" }),
+      ],
+      priorContext: [{ canonical_id: "session_event:1" }],
+    });
+    expect(result.items.map((i) => i.identity.canonical_id)).toEqual([
+      "session_event:2",
+    ]);
+    expect(result.suppression).toEqual({
+      recalled: 2,
+      suppressed: 1,
+      net_new: 1,
+    });
+  });
+
+  it("suppresses across canonical id, citation id, and source ref families", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [
+        item({ canonical_id: "session_event:1" }),
+        item({ citation_id: "session_event:2" }),
+        item({ source_ref: "ob_session_events/3" }),
+        item({ canonical_id: "session_event:4" }),
+      ],
+      priorContext: [
+        { canonical_id: "session_event:1" },
+        { citation_id: "session_event:2" },
+        { source_ref: "ob_session_events/3" },
+      ],
+    });
+    expect(result.items.map((i) => i.identity.canonical_id)).toEqual([
+      "session_event:4",
+    ]);
+  });
+
+  it("suppresses an item when ANY of its identity families is known", () => {
+    // Item carries canonical_id + source_ref; prior context knows only the ref.
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [
+        item({
+          canonical_id: "session_event:9",
+          source_ref: "ob_session_events/9",
+        }),
+      ],
+      priorContext: [{ source_ref: "ob_session_events/9" }],
+    });
+    expect(result.items).toHaveLength(0);
+    expect(result.suppression.suppressed).toBe(1);
+  });
+
+  it("does not cross-collide different families that share a raw string", () => {
+    // A canonical_id string equal to a source_ref string must not suppress.
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [item({ canonical_id: "shared-string" })],
+      priorContext: [{ source_ref: "shared-string" }],
+    });
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("retains unknown relevant items", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: ["rollout"],
+      recalled: [
+        item({ canonical_id: "session_event:10" }),
+        item({ canonical_id: "session_event:11" }),
+      ],
+      priorContext: [{ canonical_id: "session_event:99" }],
+    });
+    expect(result.items).toHaveLength(2);
+    expect(result.suppression.suppressed).toBe(0);
+  });
+
+  it("tolerates duplicate prior-context references", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [
+        item({ canonical_id: "session_event:1" }),
+        item({ canonical_id: "session_event:2" }),
+      ],
+      priorContext: [
+        { canonical_id: "session_event:1" },
+        { canonical_id: "session_event:1" },
+        { canonical_id: "session_event:1" },
+      ],
+    });
+    expect(result.items.map((i) => i.identity.canonical_id)).toEqual([
+      "session_event:2",
+    ]);
+    expect(result.suppression.suppressed).toBe(1);
+  });
+
+  it("preserves original relevance order of net-new items", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [
+        item({ canonical_id: "session_event:5" }),
+        item({ canonical_id: "session_event:1" }),
+        item({ canonical_id: "session_event:9" }),
+        item({ canonical_id: "session_event:3" }),
+      ],
+      priorContext: [{ canonical_id: "session_event:9" }],
+    });
+    expect(result.items.map((i) => i.identity.canonical_id)).toEqual([
+      "session_event:5",
+      "session_event:1",
+      "session_event:3",
+    ]);
+  });
+
+  it("returns empty when nothing is recalled", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [],
+      priorContext: [{ canonical_id: "session_event:1" }],
+    });
+    expect(result.items).toEqual([]);
+    expect(result.suppression).toEqual({
+      recalled: 0,
+      suppressed: 0,
+      net_new: 0,
+    });
+  });
+
+  it("returns all items when prior context is empty", () => {
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [
+        item({ canonical_id: "session_event:1" }),
+        item({ canonical_id: "session_event:2" }),
+      ],
+      priorContext: [],
+    });
+    expect(result.items).toHaveLength(2);
+  });
+
+  it("does not read or compare raw payload bodies", () => {
+    // Two items with identical payloads but distinct identities both survive;
+    // suppression never dedupes by body.
+    const body = { text: "the same durable body" };
+    const result = suppressPriorContext({
+      scope,
+      conceptKeys: [],
+      recalled: [
+        item({ canonical_id: "session_event:1" }, body),
+        item({ canonical_id: "session_event:2" }, body),
+      ],
+      priorContext: [],
+    });
+    expect(result.items).toHaveLength(2);
+  });
+
+  describe("malformed input", () => {
+    it("rejects a recalled item with no resolvable identity", () => {
+      expect(() =>
+        suppressPriorContext({
+          scope,
+          conceptKeys: [],
+          recalled: [item({} as never)],
+          priorContext: [],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects a prior-context reference with no resolvable identity", () => {
+      expect(() =>
+        suppressPriorContext({
+          scope,
+          conceptKeys: [],
+          recalled: [item({ canonical_id: "session_event:1" })],
+          priorContext: [{} as never],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects an unknown scope coordinate", () => {
+      expect(() =>
+        suppressPriorContext({
+          scope: { ...scope, extra: "leak" } as never,
+          conceptKeys: [],
+          recalled: [],
+          priorContext: [],
+        }),
+      ).toThrow();
+    });
+
+    it("rejects a scope missing a coordinate", () => {
+      const { thread_id: _omit, ...partial } = scope;
+      void _omit;
+      expect(() =>
+        suppressPriorContext({
+          scope: partial as never,
+          conceptKeys: [],
+          recalled: [],
+          priorContext: [],
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("namespace / scope isolation", () => {
+    it("fails closed on a recalled item from a different namespace", () => {
+      expect(() =>
+        suppressPriorContext({
+          scope,
+          conceptKeys: [],
+          recalled: [
+            item({ canonical_id: "session_event:1" }, {}, "other-tenant"),
+          ],
+          priorContext: [],
+        }),
+      ).toThrow(/namespace/);
+    });
+
+    it("fails closed even when the cross-namespace item would be suppressed", () => {
+      // A malicious/buggy upstream could try to hide a cross-namespace item by
+      // making it look like prior context; the namespace check still throws.
+      expect(() =>
+        suppressPriorContext({
+          scope,
+          conceptKeys: [],
+          recalled: [
+            item({ canonical_id: "session_event:1" }, {}, "other-tenant"),
+          ],
+          priorContext: [{ canonical_id: "session_event:1" }],
+        }),
+      ).toThrow(/namespace/);
+    });
+
+    it("accepts items whose namespace exactly matches the scope namespace", () => {
+      const result = suppressPriorContext({
+        scope,
+        conceptKeys: [],
+        recalled: [item({ canonical_id: "session_event:1" })],
+        priorContext: [],
+      });
+      expect(result.items).toHaveLength(1);
+      expect(result.scope.namespace).toBe("acme");
+    });
+  });
+});
+
+describe("scope query predicate", () => {
+  it("binds all seven coordinates with exact equality and null-safe thread", () => {
+    const predicate = scopeQueryPredicate(scope);
+    expect(predicate.sql).toBe(
+      "namespace = $1" +
+        " AND agent = $2" +
+        " AND platform = $3" +
+        " AND server_id = $4" +
+        " AND channel_id = $5" +
+        " AND thread_id IS NOT DISTINCT FROM $6::text" +
+        " AND session_key = $7",
+    );
+    expect(predicate.params).toEqual([
+      "acme",
+      "skippy",
+      "discord",
+      "guild-1",
+      "chan-1",
+      "thread-1",
+      "sess-1",
+    ]);
+  });
+
+  it("binds a null thread_id exactly", () => {
+    const predicate = scopeQueryPredicate({ ...scope, thread_id: null });
+    expect(predicate.params[5]).toBeNull();
+  });
+
+  it("supports column aliases and a start param offset", () => {
+    const predicate = scopeQueryPredicate(
+      scope,
+      {
+        namespace: "l.namespace",
+        platform: "l.source",
+        thread_id: "l.thread_id",
+      },
+      4,
+    );
+    expect(predicate.sql).toContain("l.namespace = $4");
+    expect(predicate.sql).toContain("l.source = $6");
+    expect(predicate.sql).toContain(
+      "l.thread_id IS NOT DISTINCT FROM $9::text",
+    );
+    expect(predicate.sql).toContain("session_key = $10");
+  });
+
+  it("validates scope before emitting a predicate", () => {
+    expect(() =>
+      scopeQueryPredicate({ ...scope, namespace: "" } as never),
+    ).toThrow();
+  });
+});
+
+describe("canonicalSourceRefKey", () => {
+  // The structural key joins identity coordinates with the UNIT SEPARATOR
+  // control char, which a trimmed non-empty field can never contain.
+  const SEP = String.fromCharCode(0x1f);
+
+  it("tags string vs structural refs into distinct key families that never collide", () => {
+    // A string ref keys verbatim under `s:`; a structural ref reduces to identity
+    // coordinates under `o:`, so a bare string and an object never collide.
+    expect(canonicalSourceRefKey("ob_session_events/9")).toBe(
+      "s:ob_session_events/9",
+    );
+    expect(
+      canonicalSourceRefKey({ source: "brain", type: "decisions", id: "d1" }),
+    ).toBe(`o:brain${SEP}decisions${SEP}d1${SEP}`);
+  });
+
+  it("ignores display-only fields and key ordering on structural refs", () => {
+    const a = canonicalSourceRefKey({
+      source: "brain",
+      type: "decisions",
+      id: "d1",
+      namespace: "acme",
+      // display-only fields must not affect the key
+      label: "a label",
+      preview: "a preview",
+    } as never);
+    const b = canonicalSourceRefKey({
+      id: "d1",
+      namespace: "acme",
+      type: "decisions",
+      source: "brain",
+    } as never);
+    expect(a).toBe(b);
+    expect(a).toBe(`o:brain${SEP}decisions${SEP}d1${SEP}acme`);
+  });
+
+  it("distinguishes refs that differ only in namespace", () => {
+    expect(
+      canonicalSourceRefKey({
+        source: "brain",
+        type: "decisions",
+        id: "d1",
+        namespace: "acme",
+      }),
+    ).not.toBe(
+      canonicalSourceRefKey({
+        source: "brain",
+        type: "decisions",
+        id: "d1",
+        namespace: "other",
+      }),
+    );
+  });
+});
+
+describe("suppressReferencedRecords (durable_memory integration)", () => {
+  type Row = { citation_id?: string; source_ref?: unknown; note?: string };
+  const identify = (row: Row) => ({
+    citation_id: row.citation_id,
+    source_ref: row.source_ref as never,
+  });
+
+  it("suppresses a record whose citation id is in prior context", () => {
+    const rows: Row[] = [
+      { citation_id: "brain_record:decisions:1" },
+      { citation_id: "brain_record:decisions:2" },
+    ];
+    const result = suppressReferencedRecords(rows, identify, [
+      { citation_id: "brain_record:decisions:1" },
+    ]);
+    expect(result.kept.map((r) => r.citation_id)).toEqual([
+      "brain_record:decisions:2",
+    ]);
+    expect(result.suppression).toEqual({
+      recalled: 2,
+      suppressed: 1,
+      net_new: 1,
+    });
+  });
+
+  it("suppresses a record by a structural source_ref echoed from prior context", () => {
+    const rows: Row[] = [
+      {
+        citation_id: "brain_record:decisions:1",
+        source_ref: { source: "brain", type: "decisions", id: "1" },
+      },
+      {
+        citation_id: "brain_record:decisions:2",
+        source_ref: { source: "brain", type: "decisions", id: "2" },
+      },
+    ];
+    // Prior context knows only the structural source_ref of record 1 (with
+    // display fields that must be ignored) — it still suppresses.
+    const result = suppressReferencedRecords(rows, identify, [
+      {
+        source_ref: {
+          source: "brain",
+          type: "decisions",
+          id: "1",
+          label: "ignored",
+        } as never,
+      },
+    ]);
+    expect(result.kept.map((r) => r.citation_id)).toEqual([
+      "brain_record:decisions:2",
+    ]);
+  });
+
+  it("keeps a record with no resolvable identity rather than dropping it", () => {
+    const rows: Row[] = [{ note: "no ids" }, { citation_id: "c:2" }];
+    const result = suppressReferencedRecords(rows, identify, [
+      { citation_id: "c:2" },
+    ]);
+    // The identity-less record cannot be proven prior context, so it survives;
+    // only the referenced one is removed.
+    expect(result.kept).toEqual([{ note: "no ids" }]);
+    expect(result.suppression.suppressed).toBe(1);
+  });
+
+  it("preserves original relevance order of net-new records", () => {
+    const rows: Row[] = [
+      { citation_id: "c:5" },
+      { citation_id: "c:1" },
+      { citation_id: "c:9" },
+      { citation_id: "c:3" },
+    ];
+    const result = suppressReferencedRecords(rows, identify, [
+      { citation_id: "c:9" },
+    ]);
+    expect(result.kept.map((r) => r.citation_id)).toEqual([
+      "c:5",
+      "c:1",
+      "c:3",
+    ]);
+  });
+
+  it("is deterministic and tolerates duplicate prior references", () => {
+    const rows: Row[] = [{ citation_id: "c:1" }, { citation_id: "c:2" }];
+    const prior = [
+      { citation_id: "c:1" },
+      { citation_id: "c:1" },
+      { citation_id: "c:1" },
+    ];
+    const a = suppressReferencedRecords(rows, identify, prior);
+    const b = suppressReferencedRecords(rows, identify, prior);
+    expect(a.kept).toEqual(b.kept);
+    expect(a.kept.map((r) => r.citation_id)).toEqual(["c:2"]);
+    expect(a.suppression.suppressed).toBe(1);
+  });
+
+  it("returns all records net-new when prior context is empty", () => {
+    const rows: Row[] = [{ citation_id: "c:1" }, { citation_id: "c:2" }];
+    const result = suppressReferencedRecords(rows, identify, []);
+    expect(result.kept).toHaveLength(2);
+    expect(result.suppression).toEqual({
+      recalled: 2,
+      suppressed: 0,
+      net_new: 2,
+    });
+  });
+
+  it("rejects a prior-context reference with no resolvable identity", () => {
+    expect(() =>
+      suppressReferencedRecords([{ citation_id: "c:1" }], identify, [
+        {} as never,
+      ]),
+    ).toThrow();
+  });
+
+  it("does not cross-collide a citation id string with a source_ref string", () => {
+    const rows: Row[] = [{ citation_id: "shared-string" }];
+    // Prior context references a string source_ref equal to the citation id;
+    // families are tagged, so it must NOT suppress.
+    const result = suppressReferencedRecords(rows, identify, [
+      { source_ref: "shared-string" },
+    ]);
+    expect(result.kept).toHaveLength(1);
+  });
+});

--- a/src/prior-context-suppression.ts
+++ b/src/prior-context-suppression.ts
@@ -1,0 +1,426 @@
+import { z } from "zod";
+
+/**
+ * Prior-context suppression (#333, workstream REFLEX-2).
+ *
+ * Runtime-owned deterministic primitive that sits at the in-memory recall
+ * handoff boundary: given the auth-derived seven-coordinate scope, the
+ * extracted concept keys that produced the recall, the authorized recalled
+ * items, and the explicit prior-context identifiers/references already supplied
+ * to the model, return ONLY the net-new items in their original relevance
+ * order.
+ *
+ * This module performs no retrieval, no formatting, no prompt placement, and
+ * persists nothing. It never reads or compares raw turn/memory bodies and emits
+ * no content telemetry. Suppression is deterministic across three identifier
+ * families — canonical IDs, citation IDs, and source refs — so an item already
+ * represented in prior context under any of those references is removed.
+ *
+ * Namespace/scope isolation is a security boundary: the scope is validated,
+ * every recalled item's namespace must equal the scope namespace, and any
+ * mismatch fails closed by throwing rather than silently returning a
+ * cross-namespace item.
+ */
+
+/**
+ * The seven exact scope coordinates, kept in lockstep with
+ * `agent_context_pack.scope_keys` in src/contract.ts and the durable-lane
+ * scope predicate. `thread_id` is the only nullable coordinate.
+ */
+export const recallScopeSchema = z
+  .object({
+    namespace: z.string().trim().min(1).max(200),
+    agent: z.string().trim().min(1).max(200),
+    platform: z.string().trim().min(1).max(200),
+    server_id: z.string().trim().min(1).max(500),
+    channel_id: z.string().trim().min(1).max(500),
+    thread_id: z.string().trim().min(1).max(500).nullable(),
+    session_key: z.string().trim().min(1).max(500),
+  })
+  .strict();
+
+export type RecallScope = z.infer<typeof recallScopeSchema>;
+
+/**
+ * A structural source pointer. It is matched on identity, not body, so only the
+ * stable identity-bearing coordinates are declared and canonicalized — a
+ * `brain_record` source_ref is `{ source, type, id, namespace }`. Display-only
+ * fields such as `label`/`preview` are deliberately NOT part of the schema: they
+ * carry (bounded) content, vary with truncation, and must never influence
+ * whether two references resolve to the same record. Unknown keys are stripped
+ * (non-strict) so a caller passing the full emitted source_ref object still
+ * matches on its identity coordinates alone.
+ */
+export const structuralSourceRefSchema = z
+  .object({
+    source: z.string().trim().min(1).max(200),
+    type: z.string().trim().min(1).max(200),
+    id: z.string().trim().min(1).max(500),
+    namespace: z.string().trim().min(1).max(200).optional(),
+  })
+  .passthrough();
+
+/**
+ * The minimal identity-bearing shape a structural source_ref must carry. Typed
+ * explicitly (rather than inferred from the passthrough schema) so any richer
+ * emitted source_ref object — which may carry display fields like
+ * `label`/`preview` — is assignable without an index-signature mismatch. Only
+ * these coordinates are canonicalized; extra fields are ignored at runtime.
+ */
+export interface StructuralSourceRef {
+  source: string;
+  type: string;
+  id: string;
+  namespace?: string;
+}
+
+/**
+ * A source_ref may be supplied either as an opaque string pointer (e.g.
+ * `ob_session_events/123`) or as a structural object (e.g. the `brain_record`
+ * pointer `{ source: "brain", type, id, namespace }`). Both canonicalize to a
+ * single deterministic key so a string and its structural equivalent never
+ * silently fail to suppress each other, and two structural refs that differ only
+ * in display fields still match.
+ */
+export const sourceRefSchema = z.union([
+  z.string().trim().min(1).max(1000),
+  structuralSourceRefSchema,
+]);
+
+export type SourceRefValue = string | StructuralSourceRef;
+
+/**
+ * Deterministic canonical key for a source_ref, independent of its input shape.
+ * A string ref is used verbatim; a structural ref is reduced to its ordered
+ * identity coordinates only (source/type/id/namespace) so display fields and key
+ * ordering never affect the key. Never derived from a record body.
+ */
+export function canonicalSourceRefKey(sourceRef: SourceRefValue): string {
+  if (typeof sourceRef === "string") {
+    return `s:${sourceRef}`;
+  }
+  const ns = sourceRef.namespace ?? "";
+  // Join identity coordinates with the UNIT SEPARATOR control char, which a
+  // trimmed non-empty string field can never contain, so no coordinate value
+  // can be crafted to collide across field boundaries (e.g. an embedded delimiter).
+  const sep = String.fromCharCode(0x1f);
+  return `o:${sourceRef.source}${sep}${sourceRef.type}${sep}${sourceRef.id}${sep}${ns}`;
+}
+
+/**
+ * The resolvable identity a recalled item and a prior-context reference are
+ * matched on. At least one of the three identifier families must be present so
+ * the item is addressable without inspecting its body.
+ *
+ * - `canonical_id`: the item's stable canonical identity (e.g. a citation id
+ *   such as `session_event:123` carried as `citation_id`).
+ * - `citation_id`: the citation identity emitted alongside the item, when it
+ *   differs from the canonical id.
+ * - `source_ref`: the structural source pointer — a string (e.g.
+ *   `ob_session_events/123`) or a structural object (e.g. the `brain_record`
+ *   pointer `{ source, type, id, namespace }`). Canonicalized before matching.
+ */
+export const recallIdentitySchema = z
+  .object({
+    canonical_id: z.string().trim().min(1).max(500).optional(),
+    citation_id: z.string().trim().min(1).max(500).optional(),
+    source_ref: sourceRefSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.canonical_id !== undefined ||
+      value.citation_id !== undefined ||
+      value.source_ref !== undefined,
+    {
+      message:
+        "recall identity requires canonical_id, citation_id, or source_ref",
+      path: ["canonical_id"],
+    },
+  );
+
+export type RecallIdentity = z.infer<typeof recallIdentitySchema>;
+
+/**
+ * An authorized recalled item handed to the suppression boundary. It carries
+ * the namespace it was recalled under (asserted against scope, fail closed),
+ * its resolvable identity, and the opaque relevance-ordered payload the runtime
+ * will place downstream. The payload body is never read here.
+ */
+export interface RecalledItem<TPayload = unknown> {
+  namespace: string;
+  identity: RecallIdentity;
+  payload: TPayload;
+}
+
+/**
+ * An explicit prior-context reference: an identifier or source ref already
+ * supplied to the model in this turn. Only the resolvable identity is provided;
+ * raw prior-context bodies are never accepted or compared.
+ */
+export const priorContextReferenceSchema = recallIdentitySchema;
+
+export type PriorContextReference = RecallIdentity;
+
+export interface SuppressPriorContextInput<TPayload = unknown> {
+  /** Auth-derived seven-coordinate scope. Validated; namespace is the boundary. */
+  scope: RecallScope;
+  /** Extracted concept keys that produced this recall (carried, not matched on bodies). */
+  conceptKeys: readonly string[];
+  /** Authorized recalled items in original relevance order. */
+  recalled: ReadonlyArray<RecalledItem<TPayload>>;
+  /** Explicit prior-context identifiers/references already supplied to the model. */
+  priorContext: ReadonlyArray<PriorContextReference>;
+}
+
+export interface SuppressPriorContextResult<TPayload = unknown> {
+  /** The validated, canonicalized scope every downstream query must retain. */
+  scope: RecallScope;
+  /** Net-new recalled items, in the original relevance order. */
+  items: Array<RecalledItem<TPayload>>;
+  /** Content-free counters for observability. Emits no bodies. */
+  suppression: {
+    recalled: number;
+    suppressed: number;
+    net_new: number;
+  };
+}
+
+/**
+ * Deterministic, family-tagged suppression keys derived from a resolvable
+ * identity. Keys are tagged by family so a canonical id and a source ref that
+ * happen to share a string never collide, while all three families for the
+ * SAME item still suppress it. Never derived from raw bodies.
+ */
+function suppressionKeys(identity: RecallIdentity): string[] {
+  const keys: string[] = [];
+  if (identity.canonical_id !== undefined) {
+    keys.push(`canonical:${identity.canonical_id}`);
+  }
+  if (identity.citation_id !== undefined) {
+    keys.push(`citation:${identity.citation_id}`);
+  }
+  if (identity.source_ref !== undefined) {
+    keys.push(`source_ref:${canonicalSourceRefKey(identity.source_ref)}`);
+  }
+  return keys;
+}
+
+/**
+ * Assert a recalled item belongs to the scope namespace. Fails closed: a
+ * mismatched namespace throws rather than being silently dropped, so a
+ * cross-namespace item can never be quietly accepted or leaked downstream.
+ */
+function assertItemNamespace(scope: RecallScope, item: RecalledItem): void {
+  const itemNamespace = item.namespace.trim();
+  if (itemNamespace !== scope.namespace) {
+    throw new Error(
+      "recalled item namespace does not match auth-derived scope namespace",
+    );
+  }
+}
+
+/**
+ * Suppress prior-context items from an authorized recall, returning only
+ * net-new items in original relevance order.
+ *
+ * Deterministic: identical inputs always yield identical output. Suppression is
+ * by resolvable identity across canonical IDs, citation IDs, and source refs —
+ * raw bodies are never compared. Fails closed on any recalled-item namespace
+ * that does not match the scope namespace.
+ */
+/**
+ * Build the family-tagged suppression key set from validated prior-context
+ * references. Malformed references are rejected up front so a bad reference can
+ * never silently fail to suppress a known prior-context item. Duplicate
+ * references collapse into the set, so repeated prior references are a no-op.
+ * Shared by every suppression entry point so canonicalization is identical.
+ */
+function buildSuppressionSet(
+  priorContext: ReadonlyArray<PriorContextReference>,
+): Set<string> {
+  const suppressed = new Set<string>();
+  for (const reference of priorContext) {
+    const parsed = recallIdentitySchema.parse(reference);
+    for (const key of suppressionKeys(parsed)) {
+      suppressed.add(key);
+    }
+  }
+  return suppressed;
+}
+
+export function suppressPriorContext<TPayload = unknown>(
+  input: SuppressPriorContextInput<TPayload>,
+): SuppressPriorContextResult<TPayload> {
+  const scope = recallScopeSchema.parse(input.scope);
+
+  const suppressed = buildSuppressionSet(input.priorContext);
+
+  const items: Array<RecalledItem<TPayload>> = [];
+  for (const item of input.recalled) {
+    const identity = recallIdentitySchema.parse(item.identity);
+    // Namespace boundary check runs for every item, suppressed or not, so a
+    // cross-namespace item can never pass through even if it would be dropped.
+    assertItemNamespace(scope, item);
+
+    const keys = suppressionKeys(identity);
+    const isPriorContext = keys.some((key) => suppressed.has(key));
+    if (isPriorContext) continue;
+
+    items.push({ namespace: item.namespace, identity, payload: item.payload });
+  }
+
+  return {
+    scope,
+    items,
+    suppression: {
+      recalled: input.recalled.length,
+      suppressed: input.recalled.length - items.length,
+      net_new: items.length,
+    },
+  };
+}
+
+/**
+ * A recalled durable-memory record's resolvable identity, as emitted by the
+ * `durable_memory` context-pack recall: the stable `citation_id` string and the
+ * item's structural `source_ref`. Both are matched on identity only; the record
+ * body is never read.
+ */
+export interface RecalledRecordIdentity {
+  citation_id?: string;
+  source_ref?: SourceRefValue;
+}
+
+export interface SuppressReferencedRecordsResult<T> {
+  /** Records not represented in prior context, in original relevance order. */
+  kept: T[];
+  /** Content-free counters: how many were recalled, suppressed, and net-new. */
+  suppression: {
+    recalled: number;
+    suppressed: number;
+    net_new: number;
+  };
+}
+
+/**
+ * Deterministically remove durable-memory records already represented in prior
+ * context, keyed by explicit citation ids and canonicalized source refs. This is
+ * the owned integration point for the `durable_memory` recall section (#333): it
+ * reuses the SAME identity families and canonicalization as
+ * {@link suppressPriorContext} but operates on the recall's own record shape and
+ * makes NO single-namespace assertion — durable_memory recall is bound to the
+ * caller's readable namespace set by its SQL predicate, which legitimately spans
+ * more than one namespace for privileged roles. Suppression is pure removal in
+ * original relevance order: it can never add, reorder, or leak a record, and a
+ * record with no resolvable identity is never suppressed (it is kept, since it
+ * cannot be proven to be prior context).
+ *
+ * `identify` maps each record to its resolvable identity without exposing its
+ * body to this module. Records and prior-context references canonicalize through
+ * the identical key derivation, so a string source_ref, a structural source_ref,
+ * and a citation id all suppress consistently.
+ */
+export function suppressReferencedRecords<T>(
+  records: readonly T[],
+  identify: (record: T) => RecalledRecordIdentity,
+  priorContext: ReadonlyArray<PriorContextReference>,
+): SuppressReferencedRecordsResult<T> {
+  const suppressed = buildSuppressionSet(priorContext);
+
+  const kept: T[] = [];
+  for (const record of records) {
+    const raw = identify(record);
+    // A record must be addressable by at least one identity family to be
+    // suppressible; if none is present it cannot be proven to be prior context,
+    // so it is kept rather than dropped. recallIdentitySchema enforces the
+    // at-least-one-family invariant and canonicalizes the source_ref shape.
+    const identity: RecallIdentity | null =
+      raw.citation_id !== undefined || raw.source_ref !== undefined
+        ? recallIdentitySchema.parse({
+            ...(raw.citation_id !== undefined
+              ? { citation_id: raw.citation_id }
+              : {}),
+            ...(raw.source_ref !== undefined
+              ? { source_ref: raw.source_ref }
+              : {}),
+          })
+        : null;
+
+    if (identity !== null) {
+      const keys = suppressionKeys(identity);
+      if (keys.some((key) => suppressed.has(key))) continue;
+    }
+    kept.push(record);
+  }
+
+  return {
+    kept,
+    suppression: {
+      recalled: records.length,
+      suppressed: records.length - kept.length,
+      net_new: kept.length,
+    },
+  };
+}
+
+/**
+ * The exact namespace/scope predicate every downstream recall query or request
+ * must retain. Returns the seven ordered scope values and a parameterized SQL
+ * predicate that binds all seven coordinates against the given column aliases.
+ *
+ * This is the single place that encodes "retain exact namespace/scope" so a
+ * downstream query cannot accidentally widen the scope. `thread_id` uses
+ * `IS NOT DISTINCT FROM` to bind null exactly, matching the durable-lane
+ * predicate in agent-context-pack-durable-lane.ts.
+ */
+export interface ScopePredicate {
+  sql: string;
+  params: [string, string, string, string, string, string | null, string];
+}
+
+export function scopeQueryPredicate(
+  scope: RecallScope,
+  columns: {
+    namespace?: string;
+    agent?: string;
+    platform?: string;
+    server_id?: string;
+    channel_id?: string;
+    thread_id?: string;
+    session_key?: string;
+  } = {},
+  startParamIndex = 1,
+): ScopePredicate {
+  const validated = recallScopeSchema.parse(scope);
+  const namespaceCol = columns.namespace ?? "namespace";
+  const agentCol = columns.agent ?? "agent";
+  const platformCol = columns.platform ?? "platform";
+  const serverCol = columns.server_id ?? "server_id";
+  const channelCol = columns.channel_id ?? "channel_id";
+  const threadCol = columns.thread_id ?? "thread_id";
+  const sessionCol = columns.session_key ?? "session_key";
+
+  const p = (offset: number): string => `$${startParamIndex + offset}`;
+  const sql =
+    `${namespaceCol} = ${p(0)}` +
+    ` AND ${agentCol} = ${p(1)}` +
+    ` AND ${platformCol} = ${p(2)}` +
+    ` AND ${serverCol} = ${p(3)}` +
+    ` AND ${channelCol} = ${p(4)}` +
+    ` AND ${threadCol} IS NOT DISTINCT FROM ${p(5)}::text` +
+    ` AND ${sessionCol} = ${p(6)}`;
+
+  return {
+    sql,
+    params: [
+      validated.namespace,
+      validated.agent,
+      validated.platform,
+      validated.server_id,
+      validated.channel_id,
+      validated.thread_id,
+      validated.session_key,
+    ],
+  };
+}

--- a/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
@@ -710,6 +710,209 @@ describe("agent_context_pack durable_memory", () => {
     }
   });
 
+  it("suppresses a recalled record whose citation_id is echoed in prior_context, retaining the rest in order", async () => {
+    // #333: prior-context suppression. A record already supplied to the model
+    // this turn is passed back by citation_id; recall must drop it and return
+    // only net-new records, preserving the original relevance order.
+    const records = [
+      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({
+        id: "th-1",
+        source_type: "thoughts",
+        content_preview: "a durable thought",
+      }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+          prior_context: [{ citation_id: "brain_record:decisions:dec-1" }],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      // Only the net-new record survives; the echoed one is gone.
+      expect(section.items.map((i: any) => i.id)).toEqual(["th-1"]);
+      expect(section.item_count).toBe(1);
+      // Content-free suppression counters reconcile to what was recalled/emitted.
+      expect(section.prior_context_suppression).toEqual({
+        recalled: 2,
+        suppressed: 1,
+        net_new: 1,
+        emitted: 1,
+      });
+      // A suppressed record is NOT a truncation.
+      expect(section.truncated).toBe(false);
+      expect(section.empty_reason).toBeUndefined();
+      // No citation dangles onto the suppressed record.
+      const citationIds = new Set(payload.citations.map((c: any) => c.id));
+      expect(citationIds.has("brain_record:decisions:dec-1")).toBe(false);
+      const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
+      for (const citation of payload.citations) {
+        expect(retainedIds.has(citation.id)).toBe(true);
+      }
+      // The counters carry no id, reference, or body — only integers.
+      for (const value of Object.values(section.prior_context_suppression)) {
+        expect(typeof value).toBe("number");
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("suppresses a record by an echoed structural source_ref that ignores display fields", async () => {
+    // Prior context can echo back the item's own structural source_ref; matching
+    // is on identity coordinates (source/type/id/namespace) only, so display
+    // fields the caller round-trips must not defeat suppression.
+    const records = [
+      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({ id: "dec-2", source_type: "decisions" }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+          prior_context: [
+            {
+              source_ref: {
+                source: "brain",
+                type: "decisions",
+                id: "dec-1",
+                namespace: "rico",
+                label: "round-tripped display text",
+                preview: "round-tripped preview",
+              },
+            },
+          ],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section.items.map((i: any) => i.id)).toEqual(["dec-2"]);
+      expect(section.prior_context_suppression.suppressed).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("retains recalled records not referenced in prior_context", async () => {
+    // An unknown/unmatched prior reference removes nothing: relevant records the
+    // model has not already seen are all retained.
+    const records = [
+      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({ id: "dec-2", source_type: "decisions" }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+          prior_context: [
+            { citation_id: "brain_record:decisions:not-recalled" },
+          ],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section.items.map((i: any) => i.id)).toEqual(["dec-1", "dec-2"]);
+      expect(section.prior_context_suppression).toMatchObject({
+        recalled: 2,
+        suppressed: 0,
+        net_new: 2,
+        emitted: 2,
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reports all_suppressed (distinct from no_matches) when every recalled record is prior context", async () => {
+    // When recall DID find records but every one is already in prior context, the
+    // empty envelope must say all_suppressed — not no_matches, which would falsely
+    // claim recall found nothing.
+    const records = [
+      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({ id: "dec-2", source_type: "decisions" }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+          prior_context: [
+            { citation_id: "brain_record:decisions:dec-1" },
+            { citation_id: "brain_record:decisions:dec-2" },
+          ],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section.items).toEqual([]);
+      expect(section.item_count).toBe(0);
+      expect(section.empty_reason).toBe("all_suppressed");
+      // Not a truncation — the records were suppressed, not budget-shed.
+      expect(section.truncated).toBe(false);
+      expect(section.prior_context_suppression).toMatchObject({
+        recalled: 2,
+        suppressed: 2,
+        net_new: 0,
+        emitted: 0,
+      });
+      expect(payload.citations).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rejects a prior_context reference with no resolvable identity", async () => {
+    // A reference must carry citation_id or source_ref; an empty object cannot be
+    // resolved and must be rejected at the input boundary rather than silently
+    // failing to suppress.
+    const { pool } = searchPool([brainRecord()]);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+          prior_context: [{}],
+        },
+      });
+      expect(pack.isError).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("multi-query determinism: identical inputs produce identical durable_memory allocation", async () => {
     const records = Array.from({ length: 5 }, (_, index) =>
       brainRecord({

--- a/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
@@ -890,6 +890,149 @@ describe("agent_context_pack durable_memory", () => {
     }
   });
 
+  it("reports content_unavailable (not no_matches) when a net-new record has a null content_preview", async () => {
+    // #359 P2: a record survives suppression (net_new > 0) but carries no
+    // emittable body (null content_preview). The section is empty and truncated,
+    // but the ONLY net-new record was unemittable — so the reason must be the
+    // distinct content_unavailable, never no_matches (which would falsely claim
+    // recall found nothing) and never all_suppressed (nothing was suppressed).
+    const records = [brainRecord({ id: "dec-1", content_preview: null })];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      // Empty because the sole net-new record had no emittable body.
+      expect(section.items).toEqual([]);
+      expect(section.item_count).toBe(0);
+      // The truthful reason: net-new content existed but could not be emitted.
+      expect(section.empty_reason).toBe("content_unavailable");
+      // Counters reconcile: recall returned one net-new record, none emitted.
+      expect(section.prior_context_suppression).toMatchObject({
+        recalled: 1,
+        suppressed: 0,
+        net_new: 1,
+        emitted: 0,
+      });
+      // A net-new-but-unemittable record IS a truncation of the section body.
+      expect(section.truncated).toBe(true);
+      // No citation dangles onto a record that was never emitted.
+      expect(payload.citations).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("reports content_unavailable when a net-new record has an empty-string content_preview", async () => {
+    // #359 P2 sibling case: an empty-string (not null) content_preview is equally
+    // unemittable. boundedText treats "" and null identically (no body, not a
+    // truncation of a non-empty string), so the same content_unavailable reason
+    // and the same counters/truncation/citation reconciliation must hold.
+    const records = [brainRecord({ id: "dec-1", content_preview: "" })];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      expect(section.items).toEqual([]);
+      expect(section.item_count).toBe(0);
+      expect(section.empty_reason).toBe("content_unavailable");
+      expect(section.prior_context_suppression).toMatchObject({
+        recalled: 1,
+        suppressed: 0,
+        net_new: 1,
+        emitted: 0,
+      });
+      expect(section.truncated).toBe(true);
+      expect(payload.citations).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("does not over-suppress: an emittable net-new record is still emitted when a lower-ranked sibling is content-free", async () => {
+    // #359 P2 no-over-suppression guard: a content-free (null-body) net-new record
+    // must not starve or hide an emittable net-new record, and the section is not
+    // content_unavailable when something WAS emitted. The emittable record is
+    // ranked first (better relevance) so it emits before the loop halts on the
+    // unemittable tail record; both are counted net-new, only the good one emits.
+    const records = [
+      brainRecord({
+        id: "good-1",
+        content_preview: "a real durable body",
+        distance: 0.05,
+        fts_rank: 0.99,
+        usefulness: 0.99,
+      }),
+      brainRecord({
+        id: "empty-1",
+        content_preview: null,
+        distance: 0.5,
+        fts_rank: 0.1,
+        usefulness: 0.1,
+      }),
+    ];
+    const { pool } = searchPool(records);
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const section = payload.sections.durable_memory;
+      // The emittable record surfaces; the empty-body one is dropped, not hidden
+      // behind an all-empty envelope.
+      expect(section.items.map((i: any) => i.id)).toEqual(["good-1"]);
+      expect(section.item_count).toBe(1);
+      // Something was emitted, so this is NOT the content-free empty state.
+      expect(section.empty_reason).toBeUndefined();
+      // Both recalled records are net-new; only one was emittable.
+      expect(section.prior_context_suppression).toMatchObject({
+        recalled: 2,
+        suppressed: 0,
+        net_new: 2,
+        emitted: 1,
+      });
+      // Only the emitted record's citation exists; the empty-body one dangles nowhere.
+      const citationIds = new Set(payload.citations.map((c: any) => c.id));
+      expect(citationIds.has("brain_record:decisions:good-1")).toBe(true);
+      expect(citationIds.has("brain_record:decisions:empty-1")).toBe(false);
+      const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
+      for (const citation of payload.citations) {
+        expect(retainedIds.has(citation.id)).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
   it("rejects a prior_context reference with no resolvable identity", async () => {
     // A reference must carry citation_id or source_ref; an empty object cannot be
     // resolved and must be rejected at the input boundary rather than silently

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -291,15 +291,27 @@ export async function loadDurableMemoryContext(
     });
   }
 
-  // Truthful empty state: when nothing survives, distinguish "recall matched
-  // nothing" from "every match was already in prior context". `all_suppressed`
-  // only applies when the recall DID return rows and suppression removed them
-  // all; otherwise the recall genuinely found no matches.
+  // Truthful empty state: when nothing survives, distinguish the three genuine
+  // zero-item causes, in the only order that reads correctly:
+  //   - `content_unavailable`: net-new records DID survive suppression but none
+  //     produced an emittable body (null/empty content_preview, or the char
+  //     budget was too small for even the first body). This is NOT "no_matches"
+  //     (there was a net-new match) and NOT "all_suppressed" (nothing was
+  //     suppressed away). It is a content-free empty: net-new existed but was
+  //     unemittable, and `truncated` is already true for it above.
+  //   - `all_suppressed`: recall DID return rows and suppression removed every
+  //     one, so there is no net-new content at all.
+  //   - `no_matches`: recall genuinely found nothing to begin with.
+  // net_new is checked first so a net-new-but-unemittable section can never be
+  // mislabeled no_matches; all_suppressed keeps its exact prior meaning (rows
+  // recalled, none net-new because all were suppressed).
   const emptyReason =
     items.length === 0
-      ? rows.length > 0 && suppression.suppression.suppressed === rows.length
-        ? "all_suppressed"
-        : "no_matches"
+      ? suppression.suppression.net_new > 0
+        ? "content_unavailable"
+        : rows.length > 0 && suppression.suppression.suppressed === rows.length
+          ? "all_suppressed"
+          : "no_matches"
       : undefined;
 
   return {

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -9,6 +9,10 @@ import {
   CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
   boundedText,
 } from "./agent-context-pack-durable-lane.ts";
+import {
+  suppressReferencedRecords,
+  type PriorContextReference,
+} from "../prior-context-suppression.ts";
 
 const DURABLE_MEMORY_MAX_CONTENT_CHARS = 8_000;
 const DURABLE_MEMORY_MAX_ITEMS = 8;
@@ -51,6 +55,34 @@ export type DurableMemoryContextFragment = {
   budget: Record<string, unknown>;
   citations: Array<Record<string, unknown>>;
 };
+
+/**
+ * The stable citation id emitted for a recalled brain record. Kept in one place
+ * so prior-context suppression keys off the EXACT string that becomes the item's
+ * `citation_id`, and the emitted item derives its id from the same call.
+ */
+function recordCitationId(row: SearchRow): string {
+  return `brain_record:${row.source_type}:${row.id}`;
+}
+
+/**
+ * The bounded structural source_ref emitted for a recalled brain record: the
+ * store's own source_ref when present, else a derived `brain_record` pointer.
+ * Its identity coordinates (source/type/id/namespace) are what suppression
+ * canonicalizes on; `label`/`preview` are display-only and never affect matching.
+ */
+function recordSourceRef(row: SearchRow) {
+  return (
+    row.source_ref ?? {
+      source: "brain",
+      type: row.source_type,
+      id: row.id,
+      namespace: row.namespace,
+      label: (row.content_preview ?? "").slice(0, 120),
+      preview: (row.content_preview ?? "").slice(0, 300),
+    }
+  );
+}
 
 /**
  * Build the `durable_memory` section: query-driven hybrid-RRF recall over the
@@ -178,12 +210,32 @@ export async function loadDurableMemoryContext(
     };
   }
 
+  // Prior-context suppression (#333): deterministically drop records already
+  // represented in prior context BEFORE the char budget selects and bounds
+  // bodies, so the surviving relevance order, item selection, citations, and
+  // budget accounting all reconcile against net-new results only. Suppression is
+  // pure removal — it can never add, reorder, or leak a record — and keys off the
+  // exact citation_id and structural source_ref each record emits. Records with
+  // no resolvable identity are kept (they cannot be proven prior context). No raw
+  // prior-context text is consulted; only resolvable identity references are.
+  const priorContext = (args.prior_context ??
+    []) as ReadonlyArray<PriorContextReference>;
+  const suppression = suppressReferencedRecords(
+    rows,
+    (row) => ({
+      citation_id: recordCitationId(row),
+      source_ref: recordSourceRef(row),
+    }),
+    priorContext,
+  );
+  const netNewRows = suppression.kept;
+
   let remainingChars = maxContentChars;
   const items: Array<Record<string, unknown>> = [];
   const citations: Array<Record<string, unknown>> = [];
   let itemsTruncated = false;
 
-  for (const row of rows) {
+  for (const row of netNewRows) {
     const bounded = boundedText(
       row.content_preview,
       Math.min(DURABLE_MEMORY_MAX_ITEM_CHARS, remainingChars),
@@ -197,21 +249,14 @@ export async function loadDurableMemoryContext(
       }
       break;
     }
-    const citationId = `brain_record:${row.source_type}:${row.id}`;
+    const citationId = recordCitationId(row);
     // Build the bounded source_ref once per row and attach the SAME object to
     // both the item and its citation, so an item is independently resolvable back
     // to its brain record without a citation lookup, and item.source_ref is
     // identical to citation.source_ref. Citation reconciliation after whole-pack
     // trimming keys off citation_id, so co-locating source_ref on the item keeps
     // the two consistent through partial and full trims.
-    const sourceRef = row.source_ref ?? {
-      source: "brain",
-      type: row.source_type,
-      id: row.id,
-      namespace: row.namespace,
-      label: (row.content_preview ?? "").slice(0, 120),
-      preview: (row.content_preview ?? "").slice(0, 300),
-    };
+    const sourceRef = recordSourceRef(row);
     items.push({
       id: row.id,
       source_type: row.source_type,
@@ -231,8 +276,10 @@ export async function loadDurableMemoryContext(
     remainingChars -= bounded.text.length;
     if (bounded.truncated) itemsTruncated = true;
   }
-  // Records beyond the ones whose bodies fit were dropped by the char budget.
-  if (items.length < rows.length) itemsTruncated = true;
+  // Net-new records beyond the ones whose bodies fit were dropped by the char
+  // budget. Compare against the post-suppression set: records removed as prior
+  // context are not a truncation, so they must not flip this flag.
+  if (items.length < netNewRows.length) itemsTruncated = true;
 
   const truncation: Array<Record<string, unknown>> = [];
   if (itemsTruncated) {
@@ -244,15 +291,35 @@ export async function loadDurableMemoryContext(
     });
   }
 
+  // Truthful empty state: when nothing survives, distinguish "recall matched
+  // nothing" from "every match was already in prior context". `all_suppressed`
+  // only applies when the recall DID return rows and suppression removed them
+  // all; otherwise the recall genuinely found no matches.
+  const emptyReason =
+    items.length === 0
+      ? rows.length > 0 && suppression.suppression.suppressed === rows.length
+        ? "all_suppressed"
+        : "no_matches"
+      : undefined;
+
   return {
     section: {
       label: "durable_memory",
       namespace_scoped: true,
       query,
-      ...(items.length === 0 ? { empty_reason: "no_matches" } : {}),
+      ...(emptyReason ? { empty_reason: emptyReason } : {}),
       items,
       item_count: items.length,
       truncated: truncation.length > 0,
+      // Content-free suppression counters (#333): counts only, never an id, a
+      // reference, or a body. `net_new` is pre-budget net-new records; `emitted`
+      // is how many survived the char budget.
+      prior_context_suppression: {
+        recalled: suppression.suppression.recalled,
+        suppressed: suppression.suppression.suppressed,
+        net_new: suppression.suppression.net_new,
+        emitted: items.length,
+      },
     },
     scopeDenials: [],
     truncation,

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -78,6 +78,41 @@ export const scopeInputSchema = {
   session_key: z.string().min(1).max(500).describe("Stable active-session key"),
 };
 
+/**
+ * One explicit prior-context reference: an identifier or structural source
+ * pointer for a record already supplied to the model this turn. Only resolvable
+ * identity is accepted — never raw prior-context text — and at least one of
+ * `citation_id`/`source_ref` must be present so the reference is addressable
+ * without inspecting a body. `source_ref` accepts the string or structural form
+ * the recall emits, so a caller can echo back an item's own `source_ref`.
+ */
+export const priorContextReferenceInputSchema = z
+  .object({
+    citation_id: z.string().trim().min(1).max(500).optional(),
+    source_ref: z
+      .union([
+        z.string().trim().min(1).max(1000),
+        z
+          .object({
+            source: z.string().trim().min(1).max(200),
+            type: z.string().trim().min(1).max(200),
+            id: z.string().trim().min(1).max(500),
+            namespace: z.string().trim().min(1).max(200).optional(),
+          })
+          .passthrough(),
+      ])
+      .optional(),
+  })
+  .strict()
+  .refine(
+    (value) =>
+      value.citation_id !== undefined || value.source_ref !== undefined,
+    {
+      message: "prior_context reference requires citation_id or source_ref",
+      path: ["citation_id"],
+    },
+  );
+
 export const agentContextPackInputSchema = {
   ...scopeInputSchema,
   query: z.string().max(4000).optional(),
@@ -90,6 +125,16 @@ export const agentContextPackInputSchema = {
       "Active repository slug (e.g. owner/name) that repo_facts binds to exactly. " +
         "When absent, repo_facts returns its defined no-active-repo empty state; " +
         "repo_facts never falls back to any other repository.",
+    ),
+  prior_context: z
+    .array(priorContextReferenceInputSchema)
+    .max(200)
+    .optional()
+    .describe(
+      "Explicit identifiers/source refs already supplied to the model this " +
+        "turn. durable_memory recall removes records already represented by " +
+        "these references and returns only net-new results. Raw prior-context " +
+        "text is never accepted; references carry resolvable identity only.",
     ),
   requested_sections: z
     .array(z.enum(SECTION_NAMES))


### PR DESCRIPTION
## Summary

Adds deterministic prior-context suppression to the existing `agent_context_pack` durable-memory recall path.

- accepts a bounded optional `prior_context` array containing only explicit `citation_id` and/or `source_ref` references
- reuses the existing #327 hybrid durable-memory retrieval stack unchanged
- suppresses exact referenced matches after recall and before the final character budget
- retains unknown, identity-less, and still-relevant records
- reconciles item counts, truncation, citations, source references, and budget accounting against the net-new result
- preserves auth-derived namespace and seven-coordinate scope predicates
- persists no extracted suppression keys and performs no raw prompt/transcript inference
- introduces no MCP `_meta` injection or runtime-owned prompt placement

Closes #333
Part of #320

## Verification

- prior-context suppression + durable-memory + context-pack: 59 passed, 0 failed
- merged #328 guidance/repo-facts regression cross-check: 77 passed, 0 failed
- `bunx tsc --noEmit`: passed
- `git diff --check origin/main...HEAD`: passed
- post-fix head `3fa24fd5d14dc5da3acc538cecc22b362ff542f5`
- initial review found one P2 empty-envelope truth defect; fixed with mutation-sensitive regressions
- focused fix verification: ZERO KNOWN ISSUES
- exact-head GitHub checks: passed

## Critical Self-Review

- Highest-risk behavior: suppression could remove unreferenced memories, hide cross-namespace leakage instead of rejecting it, or leave stale citations/counts after filtering.
- Assumptions that could be wrong: citation IDs and source references remain stable enough for callers to echo explicitly; identity-less records should remain visible because they cannot be proven already supplied.
- Missing/weak tests: no hosted caller replay yet; deterministic unit/integration tests cover citation-only, source-ref-only, mixed, unknown, duplicate, all-suppressed, namespace-negative, counts, citations, and budget behavior.
- Security/permission risk: suppression occurs only after the existing namespace- and seven-coordinate-scoped recall query; it cannot broaden reads or authorize another namespace, and raw prior content is not accepted.
- Migration/deploy risk: no database migration; additive optional tool input defaults to existing behavior when omitted.
- Downstream client/runtime risk: direct callers may optionally pass the new input; no standalone Python/TypeScript wrapper is changed in this slice and no implicit prompt placement is introduced.
- Rollback/cleanup concern: revert the one feature commit; no stored data or extracted keys require cleanup.
- Fixes made before PR: preserved and completed the prior worker WIP, added five durable-memory integration regressions, and resolved the #328 schema overlap additively during rebase.
- Known residual risk: the record-level suppression helper trusts the owning recall SQL namespace predicate rather than duplicating per-row authority checks; existing durable-memory isolation tests guard that boundary.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: hosted changed-tool validation occurs only after merge, before issue closure.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this adds an optional server tool input without changing standalone wrapper call shapes or the required manifest contract.

## Downstream Rollout

- [x] Checked `docs/downstream-rollout.md`
- Hosted Open Brain changed-tool canary remains the post-merge closure gate
- Python and future TypeScript clients remain runtime-neutral; no direct Hermes integration is in scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
