### PR TITLE
fix(370): prove literal database host address

### DIFF
--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -311,8 +311,7 @@ describe.skipIf(!REAL_PG_URL)(
       expect(proof).toMatchObject({
         database,
         user,
-        // node-postgres renders inet as CIDR text (127.0.0.1/32, ::1/128).
-        serverAddress: host === "127.0.0.1" ? "127.0.0.1/32" : "::1/128",
+        serverAddress: host,
         serverPort: Number.parseInt(url.port || "5432", 10),
         postgresMajor: 18,
         transactionReadOnly: true,

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -305,7 +305,7 @@ export const productionDependencies: LocalCloneLauncherDependencies = {
           SELECT
             current_database() AS database,
             current_user AS user_name,
-            inet_server_addr()::text AS server_address,
+            host(inet_server_addr()) AS server_address,
             inet_server_port() AS server_port,
             current_setting('server_version') AS server_version,
             current_setting('transaction_read_only') AS transaction_read_only,


### PR DESCRIPTION
## Summary

- return PostgreSQL's server address with `host(inet_server_addr())` instead of `inet_server_addr()::text`
- preserve exact literal `DB_HOST` equality while avoiding the CIDR suffix (`/32` or `/128`) added by the `inet` text representation
- update the existing real local-clone PostgreSQL test to assert the literal host returned by the production dependency

Tracks #370
Parent #369

## Validation

- focused local-clone suite against the restored clone role/database: **7 passed, 0 failed, 24 assertions**
- `bunx tsc --noEmit`: passed
- actual local clone preflight: `openbrain.local_clone_verify_receipt.v1`, status `verified`
  - database identity/read-only/PostgreSQL 18/pgvector: verified
  - embedding model and 768 dimensions: verified
- `git diff --check`: passed

## Local-only rollout classification

- This fixes the local dogfood preflight discovered after the verified database restore.
- No core01 deployment or mutation is included.
- The literal loopback equality check is preserved; only PostgreSQL's CIDR formatting is removed at the query boundary.

## Contract Parity

- Contract parity: [x] not applicable because: no MCP, client, package, or wire contract changes; this corrects an internal operator preflight query representation

## Critical self-review

- Highest-risk behavior: weakening the database identity gate could allow a non-loopback or wrong-address target.
- Assumptions that could be wrong: PostgreSQL `host(inet_server_addr())` returns the address literal without network prefix for both IPv4 and IPv6.
- Missing/weak tests: the existing env-gated real PostgreSQL test now runs against the exact restored clone role/database; no mock-only SQL assertion was added.
- Security/permission risk: exact equality against configured `DB_HOST` remains unchanged and the probe remains read-only.
- Migration/deploy risk: none; no schema or data mutation. Startup preflight behavior changes from false rejection to verified.
- Downstream client/runtime risk: none outside the local-clone operator path.
- Rollback/cleanup concern: reverting restores the false-negative `127.0.0.1/32` mismatch; no persisted state changes.
- Fixes made before PR: removed an implementation-detail SQL-string test and kept the functional live boundary as the regression.
- Known residual risk: local Open Brain startup and health/socket proof still follow after merge.
- SME review-memory update: [x] not applicable because: the owning operator-clone live-boundary pattern already exists in `docs/sme/correctness.md`; this is the direct functional follow-up

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: the repository-owned local-clone preflight itself was run against the restored database and managed embedding service; server startup follows merge
