### PR TITLE
feat(335): validate reflex suppression with live A/B gate

### DIFF
--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -262,22 +262,34 @@ One run:
    namespace) with the sealed synthetic corpus in
    `fixtures/reflex-ab-v1.json`. Primary seeds are either `prior_known`
    (already-supplied-this-turn) or net-new; negative seeds must never surface.
-2. Calls `agent_reflex_pointers` **twice** over the same evidence and exact
-   scope:
+2. Calls `agent_reflex_pointers` **three times** over the same evidence and
+   exact scope:
    - **OFF arm** — no `prior_context`. Every net-new authorized durable record
      surfaces as a body-free cited pointer, including the already-known seeds
      (the redundant-resurfacing baseline).
+   - **CONTROL arm** — a second unsuppressed call (still no `prior_context`)
+     over the same seed/query. It proves the known items resurface **stably**
+     across two unsuppressed calls; without it, a variable ranked recall that
+     dropped the known items on its own could be misattributed to suppression on
+     the ON arm. The OFF and CONTROL arms must resurface the **exact same
+     non-vacuous** already-known set.
    - **ON arm** — the already-known seeds' **own emitted pointer references**
      (the exact `citation_id` + structural `source_ref` the OFF arm returned for
      them, i.e. the identities a real agent would echo back) are sent as
      `prior_context`, so the shared recall suppresses them before any pointer is
-     emitted.
+     emitted. The receipt records a content-free `references_sent` count, and the
+     references must be **non-empty** and **exactly cover** the OFF arm's emitted
+     already-known set — so suppression is proven to act on precisely the items
+     that were resurfaced.
 3. Compares the arms and records content-free relevance and
-   redundant-resurfacing metrics. PASS requires suppression ON to return
-   strictly fewer already-known items (zero resurfacing) while preserving the
-   net-new evidence on **both** arms.
+   redundant-resurfacing metrics. PASS requires the two unsuppressed arms
+   (OFF/CONTROL) to resurface the same non-vacuous known set, a non-empty
+   prior_context that exactly covers it, and suppression ON to then return zero
+   redundant resurfacing while preserving the net-new evidence on **all** arms.
 4. Requires each arm to independently clear the established EVAL-3 functional
-   bar: every pointer cited (citation bijection), body-free
+   bar: every pointer cited (citation bijection with **strict per-identity
+   multiplicity** — the emitted count must equal the cited count for every
+   identity, so a duplicated or missing citation fails), body-free
    (identity/`source_ref` only — any body-bearing field fails), whole-pack
    budget respected with a complete nine-section allocation order, exact-scope
    authorized under the throwaway namespace, placement `client_owned` (no MCP

--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -223,6 +223,78 @@ bounded, operator-driven cleanup, not a gate responsibility:
 3. Never widen this into an automatic sweep inside the gate — the per-record,
    namespace-scoped teardown is the only mutation the gate is allowed to make.
 
+## Complete Context Pack Gate (EVAL-3, issue #330)
+
+A companion live gate under `eval/open-brain/live/complete-pack-*.ts` seeds a
+per-run throwaway namespace, calls the real `agent_context_pack` tool requesting
+all nine sections under one whole-pack budget, and verifies six functional
+properties (presence-or-defined-empty, exact-scope isolation, citation
+bijection, serialized whole-pack budget, per-section contribution, and an
+explicit cross-namespace denial control), then tears down exactly this run's
+records. It reuses the recall gate's config/transport/setup discipline and is
+run directly:
+
+```bash
+bun run eval/open-brain/live/complete-pack-cli.ts
+bun run eval/open-brain/live/complete-pack-cli.ts --json
+bun run eval/open-brain/live/complete-pack-cli.ts --report /Volumes/ThunderBolt/_tmp/open-brain/complete-pack.json
+```
+
+## Reflex A/B Suppression Gate (REFLEX-4, issue #335)
+
+This gate exercises the already-landed complete reflex (`agent_reflex_pointers`,
+#334 — detect/query, durable recall, prior-context suppression, cited body-free
+pointers) end to end and proves the A/B suppression contrast: suppression ON
+returns **demonstrably fewer already-known items** than suppression OFF over the
+**same seeded evidence**, with zero redundant resurfacing and the net-new
+evidence preserved.
+
+```bash
+bun run eval:reflex-ab
+bun run eval:reflex-ab -- --json
+bun run eval:reflex-ab -- --report /Volumes/ThunderBolt/_tmp/open-brain/reflex-ab.json
+bun run eval:reflex-ab -- --budget-tokens 8000
+```
+
+One run:
+
+1. Seeds a per-run throwaway namespace (plus a mandatory sibling negative
+   namespace) with the sealed synthetic corpus in
+   `fixtures/reflex-ab-v1.json`. Primary seeds are either `prior_known`
+   (already-supplied-this-turn) or net-new; negative seeds must never surface.
+2. Calls `agent_reflex_pointers` **twice** over the same evidence and exact
+   scope:
+   - **OFF arm** — no `prior_context`. Every net-new authorized durable record
+     surfaces as a body-free cited pointer, including the already-known seeds
+     (the redundant-resurfacing baseline).
+   - **ON arm** — the already-known seeds' **own emitted pointer references**
+     (the exact `citation_id` + structural `source_ref` the OFF arm returned for
+     them, i.e. the identities a real agent would echo back) are sent as
+     `prior_context`, so the shared recall suppresses them before any pointer is
+     emitted.
+3. Compares the arms and records content-free relevance and
+   redundant-resurfacing metrics. PASS requires suppression ON to return
+   strictly fewer already-known items (zero resurfacing) while preserving the
+   net-new evidence on **both** arms.
+4. Requires each arm to independently clear the established EVAL-3 functional
+   bar: every pointer cited (citation bijection), body-free
+   (identity/`source_ref` only — any body-bearing field fails), whole-pack
+   budget respected with a complete nine-section allocation order, exact-scope
+   authorized under the throwaway namespace, placement `client_owned` (no MCP
+   `_meta` injection), and no negative-namespace leak.
+5. Proves cross-namespace isolation with an explicit negative control (the
+   primary caller's read of the negative namespace must be **denied**; an
+   allowed-but-empty read is not proof), then tears down exactly this run's
+   records via per-record namespace-scoped `archive_entry`.
+
+Prompt placement is client-owned by contract: the gate only asserts the reflex
+returns resolvable pointers and `placement: "client_owned"`; it never injects
+anything into an MCP `_meta` channel. Opt-in and required environment are
+identical to the live recall gate above (`OPEN_BRAIN_LIVE_EVAL=1` plus base
+URL + token). The receipt (`schema: openbrain.reflex_ab_gate.v1`) is
+content-free: only ids, namespaces, labels, counts, and booleans — no memory
+bodies, tokens, or secrets.
+
 ## Next Expansion Points
 
 - Add a live Open Brain adapter that loads fixtures into an isolated namespace

--- a/eval/open-brain/fixtures/reflex-ab-v1.json
+++ b/eval/open-brain/fixtures/reflex-ab-v1.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "fixture_id": "open-brain-reflex-ab-v1",
+  "description": "Sealed synthetic corpus for the live REFLEX A/B suppression gate (REFLEX-4, #335). All content is invented for evaluation only and carries no real memory, secret, or token. Primary-role entries are seeded under a per-run throwaway namespace and are recallable by the reflex query as body-free pointers. prior_known entries are the 'already-known' records the model is treated as having been given this turn: the gate echoes their emitted citation ids back as prior_context on the suppression-ON arm, so a correct reflex suppresses them there while still emitting them on the suppression-OFF arm. net_new entries must survive on BOTH arms (suppression never drops net-new evidence). negative-role entries are seeded into a sibling namespace the reflex caller cannot read and must never surface as a pointer or citation on either arm.",
+  "query": "What is the pelagic drifter buoy telemetry cache eviction window, how is the sonar beacon rotation scheduled, and how does the handoff checkpoint replay work?",
+  "corpus": [
+    {
+      "id": "known-cache-eviction",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "prior_known": true,
+      "content": "The pelagic drifter buoy telemetry cache evicts every buffered reading after one hundred twenty seconds so a stale sonar sample can never dominate the fused drift estimate.",
+      "tags": ["drifter", "telemetry", "cache", "eviction"]
+    },
+    {
+      "id": "known-beacon-rotation",
+      "table": "decisions",
+      "namespace_role": "primary",
+      "prior_known": true,
+      "content": "We rotate the drifter sonar beacon channel on a ninety second schedule so overlapping estuary transmitters never collide during the telemetry handoff.",
+      "tags": ["drifter", "beacon", "rotation", "sonar"]
+    },
+    {
+      "id": "netnew-handoff-checkpoint",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "During a drifter sonar beacon rotation the handoff replays the last cached reading from the checkpoint so the drift estimate stays continuous across the channel switch.",
+      "tags": ["drifter", "beacon", "handoff", "checkpoint"]
+    },
+    {
+      "id": "netnew-fusion-weighting",
+      "table": "decisions",
+      "namespace_role": "primary",
+      "content": "The drifter fusion stage weights each sonar beacon reading by its telemetry cache age so a freshly evicted reading is trusted more than a near-stale one during the handoff.",
+      "tags": ["drifter", "fusion", "telemetry", "beacon"]
+    },
+    {
+      "id": "netnew-checkpoint-window",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The drifter handoff checkpoint retains the last sonar beacon telemetry reading for one rotation window so the replay always has a cached sample to restore.",
+      "tags": ["drifter", "checkpoint", "telemetry", "rotation"]
+    },
+    {
+      "id": "distractor-drifter-unrelated",
+      "table": "thoughts",
+      "namespace_role": "primary",
+      "content": "The coastal drifter buoy paint refurbishment schedule tracks hull maintenance and has nothing to do with the telemetry cache or sonar beacon program.",
+      "tags": ["drifter", "maintenance", "hull", "coastal"]
+    },
+    {
+      "id": "negative-beacon-secret-key",
+      "table": "decisions",
+      "namespace_role": "negative",
+      "content": "Confidential drifter sonar beacon rotation keying schedule that lives in a private namespace the eval reflex token cannot read and must never surface.",
+      "tags": ["drifter", "beacon", "rotation", "confidential"]
+    },
+    {
+      "id": "negative-telemetry-secret-cache",
+      "table": "thoughts",
+      "namespace_role": "negative",
+      "content": "Private drifter telemetry cache credential note that belongs to a namespace outside the eval token's read scope and must never be pointed at by the reflex.",
+      "tags": ["drifter", "telemetry", "cache", "private"]
+    }
+  ],
+  "prior_known_ids": ["known-cache-eviction", "known-beacon-rotation"],
+  "net_new_ids": [
+    "netnew-handoff-checkpoint",
+    "netnew-fusion-weighting",
+    "netnew-checkpoint-window"
+  ],
+  "forbidden_ids": [
+    "negative-beacon-secret-key",
+    "negative-telemetry-secret-cache"
+  ]
+}

--- a/eval/open-brain/live/__tests__/reflex-ab-fixtures.test.ts
+++ b/eval/open-brain/live/__tests__/reflex-ab-fixtures.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseReflexAbFixture } from "../reflex-ab-fixtures.ts";
+import { parseReflexPointersPayload } from "../transport.ts";
+
+// Fixture-validation + payload-parse tests for the reflex A/B gate (#335).
+// These prove the fixture's referential integrity guards fire (so the gate can
+// never seed a fixture whose known/net-new/forbidden lists disagree with the
+// corpus) and that the transport payload parser fails closed content-free on a
+// malformed body while normalizing containers on a well-formed one.
+
+const SHIPPED = JSON.parse(
+  readFileSync(
+    join(import.meta.dir, "../../fixtures/reflex-ab-v1.json"),
+    "utf8",
+  ),
+);
+
+/** A minimal structurally-valid fixture, cloned and perturbed per test. */
+function baseFixture() {
+  return {
+    schema_version: 1,
+    fixture_id: "reflex-ab-unit",
+    description: "unit",
+    query: "q",
+    corpus: [
+      {
+        id: "k1",
+        table: "thoughts",
+        namespace_role: "primary",
+        prior_known: true,
+        content: "k1",
+        tags: [],
+      },
+      {
+        id: "n1",
+        table: "thoughts",
+        namespace_role: "primary",
+        content: "n1",
+        tags: [],
+      },
+      {
+        id: "neg1",
+        table: "thoughts",
+        namespace_role: "negative",
+        content: "neg1",
+        tags: [],
+      },
+    ],
+    prior_known_ids: ["k1"],
+    net_new_ids: ["n1"],
+    forbidden_ids: ["neg1"],
+  };
+}
+
+describe("reflex A/B fixture validation", () => {
+  it("parses the shipped fixture with known/net-new/forbidden roles intact", () => {
+    const fixture = parseReflexAbFixture(SHIPPED);
+    expect(fixture.fixture_id).toBe("open-brain-reflex-ab-v1");
+    expect(fixture.prior_known_ids.length).toBeGreaterThan(0);
+    expect(fixture.net_new_ids.length).toBeGreaterThan(0);
+    // Every prior_known id is a primary-role, prior_known-flagged entry.
+    for (const id of fixture.prior_known_ids) {
+      const entry = fixture.corpus.find((c) => c.id === id)!;
+      expect(entry.namespace_role).toBe("primary");
+      expect(entry.prior_known).toBe(true);
+    }
+    // No net_new id is prior_known; forbidden ids are negative-role.
+    for (const id of fixture.net_new_ids) {
+      expect(fixture.prior_known_ids).not.toContain(id);
+    }
+    for (const id of fixture.forbidden_ids) {
+      const entry = fixture.corpus.find((c) => c.id === id)!;
+      expect(entry.namespace_role).toBe("negative");
+    }
+  });
+
+  it("accepts the minimal base fixture", () => {
+    expect(() => parseReflexAbFixture(baseFixture())).not.toThrow();
+  });
+
+  it("rejects a prior_known id that is not flagged prior_known on its entry", () => {
+    const f = baseFixture();
+    f.corpus[0]!.prior_known = false;
+    expect(() => parseReflexAbFixture(f)).toThrow(/prior_known: true/);
+  });
+
+  it("rejects a prior_known id pointing at a negative-role entry", () => {
+    const f = baseFixture();
+    f.prior_known_ids = ["neg1"];
+    expect(() => parseReflexAbFixture(f)).toThrow(/must be a primary-role/);
+  });
+
+  it("rejects a net_new id that is also prior_known", () => {
+    const f = baseFixture();
+    f.net_new_ids = ["k1"];
+    // k1 is a prior_known entry, so the prior_known-loop disjointness check fires
+    // first: an id cannot be both prior_known and net_new.
+    expect(() => parseReflexAbFixture(f)).toThrow(
+      /cannot be both prior_known and net_new/,
+    );
+  });
+
+  it("rejects a forbidden id pointing at a primary-role entry", () => {
+    const f = baseFixture();
+    f.forbidden_ids = ["n1"];
+    expect(() => parseReflexAbFixture(f)).toThrow(/must be a negative-role/);
+  });
+
+  it("rejects a corpus entry flagged prior_known but absent from prior_known_ids", () => {
+    const f = baseFixture();
+    // Add a primary seed flagged prior_known but listed in NEITHER prior_known_ids
+    // NOR net_new_ids: a silently-known seed the gate would never suppress.
+    f.corpus.push({
+      id: "k2",
+      table: "thoughts",
+      namespace_role: "primary",
+      prior_known: true,
+      content: "k2",
+      tags: [],
+    });
+    expect(() => parseReflexAbFixture(f)).toThrow(
+      /missing from prior_known_ids/,
+    );
+  });
+
+  it("rejects a duplicate corpus id", () => {
+    const f = baseFixture();
+    f.corpus.push({ ...f.corpus[1]!, prior_known: false });
+    expect(() => parseReflexAbFixture(f)).toThrow(/duplicate corpus id/);
+  });
+
+  it("rejects an unknown prior_known reference", () => {
+    const f = baseFixture();
+    f.prior_known_ids = ["does-not-exist"];
+    expect(() => parseReflexAbFixture(f)).toThrow(/unknown id/);
+  });
+});
+
+describe("parseReflexPointersPayload", () => {
+  it("fails closed content-free on a non-object body", () => {
+    expect(() => parseReflexPointersPayload("[]")).toThrow(
+      /agent_reflex_pointers:malformed-payload/,
+    );
+    expect(() => parseReflexPointersPayload("not json")).toThrow(
+      /agent_reflex_pointers:malformed-payload/,
+    );
+  });
+
+  it("normalizes missing containers to their empty forms", () => {
+    const parsed = parseReflexPointersPayload(JSON.stringify({ status: "ok" }));
+    expect(parsed.status).toBe("ok");
+    expect(parsed.placement).toBe("");
+    expect(parsed.pointers).toEqual({});
+    expect(parsed.citations).toEqual([]);
+    expect(parsed.budget).toEqual({});
+    expect(parsed.warnings.scope_denials).toEqual([]);
+    expect(parsed.warnings.degraded_sources).toEqual([]);
+    expect(parsed.warnings.truncation).toEqual([]);
+  });
+
+  it("preserves a well-formed reflex payload's structural fields", () => {
+    const body = {
+      status: "ok",
+      placement: "client_owned",
+      pointers: {
+        label: "pointers",
+        items: [{ id: "srv-1", citation_id: "brain_record:thought:srv-1" }],
+        item_count: 1,
+      },
+      citations: [{ id: "brain_record:thought:srv-1", kind: "pointer" }],
+      budget: { whole_pack: { content_char_limit: 999 } },
+      warnings: { scope_denials: [], degraded_sources: [], truncation: [] },
+    };
+    const parsed = parseReflexPointersPayload(JSON.stringify(body));
+    expect(parsed.placement).toBe("client_owned");
+    expect((parsed.pointers.items as unknown[]).length).toBe(1);
+    expect(parsed.citations.length).toBe(1);
+  });
+});

--- a/eval/open-brain/live/__tests__/reflex-ab-gate.test.ts
+++ b/eval/open-brain/live/__tests__/reflex-ab-gate.test.ts
@@ -1,0 +1,696 @@
+import { describe, expect, it } from "bun:test";
+import {
+  runReflexAbGate,
+  type ReflexAbGateClients,
+} from "../reflex-ab-gate.ts";
+import type { ReflexAbFixture } from "../reflex-ab-types.ts";
+import type { LiveEvalConfig } from "../config.ts";
+import {
+  LiveTransportError,
+  type ContextPackScope,
+  type OpenBrainLiveClient,
+  type ReflexPointersPayload,
+  type ReflexPriorContextRef,
+} from "../transport.ts";
+
+// Orchestrator tests for runReflexAbGate (REFLEX-4, #335). These drive a
+// structural fake at the OpenBrainLiveClient seam so no hosted server is
+// touched. They assert FUNCTIONAL OUTCOMES of the A/B suppression comparison —
+// suppression enabled returns demonstrably fewer already-known items with zero
+// redundant resurfacing while preserving net-new evidence, both arms are cited /
+// body-free / budget-bounded / exact-scope isolated, and the cross-namespace
+// denial control holds — never SQL shape or internal call counts. The receipt is
+// proven content-free: only ids, namespaces, counts, booleans.
+
+const CONFIG: LiveEvalConfig = {
+  baseUrl: "http://127.0.0.1:3100",
+  primaryToken: "primary-token",
+  negativeToken: "primary-token",
+  negativeTokenIsDistinct: false,
+  primaryNamespace: "eval-live-recall-reflex-ab-test",
+  negativeNamespace: "eval-live-recall-reflex-ab-test-negative",
+  searchMode: "hybrid",
+  timeoutMs: 1000,
+};
+
+const SCOPE = {
+  agent: "reflex-ab-eval",
+  platform: "eval",
+  server_id: "open-brain-reflex-ab",
+  channel_id: "reflex-ab-v1",
+  session_key: "eval:reflex-ab:v1",
+} as const;
+
+// Two prior-known primary seeds, two net-new primary seeds, one negative.
+const FIXTURE: ReflexAbFixture = {
+  schema_version: 1,
+  fixture_id: "reflex-ab-test-v1",
+  description: "test",
+  query: "drifter telemetry cache and beacon rotation and handoff checkpoint",
+  corpus: [
+    {
+      id: "known-a",
+      table: "thoughts",
+      namespace_role: "primary",
+      prior_known: true,
+      content: "known a cache eviction body",
+      tags: ["t"],
+    },
+    {
+      id: "known-b",
+      table: "decisions",
+      namespace_role: "primary",
+      prior_known: true,
+      content: "known b beacon rotation body",
+      tags: ["t"],
+    },
+    {
+      id: "netnew-a",
+      table: "thoughts",
+      namespace_role: "primary",
+      content: "netnew a handoff checkpoint body",
+      tags: ["t"],
+    },
+    {
+      id: "netnew-b",
+      table: "decisions",
+      namespace_role: "primary",
+      content: "netnew b fusion weighting body",
+      tags: ["t"],
+    },
+    {
+      id: "neg-secret",
+      table: "thoughts",
+      namespace_role: "negative",
+      content: "negative secret body that must never surface",
+      tags: ["t"],
+    },
+  ],
+  prior_known_ids: ["known-a", "known-b"],
+  net_new_ids: ["netnew-a", "netnew-b"],
+  forbidden_ids: ["neg-secret"],
+};
+
+const serverId = (fixtureId: string) => `srv-${fixtureId}`;
+const sourceTypeOf = (table: string) =>
+  table === "decisions" ? "decision" : "thought";
+const canonical = (source: string, id: string) =>
+  `brain_record:${source}:${id}`;
+
+/** Build a body-free pointer item for a primary seed's server id. */
+function pointerFor(fixtureId: string): Record<string, unknown> {
+  const entry = FIXTURE.corpus.find((c) => c.id === fixtureId)!;
+  const st = sourceTypeOf(entry.table);
+  const id = serverId(fixtureId);
+  return {
+    id,
+    source_type: st,
+    namespace: CONFIG.primaryNamespace,
+    tier: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: null,
+    citation_id: canonical(st, id),
+    source_ref: {
+      source: "brain",
+      type: st,
+      id,
+      namespace: CONFIG.primaryNamespace,
+    },
+  };
+}
+
+/**
+ * Build a well-formed reflex-pointers payload emitting the given primary fixture
+ * ids as body-free cited pointers, with a clean citation bijection, a whole-pack
+ * budget the serialized pointers fit inside, and a complete allocation order.
+ */
+function reflexPayload(
+  emittedFixtureIds: string[],
+  overrides: Partial<{
+    citations: Array<Record<string, unknown>>;
+    budget: Record<string, unknown>;
+    status: string;
+    placement: string;
+    extraPointer: Record<string, unknown>;
+    pointers: Record<string, unknown>;
+    warnings: ReflexPointersPayload["warnings"];
+  }> = {},
+): ReflexPointersPayload {
+  const items = emittedFixtureIds.map(pointerFor);
+  if (overrides.extraPointer) items.push(overrides.extraPointer);
+  const citations =
+    overrides.citations ??
+    items.map((i) => ({
+      id: i.citation_id,
+      kind: "pointer",
+      source_ref: i.source_ref,
+    }));
+
+  const pointers = overrides.pointers ?? {
+    label: "pointers",
+    namespace_scoped: true,
+    resolvable_reference_only: true,
+    items,
+    item_count: items.length,
+    truncated: false,
+  };
+  const serialized = JSON.stringify(pointers).length;
+  const budget = overrides.budget ?? {
+    requested: { max_tokens: 6000 },
+    whole_pack: {
+      content_char_limit: serialized + 500,
+      content_chars_used: serialized,
+      allocation_order: [
+        "working_set",
+        "recovery",
+        "durable_lane_context",
+        "durable_memory",
+        "profile_guidance",
+        "process_guidance",
+        "repo_facts",
+        "pointers",
+        "candidate_memory",
+      ],
+    },
+  };
+
+  return {
+    status: overrides.status ?? "ok",
+    placement: overrides.placement ?? "client_owned",
+    pointers,
+    citations,
+    budget,
+    warnings: overrides.warnings ?? {
+      scope_denials: [],
+      degraded_sources: [],
+      truncation: [],
+    },
+  };
+}
+
+interface FakeOptions {
+  /** Payload for the OFF arm (no prior_context). Defaults to all 4 primaries. */
+  offPayload?: ReflexPointersPayload;
+  /**
+   * Payload for the ON arm. When omitted, the fake computes a REALISTIC
+   * suppressed payload: it drops any pointer whose citation_id/source_ref was
+   * passed as prior_context, so a correct suppression is simulated end to end.
+   */
+  onPayload?: ReflexPointersPayload;
+  /** Override the ON arm to ignore prior_context (simulate broken suppression). */
+  onIgnoresPriorContext?: boolean;
+  reflexThrowsOn?: "off" | "on";
+  seedFailFor?: string[];
+  archiveFailFor?: string[];
+  negativeRead?: "denied" | "empty" | "leak" | "throws";
+}
+
+interface FakeState {
+  seeded: Map<string, { table: string; namespace: string }>;
+  archived: string[];
+  reflexScopes: ContextPackScope[];
+  priorContextByCall: Array<readonly ReflexPriorContextRef[] | undefined>;
+  attemptReadNamespaces: string[];
+}
+
+function makeFakeClients(opts: FakeOptions = {}): {
+  clients: ReflexAbGateClients;
+  state: FakeState;
+} {
+  const state: FakeState = {
+    seeded: new Map(),
+    archived: [],
+    reflexScopes: [],
+    priorContextByCall: [],
+    attemptReadNamespaces: [],
+  };
+  const seedFail = new Set(opts.seedFailFor ?? []);
+  const archiveFail = new Set(opts.archiveFailFor ?? []);
+  const byServerId = (id: string) => id.replace(/^srv-/, "");
+
+  const offPayload =
+    opts.offPayload ??
+    reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+
+  function suppressedPayload(
+    priorContext: readonly ReflexPriorContextRef[] | undefined,
+  ): ReflexPointersPayload {
+    if (opts.onPayload) return opts.onPayload;
+    if (opts.onIgnoresPriorContext) {
+      // Broken suppression: emit exactly what the OFF arm did.
+      return reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+    }
+    // Realistic suppression: drop any emitted pointer whose identity was passed
+    // as prior_context (by citation_id).
+    const suppressedCitations = new Set(
+      (priorContext ?? [])
+        .map((r) => r.citation_id)
+        .filter((c): c is string => typeof c === "string"),
+    );
+    const surviving = ["known-a", "known-b", "netnew-a", "netnew-b"].filter(
+      (fid) => {
+        const entry = FIXTURE.corpus.find((c) => c.id === fid)!;
+        const cid = canonical(sourceTypeOf(entry.table), serverId(fid));
+        return !suppressedCitations.has(cid);
+      },
+    );
+    return reflexPayload(surviving);
+  }
+
+  function makeClient(role: "primary" | "negative"): OpenBrainLiveClient {
+    let reflexCall = 0;
+    const fake = {
+      async logMemory(o: {
+        table: string;
+        content: string;
+        tags: string[];
+        namespace: string;
+      }) {
+        const entry = FIXTURE.corpus.find((c) => c.content === o.content);
+        const fixtureId = entry?.id ?? "unknown";
+        if (seedFail.has(fixtureId)) {
+          throw new LiveTransportError(`log:${fixtureId}:error`, false);
+        }
+        const id = serverId(fixtureId);
+        state.seeded.set(id, { table: o.table, namespace: o.namespace });
+        return { id, namespace: o.namespace, merged: false };
+      },
+      async reflexPointers(o: {
+        scope: ContextPackScope;
+        priorContext?: readonly ReflexPriorContextRef[];
+      }) {
+        state.reflexScopes.push(o.scope);
+        state.priorContextByCall.push(o.priorContext);
+        const arm = reflexCall === 0 ? "off" : "on";
+        reflexCall += 1;
+        if (opts.reflexThrowsOn === arm) {
+          throw new LiveTransportError("agent_reflex_pointers:timeout", false);
+        }
+        return arm === "off" ? offPayload : suppressedPayload(o.priorContext);
+      },
+      async attemptRead(o: {
+        namespace: string;
+      }): Promise<{ denied: boolean; hitCount: number }> {
+        if (role === "primary") {
+          state.attemptReadNamespaces.push(o.namespace);
+        }
+        switch (opts.negativeRead ?? "denied") {
+          case "denied":
+            return { denied: true, hitCount: 0 };
+          case "empty":
+            return { denied: false, hitCount: 0 };
+          case "leak":
+            return { denied: false, hitCount: 1 };
+          case "throws":
+            throw new LiveTransportError("search_brain:timeout", false);
+        }
+      },
+      async archive(o: { table: string; id: string }) {
+        const fixtureId = byServerId(o.id);
+        if (archiveFail.has(fixtureId)) {
+          throw new LiveTransportError("archive_entry:error", false);
+        }
+        state.archived.push(o.id);
+        return state.seeded.has(o.id) ? "archived" : "already_absent";
+      },
+      async close() {},
+    };
+    return fake as unknown as OpenBrainLiveClient;
+  }
+
+  return {
+    clients: {
+      primary: makeClient("primary"),
+      negative: makeClient("negative"),
+    },
+    state,
+  };
+}
+
+function run(opts: FakeOptions = {}) {
+  const { clients, state } = makeFakeClients(opts);
+  return {
+    outcome: runReflexAbGate({
+      fixture: FIXTURE,
+      config: CONFIG,
+      clients,
+      budgetMaxTokens: 6000,
+      scope: SCOPE,
+      commit: "testcommit",
+      generatedAt: "2026-07-23T00:00:00.000Z",
+    }),
+    state,
+  };
+}
+
+function assertContentFree(receipt: unknown): void {
+  const json = JSON.stringify(receipt);
+  expect(json).not.toContain("must never surface");
+  expect(json).not.toContain("cache eviction body");
+  expect(json).not.toContain("beacon rotation body");
+  expect(json).not.toContain("handoff checkpoint body");
+}
+
+describe("runReflexAbGate happy path", () => {
+  it("proves suppression returns fewer known items, preserves net-new, and PASSES", async () => {
+    const { outcome, state } = run();
+    const { receipt, passed } = await outcome;
+
+    expect(passed).toBe(true);
+    expect(receipt.failures).toEqual([]);
+    expect(receipt.seeded).toEqual({
+      primary: 4,
+      negative: 1,
+      prior_known: 2,
+      net_new: 2,
+    });
+
+    // OFF arm: all 4 primaries emitted, both known items resurfaced.
+    expect(receipt.arm_off.pointer_count).toBe(4);
+    expect(receipt.arm_off.redundant_resurfacing).toBe(2);
+    expect(receipt.arm_off.net_new_present).toBe(2);
+    expect(receipt.arm_off.net_new_missing).toBe(0);
+    expect(receipt.arm_off.namespace_leaks).toBe(0);
+    expect(receipt.arm_off.citations_bijective).toBe(true);
+    expect(receipt.arm_off.body_free).toBe(true);
+    expect(receipt.arm_off.placement_client_owned).toBe(true);
+    expect(receipt.arm_off.budget.within_budget).toBe(true);
+    expect(receipt.arm_off.budget.allocation_order_complete).toBe(true);
+
+    // ON arm: both known items suppressed, net-new preserved.
+    expect(receipt.arm_on.pointer_count).toBe(2);
+    expect(receipt.arm_on.redundant_resurfacing).toBe(0);
+    expect(receipt.arm_on.net_new_present).toBe(2);
+    expect(receipt.arm_on.net_new_missing).toBe(0);
+
+    // A/B comparison: the REFLEX-4 acceptance signal.
+    expect(receipt.comparison.known_resurfaced_off).toBe(2);
+    expect(receipt.comparison.known_resurfaced_on).toBe(0);
+    expect(receipt.comparison.known_suppressed_delta).toBe(2);
+    expect(receipt.comparison.fewer_known_when_enabled).toBe(true);
+    expect(receipt.comparison.net_new_preserved).toBe(2);
+    expect(receipt.comparison.net_new_preserved_on_both).toBe(true);
+
+    // The ON arm received the OFF arm's known-seed references as prior_context.
+    const onPriorContext = state.priorContextByCall[1];
+    expect(onPriorContext).toBeDefined();
+    expect(onPriorContext!.length).toBe(2);
+    const sentCitations = onPriorContext!.map((r) => r.citation_id).sort();
+    expect(sentCitations).toEqual(
+      [
+        canonical("thought", serverId("known-a")),
+        canonical("decision", serverId("known-b")),
+      ].sort(),
+    );
+    // The OFF arm sent NO prior_context.
+    expect(state.priorContextByCall[0]).toBeUndefined();
+
+    // Cross-namespace denial ran and denied, probing the NEGATIVE namespace.
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(true);
+    expect(state.attemptReadNamespaces).toEqual([CONFIG.negativeNamespace]);
+
+    // Both reflex calls ran under the PRIMARY throwaway namespace.
+    expect(state.reflexScopes.length).toBe(2);
+    for (const s of state.reflexScopes) {
+      expect(s.namespace).toBe(CONFIG.primaryNamespace);
+    }
+
+    // Teardown archived exactly the 5 seeded records.
+    expect(receipt.teardown).toEqual({
+      attempted: 5,
+      archived: 5,
+      already_absent: 0,
+      failed: 0,
+    });
+    assertContentFree(receipt);
+  });
+});
+
+describe("runReflexAbGate A/B contrast", () => {
+  it("fails when suppression enabled still resurfaces a known item (broken suppression)", async () => {
+    const { outcome } = run({ onIgnoresPriorContext: true });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.comparison.known_resurfaced_on).toBe(2);
+    expect(receipt.comparison.fewer_known_when_enabled).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("already-known item"))).toBe(
+      true,
+    );
+    assertContentFree(receipt);
+  });
+
+  it("fails vacuously when the OFF arm resurfaced no known items (nothing to suppress)", async () => {
+    // OFF arm emits only net-new: the known items never surfaced, so the contrast
+    // has nothing to prove. Both arms would look 'equal' on known items -> fail.
+    const offOnlyNetNew = reflexPayload(["netnew-a", "netnew-b"]);
+    const { outcome } = run({
+      offPayload: offOnlyNetNew,
+      onPayload: reflexPayload(["netnew-a", "netnew-b"]),
+    });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.comparison.known_resurfaced_off).toBe(0);
+    expect(receipt.failures.some((f) => f.includes("vacuous"))).toBe(true);
+  });
+
+  it("fails when suppression drops a net-new item (over-suppression)", async () => {
+    // ON arm drops a net-new pointer as well as the known ones — net-new must be
+    // preserved on both arms.
+    const { outcome } = run({
+      onPayload: reflexPayload(["netnew-a"]), // netnew-b missing
+    });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_on.net_new_missing).toBe(1);
+    expect(receipt.comparison.net_new_preserved_on_both).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("net-new evidence"))).toBe(
+      true,
+    );
+  });
+
+  it("fails when a net-new item is missing on the OFF arm (hollow recall)", async () => {
+    const { outcome } = run({
+      offPayload: reflexPayload(["known-a", "known-b", "netnew-a"]),
+    });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.net_new_missing).toBe(1);
+    expect(
+      receipt.failures.some((f) => f.includes("net-new record(s) missing")),
+    ).toBe(true);
+  });
+});
+
+describe("runReflexAbGate EVAL-3 functional bar per arm", () => {
+  it("fails when a pointer carries a body-bearing field (leakage)", async () => {
+    const leaky = pointerFor("netnew-a");
+    leaky.content = "netnew a handoff checkpoint body";
+    const off = reflexPayload(["known-a", "known-b", "netnew-b"], {
+      extraPointer: leaky,
+    });
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.body_free).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("body-bearing"))).toBe(true);
+    // The leaked body content never lands in the receipt.
+    assertContentFree(receipt);
+  });
+
+  it("fails when placement is not client_owned (implicit injection)", async () => {
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"], {
+      placement: "meta_injected",
+    });
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.placement_client_owned).toBe(false);
+    expect(receipt.failures.some((f) => f.includes("client_owned"))).toBe(true);
+  });
+
+  it("fails on a dangling citation with no emitted pointer", async () => {
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+    off.citations = [
+      ...off.citations,
+      { id: "brain_record:thought:ghost", kind: "pointer" },
+    ];
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.dangling_citations).toBe(1);
+    expect(receipt.arm_off.citations_bijective).toBe(false);
+  });
+
+  it("fails on an uncited emitted pointer", async () => {
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+    off.citations = off.citations.slice(0, 3);
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.uncited_pointers).toBe(1);
+    expect(receipt.arm_off.citations_bijective).toBe(false);
+  });
+
+  it("fails when serialized pointers exceed the whole-pack limit", async () => {
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+    const serialized = JSON.stringify(off.pointers).length;
+    off.budget = {
+      whole_pack: {
+        content_char_limit: serialized - 10,
+        content_chars_used: serialized,
+        allocation_order: [
+          "working_set",
+          "recovery",
+          "durable_lane_context",
+          "durable_memory",
+          "profile_guidance",
+          "process_guidance",
+          "repo_facts",
+          "pointers",
+          "candidate_memory",
+        ],
+      },
+    };
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.budget.within_budget).toBe(false);
+  });
+
+  it("fails when the whole-pack allocation order is incomplete", async () => {
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+    const serialized = JSON.stringify(off.pointers).length;
+    off.budget = {
+      whole_pack: {
+        content_char_limit: serialized + 500,
+        content_chars_used: serialized,
+        allocation_order: ["pointers"],
+      },
+    };
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.budget.allocation_order_complete).toBe(false);
+  });
+
+  it("fails when no whole-pack budget block is reported at all", async () => {
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+    off.budget = { requested: { max_tokens: 6000 } };
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.budget.content_char_limit).toBeNull();
+    expect(receipt.arm_off.budget.within_budget).toBe(false);
+  });
+});
+
+describe("runReflexAbGate isolation", () => {
+  it("fails when a forbidden negative record surfaces as a pointer", async () => {
+    // Inject the negative seeded server id as a body-free pointer (a leak). Cite
+    // it so the ONLY failure is the isolation breach.
+    const negId = serverId("neg-secret");
+    const leak = {
+      id: negId,
+      source_type: "thought",
+      namespace: CONFIG.primaryNamespace,
+      tier: null,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: null,
+      citation_id: canonical("thought", negId),
+      source_ref: { source: "brain", type: "thought", id: negId },
+    };
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"], {
+      extraPointer: leak,
+    });
+    const { outcome } = run({ offPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.namespace_leaks).toBe(1);
+    expect(receipt.failures.some((f) => f.includes("isolation breach"))).toBe(
+      true,
+    );
+    assertContentFree(receipt);
+  });
+});
+
+describe("runReflexAbGate cross-namespace denial control", () => {
+  it("FALSE-PASS regression: an allowed-but-empty negative read FAILS the gate", async () => {
+    const { outcome } = run({ negativeRead: "empty" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.arm_off.namespace_leaks).toBe(0);
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(passed).toBe(false);
+    expect(
+      receipt.failures.some((f) => f.includes("negative-control not denied")),
+    ).toBe(true);
+    assertContentFree(receipt);
+  });
+
+  it("fails on a permitted non-empty read of the negative namespace", async () => {
+    const { outcome } = run({ negativeRead: "leak" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(receipt.negative_control.observed_hit_count).toBe(1);
+    expect(passed).toBe(false);
+  });
+
+  it("fails the proof without throwing when the probe read errors", async () => {
+    const { outcome } = run({ negativeRead: "throws" });
+    const { receipt, passed } = await outcome;
+    expect(receipt.negative_control.ran).toBe(true);
+    expect(receipt.negative_control.denied).toBe(false);
+    expect(receipt.negative_control.failure).toContain(
+      "negative-control read failed",
+    );
+    expect(passed).toBe(false);
+    assertContentFree(receipt);
+  });
+});
+
+describe("runReflexAbGate teardown discipline", () => {
+  it("tears down seeded records even when the OFF reflex call throws", async () => {
+    const { outcome, state } = run({ reflexThrowsOn: "off" });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    expect(state.archived.length).toBe(5);
+  });
+
+  it("tears down seeded records even when the ON reflex call throws", async () => {
+    const { outcome, state } = run({ reflexThrowsOn: "on" });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    expect(state.archived.length).toBe(5);
+  });
+
+  it("tears down records seeded so far when seeding fails partway", async () => {
+    const { outcome, state } = run({ seedFailFor: ["neg-secret"] });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    // All four primaries seeded before the negative seed failed.
+    expect(state.archived.sort()).toEqual(
+      ["srv-known-a", "srv-known-b", "srv-netnew-a", "srv-netnew-b"].sort(),
+    );
+  });
+
+  it("preserves the content-free teardown failed count on a deferred error", async () => {
+    const { outcome } = run({
+      reflexThrowsOn: "off",
+      archiveFailFor: ["known-a"],
+    });
+    const err = await outcome.catch((e) => e as LiveTransportError);
+    expect(err).toBeInstanceOf(LiveTransportError);
+    expect(err.label).toBe("agent_reflex_pointers:timeout;teardown-failed=1");
+    expect(err.label).not.toContain("srv-");
+    expect(err.label).not.toContain("body");
+  });
+
+  it("fails the gate (never PASS) when a teardown archive fails", async () => {
+    const { outcome } = run({ archiveFailFor: ["known-a"] });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.teardown.failed).toBe(1);
+    expect(
+      receipt.failures.some((f) => f.includes("teardown failed to archive")),
+    ).toBe(true);
+    assertContentFree(receipt);
+  });
+});

--- a/eval/open-brain/live/__tests__/reflex-ab-gate.test.ts
+++ b/eval/open-brain/live/__tests__/reflex-ab-gate.test.ts
@@ -192,6 +192,12 @@ interface FakeOptions {
   /** Payload for the OFF arm (no prior_context). Defaults to all 4 primaries. */
   offPayload?: ReflexPointersPayload;
   /**
+   * Payload for the second unsuppressed CONTROL arm (no prior_context). When
+   * omitted it mirrors the OFF arm exactly (stable resurfacing). Override it to
+   * simulate a variable ranked recall that drops the known items on its own.
+   */
+  controlPayload?: ReflexPointersPayload;
+  /**
    * Payload for the ON arm. When omitted, the fake computes a REALISTIC
    * suppressed payload: it drops any pointer whose citation_id/source_ref was
    * passed as prior_context, so a correct suppression is simulated end to end.
@@ -199,7 +205,7 @@ interface FakeOptions {
   onPayload?: ReflexPointersPayload;
   /** Override the ON arm to ignore prior_context (simulate broken suppression). */
   onIgnoresPriorContext?: boolean;
-  reflexThrowsOn?: "off" | "on";
+  reflexThrowsOn?: "off" | "control" | "on";
   seedFailFor?: string[];
   archiveFailFor?: string[];
   negativeRead?: "denied" | "empty" | "leak" | "throws";
@@ -231,6 +237,9 @@ function makeFakeClients(opts: FakeOptions = {}): {
   const offPayload =
     opts.offPayload ??
     reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]);
+  // The control arm is a second unsuppressed call; by default it mirrors the OFF
+  // arm exactly, so the known items resurface stably across both.
+  const controlPayload = opts.controlPayload ?? offPayload;
 
   function suppressedPayload(
     priorContext: readonly ReflexPriorContextRef[] | undefined,
@@ -281,12 +290,15 @@ function makeFakeClients(opts: FakeOptions = {}): {
       }) {
         state.reflexScopes.push(o.scope);
         state.priorContextByCall.push(o.priorContext);
-        const arm = reflexCall === 0 ? "off" : "on";
+        const arm =
+          reflexCall === 0 ? "off" : reflexCall === 1 ? "control" : "on";
         reflexCall += 1;
         if (opts.reflexThrowsOn === arm) {
           throw new LiveTransportError("agent_reflex_pointers:timeout", false);
         }
-        return arm === "off" ? offPayload : suppressedPayload(o.priorContext);
+        if (arm === "off") return offPayload;
+        if (arm === "control") return controlPayload;
+        return suppressedPayload(o.priorContext);
       },
       async attemptRead(o: {
         namespace: string;
@@ -377,6 +389,13 @@ describe("runReflexAbGate happy path", () => {
     expect(receipt.arm_off.budget.within_budget).toBe(true);
     expect(receipt.arm_off.budget.allocation_order_complete).toBe(true);
 
+    // CONTROL arm (second unsuppressed call): mirrors the OFF baseline exactly,
+    // proving the known items resurface stably across two unsuppressed calls.
+    expect(receipt.arm_control.pointer_count).toBe(4);
+    expect(receipt.arm_control.redundant_resurfacing).toBe(2);
+    expect(receipt.arm_control.net_new_present).toBe(2);
+    expect(receipt.arm_control.net_new_missing).toBe(0);
+
     // ON arm: both known items suppressed, net-new preserved.
     expect(receipt.arm_on.pointer_count).toBe(2);
     expect(receipt.arm_on.redundant_resurfacing).toBe(0);
@@ -385,14 +404,26 @@ describe("runReflexAbGate happy path", () => {
 
     // A/B comparison: the REFLEX-4 acceptance signal.
     expect(receipt.comparison.known_resurfaced_off).toBe(2);
+    expect(receipt.comparison.known_resurfaced_control).toBe(2);
     expect(receipt.comparison.known_resurfaced_on).toBe(0);
     expect(receipt.comparison.known_suppressed_delta).toBe(2);
     expect(receipt.comparison.fewer_known_when_enabled).toBe(true);
+    // Stability control: OFF and CONTROL resurfaced the SAME non-vacuous set.
+    expect(receipt.comparison.known_resurfacing_stable).toBe(true);
+    expect(receipt.comparison.stable_known_count).toBe(2);
+    // Reference-coverage control: a non-empty prior_context that exactly covers
+    // the OFF arm's emitted known set was sent to the ON arm.
+    expect(receipt.comparison.references_sent).toBe(2);
+    expect(receipt.comparison.references_cover_off_known).toBe(true);
     expect(receipt.comparison.net_new_preserved).toBe(2);
     expect(receipt.comparison.net_new_preserved_on_both).toBe(true);
 
-    // The ON arm received the OFF arm's known-seed references as prior_context.
-    const onPriorContext = state.priorContextByCall[1];
+    // Only the ON arm (third call) received prior_context; both unsuppressed
+    // arms (OFF, CONTROL) sent none.
+    expect(state.priorContextByCall.length).toBe(3);
+    expect(state.priorContextByCall[0]).toBeUndefined();
+    expect(state.priorContextByCall[1]).toBeUndefined();
+    const onPriorContext = state.priorContextByCall[2];
     expect(onPriorContext).toBeDefined();
     expect(onPriorContext!.length).toBe(2);
     const sentCitations = onPriorContext!.map((r) => r.citation_id).sort();
@@ -402,16 +433,14 @@ describe("runReflexAbGate happy path", () => {
         canonical("decision", serverId("known-b")),
       ].sort(),
     );
-    // The OFF arm sent NO prior_context.
-    expect(state.priorContextByCall[0]).toBeUndefined();
 
     // Cross-namespace denial ran and denied, probing the NEGATIVE namespace.
     expect(receipt.negative_control.ran).toBe(true);
     expect(receipt.negative_control.denied).toBe(true);
     expect(state.attemptReadNamespaces).toEqual([CONFIG.negativeNamespace]);
 
-    // Both reflex calls ran under the PRIMARY throwaway namespace.
-    expect(state.reflexScopes.length).toBe(2);
+    // All three reflex calls ran under the PRIMARY throwaway namespace.
+    expect(state.reflexScopes.length).toBe(3);
     for (const s of state.reflexScopes) {
       expect(s.namespace).toBe(CONFIG.primaryNamespace);
     }
@@ -479,6 +508,134 @@ describe("runReflexAbGate A/B contrast", () => {
     expect(
       receipt.failures.some((f) => f.includes("net-new record(s) missing")),
     ).toBe(true);
+  });
+});
+
+describe("runReflexAbGate stability control", () => {
+  it("fails when the unsuppressed control arm resurfaces a DIFFERENT known set (variable recall)", async () => {
+    // OFF resurfaces both known items; the CONTROL replay resurfaces only one of
+    // them. A variable recall dropped a known item on its own, so the ON arm's
+    // zero cannot be attributed to suppression -> the contrast is not sound.
+    const { outcome } = run({
+      offPayload: reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"]),
+      controlPayload: reflexPayload(["known-a", "netnew-a", "netnew-b"]),
+    });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.comparison.known_resurfaced_off).toBe(2);
+    expect(receipt.comparison.known_resurfaced_control).toBe(1);
+    expect(receipt.comparison.known_resurfacing_stable).toBe(false);
+    expect(receipt.comparison.stable_known_count).toBe(0);
+    expect(
+      receipt.failures.some((f) =>
+        f.includes("unsuppressed known resurfacing is not stable"),
+      ),
+    ).toBe(true);
+    assertContentFree(receipt);
+  });
+
+  it("fails when a known item is emitted without a resolvable identity (references cannot cover it)", async () => {
+    // known-b surfaces on the OFF arm as a body-free pointer but carries NO
+    // citation_id and NO structural source_ref, so the gate cannot build a
+    // prior_context reference for it. references_sent then does not cover the
+    // OFF arm's emitted known set and the suppression contrast is unattributable.
+    const strippedKnownB: Record<string, unknown> = {
+      id: serverId("known-b"),
+      source_type: "decision",
+      namespace: CONFIG.primaryNamespace,
+      tier: null,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: null,
+    };
+    const off = reflexPayload(["known-a", "netnew-a", "netnew-b"], {
+      extraPointer: strippedKnownB,
+    });
+    // The emitted known-b pointer has no citation_id, so it needs no citation to
+    // stay bijective; the OFF arm's citations already cover the cited pointers.
+    const { outcome } = run({
+      offPayload: off,
+      controlPayload: off,
+    });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    // Both known items resurfaced, but only known-a was referenceable.
+    expect(receipt.comparison.known_resurfaced_off).toBe(2);
+    expect(receipt.comparison.references_sent).toBe(1);
+    expect(receipt.comparison.references_cover_off_known).toBe(false);
+    expect(
+      receipt.failures.some((f) =>
+        f.includes(
+          "do not exactly cover the off arm's emitted already-known set",
+        ),
+      ),
+    ).toBe(true);
+    assertContentFree(receipt);
+  });
+});
+
+describe("runReflexAbGate citation multiplicity bijection", () => {
+  // Build the natural one-citation-per-emitted-pointer list for a fixture set,
+  // matching reflexPayload's default so a test can then perturb ONE identity.
+  const citationsFor = (fixtureIds: string[]) =>
+    fixtureIds.map((fid) => {
+      const entry = FIXTURE.corpus.find((c) => c.id === fid)!;
+      const st = sourceTypeOf(entry.table);
+      return {
+        id: canonical(st, serverId(fid)),
+        kind: "pointer",
+      };
+    });
+
+  it("accepts an identity emitted and cited with equal multiplicity (>1)", async () => {
+    // Emit known-a twice (same identity) and cite it twice: emitted count ==
+    // cited count per identity, so the bijection must hold even though the old
+    // Math.max(-1) logic wrongly flagged a legitimate equal-multiplicity pair.
+    const dupPointer = pointerFor("known-a");
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"], {
+      extraPointer: dupPointer,
+      // known-a cited twice (once for each emitted copy); everything else once.
+      citations: [
+        ...citationsFor(["known-a", "known-b", "netnew-a", "netnew-b"]),
+        { id: canonical("thought", serverId("known-a")), kind: "pointer" },
+      ],
+    });
+    const { outcome } = run({ offPayload: off, controlPayload: off });
+    const { receipt } = await outcome;
+    expect(receipt.arm_off.citations_bijective).toBe(true);
+    expect(receipt.arm_off.dangling_citations).toBe(0);
+    expect(receipt.arm_off.uncited_pointers).toBe(0);
+  });
+
+  it("fails when an identity is emitted twice but cited once (uncited surplus)", async () => {
+    const dupPointer = pointerFor("known-a");
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"], {
+      extraPointer: dupPointer,
+      // known-a emitted twice but cited ONLY once: emitted=2, cited=1 -> one
+      // uncited surplus. The old lenient logic tolerated this off-by-one.
+      citations: citationsFor(["known-a", "known-b", "netnew-a", "netnew-b"]),
+    });
+    const { outcome } = run({ offPayload: off, controlPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.citations_bijective).toBe(false);
+    expect(receipt.arm_off.uncited_pointers).toBe(1);
+    expect(receipt.arm_off.dangling_citations).toBe(0);
+  });
+
+  it("fails when an identity is cited twice but emitted once (dangling surplus)", async () => {
+    // known-a emitted once but cited TWICE: cited=2, emitted=1 -> one dangling.
+    const off = reflexPayload(["known-a", "known-b", "netnew-a", "netnew-b"], {
+      citations: [
+        ...citationsFor(["known-a", "known-b", "netnew-a", "netnew-b"]),
+        { id: canonical("thought", serverId("known-a")), kind: "pointer" },
+      ],
+    });
+    const { outcome } = run({ offPayload: off, controlPayload: off });
+    const { receipt, passed } = await outcome;
+    expect(passed).toBe(false);
+    expect(receipt.arm_off.citations_bijective).toBe(false);
+    expect(receipt.arm_off.dangling_citations).toBe(1);
+    expect(receipt.arm_off.uncited_pointers).toBe(0);
   });
 });
 
@@ -652,6 +809,12 @@ describe("runReflexAbGate cross-namespace denial control", () => {
 describe("runReflexAbGate teardown discipline", () => {
   it("tears down seeded records even when the OFF reflex call throws", async () => {
     const { outcome, state } = run({ reflexThrowsOn: "off" });
+    await expect(outcome).rejects.toThrow(LiveTransportError);
+    expect(state.archived.length).toBe(5);
+  });
+
+  it("tears down seeded records even when the CONTROL reflex call throws", async () => {
+    const { outcome, state } = run({ reflexThrowsOn: "control" });
     await expect(outcome).rejects.toThrow(LiveTransportError);
     expect(state.archived.length).toBe(5);
   });

--- a/eval/open-brain/live/reflex-ab-cli.ts
+++ b/eval/open-brain/live/reflex-ab-cli.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bun
+// Single-command live REFLEX A/B suppression gate (REFLEX-4, issue #335).
+//
+//   bun run eval/open-brain/live/reflex-ab-cli.ts
+//   bun run eval/open-brain/live/reflex-ab-cli.ts --json
+//   bun run eval/open-brain/live/reflex-ab-cli.ts --report <path>
+//   bun run eval/open-brain/live/reflex-ab-cli.ts --budget-tokens 8000
+//
+// Requires opt-in: OPEN_BRAIN_LIVE_EVAL=1 plus base URL + token env vars (see
+// eval/open-brain/README.md). One invocation seeds a unique throwaway namespace
+// with the sealed synthetic corpus, calls the real `agent_reflex_pointers` tool
+// TWICE over the same seeded evidence (suppression OFF then ON), compares the two
+// arms (suppression enabled must return demonstrably fewer already-known items
+// with zero redundant resurfacing while preserving net-new evidence), proves
+// cross-namespace denial, tears down exactly this run's records, and exits
+// nonzero on any failed property.
+//
+// Output is content-free: only ids, namespaces, labels, counts, and statuses.
+// No memory bodies, tokens, or secrets are ever printed.
+
+import { randomUUID } from "node:crypto";
+import { loadLiveConfig, makeRunId } from "./config.ts";
+import { loadReflexAbFixture } from "./reflex-ab-fixtures.ts";
+import { runReflexAbGate } from "./reflex-ab-gate.ts";
+import type { ReflexAbGateClients } from "./reflex-ab-gate.ts";
+import { setUpReflexAbClients } from "./reflex-ab-setup.ts";
+import type { ReflexArmVerdict } from "./reflex-ab-types.ts";
+
+const FIXTURE_PATH = "eval/open-brain/fixtures/reflex-ab-v1.json";
+// Whole-pack budget large enough to admit every seeded pointer plus its
+// citations on the OFF arm while still exercising the serialized-budget
+// accounting. It is an eval knob (overridable with --budget-tokens), not a
+// production threshold, so it lives here rather than in thresholds.json.
+const DEFAULT_BUDGET_MAX_TOKENS = 6000;
+
+// A fixed synthetic active scope for the reflex build. The namespace is the
+// per-run throwaway namespace (bound inside the gate); these coordinates address
+// a lane that does not exist for the fresh scope, exactly like the complete-pack
+// gate.
+const REFLEX_SCOPE = {
+  agent: "reflex-ab-eval",
+  platform: "eval",
+  server_id: "open-brain-reflex-ab",
+  channel_id: "reflex-ab-v1",
+  session_key: "eval:reflex-ab:v1",
+} as const;
+
+function argValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of Bun.argv.slice(2)) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  const index = Bun.argv.indexOf(`--${name}`);
+  const next = index >= 0 ? Bun.argv[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+async function gitCommit(): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    return code === 0 ? output.trim() : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+async function main(): Promise<number> {
+  const commit = await gitCommit();
+  const runId = makeRunId({
+    prefix: commit.slice(0, 12),
+    randomHex: randomUUID().replace(/-/g, "").slice(0, 12),
+  });
+  const config = loadLiveConfig(runId);
+  const fixture = await loadReflexAbFixture(FIXTURE_PATH);
+  const generatedAt = new Date().toISOString();
+
+  const budgetRaw = argValue("budget-tokens");
+  let budgetMaxTokens = DEFAULT_BUDGET_MAX_TOKENS;
+  if (budgetRaw !== undefined) {
+    const parsed = Number.parseInt(budgetRaw, 10);
+    if (Number.isNaN(parsed) || parsed < 100) {
+      throw new Error("--budget-tokens must be an integer >= 100");
+    }
+    budgetMaxTokens = parsed;
+  }
+
+  const clients: ReflexAbGateClients = await setUpReflexAbClients(config);
+
+  try {
+    const outcome = await runReflexAbGate({
+      fixture,
+      config,
+      clients,
+      budgetMaxTokens,
+      scope: REFLEX_SCOPE,
+      commit,
+      generatedAt,
+    });
+
+    const reportPath = argValue("report");
+    if (reportPath) {
+      await Bun.write(
+        reportPath,
+        `${JSON.stringify(outcome.receipt, null, 2)}\n`,
+      );
+    }
+
+    if (Bun.argv.includes("--json")) {
+      console.log(JSON.stringify(outcome.receipt, null, 2));
+    } else {
+      printReceipt(outcome.receipt);
+      if (reportPath) console.log(`\nWrote receipt: ${reportPath}`);
+    }
+
+    return outcome.passed ? 0 : 1;
+  } finally {
+    await clients.primary.close().catch(() => {});
+    await clients.negative.close().catch(() => {});
+  }
+}
+
+function armLine(v: ReflexArmVerdict): string {
+  return (
+    `- arm=${v.arm} pointers=${v.pointer_count} net_new_present=${v.net_new_present} ` +
+    `net_new_missing=${v.net_new_missing} redundant_resurfacing=${v.redundant_resurfacing} ` +
+    `leaks=${v.namespace_leaks} bijective=${v.citations_bijective} body_free=${v.body_free} ` +
+    `client_owned=${v.placement_client_owned} within_budget=${v.budget.within_budget} ` +
+    `alloc_order_complete=${v.budget.allocation_order_complete} ` +
+    `serialized=${v.budget.serialized_pointers_chars}/${v.budget.content_char_limit ?? "none"}`
+  );
+}
+
+function printReceipt(
+  receipt: Awaited<ReturnType<typeof runReflexAbGate>>["receipt"],
+): void {
+  const verdict = receipt.passed ? "PASS" : "FAIL";
+  const lines = [
+    `Open Brain reflex A/B suppression gate: ${verdict}`,
+    `fixture=${receipt.fixture_id} commit=${receipt.commit}`,
+    `namespace=${receipt.primary_namespace} (negative=${receipt.negative_namespace})`,
+    `seeded primary=${receipt.seeded.primary} negative=${receipt.seeded.negative} prior_known=${receipt.seeded.prior_known} net_new=${receipt.seeded.net_new}`,
+    armLine(receipt.arm_off),
+    armLine(receipt.arm_on),
+    `comparison known_off=${receipt.comparison.known_resurfaced_off} known_on=${receipt.comparison.known_resurfaced_on} suppressed_delta=${receipt.comparison.known_suppressed_delta} fewer_when_enabled=${receipt.comparison.fewer_known_when_enabled} net_new_preserved=${receipt.comparison.net_new_preserved} preserved_on_both=${receipt.comparison.net_new_preserved_on_both}`,
+    `negative_control ran=${receipt.negative_control.ran} denied=${receipt.negative_control.denied} observed_hit_count=${receipt.negative_control.observed_hit_count} cross_token=${receipt.negative_control.cross_token}${receipt.negative_control.failure ? ` failure=${receipt.negative_control.failure}` : ""}`,
+    `teardown attempted=${receipt.teardown.attempted} archived=${receipt.teardown.archived} already_absent=${receipt.teardown.already_absent} failed=${receipt.teardown.failed}`,
+  ];
+  if (receipt.failures.length > 0) {
+    lines.push(`failures: ${receipt.failures.join("; ")}`);
+  }
+  console.log(lines.join("\n"));
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Reflex A/B suppression gate error: ${message}`);
+      process.exitCode = 2;
+    });
+}

--- a/eval/open-brain/live/reflex-ab-cli.ts
+++ b/eval/open-brain/live/reflex-ab-cli.ts
@@ -124,9 +124,9 @@ async function main(): Promise<number> {
   }
 }
 
-function armLine(v: ReflexArmVerdict): string {
+function armLine(v: ReflexArmVerdict, label?: string): string {
   return (
-    `- arm=${v.arm} pointers=${v.pointer_count} net_new_present=${v.net_new_present} ` +
+    `- arm=${label ?? v.arm} pointers=${v.pointer_count} net_new_present=${v.net_new_present} ` +
     `net_new_missing=${v.net_new_missing} redundant_resurfacing=${v.redundant_resurfacing} ` +
     `leaks=${v.namespace_leaks} bijective=${v.citations_bijective} body_free=${v.body_free} ` +
     `client_owned=${v.placement_client_owned} within_budget=${v.budget.within_budget} ` +
@@ -145,8 +145,9 @@ function printReceipt(
     `namespace=${receipt.primary_namespace} (negative=${receipt.negative_namespace})`,
     `seeded primary=${receipt.seeded.primary} negative=${receipt.seeded.negative} prior_known=${receipt.seeded.prior_known} net_new=${receipt.seeded.net_new}`,
     armLine(receipt.arm_off),
+    armLine(receipt.arm_control, "control"),
     armLine(receipt.arm_on),
-    `comparison known_off=${receipt.comparison.known_resurfaced_off} known_on=${receipt.comparison.known_resurfaced_on} suppressed_delta=${receipt.comparison.known_suppressed_delta} fewer_when_enabled=${receipt.comparison.fewer_known_when_enabled} net_new_preserved=${receipt.comparison.net_new_preserved} preserved_on_both=${receipt.comparison.net_new_preserved_on_both}`,
+    `comparison known_off=${receipt.comparison.known_resurfaced_off} known_control=${receipt.comparison.known_resurfaced_control} known_on=${receipt.comparison.known_resurfaced_on} suppressed_delta=${receipt.comparison.known_suppressed_delta} fewer_when_enabled=${receipt.comparison.fewer_known_when_enabled} stable=${receipt.comparison.known_resurfacing_stable} stable_known=${receipt.comparison.stable_known_count} references_sent=${receipt.comparison.references_sent} references_cover=${receipt.comparison.references_cover_off_known} net_new_preserved=${receipt.comparison.net_new_preserved} preserved_on_all=${receipt.comparison.net_new_preserved_on_both}`,
     `negative_control ran=${receipt.negative_control.ran} denied=${receipt.negative_control.denied} observed_hit_count=${receipt.negative_control.observed_hit_count} cross_token=${receipt.negative_control.cross_token}${receipt.negative_control.failure ? ` failure=${receipt.negative_control.failure}` : ""}`,
     `teardown attempted=${receipt.teardown.attempted} archived=${receipt.teardown.archived} already_absent=${receipt.teardown.already_absent} failed=${receipt.teardown.failed}`,
   ];

--- a/eval/open-brain/live/reflex-ab-fixtures.ts
+++ b/eval/open-brain/live/reflex-ab-fixtures.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import type { ReflexAbFixture } from "./reflex-ab-types.ts";
+
+// Zod validation for the reflex A/B fixture. Loading is fail-closed: a malformed
+// fixture aborts the gate before any live write happens, exactly like the
+// recall/complete-pack gates' fixture loaders.
+
+const corpusEntrySchema = z.object({
+  id: z.string().min(1),
+  table: z.enum(["thoughts", "decisions"]),
+  namespace_role: z.enum(["primary", "negative"]),
+  prior_known: z.boolean().optional(),
+  content: z.string().min(1),
+  tags: z.array(z.string()),
+});
+
+export const reflexAbFixtureSchema: z.ZodType<ReflexAbFixture> = z.object({
+  schema_version: z.literal(1),
+  fixture_id: z.string().min(1),
+  description: z.string(),
+  query: z.string().min(1),
+  corpus: z.array(corpusEntrySchema).min(1),
+  prior_known_ids: z.array(z.string().min(1)).min(1),
+  net_new_ids: z.array(z.string().min(1)).min(1),
+  forbidden_ids: z.array(z.string().min(1)).min(1),
+});
+
+/**
+ * Parse and structurally validate a reflex A/B fixture, then check referential
+ * integrity so the gate can never seed a fixture whose expectations do not match
+ * its corpus:
+ *  - corpus ids are unique;
+ *  - every prior_known id exists, is a primary-role entry, AND is flagged
+ *    `prior_known: true` (the flag and the list must agree, so the suppression
+ *    references the gate sends match the ground-truth known set exactly);
+ *  - every net_new id exists, is a primary-role entry, and is NOT prior_known
+ *    (a seed cannot be both already-known and net-new);
+ *  - prior_known and net_new are disjoint;
+ *  - every forbidden id exists and is a negative-role entry;
+ *  - every `prior_known: true` corpus entry is listed in prior_known_ids (no
+ *    silently-known seed the gate would fail to send as prior context).
+ */
+export function parseReflexAbFixture(raw: unknown): ReflexAbFixture {
+  const fixture = reflexAbFixtureSchema.parse(raw);
+
+  const byId = new Map<string, (typeof fixture.corpus)[number]>();
+  for (const entry of fixture.corpus) {
+    if (byId.has(entry.id)) {
+      throw new Error(`duplicate corpus id: ${entry.id}`);
+    }
+    byId.set(entry.id, entry);
+  }
+
+  const priorKnownSet = new Set(fixture.prior_known_ids);
+  const netNewSet = new Set(fixture.net_new_ids);
+
+  for (const id of fixture.prior_known_ids) {
+    const entry = byId.get(id);
+    if (!entry) {
+      throw new Error(`prior_known_ids references unknown id ${id}`);
+    }
+    if (entry.namespace_role !== "primary") {
+      throw new Error(`prior_known id ${id} must be a primary-role entry`);
+    }
+    if (entry.prior_known !== true) {
+      throw new Error(
+        `prior_known id ${id} must carry prior_known: true on its corpus entry`,
+      );
+    }
+    if (netNewSet.has(id)) {
+      throw new Error(`id ${id} cannot be both prior_known and net_new`);
+    }
+  }
+
+  for (const id of fixture.net_new_ids) {
+    const entry = byId.get(id);
+    if (!entry) {
+      throw new Error(`net_new_ids references unknown id ${id}`);
+    }
+    if (entry.namespace_role !== "primary") {
+      throw new Error(`net_new id ${id} must be a primary-role entry`);
+    }
+    if (entry.prior_known === true || priorKnownSet.has(id)) {
+      throw new Error(`net_new id ${id} must not be prior_known`);
+    }
+  }
+
+  for (const id of fixture.forbidden_ids) {
+    const entry = byId.get(id);
+    if (!entry) {
+      throw new Error(`forbidden_ids references unknown id ${id}`);
+    }
+    if (entry.namespace_role !== "negative") {
+      throw new Error(`forbidden id ${id} must be a negative-role entry`);
+    }
+  }
+
+  // Every corpus entry flagged prior_known must be declared in prior_known_ids,
+  // so the gate always sends a prior_context reference for it. A silently-flagged
+  // seed the gate never suppresses would let the ON arm resurface it and the gate
+  // would not even know it was supposed to be suppressed.
+  for (const entry of fixture.corpus) {
+    if (entry.prior_known === true && !priorKnownSet.has(entry.id)) {
+      throw new Error(
+        `corpus entry ${entry.id} is prior_known but missing from prior_known_ids`,
+      );
+    }
+  }
+
+  return fixture;
+}
+
+/** Load and validate a reflex A/B fixture from disk. */
+export async function loadReflexAbFixture(
+  path: string,
+): Promise<ReflexAbFixture> {
+  let raw: unknown;
+  try {
+    raw = await Bun.file(path).json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read reflex A/B fixture ${path}: ${message}`);
+  }
+  try {
+    return parseReflexAbFixture(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid reflex A/B fixture ${path}: ${message}`);
+  }
+}

--- a/eval/open-brain/live/reflex-ab-gate.ts
+++ b/eval/open-brain/live/reflex-ab-gate.ts
@@ -1,0 +1,706 @@
+import type { LiveEvalConfig } from "./config.ts";
+import {
+  LiveTransportError,
+  type ContextPackScope,
+  type OpenBrainLiveClient,
+  type ReflexPointersPayload,
+  type ReflexPriorContextRef,
+} from "./transport.ts";
+import { withTeardownFailedCount } from "./gate.ts";
+import type {
+  ReflexAbComparison,
+  ReflexAbFixture,
+  ReflexAbNegativeControl,
+  ReflexAbReceipt,
+  ReflexAbSeededRecord,
+  ReflexArmVerdict,
+} from "./reflex-ab-types.ts";
+
+// Live REFLEX A/B suppression gate orchestrator (REFLEX-4, issue #335).
+//
+// One run:
+//   1. Seed a unique throwaway namespace (and a mandatory sibling negative
+//      namespace) with the sealed synthetic corpus.
+//   2. Call the real `agent_reflex_pointers` tool TWICE over the SAME seeded
+//      evidence and exact scope:
+//        - OFF arm: no prior_context. Every net-new authorized durable record
+//          surfaces as a body-free cited pointer -- including the "already-known"
+//          seeds (that is the redundant-resurfacing baseline).
+//        - ON arm: the ALREADY-KNOWN seeds' OWN emitted pointer references
+//          (the exact citation_id + source_ref the OFF arm returned for them) are
+//          echoed back as prior_context, so the shared recall suppresses them
+//          before any pointer is emitted.
+//   3. Compare: suppression ENABLED must return DEMONSTRABLY FEWER already-known
+//      items (zero redundant resurfacing) while preserving the net-new evidence
+//      both arms share.
+//   4. Prove cross-namespace denial with an explicit negative control.
+//   5. ALWAYS tear down exactly this run's records -- even on partial failure.
+//
+// The A/B contrast is built from the REAL references the tool emitted for the
+// known seeds, not a fabricated citation string: a real agent echoes back the
+// identities it was handed, so feeding the OFF arm's own known-seed pointers as
+// the ON arm's prior_context exercises the exact suppression bijection.
+//
+// Both arms independently clear the established EVAL-3 functional bar: every
+// pointer cited (citation bijection), body-free (identity/source_ref only),
+// whole-pack budget respected with a complete allocation order, exact-scope
+// authorized, and no negative-namespace leak. The receipt is content-free:
+// labels, ids, counts, booleans -- never a memory body. Placement stays
+// client-owned; the gate never injects into an MCP _meta channel.
+
+export interface ReflexAbGateClients {
+  /** Reads/writes/archives the primary throwaway namespace and runs the reflex. */
+  primary: OpenBrainLiveClient;
+  /** Seeds/archives the negative sibling namespace (mandatory isolation control). */
+  negative: OpenBrainLiveClient;
+}
+
+export interface RunReflexAbGateOptions {
+  fixture: ReflexAbFixture;
+  config: LiveEvalConfig;
+  clients: ReflexAbGateClients;
+  /** Whole-pack budget in tokens for each reflex build (shared by both arms). */
+  budgetMaxTokens: number;
+  /** Exact non-namespace scope coordinates for the reflex call. */
+  scope: {
+    agent: string;
+    platform: string;
+    server_id: string;
+    channel_id: string;
+    thread_id?: string | null;
+    session_key: string;
+  };
+  commit: string;
+  generatedAt: string;
+}
+
+export interface ReflexAbGateOutcome {
+  receipt: ReflexAbReceipt;
+  passed: boolean;
+}
+
+interface TeardownTally {
+  attempted: number;
+  archived: number;
+  already_absent: number;
+  failed: number;
+}
+
+/**
+ * Seed one entry with the owning client for its namespace role. Both clients
+ * always exist (the negative control is mandatory), so seeding never silently
+ * skips a corpus entry. Mirrors the complete-pack gate's seedEntry.
+ */
+async function seedEntry(
+  entry: ReflexAbFixture["corpus"][number],
+  config: LiveEvalConfig,
+  clients: ReflexAbGateClients,
+): Promise<ReflexAbSeededRecord> {
+  const isNegative = entry.namespace_role === "negative";
+  const client = isNegative ? clients.negative : clients.primary;
+  const namespace = isNegative
+    ? config.negativeNamespace
+    : config.primaryNamespace;
+
+  const result = await client.logMemory({
+    table: entry.table,
+    content: entry.content,
+    tags: entry.tags,
+    namespace,
+  });
+  return {
+    fixture_id: entry.id,
+    table: entry.table,
+    server_id: result.id,
+    namespace,
+    namespace_role: entry.namespace_role,
+    prior_known: entry.prior_known === true,
+  };
+}
+
+/**
+ * Archive every seeded record through its owning client, tolerating individual
+ * failures so one bad archive never strands the rest. Identical discipline to the
+ * recall/complete-pack gates' teardown.
+ */
+async function teardown(
+  seeded: ReflexAbSeededRecord[],
+  clients: ReflexAbGateClients,
+): Promise<TeardownTally> {
+  const tally: TeardownTally = {
+    attempted: 0,
+    archived: 0,
+    already_absent: 0,
+    failed: 0,
+  };
+  for (const record of seeded) {
+    const client =
+      record.namespace_role === "negative" ? clients.negative : clients.primary;
+    tally.attempted += 1;
+    try {
+      const outcome = await client.archive({
+        table: record.table,
+        id: record.server_id,
+      });
+      if (outcome === "archived") tally.archived += 1;
+      else tally.already_absent += 1;
+    } catch {
+      // Content-free: the count is the only signal the receipt needs.
+      tally.failed += 1;
+    }
+  }
+  return tally;
+}
+
+/** Read the emitted pointer items array (opaque records) from a reflex payload. */
+function pointerItemsOf(
+  payload: ReflexPointersPayload,
+): Array<Record<string, unknown>> {
+  const items = payload.pointers.items;
+  if (!Array.isArray(items)) return [];
+  return items.filter(
+    (row): row is Record<string, unknown> =>
+      !!row && typeof row === "object" && !Array.isArray(row),
+  );
+}
+
+/** Extract a pointer item's server id (the durable record's own id). */
+function pointerServerId(item: Record<string, unknown>): string | null {
+  const id = item.id;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+/**
+ * True when a pointer item is body-free: it carries ONLY identity/structural
+ * coordinates and NO body-bearing field. Any of content/content_preview/label/
+ * preview/text/rationale/title on a pointer is body leakage and fails the arm.
+ * The structural source_ref is allowed (it is identity coordinates only); a
+ * source_ref carrying a display/body field is itself a leak.
+ */
+const BODY_BEARING_FIELDS = [
+  "content",
+  "content_preview",
+  "label",
+  "preview",
+  "text",
+  "rationale",
+  "title",
+  "body",
+];
+
+function pointerIsBodyFree(item: Record<string, unknown>): boolean {
+  for (const field of BODY_BEARING_FIELDS) {
+    if (field in item) return false;
+  }
+  const ref = item.source_ref;
+  if (ref && typeof ref === "object" && !Array.isArray(ref)) {
+    const refRec = ref as Record<string, unknown>;
+    for (const field of BODY_BEARING_FIELDS) {
+      if (field in refRec) return false;
+    }
+  }
+  return true;
+}
+
+/** The nine canonical pack sections the whole-pack allocation order must cover. */
+const PACK_ALLOCATION_SECTIONS = [
+  "working_set",
+  "recovery",
+  "durable_lane_context",
+  "durable_memory",
+  "profile_guidance",
+  "process_guidance",
+  "repo_facts",
+  "pointers",
+  "candidate_memory",
+] as const;
+
+/**
+ * The prior-context references (citation_id + structural source_ref) the OFF arm
+ * emitted for the already-known seeds. These exact references are fed back to the
+ * ON arm as prior_context -- the real identities a model would echo back -- so
+ * the ON arm exercises the actual suppression bijection rather than a fabricated
+ * citation string.
+ */
+interface KnownPointerRefs {
+  refs: ReflexPriorContextRef[];
+  /** Fixture ids of known seeds that were actually emitted by the OFF arm. */
+  emittedKnownFixtureIds: string[];
+}
+
+function collectKnownPointerRefs(
+  offPayload: ReflexPointersPayload,
+  serverIdToRecord: Map<string, ReflexAbSeededRecord>,
+): KnownPointerRefs {
+  const refs: ReflexPriorContextRef[] = [];
+  const emittedKnownFixtureIds: string[] = [];
+  for (const item of pointerItemsOf(offPayload)) {
+    const serverId = pointerServerId(item);
+    if (!serverId) continue;
+    const record = serverIdToRecord.get(serverId);
+    if (!record || !record.prior_known) continue;
+
+    const ref: ReflexPriorContextRef = {};
+    if (typeof item.citation_id === "string" && item.citation_id.length > 0) {
+      ref.citation_id = item.citation_id;
+    }
+    const sourceRef = item.source_ref;
+    if (
+      sourceRef &&
+      typeof sourceRef === "object" &&
+      !Array.isArray(sourceRef)
+    ) {
+      const sr = sourceRef as Record<string, unknown>;
+      if (
+        typeof sr.source === "string" &&
+        typeof sr.type === "string" &&
+        typeof sr.id === "string"
+      ) {
+        ref.source_ref = {
+          source: sr.source,
+          type: sr.type,
+          id: sr.id,
+          ...(typeof sr.namespace === "string"
+            ? { namespace: sr.namespace }
+            : {}),
+        };
+      }
+    }
+    // Only echo a reference that actually carries a resolvable identity. A known
+    // seed emitted without any identity cannot be suppressed by reference and is
+    // simply not sent (the arm-level relevance/leak checks still cover it).
+    if (ref.citation_id !== undefined || ref.source_ref !== undefined) {
+      refs.push(ref);
+      emittedKnownFixtureIds.push(record.fixture_id);
+    }
+  }
+  return { refs, emittedKnownFixtureIds };
+}
+
+/** Serialized whole-pack budget accounting for one reflex arm. */
+function budgetOf(payload: ReflexPointersPayload): ReflexArmVerdict["budget"] {
+  const serialized = JSON.stringify(payload.pointers).length;
+  const wholePack =
+    payload.budget.whole_pack &&
+    typeof payload.budget.whole_pack === "object" &&
+    !Array.isArray(payload.budget.whole_pack)
+      ? (payload.budget.whole_pack as Record<string, unknown>)
+      : null;
+  const limit =
+    wholePack && typeof wholePack.content_char_limit === "number"
+      ? wholePack.content_char_limit
+      : null;
+  const order = wholePack?.allocation_order;
+  const orderComplete =
+    Array.isArray(order) &&
+    PACK_ALLOCATION_SECTIONS.every((s) => order.includes(s));
+  return {
+    content_char_limit: limit,
+    serialized_pointers_chars: serialized,
+    within_budget: limit === null ? false : serialized <= limit,
+    allocation_order_complete: orderComplete,
+  };
+}
+
+/**
+ * Verify one reflex arm against the EVAL-3 functional bar and the A/B ground
+ * truth. Content-free: every derived signal is a count/boolean over server ids
+ * mapped back to fixture ids, never a pointer body.
+ */
+function verifyArm(
+  arm: "on" | "off",
+  payload: ReflexPointersPayload,
+  seeded: ReflexAbSeededRecord[],
+  fixture: ReflexAbFixture,
+  serverIdToRecord: Map<string, ReflexAbSeededRecord>,
+): ReflexArmVerdict {
+  const items = pointerItemsOf(payload);
+
+  const netNewServerIds = new Set(
+    seeded
+      .filter(
+        (r) =>
+          r.namespace_role === "primary" &&
+          fixture.net_new_ids.includes(r.fixture_id),
+      )
+      .map((r) => r.server_id),
+  );
+  const priorKnownServerIds = new Set(
+    seeded
+      .filter(
+        (r) =>
+          r.namespace_role === "primary" &&
+          fixture.prior_known_ids.includes(r.fixture_id),
+      )
+      .map((r) => r.server_id),
+  );
+  const forbiddenServerIds = new Set(
+    seeded
+      .filter(
+        (r) =>
+          r.namespace_role === "negative" &&
+          fixture.forbidden_ids.includes(r.fixture_id),
+      )
+      .map((r) => r.server_id),
+  );
+
+  const emittedNetNew = new Set<string>();
+  let redundantResurfacing = 0;
+  let leaks = 0;
+  let bodyFree = true;
+  // Multiset of emitted pointer citation ids for the bijection check.
+  const emittedCitationCounts = new Map<string, number>();
+
+  for (const item of items) {
+    if (!pointerIsBodyFree(item)) bodyFree = false;
+    const cid = item.citation_id;
+    if (typeof cid === "string" && cid.length > 0) {
+      emittedCitationCounts.set(cid, (emittedCitationCounts.get(cid) ?? 0) + 1);
+    }
+    const serverId = pointerServerId(item);
+    if (!serverId) continue;
+    if (netNewServerIds.has(serverId)) emittedNetNew.add(serverId);
+    if (priorKnownServerIds.has(serverId)) redundantResurfacing += 1;
+    // A forbidden id is a leak whether it is the exact pointer id or embedded in
+    // the pointer's structural source_ref id.
+    if (forbiddenServerIds.has(serverId)) leaks += 1;
+  }
+  // Also scan structural source_ref ids for a forbidden id that surfaced without
+  // matching the top-level pointer id (defensive: a leak is a leak wherever it
+  // appears in the emitted structure).
+  for (const item of items) {
+    const ref = item.source_ref;
+    if (ref && typeof ref === "object" && !Array.isArray(ref)) {
+      const refId = (ref as Record<string, unknown>).id;
+      if (typeof refId === "string" && forbiddenServerIds.has(refId)) {
+        const serverId = pointerServerId(item);
+        // Avoid double-counting when the pointer id itself already matched.
+        if (serverId === null || !forbiddenServerIds.has(serverId)) leaks += 1;
+      }
+    }
+  }
+
+  // Citation bijection: the top-level citations must be a one-to-one match of the
+  // emitted pointer citation_ids (occurrence counts on both sides).
+  const citationCounts = new Map<string, number>();
+  for (const citation of payload.citations) {
+    const id = citation.id;
+    if (typeof id === "string" && id.length > 0) {
+      citationCounts.set(id, (citationCounts.get(id) ?? 0) + 1);
+    }
+  }
+  const allIds = new Set<string>([
+    ...emittedCitationCounts.keys(),
+    ...citationCounts.keys(),
+  ]);
+  let dangling = 0;
+  let uncited = 0;
+  for (const id of allIds) {
+    const emittedN = emittedCitationCounts.get(id) ?? 0;
+    const citedN = citationCounts.get(id) ?? 0;
+    dangling += emittedN === 0 ? citedN : Math.max(citedN - 1, 0);
+    uncited += citedN === 0 ? emittedN : Math.max(emittedN - 1, 0);
+  }
+  const bijective = dangling === 0 && uncited === 0;
+
+  const netNewPresent = emittedNetNew.size;
+  const netNewMissing = netNewServerIds.size - netNewPresent;
+
+  const budget = budgetOf(payload);
+  const placementClientOwned = payload.placement === "client_owned";
+
+  const failures: string[] = [];
+  // EVAL-3 functional bar, applied per arm.
+  if (payload.status !== "ok") {
+    failures.push(`${arm}: reflex status is not 'ok'`);
+  }
+  if (!bijective) {
+    failures.push(
+      `${arm}: citations not bijective (dangling=${dangling} uncited=${uncited})`,
+    );
+  }
+  if (!bodyFree) {
+    failures.push(`${arm}: a pointer carried a body-bearing field (leakage)`);
+  }
+  if (!placementClientOwned) {
+    failures.push(`${arm}: placement is not client_owned`);
+  }
+  if (!budget.within_budget) {
+    failures.push(
+      `${arm}: serialized pointers ${budget.serialized_pointers_chars} exceed whole-pack limit ${budget.content_char_limit ?? "none"}`,
+    );
+  }
+  if (!budget.allocation_order_complete) {
+    failures.push(`${arm}: whole-pack allocation order missing or incomplete`);
+  }
+  if (leaks > 0) {
+    failures.push(
+      `${arm}: namespace isolation breach (${leaks} forbidden pointer(s))`,
+    );
+  }
+  // Net-new evidence must be present on BOTH arms: suppression never drops a
+  // net-new item, and a hollow empty reflex would otherwise hide a broken recall.
+  if (netNewMissing > 0) {
+    failures.push(
+      `${arm}: ${netNewMissing} expected net-new record(s) missing from pointers`,
+    );
+  }
+  // The ON arm must have suppressed every already-known reference: any resurfaced
+  // known item is a suppression failure.
+  if (arm === "on" && redundantResurfacing > 0) {
+    failures.push(
+      `on: suppression enabled but ${redundantResurfacing} already-known item(s) resurfaced`,
+    );
+  }
+
+  return {
+    arm,
+    pointer_count: items.length,
+    net_new_present: netNewPresent,
+    net_new_missing: netNewMissing,
+    redundant_resurfacing: redundantResurfacing,
+    namespace_leaks: leaks,
+    citations_bijective: bijective,
+    dangling_citations: dangling,
+    uncited_pointers: uncited,
+    body_free: bodyFree,
+    placement_client_owned: placementClientOwned,
+    budget,
+    failures,
+  };
+}
+
+/** Fixed top-k for the cross-namespace denial probe read. */
+const NEGATIVE_CONTROL_PROBE_TOP_K = 10;
+
+/**
+ * Explicit cross-namespace denial proof, mirroring the complete-pack gate's
+ * probeNegativeControl. The PRIMARY caller attempts a primary-identity read of
+ * the NEGATIVE namespace, and the server must DENY it. An allowed-but-empty read
+ * is NOT proof. Runs after seeding, before teardown. Content-free.
+ */
+async function probeNegativeControl(
+  fixture: ReflexAbFixture,
+  config: LiveEvalConfig,
+  clients: ReflexAbGateClients,
+): Promise<ReflexAbNegativeControl> {
+  const proof: ReflexAbNegativeControl = {
+    ran: true,
+    denied: false,
+    observed_hit_count: 0,
+    cross_token: config.negativeTokenIsDistinct,
+  };
+
+  let result;
+  try {
+    result = await clients.primary.attemptRead({
+      query: fixture.query,
+      namespace: config.negativeNamespace,
+      limit: NEGATIVE_CONTROL_PROBE_TOP_K,
+      searchMode: config.searchMode,
+    });
+  } catch (error) {
+    const label =
+      error instanceof LiveTransportError ? error.label : "attempt-read-error";
+    proof.denied = false;
+    proof.failure = `negative-control read failed: ${label}`;
+    return proof;
+  }
+
+  proof.observed_hit_count = result.hitCount;
+  proof.denied = result.denied;
+  if (!proof.denied) {
+    proof.failure =
+      result.hitCount > 0
+        ? "primary caller was permitted to read the negative namespace (non-empty)"
+        : "primary caller's read of the negative namespace was allowed (empty), not denied";
+  }
+  return proof;
+}
+
+/**
+ * Run the full reflex A/B gate. Seeding, both reflex calls, and the denial probe
+ * are wrapped so teardown always runs; a thrown error is re-raised only AFTER
+ * teardown, with the content-free teardown failed count preserved. PASS requires
+ * both arms clear the EVAL-3 bar, the A/B contrast holds, the net-new evidence is
+ * preserved, the denial control ran and denied, and teardown is clean.
+ */
+export async function runReflexAbGate(
+  opts: RunReflexAbGateOptions,
+): Promise<ReflexAbGateOutcome> {
+  const { fixture, config, clients, budgetMaxTokens, scope, commit } = opts;
+
+  const seeded: ReflexAbSeededRecord[] = [];
+  const serverIdToRecord = new Map<string, ReflexAbSeededRecord>();
+  let deferredError: unknown = null;
+  let offPayload: ReflexPointersPayload | null = null;
+  let onPayload: ReflexPointersPayload | null = null;
+  let negativeControl: ReflexAbNegativeControl = {
+    ran: false,
+    denied: false,
+    observed_hit_count: 0,
+    cross_token: config.negativeTokenIsDistinct,
+    failure: "negative-control proof did not run",
+  };
+
+  const reflexScope: ContextPackScope = {
+    namespace: config.primaryNamespace,
+    agent: scope.agent,
+    platform: scope.platform,
+    server_id: scope.server_id,
+    channel_id: scope.channel_id,
+    thread_id: scope.thread_id ?? null,
+    session_key: scope.session_key,
+  };
+
+  try {
+    for (const entry of fixture.corpus) {
+      const record = await seedEntry(entry, config, clients);
+      seeded.push(record);
+      serverIdToRecord.set(record.server_id, record);
+    }
+
+    // --- OFF arm: no prior_context. Establishes the resurfacing baseline. ---
+    offPayload = await clients.primary.reflexPointers({
+      scope: reflexScope,
+      query: fixture.query,
+      budgetMaxTokens,
+    });
+
+    // Build the ON arm's prior_context from the EXACT references the OFF arm
+    // emitted for the already-known seeds -- the identities a model would echo
+    // back. This exercises the real suppression bijection, not a fabricated key.
+    const knownRefs = collectKnownPointerRefs(offPayload, serverIdToRecord);
+
+    // --- ON arm: prior_context set to the already-known seeds' own references. ---
+    onPayload = await clients.primary.reflexPointers({
+      scope: reflexScope,
+      query: fixture.query,
+      priorContext: knownRefs.refs,
+      budgetMaxTokens,
+    });
+
+    // --- Explicit cross-namespace denial proof (after seeding, before teardown) ---
+    negativeControl = await probeNegativeControl(fixture, config, clients);
+  } catch (error) {
+    deferredError = error;
+  }
+
+  const teardownTally = await teardown(seeded, clients);
+
+  if (deferredError) {
+    throw withTeardownFailedCount(deferredError, teardownTally.failed);
+  }
+  if (!offPayload || !onPayload) {
+    throw new LiveTransportError("agent_reflex_pointers:no-payload", false);
+  }
+
+  // --- Verify each arm against the EVAL-3 functional bar + ground truth ---
+  const armOff = verifyArm(
+    "off",
+    offPayload,
+    seeded,
+    fixture,
+    serverIdToRecord,
+  );
+  const armOn = verifyArm("on", onPayload, seeded, fixture, serverIdToRecord);
+
+  // --- A/B comparison: the REFLEX-4 acceptance signal ---
+  const comparison: ReflexAbComparison = {
+    known_resurfaced_off: armOff.redundant_resurfacing,
+    known_resurfaced_on: armOn.redundant_resurfacing,
+    known_suppressed_delta:
+      armOff.redundant_resurfacing - armOn.redundant_resurfacing,
+    fewer_known_when_enabled:
+      armOn.redundant_resurfacing < armOff.redundant_resurfacing,
+    net_new_preserved: Math.min(armOff.net_new_present, armOn.net_new_present),
+    net_new_preserved_on_both:
+      armOff.net_new_missing === 0 && armOn.net_new_missing === 0,
+  };
+
+  const primarySeeded = seeded.filter(
+    (r) => r.namespace_role === "primary",
+  ).length;
+  const negativeSeeded = seeded.filter(
+    (r) => r.namespace_role === "negative",
+  ).length;
+  const priorKnownSeeded = seeded.filter(
+    (r) => r.namespace_role === "primary" && r.prior_known,
+  ).length;
+  const netNewSeeded = seeded.filter(
+    (r) =>
+      r.namespace_role === "primary" &&
+      fixture.net_new_ids.includes(r.fixture_id),
+  ).length;
+
+  const failures: string[] = [...armOff.failures, ...armOn.failures];
+
+  // A/B contrast: suppression ENABLED must return strictly fewer already-known
+  // items. The OFF arm must ACTUALLY have resurfaced at least one known item,
+  // otherwise there is nothing to suppress and the contrast is vacuous.
+  if (armOff.redundant_resurfacing === 0) {
+    failures.push(
+      "off arm resurfaced zero already-known items: the A/B contrast is vacuous (suppression had nothing to remove)",
+    );
+  }
+  if (!comparison.fewer_known_when_enabled) {
+    failures.push(
+      `suppression did not return fewer already-known items (off=${comparison.known_resurfaced_off} on=${comparison.known_resurfaced_on})`,
+    );
+  }
+  if (comparison.known_resurfaced_on !== 0) {
+    failures.push(
+      `suppression enabled still resurfaced ${comparison.known_resurfaced_on} already-known item(s)`,
+    );
+  }
+  if (!comparison.net_new_preserved_on_both) {
+    failures.push(
+      "suppression did not preserve the net-new evidence on both arms",
+    );
+  }
+
+  // Cross-namespace denial control.
+  if (!negativeControl.ran) {
+    failures.push(
+      `negative-control proof did not run: ${negativeControl.failure ?? "unknown"}`,
+    );
+  } else if (!negativeControl.denied) {
+    failures.push(
+      `negative-control not denied: ${negativeControl.failure ?? "isolation not proven"}`,
+    );
+  }
+
+  // Teardown discipline.
+  const teardownClean = teardownTally.failed === 0;
+  if (!teardownClean) {
+    failures.push(
+      `teardown failed to archive ${teardownTally.failed} of ${teardownTally.attempted} seeded records`,
+    );
+  }
+
+  const passed = failures.length === 0;
+
+  const receipt: ReflexAbReceipt = {
+    schema: "openbrain.reflex_ab_gate.v1",
+    generated_at: opts.generatedAt,
+    commit,
+    fixture_id: fixture.fixture_id,
+    primary_namespace: config.primaryNamespace,
+    negative_namespace: config.negativeNamespace,
+    seeded: {
+      primary: primarySeeded,
+      negative: negativeSeeded,
+      prior_known: priorKnownSeeded,
+      net_new: netNewSeeded,
+    },
+    arm_off: armOff,
+    arm_on: armOn,
+    comparison,
+    negative_control: negativeControl,
+    passed,
+    failures,
+    teardown: teardownTally,
+  };
+
+  return { receipt, passed };
+}

--- a/eval/open-brain/live/reflex-ab-gate.ts
+++ b/eval/open-brain/live/reflex-ab-gate.ts
@@ -21,18 +21,25 @@ import type {
 // One run:
 //   1. Seed a unique throwaway namespace (and a mandatory sibling negative
 //      namespace) with the sealed synthetic corpus.
-//   2. Call the real `agent_reflex_pointers` tool TWICE over the SAME seeded
-//      evidence and exact scope:
+//   2. Call the real `agent_reflex_pointers` tool THREE times over the SAME
+//      seeded evidence and exact scope:
 //        - OFF arm: no prior_context. Every net-new authorized durable record
 //          surfaces as a body-free cited pointer -- including the "already-known"
 //          seeds (that is the redundant-resurfacing baseline).
+//        - CONTROL arm: a SECOND unsuppressed call (no prior_context) over the
+//          same seed/query. It exists so the gate can prove the known items
+//          resurface STABLY across two unsuppressed calls; without it, a variable
+//          ranked recall that dropped the known items on its own could be
+//          misattributed to suppression on the ON arm.
 //        - ON arm: the ALREADY-KNOWN seeds' OWN emitted pointer references
 //          (the exact citation_id + source_ref the OFF arm returned for them) are
 //          echoed back as prior_context, so the shared recall suppresses them
 //          before any pointer is emitted.
-//   3. Compare: suppression ENABLED must return DEMONSTRABLY FEWER already-known
-//      items (zero redundant resurfacing) while preserving the net-new evidence
-//      both arms share.
+//   3. Compare: the two unsuppressed arms (OFF/CONTROL) must resurface the SAME
+//      non-vacuous already-known set (stable baseline), the gate must have fed the
+//      ON arm a non-empty prior_context that EXACTLY covers that emitted known
+//      set, and suppression ENABLED must then return zero redundant resurfacing
+//      while preserving the net-new evidence every arm shares.
 //   4. Prove cross-namespace denial with an explicit negative control.
 //   5. ALWAYS tear down exactly this run's records -- even on partial failure.
 //
@@ -226,6 +233,14 @@ interface KnownPointerRefs {
   refs: ReflexPriorContextRef[];
   /** Fixture ids of known seeds that were actually emitted by the OFF arm. */
   emittedKnownFixtureIds: string[];
+  /**
+   * Server ids of the known seeds the gate built a resolvable prior_context
+   * reference for. This is the set the ON arm's prior_context actually covers,
+   * and it must exactly equal the OFF arm's emitted-known server id set for the
+   * suppression contrast to be attributable (a known item emitted without any
+   * resolvable identity would be un-referenceable and break coverage).
+   */
+  referencedServerIds: Set<string>;
 }
 
 function collectKnownPointerRefs(
@@ -234,6 +249,7 @@ function collectKnownPointerRefs(
 ): KnownPointerRefs {
   const refs: ReflexPriorContextRef[] = [];
   const emittedKnownFixtureIds: string[] = [];
+  const referencedServerIds = new Set<string>();
   for (const item of pointerItemsOf(offPayload)) {
     const serverId = pointerServerId(item);
     if (!serverId) continue;
@@ -267,14 +283,42 @@ function collectKnownPointerRefs(
       }
     }
     // Only echo a reference that actually carries a resolvable identity. A known
-    // seed emitted without any identity cannot be suppressed by reference and is
-    // simply not sent (the arm-level relevance/leak checks still cover it).
+    // seed emitted without any identity cannot be suppressed by reference; it is
+    // simply not sent, and the reference-coverage check below fails the contrast
+    // rather than letting an un-referenceable known item pass silently.
     if (ref.citation_id !== undefined || ref.source_ref !== undefined) {
       refs.push(ref);
       emittedKnownFixtureIds.push(record.fixture_id);
+      referencedServerIds.add(serverId);
     }
   }
-  return { refs, emittedKnownFixtureIds };
+  return { refs, emittedKnownFixtureIds, referencedServerIds };
+}
+
+/**
+ * The set of prior-known SERVER ids a reflex arm actually emitted as pointers.
+ * Content-free (server ids only, never a body). Used to prove the OFF and
+ * CONTROL arms resurfaced the SAME known set (stability) and that the
+ * prior_context the gate sent the ON arm exactly covers the OFF arm's emitted
+ * known set.
+ */
+function emittedKnownServerIds(
+  payload: ReflexPointersPayload,
+  priorKnownServerIds: Set<string>,
+): Set<string> {
+  const emitted = new Set<string>();
+  for (const item of pointerItemsOf(payload)) {
+    const serverId = pointerServerId(item);
+    if (serverId && priorKnownServerIds.has(serverId)) emitted.add(serverId);
+  }
+  return emitted;
+}
+
+/** True when two content-free server-id sets are exactly equal (same members). */
+function serverIdSetsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
 }
 
 /** Serialized whole-pack budget accounting for one reflex arm. */
@@ -393,13 +437,19 @@ function verifyArm(
     ...emittedCitationCounts.keys(),
     ...citationCounts.keys(),
   ]);
+  // A true multiplicity bijection requires the emitted count to EQUAL the cited
+  // count for EVERY identity. Any surplus on the citation side is dangling
+  // (cited more than emitted); any surplus on the pointer side is uncited
+  // (emitted more than cited). Both are counted per identity so a single
+  // identity can never mask its own duplicate: emitted=2/cited=1 is one uncited,
+  // emitted=1/cited=2 is one dangling, and emitted=2/cited=2 is clean.
   let dangling = 0;
   let uncited = 0;
   for (const id of allIds) {
     const emittedN = emittedCitationCounts.get(id) ?? 0;
     const citedN = citationCounts.get(id) ?? 0;
-    dangling += emittedN === 0 ? citedN : Math.max(citedN - 1, 0);
-    uncited += citedN === 0 ? emittedN : Math.max(emittedN - 1, 0);
+    if (citedN > emittedN) dangling += citedN - emittedN;
+    else if (emittedN > citedN) uncited += emittedN - citedN;
   }
   const bijective = dangling === 0 && uncited === 0;
 
@@ -534,7 +584,13 @@ export async function runReflexAbGate(
   const serverIdToRecord = new Map<string, ReflexAbSeededRecord>();
   let deferredError: unknown = null;
   let offPayload: ReflexPointersPayload | null = null;
+  let controlPayload: ReflexPointersPayload | null = null;
   let onPayload: ReflexPointersPayload | null = null;
+  let knownRefs: KnownPointerRefs = {
+    refs: [],
+    emittedKnownFixtureIds: [],
+    referencedServerIds: new Set<string>(),
+  };
   let negativeControl: ReflexAbNegativeControl = {
     ran: false,
     denied: false,
@@ -567,10 +623,21 @@ export async function runReflexAbGate(
       budgetMaxTokens,
     });
 
+    // --- CONTROL arm: a SECOND unsuppressed call over the SAME seed/query, still
+    // with no prior_context. It exists solely to prove the known items resurface
+    // STABLY across two unsuppressed calls, so a variable ranked recall that
+    // happened to drop the known items cannot be misattributed to suppression on
+    // the ON arm. It shares the OFF arm's exact scope, query, and budget. ---
+    controlPayload = await clients.primary.reflexPointers({
+      scope: reflexScope,
+      query: fixture.query,
+      budgetMaxTokens,
+    });
+
     // Build the ON arm's prior_context from the EXACT references the OFF arm
     // emitted for the already-known seeds -- the identities a model would echo
     // back. This exercises the real suppression bijection, not a fabricated key.
-    const knownRefs = collectKnownPointerRefs(offPayload, serverIdToRecord);
+    knownRefs = collectKnownPointerRefs(offPayload, serverIdToRecord);
 
     // --- ON arm: prior_context set to the already-known seeds' own references. ---
     onPayload = await clients.primary.reflexPointers({
@@ -591,7 +658,7 @@ export async function runReflexAbGate(
   if (deferredError) {
     throw withTeardownFailedCount(deferredError, teardownTally.failed);
   }
-  if (!offPayload || !onPayload) {
+  if (!offPayload || !controlPayload || !onPayload) {
     throw new LiveTransportError("agent_reflex_pointers:no-payload", false);
   }
 
@@ -603,19 +670,70 @@ export async function runReflexAbGate(
     fixture,
     serverIdToRecord,
   );
+  // The control arm is unsuppressed, so it is verified as an "off" arm: it must
+  // clear the exact same functional bar (cited, body-free, budgeted, no leaks,
+  // net-new present) as the OFF arm.
+  const armControl = verifyArm(
+    "off",
+    controlPayload,
+    seeded,
+    fixture,
+    serverIdToRecord,
+  );
   const armOn = verifyArm("on", onPayload, seeded, fixture, serverIdToRecord);
+
+  // Content-free emitted prior-known server id sets for the stability/coverage
+  // controls. `priorKnownServerIds` is the ground-truth known set (primary-role,
+  // prior_known seeds); the emitted sets are what each unsuppressed arm surfaced.
+  const priorKnownServerIds = new Set(
+    seeded
+      .filter(
+        (r) =>
+          r.namespace_role === "primary" &&
+          fixture.prior_known_ids.includes(r.fixture_id),
+      )
+      .map((r) => r.server_id),
+  );
+  const offKnownEmitted = emittedKnownServerIds(
+    offPayload,
+    priorKnownServerIds,
+  );
+  const controlKnownEmitted = emittedKnownServerIds(
+    controlPayload,
+    priorKnownServerIds,
+  );
+  const knownResurfacingStable =
+    offKnownEmitted.size > 0 &&
+    serverIdSetsEqual(offKnownEmitted, controlKnownEmitted);
+  // The prior_context the gate sent must EXACTLY cover the OFF arm's emitted
+  // known set: every emitted known item is referenced and no reference points at
+  // a known item the OFF arm did not resurface.
+  const referencesCoverOffKnown =
+    knownRefs.referencedServerIds.size > 0 &&
+    serverIdSetsEqual(knownRefs.referencedServerIds, offKnownEmitted);
 
   // --- A/B comparison: the REFLEX-4 acceptance signal ---
   const comparison: ReflexAbComparison = {
     known_resurfaced_off: armOff.redundant_resurfacing,
+    known_resurfaced_control: armControl.redundant_resurfacing,
     known_resurfaced_on: armOn.redundant_resurfacing,
     known_suppressed_delta:
       armOff.redundant_resurfacing - armOn.redundant_resurfacing,
     fewer_known_when_enabled:
       armOn.redundant_resurfacing < armOff.redundant_resurfacing,
-    net_new_preserved: Math.min(armOff.net_new_present, armOn.net_new_present),
+    known_resurfacing_stable: knownResurfacingStable,
+    stable_known_count: knownResurfacingStable ? offKnownEmitted.size : 0,
+    references_sent: knownRefs.refs.length,
+    references_cover_off_known: referencesCoverOffKnown,
+    net_new_preserved: Math.min(
+      armOff.net_new_present,
+      armControl.net_new_present,
+      armOn.net_new_present,
+    ),
     net_new_preserved_on_both:
-      armOff.net_new_missing === 0 && armOn.net_new_missing === 0,
+      armOff.net_new_missing === 0 &&
+      armControl.net_new_missing === 0 &&
+      armOn.net_new_missing === 0,
   };
 
   const primarySeeded = seeded.filter(
@@ -633,7 +751,11 @@ export async function runReflexAbGate(
       fixture.net_new_ids.includes(r.fixture_id),
   ).length;
 
-  const failures: string[] = [...armOff.failures, ...armOn.failures];
+  const failures: string[] = [
+    ...armOff.failures,
+    ...armControl.failures,
+    ...armOn.failures,
+  ];
 
   // A/B contrast: suppression ENABLED must return strictly fewer already-known
   // items. The OFF arm must ACTUALLY have resurfaced at least one known item,
@@ -641,6 +763,28 @@ export async function runReflexAbGate(
   if (armOff.redundant_resurfacing === 0) {
     failures.push(
       "off arm resurfaced zero already-known items: the A/B contrast is vacuous (suppression had nothing to remove)",
+    );
+  }
+  // Stability control: the two UNSUPPRESSED arms (OFF and CONTROL) must resurface
+  // the SAME non-vacuous already-known set. If they disagree, a variable ranked
+  // recall dropped known items on its own and the ON arm's zero cannot be
+  // attributed to suppression.
+  if (!comparison.known_resurfacing_stable) {
+    failures.push(
+      `unsuppressed known resurfacing is not stable across off/control (off=${comparison.known_resurfaced_off} control=${comparison.known_resurfaced_control} stable_known=${comparison.stable_known_count}): a variable recall could masquerade as suppression`,
+    );
+  }
+  // Reference-coverage control: the prior_context the gate fed the ON arm must be
+  // non-empty AND exactly cover the OFF arm's emitted known set, so suppression
+  // is acting on precisely the items that were resurfaced.
+  if (comparison.references_sent === 0) {
+    failures.push(
+      "no prior_context references were sent to the suppression arm: suppression had nothing to act on",
+    );
+  }
+  if (!comparison.references_cover_off_known) {
+    failures.push(
+      `prior_context references (${comparison.references_sent}) do not exactly cover the off arm's emitted already-known set (${armOff.redundant_resurfacing}): the suppression contrast is not attributable`,
     );
   }
   if (!comparison.fewer_known_when_enabled) {
@@ -655,7 +799,7 @@ export async function runReflexAbGate(
   }
   if (!comparison.net_new_preserved_on_both) {
     failures.push(
-      "suppression did not preserve the net-new evidence on both arms",
+      "suppression did not preserve the net-new evidence on all arms (off/control/on)",
     );
   }
 
@@ -694,6 +838,7 @@ export async function runReflexAbGate(
       net_new: netNewSeeded,
     },
     arm_off: armOff,
+    arm_control: armControl,
     arm_on: armOn,
     comparison,
     negative_control: negativeControl,

--- a/eval/open-brain/live/reflex-ab-setup.ts
+++ b/eval/open-brain/live/reflex-ab-setup.ts
@@ -1,0 +1,48 @@
+import type { LiveEvalConfig } from "./config.ts";
+import type { ReflexAbGateClients } from "./reflex-ab-gate.ts";
+import { OpenBrainLiveClient, createMcpCaller } from "./transport.ts";
+import type { CallerFactory } from "./complete-pack-setup.ts";
+
+// Client lifecycle for the reflex A/B gate.
+//
+// Identical discipline to the complete-pack gate's setUpCompletePackClients:
+// connect the primary and negative callers in order (the negative control is
+// mandatory, so BOTH must connect), and if the primary connects but the negative
+// connect fails, close the primary before propagating so a live MCP session
+// never leaks on a setup failure. The CallerFactory shape is reused from the
+// complete-pack setup so both gates share one injectable connect seam.
+
+export type { CallerFactory } from "./complete-pack-setup.ts";
+
+export async function setUpReflexAbClients(
+  config: LiveEvalConfig,
+  factory: CallerFactory = createMcpCaller,
+): Promise<ReflexAbGateClients> {
+  const primaryCaller = await factory({
+    baseUrl: config.baseUrl,
+    token: config.primaryToken,
+    namespace: config.primaryNamespace,
+    timeoutMs: config.timeoutMs,
+  });
+
+  let negativeCaller;
+  try {
+    negativeCaller = await factory({
+      baseUrl: config.baseUrl,
+      token: config.negativeToken,
+      namespace: config.negativeNamespace,
+      timeoutMs: config.timeoutMs,
+    });
+  } catch (error) {
+    // Close the already-connected primary so a negative-connect failure does not
+    // strand it. Swallow the close outcome (content-free) so the original connect
+    // error is what the caller sees.
+    await primaryCaller.close().catch(() => {});
+    throw error;
+  }
+
+  return {
+    primary: new OpenBrainLiveClient(primaryCaller),
+    negative: new OpenBrainLiveClient(negativeCaller),
+  };
+}

--- a/eval/open-brain/live/reflex-ab-types.ts
+++ b/eval/open-brain/live/reflex-ab-types.ts
@@ -139,22 +139,67 @@ export interface ReflexArmVerdict {
 }
 
 /**
- * The A/B contrast between the two arms. This is the REFLEX-4 acceptance signal:
+ * The A/B contrast between the arms. This is the REFLEX-4 acceptance signal:
  * suppression ENABLED must return demonstrably fewer already-known items and no
- * redundant resurfacing, while preserving the net-new evidence both arms share.
+ * redundant resurfacing, while preserving the net-new evidence every arm shares.
+ *
+ * The contrast is only trustworthy when the disappearance of the known items on
+ * the ON arm is ATTRIBUTABLE TO SUPPRESSION rather than to a variable ranked
+ * recall that happened to drop them anyway. Two guards make that attribution
+ * sound:
+ *  - `references_sent` proves the gate actually fed the ON arm a non-empty
+ *    prior_context that EXACTLY covers the known items the OFF arm emitted; an
+ *    empty or partial prior_context would leave "suppression" with nothing (or
+ *    too little) to act on and any disappearance would be unattributable.
+ *  - the unsuppressed CONTROL arm (same seed/query, no prior_context) must
+ *    resurface the SAME known set the OFF arm did. Stable known resurfacing
+ *    across the two unsuppressed calls rules out a variable recall silently
+ *    dropping the known items; only then can the ON arm's zero be credited to
+ *    suppression.
  */
 export interface ReflexAbComparison {
   /** Already-known items resurfaced with suppression OFF (baseline > 0). */
   known_resurfaced_off: number;
+  /**
+   * Already-known items resurfaced on the second unsuppressed CONTROL arm (same
+   * seed/query, no prior_context). Must equal the OFF baseline: stable known
+   * resurfacing across the two unsuppressed calls proves the recall did not
+   * variably drop the known items on its own.
+   */
+  known_resurfaced_control: number;
   /** Already-known items resurfaced with suppression ON (must be 0). */
   known_resurfaced_on: number;
   /** off - on: net already-known items suppression removed (must be > 0). */
   known_suppressed_delta: number;
   /** True when ON returned strictly fewer already-known items than OFF. */
   fewer_known_when_enabled: boolean;
+  /**
+   * True when the OFF and CONTROL arms resurfaced the EXACT SAME already-known
+   * set (stable, non-vacuous). This is the control that stops a variable recall
+   * from being mistaken for suppression: without a stable unsuppressed baseline,
+   * the ON arm's zero could just be recall variance.
+   */
+  known_resurfacing_stable: boolean;
+  /**
+   * Count of already-known identities the OFF and CONTROL arms agreed on. When
+   * `known_resurfacing_stable` is true this equals both arms' resurfacing count.
+   */
+  stable_known_count: number;
+  /**
+   * Count of prior_context references the gate sent to the ON arm. Content-free:
+   * the number of identities echoed back, never the identities themselves. Must
+   * be non-zero and must exactly cover the OFF arm's emitted known set.
+   */
+  references_sent: number;
+  /**
+   * True when `references_sent` exactly covers (one-to-one) the already-known
+   * items the OFF arm emitted -- no known item left un-referenced and no extra
+   * reference for an item the OFF arm did not resurface.
+   */
+  references_cover_off_known: boolean;
   /** Net-new pointers common to both arms (suppression preserved the evidence). */
   net_new_preserved: number;
-  /** True when every expected net-new seed survived on BOTH arms. */
+  /** True when every expected net-new seed survived on ALL arms (off/control/on). */
   net_new_preserved_on_both: boolean;
 }
 
@@ -188,15 +233,24 @@ export interface ReflexAbReceipt {
     net_new: number;
   };
   arm_off: ReflexArmVerdict;
+  /**
+   * The second UNSUPPRESSED control arm (same seed/query, no prior_context). Its
+   * already-known resurfacing must match the OFF baseline so a variable recall
+   * cannot be mistaken for suppression.
+   */
+  arm_control: ReflexArmVerdict;
   arm_on: ReflexArmVerdict;
   comparison: ReflexAbComparison;
   negative_control: ReflexAbNegativeControl;
   /**
-   * Composite verdict. PASS requires ALL of: both arms independently clear the
-   * EVAL-3 functional bar (cited, body-free, budget-bounded, no leaks), the A/B
-   * contrast shows suppression ENABLED returns strictly fewer already-known items
-   * with zero redundant resurfacing, the net-new evidence is preserved on both
-   * arms, the cross-namespace denial control ran and was denied, and teardown
+   * Composite verdict. PASS requires ALL of: every arm independently clears the
+   * EVAL-3 functional bar (cited with strict per-identity citation multiplicity,
+   * body-free, budget-bounded, no leaks); the two unsuppressed arms (OFF and the
+   * CONTROL replay) resurface the SAME non-vacuous already-known set (stable
+   * baseline); the gate fed the ON arm a non-empty prior_context that exactly
+   * covers that emitted known set; the ON arm returns strictly fewer already-known
+   * items with zero redundant resurfacing; the net-new evidence is preserved on
+   * every arm; the cross-namespace denial control ran and was denied; and teardown
    * left nothing behind.
    */
   passed: boolean;

--- a/eval/open-brain/live/reflex-ab-types.ts
+++ b/eval/open-brain/live/reflex-ab-types.ts
@@ -1,0 +1,210 @@
+// Types for the live Open Brain REFLEX A/B suppression gate (REFLEX-4, #335).
+//
+// This gate exercises the already-landed complete reflex (`agent_reflex_pointers`,
+// #334) end-to-end under ONE per-run throwaway namespace, calling it TWICE over
+// the SAME seeded evidence:
+//
+//   - suppression ENABLED: the already-known seeds' citation ids are echoed back
+//     as `prior_context`, so the shared durable_memory recall drops records
+//     already represented before any pointer is emitted.
+//   - suppression DISABLED: no `prior_context` is sent, so every net-new
+//     authorized durable record is emitted as a pointer.
+//
+// The comparison is the whole point: suppression ENABLED must return
+// DEMONSTRABLY FEWER already-known items (zero redundant resurfacings), while
+// still surfacing the net-new evidence. Both arms must independently clear the
+// established EVAL-3 functional bar: every pointer cited (citation bijection),
+// whole-pack budget respected, exact-scope authorized, and a cross-namespace
+// denial control proven.
+//
+// Nothing here carries a secret, token, or memory body off-box: the corpus is
+// synthetic and the receipt is content-free (labels, ids, counts, booleans).
+
+/** Brain tables the reflex A/B gate seeds and archives. */
+export type ReflexAbTable = "thoughts" | "decisions";
+
+/**
+ * One sealed synthetic seed for the reflex A/B corpus.
+ *
+ * `id` is a fixture-local handle, mapped to the server-assigned UUID at seed
+ * time. `namespace_role` decides which caller seeds it and where:
+ *  - "primary": seeded under the primary throwaway namespace; a
+ *    durable_memory-eligible record the reflex recall can surface as a pointer.
+ *  - "negative": seeded into the sibling namespace the reflex caller cannot
+ *    read; it must never appear in any pointer or citation.
+ *
+ * `prior_known` marks a PRIMARY-role seed the model is treated as having ALREADY
+ * been given this turn. Its emitted citation id is echoed back as
+ * `prior_context` on the suppression-ON arm, so a correct reflex must suppress
+ * it there while still emitting it on the suppression-OFF arm. It is meaningless
+ * (and rejected) on a negative-role seed.
+ */
+export interface ReflexAbCorpusEntry {
+  id: string;
+  table: ReflexAbTable;
+  namespace_role: "primary" | "negative";
+  /**
+   * True when this primary-role seed is "already-known" prior context. Suppressed
+   * on the ON arm, resurfaced on the OFF arm. Defaults false.
+   */
+  prior_known?: boolean;
+  content: string;
+  tags: string[];
+}
+
+export interface ReflexAbFixture {
+  schema_version: 1;
+  fixture_id: string;
+  description: string;
+  /** The recall query the reflex is built around (drives the pointer pool). */
+  query: string;
+  corpus: ReflexAbCorpusEntry[];
+  /**
+   * Fixture-local ids of primary-role, prior-known seeds that must:
+   *  - be emitted as pointers on the suppression-OFF arm (redundant resurfacing),
+   *  - and be ABSENT on the suppression-ON arm (suppressed as prior context).
+   * Non-empty: the A/B contrast has no meaning without at least one known item.
+   */
+  prior_known_ids: string[];
+  /**
+   * Fixture-local ids of primary-role, NET-NEW seeds that must be emitted as
+   * pointers on BOTH arms (suppression never drops a net-new item). Non-empty: a
+   * gate that only ever suppressed everything would trivially "return fewer".
+   */
+  net_new_ids: string[];
+  /**
+   * Fixture-local ids of negative-role seeds that must never appear as a pointer
+   * or citation on EITHER arm (isolation).
+   */
+  forbidden_ids: string[];
+}
+
+/**
+ * A resolved seeded record: fixture handle, table, server UUID, physical
+ * namespace, role, and prior-known flag. Teardown only ever archives records
+ * described by this shape, exactly like the recall/complete-pack gates.
+ */
+export interface ReflexAbSeededRecord {
+  fixture_id: string;
+  table: ReflexAbTable;
+  server_id: string;
+  namespace: string;
+  namespace_role: "primary" | "negative";
+  prior_known: boolean;
+}
+
+/**
+ * The functional outcome of ONE reflex arm (suppression on or off). Content-free:
+ * only ids/counts/booleans, never a pointer body. The pointer identity sets are
+ * derived from the emitted pointers' SERVER ids (mapped back to fixture ids), so
+ * relevance and resurfacing are measured against the seeded ground truth without
+ * inspecting any memory body.
+ */
+export interface ReflexArmVerdict {
+  /** "on" (prior_context sent) or "off" (no prior_context). */
+  arm: "on" | "off";
+  /** Total pointers emitted by this arm. */
+  pointer_count: number;
+  /** Count of expected net-new seeds surfaced as pointers (relevance signal). */
+  net_new_present: number;
+  /** Count of expected net-new seeds MISSING from pointers (relevance defect). */
+  net_new_missing: number;
+  /**
+   * Count of already-known (prior-context) seeds that surfaced as pointers on
+   * this arm. On the OFF arm this is the redundant-resurfacing baseline; on the
+   * ON arm it MUST be zero (suppression removed them).
+   */
+  redundant_resurfacing: number;
+  /** Count of forbidden (negative-namespace) ids that leaked into pointers. */
+  namespace_leaks: number;
+  /** True when the emitted pointers/citations form a clean bijection. */
+  citations_bijective: boolean;
+  /** Dangling citations (a citation with no emitted pointer). */
+  dangling_citations: number;
+  /** Uncited pointers (an emitted pointer with no citation). */
+  uncited_pointers: number;
+  /** True when the reflex kept every pointer body-free (identity/source_ref only). */
+  body_free: boolean;
+  /** True when placement is client-owned (no implicit _meta injection). */
+  placement_client_owned: boolean;
+  /** Whole-pack serialized budget accounting for this arm. */
+  budget: {
+    content_char_limit: number | null;
+    serialized_pointers_chars: number;
+    within_budget: boolean;
+    allocation_order_complete: boolean;
+  };
+  /** Content-free reasons this arm failed its own functional bar, if any. */
+  failures: string[];
+}
+
+/**
+ * The A/B contrast between the two arms. This is the REFLEX-4 acceptance signal:
+ * suppression ENABLED must return demonstrably fewer already-known items and no
+ * redundant resurfacing, while preserving the net-new evidence both arms share.
+ */
+export interface ReflexAbComparison {
+  /** Already-known items resurfaced with suppression OFF (baseline > 0). */
+  known_resurfaced_off: number;
+  /** Already-known items resurfaced with suppression ON (must be 0). */
+  known_resurfaced_on: number;
+  /** off - on: net already-known items suppression removed (must be > 0). */
+  known_suppressed_delta: number;
+  /** True when ON returned strictly fewer already-known items than OFF. */
+  fewer_known_when_enabled: boolean;
+  /** Net-new pointers common to both arms (suppression preserved the evidence). */
+  net_new_preserved: number;
+  /** True when every expected net-new seed survived on BOTH arms. */
+  net_new_preserved_on_both: boolean;
+}
+
+/**
+ * Explicit cross-namespace denial proof, mirroring the recall/complete-pack
+ * gates' negative control. The PRIMARY caller attempts a primary-identity read
+ * of the NEGATIVE namespace, and the server MUST deny it. A denial is the ONLY
+ * proof of isolation the gate trusts: an allowed-but-empty read looks identical
+ * to a working boundary but proves nothing, so both allowed cases fail here.
+ */
+export interface ReflexAbNegativeControl {
+  ran: boolean;
+  denied: boolean;
+  observed_hit_count: number;
+  cross_token: boolean;
+  failure?: string;
+}
+
+/** Content-free structured baseline receipt for the reflex A/B gate. */
+export interface ReflexAbReceipt {
+  schema: "openbrain.reflex_ab_gate.v1";
+  generated_at: string;
+  commit: string;
+  fixture_id: string;
+  primary_namespace: string;
+  negative_namespace: string;
+  seeded: {
+    primary: number;
+    negative: number;
+    prior_known: number;
+    net_new: number;
+  };
+  arm_off: ReflexArmVerdict;
+  arm_on: ReflexArmVerdict;
+  comparison: ReflexAbComparison;
+  negative_control: ReflexAbNegativeControl;
+  /**
+   * Composite verdict. PASS requires ALL of: both arms independently clear the
+   * EVAL-3 functional bar (cited, body-free, budget-bounded, no leaks), the A/B
+   * contrast shows suppression ENABLED returns strictly fewer already-known items
+   * with zero redundant resurfacing, the net-new evidence is preserved on both
+   * arms, the cross-namespace denial control ran and was denied, and teardown
+   * left nothing behind.
+   */
+  passed: boolean;
+  failures: string[];
+  teardown: {
+    attempted: number;
+    archived: number;
+    already_absent: number;
+    failed: number;
+  };
+}

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -117,6 +117,42 @@ export interface DenialProbeResult {
 }
 
 /**
+ * One explicit prior-context reference for a reflex-pointers call: an identifier
+ * or structural source pointer for a record already supplied to the model this
+ * turn. Only resolvable identity is ever carried -- never a raw prior-context
+ * body -- mirroring `agent_reflex_pointers.prior_context`. The suppression-ON
+ * arm of the A/B gate echoes back the citation ids the already-known seeds were
+ * emitted under; the suppression-OFF arm sends none.
+ */
+export interface ReflexPriorContextRef {
+  citation_id?: string;
+  source_ref?:
+    string | { source: string; type: string; id: string; namespace?: string };
+}
+
+/**
+ * The structural fields the reflex-A/B gate reads out of an
+ * `agent_reflex_pointers` payload. Deliberately narrow: the body-free pointer
+ * section (items carry identity + structural source_ref only), the top-level
+ * citations, the whole-pack budget, and the warnings channel. Section item
+ * bodies stay opaque records so the gate reads pointer ids / citation ids /
+ * counts WITHOUT ever inspecting a memory body. The raw payload text is never
+ * carried past this boundary.
+ */
+export interface ReflexPointersPayload {
+  status: string;
+  placement: string;
+  pointers: Record<string, unknown>;
+  citations: Array<Record<string, unknown>>;
+  budget: Record<string, unknown>;
+  warnings: {
+    scope_denials: Array<Record<string, unknown>>;
+    degraded_sources: Array<Record<string, unknown>>;
+    truncation: Array<Record<string, unknown>>;
+  };
+}
+
+/**
  * The public error surface for a live transport failure. Callers may log or
  * embed `label` in a receipt; it is redacted to tool/class/status/reason
  * keywords only and never contains raw response text.
@@ -312,6 +348,61 @@ export class OpenBrainLiveClient {
   }
 
   /**
+   * Call the per-turn reflex `agent_reflex_pointers` for the exact active scope,
+   * returning the parsed body-free pointer payload. This is the single tool the
+   * REFLEX-4 A/B gate exercises: it reuses `agent_context_pack`'s scope, query,
+   * prior-context, and whole-pack budget contract but returns only cited
+   * resolvable pointers (no memory bodies). Passing `priorContext` (the
+   * suppression-ON arm) makes the shared recall drop records already represented
+   * by those references before any pointer is emitted; omitting it (the
+   * suppression-OFF arm) emits every net-new authorized pointer.
+   *
+   * Fails closed content-free exactly like `contextPack`: a permission denial is
+   * a redacted LiveTransportError, and the raw payload text (which could carry a
+   * body if the tool ever regressed) is never logged -- only structural fields
+   * the gate reads (pointer ids, citation ids, counts, budget numbers).
+   */
+  async reflexPointers(opts: {
+    scope: ContextPackScope;
+    query: string;
+    priorContext?: readonly ReflexPriorContextRef[];
+    budgetMaxTokens?: number;
+  }): Promise<ReflexPointersPayload> {
+    const args: Record<string, unknown> = {
+      namespace: opts.scope.namespace,
+      agent: opts.scope.agent,
+      platform: opts.scope.platform,
+      server_id: opts.scope.server_id,
+      channel_id: opts.scope.channel_id,
+      session_key: opts.scope.session_key,
+      query: opts.query,
+    };
+    if (opts.scope.thread_id !== undefined && opts.scope.thread_id !== null) {
+      args.thread_id = opts.scope.thread_id;
+    }
+    // Only attach prior_context on the suppression-ON arm. An empty array is the
+    // suppression-OFF arm and is deliberately OMITTED rather than sent as [], so
+    // the two arms differ exactly by the presence of the references -- never by
+    // an incidental empty-array vs absent distinction.
+    if (opts.priorContext !== undefined && opts.priorContext.length > 0) {
+      args.prior_context = opts.priorContext.map((ref) => {
+        const out: Record<string, unknown> = {};
+        if (ref.citation_id !== undefined) out.citation_id = ref.citation_id;
+        if (ref.source_ref !== undefined) out.source_ref = ref.source_ref;
+        return out;
+      });
+    }
+    if (opts.budgetMaxTokens !== undefined) {
+      args.budget = { max_tokens: opts.budgetMaxTokens };
+    }
+    const result = await this.caller.callTool("agent_reflex_pointers", args);
+    if (result.isError) {
+      throw new LiveTransportError(result.errorLabel, result.denied);
+    }
+    return parseReflexPointersPayload(result.data);
+  }
+
+  /**
    * Archive exactly one record by table + id. archive_entry is namespace-scoped
    * server-side (it appends the caller's write-namespace predicate), so a token
    * can only ever archive records it owns -- this is what makes per-record
@@ -472,6 +563,55 @@ export function parseContextPackPayload(text: string): ContextPackPayload {
   return {
     status: typeof parsed.status === "string" ? parsed.status : "",
     sections: asRecord(parsed.sections),
+    citations: asRecordArray(parsed.citations),
+    budget: asRecord(parsed.budget),
+    warnings: {
+      scope_denials: asRecordArray(warnings.scope_denials),
+      degraded_sources: asRecordArray(warnings.degraded_sources),
+      truncation: asRecordArray(warnings.truncation),
+    },
+  };
+}
+
+/**
+ * Parse the reflex-pointers payload from a JSON object body. Never logs the
+ * body. Fails closed content-free rather than defaulting a malformed body to an
+ * empty reflex: a non-object body or invalid JSON is a malformed reflex
+ * (`agent_reflex_pointers:malformed-payload`), NOT an empty one -- conflating
+ * the two would let a broken reflex pass as a clean empty. `pointers`,
+ * `citations`, `budget`, and `warnings.*` are normalized to their expected
+ * container shapes, defaulting a MISSING container to its empty form so the gate
+ * can classify a genuinely-empty reflex without inspecting any body. The pointer
+ * item bodies stay opaque records; the gate reads only their structural fields
+ * (id, citation_id, source_ref identity coordinates).
+ */
+export function parseReflexPointersPayload(
+  text: string,
+): ReflexPointersPayload {
+  const parsed = safeJson(text);
+  if (!parsed) {
+    throw new LiveTransportError(
+      "agent_reflex_pointers:malformed-payload",
+      false,
+    );
+  }
+  const asRecordArray = (value: unknown): Array<Record<string, unknown>> => {
+    if (!Array.isArray(value)) return [];
+    return value.filter(
+      (row): row is Record<string, unknown> =>
+        !!row && typeof row === "object" && !Array.isArray(row),
+    );
+  };
+  const asRecord = (value: unknown): Record<string, unknown> =>
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  const warnings = asRecord(parsed.warnings);
+  return {
+    status: typeof parsed.status === "string" ? parsed.status : "",
+    placement: typeof parsed.placement === "string" ? parsed.placement : "",
+    pointers: asRecord(parsed.pointers),
     citations: asRecordArray(parsed.citations),
     budget: asRecord(parsed.budget),
     warnings: {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "codex-memory-smoke": "bun run scripts/codex-memory-smoke.ts",
     "eval:memory": "bun run scripts/eval-open-brain-memory.ts",
     "eval:live": "bun run scripts/eval-open-brain-live.ts",
+    "eval:reflex-ab": "bun run eval/open-brain/live/reflex-ab-cli.ts",
     "import-kb": "bun run scripts/import-legacy-kb.ts",
     "promote:legacy-shared": "bun run scripts/promote-legacy-shared.ts",
     "promote:qmd-facts": "bun run scripts/promote-qmd-repo-facts.ts",


### PR DESCRIPTION
## Summary

- add a sealed live REFLEX-4 suppression gate around the existing `agent_reflex_pointers` stack
- compare identical seeded evidence across two unsuppressed stability arms and one prior-context-suppressed arm
- emit a content-free structured receipt for attribution, relevance, redundant resurfacing, citation multiplicity, budget, exact-scope isolation, and teardown

Closes #335

## Validation

- focused fixture/gate tests: **39 passed, 0 failed**
- full `eval/open-brain` suite: **194 passed, 0 failed** (799 assertions)
- `bunx tsc --noEmit`: passed
- `git diff --check`: passed
- focused fix verification: **FOCUSED CLEAN**; 0 P0/P1/P2 findings
- exact-head hosted three-arm gate on deployed v23 at `f828787cac87b4e0d8450f5056e8afc8bd8080b5`: **PASS**
  - suppression OFF: 6 pointers; 3/3 net-new present; 2 already-known resurfaced
  - unsuppressed CONTROL: 6 pointers; 3/3 net-new present; same 2 already-known resurfaced
  - suppression ON: 4 pointers; 3/3 net-new present; 0 already-known resurfaced
  - stable known baseline: true; stable known count: 2
  - prior-context references sent: 2; exact OFF-known coverage: true
  - suppression delta: 2; citations multiplicity-bijective; body-free; client-owned placement; within whole-pack budget
  - negative namespace denied; 0 leaks
  - teardown: 8/8 archived; 0 failures

## Downstream rollout classification

Not applicable. This PR adds an eval fixture/gate and CLI only; it does not change the hosted MCP contract, transport, server behavior, Python/TypeScript client API, or generated skill guidance.

## Critical self-review

- Highest-risk behavior: a false PASS from unstable recall, empty/partial prior-context, vacuous suppression, duplicate citation multiplicity, allowed-but-empty negative reads, or stranded seeded records.
- Assumptions that could be wrong: seeded records rank inside the reflex pointer budget and server-assigned ids map exactly to emitted pointer ids.
- Missing/weak tests: the live gate remains opt-in; deterministic fake transport tests cover stability, reference coverage, citation multiplicity, failure, and teardown branches, while the exact-head hosted receipt proves the real boundary.
- Security/permission risk: exact namespace/session scope and an explicit denied cross-namespace read are required; receipts contain counts/labels/booleans only and never bodies, tokens, or pointer identities.
- Migration/deploy risk: none; eval-only.
- Downstream client/runtime risk: none; the gate consumes the existing public tool without changing it.
- Rollback/cleanup concern: teardown archives only server ids returned from this run; failures preserve a content-free failed count.
- Fixes made before PR: required two stable non-vacuous unsuppressed arms, non-empty exact prior-context coverage, zero ON resurfacing, strict per-identity citation multiplicity, client-owned placement, body-free pointers, and denial rather than empty-read isolation.
- Known residual risk: a committed seed whose response is lost cannot be auto-identified for teardown; the unique namespace contains that bounded operator-cleanup case. The third call intentionally fails closed if ranked recall is unstable.
- SME review-memory update: [x] not applicable because: this eval-only gate applies already-captured citation/isolation/teardown patterns without introducing a new missed-review pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below — exact-head hosted three-arm PASS receipt is recorded in Validation above
