### PR TITLE
feat(341): add language-aware full-text search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ PORT=3100
 DB_POOL_MAX=10
 OPEN_BRAIN_RUN_MIGRATIONS=1
 
+# Optional operator opt-in for the public search_brain default.
+# Non-English keyword/hybrid FTS recomputes tsvectors on the fly and is not index-backed.
+# OPENBRAIN_FTS_CONFIG=german
+
 # CORS allowed origins (comma-separated, empty for none)
 ALLOWED_ORIGINS=
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,17 @@ jobs:
         run: bunx tsc --noEmit
 
       - name: Create isolated test databases
+        # Pin UTF8 explicitly (-E UTF8 -T template0). A bare `createdb` inherits
+        # the runner cluster's template1 encoding; a cluster initialized with a
+        # C/POSIX locale and no explicit encoding defaults to SQL_ASCII, under
+        # which the snowball stemmers split multibyte accented characters (ä, ó)
+        # and every non-English FTS ranking assertion (#341) silently fails while
+        # ASCII-only English passes. Open Brain is UTF8 in production, so a
+        # non-UTF8 test DB is simply an invalid harness. `-T template0` is
+        # required because a new encoding cannot be chosen when copying template1.
         run: |
-          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
-          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -E UTF8 -T template0 "${DB_NAME}"
+          PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -E UTF8 -T template0 "${DB_NAME_TEST}"
           PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
@@ -180,10 +188,15 @@ jobs:
           exit 1
 
       - name: Create isolated migration-test database
+        # Pin UTF8 (ENCODING 'UTF8' TEMPLATE template0) for the same reason as
+        # the `check` job: the snowball stemmers require UTF8 to fold multibyte
+        # accented characters. The pgvector image's open_brain_ci defaults to
+        # UTF8, but this migration-test DB is created explicitly, so pin it too
+        # so a future base-image change cannot regress the #341 FTS suite.
         run: |
           PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d open_brain_ci \
             -v ON_ERROR_STOP=1 \
-            -c "CREATE DATABASE ${DB_NAME_TEST};"
+            -c "CREATE DATABASE ${DB_NAME_TEST} ENCODING 'UTF8' TEMPLATE template0;"
           PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d "${DB_NAME_TEST}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,10 @@ EMBEDDING_API_KEY=your-key
 EMBEDDING_MODEL=embeddinggemma-300m-8bit
 EMBEDDING_DIMENSIONS=768
 
+# Optional operator opt-in for the public search_brain default
+# Non-English keyword/hybrid FTS is recomputed on the fly and is not index-backed
+# OPENBRAIN_FTS_CONFIG=german
+
 # Server
 PORT=3100
 
@@ -333,7 +337,9 @@ Supporting tables: `entry_access_log` (usage tracking), `discarded_entries` (arc
 `search_brain` fuses results from two retrieval paths:
 
 1. **Vector search** — HNSW nearest-neighbor over halfvec(768) embeddings (cosine distance)
-2. **Full-text search** — PostgreSQL `tsvector` with English stemming
+2. **Full-text search** — PostgreSQL `tsvector`; English uses the stored GIN-indexed `search_vector`
+
+English is the shared default and preserves existing search behavior. Supported non-English configurations recompute the same source text with PostgreSQL `to_tsvector` on the fly for keyword and hybrid searches, so those scans are not index-backed. `OPENBRAIN_FTS_CONFIG` is an operator opt-in that changes the public `search_brain` deployment default; it does not implicitly change sibling `executeSearch` consumers. A caller may explicitly select English, while an explicitly requested effective non-English `fts_config` requires the `admin` or `ob-admin` role.
 
 Results are merged via Reciprocal Rank Fusion (RRF) with adjustments for:
 - **Cognitive tier** — hot entries boosted (+0.3), cold entries penalized (−0.2)

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1335,3 +1335,37 @@ Two coupled receipt-truth defects shipped together:
 - Is there a regression that submits the same identity twice and proves the second
   call is rejected (no mutation, honest verdict), failing on the pre-fix
   mutate-then-check ordering?
+
+## [2026-07-23] Shared search helpers need caller-stable defaults
+
+**Severity:** MEDIUM
+**Source:** PR #368 review, 2026-07-23
+**Scope:** shared search helpers and deployment configuration
+**Status:** fixed-pre-merge
+
+A deployment env default must be resolved at the public boundary and passed
+explicitly; putting it inside a shared helper silently changes sibling consumers
+that never opted into the new behavior.
+
+### Review Questions
+
+- Is deployment configuration resolved by the owning public caller and passed
+  explicitly, while shared helpers retain a caller-stable default?
+
+## [2026-07-23] Every env-gated PG suite needs anti-skip registration
+
+**Severity:** MEDIUM
+**Source:** PR #368 review, 2026-07-23
+**Scope:** env-gated live-Postgres suites and CI anti-skip guards
+**Status:** fixed-pre-merge; all three PR #368 suites registered
+
+Adding an `OPENBRAIN_TEST_DATABASE_URL` suite is incomplete until its exact
+suite name and minimum case count are registered in the CI anti-skip allowlist,
+so a missing DB cannot turn new functional coverage into a green skip. The
+pre-merge fix registers all three PR #368 suites, raises the aggregate floor, and
+tests missing and skipped-suite failures.
+
+### Review Questions
+
+- Does every new env-gated PG suite appear in the anti-skip allowlist with a
+  minimum executed count and a guard regression?

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -319,3 +319,25 @@ identity-and-receipt-fields-must-be-reachable).
 - Is `git diff --check` clean, and does the repo guard against stray control
   bytes (`.gitattributes text`, a control-char lint) so security-sensitive code
   cannot silently become unreviewable?
+
+## [2026-07-23] Migration-mirrored search expressions need all-table parity and unindexed-mode runbooks
+
+**Severity:** MEDIUM
+**Source:** PR #368 review, 2026-07-23
+**Scope:** runtime SQL that mirrors generated-column migrations and operational
+query-mode configuration
+**Status:** active
+
+When runtime SQL duplicates a migration-owned generated-column expression,
+functional parity must cover every table and every contributing field, not one
+representative table or SQL-string inspection. If a selectable mode recomputes
+that expression without its index, operator docs must state the scan/cost
+tradeoff, safe enablement boundary, monitoring/timeout expectations, and
+rollback procedure.
+
+### Review Questions
+
+- Do real-Postgres tests prove indexed/default versus recomputed-mode parity for
+  every table and each migration-owned text source?
+- Do operator docs identify the unindexed path, expected cost controls,
+  observability, enablement scope, and rollback?

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -758,3 +758,24 @@ digest is not observed-content truth — hash received bytes server-side).
 - Is there a regression proving forged caller-attributed content for an approved
   root is rejected/ignored in favor of the server-derived content, failing on the
   pre-fix accept-caller-body path?
+
+## [2026-07-23] Caller-selectable unindexed query modes need privilege, rate, and cost controls
+
+**Severity:** MEDIUM
+**Source:** PR #368 review, 2026-07-23
+**Scope:** caller-selected FTS configurations and other query modes that bypass
+an index
+**Status:** active
+
+An allowlisted query mode can still be a resource-exhaustion surface. If a
+caller can replace an indexed predicate with per-row computation across multiple
+tables, the server must constrain who may select it and bound its aggregate
+frequency and database cost; ordinary result limits do not bound the scan work
+performed before rows are returned.
+
+### Review Questions
+
+- Is the unindexed mode restricted to an appropriate role or server-owned
+  corpus setting rather than every reader?
+- Are rate, concurrency, statement-timeout, and cost/table-scope limits enforced
+  and tested on the expensive path?

--- a/scripts/assert-db-tests-ran.test.ts
+++ b/scripts/assert-db-tests-ran.test.ts
@@ -21,8 +21,7 @@ function suiteXml(
     opts.testcases ??
     Array.from(
       { length: tests },
-      (_, i) =>
-        `<testcase name="case ${i}" classname="${name}" time="0.01" />`,
+      (_, i) => `<testcase name="case ${i}" classname="${name}" time="0.01" />`,
     ).join("\n");
   return (
     `<testsuite name="${name}" tests="${tests}" failures="${failures}" ` +
@@ -31,9 +30,9 @@ function suiteXml(
 }
 
 function allSuitesGreen(): string {
-  return REQUIRED_SUITES.map((s) => suiteXml(s.name, { tests: s.minTests })).join(
-    "\n",
-  );
+  return REQUIRED_SUITES.map((s) =>
+    suiteXml(s.name, { tests: s.minTests }),
+  ).join("\n");
 }
 
 function wrap(inner: string): string {
@@ -44,14 +43,103 @@ describe("assert-db-tests-ran anti-skip guard", () => {
   it("passes when every required live-Postgres suite executed cleanly", () => {
     const result = evaluateJunit(wrap(allSuitesGreen()));
     expect(result.errors).toEqual([]);
-    expect(result.executedLiveTestcases).toBe(19);
+    expect(result.executedLiveTestcases).toBe(27);
+    expect(
+      result.executedLiveTestcasesBySuite.get(
+        "search_brain language-aware FTS ranking (live Postgres)",
+      ),
+    ).toBe(4);
+    expect(
+      result.executedLiveTestcasesBySuite.get(
+        "language-aware FTS covers every migration-007 source field (live Postgres)",
+      ),
+    ).toBe(1);
+    expect(
+      result.executedLiveTestcasesBySuite.get(
+        "declared source language selects the real search config via explicit request (live Postgres)",
+      ),
+    ).toBe(3);
+  });
+
+  it("fails when the language-aware FTS ranking suite is omitted", () => {
+    const missingName =
+      "search_brain language-aware FTS ranking (live Postgres)";
+    const xml = wrap(
+      REQUIRED_SUITES.filter((s) => s.name !== missingName)
+        .map((s) => suiteXml(s.name, { tests: s.minTests }))
+        .join("\n"),
+    );
+    const result = evaluateJunit(xml);
+    expect(
+      result.errors.some((e) => e.includes(`MISSING suite "${missingName}"`)),
+    ).toBe(true);
+  });
+
+  it("fails when the all-table language parity suite is omitted", () => {
+    const missingName =
+      "language-aware FTS covers every migration-007 source field (live Postgres)";
+    const xml = wrap(
+      REQUIRED_SUITES.filter((s) => s.name !== missingName)
+        .map((s) => suiteXml(s.name, { tests: s.minTests }))
+        .join("\n"),
+    );
+    const result = evaluateJunit(xml);
+    expect(
+      result.errors.some((e) => e.includes(`MISSING suite "${missingName}"`)),
+    ).toBe(true);
+  });
+
+  it("fails when the all-table language parity suite is skipped", () => {
+    const skippedName =
+      "language-aware FTS covers every migration-007 source field (live Postgres)";
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === skippedName
+        ? suiteXml(s.name, {
+            tests: s.minTests,
+            skipped: s.minTests,
+            testcases: Array.from(
+              { length: s.minTests },
+              (_, i) =>
+                `<testcase name="case ${i}" classname="${s.name}"><skipped /></testcase>`,
+            ).join("\n"),
+          })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) =>
+        e.includes(`SKIPPED tests in "${skippedName}"`),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when the declared-source language suite is skipped", () => {
+    const skippedName =
+      "declared source language selects the real search config via explicit request (live Postgres)";
+    const suites = REQUIRED_SUITES.map((s) =>
+      s.name === skippedName
+        ? suiteXml(s.name, {
+            tests: s.minTests,
+            skipped: s.minTests,
+            testcases: Array.from(
+              { length: s.minTests },
+              (_, i) =>
+                `<testcase name="case ${i}" classname="${s.name}"><skipped /></testcase>`,
+            ).join("\n"),
+          })
+        : suiteXml(s.name, { tests: s.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((e) =>
+        e.includes(`SKIPPED tests in "${skippedName}"`),
+      ),
+    ).toBe(true);
   });
 
   it("fails when a required suite is missing entirely", () => {
     const xml = wrap(
-      REQUIRED_SUITES.filter(
-        (s) => s.name !== "lane_upsert (live Postgres)",
-      )
+      REQUIRED_SUITES.filter((s) => s.name !== "lane_upsert (live Postgres)")
         .map((s) => suiteXml(s.name, { tests: s.minTests }))
         .join("\n"),
     );
@@ -123,8 +211,7 @@ describe("assert-db-tests-ran anti-skip guard", () => {
               `<testcase name="boom" classname="${name}"><error message="thrown" /></testcase>\n` +
               Array.from(
                 { length: s.minTests - 1 },
-                (_, i) =>
-                  `<testcase name="case ${i}" classname="${name}" />`,
+                (_, i) => `<testcase name="case ${i}" classname="${name}" />`,
               ).join("\n"),
           })
         : suiteXml(s.name, { tests: s.minTests }),
@@ -181,7 +268,7 @@ describe("assert-db-tests-ran anti-skip guard", () => {
     }).join("\n");
 
     const result = evaluateJunit(wrap(suites));
-    expect(result.executedLiveTestcases).toBe(19);
+    expect(result.executedLiveTestcases).toBe(27);
     expect(
       result.errors.some((e) =>
         e.includes(

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -25,25 +25,39 @@ import { readFileSync } from "node:fs";
 // Required live-Postgres suites and the minimum executed testcase count each
 // must contribute. Counts are lower bounds: adding tests must not require
 // touching this guard, but deleting/skipping them will trip it.
-export const REQUIRED_SUITES: ReadonlyArray<{ name: string; minTests: number }> =
-  [
-    { name: "lane_upsert (live Postgres)", minTests: 2 },
-    { name: "promote_shared (live Postgres)", minTests: 1 },
-    { name: "tier_lane (live Postgres)", minTests: 2 },
-    {
-      name: "append_session_event create_if_missing (live Postgres)",
-      minTests: 4,
-    },
-    { name: "runSharedPromoter cursor-stall fix (live Postgres)", minTests: 8 },
-    {
-      name: "search_brain relational retrieval eval fixture (live Postgres)",
-      minTests: 2,
-    },
-  ];
+export const REQUIRED_SUITES: ReadonlyArray<{
+  name: string;
+  minTests: number;
+}> = [
+  { name: "lane_upsert (live Postgres)", minTests: 2 },
+  { name: "promote_shared (live Postgres)", minTests: 1 },
+  { name: "tier_lane (live Postgres)", minTests: 2 },
+  {
+    name: "append_session_event create_if_missing (live Postgres)",
+    minTests: 4,
+  },
+  { name: "runSharedPromoter cursor-stall fix (live Postgres)", minTests: 8 },
+  {
+    name: "search_brain relational retrieval eval fixture (live Postgres)",
+    minTests: 2,
+  },
+  {
+    name: "search_brain language-aware FTS ranking (live Postgres)",
+    minTests: 4,
+  },
+  {
+    name: "language-aware FTS covers every migration-007 source field (live Postgres)",
+    minTests: 1,
+  },
+  {
+    name: "declared source language selects the real search config via explicit request (live Postgres)",
+    minTests: 3,
+  },
+];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
 // independent of the per-suite breakdown above.
-export const MIN_TOTAL_LIVE_TESTCASES = 19;
+export const MIN_TOTAL_LIVE_TESTCASES = 27;
 
 export interface SuiteStats {
   tests: number;

--- a/src/tools/__tests__/fts-config.test.ts
+++ b/src/tools/__tests__/fts-config.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "bun:test";
+import {
+  SUPPORTED_FTS_CONFIGS,
+  DEFAULT_FTS_CONFIG,
+  ftsConfigSchema,
+  resolveFtsConfig,
+  corpusFtsConfig,
+  requestFtsConfig,
+  ftsConfigLiteral,
+} from "../fts-config.ts";
+
+describe("fts-config supported-language policy", () => {
+  it("keeps english as the default so unset corpora behave exactly as before", () => {
+    expect(DEFAULT_FTS_CONFIG).toBe("english");
+    expect(SUPPORTED_FTS_CONFIGS[0]).toBe("english");
+  });
+
+  it("only allows Postgres-shipped regconfigs on the allowlist", () => {
+    // Guard against accidentally adding a config Postgres does not ship by
+    // default. Widening this set is a deliberate, tested change.
+    expect(new Set(SUPPORTED_FTS_CONFIGS)).toEqual(
+      new Set([
+        "english",
+        "simple",
+        "spanish",
+        "french",
+        "german",
+        "portuguese",
+      ]),
+    );
+  });
+
+  it("rejects any value not on the allowlist at the schema boundary", () => {
+    expect(ftsConfigSchema.safeParse("english").success).toBe(true);
+    expect(ftsConfigSchema.safeParse("german").success).toBe(true);
+    expect(ftsConfigSchema.safeParse("klingon").success).toBe(false);
+    // An injection attempt must never validate.
+    expect(
+      ftsConfigSchema.safeParse("english'); DROP TABLE thoughts; --").success,
+    ).toBe(false);
+  });
+});
+
+describe("resolveFtsConfig -- source language metadata -> config", () => {
+  it("maps recognized ISO-639-1 codes to their stemmer config", () => {
+    expect(resolveFtsConfig("en")).toBe("english");
+    expect(resolveFtsConfig("es")).toBe("spanish");
+    expect(resolveFtsConfig("fr")).toBe("french");
+    expect(resolveFtsConfig("de")).toBe("german");
+    expect(resolveFtsConfig("pt")).toBe("portuguese");
+  });
+
+  it("accepts BCP-47 region variants by their primary subtag", () => {
+    expect(resolveFtsConfig("en-US")).toBe("english");
+    expect(resolveFtsConfig("de-DE")).toBe("german");
+    expect(resolveFtsConfig("pt_BR")).toBe("portuguese");
+    expect(resolveFtsConfig("es-419")).toBe("spanish");
+  });
+
+  it("accepts full language names case-insensitively", () => {
+    expect(resolveFtsConfig("German")).toBe("german");
+    expect(resolveFtsConfig("  FRENCH  ")).toBe("french");
+  });
+
+  it("maps mixed/unknown-language markers to the language-neutral simple config", () => {
+    expect(resolveFtsConfig("simple")).toBe("simple");
+    expect(resolveFtsConfig("und")).toBe("simple");
+  });
+
+  it("falls back to english for empty, null, or unrecognized languages", () => {
+    expect(resolveFtsConfig(null)).toBe("english");
+    expect(resolveFtsConfig(undefined)).toBe("english");
+    expect(resolveFtsConfig("")).toBe("english");
+    expect(resolveFtsConfig("klingon")).toBe("english");
+    expect(resolveFtsConfig("zz-ZZ")).toBe("english");
+  });
+});
+
+describe("corpusFtsConfig -- deployment env resolution", () => {
+  it("defaults to english when OPENBRAIN_FTS_CONFIG is unset or blank", () => {
+    expect(corpusFtsConfig({})).toBe("english");
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "" })).toBe("english");
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "   " })).toBe("english");
+  });
+
+  it("accepts a direct supported regconfig name", () => {
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "german" })).toBe("german");
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "SPANISH" })).toBe(
+      "spanish",
+    );
+  });
+
+  it("accepts a source-style language token via the same allowlist", () => {
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "de-DE" })).toBe("german");
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "pt" })).toBe("portuguese");
+  });
+
+  it("never disables lexical search on a typo -- unknown falls back to english", () => {
+    expect(corpusFtsConfig({ OPENBRAIN_FTS_CONFIG: "gernam" })).toBe("english");
+  });
+});
+
+describe("requestFtsConfig -- explicit per-request selection", () => {
+  it("uses the corpus default when no explicit config is given", () => {
+    expect(requestFtsConfig(undefined, {})).toBe("english");
+    expect(requestFtsConfig(null, {})).toBe("english");
+    expect(requestFtsConfig("  ", {})).toBe("english");
+    expect(
+      requestFtsConfig(undefined, { OPENBRAIN_FTS_CONFIG: "german" }),
+    ).toBe("german");
+  });
+
+  it("an explicit supported regconfig wins over the env default", () => {
+    expect(
+      requestFtsConfig("spanish", { OPENBRAIN_FTS_CONFIG: "german" }),
+    ).toBe("spanish");
+    expect(requestFtsConfig("GERMAN", {})).toBe("german");
+  });
+
+  it("accepts an explicit language token via the same allowlist", () => {
+    expect(requestFtsConfig("de-DE", {})).toBe("german");
+    expect(requestFtsConfig("pt", {})).toBe("portuguese");
+  });
+
+  it("honors an explicit english token even when the corpus default differs", () => {
+    // A caller explicitly asking for english must get english, not the corpus.
+    expect(requestFtsConfig("en", { OPENBRAIN_FTS_CONFIG: "german" })).toBe(
+      "english",
+    );
+    expect(
+      requestFtsConfig("english", { OPENBRAIN_FTS_CONFIG: "spanish" }),
+    ).toBe("english");
+  });
+
+  it("unrecognized explicit values fall back to the corpus default, not english", () => {
+    // A typo must never silently override a configured corpus with english.
+    expect(requestFtsConfig("gernam", { OPENBRAIN_FTS_CONFIG: "german" })).toBe(
+      "german",
+    );
+    // With no corpus configured, an unrecognized value degrades to english.
+    expect(requestFtsConfig("klingon", {})).toBe("english");
+  });
+
+  it("never yields a value off the allowlist for a hostile input", () => {
+    const hostile = "english'); DROP TABLE thoughts; --";
+    const result = requestFtsConfig(hostile, {});
+    expect(SUPPORTED_FTS_CONFIGS).toContain(result);
+  });
+});
+
+describe("ftsConfigLiteral -- SQL interpolation backstop", () => {
+  it("returns the config unchanged for allowlisted values", () => {
+    for (const config of SUPPORTED_FTS_CONFIGS) {
+      expect(ftsConfigLiteral(config)).toBe(config);
+    }
+  });
+
+  it("throws if a non-allowlisted value reaches interpolation", () => {
+    // Simulate a caller bypassing the type system.
+    expect(() =>
+      ftsConfigLiteral("english'; DROP TABLE thoughts; --" as never),
+    ).toThrow(/Unsupported FTS configuration/);
+  });
+});

--- a/src/tools/__tests__/search-brain-fts-language.pg.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.pg.test.ts
@@ -201,6 +201,165 @@ dbDescribe("search_brain language-aware FTS ranking (live Postgres)", () => {
 });
 
 dbDescribe(
+  "language-aware FTS covers every migration-007 source field (live Postgres)",
+  () => {
+    const pool = new Pool({ connectionString: DB_URL });
+    const deps = { pool: pool as any, embedFn: embed };
+    const ns = "test-fts-language-all-tables";
+
+    const tableCases = [
+      {
+        table: "decisions" as const,
+        ids: [
+          "22000000-0000-4000-8000-000000000001",
+          "22000000-0000-4000-8000-000000000002",
+          "22000000-0000-4000-8000-000000000003",
+          "22000000-0000-4000-8000-000000000004",
+        ],
+        seed: () =>
+          pool.query(
+            `INSERT INTO decisions
+               (id, title, rationale, context, tags, namespace, created_by)
+             VALUES
+               ($2, 'Häuser', 'neutral rationale', NULL, '{}', $1, 'test'),
+               ($3, 'neutral title 2', 'Häuser', NULL, '{}', $1, 'test'),
+               ($4, 'neutral title 3', 'neutral rationale', 'Häuser', '{}', $1, 'test'),
+               ($5, 'neutral title 4', 'neutral rationale', NULL, ARRAY['Häuser'], $1, 'test')`,
+            [
+              ns,
+              "22000000-0000-4000-8000-000000000001",
+              "22000000-0000-4000-8000-000000000002",
+              "22000000-0000-4000-8000-000000000003",
+              "22000000-0000-4000-8000-000000000004",
+            ],
+          ),
+      },
+      {
+        table: "relationships" as const,
+        ids: [
+          "22000000-0000-4000-8000-000000000011",
+          "22000000-0000-4000-8000-000000000012",
+          "22000000-0000-4000-8000-000000000013",
+        ],
+        seed: () =>
+          pool.query(
+            `INSERT INTO relationships
+               (id, person_name, context, tags, namespace, created_by)
+             VALUES
+               ($2, 'Häuser', NULL, '{}', $1, 'test'),
+               ($3, 'neutral person 12', 'Häuser', '{}', $1, 'test'),
+               ($4, 'neutral person 13', NULL, ARRAY['Häuser'], $1, 'test')`,
+            [
+              ns,
+              "22000000-0000-4000-8000-000000000011",
+              "22000000-0000-4000-8000-000000000012",
+              "22000000-0000-4000-8000-000000000013",
+            ],
+          ),
+      },
+      {
+        table: "projects" as const,
+        ids: [
+          "22000000-0000-4000-8000-000000000021",
+          "22000000-0000-4000-8000-000000000022",
+          "22000000-0000-4000-8000-000000000023",
+        ],
+        seed: () =>
+          pool.query(
+            `INSERT INTO projects
+               (id, name, description, tags, namespace, created_by)
+             VALUES
+               ($2, 'Häuser', NULL, '{}', $1, 'test'),
+               ($3, 'neutral project 22', 'Häuser', '{}', $1, 'test'),
+               ($4, 'neutral project 23', NULL, ARRAY['Häuser'], $1, 'test')`,
+            [
+              ns,
+              "22000000-0000-4000-8000-000000000021",
+              "22000000-0000-4000-8000-000000000022",
+              "22000000-0000-4000-8000-000000000023",
+            ],
+          ),
+      },
+      {
+        table: "sessions" as const,
+        ids: [
+          "22000000-0000-4000-8000-000000000031",
+          "22000000-0000-4000-8000-000000000032",
+          "22000000-0000-4000-8000-000000000033",
+          "22000000-0000-4000-8000-000000000034",
+        ],
+        seed: () =>
+          pool.query(
+            `INSERT INTO sessions
+               (id, summary, next_steps, key_decisions, tags, namespace, created_by)
+             VALUES
+               ($2, 'Häuser', '{}', '{}', '{}', $1, 'test'),
+               ($3, 'neutral summary 32', ARRAY['Häuser'], '{}', '{}', $1, 'test'),
+               ($4, 'neutral summary 33', '{}', ARRAY['Häuser'], '{}', $1, 'test'),
+               ($5, 'neutral summary 34', '{}', '{}', ARRAY['Häuser'], $1, 'test')`,
+            [
+              ns,
+              "22000000-0000-4000-8000-000000000031",
+              "22000000-0000-4000-8000-000000000032",
+              "22000000-0000-4000-8000-000000000033",
+              "22000000-0000-4000-8000-000000000034",
+            ],
+          ),
+      },
+    ];
+
+    beforeAll(async () => {
+      await assertUtf8Harness(pool);
+    });
+
+    afterAll(async () => {
+      await cleanup();
+      await pool.end();
+    });
+
+    async function cleanup(): Promise<void> {
+      for (const { table } of tableCases.toReversed()) {
+        await pool.query(`DELETE FROM ${table} WHERE namespace = $1`, [ns]);
+      }
+    }
+
+    async function keywordIds(
+      table: (typeof tableCases)[number]["table"],
+      ftsConfig: "english" | "german",
+    ): Promise<string[]> {
+      const rows = await executeSearch(
+        deps as any,
+        [table],
+        "Haus",
+        10,
+        "keyword",
+        undefined,
+        0,
+        ns,
+        false,
+        undefined,
+        { ftsConfig },
+      );
+      return rows.map((row) => row.id);
+    }
+
+    it("finds an isolated German inflection in every indexed field", async () => {
+      await cleanup();
+
+      for (const tableCase of tableCases) {
+        await tableCase.seed();
+
+        const underGerman = await keywordIds(tableCase.table, "german");
+        const underEnglish = await keywordIds(tableCase.table, "english");
+
+        expect(underGerman.toSorted()).toEqual(tableCase.ids.toSorted());
+        expect(underEnglish).toEqual([]);
+      }
+    });
+  },
+);
+
+dbDescribe(
   "declared source language selects the real search config via explicit request (live Postgres)",
   () => {
     const pool = new Pool({ connectionString: DB_URL });

--- a/src/tools/__tests__/search-brain-fts-language.pg.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.pg.test.ts
@@ -1,0 +1,360 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { executeSearch } from "../search-brain.ts";
+import { requestFtsConfig, resolveFtsConfig } from "../fts-config.ts";
+import { createMockEmbed } from "./test-helpers.ts";
+
+/**
+ * Live-PostgreSQL functional ranking coverage for language-aware FTS (#341).
+ *
+ * These run only when OPENBRAIN_TEST_DATABASE_URL points at a real Postgres
+ * with the migrations applied (the stored english search_vector column and the
+ * bundled snowball text-search configs). They prove the actual retrieval
+ * benefit: content that only matches once its language is stemmed correctly is
+ * found under the language-aware config and NOT under a mismatched english
+ * config -- the before/after that motivates the change.
+ *
+ * HONEST SCOPE. There is NO thought->ob_sources linkage in the schema
+ * (`thoughts` has no source_id), so an ob_sources.language value cannot, on its
+ * own, control the config a search analyzes with. The truthful causal chain is:
+ * a corpus's declared language -> an explicit request `fts_config` setting ->
+ * the regconfig the real search path actually uses. The per-source-kind block
+ * below exercises exactly that chain (resolveFtsConfig(language) fed as the
+ * explicit request config), and does NOT pretend an unlinked source row drives
+ * retrieval by itself.
+ */
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+// Vector arm is irrelevant here; force keyword mode so we isolate the lexical
+// FTS config behavior deterministically.
+const embed = createMockEmbed(null);
+const THOUGHTS_ONLY: "thoughts"[] = ["thoughts"];
+
+dbDescribe("search_brain language-aware FTS ranking (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const deps = { pool: pool as any, embedFn: embed };
+  const ns = "test-fts-language";
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM entry_access_log WHERE query_text LIKE $1", [
+      "%__fts_lang_probe__%",
+    ]);
+    await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+    await pool.query(
+      "DELETE FROM ob_sources WHERE namespace = $1 AND external_id LIKE $2",
+      [ns, "fts-lang/%"],
+    );
+  }
+
+  async function seedThought(id: string, content: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
+       VALUES ($1, $2, $3, 'test', $4)
+       ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content`,
+      [id, content, ns, `fts-lang-${id}`],
+    );
+  }
+
+  /**
+   * Seed a thought whose matchable non-english token lives ONLY in `tags`, not
+   * in `content`. Both FTS paths fold tags into the analyzed text (english via
+   * the stored generated `search_vector`, non-english via the on-the-fly
+   * to_tsvector over FTS_SOURCE_TEXT), so this isolates tag-token stemming.
+   */
+  async function seedThoughtWithTags(
+    id: string,
+    content: string,
+    tags: string[],
+  ): Promise<void> {
+    await pool.query(
+      `INSERT INTO thoughts (id, content, tags, namespace, created_by, content_hash)
+       VALUES ($1, $2, $3, $4, 'test', $5)
+       ON CONFLICT (id) DO UPDATE
+         SET content = EXCLUDED.content, tags = EXCLUDED.tags`,
+      [id, content, tags, ns, `fts-lang-${id}`],
+    );
+  }
+
+  async function keywordIds(
+    query: string,
+    ftsConfig: "english" | "german" | "spanish",
+  ): Promise<string[]> {
+    const rows = await executeSearch(
+      deps as any,
+      THOUGHTS_ONLY,
+      query,
+      10,
+      "keyword",
+      undefined,
+      0,
+      ns,
+      false,
+      undefined,
+      { ftsConfig },
+    );
+    return rows.map((r) => r.id);
+  }
+
+  it("german stemming finds a document english analysis misses (before/after)", async () => {
+    await cleanup();
+    // "Häuser" (houses) stems to "haus" under german; english leaves it intact,
+    // so an english analysis of the query "Haus" never matches the document.
+    const doc = "20000000-0000-4000-8000-000000000001";
+    await seedThought(
+      doc,
+      "Die Häuser in der Stadt sind alt __fts_lang_probe__",
+    );
+
+    const underGerman = await keywordIds("Haus", "german");
+    const underEnglish = await keywordIds("Haus", "english");
+
+    // AFTER (language-aware): the german-stemmed query matches the document.
+    expect(underGerman).toContain(doc);
+    // BEFORE (mismatched english config): the same query misses it.
+    expect(underEnglish).not.toContain(doc);
+  });
+
+  it("token present ONLY in tags is found under language-aware stemming, missed under english", async () => {
+    await cleanup();
+    // The German inflection "Häuser" lives ONLY in tags -- the content has no
+    // German word. german stems the tag "haeuser"->"haus", so the query "Haus"
+    // matches via the tag; english leaves the tag token intact and never does.
+    const doc = "20000000-0000-4000-8000-000000000004";
+    await seedThoughtWithTags(
+      doc,
+      "Neutral english body with no german word __fts_lang_probe__",
+      ["Häuser", "stadt"],
+    );
+
+    const underGerman = await keywordIds("Haus", "german");
+    const underEnglish = await keywordIds("Haus", "english");
+
+    // AFTER (language-aware): the german-stemmed tag matches the query.
+    expect(underGerman).toContain(doc);
+    // BEFORE (mismatched english config): the same tag token misses it.
+    expect(underEnglish).not.toContain(doc);
+  });
+
+  it("spanish stemming matches an inflected form english analysis misses", async () => {
+    await cleanup();
+    // "corriendo"/"corrió" share the stem "corr" under spanish.
+    const doc = "20000000-0000-4000-8000-000000000002";
+    await seedThought(
+      doc,
+      "El atleta estaba corriendo por el parque __fts_lang_probe__",
+    );
+
+    const underSpanish = await keywordIds("corrió", "spanish");
+    const underEnglish = await keywordIds("corrió", "english");
+
+    expect(underSpanish).toContain(doc);
+    expect(underEnglish).not.toContain(doc);
+  });
+
+  it("english default path is unchanged for english content", async () => {
+    await cleanup();
+    const doc = "20000000-0000-4000-8000-000000000003";
+    await seedThought(
+      doc,
+      "The runner was running through the park __fts_lang_probe__",
+    );
+    // english stems running->run; the query "runners" matches.
+    const ids = await keywordIds("runners", "english");
+    expect(ids).toContain(doc);
+  });
+});
+
+dbDescribe(
+  "declared source language selects the real search config via explicit request (live Postgres)",
+  () => {
+    const pool = new Pool({ connectionString: DB_URL });
+    const deps = { pool: pool as any, embedFn: embed };
+    const ns = "test-fts-language-e2e";
+
+    afterAll(async () => {
+      await cleanup();
+      await pool.end();
+    });
+
+    async function cleanup(): Promise<void> {
+      await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+      await pool.query(
+        "DELETE FROM ob_sources WHERE namespace = $1 AND external_id LIKE $2",
+        [ns, "fts-lang-e2e/%"],
+      );
+    }
+
+    // One representative supported-language corpus per approved source kind:
+    // synchronized file source (directory), approved drop-folder (drop), and
+    // approved conversation content (conversation). Each declares a language on
+    // its ob_sources row; that declared language is fed as the explicit request
+    // `fts_config` (via requestFtsConfig) -- the same knob a caller uses -- and
+    // that is what selects the config the real search path analyzes with.
+    const sources = [
+      {
+        kind: "directory" as const,
+        externalId: "fts-lang-e2e/repo-de",
+        language: "de-DE",
+        expectConfig: "german" as const,
+        thoughtId: "21000000-0000-4000-8000-000000000001",
+        content: "Die Häuser wurden im Repository dokumentiert",
+        query: "Haus",
+        missUnder: "english" as const,
+      },
+      {
+        kind: "drop" as const,
+        externalId: "fts-lang-e2e/drop-es",
+        language: "es",
+        expectConfig: "spanish" as const,
+        thoughtId: "21000000-0000-4000-8000-000000000002",
+        content: "El documento describe atletas corriendo",
+        query: "corrió",
+        missUnder: "english" as const,
+      },
+      {
+        kind: "conversation" as const,
+        externalId: "fts-lang-e2e/convo-en",
+        language: "en-US",
+        expectConfig: "english" as const,
+        thoughtId: "21000000-0000-4000-8000-000000000003",
+        content: "The teams were running the deployment",
+        query: "runs",
+        missUnder: null,
+      },
+    ];
+
+    /** Seed the approved source row AND read its stored language back. */
+    async function seedSource(s: (typeof sources)[number]): Promise<string> {
+      const { rows } = await pool.query(
+        `INSERT INTO ob_sources
+           (namespace, source_kind, external_id, approval_state, approved_by,
+            approved_at, lifecycle_state, language, created_by)
+         VALUES ($1, $2, $3, 'approved', 'test-approver', now(), 'active', $4, 'test')
+         ON CONFLICT (namespace, source_kind, external_id)
+         DO UPDATE SET language = EXCLUDED.language, approval_state = 'approved'
+         RETURNING language`,
+        [ns, s.kind, s.externalId, s.language],
+      );
+      await pool.query(
+        `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
+         VALUES ($1, $2, $3, 'test', $4)
+         ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content`,
+        [s.thoughtId, s.content, ns, `fts-lang-e2e-${s.thoughtId}`],
+      );
+      return rows[0].language as string;
+    }
+
+    /**
+     * Run the real search path. `declaredLanguage` is the value stored on the
+     * source row; it flows through requestFtsConfig exactly as the public
+     * `search_brain` handler routes its `fts_config` argument -- there is no
+     * hand-picked internal config literal here.
+     */
+    async function keywordIdsForLanguage(
+      query: string,
+      declaredLanguage: string,
+    ): Promise<string[]> {
+      const rows = await executeSearch(
+        deps as any,
+        THOUGHTS_ONLY,
+        query,
+        10,
+        "keyword",
+        undefined,
+        0,
+        ns,
+        false,
+        undefined,
+        // requestFtsConfig(declaredLanguage) is the caller-visible selection;
+        // pass an empty env so ONLY the declared language can drive the config.
+        { ftsConfig: requestFtsConfig(declaredLanguage, {}) },
+      );
+      return rows.map((r) => r.id);
+    }
+
+    it("each source's stored language maps to the expected config (metadata only)", async () => {
+      // Pure metadata-mapping check: the stored ob_sources.language round-trips
+      // to the right regconfig. This does NOT by itself drive retrieval -- the
+      // ranking test below proves the retrieval effect via the explicit request.
+      await cleanup();
+      for (const s of sources) {
+        const stored = await seedSource(s);
+        expect(resolveFtsConfig(stored)).toBe(s.expectConfig);
+      }
+    });
+
+    it("declared source language, fed as the explicit request config, drives ranking", async () => {
+      await cleanup();
+      for (const s of sources) {
+        const declaredLanguage = await seedSource(s);
+        const underOwn = await keywordIdsForLanguage(s.query, declaredLanguage);
+        expect(underOwn).toContain(s.thoughtId);
+        if (s.missUnder) {
+          // Same query, but english (the mismatched config) misses it.
+          const underMismatch = await keywordIdsForLanguage(s.query, "en");
+          expect(underMismatch).not.toContain(s.thoughtId);
+        }
+      }
+    });
+
+    it("deterministic before/after comparison across the three source kinds", async () => {
+      await cleanup();
+      // Structured, order-stable table: for each representative fixture, record
+      // whether its document is found under (a) english = the pre-#341 baseline
+      // and (b) its declared language config. english-content fixtures must
+      // show NO regression; non-english fixtures show the language-aware gain.
+      const comparison = [];
+      for (const s of sources) {
+        const declaredLanguage = await seedSource(s);
+        const foundUnderEnglish = (
+          await keywordIdsForLanguage(s.query, "en")
+        ).includes(s.thoughtId);
+        const foundUnderDeclared = (
+          await keywordIdsForLanguage(s.query, declaredLanguage)
+        ).includes(s.thoughtId);
+        comparison.push({
+          kind: s.kind,
+          declaredLanguage,
+          config: s.expectConfig,
+          query: s.query,
+          before_english: foundUnderEnglish,
+          after_declared: foundUnderDeclared,
+        });
+      }
+
+      expect(comparison).toEqual([
+        {
+          kind: "directory",
+          declaredLanguage: "de-DE",
+          config: "german",
+          query: "Haus",
+          before_english: false, // english analysis misses the german inflection
+          after_declared: true, // german stemming finds it
+        },
+        {
+          kind: "drop",
+          declaredLanguage: "es",
+          config: "spanish",
+          query: "corrió",
+          before_english: false,
+          after_declared: true,
+        },
+        {
+          kind: "conversation",
+          declaredLanguage: "en-US",
+          config: "english",
+          query: "runs",
+          before_english: true, // english content: no regression
+          after_declared: true, // declared english == baseline
+        },
+      ]);
+    });
+  },
+);

--- a/src/tools/__tests__/search-brain-fts-language.pg.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.pg.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { executeSearch } from "../search-brain.ts";
 import { requestFtsConfig, resolveFtsConfig } from "../fts-config.ts";
@@ -27,6 +27,31 @@ import { createMockEmbed } from "./test-helpers.ts";
 const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
 const dbDescribe = DB_URL ? describe : describe.skip;
 
+/**
+ * Fail loudly on a non-UTF8 test harness. Under SQL_ASCII (or any non-UTF8
+ * encoding) the snowball stemmers split the multibyte bytes of accented
+ * characters (ä -> two single-byte chars), so "Häuser" never stems to "haus"
+ * and every non-english ranking assertion below returns []. That looks like a
+ * product bug but is purely an invalid harness -- Open Brain is UTF8 in
+ * production. This turns the confusing empty-ranking failure into a clear
+ * "test DB must be UTF8" signal. See .github/workflows/ci.yml (`createdb
+ * -E UTF8 -T template0`).
+ */
+async function assertUtf8Harness(pool: Pool): Promise<void> {
+  const { rows } = await pool.query<{ server_encoding: string }>(
+    "SHOW server_encoding",
+  );
+  const encoding = rows[0]?.server_encoding;
+  if (encoding !== "UTF8") {
+    throw new Error(
+      `language-aware FTS tests require a UTF8 test database; server_encoding is ` +
+        `${encoding ?? "unknown"}. Snowball stemming of accented multibyte text ` +
+        `is broken under non-UTF8 encodings. Recreate the DB with ` +
+        `\`createdb -E UTF8 -T template0\`.`,
+    );
+  }
+}
+
 // Vector arm is irrelevant here; force keyword mode so we isolate the lexical
 // FTS config behavior deterministically.
 const embed = createMockEmbed(null);
@@ -36,6 +61,10 @@ dbDescribe("search_brain language-aware FTS ranking (live Postgres)", () => {
   const pool = new Pool({ connectionString: DB_URL });
   const deps = { pool: pool as any, embedFn: embed };
   const ns = "test-fts-language";
+
+  beforeAll(async () => {
+    await assertUtf8Harness(pool);
+  });
 
   afterAll(async () => {
     await cleanup();
@@ -177,6 +206,10 @@ dbDescribe(
     const pool = new Pool({ connectionString: DB_URL });
     const deps = { pool: pool as any, embedFn: embed };
     const ns = "test-fts-language-e2e";
+
+    beforeAll(async () => {
+      await assertUtf8Harness(pool);
+    });
 
     afterAll(async () => {
       await cleanup();

--- a/src/tools/__tests__/search-brain-fts-language.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { registerSearchBrain } from "../search-brain.ts";
+import type { AuthInfo } from "../../types.ts";
+import { createMockEmbed, setupMcpClient } from "./test-helpers.ts";
+
+/**
+ * Functional coverage for language-aware FTS configuration selection (#341).
+ *
+ * These assert the OBSERVABLE lexical behavior of the search boundary: which
+ * text-search configuration the emitted FTS SQL analyzes with for a given
+ * corpus config, that the english default preserves the fast GIN-indexed stored
+ * column, that a non-english corpus stays internally consistent (match arm and
+ * rank arm share one config against the same text), and that isolation and
+ * parameterization survive. They do not assert call order or SQL line shape
+ * beyond the config that actually governs matching.
+ */
+
+const admin: AuthInfo = { role: "admin", clientId: "admin-client" };
+
+/** Pool that records every FTS-arm SQL statement it is asked to run. */
+function recordingPool() {
+  const ftsSql: string[] = [];
+  const allSql: string[] = [];
+  return {
+    ftsSql,
+    allSql,
+    pool: {
+      query: async (...args: any[]) => {
+        const sql = String(args[0]);
+        allSql.push(sql);
+        if (sql.includes("fts_query")) ftsSql.push(sql);
+        if (sql.includes("FROM ob_links")) return { rows: [] };
+        return { rows: [] };
+      },
+    },
+  };
+}
+
+async function runKeywordSearch(
+  pool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+  query: string,
+  opts: { namespace?: string; ftsConfig?: string } = {},
+): Promise<void> {
+  const { client, cleanup } = await setupMcpClient(
+    registerSearchBrain,
+    pool,
+    createMockEmbed(),
+    admin,
+  );
+  try {
+    await client.callTool({
+      name: "search_brain",
+      arguments: {
+        query,
+        search_mode: "keyword",
+        table: "thoughts",
+        ...(opts.namespace ? { namespace: opts.namespace } : {}),
+        ...(opts.ftsConfig ? { fts_config: opts.ftsConfig } : {}),
+      },
+    });
+  } finally {
+    await cleanup();
+  }
+}
+
+const savedFtsConfig = process.env.OPENBRAIN_FTS_CONFIG;
+afterEach(() => {
+  if (savedFtsConfig === undefined) delete process.env.OPENBRAIN_FTS_CONFIG;
+  else process.env.OPENBRAIN_FTS_CONFIG = savedFtsConfig;
+});
+
+describe("search_brain FTS configuration selection", () => {
+  it("english default: analyzes with english and uses the stored search_vector column", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "quarterly planning");
+
+    expect(ftsSql.length).toBeGreaterThan(0);
+    const sql = ftsSql.join("\n");
+    // Default path is byte-identical to pre-#341: stored column + english tsquery.
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+    // It must NOT recompute a tsvector on the fly for the default path.
+    expect(sql).not.toContain("to_tsvector('english'");
+  });
+
+  it("german corpus: match AND rank arms share one allowlisted german config, off the stored column", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "vierteljährliche Planung");
+
+    const sql = ftsSql.join("\n");
+    // The regconfig literal is the allowlisted 'german' -- the one internal
+    // detail no public result can distinguish (english vs german stemming is
+    // proven functionally by the live-Postgres ranking test). Both arms use it:
+    // the WHERE match arm recomputes to_tsvector('german', ...) @@ ..., and the
+    // rank arm ranks with the same recomputed german tsvector.
+    expect(sql).toContain("to_tsvector('german',"); // recomputed, not stored col
+    expect(sql).toContain("@@ plainto_tsquery('german',"); // match arm config
+    expect(sql).toMatch(/ts_rank_cd\(to_tsvector\('german',/); // rank arm config
+    // Non-english path abandons the english stored column entirely -- no mixed
+    // config, so the query arm can never mismatch the analyzed text.
+    expect(sql).not.toContain("t.search_vector @@");
+    expect(sql).not.toContain("'english'");
+  });
+
+  it("non-english recompute folds in the same tags term the stored column indexes", async () => {
+    // Regression guard: the stored search_vector (migration 007) analyzes
+    // content + tags. If the on-the-fly recompute dropped the tags term it would
+    // silently under-index non-english corpora vs the english default. There is
+    // no stored-column output to diff against here, so assert the source text.
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "Planung");
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("immutable_array_to_string(t.tags, ' ')");
+  });
+
+  it("resolves a source-style language token (de-DE) to the german config", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "de-DE";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "Planung");
+    expect(ftsSql.join("\n")).toContain("plainto_tsquery('german',");
+  });
+
+  it("spanish corpus: analyzes with the spanish config", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "spanish";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "planificación trimestral");
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("to_tsvector('spanish',");
+    expect(sql).toContain("@@ plainto_tsquery('spanish',");
+  });
+
+  it("unknown corpus config falls back to the english stored-column path", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "gernam"; // typo
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "planning");
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+  });
+
+  it("keeps the query text parameterized regardless of config", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    const injection = "'; DROP TABLE thoughts; --";
+    await runKeywordSearch(pool, injection);
+    const sql = ftsSql.join("\n");
+    // Query text flows through the parameterized fts_query CTE, never inlined.
+    expect(sql).toContain("SELECT q FROM fts_query");
+    expect(sql).not.toContain(injection);
+    // Config is a fixed allowlisted literal; the query is never a config literal.
+    expect(sql).not.toContain(`plainto_tsquery('${injection}'`);
+  });
+
+  it("preserves the namespace predicate under a non-english config", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, allSql, pool } = recordingPool();
+    const namespace = "client-42";
+    await runKeywordSearch(pool, "Planung", { namespace });
+    const sql = ftsSql.join("\n");
+    // Namespace stays a parameter, still applied on the language-aware path.
+    expect(sql).toContain("t.namespace = $");
+    // Namespace value is never inlined into any statement.
+    expect(allSql.join("\n")).not.toContain(namespace);
+  });
+});
+
+describe("search_brain explicit fts_config request argument", () => {
+  it("an explicit fts_config selects the config in the real search path (no env)", async () => {
+    // The caller-visible knob, not an env var, drives the emitted SQL.
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "vierteljährliche Planung", {
+      ftsConfig: "german",
+    });
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("to_tsvector('german',");
+    expect(sql).toContain("@@ plainto_tsquery('german',");
+    expect(sql).not.toContain("t.search_vector @@");
+  });
+
+  it("accepts a language token (de-DE) as the explicit request config", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "Planung", { ftsConfig: "de-DE" });
+    expect(ftsSql.join("\n")).toContain("plainto_tsquery('german',");
+  });
+
+  it("an explicit request config overrides the deployment env default", async () => {
+    // Deployment corpus is german, but this request asks for spanish.
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "planificación", { ftsConfig: "spanish" });
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("plainto_tsquery('spanish',");
+    expect(sql).not.toContain("plainto_tsquery('german',");
+  });
+
+  it("an unrecognized explicit config falls back to the env corpus default", async () => {
+    // A typo in the request must not force english when a corpus is configured.
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "Planung", { ftsConfig: "gernam" });
+    expect(ftsSql.join("\n")).toContain("plainto_tsquery('german',");
+  });
+
+  it("no explicit config uses the env corpus default", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "spanish";
+    const { ftsSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "planificación");
+    expect(ftsSql.join("\n")).toContain("plainto_tsquery('spanish',");
+  });
+
+  it("the injected config literal is always allowlisted, never caller text", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    const { ftsSql, pool } = recordingPool();
+    // A config-injection attempt is not on the allowlist -> falls back safely.
+    await runKeywordSearch(pool, "planning", {
+      ftsConfig: "english'); DROP TABLE thoughts; --",
+    });
+    const sql = ftsSql.join("\n");
+    expect(sql).not.toContain("DROP TABLE");
+    expect(sql).toContain("plainto_tsquery('english',");
+  });
+});

--- a/src/tools/__tests__/search-brain-fts-language.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, afterEach } from "bun:test";
-import { registerSearchBrain } from "../search-brain.ts";
+import { executeSearch, registerSearchBrain } from "../search-brain.ts";
 import type { AuthInfo } from "../../types.ts";
-import { createMockEmbed, setupMcpClient } from "./test-helpers.ts";
+import {
+  createMockEmbed,
+  getErrorText,
+  setupMcpClient,
+} from "./test-helpers.ts";
 
 /**
  * Functional coverage for language-aware FTS configuration selection (#341).
@@ -16,6 +20,11 @@ import { createMockEmbed, setupMcpClient } from "./test-helpers.ts";
  */
 
 const admin: AuthInfo = { role: "admin", clientId: "admin-client" };
+const agent: AuthInfo = { role: "agent", clientId: "agent-client" };
+const obAdmin: AuthInfo = {
+  role: "ob-admin",
+  clientId: "ob-admin-client",
+};
 
 /** Pool that records every FTS-arm SQL statement it is asked to run. */
 function recordingPool() {
@@ -39,16 +48,20 @@ function recordingPool() {
 async function runKeywordSearch(
   pool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
   query: string,
-  opts: { namespace?: string; ftsConfig?: string } = {},
-): Promise<void> {
+  opts: {
+    namespace?: string;
+    ftsConfig?: string;
+    auth?: AuthInfo;
+  } = {},
+): Promise<any> {
   const { client, cleanup } = await setupMcpClient(
     registerSearchBrain,
     pool,
     createMockEmbed(),
-    admin,
+    opts.auth ?? admin,
   );
   try {
-    await client.callTool({
+    return await client.callTool({
       name: "search_brain",
       arguments: {
         query,
@@ -67,6 +80,108 @@ const savedFtsConfig = process.env.OPENBRAIN_FTS_CONFIG;
 afterEach(() => {
   if (savedFtsConfig === undefined) delete process.env.OPENBRAIN_FTS_CONFIG;
   else process.env.OPENBRAIN_FTS_CONFIG = savedFtsConfig;
+});
+
+describe("shared executeSearch FTS default", () => {
+  it("ignores OPENBRAIN_FTS_CONFIG for sibling keyword callers", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+
+    await executeSearch(
+      { pool: pool as any, embedFn: createMockEmbed() },
+      ["thoughts"],
+      "quarterly planning",
+      10,
+      "keyword",
+      undefined,
+      0,
+      undefined,
+      false,
+    );
+
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+    expect(sql).not.toContain("to_tsvector('german'");
+    expect(sql).not.toContain("plainto_tsquery('german',");
+  });
+
+  it("keeps english when a sibling hybrid caller falls back after embedding failure", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+
+    await executeSearch(
+      { pool: pool as any, embedFn: createMockEmbed(null) },
+      ["thoughts"],
+      "quarterly planning",
+      10,
+      "hybrid",
+      undefined,
+      0,
+      undefined,
+      false,
+    );
+
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+    expect(sql).not.toContain("to_tsvector('german'");
+    expect(sql).not.toContain("plainto_tsquery('german',");
+  });
+
+  it("keeps english for a sibling hybrid caller when vector search succeeds", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const allSql: string[] = [];
+    const pool = {
+      query: async (...args: any[]) => {
+        const sql = String(args[0]);
+        allSql.push(sql);
+        if (sql.includes("query_embedding")) {
+          return {
+            rows: [
+              {
+                source_type: "thought",
+                id: "vector-hit",
+                namespace: "rico",
+                content_preview: "Quarterly planning",
+                tags: [],
+                created_by: "test",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                tier: "warm",
+                distance: 0.1,
+                fts_rank: null,
+                usefulness: 0.5,
+                access_count: 0,
+                extracted_metadata: null,
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      },
+    };
+
+    const rows = await executeSearch(
+      { pool: pool as any, embedFn: createMockEmbed() },
+      ["thoughts"],
+      "quarterly planning",
+      10,
+      "hybrid",
+      undefined,
+      0,
+      undefined,
+      false,
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(["vector-hit"]);
+    expect(allSql.some((sql) => sql.includes("query_embedding"))).toBe(true);
+    const ftsSql = allSql.find((sql) => sql.includes("fts_query"));
+    expect(ftsSql).toContain("t.search_vector @@");
+    expect(ftsSql).toContain("plainto_tsquery('english',");
+    expect(ftsSql).not.toContain("to_tsvector('german'");
+    expect(ftsSql).not.toContain("plainto_tsquery('german',");
+  });
 });
 
 describe("search_brain FTS configuration selection", () => {
@@ -168,6 +283,74 @@ describe("search_brain FTS configuration selection", () => {
 });
 
 describe("search_brain explicit fts_config request argument", () => {
+  it("denies an ordinary caller's effective non-english config before search", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    for (const ftsConfig of ["german", "de-DE"]) {
+      const { allSql, pool } = recordingPool();
+      const result = await runKeywordSearch(pool, "Planung", {
+        ftsConfig,
+        auth: agent,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toBe(
+        "Permission denied: non-English FTS configuration requires admin or ob-admin",
+      );
+      expect(allSql).toEqual([]);
+    }
+  });
+
+  it("allows ob-admin to request a non-english config", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    const { ftsSql, pool } = recordingPool();
+    const result = await runKeywordSearch(pool, "Planung", {
+      ftsConfig: "german",
+      auth: obAdmin,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(ftsSql.join("\n")).toContain("plainto_tsquery('german',");
+  });
+
+  it("allows an ordinary caller to request english under a non-english operator default", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    const result = await runKeywordSearch(pool, "planning", {
+      ftsConfig: "english",
+      auth: agent,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+    expect(sql).not.toContain("plainto_tsquery('german',");
+  });
+
+  it("allows an operator-controlled non-english default for an ordinary caller", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    const result = await runKeywordSearch(pool, "Planung", { auth: agent });
+
+    expect(result.isError).toBeFalsy();
+    expect(ftsSql.join("\n")).toContain("plainto_tsquery('german',");
+  });
+
+  it("denies an explicit typo when its effective operator default is non-english", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { allSql, pool } = recordingPool();
+    const result = await runKeywordSearch(pool, "Planung", {
+      ftsConfig: "gernam",
+      auth: agent,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getErrorText(result)).toBe(
+      "Permission denied: non-English FTS configuration requires admin or ob-admin",
+    );
+    expect(allSql).toEqual([]);
+  });
+
   it("an explicit fts_config selects the config in the real search path (no env)", async () => {
     // The caller-visible knob, not an env var, drives the emitted SQL.
     delete process.env.OPENBRAIN_FTS_CONFIG;

--- a/src/tools/fts-config.ts
+++ b/src/tools/fts-config.ts
@@ -1,0 +1,193 @@
+import { z } from "zod";
+
+/**
+ * Language-aware PostgreSQL full-text-search (FTS) configuration selection for
+ * hybrid retrieval (Issue #341, SOURCE-5).
+ *
+ * WHY THIS EXISTS
+ * The hybrid lexical arm (src/tools/search-brain.ts buildFtsCTE) builds its
+ * tsvector/tsquery with a Postgres text-search configuration ("regconfig").
+ * That config controls stemming and stopword handling. If the query arm uses a
+ * different config than the one the indexed text was analyzed with, recall and
+ * ranking silently degrade -- a German document analyzed as English keeps its
+ * un-stemmed German tokens, and an English tsquery never matches them.
+ *
+ * SCOPE (deliberately narrow)
+ * - `english` is the default and preserves today's behavior byte-for-byte.
+ * - Only Postgres-shipped regconfigs on an explicit allowlist are selectable.
+ *   The selected value is validated against a Zod enum BEFORE it is ever
+ *   interpolated into SQL, so the config literal can be inlined safely (same
+ *   discipline the repo applies to interpolated table names). tsquery text and
+ *   all namespace / source-scope predicates stay fully parameterized.
+ * - The config that governs a search is selected by an EXPLICIT setting on the
+ *   real search path: the `search_brain` `fts_config` request argument, or the
+ *   deployment-wide OPENBRAIN_FTS_CONFIG env default. A free-text source
+ *   language (`ob_sources.language`, BCP-47-ish) is only a candidate value for
+ *   that setting -- resolveFtsConfig maps such a token to a supported regconfig
+ *   (english fallback for the unrecognized). It is NOT auto-linked to a row's
+ *   retrieval: `thoughts` has no source_id, so an ob_sources row cannot, on its
+ *   own, control the config a search analyzes with. This never invents a config
+ *   Postgres does not ship, and never widens an isolation boundary.
+ *
+ * NON-GOALS
+ * - No per-row language column, no generated-column rewrite, no migration. The
+ *   default path keeps using the stored `search_vector` GIN column; a non-default
+ *   corpus config recomputes `to_tsvector(config, <same source columns>)` on the
+ *   fly so the query arm and the analyzed text always share one config.
+ * - No language framework, no auto-detection, no embedding-model change.
+ */
+
+/**
+ * Allowlist of selectable Postgres text-search configurations. Every entry is a
+ * configuration PostgreSQL ships in a default install (`snowball` dictionaries
+ * plus the language-neutral `simple`). `english` is first and is the default.
+ *
+ * This list is the supported-language policy. It is intentionally conservative:
+ * a language is supported only when Postgres can actually stem it out of the box
+ * and we have a fixture proving the ranking behavior. Widening it is a
+ * deliberate, tested change -- not something a caller can do at runtime.
+ */
+export const SUPPORTED_FTS_CONFIGS = [
+  "english",
+  "simple",
+  "spanish",
+  "french",
+  "german",
+  "portuguese",
+] as const;
+
+export type FtsConfig = (typeof SUPPORTED_FTS_CONFIGS)[number];
+
+/** Default configuration -- preserves the pre-#341 english-only behavior. */
+export const DEFAULT_FTS_CONFIG: FtsConfig = "english";
+
+/**
+ * Zod enum guarding every value that reaches SQL interpolation. A value that is
+ * not on the allowlist can never be turned into a config literal.
+ */
+export const ftsConfigSchema = z.enum(SUPPORTED_FTS_CONFIGS);
+
+/**
+ * Map of recognized `ob_sources.language` tokens to a supported regconfig. Keys
+ * are lowercased; we accept both bare ISO-639-1 codes and common BCP-47 region
+ * variants (e.g. `en`, `en-US`) plus the English language name. Anything not
+ * present resolves to the default via resolveFtsConfig.
+ */
+const LANGUAGE_TOKEN_TO_CONFIG: Record<string, FtsConfig> = {
+  en: "english",
+  eng: "english",
+  english: "english",
+  es: "spanish",
+  spa: "spanish",
+  spanish: "spanish",
+  fr: "french",
+  fra: "french",
+  fre: "french",
+  french: "french",
+  de: "german",
+  deu: "german",
+  ger: "german",
+  german: "german",
+  pt: "portuguese",
+  por: "portuguese",
+  portuguese: "portuguese",
+  // Language-neutral: an operator can pin a corpus to `simple` when its content
+  // is mixed-language or code-like and stemming would hurt more than help.
+  simple: "simple",
+  und: "simple",
+};
+
+/** Normalize a language token to its primary subtag, lowercased. */
+function primarySubtag(language: string): string {
+  const trimmed = language.trim().toLowerCase();
+  // Split BCP-47 on `-`/`_` and keep the leading language subtag.
+  const [primary] = trimmed.split(/[-_]/);
+  return (primary ?? "").trim();
+}
+
+/**
+ * Resolve an approved source's free-text language into a supported FTS config.
+ * Unknown, empty, or unsupported values fall back to the english default so a
+ * corpus without a recognized language keeps exactly today's behavior.
+ *
+ * This is a pure mapping and does NOT by itself wire a source to a search: a
+ * thought carries no source_id, so nothing links a stored ob_sources.language
+ * to a given row's retrieval. Agreement happens only when a caller or route
+ * feeds a declared language into the search path as an explicit setting -- see
+ * requestFtsConfig, which the public `search_brain` `fts_config` argument uses.
+ */
+export function resolveFtsConfig(
+  language: string | null | undefined,
+): FtsConfig {
+  if (!language) return DEFAULT_FTS_CONFIG;
+  const exact = LANGUAGE_TOKEN_TO_CONFIG[language.trim().toLowerCase()];
+  if (exact) return exact;
+  const primary = LANGUAGE_TOKEN_TO_CONFIG[primarySubtag(language)];
+  return primary ?? DEFAULT_FTS_CONFIG;
+}
+
+/**
+ * Resolve the effective corpus FTS config for a search invocation. Retrieval
+ * does not carry a per-row language, so a deployment declares its corpus FTS
+ * config out of band via env; unset or unsupported keeps the english default.
+ *
+ * OPENBRAIN_FTS_CONFIG accepts either a supported regconfig name directly
+ * (`german`) or a source-style language token (`de`, `de-DE`); both resolve
+ * through the same allowlist. An unrecognized value logs nothing and falls back
+ * to english so a typo can never disable lexical search.
+ */
+export function corpusFtsConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): FtsConfig {
+  const raw = env.OPENBRAIN_FTS_CONFIG?.trim();
+  if (!raw) return DEFAULT_FTS_CONFIG;
+  const direct = ftsConfigSchema.safeParse(raw.toLowerCase());
+  if (direct.success) return direct.data;
+  return resolveFtsConfig(raw);
+}
+
+/**
+ * Resolve the FTS config for a single search request. An explicit caller
+ * setting (the `search_brain` `fts_config` argument) wins when it names a
+ * supported regconfig or a recognized language token; anything else falls back
+ * to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english).
+ *
+ * This is the caller-visible, provenance-bound selector: the config is carried
+ * by the request itself, not inferred from an unlinked source row, so what a
+ * caller (or an ingest route that knows a corpus's language) asks for is what
+ * the real search path actually analyzes with. An unrecognized value can never
+ * disable lexical search -- it degrades to the corpus default.
+ */
+export function requestFtsConfig(
+  requested: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): FtsConfig {
+  const raw = requested?.trim();
+  if (!raw) return corpusFtsConfig(env);
+  const direct = ftsConfigSchema.safeParse(raw.toLowerCase());
+  if (direct.success) return direct.data;
+  const resolved = resolveFtsConfig(raw);
+  // resolveFtsConfig returns english for anything unrecognized; when the caller
+  // passed an unrecognized token, prefer the corpus default over silently
+  // forcing english (which may not be the deployment's configured corpus).
+  if (resolved !== DEFAULT_FTS_CONFIG) return resolved;
+  const knownEnglishToken =
+    LANGUAGE_TOKEN_TO_CONFIG[raw.toLowerCase()] === "english" ||
+    LANGUAGE_TOKEN_TO_CONFIG[primarySubtag(raw)] === "english";
+  return knownEnglishToken ? "english" : corpusFtsConfig(env);
+}
+
+/**
+ * Assert a config is on the allowlist and return it as a bare regconfig literal
+ * safe to interpolate. Throws on anything unexpected -- a defensive backstop in
+ * case a caller bypasses the schema. Callers already hold an FtsConfig, so this
+ * never throws in normal flow; it exists so a future refactor cannot smuggle an
+ * arbitrary string into the SQL config literal.
+ */
+export function ftsConfigLiteral(config: FtsConfig): string {
+  const parsed = ftsConfigSchema.safeParse(config);
+  if (!parsed.success) {
+    throw new Error(`Unsupported FTS configuration: ${String(config)}`);
+  }
+  return parsed.data;
+}

--- a/src/tools/fts-config.ts
+++ b/src/tools/fts-config.ts
@@ -19,15 +19,17 @@ import { z } from "zod";
  *   interpolated into SQL, so the config literal can be inlined safely (same
  *   discipline the repo applies to interpolated table names). tsquery text and
  *   all namespace / source-scope predicates stay fully parameterized.
- * - The config that governs a search is selected by an EXPLICIT setting on the
- *   real search path: the `search_brain` `fts_config` request argument, or the
- *   deployment-wide OPENBRAIN_FTS_CONFIG env default. A free-text source
- *   language (`ob_sources.language`, BCP-47-ish) is only a candidate value for
- *   that setting -- resolveFtsConfig maps such a token to a supported regconfig
- *   (english fallback for the unrecognized). It is NOT auto-linked to a row's
- *   retrieval: `thoughts` has no source_id, so an ob_sources row cannot, on its
- *   own, control the config a search analyzes with. This never invents a config
- *   Postgres does not ship, and never widens an isolation boundary.
+ * - The public `search_brain` handler selects its config from the request's
+ *   `fts_config` argument or the operator-controlled OPENBRAIN_FTS_CONFIG env
+ *   default, then passes the resolved value explicitly to the shared search
+ *   primitive. Other executeSearch callers always retain the english default.
+ *   A free-text source language (`ob_sources.language`, BCP-47-ish) is only a
+ *   candidate value for that public setting -- resolveFtsConfig maps such a
+ *   token to a supported regconfig (english fallback for the unrecognized). It
+ *   is NOT auto-linked to a row's retrieval: `thoughts` has no source_id, so an
+ *   ob_sources row cannot, on its own, control the config a search analyzes
+ *   with. This never invents a config Postgres does not ship, and never widens
+ *   an isolation boundary.
  *
  * NON-GOALS
  * - No per-row language column, no generated-column rewrite, no migration. The
@@ -127,9 +129,10 @@ export function resolveFtsConfig(
 }
 
 /**
- * Resolve the effective corpus FTS config for a search invocation. Retrieval
- * does not carry a per-row language, so a deployment declares its corpus FTS
- * config out of band via env; unset or unsupported keeps the english default.
+ * Resolve the operator-controlled corpus FTS config for the public search
+ * handler. Retrieval does not carry a per-row language, so a deployment opts
+ * into its corpus FTS config out of band via env; unset or unsupported keeps
+ * the english default.
  *
  * OPENBRAIN_FTS_CONFIG accepts either a supported regconfig name directly
  * (`german`) or a source-style language token (`de`, `de-DE`); both resolve
@@ -147,10 +150,10 @@ export function corpusFtsConfig(
 }
 
 /**
- * Resolve the FTS config for a single search request. An explicit caller
- * setting (the `search_brain` `fts_config` argument) wins when it names a
- * supported regconfig or a recognized language token; anything else falls back
- * to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english).
+ * Resolve the FTS config for one public `search_brain` request. An explicit
+ * caller setting (`fts_config`) wins when it names a supported regconfig or a
+ * recognized language token; anything else falls back to the deployment corpus
+ * default (OPENBRAIN_FTS_CONFIG, else english).
  *
  * This is the caller-visible, provenance-bound selector: the config is carried
  * by the request itself, not inferred from an unlinked source row, so what a

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -28,7 +28,7 @@ import {
   VALID_TIERS,
 } from "./table-constants.ts";
 import {
-  corpusFtsConfig,
+  DEFAULT_FTS_CONFIG,
   ftsConfigLiteral,
   requestFtsConfig,
   SUPPORTED_FTS_CONFIGS,
@@ -54,14 +54,16 @@ type ExecuteSearchOptions = {
   enableGraph?: boolean;
   /**
    * Text-search configuration for the lexical arm. When unset, defaults to the
-   * deployment corpus config (english unless OPENBRAIN_FTS_CONFIG selects a
-   * supported language). The `search_brain` handler sets this from its explicit
-   * `fts_config` request argument via requestFtsConfig, so a caller-visible
-   * setting -- not an unlinked source row -- selects the regconfig the real
-   * search path analyzes with.
+   * shared english configuration. The public `search_brain` handler is the only
+   * boundary that resolves its request argument and deployment env; sibling
+   * executeSearch callers remain byte-compatible unless they explicitly pass a
+   * config.
    */
   ftsConfig?: FtsConfig;
 };
+
+const NON_ENGLISH_FTS_AUTHORIZATION_ERROR =
+  "Permission denied: non-English FTS configuration requires admin or ob-admin";
 
 /** RRF constant -- standard value from Cormack et al. 2009 */
 const RRF_K = 60;
@@ -864,7 +866,7 @@ async function ftsSearch(
   offset = 0,
   namespace?: NamespaceFilter,
   sourceScope?: SourceScope,
-  ftsConfig: FtsConfig = corpusFtsConfig(),
+  ftsConfig: FtsConfig = DEFAULT_FTS_CONFIG,
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const params = [query, fetchLimit, offset];
@@ -1044,7 +1046,7 @@ export async function executeSearch(
   options: ExecuteSearchOptions = {},
 ): Promise<SearchRow[]> {
   const enableGraph = options.enableGraph === true;
-  const ftsConfig = options.ftsConfig ?? corpusFtsConfig();
+  const ftsConfig = options.ftsConfig ?? DEFAULT_FTS_CONFIG;
   if (sourceScope) {
     accessibleTables = accessibleTables.filter((table) => table !== "entities");
     if (accessibleTables.length === 0) return [];
@@ -1421,6 +1423,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
               `Accepts a supported Postgres regconfig (${SUPPORTED_FTS_CONFIGS.join(", ")}) ` +
               `or a language token (e.g. 'de', 'de-DE', 'spanish'). Unrecognized values ` +
               `fall back to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english). ` +
+              `An explicitly requested effective non-English config requires admin or ob-admin. ` +
               `Affects keyword/hybrid stemming only; english is byte-identical to prior behavior.`,
           ),
       },
@@ -1500,7 +1503,24 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const tier = args.tier as Tier | undefined;
       const requestedNamespace = args.namespace as string | undefined;
       const sourceScope = args.source_scope as SourceScope | undefined;
-      const ftsConfig = requestFtsConfig(args.fts_config as string | undefined);
+      const requestedFtsConfig = args.fts_config as string | undefined;
+      const ftsConfig = requestFtsConfig(requestedFtsConfig);
+      if (
+        requestedFtsConfig !== undefined &&
+        ftsConfig !== DEFAULT_FTS_CONFIG &&
+        auth.role !== "admin" &&
+        auth.role !== "ob-admin"
+      ) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: NON_ENGLISH_FTS_AUTHORIZATION_ERROR,
+            },
+          ],
+          isError: true,
+        };
+      }
       const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
       if (sourceScopeError) {
         return {

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -22,10 +22,18 @@ import {
   ALL_TABLES,
   SOURCE_LABELS,
   CONTENT_PREVIEW,
+  FTS_SOURCE_TEXT,
   LINK_RELATIONS,
   TABLE_ALIAS,
   VALID_TIERS,
 } from "./table-constants.ts";
+import {
+  corpusFtsConfig,
+  ftsConfigLiteral,
+  requestFtsConfig,
+  SUPPORTED_FTS_CONFIGS,
+  type FtsConfig,
+} from "./fts-config.ts";
 
 export { ALL_TABLES };
 
@@ -44,6 +52,15 @@ export type { SourceScope };
 
 type ExecuteSearchOptions = {
   enableGraph?: boolean;
+  /**
+   * Text-search configuration for the lexical arm. When unset, defaults to the
+   * deployment corpus config (english unless OPENBRAIN_FTS_CONFIG selects a
+   * supported language). The `search_brain` handler sets this from its explicit
+   * `fts_config` request argument via requestFtsConfig, so a caller-visible
+   * setting -- not an unlinked source row -- selects the regconfig the real
+   * search path analyzes with.
+   */
+  ftsConfig?: FtsConfig;
 };
 
 /** RRF constant -- standard value from Cormack et al. 2009 */
@@ -557,9 +574,39 @@ function buildTableCTE(
 )`;
 }
 
+/**
+ * Build the lexical (FTS) match + rank expressions for one table under a chosen
+ * text-search configuration.
+ *
+ * english (default): use the GIN-indexed stored `search_vector` column exactly
+ * as before -- byte-identical to the pre-#341 behavior and index-fast.
+ *
+ * non-english supported config: recompute `to_tsvector(<config>, <source text>)`
+ * on the fly against the same columns the stored column indexes, so the query
+ * arm and the analyzed text share one configuration (correct stemming, no
+ * index/query mismatch, no migration). `config` is an allowlist-validated
+ * FtsConfig; ftsConfigLiteral re-asserts that before it is interpolated.
+ */
+function ftsMatchExpressions(
+  table: Table,
+  config: FtsConfig,
+): {
+  vectorSql: string;
+  querySql: string;
+} {
+  const querySql = `plainto_tsquery('${ftsConfigLiteral(config)}', (SELECT q FROM fts_query))`;
+  if (config === "english") {
+    const alias = TABLE_ALIAS[table];
+    return { vectorSql: `${alias}.search_vector`, querySql };
+  }
+  const vectorSql = `to_tsvector('${ftsConfigLiteral(config)}', ${FTS_SOURCE_TEXT[table]})`;
+  return { vectorSql, querySql };
+}
+
 function buildFtsCTE(
   table: SearchTable,
   perTableLimit: number,
+  ftsConfig: FtsConfig,
   tier?: Tier,
   namespaceParamIndex?: number,
   namespaceIsArray = false,
@@ -617,6 +664,8 @@ function buildFtsCTE(
     ? `${alias}.extracted_metadata`
     : "NULL::jsonb AS extracted_metadata";
 
+  const { vectorSql, querySql } = ftsMatchExpressions(table, ftsConfig);
+
   return `${cteName} AS (
   SELECT
     '${label}' AS source_type,
@@ -628,12 +677,12 @@ function buildFtsCTE(
     ${alias}.created_at,
     ${alias}.updated_at,
     ${alias}.tier,
-    ts_rank_cd(${alias}.search_vector, plainto_tsquery('english', (SELECT q FROM fts_query))) AS fts_rank,
+    ts_rank_cd(${vectorSql}, ${querySql}) AS fts_rank,
     COALESCE(${alias}.usefulness_score, 0.5) AS usefulness,
     COALESCE(${alias}.access_count, 0) AS access_count,
     ${metaCol}
   FROM ${table} ${alias}
-  WHERE ${alias}.search_vector @@ plainto_tsquery('english', (SELECT q FROM fts_query))
+  WHERE ${vectorSql} @@ ${querySql}
     AND ${alias}.archived_at IS NULL${tierFilter}${nsFilter}${sourceScopeFilter}
   ORDER BY fts_rank DESC
   LIMIT ${perTableLimit}
@@ -815,6 +864,7 @@ async function ftsSearch(
   offset = 0,
   namespace?: NamespaceFilter,
   sourceScope?: SourceScope,
+  ftsConfig: FtsConfig = corpusFtsConfig(),
 ): Promise<SearchRow[]> {
   const perTableLimit = fetchLimit;
   const params = [query, fetchLimit, offset];
@@ -825,6 +875,7 @@ async function ftsSearch(
     buildFtsCTE(
       t,
       perTableLimit,
+      ftsConfig,
       tier,
       namespaceParamIndex,
       namespaceIsArray,
@@ -993,6 +1044,7 @@ export async function executeSearch(
   options: ExecuteSearchOptions = {},
 ): Promise<SearchRow[]> {
   const enableGraph = options.enableGraph === true;
+  const ftsConfig = options.ftsConfig ?? corpusFtsConfig();
   if (sourceScope) {
     accessibleTables = accessibleTables.filter((table) => table !== "entities");
     if (accessibleTables.length === 0) return [];
@@ -1008,6 +1060,7 @@ export async function executeSearch(
       offset,
       namespace,
       sourceScope,
+      ftsConfig,
     );
     if (includeLinks !== false) {
       rows = await attachExplicitLinks(deps, rows, namespace);
@@ -1046,6 +1099,7 @@ export async function executeSearch(
           0,
           namespace,
           sourceScope,
+          ftsConfig,
         );
         rows = rrfMerge([], ftsRows, totalNeeded, graphRows).slice(offset);
       } else {
@@ -1058,6 +1112,7 @@ export async function executeSearch(
           offset,
           namespace,
           sourceScope,
+          ftsConfig,
         );
       }
       if (includeLinks !== false) {
@@ -1110,6 +1165,7 @@ export async function executeSearch(
       0,
       namespace,
       sourceScope,
+      ftsConfig,
     ),
   ]);
   const graphRows =
@@ -1354,6 +1410,19 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           .describe(
             "Optional: require matching source reference client_id, matter_id, document_id, path, and/or dms_id.",
           ),
+        fts_config: z
+          .string()
+          .trim()
+          .min(1)
+          .max(64)
+          .optional()
+          .describe(
+            `Optional: keyword full-text-search language configuration for this request. ` +
+              `Accepts a supported Postgres regconfig (${SUPPORTED_FTS_CONFIGS.join(", ")}) ` +
+              `or a language token (e.g. 'de', 'de-DE', 'spanish'). Unrecognized values ` +
+              `fall back to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english). ` +
+              `Affects keyword/hybrid stemming only; english is byte-identical to prior behavior.`,
+          ),
       },
       annotations: {
         title: "Search Brain",
@@ -1431,6 +1500,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const tier = args.tier as Tier | undefined;
       const requestedNamespace = args.namespace as string | undefined;
       const sourceScope = args.source_scope as SourceScope | undefined;
+      const ftsConfig = requestFtsConfig(args.fts_config as string | undefined);
       const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
       if (sourceScopeError) {
         return {
@@ -1483,7 +1553,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
               namespace,
               undefined,
               sourceScope,
-              { enableGraph: true },
+              { enableGraph: true, ftsConfig },
             )
           : await executeSearchWithScopedSharedFallback(
               deps,
@@ -1496,7 +1566,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
               namespace,
               undefined,
               sourceScope,
-              { enableGraph: true },
+              { enableGraph: true, ftsConfig },
             );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/tools/table-constants.ts
+++ b/src/tools/table-constants.ts
@@ -42,6 +42,50 @@ export const CONTENT_PREVIEW: Record<Table, string> = {
     " THEN E'\\nNext: ' || immutable_array_to_string(s.next_steps, '; ') ELSE '' END",
 };
 
+/**
+ * FTS source-text SQL expression per table -- the exact text the stored
+ * `search_vector` generated column analyzes.
+ *
+ * The stored column's CURRENT definition is migration 007_search_improvements
+ * (which dropped and rebuilt every `search_vector` from 005_fts_hybrid to also
+ * fold in `tags`), so each expression here mirrors 007 exactly, INCLUDING the
+ * trailing `immutable_array_to_string(tags, ' ')` term. This MUST stay
+ * byte-for-byte aligned with the `to_tsvector(...)` argument in the migration
+ * that currently owns the column, or the language-aware path would analyze
+ * strictly less text than the english default -- silently dropping tag-token
+ * recall for non-english corpora.
+ *
+ * It is used only on the language-aware FTS path, where the lexical arm
+ * recomputes `to_tsvector(<config>, <this expression>)` on the fly so a
+ * non-english corpus config analyzes the same text the english stored column
+ * would -- just under the corpus's configuration. The english default path
+ * never uses this; it keeps using the GIN-indexed stored column.
+ *
+ * Column aliases here (`t.`, `d.`, ... per TABLE_ALIAS) match the FROM aliases
+ * in buildFtsCTE; the migration uses unqualified names because it runs inside
+ * the table's own generated-column context.
+ */
+export const FTS_SOURCE_TEXT: Record<Table, string> = {
+  thoughts:
+    "COALESCE(t.content, '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(t.tags, ' '), '')",
+  decisions:
+    "COALESCE(d.title, '') || ' ' || COALESCE(d.rationale, '') || ' ' || " +
+    "COALESCE(d.context, '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(d.tags, ' '), '')",
+  relationships:
+    "COALESCE(r.person_name, '') || ' ' || COALESCE(r.context, '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(r.tags, ' '), '')",
+  projects:
+    "COALESCE(p.name, '') || ' ' || COALESCE(p.description, '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(p.tags, ' '), '')",
+  sessions:
+    "COALESCE(s.summary, '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(s.next_steps, ' '), '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(s.key_decisions, ' '), '') || ' ' || " +
+    "COALESCE(immutable_array_to_string(s.tags, ' '), '')",
+};
+
 /** Valid session event types */
 export const EVENT_TYPES = [
   "fact",


### PR DESCRIPTION
## Summary

- add an explicit, validated `fts_config` argument to `search_brain` for language-aware lexical retrieval
- preserve the indexed English fast path and keep all sibling `executeSearch` consumers English unless they explicitly opt in
- analyze supported non-English searches with matching PostgreSQL regconfig stemming; explicit effective non-English requests require `admin` or `ob-admin`
- pin CI test databases to UTF8 and require all language-aware PostgreSQL suites through the anti-skip guard
- add functional MCP and real-PostgreSQL before/after tests across all five searchable table families

Tracks #341

## Validation

- focused config/search/anti-skip tests: **54 passed, 0 failed**
- focused search/answer regression tests: **90 passed, 0 failed**
- disposable PostgreSQL 18.4 + pgvector 0.8.2:
  - all 32 migrations applied
  - language-aware and all-table parity suites passed
  - all PostgreSQL suites passed during fix development
  - disposable databases dropped and verified absent
- supported regconfigs present: english, simple, spanish, french, german, portuguese
- `bun contracts/check-parity.ts`: passed; 13 fixtures across 8 capabilities
- `bunx tsc --noEmit`: passed
- `git diff --check`: passed
- exact-head GPT-5.6-family focused verification at `f1e5975df85efc9e8c8befa4b7a498f11a5dcf84`: **FOCUSED CLEAN**
- Full-tier opposite-family terminal verification at `f1e5975df85efc9e8c8befa4b7a498f11a5dcf84` by Claude Opus 4.8 high: **CLEAN — no P0/P1/P2 findings**

Functional before/after:
- German `Haus` misses German `Häuser` content under English analysis and matches under German analysis.
- Spanish `corrió` misses Spanish `corriendo` content under English analysis and matches under Spanish analysis.
- English content remains matched through the unchanged stored `search_vector` path.
- German tokens present only in table-specific indexed fields match under German stemming across thoughts, decisions, relationships, projects, and sessions.
- A German deployment env cannot silently change sibling keyword, successful-hybrid, or embedding-failure search consumers.

## Public contract and downstream rollout classification

This is an additive public MCP input-schema and behavior change, so downstream rollout applies. The current phase is explicitly local-only: merge supplies the local dogfood candidate but does not deploy or mutate core01.

- Open Brain local verification: complete.
- Canonical required-memory contract hash/parity: unchanged because optional `search_brain` is outside `TOOL_CONTRACTS`; Python `search_brain(**arguments)` and the TypeScript transport remain generic pass-throughs.
- Hosted Open Brain: deferred until the local dogfood phase is accepted. No core01 deployment is authorized now.
- rtech-mcps: deferred with hosted rollout; registry/secret-map changes are expected not applicable because the existing service definition and credentials do not change.
- mcp2cli: deferred with hosted rollout; later verify fresh `search_brain` schema and regenerate Open Brain skills.
- Python client: no package change; generic argument pass-through remains compatible.
- TypeScript client: no package/API change; generic tool invocation remains compatible.
- Hermes: not applicable and must not be added, deployed, or canaried.
- Issue #341 remains open through local dogfood and the later applicable downstream rollout.

## Critical self-review

- Highest-risk behavior: arbitrary regconfig interpolation, sibling-consumer semantic drift, caller-forced unindexed scans, or mismatched query/document analysis could cause injection, denial of service, or silent recall loss.
- Assumptions that could be wrong: target PostgreSQL installations provide the six allowlisted regconfigs; operator-enabled non-English corpora accept the documented unindexed scan cost.
- Missing/weak tests: German, Spanish, English, all five table families, sibling paths, privilege, UTF8 harnesses, and anti-skip behavior are covered; French, Portuguese, and `simple` do not each have independent stemming fixtures.
- Security/permission risk: config input is allowlist validated; explicit effective non-English requests require admin/ob-admin; query text, namespace, and source-scope remain parameterized and server-authorized.
- Migration/deploy risk: no migration; English stays on the generated GIN-indexed `search_vector`; operator-enabled non-English configs recompute `to_tsvector` and may be slower at scale.
- Downstream client/runtime risk: additive MCP schema requires hosted discovery/cache/generated-skill refresh; required-memory contract hash and generic clients remain compatible.
- Rollback/cleanup concern: rollback is code-only; no persisted data or schema changes. PostgreSQL test databases were disposable and verified removed.
- Fixes made before PR: replaced false source-row causality with an explicit request/operator setting; aligned source text with migration 007; pinned UTF8 CI databases; isolated sibling defaults; privileged explicit non-English scans; registered all live-PG suites in anti-skip; added all-table functional parity.
- Known residual risk: operator-enabled non-English lexical search is unindexed and should be monitored on large corpora; hosted deployment and downstream schema refresh are deferred during the explicitly local-only dogfood phase.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: hosted deployment and changed-behavior canaries are required post-merge and listed above

