### PR TITLE
test(330): validate the complete context pack

### DIFF
--- a/eval/open-brain/fixtures/complete-pack-v1.json
+++ b/eval/open-brain/fixtures/complete-pack-v1.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "fixture_id": "open-brain-complete-pack-v1",
+  "description": "Sealed synthetic corpus for the live COMPLETE CONTEXT PACK gate (EVAL-3, #330). All content is invented for evaluation only and carries no real memory, secret, or token. Primary-role entries are seeded under a per-run throwaway namespace and must be recallable by the pack's durable_memory query; negative-role entries are seeded into a sibling namespace the pack caller cannot read and must never surface in any section item or citation. The gate requests all nine sections under one whole-pack budget; RAM-only working_set and recovery are legitimately defined-empty on a fresh remote scope, and durable_lane_context returns its exact-scope defined-empty because no seven-coordinate lane exists for the throwaway scope.",
+  "query": "What is the marlin telemetry cache eviction window and how is the beacon rotation scheduled?",
+  "corpus": [
+    {
+      "id": "marlin-cache-eviction",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The marlin telemetry cache evicts every buffered reading after one hundred twenty seconds so a stale beacon sample can never dominate the fused position estimate.",
+      "tags": ["marlin", "telemetry", "cache", "eviction"]
+    },
+    {
+      "id": "beacon-rotation-decision",
+      "table": "decisions",
+      "namespace_role": "primary",
+      "content": "We rotate the marlin beacon channel on a ninety second schedule so overlapping estuary transmitters never collide during the telemetry handoff.",
+      "tags": ["marlin", "beacon", "rotation", "telemetry"]
+    },
+    {
+      "id": "beacon-handoff-note",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "During a marlin beacon rotation the handoff replays the last cached reading from the checkpoint so the position estimate stays continuous across the channel switch.",
+      "tags": ["marlin", "beacon", "handoff", "checkpoint"]
+    },
+    {
+      "id": "distractor-marlin-unrelated",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The coastal marlin fishing tournament schedule tracks tide charts and has nothing to do with the telemetry cache or beacon program.",
+      "tags": ["marlin", "tournament", "tide", "coastal"]
+    },
+    {
+      "id": "negative-marlin-secret-key",
+      "table": "decisions",
+      "namespace_role": "negative",
+      "content": "Confidential marlin beacon rotation keying schedule that lives in a private namespace the eval pack token cannot read and must never surface.",
+      "tags": ["marlin", "beacon", "rotation", "confidential"]
+    },
+    {
+      "id": "negative-telemetry-secret-cache",
+      "table": "thoughts",
+      "namespace_role": "negative",
+      "content": "Private marlin telemetry cache credential note that belongs to a namespace outside the eval token's read scope and must never be recalled by the pack.",
+      "tags": ["marlin", "telemetry", "cache", "private"]
+    }
+  ],
+  "expected_recall_ids": [
+    "marlin-cache-eviction",
+    "beacon-rotation-decision"
+  ],
+  "forbidden_ids": [
+    "negative-marlin-secret-key",
+    "negative-telemetry-secret-cache"
+  ]
+}

--- a/eval/open-brain/live/__tests__/complete-pack-gate.test.ts
+++ b/eval/open-brain/live/__tests__/complete-pack-gate.test.ts
@@ -958,6 +958,331 @@ describe("runCompletePackGate durable_lane_context events/lane walkers (finding 
   });
 });
 
+describe("runCompletePackGate citation occurrence-count bijection (terminal finding #1)", () => {
+  it("flags TWO distinct emitted units sharing ONE citation_id (set-based would pass)", async () => {
+    // Two DISTINCT durable_memory items carry the SAME citation_id. A single
+    // top-level citation for that id cannot cite both units. The old set-based
+    // bijection collapsed both emitted occurrences to one member and matched the
+    // single citation -> false PASS. Occurrence counting sees 2 emitted vs 1
+    // cited for that id -> 1 uncited, not bijective.
+    const shared = canonical("thought", serverId("prim-a"));
+    const payload = goodPayload({
+      sections: {
+        durable_memory: {
+          label: "durable_memory",
+          namespace_scoped: true,
+          query: FIXTURE.query,
+          items: [
+            {
+              id: serverId("prim-a"),
+              source_type: "thought",
+              namespace: CONFIG.primaryNamespace,
+              citation_id: shared,
+              source_ref: {
+                source: "brain",
+                type: "thought",
+                id: serverId("prim-a"),
+                namespace: CONFIG.primaryNamespace,
+              },
+            },
+            {
+              // A distinct unit (different server id) reusing prim-a's citation_id.
+              id: serverId("prim-b"),
+              source_type: "decision",
+              namespace: CONFIG.primaryNamespace,
+              citation_id: shared,
+              source_ref: {
+                source: "brain",
+                type: "decision",
+                id: serverId("prim-b"),
+                namespace: CONFIG.primaryNamespace,
+              },
+            },
+          ],
+          item_count: 2,
+          truncated: false,
+        },
+      },
+      // Exactly ONE top-level citation for the shared id.
+      citations: [{ id: shared, kind: "brain_record" }],
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    // 2 emitted occurrences of the shared id, 1 cited -> 1 uncited occurrence.
+    expect(receipt.citations.emitted_item_citations).toBe(2);
+    expect(receipt.citations.uncited_items).toBe(1);
+    expect(receipt.citations.bijective).toBe(false);
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+
+  it("still rejects matching duplicate counts when two units share one citation identity", async () => {
+    const shared = canonical("thought", serverId("prim-a"));
+    const payload = goodPayload({
+      sections: {
+        durable_memory: {
+          label: "durable_memory",
+          namespace_scoped: true,
+          query: FIXTURE.query,
+          items: [
+            {
+              id: serverId("prim-a"),
+              source_type: "thought",
+              namespace: CONFIG.primaryNamespace,
+              citation_id: shared,
+              source_ref: {
+                source: "brain",
+                type: "thought",
+                id: serverId("prim-a"),
+                namespace: CONFIG.primaryNamespace,
+              },
+            },
+            {
+              id: serverId("prim-b"),
+              source_type: "decision",
+              namespace: CONFIG.primaryNamespace,
+              citation_id: shared,
+              source_ref: {
+                source: "brain",
+                type: "decision",
+                id: serverId("prim-b"),
+                namespace: CONFIG.primaryNamespace,
+              },
+            },
+          ],
+          item_count: 2,
+          truncated: false,
+        },
+      },
+      // Repeating the same top-level id does not make the identity bijective:
+      // two distinct emitted units still cannot share one citation identity.
+      citations: [
+        { id: shared, kind: "brain_record" },
+        { id: shared, kind: "brain_record" },
+      ],
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(receipt.citations.emitted_item_citations).toBe(2);
+    expect(receipt.citations.uncited_items).toBe(1);
+    expect(receipt.citations.dangling_citations).toBe(1);
+    expect(receipt.citations.bijective).toBe(false);
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+
+  it("flags a DUPLICATE top-level citation occurrence for one emitted unit (set-based would pass)", async () => {
+    // One emitted durable_memory item, but its citation_id appears TWICE in the
+    // top-level citations array. The old set-based check deduped the two
+    // citations to one member and matched -> false PASS. Occurrence counting
+    // sees 1 emitted vs 2 cited -> 1 dangling surplus, not bijective.
+    const payload = goodPayload();
+    const firstCitation = payload.citations[0]!;
+    payload.citations = [...payload.citations, { ...firstCitation }];
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(receipt.citations.dangling_citations).toBe(1);
+    expect(receipt.citations.bijective).toBe(false);
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+});
+
+describe("runCompletePackGate every-expected-recall (terminal finding #2)", () => {
+  it("fails when only ONE of the two expected recall ids surfaces (one-of-many)", async () => {
+    // durable_memory surfaces ONLY prim-a; prim-b (also expected) never recalls.
+    // The old "any one expected id present" check passed because prim-a appeared;
+    // requiring EVERY expected id catches the missing prim-b as a partial-recall
+    // defect. Citations kept bijective (only prim-a cited) so the ONLY failure is
+    // the incomplete expected recall.
+    const payload = goodPayload({
+      sections: {
+        durable_memory: {
+          label: "durable_memory",
+          namespace_scoped: true,
+          query: FIXTURE.query,
+          items: [
+            {
+              id: serverId("prim-a"),
+              source_type: "thought",
+              namespace: CONFIG.primaryNamespace,
+              citation_id: canonical("thought", serverId("prim-a")),
+              source_ref: {
+                source: "brain",
+                type: "thought",
+                id: serverId("prim-a"),
+                namespace: CONFIG.primaryNamespace,
+              },
+            },
+          ],
+          item_count: 1,
+          truncated: false,
+        },
+      },
+      citations: [
+        {
+          id: canonical("thought", serverId("prim-a")),
+          kind: "brain_record",
+          source_ref: {
+            source: "brain",
+            type: "thought",
+            id: serverId("prim-a"),
+          },
+        },
+      ],
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    // The section is fine and prim-a surfaced, but prim-b did not.
+    expect(receipt.citations.bijective).toBe(true);
+    expect(receipt.isolation.expected_recall_present).toBe(false);
+    expect(passed).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("hollow recall"))).toBe(
+      true,
+    );
+    assertContentFree(receipt);
+  });
+});
+
+describe("runCompletePackGate populated-section denial + reason allowlist (terminal finding #3)", () => {
+  it("fails a POPULATED section that also claims a scope-denial for itself (forged denial)", async () => {
+    // durable_lane_context is emitted with items AND its exact_scope denial is
+    // present. A denial must agree with an actually empty/omitted section; a
+    // populated section claiming denial is forged/stale. The old classifier
+    // returned "items" and passed the section, letting the contradictory denial
+    // stand; now the populated-with-denial case fails the section.
+    const payload = goodPayload({
+      sections: {
+        durable_lane_context: {
+          label: "durable_lane_context",
+          exact_scope_required: true,
+          items: [
+            {
+              id: "lane-item-1",
+              source_type: "session_event",
+              citation_id: "session_event:lane-item-1",
+              source_ref: "ob_session_events/lane-item-1",
+            },
+          ],
+          item_count: 1,
+          truncated: false,
+        },
+      },
+      // The denial is retained for durable_lane_context even though it is now
+      // populated -- the contradiction the gate must catch.
+      warnings: {
+        scope_denials: [
+          { source: "durable_lane_context", reasons: ["exact_scope"] },
+          { source: "repo_facts", reasons: ["no_active_repo"] },
+        ],
+        degraded_sources: [],
+        truncation: [],
+      },
+    });
+    payload.citations = [
+      ...payload.citations,
+      { id: "session_event:lane-item-1", kind: "session_event" },
+    ];
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    const lane = receipt.sections.find(
+      (s) => s.section === "durable_lane_context",
+    );
+    expect(lane!.has_items).toBe(true);
+    expect(lane!.defined_empty).toBe(false);
+    expect(
+      receipt.failures.some(
+        (f) => f.includes("durable_lane_context") && f.includes("populated"),
+      ),
+    ).toBe(true);
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+
+  it("rejects an omitted section 'explained' by an ARBITRARY non-allowlisted denial reason", async () => {
+    // candidate_memory is dropped and 'explained' by a made-up scope-denial
+    // reason that is NOT in candidate_memory's allowlist (candidate_memory has no
+    // allowed scope-denial reasons at all). The old classifier accepted any
+    // source-matched denial and marked it defined-empty; the allowlist now
+    // rejects the arbitrary reason so the omitted section fails.
+    const payload = goodPayload({
+      dropSection: "candidate_memory",
+      warnings: {
+        scope_denials: [
+          { source: "durable_lane_context", reasons: ["exact_scope"] },
+          { source: "repo_facts", reasons: ["no_active_repo"] },
+          {
+            source: "candidate_memory",
+            reasons: ["totally_made_up_reason"],
+          },
+        ],
+        degraded_sources: [],
+        truncation: [],
+      },
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    const candidate = receipt.sections.find(
+      (s) => s.section === "candidate_memory",
+    );
+    expect(candidate!.present).toBe(false);
+    expect(candidate!.defined_empty).toBe(false);
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+});
+
+describe("runCompletePackGate reason/status sentinel sanitization (terminal finding #4)", () => {
+  it("never echoes a malicious server reason into a section disposition", async () => {
+    // repo_facts present-empty but its scope-denial reason carries an injected
+    // sentinel. definedScopeDenialReasons only returns allowlisted reasons, so
+    // this unrecognized reason yields null -> the present-empty repo_facts falls
+    // through to the unmarked-empty defect (generic disposition), and the raw
+    // sentinel never lands in the receipt.
+    const sentinel = "SENTINEL_LEAK_marlin cache body";
+    const payload = goodPayload({
+      warnings: {
+        scope_denials: [
+          { source: "durable_lane_context", reasons: ["exact_scope"] },
+          { source: "repo_facts", reasons: [sentinel] },
+        ],
+        degraded_sources: [],
+        truncation: [],
+      },
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    const repoFacts = receipt.sections.find((s) => s.section === "repo_facts");
+    // The arbitrary reason is NOT accepted as a defined denial; disposition is a
+    // finite generic label, never the raw sentinel string.
+    expect(repoFacts!.defined_empty).toBe(false);
+    expect(repoFacts!.disposition).not.toContain("SENTINEL_LEAK");
+    expect(JSON.stringify(receipt)).not.toContain("SENTINEL_LEAK");
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+
+  it("sanitizes a malicious pack status to a finite label in the failures list", async () => {
+    // A non-ok status that carries an injected sentinel/body must be reduced to a
+    // finite allowlisted label (or the fixed generic) before entering failures.
+    const payload = goodPayload({
+      status: "error: leaked marlin cache body SENTINEL_STATUS",
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    const statusFailure = receipt.failures.find((f) =>
+      f.includes("pack status is"),
+    );
+    expect(statusFailure).toBeDefined();
+    expect(statusFailure).toContain("'unrecognized'");
+    expect(statusFailure).not.toContain("SENTINEL_STATUS");
+    expect(statusFailure).not.toContain("marlin cache body");
+    expect(JSON.stringify(receipt)).not.toContain("SENTINEL_STATUS");
+    assertContentFree(receipt);
+  });
+});
+
 describe("runCompletePackGate teardown discipline", () => {
   it("tears down seeded records even when the pack call throws", async () => {
     const { outcome, state } = run({ packThrows: true });

--- a/eval/open-brain/live/__tests__/complete-pack-gate.test.ts
+++ b/eval/open-brain/live/__tests__/complete-pack-gate.test.ts
@@ -1,0 +1,654 @@
+import { describe, expect, it } from "bun:test";
+import {
+  runCompletePackGate,
+  type CompletePackGateClients,
+} from "../complete-pack-gate.ts";
+import { COMPLETE_PACK_SECTION_NAMES } from "../complete-pack-types.ts";
+import type { CompletePackFixture } from "../complete-pack-types.ts";
+import type { LiveEvalConfig } from "../config.ts";
+import {
+  LiveTransportError,
+  type ContextPackPayload,
+  type ContextPackScope,
+  type OpenBrainLiveClient,
+} from "../transport.ts";
+
+// Orchestrator tests for runCompletePackGate (issue #330). These drive a
+// structural fake at the OpenBrainLiveClient seam so no hosted server is
+// touched. They assert FUNCTIONAL OUTCOMES of the assembled pack — presence or
+// defined emptiness of each of the nine sections, exact-scope isolation,
+// citation bijection, serialized whole-pack budget, per-section contribution,
+// and teardown discipline — never SQL shape or internal call counts. The
+// receipt is proven content-free: only ids, namespaces, counts, booleans.
+
+const CONFIG: LiveEvalConfig = {
+  baseUrl: "http://127.0.0.1:3100",
+  primaryToken: "primary-token",
+  negativeToken: "primary-token",
+  negativeTokenIsDistinct: false,
+  primaryNamespace: "eval-live-recall-pack-test",
+  negativeNamespace: "eval-live-recall-pack-test-negative",
+  searchMode: "hybrid",
+  timeoutMs: 1000,
+};
+
+const SCOPE = {
+  agent: "complete-pack-eval",
+  platform: "eval",
+  server_id: "open-brain-complete-pack",
+  channel_id: "complete-pack-v1",
+  session_key: "eval:complete-pack:v1",
+} as const;
+
+// Two primary records the recall should surface, one negative record forbidden.
+const FIXTURE: CompletePackFixture = {
+  schema_version: 1,
+  fixture_id: "complete-pack-test-v1",
+  description: "test",
+  query: "marlin telemetry cache and beacon rotation",
+  corpus: [
+    {
+      id: "prim-a",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "primary a marlin cache body",
+      tags: ["t"],
+    },
+    {
+      id: "prim-b",
+      table: "decisions",
+      namespace_role: "primary",
+      content: "primary b beacon rotation body",
+      tags: ["t"],
+    },
+    {
+      id: "neg-secret",
+      table: "thoughts",
+      namespace_role: "negative",
+      content: "negative secret body that must never surface",
+      tags: ["t"],
+    },
+  ],
+  expected_recall_ids: ["prim-a", "prim-b"],
+  forbidden_ids: ["neg-secret"],
+};
+
+const serverId = (fixtureId: string) => `srv-${fixtureId}`;
+const canonical = (source: string, id: string) =>
+  `brain_record:${source}:${id}`;
+
+/**
+ * Build a well-formed emitted pack payload for the two seeded primary records,
+ * with all nine sections present-or-defined-empty, a clean citation bijection,
+ * a whole-pack budget the serialized sections fit inside, and durable_lane's
+ * exact-scope denial. Overrides let each test perturb exactly one property.
+ */
+function goodPayload(
+  overrides: Partial<{
+    sections: Record<string, unknown>;
+    citations: Array<Record<string, unknown>>;
+    budget: Record<string, unknown>;
+    warnings: ContextPackPayload["warnings"];
+    status: string;
+    dropSection: string;
+    extraDurableItem: Record<string, unknown>;
+  }> = {},
+): ContextPackPayload {
+  const durableItems = [
+    {
+      id: serverId("prim-a"),
+      source_type: "thought",
+      namespace: CONFIG.primaryNamespace,
+      content: "primary a marlin cache body",
+      citation_id: canonical("thought", serverId("prim-a")),
+      source_ref: {
+        source: "brain",
+        type: "thought",
+        id: serverId("prim-a"),
+        namespace: CONFIG.primaryNamespace,
+      },
+    },
+    {
+      id: serverId("prim-b"),
+      source_type: "decision",
+      namespace: CONFIG.primaryNamespace,
+      content: "primary b beacon rotation body",
+      citation_id: canonical("decision", serverId("prim-b")),
+      source_ref: {
+        source: "brain",
+        type: "decision",
+        id: serverId("prim-b"),
+        namespace: CONFIG.primaryNamespace,
+      },
+    },
+  ];
+  if (overrides.extraDurableItem) durableItems.push(overrides.extraDurableItem);
+
+  const durableCitations = durableItems.map((i) => ({
+    id: i.citation_id,
+    kind: "brain_record",
+    source_ref: i.source_ref,
+  }));
+
+  const sections: Record<string, unknown> = {
+    working_set: {
+      label: "working_set",
+      items: [],
+      item_count: 0,
+    },
+    recovery: undefined, // recovery is not requested unless opted-in; absent OK
+    durable_memory: {
+      label: "durable_memory",
+      namespace_scoped: true,
+      query: FIXTURE.query,
+      items: durableItems,
+      item_count: durableItems.length,
+      truncated: false,
+    },
+    profile_guidance: {
+      label: "profile_guidance",
+      namespace_bound: true,
+      items: [],
+      item_count: 0,
+    },
+    process_guidance: {
+      label: "process_guidance",
+      namespace_bound: true,
+      items: [],
+      item_count: 0,
+    },
+    pointers: {
+      label: "pointers",
+      namespace_scoped: true,
+      resolvable_reference_only: true,
+      items: [],
+      item_count: 0,
+      truncated: false,
+    },
+    candidate_memory: {
+      label: "candidate_memory",
+      items: [],
+      item_count: 0,
+      empty_reason: "candidate_predicate_unavailable",
+      confidence: "unconfirmed",
+      auto_promotable: false,
+    },
+    ...(overrides.sections ?? {}),
+  };
+  // Empty-section dispositions modeled exactly as the live pack reports them on a
+  // fresh throwaway scope:
+  //  - working_set / recovery are RAM-only (recovery is absent unless opted in);
+  //  - profile_guidance / process_guidance / pointers emit a truthful empty body
+  //    with a namespace-binding flag and NO empty_reason and NO scope-denial
+  //    (the guidance loaders and pointer builder return scopeDenials: []);
+  //  - durable_lane_context reports its exact_scope denial;
+  //  - repo_facts reports its no_active_repo denial.
+  // So the only scope-denials the server surfaces here are durable_lane_context
+  // and repo_facts — the guidance/pointer empties are self-describing bodies.
+
+  if (overrides.dropSection) delete sections[overrides.dropSection];
+
+  const warnings: ContextPackPayload["warnings"] = overrides.warnings ?? {
+    scope_denials: [
+      { source: "durable_lane_context", reasons: ["exact_scope"] },
+      { source: "repo_facts", reasons: ["no_active_repo"] },
+    ],
+    degraded_sources: [],
+    truncation: [],
+  };
+
+  const baseSections = Object.fromEntries(
+    Object.entries(sections).filter(([, v]) => v !== undefined),
+  );
+  const serialized = JSON.stringify(baseSections).length;
+
+  const budget: Record<string, unknown> = overrides.budget ?? {
+    requested: { max_tokens: 6000 },
+    whole_pack: {
+      content_char_limit: serialized + 500,
+      content_chars_used: serialized,
+      allocation_order: [...COMPLETE_PACK_SECTION_NAMES],
+    },
+  };
+
+  return {
+    status: overrides.status ?? "ok",
+    sections: baseSections,
+    citations: overrides.citations ?? durableCitations,
+    budget,
+    warnings,
+  };
+}
+
+interface FakeOptions {
+  payload?: ContextPackPayload;
+  packThrows?: boolean;
+  seedFailFor?: string[];
+  archiveFailFor?: string[];
+}
+
+interface FakeState {
+  seeded: Map<string, { table: string; namespace: string }>;
+  archived: string[];
+  packScopes: ContextPackScope[];
+}
+
+function makeFakeClients(opts: FakeOptions = {}): {
+  clients: CompletePackGateClients;
+  state: FakeState;
+} {
+  const state: FakeState = {
+    seeded: new Map(),
+    archived: [],
+    packScopes: [],
+  };
+  const seedFail = new Set(opts.seedFailFor ?? []);
+  const archiveFail = new Set(opts.archiveFailFor ?? []);
+  const byServerId = (id: string) => id.replace(/^srv-/, "");
+
+  function makeClient(): OpenBrainLiveClient {
+    const fake = {
+      async logMemory(o: {
+        table: string;
+        content: string;
+        tags: string[];
+        namespace: string;
+      }) {
+        const entry = FIXTURE.corpus.find((c) => c.content === o.content);
+        const fixtureId = entry?.id ?? "unknown";
+        if (seedFail.has(fixtureId)) {
+          throw new LiveTransportError(`log:${fixtureId}:error`, false);
+        }
+        const id = serverId(fixtureId);
+        state.seeded.set(id, { table: o.table, namespace: o.namespace });
+        return { id, namespace: o.namespace, merged: false };
+      },
+      async contextPack(o: { scope: ContextPackScope }) {
+        state.packScopes.push(o.scope);
+        if (opts.packThrows) {
+          throw new LiveTransportError("agent_context_pack:timeout", false);
+        }
+        return opts.payload ?? goodPayload();
+      },
+      async archive(o: { table: string; id: string }) {
+        const fixtureId = byServerId(o.id);
+        if (archiveFail.has(fixtureId)) {
+          throw new LiveTransportError("archive_entry:error", false);
+        }
+        state.archived.push(o.id);
+        return state.seeded.has(o.id) ? "archived" : "already_absent";
+      },
+      async close() {},
+    };
+    return fake as unknown as OpenBrainLiveClient;
+  }
+
+  return {
+    clients: { primary: makeClient(), negative: makeClient() },
+    state,
+  };
+}
+
+function run(opts: FakeOptions = {}) {
+  const { clients, state } = makeFakeClients(opts);
+  return {
+    outcome: runCompletePackGate({
+      fixture: FIXTURE,
+      config: CONFIG,
+      clients,
+      budgetMaxTokens: 6000,
+      scope: SCOPE,
+      commit: "testcommit",
+      generatedAt: "2026-07-23T00:00:00.000Z",
+    }),
+    state,
+  };
+}
+
+function assertContentFree(receipt: unknown): void {
+  const json = JSON.stringify(receipt);
+  expect(json).not.toContain("must never surface");
+  expect(json).not.toContain("marlin cache body");
+  expect(json).not.toContain("beacon rotation body");
+}
+
+describe("runCompletePackGate happy path", () => {
+  it("verifies all five properties, tears down, and reports PASS", async () => {
+    const { outcome, state } = run();
+    const { receipt, passed } = await outcome;
+
+    expect(passed).toBe(true);
+    expect(receipt.failures).toEqual([]);
+    expect(receipt.seeded).toEqual({ primary: 2, negative: 1 });
+
+    // 1. Every requested section is present or defined-empty.
+    for (const name of COMPLETE_PACK_SECTION_NAMES) {
+      const v = receipt.sections.find((s) => s.section === name);
+      expect(v).toBeDefined();
+      expect(v!.has_items || v!.defined_empty).toBe(true);
+    }
+    // durable_memory carried items; the RAM-only + guidance sections are empty.
+    const durable = receipt.sections.find(
+      (s) => s.section === "durable_memory",
+    );
+    expect(durable!.has_items).toBe(true);
+    expect(durable!.item_count).toBe(2);
+    const candidate = receipt.sections.find(
+      (s) => s.section === "candidate_memory",
+    );
+    expect(candidate!.disposition).toBe("candidate_predicate_unavailable");
+
+    // 2. Isolation.
+    expect(receipt.isolation.exact_scope_denied).toBe(true);
+    expect(receipt.isolation.namespace_leaks).toBe(0);
+    expect(receipt.isolation.expected_recall_present).toBe(true);
+
+    // 3. Citation bijection.
+    expect(receipt.citations.bijective).toBe(true);
+    expect(receipt.citations.dangling_citations).toBe(0);
+    expect(receipt.citations.uncited_items).toBe(0);
+
+    // 4. Serialized budget respected with a complete allocation order.
+    expect(receipt.budget.within_budget).toBe(true);
+    expect(receipt.budget.allocation_order_complete).toBe(true);
+
+    // 5. Per-section contribution recorded.
+    for (const v of receipt.sections) {
+      expect(typeof v.serialized_chars).toBe("number");
+    }
+
+    // The pack was built under the PRIMARY throwaway namespace (isolation seam).
+    expect(state.packScopes.length).toBe(1);
+    expect(state.packScopes[0]!.namespace).toBe(CONFIG.primaryNamespace);
+
+    // Teardown archived exactly the 3 seeded records.
+    expect(receipt.teardown).toEqual({
+      attempted: 3,
+      archived: 3,
+      already_absent: 0,
+      failed: 0,
+    });
+    assertContentFree(receipt);
+  });
+});
+
+describe("runCompletePackGate presence-or-defined-emptiness", () => {
+  it("fails when a requested section is missing with no defined denial/degrade", async () => {
+    // Drop candidate_memory entirely and remove any warning explaining it.
+    const payload = goodPayload({
+      dropSection: "candidate_memory",
+      warnings: {
+        scope_denials: [
+          { source: "durable_lane_context", reasons: ["exact_scope"] },
+        ],
+        degraded_sources: [],
+        truncation: [],
+      },
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    const v = receipt.sections.find((s) => s.section === "candidate_memory");
+    expect(v!.present).toBe(false);
+    expect(v!.defined_empty).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("candidate_memory"))).toBe(
+      true,
+    );
+  });
+
+  it("accepts a section omitted but explained by a degraded-source", async () => {
+    const payload = goodPayload({
+      dropSection: "durable_memory",
+      warnings: {
+        scope_denials: [
+          { source: "durable_lane_context", reasons: ["exact_scope"] },
+          { source: "profile_guidance", reasons: ["no_promoted_guidance"] },
+          { source: "process_guidance", reasons: ["no_promoted_guidance"] },
+          { source: "repo_facts", reasons: ["no_active_repo"] },
+        ],
+        degraded_sources: [
+          { source: "durable_memory", reason: "recall_failed" },
+        ],
+        truncation: [],
+      },
+      // With durable dropped, no items, no citations, no expected recall.
+      citations: [],
+    });
+    const { outcome } = run({ payload });
+    const { receipt } = await outcome;
+    const v = receipt.sections.find((s) => s.section === "durable_memory");
+    expect(v!.defined_empty).toBe(true);
+    expect(v!.disposition).toBe("recall_failed");
+    // Expected recall is now absent -> the run still FAILS on the hollow-recall
+    // guard even though the section itself is defined-empty.
+    expect(receipt.isolation.expected_recall_present).toBe(false);
+    expect(receipt.passed).toBe(false);
+  });
+
+  it("fails a present-but-empty section with no recognized empty marker", async () => {
+    // durable_memory present, zero items, and NO empty_reason: an unmarked empty
+    // is a defect (it does not truthfully state why it is empty).
+    const payload = goodPayload({
+      sections: {
+        durable_memory: {
+          label: "durable_memory",
+          namespace_scoped: true,
+          query: FIXTURE.query,
+          items: [],
+          item_count: 0,
+          truncated: false,
+        },
+      },
+      citations: [],
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    const v = receipt.sections.find((s) => s.section === "durable_memory");
+    expect(v!.present).toBe(true);
+    expect(v!.has_items).toBe(false);
+    expect(v!.defined_empty).toBe(false);
+    expect(passed).toBe(false);
+  });
+});
+
+describe("runCompletePackGate citation truth", () => {
+  it("fails on a dangling citation referencing no emitted item", async () => {
+    const payload = goodPayload();
+    payload.citations = [
+      ...payload.citations,
+      { id: "brain_record:thought:ghost", kind: "brain_record" },
+    ];
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.citations.dangling_citations).toBe(1);
+    expect(receipt.citations.bijective).toBe(false);
+  });
+
+  it("fails on an emitted item with no matching citation", async () => {
+    const payload = goodPayload();
+    // Drop one citation, leaving its item uncited.
+    payload.citations = payload.citations.slice(0, 1);
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.citations.uncited_items).toBe(1);
+    expect(receipt.citations.bijective).toBe(false);
+  });
+});
+
+describe("runCompletePackGate serialized budget", () => {
+  it("fails when serialized sections exceed the whole-pack limit", async () => {
+    const payload = goodPayload();
+    const serialized = JSON.stringify(payload.sections).length;
+    payload.budget = {
+      whole_pack: {
+        content_char_limit: serialized - 10, // too small to admit the sections
+        content_chars_used: serialized,
+        allocation_order: [...COMPLETE_PACK_SECTION_NAMES],
+      },
+    };
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.budget.within_budget).toBe(false);
+  });
+
+  it("fails when the whole-pack allocation order is incomplete", async () => {
+    const payload = goodPayload();
+    const serialized = JSON.stringify(payload.sections).length;
+    payload.budget = {
+      whole_pack: {
+        content_char_limit: serialized + 500,
+        content_chars_used: serialized,
+        allocation_order: ["working_set", "durable_memory"], // missing seven
+      },
+    };
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.budget.allocation_order_complete).toBe(false);
+  });
+
+  it("fails when no whole-pack budget block is reported at all", async () => {
+    const payload = goodPayload();
+    payload.budget = { requested: { max_tokens: 6000 } };
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.budget.content_char_limit).toBeNull();
+    expect(receipt.budget.within_budget).toBe(false);
+  });
+});
+
+describe("runCompletePackGate exact-scope isolation", () => {
+  it("fails when a forbidden negative record surfaces in a section item", async () => {
+    // Inject the negative seeded server id as a pointer item (a leak).
+    const payload = goodPayload({
+      sections: {
+        pointers: {
+          label: "pointers",
+          items: [
+            {
+              id: serverId("neg-secret"),
+              source_type: "thought",
+              namespace: CONFIG.primaryNamespace,
+              citation_id: canonical("thought", serverId("neg-secret")),
+              source_ref: {
+                source: "brain",
+                type: "thought",
+                id: serverId("neg-secret"),
+              },
+            },
+          ],
+          item_count: 1,
+          truncated: false,
+        },
+      },
+    });
+    // Add the pointer citation so citation-truth stays clean and the ONLY failure
+    // is the isolation leak.
+    payload.citations = [
+      ...payload.citations,
+      {
+        id: canonical("thought", serverId("neg-secret")),
+        kind: "pointer",
+        source_ref: {
+          source: "brain",
+          type: "thought",
+          id: serverId("neg-secret"),
+        },
+      },
+    ];
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.isolation.namespace_leaks).toBe(1);
+    expect(receipt.failures.some((f) => f.includes("isolation breach"))).toBe(
+      true,
+    );
+    assertContentFree(receipt);
+  });
+
+  it("fails when durable_lane_context does not report its exact-scope empty", async () => {
+    const payload = goodPayload({
+      warnings: {
+        scope_denials: [
+          { source: "repo_facts", reasons: ["no_active_repo"] },
+          { source: "profile_guidance", reasons: ["no_promoted_guidance"] },
+          { source: "process_guidance", reasons: ["no_promoted_guidance"] },
+        ],
+        degraded_sources: [],
+        truncation: [],
+      },
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.isolation.exact_scope_denied).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("exact-scope"))).toBe(true);
+  });
+
+  it("fails when the expected primary recall does not surface (hollow recall)", async () => {
+    // durable_memory present-and-empty with a truthful no_matches reason, so the
+    // section itself is defined-empty, but the expected records never surfaced —
+    // a broken predicate would look exactly like this, so the gate fails it.
+    const payload = goodPayload({
+      sections: {
+        durable_memory: {
+          label: "durable_memory",
+          namespace_scoped: true,
+          query: FIXTURE.query,
+          items: [],
+          item_count: 0,
+          empty_reason: "no_matches",
+          truncated: false,
+        },
+      },
+      citations: [],
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    const v = receipt.sections.find((s) => s.section === "durable_memory");
+    expect(v!.defined_empty).toBe(true); // section is fine on its own
+    expect(receipt.isolation.expected_recall_present).toBe(false);
+    expect(passed).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("hollow recall"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("runCompletePackGate teardown discipline", () => {
+  it("tears down seeded records even when the pack call throws", async () => {
+    const { outcome, state } = run({ packThrows: true });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    expect(state.archived.length).toBe(3);
+  });
+
+  it("tears down the records seeded so far when seeding fails partway", async () => {
+    const { outcome, state } = run({ seedFailFor: ["neg-secret"] });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    expect(state.archived.sort()).toEqual(["srv-prim-a", "srv-prim-b"].sort());
+  });
+
+  it("preserves the content-free teardown failed count on a deferred error", async () => {
+    const { outcome } = run({ packThrows: true, archiveFailFor: ["prim-a"] });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("agent_context_pack:timeout;teardown-failed=1");
+    expect(err.label).not.toContain("srv-");
+    expect(err.label).not.toContain("body");
+  });
+
+  it("fails the gate (never PASS) when a teardown archive fails", async () => {
+    const { outcome } = run({ archiveFailFor: ["prim-a"] });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.teardown.failed).toBe(1);
+    expect(
+      receipt.failures.some((f) => f.includes("teardown failed to archive")),
+    ).toBe(true);
+    assertContentFree(receipt);
+  });
+});

--- a/eval/open-brain/live/__tests__/complete-pack-gate.test.ts
+++ b/eval/open-brain/live/__tests__/complete-pack-gate.test.ts
@@ -157,6 +157,18 @@ function goodPayload(
       items: [],
       item_count: 0,
     },
+    repo_facts: {
+      // Production present-empty shape for no active repo
+      // (src/tools/agent-context-pack-repo-facts.ts): a present body carrying
+      // {repo: null, repo_bound: false, items: []} PLUS a no_active_repo denial.
+      label: "repo_facts",
+      repo: null,
+      namespace_bound: true,
+      repo_bound: false,
+      items: [],
+      item_count: 0,
+      truncated: false,
+    },
     pointers: {
       label: "pointers",
       namespace_scoped: true,
@@ -181,8 +193,10 @@ function goodPayload(
   //  - profile_guidance / process_guidance / pointers emit a truthful empty body
   //    with a namespace-binding flag and NO empty_reason and NO scope-denial
   //    (the guidance loaders and pointer builder return scopeDenials: []);
-  //  - durable_lane_context reports its exact_scope denial;
-  //  - repo_facts reports its no_active_repo denial.
+  //  - durable_lane_context reports its exact_scope denial (body omitted);
+  //  - repo_facts is PRESENT-empty ({repo: null, repo_bound: false}) AND reports
+  //    its no_active_repo denial — its disposition must derive from that reason,
+  //    not the hardcoded exact_scope of durable_lane_context.
   // So the only scope-denials the server surfaces here are durable_lane_context
   // and repo_facts — the guidance/pointer empties are self-describing bodies.
 
@@ -225,12 +239,21 @@ interface FakeOptions {
   packThrows?: boolean;
   seedFailFor?: string[];
   archiveFailFor?: string[];
+  /**
+   * How the PRIMARY caller's cross-namespace read of the NEGATIVE namespace
+   * resolves. "denied" is the only isolation-proving outcome; "empty" and "leak"
+   * are allowed reads that must fail the gate; "throws" is a non-denial transport
+   * error that leaves the proof unestablished (denied=false, no gate throw).
+   */
+  negativeRead?: "denied" | "empty" | "leak" | "throws";
 }
 
 interface FakeState {
   seeded: Map<string, { table: string; namespace: string }>;
   archived: string[];
   packScopes: ContextPackScope[];
+  /** Namespaces the PRIMARY caller's isolation probe (attemptRead) targeted. */
+  attemptReadNamespaces: string[];
 }
 
 function makeFakeClients(opts: FakeOptions = {}): {
@@ -241,12 +264,13 @@ function makeFakeClients(opts: FakeOptions = {}): {
     seeded: new Map(),
     archived: [],
     packScopes: [],
+    attemptReadNamespaces: [],
   };
   const seedFail = new Set(opts.seedFailFor ?? []);
   const archiveFail = new Set(opts.archiveFailFor ?? []);
   const byServerId = (id: string) => id.replace(/^srv-/, "");
 
-  function makeClient(): OpenBrainLiveClient {
+  function makeClient(role: "primary" | "negative"): OpenBrainLiveClient {
     const fake = {
       async logMemory(o: {
         table: string;
@@ -270,6 +294,26 @@ function makeFakeClients(opts: FakeOptions = {}): {
         }
         return opts.payload ?? goodPayload();
       },
+      async attemptRead(o: {
+        namespace: string;
+      }): Promise<{ denied: boolean; hitCount: number }> {
+        // Record the namespace the PRIMARY isolation probe targeted so a test can
+        // pin the live-proven call shape: the gate must probe the NEGATIVE
+        // namespace with the PRIMARY caller.
+        if (role === "primary") {
+          state.attemptReadNamespaces.push(o.namespace);
+        }
+        switch (opts.negativeRead ?? "denied") {
+          case "denied":
+            return { denied: true, hitCount: 0 };
+          case "empty":
+            return { denied: false, hitCount: 0 };
+          case "leak":
+            return { denied: false, hitCount: 1 };
+          case "throws":
+            throw new LiveTransportError("search_brain:timeout", false);
+        }
+      },
       async archive(o: { table: string; id: string }) {
         const fixtureId = byServerId(o.id);
         if (archiveFail.has(fixtureId)) {
@@ -284,7 +328,10 @@ function makeFakeClients(opts: FakeOptions = {}): {
   }
 
   return {
-    clients: { primary: makeClient(), negative: makeClient() },
+    clients: {
+      primary: makeClient("primary"),
+      negative: makeClient("negative"),
+    },
     state,
   };
 }
@@ -313,7 +360,7 @@ function assertContentFree(receipt: unknown): void {
 }
 
 describe("runCompletePackGate happy path", () => {
-  it("verifies all five properties, tears down, and reports PASS", async () => {
+  it("verifies all six properties, tears down, and reports PASS", async () => {
     const { outcome, state } = run();
     const { receipt, passed } = await outcome;
 
@@ -337,11 +384,25 @@ describe("runCompletePackGate happy path", () => {
       (s) => s.section === "candidate_memory",
     );
     expect(candidate!.disposition).toBe("candidate_predicate_unavailable");
+    // repo_facts is present-empty with a no_active_repo denial: its disposition
+    // is that ACTUAL reason, never the hardcoded exact_scope (finding #3).
+    const repoFacts = receipt.sections.find((s) => s.section === "repo_facts");
+    expect(repoFacts!.present).toBe(true);
+    expect(repoFacts!.defined_empty).toBe(true);
+    expect(repoFacts!.disposition).toBe("no_active_repo");
 
     // 2. Isolation.
     expect(receipt.isolation.exact_scope_denied).toBe(true);
     expect(receipt.isolation.namespace_leaks).toBe(0);
     expect(receipt.isolation.expected_recall_present).toBe(true);
+
+    // 6. Explicit cross-namespace denial ran and was denied, and the probe
+    // targeted the NEGATIVE namespace with the PRIMARY caller.
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(true);
+    expect(receipt.negative_control.observed_hit_count).toBe(0);
+    expect(state.attemptReadNamespaces).toEqual([CONFIG.negativeNamespace]);
+    expect(state.attemptReadNamespaces).not.toContain(CONFIG.primaryNamespace);
 
     // 3. Citation bijection.
     expect(receipt.citations.bijective).toBe(true);
@@ -616,6 +677,284 @@ describe("runCompletePackGate exact-scope isolation", () => {
     expect(receipt.failures.some((f) => f.includes("hollow recall"))).toBe(
       true,
     );
+  });
+});
+
+describe("runCompletePackGate present-empty scope-denial disposition", () => {
+  it("labels a present-empty repo_facts with its actual no_active_repo reason, not exact_scope", async () => {
+    // Finding #3 false-pass regression: the goodPayload repo_facts is present
+    // (repo: null) with a no_active_repo denial. The hardcoded-exact_scope bug
+    // would mislabel it; the disposition must be the real reason.
+    const { outcome } = run();
+    const { receipt } = await outcome;
+    const repoFacts = receipt.sections.find((s) => s.section === "repo_facts");
+    expect(repoFacts!.present).toBe(true);
+    expect(repoFacts!.has_items).toBe(false);
+    expect(repoFacts!.defined_empty).toBe(true);
+    expect(repoFacts!.disposition).toBe("no_active_repo");
+    // durable_lane_context (omitted body) still carries its own exact_scope
+    // reason: the two present/absent denials are NOT conflated to one label.
+    const lane = receipt.sections.find(
+      (s) => s.section === "durable_lane_context",
+    );
+    expect(lane!.disposition).toBe("exact_scope");
+  });
+
+  it("joins multiple present-empty denial reasons instead of one hardcoded label", async () => {
+    // A present-empty repo_facts reporting two reasons must surface both, proving
+    // the disposition is derived from scopeDenial.reasons, not a constant.
+    const payload = goodPayload({
+      warnings: {
+        scope_denials: [
+          { source: "durable_lane_context", reasons: ["exact_scope"] },
+          {
+            source: "repo_facts",
+            reasons: ["no_active_repo", "namespace_bound"],
+          },
+        ],
+        degraded_sources: [],
+        truncation: [],
+      },
+    });
+    const { outcome } = run({ payload });
+    const { receipt } = await outcome;
+    const repoFacts = receipt.sections.find((s) => s.section === "repo_facts");
+    expect(repoFacts!.disposition).toBe("no_active_repo,namespace_bound");
+  });
+});
+
+describe("runCompletePackGate cross-namespace denial probe (finding #1)", () => {
+  it("passes when the primary caller's read of the negative namespace is denied", async () => {
+    const { outcome } = run({ negativeRead: "denied" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(true);
+    expect(passed).toBe(true);
+  });
+
+  it("FALSE-PASS regression: an allowed-but-empty negative read must FAIL the gate", async () => {
+    // The emitted-pack leak walk is clean (no forbidden id surfaced), so the old
+    // gate would PASS. But an allowed-but-empty read is not proof of isolation —
+    // a forbidden record ranked below the cut looks identical. The denial probe
+    // fails the gate closed.
+    const { outcome } = run({ negativeRead: "empty" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.isolation.namespace_leaks).toBe(0); // walk is clean...
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(false); // ...but read was allowed
+    expect(receipt.negative_control.observed_hit_count).toBe(0);
+    expect(passed).toBe(false);
+    expect(
+      receipt.failures.some((f) => f.includes("negative-control not denied")),
+    ).toBe(true);
+    assertContentFree(receipt);
+  });
+
+  it("fails when the primary caller is permitted a NON-empty read of the negative namespace", async () => {
+    const { outcome } = run({ negativeRead: "leak" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(receipt.negative_control.observed_hit_count).toBe(1);
+    expect(passed).toBe(false);
+    expect(
+      receipt.failures.some((f) => f.includes("negative-control not denied")),
+    ).toBe(true);
+  });
+
+  it("fails the proof (denied=false) without throwing when the probe read errors", async () => {
+    // A non-denial transport error means the proof could not be established;
+    // probeNegativeControl catches it and reports denied=false with a redacted
+    // failure label, so the gate does NOT throw but still fails closed.
+    const { outcome } = run({ negativeRead: "throws" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(receipt.negative_control.failure).toContain(
+      "negative-control read failed",
+    );
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+});
+
+describe("runCompletePackGate durable_lane_context events/lane walkers (finding #2)", () => {
+  const laneId = "lane-uuid-777";
+  const eventAId = "event-uuid-111";
+  const eventBId = "event-uuid-222";
+
+  /**
+   * A production-accurate POPULATED durable_lane_context section: an exact-scope
+   * lane WITH events, each citing itself via session_event:<id>, exactly as
+   * src/tools/agent-context-pack-durable-lane.ts emits it. No exact_scope
+   * scope-denial (the lane exists), so this run is used to exercise the citation
+   * bijection over events and lane-scoped leak detection, not overall PASS.
+   */
+  function populatedLanePayload(
+    overrides: {
+      leakEventSourceRef?: string;
+      dropEventCitations?: boolean;
+    } = {},
+  ): ContextPackPayload {
+    const laneCitationId = `session_lane:${laneId}`;
+    const eventACitation = `session_event:${eventAId}`;
+    const eventBCitation = `session_event:${eventBId}`;
+    const payload = goodPayload({
+      warnings: {
+        // Lane exists -> no exact_scope denial; repo_facts still present-empty.
+        scope_denials: [{ source: "repo_facts", reasons: ["no_active_repo"] }],
+        degraded_sources: [],
+        truncation: [],
+      },
+      sections: {
+        durable_lane_context: {
+          label: "durable_lane_context",
+          exact_scope_required: true,
+          lane: {
+            id: laneId,
+            session_key: "eval:complete-pack:v1",
+            status: "active",
+            citation_id: laneCitationId,
+          },
+          events: [
+            {
+              id: eventAId,
+              event_type: "decision",
+              content: "lane event a body",
+              citation_id: eventACitation,
+              source_ref:
+                overrides.leakEventSourceRef ?? `ob_session_events/${eventAId}`,
+            },
+            {
+              id: eventBId,
+              event_type: "thought",
+              content: "lane event b body",
+              citation_id: eventBCitation,
+              source_ref: `ob_session_events/${eventBId}`,
+            },
+          ],
+          event_count: 2,
+          truncated: false,
+        },
+      },
+    });
+    // The pack cites the lane and every event. Drop the event citations when a
+    // test wants to prove the events are walked (uncited detection).
+    const laneCitations = overrides.dropEventCitations
+      ? [
+          {
+            id: laneCitationId,
+            kind: "session_lane",
+            source_ref: `ob_session_lanes/${laneId}`,
+          },
+        ]
+      : [
+          {
+            id: laneCitationId,
+            kind: "session_lane",
+            source_ref: `ob_session_lanes/${laneId}`,
+          },
+          {
+            id: eventACitation,
+            kind: "session_event",
+            source_ref: `ob_session_events/${eventAId}`,
+          },
+          {
+            id: eventBCitation,
+            kind: "session_event",
+            source_ref: `ob_session_events/${eventBId}`,
+          },
+        ];
+    payload.citations = [...payload.citations, ...laneCitations];
+    return payload;
+  }
+
+  it("counts each lane event citation as emitted so a populated lane stays bijective", async () => {
+    const { outcome } = run({ payload: populatedLanePayload() });
+    const { receipt } = await outcome;
+    // The two durable_memory items + lane + two events are all cited: bijective.
+    expect(receipt.citations.dangling_citations).toBe(0);
+    expect(receipt.citations.uncited_items).toBe(0);
+    expect(receipt.citations.bijective).toBe(true);
+    // emitted item citations now include the lane and both events.
+    expect(receipt.citations.emitted_item_citations).toBe(5);
+  });
+
+  it("flags an uncited lane event as a bijection break (events ARE walked)", async () => {
+    const { outcome } = run({
+      payload: populatedLanePayload({ dropEventCitations: true }),
+    });
+    const { receipt, passed } = await outcome;
+    // Two event citations were dropped but the events are still emitted, so they
+    // are now uncited — proving the walker reaches events[], not just items/lane.
+    expect(receipt.citations.uncited_items).toBe(2);
+    expect(receipt.citations.bijective).toBe(false);
+    expect(passed).toBe(false);
+  });
+
+  it("detects a forbidden negative id embedded in a lane event source_ref pointer", async () => {
+    // A leaked negative record surfacing as an event source_ref pointer must be
+    // caught even though it lives on events[], not items[]. Cite it so the ONLY
+    // failure is the isolation leak.
+    const forbidden = serverId("neg-secret");
+    const payload = populatedLanePayload({
+      leakEventSourceRef: `ob_session_events/${forbidden}`,
+    });
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(receipt.isolation.namespace_leaks).toBeGreaterThanOrEqual(1);
+    expect(passed).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("isolation breach"))).toBe(
+      true,
+    );
+    assertContentFree(receipt);
+  });
+
+  it("detects a forbidden negative id surfacing as a lane event id", async () => {
+    // The forbidden id as an event's own `id` (not a source_ref) is still a leak.
+    const forbidden = serverId("neg-secret");
+    const payload = goodPayload({
+      warnings: {
+        scope_denials: [{ source: "repo_facts", reasons: ["no_active_repo"] }],
+        degraded_sources: [],
+        truncation: [],
+      },
+      sections: {
+        durable_lane_context: {
+          label: "durable_lane_context",
+          exact_scope_required: true,
+          lane: { id: "lane-ok", citation_id: "session_lane:lane-ok" },
+          events: [
+            {
+              id: forbidden,
+              event_type: "decision",
+              content: "leaked event body",
+              citation_id: `session_event:${forbidden}`,
+              source_ref: `ob_session_events/${forbidden}`,
+            },
+          ],
+          event_count: 1,
+          truncated: false,
+        },
+      },
+    });
+    payload.citations = [
+      ...payload.citations,
+      {
+        id: "session_lane:lane-ok",
+        kind: "session_lane",
+        source_ref: "ob_session_lanes/lane-ok",
+      },
+      {
+        id: `session_event:${forbidden}`,
+        kind: "session_event",
+        source_ref: `ob_session_events/${forbidden}`,
+      },
+    ];
+    const { outcome } = run({ payload });
+    const { receipt, passed } = await outcome;
+    expect(receipt.isolation.namespace_leaks).toBeGreaterThanOrEqual(1);
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
   });
 });
 

--- a/eval/open-brain/live/__tests__/complete-pack-transport.test.ts
+++ b/eval/open-brain/live/__tests__/complete-pack-transport.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "bun:test";
+import {
+  LiveTransportError,
+  OpenBrainLiveClient,
+  parseContextPackPayload,
+  type OpenBrainToolCaller,
+  type ToolCallResult,
+} from "../transport.ts";
+import { setUpCompletePackClients } from "../complete-pack-setup.ts";
+import type { LiveEvalConfig } from "../config.ts";
+
+// Transport-boundary tests for the complete-pack additions: parseContextPackPayload
+// normalization / fail-closed behavior, the OpenBrainLiveClient.contextPack call
+// shape, and the client-setup lifecycle (primary closed if negative connect
+// fails). These exercise the REAL parse path, not a fake at the client seam.
+
+describe("parseContextPackPayload", () => {
+  it("normalizes a well-formed pack object into structural containers", () => {
+    const payload = parseContextPackPayload(
+      JSON.stringify({
+        status: "ok",
+        sections: { durable_memory: { items: [], item_count: 0 } },
+        citations: [{ id: "brain_record:thought:x" }, "not-an-object"],
+        budget: { whole_pack: { content_char_limit: 100 } },
+        warnings: {
+          scope_denials: [{ source: "durable_lane_context" }],
+          degraded_sources: [],
+          truncation: [{ source: "durable_memory", starved: true }],
+        },
+      }),
+    );
+    expect(payload.status).toBe("ok");
+    expect(payload.sections.durable_memory).toBeDefined();
+    // Non-object citation entries are filtered out.
+    expect(payload.citations.length).toBe(1);
+    expect(payload.warnings.scope_denials.length).toBe(1);
+    expect(payload.warnings.truncation[0]!.starved).toBe(true);
+  });
+
+  it("defaults missing containers to their empty forms", () => {
+    const payload = parseContextPackPayload(JSON.stringify({ status: "ok" }));
+    expect(payload.sections).toEqual({});
+    expect(payload.citations).toEqual([]);
+    expect(payload.budget).toEqual({});
+    expect(payload.warnings.scope_denials).toEqual([]);
+    expect(payload.warnings.degraded_sources).toEqual([]);
+    expect(payload.warnings.truncation).toEqual([]);
+  });
+
+  it("fails closed content-free on a non-object body (never an empty pack)", () => {
+    expect(() => parseContextPackPayload("[1,2,3]")).toThrow(
+      LiveTransportError,
+    );
+    expect(() => parseContextPackPayload("not json")).toThrow(
+      LiveTransportError,
+    );
+    try {
+      parseContextPackPayload("[1,2,3]");
+    } catch (error) {
+      const err = error as LiveTransportError;
+      expect(err.label).toBe("agent_context_pack:malformed-payload");
+    }
+  });
+});
+
+describe("OpenBrainLiveClient.contextPack", () => {
+  function scriptedCaller(result: ToolCallResult): {
+    caller: OpenBrainToolCaller;
+    calls: Array<{ name: string; args: Record<string, unknown> }>;
+  } {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    return {
+      caller: {
+        async callTool(name, args) {
+          calls.push({ name, args });
+          return result;
+        },
+        async close() {},
+      },
+      calls,
+    };
+  }
+
+  const ok = (data: string): ToolCallResult => ({
+    isError: false,
+    denied: false,
+    data,
+    errorLabel: "",
+  });
+
+  it("sends the requested sections + budget + scope and parses the payload", async () => {
+    const { caller, calls } = scriptedCaller(
+      ok(JSON.stringify({ status: "ok", sections: {}, citations: [] })),
+    );
+    const client = new OpenBrainLiveClient(caller);
+    const payload = await client.contextPack({
+      scope: {
+        namespace: "eval-ns",
+        agent: "a",
+        platform: "p",
+        server_id: "s",
+        channel_id: "c",
+        session_key: "k",
+      },
+      query: "q",
+      requestedSections: ["working_set", "durable_memory"],
+      budgetMaxTokens: 6000,
+    });
+    expect(payload.status).toBe("ok");
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.name).toBe("agent_context_pack");
+    expect(calls[0]!.args.namespace).toBe("eval-ns");
+    expect(calls[0]!.args.requested_sections).toEqual([
+      "working_set",
+      "durable_memory",
+    ]);
+    expect(calls[0]!.args.budget).toEqual({ max_tokens: 6000 });
+    // No thread_id in scope -> not sent.
+    expect("thread_id" in (calls[0]!.args as object)).toBe(false);
+  });
+
+  it("throws a redacted error on a denied pack call", async () => {
+    const { caller } = scriptedCaller({
+      isError: true,
+      denied: true,
+      data: "",
+      errorLabel: "agent_context_pack:permission-denied",
+    });
+    const client = new OpenBrainLiveClient(caller);
+    await expect(
+      client.contextPack({
+        scope: {
+          namespace: "eval-ns",
+          agent: "a",
+          platform: "p",
+          server_id: "s",
+          channel_id: "c",
+          session_key: "k",
+        },
+        query: "q",
+        requestedSections: ["working_set"],
+      }),
+    ).rejects.toThrow(LiveTransportError);
+  });
+});
+
+describe("setUpCompletePackClients lifecycle", () => {
+  const CONFIG: LiveEvalConfig = {
+    baseUrl: "http://127.0.0.1:3100",
+    primaryToken: "t",
+    negativeToken: "t",
+    negativeTokenIsDistinct: false,
+    primaryNamespace: "ns-primary",
+    negativeNamespace: "ns-negative",
+    searchMode: "hybrid",
+    timeoutMs: 1000,
+  };
+
+  it("closes the primary caller when the negative connect fails", async () => {
+    let primaryClosed = 0;
+    const factory = async (opts: { namespace: string }) => {
+      if (opts.namespace === CONFIG.negativeNamespace) {
+        throw new LiveTransportError("connect:transport-error", false);
+      }
+      return {
+        async callTool() {
+          return { isError: false, denied: false, data: "", errorLabel: "" };
+        },
+        async close() {
+          primaryClosed += 1;
+        },
+      } as OpenBrainToolCaller;
+    };
+    await expect(setUpCompletePackClients(CONFIG, factory)).rejects.toThrow(
+      LiveTransportError,
+    );
+    // The successfully-connected primary was closed so no session leaks.
+    expect(primaryClosed).toBe(1);
+  });
+});

--- a/eval/open-brain/live/complete-pack-cli.ts
+++ b/eval/open-brain/live/complete-pack-cli.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+// Single-command live COMPLETE CONTEXT PACK gate (EVAL-3, issue #330).
+//
+//   bun run eval/open-brain/live/complete-pack-cli.ts
+//   bun run eval/open-brain/live/complete-pack-cli.ts --json
+//   bun run eval/open-brain/live/complete-pack-cli.ts --report <path>
+//   bun run eval/open-brain/live/complete-pack-cli.ts --budget-tokens 8000
+//
+// Requires opt-in: OPEN_BRAIN_LIVE_EVAL=1 plus base URL + token env vars (see
+// eval/open-brain/README.md). One invocation seeds a unique throwaway namespace
+// with the sealed synthetic corpus, calls the real `agent_context_pack` tool
+// requesting all nine sections under one whole-pack budget, verifies the five
+// functional properties (presence-or-defined-empty, exact-scope isolation,
+// citation truth, serialized budget, per-section contribution), tears down
+// exactly this run's records, and exits nonzero on any failed property.
+//
+// Output is content-free: only section names, ids, namespaces, labels, counts,
+// and statuses. No memory bodies, tokens, or secrets are ever printed.
+
+import { randomUUID } from "node:crypto";
+import { loadLiveConfig, makeRunId } from "./config.ts";
+import { loadCompletePackFixture } from "./complete-pack-fixtures.ts";
+import { runCompletePackGate } from "./complete-pack-gate.ts";
+import type { CompletePackGateClients } from "./complete-pack-gate.ts";
+import { setUpCompletePackClients } from "./complete-pack-setup.ts";
+
+const FIXTURE_PATH = "eval/open-brain/fixtures/complete-pack-v1.json";
+// Whole-pack budget large enough to admit the seeded durable_memory recall and
+// its citations while still exercising the serialized-budget accounting. It is
+// an eval knob (overridable with --budget-tokens), not a production threshold,
+// so it lives here rather than in thresholds.json (which versions the
+// recall-quality gate, not this pack-assembly gate).
+const DEFAULT_BUDGET_MAX_TOKENS = 6000;
+
+// A fixed synthetic active scope for the pack build. The namespace is the per-run
+// throwaway namespace (bound inside the gate); these coordinates address a lane
+// that does not exist for the fresh scope, so durable_lane_context and the
+// RAM-only sections land in their defined-empty states -- exactly the shape the
+// gate verifies as present-or-defined-empty.
+const PACK_SCOPE = {
+  agent: "complete-pack-eval",
+  platform: "eval",
+  server_id: "open-brain-complete-pack",
+  channel_id: "complete-pack-v1",
+  session_key: "eval:complete-pack:v1",
+} as const;
+
+function argValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of Bun.argv.slice(2)) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  const index = Bun.argv.indexOf(`--${name}`);
+  const next = index >= 0 ? Bun.argv[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+async function gitCommit(): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    return code === 0 ? output.trim() : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+async function main(): Promise<number> {
+  const commit = await gitCommit();
+  const runId = makeRunId({
+    prefix: commit.slice(0, 12),
+    randomHex: randomUUID().replace(/-/g, "").slice(0, 12),
+  });
+  const config = loadLiveConfig(runId);
+  const fixture = await loadCompletePackFixture(FIXTURE_PATH);
+  const generatedAt = new Date().toISOString();
+
+  const budgetRaw = argValue("budget-tokens");
+  let budgetMaxTokens = DEFAULT_BUDGET_MAX_TOKENS;
+  if (budgetRaw !== undefined) {
+    const parsed = Number.parseInt(budgetRaw, 10);
+    if (Number.isNaN(parsed) || parsed < 100) {
+      throw new Error("--budget-tokens must be an integer >= 100");
+    }
+    budgetMaxTokens = parsed;
+  }
+
+  const clients: CompletePackGateClients =
+    await setUpCompletePackClients(config);
+
+  try {
+    const outcome = await runCompletePackGate({
+      fixture,
+      config,
+      clients,
+      budgetMaxTokens,
+      scope: PACK_SCOPE,
+      commit,
+      generatedAt,
+    });
+
+    const reportPath = argValue("report");
+    if (reportPath) {
+      await Bun.write(
+        reportPath,
+        `${JSON.stringify(outcome.receipt, null, 2)}\n`,
+      );
+    }
+
+    if (Bun.argv.includes("--json")) {
+      console.log(JSON.stringify(outcome.receipt, null, 2));
+    } else {
+      printReceipt(outcome.receipt);
+      if (reportPath) console.log(`\nWrote receipt: ${reportPath}`);
+    }
+
+    return outcome.passed ? 0 : 1;
+  } finally {
+    await clients.primary.close().catch(() => {});
+    await clients.negative.close().catch(() => {});
+  }
+}
+
+function printReceipt(
+  receipt: Awaited<ReturnType<typeof runCompletePackGate>>["receipt"],
+): void {
+  const verdict = receipt.passed ? "PASS" : "FAIL";
+  const lines = [
+    `Open Brain complete context pack gate: ${verdict}`,
+    `fixture=${receipt.fixture_id} commit=${receipt.commit}`,
+    `namespace=${receipt.primary_namespace} (negative=${receipt.negative_namespace})`,
+    `seeded primary=${receipt.seeded.primary} negative=${receipt.seeded.negative}`,
+    `budget serialized=${receipt.budget.serialized_sections_chars}/${receipt.budget.content_char_limit ?? "none"} within=${receipt.budget.within_budget} allocation_order_complete=${receipt.budget.allocation_order_complete}`,
+    `citations total=${receipt.citations.citations_total} emitted_item_citations=${receipt.citations.emitted_item_citations} dangling=${receipt.citations.dangling_citations} uncited=${receipt.citations.uncited_items} bijective=${receipt.citations.bijective}`,
+    `isolation exact_scope_denied=${receipt.isolation.exact_scope_denied} namespace_leaks=${receipt.isolation.namespace_leaks} expected_recall_present=${receipt.isolation.expected_recall_present}`,
+    `teardown attempted=${receipt.teardown.attempted} archived=${receipt.teardown.archived} already_absent=${receipt.teardown.already_absent} failed=${receipt.teardown.failed}`,
+  ];
+  for (const section of receipt.sections) {
+    const ok = section.defined_empty || section.has_items ? "ok" : "FAIL";
+    lines.push(
+      `- ${section.section}: present=${section.present} items=${section.item_count} disposition=${section.disposition} chars=${section.serialized_chars} ${ok}`,
+    );
+  }
+  if (receipt.failures.length > 0) {
+    lines.push(`failures: ${receipt.failures.join("; ")}`);
+  }
+  console.log(lines.join("\n"));
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Complete context pack gate error: ${message}`);
+      process.exitCode = 2;
+    });
+}

--- a/eval/open-brain/live/complete-pack-cli.ts
+++ b/eval/open-brain/live/complete-pack-cli.ts
@@ -137,6 +137,7 @@ function printReceipt(
     `budget serialized=${receipt.budget.serialized_sections_chars}/${receipt.budget.content_char_limit ?? "none"} within=${receipt.budget.within_budget} allocation_order_complete=${receipt.budget.allocation_order_complete}`,
     `citations total=${receipt.citations.citations_total} emitted_item_citations=${receipt.citations.emitted_item_citations} dangling=${receipt.citations.dangling_citations} uncited=${receipt.citations.uncited_items} bijective=${receipt.citations.bijective}`,
     `isolation exact_scope_denied=${receipt.isolation.exact_scope_denied} namespace_leaks=${receipt.isolation.namespace_leaks} expected_recall_present=${receipt.isolation.expected_recall_present}`,
+    `negative_control ran=${receipt.negative_control.ran} denied=${receipt.negative_control.denied} observed_hit_count=${receipt.negative_control.observed_hit_count} cross_token=${receipt.negative_control.cross_token}${receipt.negative_control.failure ? ` failure=${receipt.negative_control.failure}` : ""}`,
     `teardown attempted=${receipt.teardown.attempted} archived=${receipt.teardown.archived} already_absent=${receipt.teardown.already_absent} failed=${receipt.teardown.failed}`,
   ];
   for (const section of receipt.sections) {

--- a/eval/open-brain/live/complete-pack-fixtures.ts
+++ b/eval/open-brain/live/complete-pack-fixtures.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { CompletePackFixture } from "./complete-pack-types.ts";
+
+// Zod validation for the complete-pack fixture. Loading is fail-closed: a
+// malformed fixture aborts the gate before any live write happens, exactly like
+// the recall gate's parseLiveFixture.
+
+const corpusEntrySchema = z.object({
+  id: z.string().min(1),
+  table: z.enum(["thoughts", "decisions"]),
+  namespace_role: z.enum(["primary", "negative"]),
+  content: z.string().min(1),
+  tags: z.array(z.string()),
+});
+
+export const completePackFixtureSchema: z.ZodType<CompletePackFixture> =
+  z.object({
+    schema_version: z.literal(1),
+    fixture_id: z.string().min(1),
+    description: z.string(),
+    query: z.string().min(1),
+    corpus: z.array(corpusEntrySchema).min(1),
+    expected_recall_ids: z.array(z.string().min(1)).min(1),
+    forbidden_ids: z.array(z.string().min(1)).min(1),
+  });
+
+/**
+ * Parse and structurally validate a complete-pack fixture, then check
+ * referential integrity: every expected/forbidden id must exist in the corpus,
+ * corpus ids are unique, expected ids point at primary-role entries, and
+ * forbidden ids point at negative-role entries. Throws on any gap so the gate
+ * can never seed a fixture whose expectations do not match its corpus.
+ */
+export function parseCompletePackFixture(raw: unknown): CompletePackFixture {
+  const fixture = completePackFixtureSchema.parse(raw);
+
+  const byId = new Map<string, (typeof fixture.corpus)[number]>();
+  for (const entry of fixture.corpus) {
+    if (byId.has(entry.id)) {
+      throw new Error(`duplicate corpus id: ${entry.id}`);
+    }
+    byId.set(entry.id, entry);
+  }
+
+  for (const id of fixture.expected_recall_ids) {
+    const entry = byId.get(id);
+    if (!entry) {
+      throw new Error(`expected_recall_ids references unknown id ${id}`);
+    }
+    if (entry.namespace_role !== "primary") {
+      throw new Error(`expected_recall id ${id} must be a primary-role entry`);
+    }
+  }
+  for (const id of fixture.forbidden_ids) {
+    const entry = byId.get(id);
+    if (!entry) {
+      throw new Error(`forbidden_ids references unknown id ${id}`);
+    }
+    if (entry.namespace_role !== "negative") {
+      throw new Error(`forbidden id ${id} must be a negative-role entry`);
+    }
+  }
+
+  return fixture;
+}
+
+/** Load and validate a complete-pack fixture from disk. */
+export async function loadCompletePackFixture(
+  path: string,
+): Promise<CompletePackFixture> {
+  let raw: unknown;
+  try {
+    raw = await Bun.file(path).json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read complete-pack fixture ${path}: ${message}`);
+  }
+  try {
+    return parseCompletePackFixture(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid complete-pack fixture ${path}: ${message}`);
+  }
+}

--- a/eval/open-brain/live/complete-pack-gate.ts
+++ b/eval/open-brain/live/complete-pack-gate.ts
@@ -15,6 +15,7 @@ import {
   type CompletePackSeededRecord,
   type CompletePackSectionName,
   type IsolationVerdict,
+  type NegativeControlVerdict,
   type SectionVerdict,
 } from "./complete-pack-types.ts";
 
@@ -23,26 +24,36 @@ import {
 // One run: seed a unique throwaway namespace (and a sibling negative namespace)
 // with the sealed synthetic corpus, call the real `agent_context_pack` tool
 // under the primary namespace requesting ALL NINE sections and one whole-pack
-// budget, verify the assembled pack against five functional properties, and
+// budget, verify the assembled pack against six functional properties, and
 // ALWAYS tear down exactly the records this run created -- even when the pack
 // call or a verification fails partway through.
 //
-// The five properties, all functional (no assertions about SQL shape or
+// The six properties, all functional (no assertions about SQL shape or
 // internal call counts):
 //   1. Presence-or-defined-emptiness: every requested section either carries
 //      items or is in its DEFINED-EMPTY state (a recognized empty/denial marker,
 //      or a legitimately-empty RAM-only section, or a defined scope-denial).
 //   2. Exact-scope isolation: durable_lane_context reports its exact-scope
 //      defined-empty for the fresh throwaway scope, no negative-namespace record
-//      surfaces in any section item or citation, and the expected primary recall
-//      IS present (a hollow empty recall would otherwise hide a broken predicate).
+//      surfaces in any section item, lane, event, source_ref, or citation, and
+//      the expected primary recall IS present (a hollow empty recall would
+//      otherwise hide a broken predicate).
 //   3. Citation truth: the top-level citations array is a bijection of the
-//      emitted item citation_ids -- no dangling citation, no uncited item.
+//      emitted item citation_ids (durable_memory/pointer items, the lane, AND
+//      each durable_lane_context event) -- no dangling citation, no uncited item.
 //   4. Serialized budget: JSON.stringify(sections) stays within the reported
 //      whole-pack content_char_limit, and an allocation order covering all nine
 //      sections is present.
 //   5. Per-section contribution: the serialized-character contribution and item
 //      count of every section is recorded in the receipt.
+//   6. Explicit cross-namespace denial: the PRIMARY caller attempts a
+//      primary-identity read against the NEGATIVE namespace and the server MUST
+//      deny it. A leak-scan over the emitted pack only catches a forbidden id
+//      that happened to surface; a forbidden record ranked below the result cut
+//      would still pass. The denial probe proves the boundary REFUSES the read
+//      outright -- an allowed-but-empty read (which looks identical to a working
+//      boundary) is NOT proof and fails the gate. Reuses the recall gate's
+//      attemptRead probe transport.
 //
 // Teardown reuses the recall gate's discipline: per-record, namespace-scoped
 // archive_entry only, never a bulk or query-shaped delete, so it can only touch
@@ -349,17 +360,23 @@ function classifySection(
       serialized_chars: serializedChars,
     };
   }
-  // durable_lane_context present-but-empty is reported through its scope-denial
-  // (exact_scope), so a present empty lane body with no items and a matching
-  // denial is defined-empty too.
+  // A present-but-empty section reported through its own scope-denial is
+  // defined-empty. The disposition is the ACTUAL denial reason(s), not a
+  // hardcoded label: durable_lane_context reports `exact_scope`, but repo_facts
+  // is present-empty with `no_active_repo` (a `{repo: null, repo_bound: false}`
+  // body plus a `no_active_repo` denial -- src/tools/agent-context-pack-repo-facts.ts),
+  // and hardcoding `exact_scope` would mislabel it. Derive from scopeDenial.reasons.
   if (scopeDenial) {
+    const reasons = Array.isArray(scopeDenial.reasons)
+      ? scopeDenial.reasons.map(String).join(",")
+      : "scope_denied";
     return {
       section: name,
       present: true,
       has_items: false,
       defined_empty: true,
       item_count: 0,
-      disposition: "exact_scope",
+      disposition: reasons || "scope_denied",
       serialized_chars: serializedChars,
     };
   }
@@ -409,9 +426,23 @@ function classifySection(
   };
 }
 
+/** Add one record's `citation_id` to the id set when it carries one. */
+function addCitationId(ids: Set<string>, record: unknown): void {
+  if (!record || typeof record !== "object" || Array.isArray(record)) return;
+  const cid = (record as Record<string, unknown>).citation_id;
+  if (typeof cid === "string" && cid.length > 0) ids.add(cid);
+}
+
 /**
- * Collect every emitted item's `citation_id` across all sections, plus the
- * lane's own citation_id. Content-free: only the id strings, never a body.
+ * Collect every emitted citable unit's `citation_id` across all sections. A
+ * unit is any record the pack emits with its own citation: durable_memory /
+ * pointer items (in `items[]`), and -- for durable_lane_context -- the lane
+ * object AND each event in `events[]`. A populated lane emits a
+ * `session_lane:<id>` citation for the lane and a `session_event:<id>` citation
+ * for each event (src/tools/agent-context-pack-durable-lane.ts); missing the
+ * events here would classify every event citation as dangling and break the
+ * bijection on any populated lane. Content-free: only the id strings, never a
+ * body.
  */
 function collectEmittedItemCitationIds(
   payload: ContextPackPayload,
@@ -419,12 +450,7 @@ function collectEmittedItemCitationIds(
   const ids = new Set<string>();
   const addFrom = (items: unknown) => {
     if (!Array.isArray(items)) return;
-    for (const item of items) {
-      if (item && typeof item === "object" && !Array.isArray(item)) {
-        const cid = (item as Record<string, unknown>).citation_id;
-        if (typeof cid === "string" && cid.length > 0) ids.add(cid);
-      }
-    }
+    for (const item of items) addCitationId(ids, item);
   };
   for (const name of COMPLETE_PACK_SECTION_NAMES) {
     const body = payload.sections[name];
@@ -432,12 +458,11 @@ function collectEmittedItemCitationIds(
     const section = body as Record<string, unknown>;
     addFrom(section.items);
     // durable_lane_context carries its lane citation_id on the lane object, not
-    // in an items array; it is an emitted, citable unit too.
-    const lane = section.lane;
-    if (lane && typeof lane === "object" && !Array.isArray(lane)) {
-      const cid = (lane as Record<string, unknown>).citation_id;
-      if (typeof cid === "string" && cid.length > 0) ids.add(cid);
-    }
+    // in an items array; the lane is an emitted, citable unit too.
+    addCitationId(ids, section.lane);
+    // durable_lane_context also emits its events in an events[] array, each with
+    // its own session_event citation_id -- a populated lane cites every event.
+    addFrom(section.events);
   }
   return ids;
 }
@@ -493,13 +518,38 @@ function verifyBudget(payload: ContextPackPayload): BudgetVerdict {
 }
 
 /**
+ * Collect one record's structural identity strings (never a body): its own `id`,
+ * and its `source_ref` -- which the pack emits either as an OBJECT carrying an
+ * `id` (durable_memory / pointer items) OR as a plain STRING pointer such as
+ * `ob_session_events/<id>` (durable_lane_context lane + events). Both forms are
+ * captured: object source_refs contribute their `id`, string source_refs the
+ * whole pointer string (so an embedded forbidden id is caught by containment).
+ */
+function collectIdentityStrings(record: unknown, into: Set<string>): void {
+  if (!record || typeof record !== "object" || Array.isArray(record)) return;
+  const rec = record as Record<string, unknown>;
+  if (typeof rec.id === "string" && rec.id.length > 0) into.add(rec.id);
+  const ref = rec.source_ref;
+  if (typeof ref === "string" && ref.length > 0) {
+    into.add(ref);
+  } else if (ref && typeof ref === "object" && !Array.isArray(ref)) {
+    const refId = (ref as Record<string, unknown>).id;
+    if (typeof refId === "string" && refId.length > 0) into.add(refId);
+  }
+}
+
+/**
  * Verify isolation: durable_lane_context reports its exact-scope defined-empty,
  * no forbidden (negative-namespace) server id surfaces anywhere in the pack, and
  * the expected primary recall ids surfaced in durable_memory items or pointers.
  *
  * Forbidden ids are checked by their SERVER ids (the ids this run seeded into the
- * negative namespace), matched against every item id and source_ref id in the
- * pack -- so a leak is detected structurally, without inspecting any body.
+ * negative namespace), matched against every emitted identity string across the
+ * pack -- item ids and item source_ref ids, AND the durable_lane_context lane id
+ * plus every event id and event source_ref pointer. A forbidden id is a leak
+ * whether it appears as an exact identity id or is embedded in a string
+ * source_ref pointer (e.g. `ob_session_events/<forbidden-id>`), so leaks are
+ * detected structurally without inspecting any body.
  */
 function verifyIsolation(
   payload: ContextPackPayload,
@@ -525,30 +575,34 @@ function verifyIsolation(
       .map((r) => r.server_id),
   );
 
-  // Walk every emitted item id + source_ref id across all sections.
+  // Walk every emitted identity string across all sections: item ids +
+  // source_refs, and durable_lane_context's lane id + each event id/source_ref.
   const emittedIds = new Set<string>();
   const collectIds = (items: unknown) => {
     if (!Array.isArray(items)) return;
-    for (const item of items) {
-      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-      const rec = item as Record<string, unknown>;
-      if (typeof rec.id === "string") emittedIds.add(rec.id);
-      const ref = rec.source_ref;
-      if (ref && typeof ref === "object" && !Array.isArray(ref)) {
-        const refId = (ref as Record<string, unknown>).id;
-        if (typeof refId === "string") emittedIds.add(refId);
-      }
-    }
+    for (const item of items) collectIdentityStrings(item, emittedIds);
   };
   for (const name of COMPLETE_PACK_SECTION_NAMES) {
     const body = payload.sections[name];
     if (!body || typeof body !== "object" || Array.isArray(body)) continue;
-    collectIds((body as Record<string, unknown>).items);
+    const section = body as Record<string, unknown>;
+    collectIds(section.items);
+    // durable_lane_context: the lane object and each event are emitted, citable
+    // units with their own identity -- walk them for leaks too.
+    collectIdentityStrings(section.lane, emittedIds);
+    collectIds(section.events);
   }
 
+  // A forbidden id is a leak whether it is an exact emitted id OR is embedded in
+  // a string source_ref pointer (ob_session_events/<forbidden-id>).
   let leaks = 0;
-  for (const id of emittedIds) {
-    if (forbiddenServerIds.has(id)) leaks += 1;
+  for (const forbidden of forbiddenServerIds) {
+    for (const id of emittedIds) {
+      if (id === forbidden || id.includes(forbidden)) {
+        leaks += 1;
+        break;
+      }
+    }
   }
   let expectedPresent = false;
   for (const id of emittedIds) {
@@ -574,12 +628,73 @@ function verifyIsolation(
   };
 }
 
+/** Fixed top-k for the cross-namespace denial probe read. */
+const NEGATIVE_CONTROL_PROBE_TOP_K = 10;
+
 /**
- * Run the full complete-pack gate. Seeding and the pack call are wrapped so
- * teardown always runs; a thrown error is re-raised only AFTER teardown, with
- * the content-free teardown failed count preserved (shared with the recall gate
- * via withTeardownFailedCount). PASS requires all five properties AND clean
- * teardown.
+ * Explicit cross-namespace denial proof, mirroring the recall gate's
+ * probeNegativeControl. The PRIMARY caller attempts a primary-identity read of
+ * the NEGATIVE namespace (which the negative control seeded), and the server
+ * must DENY it. An allowed-but-empty read is NOT proof: the namespace being
+ * empty for the primary caller looks identical to a working isolation boundary,
+ * so we require an actual permission denial. This closes the gap the emitted-pack
+ * leak walk leaves open -- a forbidden record ranked below the result cut never
+ * surfaces in the pack, so the walk passes, but the denial probe still fails
+ * closed because the read is refused outright.
+ *
+ * The probe reuses the pack's recall `query` (the query the forbidden negative
+ * records are most likely to match if isolation were broken). Runs after seeding
+ * (records exist) and before teardown. Content-free: only booleans, a count, and
+ * a redacted failure label -- never a hit body.
+ */
+async function probeNegativeControl(
+  fixture: CompletePackFixture,
+  config: LiveEvalConfig,
+  clients: CompletePackGateClients,
+): Promise<NegativeControlVerdict> {
+  const proof: NegativeControlVerdict = {
+    ran: true,
+    denied: false,
+    observed_hit_count: 0,
+    cross_token: config.negativeTokenIsDistinct,
+  };
+
+  let result;
+  try {
+    result = await clients.primary.attemptRead({
+      query: fixture.query,
+      namespace: config.negativeNamespace,
+      limit: NEGATIVE_CONTROL_PROBE_TOP_K,
+      searchMode: config.searchMode,
+    });
+  } catch (error) {
+    // A non-denial transport error means we could not establish the proof.
+    const label =
+      error instanceof LiveTransportError ? error.label : "attempt-read-error";
+    proof.denied = false;
+    proof.failure = `negative-control read failed: ${label}`;
+    return proof;
+  }
+
+  proof.observed_hit_count = result.hitCount;
+  // Isolation is proven ONLY by an actual denial. A successful read -- empty or
+  // not -- fails: allowed-empty proves nothing and allowed-nonempty is a breach.
+  proof.denied = result.denied;
+  if (!proof.denied) {
+    proof.failure =
+      result.hitCount > 0
+        ? "primary caller was permitted to read the negative namespace (non-empty)"
+        : "primary caller's read of the negative namespace was allowed (empty), not denied";
+  }
+  return proof;
+}
+
+/**
+ * Run the full complete-pack gate. Seeding, the pack call, and the
+ * cross-namespace denial probe are wrapped so teardown always runs; a thrown
+ * error is re-raised only AFTER teardown, with the content-free teardown failed
+ * count preserved (shared with the recall gate via withTeardownFailedCount).
+ * PASS requires all six properties AND clean teardown.
  */
 export async function runCompletePackGate(
   opts: RunCompletePackGateOptions,
@@ -589,6 +704,15 @@ export async function runCompletePackGate(
   const seeded: CompletePackSeededRecord[] = [];
   let deferredError: unknown = null;
   let payload: ContextPackPayload | null = null;
+  // Default proof: did-not-run. Only replaced by a real probe result when
+  // seeding + the pack call complete without a deferred error.
+  let negativeControl: NegativeControlVerdict = {
+    ran: false,
+    denied: false,
+    observed_hit_count: 0,
+    cross_token: config.negativeTokenIsDistinct,
+    failure: "negative-control proof did not run",
+  };
 
   const packScope: ContextPackScope = {
     namespace: config.primaryNamespace,
@@ -611,6 +735,9 @@ export async function runCompletePackGate(
       requestedSections: COMPLETE_PACK_SECTION_NAMES,
       budgetMaxTokens,
     });
+
+    // --- Explicit cross-namespace denial proof (after seeding, before teardown) ---
+    negativeControl = await probeNegativeControl(fixture, config, clients);
   } catch (error) {
     deferredError = error;
   }
@@ -683,6 +810,18 @@ export async function runCompletePackGate(
       "expected primary recall did not surface in durable_memory/pointers (hollow recall would hide a broken predicate)",
     );
   }
+  // 6. Explicit cross-namespace denial. A leak-free emitted pack is NOT enough:
+  // the boundary must actually REFUSE the primary caller's read of the negative
+  // namespace. An allowed read -- empty or not -- fails.
+  if (!negativeControl.ran) {
+    failures.push(
+      `negative-control proof did not run: ${negativeControl.failure ?? "unknown"}`,
+    );
+  } else if (!negativeControl.denied) {
+    failures.push(
+      `negative-control not denied: ${negativeControl.failure ?? "isolation not proven"}`,
+    );
+  }
   // Teardown discipline.
   const teardownClean = teardownTally.failed === 0;
   if (!teardownClean) {
@@ -706,6 +845,7 @@ export async function runCompletePackGate(
     budget,
     citations,
     isolation,
+    negative_control: negativeControl,
     passed,
     failures,
     teardown: teardownTally,

--- a/eval/open-brain/live/complete-pack-gate.ts
+++ b/eval/open-brain/live/complete-pack-gate.ts
@@ -194,6 +194,117 @@ const RECOGNIZED_EMPTY_REASONS = new Set<string>([
   "whole_pack_budget",
 ]);
 
+/**
+ * The finite allowlist of scope-denial reasons the gate recognizes, keyed by the
+ * section that is permitted to report each one. A `scope_denials[]` entry is a
+ * DEFINED denial only when its `source` is a real section AND every reason it
+ * carries is in that section's allowlist -- an arbitrary server-supplied reason
+ * string (or a reason attributed to the wrong section) is NOT a recognized
+ * denial and must not turn an otherwise-undefined section into defined-empty.
+ * These are the exact reasons the production builders emit
+ * (src/tools/agent-context-pack-*.ts): durable_lane_context -> exact_scope,
+ * repo_facts -> no_active_repo (optionally namespace_bound), and the guidance
+ * loaders -> no_promoted_guidance.
+ */
+const ALLOWED_SCOPE_DENIAL_REASONS: Partial<
+  Record<CompletePackSectionName, ReadonlySet<string>>
+> = {
+  durable_lane_context: new Set(["exact_scope"]),
+  repo_facts: new Set(["no_active_repo", "namespace_bound"]),
+  profile_guidance: new Set(["no_promoted_guidance"]),
+  process_guidance: new Set(["no_promoted_guidance"]),
+};
+
+/**
+ * The finite allowlist of degraded-source reasons, keyed by the section allowed
+ * to report each one. A `degraded_sources[]` entry is a DEFINED degrade only
+ * when its `source` is a real section AND its `reason` is in that section's
+ * allowlist. durable_memory degrades to a recognized recall failure; a
+ * database_unavailable degrade may be stamped on any recall/pointer section by
+ * the fitter when the store is unreachable.
+ */
+const ALLOWED_DEGRADE_REASONS: Partial<
+  Record<CompletePackSectionName, ReadonlySet<string>>
+> = {
+  durable_memory: new Set([
+    "recall_failed",
+    "no_readable_tables",
+    "database_unavailable",
+  ]),
+  pointers: new Set(["database_unavailable"]),
+  candidate_memory: new Set([
+    "candidate_predicate_unavailable",
+    "database_unavailable",
+  ]),
+};
+
+/** Fixed generic label substituted for any unrecognized server-controlled reason. */
+const GENERIC_REASON = "unrecognized_reason";
+
+/** Fixed generic label substituted for any unrecognized server-controlled status. */
+const GENERIC_STATUS = "unrecognized";
+
+/** The finite allowlist of pack `status` values the gate will name verbatim. */
+const ALLOWED_STATUSES = new Set<string>([
+  "ok",
+  "degraded",
+  "partial",
+  "error",
+]);
+
+/**
+ * Reduce a server-controlled `status` to a finite label: the value verbatim only
+ * when it is in the allowlist, else a fixed generic. Keeps a raw server string
+ * (which could carry an injected sentinel or body) out of the receipt/failures.
+ */
+function sanitizeStatus(status: unknown): string {
+  return typeof status === "string" && ALLOWED_STATUSES.has(status)
+    ? status
+    : GENERIC_STATUS;
+}
+
+/**
+ * A scope-denial for `section` is DEFINED only when its reasons array is present,
+ * non-empty, and every reason is in that section's allowlist. Returns the joined
+ * allowlisted reasons (a finite, content-free label) when defined, else null.
+ * An arbitrary or wrong-section reason yields null so it cannot mark a section
+ * defined-empty. A partially-recognized denial (one bad reason among good ones)
+ * is rejected whole -- a mixed denial is not a trustworthy definition.
+ */
+function definedScopeDenialReasons(
+  section: CompletePackSectionName,
+  denial: Record<string, unknown> | undefined,
+): string | null {
+  if (!denial) return null;
+  const allowed = ALLOWED_SCOPE_DENIAL_REASONS[section];
+  if (!allowed) return null;
+  const reasons = denial.reasons;
+  if (!Array.isArray(reasons) || reasons.length === 0) return null;
+  const labels: string[] = [];
+  for (const raw of reasons) {
+    if (typeof raw !== "string" || !allowed.has(raw)) return null;
+    labels.push(raw);
+  }
+  return labels.join(",");
+}
+
+/**
+ * A degraded-source for `section` is DEFINED only when its reason is a string in
+ * that section's allowlist. Returns the allowlisted reason (finite label) when
+ * defined, else null so an arbitrary server reason cannot mark a section
+ * defined-empty.
+ */
+function definedDegradeReason(
+  section: CompletePackSectionName,
+  degrade: Record<string, unknown> | undefined,
+): string | null {
+  if (!degrade) return null;
+  const allowed = ALLOWED_DEGRADE_REASONS[section];
+  if (!allowed) return null;
+  const reason = degrade.reason;
+  return typeof reason === "string" && allowed.has(reason) ? reason : null;
+}
+
 /** RAM-only sections that are legitimately empty on a fresh remote scope. */
 const RAM_ONLY_SECTIONS = new Set<CompletePackSectionName>([
   "working_set",
@@ -262,37 +373,40 @@ function classifySection(
     (d) => d.source === name,
   );
 
+  // A defined scope-denial / degraded-source for this section carries a finite
+  // ALLOWLISTED reason attributed to this exact section, or it is not a defined
+  // disposition at all. An arbitrary server-supplied reason, or one attributed
+  // to the wrong section, returns null and cannot mark the section defined-empty.
+  const deniedReasons = definedScopeDenialReasons(name, scopeDenial);
+  const degradeReason = definedDegradeReason(name, degraded);
+
   if (!section) {
-    // Body omitted. Legitimate ONLY when a defined denial/degrade explains it,
-    // OR the whole-pack budget starved it out (recorded as a truncation marker
-    // with starved:true on this source).
+    // Body omitted. Legitimate ONLY when a defined (allowlisted) denial/degrade
+    // explains it, OR the whole-pack budget starved it out (recorded as a
+    // truncation marker with starved:true on this source). An omitted body IS an
+    // empty section, so a denial/degrade here trivially agrees with emptiness.
     const starved = payload.warnings.truncation.some(
       (t) => t.source === name && t.starved === true,
     );
-    if (scopeDenial) {
-      const reasons = Array.isArray(scopeDenial.reasons)
-        ? scopeDenial.reasons.map(String).join(",")
-        : "scope_denied";
+    if (deniedReasons !== null) {
       return {
         section: name,
         present: false,
         has_items: false,
         defined_empty: true,
         item_count: 0,
-        disposition: reasons || "scope_denied",
+        disposition: deniedReasons,
         serialized_chars: 0,
       };
     }
-    if (degraded) {
-      const reason =
-        typeof degraded.reason === "string" ? degraded.reason : "degraded";
+    if (degradeReason !== null) {
       return {
         section: name,
         present: false,
         has_items: false,
         defined_empty: true,
         item_count: 0,
-        disposition: reason,
+        disposition: degradeReason,
         serialized_chars: 0,
       };
     }
@@ -335,6 +449,24 @@ function classifySection(
 
   const itemCount = itemCountOf(section);
   if (itemCount > 0) {
+    // A scope-denial or degrade claims this section is empty/unavailable, yet the
+    // section is POPULATED: the denial contradicts the body. A defined empty
+    // disposition must agree with an actually empty or omitted section, so a
+    // populated section that ALSO carries a denial/degrade for itself is a forged
+    // or stale denial and fails -- never accepted as defined-empty on the
+    // strength of a warning the body contradicts.
+    if (deniedReasons !== null || degradeReason !== null) {
+      return {
+        section: name,
+        present: true,
+        has_items: true,
+        defined_empty: false,
+        item_count: itemCount,
+        disposition: "items",
+        serialized_chars: serializedChars,
+        failure: `${name}: reports a scope-denial/degrade but the section is populated (${itemCount} item(s))`,
+      };
+    }
     return {
       section: name,
       present: true,
@@ -346,7 +478,9 @@ function classifySection(
     };
   }
 
-  // Present with zero items: must be a recognized defined-empty.
+  // Present with zero items: must be a recognized defined-empty. `empty_reason`
+  // is already gated to the finite RECOGNIZED_EMPTY_REASONS allowlist, so a raw
+  // server-controlled reason string can never become the disposition here.
   const emptyReason =
     typeof section.empty_reason === "string" ? section.empty_reason : null;
   if (emptyReason && RECOGNIZED_EMPTY_REASONS.has(emptyReason)) {
@@ -361,22 +495,36 @@ function classifySection(
     };
   }
   // A present-but-empty section reported through its own scope-denial is
-  // defined-empty. The disposition is the ACTUAL denial reason(s), not a
-  // hardcoded label: durable_lane_context reports `exact_scope`, but repo_facts
-  // is present-empty with `no_active_repo` (a `{repo: null, repo_bound: false}`
-  // body plus a `no_active_repo` denial -- src/tools/agent-context-pack-repo-facts.ts),
-  // and hardcoding `exact_scope` would mislabel it. Derive from scopeDenial.reasons.
-  if (scopeDenial) {
-    const reasons = Array.isArray(scopeDenial.reasons)
-      ? scopeDenial.reasons.map(String).join(",")
-      : "scope_denied";
+  // defined-empty. The disposition is the ACTUAL allowlisted denial reason(s),
+  // not a hardcoded label: durable_lane_context reports `exact_scope`, but
+  // repo_facts is present-empty with `no_active_repo` (a
+  // `{repo: null, repo_bound: false}` body plus a `no_active_repo` denial --
+  // src/tools/agent-context-pack-repo-facts.ts), and hardcoding `exact_scope`
+  // would mislabel it. definedScopeDenialReasons returns only allowlisted,
+  // section-attributed reasons (or null), so an arbitrary server reason cannot
+  // mark this section defined-empty.
+  if (deniedReasons !== null) {
     return {
       section: name,
       present: true,
       has_items: false,
       defined_empty: true,
       item_count: 0,
-      disposition: reasons || "scope_denied",
+      disposition: deniedReasons,
+      serialized_chars: serializedChars,
+    };
+  }
+  // A present-but-empty section reported through an allowlisted degrade reason is
+  // likewise defined-empty (e.g. durable_memory present-empty with a
+  // database_unavailable degrade).
+  if (degradeReason !== null) {
+    return {
+      section: name,
+      present: true,
+      has_items: false,
+      defined_empty: true,
+      item_count: 0,
+      disposition: degradeReason,
       serialized_chars: serializedChars,
     };
   }
@@ -413,44 +561,53 @@ function classifySection(
     };
   }
   // Present, empty, no recognized marker: a defect (an empty section that does
-  // not truthfully state WHY it is empty).
+  // not truthfully state WHY it is empty). The disposition is a fixed label --
+  // never the raw `empty_reason` string, which is server-controlled and could
+  // carry an injected sentinel or body -- so an unrecognized reason is reported
+  // as the generic marker rather than echoed verbatim.
   return {
     section: name,
     present: true,
     has_items: false,
     defined_empty: false,
     item_count: 0,
-    disposition: emptyReason ?? "unmarked_empty",
+    disposition: emptyReason ? GENERIC_REASON : "unmarked_empty",
     serialized_chars: serializedChars,
     failure: `${name}: present but empty with no recognized empty marker`,
   };
 }
 
-/** Add one record's `citation_id` to the id set when it carries one. */
-function addCitationId(ids: Set<string>, record: unknown): void {
+/** Tally one record's `citation_id` occurrence into the multiset when present. */
+function addCitationId(counts: Map<string, number>, record: unknown): void {
   if (!record || typeof record !== "object" || Array.isArray(record)) return;
   const cid = (record as Record<string, unknown>).citation_id;
-  if (typeof cid === "string" && cid.length > 0) ids.add(cid);
+  if (typeof cid === "string" && cid.length > 0) {
+    counts.set(cid, (counts.get(cid) ?? 0) + 1);
+  }
 }
 
 /**
- * Collect every emitted citable unit's `citation_id` across all sections. A
- * unit is any record the pack emits with its own citation: durable_memory /
- * pointer items (in `items[]`), and -- for durable_lane_context -- the lane
- * object AND each event in `events[]`. A populated lane emits a
- * `session_lane:<id>` citation for the lane and a `session_event:<id>` citation
- * for each event (src/tools/agent-context-pack-durable-lane.ts); missing the
- * events here would classify every event citation as dangling and break the
- * bijection on any populated lane. Content-free: only the id strings, never a
- * body.
+ * Tally every emitted citable unit's `citation_id` across all sections as a
+ * MULTISET (id -> occurrence count), not a set. A unit is any record the pack
+ * emits with its own citation: durable_memory / pointer items (in `items[]`),
+ * and -- for durable_lane_context -- the lane object AND each event in
+ * `events[]`. A populated lane emits a `session_lane:<id>` citation for the lane
+ * and a `session_event:<id>` citation for each event
+ * (src/tools/agent-context-pack-durable-lane.ts).
+ *
+ * Counting OCCURRENCES rather than distinct ids is what makes the bijection
+ * real: two DISTINCT emitted units that share one citation_id, or one unit
+ * emitted twice, are a truth defect (the shared id cannot cite both) that a set
+ * would silently collapse to a single member and pass. Content-free: only the id
+ * strings and their counts, never a body.
  */
-function collectEmittedItemCitationIds(
+function tallyEmittedItemCitationIds(
   payload: ContextPackPayload,
-): Set<string> {
-  const ids = new Set<string>();
+): Map<string, number> {
+  const counts = new Map<string, number>();
   const addFrom = (items: unknown) => {
     if (!Array.isArray(items)) return;
-    for (const item of items) addCitationId(ids, item);
+    for (const item of items) addCitationId(counts, item);
   };
   for (const name of COMPLETE_PACK_SECTION_NAMES) {
     const body = payload.sections[name];
@@ -459,33 +616,62 @@ function collectEmittedItemCitationIds(
     addFrom(section.items);
     // durable_lane_context carries its lane citation_id on the lane object, not
     // in an items array; the lane is an emitted, citable unit too.
-    addCitationId(ids, section.lane);
+    addCitationId(counts, section.lane);
     // durable_lane_context also emits its events in an events[] array, each with
     // its own session_event citation_id -- a populated lane cites every event.
     addFrom(section.events);
   }
-  return ids;
+  return counts;
 }
 
-/** Verify the citations array is a bijection of the emitted item citation_ids. */
+/** Sum a multiset's occurrence counts (total emitted citable units). */
+function sumCounts(counts: Map<string, number>): number {
+  let total = 0;
+  for (const n of counts.values()) total += n;
+  return total;
+}
+
+/**
+ * Verify the top-level citations array is a strict bijection of the emitted
+ * citable units, comparing OCCURRENCE COUNTS rather than set membership so
+ * duplicate occurrences on either side are caught:
+ *
+ *  - EXACTLY ONE emitted unit and ONE top-level citation per identity. Two
+ *    distinct units sharing one citation_id are ambiguous even if the top-level
+ *    array repeats that id twice; matching duplicate counts must still fail.
+ *  - A top-level citation occurrence with no emitted occurrence is dangling; an
+ *    emitted occurrence with no citation is uncited. Any occurrence beyond the
+ *    first on either side is also a defect for that side.
+ *
+ * dangling + uncited are occurrence counts, so the bijection holds only when
+ * every id appears exactly once on both sides.
+ */
 function verifyCitations(payload: ContextPackPayload): CitationVerdict {
-  const emitted = collectEmittedItemCitationIds(payload);
-  const citationIds = new Set<string>();
+  const emitted = tallyEmittedItemCitationIds(payload);
+  const citationCounts = new Map<string, number>();
   for (const citation of payload.citations) {
     const id = citation.id;
-    if (typeof id === "string" && id.length > 0) citationIds.add(id);
+    if (typeof id === "string" && id.length > 0) {
+      citationCounts.set(id, (citationCounts.get(id) ?? 0) + 1);
+    }
   }
+  const ids = new Set<string>([...emitted.keys(), ...citationCounts.keys()]);
   let dangling = 0;
-  for (const id of citationIds) {
-    if (!emitted.has(id)) dangling += 1;
-  }
   let uncited = 0;
-  for (const id of emitted) {
-    if (!citationIds.has(id)) uncited += 1;
+  for (const id of ids) {
+    const emittedN = emitted.get(id) ?? 0;
+    const citedN = citationCounts.get(id) ?? 0;
+    // A bijection requires ONE emitted unit and ONE top-level citation for each
+    // id. Matching duplicate counts are still ambiguous (two units cannot share
+    // one citation identity), so count every occurrence beyond the first as a
+    // defect on its own side. If the opposite side is absent, every occurrence is
+    // unmatched rather than treating one as the allowed representative.
+    dangling += emittedN === 0 ? citedN : Math.max(citedN - 1, 0);
+    uncited += citedN === 0 ? emittedN : Math.max(emittedN - 1, 0);
   }
   return {
     citations_total: payload.citations.length,
-    emitted_item_citations: emitted.size,
+    emitted_item_citations: sumCounts(emitted),
     dangling_citations: dangling,
     uncited_items: uncited,
     bijective: dangling === 0 && uncited === 0,
@@ -604,10 +790,16 @@ function verifyIsolation(
       }
     }
   }
-  let expectedPresent = false;
-  for (const id of emittedIds) {
-    if (expectedServerIds.has(id)) {
-      expectedPresent = true;
+  // Require EVERY expected server id to surface, not merely one of them. Any one
+  // seed appearing anywhere would pass a "some" check while the other expected
+  // seeds silently never recalled -- a partial-recall defect that hides a broken
+  // predicate for the missing ids. The recall is proven only when the whole
+  // expected set is present. An empty expected set (a fixture that expects
+  // nothing) cannot prove recall reached the seeded namespace, so it fails too.
+  let expectedPresent = expectedServerIds.size > 0;
+  for (const expected of expectedServerIds) {
+    if (!emittedIds.has(expected)) {
+      expectedPresent = false;
       break;
     }
   }
@@ -768,14 +960,26 @@ export async function runCompletePackGate(
   ).length;
 
   const failures: string[] = [];
-  // 1. Presence-or-defined-emptiness for all nine.
+  // 1. Presence-or-defined-emptiness for all nine. A section fails when it is
+  // neither present-with-items nor defined-empty, OR when it recorded any other
+  // classification defect (e.g. a POPULATED section that also claims a
+  // scope-denial for itself -- a forged/contradictory denial carries a `failure`
+  // even though it has items). Surface a recorded `failure` regardless of
+  // has_items so the populated-denial contradiction is not swallowed.
   for (const verdict of sections) {
-    if (!verdict.has_items && !verdict.defined_empty) {
-      failures.push(verdict.failure ?? `${verdict.section}: not defined-empty`);
+    if (verdict.failure) {
+      failures.push(verdict.failure);
+    } else if (!verdict.has_items && !verdict.defined_empty) {
+      failures.push(`${verdict.section}: not defined-empty`);
     }
   }
   if (payload.status !== "ok") {
-    failures.push(`pack status is '${payload.status}', expected 'ok'`);
+    // The raw status is server-controlled and could carry an injected sentinel
+    // or body, so it is sanitized to a finite allowlisted label (or a fixed
+    // generic) before it enters the content-free failures list.
+    failures.push(
+      `pack status is '${sanitizeStatus(payload.status)}', expected 'ok'`,
+    );
   }
   // 3. Citation truth.
   if (!citations.bijective) {

--- a/eval/open-brain/live/complete-pack-gate.ts
+++ b/eval/open-brain/live/complete-pack-gate.ts
@@ -1,0 +1,715 @@
+import type { LiveEvalConfig } from "./config.ts";
+import {
+  LiveTransportError,
+  type ContextPackPayload,
+  type ContextPackScope,
+  type OpenBrainLiveClient,
+} from "./transport.ts";
+import { withTeardownFailedCount } from "./gate.ts";
+import {
+  COMPLETE_PACK_SECTION_NAMES,
+  type BudgetVerdict,
+  type CitationVerdict,
+  type CompletePackFixture,
+  type CompletePackReceipt,
+  type CompletePackSeededRecord,
+  type CompletePackSectionName,
+  type IsolationVerdict,
+  type SectionVerdict,
+} from "./complete-pack-types.ts";
+
+// Live COMPLETE CONTEXT PACK gate orchestrator (EVAL-3, issue #330).
+//
+// One run: seed a unique throwaway namespace (and a sibling negative namespace)
+// with the sealed synthetic corpus, call the real `agent_context_pack` tool
+// under the primary namespace requesting ALL NINE sections and one whole-pack
+// budget, verify the assembled pack against five functional properties, and
+// ALWAYS tear down exactly the records this run created -- even when the pack
+// call or a verification fails partway through.
+//
+// The five properties, all functional (no assertions about SQL shape or
+// internal call counts):
+//   1. Presence-or-defined-emptiness: every requested section either carries
+//      items or is in its DEFINED-EMPTY state (a recognized empty/denial marker,
+//      or a legitimately-empty RAM-only section, or a defined scope-denial).
+//   2. Exact-scope isolation: durable_lane_context reports its exact-scope
+//      defined-empty for the fresh throwaway scope, no negative-namespace record
+//      surfaces in any section item or citation, and the expected primary recall
+//      IS present (a hollow empty recall would otherwise hide a broken predicate).
+//   3. Citation truth: the top-level citations array is a bijection of the
+//      emitted item citation_ids -- no dangling citation, no uncited item.
+//   4. Serialized budget: JSON.stringify(sections) stays within the reported
+//      whole-pack content_char_limit, and an allocation order covering all nine
+//      sections is present.
+//   5. Per-section contribution: the serialized-character contribution and item
+//      count of every section is recorded in the receipt.
+//
+// Teardown reuses the recall gate's discipline: per-record, namespace-scoped
+// archive_entry only, never a bulk or query-shaped delete, so it can only touch
+// records this run created. The receipt is content-free: labels, ids, counts,
+// booleans -- never a memory body.
+
+export interface CompletePackGateClients {
+  /** Reads/writes/archives the primary throwaway namespace and builds the pack. */
+  primary: OpenBrainLiveClient;
+  /** Seeds/archives the negative sibling namespace (mandatory isolation control). */
+  negative: OpenBrainLiveClient;
+}
+
+export interface RunCompletePackGateOptions {
+  fixture: CompletePackFixture;
+  config: LiveEvalConfig;
+  clients: CompletePackGateClients;
+  /** Whole-pack budget in tokens for the single pack build. */
+  budgetMaxTokens: number;
+  /** Exact non-namespace scope coordinates for the pack call. */
+  scope: {
+    agent: string;
+    platform: string;
+    server_id: string;
+    channel_id: string;
+    thread_id?: string | null;
+    session_key: string;
+  };
+  commit: string;
+  generatedAt: string;
+}
+
+export interface CompletePackGateOutcome {
+  receipt: CompletePackReceipt;
+  passed: boolean;
+}
+
+interface TeardownTally {
+  attempted: number;
+  archived: number;
+  already_absent: number;
+  failed: number;
+}
+
+/**
+ * Seed one entry with the owning client for its namespace role. Both clients
+ * always exist (the negative control is mandatory), so seeding never silently
+ * skips a corpus entry. Mirrors the recall gate's seedEntry.
+ */
+async function seedEntry(
+  entry: CompletePackFixture["corpus"][number],
+  config: LiveEvalConfig,
+  clients: CompletePackGateClients,
+): Promise<CompletePackSeededRecord> {
+  const isNegative = entry.namespace_role === "negative";
+  const client = isNegative ? clients.negative : clients.primary;
+  const namespace = isNegative
+    ? config.negativeNamespace
+    : config.primaryNamespace;
+
+  const result = await client.logMemory({
+    table: entry.table,
+    content: entry.content,
+    tags: entry.tags,
+    namespace,
+  });
+  return {
+    fixture_id: entry.id,
+    table: entry.table,
+    server_id: result.id,
+    namespace,
+    namespace_role: entry.namespace_role,
+  };
+}
+
+/**
+ * Archive every seeded record through its owning client, tolerating individual
+ * failures so one bad archive never strands the rest. Identical discipline to
+ * the recall gate's teardown.
+ */
+async function teardown(
+  seeded: CompletePackSeededRecord[],
+  clients: CompletePackGateClients,
+): Promise<TeardownTally> {
+  const tally: TeardownTally = {
+    attempted: 0,
+    archived: 0,
+    already_absent: 0,
+    failed: 0,
+  };
+  for (const record of seeded) {
+    const client =
+      record.namespace_role === "negative" ? clients.negative : clients.primary;
+    tally.attempted += 1;
+    try {
+      const outcome = await client.archive({
+        table: record.table,
+        id: record.server_id,
+      });
+      if (outcome === "archived") tally.archived += 1;
+      else tally.already_absent += 1;
+    } catch {
+      // Content-free: the count is the only signal the receipt needs.
+      tally.failed += 1;
+    }
+  }
+  return tally;
+}
+
+/** A recognized non-empty item container: has an integer item_count > 0. */
+function itemCountOf(section: Record<string, unknown>): number {
+  const count = section.item_count;
+  return typeof count === "number" && Number.isFinite(count) && count >= 0
+    ? count
+    : Array.isArray(section.items)
+      ? section.items.length
+      : 0;
+}
+
+/**
+ * The set of content-free empty/denial markers each section is allowed to carry
+ * when it holds zero items. A section with zero items is DEFINED-EMPTY only when
+ * it carries one of these (or, for the RAM-only sections, is simply empty on a
+ * fresh scope). This is what turns "empty" into "defined-empty" -- an empty
+ * section with no recognized marker is a defect, not a pass.
+ */
+const RECOGNIZED_EMPTY_REASONS = new Set<string>([
+  // durable_memory
+  "no_query",
+  "no_readable_tables",
+  "recall_failed",
+  "no_matches",
+  "all_suppressed",
+  "content_unavailable",
+  // candidate_memory
+  "candidate_predicate_unavailable",
+  // whole-pack starvation stamped by the fitter on any trimmed-to-empty section
+  "whole_pack_budget",
+]);
+
+/** RAM-only sections that are legitimately empty on a fresh remote scope. */
+const RAM_ONLY_SECTIONS = new Set<CompletePackSectionName>([
+  "working_set",
+  "recovery",
+]);
+
+/**
+ * Opt-in sections the pack only emits when their explicit opt-in was requested.
+ * `recovery` is only assembled when `include_unreviewed_recovery: true` is sent
+ * (requesting the section name alone is not enough), so on a pack built without
+ * that flag `recovery` is legitimately ABSENT — not a missing-section defect.
+ * The gate treats an absent opt-in section as defined-empty; a present-empty one
+ * still flows through the normal present-empty checks (RAM_ONLY).
+ */
+const OPT_IN_ABSENT_OK = new Set<CompletePackSectionName>(["recovery"]);
+
+/**
+ * Sections whose production builders emit a TRUTHFUL empty body carrying NO
+ * `empty_reason` when they are genuinely empty: the guidance loaders
+ * (no promoted user_preference / process_rule) and the pointer builder (no
+ * surplus durable pool after dedupe). Their defined-empty state is declared by
+ * construction via a namespace-binding flag (`namespace_scoped` /
+ * `namespace_bound: true`) and an empty items array, not an empty_reason string.
+ * durable_memory is deliberately EXCLUDED: it is a recall section that always
+ * stamps a recognized `empty_reason` (no_matches/no_query/...) when empty, so a
+ * marker-less empty durable_memory stays a defect.
+ */
+const DEFINED_EMPTY_WITHOUT_MARKER = new Set<CompletePackSectionName>([
+  "profile_guidance",
+  "process_guidance",
+  "pointers",
+]);
+
+/** True only for the exact truthful namespace-bound empty envelope. */
+function isNamespaceBoundEmpty(section: Record<string, unknown>): boolean {
+  return section.namespace_scoped === true || section.namespace_bound === true;
+}
+
+/**
+ * Classify one requested section's disposition against the emitted pack. A
+ * section passes when it is PRESENT-with-items, or in a recognized DEFINED-EMPTY
+ * state (empty items + a recognized marker, or a legitimately-empty RAM-only
+ * section), or reported through a defined scope-denial / degraded-source in the
+ * warnings channel (durable_lane_context exact_scope, repo_facts no_active_repo,
+ * a database_unavailable degrade). Everything else fails the present-or-empty
+ * check. Records the serialized-character contribution either way.
+ */
+function classifySection(
+  name: CompletePackSectionName,
+  payload: ContextPackPayload,
+): SectionVerdict {
+  const body = payload.sections[name];
+  const present = body !== undefined;
+  const section =
+    present && body && typeof body === "object" && !Array.isArray(body)
+      ? (body as Record<string, unknown>)
+      : null;
+  const serializedChars = present ? JSON.stringify(body).length : 0;
+
+  // A defined scope-denial or degraded-source for this section is itself a
+  // defined-empty disposition even when the section body is omitted.
+  const scopeDenial = payload.warnings.scope_denials.find(
+    (d) => d.source === name,
+  );
+  const degraded = payload.warnings.degraded_sources.find(
+    (d) => d.source === name,
+  );
+
+  if (!section) {
+    // Body omitted. Legitimate ONLY when a defined denial/degrade explains it,
+    // OR the whole-pack budget starved it out (recorded as a truncation marker
+    // with starved:true on this source).
+    const starved = payload.warnings.truncation.some(
+      (t) => t.source === name && t.starved === true,
+    );
+    if (scopeDenial) {
+      const reasons = Array.isArray(scopeDenial.reasons)
+        ? scopeDenial.reasons.map(String).join(",")
+        : "scope_denied";
+      return {
+        section: name,
+        present: false,
+        has_items: false,
+        defined_empty: true,
+        item_count: 0,
+        disposition: reasons || "scope_denied",
+        serialized_chars: 0,
+      };
+    }
+    if (degraded) {
+      const reason =
+        typeof degraded.reason === "string" ? degraded.reason : "degraded";
+      return {
+        section: name,
+        present: false,
+        has_items: false,
+        defined_empty: true,
+        item_count: 0,
+        disposition: reason,
+        serialized_chars: 0,
+      };
+    }
+    if (starved) {
+      return {
+        section: name,
+        present: false,
+        has_items: false,
+        defined_empty: true,
+        item_count: 0,
+        disposition: "whole_pack_budget",
+        serialized_chars: 0,
+      };
+    }
+    if (OPT_IN_ABSENT_OK.has(name)) {
+      // Opt-in section legitimately absent: the pack only assembles it when its
+      // explicit opt-in was requested (recovery -> include_unreviewed_recovery).
+      // Its absence is the defined state, not a dropped section.
+      return {
+        section: name,
+        present: false,
+        has_items: false,
+        defined_empty: true,
+        item_count: 0,
+        disposition: "opt_in_absent",
+        serialized_chars: 0,
+      };
+    }
+    return {
+      section: name,
+      present: false,
+      has_items: false,
+      defined_empty: false,
+      item_count: 0,
+      disposition: "missing",
+      serialized_chars: 0,
+      failure: `${name}: not present and no defined scope-denial/degrade/starve`,
+    };
+  }
+
+  const itemCount = itemCountOf(section);
+  if (itemCount > 0) {
+    return {
+      section: name,
+      present: true,
+      has_items: true,
+      defined_empty: false,
+      item_count: itemCount,
+      disposition: "items",
+      serialized_chars: serializedChars,
+    };
+  }
+
+  // Present with zero items: must be a recognized defined-empty.
+  const emptyReason =
+    typeof section.empty_reason === "string" ? section.empty_reason : null;
+  if (emptyReason && RECOGNIZED_EMPTY_REASONS.has(emptyReason)) {
+    return {
+      section: name,
+      present: true,
+      has_items: false,
+      defined_empty: true,
+      item_count: 0,
+      disposition: emptyReason,
+      serialized_chars: serializedChars,
+    };
+  }
+  // durable_lane_context present-but-empty is reported through its scope-denial
+  // (exact_scope), so a present empty lane body with no items and a matching
+  // denial is defined-empty too.
+  if (scopeDenial) {
+    return {
+      section: name,
+      present: true,
+      has_items: false,
+      defined_empty: true,
+      item_count: 0,
+      disposition: "exact_scope",
+      serialized_chars: serializedChars,
+    };
+  }
+  // Guidance loaders and the pointer builder emit a truthful empty body with NO
+  // empty_reason when genuinely empty; their defined-empty state is declared by
+  // construction through the namespace-binding flag on an empty items array.
+  // Require the binding flag so a body that merely dropped its marker (a real
+  // defect) is not silently accepted.
+  if (
+    DEFINED_EMPTY_WITHOUT_MARKER.has(name) &&
+    isNamespaceBoundEmpty(section)
+  ) {
+    return {
+      section: name,
+      present: true,
+      has_items: false,
+      defined_empty: true,
+      item_count: 0,
+      disposition: "namespace_bound_empty",
+      serialized_chars: serializedChars,
+    };
+  }
+  // RAM-only sections are legitimately empty on a fresh remote scope: an empty
+  // items array with no reason is their defined state, not a defect.
+  if (RAM_ONLY_SECTIONS.has(name)) {
+    return {
+      section: name,
+      present: true,
+      has_items: false,
+      defined_empty: true,
+      item_count: 0,
+      disposition: "ram_only_empty",
+      serialized_chars: serializedChars,
+    };
+  }
+  // Present, empty, no recognized marker: a defect (an empty section that does
+  // not truthfully state WHY it is empty).
+  return {
+    section: name,
+    present: true,
+    has_items: false,
+    defined_empty: false,
+    item_count: 0,
+    disposition: emptyReason ?? "unmarked_empty",
+    serialized_chars: serializedChars,
+    failure: `${name}: present but empty with no recognized empty marker`,
+  };
+}
+
+/**
+ * Collect every emitted item's `citation_id` across all sections, plus the
+ * lane's own citation_id. Content-free: only the id strings, never a body.
+ */
+function collectEmittedItemCitationIds(
+  payload: ContextPackPayload,
+): Set<string> {
+  const ids = new Set<string>();
+  const addFrom = (items: unknown) => {
+    if (!Array.isArray(items)) return;
+    for (const item of items) {
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const cid = (item as Record<string, unknown>).citation_id;
+        if (typeof cid === "string" && cid.length > 0) ids.add(cid);
+      }
+    }
+  };
+  for (const name of COMPLETE_PACK_SECTION_NAMES) {
+    const body = payload.sections[name];
+    if (!body || typeof body !== "object" || Array.isArray(body)) continue;
+    const section = body as Record<string, unknown>;
+    addFrom(section.items);
+    // durable_lane_context carries its lane citation_id on the lane object, not
+    // in an items array; it is an emitted, citable unit too.
+    const lane = section.lane;
+    if (lane && typeof lane === "object" && !Array.isArray(lane)) {
+      const cid = (lane as Record<string, unknown>).citation_id;
+      if (typeof cid === "string" && cid.length > 0) ids.add(cid);
+    }
+  }
+  return ids;
+}
+
+/** Verify the citations array is a bijection of the emitted item citation_ids. */
+function verifyCitations(payload: ContextPackPayload): CitationVerdict {
+  const emitted = collectEmittedItemCitationIds(payload);
+  const citationIds = new Set<string>();
+  for (const citation of payload.citations) {
+    const id = citation.id;
+    if (typeof id === "string" && id.length > 0) citationIds.add(id);
+  }
+  let dangling = 0;
+  for (const id of citationIds) {
+    if (!emitted.has(id)) dangling += 1;
+  }
+  let uncited = 0;
+  for (const id of emitted) {
+    if (!citationIds.has(id)) uncited += 1;
+  }
+  return {
+    citations_total: payload.citations.length,
+    emitted_item_citations: emitted.size,
+    dangling_citations: dangling,
+    uncited_items: uncited,
+    bijective: dangling === 0 && uncited === 0,
+  };
+}
+
+/** Verify the serialized whole-pack budget was respected. */
+function verifyBudget(payload: ContextPackPayload): BudgetVerdict {
+  const serialized = JSON.stringify(payload.sections).length;
+  const wholePack =
+    payload.budget.whole_pack &&
+    typeof payload.budget.whole_pack === "object" &&
+    !Array.isArray(payload.budget.whole_pack)
+      ? (payload.budget.whole_pack as Record<string, unknown>)
+      : null;
+  const limit =
+    wholePack && typeof wholePack.content_char_limit === "number"
+      ? wholePack.content_char_limit
+      : null;
+  const order = wholePack?.allocation_order;
+  const orderComplete =
+    Array.isArray(order) &&
+    COMPLETE_PACK_SECTION_NAMES.every((s) => order.includes(s));
+  return {
+    content_char_limit: limit,
+    serialized_sections_chars: serialized,
+    within_budget: limit === null ? false : serialized <= limit,
+    allocation_order_complete: orderComplete,
+  };
+}
+
+/**
+ * Verify isolation: durable_lane_context reports its exact-scope defined-empty,
+ * no forbidden (negative-namespace) server id surfaces anywhere in the pack, and
+ * the expected primary recall ids surfaced in durable_memory items or pointers.
+ *
+ * Forbidden ids are checked by their SERVER ids (the ids this run seeded into the
+ * negative namespace), matched against every item id and source_ref id in the
+ * pack -- so a leak is detected structurally, without inspecting any body.
+ */
+function verifyIsolation(
+  payload: ContextPackPayload,
+  seeded: CompletePackSeededRecord[],
+  fixture: CompletePackFixture,
+): IsolationVerdict {
+  const forbiddenServerIds = new Set(
+    seeded
+      .filter(
+        (r) =>
+          r.namespace_role === "negative" &&
+          fixture.forbidden_ids.includes(r.fixture_id),
+      )
+      .map((r) => r.server_id),
+  );
+  const expectedServerIds = new Set(
+    seeded
+      .filter(
+        (r) =>
+          r.namespace_role === "primary" &&
+          fixture.expected_recall_ids.includes(r.fixture_id),
+      )
+      .map((r) => r.server_id),
+  );
+
+  // Walk every emitted item id + source_ref id across all sections.
+  const emittedIds = new Set<string>();
+  const collectIds = (items: unknown) => {
+    if (!Array.isArray(items)) return;
+    for (const item of items) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const rec = item as Record<string, unknown>;
+      if (typeof rec.id === "string") emittedIds.add(rec.id);
+      const ref = rec.source_ref;
+      if (ref && typeof ref === "object" && !Array.isArray(ref)) {
+        const refId = (ref as Record<string, unknown>).id;
+        if (typeof refId === "string") emittedIds.add(refId);
+      }
+    }
+  };
+  for (const name of COMPLETE_PACK_SECTION_NAMES) {
+    const body = payload.sections[name];
+    if (!body || typeof body !== "object" || Array.isArray(body)) continue;
+    collectIds((body as Record<string, unknown>).items);
+  }
+
+  let leaks = 0;
+  for (const id of emittedIds) {
+    if (forbiddenServerIds.has(id)) leaks += 1;
+  }
+  let expectedPresent = false;
+  for (const id of emittedIds) {
+    if (expectedServerIds.has(id)) {
+      expectedPresent = true;
+      break;
+    }
+  }
+
+  // durable_lane_context exact-scope defined-empty: reported through its
+  // scope-denial (exact_scope) on a fresh throwaway scope.
+  const exactScopeDenied = payload.warnings.scope_denials.some(
+    (d) =>
+      d.source === "durable_lane_context" &&
+      Array.isArray(d.reasons) &&
+      d.reasons.map(String).includes("exact_scope"),
+  );
+
+  return {
+    exact_scope_denied: exactScopeDenied,
+    namespace_leaks: leaks,
+    expected_recall_present: expectedPresent,
+  };
+}
+
+/**
+ * Run the full complete-pack gate. Seeding and the pack call are wrapped so
+ * teardown always runs; a thrown error is re-raised only AFTER teardown, with
+ * the content-free teardown failed count preserved (shared with the recall gate
+ * via withTeardownFailedCount). PASS requires all five properties AND clean
+ * teardown.
+ */
+export async function runCompletePackGate(
+  opts: RunCompletePackGateOptions,
+): Promise<CompletePackGateOutcome> {
+  const { fixture, config, clients, budgetMaxTokens, scope, commit } = opts;
+
+  const seeded: CompletePackSeededRecord[] = [];
+  let deferredError: unknown = null;
+  let payload: ContextPackPayload | null = null;
+
+  const packScope: ContextPackScope = {
+    namespace: config.primaryNamespace,
+    agent: scope.agent,
+    platform: scope.platform,
+    server_id: scope.server_id,
+    channel_id: scope.channel_id,
+    thread_id: scope.thread_id ?? null,
+    session_key: scope.session_key,
+  };
+
+  try {
+    for (const entry of fixture.corpus) {
+      seeded.push(await seedEntry(entry, config, clients));
+    }
+
+    payload = await clients.primary.contextPack({
+      scope: packScope,
+      query: fixture.query,
+      requestedSections: COMPLETE_PACK_SECTION_NAMES,
+      budgetMaxTokens,
+    });
+  } catch (error) {
+    deferredError = error;
+  }
+
+  const teardownTally = await teardown(seeded, clients);
+
+  if (deferredError) {
+    throw withTeardownFailedCount(deferredError, teardownTally.failed);
+  }
+  // Unreachable when deferredError is null: payload is set. Guard for the type.
+  if (!payload) {
+    throw new LiveTransportError("agent_context_pack:no-payload", false);
+  }
+
+  // --- Verify the five functional properties ---
+  const sections = COMPLETE_PACK_SECTION_NAMES.map((name) =>
+    classifySection(name, payload as ContextPackPayload),
+  );
+  const citations = verifyCitations(payload);
+  const budget = verifyBudget(payload);
+  const isolation = verifyIsolation(payload, seeded, fixture);
+
+  const primarySeeded = seeded.filter(
+    (r) => r.namespace_role === "primary",
+  ).length;
+  const negativeSeeded = seeded.filter(
+    (r) => r.namespace_role === "negative",
+  ).length;
+
+  const failures: string[] = [];
+  // 1. Presence-or-defined-emptiness for all nine.
+  for (const verdict of sections) {
+    if (!verdict.has_items && !verdict.defined_empty) {
+      failures.push(verdict.failure ?? `${verdict.section}: not defined-empty`);
+    }
+  }
+  if (payload.status !== "ok") {
+    failures.push(`pack status is '${payload.status}', expected 'ok'`);
+  }
+  // 3. Citation truth.
+  if (!citations.bijective) {
+    failures.push(
+      `citations not bijective: dangling=${citations.dangling_citations} uncited=${citations.uncited_items}`,
+    );
+  }
+  // 4. Serialized budget.
+  if (!budget.within_budget) {
+    failures.push(
+      `serialized sections ${budget.serialized_sections_chars} exceed whole-pack limit ${budget.content_char_limit ?? "none"}`,
+    );
+  }
+  if (!budget.allocation_order_complete) {
+    failures.push(
+      "whole-pack allocation order missing or does not cover all nine sections",
+    );
+  }
+  // 2. Exact-scope isolation.
+  if (!isolation.exact_scope_denied) {
+    failures.push(
+      "durable_lane_context did not report its exact-scope defined-empty",
+    );
+  }
+  if (isolation.namespace_leaks > 0) {
+    failures.push(
+      `namespace isolation breach: ${isolation.namespace_leaks} forbidden record(s) surfaced in the pack`,
+    );
+  }
+  if (!isolation.expected_recall_present) {
+    failures.push(
+      "expected primary recall did not surface in durable_memory/pointers (hollow recall would hide a broken predicate)",
+    );
+  }
+  // Teardown discipline.
+  const teardownClean = teardownTally.failed === 0;
+  if (!teardownClean) {
+    failures.push(
+      `teardown failed to archive ${teardownTally.failed} of ${teardownTally.attempted} seeded records`,
+    );
+  }
+
+  const passed = failures.length === 0;
+
+  const receipt: CompletePackReceipt = {
+    schema: "openbrain.complete_pack_gate.v1",
+    generated_at: opts.generatedAt,
+    commit,
+    fixture_id: fixture.fixture_id,
+    primary_namespace: config.primaryNamespace,
+    negative_namespace: config.negativeNamespace,
+    requested_sections: [...COMPLETE_PACK_SECTION_NAMES],
+    seeded: { primary: primarySeeded, negative: negativeSeeded },
+    sections,
+    budget,
+    citations,
+    isolation,
+    passed,
+    failures,
+    teardown: teardownTally,
+  };
+
+  return { receipt, passed };
+}

--- a/eval/open-brain/live/complete-pack-setup.ts
+++ b/eval/open-brain/live/complete-pack-setup.ts
@@ -1,0 +1,59 @@
+import type { LiveEvalConfig } from "./config.ts";
+import type { CompletePackGateClients } from "./complete-pack-gate.ts";
+import type { OpenBrainToolCaller } from "./transport.ts";
+import { OpenBrainLiveClient, createMcpCaller } from "./transport.ts";
+
+// Client lifecycle for the complete-pack gate.
+//
+// Identical discipline to the recall gate's setUpGateClients: connect the
+// primary and negative callers in order (the negative control is mandatory, so
+// BOTH must connect), and if the primary connects but the negative connect
+// fails, close the primary before propagating so a live MCP session never leaks
+// on a setup failure. Kept in the eval tree so the complete-pack gate is
+// self-contained without importing from the recall gate's CLI script.
+
+/**
+ * Factory that connects one MCP caller for a (token, namespace) pair. Injected
+ * so the setup lifecycle is unit-testable without a hosted server: a fake factory
+ * can simulate a successful primary connect and a failing negative connect,
+ * proving the primary is closed and no caller leaks.
+ */
+export type CallerFactory = (opts: {
+  baseUrl: string;
+  token: string;
+  namespace: string;
+  timeoutMs: number;
+}) => Promise<OpenBrainToolCaller>;
+
+export async function setUpCompletePackClients(
+  config: LiveEvalConfig,
+  factory: CallerFactory = createMcpCaller,
+): Promise<CompletePackGateClients> {
+  const primaryCaller = await factory({
+    baseUrl: config.baseUrl,
+    token: config.primaryToken,
+    namespace: config.primaryNamespace,
+    timeoutMs: config.timeoutMs,
+  });
+
+  let negativeCaller: OpenBrainToolCaller;
+  try {
+    negativeCaller = await factory({
+      baseUrl: config.baseUrl,
+      token: config.negativeToken,
+      namespace: config.negativeNamespace,
+      timeoutMs: config.timeoutMs,
+    });
+  } catch (error) {
+    // Close the already-connected primary so a negative-connect failure does not
+    // strand it. Swallow the close outcome (content-free) so the original
+    // connect error is what the caller sees.
+    await primaryCaller.close().catch(() => {});
+    throw error;
+  }
+
+  return {
+    primary: new OpenBrainLiveClient(primaryCaller),
+    negative: new OpenBrainLiveClient(negativeCaller),
+  };
+}

--- a/eval/open-brain/live/complete-pack-types.ts
+++ b/eval/open-brain/live/complete-pack-types.ts
@@ -1,0 +1,192 @@
+// Types for the live Open Brain COMPLETE CONTEXT PACK gate (EVAL-3, issue #330).
+//
+// This gate is the live counterpart of the offline pack tests: it seeds a unique
+// throwaway namespace with a sealed synthetic corpus, calls the real
+// `agent_context_pack` tool requesting ALL NINE sections under ONE whole-pack
+// budget, and verifies functional outcomes:
+//
+//   - every requested section is PRESENT or in its DEFINED-EMPTY state,
+//   - exact-scope isolation (seven coordinates + negative namespace) holds,
+//   - citation truth (citations are a bijection of emitted item citation_ids),
+//   - the serialized `sections` object stays within the whole-pack budget,
+//   - per-section contribution (serialized chars + item counts) is recorded.
+//
+// Nothing here carries a secret, token, or memory body off-box: the corpus is
+// synthetic and the receipt is content-free (labels, ids, counts, booleans).
+
+/** Brain tables the complete-pack gate seeds and archives. */
+export type CompletePackTable = "thoughts" | "decisions";
+
+/**
+ * The nine context-pack sections, in the tool's canonical priority order. The
+ * gate requests exactly these and verifies each one lands present-or-empty.
+ * Kept as a literal here (not imported from src) so the eval declares the exact
+ * contract it asserts against and a production reshuffle is caught, not masked.
+ */
+export const COMPLETE_PACK_SECTION_NAMES = [
+  "working_set",
+  "recovery",
+  "durable_lane_context",
+  "durable_memory",
+  "profile_guidance",
+  "process_guidance",
+  "repo_facts",
+  "pointers",
+  "candidate_memory",
+] as const;
+
+export type CompletePackSectionName =
+  (typeof COMPLETE_PACK_SECTION_NAMES)[number];
+
+/**
+ * One sealed synthetic seed for the complete-pack corpus.
+ *
+ * `id` is a fixture-local handle, mapped to the server-assigned UUID at seed
+ * time. `namespace_role` decides which caller seeds it and where:
+ *  - "primary": seeded under the primary throwaway namespace; a
+ *    durable_memory-eligible record the pack recall should be able to surface.
+ *  - "negative": seeded into the sibling namespace the pack caller cannot read;
+ *    it must never appear in any pack section item or citation.
+ */
+export interface CompletePackCorpusEntry {
+  id: string;
+  table: CompletePackTable;
+  namespace_role: "primary" | "negative";
+  content: string;
+  tags: string[];
+}
+
+export interface CompletePackFixture {
+  schema_version: 1;
+  fixture_id: string;
+  description: string;
+  /** The recall query the pack is built around (drives durable_memory/pointers). */
+  query: string;
+  corpus: CompletePackCorpusEntry[];
+  /**
+   * Fixture-local ids of primary-role seeds the durable_memory recall is
+   * expected to be able to surface for `query` (so a completely empty recall on
+   * a namespace we just seeded is caught as a defect, not passed as "empty").
+   */
+  expected_recall_ids: string[];
+  /**
+   * Fixture-local ids of negative-role seeds that must never appear in any pack
+   * section item or citation (isolation).
+   */
+  forbidden_ids: string[];
+}
+
+/**
+ * A resolved seeded record: fixture handle, table, server UUID, physical
+ * namespace, and role. Teardown only ever archives records described by this
+ * shape, exactly like the recall gate's SeededRecord.
+ */
+export interface CompletePackSeededRecord {
+  fixture_id: string;
+  table: CompletePackTable;
+  server_id: string;
+  namespace: string;
+  namespace_role: "primary" | "negative";
+}
+
+/**
+ * One section's disposition after the pack is assembled. Content-free: only the
+ * section name, a present/empty classification, a defined-empty reason label
+ * (never a body), the item count, and the serialized-character contribution the
+ * section made to the whole pack.
+ */
+export interface SectionVerdict {
+  section: CompletePackSectionName;
+  /** True when the section appeared in the emitted `sections` object at all. */
+  present: boolean;
+  /** True when the section had at least one emitted item. */
+  has_items: boolean;
+  /**
+   * True when the section is in a DEFINED-EMPTY state: present with zero items
+   * and a recognized empty/denial marker (or a legitimately-empty RAM-only
+   * section), OR reported through a defined scope-denial / degraded-source.
+   */
+  defined_empty: boolean;
+  /** Emitted item count (0 for empty/RAM-only sections). */
+  item_count: number;
+  /**
+   * Content-free empty/denial classification, e.g. "items" (had items),
+   * "candidate_predicate_unavailable", "exact_scope", "no_matches",
+   * "ram_only_empty", "whole_pack_budget". Never a body.
+   */
+  disposition: string;
+  /** Serialized characters this section contributed to the whole pack. */
+  serialized_chars: number;
+  /** Set only when the section failed its present-or-defined-empty check. */
+  failure?: string;
+}
+
+/** Whole-pack serialized-budget accounting captured from the emitted pack. */
+export interface BudgetVerdict {
+  /** The whole-pack serialized char limit the tool reported. */
+  content_char_limit: number | null;
+  /** Serialized characters the whole `sections` object actually used. */
+  serialized_sections_chars: number;
+  /** True when serialized `sections` is within the reported limit. */
+  within_budget: boolean;
+  /** True when the tool reported a whole-pack allocation order for all nine. */
+  allocation_order_complete: boolean;
+}
+
+/** Citation-truth accounting: citations must be a bijection of emitted items. */
+export interface CitationVerdict {
+  /** Total citations in the top-level citations array. */
+  citations_total: number;
+  /** Distinct emitted item citation_ids across all sections. */
+  emitted_item_citations: number;
+  /** Citation ids that reference no emitted item (dangling). */
+  dangling_citations: number;
+  /** Emitted item citation_ids with no matching top-level citation. */
+  uncited_items: number;
+  /** True when citations and emitted item citation_ids are a clean bijection. */
+  bijective: boolean;
+}
+
+/** Isolation accounting for the complete pack. */
+export interface IsolationVerdict {
+  /** True when durable_lane_context reported its exact-scope defined-empty. */
+  exact_scope_denied: boolean;
+  /** Count of forbidden (negative-namespace) ids that surfaced anywhere. */
+  namespace_leaks: number;
+  /**
+   * True when the expected primary recall ids surfaced in durable_memory items
+   * (or as pointers), proving the recall actually reached the seeded namespace
+   * rather than returning a hollow empty that would hide a broken predicate.
+   */
+  expected_recall_present: boolean;
+}
+
+/** Content-free structured baseline receipt for the complete-pack gate. */
+export interface CompletePackReceipt {
+  schema: "openbrain.complete_pack_gate.v1";
+  generated_at: string;
+  commit: string;
+  fixture_id: string;
+  primary_namespace: string;
+  negative_namespace: string;
+  requested_sections: CompletePackSectionName[];
+  seeded: { primary: number; negative: number };
+  sections: SectionVerdict[];
+  budget: BudgetVerdict;
+  citations: CitationVerdict;
+  isolation: IsolationVerdict;
+  /**
+   * Composite verdict. PASS requires ALL of: every requested section present or
+   * defined-empty, citation bijection, serialized budget respected with a
+   * complete allocation order, exact-scope isolation with zero namespace leaks
+   * and the expected recall present, and teardown left nothing behind.
+   */
+  passed: boolean;
+  failures: string[];
+  teardown: {
+    attempted: number;
+    archived: number;
+    already_absent: number;
+    failed: number;
+  };
+}

--- a/eval/open-brain/live/complete-pack-types.ts
+++ b/eval/open-brain/live/complete-pack-types.ts
@@ -161,6 +161,34 @@ export interface IsolationVerdict {
   expected_recall_present: boolean;
 }
 
+/**
+ * Explicit cross-namespace denial proof for the complete-pack gate, mirroring
+ * the recall gate's NegativeControlProof. The PRIMARY caller attempts a
+ * primary-identity read against the NEGATIVE namespace, and the server MUST deny
+ * it. A denial is the ONLY proof of isolation the gate trusts: an
+ * allowed-but-empty read looks identical to a working boundary but proves
+ * nothing, so `allowed-empty` and `allowed-nonempty` both fail here. This is
+ * distinct from the leak walk over the emitted pack (which only catches a
+ * forbidden id that happened to surface below the result cut); the denial probe
+ * proves the boundary refuses the read at all. Content-free: only booleans, a
+ * count, and a redacted failure label.
+ */
+export interface NegativeControlVerdict {
+  /** True when the cross-namespace read was actually attempted this run. */
+  ran: boolean;
+  /** True when the primary caller's read of the negative namespace was denied. */
+  denied: boolean;
+  /**
+   * Hit count observed if the read unexpectedly SUCCEEDED; 0 on denial. Lets the
+   * receipt distinguish "denied" from "allowed but empty" content-free.
+   */
+  observed_hit_count: number;
+  /** True when a distinct negative token also exercised cross-token denial. */
+  cross_token: boolean;
+  /** Content-free reason the proof did not establish isolation, if any. */
+  failure?: string;
+}
+
 /** Content-free structured baseline receipt for the complete-pack gate. */
 export interface CompletePackReceipt {
   schema: "openbrain.complete_pack_gate.v1";
@@ -175,11 +203,13 @@ export interface CompletePackReceipt {
   budget: BudgetVerdict;
   citations: CitationVerdict;
   isolation: IsolationVerdict;
+  negative_control: NegativeControlVerdict;
   /**
    * Composite verdict. PASS requires ALL of: every requested section present or
    * defined-empty, citation bijection, serialized budget respected with a
    * complete allocation order, exact-scope isolation with zero namespace leaks
-   * and the expected recall present, and teardown left nothing behind.
+   * and the expected recall present, the cross-namespace denial probe ran and
+   * was denied, and teardown left nothing behind.
    */
   passed: boolean;
   failures: string[];

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -69,6 +69,42 @@ export interface SearchHit {
 }
 
 /**
+ * The exact seven-coordinate active scope the complete-pack gate binds. The
+ * namespace is the isolation predicate (the per-run throwaway namespace); the
+ * remaining coordinates address the exact working-set / durable-lane scope. A
+ * missing `thread_id` means the unthreaded lane, exactly as the pack tool treats
+ * an omitted thread id.
+ */
+export interface ContextPackScope {
+  namespace: string;
+  agent: string;
+  platform: string;
+  server_id: string;
+  channel_id: string;
+  thread_id?: string | null;
+  session_key: string;
+}
+
+/**
+ * The structural fields the complete-pack gate reads out of the pack payload.
+ * Deliberately narrow: only the shape needed to verify presence/emptiness,
+ * citations, budget, and warnings. Section bodies are kept as opaque records so
+ * the gate reads item counts / citation ids / empty markers WITHOUT the eval
+ * code ever needing to log a memory body. The raw payload text is never carried.
+ */
+export interface ContextPackPayload {
+  status: string;
+  sections: Record<string, unknown>;
+  citations: Array<Record<string, unknown>>;
+  budget: Record<string, unknown>;
+  warnings: {
+    scope_denials: Array<Record<string, unknown>>;
+    degraded_sources: Array<Record<string, unknown>>;
+    truncation: Array<Record<string, unknown>>;
+  };
+}
+
+/**
  * Result of an explicit isolation probe: an attempt by one caller to read a
  * namespace it must not be able to read. `denied` is the only signal the gate
  * trusts as proof of isolation; an empty-but-successful search is NOT denial.
@@ -230,6 +266,52 @@ export class OpenBrainLiveClient {
   }
 
   /**
+   * Build the complete agent context pack for the exact active scope, requesting
+   * all of `requestedSections` under one whole-pack budget. Returns the parsed
+   * structured payload object (sections/citations/budget/warnings) for the
+   * complete-pack gate to verify functional outcomes against.
+   *
+   * The pack tool returns a JSON OBJECT (never an array). We fail closed
+   * content-free on a body that is not a JSON object or that the server flagged
+   * as an error: the pack payload can carry memory bodies inside its section
+   * items, so the raw text is NEVER logged or surfaced -- only structural fields
+   * the gate reads (ids, counts, citation ids, budget numbers). A permission
+   * denial is thrown as a redacted LiveTransportError, exactly like `search`.
+   */
+  async contextPack(opts: {
+    scope: ContextPackScope;
+    query: string;
+    requestedSections: readonly string[];
+    budgetMaxTokens?: number;
+    includeUnreviewedRecovery?: boolean;
+  }): Promise<ContextPackPayload> {
+    const args: Record<string, unknown> = {
+      namespace: opts.scope.namespace,
+      agent: opts.scope.agent,
+      platform: opts.scope.platform,
+      server_id: opts.scope.server_id,
+      channel_id: opts.scope.channel_id,
+      session_key: opts.scope.session_key,
+      query: opts.query,
+      requested_sections: [...opts.requestedSections],
+    };
+    if (opts.scope.thread_id !== undefined && opts.scope.thread_id !== null) {
+      args.thread_id = opts.scope.thread_id;
+    }
+    if (opts.includeUnreviewedRecovery) {
+      args.include_unreviewed_recovery = true;
+    }
+    if (opts.budgetMaxTokens !== undefined) {
+      args.budget = { max_tokens: opts.budgetMaxTokens };
+    }
+    const result = await this.caller.callTool("agent_context_pack", args);
+    if (result.isError) {
+      throw new LiveTransportError(result.errorLabel, result.denied);
+    }
+    return parseContextPackPayload(result.data);
+  }
+
+  /**
    * Archive exactly one record by table + id. archive_entry is namespace-scoped
    * server-side (it appends the caller's write-namespace predicate), so a token
    * can only ever archive records it owns -- this is what makes per-record
@@ -353,6 +435,51 @@ export function parseHits(text: string): SearchHit[] {
     });
   }
   return hits;
+}
+
+/**
+ * Parse the complete context-pack payload from a JSON object body. Never logs
+ * the body, which can carry memory bodies inside its section items.
+ *
+ * Fails closed content-free rather than defaulting a malformed body to an empty
+ * pack: a non-object body, or invalid JSON, is a malformed pack
+ * (`agent_context_pack:malformed-payload`), NOT an empty pack -- conflating the
+ * two would let a broken pack pass as a clean empty. `sections`, `citations`,
+ * `budget`, and `warnings.*` are normalized to their expected container shapes
+ * (object / array), defaulting a MISSING container to its empty form so the gate
+ * can classify a genuinely-empty pack without inspecting any body. The section
+ * bodies themselves stay opaque records; the gate reads only their structural
+ * fields.
+ */
+export function parseContextPackPayload(text: string): ContextPackPayload {
+  const parsed = safeJson(text);
+  if (!parsed) {
+    throw new LiveTransportError("agent_context_pack:malformed-payload", false);
+  }
+  const asRecordArray = (value: unknown): Array<Record<string, unknown>> => {
+    if (!Array.isArray(value)) return [];
+    return value.filter(
+      (row): row is Record<string, unknown> =>
+        !!row && typeof row === "object" && !Array.isArray(row),
+    );
+  };
+  const asRecord = (value: unknown): Record<string, unknown> =>
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  const warnings = asRecord(parsed.warnings);
+  return {
+    status: typeof parsed.status === "string" ? parsed.status : "",
+    sections: asRecord(parsed.sections),
+    citations: asRecordArray(parsed.citations),
+    budget: asRecord(parsed.budget),
+    warnings: {
+      scope_denials: asRecordArray(warnings.scope_denials),
+      degraded_sources: asRecordArray(warnings.degraded_sources),
+      truncation: asRecordArray(warnings.truncation),
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- add the EVAL-3 complete context-pack fixture, transport support, gate, CLI, and functional tests
- assemble and classify all nine declared sections under one serialized budget
- verify exact-scope isolation, citation bijection, expected recall, content-free receipts, and per-record teardown

Closes #330

## Validation

- focused complete-pack tests: **40 passed, 0 failed**
- full `eval/open-brain/` suite: **155 passed, 0 failed**
- `bunx tsc --noEmit`: passed
- `git diff --check`: passed
- real hosted EVAL-3 run against core01 at exact head `e8c07e071115fb002daf3572460ba7b4caf7d947`: **PASS**
  - serialized sections `6199 / 22800`
  - 4 emitted items and 4 matching unique citations; no dangling or uncited items
  - every expected recall ID present
  - exact-scope denial passed; zero namespace leaks
  - explicit negative control denied the cross-namespace read
  - six seeded records archived; zero teardown failures
  - every section present or classified as a production-truthful defined empty/opt-in absence

## Downstream rollout classification

Not a server behavior or public schema change. This PR adds a local/live functional validation gate and transport support for existing tools.

- Open Brain local functional validation: complete
- hosted Open Brain EVAL-3 canary: complete and passed on exact head `e8c07e0`
- server deploy, mcp2cli, rtech-mcps, client, and Hermes changes: not applicable

## Critical Self-Review

- Highest-risk behavior: a false-pass gate that accepts missing sections, duplicate/orphan citations, partial expected recall, forged scope-denial warnings, content-bearing status/reason labels, budget overflow, or incomplete teardown.
- Assumptions that could be wrong: recovery is legitimately absent without explicit opt-in, while namespace-bound empty guidance/pointer envelopes are truthful defined-empty states.
- Missing/weak tests: per-section relevance contribution is structural/count-based in this gate; broader quality A/B tuning remains #335/#347.
- Security/permission risk: live fixtures use a fresh isolated namespace, seed a negative namespace, require an explicit cross-namespace authorization denial, and archive only per-record seeded IDs.
- Migration/deploy risk: no migration or server deployment; the gate calls the hosted server only under explicit env opt-in.
- Downstream client/runtime risk: none; no public server/client contract changes.
- Rollback/cleanup concern: revert eval-only files; the final live teardown archived all six seeded records with zero failures.
- Fixes made before PR: aligned the classifier with production empty shapes, then hardened citation identity to exactly one unit/one citation, required every expected seed, rejected populated-section denial contradictions, and sanitized server-controlled labels.
- Known residual risk: final integrated metric tuning remains #347 after reflex/source/FTS work lands.
- SME review-memory update: [x] `docs/sme/` updated — the explicit-isolation-denial review pattern is captured by PR #361 commit `bdb6dc4`.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Hosted EVAL-3 evidence is recorded in Validation above; the final run used a fresh isolated namespace and completed clean teardown.
