### PR TITLE
feat(370): add safe local clone runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ MLX_EMBED_RESTART_LOCK_STALE_AFTER_SECONDS=300
 
 # Server
 PORT=3100
+OPEN_BRAIN_BIND_HOST=
+OPENBRAIN_LOCAL_CLONE=0
+OPENBRAIN_LOCAL_CLONE_ROOT=
+# Local clone mode requires an explicit empty QMD_PATH to disable the production default:
+# QMD_PATH=
 DB_POOL_MAX=10
 OPEN_BRAIN_RUN_MIGRATIONS=1
 
@@ -41,3 +46,4 @@ AUTH_TOKEN_AGENT=generate-a-secure-token
 AUTH_TOKEN_DISCORD=generate-a-secure-token
 AUTH_TOKEN_READONLY=generate-a-secure-token
 AUTH_TOKEN_OB_ADMIN=generate-a-secure-token
+AUTH_TOKEN_PROMOTER=generate-a-secure-token

--- a/.env.schema
+++ b/.env.schema
@@ -29,6 +29,10 @@ MLX_EMBED_RESTART_LOCK_STALE_AFTER_SECONDS=300
 
 # Server
 PORT=3100
+OPEN_BRAIN_BIND_HOST=@optional
+OPENBRAIN_LOCAL_CLONE=0
+OPENBRAIN_LOCAL_CLONE_ROOT=@optional
+QMD_PATH=@optional
 DB_POOL_MAX=10
 OPEN_BRAIN_RUN_MIGRATIONS=1
 
@@ -40,4 +44,5 @@ AUTH_TOKEN_ADMIN=@secret(exec(./fetch-secrets.sh AUTH_TOKEN_ADMIN))
 AUTH_TOKEN_AGENT=@secret(exec(./fetch-secrets.sh AUTH_TOKEN_AGENT))
 AUTH_TOKEN_DISCORD=@secret(exec(./fetch-secrets.sh AUTH_TOKEN_DISCORD))
 AUTH_TOKEN_OB_ADMIN=@secret(exec(./fetch-secrets.sh AUTH_TOKEN_OB_ADMIN))
+AUTH_TOKEN_PROMOTER=@secret(exec(./fetch-secrets.sh AUTH_TOKEN_PROMOTER))
 AUTH_TOKEN_READONLY=@secret(exec(./fetch-secrets.sh AUTH_TOKEN_READONLY))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,12 @@ jobs:
       # migration test's DROP TABLE cannot clobber the live-Postgres suites.
       DB_NAME: open_brain_ci
       DB_NAME_TEST: open_brain_ci_migrations
+      # The local-clone boundary is a separate fresh database owned by the
+      # exact non-superuser role the runbook creates. It is intentionally not
+      # the admin/migration database above.
+      DB_NAME_LOCAL_CLONE: open_brain_local_ci_clone
+      DB_USER_LOCAL_CLONE: open_brain_local_clone
+      DB_PASSWORD_LOCAL_CLONE: local-clone-ci
       OB_CI_PG_CONTAINER: obci-pg-${{ github.run_id }}-${{ github.run_attempt }}
       # Digest-pinned image: this job gates deploy, so a mutable tag must not
       # be able to change under us. Digest is pgvector/pgvector:pg18
@@ -187,7 +193,7 @@ jobs:
           docker logs "${OB_CI_PG_CONTAINER}" 2>&1 | tail -20 || true
           exit 1
 
-      - name: Create isolated migration-test database
+      - name: Create isolated migration-test and local-clone databases
         # Pin UTF8 (ENCODING 'UTF8' TEMPLATE template0) for the same reason as
         # the `check` job: the snowball stemmers require UTF8 to fold multibyte
         # accented characters. The pgvector image's open_brain_ci defaults to
@@ -200,6 +206,21 @@ jobs:
           PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d "${DB_NAME_TEST}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d open_brain_ci \
+            -v ON_ERROR_STOP=1 \
+            -v clone_role="${DB_USER_LOCAL_CLONE}" \
+            -v clone_password="${DB_PASSWORD_LOCAL_CLONE}" <<'SQL'
+          CREATE ROLE :"clone_role" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD :'clone_password';
+          SQL
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d open_brain_ci \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE DATABASE ${DB_NAME_LOCAL_CLONE} OWNER ${DB_USER_LOCAL_CLONE} ENCODING 'UTF8' TEMPLATE template0;"
+          # Administrative bootstrap only: the clone user remains a
+          # non-superuser and restores into this fresh database.
+          PGPASSWORD=ci psql -h 127.0.0.1 -p "${DB_PORT}" -U ci -d "${DB_NAME_LOCAL_CLONE}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION vector;" \
+            -c "CREATE EXTENSION pg_stat_statements;"
 
       - name: Run migrations against ephemeral Postgres
         run: bun run migrate
@@ -207,6 +228,7 @@ jobs:
       - name: Test (JUnit reporter for the anti-skip guard)
         run: |
           export OPENBRAIN_TEST_DATABASE_URL="postgres://ci:ci@127.0.0.1:${DB_PORT}/open_brain_ci"
+          export OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL="postgres://${DB_USER_LOCAL_CLONE}:${DB_PASSWORD_LOCAL_CLONE}@127.0.0.1:${DB_PORT}/${DB_NAME_LOCAL_CLONE}"
           bun test \
             --reporter=junit \
             --reporter-outfile=${{ runner.temp }}/junit-db.xml
@@ -242,6 +264,7 @@ jobs:
           # URL assembled from the job's env (throwaway ephemeral-container
           # credential) so no user:pass URI literal lives in the workflow.
           export OPENBRAIN_TEST_DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${DB_PORT}/${DB_NAME}"
+          export OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL="postgres://${DB_USER_LOCAL_CLONE}:${DB_PASSWORD_LOCAL_CLONE}@127.0.0.1:${DB_PORT}/${DB_NAME_LOCAL_CLONE}"
           export OPENBRAIN_BACKUP_DRILL=1
           export OPENBRAIN_PG_DUMP_BIN="docker exec -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_dump"
           export OPENBRAIN_PG_RESTORE_BIN="docker exec -i -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_restore"

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -4,6 +4,8 @@ Operator-run backup/restore substrate for the Open Brain database (issue
 #298). Three CLIs — `scripts/backup.ts`, `scripts/backup-verify.ts`,
 `scripts/restore.ts` — plus a content-free manifest format
 (`openbrain.backup_manifest.v1`) and a live restore drill that runs in CI.
+For the loopback-only dogfood clone procedure, see
+[`local-clone-dogfood.md`](local-clone-dogfood.md).
 
 Everything here is honest about its verification level: each procedure is
 marked **TESTED** (with the test that proves it) or **DOCUMENTED-ONLY**.
@@ -35,6 +37,11 @@ sizes, per-table row counts, per-table archived-row counts, and the
 distinct-namespace COUNT. Namespace names are scope metadata and never appear
 in manifests or receipts; the namespace boundary itself lives inside the dump
 (every row keeps its `namespace` column) and is re-validated on restore.
+
+A backup set is one coordinated snapshot: `openbrain.dump` and its
+`manifest.json` must be created together by one successful `backup.ts` run and
+transferred together without substitution. Never assemble a clone from files
+belonging to different sets.
 
 ## Operations
 

--- a/docs/local-clone-dogfood.md
+++ b/docs/local-clone-dogfood.md
@@ -54,10 +54,24 @@ createuser -h 127.0.0.1 -p 5432 -U <local-admin-role> \
 
 createdb -h 127.0.0.1 -p 5432 -U <local-admin-role> \
   --owner open_brain_local_clone open_brain_local_<clone-id>
+
+# The database is fresh: bootstrap both source-required extensions once as the
+# local administrator. Do not use IF NOT EXISTS; an existing extension means
+# this was not a fresh target.
+psql -h 127.0.0.1 -p 5432 -U <local-admin-role> \
+  -d open_brain_local_<clone-id> -v ON_ERROR_STOP=1 \
+  -c 'CREATE EXTENSION vector;' \
+  -c 'CREATE EXTENSION pg_stat_statements;'
 ```
 
 The role and database must be new. Do not point the procedure at a production
 role, an existing application database, or a non-loopback PostgreSQL server.
+The administrative `vector` and `pg_stat_statements` bootstrap is intentionally
+limited to the new target database; these are the extensions created by the
+repository migrations and therefore present in the source archive. The restore
+still runs as `open_brain_local_clone`, which is a non-superuser with no database
+or role creation privileges. The restore omits archive comments so it does not
+need ownership of these administrator-created extensions.
 The restore CLI refuses a non-empty target unless its separate destructive wipe
 approval is supplied; this runbook does not use that escape hatch.
 
@@ -210,9 +224,24 @@ case "${OPEN_BRAIN_BIND_HOST}" in
     ;;
 esac
 
-curl --fail --silent --show-error \
-  "http://${health_host}:${PORT}/health"
+health_body="$(curl --fail --silent --show-error \
+  "http://${health_host}:${PORT}/health")" || exit 1
+printf '%s' "${health_body}" | bun -e '
+  const health = JSON.parse(await Bun.stdin.text());
+  if (
+    health.database?.connected !== true ||
+    health.embedding?.configured !== true ||
+    health.embedding?.connected !== true
+  ) {
+    console.error("health body does not prove database and embedding readiness");
+    process.exit(1);
+  }
+'
 ```
+
+HTTP success alone is insufficient: `/health` can return `200` while an
+embedding provider is disconnected. Continue only when all three structured
+fields above are `true`.
 
 Prove the application has exactly one listener and that its address and port
 equal the configured literal loopback endpoint. macOS `lsof` renders an IPv6
@@ -249,8 +278,8 @@ Expected fields are the configured clone database,
 PostgreSQL port. Do not use `pg_isready` alone: it does not prove the database,
 role, or resolved server address.
 
-For foreground operation, status is the successful `/health` response plus the
-exact listener check above. When another supervisor records the foreground
+For foreground operation, status is the structured `/health` proof above plus
+the exact listener check above. When another supervisor records the foreground
 launcher PID, prove both launcher and child are present:
 
 ```zsh

--- a/docs/local-clone-dogfood.md
+++ b/docs/local-clone-dogfood.md
@@ -1,0 +1,290 @@
+# Local Clone Dogfood
+
+This runbook creates and operates a loopback-only Open Brain clone from one
+encrypted, verified backup set. It is an operator procedure, not replication:
+the launcher never creates or drops a database, rotates tokens, reads a
+production environment file, contacts a production host, or transfers a
+backup.
+
+The clone is disposable. Refresh it by restoring into another freshly created
+database, verifying and launching that database, then stopping and retiring the
+old clone. Never restore over or refresh the running clone in place.
+
+## 1. Stage one encrypted backup set
+
+Create the backup only when no migration or schema upgrade is running. Normal
+application writes may continue: `backup.ts` holds one exported PostgreSQL
+snapshot for both manifest facts and `pg_dump`. A set is coordinated only when
+`openbrain.dump` and `manifest.json` came from the same successful run. Do not
+mix files from different sets.
+
+Transfer is an operator-owned step outside the launcher. On a trusted source
+host, encrypt the complete set before it leaves that host:
+
+```zsh
+tar -C <backups-root> -cf - <set-dir> \
+  | age -r <local-clone-recipient> > <set-dir>.tar.age
+```
+
+Move the encrypted artifact through an approved transfer channel. Do not give
+the local-clone launcher network access to the source host. On the clone host,
+decrypt it into a private directory beneath the configured clone root:
+
+```zsh
+umask 077
+mkdir -p <clone-root>/backups
+age -d <set-dir>.tar.age \
+  | tar -C <clone-root>/backups -xf -
+chmod -R go-rwx <clone-root>
+```
+
+Keep the encrypted artifact until the clone has passed verification. Do not
+print encryption identities, database passwords, API keys, or bearer tokens in
+the shell transcript.
+
+## 2. Create a fresh local role and database
+
+Use a local PostgreSQL 18 administrative role. Both commands prompt without
+putting a password in argv:
+
+```zsh
+createuser -h 127.0.0.1 -p 5432 -U <local-admin-role> \
+  --pwprompt --no-superuser --no-createdb --no-createrole \
+  open_brain_local_clone
+
+createdb -h 127.0.0.1 -p 5432 -U <local-admin-role> \
+  --owner open_brain_local_clone open_brain_local_<clone-id>
+```
+
+The role and database must be new. Do not point the procedure at a production
+role, an existing application database, or a non-loopback PostgreSQL server.
+The restore CLI refuses a non-empty target unless its separate destructive wipe
+approval is supplied; this runbook does not use that escape hatch.
+
+## 3. Verify the set, then restore it
+
+From the exact repo revision that will run the clone, verify the backup before
+any restore:
+
+```zsh
+bun run scripts/backup-verify.ts \
+  --dir <clone-root>/backups/<set-dir>
+```
+
+The command emits one content-free
+`openbrain.backup_verify_receipt.v1` line. Continue only when it exits `0` and
+the receipt status is `passed` or `warned`. Do not use
+`--allow-embedding-mismatch` for dogfood: the restored vectors must match the
+runtime model and dimension.
+
+Set the target password privately, then restore into the fresh database. Keep
+the password out of the URL and shell history:
+
+```zsh
+read -s "DB_PASSWORD?Local clone database password: "
+export DB_PASSWORD
+
+bun run scripts/restore.ts \
+  --dir <clone-root>/backups/<set-dir> \
+  --target-db-url \
+  postgres://open_brain_local_clone@127.0.0.1:5432/open_brain_local_<clone-id>
+
+unset DB_PASSWORD
+```
+
+`restore.ts` reruns the full verification pass before touching the target,
+restores through the existing `pg_restore` boundary, validates row and archive
+counts, namespace predicates, migrations, pgvector, `halfvec(768)`, and
+writability, and emits a content-free receipt. Do not launch unless it exits
+`0`.
+
+## 4. Create the private clone environment
+
+Create `<clone-root>/local-clone.env` with `umask 077`, then enforce mode
+`0600`:
+
+```zsh
+umask 077
+touch <clone-root>/local-clone.env
+chmod 600 <clone-root>/local-clone.env
+```
+
+Populate it locally without echoing values. The explicit local-clone boundary
+requires at least:
+
+```dotenv
+OPENBRAIN_LOCAL_CLONE=1
+OPENBRAIN_LOCAL_CLONE_ROOT=<absolute-clone-root>
+OPEN_BRAIN_BIND_HOST=127.0.0.1
+PORT=<unused-loopback-port>
+
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_NAME=open_brain_local_<clone-id>
+DB_USER=open_brain_local_clone
+DB_PASSWORD=<local-only-password>
+DB_POOL_MAX=10
+OPEN_BRAIN_RUN_MIGRATIONS=0
+
+EMBEDDING_BASE_URL=http://127.0.0.1:<local-embedding-port>/v1
+EMBEDDING_API_KEY=<local-only-key-if-required>
+EMBEDDING_MODEL=embeddinggemma-300m-8bit
+EMBEDDING_DIMENSIONS=768
+EMBEDDING_WATCHDOG_RESTART_SCRIPT=
+
+QMD_PATH=
+OPENBRAIN_TRANSPORT=
+ALLOWED_ORIGINS=
+
+AUTH_TOKEN_ADMIN=<unique-local-token>
+AUTH_TOKEN_AGENT=<unique-local-token>
+AUTH_TOKEN_DISCORD=<unique-local-token>
+AUTH_TOKEN_OB_ADMIN=<unique-local-token>
+AUTH_TOKEN_PROMOTER=<unique-local-token>
+AUTH_TOKEN_READONLY=<unique-local-token>
+```
+
+All six tokens must be non-empty and mutually unique. Any
+`AUTH_TOKEN_USER_*` value must also carry a non-empty token unique across the
+complete set. Generate local-only values into the file; never copy or rotate
+production tokens. Leave every `OPENBRAIN_NATS_*` variable unset. If configured,
+`OPENBRAIN_RECOVERY_WAL_PATH` and `LOG_FILE` must be absolute paths strictly
+beneath `OPENBRAIN_LOCAL_CLONE_ROOT`.
+
+Before each launch, confirm the file remains private:
+
+```zsh
+test "$(stat -f '%Lp' <clone-root>/local-clone.env)" = 600
+```
+
+## 5. Verify and launch
+
+Run the launcher from a shell that explicitly loads only the private clone
+environment:
+
+```zsh
+set -a
+source <clone-root>/local-clone.env
+set +a
+
+# Read-only preflight only:
+bun run scripts/local-clone.ts --verify
+
+# Preflight, then launch src/index.ts:
+bun run scripts/local-clone.ts --start
+```
+
+The read-only preflight must succeed before the server child starts. Its single
+content-free JSON line has schema
+`openbrain.local_clone_verify_receipt.v1`, operation `local_clone_verify`, and
+status `verified`. It proves:
+
+- `current_database`, `current_user`, `inet_server_addr`, and
+  `inet_server_port` match the explicit clone environment;
+- PostgreSQL major version is 18;
+- pgvector is available and installed in the target;
+- the configured embedding provider is healthy and returns the configured
+  model/dimension.
+
+The launcher passes the child only its allowlisted clone environment and
+forwards `SIGINT` and `SIGTERM`. It does not load an env file itself.
+
+## 6. Health, socket status, and stop
+
+In another shell, load the same private environment as above. Normalize the
+literal loopback host for an HTTP URL and the exact macOS `lsof` socket form:
+
+```zsh
+case "${OPEN_BRAIN_BIND_HOST}" in
+  127.0.0.1)
+    health_host="127.0.0.1"
+    expected_socket="127.0.0.1:${PORT}"
+    ;;
+  ::1)
+    health_host="[::1]"
+    expected_socket="[::1]:${PORT}"
+    ;;
+  *)
+    echo "OPEN_BRAIN_BIND_HOST is not a literal loopback address" >&2
+    exit 1
+    ;;
+esac
+
+curl --fail --silent --show-error \
+  "http://${health_host}:${PORT}/health"
+```
+
+Prove the application has exactly one listener and that its address and port
+equal the configured literal loopback endpoint. macOS `lsof` renders an IPv6
+loopback listener as `[::1]:<port>`:
+
+```zsh
+actual_sockets="$(
+  lsof -nP -a -iTCP:"${PORT}" -sTCP:LISTEN -Fn 2>/dev/null \
+    | sed -n 's/^n//p'
+)"
+
+if [ "${actual_sockets}" != "${expected_socket}" ]; then
+  echo "listener is absent, duplicated, wildcard, or non-loopback" >&2
+  exit 1
+fi
+```
+
+This equality check deliberately rejects `*:<port>`, `0.0.0.0:<port>`,
+`[::]:<port>`, every non-loopback address, and multiple newline-separated
+listeners. Do not replace it with visual inspection.
+
+Prove PostgreSQL resolved to the intended local socket from the clone
+credentials:
+
+```zsh
+PGPASSWORD="${DB_PASSWORD}" psql \
+  -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" \
+  -XAtc \
+  "select current_database(), current_user, inet_server_addr(), inet_server_port();"
+```
+
+Expected fields are the configured clone database,
+`open_brain_local_clone`, a literal loopback address, and the configured
+PostgreSQL port. Do not use `pg_isready` alone: it does not prove the database,
+role, or resolved server address.
+
+For foreground operation, status is the successful `/health` response plus the
+exact listener check above. When another supervisor records the foreground
+launcher PID, prove both launcher and child are present:
+
+```zsh
+ps -p <launcher-pid> -o pid=,ppid=,command=
+pgrep -P <launcher-pid> -fl 'src/index.ts'
+```
+
+Stop with `Ctrl-C`; the launcher forwards `SIGINT` and waits for `src/index.ts`
+to shut down. For a managed foreground process, send `SIGTERM` to the launcher
+PID and wait for it to exit:
+
+```zsh
+kill -TERM <launcher-pid>
+```
+
+After stop, `ps -p <launcher-pid>` must fail and
+`pgrep -P <launcher-pid>` must return no child. Prove the application port has
+no remaining listener:
+
+```zsh
+if lsof -nP -a -iTCP:"${PORT}" -sTCP:LISTEN -Fn 2>/dev/null \
+  | sed -n 's/^n//p' | grep -q .; then
+  echo "application listener remains after stop" >&2
+  exit 1
+fi
+```
+
+The health request must also fail. Do not kill PostgreSQL or the embedding
+provider as part of stopping the clone.
+
+## Refresh and cleanup
+
+Never refresh in place. Stage and verify a new coordinated backup set, create a
+new `open_brain_local_<clone-id>` database, restore and preflight it, launch it
+on a different loopback port, and verify health/socket identity. Only then stop
+the old launcher. Database retirement is an explicit operator action outside
+the launcher; re-check the exact local target before dropping it.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -182,6 +182,33 @@ exact write paths the discipline rule exists to protect had zero CI coverage.
 PR #171 set `OPENBRAIN_TEST_DATABASE_URL` in the CI `check` job env, built from
 the existing `DB_*` values, enabling all env-gated suites in CI.
 
+## [2026-07-23] Operator clone procedures need their own required live boundary
+
+**Severity:** HIGH
+**Source:** PR #373 review findings P1/P2
+**Scope:** local-clone runbook, `scripts/local-clone.test.ts`, backup/restore CI wiring
+**Status:** fixed in PR #373
+
+### Pattern
+
+A clone-only test can be env-gated and silently skip even while generic
+database integration suites run. A non-superuser restore additionally cannot
+create source-required untrusted extensions or replay their comments. The
+administrative bootstrap must cover every extension created by repository
+migrations (`vector` and `pg_stat_statements`), not only the extension named by
+post-restore validation.
+
+### Review Questions
+
+- Does CI create a fresh clone-named database owned by the exact clone role and
+  export the clone URL to the live suite?
+- Does the anti-skip guard require that exact suite, rather than only generic
+  live-Postgres suites?
+- Does the administrative bootstrap cover every extension created by the source
+  migrations/archive, not only extensions checked by post-restore validation?
+- With those extensions preinstalled, does restore omit nonfunctional comments
+  and prove actual read/write as the clone role?
+
 ## [2026-06-28] Cross-tool write/read shape coherence on shared rows
 
 **Severity:** MEDIUM

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -779,3 +779,30 @@ performed before rows are returned.
   corpus setting rather than every reader?
 - Are rate, concurrency, statement-timeout, and cost/table-scope limits enforced
   and tested on the expensive path?
+
+## [2026-07-23] Lexical path confinement does not stop symlink escapes
+
+**Severity:** MEDIUM
+**Source:** PR #373
+**Scope:** local-clone path validation and any filesystem boundary checked
+before a child process receives a path
+**Status:** fixed in PR #373
+
+### Pattern
+
+`resolve()` plus `relative()` proves only that a configured path is lexically
+beneath a root. An existing symlink at the target or in any parent component can
+still redirect a later open outside that root. Fail-closed validation must
+canonicalize the existing root and the target's nearest existing filesystem
+entry, allowing only a not-yet-created suffix whose canonical ancestor remains
+inside the canonical root.
+
+### Review Questions
+
+- Does the validator realpath both the existing root and the target's nearest
+  existing entry before a child process receives the path?
+- Do regressions cover a symlink at the target and a symlink in a parent
+  component, including a nonexistent final leaf?
+- Are lexical outside-root paths still rejected before canonicalization?
+- Can an untrusted local writer swap a checked component after validation, and
+  if so, does the owning operation need descriptor-relative or no-follow I/O?

--- a/scripts/__tests__/backup-restore-live.test.ts
+++ b/scripts/__tests__/backup-restore-live.test.ts
@@ -42,12 +42,13 @@ import {
 } from "../restore.ts";
 
 const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const LOCAL_CLONE_URL = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
 const DRILL_ENABLED = process.env.OPENBRAIN_BACKUP_DRILL === "1";
 const TOOLS_AVAILABLE =
   pgToolAvailable("pg_dump") && pgToolAvailable("pg_restore");
 
 const drillDescribe = DRILL_ENABLED ? describe : describe.skip;
-const READY = Boolean(DB_URL) && TOOLS_AVAILABLE;
+const READY = Boolean(DB_URL) && Boolean(LOCAL_CLONE_URL) && TOOLS_AVAILABLE;
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const MIGRATIONS_DIR = join(REPO_ROOT, "src", "db", "migrations");
@@ -141,6 +142,7 @@ drillDescribe("backup restore drill (live Postgres, #298)", () => {
     // OPENBRAIN_BACKUP_DRILL=1 means "the drill MUST run" — missing DB URL or
     // pg client tools is a wiring failure, not a skip.
     expect(Boolean(DB_URL)).toBe(true);
+    expect(Boolean(LOCAL_CLONE_URL)).toBe(true);
     expect(TOOLS_AVAILABLE).toBe(true);
   });
 
@@ -150,6 +152,9 @@ drillDescribe("backup restore drill (live Postgres, #298)", () => {
     // the drill is actually ready to run.
     const admin: Conn & { database: string } = READY
       ? parseAdminUrl(DB_URL!)
+      : { host: "", port: 0, user: "", password: undefined, database: "" };
+    const clone: Conn & { database: string } = READY
+      ? parseAdminUrl(LOCAL_CLONE_URL!)
       : { host: "", port: 0, user: "", password: undefined, database: "" };
     let adminClient: pg.Client;
     const tempDirs: string[] = [];
@@ -386,6 +391,55 @@ drillDescribe("backup restore drill (live Postgres, #298)", () => {
         expect(eventRows[0]!.count).toBe(2);
       } finally {
         await tgtPool.end();
+      }
+    }, 180_000);
+
+    it("restores into the fresh administrator-bootstrapped non-superuser clone", async () => {
+      expect(clone.host).toBe("127.0.0.1");
+      expect(clone.user).toBe("open_brain_local_clone");
+      expect(clone.database.startsWith("open_brain_local_")).toBe(true);
+
+      const restore = await runCli(
+        "restore.ts",
+        ["--dir", backupDir, "--target-db-url", dbUrl(clone, clone.database)],
+        cliEnv(admin, SRC_DB),
+      );
+      expect(restore.exitCode).toBe(0);
+      expect(restore.receipt?.status).toBe("ok");
+      expect(
+        (restore.receipt?.validations ?? []).every(
+          (v: any) => v.verdict === "ok",
+        ),
+      ).toBe(true);
+
+      const restored = makePool(clone, clone.database);
+      try {
+        const { rows: identity } = await restored.query(
+          `SELECT current_user,
+                  EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS vector_installed,
+                  EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') AS pg_stat_statements_installed`,
+        );
+        expect(identity[0]).toEqual({
+          current_user: "open_brain_local_clone",
+          vector_installed: true,
+          pg_stat_statements_installed: true,
+        });
+        const { rows: readRows } = await restored.query(
+          "SELECT COUNT(*)::int AS count FROM thoughts",
+        );
+        expect(readRows[0]!.count).toBeGreaterThan(0);
+        await restored.query(
+          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+             VALUES ($1, $2, $3, $4)`,
+          [
+            "non-superuser clone restore write",
+            "drill",
+            NS_ALPHA,
+            "drill-clone-write",
+          ],
+        );
+      } finally {
+        await restored.end();
       }
     }, 180_000);
 

--- a/scripts/__tests__/backup-restore-live.test.ts
+++ b/scripts/__tests__/backup-restore-live.test.ts
@@ -35,7 +35,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import pg from "pg";
 import { runMigrations } from "../../src/db/migrate.ts";
-import { pgToolAvailable } from "../backup-lib.ts";
+import { pgToolAvailable, resolvePgTool } from "../backup-lib.ts";
 import {
   RESTORE_WIPE_APPROVAL_ENV,
   RESTORE_WIPE_APPROVAL_VALUE,
@@ -56,7 +56,8 @@ const SRC_DB = "open_brain_ci_restore_src";
 const TGT_DB = "open_brain_ci_restore_tgt";
 const OLD_SRC_DB = "open_brain_ci_restore_oldsrc";
 const OLD_TGT_DB = "open_brain_ci_restore_oldtgt";
-const SCRATCH_DBS = [SRC_DB, TGT_DB, OLD_SRC_DB, OLD_TGT_DB];
+const SNAPSHOT_TGT_DB = "open_brain_ci_restore_snapshot_tgt";
+const SCRATCH_DBS = [SRC_DB, TGT_DB, OLD_SRC_DB, OLD_TGT_DB, SNAPSHOT_TGT_DB];
 
 const NS_ALPHA = "drill-ns-alpha";
 const NS_BETA = "drill-ns-beta";
@@ -385,6 +386,101 @@ drillDescribe("backup restore drill (live Postgres, #298)", () => {
         expect(eventRows[0]!.count).toBe(2);
       } finally {
         await tgtPool.end();
+      }
+    }, 180_000);
+
+    it("uses one exported snapshot for manifest counts and dump contents across a concurrent commit", async () => {
+      const coordinationDir = await tempDir();
+      const readyPath = join(coordinationDir, "pg-dump-ready");
+      const releasePath = join(coordinationDir, "pg-dump-release");
+      const wrapperPath = join(coordinationDir, "coordinated-pg-dump.ts");
+      const realPgDump = resolvePgTool("pg_dump");
+      await Bun.write(
+        wrapperPath,
+        [
+          `await Bun.write(process.env.OB_SNAPSHOT_TEST_READY!, "ready");`,
+          `while (!(await Bun.file(process.env.OB_SNAPSHOT_TEST_RELEASE!).exists())) await Bun.sleep(20);`,
+          `const tool = JSON.parse(process.env.OB_SNAPSHOT_TEST_TOOL!) as string[];`,
+          `const proc = Bun.spawn([...tool, ...Bun.argv.slice(2)], {`,
+          `  env: process.env, stdin: "inherit", stdout: "inherit", stderr: "inherit",`,
+          `});`,
+          `process.exit(await proc.exited);`,
+          "",
+        ].join("\n"),
+      );
+
+      const snapshotBackupDir = join(await tempDir(), "set-snapshot");
+      const backupPromise = runCli("backup.ts", ["--out", snapshotBackupDir], {
+        ...cliEnv(admin, SRC_DB),
+        OPENBRAIN_PG_DUMP_BIN: `bun ${wrapperPath}`,
+        OB_SNAPSHOT_TEST_READY: readyPath,
+        OB_SNAPSHOT_TEST_RELEASE: releasePath,
+        OB_SNAPSHOT_TEST_TOOL: JSON.stringify(realPgDump),
+      });
+
+      const readyDeadline = Date.now() + 30_000;
+      while (!(await Bun.file(readyPath).exists())) {
+        if (Date.now() >= readyDeadline) {
+          await Bun.write(releasePath, "release");
+          await backupPromise;
+          throw new Error("timed out waiting for coordinated pg_dump");
+        }
+        await Bun.sleep(20);
+      }
+
+      const concurrentHash = "drill-concurrent-after-snapshot";
+      const writer = makePool(admin, SRC_DB);
+      try {
+        await writer.query(
+          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+             VALUES ($1, $2, $3, $4)`,
+          [
+            "concurrent write after exported snapshot",
+            "drill",
+            NS_ALPHA,
+            concurrentHash,
+          ],
+        );
+      } finally {
+        await writer.end();
+        // Always unblock the wrapper, including when the concurrent write
+        // fails, so the backup subprocess cannot leak into later tests.
+        await Bun.write(releasePath, "release");
+      }
+
+      const backup = await backupPromise;
+      expect(backup.exitCode).toBe(0);
+      expect(backup.receipt?.status).toBe("ok");
+      const manifest = JSON.parse(
+        await Bun.file(join(snapshotBackupDir, "manifest.json")).text(),
+      );
+
+      const restore = await runCli(
+        "restore.ts",
+        [
+          "--dir",
+          snapshotBackupDir,
+          "--target-db-url",
+          dbUrl(admin, SNAPSHOT_TGT_DB),
+        ],
+        cliEnv(admin, SRC_DB),
+      );
+      expect(restore.exitCode).toBe(0);
+      expect(restore.receipt?.status).toBe("ok");
+
+      const restored = makePool(admin, SNAPSHOT_TGT_DB);
+      try {
+        const { rows: countRows } = await restored.query(
+          "SELECT COUNT(*)::int AS count FROM thoughts",
+        );
+        expect(countRows[0]!.count).toBe(manifest.row_counts.thoughts);
+        const { rows: concurrentRows } = await restored.query(
+          "SELECT 1 FROM thoughts WHERE content_hash = $1",
+          [concurrentHash],
+        );
+        expect(concurrentRows).toEqual([]);
+      } finally {
+        await restored.end();
       }
     }, 180_000);
 

--- a/scripts/assert-db-tests-ran.test.ts
+++ b/scripts/assert-db-tests-ran.test.ts
@@ -43,7 +43,7 @@ describe("assert-db-tests-ran anti-skip guard", () => {
   it("passes when every required live-Postgres suite executed cleanly", () => {
     const result = evaluateJunit(wrap(allSuitesGreen()));
     expect(result.errors).toEqual([]);
-    expect(result.executedLiveTestcases).toBe(27);
+    expect(result.executedLiveTestcases).toBe(28);
     expect(
       result.executedLiveTestcasesBySuite.get(
         "search_brain language-aware FTS ranking (live Postgres)",
@@ -268,12 +268,44 @@ describe("assert-db-tests-ran anti-skip guard", () => {
     }).join("\n");
 
     const result = evaluateJunit(wrap(suites));
-    expect(result.executedLiveTestcases).toBe(27);
+    expect(result.executedLiveTestcases).toBe(28);
     expect(
       result.errors.some((e) =>
         e.includes(
           `"${skippedName}" executed 0 non-skipped live-Postgres testcases`,
         ),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when the required local-clone boundary suite is missing", () => {
+    const name = "local clone real PostgreSQL boundary (live Postgres)";
+    const xml = wrap(
+      REQUIRED_SUITES.filter((suite) => suite.name !== name)
+        .map((suite) => suiteXml(suite.name, { tests: suite.minTests }))
+        .join("\n"),
+    );
+    const result = evaluateJunit(xml);
+    expect(result.errors).toContain(
+      `MISSING suite "${name}" — it did not run at all (SKIPPED or never registered). The CI Postgres / OPENBRAIN_TEST_DATABASE_URL is not wired correctly.`,
+    );
+  });
+
+  it("fails when the required local-clone boundary suite is skipped", () => {
+    const name = "local clone real PostgreSQL boundary (live Postgres)";
+    const suites = REQUIRED_SUITES.map((suite) =>
+      suite.name === name
+        ? suiteXml(name, {
+            tests: suite.minTests,
+            skipped: suite.minTests,
+            testcases: `<testcase name="boundary" classname="${name}"><skipped /></testcase>`,
+          })
+        : suiteXml(suite.name, { tests: suite.minTests }),
+    ).join("\n");
+    const result = evaluateJunit(wrap(suites));
+    expect(
+      result.errors.some((error) =>
+        error.includes(`SKIPPED tests in "${name}"`),
       ),
     ).toBe(true);
   });

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -53,11 +53,12 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "declared source language selects the real search config via explicit request (live Postgres)",
     minTests: 3,
   },
+  { name: "local clone real PostgreSQL boundary (live Postgres)", minTests: 1 },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
 // independent of the per-suite breakdown above.
-export const MIN_TOTAL_LIVE_TESTCASES = 27;
+export const MIN_TOTAL_LIVE_TESTCASES = 28;
 
 export interface SuiteStats {
   tests: number;

--- a/scripts/backup.test.ts
+++ b/scripts/backup.test.ts
@@ -60,6 +60,7 @@ describe("runPgDump failure handling", () => {
           password: ["dump-secret", "pw"].join("-"),
           dbName: "never_connected",
           dumpPath,
+          snapshot: "00000003-0000001B-1",
         });
       } catch (err) {
         thrown = err as Error;
@@ -94,8 +95,39 @@ describe("runPgDump failure handling", () => {
         password: undefined,
         dbName: "never_connected",
         dumpPath,
+        snapshot: "00000003-0000001B-1",
       });
       expect(await Bun.file(dumpPath).text()).toBe("full-dump-bytes");
+    });
+  });
+
+  it("passes the exported snapshot as a distinct pg_dump option and value", async () => {
+    const dir = await tempDir();
+    const argvPath = join(dir, "argv.json");
+    const script = [
+      `await Bun.write(${JSON.stringify(argvPath)}, JSON.stringify(Bun.argv.slice(2)));`,
+      `process.stdout.write("dump");`,
+      "",
+    ].join("\n");
+    await withFakePgDump(script, async () => {
+      const dumpPath = join(await tempDir(), "openbrain.dump");
+      const snapshot = "00000003-0000001B-1 --no-data";
+      await runPgDump({
+        host: "127.0.0.1",
+        port: 5432,
+        user: "drill",
+        password: undefined,
+        dbName: "never_connected",
+        dumpPath,
+        snapshot,
+      });
+      const argv = JSON.parse(await Bun.file(argvPath).text()) as string[];
+      const snapshotIndex = argv.indexOf("--snapshot");
+      expect(snapshotIndex).toBeGreaterThanOrEqual(0);
+      expect(argv[snapshotIndex + 1]).toBe(snapshot);
+      expect(argv).not.toContain(`--snapshot=${snapshot}`);
+      expect(argv).not.toContain("--no-data");
+      expect(argv).toContain("-Fc");
     });
   });
 });

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -89,6 +89,7 @@ export async function runPgDump(opts: {
   password: string | undefined;
   dbName: string;
   dumpPath: string;
+  snapshot: string;
 }): Promise<void> {
   const tool = resolvePgTool("pg_dump");
   // Custom format to stdout, streamed to a host-side file. Writing via stdout
@@ -105,6 +106,8 @@ export async function runPgDump(opts: {
     opts.user,
     "-d",
     opts.dbName,
+    "--snapshot",
+    opts.snapshot,
   ];
   const proc = Bun.spawn([...tool, ...args], {
     // Only override PGPASSWORD when a password was configured; otherwise the
@@ -171,13 +174,45 @@ async function main(): Promise<void> {
   const startedAt = Date.now();
   const pool = createPool({ max: 2, application_name: "openbrain-backup" });
   try {
-    // Gather content-free DB facts first, then dump. The dump is written
-    // before the manifest so a valid set always has manifest mtime >= dump
-    // mtime (the verify drift heuristic relies on this ordering).
-    const dbInfo = await gatherDbInfo(pool);
-    const dumpStartedAt = Date.now();
-    await runPgDump({ host, port, user, password, dbName, dumpPath });
-    const dumpDurationMs = Date.now() - dumpStartedAt;
+    // Hold one read-only, repeatable-read transaction while both the manifest
+    // facts and pg_dump read its exported snapshot. This prevents a concurrent
+    // commit from landing in only one half of the backup set.
+    const client = await pool.connect();
+    let dbInfo;
+    let dumpDurationMs: number;
+    try {
+      await client.query(
+        "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+      );
+      const { rows: snapshotRows } = await client.query(
+        "SELECT pg_export_snapshot() AS snapshot",
+      );
+      const snapshot = String(snapshotRows[0]?.snapshot ?? "");
+      if (!snapshot) {
+        throw new Error("PostgreSQL did not return an exported snapshot");
+      }
+
+      // The dump is written before the manifest so a valid set always has
+      // manifest mtime >= dump mtime (verify's drift heuristic relies on it).
+      dbInfo = await gatherDbInfo(client);
+      const dumpStartedAt = Date.now();
+      await runPgDump({
+        host,
+        port,
+        user,
+        password,
+        dbName,
+        dumpPath,
+        snapshot,
+      });
+      dumpDurationMs = Date.now() - dumpStartedAt;
+      await client.query("ROLLBACK");
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
 
     const { sha256, bytes } = await sha256File(dumpPath);
     const manifest = buildManifest({

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -271,50 +271,54 @@ describe("local clone launcher", () => {
 
 const REAL_PG_URL = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
 
-describe.skipIf(!REAL_PG_URL)("local clone real PostgreSQL boundary", () => {
-  it("proves the explicit loopback clone in a read-only transaction", async () => {
-    const url = new URL(REAL_PG_URL!);
-    const host = url.hostname === "[::1]" ? "::1" : url.hostname;
-    if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
-      throw new Error(
-        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must be a PostgreSQL URL",
-      );
-    }
-    if (host !== "127.0.0.1" && host !== "::1") {
-      throw new Error(
-        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use literal loopback",
-      );
-    }
-    const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
-    const user = decodeURIComponent(url.username);
-    if (!database.startsWith("open_brain_local_")) {
-      throw new Error(
-        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must name a local clone",
-      );
-    }
-    if (user !== "open_brain_local_clone") {
-      throw new Error(
-        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use the clone role",
-      );
-    }
+describe.skipIf(!REAL_PG_URL)(
+  "local clone real PostgreSQL boundary (live Postgres)",
+  () => {
+    it("proves the explicit loopback clone in a read-only transaction", async () => {
+      const url = new URL(REAL_PG_URL!);
+      const host = url.hostname === "[::1]" ? "::1" : url.hostname;
+      if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+        throw new Error(
+          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must be a PostgreSQL URL",
+        );
+      }
+      if (host !== "127.0.0.1" && host !== "::1") {
+        throw new Error(
+          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use literal loopback",
+        );
+      }
+      const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
+      const user = decodeURIComponent(url.username);
+      if (!database.startsWith("open_brain_local_")) {
+        throw new Error(
+          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must name a local clone",
+        );
+      }
+      if (user !== "open_brain_local_clone") {
+        throw new Error(
+          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use the clone role",
+        );
+      }
 
-    const proof = await productionDependencies.database.prove({
-      DB_HOST: host,
-      DB_PORT: url.port || "5432",
-      DB_NAME: database,
-      DB_USER: user,
-      DB_PASSWORD: decodeURIComponent(url.password),
-    });
+      const proof = await productionDependencies.database.prove({
+        DB_HOST: host,
+        DB_PORT: url.port || "5432",
+        DB_NAME: database,
+        DB_USER: user,
+        DB_PASSWORD: decodeURIComponent(url.password),
+      });
 
-    expect(proof).toMatchObject({
-      database,
-      user,
-      serverAddress: host,
-      serverPort: Number.parseInt(url.port || "5432", 10),
-      postgresMajor: 18,
-      transactionReadOnly: true,
-      pgvectorAvailable: true,
-      pgvectorInstalled: true,
+      expect(proof).toMatchObject({
+        database,
+        user,
+        // node-postgres renders inet as CIDR text (127.0.0.1/32, ::1/128).
+        serverAddress: host === "127.0.0.1" ? "127.0.0.1/32" : "::1/128",
+        serverPort: Number.parseInt(url.port || "5432", 10),
+        postgresMajor: 18,
+        transactionReadOnly: true,
+        pgvectorAvailable: true,
+        pgvectorInstalled: true,
+      });
     });
-  });
-});
+  },
+);

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import {
+  buildChildEnvironment,
+  LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA,
+  productionDependencies,
+  runLocalCloneLauncher,
+  type LocalCloneLauncherDependencies,
+} from "./local-clone.ts";
+
+function cloneEnv(): Record<string, string | undefined> {
+  return {
+    OPENBRAIN_LOCAL_CLONE: "1",
+    OPENBRAIN_LOCAL_CLONE_ROOT: "/safe/local-clone",
+    OPEN_BRAIN_BIND_HOST: "127.0.0.1",
+    OPEN_BRAIN_RUN_MIGRATIONS: "0",
+    DB_HOST: "127.0.0.1",
+    DB_PORT: "55432",
+    DB_NAME: "open_brain_local_dogfood",
+    DB_USER: "open_brain_local_clone",
+    DB_PASSWORD: "local-secret",
+    EMBEDDING_BASE_URL: "http://127.0.0.1:8791/v1",
+    EMBEDDING_MODEL: "local-model",
+    EMBEDDING_DIMENSIONS: "768",
+    QMD_PATH: "",
+    AUTH_TOKEN_ADMIN: "local-admin",
+    AUTH_TOKEN_AGENT: "local-agent",
+    AUTH_TOKEN_DISCORD: "local-discord",
+    AUTH_TOKEN_OB_ADMIN: "local-ob-admin",
+    AUTH_TOKEN_PROMOTER: "local-promoter",
+    AUTH_TOKEN_READONLY: "local-readonly",
+  };
+}
+
+function childProcess(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, {
+    exitCode: null,
+    signalCode: null,
+    kill: () => true,
+  });
+  return child;
+}
+
+function fakeDependencies(
+  overrides: Partial<LocalCloneLauncherDependencies> = {},
+): LocalCloneLauncherDependencies {
+  return {
+    database: {
+      prove: async () => ({
+        database: "open_brain_local_dogfood",
+        user: "open_brain_local_clone",
+        serverAddress: "127.0.0.1",
+        serverPort: 55432,
+        postgresMajor: 18,
+        transactionReadOnly: true,
+        pgvectorAvailable: true,
+        pgvectorInstalled: true,
+      }),
+    },
+    embedding: {
+      prove: async () => ({ model: "local-model", dimensions: 768 }),
+    },
+    child: { spawn: () => childProcess() },
+    writeReceipt: () => undefined,
+    onSignal: () => () => undefined,
+    ...overrides,
+  };
+}
+
+describe("local clone launcher", () => {
+  it("emits one content-free receipt after both compatibility proofs", async () => {
+    const calls: string[] = [];
+    const receipts: unknown[] = [];
+    const deps = fakeDependencies({
+      database: {
+        prove: async () => {
+          calls.push("database");
+          return {
+            database: "open_brain_local_dogfood",
+            user: "open_brain_local_clone",
+            serverAddress: "127.0.0.1",
+            serverPort: 55432,
+            postgresMajor: 18,
+            transactionReadOnly: true,
+            pgvectorAvailable: true,
+            pgvectorInstalled: true,
+          };
+        },
+      },
+      embedding: {
+        prove: async () => {
+          calls.push("embedding");
+          return { model: "local-model", dimensions: 768 };
+        },
+      },
+      writeReceipt: (receipt) => receipts.push(receipt),
+    });
+
+    expect(await runLocalCloneLauncher("verify", cloneEnv(), deps)).toBe(0);
+    expect(calls).toEqual(["database", "embedding"]);
+    expect(receipts).toEqual([
+      {
+        schema: LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA,
+        operation: "local_clone_verify",
+        status: "verified",
+        database: {
+          identity_verified: true,
+          read_only: true,
+          postgres_major: 18,
+          pgvector_available: true,
+          pgvector_installed: true,
+        },
+        embedding: {
+          model_verified: true,
+          dimensions: 768,
+          healthy: true,
+        },
+      },
+    ]);
+    expect(JSON.stringify(receipts)).not.toContain("local-secret");
+  });
+
+  it("fails closed before embedding or spawn when database identity differs", async () => {
+    let embeddingCalled = false;
+    let spawnCalled = false;
+    const deps = fakeDependencies({
+      database: {
+        prove: async () => ({
+          database: "open_brain",
+          user: "open_brain_local_clone",
+          serverAddress: "127.0.0.1",
+          serverPort: 55432,
+          postgresMajor: 18,
+          transactionReadOnly: true,
+          pgvectorAvailable: true,
+          pgvectorInstalled: true,
+        }),
+      },
+      embedding: {
+        prove: async () => {
+          embeddingCalled = true;
+          return { model: "local-model", dimensions: 768 };
+        },
+      },
+      child: {
+        spawn: () => {
+          spawnCalled = true;
+          return childProcess();
+        },
+      },
+    });
+
+    await expect(
+      runLocalCloneLauncher("start", cloneEnv(), deps),
+    ).rejects.toThrow("identity does not match DB_NAME");
+    expect(embeddingCalled).toBe(false);
+    expect(spawnCalled).toBe(false);
+  });
+
+  it("fails closed on PostgreSQL, pgvector, and embedding incompatibility", async () => {
+    for (const database of [
+      { postgresMajor: 17 },
+      { pgvectorAvailable: false },
+      { pgvectorInstalled: false },
+      { transactionReadOnly: false },
+    ]) {
+      const base = await fakeDependencies().database.prove(cloneEnv());
+      await expect(
+        runLocalCloneLauncher(
+          "verify",
+          cloneEnv(),
+          fakeDependencies({
+            database: { prove: async () => ({ ...base, ...database }) },
+          }),
+        ),
+      ).rejects.toThrow();
+    }
+
+    await expect(
+      runLocalCloneLauncher(
+        "verify",
+        cloneEnv(),
+        fakeDependencies({
+          embedding: {
+            prove: async () => ({ model: "local-model", dimensions: 384 }),
+          },
+        }),
+      ),
+    ).rejects.toThrow("incompatible dimension");
+  });
+
+  it("spawns only after proofs with an allowlisted environment and forwards signals", async () => {
+    const child = childProcess();
+    const killed: NodeJS.Signals[] = [];
+    child.kill = ((signal?: NodeJS.Signals | number) => {
+      if (typeof signal === "string") {
+        killed.push(signal);
+        queueMicrotask(() => child.emit("exit", 0, null));
+      }
+      return true;
+    }) as ChildProcess["kill"];
+    const handlers = new Map<NodeJS.Signals, () => void>();
+    let signalHandlersReady!: () => void;
+    const signalsReady = new Promise<void>((resolve) => {
+      signalHandlersReady = resolve;
+    });
+    let spawnedEnv: Record<string, string> | undefined;
+    const env = {
+      ...cloneEnv(),
+      PATH: "/should/not/be/inherited",
+      SSH_AUTH_SOCK: "/should/not/be/inherited",
+      CORE01_HOST: "10.71.1.21",
+      AUTH_TOKEN_USER_LOCAL: "rico:local-user-token",
+    };
+    const deps = fakeDependencies({
+      child: {
+        spawn: (childEnv) => {
+          spawnedEnv = childEnv;
+          return child;
+        },
+      },
+      onSignal: (signal, handler) => {
+        handlers.set(signal, handler);
+        if (handlers.size === 2) signalHandlersReady();
+        return () => handlers.delete(signal);
+      },
+    });
+
+    const result = runLocalCloneLauncher("start", env, deps);
+    await signalsReady;
+    handlers.get("SIGTERM")?.();
+    expect(await result).toBe(0);
+    expect(killed).toEqual(["SIGTERM"]);
+    expect(spawnedEnv).toEqual(buildChildEnvironment(env));
+    expect(spawnedEnv?.DB_PASSWORD).toBe("local-secret");
+    expect(spawnedEnv?.AUTH_TOKEN_USER_LOCAL).toBe("rico:local-user-token");
+    expect(spawnedEnv).not.toHaveProperty("PATH");
+    expect(spawnedEnv).not.toHaveProperty("SSH_AUTH_SOCK");
+    expect(spawnedEnv).not.toHaveProperty("CORE01_HOST");
+    expect(handlers.size).toBe(0);
+  });
+
+  it("rejects an environment that is not explicitly local-clone mode", async () => {
+    const env = cloneEnv();
+    delete env.OPENBRAIN_LOCAL_CLONE;
+    await expect(
+      runLocalCloneLauncher("verify", env, fakeDependencies()),
+    ).rejects.toThrow("OPENBRAIN_LOCAL_CLONE=1");
+  });
+
+  it("redacts arbitrary external-boundary failures", async () => {
+    await expect(
+      runLocalCloneLauncher(
+        "verify",
+        cloneEnv(),
+        fakeDependencies({
+          database: {
+            prove: async () => {
+              throw new Error(
+                "password=should-not-escape host=external.example",
+              );
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow("Local clone database preflight failed");
+  });
+});
+
+const REAL_PG_URL = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
+
+describe.skipIf(!REAL_PG_URL)("local clone real PostgreSQL boundary", () => {
+  it("proves the explicit loopback clone in a read-only transaction", async () => {
+    const url = new URL(REAL_PG_URL!);
+    const host = url.hostname === "[::1]" ? "::1" : url.hostname;
+    if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+      throw new Error(
+        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must be a PostgreSQL URL",
+      );
+    }
+    if (host !== "127.0.0.1" && host !== "::1") {
+      throw new Error(
+        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use literal loopback",
+      );
+    }
+    const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
+    const user = decodeURIComponent(url.username);
+    if (!database.startsWith("open_brain_local_")) {
+      throw new Error(
+        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must name a local clone",
+      );
+    }
+    if (user !== "open_brain_local_clone") {
+      throw new Error(
+        "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use the clone role",
+      );
+    }
+
+    const proof = await productionDependencies.database.prove({
+      DB_HOST: host,
+      DB_PORT: url.port || "5432",
+      DB_NAME: database,
+      DB_USER: user,
+      DB_PASSWORD: decodeURIComponent(url.password),
+    });
+
+    expect(proof).toMatchObject({
+      database,
+      user,
+      serverAddress: host,
+      serverPort: Number.parseInt(url.port || "5432", 10),
+      postgresMajor: 18,
+      transactionReadOnly: true,
+      pgvectorAvailable: true,
+      pgvectorInstalled: true,
+    });
+  });
+});

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -1,0 +1,427 @@
+#!/usr/bin/env bun
+/**
+ * Fail-closed launcher for an explicitly configured local Open Brain clone.
+ *
+ * This launcher never discovers configuration or mutates PostgreSQL. It first
+ * proves the configured database and embedding provider through read-only
+ * probes, then either prints one content-free verification receipt or replaces
+ * that verification step with a tightly scoped src/index.ts child process.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import pg from "pg";
+import { validateLocalCloneMode } from "../src/local-clone-mode.ts";
+
+export const LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA =
+  "openbrain.local_clone_verify_receipt.v1";
+
+const CHILD_ENV_KEYS = [
+  "ALLOWED_ORIGINS",
+  "AUTH_TOKEN_ADMIN",
+  "AUTH_TOKEN_AGENT",
+  "AUTH_TOKEN_DISCORD",
+  "AUTH_TOKEN_OB_ADMIN",
+  "AUTH_TOKEN_PROMOTER",
+  "AUTH_TOKEN_READONLY",
+  "DB_HOST",
+  "DB_NAME",
+  "DB_PASSWORD",
+  "DB_POOL_MAX",
+  "DB_PORT",
+  "DB_USER",
+  "EMBEDDING_API_KEY",
+  "EMBEDDING_BASE_URL",
+  "EMBEDDING_DIMENSIONS",
+  "EMBEDDING_MODEL",
+  "EMBEDDING_TIMEOUT_MS",
+  "LOG_FILE",
+  "NODE_ENV",
+  "OPENBRAIN_LOCAL_CLONE",
+  "OPENBRAIN_LOCAL_CLONE_ROOT",
+  "OPENBRAIN_RECOVERY_WAL_PATH",
+  "OPEN_BRAIN_BIND_HOST",
+  "OPEN_BRAIN_MAINTENANCE_ENABLED",
+  "OPEN_BRAIN_RUN_MIGRATIONS",
+  "OPENBRAIN_TRANSPORT",
+  "PORT",
+  "QMD_PATH",
+  "TZ",
+] as const;
+
+type LauncherMode = "verify" | "start";
+
+export interface DatabaseProof {
+  database: string;
+  user: string;
+  serverAddress: string;
+  serverPort: number;
+  postgresMajor: number;
+  transactionReadOnly: boolean;
+  pgvectorAvailable: boolean;
+  pgvectorInstalled: boolean;
+}
+
+export interface EmbeddingProof {
+  model: string;
+  dimensions: number;
+}
+
+export interface DatabaseBoundary {
+  prove(env: Record<string, string | undefined>): Promise<DatabaseProof>;
+}
+
+export interface EmbeddingBoundary {
+  prove(env: Record<string, string | undefined>): Promise<EmbeddingProof>;
+}
+
+export interface ChildBoundary {
+  spawn(env: Record<string, string>): ChildProcess;
+}
+
+export interface LocalCloneLauncherDependencies {
+  database: DatabaseBoundary;
+  embedding: EmbeddingBoundary;
+  child: ChildBoundary;
+  writeReceipt(receipt: unknown): void;
+  onSignal(signal: NodeJS.Signals, handler: () => void): () => void;
+}
+
+interface DatabaseProbeRow {
+  database: string;
+  user_name: string;
+  server_address: string | null;
+  server_port: number | string | null;
+  server_version: string;
+  transaction_read_only: string;
+  pgvector_available: boolean;
+  pgvector_installed: boolean;
+}
+
+function required(
+  env: Record<string, string | undefined>,
+  key: string,
+): string {
+  const configured = env[key]?.trim();
+  if (!configured) throw new Error(`Local clone launcher requires ${key}`);
+  return configured;
+}
+
+function configuredPort(
+  env: Record<string, string | undefined>,
+  key: string,
+  fallback: number,
+): number {
+  const parsed = Number.parseInt(env[key] ?? String(fallback), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`Local clone launcher requires a valid ${key}`);
+  }
+  return parsed;
+}
+
+export function parseLocalCloneArgs(argv: string[]): LauncherMode {
+  if (argv.length === 1 && argv[0] === "--verify") return "verify";
+  if (argv.length === 1 && argv[0] === "--start") return "start";
+  throw new Error("Usage: bun run scripts/local-clone.ts --verify | --start");
+}
+
+export function buildChildEnvironment(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  const childEnv: Record<string, string> = {};
+  for (const key of CHILD_ENV_KEYS) {
+    const configured = env[key];
+    if (configured !== undefined) childEnv[key] = configured;
+  }
+  for (const [key, configured] of Object.entries(env)) {
+    if (key.startsWith("AUTH_TOKEN_USER_") && configured !== undefined) {
+      childEnv[key] = configured;
+    }
+  }
+  return childEnv;
+}
+
+function assertDatabaseProof(
+  proof: DatabaseProof,
+  env: Record<string, string | undefined>,
+): void {
+  if (!proof.transactionReadOnly) {
+    throw new Error("Local clone database probe was not read-only");
+  }
+  if (proof.database !== required(env, "DB_NAME")) {
+    throw new Error("Local clone database identity does not match DB_NAME");
+  }
+  if (proof.user !== required(env, "DB_USER")) {
+    throw new Error("Local clone database identity does not match DB_USER");
+  }
+  if (proof.serverAddress !== required(env, "DB_HOST")) {
+    throw new Error("Local clone database address does not match DB_HOST");
+  }
+  if (proof.serverPort !== configuredPort(env, "DB_PORT", 5432)) {
+    throw new Error("Local clone database port does not match DB_PORT");
+  }
+  if (proof.postgresMajor !== 18) {
+    throw new Error("Local clone launcher requires PostgreSQL major 18");
+  }
+  if (!proof.pgvectorAvailable || !proof.pgvectorInstalled) {
+    throw new Error(
+      "Local clone launcher requires pgvector to be available and installed",
+    );
+  }
+}
+
+function expectedEmbedding(
+  env: Record<string, string | undefined>,
+): EmbeddingProof {
+  const dimensions = Number.parseInt(env.EMBEDDING_DIMENSIONS ?? "768", 10);
+  if (!Number.isInteger(dimensions) || dimensions <= 0) {
+    throw new Error(
+      "Local clone launcher requires a valid EMBEDDING_DIMENSIONS",
+    );
+  }
+  return {
+    model: env.EMBEDDING_MODEL?.trim() || "gemini-embedding-001",
+    dimensions,
+  };
+}
+
+function assertEmbeddingProof(
+  proof: EmbeddingProof,
+  env: Record<string, string | undefined>,
+): void {
+  const expected = expectedEmbedding(env);
+  if (proof.model !== expected.model) {
+    throw new Error(
+      "Local clone embedding provider does not expose EMBEDDING_MODEL",
+    );
+  }
+  if (proof.dimensions !== expected.dimensions) {
+    throw new Error(
+      "Local clone embedding provider returned an incompatible dimension",
+    );
+  }
+}
+
+function waitForChild(child: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        resolve(128 + (signal === "SIGINT" ? 2 : 15));
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+export async function runLocalCloneLauncher(
+  mode: LauncherMode,
+  env: Record<string, string | undefined>,
+  deps: LocalCloneLauncherDependencies,
+): Promise<number> {
+  const clone = validateLocalCloneMode(env);
+  if (!clone.enabled) {
+    throw new Error("Local clone launcher requires OPENBRAIN_LOCAL_CLONE=1");
+  }
+
+  let database: DatabaseProof;
+  try {
+    database = await deps.database.prove(env);
+  } catch {
+    throw new Error("Local clone database preflight failed");
+  }
+  assertDatabaseProof(database, env);
+  let embedding: EmbeddingProof;
+  try {
+    embedding = await deps.embedding.prove(env);
+  } catch {
+    throw new Error("Local clone embedding preflight failed");
+  }
+  assertEmbeddingProof(embedding, env);
+
+  if (mode === "verify") {
+    deps.writeReceipt({
+      schema: LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA,
+      operation: "local_clone_verify",
+      status: "verified",
+      database: {
+        identity_verified: true,
+        read_only: true,
+        postgres_major: 18,
+        pgvector_available: true,
+        pgvector_installed: true,
+      },
+      embedding: {
+        model_verified: true,
+        dimensions: embedding.dimensions,
+        healthy: true,
+      },
+    });
+    return 0;
+  }
+
+  let child: ChildProcess;
+  try {
+    child = deps.child.spawn(buildChildEnvironment(env));
+  } catch {
+    throw new Error("Local clone runtime failed to start");
+  }
+  const removeSignalHandlers = (["SIGINT", "SIGTERM"] as const).map((signal) =>
+    deps.onSignal(signal, () => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill(signal);
+      }
+    }),
+  );
+  try {
+    try {
+      return await waitForChild(child);
+    } catch {
+      throw new Error("Local clone runtime child failed");
+    }
+  } finally {
+    for (const remove of removeSignalHandlers) remove();
+  }
+}
+
+export const productionDependencies: LocalCloneLauncherDependencies = {
+  database: {
+    async prove(env): Promise<DatabaseProof> {
+      const client = new pg.Client({
+        host: required(env, "DB_HOST"),
+        port: configuredPort(env, "DB_PORT", 5432),
+        database: required(env, "DB_NAME"),
+        user: required(env, "DB_USER"),
+        password: async () => env.DB_PASSWORD ?? "",
+        ssl: false,
+        options: "-c default_transaction_read_only=on",
+        connectionTimeoutMillis: 5_000,
+        statement_timeout: 5_000,
+        application_name: "open-brain-local-clone-preflight",
+      });
+      await client.connect();
+      try {
+        await client.query("BEGIN READ ONLY");
+        const result = await client.query<DatabaseProbeRow>(`
+          SELECT
+            current_database() AS database,
+            current_user AS user_name,
+            inet_server_addr()::text AS server_address,
+            inet_server_port() AS server_port,
+            current_setting('server_version') AS server_version,
+            current_setting('transaction_read_only') AS transaction_read_only,
+            EXISTS (
+              SELECT 1 FROM pg_available_extensions WHERE name = 'vector'
+            ) AS pgvector_available,
+            EXISTS (
+              SELECT 1 FROM pg_extension WHERE extname = 'vector'
+            ) AS pgvector_installed
+        `);
+        const row = result.rows[0];
+        if (!row || row.server_address === null || row.server_port === null) {
+          throw new Error("Local clone database did not return TCP identity");
+        }
+        return {
+          database: row.database,
+          user: row.user_name,
+          serverAddress: row.server_address,
+          serverPort: Number(row.server_port),
+          postgresMajor: Number.parseInt(row.server_version, 10),
+          transactionReadOnly: row.transaction_read_only === "on",
+          pgvectorAvailable: row.pgvector_available,
+          pgvectorInstalled: row.pgvector_installed,
+        };
+      } finally {
+        await client.query("ROLLBACK").catch(() => undefined);
+        await client.end();
+      }
+    },
+  },
+  embedding: {
+    async prove(env): Promise<EmbeddingProof> {
+      const baseUrl = required(env, "EMBEDDING_BASE_URL").replace(/\/+$/, "");
+      const expected = expectedEmbedding(env);
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+      };
+      const apiKey = env.EMBEDDING_API_KEY?.trim();
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+      const modelsResponse = await fetch(`${baseUrl}/models`, {
+        headers,
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!modelsResponse.ok) {
+        throw new Error("Local clone embedding provider health check failed");
+      }
+      const models = (await modelsResponse.json()) as {
+        data?: Array<{ id?: unknown }>;
+      };
+      if (
+        !models.data?.some(
+          (model) =>
+            typeof model.id === "string" && model.id === expected.model,
+        )
+      ) {
+        throw new Error(
+          "Local clone embedding provider does not expose EMBEDDING_MODEL",
+        );
+      }
+
+      const embeddingResponse = await fetch(`${baseUrl}/embeddings`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: expected.model,
+          input: "local clone compatibility probe",
+        }),
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!embeddingResponse.ok) {
+        throw new Error("Local clone embedding provider probe failed");
+      }
+      const payload = (await embeddingResponse.json()) as {
+        data?: Array<{ embedding?: unknown }>;
+      };
+      const vector = payload.data?.[0]?.embedding;
+      if (!Array.isArray(vector)) {
+        throw new Error("Local clone embedding provider returned no vector");
+      }
+      return { model: expected.model, dimensions: vector.length };
+    },
+  },
+  child: {
+    spawn(env): ChildProcess {
+      return spawn(process.execPath, ["run", "src/index.ts"], {
+        cwd: process.cwd(),
+        env,
+        stdio: "inherit",
+      });
+    },
+  },
+  writeReceipt(receipt): void {
+    process.stdout.write(`${JSON.stringify(receipt)}\n`);
+  },
+  onSignal(signal, handler): () => void {
+    process.on(signal, handler);
+    return () => process.off(signal, handler);
+  },
+};
+
+if (import.meta.main) {
+  try {
+    const mode = parseLocalCloneArgs(Bun.argv.slice(2));
+    process.exitCode = await runLocalCloneLauncher(
+      mode,
+      process.env,
+      productionDependencies,
+    );
+  } catch (error) {
+    console.error(
+      error instanceof Error ? error.message : "Local clone launcher failed",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/restore.ts
+++ b/scripts/restore.ts
@@ -621,6 +621,11 @@ export async function runPgRestore(
   const args = [
     "--no-owner",
     "--no-privileges",
+    // A fresh local-clone target preinstalls pgvector through its local admin.
+    // That extension remains admin-owned, so replaying the archive's COMMENT
+    // would require the non-superuser clone role to own it. Comments are not
+    // functional restore state; omit them while keeping the archive DDL/data.
+    "--no-comments",
     "--exit-on-error",
     "--single-transaction",
     "-h",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
   type MaintenanceRuntime,
 } from "./maintenance-bootstrap.ts";
 import { safeMaintenanceErrorCategory } from "./maintenance-queue.ts";
+import { validateLocalCloneMode } from "./local-clone-mode.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
 
@@ -242,6 +243,10 @@ export function createApp(
 }
 
 if (import.meta.main) {
+  const localClone = validateLocalCloneMode(
+    process.env as Record<string, string | undefined>,
+  );
+
   // The vector columns are halfvec(768) in the schema; a mismatched
   // EMBEDDING_DIMENSIONS makes every embedding INSERT fail at runtime.
   if (EMBEDDING_DIMENSIONS !== 768) {
@@ -333,9 +338,20 @@ if (import.meta.main) {
   const app = createApp(pool, tokenMap, toolDeps);
   const port = parseInt(process.env.PORT || "3100", 10);
 
-  const server = app.listen(port, () => {
-    logger.info("open-brain server started", { port });
-  });
+  const bindHost = localClone.enabled
+    ? localClone.bindHost
+    : process.env.OPEN_BRAIN_BIND_HOST?.trim();
+  const server = bindHost
+    ? app.listen(port, bindHost, () => {
+        logger.info("open-brain server started", {
+          port,
+          bind_host: bindHost,
+          local_clone: localClone.enabled,
+        });
+      })
+    : app.listen(port, () => {
+        logger.info("open-brain server started", { port });
+      });
 
   // Server-owned maintenance queue (#343 substrate + #345 embedding-repair
   // handler). Started only here, after migrations ran, tokens were validated,

--- a/src/local-clone-mode.test.ts
+++ b/src/local-clone-mode.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "bun:test";
+import { validateLocalCloneMode } from "./local-clone-mode.ts";
+
+function validCloneEnv(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  return {
+    OPENBRAIN_LOCAL_CLONE: "1",
+    OPEN_BRAIN_BIND_HOST: "127.0.0.1",
+    DB_HOST: "127.0.0.1",
+    DB_NAME: "open_brain_local_issue_370",
+    DB_USER: "open_brain_local_clone",
+    EMBEDDING_BASE_URL: "http://127.0.0.1:8791/v1",
+    QMD_PATH: "",
+    OPEN_BRAIN_RUN_MIGRATIONS: "0",
+    OPENBRAIN_LOCAL_CLONE_ROOT: "/tmp/open-brain-local",
+    AUTH_TOKEN_ADMIN: "local-admin",
+    AUTH_TOKEN_AGENT: "local-agent",
+    AUTH_TOKEN_DISCORD: "local-discord",
+    AUTH_TOKEN_OB_ADMIN: "local-ob-admin",
+    AUTH_TOKEN_PROMOTER: "local-promoter",
+    AUTH_TOKEN_READONLY: "local-readonly",
+    ...overrides,
+  };
+}
+
+describe("validateLocalCloneMode", () => {
+  it("preserves non-clone behavior", () => {
+    expect(validateLocalCloneMode({})).toEqual({ enabled: false });
+  });
+
+  it("accepts an isolated loopback-only clone", () => {
+    expect(validateLocalCloneMode(validCloneEnv())).toEqual({
+      enabled: true,
+      bindHost: "127.0.0.1",
+    });
+  });
+
+  it("accepts literal IPv6 loopback values", () => {
+    expect(
+      validateLocalCloneMode(
+        validCloneEnv({
+          OPEN_BRAIN_BIND_HOST: "::1",
+          DB_HOST: "::1",
+          EMBEDDING_BASE_URL: "http://[::1]:8791/v1",
+        }),
+      ),
+    ).toEqual({ enabled: true, bindHost: "::1" });
+  });
+
+  it.each([
+    ["OPEN_BRAIN_BIND_HOST", "localhost"],
+    ["OPEN_BRAIN_BIND_HOST", "[::1]"],
+    ["DB_HOST", "10.71.1.21"],
+    ["DB_HOST", "[::1]"],
+    ["EMBEDDING_BASE_URL", "http://embedding.internal:8791/v1"],
+  ])("rejects non-literal-loopback %s", (key, configured) => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+    ).toThrow("literal loopback");
+  });
+
+  it.each([
+    ["DB_NAME", "open_brain"],
+    ["DB_USER", "open_brain"],
+    ["OPEN_BRAIN_RUN_MIGRATIONS", "1"],
+  ])("rejects unsafe %s", (key, configured) => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+    ).toThrow(key);
+  });
+
+  it.each([
+    "OPEN_BRAIN_BIND_HOST",
+    "DB_HOST",
+    "EMBEDDING_BASE_URL",
+    "DB_NAME",
+    "DB_USER",
+    "OPENBRAIN_LOCAL_CLONE_ROOT",
+  ])("rejects missing required %s", (key) => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ [key]: undefined })),
+    ).toThrow(key);
+  });
+
+  it.each(["not-a-url", "ftp://127.0.0.1/embeddings"])(
+    "rejects invalid embedding URL %s",
+    (configured) => {
+      expect(() =>
+        validateLocalCloneMode(
+          validCloneEnv({ EMBEDDING_BASE_URL: configured }),
+        ),
+      ).toThrow("valid loopback URL");
+    },
+  );
+
+  it.each([
+    ["OPENBRAIN_NATS_URL", "nats://127.0.0.1:4222"],
+    ["EMBEDDING_WATCHDOG_RESTART_SCRIPT", "/some/restart-script"],
+  ])("rejects prohibited %s configuration", (key, configured) => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+    ).toThrow("prohibit");
+  });
+
+  it.each([
+    ["OPENBRAIN_RECOVERY_WAL_PATH", "/tmp/open-brain-local/state/recovery.wal"],
+    ["LOG_FILE", "/tmp/open-brain-local/log/open-brain.log"],
+  ])(
+    "accepts local runtime path %s beneath the clone root",
+    (key, configured) => {
+      expect(
+        validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+      ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
+    },
+  );
+
+  it.each([
+    [
+      "OPENBRAIN_RECOVERY_WAL_PATH",
+      "/Volumes/ThunderBolt/open-brain/recovery.wal",
+    ],
+    ["LOG_FILE", "/tmp/open-brain.log"],
+  ])("rejects runtime path %s outside the clone root", (key, configured) => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+    ).toThrow("OPENBRAIN_LOCAL_CLONE_ROOT");
+  });
+
+  it("requires an absolute local clone root", () => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({ OPENBRAIN_LOCAL_CLONE_ROOT: "relative/root" }),
+      ),
+    ).toThrow("absolute path");
+  });
+
+  it.each([undefined, "/Volumes/ThunderBolt/qmd/src/qmd.ts"])(
+    "rejects unsafe QMD_PATH %s because absence enables the production default",
+    (configured) => {
+      expect(() =>
+        validateLocalCloneMode(validCloneEnv({ QMD_PATH: configured })),
+      ).toThrow("QMD_PATH");
+    },
+  );
+
+  it("requires every role token explicitly", () => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ AUTH_TOKEN_PROMOTER: "" })),
+    ).toThrow("AUTH_TOKEN_PROMOTER");
+  });
+
+  it("rejects duplicate role and per-user token values", () => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({ AUTH_TOKEN_READONLY: "local-admin" }),
+      ),
+    ).toThrow("unique local auth tokens");
+
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({ AUTH_TOKEN_USER_RICO: "admin:local-admin" }),
+      ),
+    ).toThrow("unique local auth tokens");
+  });
+
+  it.each(["", "admin:"])(
+    "rejects an empty configured per-user token value",
+    (configured) => {
+      expect(() =>
+        validateLocalCloneMode(
+          validCloneEnv({ AUTH_TOKEN_USER_RICO: configured }),
+        ),
+      ).toThrow(/non-empty|unique/);
+    },
+  );
+
+  it("accepts a unique configured per-user token", () => {
+    expect(
+      validateLocalCloneMode(
+        validCloneEnv({ AUTH_TOKEN_USER_RICO: "admin:local-rico" }),
+      ),
+    ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
+  });
+});

--- a/src/local-clone-mode.test.ts
+++ b/src/local-clone-mode.test.ts
@@ -1,5 +1,24 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { validateLocalCloneMode } from "./local-clone-mode.ts";
+
+const localCloneTestDir = mkdtempSync(join(tmpdir(), "open-brain-clone-"));
+const localCloneRoot = join(localCloneTestDir, "clone");
+const outsideRoot = join(localCloneTestDir, "outside");
+mkdirSync(localCloneRoot);
+mkdirSync(outsideRoot);
+
+afterAll(() => {
+  rmSync(localCloneTestDir, { recursive: true, force: true });
+});
 
 function validCloneEnv(
   overrides: Record<string, string | undefined> = {},
@@ -13,7 +32,7 @@ function validCloneEnv(
     EMBEDDING_BASE_URL: "http://127.0.0.1:8791/v1",
     QMD_PATH: "",
     OPEN_BRAIN_RUN_MIGRATIONS: "0",
-    OPENBRAIN_LOCAL_CLONE_ROOT: "/tmp/open-brain-local",
+    OPENBRAIN_LOCAL_CLONE_ROOT: localCloneRoot,
     AUTH_TOKEN_ADMIN: "local-admin",
     AUTH_TOKEN_AGENT: "local-agent",
     AUTH_TOKEN_DISCORD: "local-discord",
@@ -103,27 +122,74 @@ describe("validateLocalCloneMode", () => {
     ).toThrow("prohibit");
   });
 
-  it.each([
-    ["OPENBRAIN_RECOVERY_WAL_PATH", "/tmp/open-brain-local/state/recovery.wal"],
-    ["LOG_FILE", "/tmp/open-brain-local/log/open-brain.log"],
-  ])(
-    "accepts local runtime path %s beneath the clone root",
-    (key, configured) => {
+  it.each(["OPENBRAIN_RECOVERY_WAL_PATH", "LOG_FILE"])(
+    "accepts existing and nonexistent %s leaves beneath the clone root",
+    (key) => {
+      const existing = join(localCloneRoot, "existing", key.toLowerCase());
+      const nonexistent = join(
+        localCloneRoot,
+        "nonexistent",
+        key.toLowerCase(),
+      );
+      mkdirSync(dirname(existing), { recursive: true });
+      writeFileSync(existing, "");
+
       expect(
-        validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+        validateLocalCloneMode(validCloneEnv({ [key]: existing })),
+      ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
+      expect(
+        validateLocalCloneMode(validCloneEnv({ [key]: nonexistent })),
       ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
     },
   );
 
-  it.each([
-    [
-      "OPENBRAIN_RECOVERY_WAL_PATH",
-      "/Volumes/ThunderBolt/open-brain/recovery.wal",
-    ],
-    ["LOG_FILE", "/tmp/open-brain.log"],
-  ])("rejects runtime path %s outside the clone root", (key, configured) => {
+  it.each(["OPENBRAIN_RECOVERY_WAL_PATH", "LOG_FILE"])(
+    "rejects direct %s symlink escapes",
+    (key) => {
+      const outside = join(outsideRoot, `direct-${key.toLowerCase()}`);
+      const configured = join(localCloneRoot, `direct-${key.toLowerCase()}`);
+      writeFileSync(outside, "");
+      symlinkSync(outside, configured);
+
+      expect(() =>
+        validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+      ).toThrow("OPENBRAIN_LOCAL_CLONE_ROOT");
+    },
+  );
+
+  it.each(["OPENBRAIN_RECOVERY_WAL_PATH", "LOG_FILE"])(
+    "rejects nested %s symlink escapes",
+    (key) => {
+      const symlink = join(localCloneRoot, `nested-${key.toLowerCase()}`);
+      symlinkSync(outsideRoot, symlink, "dir");
+      const configured = join(symlink, "not-yet-created");
+
+      expect(() =>
+        validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+      ).toThrow("OPENBRAIN_LOCAL_CLONE_ROOT");
+    },
+  );
+
+  it.each(["OPENBRAIN_RECOVERY_WAL_PATH", "LOG_FILE"])(
+    "rejects lexical %s paths outside the clone root",
+    (key) => {
+      const configured = join(outsideRoot, key.toLowerCase());
+
+      expect(() =>
+        validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+      ).toThrow("OPENBRAIN_LOCAL_CLONE_ROOT");
+    },
+  );
+
+  it("rejects a missing clone root when a runtime path is configured", () => {
+    const missingRoot = join(localCloneTestDir, "missing-root");
     expect(() =>
-      validateLocalCloneMode(validCloneEnv({ [key]: configured })),
+      validateLocalCloneMode(
+        validCloneEnv({
+          OPENBRAIN_LOCAL_CLONE_ROOT: missingRoot,
+          LOG_FILE: join(missingRoot, "open-brain.log"),
+        }),
+      ),
     ).toThrow("OPENBRAIN_LOCAL_CLONE_ROOT");
   });
 

--- a/src/local-clone-mode.ts
+++ b/src/local-clone-mode.ts
@@ -1,0 +1,180 @@
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1"]);
+
+const REQUIRED_LOCAL_TOKEN_KEYS = [
+  "AUTH_TOKEN_ADMIN",
+  "AUTH_TOKEN_AGENT",
+  "AUTH_TOKEN_DISCORD",
+  "AUTH_TOKEN_OB_ADMIN",
+  "AUTH_TOKEN_PROMOTER",
+  "AUTH_TOKEN_READONLY",
+] as const;
+
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+const PROHIBITED_PATH_KEYS = ["EMBEDDING_WATCHDOG_RESTART_SCRIPT"] as const;
+
+const LOCAL_RUNTIME_PATH_KEYS = [
+  "OPENBRAIN_RECOVERY_WAL_PATH",
+  "LOG_FILE",
+] as const;
+
+export type LocalCloneConfig =
+  { enabled: false } | { enabled: true; bindHost: string };
+
+function value(
+  env: Record<string, string | undefined>,
+  key: string,
+): string | undefined {
+  const configured = env[key]?.trim();
+  return configured ? configured : undefined;
+}
+
+function requireValue(
+  env: Record<string, string | undefined>,
+  key: string,
+): string {
+  const configured = value(env, key);
+  if (!configured) {
+    throw new Error(`Local clone mode requires ${key}`);
+  }
+  return configured;
+}
+
+function requireLiteralLoopback(host: string, key: string): void {
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `Local clone mode requires ${key} to be a literal loopback address`,
+    );
+  }
+}
+
+function requirePathInsideRoot(path: string, root: string, key: string): void {
+  if (!isAbsolute(path)) {
+    throw new Error(`Local clone mode requires ${key} to be an absolute path`);
+  }
+  const resolvedRoot = resolve(root);
+  const resolvedPath = resolve(path);
+  const fromRoot = relative(resolvedRoot, resolvedPath);
+  if (
+    fromRoot === "" ||
+    fromRoot === ".." ||
+    fromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(fromRoot)
+  ) {
+    throw new Error(
+      `Local clone mode requires ${key} beneath OPENBRAIN_LOCAL_CLONE_ROOT`,
+    );
+  }
+}
+
+/**
+ * Validate the complete fail-closed boundary for a local clone before any
+ * database connection or migration can be attempted.
+ */
+export function validateLocalCloneMode(
+  env: Record<string, string | undefined>,
+): LocalCloneConfig {
+  if (env.OPENBRAIN_LOCAL_CLONE !== "1") {
+    return { enabled: false };
+  }
+
+  const bindHost = requireValue(env, "OPEN_BRAIN_BIND_HOST");
+  requireLiteralLoopback(bindHost, "OPEN_BRAIN_BIND_HOST");
+  requireLiteralLoopback(requireValue(env, "DB_HOST"), "DB_HOST");
+
+  const embeddingBaseUrl = requireValue(env, "EMBEDDING_BASE_URL");
+  let embeddingUrl: URL;
+  try {
+    embeddingUrl = new URL(embeddingBaseUrl);
+  } catch {
+    throw new Error(
+      "Local clone mode requires EMBEDDING_BASE_URL to be a valid loopback URL",
+    );
+  }
+  if (embeddingUrl.protocol !== "http:" && embeddingUrl.protocol !== "https:") {
+    throw new Error(
+      "Local clone mode requires EMBEDDING_BASE_URL to be a valid loopback URL",
+    );
+  }
+  const embeddingHost =
+    embeddingUrl.hostname === "[::1]" ? "::1" : embeddingUrl.hostname;
+  requireLiteralLoopback(embeddingHost, "EMBEDDING_BASE_URL");
+
+  const database = requireValue(env, "DB_NAME");
+  if (!database.startsWith("open_brain_local_")) {
+    throw new Error(
+      "Local clone mode requires DB_NAME to use the open_brain_local_ prefix",
+    );
+  }
+
+  if (requireValue(env, "DB_USER") !== "open_brain_local_clone") {
+    throw new Error("Local clone mode requires DB_USER=open_brain_local_clone");
+  }
+
+  if (env.OPEN_BRAIN_RUN_MIGRATIONS !== "0") {
+    throw new Error("Local clone mode requires OPEN_BRAIN_RUN_MIGRATIONS=0");
+  }
+
+  const localRoot = requireValue(env, "OPENBRAIN_LOCAL_CLONE_ROOT");
+  if (!isAbsolute(localRoot)) {
+    throw new Error(
+      "Local clone mode requires OPENBRAIN_LOCAL_CLONE_ROOT to be an absolute path",
+    );
+  }
+
+  if (
+    value(env, "OPENBRAIN_TRANSPORT")?.toLowerCase() === "nats" ||
+    Object.entries(env).some(
+      ([key, configured]) =>
+        key.startsWith("OPENBRAIN_NATS_") && Boolean(configured?.trim()),
+    )
+  ) {
+    throw new Error("Local clone mode prohibits NATS configuration");
+  }
+
+  for (const key of PROHIBITED_PATH_KEYS) {
+    if (value(env, key)) {
+      throw new Error(`Local clone mode prohibits ${key}`);
+    }
+  }
+
+  for (const key of LOCAL_RUNTIME_PATH_KEYS) {
+    const configured = value(env, key);
+    if (configured) {
+      requirePathInsideRoot(configured, localRoot, key);
+    }
+  }
+
+  // QMD_PATH normally defaults to the production /opt/qmd entrypoint when
+  // absent, so clone mode must explicitly suppress that fallback.
+  if (env.QMD_PATH !== "") {
+    throw new Error(
+      "Local clone mode requires QMD_PATH to be explicitly empty",
+    );
+  }
+
+  const seenTokens = new Set<string>();
+  for (const key of REQUIRED_LOCAL_TOKEN_KEYS) {
+    const token = requireValue(env, key);
+    if (seenTokens.has(token)) {
+      throw new Error("Local clone mode requires unique local auth tokens");
+    }
+    seenTokens.add(token);
+  }
+
+  for (const [key, configured] of Object.entries(env)) {
+    if (!key.startsWith("AUTH_TOKEN_USER_")) continue;
+    const raw = configured?.trim();
+    if (!raw) {
+      throw new Error(`Local clone mode requires a non-empty value for ${key}`);
+    }
+    const separator = raw.indexOf(":");
+    const token = separator >= 0 ? raw.slice(separator + 1).trim() : "";
+    if (!token || seenTokens.has(token)) {
+      throw new Error("Local clone mode requires unique local auth tokens");
+    }
+    seenTokens.add(token);
+  }
+
+  return { enabled: true, bindHost };
+}

--- a/src/local-clone-mode.ts
+++ b/src/local-clone-mode.ts
@@ -9,7 +9,8 @@ const REQUIRED_LOCAL_TOKEN_KEYS = [
   "AUTH_TOKEN_READONLY",
 ] as const;
 
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { lstatSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 const PROHIBITED_PATH_KEYS = ["EMBEDDING_WATCHDOG_RESTART_SCRIPT"] as const;
 
@@ -60,6 +61,55 @@ function requirePathInsideRoot(path: string, root: string, key: string): void {
     fromRoot === ".." ||
     fromRoot.startsWith(`..${sep}`) ||
     isAbsolute(fromRoot)
+  ) {
+    throw new Error(
+      `Local clone mode requires ${key} beneath OPENBRAIN_LOCAL_CLONE_ROOT`,
+    );
+  }
+
+  let canonicalRoot: string;
+  try {
+    canonicalRoot = realpathSync(resolvedRoot);
+  } catch {
+    throw new Error(
+      "Local clone mode requires OPENBRAIN_LOCAL_CLONE_ROOT to exist",
+    );
+  }
+
+  let existingPath = resolvedPath;
+  while (true) {
+    try {
+      lstatSync(existingPath);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw new Error(
+          `Local clone mode requires ${key} beneath OPENBRAIN_LOCAL_CLONE_ROOT`,
+        );
+      }
+      const parent = dirname(existingPath);
+      if (parent === existingPath) {
+        throw new Error(
+          `Local clone mode requires ${key} beneath OPENBRAIN_LOCAL_CLONE_ROOT`,
+        );
+      }
+      existingPath = parent;
+    }
+  }
+
+  let canonicalExistingPath: string;
+  try {
+    canonicalExistingPath = realpathSync(existingPath);
+  } catch {
+    throw new Error(
+      `Local clone mode requires ${key} beneath OPENBRAIN_LOCAL_CLONE_ROOT`,
+    );
+  }
+  const fromCanonicalRoot = relative(canonicalRoot, canonicalExistingPath);
+  if (
+    fromCanonicalRoot === ".." ||
+    fromCanonicalRoot.startsWith(`..${sep}`) ||
+    isAbsolute(fromCanonicalRoot)
   ) {
     throw new Error(
       `Local clone mode requires ${key} beneath OPENBRAIN_LOCAL_CLONE_ROOT`,


### PR DESCRIPTION
## Summary

- make backup manifest facts and `pg_dump` share one exported PostgreSQL snapshot
- add a fail-closed loopback-only local-clone startup boundary before pool creation or migrations
- add a read-only database/pgvector/embedding preflight and allowlisted local runtime launcher
- document encrypted core01-to-local transfer, verified restore, launch, socket checks, and no-in-place refresh

Tracks #370
Parent #369

## Validation

- focused local clone/backup suite: **95 passed, 1 env-gated real-DB test skipped, 0 failed**
- real PostgreSQL 18.4 + pgvector 0.8.2 backup/verify/restore drill: **7 passed, 0 failed**
  - includes a concurrent commit while `pg_dump` is paused
  - restored row counts match the manifest exactly
  - the post-snapshot write is correctly absent
  - disposable databases were dropped and verified absent
- `bunx tsc --noEmit`: passed
- `git diff --check`: passed
- review-fix focused suite: **61 passed, 11 env-gated tests skipped, 0 failed**
- real PostgreSQL 18.4 non-superuser clone drill after review fixes: **8 passed, 0 failed**
  - source-required `vector` and `pg_stat_statements` extensions were administrator-bootstrapped in the fresh clone database
  - the archive restored as `open_brain_local_clone` with `NOSUPERUSER`, `NOCREATEDB`, and `NOCREATEROLE`
  - restored data was readable and writable as the clone role
- `bunx tsc --noEmit` after review fixes: passed
- full `bun test`: one pre-existing order/concurrency-sensitive `source-sync.test.ts` log-capture assertion failed; the exact file immediately passed **24/24** in isolation. No #370 code touches that surface.

## Local-only rollout classification

- This PR does not deploy or mutate core01.
- No MCP tool name, schema, output, auth, namespace, transport, Python client, or TypeScript client contract changes.
- Downstream client regeneration is not applicable.
- Post-merge/local activation remains required before #370 closes: encrypted backup transfer, local restore, local embedding service, local Open Brain startup, and Claude/Claudex canaries.
- Hermes: not applicable and must not be added, deployed, or canaried.

## Critical self-review

- Highest-risk behavior: an ambient production DB/provider variable or wildcard listener could expose or mutate the wrong system before validation.
- Assumptions that could be wrong: local PostgreSQL reports the configured literal TCP loopback identity; the embedding service exposes OpenAI-compatible `/v1/models` and `/v1/embeddings`; the backup role may export snapshots.
- Missing/weak tests: launcher DB/embedding production boundaries have fake functional coverage and an env-gated real-DB test; the complete local embedding/server process canary is intentionally performed during local activation.
- Security/permission risk: clone mode validates before pool creation/migrations, rejects non-loopback and production-adjacent settings, requires unique local tokens, confines log/WAL paths, and passes the server an allowlisted environment.
- Migration/deploy risk: clone mode requires migrations disabled after verified restore; normal non-clone startup behavior remains unchanged. No production deploy is part of this PR.
- Downstream client/runtime risk: additive server environment and operator behavior only; no public tool or client contract changes.
- Rollback/cleanup concern: clone refresh always creates a fresh DB and switches only after verification; no wipe-in-place path is used. Code rollback restores prior startup/backup behavior.
- Fixes made before PR: coordinated manifest/dump snapshot; literal loopback binding; DB identity/read-only/major/pgvector proof; embedding compatibility proof; local-root confinement; signal forwarding; encrypted-transfer and exact socket runbook.
- Known residual risk: full local process activation and actual cloned production-data read canary remain pending; no reverse synchronization to core01 is authorized.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR creates the local-only activation substrate; the real local clone/server canary follows merge and is required before issue #370 closure
