### PR TITLE
feat(ci): prepare Forgejo CI and core01 deploy path

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -1,0 +1,348 @@
+# Forgejo Actions CI for Open Brain.
+#
+# This is a faithful port of .github/workflows/ci.yml's REQUIRED validation
+# jobs (check, db-integration, python-package, contract-parity), targeted at
+# the repository-scoped Forgejo CI runner label set. It deliberately OMITS the
+# GitHub `deploy` job: production deploy lives in a separate, tightly scoped
+# .forgejo/workflows/deploy.yml so the CI runner never carries deploy trust.
+#
+# ACTIVATION IS DEFERRED. No Forgejo repository, runner, or secret exists for
+# this yet. GitHub remains the active CI/deploy path (see
+# docs/local-release-deploy-sop.md). This file is prepared source only.
+#
+# Runner: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]. The extra
+# `forgejo-ci-small` / `X64` labels scope these Docker-capable Linux jobs to
+# the Forgejo CI runner pool and away from the macOS/core01 deploy runner.
+#
+# Forgejo Actions runs the GitHub-compatible expression engine, so the `github`
+# and `runner` contexts below populate the same way they do on GitHub Actions
+# (github.event_name, github.ref, github.repository, github.run_id,
+# github.run_attempt, github.sha, github.event.pull_request.head.repo.full_name,
+# github.event.before, github.event.pull_request.base.sha, runner.temp).
+#
+# Action resolution note: Forgejo resolves bare `uses:` action refs against the
+# instance's configured actions registry, not github.com by default. The
+# SHA-pinned GitHub actions here match the pins already present in the GitHub
+# workflow source; on the real Forgejo instance the runner/registry must be
+# configured to fetch these actions (or their Forgejo mirrors) before this
+# workflow is activated. No secrets appear in this file.
+name: CI
+
+on:
+  push:
+    branches: ["wip/**", "feat/**", "fix/**", main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  BUN_VERSION: "1.3.13"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    # Self-hosted runner: never execute untrusted fork code. Run on pushes,
+    # trusted workflow dispatches, and same-repo PRs only; fork PRs skip (a
+    # maintainer re-pushes the branch to this repo to test).
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_USER: test
+      DB_PASSWORD: test
+      DB_NAME: open_brain_test_${{ github.run_id }}_${{ github.run_attempt }}
+      DB_NAME_TEST: open_brain_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
+      # Enable the env-gated real-Pool integration tests in CI (issue #165).
+      # Without this, every `dbDescribe`-gated suite (lane_upsert, the #161
+      # cursor-stall promoter tests) silently SKIPs and the SQL write paths get
+      # zero CI coverage — the exact gap that let the #162 lane_upsert bugs ship.
+      # Each workflow run owns its database so simultaneous push/pull_request runs
+      # cannot delete or clean up rows underneath one another.
+      OPENBRAIN_TEST_DATABASE_URL: postgres://test:test@127.0.0.1:5432/open_brain_test_${{ github.run_id }}_${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
+      - name: Create isolated test databases
+        run: |
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME_TEST}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+      - name: Run migrations
+        run: bun run migrate
+
+      - name: Test
+        run: bun test
+
+      - name: Drop isolated test databases
+        if: always()
+        run: |
+          PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
+          PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+
+  # Issue #165: authoritative DB-backed integration gate.
+  #
+  # Stands up an EPHEMERAL, ISOLATED pgvector Postgres in Docker on a
+  # dynamically-chosen free loopback port, MIGRATES it, runs the full suite, and
+  # — critically — asserts via the anti-skip guard that the
+  # `dbDescribe`/live-Postgres suites actually EXECUTED. A silent skip fails the
+  # job instead of going green with zero SQL-path coverage.
+  #
+  # Digest-pinned image: this job gates deploy, so a mutable tag must not be able
+  # to change under us. Isolation: unique container name + unique port per run,
+  # loopback-only listener, and `if: always()` teardown. Pinned to the
+  # Docker-capable Linux CI runners; the macOS/core01 deploy runner must not run
+  # Docker.
+  db-integration:
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      # 127.0.0.1 (not localhost): the ephemeral Postgres listens on the IPv4
+      # loopback only; `localhost` can resolve to ::1.
+      DB_HOST: 127.0.0.1
+      DB_USER: ci
+      # Throwaway, CI-only credential for an ephemeral loopback-only container
+      # that is destroyed at job end. Never a real Open Brain database.
+      DB_PASSWORD: ci
+      # The dbDescribe suites write to DB_NAME; the destructive 001_init
+      # migration test uses DB_NAME_TEST. Keep them on SEPARATE databases so the
+      # migration test's DROP TABLE cannot clobber the live-Postgres suites.
+      DB_NAME: open_brain_ci
+      DB_NAME_TEST: open_brain_ci_migrations
+      OB_CI_PG_CONTAINER: obci-pg-${{ github.run_id }}-${{ github.run_attempt }}
+      # Digest-pinned image: this job gates deploy, so a mutable tag must not
+      # be able to change under us. Digest is pgvector/pgvector:pg18
+      # (multi-arch index) as of 2026-07-05. To bump: run
+      #   docker buildx imagetools inspect pgvector/pgvector:pg18
+      # and replace the sha256 with the new index digest.
+      OB_CI_PG_IMAGE: pgvector/pgvector:pg18@sha256:212765b63c1462883de295c4c415edcd22191b8d8d46853e86ad05d4b577a4cb
+      # DB_PORT is chosen at runtime (free loopback port) and exported via
+      # GITHUB_ENV by the start step below.
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Start ephemeral pgvector Postgres (host network, loopback only)
+        run: |
+          started=no
+          for _attempt in 1 2 3 4 5; do
+            PORT="$(shuf -i 20000-60000 -n 1)"
+            if ss -ltn "( sport = :${PORT} )" | grep -q LISTEN; then
+              echo "port ${PORT} busy, retrying..."
+              continue
+            fi
+            echo "starting ${OB_CI_PG_CONTAINER} on 127.0.0.1:${PORT}"
+            if docker run -d --name "${OB_CI_PG_CONTAINER}" \
+                --network host \
+                -e POSTGRES_USER=ci \
+                -e POSTGRES_PASSWORD=ci \
+                -e POSTGRES_DB=open_brain_ci \
+                "${OB_CI_PG_IMAGE}" \
+                -c "port=${PORT}" -c "listen_addresses=127.0.0.1"; then
+              started=yes
+              break
+            fi
+            docker rm -f "${OB_CI_PG_CONTAINER}" >/dev/null 2>&1 || true
+          done
+          if [ "${started}" != "yes" ]; then
+            echo "could not start ephemeral Postgres container" >&2
+            exit 1
+          fi
+          # Wait for a REAL host-side connection, not just in-container
+          # readiness: the pg image runs a transient initdb server first.
+          for i in $(seq 1 30); do
+            if PGPASSWORD=ci psql -h 127.0.0.1 -p "${PORT}" -U ci \
+                -d open_brain_ci -tc "SELECT 1;" >/dev/null 2>&1; then
+              echo "Postgres reachable on 127.0.0.1:${PORT}"
+              echo "DB_PORT=${PORT}" >> "${GITHUB_ENV}"
+              exit 0
+            fi
+            echo "waiting for Postgres (attempt ${i})..."
+            sleep 2
+          done
+          echo "Postgres did not become reachable on 127.0.0.1:${PORT}" >&2
+          docker logs "${OB_CI_PG_CONTAINER}" 2>&1 | tail -20 || true
+          exit 1
+
+      - name: Create isolated migration-test database
+        run: |
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d open_brain_ci \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE DATABASE ${DB_NAME_TEST};"
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d "${DB_NAME_TEST}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+      - name: Run migrations against ephemeral Postgres
+        run: bun run migrate
+
+      - name: Test (JUnit reporter for the anti-skip guard)
+        run: |
+          export OPENBRAIN_TEST_DATABASE_URL="postgres://ci:ci@127.0.0.1:${DB_PORT}/open_brain_ci"
+          bun test \
+            --reporter=junit \
+            --reporter-outfile=${{ runner.temp }}/junit-db.xml
+
+      - name: Assert DB-backed integration tests actually ran (anti-skip guard)
+        run: bun run scripts/assert-db-tests-ran.ts ${{ runner.temp }}/junit-db.xml
+
+      # Issue #298 restore drill: exercises the real backup.ts ->
+      # backup-verify.ts -> restore.ts operator path end-to-end against the
+      # ephemeral pgvector Postgres. The drill creates and drops its OWN scratch
+      # databases (open_brain_ci_restore_*) via the admin connection, so it can
+      # never clobber open_brain_ci / open_brain_ci_migrations — mirroring the
+      # DB_NAME/DB_NAME_TEST separation documented above.
+      #
+      # pg_dump/pg_restore mechanism: `docker exec` into the digest-pinned
+      # pgvector/pgvector:pg18 container rather than the runner's
+      # postgresql-client, so the tools always match the pinned pg18 server.
+      # `-e PGPASSWORD` (no value) propagates the password from the docker CLI's
+      # environment BY NAME, so the credential never appears in argv. The
+      # container runs with --network host, so 127.0.0.1:${DB_PORT} resolves
+      # identically inside.
+      #
+      # OPENBRAIN_BACKUP_DRILL=1 makes the drill MANDATORY here: missing
+      # prerequisites FAIL the suite loudly instead of skipping, so this step
+      # cannot silently no-op.
+      - name: Restore drill (issue #298 backup/restore substrate)
+        run: |
+          # URL assembled from the job's env (throwaway ephemeral-container
+          # credential) so no user:pass URI literal lives in the workflow.
+          export OPENBRAIN_TEST_DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${DB_PORT}/${DB_NAME}"
+          export OPENBRAIN_BACKUP_DRILL=1
+          export OPENBRAIN_PG_DUMP_BIN="docker exec -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_dump"
+          export OPENBRAIN_PG_RESTORE_BIN="docker exec -i -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_restore"
+          bun test scripts/__tests__/backup-restore-live.test.ts
+
+      - name: Tear down ephemeral Postgres
+        if: always()
+        run: docker rm -f "${OB_CI_PG_CONTAINER}" >/dev/null 2>&1 || true
+
+  python-package:
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    # Self-hosted runner: same trusted-source gate as `check`/`db-integration`.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PYTHON_VERSION: "3.13"
+    defaults:
+      run:
+        working-directory: python/openbrain-memory
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        run: uv python install "${PYTHON_VERSION}"
+
+      - name: Lint python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" ruff check src tests
+
+      - name: Typecheck python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" mypy src/openbrain_memory
+
+      - name: Test python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" pytest -q
+
+      - name: Build python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv build --python "${PYTHON_VERSION}"
+
+  contract-parity:
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    # Self-hosted runner: same trusted-source gate as the existing validation jobs.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PYTHON_VERSION: "3.13"
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect client or contract changes
+        id: contract-paths
+        shell: sh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          base="${BASE_SHA}"
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
+            base="${BEFORE_SHA}"
+          fi
+          case "${base}" in
+            ""|0000000000000000000000000000000000000000)
+              # New-branch pushes have no usable 'before' SHA. Match the
+              # pre-push hook: diff against the merge-base with origin/main so
+              # CI never checks a narrower range than the hook does.
+              git rev-parse --verify origin/main >/dev/null 2>&1 || git fetch origin main
+              base="$(git merge-base "${HEAD_SHA}" origin/main 2>/dev/null || git hash-object -t tree /dev/null)"
+              ;;
+          esac
+          if git diff --quiet "${base}" "${HEAD_SHA}" -- $(cat contracts/parity-paths.txt); then
+            echo "required=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        if: steps.contract-paths.outputs.required == 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: steps.contract-paths.outputs.required == 'true'
+
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        if: steps.contract-paths.outputs.required == 'true'
+        run: uv python install "${PYTHON_VERSION}"
+
+      - name: Validate parity manifest and fixtures
+        if: steps.contract-paths.outputs.required == 'true'
+        run: bun contracts/check-parity.ts
+
+      - name: Replay fixtures against Python
+        if: steps.contract-paths.outputs.required == 'true'
+        working-directory: python/openbrain-memory
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" pytest -q tests/test_contract_fixtures.py

--- a/.forgejo/workflows/deploy.yml
+++ b/.forgejo/workflows/deploy.yml
@@ -1,0 +1,302 @@
+# Forgejo Actions production deploy for Open Brain (core01).
+#
+# ACTIVATION IS DEFERRED. No Forgejo repository, runner, or secret exists for
+# this yet, and GitHub remains the active deploy path today (see
+# docs/local-release-deploy-sop.md). This file is prepared source only; it does
+# NOT change the current GitHub deploy policy.
+#
+# Deliberately SEPARATE from .forgejo/workflows/ci.yml so the macOS/core01
+# deploy runner is isolated from the Docker-capable Linux CI pool and never
+# carries CI trust. Runner: [self-hosted, macOS, core01, open-brain-deploy].
+# The `open-brain-deploy` label scopes this to the single repository-scoped
+# production deploy runner.
+#
+# Trigger policy (mirrors the GitHub deploy job exactly):
+#   - a manual workflow_dispatch from the current main tip with
+#     deploy_core01=true; or
+#   - a pushed v* tag whose target commit is reachable from main.
+# Merging to main is NOT a deploy signal.
+#
+# Depend-on-validation model: because the core01 deploy runner is macOS and
+# cannot run the Docker/Linux validation jobs, this workflow runs the required
+# validation as in-workflow `needs` gate jobs on the Forgejo CI runner, then the
+# deploy job depends on all of them. This keeps "validate before deploy" a
+# concrete in-workflow dependency without relying on cross-workflow triggers.
+# The deploy script's own pre-mutation ref gate (scripts/deploy-ref-gate.ts) is
+# the fail-closed backstop even if a runner is mislabeled. No secrets in YAML.
+name: Deploy core01
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      deploy_core01:
+        description: "Deploy Open Brain to core01 after validation passes"
+        required: true
+        type: boolean
+        default: false
+
+env:
+  BUN_VERSION: "1.3.13"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+# Production concurrency: never cancel an in-flight core01 deploy.
+concurrency:
+  group: deploy-core01-production
+  cancel-in-progress: false
+
+jobs:
+  # ---- Validation gate (runs on the Forgejo CI runner pool) ----
+  # These are the same required checks as CI; the deploy job below `needs` them,
+  # so a red check blocks the production deploy. They run only when the deploy
+  # itself is eligible (current-main manual dispatch or a v* tag).
+  check:
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_USER: test
+      DB_PASSWORD: test
+      DB_NAME: open_brain_test_${{ github.run_id }}_${{ github.run_attempt }}
+      DB_NAME_TEST: open_brain_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
+      OPENBRAIN_TEST_DATABASE_URL: postgres://test:test@127.0.0.1:5432/open_brain_test_${{ github.run_id }}_${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bunx tsc --noEmit
+      - name: Create isolated test databases
+        run: |
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME_TEST}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      - name: Run migrations
+        run: bun run migrate
+      - name: Test
+        run: bun test
+      - name: Drop isolated test databases
+        if: always()
+        run: |
+          PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
+          PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+
+  db-integration:
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    env:
+      DB_HOST: 127.0.0.1
+      DB_USER: ci
+      DB_PASSWORD: ci
+      DB_NAME: open_brain_ci
+      DB_NAME_TEST: open_brain_ci_migrations
+      OB_CI_PG_CONTAINER: obci-pg-${{ github.run_id }}-${{ github.run_attempt }}
+      # Digest-pinned pgvector image; see .forgejo/workflows/ci.yml for the bump
+      # procedure. A mutable tag must not change under a deploy gate.
+      OB_CI_PG_IMAGE: pgvector/pgvector:pg18@sha256:212765b63c1462883de295c4c415edcd22191b8d8d46853e86ad05d4b577a4cb
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Start ephemeral pgvector Postgres (host network, loopback only)
+        run: |
+          started=no
+          for _attempt in 1 2 3 4 5; do
+            PORT="$(shuf -i 20000-60000 -n 1)"
+            if ss -ltn "( sport = :${PORT} )" | grep -q LISTEN; then
+              echo "port ${PORT} busy, retrying..."
+              continue
+            fi
+            echo "starting ${OB_CI_PG_CONTAINER} on 127.0.0.1:${PORT}"
+            if docker run -d --name "${OB_CI_PG_CONTAINER}" \
+                --network host \
+                -e POSTGRES_USER=ci \
+                -e POSTGRES_PASSWORD=ci \
+                -e POSTGRES_DB=open_brain_ci \
+                "${OB_CI_PG_IMAGE}" \
+                -c "port=${PORT}" -c "listen_addresses=127.0.0.1"; then
+              started=yes
+              break
+            fi
+            docker rm -f "${OB_CI_PG_CONTAINER}" >/dev/null 2>&1 || true
+          done
+          if [ "${started}" != "yes" ]; then
+            echo "could not start ephemeral Postgres container" >&2
+            exit 1
+          fi
+          for i in $(seq 1 30); do
+            if PGPASSWORD=ci psql -h 127.0.0.1 -p "${PORT}" -U ci \
+                -d open_brain_ci -tc "SELECT 1;" >/dev/null 2>&1; then
+              echo "Postgres reachable on 127.0.0.1:${PORT}"
+              echo "DB_PORT=${PORT}" >> "${GITHUB_ENV}"
+              exit 0
+            fi
+            echo "waiting for Postgres (attempt ${i})..."
+            sleep 2
+          done
+          echo "Postgres did not become reachable on 127.0.0.1:${PORT}" >&2
+          docker logs "${OB_CI_PG_CONTAINER}" 2>&1 | tail -20 || true
+          exit 1
+      - name: Create isolated migration-test database
+        run: |
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d open_brain_ci \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE DATABASE ${DB_NAME_TEST};"
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d "${DB_NAME_TEST}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      - name: Run migrations against ephemeral Postgres
+        run: bun run migrate
+      - name: Test (JUnit reporter for the anti-skip guard)
+        run: |
+          export OPENBRAIN_TEST_DATABASE_URL="postgres://ci:ci@127.0.0.1:${DB_PORT}/open_brain_ci"
+          bun test \
+            --reporter=junit \
+            --reporter-outfile=${{ runner.temp }}/junit-db.xml
+      - name: Assert DB-backed integration tests actually ran (anti-skip guard)
+        run: bun run scripts/assert-db-tests-ran.ts ${{ runner.temp }}/junit-db.xml
+      - name: Restore drill (issue #298 backup/restore substrate)
+        run: |
+          export OPENBRAIN_TEST_DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${DB_PORT}/${DB_NAME}"
+          export OPENBRAIN_BACKUP_DRILL=1
+          export OPENBRAIN_PG_DUMP_BIN="docker exec -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_dump"
+          export OPENBRAIN_PG_RESTORE_BIN="docker exec -i -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_restore"
+          bun test scripts/__tests__/backup-restore-live.test.ts
+      - name: Tear down ephemeral Postgres
+        if: always()
+        run: docker rm -f "${OB_CI_PG_CONTAINER}" >/dev/null 2>&1 || true
+
+  python-package:
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    env:
+      PYTHON_VERSION: "3.13"
+    defaults:
+      run:
+        working-directory: python/openbrain-memory
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        run: uv python install "${PYTHON_VERSION}"
+      - name: Lint python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" ruff check src tests
+      - name: Typecheck python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" mypy src/openbrain_memory
+      - name: Test python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" pytest -q
+      - name: Build python package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv build --python "${PYTHON_VERSION}"
+
+  contract-parity:
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: [self-hosted, Linux, X64, rodaddy, forgejo-ci-small]
+    env:
+      PYTHON_VERSION: "3.13"
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+      - name: Detect client or contract changes
+        id: contract-paths
+        shell: sh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          base="${BASE_SHA}"
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
+            base="${BEFORE_SHA}"
+          fi
+          case "${base}" in
+            ""|0000000000000000000000000000000000000000)
+              git rev-parse --verify origin/main >/dev/null 2>&1 || git fetch origin main
+              base="$(git merge-base "${HEAD_SHA}" origin/main 2>/dev/null || git hash-object -t tree /dev/null)"
+              ;;
+          esac
+          if git diff --quiet "${base}" "${HEAD_SHA}" -- $(cat contracts/parity-paths.txt); then
+            echo "required=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+          fi
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        if: steps.contract-paths.outputs.required == 'true'
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: steps.contract-paths.outputs.required == 'true'
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        if: steps.contract-paths.outputs.required == 'true'
+        run: uv python install "${PYTHON_VERSION}"
+      - name: Validate parity manifest and fixtures
+        if: steps.contract-paths.outputs.required == 'true'
+        run: bun contracts/check-parity.ts
+      - name: Replay fixtures against Python
+        if: steps.contract-paths.outputs.required == 'true'
+        working-directory: python/openbrain-memory
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" pytest -q tests/test_contract_fixtures.py
+
+  # ---- Production deploy (core01 macOS runner only) ----
+  deploy:
+    needs: [check, db-integration, python-package, contract-parity]
+    runs-on: [self-hosted, macOS, core01, open-brain-deploy]
+    # Same eligibility as the GitHub deploy job: current-main manual dispatch
+    # with deploy_core01=true, or a v* tag reachable from main. The deploy
+    # script's ref gate re-verifies reachability as the fail-closed backstop.
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    env:
+      RUNTIME_DIR: /Volumes/ThunderBolt/open-brain/app
+      # Provider-neutral inputs consumed by scripts/deploy-ref-gate.ts. The
+      # gate falls back to GitHub env on the GitHub path; here we set them
+      # explicitly so the Forgejo path never relies on the compatibility mirror.
+      DEPLOY_PROVIDER: forgejo
+      DEPLOY_EVENT_NAME: ${{ github.event_name }}
+      DEPLOY_REF: ${{ github.ref }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+      - name: Deploy to core01 launchd runtime
+        run: /opt/homebrew/bin/bash scripts/core01-deploy-local.sh

--- a/docs/local-release-deploy-sop.md
+++ b/docs/local-release-deploy-sop.md
@@ -13,6 +13,9 @@ deliberately.
     `deploy_core01=true`; or
   - a pushed version tag matching `v*` whose target commit is reachable from
     `origin/main`.
+- This allow/refuse policy is enforced provider-neutrally by
+  `scripts/deploy-ref-gate.ts` (see the Forgejo section below). GitHub Actions
+  remains the active deploy path today.
 - Never use production secrets in command logs, PR bodies, issues, or reports.
   Evidence may name env vars and commands only.
 - Use a clean release-candidate worktree under
@@ -221,6 +224,54 @@ echoing the request `id`) — see the runbook's Verification section and
 `docs/fleet-nats-integration.md` for the authoritative shape. If the release does
 not include the NATS worker runtime entrypoint, leave the launchd template
 uninstalled and record the worker rollout as deferred.
+
+## Forgejo Deploy Path (Prepared, Deferred)
+
+GitHub Actions is the active CI and core01 deploy path today. Nothing in this
+section changes that. A parallel Forgejo Actions path exists in source only, so
+a future migration to a self-hosted Forgejo repository is a config-and-runner
+task rather than a re-authoring task.
+
+Prepared source:
+
+- `.forgejo/workflows/ci.yml` ports the required validation jobs (`check`,
+  `db-integration`, `python-package`, `contract-parity`) to the Forgejo CI
+  runner pool `[self-hosted, Linux, X64, rodaddy, forgejo-ci-small]`.
+- `.forgejo/workflows/deploy.yml` is a separate workflow scoped to the
+  repository's production deploy runner
+  `[self-hosted, macOS, core01, open-brain-deploy]`, with non-canceling
+  `deploy-core01-production` concurrency. It runs the same validation jobs as
+  in-workflow `needs` gates and deploys only after all pass. Merging to `main`
+  is not a deploy signal on this path either.
+- `scripts/core01-deploy-local.sh` and `scripts/deploy-ref-gate.ts` implement a
+  provider-neutral pre-mutation ref gate. The gate accepts explicit
+  `DEPLOY_PROVIDER` / `DEPLOY_EVENT_NAME` / `DEPLOY_REF` inputs and falls back
+  to the GitHub Actions environment for backward compatibility, so the exact
+  same allow/refuse policy protects both paths: manual dispatch only from the
+  current `main` tip, or a `v*` tag reachable from `main`. In CI, missing or
+  unsupported metadata fails closed.
+
+Repository-scoped deploy label: the Forgejo deploy runner is scoped by the
+`open-brain-deploy` label so only this repository's production runner is
+eligible to mutate core01. The Docker/Linux `forgejo-ci-small` CI runners
+cannot deploy, and the macOS deploy runner does not run CI.
+
+Host-local secret boundary is unchanged. The deploy runner reads
+`/Users/rico/.config/open-brain/env` on the host, exactly as the GitHub path
+does. No production secrets are stored in `.forgejo/` YAML, in the Forgejo
+repository, or in any workflow variable. Evidence may name env vars and
+commands only.
+
+Action resolution caveat: Forgejo resolves `uses:` action refs against the
+instance's configured actions registry, not github.com by default. The
+SHA-pinned GitHub actions in `.forgejo/workflows/*.yml` match the pins in the
+GitHub workflow; before activation, the Forgejo instance/runner must be
+configured to fetch those actions (or their Forgejo mirrors).
+
+Activation is explicitly deferred. Do not create or backfill a Forgejo
+repository, register a Forgejo runner, copy production secrets, or enable this
+path until an existing-repository cutover is authorized. Until then, follow the
+GitHub deploy path above.
 
 ## Rollback
 

--- a/scripts/core01-deploy-local.integration.test.ts
+++ b/scripts/core01-deploy-local.integration.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SOURCE_ROOT = join(import.meta.dir, "..");
+const DEPLOY_SCRIPT = join(SOURCE_ROOT, "scripts", "core01-deploy-local.sh");
+const GATE_SOURCE = join(SOURCE_ROOT, "scripts", "deploy-ref-gate.ts");
+const ownedTempDirs: string[] = [];
+
+interface GitFixture {
+  checkout: string;
+  mainSha: string;
+  reachableTagSha: string;
+  outsideTagSha: string;
+  root: string;
+}
+
+interface DeployResult {
+  exitCode: number;
+  output: string;
+  runtimeDir: string;
+  stagingDir: string;
+}
+
+async function run(
+  command: string[],
+  options: { cwd?: string; env?: Record<string, string | undefined> } = {},
+): Promise<{ exitCode: number; output: string }> {
+  const proc = Bun.spawn(command, {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { exitCode, output: stdout + stderr };
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const result = await run(["git", ...args], { cwd });
+  if (result.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed:\n${result.output}`);
+  }
+  return result.output.trim();
+}
+
+async function createGitFixture(): Promise<GitFixture> {
+  const root = await mkdtemp(join(tmpdir(), "open-brain-deploy-ref-"));
+  ownedTempDirs.push(root);
+
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  const checkout = join(root, "checkout");
+  await mkdir(seed);
+  await git(root, "init", "--bare", remote);
+  await git(seed, "init", "-b", "fixture-main");
+  await git(seed, "config", "user.name", "Deploy Gate Test");
+  await git(seed, "config", "user.email", "deploy-gate@example.invalid");
+
+  await writeFile(join(seed, "fixture.txt"), "reachable tag\n");
+  await git(seed, "add", "fixture.txt");
+  await git(seed, "commit", "-m", "reachable tag commit");
+  const reachableTagSha = await git(seed, "rev-parse", "HEAD");
+  await git(seed, "tag", "v1.0.0");
+
+  await writeFile(join(seed, "fixture.txt"), "current main\n");
+  await git(seed, "commit", "-am", "current main commit");
+  const mainSha = await git(seed, "rev-parse", "HEAD");
+
+  await git(seed, "switch", "--orphan", "outside-main");
+  await writeFile(join(seed, "outside.txt"), "outside main ancestry\n");
+  await git(seed, "add", "outside.txt");
+  await git(seed, "commit", "-m", "outside main commit");
+  const outsideTagSha = await git(seed, "rev-parse", "HEAD");
+  await git(seed, "tag", "v9.9.9");
+
+  await git(seed, "remote", "add", "origin", remote);
+  await git(
+    seed,
+    "push",
+    "origin",
+    "fixture-main:main",
+    "outside-main",
+    "--tags",
+  );
+  await git(remote, "symbolic-ref", "HEAD", "refs/heads/main");
+  await git(root, "clone", remote, checkout);
+
+  await mkdir(join(checkout, "scripts"));
+  await writeFile(
+    join(checkout, "scripts", "deploy-ref-gate.ts"),
+    await Bun.file(GATE_SOURCE).text(),
+  );
+
+  return { checkout, mainSha, reachableTagSha, outsideTagSha, root };
+}
+
+async function invokeDeploy(
+  fixture: GitFixture,
+  metadata: Record<string, string>,
+): Promise<DeployResult> {
+  const runtimeDir = join(fixture.root, "runtime");
+  const stagingDir = join(fixture.root, "staging");
+  const envFile = join(fixture.root, "guaranteed-missing.env");
+  const result = await run([DEPLOY_SCRIPT], {
+    env: {
+      ...process.env,
+      BUN_BIN: process.execPath,
+      REPO_DIR: fixture.checkout,
+      ENV_FILE: envFile,
+      RUNTIME_DIR: runtimeDir,
+      STAGING_DIR: stagingDir,
+      PREVIOUS_DIR: join(fixture.root, "previous"),
+      QMD_PATH_VALUE: join(fixture.root, "qmd.ts"),
+      SERVICE_LABEL: "invalid.test.open-brain",
+      NATS_WORKER_LABEL: "invalid.test.open-brain-nats-worker",
+      GITHUB_ACTIONS: undefined,
+      GITHUB_EVENT_NAME: undefined,
+      GITHUB_REF: undefined,
+      FORGEJO_ACTIONS: undefined,
+      DEPLOY_PROVIDER: metadata.DEPLOY_PROVIDER,
+      DEPLOY_EVENT_NAME: metadata.DEPLOY_EVENT_NAME,
+      DEPLOY_REF: metadata.DEPLOY_REF,
+    },
+  });
+  return { ...result, runtimeDir, stagingDir };
+}
+
+function expectAllowedPreflight(result: DeployResult): void {
+  const fatalLines = result.output
+    .split("\n")
+    .filter((line) => line.startsWith("FATAL:"));
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain("deploy ref gate PASSED:");
+  expect(fatalLines).toHaveLength(1);
+  expect(fatalLines[0]).toMatch(
+    /FATAL: (\/Volumes\/ThunderBolt is not mounted|env file missing: )/,
+  );
+  expect(result.output).not.toContain("refusing core01 deploy");
+  expect(existsSync(result.runtimeDir)).toBe(false);
+  expect(existsSync(result.stagingDir)).toBe(false);
+}
+
+function expectGateRefusal(result: DeployResult, expectedReason: string): void {
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(expectedReason);
+  expect(result.output).not.toContain("deploy ref gate PASSED:");
+  expect(result.output).not.toContain("env file missing:");
+  expect(result.output).not.toContain("/Volumes/ThunderBolt is not mounted");
+  expect(existsSync(result.runtimeDir)).toBe(false);
+  expect(existsSync(result.stagingDir)).toBe(false);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    ownedTempDirs
+      .splice(0)
+      .map((ownedDir) => rm(ownedDir, { recursive: true, force: true })),
+  );
+});
+
+describe("core01 deploy shell ref-gate wiring", () => {
+  it("lets a current-main manual dispatch reach only host preflight", async () => {
+    const fixture = await createGitFixture();
+    await git(fixture.checkout, "checkout", fixture.mainSha);
+
+    const result = await invokeDeploy(fixture, {
+      DEPLOY_PROVIDER: "forgejo",
+      DEPLOY_EVENT_NAME: "workflow_dispatch",
+      DEPLOY_REF: "refs/heads/main",
+    });
+
+    expectAllowedPreflight(result);
+  });
+
+  it("lets a reachable version tag reach only host preflight", async () => {
+    const fixture = await createGitFixture();
+    await git(fixture.checkout, "checkout", fixture.reachableTagSha);
+
+    const result = await invokeDeploy(fixture, {
+      DEPLOY_PROVIDER: "forgejo",
+      DEPLOY_EVENT_NAME: "push",
+      DEPLOY_REF: "refs/tags/v1.0.0",
+    });
+
+    expectAllowedPreflight(result);
+  });
+
+  it("refuses a stale manual commit before env loading or staging", async () => {
+    const fixture = await createGitFixture();
+    await git(fixture.checkout, "checkout", fixture.reachableTagSha);
+
+    const result = await invokeDeploy(fixture, {
+      DEPLOY_PROVIDER: "forgejo",
+      DEPLOY_EVENT_NAME: "workflow_dispatch",
+      DEPLOY_REF: "refs/heads/main",
+    });
+
+    expectGateRefusal(result, "HEAD is not the current main tip");
+  });
+
+  it("refuses a tag outside main ancestry before env loading or staging", async () => {
+    const fixture = await createGitFixture();
+    await git(fixture.checkout, "checkout", fixture.outsideTagSha);
+
+    const result = await invokeDeploy(fixture, {
+      DEPLOY_PROVIDER: "forgejo",
+      DEPLOY_EVENT_NAME: "push",
+      DEPLOY_REF: "refs/tags/v9.9.9",
+    });
+
+    expectGateRefusal(result, "HEAD is not reachable from main");
+  });
+
+  it("refuses unsupported provider and event metadata before preflight", async () => {
+    const fixture = await createGitFixture();
+    await git(fixture.checkout, "checkout", fixture.mainSha);
+
+    const unsupportedProvider = await invokeDeploy(fixture, {
+      DEPLOY_PROVIDER: "gitlab",
+      DEPLOY_EVENT_NAME: "workflow_dispatch",
+      DEPLOY_REF: "refs/heads/main",
+    });
+    expectGateRefusal(unsupportedProvider, "unsupported provider: gitlab");
+
+    const unsupportedEvent = await invokeDeploy(fixture, {
+      DEPLOY_PROVIDER: "forgejo",
+      DEPLOY_EVENT_NAME: "pull_request",
+      DEPLOY_REF: "refs/heads/main",
+    });
+    expectGateRefusal(
+      unsupportedEvent,
+      "unsupported trigger: event=pull_request",
+    );
+  });
+});

--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -31,45 +31,41 @@ cleanup_previous_dir() {
   return 1
 }
 
-verify_github_deploy_ref() {
-  if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+# Pre-mutation deploy ref gate. Provider-neutral: supports GitHub Actions and a
+# future Forgejo Actions repository-scoped runner. Provider/event/ref come from
+# explicit DEPLOY_* inputs, falling back to GitHub Actions env for backward
+# compatibility. The ALLOW/REFUSE decision itself lives in the unit-tested
+# scripts/deploy-ref-gate.ts so it can be exercised without touching git, env
+# loading, launchctl, runtime dirs, or production state.
+#
+# Fail closed: inside CI (any supported provider) a missing/unsupported/stale
+# trigger refuses the deploy. Outside CI the gate is a no-op, preserving the
+# prior operator-run behavior.
+verify_deploy_ref() {
+  local bun_bin="$1"
+
+  # Detect CI. Explicit DEPLOY_PROVIDER wins; otherwise fall back to the
+  # provider-native "actions" flags. Outside CI, skip the gate entirely.
+  if [[ -z "${DEPLOY_PROVIDER:-}" \
+        && "${GITHUB_ACTIONS:-}" != "true" \
+        && "${FORGEJO_ACTIONS:-}" != "true" ]]; then
     return 0
   fi
 
-  local event_name="${GITHUB_EVENT_NAME:-}"
-  local ref="${GITHUB_REF:-}"
-  local head_sha
-  local main_sha
-
-  case "$event_name:$ref" in
-    workflow_dispatch:refs/heads/main)
-      ;;
-    push:refs/tags/v*)
-      ;;
-    *)
-      echo "FATAL: refusing core01 deploy from unsupported GitHub ref: event=$event_name ref=$ref" >&2
-      exit 1
-      ;;
-  esac
-
+  # Gather git facts here (preserving the exact fetch/rev-parse/merge-base
+  # behavior) and hand the decision to the TS gate.
+  local head_sha main_sha reachable="false"
   git -C "$REPO_DIR" fetch --no-tags origin main:refs/remotes/origin/main
   head_sha="$(git -C "$REPO_DIR" rev-parse HEAD)"
   main_sha="$(git -C "$REPO_DIR" rev-parse origin/main)"
+  if git -C "$REPO_DIR" merge-base --is-ancestor "$head_sha" origin/main; then
+    reachable="true"
+  fi
 
-  case "$event_name:$ref" in
-    workflow_dispatch:refs/heads/main)
-      if [[ "$head_sha" != "$main_sha" ]]; then
-        echo "FATAL: refusing manual core01 deploy because HEAD is not the current origin/main tip: head=$head_sha origin/main=$main_sha" >&2
-        exit 1
-      fi
-      ;;
-    push:refs/tags/v*)
-      if ! git -C "$REPO_DIR" merge-base --is-ancestor "$head_sha" origin/main; then
-        echo "FATAL: refusing tag core01 deploy because HEAD is not reachable from origin/main: $head_sha" >&2
-        exit 1
-      fi
-      ;;
-  esac
+  DEPLOY_HEAD_SHA="$head_sha" \
+  DEPLOY_MAIN_SHA="$main_sha" \
+  DEPLOY_HEAD_REACHABLE_FROM_MAIN="$reachable" \
+    "$bun_bin" run "$REPO_DIR/scripts/deploy-ref-gate.ts"
 }
 
 wait_for_health() {
@@ -86,8 +82,6 @@ wait_for_health() {
   return 1
 }
 
-verify_github_deploy_ref
-
 if [[ -z "$BUN_BIN" ]]; then
   if [[ -x "/Users/rico/Library/Application Support/reflex/bun/bin/bun" ]]; then
     BUN_BIN="/Users/rico/Library/Application Support/reflex/bun/bin/bun"
@@ -98,6 +92,11 @@ if [[ -z "$BUN_BIN" ]]; then
     exit 1
   fi
 fi
+
+# Ref gate runs before ANY mutation (env load, staging, tar, migrate, swap).
+# It needs bun to run the unit-tested decision module, so it follows bun
+# resolution but precedes every side effect below.
+verify_deploy_ref "$BUN_BIN"
 
 if [[ ! -d "/Volumes/ThunderBolt" ]]; then
   echo "FATAL: /Volumes/ThunderBolt is not mounted" >&2
@@ -121,6 +120,7 @@ mkdir -p "$STAGING_DIR"
 tar \
   --exclude "./.git" \
   --exclude "./.github" \
+  --exclude "./.forgejo" \
   --exclude "./.planning" \
   --exclude "./.pi" \
   --exclude "./.omc" \

--- a/scripts/deploy-ref-gate.test.ts
+++ b/scripts/deploy-ref-gate.test.ts
@@ -1,0 +1,270 @@
+// Tests for the provider-neutral core01 deploy ref gate
+// (scripts/deploy-ref-gate.ts). These exercise ONLY the pure decision function
+// and the env-input assembly. They never load an env file, run migrations,
+// touch launchctl, mkdir a runtime dir, or reach production state — the whole
+// point of extracting the gate into a pure module.
+import { describe, it, expect } from "bun:test";
+import {
+  evaluateDeployGate,
+  readGateInputsFromEnv,
+} from "./deploy-ref-gate.ts";
+
+const MAIN = "1111111111111111111111111111111111111111";
+const STALE = "2222222222222222222222222222222222222222";
+
+describe("evaluateDeployGate", () => {
+  it("allows a manual dispatch from the current main tip (github)", () => {
+    const result = evaluateDeployGate({
+      provider: "github",
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows a manual dispatch from the current main tip (forgejo)", () => {
+    const result = evaluateDeployGate({
+      provider: "forgejo",
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows a version tag reachable from main", () => {
+    const result = evaluateDeployGate({
+      provider: "forgejo",
+      event: "push",
+      ref: "refs/tags/v0.1.1",
+      headSha: STALE,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("refuses a stale manual-dispatch commit that is not the main tip", () => {
+    const result = evaluateDeployGate({
+      provider: "github",
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      headSha: STALE,
+      mainSha: MAIN,
+      // Even an ancestor of main must be refused for a manual dispatch: the
+      // deploy must be the EXACT current tip.
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("not the current main tip");
+  });
+
+  it("refuses a version tag outside main ancestry", () => {
+    const result = evaluateDeployGate({
+      provider: "forgejo",
+      event: "push",
+      ref: "refs/tags/v9.9.9",
+      headSha: STALE,
+      mainSha: MAIN,
+      headReachableFromMain: false,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("not reachable from main");
+  });
+
+  it("refuses an unsupported event", () => {
+    const result = evaluateDeployGate({
+      provider: "github",
+      event: "pull_request",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("unsupported trigger");
+  });
+
+  it("refuses a push to a non-tag ref", () => {
+    const result = evaluateDeployGate({
+      provider: "forgejo",
+      event: "push",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("unsupported trigger");
+  });
+
+  it("refuses a manual dispatch on a non-main branch ref", () => {
+    const result = evaluateDeployGate({
+      provider: "github",
+      event: "workflow_dispatch",
+      ref: "refs/heads/feat/x",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("unsupported trigger");
+  });
+
+  it("refuses an unsupported provider", () => {
+    const result = evaluateDeployGate({
+      provider: "gitlab",
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("unsupported provider");
+  });
+
+  it("fails closed on missing provider metadata in CI", () => {
+    const result = evaluateDeployGate({
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("missing CI provider metadata");
+  });
+
+  it("fails closed on missing event metadata in CI", () => {
+    const result = evaluateDeployGate({
+      provider: "forgejo",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("missing CI event metadata");
+  });
+
+  it("fails closed on missing ref metadata in CI", () => {
+    const result = evaluateDeployGate({
+      provider: "forgejo",
+      event: "push",
+      headSha: MAIN,
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("missing CI ref metadata");
+  });
+
+  it("fails closed on missing HEAD/main commit metadata in CI", () => {
+    const noHead = evaluateDeployGate({
+      provider: "github",
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      mainSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(noHead.allowed).toBe(false);
+    expect(noHead.reason).toContain("missing HEAD commit metadata");
+
+    const noMain = evaluateDeployGate({
+      provider: "github",
+      event: "workflow_dispatch",
+      ref: "refs/heads/main",
+      headSha: MAIN,
+      headReachableFromMain: true,
+      isCi: true,
+    });
+    expect(noMain.allowed).toBe(false);
+    expect(noMain.reason).toContain("missing main-tip commit metadata");
+  });
+
+  it("skips the gate outside CI (operator-run deploy)", () => {
+    const result = evaluateDeployGate({ isCi: false });
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toContain("ref gate skipped");
+  });
+});
+
+describe("readGateInputsFromEnv", () => {
+  const repoFacts = {
+    headSha: MAIN,
+    mainSha: MAIN,
+    headReachableFromMain: true,
+  };
+
+  it("derives github provider from GITHUB_ACTIONS with GITHUB_* fallbacks", () => {
+    const inputs = readGateInputsFromEnv(
+      {
+        GITHUB_ACTIONS: "true",
+        GITHUB_EVENT_NAME: "workflow_dispatch",
+        GITHUB_REF: "refs/heads/main",
+      },
+      repoFacts,
+    );
+    expect(inputs.provider).toBe("github");
+    expect(inputs.event).toBe("workflow_dispatch");
+    expect(inputs.ref).toBe("refs/heads/main");
+    expect(inputs.isCi).toBe(true);
+  });
+
+  it("derives forgejo provider from FORGEJO_ACTIONS", () => {
+    const inputs = readGateInputsFromEnv(
+      {
+        FORGEJO_ACTIONS: "true",
+        GITHUB_EVENT_NAME: "push",
+        GITHUB_REF: "refs/tags/v1.0.0",
+      },
+      repoFacts,
+    );
+    expect(inputs.provider).toBe("forgejo");
+    expect(inputs.isCi).toBe(true);
+  });
+
+  it("prefers explicit DEPLOY_* inputs over GitHub env fallbacks", () => {
+    const inputs = readGateInputsFromEnv(
+      {
+        DEPLOY_PROVIDER: "forgejo",
+        DEPLOY_EVENT_NAME: "push",
+        DEPLOY_REF: "refs/tags/v2.0.0",
+        // Stale GitHub mirror must be ignored when explicit inputs are set.
+        GITHUB_ACTIONS: "true",
+        GITHUB_EVENT_NAME: "workflow_dispatch",
+        GITHUB_REF: "refs/heads/main",
+      },
+      repoFacts,
+    );
+    expect(inputs.provider).toBe("forgejo");
+    expect(inputs.event).toBe("push");
+    expect(inputs.ref).toBe("refs/tags/v2.0.0");
+    expect(inputs.isCi).toBe(true);
+  });
+
+  it("reports not-in-CI when no provider signal is present", () => {
+    const inputs = readGateInputsFromEnv({}, repoFacts);
+    expect(inputs.isCi).toBe(false);
+    expect(inputs.provider).toBe("");
+  });
+});

--- a/scripts/deploy-ref-gate.ts
+++ b/scripts/deploy-ref-gate.ts
@@ -1,0 +1,249 @@
+/**
+ * Pre-mutation deploy ref gate for the core01 production deploy.
+ *
+ * This is the single decision point that decides whether a core01 deploy is
+ * ALLOWED to mutate production, independent of which CI provider triggered it.
+ * `scripts/core01-deploy-local.sh` calls this BEFORE any staging, swap,
+ * launchd, or migration step. The gate must fail CLOSED: an unsupported,
+ * stale, or unattested trigger refuses the deploy.
+ *
+ * Two providers are supported today:
+ *   - github  (the active deploy path)
+ *   - forgejo (prepared for a future repository-scoped core01 runner)
+ *
+ * Allowed triggers (identical policy for both providers):
+ *   - a manual dispatch whose HEAD is EXACTLY the current main tip; or
+ *   - a pushed `v*` tag whose target commit is REACHABLE from main.
+ *
+ * The provider/event/ref/main-relationship facts are gathered by the caller and
+ * passed in explicitly. This module contains no git or environment access so it
+ * can be unit-tested without touching a repo, env loading, launchctl, runtime
+ * dirs, or production state.
+ *
+ * CLI usage (invoked by core01-deploy-local.sh):
+ *   bun run scripts/deploy-ref-gate.ts
+ * Inputs are read from the environment (see readGateInputsFromEnv). On an
+ * allowed deploy it exits 0; otherwise it prints a FATAL reason and exits 1.
+ */
+
+export type DeployProvider = "github" | "forgejo";
+
+export type DeployEvent = "workflow_dispatch" | "push" | (string & {});
+
+export interface DeployGateInputs {
+  /** CI provider that produced this run. */
+  provider: DeployProvider | string;
+  /** Normalized event name (workflow_dispatch or push). */
+  event: DeployEvent;
+  /** Full ref, e.g. refs/heads/main or refs/tags/v0.1.1. */
+  ref: string;
+  /** Commit being deployed (HEAD). */
+  headSha: string;
+  /** Current main-branch tip the deploy is validated against. */
+  mainSha: string;
+  /**
+   * True when headSha is reachable from mainSha (an ancestor of, or equal to,
+   * the main tip). The caller computes this from the real repo.
+   */
+  headReachableFromMain: boolean;
+  /**
+   * True when running inside a CI provider. Outside CI the gate is a no-op
+   * (local/manual operator runs are trusted), matching the prior GitHub-only
+   * behavior.
+   */
+  isCi: boolean;
+}
+
+export interface DeployGateResult {
+  allowed: boolean;
+  /** Human-readable reason, always set (success or refusal). */
+  reason: string;
+}
+
+const SUPPORTED_PROVIDERS: readonly DeployProvider[] = ["github", "forgejo"];
+
+function isVersionTagRef(ref: string): boolean {
+  return ref.startsWith("refs/tags/v");
+}
+
+function isMainBranchRef(ref: string): boolean {
+  return ref === "refs/heads/main";
+}
+
+/**
+ * Decide whether a core01 deploy is allowed. Pure: no I/O, no git, no env.
+ * Fails closed on any missing, unsupported, or stale metadata.
+ */
+export function evaluateDeployGate(
+  inputs: Partial<DeployGateInputs>,
+): DeployGateResult {
+  // Outside CI the gate does not apply (operator-run deploys are trusted, as
+  // in the original GitHub-only script). isCi must be explicitly false to skip.
+  if (inputs.isCi === false) {
+    return { allowed: true, reason: "not running in CI; ref gate skipped" };
+  }
+
+  const provider = inputs.provider;
+  const event = inputs.event;
+  const ref = inputs.ref;
+  const headSha = inputs.headSha;
+  const mainSha = inputs.mainSha;
+
+  // Fail closed when any required CI metadata is missing. Do not guess.
+  if (!provider) {
+    return {
+      allowed: false,
+      reason: "refusing core01 deploy: missing CI provider metadata",
+    };
+  }
+  if (!SUPPORTED_PROVIDERS.includes(provider as DeployProvider)) {
+    return {
+      allowed: false,
+      reason:
+        `refusing core01 deploy from unsupported provider: ${provider} ` +
+        `(supported: ${SUPPORTED_PROVIDERS.join(", ")})`,
+    };
+  }
+  if (!event) {
+    return {
+      allowed: false,
+      reason: "refusing core01 deploy: missing CI event metadata",
+    };
+  }
+  if (!ref) {
+    return {
+      allowed: false,
+      reason: "refusing core01 deploy: missing CI ref metadata",
+    };
+  }
+  if (!headSha) {
+    return {
+      allowed: false,
+      reason: "refusing core01 deploy: missing HEAD commit metadata",
+    };
+  }
+  if (!mainSha) {
+    return {
+      allowed: false,
+      reason: "refusing core01 deploy: missing main-tip commit metadata",
+    };
+  }
+
+  if (event === "workflow_dispatch" && isMainBranchRef(ref)) {
+    if (headSha !== mainSha) {
+      return {
+        allowed: false,
+        reason:
+          "refusing manual core01 deploy because HEAD is not the current " +
+          `main tip: head=${headSha} main=${mainSha}`,
+      };
+    }
+    return {
+      allowed: true,
+      reason: `manual deploy from current main tip: ${headSha}`,
+    };
+  }
+
+  if (event === "push" && isVersionTagRef(ref)) {
+    if (!inputs.headReachableFromMain) {
+      return {
+        allowed: false,
+        reason:
+          "refusing tag core01 deploy because HEAD is not reachable from " +
+          `main: ${headSha}`,
+      };
+    }
+    return {
+      allowed: true,
+      reason: `tag deploy reachable from main: ref=${ref} head=${headSha}`,
+    };
+  }
+
+  return {
+    allowed: false,
+    reason: `refusing core01 deploy from unsupported trigger: event=${event} ref=${ref}`,
+  };
+}
+
+/**
+ * Assemble gate inputs from the environment with backward-compatible GitHub
+ * fallbacks. Provider-neutral inputs win; GitHub Actions env vars are used only
+ * when the explicit inputs are absent. headSha/mainSha/headReachableFromMain
+ * are supplied by the caller (the bash script computes them from the repo).
+ */
+export function readGateInputsFromEnv(
+  env: Record<string, string | undefined>,
+  repoFacts: {
+    headSha: string;
+    mainSha: string;
+    headReachableFromMain: boolean;
+  },
+): DeployGateInputs {
+  // Explicit provider-neutral inputs take precedence.
+  const explicitProvider = env.DEPLOY_PROVIDER;
+  const explicitEvent = env.DEPLOY_EVENT_NAME;
+  const explicitRef = env.DEPLOY_REF;
+
+  // Backward-compatible fallbacks. GitHub Actions sets GITHUB_ACTIONS=true and
+  // GITHUB_EVENT_NAME/GITHUB_REF. Forgejo Actions sets FORGEJO_ACTIONS=true (and
+  // mirrors GITHUB_* for compatibility), but a repository-scoped runner should
+  // set DEPLOY_PROVIDER=forgejo explicitly so we never rely on the mirror.
+  const githubCi = env.GITHUB_ACTIONS === "true";
+  const forgejoCi = env.FORGEJO_ACTIONS === "true";
+
+  let provider = explicitProvider;
+  if (!provider) {
+    if (forgejoCi) provider = "forgejo";
+    else if (githubCi) provider = "github";
+  }
+
+  const isCi = Boolean(explicitProvider) || githubCi || forgejoCi;
+
+  const event = explicitEvent ?? env.GITHUB_EVENT_NAME ?? "";
+  const ref = explicitRef ?? env.GITHUB_REF ?? "";
+
+  return {
+    provider: provider ?? "",
+    event,
+    ref,
+    headSha: repoFacts.headSha,
+    mainSha: repoFacts.mainSha,
+    headReachableFromMain: repoFacts.headReachableFromMain,
+    isCi,
+  };
+}
+
+/**
+ * CLI entrypoint. Called by core01-deploy-local.sh, which has already gathered
+ * the repo facts (HEAD sha, main tip sha, reachability) from the real git repo
+ * and exported them, plus the provider/event/ref metadata. This process only
+ * makes the ALLOW/REFUSE decision and exits accordingly. It performs no git,
+ * env-file, launchctl, or runtime I/O.
+ *
+ * Required repo-fact env (set by the caller):
+ *   DEPLOY_HEAD_SHA              HEAD commit
+ *   DEPLOY_MAIN_SHA              current main tip
+ *   DEPLOY_HEAD_REACHABLE_FROM_MAIN  "true" when HEAD is an ancestor of main
+ */
+function main(): void {
+  const env = process.env;
+
+  const inputs = readGateInputsFromEnv(env, {
+    headSha: env.DEPLOY_HEAD_SHA ?? "",
+    mainSha: env.DEPLOY_MAIN_SHA ?? "",
+    headReachableFromMain: env.DEPLOY_HEAD_REACHABLE_FROM_MAIN === "true",
+  });
+
+  const result = evaluateDeployGate(inputs);
+
+  if (!result.allowed) {
+    console.error(`FATAL: ${result.reason}`);
+    process.exit(1);
+  }
+
+  console.log(`deploy ref gate PASSED: ${result.reason}`);
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

- add prepared Forgejo CI workflows for the current required Bun, PostgreSQL, Python, and contract gates
- isolate a future repository-scoped core01 deploy workflow from the general Linux CI pool
- generalize the deploy ref gate across GitHub and Forgejo while preserving the current GitHub policy
- add pure and temporary-git integration regressions that stop before production mutation
- document that activation and existing-repository backfill remain deferred

GitHub remains the active CI/deploy path. This PR does not create a Forgejo repository, register a runner, copy secrets, or deploy core01.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — 23 focused tests and TypeScript passed; no migration behavior changed
- [x] Python package checks passed or are not applicable — existing GitHub CI Python job passed at `4f61255`
- [x] Live Open Brain smoke passed or is not applicable — not applicable; source prep is deliberately inactive and no live deploy ran
- `shellcheck scripts/core01-deploy-local.sh`
- `/opt/homebrew/bin/bash -n scripts/core01-deploy-local.sh`
- both `.forgejo/workflows/*.yml` parse with `yq`
- every action reference is SHA-pinned
- `git diff --check`; pre-commit secret scan passed

## Critical Self-Review

- Highest-risk behavior: production ref eligibility and git ancestry calculation before core01 mutation.
- Assumptions that could be wrong: Forgejo action resolution must be configured for the pinned external actions before activation; this is documented and activation remains deferred.
- Missing/weak tests: live migration, launchd, and rollback are intentionally not executed; existing deploy behavior is preserved and the new tests prove refusal/allowed preflight stops before those paths.
- Security/permission risk: general CI and deployment labels are disjoint; no production credentials are added to workflow YAML.
- Migration/deploy risk: GitHub remains active and no Forgejo repository/runner is activated by this PR.
- Downstream client/runtime risk: none; no MCP/API contract changes.
- Rollback/cleanup concern: revert this source-only commit; current GitHub workflow remains unchanged.
- Fixes made before PR: pinned all actions by SHA and added shell/git integration coverage beyond the pure gate tests.
- Known residual risk: Forgejo-specific action resolution and live runner labels require infrastructure proof before activation.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no accepted MEDIUM+ reusable pattern has emerged from this source-only workflow preparation; any review finding will be handled before merge.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable — none accepted at the current head; exact-head review is running
- Live Open Brain checks: [ ] linked below or [x] not applicable because: activation, runner registration, and core01 deployment are explicitly deferred

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable; no MCP contract change
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- Candidate: `4f6125587e3e1f6a7608f9061eaa6c3090161383`
- GitHub remains the active production path until a separately authorized Forgejo repository cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)