### PR TITLE
feat(371): opt-in unreviewed recovery recall flag (openbrain-memory 0.1.17)

### DIFF
--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.16"
+version = "0.1.17"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -22,7 +22,13 @@ MAX_JSON_INPUT_BYTES = 64 * 1024
 MAX_JSON_OUTPUT_BYTES = 1_000_000
 _COMMON_KEYS = {"config", "operation", "scope"}
 _OPERATION_KEYS = {
-    "recall": {"max_latency_ms", "max_tokens", "query", "requested_sections"},
+    "recall": {
+        "include_unreviewed_recovery",
+        "max_latency_ms",
+        "max_tokens",
+        "query",
+        "requested_sections",
+    },
     "reflex": {"max_latency_ms", "max_tokens", "prior_context", "query"},
     "capture": {"content", "distilled", "event_type"},
     "checkpoint": {
@@ -142,6 +148,10 @@ def _dispatch(
                 payload,
                 "requested_sections",
             ),
+            include_unreviewed_recovery=_mapping_optional_bool(
+                payload,
+                "include_unreviewed_recovery",
+            ),
         )
     if operation == "reflex":
         return runtime.reflex(
@@ -214,6 +224,15 @@ def _mapping_optional_int(value: Mapping[str, Any], name: str) -> int | None:
         return None
     if isinstance(item, bool) or not isinstance(item, int):
         raise ValueError(f"{name} must be an integer")
+    return item
+
+
+def _mapping_optional_bool(value: Mapping[str, Any], name: str) -> bool | None:
+    item = value.get(name)
+    if item is None:
+        return None
+    if not isinstance(item, bool):
+        raise ValueError(f"{name} must be a boolean")
     return item
 
 

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -619,10 +619,24 @@ class FirstClassMemoryRuntime:
             # prior request shape exactly. Revalidate boolean-ness here as well
             # because programmatic callers can bypass the CLI type boundary.
             if include_unreviewed_recovery is not None:
-                arguments["include_unreviewed_recovery"] = _require_bool(
+                opted_in = _require_bool(
                     include_unreviewed_recovery,
                     "include_unreviewed_recovery",
                 )
+                # The server drops the opt-in when requested_sections omits
+                # "recovery"; reject that provably ineffective combination
+                # loudly instead of returning a silently recovery-free pack.
+                if (
+                    opted_in
+                    and requested_sections is not None
+                    and "recovery" not in arguments["requested_sections"]
+                ):
+                    raise ValueError(
+                        "include_unreviewed_recovery=true requires "
+                        "requested_sections to include 'recovery' "
+                        "(or requested_sections to be omitted)"
+                    )
+                arguments["include_unreviewed_recovery"] = opted_in
             local_timeout = (
                 max_latency_ms / 1000 if max_latency_ms is not None else None
             )

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -560,6 +560,7 @@ class FirstClassMemoryRuntime:
         max_tokens: int | None = None,
         max_latency_ms: int | None = None,
         requested_sections: Sequence[str] | None = None,
+        include_unreviewed_recovery: bool | None = None,
     ) -> RuntimeOutput:
         """Fail open while recalling the exact-scope server context pack."""
         with self._operation_lock:
@@ -568,6 +569,7 @@ class FirstClassMemoryRuntime:
                 max_tokens=max_tokens,
                 max_latency_ms=max_latency_ms,
                 requested_sections=requested_sections,
+                include_unreviewed_recovery=include_unreviewed_recovery,
             )
 
     def _recall_context(
@@ -577,6 +579,7 @@ class FirstClassMemoryRuntime:
         max_tokens: int | None,
         max_latency_ms: int | None,
         requested_sections: Sequence[str] | None,
+        include_unreviewed_recovery: bool | None = None,
     ) -> RuntimeOutput:
         self._router.reset()
         try:
@@ -610,6 +613,16 @@ class FirstClassMemoryRuntime:
                         f"{', '.join(sorted(unsupported))}"
                     )
                 arguments["requested_sections"] = sections
+            # Runtime-specific projection of an already server-supported
+            # agent_context_pack argument (#371): forward it only when the
+            # caller explicitly opted in, so an omitted flag preserves the
+            # prior request shape exactly. Revalidate boolean-ness here as well
+            # because programmatic callers can bypass the CLI type boundary.
+            if include_unreviewed_recovery is not None:
+                arguments["include_unreviewed_recovery"] = _require_bool(
+                    include_unreviewed_recovery,
+                    "include_unreviewed_recovery",
+                )
             local_timeout = (
                 max_latency_ms / 1000 if max_latency_ms is not None else None
             )
@@ -1107,6 +1120,12 @@ def _distilled_content(value: str, name: str) -> str:
 
 def _persisted_text(value: Any, name: str) -> str:
     return _validate_persisted_text(value, name, _reject_secret_payload)
+
+
+def _require_bool(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
 
 
 def _wrap_metadata(

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -161,8 +161,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.16"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.16"
+    assert CURRENT_CLIENT_VERSION == "0.1.17"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.17"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.15 <1.0.0"
     )

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -193,6 +193,64 @@ def test_recall_rejects_non_boolean_recovery_before_transport() -> None:
     assert tool_calls(transport) == []
 
 
+def test_recall_rejects_recovery_opt_in_without_recovery_section() -> None:
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(), runtime_scope(), transport=transport
+    )
+
+    output = runtime.recall_context(
+        "what changed?",
+        requested_sections=["working_set"],
+        include_unreviewed_recovery=True,
+    )
+
+    assert output.receipt.status is ReceiptStatus.FAILED
+    assert output.receipt.error == (
+        "include_unreviewed_recovery=true requires requested_sections to "
+        "include 'recovery' (or requested_sections to be omitted)"
+    )
+    assert tool_calls(transport) == []
+
+
+def test_recall_allows_recovery_opt_in_with_recovery_section() -> None:
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(), runtime_scope(), transport=transport
+    )
+
+    output = runtime.recall_context(
+        "what changed?",
+        requested_sections=["working_set", "recovery"],
+        include_unreviewed_recovery=True,
+    )
+
+    assert output.receipt.status is ReceiptStatus.DIRECT
+    calls = tool_calls(transport)
+    arguments = calls[1]["params"]["arguments"]
+    assert arguments["include_unreviewed_recovery"] is True
+    assert arguments["requested_sections"] == ["working_set", "recovery"]
+
+
+def test_recall_allows_explicit_false_opt_out_without_recovery_section() -> None:
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(), runtime_scope(), transport=transport
+    )
+
+    output = runtime.recall_context(
+        "what changed?",
+        requested_sections=["working_set"],
+        include_unreviewed_recovery=False,
+    )
+
+    assert output.receipt.status is ReceiptStatus.DIRECT
+    calls = tool_calls(transport)
+    assert (
+        calls[1]["params"]["arguments"]["include_unreviewed_recovery"] is False
+    )
+
+
 def test_recall_omitting_recovery_opt_in_preserves_prior_argument_shape() -> None:
     transport = LaneAwareTransport()
     runtime = FirstClassMemoryRuntime(

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -160,6 +160,104 @@ def test_recall_rejects_schema_invalid_budget_and_sections_before_transport() ->
     assert tool_calls(transport) == []
 
 
+def test_recall_forwards_recovery_opt_in_to_context_pack_arguments() -> None:
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(), runtime_scope(), transport=transport
+    )
+
+    output = runtime.recall_context(
+        "what changed?",
+        include_unreviewed_recovery=True,
+    )
+
+    assert output.receipt.status is ReceiptStatus.DIRECT
+    calls = tool_calls(transport)
+    assert calls[1]["params"]["name"] == "agent_context_pack"
+    assert calls[1]["params"]["arguments"]["include_unreviewed_recovery"] is True
+
+
+def test_recall_rejects_non_boolean_recovery_before_transport() -> None:
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(), runtime_scope(), transport=transport
+    )
+
+    output = runtime.recall_context(
+        "what changed?",
+        include_unreviewed_recovery=1,  # type: ignore[arg-type]
+    )
+
+    assert output.receipt.status is ReceiptStatus.FAILED
+    assert output.receipt.error == "include_unreviewed_recovery must be a boolean"
+    assert tool_calls(transport) == []
+
+
+def test_recall_omitting_recovery_opt_in_preserves_prior_argument_shape() -> None:
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(), runtime_scope(), transport=transport
+    )
+
+    output = runtime.recall_context("what changed?")
+
+    assert output.receipt.status is ReceiptStatus.DIRECT
+    calls = tool_calls(transport)
+    arguments = calls[1]["params"]["arguments"]
+    assert "include_unreviewed_recovery" not in arguments
+    assert arguments == {
+        "agent": "bilby",
+        "platform": "discord",
+        "server_id": "guild-1",
+        "channel_id": "channel-2",
+        "thread_id": "thread-3",
+        "session_key": "repo/session-4",
+        "query": "what changed?",
+    }
+
+
+def test_json_adapter_recall_forwards_recovery_opt_in() -> None:
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        request_payload(
+            "recall",
+            query="current task",
+            include_unreviewed_recovery=True,
+        ),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "direct"
+    calls = tool_calls(transport)
+    assert calls[1]["params"]["name"] == "agent_context_pack"
+    assert calls[1]["params"]["arguments"]["include_unreviewed_recovery"] is True
+
+
+def test_json_adapter_recall_rejects_non_boolean_recovery_before_transport() -> None:
+    transport = LaneAwareTransport()
+
+    # A string, an int, and a list must all fail as non-boolean input. The
+    # error names the boolean requirement (the type validator's message), which
+    # distinguishes accept-key-then-type-reject from a pre-fix unknown-key
+    # rejection.
+    for bad in ("true", 1, [True]):
+        output = execute_json(
+            request_payload(
+                "recall",
+                query="current task",
+                include_unreviewed_recovery=bad,
+            ),
+            transport=transport,
+        )
+        assert output["receipt"]["status"] == "failed"
+        assert "include_unreviewed_recovery must be a boolean" in (
+            output["receipt"].get("error") or ""
+        )
+
+    assert tool_calls(transport) == []
+
+
 def test_first_capture_establishes_lane_before_append() -> None:
     transport = LaneAwareTransport()
     runtime = FirstClassMemoryRuntime(

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes nothing directly; part of #371 rollout (Python client 0.1.17).

Adds an optional `include_unreviewed_recovery` boolean to the `recall` operation. It is forwarded to `agent_context_pack` only on explicit opt-in, so an omitted flag preserves the prior request shape exactly. Boolean-ness is validated at both the CLI JSON boundary and the runtime facade (programmatic callers can bypass the CLI).

Validation: `uv run mypy src/openbrain_memory` clean, `uv run ruff check src tests` clean, `uv run pytest -q` 491 passed / 5 skipped. Wheel 0.1.17 built from this tree passed live local-clone dogfood (SessionStart recall `status=direct` against the loopback clone) and read-only recall against core01.

Critical self-review:
- Highest-risk behavior: request-shape drift for existing callers; mitigated by opt-in-only forwarding (omitted flag sends the exact prior arguments) and contract tests asserting the unchanged default shape.
- Assumptions that could be wrong: server ignores/errors unknown args on older deployments — flag is only sent on explicit opt-in, and the server already supports the argument on main (pre-#368-deploy risk is limited to opt-in callers).
- Missing/weak tests: no live-server integration test for the opt-in path in CI (env-gated canaries only); covered by fake-transport tests for call shape.
- Security/permission risk: none new — flag gates recovery-lane visibility already enforced server-side by role; client sends no privileged header change.
- Migration/deploy risk: none (client-only; no schema/server change).
- Downstream client/runtime risk: Claudex hook adapter pins wheel by sha; adapter stays at 0.1.16 until its own activation bump — 0.1.17 is backward compatible for all existing call shapes.
- Rollback/cleanup concern: revert = uninstall wheel; no persisted state format change.
- Fixes made before PR: revalidated boolean at runtime boundary, added contract-parity commit line.
- Known residual risk: opt-in callers against a server predating the argument get a server-side validation error; acceptable and observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)