### PR TITLE
feat(329): populate pointers and candidate memory

### DIFF
--- a/src/tools/__tests__/agent-context-pack-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-budget.test.ts
@@ -197,6 +197,8 @@ describe("agent_context_pack whole-pack budget", () => {
           "profile_guidance",
           "process_guidance",
           "repo_facts",
+          "pointers",
+          "candidate_memory",
         ],
       });
     } finally {

--- a/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-memory.test.ts
@@ -47,7 +47,7 @@ function brainRecord(
   overrides: Partial<Record<string, unknown>> = {},
 ): Record<string, unknown> {
   return {
-    source_type: "decisions",
+    source_type: "decision",
     id: overrides.id ?? "dec-1",
     namespace: "rico",
     content_preview: "durable decision content",
@@ -153,10 +153,10 @@ describe("agent_context_pack durable_memory", () => {
 
   it("returns recalled records with a resolvable source_ref and matching citation on every item", async () => {
     const records = [
-      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({ id: "dec-1", source_type: "decision" }),
       brainRecord({
         id: "th-1",
-        source_type: "thoughts",
+        source_type: "thought",
         content_preview: "a durable thought",
       }),
     ];
@@ -300,7 +300,7 @@ describe("agent_context_pack durable_memory", () => {
     const records = Array.from({ length: 8 }, (_, index) =>
       brainRecord({
         id: `rank-${index}`,
-        source_type: "decisions",
+        source_type: "decision",
         content_preview: `rank-${index}:` + "D".repeat(800),
         // Descending relevance so RRF keeps rank-0 first, rank-7 last.
         distance: 0.1 + index * 0.05,
@@ -380,7 +380,7 @@ describe("agent_context_pack durable_memory", () => {
     const records = Array.from({ length: 8 }, (_, index) =>
       brainRecord({
         id: `trim-${index}`,
-        source_type: "decisions",
+        source_type: "decision",
         content_preview: `trim-${index}:` + "D".repeat(800),
         distance: 0.1 + index * 0.05,
         fts_rank: 1 - index * 0.1,
@@ -450,7 +450,7 @@ describe("agent_context_pack durable_memory", () => {
     const records = Array.from({ length: 8 }, (_, index) =>
       brainRecord({
         id: `ref-${index}`,
-        source_type: "decisions",
+        source_type: "decision",
         content_preview: `ref-${index}:` + "D".repeat(800),
         distance: 0.1 + index * 0.05,
         fts_rank: 1 - index * 0.1,
@@ -515,7 +515,7 @@ describe("agent_context_pack durable_memory", () => {
     const records = [
       brainRecord({
         id: "solo-1",
-        source_type: "decisions",
+        source_type: "decision",
         content_preview: "solo:" + "D".repeat(2000),
       }),
     ];
@@ -715,10 +715,10 @@ describe("agent_context_pack durable_memory", () => {
     // this turn is passed back by citation_id; recall must drop it and return
     // only net-new records, preserving the original relevance order.
     const records = [
-      brainRecord({ id: "dec-1", source_type: "decisions" }),
+      brainRecord({ id: "dec-1", source_type: "decision" }),
       brainRecord({
         id: "th-1",
-        source_type: "thoughts",
+        source_type: "thought",
         content_preview: "a durable thought",
       }),
     ];
@@ -732,7 +732,7 @@ describe("agent_context_pack durable_memory", () => {
           ...SCOPE,
           query: "durable",
           requested_sections: ["durable_memory"],
-          prior_context: [{ citation_id: "brain_record:decisions:dec-1" }],
+          prior_context: [{ citation_id: "brain_record:decision:dec-1" }],
         },
       });
       const payload = JSON.parse((pack.content as any)[0].text);
@@ -753,7 +753,7 @@ describe("agent_context_pack durable_memory", () => {
       expect(section.empty_reason).toBeUndefined();
       // No citation dangles onto the suppressed record.
       const citationIds = new Set(payload.citations.map((c: any) => c.id));
-      expect(citationIds.has("brain_record:decisions:dec-1")).toBe(false);
+      expect(citationIds.has("brain_record:decision:dec-1")).toBe(false);
       const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
       for (const citation of payload.citations) {
         expect(retainedIds.has(citation.id)).toBe(true);
@@ -772,8 +772,8 @@ describe("agent_context_pack durable_memory", () => {
     // is on identity coordinates (source/type/id/namespace) only, so display
     // fields the caller round-trips must not defeat suppression.
     const records = [
-      brainRecord({ id: "dec-1", source_type: "decisions" }),
-      brainRecord({ id: "dec-2", source_type: "decisions" }),
+      brainRecord({ id: "dec-1", source_type: "decision" }),
+      brainRecord({ id: "dec-2", source_type: "decision" }),
     ];
     const { pool } = searchPool(records);
     const auth: AuthInfo = { role: "admin", clientId: "rico" };
@@ -789,7 +789,7 @@ describe("agent_context_pack durable_memory", () => {
             {
               source_ref: {
                 source: "brain",
-                type: "decisions",
+                type: "decision",
                 id: "dec-1",
                 namespace: "rico",
                 label: "round-tripped display text",
@@ -813,8 +813,8 @@ describe("agent_context_pack durable_memory", () => {
     // An unknown/unmatched prior reference removes nothing: relevant records the
     // model has not already seen are all retained.
     const records = [
-      brainRecord({ id: "dec-1", source_type: "decisions" }),
-      brainRecord({ id: "dec-2", source_type: "decisions" }),
+      brainRecord({ id: "dec-1", source_type: "decision" }),
+      brainRecord({ id: "dec-2", source_type: "decision" }),
     ];
     const { pool } = searchPool(records);
     const auth: AuthInfo = { role: "admin", clientId: "rico" };
@@ -827,7 +827,7 @@ describe("agent_context_pack durable_memory", () => {
           query: "durable",
           requested_sections: ["durable_memory"],
           prior_context: [
-            { citation_id: "brain_record:decisions:not-recalled" },
+            { citation_id: "brain_record:decision:not-recalled" },
           ],
         },
       });
@@ -851,8 +851,8 @@ describe("agent_context_pack durable_memory", () => {
     // empty envelope must say all_suppressed — not no_matches, which would falsely
     // claim recall found nothing.
     const records = [
-      brainRecord({ id: "dec-1", source_type: "decisions" }),
-      brainRecord({ id: "dec-2", source_type: "decisions" }),
+      brainRecord({ id: "dec-1", source_type: "decision" }),
+      brainRecord({ id: "dec-2", source_type: "decision" }),
     ];
     const { pool } = searchPool(records);
     const auth: AuthInfo = { role: "admin", clientId: "rico" };
@@ -865,8 +865,8 @@ describe("agent_context_pack durable_memory", () => {
           query: "durable",
           requested_sections: ["durable_memory"],
           prior_context: [
-            { citation_id: "brain_record:decisions:dec-1" },
-            { citation_id: "brain_record:decisions:dec-2" },
+            { citation_id: "brain_record:decision:dec-1" },
+            { citation_id: "brain_record:decision:dec-2" },
           ],
         },
       });
@@ -1022,8 +1022,8 @@ describe("agent_context_pack durable_memory", () => {
       });
       // Only the emitted record's citation exists; the empty-body one dangles nowhere.
       const citationIds = new Set(payload.citations.map((c: any) => c.id));
-      expect(citationIds.has("brain_record:decisions:good-1")).toBe(true);
-      expect(citationIds.has("brain_record:decisions:empty-1")).toBe(false);
+      expect(citationIds.has("brain_record:decision:good-1")).toBe(true);
+      expect(citationIds.has("brain_record:decision:empty-1")).toBe(false);
       const retainedIds = new Set(section.items.map((i: any) => i.citation_id));
       for (const citation of payload.citations) {
         expect(retainedIds.has(citation.id)).toBe(true);

--- a/src/tools/__tests__/agent-context-pack-pointers-candidates-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-pointers-candidates-budget.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { AuthInfo } from "../../types.ts";
+import type { ToolDeps } from "../index.ts";
+import { WorkingSetStore } from "../../realtime/working-set.ts";
+import { RecoveryWalStore } from "../../realtime/recovery-wal.ts";
+import { registerAgentContextPack } from "../agent-context-pack.ts";
+import { registerGetEntry } from "../get-entry.ts";
+import {
+  AGENT_CONTEXT_PACK_SCOPE as SCOPE,
+  admin,
+  brainRecord,
+  canonical,
+  isRecallSql,
+  nRecords,
+  searchPool,
+  setupAgentContextPackToolClient as setupToolClient,
+} from "./agent-context-pack-test-helpers.ts";
+
+/**
+ * pointers + candidate_memory (#329) — whole-pack budget, cross-section
+ * coexistence/allocation-order, and the author-side get_entry resolution proof.
+ * These exercise the shared structured-section fitter (one whole-pack budget,
+ * citation, and truncation reconciliation) and prove an emitted pointer is a
+ * genuine resolvable reference that binds the SAME auth-derived namespace
+ * predicate the recall applied. Baseline per-section behavior lives in
+ * agent-context-pack-pointers-candidates.test.ts.
+ */
+
+describe("agent_context_pack pointers + candidate_memory budget/integration (#329)", () => {
+  it("whole-pack trimming actually trims durable and resurfaces the trimmed row as a pointer, never silently losing it", async () => {
+    // A calibrated whole-pack budget (max_tokens 600) trims the durable_memory
+    // bodies from the normal cap of 8 down to a SINGLE retained item and stamps a
+    // durable_memory whole_pack_budget truncation marker. The row the durable
+    // section shed for budget must resurface as a pointer (a pointer envelope is
+    // far smaller than a body), never silently lost.
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory", "pointers"],
+          budget: { max_tokens: 600 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const durable = payload.sections.durable_memory;
+      const pointers = payload.sections.pointers;
+
+      // Durable was ACTUALLY trimmed: retained count is below the normal cap of 8
+      // (exactly 1 at this calibrated budget) and its body is marked truncated.
+      expect(durable.item_count).toBe(1);
+      expect(durable.item_count).toBeLessThan(8);
+      expect(durable.truncated).toBe(true);
+      // A whole_pack_budget durable_memory truncation marker is present.
+      const truncation = payload.warnings.truncation as Array<any>;
+      const durableMarker = truncation.find(
+        (t) =>
+          t.source === "durable_memory" && t.reason === "whole_pack_budget",
+      );
+      expect(durableMarker).toBeDefined();
+
+      // The trimmed durable row resurfaces as a pointer.
+      const durableIds = new Set(
+        durable.items.map((i: any) => i.citation_id as string),
+      );
+      const pointerIds = new Set(
+        pointers.items.map((p: any) => p.citation_id as string),
+      );
+      expect(pointerIds.size).toBeGreaterThan(0);
+      // No identity is both durable and pointer.
+      for (const id of pointerIds) {
+        expect(durableIds.has(id)).toBe(false);
+      }
+      // The pointer surfaces a row that was NOT retained as a durable item: the
+      // top-ranked dec-1 was kept durable, dec-2 (next-ranked, trimmed for
+      // budget) resurfaces as the pointer.
+      expect(durableIds.has(canonical("decisions", "dec-1"))).toBe(true);
+      expect(pointerIds.has(canonical("decisions", "dec-2"))).toBe(true);
+      // Union covers strictly more than the retained durable set alone.
+      const union = new Set([...durableIds, ...pointerIds]);
+      expect(union.size).toBeGreaterThan(durableIds.size);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("an emitted pointer's structural source_ref resolves through get_entry under the same auth-derived namespace predicate", async () => {
+    // Author-side proof that a pointer is a genuine resolvable reference: take the
+    // structural source_ref (type + id) an emitted pointer carries and resolve it
+    // through get_entry using a token-scoped agent, then assert the resolution
+    // query bound the caller's auth-derived namespace predicate (the SAME
+    // isolation boundary the recall applied), not an arbitrary namespace.
+    const agentAuth: AuthInfo = {
+      role: "agent",
+      clientId: "team-alpha",
+      namespaceSource: "token",
+    };
+    // Two recallable records in the agent's own namespace. Real UUIDs so
+    // get_entry's uuid-typed id input accepts the resolved id.
+    const idA = "11111111-1111-4111-8111-111111111111";
+    const idB = "22222222-2222-4222-8222-222222222222";
+    const records = [
+      brainRecord({
+        id: idA,
+        namespace: "team-alpha",
+        content_preview: "record A",
+        distance: 0.01,
+        fts_rank: 0.99,
+      }),
+      brainRecord({
+        id: idB,
+        namespace: "team-alpha",
+        content_preview: "record B",
+        distance: 0.02,
+        fts_rank: 0.98,
+      }),
+    ];
+
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    // A shared fake pool: recall arms return the records; a get_entry SELECT
+    // against the decisions table returns the matching row only when its id and
+    // the namespace predicate param are satisfied.
+    const pool = {
+      query: async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params });
+        if (isRecallSql(sql)) {
+          return { rows: records };
+        }
+        // get_entry full-render SELECT ... FROM decisions d WHERE d.id = $1 ...
+        if (sql.includes("FROM decisions")) {
+          const id = params?.[0];
+          const nsParam = params?.[1];
+          const namespaces = Array.isArray(nsParam)
+            ? (nsParam as string[])
+            : null;
+          const match = records.find(
+            (r) =>
+              r.id === id &&
+              (!namespaces || namespaces.includes(r.namespace as string)),
+          );
+          return { rows: match ? [{ ...match }] : [] };
+        }
+        return { rows: [] };
+      },
+    };
+
+    // Register both tools against the one shared pool.
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: pool as any,
+      embedFn: async () => Array(768).fill(0.1),
+      workingSetStore: new WorkingSetStore(),
+      recoveryWalStore: new RecoveryWalStore(),
+    };
+    registerAgentContextPack(server, deps);
+    registerGetEntry(server, deps);
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: agentAuth });
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      // No namespace override: the token-scoped agent reads its own namespace.
+      const { namespace: _drop, ...unnamespacedScope } = SCOPE;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...unnamespacedScope,
+          query: "durable",
+          requested_sections: ["pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const pointers = payload.sections.pointers;
+      expect(pointers.item_count).toBeGreaterThan(0);
+
+      // Take the FIRST emitted pointer's STRUCTURAL source_ref (type + id) and
+      // resolve it. type is the source_type ("decisions"), which is exactly the
+      // get_entry table name; id is the entry UUID.
+      const pointer = pointers.items[0];
+      const table = pointer.source_ref.type as string;
+      const id = pointer.source_ref.id as string;
+      expect(table).toBe("decisions");
+
+      // Clear captured so we inspect only the resolution query's params.
+      captured.length = 0;
+      const entry = await client.callTool({
+        name: "get_entry",
+        arguments: { table, id, render: "full" },
+      });
+      const entryPayload = JSON.parse((entry.content as any)[0].text);
+      expect(entry.isError).toBeFalsy();
+      // The pointer resolved to the exact record it referenced.
+      expect(entryPayload.id).toBe(id);
+      expect(entryPayload.namespace).toBe("team-alpha");
+
+      // The resolution bound the auth-derived namespace predicate: the SELECT
+      // carried a `= ANY($n::text[])` namespace filter and the param array is the
+      // caller's readable namespaces (includes their own clientId), never open.
+      const resolveQuery = captured.find((c) =>
+        (c.sql as string).includes("FROM decisions"),
+      );
+      expect(resolveQuery).toBeDefined();
+      expect(resolveQuery!.sql).toContain("namespace = ANY(");
+      const nsParam = resolveQuery!.params?.[1];
+      expect(Array.isArray(nsParam)).toBe(true);
+      expect(nsParam as string[]).toContain("team-alpha");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("pointers/candidate coexist with actually-present guidance + repo_facts envelopes and appear last in allocation order", async () => {
+    // A query fake that returns the RIGHT row shapes per SQL so profile_guidance,
+    // process_guidance, and repo_facts each produce a real non-empty envelope —
+    // proving coexistence, not just that pointers/candidate appear.
+    const repoFactId = "33333333-3333-4333-8333-333333333333";
+    const pool = {
+      query: async (sql: string) => {
+        if (
+          sql.includes("FROM ob_session_events") &&
+          sql.includes("candidate_type")
+        ) {
+          // profile_guidance (user_preference) and process_guidance
+          // (process_rule) both read this shape; return one promoted row for each
+          // candidate_type the loader asks for. The loader filters by $2, but the
+          // in-process filter also checks row.candidateType, so return both.
+          return {
+            rows: [
+              {
+                id: "evt-pref",
+                content: "prefer brevity",
+                created_at: "2026-07-01T00:00:00Z",
+                memory_lifecycle_action: "promote",
+                candidate_type: "user_preference",
+                candidate_reason: "stated",
+                candidate_confidence: 0.9,
+                candidate_scope: { key: "brevity" },
+              },
+              {
+                id: "evt-rule",
+                content: "branch before coding",
+                created_at: "2026-07-01T00:00:00Z",
+                memory_lifecycle_action: "promote",
+                candidate_type: "process_rule",
+                candidate_reason: "policy",
+                candidate_confidence: 0.9,
+                candidate_scope: { key: "branching" },
+              },
+            ],
+          };
+        }
+        if (sql.includes("FROM ob_entities") && sql.includes("repo_fact")) {
+          return {
+            rows: [
+              {
+                id: repoFactId,
+                namespace: "rico",
+                updated_at: "2026-07-01T00:00:00Z",
+                metadata: {
+                  repo: "rodaddy/open-brain",
+                  fact: "uses Bun runtime",
+                  source_url: "https://example/repo",
+                  source_commit: "abc123",
+                  verified_at: "2026-07-01T00:00:00Z",
+                },
+              },
+            ],
+          };
+        }
+        if (
+          sql.includes("query_embedding") ||
+          sql.includes("fts_query") ||
+          sql.includes("FROM ob_")
+        ) {
+          return { rows: nRecords(3) };
+        }
+        return { rows: [] };
+      },
+    };
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          repo: "rodaddy/open-brain",
+          requested_sections: [
+            "profile_guidance",
+            "process_guidance",
+            "repo_facts",
+            "pointers",
+            "candidate_memory",
+          ],
+          budget: { max_tokens: 4000 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+
+      // Requested guidance + repo_facts envelopes are ACTUALLY present and
+      // non-empty — coexistence is proven, not just pointers/candidate presence.
+      const profile = payload.sections.profile_guidance;
+      const process = payload.sections.process_guidance;
+      const repoFacts = payload.sections.repo_facts;
+      expect(profile).toBeDefined();
+      expect(profile.item_count).toBeGreaterThan(0);
+      expect(process).toBeDefined();
+      expect(process.item_count).toBeGreaterThan(0);
+      expect(repoFacts).toBeDefined();
+      expect(repoFacts.item_count).toBeGreaterThan(0);
+
+      // pointers + candidate_memory coexist alongside them.
+      expect(payload.sections.pointers).toBeDefined();
+      expect(payload.sections.candidate_memory).toBeDefined();
+
+      // Allocation order lists pointers + candidate_memory LAST, after repo_facts.
+      const order = payload.budget.whole_pack.allocation_order as string[];
+      expect(order[order.length - 2]).toBe("pointers");
+      expect(order[order.length - 1]).toBe("candidate_memory");
+      expect(order.indexOf("pointers")).toBeGreaterThan(
+        order.indexOf("repo_facts"),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("under a calibrated tight budget the lowest-priority pointers section is starved while a higher-value section survives", async () => {
+    // Budget max_tokens 700: working_set (a real appended item) and durable_memory
+    // both survive, but the lowest-priority pointers section is fully STARVED with
+    // an explicit starved marker — a non-vacuous ordering proof.
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      // Append a real working_set item so a higher-value section has content to
+      // survive the budget (an empty working_set would starve regardless).
+      await client.callTool({
+        name: "working_set_append",
+        arguments: {
+          ...SCOPE,
+          kind: "current_intent",
+          content: "active intent to keep",
+        },
+      });
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["working_set", "durable_memory", "pointers"],
+          budget: { max_tokens: 700 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+
+      // Higher-value sections survived the same budget that starved pointers.
+      expect(payload.sections.working_set).toBeDefined();
+      expect(payload.sections.working_set.item_count).toBeGreaterThan(0);
+      expect(payload.sections.durable_memory).toBeDefined();
+      expect(payload.sections.durable_memory.item_count).toBeGreaterThan(0);
+
+      // Lowest-priority pointers section was fully starved out.
+      expect(payload.sections.pointers).toBeUndefined();
+      const truncation = payload.warnings.truncation as Array<any>;
+      const pointerStarve = truncation.find((t) => t.source === "pointers");
+      expect(pointerStarve).toBeDefined();
+      expect(pointerStarve.starved).toBe(true);
+      expect(pointerStarve.reason).toBe("whole_pack_budget");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/agent-context-pack-pointers-candidates-budget.test.ts
+++ b/src/tools/__tests__/agent-context-pack-pointers-candidates-budget.test.ts
@@ -31,7 +31,7 @@ import {
 
 describe("agent_context_pack pointers + candidate_memory budget/integration (#329)", () => {
   it("whole-pack trimming actually trims durable and resurfaces the trimmed row as a pointer, never silently losing it", async () => {
-    // A calibrated whole-pack budget (max_tokens 600) trims the durable_memory
+    // A calibrated whole-pack budget (max_tokens 580) trims the durable_memory
     // bodies from the normal cap of 8 down to a SINGLE retained item and stamps a
     // durable_memory whole_pack_budget truncation marker. The row the durable
     // section shed for budget must resurface as a pointer (a pointer envelope is
@@ -45,7 +45,7 @@ describe("agent_context_pack pointers + candidate_memory budget/integration (#32
           ...SCOPE,
           query: "durable",
           requested_sections: ["durable_memory", "pointers"],
-          budget: { max_tokens: 600 },
+          budget: { max_tokens: 580 },
         },
       });
       const payload = JSON.parse((pack.content as any)[0].text);
@@ -81,8 +81,8 @@ describe("agent_context_pack pointers + candidate_memory budget/integration (#32
       // The pointer surfaces a row that was NOT retained as a durable item: the
       // top-ranked dec-1 was kept durable, dec-2 (next-ranked, trimmed for
       // budget) resurfaces as the pointer.
-      expect(durableIds.has(canonical("decisions", "dec-1"))).toBe(true);
-      expect(pointerIds.has(canonical("decisions", "dec-2"))).toBe(true);
+      expect(durableIds.has(canonical("decision", "dec-1"))).toBe(true);
+      expect(pointerIds.has(canonical("decision", "dec-2"))).toBe(true);
       // Union covers strictly more than the retained durable set alone.
       const union = new Set([...durableIds, ...pointerIds]);
       expect(union.size).toBeGreaterThan(durableIds.size);
@@ -187,11 +187,16 @@ describe("agent_context_pack pointers + candidate_memory budget/integration (#32
       expect(pointers.item_count).toBeGreaterThan(0);
 
       // Take the FIRST emitted pointer's STRUCTURAL source_ref (type + id) and
-      // resolve it. type is the source_type ("decisions"), which is exactly the
-      // get_entry table name; id is the entry UUID.
+      // resolve it. type is the SINGULAR source_type ("decision") production's
+      // executeSearch emits; get_entry's table is that source_type + "s"
+      // ("decisions"). Deriving the table this way — rather than passing
+      // source_ref.type through verbatim — is the exact resolution contract a
+      // client follows, and it fails loudly if the fixture ever regresses to
+      // emitting a plural source_type again.
       const pointer = pointers.items[0];
-      const table = pointer.source_ref.type as string;
       const id = pointer.source_ref.id as string;
+      expect(pointer.source_ref.type).toBe("decision");
+      const table = `${pointer.source_ref.type as string}s`;
       expect(table).toBe("decisions");
 
       // Clear captured so we inspect only the resolution query's params.

--- a/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
+++ b/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
@@ -99,8 +99,13 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
         expect(durableIds.has(id)).toBe(false);
       }
       // Every id is canonical brain_record:${source_type}:${id}; no bare key.
+      // source_type is the SINGULAR production label ("decision"), so the
+      // canonical identity is brain_record:decision:<id> — this fails if the
+      // fake ever regresses to emitting a plural source_type.
       for (const item of [...durable.items, ...pointers.items]) {
+        expect(item.source_type).toBe("decision");
         expect(item.citation_id).toBe(canonical(item.source_type, item.id));
+        expect(item.citation_id).toBe(`brain_record:decision:${item.id}`);
       }
       // The rows beyond the cap surface as pointers.
       expect(pointers.item_count).toBe(2);
@@ -195,7 +200,7 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
           ...SCOPE,
           query: "durable",
           requested_sections: ["pointers"],
-          prior_context: [{ citation_id: canonical("decisions", "dec-1") }],
+          prior_context: [{ citation_id: canonical("decision", "dec-1") }],
         },
       });
       const payload = JSON.parse((pack.content as any)[0].text);

--- a/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
+++ b/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
@@ -2,85 +2,29 @@ import { describe, expect, it } from "bun:test";
 import type { AuthInfo } from "../../types.ts";
 import {
   AGENT_CONTEXT_PACK_SCOPE as SCOPE,
+  admin,
+  brainRecord,
+  canonical,
+  isRecallSql,
+  nRecords,
+  searchPool,
   setupAgentContextPackToolClient as setupToolClient,
 } from "./agent-context-pack-test-helpers.ts";
 
 /**
- * pointers + candidate_memory (#329). These sections are pure transforms over
- * the durable_memory hybrid recall's already-authorized, already-suppressed
- * surplus pool — no second retrieval stack. They are black-boxed through the MCP
- * tool: vary requested sections, budget, prior_context, and namespace, and
- * assert the observable envelope, dedupe contract, structural (body-free)
- * source_ref, citation bijection, and the truthful empty candidate shape. The
- * internal SQL is not asserted beyond the single-recall and namespace-predicate
+ * pointers + candidate_memory (#329) — baseline section behavior. These sections
+ * are pure transforms over the durable_memory hybrid recall's already-authorized,
+ * already-suppressed surplus pool (pointers) or independently truthful-empty
+ * (candidate_memory) — no second retrieval stack. They are black-boxed through
+ * the MCP tool: vary requested sections, prior_context, and namespace, and assert
+ * the observable envelope, dedupe contract, structural (body-free) source_ref,
+ * citation bijection, and the truthful empty candidate shape. The internal SQL is
+ * not asserted beyond the single-recall, zero-recall, and namespace-predicate
  * invariants the issue requires proving.
+ *
+ * Whole-pack budget/coexistence and the get_entry resolution proof live in the
+ * companion file agent-context-pack-pointers-candidates-budget.test.ts.
  */
-
-/**
- * A mock pool that answers the hybrid search CTEs (vector + FTS) with a supplied
- * set of brain records and records every query's params so isolation predicates
- * and the single-recall invariant can be asserted.
- */
-function searchPool(
-  records: Array<Record<string, unknown>>,
-  captured: Array<{ sql: string; params?: unknown[] }> = [],
-) {
-  return {
-    pool: {
-      query: async (sql: string, params?: unknown[]) => {
-        captured.push({ sql, params });
-        if (
-          sql.includes("query_embedding") ||
-          sql.includes("fts_query") ||
-          sql.includes("FROM ob_")
-        ) {
-          return { rows: records };
-        }
-        return { rows: [] };
-      },
-    },
-    captured,
-  };
-}
-
-function brainRecord(
-  overrides: Partial<Record<string, unknown>> = {},
-): Record<string, unknown> {
-  return {
-    source_type: "decisions",
-    id: overrides.id ?? "dec-1",
-    namespace: "rico",
-    content_preview: "durable decision content",
-    tags: null,
-    created_by: "rico",
-    created_at: "2026-07-01T00:00:00Z",
-    updated_at: "2026-07-02T00:00:00Z",
-    usefulness: 0.9,
-    tier: "warm",
-    distance: 0.1,
-    fts_rank: 0.9,
-    ...overrides,
-  };
-}
-
-/** N distinct decision records dec-1..dec-N with distinct ranked previews. */
-function nRecords(n: number): Array<Record<string, unknown>> {
-  return Array.from({ length: n }, (_v, i) =>
-    brainRecord({
-      id: `dec-${i + 1}`,
-      content_preview: `durable decision content ${i + 1}`,
-      // Descending distance keeps dec-1 highest-ranked, dec-N lowest.
-      distance: 0.01 * (i + 1),
-      fts_rank: 1 - 0.01 * (i + 1),
-    }),
-  );
-}
-
-const admin: AuthInfo = { role: "admin", clientId: "rico" };
-
-function canonical(sourceType: string, id: string): string {
-  return `brain_record:${sourceType}:${id}`;
-}
 
 describe("agent_context_pack pointers + candidate_memory (#329)", () => {
   it("pointers-only request makes every authorized recalled row pointer-eligible, including the top durable-memory rows", async () => {
@@ -117,15 +61,8 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
 
       // The recall ran exactly once (one executeSearch => one vector CTE + one
       // FTS CTE call is the search stack; no second retrieval stack for pointers).
-      // Assert no additional recall was issued beyond the durable_memory recall.
-      const recallCalls = captured.filter(
-        (c) =>
-          typeof c.sql === "string" &&
-          (c.sql.includes("query_embedding") ||
-            c.sql.includes("fts_query") ||
-            c.sql.includes("FROM ob_")),
-      );
       // vector + FTS arms of the single hybrid recall; no third arm for pointers.
+      const recallCalls = captured.filter((c) => isRecallSql(c.sql));
       expect(recallCalls.length).toBeLessThanOrEqual(2);
     } finally {
       await cleanup();
@@ -164,55 +101,8 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
       for (const item of [...durable.items, ...pointers.items]) {
         expect(item.citation_id).toBe(canonical(item.source_type, item.id));
       }
-      // deduped_against_durable reflects the retained durable identities.
+      // The rows beyond the cap surface as pointers.
       expect(pointers.item_count).toBe(2);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("whole-pack trimming does not silently lose pointer-eligible rows: a durable row trimmed for budget stays pointer-eligible", async () => {
-    // A tight whole-pack budget starves the durable_memory bodies. Rows the
-    // durable section could not retain must resurface as pointers (a pointer
-    // envelope is far smaller than a body), never silently lost.
-    const { pool } = searchPool(nRecords(10));
-    const { client, cleanup } = await setupToolClient(admin, pool);
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          query: "durable",
-          requested_sections: ["durable_memory", "pointers"],
-          // Trims durable bodies down to a single retained item, but the far
-          // smaller pointer envelope still admits a trimmed row.
-          budget: { max_tokens: 600 },
-        },
-      });
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(pack.isError).toBeFalsy();
-      const durable = payload.sections.durable_memory;
-      const pointers = payload.sections.pointers;
-
-      const durableIds = new Set(
-        (durable?.items ?? []).map((i: any) => i.citation_id as string),
-      );
-      const pointerIds = new Set(
-        (pointers?.items ?? []).map((p: any) => p.citation_id as string),
-      );
-      // Durable was trimmed under budget pressure but did retain at least one
-      // body, and pointers surfaced at least one additional row.
-      expect(durableIds.size).toBeGreaterThan(0);
-      expect(pointerIds.size).toBeGreaterThan(0);
-      // No identity is both durable and pointer.
-      for (const id of pointerIds) {
-        expect(durableIds.has(id)).toBe(false);
-      }
-      // Union covers strictly more than the retained durable set alone: a row the
-      // durable section shed for budget is still surfaced as a pointer, never
-      // silently lost.
-      const union = new Set([...durableIds, ...pointerIds]);
-      expect(union.size).toBeGreaterThan(durableIds.size);
     } finally {
       await cleanup();
     }
@@ -345,21 +235,68 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
       expect(pack.isError).toBe(true);
       expect(String(payload.error)).toContain("Permission denied");
       // No recall query was ever issued.
-      const recallCalls = captured.filter(
-        (c) =>
-          typeof c.sql === "string" &&
-          (c.sql.includes("query_embedding") ||
-            c.sql.includes("fts_query") ||
-            c.sql.includes("FROM ob_")),
-      );
+      const recallCalls = captured.filter((c) => isRecallSql(c.sql));
       expect(recallCalls).toHaveLength(0);
     } finally {
       await cleanup();
     }
   });
 
-  it("candidate_memory is a truthful empty section: no predicate, no inference, no citations", async () => {
-    const { pool } = searchPool(nRecords(10));
+  it("candidate_memory alone runs ZERO recall queries and is a truthful empty section", async () => {
+    // candidate_memory has no write-side candidate predicate, so it always emits
+    // a truthful empty envelope. A candidate-only request must therefore NOT run
+    // the durable hybrid recall just to compute anything: zero recall queries.
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool(nRecords(10), captured);
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["candidate_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+
+      // Zero recall queries: candidate_memory alone never drives the hybrid
+      // retrieval stack.
+      const recallCalls = captured.filter((c) => isRecallSql(c.sql));
+      expect(recallCalls).toHaveLength(0);
+
+      const candidate = payload.sections.candidate_memory;
+      // Exact truthful-empty candidate contract.
+      expect(candidate).toEqual({
+        label: "candidate_memory",
+        namespace_scoped: true,
+        confidence: "unconfirmed",
+        auto_promotable: false,
+        items: [],
+        item_count: 0,
+        empty_reason: "candidate_predicate_unavailable",
+        truncated: false,
+      });
+      // No durable_memory or pointers section leaked into a candidate-only pack.
+      expect(payload.sections.durable_memory).toBeUndefined();
+      expect(payload.sections.pointers).toBeUndefined();
+      // No candidate citation is emitted.
+      const candidateCitations = payload.citations.filter(
+        (c: any) => c.kind === "candidate",
+      );
+      expect(candidateCitations).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("candidate_memory co-requested with durable/pointers reuses the single recall and stays a truthful empty section", async () => {
+    // When durable_memory or pointers is also requested the recall runs once for
+    // them; candidate_memory reuses nothing extra and still emits its exact
+    // truthful empty envelope with no dedupe-count field and no citations.
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool(nRecords(10), captured);
     const { client, cleanup } = await setupToolClient(admin, pool);
     try {
       const pack = await client.callTool({
@@ -376,98 +313,29 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
       });
       const payload = JSON.parse((pack.content as any)[0].text);
       expect(pack.isError).toBeFalsy();
+      // A single hybrid recall (its two arms) serves durable + pointers; the
+      // candidate section adds no third arm.
+      const recallCalls = captured.filter((c) => isRecallSql(c.sql));
+      expect(recallCalls.length).toBeLessThanOrEqual(2);
+
       const candidate = payload.sections.candidate_memory;
-      expect(candidate).toMatchObject({
+      expect(candidate).toEqual({
         label: "candidate_memory",
         namespace_scoped: true,
         confidence: "unconfirmed",
         auto_promotable: false,
+        items: [],
         item_count: 0,
         empty_reason: "candidate_predicate_unavailable",
         truncated: false,
       });
-      expect(candidate.items).toEqual([]);
-      // No verbose public missing-contract detail leaks.
+      // No synthetic dedupe observability is emitted.
+      expect(candidate).not.toHaveProperty("dedupe_against_count");
       expect(candidate).not.toHaveProperty("missing_contract");
-      // dedupe_against_count reflects retained durable + emitted pointer
-      // identities (candidate dedupe contract), content-free.
-      const durableCount = payload.sections.durable_memory.item_count;
-      const pointerCount = payload.sections.pointers.item_count;
-      expect(candidate.dedupe_against_count).toBe(durableCount + pointerCount);
-      // No candidate citation is emitted.
       const candidateCitations = payload.citations.filter(
         (c: any) => c.kind === "candidate",
       );
       expect(candidateCitations).toHaveLength(0);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("pointers/candidate coexist with guidance/repo_facts and appear last in allocation order", async () => {
-    const { pool } = searchPool(nRecords(3));
-    const { client, cleanup } = await setupToolClient(admin, pool);
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          query: "durable",
-          repo: "rodaddy/open-brain",
-          requested_sections: [
-            "profile_guidance",
-            "process_guidance",
-            "repo_facts",
-            "pointers",
-            "candidate_memory",
-          ],
-          budget: { max_tokens: 4000 },
-        },
-      });
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(pack.isError).toBeFalsy();
-      // All requested structured sections coexist.
-      expect(payload.sections.pointers).toBeDefined();
-      expect(payload.sections.candidate_memory).toBeDefined();
-      // Allocation order lists pointers + candidate_memory LAST, after repo_facts.
-      const order = payload.budget.whole_pack.allocation_order as string[];
-      expect(order[order.length - 2]).toBe("pointers");
-      expect(order[order.length - 1]).toBe("candidate_memory");
-      expect(order.indexOf("pointers")).toBeGreaterThan(
-        order.indexOf("repo_facts"),
-      );
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("lowest-priority pointers are starved before any higher-value section under a tight budget", async () => {
-    // A budget large enough for working_set but not for the lowest-priority
-    // pointers section drops pointers first, leaving higher-value sections.
-    const { pool } = searchPool(nRecords(10));
-    const { client, cleanup } = await setupToolClient(admin, pool);
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          query: "durable",
-          requested_sections: ["durable_memory", "pointers"],
-          budget: { max_tokens: 150 },
-        },
-      });
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(pack.isError).toBeFalsy();
-      // Under severe pressure the lowest-priority pointers section is trimmed or
-      // starved before durable_memory loses everything: if pointers is present
-      // it never overflows, and any drop is recorded in truncation.
-      const truncation = payload.warnings.truncation as Array<any>;
-      const pointerStarve = truncation.find((t) => t.source === "pointers");
-      if (!payload.sections.pointers) {
-        // Fully starved: a starved marker must record the drop.
-        expect(pointerStarve).toBeDefined();
-        expect(pointerStarve.starved).toBe(true);
-      }
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
+++ b/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthInfo } from "../../types.ts";
+import {
+  AGENT_CONTEXT_PACK_SCOPE as SCOPE,
+  setupAgentContextPackToolClient as setupToolClient,
+} from "./agent-context-pack-test-helpers.ts";
+
+/**
+ * pointers + candidate_memory (#329). These sections are pure transforms over
+ * the durable_memory hybrid recall's already-authorized, already-suppressed
+ * surplus pool — no second retrieval stack. They are black-boxed through the MCP
+ * tool: vary requested sections, budget, prior_context, and namespace, and
+ * assert the observable envelope, dedupe contract, structural (body-free)
+ * source_ref, citation bijection, and the truthful empty candidate shape. The
+ * internal SQL is not asserted beyond the single-recall and namespace-predicate
+ * invariants the issue requires proving.
+ */
+
+/**
+ * A mock pool that answers the hybrid search CTEs (vector + FTS) with a supplied
+ * set of brain records and records every query's params so isolation predicates
+ * and the single-recall invariant can be asserted.
+ */
+function searchPool(
+  records: Array<Record<string, unknown>>,
+  captured: Array<{ sql: string; params?: unknown[] }> = [],
+) {
+  return {
+    pool: {
+      query: async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params });
+        if (
+          sql.includes("query_embedding") ||
+          sql.includes("fts_query") ||
+          sql.includes("FROM ob_")
+        ) {
+          return { rows: records };
+        }
+        return { rows: [] };
+      },
+    },
+    captured,
+  };
+}
+
+function brainRecord(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    source_type: "decisions",
+    id: overrides.id ?? "dec-1",
+    namespace: "rico",
+    content_preview: "durable decision content",
+    tags: null,
+    created_by: "rico",
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-02T00:00:00Z",
+    usefulness: 0.9,
+    tier: "warm",
+    distance: 0.1,
+    fts_rank: 0.9,
+    ...overrides,
+  };
+}
+
+/** N distinct decision records dec-1..dec-N with distinct ranked previews. */
+function nRecords(n: number): Array<Record<string, unknown>> {
+  return Array.from({ length: n }, (_v, i) =>
+    brainRecord({
+      id: `dec-${i + 1}`,
+      content_preview: `durable decision content ${i + 1}`,
+      // Descending distance keeps dec-1 highest-ranked, dec-N lowest.
+      distance: 0.01 * (i + 1),
+      fts_rank: 1 - 0.01 * (i + 1),
+    }),
+  );
+}
+
+const admin: AuthInfo = { role: "admin", clientId: "rico" };
+
+function canonical(sourceType: string, id: string): string {
+  return `brain_record:${sourceType}:${id}`;
+}
+
+describe("agent_context_pack pointers + candidate_memory (#329)", () => {
+  it("pointers-only request makes every authorized recalled row pointer-eligible, including the top durable-memory rows", async () => {
+    // 10 distinct rows; durable cap is 8. A pointers-only request suppresses the
+    // durable_memory section, so the top-ranked rows must NOT be hidden — every
+    // authorized row is pointer-eligible.
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool(nRecords(10), captured);
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      // durable_memory section body is suppressed for a pointers-only request.
+      expect(payload.sections.durable_memory).toBeUndefined();
+
+      const pointers = payload.sections.pointers;
+      expect(pointers.label).toBe("pointers");
+      expect(pointers.namespace_scoped).toBe(true);
+      expect(pointers.resolvable_reference_only).toBe(true);
+      // All 10 authorized rows are pointer-eligible — the top durable rows are
+      // NOT hidden behind the durable cap just because recall built bodies.
+      expect(pointers.item_count).toBe(10);
+      const ids = pointers.items.map((p: any) => p.id);
+      expect(ids).toContain("dec-1"); // top-ranked, would be durable item #1
+      expect(ids).toContain("dec-10"); // lowest-ranked
+
+      // The recall ran exactly once (one executeSearch => one vector CTE + one
+      // FTS CTE call is the search stack; no second retrieval stack for pointers).
+      // Assert no additional recall was issued beyond the durable_memory recall.
+      const recallCalls = captured.filter(
+        (c) =>
+          typeof c.sql === "string" &&
+          (c.sql.includes("query_embedding") ||
+            c.sql.includes("fts_query") ||
+            c.sql.includes("FROM ob_")),
+      );
+      // vector + FTS arms of the single hybrid recall; no third arm for pointers.
+      expect(recallCalls.length).toBeLessThanOrEqual(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("durable_memory + pointers share no duplicate canonical identity", async () => {
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory", "pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const durable = payload.sections.durable_memory;
+      const pointers = payload.sections.pointers;
+      expect(durable.item_count).toBe(8); // hard durable cap
+      // The 2 rows beyond the cap are pointers; none of the retained durable
+      // rows re-appear as a pointer.
+      const durableIds = new Set(
+        durable.items.map((i: any) => i.citation_id as string),
+      );
+      const pointerIds = new Set(
+        pointers.items.map((p: any) => p.citation_id as string),
+      );
+      for (const id of pointerIds) {
+        expect(durableIds.has(id)).toBe(false);
+      }
+      // Every id is canonical brain_record:${source_type}:${id}; no bare key.
+      for (const item of [...durable.items, ...pointers.items]) {
+        expect(item.citation_id).toBe(canonical(item.source_type, item.id));
+      }
+      // deduped_against_durable reflects the retained durable identities.
+      expect(pointers.item_count).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("whole-pack trimming does not silently lose pointer-eligible rows: a durable row trimmed for budget stays pointer-eligible", async () => {
+    // A tight whole-pack budget starves the durable_memory bodies. Rows the
+    // durable section could not retain must resurface as pointers (a pointer
+    // envelope is far smaller than a body), never silently lost.
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory", "pointers"],
+          // Trims durable bodies down to a single retained item, but the far
+          // smaller pointer envelope still admits a trimmed row.
+          budget: { max_tokens: 600 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const durable = payload.sections.durable_memory;
+      const pointers = payload.sections.pointers;
+
+      const durableIds = new Set(
+        (durable?.items ?? []).map((i: any) => i.citation_id as string),
+      );
+      const pointerIds = new Set(
+        (pointers?.items ?? []).map((p: any) => p.citation_id as string),
+      );
+      // Durable was trimmed under budget pressure but did retain at least one
+      // body, and pointers surfaced at least one additional row.
+      expect(durableIds.size).toBeGreaterThan(0);
+      expect(pointerIds.size).toBeGreaterThan(0);
+      // No identity is both durable and pointer.
+      for (const id of pointerIds) {
+        expect(durableIds.has(id)).toBe(false);
+      }
+      // Union covers strictly more than the retained durable set alone: a row the
+      // durable section shed for budget is still surfaced as a pointer, never
+      // silently lost.
+      const union = new Set([...durableIds, ...pointerIds]);
+      expect(union.size).toBeGreaterThan(durableIds.size);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("pointers carry no body: no content, content_preview, label, or preview leaks", async () => {
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const pointers = payload.sections.pointers;
+      expect(pointers.item_count).toBeGreaterThan(0);
+      for (const item of pointers.items) {
+        expect(item).not.toHaveProperty("content");
+        expect(item).not.toHaveProperty("content_preview");
+        expect(item).not.toHaveProperty("label");
+        expect(item).not.toHaveProperty("preview");
+        // source_ref is identity coordinates only — no label/preview/body.
+        expect(item.source_ref).not.toHaveProperty("label");
+        expect(item.source_ref).not.toHaveProperty("preview");
+        expect(Object.keys(item.source_ref).sort()).toEqual(
+          ["id", "namespace", "source", "type"].sort(),
+        );
+      }
+      // Serialized section must not carry the raw preview text anywhere.
+      const serialized = JSON.stringify(pointers);
+      expect(serialized).not.toContain("durable decision content");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("pointer source_ref is structural and citations are a bijection of emitted pointers", async () => {
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const pointers = payload.sections.pointers;
+      const pointerCitations = payload.citations.filter(
+        (c: any) => c.kind === "pointer",
+      );
+      // Bijection: exactly one pointer citation per emitted pointer item, keyed
+      // on the canonical citation_id, with a structural source_ref.
+      expect(pointerCitations.length).toBe(pointers.items.length);
+      const citationIds = new Set(pointerCitations.map((c: any) => c.id));
+      for (const item of pointers.items) {
+        expect(citationIds.has(item.citation_id)).toBe(true);
+        const citation = pointerCitations.find(
+          (c: any) => c.id === item.citation_id,
+        );
+        expect(citation.source_ref).toEqual(item.source_ref);
+        expect(citation.source_ref.source).toBe("brain");
+        expect(citation.source_ref.type).toBe(item.source_type);
+        expect(citation.source_ref.id).toBe(item.id);
+      }
+      // No pointer citation references an unemitted item.
+      const emittedIds = new Set(pointers.items.map((i: any) => i.citation_id));
+      for (const citation of pointerCitations) {
+        expect(emittedIds.has(citation.id)).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("prior_context suppression still removes referenced records before they become pointers", async () => {
+    const { pool } = searchPool(nRecords(4));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["pointers"],
+          prior_context: [{ citation_id: canonical("decisions", "dec-1") }],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      const pointers = payload.sections.pointers;
+      const ids = pointers.items.map((p: any) => p.id);
+      // The suppressed record is never surfaced as a pointer either.
+      expect(ids).not.toContain("dec-1");
+      expect(ids).toContain("dec-2");
+      expect(pointers.item_count).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("unauthorized namespace override fails before any recall runs", async () => {
+    // A token-scoped agent cannot read an arbitrary namespace. The override must
+    // be denied BEFORE the recall (no query issued).
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = searchPool(nRecords(4), captured);
+    const agentAuth: AuthInfo = {
+      role: "agent",
+      clientId: "team-alpha",
+      namespaceSource: "token",
+    };
+    const { client, cleanup } = await setupToolClient(agentAuth, pool);
+    try {
+      const { namespace: _drop, ...unnamespacedScope } = SCOPE;
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...unnamespacedScope,
+          namespace: "someone-elses-namespace",
+          query: "durable",
+          requested_sections: ["pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBe(true);
+      expect(String(payload.error)).toContain("Permission denied");
+      // No recall query was ever issued.
+      const recallCalls = captured.filter(
+        (c) =>
+          typeof c.sql === "string" &&
+          (c.sql.includes("query_embedding") ||
+            c.sql.includes("fts_query") ||
+            c.sql.includes("FROM ob_")),
+      );
+      expect(recallCalls).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("candidate_memory is a truthful empty section: no predicate, no inference, no citations", async () => {
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: [
+            "durable_memory",
+            "pointers",
+            "candidate_memory",
+          ],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const candidate = payload.sections.candidate_memory;
+      expect(candidate).toMatchObject({
+        label: "candidate_memory",
+        namespace_scoped: true,
+        confidence: "unconfirmed",
+        auto_promotable: false,
+        item_count: 0,
+        empty_reason: "candidate_predicate_unavailable",
+        truncated: false,
+      });
+      expect(candidate.items).toEqual([]);
+      // No verbose public missing-contract detail leaks.
+      expect(candidate).not.toHaveProperty("missing_contract");
+      // dedupe_against_count reflects retained durable + emitted pointer
+      // identities (candidate dedupe contract), content-free.
+      const durableCount = payload.sections.durable_memory.item_count;
+      const pointerCount = payload.sections.pointers.item_count;
+      expect(candidate.dedupe_against_count).toBe(durableCount + pointerCount);
+      // No candidate citation is emitted.
+      const candidateCitations = payload.citations.filter(
+        (c: any) => c.kind === "candidate",
+      );
+      expect(candidateCitations).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("pointers/candidate coexist with guidance/repo_facts and appear last in allocation order", async () => {
+    const { pool } = searchPool(nRecords(3));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          repo: "rodaddy/open-brain",
+          requested_sections: [
+            "profile_guidance",
+            "process_guidance",
+            "repo_facts",
+            "pointers",
+            "candidate_memory",
+          ],
+          budget: { max_tokens: 4000 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      // All requested structured sections coexist.
+      expect(payload.sections.pointers).toBeDefined();
+      expect(payload.sections.candidate_memory).toBeDefined();
+      // Allocation order lists pointers + candidate_memory LAST, after repo_facts.
+      const order = payload.budget.whole_pack.allocation_order as string[];
+      expect(order[order.length - 2]).toBe("pointers");
+      expect(order[order.length - 1]).toBe("candidate_memory");
+      expect(order.indexOf("pointers")).toBeGreaterThan(
+        order.indexOf("repo_facts"),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("lowest-priority pointers are starved before any higher-value section under a tight budget", async () => {
+    // A budget large enough for working_set but not for the lowest-priority
+    // pointers section drops pointers first, leaving higher-value sections.
+    const { pool } = searchPool(nRecords(10));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["durable_memory", "pointers"],
+          budget: { max_tokens: 150 },
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      // Under severe pressure the lowest-priority pointers section is trimmed or
+      // starved before durable_memory loses everything: if pointers is present
+      // it never overflows, and any drop is recorded in truncation.
+      const truncation = payload.warnings.truncation as Array<any>;
+      const pointerStarve = truncation.find((t) => t.source === "pointers");
+      if (!payload.sections.pointers) {
+        // Fully starved: a starved marker must record the drop.
+        expect(pointerStarve).toBeDefined();
+        expect(pointerStarve.starved).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
+++ b/src/tools/__tests__/agent-context-pack-pointers-candidates.test.ts
@@ -9,6 +9,7 @@ import {
   nRecords,
   searchPool,
   setupAgentContextPackToolClient as setupToolClient,
+  throwingSearchPool,
 } from "./agent-context-pack-test-helpers.ts";
 
 /**
@@ -336,6 +337,115 @@ describe("agent_context_pack pointers + candidate_memory (#329)", () => {
         (c: any) => c.kind === "candidate",
       );
       expect(candidateCitations).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("pointers-only recall failure yields a truthful empty pointers section with exactly one degraded marker, folded once when candidate is co-requested", async () => {
+    // The shared durable recall throws. pointers was the ONLY driver of that
+    // recall (durable_memory section not requested), so its content-free
+    // recall_failed warning must surface through the pointers section exactly
+    // once — and co-requesting candidate_memory must NOT duplicate it.
+    const captured: Array<{ sql: string; params?: unknown[] }> = [];
+    const { pool } = throwingSearchPool(captured);
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["pointers", "candidate_memory"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+
+      // The recall was actually attempted (and threw) — this is a failure path,
+      // not a "never queried" path.
+      expect(captured.some((c) => isRecallSql(c.sql))).toBe(true);
+
+      // pointers is emitted, truthfully empty, with zero pointer citations.
+      const pointers = payload.sections.pointers;
+      expect(pointers.label).toBe("pointers");
+      expect(pointers.item_count).toBe(0);
+      expect(pointers.items).toEqual([]);
+      expect(pointers.truncated).toBe(false);
+      // durable_memory section body stays suppressed (it was never requested).
+      expect(payload.sections.durable_memory).toBeUndefined();
+      const pointerCitations = payload.citations.filter(
+        (c: any) => c.kind === "pointer",
+      );
+      expect(pointerCitations).toHaveLength(0);
+
+      // Exactly one degraded marker at the top level, content-free.
+      const degraded = payload.warnings.degraded_sources;
+      const recallFailed = degraded.filter(
+        (d: any) =>
+          d.source === "durable_memory" && d.reason === "recall_failed",
+      );
+      expect(recallFailed).toHaveLength(1);
+      expect(recallFailed[0]).toEqual({
+        source: "durable_memory",
+        reason: "recall_failed",
+      });
+      // Co-requested candidate_memory did not fold the same warning a second time.
+      expect(degraded).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("more than 20 eligible pointers cap at 20 with a truncation marker, complete citations, and no orphans", async () => {
+    // 25 distinct rows are recalled; a pointers-only request suppresses the
+    // durable_memory section, so all 25 are pointer-eligible (zero durable
+    // dedupe). The pointer builder's hard ceiling is 20.
+    const { pool } = searchPool(nRecords(25));
+    const { client, cleanup } = await setupToolClient(admin, pool);
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          query: "durable",
+          requested_sections: ["pointers"],
+        },
+      });
+      const payload = JSON.parse((pack.content as any)[0].text);
+      expect(pack.isError).toBeFalsy();
+      const pointers = payload.sections.pointers;
+
+      // Capped at exactly 20, section reports the truncation.
+      expect(pointers.item_count).toBe(20);
+      expect(pointers.items).toHaveLength(20);
+      expect(pointers.truncated).toBe(true);
+
+      // Exactly 20 matching pointer citations — a bijection, no orphans either way.
+      const pointerCitations = payload.citations.filter(
+        (c: any) => c.kind === "pointer",
+      );
+      expect(pointerCitations).toHaveLength(20);
+      const citationIds = new Set(pointerCitations.map((c: any) => c.id));
+      const itemIds = new Set(pointers.items.map((p: any) => p.citation_id));
+      expect(citationIds).toEqual(itemIds);
+      for (const item of pointers.items) {
+        expect(citationIds.has(item.citation_id)).toBe(true);
+      }
+      for (const citation of pointerCitations) {
+        expect(itemIds.has(citation.id)).toBe(true);
+      }
+
+      // The truncation warning names the pointer item source with the 20 ceiling.
+      const truncation = payload.warnings.truncation;
+      const pointerTruncation = truncation.filter(
+        (t: any) => t.source === "pointers.items",
+      );
+      expect(pointerTruncation).toHaveLength(1);
+      expect(pointerTruncation[0]).toMatchObject({
+        source: "pointers.items",
+        max_items: 20,
+      });
     } finally {
       await cleanup();
     }

--- a/src/tools/__tests__/agent-context-pack-test-helpers.ts
+++ b/src/tools/__tests__/agent-context-pack-test-helpers.ts
@@ -66,3 +66,79 @@ export async function setupAgentContextPackToolClient(
     },
   };
 }
+
+/**
+ * A mock pool that answers the hybrid search CTEs (vector + FTS) with a supplied
+ * set of brain records and records every query's sql/params so the single-recall
+ * / zero-recall invariants and namespace predicates can be asserted.
+ */
+export function searchPool(
+  records: Array<Record<string, unknown>>,
+  captured: Array<{ sql: string; params?: unknown[] }> = [],
+) {
+  return {
+    pool: {
+      query: async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params });
+        if (
+          sql.includes("query_embedding") ||
+          sql.includes("fts_query") ||
+          sql.includes("FROM ob_")
+        ) {
+          return { rows: records };
+        }
+        return { rows: [] };
+      },
+    },
+    captured,
+  };
+}
+
+/** True for any SQL that is a durable recall arm (vector/FTS/entity table). */
+export function isRecallSql(sql: unknown): boolean {
+  return (
+    typeof sql === "string" &&
+    (sql.includes("query_embedding") ||
+      sql.includes("fts_query") ||
+      sql.includes("FROM ob_"))
+  );
+}
+
+export function brainRecord(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    source_type: "decisions",
+    id: overrides.id ?? "dec-1",
+    namespace: "rico",
+    content_preview: "durable decision content",
+    tags: null,
+    created_by: "rico",
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-02T00:00:00Z",
+    usefulness: 0.9,
+    tier: "warm",
+    distance: 0.1,
+    fts_rank: 0.9,
+    ...overrides,
+  };
+}
+
+/** N distinct decision records dec-1..dec-N with distinct ranked previews. */
+export function nRecords(n: number): Array<Record<string, unknown>> {
+  return Array.from({ length: n }, (_v, i) =>
+    brainRecord({
+      id: `dec-${i + 1}`,
+      content_preview: `durable decision content ${i + 1}`,
+      // Descending distance keeps dec-1 highest-ranked, dec-N lowest.
+      distance: 0.01 * (i + 1),
+      fts_rank: 1 - 0.01 * (i + 1),
+    }),
+  );
+}
+
+export const admin: AuthInfo = { role: "admin", clientId: "rico" };
+
+export function canonical(sourceType: string, id: string): string {
+  return `brain_record:${sourceType}:${id}`;
+}

--- a/src/tools/__tests__/agent-context-pack-test-helpers.ts
+++ b/src/tools/__tests__/agent-context-pack-test-helpers.ts
@@ -130,7 +130,11 @@ export function brainRecord(
   overrides: Partial<Record<string, unknown>> = {},
 ): Record<string, unknown> {
   return {
-    source_type: "decisions",
+    // Production executeSearch labels rows with the SINGULAR source_type
+    // (SOURCE_LABELS: decisions -> "decision"); the plural is the table name.
+    // Emit singular here so the canonical identity is brain_record:decision:<id>
+    // and get_entry resolution must derive the table as source_type + "s".
+    source_type: "decision",
     id: overrides.id ?? "dec-1",
     namespace: "rico",
     content_preview: "durable decision content",

--- a/src/tools/__tests__/agent-context-pack-test-helpers.ts
+++ b/src/tools/__tests__/agent-context-pack-test-helpers.ts
@@ -94,6 +94,28 @@ export function searchPool(
   };
 }
 
+/**
+ * A mock pool whose recall arms (vector/FTS/entity table) reject, so
+ * `executeSearch` throws and the durable-memory loader takes its `recall_failed`
+ * degraded path. Non-recall queries still answer empty so unrelated reads work.
+ */
+export function throwingSearchPool(
+  captured: Array<{ sql: string; params?: unknown[] }> = [],
+) {
+  return {
+    pool: {
+      query: async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params });
+        if (isRecallSql(sql)) {
+          throw new Error("recall boom");
+        }
+        return { rows: [] };
+      },
+    },
+    captured,
+  };
+}
+
 /** True for any SQL that is a durable recall arm (vector/FTS/entity table). */
 export function isRecallSql(sql: unknown): boolean {
   return (

--- a/src/tools/agent-context-pack-budget.ts
+++ b/src/tools/agent-context-pack-budget.ts
@@ -18,10 +18,13 @@ export const CHARS_PER_TOKEN = 4;
  * is the exact-scope hot active state, recovery is the explicit opt-in
  * interrupted-session trace, durable_lane_context is the broader recallable
  * lane context, and durable_memory is the query-driven hybrid recall over durable
- * brain records — the lowest-priority section, allocated last against whatever
- * budget survives. A lower-priority section is only assembled against whatever
- * pack budget the higher-priority sections leave behind, so one large section
- * cannot starve a higher-value one. This order is stable for identical inputs.
+ * brain records. The structured guidance/repo_facts sections follow, and
+ * `pointers` + `candidate_memory` (#329) are the lowest-priority members,
+ * allocated LAST after repo_facts against whatever budget survives — lightweight
+ * reference/candidate views that must never starve a higher-value body-bearing
+ * section. A lower-priority section is only assembled against whatever pack
+ * budget the higher-priority sections leave behind, so one large section cannot
+ * starve a higher-value one. This order is stable for identical inputs.
  */
 export const CONTEXT_PACK_SECTION_PRIORITY = [
   "working_set",
@@ -31,6 +34,8 @@ export const CONTEXT_PACK_SECTION_PRIORITY = [
   "profile_guidance",
   "process_guidance",
   "repo_facts",
+  "pointers",
+  "candidate_memory",
 ] as const;
 
 /** Serialized size, in characters, of a section's content payload. */

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -19,6 +19,17 @@ const DURABLE_MEMORY_MAX_ITEMS = 8;
 const DURABLE_MEMORY_MAX_ITEM_CHARS = 1_000;
 
 /**
+ * Extra recall rows fetched beyond {@link DURABLE_MEMORY_MAX_ITEMS} so the
+ * `pointers` section (#329) has a net-new, already-authorized pool to draw from
+ * WITHOUT a second retrieval stack. The single `executeSearch` call below
+ * over-fetches by this much; the first rows become durable_memory items (with
+ * bodies) and the surplus net-new rows are handed to the pointer builder as
+ * lightweight references only (no body copied, no second query issued). Bounded
+ * so recall stays cheap; the pointer builder applies its own hard item ceiling.
+ */
+const DURABLE_MEMORY_POINTER_OVERFETCH = 20;
+
+/**
  * Resolve the durable-memory content char budget.
  *
  * When the whole-pack allocator supplies an explicit `contentCharLimit`, the
@@ -54,14 +65,43 @@ export type DurableMemoryContextFragment = {
   degradedSources: Array<Record<string, unknown>>;
   budget: Record<string, unknown>;
   citations: Array<Record<string, unknown>>;
+  /**
+   * The canonical `brain_record:${source_type}:${id}` identities actually
+   * EMITTED as durable_memory items — kept content-free, ids only, and byte-
+   * identical to each item's `citation_id`. The `pointers` and
+   * `candidate_memory` sections (#329) dedupe against this set so the same
+   * evidence the durable section already owns is never re-listed or
+   * double-counted. Empty on every empty/degraded/denied path (nothing was
+   * emitted to dedupe against).
+   */
+  durableIdentities: string[];
+  /**
+   * ALL net-new recall rows the SAME `executeSearch` call returned and that
+   * survived prior-context suppression, in hybrid-RRF rank order (#329). This is
+   * the pointer/candidate builders' already-authorized, already-suppressed pool;
+   * it is passed by reference so no second retrieval stack runs.
+   *
+   * It deliberately includes rows the durable_memory section DID emit as items,
+   * not only the surplus beyond the item cap. Pointer eligibility is decided in
+   * the pack against the durable identities ACTUALLY retained in the final fitted
+   * durable_memory output — so a pointers-only request (section suppressed) makes
+   * every authorized row pointer-eligible, and a whole-pack-trimmed or
+   * starved-out durable row stays pointer-eligible instead of being silently
+   * lost. Never emitted directly; the pointer builder derives lightweight
+   * references from it and copies no body. Empty on every empty/degraded/denied
+   * path.
+   */
+  pointerCandidatePool: SearchRow[];
 };
 
 /**
  * The stable citation id emitted for a recalled brain record. Kept in one place
  * so prior-context suppression keys off the EXACT string that becomes the item's
- * `citation_id`, and the emitted item derives its id from the same call.
+ * `citation_id`, and the emitted item derives its id from the same call. The
+ * pointer/candidate builders (#329) reuse this so a pointer's identity is byte-
+ * identical to the durable item it dedupes against.
  */
-function recordCitationId(row: SearchRow): string {
+export function recordCitationId(row: SearchRow): string {
   return `brain_record:${row.source_type}:${row.id}`;
 }
 
@@ -70,8 +110,13 @@ function recordCitationId(row: SearchRow): string {
  * store's own source_ref when present, else a derived `brain_record` pointer.
  * Its identity coordinates (source/type/id/namespace) are what suppression
  * canonicalizes on; `label`/`preview` are display-only and never affect matching.
+ *
+ * NOTE: this shape MAY carry `label`/`preview` (bounded content) for the durable
+ * item and its citation. The `pointers` section MUST NOT emit those display
+ * fields — it uses {@link recordStructuralSourceRef} instead, which is the same
+ * identity object stripped of any body-bearing display field.
  */
-function recordSourceRef(row: SearchRow) {
+export function recordSourceRef(row: SearchRow) {
   return (
     row.source_ref ?? {
       source: "brain",
@@ -82,6 +127,38 @@ function recordSourceRef(row: SearchRow) {
       preview: (row.content_preview ?? "").slice(0, 300),
     }
   );
+}
+
+/**
+ * The identity-only structural source_ref for a recalled brain record: the SAME
+ * identity coordinates suppression canonicalizes on (source/type/id/namespace),
+ * with every display/body field (`label`, `preview`, or any other) stripped.
+ * This is what `pointers` emit — a resolvable structural ref with NO body,
+ * content_preview, or full text — while remaining byte-comparable on identity to
+ * the durable item's source_ref. Derived from {@link recordSourceRef} so a
+ * store-supplied source_ref and a derived one are handled identically.
+ */
+export function recordStructuralSourceRef(row: SearchRow): {
+  source: string;
+  type: string;
+  id: string;
+  namespace?: string;
+} {
+  const full = recordSourceRef(row) as unknown as Record<string, unknown>;
+  const structural: {
+    source: string;
+    type: string;
+    id: string;
+    namespace?: string;
+  } = {
+    source: String(full.source),
+    type: String(full.type),
+    id: String(full.id),
+  };
+  if (full.namespace !== undefined && full.namespace !== null) {
+    structural.namespace = String(full.namespace);
+  }
+  return structural;
 }
 
 /**
@@ -139,6 +216,8 @@ export async function loadDurableMemoryContext(
       degradedSources: [],
       budget: emptyBudget(),
       citations: [],
+      durableIdentities: [],
+      pointerCandidatePool: [],
     };
   }
 
@@ -163,6 +242,8 @@ export async function loadDurableMemoryContext(
       degradedSources: [],
       budget: emptyBudget(),
       citations: [],
+      durableIdentities: [],
+      pointerCandidatePool: [],
     };
   }
 
@@ -179,7 +260,11 @@ export async function loadDurableMemoryContext(
       deps,
       accessibleTables,
       query,
-      DURABLE_MEMORY_MAX_ITEMS,
+      // Over-fetch a bounded pool so the pointers section (#329) can draw from
+      // net-new rows this SAME recall already authorized, without a second
+      // retrieval stack. durable_memory still emits only its own top
+      // DURABLE_MEMORY_MAX_ITEMS; the surplus feeds pointers as references only.
+      DURABLE_MEMORY_MAX_ITEMS + DURABLE_MEMORY_POINTER_OVERFETCH,
       "hybrid",
       undefined,
       0,
@@ -207,6 +292,8 @@ export async function loadDurableMemoryContext(
       degradedSources: [{ source: "durable_memory", reason: "recall_failed" }],
       budget: emptyBudget(),
       citations: [],
+      durableIdentities: [],
+      pointerCandidatePool: [],
     };
   }
 
@@ -234,8 +321,24 @@ export async function loadDurableMemoryContext(
   const items: Array<Record<string, unknown>> = [];
   const citations: Array<Record<string, unknown>> = [];
   let itemsTruncated = false;
+  // Canonical `brain_record:${source_type}:${id}` identity of every row EMITTED
+  // as a durable_memory item (== its citation_id), so the pointer/candidate
+  // builders never re-list evidence this section already owns. Ids only.
+  const durableIdentities: string[] = [];
+  // Every net-new authorized row, in rank order, handed to the pointer/candidate
+  // builders. It includes rows this section emitted as items — pointer
+  // eligibility is decided in the pack against the durable identities actually
+  // retained in the FINAL fitted durable_memory output, so a suppressed or
+  // whole-pack-trimmed durable row stays pointer-eligible instead of being lost.
+  const pointerCandidatePool: SearchRow[] = [...netNewRows];
 
   for (const row of netNewRows) {
+    // Hard item cap: durable_memory keeps its historical top-N selection even
+    // though recall now over-fetches. Rows beyond the cap are surfaced only as
+    // pointers, not a durable truncation, and remain in the pool above.
+    if (items.length >= DURABLE_MEMORY_MAX_ITEMS) {
+      continue;
+    }
     const bounded = boundedText(
       row.content_preview,
       Math.min(DURABLE_MEMORY_MAX_ITEM_CHARS, remainingChars),
@@ -245,9 +348,12 @@ export async function loadDurableMemoryContext(
         typeof row.content_preview === "string" &&
         row.content_preview.length > 0
       ) {
+        // Non-empty body the char budget could not admit: a genuine durable
+        // truncation, exactly as before the over-fetch change. The row still has
+        // a valid resolvable identity and stays in the pool as a pointer.
         itemsTruncated = true;
       }
-      break;
+      continue;
     }
     const citationId = recordCitationId(row);
     // Build the bounded source_ref once per row and attach the SAME object to
@@ -273,13 +379,26 @@ export async function loadDurableMemoryContext(
       kind: "brain_record",
       source_ref: sourceRef,
     });
+    // Canonical durable identity == the item's citation_id (byte-identical), so
+    // pointers/candidates dedupe on the exact string the durable item exposes.
+    durableIdentities.push(citationId);
     remainingChars -= bounded.text.length;
     if (bounded.truncated) itemsTruncated = true;
   }
-  // Net-new records beyond the ones whose bodies fit were dropped by the char
-  // budget. Compare against the post-suppression set: records removed as prior
-  // context are not a truncation, so they must not flip this flag.
-  if (items.length < netNewRows.length) itemsTruncated = true;
+  // A net-new record diverted to the pointer pool because the item cap was hit
+  // is NOT a durable truncation (it is fully surfaced as a pointer). Only a body
+  // the char budget could not admit flips itemsTruncated, which the loop already
+  // does above; do not additionally flip it here for cap-diverted rows.
+  //
+  // content_unavailable preservation: when net-new records survived suppression
+  // but NONE produced an emittable durable body (all previews null/empty, or the
+  // char budget admitted none), durable_memory reports zero items with a
+  // truncated empty state, exactly as before the over-fetch change. The diverted
+  // rows still resurface as pointers, but the durable section truthfully states
+  // it emitted no content for a net-new match.
+  if (items.length === 0 && suppression.suppression.net_new > 0) {
+    itemsTruncated = true;
+  }
 
   const truncation: Array<Record<string, unknown>> = [];
   if (itemsTruncated) {
@@ -343,5 +462,7 @@ export async function loadDurableMemoryContext(
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
     },
     citations,
+    durableIdentities,
+    pointerCandidatePool,
   };
 }

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -26,6 +26,14 @@ const DURABLE_MEMORY_MAX_ITEM_CHARS = 1_000;
  * bodies) and the surplus net-new rows are handed to the pointer builder as
  * lightweight references only (no body copied, no second query issued). Bounded
  * so recall stays cheap; the pointer builder applies its own hard item ceiling.
+ *
+ * The emitted durable_memory count is unchanged by this over-fetch: it stays
+ * capped at {@link DURABLE_MEMORY_MAX_ITEMS} regardless of how large the pool is.
+ * What CAN legitimately shift is the fused top-N itself — hybrid RRF ranks over
+ * the whole fetched/candidate pool, so a larger pool can reorder or swap which
+ * rows land in that top {@link DURABLE_MEMORY_MAX_ITEMS}. That identity/order
+ * shift is a property of fetching a deeper pool, not a change to the count; tests
+ * assert the count and the pointer/dedupe contract, not a frozen top-N identity.
  */
 const DURABLE_MEMORY_POINTER_OVERFETCH = 20;
 

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -66,16 +66,6 @@ export type DurableMemoryContextFragment = {
   budget: Record<string, unknown>;
   citations: Array<Record<string, unknown>>;
   /**
-   * The canonical `brain_record:${source_type}:${id}` identities actually
-   * EMITTED as durable_memory items — kept content-free, ids only, and byte-
-   * identical to each item's `citation_id`. The `pointers` and
-   * `candidate_memory` sections (#329) dedupe against this set so the same
-   * evidence the durable section already owns is never re-listed or
-   * double-counted. Empty on every empty/degraded/denied path (nothing was
-   * emitted to dedupe against).
-   */
-  durableIdentities: string[];
-  /**
    * ALL net-new recall rows the SAME `executeSearch` call returned and that
    * survived prior-context suppression, in hybrid-RRF rank order (#329). This is
    * the pointer/candidate builders' already-authorized, already-suppressed pool;
@@ -216,7 +206,6 @@ export async function loadDurableMemoryContext(
       degradedSources: [],
       budget: emptyBudget(),
       citations: [],
-      durableIdentities: [],
       pointerCandidatePool: [],
     };
   }
@@ -242,7 +231,6 @@ export async function loadDurableMemoryContext(
       degradedSources: [],
       budget: emptyBudget(),
       citations: [],
-      durableIdentities: [],
       pointerCandidatePool: [],
     };
   }
@@ -292,7 +280,6 @@ export async function loadDurableMemoryContext(
       degradedSources: [{ source: "durable_memory", reason: "recall_failed" }],
       budget: emptyBudget(),
       citations: [],
-      durableIdentities: [],
       pointerCandidatePool: [],
     };
   }
@@ -321,10 +308,6 @@ export async function loadDurableMemoryContext(
   const items: Array<Record<string, unknown>> = [];
   const citations: Array<Record<string, unknown>> = [];
   let itemsTruncated = false;
-  // Canonical `brain_record:${source_type}:${id}` identity of every row EMITTED
-  // as a durable_memory item (== its citation_id), so the pointer/candidate
-  // builders never re-list evidence this section already owns. Ids only.
-  const durableIdentities: string[] = [];
   // Every net-new authorized row, in rank order, handed to the pointer/candidate
   // builders. It includes rows this section emitted as items — pointer
   // eligibility is decided in the pack against the durable identities actually
@@ -379,9 +362,6 @@ export async function loadDurableMemoryContext(
       kind: "brain_record",
       source_ref: sourceRef,
     });
-    // Canonical durable identity == the item's citation_id (byte-identical), so
-    // pointers/candidates dedupe on the exact string the durable item exposes.
-    durableIdentities.push(citationId);
     remainingChars -= bounded.text.length;
     if (bounded.truncated) itemsTruncated = true;
   }
@@ -462,7 +442,6 @@ export async function loadDurableMemoryContext(
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
     },
     citations,
-    durableIdentities,
     pointerCandidatePool,
   };
 }

--- a/src/tools/agent-context-pack-pointers-candidates.ts
+++ b/src/tools/agent-context-pack-pointers-candidates.ts
@@ -1,0 +1,308 @@
+// Pointer + candidate_memory context-pack section builders (#329).
+//
+// Semantic boundary — READ THIS BEFORE CHANGING THE PREDICATE OR THE SHAPE.
+//
+// These two sections extend the durable-memory recall surface (#327) with two
+// strictly lightweight, strictly non-authoritative views. Both are PURE
+// transformers over rows the durable_memory loader ALREADY fetched and ALREADY
+// authorized: they issue no query, open no connection, and run no second
+// retrieval stack. The durable_memory loader over-fetches one bounded pool in
+// its single `executeSearch` call and hands the surplus net-new rows here by
+// reference (see agent-context-pack-durable-memory.ts).
+//
+//   1. `pointers` — resolvable references to memory a client MAY choose to fetch
+//      through the authorized read path. A pointer carries the EXACT durable
+//      identity (`brain_record:${source_type}:${id}`), the STRUCTURAL source_ref
+//      object (source/type/id/namespace — identity coordinates only), and
+//      lightweight structural metadata (source_type/id/namespace/tier/timestamps)
+//      and NOTHING that reproduces the memory body. In particular it never emits
+//      `content`, `content_preview`, `label`, `preview`, or any full text: those
+//      are body leakage. A pointer that duplicates a `durable_memory` item (by
+//      canonical `brain_record:${source_type}:${id}` identity) is dropped so the
+//      same evidence is never double-listed or double-counted against budget.
+//
+//   2. `candidate_memory` — items that are NOT confirmed durable memory. Every
+//      candidate would be explicitly `confidence: "unconfirmed"` with
+//      `auto_promotable: false`, carry identity/citation/source_ref, and be
+//      deduped against BOTH the retained durable_memory identities and the
+//      emitted pointer identities before any candidate count/budget. Candidates
+//      are never promoted here.
+//
+//      NO PREDICATE YET (documented, not invented): the current recall surface
+//      (`SearchRow` from executeSearch) carries NO explicit candidate/unconfirmed
+//      lifecycle predicate — no confidence, no candidate flag, no candidate tier,
+//      no `memory_lifecycle_action`. Every row the durable recall returns IS a
+//      confirmed durable brain record. Per #329's explicit instruction, when no
+//      safe explicit candidate predicate exists, this builder returns a truthful
+//      EMPTY candidate section (`items: []`, `item_count: 0`,
+//      `empty_reason: "candidate_predicate_unavailable"`, `confidence:
+//      "unconfirmed"`, `auto_promotable: false`, no citations) rather than
+//      relabeling confirmed recall rows as unconfirmed candidates (fabrication)
+//      or emitting a triage preview body (body leakage). No verbose public
+//      missing-contract detail is emitted; the empty_reason string alone is the
+//      discoverable marker.
+//
+// Isolation predicate. The only real, server-enforceable isolation predicate on
+// these rows is the auth-derived `namespace` column, which the durable_memory
+// loader already bound on the recall that produced this pool. These builders add
+// no widening: they only remove and re-shape rows already scoped to the caller.
+// A caller cannot override the namespace here — there is no path to.
+//
+// No body copy, no body fetch. Neither builder copies a durable-memory body and
+// neither fetches a pointer's body. Resolution is deferred to the client via the
+// authorized read path; that is a non-goal of this issue by design.
+
+import type { SearchRow } from "./search-brain.ts";
+import {
+  recordCitationId,
+  recordStructuralSourceRef,
+} from "./agent-context-pack-durable-memory.ts";
+import {
+  resolveItemBudget,
+  type SectionBudget,
+  type SectionFragment,
+} from "./agent-context-pack-sections.ts";
+
+export const POINTERS_SECTION_NAME = "pointers" as const;
+export const CANDIDATES_SECTION_NAME = "candidate_memory" as const;
+
+/** Hard ceiling on emitted pointers regardless of pool size or budget. */
+const POINTERS_MAX_ITEMS = 20;
+
+/**
+ * The canonical `brain_record:${source_type}:${id}` identity a pointer/candidate
+ * dedupes on. This is byte-identical to the durable_memory item's `citation_id`
+ * and to the retained-durable / emitted-pointer identity sets threaded through
+ * the pack, so a pointer never re-lists a retained durable item and a candidate
+ * never re-lists a retained durable item OR a pointer. Reusing
+ * {@link recordCitationId} keeps the one canonical identity shape in a single
+ * place; there is no bare `${source_type}:${id}` key anywhere in the contract.
+ */
+function identityOf(row: SearchRow): string {
+  return recordCitationId(row);
+}
+
+/**
+ * A single pointer. Resolvable reference ONLY — identity, structural source_ref,
+ * and lightweight structural metadata. No body, content_preview, or full text.
+ */
+export interface PointerItem {
+  id: string;
+  source_type: string;
+  namespace: string | null;
+  tier: string | null;
+  created_at: string;
+  updated_at: string | null;
+  citation_id: string;
+  source_ref: {
+    source: string;
+    type: string;
+    id: string;
+    namespace?: string;
+  };
+}
+
+export interface PointerBuilderInput {
+  /**
+   * ALL net-new authorized recall rows in rank order — the durable loader's
+   * already namespace-scoped, already prior-context-suppressed pool. Never
+   * re-queried here. It includes rows the durable section emitted; the
+   * `durableIdentities` exclusion below decides which are pointer-eligible.
+   */
+  pool: readonly SearchRow[];
+  /**
+   * Canonical `brain_record:${source_type}:${id}` identities ACTUALLY RETAINED
+   * in the final fitted durable_memory output. Pointers matching any of these are
+   * dropped (durable owns that evidence). This is the post-fit set, not the
+   * loader's pre-fit emitted set: a suppressed or whole-pack-trimmed durable row
+   * is absent here and therefore stays pointer-eligible.
+   */
+  durableIdentities: Iterable<string>;
+  budget?: SectionBudget;
+}
+
+/**
+ * Build the `pointers` section fragment from the durable loader's net-new
+ * surplus pool. Pure transform: dedupe against durable_memory (by identity) and
+ * within itself, emit lightweight cited references with NO body, and return a
+ * defined empty envelope when nothing citable survives dedupe.
+ *
+ * The returned fragment matches the shared {@link SectionFragment} shape so the
+ * pack admits it through the SAME `admitStructuredSection` path as guidance and
+ * repo_facts — one whole-pack fitter, one citation/budget reconciliation.
+ */
+export function buildPointerSection(
+  input: PointerBuilderInput,
+): SectionFragment {
+  // Pointers carry no per-item text body, so only the item COUNT is budgeted.
+  // `maxItemChars` is irrelevant (there is no item text field) but resolveItemBudget
+  // keeps the shared budget-shape contract.
+  const { maxItems } = resolveItemBudget(input.budget, {
+    maxItems: POINTERS_MAX_ITEMS,
+    maxItemChars: 0,
+  });
+
+  const durableIdentities = new Set(input.durableIdentities);
+  const seen = new Set<string>();
+  const items: PointerItem[] = [];
+  const citations: Array<Record<string, unknown>> = [];
+  let dedupedAgainstDurable = 0;
+  let itemsTruncated = false;
+
+  for (const row of input.pool) {
+    const identity = identityOf(row);
+    // Dedupe against durable_memory FIRST: the durable section owns this
+    // evidence, so it is never re-listed nor counted against the pointer budget.
+    if (durableIdentities.has(identity)) {
+      dedupedAgainstDurable += 1;
+      continue;
+    }
+    // Dedupe within the pointer pool: keep the first (highest-ranked)
+    // occurrence, never re-list the same record twice.
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+
+    if (items.length >= maxItems) {
+      itemsTruncated = true;
+      break;
+    }
+
+    const citationId = recordCitationId(row);
+    // Identity-only structural source_ref: same coordinates the durable item's
+    // source_ref carries, with every display/body field (label/preview) stripped.
+    const sourceRef = recordStructuralSourceRef(row);
+    items.push({
+      id: row.id,
+      source_type: row.source_type,
+      namespace: row.namespace ?? null,
+      tier: row.tier ?? null,
+      created_at: row.created_at,
+      updated_at: row.updated_at ?? null,
+      citation_id: citationId,
+      source_ref: sourceRef,
+    });
+    citations.push({
+      id: citationId,
+      kind: "pointer",
+      source_ref: sourceRef,
+    });
+  }
+
+  const truncation: Array<Record<string, unknown>> = [];
+  if (itemsTruncated) {
+    truncation.push({
+      source: `${POINTERS_SECTION_NAME}.items`,
+      max_items: maxItems,
+    });
+  }
+
+  const budget = {
+    max_items: maxItems,
+    deduped_against_durable: dedupedAgainstDurable,
+    items_emitted: items.length,
+  };
+
+  return {
+    section: {
+      label: POINTERS_SECTION_NAME,
+      namespace_scoped: true,
+      // Standing invariant: a pointer carries no memory body, only a resolvable
+      // reference a client may fetch through the authorized read path.
+      resolvable_reference_only: true,
+      items,
+      item_count: items.length,
+      truncated: itemsTruncated,
+    },
+    scopeDenials: [],
+    truncation,
+    degradedSources: [],
+    budget,
+    citations,
+  };
+}
+
+/**
+ * Stable, content-free empty reason for `candidate_memory`: the current recall
+ * surface (`SearchRow` from executeSearch) exposes no explicit
+ * unconfirmed/candidate lifecycle predicate — no confidence, candidate flag,
+ * candidate tier, or `memory_lifecycle_action` — so every recalled row is a
+ * confirmed durable record. Per #329, when no safe explicit candidate predicate
+ * exists the section stays truthfully empty with this exact reason rather than
+ * inferring candidacy from raw recall (fabrication) or emitting a triage body
+ * (leakage). No verbose public payload is emitted; the reason string alone is
+ * the discoverable marker of the missing write-side contract.
+ */
+const CANDIDATE_PREDICATE_UNAVAILABLE =
+  "candidate_predicate_unavailable" as const;
+
+export interface CandidateBuilderInput {
+  /**
+   * The same net-new authorized pool handed to the pointer builder. Present so
+   * the candidate contract can be evaluated against real authorized rows; it is
+   * NOT emitted, because no explicit candidate predicate selects from it (empty
+   * with empty_reason candidate_predicate_unavailable).
+   */
+  pool: readonly SearchRow[];
+  /**
+   * Canonical `brain_record:${source_type}:${id}` identities retained as durable
+   * memory OR emitted as pointers. Candidates would dedupe against these before
+   * any candidate count/budget; retained here so the dedupe contract is explicit
+   * and testable even while the section is truthfully empty.
+   */
+  excludedIdentities: Iterable<string>;
+}
+
+/**
+ * Build the `candidate_memory` section fragment.
+ *
+ * Truthful empty state by design (#329): no explicit candidate predicate exists
+ * in the current recall surface, so this returns a defined empty candidate
+ * envelope carrying the standing candidate invariants (`confidence:
+ * "unconfirmed"`, `auto_promotable: false`) with `items: []`, `item_count: 0`,
+ * `empty_reason: "candidate_predicate_unavailable"`, and NO citations. It never
+ * relabels confirmed recall as a candidate, never infers candidacy, and never
+ * emits a body or a verbose public missing-contract payload.
+ *
+ * The dedupe set (retained durable + emitted pointer identities) is computed so
+ * the candidate contract — candidates dedupe against retained durable AND
+ * pointer identities before any candidate count/budget — is explicit and
+ * testable even while the section is truthfully empty. It is surfaced only as a
+ * content-free count, never as ids.
+ */
+export function buildCandidateSection(
+  input: CandidateBuilderInput,
+): SectionFragment {
+  // The dedupe set is computed even though no items are emitted, so the empty
+  // section is honest about the contract it WOULD enforce. Ids-only, never
+  // surfaced except as a count.
+  const excluded = new Set(input.excludedIdentities);
+
+  return {
+    section: {
+      label: CANDIDATES_SECTION_NAME,
+      namespace_scoped: true,
+      // Standing invariants surfaced for consumers: every candidate this section
+      // could ever emit is unconfirmed and never auto-promotable.
+      confidence: "unconfirmed",
+      auto_promotable: false,
+      items: [],
+      item_count: 0,
+      // No safe explicit candidate predicate exists yet, so the section is
+      // truthfully empty for this exact reason. Distinct from a budget-starved
+      // empty (whole_pack_budget), which the pack stamps instead.
+      empty_reason: CANDIDATE_PREDICATE_UNAVAILABLE,
+      truncated: false,
+      // Content-free observability: the dedupe set size the section would apply
+      // (retained durable + emitted pointer identities). Never an id or body.
+      dedupe_against_count: excluded.size,
+    },
+    scopeDenials: [],
+    truncation: [],
+    degradedSources: [],
+    budget: {
+      max_items: 0,
+      items_emitted: 0,
+    },
+    citations: [],
+  };
+}

--- a/src/tools/agent-context-pack-pointers-candidates.ts
+++ b/src/tools/agent-context-pack-pointers-candidates.ts
@@ -88,6 +88,11 @@ function identityOf(row: SearchRow): string {
 /**
  * A single pointer. Resolvable reference ONLY — identity, structural source_ref,
  * and lightweight structural metadata. No body, content_preview, or full text.
+ *
+ * source_ref.type carries the SINGULAR source_type executeSearch emits
+ * (e.g. "decision"). To resolve a pointer through get_entry, derive the table by
+ * appending "s" (get_entry table = source_ref.type + "s", e.g. "decisions") and
+ * pass source_ref.id as the entry id.
  */
 export interface PointerItem {
   id: string;

--- a/src/tools/agent-context-pack-pointers-candidates.ts
+++ b/src/tools/agent-context-pack-pointers-candidates.ts
@@ -26,7 +26,10 @@
 //      `auto_promotable: false`, carry identity/citation/source_ref, and be
 //      deduped against BOTH the retained durable_memory identities and the
 //      emitted pointer identities before any candidate count/budget. Candidates
-//      are never promoted here.
+//      are never promoted here. Because no predicate exists yet, the section is
+//      always empty and therefore does NOT drive recall on its own: a
+//      candidate-only request runs no hybrid retrieval stack (nothing to dedupe
+//      against, nothing to emit).
 //
 //      NO PREDICATE YET (documented, not invented): the current recall surface
 //      (`SearchRow` from executeSearch) carries NO explicit candidate/unconfirmed
@@ -235,23 +238,6 @@ export function buildPointerSection(
 const CANDIDATE_PREDICATE_UNAVAILABLE =
   "candidate_predicate_unavailable" as const;
 
-export interface CandidateBuilderInput {
-  /**
-   * The same net-new authorized pool handed to the pointer builder. Present so
-   * the candidate contract can be evaluated against real authorized rows; it is
-   * NOT emitted, because no explicit candidate predicate selects from it (empty
-   * with empty_reason candidate_predicate_unavailable).
-   */
-  pool: readonly SearchRow[];
-  /**
-   * Canonical `brain_record:${source_type}:${id}` identities retained as durable
-   * memory OR emitted as pointers. Candidates would dedupe against these before
-   * any candidate count/budget; retained here so the dedupe contract is explicit
-   * and testable even while the section is truthfully empty.
-   */
-  excludedIdentities: Iterable<string>;
-}
-
 /**
  * Build the `candidate_memory` section fragment.
  *
@@ -263,20 +249,16 @@ export interface CandidateBuilderInput {
  * relabels confirmed recall as a candidate, never infers candidacy, and never
  * emits a body or a verbose public missing-contract payload.
  *
- * The dedupe set (retained durable + emitted pointer identities) is computed so
- * the candidate contract — candidates dedupe against retained durable AND
- * pointer identities before any candidate count/budget — is explicit and
- * testable even while the section is truthfully empty. It is surfaced only as a
- * content-free count, never as ids.
+ * The section owns no real selection or dedupe behavior yet: with no predicate
+ * it emits nothing, so it takes no pool and no dedupe set. Critically, a
+ * candidate_memory request MUST NOT trigger durable recall just to compute a
+ * synthetic dedupe count against rows it can never emit (that would run the
+ * hybrid retrieval stack for a section that is always empty). The dedupe
+ * contract (candidates would dedupe against retained durable AND pointer
+ * identities) is documented here and enforced only once a real write-side
+ * candidate predicate exists.
  */
-export function buildCandidateSection(
-  input: CandidateBuilderInput,
-): SectionFragment {
-  // The dedupe set is computed even though no items are emitted, so the empty
-  // section is honest about the contract it WOULD enforce. Ids-only, never
-  // surfaced except as a count.
-  const excluded = new Set(input.excludedIdentities);
-
+export function buildCandidateSection(): SectionFragment {
   return {
     section: {
       label: CANDIDATES_SECTION_NAME,
@@ -292,9 +274,6 @@ export function buildCandidateSection(
       // empty (whole_pack_budget), which the pack stamps instead.
       empty_reason: CANDIDATE_PREDICATE_UNAVAILABLE,
       truncated: false,
-      // Content-free observability: the dedupe set size the section would apply
-      // (retained durable + emitted pointer identities). Never an id or body.
-      dedupe_against_count: excluded.size,
     },
     scopeDenials: [],
     truncation: [],

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -145,7 +145,7 @@ export const agentContextPackInputSchema = {
     .optional()
     .describe(
       "Sections to assemble. durable_lane_context is queried only when explicitly requested and requires all seven exact scope coordinates. profile_guidance, process_guidance, and repo_facts are each queried only when explicitly requested. " +
-        "pointers returns resolvable-reference-only entries (identity/source_ref/structural metadata, never a body) for durable records not already emitted as durable_memory items; requesting pointers reuses the single durable_memory hybrid recall (no second retrieval stack) and needs a query. " +
+        'pointers returns resolvable-reference-only entries (identity/source_ref/structural metadata, never a body) for durable records not already emitted as durable_memory items; requesting pointers reuses the single durable_memory hybrid recall (no second retrieval stack) and needs a query. source_ref.type is the singular source_type, so resolve a pointer through get_entry with table = source_ref.type + "s" and id = source_ref.id. ' +
         "candidate_memory currently has no write-side candidate predicate, so it always returns a truthful empty section (items [], empty_reason candidate_predicate_unavailable, confidence unconfirmed, auto_promotable false) and never triggers recall on its own.",
     ),
   include_unreviewed_recovery: z

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -144,7 +144,9 @@ export const agentContextPackInputSchema = {
     .array(z.enum(SECTION_NAMES))
     .optional()
     .describe(
-      "Sections to assemble. durable_lane_context is queried only when explicitly requested and requires all seven exact scope coordinates. profile_guidance, process_guidance, and repo_facts are each queried only when explicitly requested.",
+      "Sections to assemble. durable_lane_context is queried only when explicitly requested and requires all seven exact scope coordinates. profile_guidance, process_guidance, and repo_facts are each queried only when explicitly requested. " +
+        "pointers returns resolvable-reference-only entries (identity/source_ref/structural metadata, never a body) for durable records not already emitted as durable_memory items; requesting pointers reuses the single durable_memory hybrid recall (no second retrieval stack) and needs a query. " +
+        "candidate_memory currently has no write-side candidate predicate, so it always returns a truthful empty section (items [], empty_reason candidate_predicate_unavailable, confidence unconfirmed, auto_promotable false) and never triggers recall on its own.",
     ),
   include_unreviewed_recovery: z
     .boolean()
@@ -232,14 +234,20 @@ export async function buildAgentContextPackPayload(
     args.requested_sections?.includes("pointers") === true;
   const includeCandidateMemory =
     args.requested_sections?.includes("candidate_memory") === true;
-  // pointers and candidate_memory are derived from the durable_memory hybrid
-  // recall — the single retrieval stack. Requesting either runs that recall so
+  // pointers is derived from the durable_memory hybrid recall — the single
+  // retrieval stack. Requesting durable_memory OR pointers runs that recall so
   // its net-new surplus pool and emitted-identity set are available, even when
   // the durable_memory SECTION itself was not requested for output. The
   // durable_memory section body is still only ADDED to the pack when it was
   // explicitly requested (includeDurableMemorySection).
-  const includeDurableMemory =
-    includeDurableMemorySection || includePointers || includeCandidateMemory;
+  //
+  // candidate_memory does NOT drive recall: it has no explicit candidate
+  // predicate yet, so it always emits a truthful empty envelope with nothing to
+  // dedupe against. A candidate_memory-only request must therefore run zero
+  // recall queries. The shared recall runs for candidate_memory ONLY when
+  // durable_memory or pointers is also requested (and is then reused, never
+  // re-issued).
+  const includeDurableMemory = includeDurableMemorySection || includePointers;
 
   // The auth-derived physical namespace is the single isolation predicate every
   // structured-section read binds to. `canReadNamespace(auth, ns)` above already
@@ -766,20 +774,23 @@ export async function buildAgentContextPackPayload(
   }
 
   // pointers + candidate_memory (#329): the lowest-priority members, admitted
-  // LAST after repo_facts. Both are pure transforms over the durable_memory
-  // recall's already-authorized, already-suppressed surplus pool — no second
-  // retrieval stack. Pointers dedupe against the durable identities the recall
-  // already emitted; candidates dedupe against durable identities AND the
-  // pointers just emitted. Each is admitted through the SAME structured-section
-  // fitter so it shares one whole-pack budget, citation, and truncation
-  // reconciliation with guidance/repo_facts.
+  // LAST after repo_facts. They differ in how they relate to durable recall.
+  // pointers is a pure transform over the durable_memory recall's
+  // already-authorized, already-suppressed surplus pool — no second retrieval
+  // stack — deduping against the durable identities the recall already emitted.
+  // candidate_memory has no write-side predicate yet, so it drives NO recall and
+  // takes NO pool: it is independently truthful-empty and never queries. Each is
+  // still admitted through the SAME structured-section fitter so it shares one
+  // whole-pack budget, citation, and truncation reconciliation with
+  // guidance/repo_facts.
   //
-  // The recall pool is empty (and dedupe/identity sets empty) when durable
-  // recall did not run, returned nothing, or degraded — the builders then emit
-  // their defined empty envelopes. When the durable_memory SECTION itself was
-  // not requested for output, the shared recall's content-free scope-denial /
-  // degraded-source warnings are surfaced through these sections instead (folded
-  // in once) so a failed shared recall is never silently swallowed.
+  // The pointer recall pool is empty (and dedupe/identity sets empty) when
+  // durable recall did not run, returned nothing, or degraded — the pointer
+  // builder then emits its defined empty envelope. When the durable_memory
+  // SECTION itself was not requested for output, the shared recall's
+  // content-free scope-denial / degraded-source warnings are surfaced through
+  // these sections instead (folded in once) so a failed shared recall is never
+  // silently swallowed.
   const durablePool = durableMemoryContext?.pointerCandidatePool ?? [];
   // Pointer eligibility is decided against the durable identities ACTUALLY
   // retained in the FINAL fitted durable_memory output — not the loader's
@@ -800,9 +811,6 @@ export async function buildAgentContextPackPayload(
       }
     }
   }
-  // Identities the pointer builder actually emitted, so candidates dedupe
-  // against durable memory AND pointers. Populated during pointer admission.
-  const pointerEmittedIdentities: string[] = [];
   // When the durable_memory section is suppressed for output but its recall ran
   // for pointers/candidates, its recall warnings attach to the first admitted
   // #329 section so they are emitted exactly once.
@@ -822,31 +830,17 @@ export async function buildAgentContextPackPayload(
       pool: durablePool,
       durableIdentities: retainedDurableIdentities,
     });
-    // Capture the canonical identities pointers emitted so candidate dedupe can
-    // exclude them, BEFORE admission trims the section for budget (dedupe is a
-    // semantic identity relationship, independent of whole-pack budget survival).
-    // Each pointer's `citation_id` IS the canonical
-    // `brain_record:${source_type}:${id}` identity — never a bare source_type:id.
-    const pointerItems =
-      (pointerFragment.section?.items as
-        Array<{ citation_id?: unknown }> | undefined) ?? [];
-    for (const item of pointerItems) {
-      if (typeof item.citation_id === "string") {
-        pointerEmittedIdentities.push(item.citation_id);
-      }
-    }
     foldSharedRecallWarnings(pointerFragment);
     admitStructuredSection("pointers", pointerFragment);
   }
 
   if (includeCandidateMemory) {
-    const candidateFragment = buildCandidateSection({
-      pool: durablePool,
-      excludedIdentities: [
-        ...retainedDurableIdentities,
-        ...pointerEmittedIdentities,
-      ],
-    });
+    // candidate_memory owns no selection or dedupe behavior yet (no predicate),
+    // so it takes no pool and drives no recall — a candidate-only request issues
+    // zero recall queries. Any shared-recall warnings from a co-requested
+    // durable/pointers recall are already folded into the pointers section (or
+    // reported by the durable_memory section) above.
+    const candidateFragment = buildCandidateSection();
     foldSharedRecallWarnings(candidateFragment);
     admitStructuredSection("candidate_memory", candidateFragment);
   }
@@ -1200,7 +1194,11 @@ export function registerAgentContextPack(
         "Build a scoped realtime agent context pack. working_set uses exact " +
         "active scope; recovery requires explicit unreviewed-recovery opt-in; " +
         "durable_lane_context is queried only when explicitly requested and " +
-        "returns bounded lane/events only after all seven scope coordinates match.",
+        "returns bounded lane/events only after all seven scope coordinates match. " +
+        "pointers surfaces body-free resolvable references to durable records not " +
+        "emitted as durable_memory items, reusing the single durable_memory recall; " +
+        "candidate_memory is a truthful empty section (no candidate predicate yet) " +
+        "that never drives its own recall.",
       inputSchema: agentContextPackInputSchema,
       annotations: {
         title: "Agent Context Pack",

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -42,6 +42,10 @@ import {
   type GuidanceSectionName,
 } from "./agent-context-pack-guidance.ts";
 import { loadRepoFactsSection } from "./agent-context-pack-repo-facts.ts";
+import {
+  buildCandidateSection,
+  buildPointerSection,
+} from "./agent-context-pack-pointers-candidates.ts";
 import type { SectionFragment } from "./agent-context-pack-sections.ts";
 
 export const SECTION_NAMES = [
@@ -216,7 +220,7 @@ export async function buildAgentContextPackPayload(
     (!args.requested_sections || args.requested_sections.includes("recovery"));
   const includeDurableLaneContext =
     args.requested_sections?.includes("durable_lane_context") === true;
-  const includeDurableMemory =
+  const includeDurableMemorySection =
     args.requested_sections?.includes("durable_memory") === true;
   const includeProfileGuidance =
     args.requested_sections?.includes("profile_guidance") === true;
@@ -224,6 +228,18 @@ export async function buildAgentContextPackPayload(
     args.requested_sections?.includes("process_guidance") === true;
   const includeRepoFacts =
     args.requested_sections?.includes("repo_facts") === true;
+  const includePointers =
+    args.requested_sections?.includes("pointers") === true;
+  const includeCandidateMemory =
+    args.requested_sections?.includes("candidate_memory") === true;
+  // pointers and candidate_memory are derived from the durable_memory hybrid
+  // recall — the single retrieval stack. Requesting either runs that recall so
+  // its net-new surplus pool and emitted-identity set are available, even when
+  // the durable_memory SECTION itself was not requested for output. The
+  // durable_memory section body is still only ADDED to the pack when it was
+  // explicitly requested (includeDurableMemorySection).
+  const includeDurableMemory =
+    includeDurableMemorySection || includePointers || includeCandidateMemory;
 
   // The auth-derived physical namespace is the single isolation predicate every
   // structured-section read binds to. `canReadNamespace(auth, ns)` above already
@@ -481,7 +497,15 @@ export async function buildAgentContextPackPayload(
         durableMemoryContentLimit,
       )
     : null;
-  let durableMemorySection = durableMemoryContext?.section ?? null;
+  // The durable_memory SECTION is only fitted/emitted/charged when it was
+  // explicitly requested. When the recall ran ONLY to feed pointers/candidates
+  // (includeDurableMemory true via includePointers/includeCandidateMemory but
+  // includeDurableMemorySection false), the section body is suppressed here while
+  // its surplus pool and identities still flow to the pointer/candidate builders
+  // below.
+  let durableMemorySection = includeDurableMemorySection
+    ? (durableMemoryContext?.section ?? null)
+    : null;
   let durableMemoryCitations = durableMemorySection
     ? (durableMemoryContext?.citations ?? [])
     : [];
@@ -741,6 +765,92 @@ export async function buildAgentContextPackPayload(
     admitStructuredSection("repo_facts", repoFactsFragment);
   }
 
+  // pointers + candidate_memory (#329): the lowest-priority members, admitted
+  // LAST after repo_facts. Both are pure transforms over the durable_memory
+  // recall's already-authorized, already-suppressed surplus pool — no second
+  // retrieval stack. Pointers dedupe against the durable identities the recall
+  // already emitted; candidates dedupe against durable identities AND the
+  // pointers just emitted. Each is admitted through the SAME structured-section
+  // fitter so it shares one whole-pack budget, citation, and truncation
+  // reconciliation with guidance/repo_facts.
+  //
+  // The recall pool is empty (and dedupe/identity sets empty) when durable
+  // recall did not run, returned nothing, or degraded — the builders then emit
+  // their defined empty envelopes. When the durable_memory SECTION itself was
+  // not requested for output, the shared recall's content-free scope-denial /
+  // degraded-source warnings are surfaced through these sections instead (folded
+  // in once) so a failed shared recall is never silently swallowed.
+  const durablePool = durableMemoryContext?.pointerCandidatePool ?? [];
+  // Pointer eligibility is decided against the durable identities ACTUALLY
+  // retained in the FINAL fitted durable_memory output — not the loader's
+  // pre-fit emitted set. When the durable_memory section is suppressed for output
+  // (pointers-only request) this is empty, so every authorized recalled row is
+  // pointer-eligible. When the whole-pack re-fit trimmed or starved out durable
+  // rows, those rows are absent here and stay pointer-eligible instead of being
+  // silently lost. `citation_id` on each retained item is the canonical
+  // `brain_record:${source_type}:${id}` identity.
+  const retainedDurableIdentities: string[] = [];
+  if (durableMemorySection) {
+    const retainedItems =
+      (durableMemorySection as { items?: Array<{ citation_id?: unknown }> })
+        .items ?? [];
+    for (const item of retainedItems) {
+      if (typeof item.citation_id === "string") {
+        retainedDurableIdentities.push(item.citation_id);
+      }
+    }
+  }
+  // Identities the pointer builder actually emitted, so candidates dedupe
+  // against durable memory AND pointers. Populated during pointer admission.
+  const pointerEmittedIdentities: string[] = [];
+  // When the durable_memory section is suppressed for output but its recall ran
+  // for pointers/candidates, its recall warnings attach to the first admitted
+  // #329 section so they are emitted exactly once.
+  let sharedRecallWarningsPending =
+    includeDurableMemory && !includeDurableMemorySection;
+  const foldSharedRecallWarnings = (fragment: SectionFragment): void => {
+    if (!sharedRecallWarningsPending) return;
+    sharedRecallWarningsPending = false;
+    fragment.scopeDenials.push(...(durableMemoryContext?.scopeDenials ?? []));
+    fragment.degradedSources.push(
+      ...(durableMemoryContext?.degradedSources ?? []),
+    );
+  };
+
+  if (includePointers) {
+    const pointerFragment = buildPointerSection({
+      pool: durablePool,
+      durableIdentities: retainedDurableIdentities,
+    });
+    // Capture the canonical identities pointers emitted so candidate dedupe can
+    // exclude them, BEFORE admission trims the section for budget (dedupe is a
+    // semantic identity relationship, independent of whole-pack budget survival).
+    // Each pointer's `citation_id` IS the canonical
+    // `brain_record:${source_type}:${id}` identity — never a bare source_type:id.
+    const pointerItems =
+      (pointerFragment.section?.items as
+        Array<{ citation_id?: unknown }> | undefined) ?? [];
+    for (const item of pointerItems) {
+      if (typeof item.citation_id === "string") {
+        pointerEmittedIdentities.push(item.citation_id);
+      }
+    }
+    foldSharedRecallWarnings(pointerFragment);
+    admitStructuredSection("pointers", pointerFragment);
+  }
+
+  if (includeCandidateMemory) {
+    const candidateFragment = buildCandidateSection({
+      pool: durablePool,
+      excludedIdentities: [
+        ...retainedDurableIdentities,
+        ...pointerEmittedIdentities,
+      ],
+    });
+    foldSharedRecallWarnings(candidateFragment);
+    admitStructuredSection("candidate_memory", candidateFragment);
+  }
+
   const sections: Record<string, unknown> = {};
   if (workingSetSection) sections.working_set = workingSetSection;
   if (recoverySection) sections.recovery = recoverySection;
@@ -764,12 +874,20 @@ export async function buildAgentContextPackPayload(
           ...(workingSet ? workingSet.warnings.scope_denials : []),
           ...(recovery ? recovery.warnings.scope_denials : []),
           ...(durableLaneContext?.scopeDenials ?? []),
-          ...(durableMemoryContext?.scopeDenials ?? []),
+          // durable_memory recall warnings are emitted here ONLY when the section
+          // was requested for output; when the recall ran solely for
+          // pointers/candidates they are folded into those sections' fragments
+          // instead (see foldSharedRecallWarnings) so they surface exactly once.
+          ...(includeDurableMemorySection
+            ? (durableMemoryContext?.scopeDenials ?? [])
+            : []),
           ...structuredScopeDenials,
         ],
         degraded_sources: [
           ...(durableLaneContext?.degradedSources ?? []),
-          ...(durableMemoryContext?.degradedSources ?? []),
+          ...(includeDurableMemorySection
+            ? (durableMemoryContext?.degradedSources ?? [])
+            : []),
           ...structuredDegradedSources,
         ],
         truncation: [
@@ -798,7 +916,10 @@ export async function buildAgentContextPackPayload(
         ...(durableLaneSection || durableLaneContext
           ? { durable_lane_context: durableLaneBudget }
           : {}),
-        ...(durableMemorySection || durableMemoryContext
+        // durable_memory budget is reported only when the section was requested
+        // for output. A recall that ran solely to feed pointers/candidates does
+        // not report a durable_memory budget block (the section is absent).
+        ...(includeDurableMemorySection && durableMemoryContext
           ? { durable_memory: durableMemoryBudget }
           : {}),
       },

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -506,11 +506,12 @@ export async function buildAgentContextPackPayload(
       )
     : null;
   // The durable_memory SECTION is only fitted/emitted/charged when it was
-  // explicitly requested. When the recall ran ONLY to feed pointers/candidates
-  // (includeDurableMemory true via includePointers/includeCandidateMemory but
-  // includeDurableMemorySection false), the section body is suppressed here while
-  // its surplus pool and identities still flow to the pointer/candidate builders
-  // below.
+  // explicitly requested. When the recall ran ONLY to feed pointers
+  // (includeDurableMemory true via includePointers, but includeDurableMemorySection
+  // false), the section body is suppressed here while its surplus pool and
+  // identities still flow to the pointer/candidate builders below.
+  // candidate_memory alone never drives recall (see includeDurableMemory), so a
+  // candidate-only request does not reach this suppressed-recall path.
   let durableMemorySection = includeDurableMemorySection
     ? (durableMemoryContext?.section ?? null)
     : null;


### PR DESCRIPTION
## Summary

- add lowest-priority `pointers` and `candidate_memory` sections to `agent_context_pack`
- reuse the existing authorized durable-memory hybrid recall and existing whole-pack fitter
- emit body-free structural pointers with canonical `brain_record:${source_type}:${id}` identities and citation bijection
- return a truthful empty candidate envelope until an explicit candidate predicate exists

## Behavior

- `pointers` contains resolvable identity/source references and structural metadata only; no body, preview, or label text
- pointers dedupe against items actually retained in the final fitted `durable_memory` section
- durable rows removed by whole-pack fitting remain pointer-eligible instead of disappearing
- pointers-only requests make all authorized recalled rows eligible without emitting `durable_memory`
- candidate-only requests run no recall and return:
  - `confidence: "unconfirmed"`
  - `auto_promotable: false`
  - `empty_reason: "candidate_predicate_unavailable"`
  - no items or citations
- allocation order remains deterministic, with `pointers` and `candidate_memory` after `repo_facts`

Closes #329

## Validation

- `bun test ./src/tools/__tests__`: **746 passed, 32 skipped, 0 failed** across 68 files
- focused #329 identity/pointer tests: **36 passed, 0 failed** (exact current head)
- `bunx tsc --noEmit`: passed
- `git diff --check`: passed
- full `bun test`: **2021 passed, 154 skipped, 2 failed**; both failures are unrelated backup/restore ANSI-stderr expectations and reproduce unchanged on the parked base checkout:
  - `scripts/backup.test.ts` expects `query failed`
  - `scripts/restore.test.ts` expects `COPY failed for table`

## Downstream rollout classification

Applicable because `agent_context_pack` output behavior and tool descriptions change.

- Open Brain local verification: complete
- hosted Open Brain deployment and changed-tool canary: required after merge
- mcp2cli live schema/cache verification and generated Open Brain skill refresh: required after deploy
- rtech-mcps registry/process change: not currently indicated; verify during rollout
- Python and TypeScript client code changes: not required for this server-side additive section behavior
- Hermes runtime/plugin and live Hermes canaries: not applicable by explicit project direction; this change is runtime-neutral and has no direct Hermes integration

## Critical self-review

- Highest-risk behavior: whole-pack fitting could orphan citations, duplicate a retained durable item as a pointer, or silently lose rows trimmed from `durable_memory`.
- Assumptions that could be wrong: generic authorized recall still has no explicit candidate lifecycle discriminator; the implementation therefore returns a truthful empty candidate section instead of inferring status.
- Missing/weak tests: no live PostgreSQL test is required because this slice adds no SQL and reuses the existing namespace-filtered search path; black-box MCP tests cover output, authorization denial before recall, authorized pointer resolution, fitting, and citation reconciliation.
- Security/permission risk: namespace authorization remains server-side before recall; pointers are derived only from already authorized rows and resolution is verified through `get_entry` with the token-derived namespace predicate.
- Migration/deploy risk: no schema or migration change; deployment changes only server assembly/output behavior.
- Downstream client/runtime risk: additive sections and descriptions require hosted schema/cache refresh and generated-skill verification; clients that ignore unrequested sections are unchanged.
- Rollback/cleanup concern: revert the two commits and redeploy the previous `main`; no data migration or persistent mutation requires cleanup.
- Fixes made before PR: replaced legacy/bare identities with canonical citation identity, changed dedupe to post-fit retained durable items, made pointer-only top rows eligible, removed candidate-only recall/dead identity bookkeeping, strengthened resolution/budget/isolation tests, and split an oversized test file.
- Known residual risk: `candidate_memory` intentionally remains empty until a future explicit authorized candidate predicate is added.
- SME review-memory update: [x] not applicable because: the initial swarm found no new MEDIUM+ reusable pattern; all findings were P3 test/comment hardening.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR is not merged or deployed yet; deployment and hosted canary remain post-merge gates
