### PR TITLE
fix(341): close post-merge FTS privilege, cost, and docs gaps from PR #368

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,10 @@ EMBEDDING_DIMENSIONS=768
 
 # Optional operator opt-in for the public search_brain default
 # Non-English keyword/hybrid FTS is recomputed on the fly and is not index-backed
+# (admin/ob-admin only; ordinary roles degrade to english -- see docs/fts-operations.md)
 # OPENBRAIN_FTS_CONFIG=german
+# Statement timeout for the permitted non-default (unindexed) FTS path, ms
+# OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS=5000
 
 # Server
 PORT=3100
@@ -339,7 +342,16 @@ Supporting tables: `entry_access_log` (usage tracking), `discarded_entries` (arc
 1. **Vector search** — HNSW nearest-neighbor over halfvec(768) embeddings (cosine distance)
 2. **Full-text search** — PostgreSQL `tsvector`; English uses the stored GIN-indexed `search_vector`
 
-English is the shared default and preserves existing search behavior. Supported non-English configurations recompute the same source text with PostgreSQL `to_tsvector` on the fly for keyword and hybrid searches, so those scans are not index-backed. `OPENBRAIN_FTS_CONFIG` is an operator opt-in that changes the public `search_brain` deployment default; it does not implicitly change sibling `executeSearch` consumers. A caller may explicitly select English, while an explicitly requested effective non-English `fts_config` requires the `admin` or `ob-admin` role.
+English is the shared default and preserves existing search behavior. Supported non-English configurations recompute the same source text with PostgreSQL `to_tsvector` on the fly for keyword and hybrid searches, so those scans are not index-backed. `OPENBRAIN_FTS_CONFIG` is an operator opt-in that changes the public `search_brain` deployment default; it does not implicitly change sibling `executeSearch` consumers.
+
+The non-English path is a privilege boundary on the **effective** configuration for keyword/hybrid searches, regardless of whether it came from the request or the env default:
+
+- A caller may always explicitly select English.
+- An explicitly requested effective non-English `fts_config` requires the `admin` or `ob-admin` role (content-free denial otherwise).
+- When a non-English config comes only from the `OPENBRAIN_FTS_CONFIG` env default, ordinary roles (`agent`, `readonly`, `discord`, `promoter`) silently degrade to the GIN-indexed English default instead of being denied -- availability and the pre-language-aware cost profile are preserved. Admin roles get the configured language.
+- `search_mode: "vector"` performs no FTS, so `fts_config` is ignored there and never denies a request.
+
+Permitted non-default searches are cost-bounded with a transaction-scoped statement timeout (`OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS`, default 5000 ms). Operator enable/monitor/rollback procedures live in [docs/fts-operations.md](fts-operations.md).
 
 Results are merged via Reciprocal Rank Fusion (RRF) with adjustments for:
 - **Cognitive tier** — hot entries boosted (+0.3), cold entries penalized (−0.2)

--- a/docs/fts-operations.md
+++ b/docs/fts-operations.md
@@ -1,0 +1,139 @@
+# Language-Aware FTS Operations
+
+Operator runbook for the language-aware full-text-search configuration
+introduced in #341 (PR #368) and hardened by the #368 post-merge fixes:
+enabling a non-English deployment default, what each role sees, the cost
+profile of the unindexed path, monitoring, and rollback.
+
+Audience: whoever operates a hosted Open Brain deployment (launchd service on
+core01, or any environment that sets the process env).
+
+## What the knob does
+
+`OPENBRAIN_FTS_CONFIG` sets the deployment-default text-search configuration
+for the public `search_brain` tool's keyword and hybrid modes. Accepted values
+are the allowlisted Postgres-shipped regconfigs (`english`, `simple`,
+`spanish`, `french`, `german`, `portuguese`) or a language token that resolves
+to one (`de`, `de-DE`, `pt_BR`, ...). Anything unrecognized falls back to
+`english`; a typo can never disable lexical search.
+
+- `english` (default, or unset): keyword/hybrid use the stored GIN-indexed
+  `search_vector` column -- byte-identical to pre-#341 behavior.
+- Non-English config: keyword/hybrid recompute
+  `to_tsvector('<config>', <same source columns>)` per row at query time.
+  There is no index for that expression, so these are sequential scans over
+  the candidate tables.
+
+The env default only affects the public `search_brain` handler. Sibling
+internal `executeSearch` consumers (e.g. `brain_answer`) keep the English
+default unless they pass a config explicitly.
+
+## Privilege boundary (who sees what)
+
+The boundary applies to the **effective** config for keyword/hybrid searches,
+whether it arrived via the request's `fts_config` argument or the env default:
+
+| Caller role | Explicit non-English `fts_config` | Non-English via env default only | `search_mode: "vector"` |
+|-------------|-----------------------------------|----------------------------------|-------------------------|
+| `admin`, `ob-admin` | Applied | Applied | `fts_config` unused/ignored |
+| `agent`, `readonly`, `discord`, `promoter` | Content-free permission denial | **Silently degrades to English** (indexed path, request succeeds) | `fts_config` unused/ignored; request succeeds |
+
+Notes:
+
+- The env-default degrade is deliberate: it preserves availability and the
+  exact pre-#341 behavior/cost for ordinary roles instead of turning an
+  operator env change into a fleet-wide denial. Only privileged roles pay the
+  unindexed cost.
+- Any caller may always explicitly request `english`, even when the env
+  default is non-English.
+- Vector mode performs no FTS, so `fts_config` neither denies nor influences
+  execution there.
+
+## Cost profile and the statement timeout
+
+The non-default path recomputes `to_tsvector` for every candidate row in each
+searched table on every keyword/hybrid query. Expect latency to scale with
+table row counts, not with result `limit` -- the scan work happens before
+`LIMIT` applies.
+
+To bound worst-case database cost, every permitted non-default FTS statement
+runs inside a transaction with a transaction-scoped
+`SET LOCAL statement_timeout`:
+
+- Knob: `OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS`
+- Default: `5000` (milliseconds)
+- Validation: must be a positive base-10 integer. Unset, blank, zero,
+  negative, fractional, or non-numeric values fall back to the default; the
+  raw env text is never interpolated into SQL.
+- Scope: applied only when the effective config is non-default. The English
+  GIN-indexed path never pays it and runs as a plain pooled query.
+- A query that exceeds the bound fails that search with a Postgres
+  `statement_timeout` error (surfaced as a tool error); it does not affect
+  other connections, and `SET LOCAL` guarantees the pooled connection is
+  returned with its default timeout intact.
+
+## Enable
+
+1. Set the env for the service process, e.g. in the deployment `.env`:
+
+   ```env
+   OPENBRAIN_FTS_CONFIG=german
+   # optional, ms; default 5000
+   OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS=5000
+   ```
+
+2. Restart the service (hosted core01: `launchctl kickstart -k` the
+   `com.rico.open-brain` job, or the deployment SOP's restart step).
+
+3. Verify:
+   - An `admin`/`ob-admin` keyword search returns language-stemmed matches
+     (e.g. german corpus: a query for `Haus` matches a document containing
+     `Häuser`).
+   - An ordinary-role (`agent`) keyword search still succeeds and behaves as
+     English (degrade path) -- no permission errors from the env change.
+   - Latency of admin keyword/hybrid searches is acceptable (see below).
+
+## Monitor
+
+- **Latency:** watch keyword/hybrid `search_brain` latency for privileged
+  callers after enabling. The unindexed path is the only new slow path; if
+  p95 approaches the statement timeout, either lower expectations, raise
+  `OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS` deliberately, or roll back.
+- **Timeout hits:** search errors containing `statement timeout` indicate the
+  bound is firing. Frequent hits mean the corpus is too large for on-the-fly
+  recompute; roll back or plan an indexed migration before widening use.
+- **pg_stat_statements:** on-the-fly scans are visible as statements containing
+  `to_tsvector('german'` (or the configured language) rather than
+  `search_vector`. Track their `mean_exec_time`/`calls`:
+
+  ```sql
+  SELECT calls, mean_exec_time, left(query, 120)
+  FROM pg_stat_statements
+  WHERE query LIKE '%to_tsvector(''german''%'
+  ORDER BY mean_exec_time DESC;
+  ```
+
+- **Sequential scans:** `pg_stat_user_tables.seq_scan` on `thoughts`,
+  `decisions`, `relationships`, `projects`, `sessions` will rise with
+  non-default search volume.
+
+## Rollback
+
+1. Unset `OPENBRAIN_FTS_CONFIG` (remove it from the env / `.env`).
+2. Restart the service.
+3. Behavior is byte-identical to the English-only deployment: all roles use
+   the stored GIN-indexed `search_vector` column, no statement-timeout
+   transaction wrapping, no schema or data changes to undo (the feature
+   performs no migration and stores nothing).
+
+`OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS` may stay set; it is inert while the
+effective config is English.
+
+## Related
+
+- `src/tools/fts-config.ts` -- allowlist, env resolution, timeout validation.
+- `src/tools/search-brain.ts` -- privilege gate, `runBoundedFtsQuery`
+  execution boundary.
+- `docs/README.md` "Search" section -- user-facing summary.
+- `docs/sme/security.md` [2026-07-23] "Caller-selectable unindexed query modes
+  need privilege, rate, and cost controls".

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -765,7 +765,13 @@ digest is not observed-content truth — hash received bytes server-side).
 **Source:** PR #368 review, 2026-07-23
 **Scope:** caller-selected FTS configurations and other query modes that bypass
 an index
-**Status:** active
+**Status:** active (FTS instance addressed post-merge: the privilege gate now
+applies to the EFFECTIVE config regardless of provenance -- env-default
+non-English degrades ordinary roles to the indexed english path; vector mode
+ignores the unused `fts_config`; and permitted non-default statements are
+bounded by a transaction-scoped `SET LOCAL statement_timeout` from validated
+`OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS`, default 5000 ms. Pattern stays active for
+future unindexed modes.)
 
 An allowlisted query mode can still be a resource-exhaustion surface. If a
 caller can replace an indexed predicate with per-row computation across multiple

--- a/src/tools/__tests__/fts-config.test.ts
+++ b/src/tools/__tests__/fts-config.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "bun:test";
 import {
   SUPPORTED_FTS_CONFIGS,
   DEFAULT_FTS_CONFIG,
+  DEFAULT_FTS_STATEMENT_TIMEOUT_MS,
   ftsConfigSchema,
+  ftsStatementTimeoutMs,
   resolveFtsConfig,
   corpusFtsConfig,
   requestFtsConfig,
@@ -145,6 +147,70 @@ describe("requestFtsConfig -- explicit per-request selection", () => {
     const hostile = "english'); DROP TABLE thoughts; --";
     const result = requestFtsConfig(hostile, {});
     expect(SUPPORTED_FTS_CONFIGS).toContain(result);
+  });
+});
+
+describe("ftsStatementTimeoutMs -- non-default FTS cost bound", () => {
+  it("defaults to 5000 ms when the env knob is unset or blank", () => {
+    expect(DEFAULT_FTS_STATEMENT_TIMEOUT_MS).toBe(5000);
+    expect(ftsStatementTimeoutMs({})).toBe(5000);
+    expect(
+      ftsStatementTimeoutMs({ OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: "" }),
+    ).toBe(5000);
+    expect(
+      ftsStatementTimeoutMs({ OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: "   " }),
+    ).toBe(5000);
+  });
+
+  it("accepts a positive integer override (whitespace tolerated)", () => {
+    expect(
+      ftsStatementTimeoutMs({ OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: "250" }),
+    ).toBe(250);
+    expect(
+      ftsStatementTimeoutMs({ OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: " 15000 " }),
+    ).toBe(15000);
+  });
+
+  it("falls back to the default for anything that is not a positive integer", () => {
+    for (const invalid of [
+      "abc",
+      "-5",
+      "0",
+      "2.5",
+      "1e3",
+      "0x10",
+      "5000ms",
+      "5; DROP TABLE thoughts",
+      "9007199254740993", // beyond Number.MAX_SAFE_INTEGER
+    ]) {
+      expect(
+        ftsStatementTimeoutMs({ OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: invalid }),
+      ).toBe(5000);
+    }
+  });
+
+  it("falls back to the default above the 32-bit statement_timeout maximum", () => {
+    expect(
+      ftsStatementTimeoutMs({
+        OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: "2147483647",
+      }),
+    ).toBe(2147483647);
+    for (const overflow of ["2147483648", "3000000000", "9007199254740991"]) {
+      expect(
+        ftsStatementTimeoutMs({ OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: overflow }),
+      ).toBe(5000);
+    }
+  });
+
+  it("always returns a finite positive number, never env text", () => {
+    for (const raw of ["german", "'; --", "NaN", "Infinity", "01000"]) {
+      const value = ftsStatementTimeoutMs({
+        OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS: raw,
+      });
+      expect(typeof value).toBe("number");
+      expect(Number.isSafeInteger(value)).toBe(true);
+      expect(value).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/src/tools/__tests__/search-brain-fts-language.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.test.ts
@@ -26,38 +26,65 @@ const obAdmin: AuthInfo = {
   clientId: "ob-admin-client",
 };
 
-/** Pool that records every FTS-arm SQL statement it is asked to run. */
-function recordingPool() {
+/**
+ * Pool that records every FTS-arm SQL statement it is asked to run.
+ *
+ * `allSql`/`ftsSql` record statements regardless of which boundary ran them.
+ * `clientSql` records ONLY statements run on a dedicated checked-out client
+ * (deps.pool.connect()), which is the transaction-scoped execution boundary the
+ * non-default FTS statement-timeout uses -- so tests can observe whether the
+ * cost bound applied without asserting broader SQL shape.
+ */
+function recordingPool(rowsFor?: (sql: string) => any[]) {
   const ftsSql: string[] = [];
   const allSql: string[] = [];
+  const clientSql: string[] = [];
+  const record = (sql: string) => {
+    allSql.push(sql);
+    if (sql.includes("fts_query")) ftsSql.push(sql);
+  };
+  const respond = (sql: string) => ({ rows: rowsFor ? rowsFor(sql) : [] });
   return {
     ftsSql,
     allSql,
+    clientSql,
     pool: {
       query: async (...args: any[]) => {
         const sql = String(args[0]);
-        allSql.push(sql);
-        if (sql.includes("fts_query")) ftsSql.push(sql);
-        if (sql.includes("FROM ob_links")) return { rows: [] };
-        return { rows: [] };
+        record(sql);
+        return respond(sql);
       },
+      connect: async () => ({
+        query: async (...args: any[]) => {
+          const sql = String(args[0]);
+          clientSql.push(sql);
+          record(sql);
+          return respond(sql);
+        },
+        release: () => {},
+      }),
     },
   };
 }
 
-async function runKeywordSearch(
-  pool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+async function runSearch(
+  pool: {
+    query: (...args: any[]) => Promise<{ rows: any[] }>;
+    connect?: (...args: any[]) => Promise<any>;
+  },
   query: string,
   opts: {
     namespace?: string;
     ftsConfig?: string;
     auth?: AuthInfo;
+    mode?: "hybrid" | "vector" | "keyword";
+    embed?: ReturnType<typeof createMockEmbed>;
   } = {},
 ): Promise<any> {
   const { client, cleanup } = await setupMcpClient(
     registerSearchBrain,
     pool,
-    createMockEmbed(),
+    opts.embed ?? createMockEmbed(),
     opts.auth ?? admin,
   );
   try {
@@ -65,7 +92,7 @@ async function runKeywordSearch(
       name: "search_brain",
       arguments: {
         query,
-        search_mode: "keyword",
+        search_mode: opts.mode ?? "keyword",
         table: "thoughts",
         ...(opts.namespace ? { namespace: opts.namespace } : {}),
         ...(opts.ftsConfig ? { fts_config: opts.ftsConfig } : {}),
@@ -76,10 +103,18 @@ async function runKeywordSearch(
   }
 }
 
+const runKeywordSearch = runSearch;
+
 const savedFtsConfig = process.env.OPENBRAIN_FTS_CONFIG;
+const savedFtsTimeout = process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS;
 afterEach(() => {
   if (savedFtsConfig === undefined) delete process.env.OPENBRAIN_FTS_CONFIG;
   else process.env.OPENBRAIN_FTS_CONFIG = savedFtsConfig;
+  if (savedFtsTimeout === undefined) {
+    delete process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS;
+  } else {
+    process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS = savedFtsTimeout;
+  }
 });
 
 describe("shared executeSearch FTS default", () => {
@@ -327,13 +362,55 @@ describe("search_brain explicit fts_config request argument", () => {
     expect(sql).not.toContain("plainto_tsquery('german',");
   });
 
-  it("allows an operator-controlled non-english default for an ordinary caller", async () => {
+  it("degrades an ordinary caller to indexed english under a non-english env default (keyword)", async () => {
+    // #368 post-merge finding 1: the env default must not hand ordinary roles
+    // the unindexed non-english path. It degrades to english (availability
+    // preserved, pre-#341 behavior and cost) rather than denying.
     process.env.OPENBRAIN_FTS_CONFIG = "german";
-    const { ftsSql, pool } = recordingPool();
+    const { ftsSql, clientSql, pool } = recordingPool();
     const result = await runKeywordSearch(pool, "Planung", { auth: agent });
 
     expect(result.isError).toBeFalsy();
-    expect(ftsSql.join("\n")).toContain("plainto_tsquery('german',");
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+    expect(sql).not.toContain("german");
+    // The degraded path is the indexed default -- no bounded-transaction
+    // client checkout, no statement_timeout cost bound needed.
+    expect(clientSql).toEqual([]);
+  });
+
+  it("degrades an ordinary caller to indexed english under a non-english env default (hybrid)", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    const { ftsSql, pool } = recordingPool();
+    const result = await runSearch(pool, "Planung", {
+      auth: agent,
+      mode: "hybrid",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(ftsSql.length).toBeGreaterThan(0);
+    const sql = ftsSql.join("\n");
+    expect(sql).toContain("t.search_vector @@");
+    expect(sql).toContain("plainto_tsquery('english',");
+    expect(sql).not.toContain("german");
+  });
+
+  it("keeps the env-default german config for an admin caller (keyword and hybrid)", async () => {
+    process.env.OPENBRAIN_FTS_CONFIG = "german";
+    for (const mode of ["keyword", "hybrid"] as const) {
+      const { ftsSql, pool } = recordingPool();
+      const result = await runSearch(pool, "vierteljährliche Planung", {
+        auth: admin,
+        mode,
+      });
+
+      expect(result.isError).toBeFalsy();
+      const sql = ftsSql.join("\n");
+      expect(sql).toContain("to_tsvector('german',");
+      expect(sql).toContain("@@ plainto_tsquery('german',");
+      expect(sql).not.toContain("t.search_vector @@");
+    }
   });
 
   it("denies an explicit typo when its effective operator default is non-english", async () => {
@@ -406,5 +483,143 @@ describe("search_brain explicit fts_config request argument", () => {
     const sql = ftsSql.join("\n");
     expect(sql).not.toContain("DROP TABLE");
     expect(sql).toContain("plainto_tsquery('english',");
+  });
+});
+
+/** A vector-arm result row as the search SQL would return it. */
+function vectorHit(id: string) {
+  return {
+    source_type: "thought",
+    id,
+    namespace: "rico",
+    content_preview: "Quarterly planning",
+    tags: [],
+    created_by: "test",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    tier: "warm",
+    distance: 0.1,
+    fts_rank: null,
+    usefulness: 0.5,
+    access_count: 0,
+    extracted_metadata: null,
+  };
+}
+
+describe("search_brain vector mode ignores fts_config (#368 finding 2)", () => {
+  it("lets an ordinary caller run a vector search with an explicit non-english fts_config", async () => {
+    // vector mode performs no FTS; the unused fts_config argument must neither
+    // deny the request nor influence execution. Pre-fix this returned the
+    // non-English privilege denial.
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    const { ftsSql, allSql, pool } = recordingPool((sql) =>
+      sql.includes("query_embedding") ? [vectorHit("vector-hit")] : [],
+    );
+    const result = await runSearch(pool, "vierteljährliche Planung", {
+      auth: agent,
+      mode: "vector",
+      ftsConfig: "german",
+    });
+
+    expect(result.isError).toBeFalsy();
+    const rows = JSON.parse((result.content as any)[0].text);
+    expect(rows.map((row: any) => row.id)).toEqual(["vector-hit"]);
+    // No FTS statement ran at all, and the unused config never reached SQL.
+    expect(ftsSql).toEqual([]);
+    expect(allSql.join("\n")).not.toContain("german");
+  });
+
+  it("keeps the keyword/hybrid denial for the same ordinary explicit request", async () => {
+    // Same caller, same argument -- only the mode changes the outcome, proving
+    // the gate keys off whether FTS actually runs.
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    for (const mode of ["keyword", "hybrid"] as const) {
+      const { allSql, pool } = recordingPool();
+      const result = await runSearch(pool, "Planung", {
+        auth: agent,
+        mode,
+        ftsConfig: "german",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(getErrorText(result)).toBe(
+        "Permission denied: non-English FTS configuration requires admin or ob-admin",
+      );
+      expect(allSql).toEqual([]);
+    }
+  });
+});
+
+describe("non-default FTS statement timeout (#368 finding 1 cost control)", () => {
+  it("bounds a permitted non-english FTS statement with the 5000 ms default", async () => {
+    // Admin on the unindexed german path: the FTS statement must run on a
+    // dedicated client inside a transaction carrying the SET LOCAL bound.
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    delete process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS;
+    const { ftsSql, clientSql, pool } = recordingPool();
+    const result = await runKeywordSearch(pool, "Planung", {
+      auth: admin,
+      ftsConfig: "german",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(clientSql).toContain("BEGIN");
+    expect(clientSql).toContain("SET LOCAL statement_timeout = 5000");
+    expect(clientSql).toContain("COMMIT");
+    // The bounded transaction is the boundary that actually ran the FTS scan.
+    const ftsOnClient = clientSql.filter((sql) => sql.includes("fts_query"));
+    expect(ftsOnClient).toEqual(ftsSql);
+    expect(ftsSql.length).toBeGreaterThan(0);
+    // The timeout precedes the bounded statement inside the transaction.
+    expect(clientSql.indexOf("BEGIN")).toBeLessThan(
+      clientSql.indexOf("SET LOCAL statement_timeout = 5000"),
+    );
+    expect(
+      clientSql.indexOf("SET LOCAL statement_timeout = 5000"),
+    ).toBeLessThan(clientSql.findIndex((sql) => sql.includes("fts_query")));
+  });
+
+  it("applies a valid OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS override", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS = "250";
+    const { clientSql, pool } = recordingPool();
+    await runKeywordSearch(pool, "Planung", {
+      auth: admin,
+      ftsConfig: "german",
+    });
+
+    expect(clientSql).toContain("SET LOCAL statement_timeout = 250");
+  });
+
+  it("falls back to the default for invalid timeout env values", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    for (const invalid of ["abc", "-5", "0", "2.5", "5; DROP TABLE thoughts"]) {
+      process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS = invalid;
+      const { clientSql, allSql, pool } = recordingPool();
+      await runKeywordSearch(pool, "Planung", {
+        auth: admin,
+        ftsConfig: "german",
+      });
+
+      expect(clientSql).toContain("SET LOCAL statement_timeout = 5000");
+      // The raw env text is never interpolated into any statement.
+      expect(allSql.join("\n")).not.toContain("DROP TABLE");
+      expect(allSql.join("\n")).not.toContain(
+        invalid === "0" ? "= 0" : invalid,
+      );
+    }
+  });
+
+  it("never pays the bound on the default english indexed path", async () => {
+    delete process.env.OPENBRAIN_FTS_CONFIG;
+    process.env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS = "250";
+    const { ftsSql, clientSql, pool } = recordingPool();
+    const result = await runKeywordSearch(pool, "planning", { auth: agent });
+
+    expect(result.isError).toBeFalsy();
+    expect(ftsSql.length).toBeGreaterThan(0);
+    // Default path: plain pooled query, no transaction, no SET LOCAL.
+    expect(clientSql).toEqual([]);
+    expect(ftsSql.join("\n")).not.toContain("statement_timeout");
   });
 });

--- a/src/tools/fts-config.ts
+++ b/src/tools/fts-config.ts
@@ -181,6 +181,42 @@ export function requestFtsConfig(
 }
 
 /**
+ * Default per-statement time bound for the non-default (unindexed) FTS path,
+ * in milliseconds.
+ */
+export const DEFAULT_FTS_STATEMENT_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve the operator-tunable statement timeout for non-default FTS searches
+ * (OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS). A non-default config recomputes
+ * `to_tsvector` per row with no index, so its statement is bounded via a
+ * transaction-scoped `SET LOCAL statement_timeout` at the query execution
+ * boundary (search-brain runBoundedFtsQuery). The default GIN-indexed english
+ * path never pays this bound.
+ *
+ * The raw env value is validated to a positive base-10 integer BEFORE use;
+ * anything else (unset, blank, non-numeric, zero, negative, fractional,
+ * overflow) falls back to the 5000 ms default so a typo can never disable the
+ * bound or smuggle text toward SQL. Callers must only ever interpolate the
+ * returned number, never the raw env string.
+ */
+export function ftsStatementTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_FTS_STATEMENT_TIMEOUT_MS;
+  if (!/^\d+$/.test(raw)) return DEFAULT_FTS_STATEMENT_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  // statement_timeout is a 32-bit Postgres parameter; anything outside
+  // (0, 2147483647] would fail at SET LOCAL, so fall back like any other
+  // invalid value instead of hard-failing the permitted FTS path.
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > 2_147_483_647) {
+    return DEFAULT_FTS_STATEMENT_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+/**
  * Assert a config is on the allowlist and return it as a bare regconfig literal
  * safe to interpolate. Throws on anything unexpected -- a defensive backstop in
  * case a caller bypasses the schema. Callers already hold an FtsConfig, so this

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -30,6 +30,7 @@ import {
 import {
   DEFAULT_FTS_CONFIG,
   ftsConfigLiteral,
+  ftsStatementTimeoutMs,
   requestFtsConfig,
   SUPPORTED_FTS_CONFIGS,
   type FtsConfig,
@@ -857,6 +858,58 @@ LIMIT $2 OFFSET $3`;
   return withSourceRefs(rows as SearchRow[]);
 }
 
+/**
+ * Execute one FTS statement under the cost policy for its configuration
+ * (the query execution boundary for the lexical arm).
+ *
+ * english (default): a plain pooled query. The GIN-indexed stored-column path
+ * needs no extra bound and stays byte-identical to the pre-#341 execution.
+ *
+ * non-default config: the match arm recomputes `to_tsvector` per row with no
+ * index (see ftsMatchExpressions), so the statement runs inside a transaction
+ * bounded by a transaction-scoped `SET LOCAL statement_timeout`. The bound
+ * comes from OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS validated to a positive
+ * integer (default 5000 ms) by ftsStatementTimeoutMs -- the raw env string is
+ * never interpolated. `SET` accepts no bind parameters, so the vetted number
+ * (and only the number) is inlined, mirroring the allowlist-then-interpolate
+ * discipline used for table names and the regconfig literal. SET LOCAL scopes
+ * the timeout to this transaction, so the pooled connection is returned clean.
+ */
+async function runBoundedFtsQuery(
+  deps: ToolDeps,
+  sql: string,
+  params: unknown[],
+  ftsConfig: FtsConfig,
+): Promise<{ rows: unknown[] }> {
+  if (ftsConfig === DEFAULT_FTS_CONFIG) {
+    return deps.pool.query(sql, params as unknown[] as never[]);
+  }
+  const timeoutMs = ftsStatementTimeoutMs();
+  const client = await deps.pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await (async () => {
+      await client.query(`SET LOCAL statement_timeout = ${timeoutMs}`);
+      const queried = await client.query(sql, params as unknown[] as never[]);
+      await client.query("COMMIT");
+      return queried;
+    })();
+    client.release();
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+      client.release();
+    } catch {
+      // The original error is the signal; a failed ROLLBACK must not mask
+      // it. Destroy the client so a connection with an aborted transaction
+      // (or a dead socket) can never be handed back to the shared pool.
+      client.release(err instanceof Error ? err : new Error(String(err)));
+    }
+    throw err;
+  }
+}
+
 async function ftsSearch(
   deps: ToolDeps,
   accessibleTables: SearchTable[],
@@ -899,7 +952,7 @@ ${unionAll}
 ORDER BY fts_rank DESC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, params);
+  const { rows } = await runBoundedFtsQuery(deps, sql, params, ftsConfig);
   return withSourceRefs(rows as SearchRow[]);
 }
 
@@ -1423,7 +1476,10 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
               `Accepts a supported Postgres regconfig (${SUPPORTED_FTS_CONFIGS.join(", ")}) ` +
               `or a language token (e.g. 'de', 'de-DE', 'spanish'). Unrecognized values ` +
               `fall back to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english). ` +
-              `An explicitly requested effective non-English config requires admin or ob-admin. ` +
+              `An explicitly requested effective non-English config requires admin or ob-admin ` +
+              `for keyword/hybrid searches; vector mode performs no FTS, so fts_config is ` +
+              `ignored there. For ordinary roles, a non-English deployment env default ` +
+              `degrades to english rather than denying. ` +
               `Affects keyword/hybrid stemming only; english is byte-identical to prior behavior.`,
           ),
       },
@@ -1504,22 +1560,33 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
       const requestedNamespace = args.namespace as string | undefined;
       const sourceScope = args.source_scope as SourceScope | undefined;
       const requestedFtsConfig = args.fts_config as string | undefined;
-      const ftsConfig = requestFtsConfig(requestedFtsConfig);
-      if (
-        requestedFtsConfig !== undefined &&
-        ftsConfig !== DEFAULT_FTS_CONFIG &&
-        auth.role !== "admin" &&
-        auth.role !== "ob-admin"
-      ) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: NON_ENGLISH_FTS_AUTHORIZATION_ERROR,
-            },
-          ],
-          isError: true,
-        };
+      const ftsPrivileged = auth.role === "admin" || auth.role === "ob-admin";
+      // The non-English privilege boundary applies to the EFFECTIVE config for
+      // keyword/hybrid searches regardless of provenance (request argument or
+      // OPENBRAIN_FTS_CONFIG env default), because either one selects the
+      // unindexed on-the-fly to_tsvector path (#368 post-merge finding 1).
+      let ftsConfig = requestFtsConfig(requestedFtsConfig);
+      if (ftsConfig !== DEFAULT_FTS_CONFIG && !ftsPrivileged) {
+        if (mode !== "vector" && requestedFtsConfig !== undefined) {
+          // An ordinary role explicitly asked for an effective non-English
+          // config on a mode that runs FTS: content-free denial (unchanged).
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: NON_ENGLISH_FTS_AUTHORIZATION_ERROR,
+              },
+            ],
+            isError: true,
+          };
+        }
+        // Non-English arrived only via the operator env default, or the mode
+        // is vector (which performs no FTS, so fts_config is unused -- #368
+        // post-merge finding 2). Degrade to the GIN-indexed english default
+        // instead of denying: ordinary roles keep exactly the pre-#341
+        // availability and cost profile, and an unused argument can neither
+        // deny nor influence execution.
+        ftsConfig = DEFAULT_FTS_CONFIG;
       }
       const sourceScopeError = sourceScopeAuthorizationError(auth, sourceScope);
       if (sourceScopeError) {


### PR DESCRIPTION
Fixes the three verified post-merge findings against #368 (merged as 8306253, not yet deployed). Part of #341 rollout.

1. **Env-default non-English ordinary-role bypass + DB cost controls.** The admin/ob-admin boundary now applies to the *effective* FTS config for keyword/hybrid. Ordinary roles on a non-English `OPENBRAIN_FTS_CONFIG` deployment degrade to the GIN-indexed english default (availability preserved, pre-#341 behavior byte-identical); explicit non-English requests keep the content-free denial. Permitted non-default searches run on a dedicated client inside `BEGIN` / `SET LOCAL statement_timeout` / `COMMIT` with the timeout from validated `OPENBRAIN_FTS_STATEMENT_TIMEOUT_MS` (default 5000 ms, int32-clamped, raw env never interpolated); a failed rollback destroys the client so an aborted transaction can never re-enter the shared pool.
2. **Vector-only false denial.** `search_mode: "vector"` performs no FTS; an unused `fts_config` no longer denies ordinary roles or influences execution.
3. **Operator docs.** New `docs/fts-operations.md` (enable, role/degrade matrix, cost profile, timeout knob, `pg_stat_statements` monitoring, rollback); README section + env example updated.

Validation: `bunx tsc --noEmit` clean. Full suite with live PostgreSQL 18 + pgvector (throwaway UTF8 DB): **2455 pass / 35 skip / 1 fail** — the failure is the pre-existing `source-sync` sentinel test, which fails identically on clean base in full runs and passes in isolation. New regressions proven to fail pre-fix (6 fail on base via stash run, 0 post-fix). Review swarm: security + correctness lanes, 0 HIGH / 0 MEDIUM / 3 LOW — all three LOW fixed in this head (release-on-error destroy semantics, int32 timeout clamp + test).

Critical self-review:
- Highest-risk behavior: silent degrade-to-english for ordinary roles on non-English deployments changes their result ranking vs today's (bypassed) german path; intentional — it restores the documented privilege boundary and the pre-#341 behavior.
- Assumptions that could be wrong: no legitimate ordinary-role consumer depends on the env-default non-English results; if one exists, the operator grants admin/ob-admin or the caller passes explicit config with a privileged token.
- Missing/weak tests: rollback-failure client-destroy path is not covered by a live-PG test (hard to force deterministically); covered by code-path review.
- Security/permission risk: boundary is server-side and content-free; config literal remains Zod-enum-guarded; timeout is a validated number, never raw env text.
- Migration/deploy risk: none (no schema change; new env knob optional with safe default).
- Downstream client/runtime risk: `search_brain` schema description updated; no argument shape change — classify with docs/downstream-rollout.md at release.
- Rollback/cleanup concern: unset both env knobs → byte-identical english behavior.
- Fixes made before PR: review-lane LOWs (client destroy on failed rollback, int32 clamp).
- Known residual risk: unindexed non-English path remains expensive for admins within the 5 s bound; documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)