### PR TITLE
feat: tolerant-reader request envelopes (0.1.18)

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -42,6 +42,16 @@ Open Brain is the **durable operational memory** for PAI agents. It stores:
 2. Update lane context via `lane_upsert` when the working state changes
 3. Link related entities via `link_entities`
 
+### Runtime Adapter Envelope Compatibility
+
+The `openbrain-memory` console request envelope is N-1 tolerant only for
+unknown optional top-level fields on a known operation. Such fields are
+projected away before dispatch and reported only through a content-free
+compatibility note and bounded count. Unknown operations, missing or invalid
+known fields, authority-bearing `scope` and `config` subobjects, reflex
+`prior_context` references, and server-response projections remain strict and
+fail closed.
+
 ### At Compaction
 1. Call `session_context` to gather current state
 2. Distill summary locally via LLM

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -73,6 +73,16 @@ For deterministic host installs, pin the package to an exact version or reviewed
 wheel, or pin the git dependency to a reviewed commit or tag rather than a
 moving branch.
 
+Claude and Claudex adapters may use a compatible floor install while the
+N-1 console contract is maintained:
+
+```bash
+uv tool install --upgrade "openbrain-memory>=0.1.17"
+```
+
+The exact-version or reviewed-wheel guidance above remains preferred for host
+rollouts that require artifact pinning.
+
 Hermes deployments usually do not call `uv pip install` by hand. In
 `rtech-hermes`, set `openbrain_memory.package_spec` in the target agent manifest
 or set `OPENBRAIN_MEMORY_PACKAGE_SPEC` for an emergency override. Both paths
@@ -249,6 +259,13 @@ read one JSON object from stdin and emit one JSON object to stdout. Input is
 capped at 64 KiB, output at 1 MB, and distilled lifecycle content at 16 KiB.
 The `recall` and `reflex` operations read; capture, checkpoint, and wrap
 requests must include `"distilled": true`.
+
+The console is an N-1 tolerant reader for unknown optional top-level operation
+fields. It projects only recognized common and operation fields into dispatch,
+never forwards unknown fields, and adds a content-free compatibility note and
+bounded ignored-key count to the receipt. Unknown operations, missing or
+mistyped known fields, nested `scope`/`config` authority fields, and reflex
+`prior_context` references remain fail-closed.
 
 Optional mcp2cli fallback is disabled by default. Enable it with
 `OPENBRAIN_MCP2CLI_FALLBACK=1` or explicit config. Calls use an argv sequence,

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.17"
+version = "0.1.18"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -20,6 +20,8 @@ from .runtime import (
 
 MAX_JSON_INPUT_BYTES = 64 * 1024
 MAX_JSON_OUTPUT_BYTES = 1_000_000
+MAX_IGNORED_OPTIONAL_KEY_COUNT = 65_535
+IGNORED_OPTIONAL_REQUEST_KEYS_NOTE = "ignored_optional_request_keys"
 _COMMON_KEYS = {"config", "operation", "scope"}
 _OPERATION_KEYS = {
     "recall": {
@@ -60,15 +62,16 @@ def execute_json(
 ) -> dict[str, Any]:
     """Execute one bounded JSON lifecycle request and return JSON-ready output."""
     runtime: FirstClassMemoryRuntime | None = None
+    ignored_optional_key_count = 0
     try:
         operation = _mapping_text(payload, "operation")
-        scope_value = payload.get("scope")
-        config_value = payload.get("config", {})
+        projected, ignored_optional_key_count = _project_request(payload, operation)
+        scope_value = projected.get("scope")
+        config_value = projected.get("config", {})
         if not isinstance(scope_value, Mapping):
             raise ValueError("scope must be a JSON object")
         if not isinstance(config_value, Mapping):
             raise ValueError("config must be a JSON object")
-        _validate_request_keys(payload, operation)
         runtime = FirstClassMemoryRuntime(
             RuntimeConfig.from_sources(config_value, environ=environ),
             RuntimeScope.from_mapping(scope_value),
@@ -78,14 +81,17 @@ def execute_json(
             fallback_runner=fallback_runner,
             spool=spool,
         )
-        output = _dispatch(runtime, operation, payload).as_dict()
+        output = _dispatch(runtime, operation, projected).as_dict()
     except Exception as error:
         output = failure_output(_safe_operation(payload.get("operation")), error)
+    _attach_compatibility_receipt(output, ignored_optional_key_count)
     if runtime is not None:
         try:
             runtime.close()
         except Exception as error:
-            return failure_output("close", error)
+            output = failure_output("close", error)
+            _attach_compatibility_receipt(output, ignored_optional_key_count)
+            return output
     return output
 
 
@@ -185,15 +191,33 @@ def _dispatch(
     raise ValueError(f"unsupported operation: {_safe_text(operation)}")
 
 
-def _validate_request_keys(payload: Mapping[str, Any], operation: str) -> None:
+def _project_request(
+    payload: Mapping[str, Any],
+    operation: str,
+) -> tuple[dict[str, Any], int]:
     allowed = _OPERATION_KEYS.get(operation)
     if allowed is None:
         raise ValueError(f"unsupported operation: {_safe_text(operation)}")
-    unknown = {str(key) for key in payload if key not in _COMMON_KEYS | allowed}
-    if unknown:
-        raise ValueError(
-            f"{operation} contains unsupported keys: {', '.join(sorted(unknown))}"
-        )
+    known_keys = _COMMON_KEYS | allowed
+    projected = {key: value for key, value in payload.items() if key in known_keys}
+    ignored_count = min(
+        sum(1 for key in payload if key not in known_keys),
+        MAX_IGNORED_OPTIONAL_KEY_COUNT,
+    )
+    return projected, ignored_count
+
+
+def _attach_compatibility_receipt(
+    output: dict[str, Any],
+    ignored_optional_key_count: int,
+) -> None:
+    if ignored_optional_key_count <= 0:
+        return
+    receipt = output.get("receipt")
+    if not isinstance(receipt, dict):
+        return
+    receipt["compatibility_note"] = IGNORED_OPTIONAL_REQUEST_KEYS_NOTE
+    receipt["ignored_optional_key_count"] = ignored_optional_key_count
 
 
 def _require_distilled(payload: Mapping[str, Any], operation: str) -> None:

--- a/python/openbrain-memory/tests/fixtures/cli-compat/adapter-0.1.17-requests.json
+++ b/python/openbrain-memory/tests/fixtures/cli-compat/adapter-0.1.17-requests.json
@@ -1,0 +1,93 @@
+{
+  "capture": {
+    "config": {
+      "base_url": "https://brain.example",
+      "namespace": "bilby",
+      "token": "fixture-token"
+    },
+    "content": "Distilled compatibility event.",
+    "distilled": true,
+    "event_type": "fact",
+    "operation": "capture",
+    "scope": {
+      "agent": "bilby",
+      "channel_id": "channel",
+      "platform": "discord",
+      "server_id": "guild",
+      "session_key": "compat/session"
+    }
+  },
+  "checkpoint": {
+    "config": {
+      "base_url": "https://brain.example",
+      "namespace": "bilby",
+      "token": "fixture-token"
+    },
+    "distilled": true,
+    "key_decisions": [
+      "Keep the console boundary tolerant."
+    ],
+    "next_steps": [
+      "Validate N-1 compatibility."
+    ],
+    "operation": "checkpoint",
+    "receipt_refs": [
+      "receipt-1"
+    ],
+    "scope": {
+      "agent": "bilby",
+      "channel_id": "channel",
+      "platform": "discord",
+      "server_id": "guild",
+      "session_key": "compat/session"
+    },
+    "summary": "Distilled compatibility checkpoint."
+  },
+  "recall": {
+    "config": {
+      "base_url": "https://brain.example",
+      "namespace": "bilby",
+      "token": "fixture-token"
+    },
+    "max_latency_ms": 250,
+    "max_tokens": 400,
+    "operation": "recall",
+    "query": "Compatibility recall query.",
+    "requested_sections": [
+      "working_set"
+    ],
+    "scope": {
+      "agent": "bilby",
+      "channel_id": "channel",
+      "platform": "discord",
+      "server_id": "guild",
+      "session_key": "compat/session"
+    }
+  },
+  "wrap": {
+    "config": {
+      "base_url": "https://brain.example",
+      "namespace": "bilby",
+      "token": "fixture-token"
+    },
+    "distilled": true,
+    "key_decisions": [
+      "Keep the console boundary tolerant."
+    ],
+    "next_steps": [
+      "Roll out the compatible package."
+    ],
+    "operation": "wrap",
+    "receipt_refs": [
+      "receipt-2"
+    ],
+    "scope": {
+      "agent": "bilby",
+      "channel_id": "channel",
+      "platform": "discord",
+      "server_id": "guild",
+      "session_key": "compat/session"
+    },
+    "summary": "Distilled compatibility wrap."
+  }
+}

--- a/python/openbrain-memory/tests/test_cli_compatibility.py
+++ b/python/openbrain-memory/tests/test_cli_compatibility.py
@@ -1,0 +1,198 @@
+"""N-1 compatibility tests for the runtime adapter JSON console boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openbrain_memory.cli import execute_json
+
+from ._runtime_fakes import LaneAwareTransport, tool_calls
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "cli-compat"
+    / "adapter-0.1.17-requests.json"
+)
+CLI_0_1_17_WHEEL = Path(
+    "/Users/rico/.local/share/openbrain-memory/wheels/"
+    "openbrain_memory-0.1.17-py3-none-any.whl"
+)
+RUN_0_1_17_COMPAT_ENV = "OPENBRAIN_RUN_0_1_17_CLI_COMPAT"
+CURRENT_ADAPTER_BASE_KEYS = {
+    "recall": {
+        "config",
+        "max_latency_ms",
+        "max_tokens",
+        "operation",
+        "query",
+        "requested_sections",
+        "scope",
+    },
+    "capture": {
+        "config",
+        "content",
+        "distilled",
+        "event_type",
+        "operation",
+        "scope",
+    },
+    "checkpoint": {
+        "config",
+        "distilled",
+        "key_decisions",
+        "next_steps",
+        "operation",
+        "receipt_refs",
+        "scope",
+        "summary",
+    },
+    "wrap": {
+        "config",
+        "distilled",
+        "key_decisions",
+        "next_steps",
+        "operation",
+        "receipt_refs",
+        "scope",
+        "summary",
+    },
+}
+
+
+def _requests() -> dict[str, dict[str, Any]]:
+    loaded = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_current_adapter_base_surface_matches_immutable_0_1_17_requests() -> None:
+    """Prove the fixture is also the current adapter's base request shape.
+
+    Version 0.1.18 adds tolerant reading and receipt metadata, not request
+    fields. Therefore these exact base envelopes are the payloads exercised in
+    the current-adapter-to-0.1.17-CLI direction below.
+    """
+    requests = _requests()
+
+    assert set(requests) == set(CURRENT_ADAPTER_BASE_KEYS)
+    for operation, expected_keys in CURRENT_ADAPTER_BASE_KEYS.items():
+        assert set(requests[operation]) == expected_keys
+
+
+@pytest.mark.parametrize("operation", ["recall", "capture", "checkpoint", "wrap"])
+def test_0_1_18_cli_dispatches_immutable_0_1_17_requests(operation: str) -> None:
+    request = _requests()[operation]
+    transport = LaneAwareTransport()
+
+    output = execute_json(request, transport=transport)
+
+    expected_status = "direct" if operation == "recall" else "saved"
+    assert output["receipt"]["operation"] == operation
+    assert output["receipt"]["status"] == expected_status
+    assert "compatibility_note" not in output["receipt"]
+    calls = tool_calls(transport)
+    dispatched = calls[-1]["params"]
+    expected_tool = {
+        "recall": "agent_context_pack",
+        "capture": "append_session_event",
+        "checkpoint": "session_wrap",
+        "wrap": "session_wrap",
+    }[operation]
+    assert dispatched["name"] == expected_tool
+    arguments = dispatched["arguments"]
+    if operation == "recall":
+        assert arguments["query"] == request["query"]
+        assert arguments["budget"] == {
+            "max_tokens": request["max_tokens"],
+            "max_latency_ms": request["max_latency_ms"],
+        }
+        assert arguments["requested_sections"] == request["requested_sections"]
+    elif operation == "capture":
+        assert arguments["content"] == request["content"]
+        assert arguments["event_type"] == request["event_type"]
+    else:
+        assert arguments["summary"] == request["summary"]
+        assert arguments["key_decisions"] == request["key_decisions"]
+        assert arguments["next_steps"] == [
+            *request["next_steps"],
+            *(f"Receipt ref: {ref}" for ref in request["receipt_refs"]),
+        ]
+
+
+@pytest.mark.parametrize("operation", ["recall", "capture", "checkpoint", "wrap"])
+def test_0_1_18_cli_tolerates_future_field_on_0_1_17_requests(
+    operation: str,
+) -> None:
+    request = {**_requests()[operation], "future_optional": "not-forwarded"}
+    transport = LaneAwareTransport()
+
+    output = execute_json(request, transport=transport)
+
+    assert (
+        output["receipt"]["compatibility_note"]
+        == "ignored_optional_request_keys"
+    )
+    assert output["receipt"]["ignored_optional_key_count"] == 1
+    assert "future_optional" not in json.dumps(tool_calls(transport))
+    assert "not-forwarded" not in json.dumps(tool_calls(transport))
+
+
+def test_0_1_18_cli_still_rejects_invalid_known_optional_type() -> None:
+    request = {**_requests()["recall"], "max_tokens": "400"}
+    transport = LaneAwareTransport()
+
+    output = execute_json(request, transport=transport)
+
+    assert output["receipt"]["status"] == "failed"
+    assert output["receipt"]["error"] == "max_tokens must be an integer"
+    assert tool_calls(transport) == []
+
+
+@pytest.mark.skipif(
+    os.environ.get(RUN_0_1_17_COMPAT_ENV) != "1",
+    reason=f"set {RUN_0_1_17_COMPAT_ENV}=1 for the local wheel proof",
+)
+@pytest.mark.parametrize("operation", ["recall", "capture", "checkpoint", "wrap"])
+def test_current_base_requests_remain_accepted_by_0_1_17_cli(
+    operation: str,
+    tmp_path: Path,
+) -> None:
+    if not CLI_0_1_17_WHEEL.is_file():
+        pytest.skip("the reviewed 0.1.17 wheel is unavailable")
+    request = _requests()[operation]
+    request["config"] = {
+        **request["config"],
+        "base_url": "https://127.0.0.1:9",
+    }
+
+    completed = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--isolated",
+            "--with",
+            str(CLI_0_1_17_WHEEL),
+            "--",
+            "python",
+            "-m",
+            "openbrain_memory",
+        ],
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode in {0, 1}, completed.stderr
+    output = json.loads(completed.stdout)
+    assert output["receipt"]["operation"] == operation
+    assert "contains unsupported keys" not in (output["receipt"].get("error") or "")

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -161,8 +161,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.17"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.17"
+    assert CURRENT_CLIENT_VERSION == "0.1.18"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.18"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.15 <1.0.0"
     )

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -316,6 +316,73 @@ def test_json_adapter_recall_rejects_non_boolean_recovery_before_transport() -> 
     assert tool_calls(transport) == []
 
 
+@pytest.mark.parametrize(
+    ("operation", "values", "expected_status"),
+    [
+        ("recall", {"query": "current task"}, "direct"),
+        ("reflex", {"query": "current pointers"}, "direct"),
+        (
+            "capture",
+            {"distilled": True, "content": "distilled event"},
+            "saved",
+        ),
+        (
+            "checkpoint",
+            {"distilled": True, "summary": "distilled checkpoint"},
+            "saved",
+        ),
+        (
+            "wrap",
+            {"distilled": True, "summary": "distilled wrap"},
+            "saved",
+        ),
+    ],
+)
+@pytest.mark.parametrize("unknown_key_count", [1, 2])
+def test_json_adapter_ignores_unknown_optional_top_level_fields(
+    operation: str,
+    values: dict[str, object],
+    expected_status: str,
+    unknown_key_count: int,
+) -> None:
+    transport = LaneAwareTransport()
+    payload = request_payload(operation, **values)
+    payload["future_optional_field"] = "must-never-be-forwarded"
+    if unknown_key_count == 2:
+        payload["second_future_field"] = {"private": "must-never-be-forwarded"}
+
+    output = execute_json(payload, transport=transport)
+
+    assert output["receipt"]["status"] == expected_status
+    assert (
+        output["receipt"]["compatibility_note"]
+        == "ignored_optional_request_keys"
+    )
+    assert output["receipt"]["ignored_optional_key_count"] == unknown_key_count
+    serialized_calls = json.dumps(tool_calls(transport))
+    assert "future_optional_field" not in serialized_calls
+    assert "second_future_field" not in serialized_calls
+    assert "must-never-be-forwarded" not in serialized_calls
+
+
+def test_json_adapter_required_field_typo_still_fails_closed() -> None:
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        request_payload("recall", qurey="misspelled required field"),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "failed"
+    assert output["receipt"]["error"] == "query must be a non-empty string"
+    assert (
+        output["receipt"]["compatibility_note"]
+        == "ignored_optional_request_keys"
+    )
+    assert output["receipt"]["ignored_optional_key_count"] == 1
+    assert tool_calls(transport) == []
+
+
 def test_first_capture_establishes_lane_before_append() -> None:
     transport = LaneAwareTransport()
     runtime = FirstClassMemoryRuntime(
@@ -1687,21 +1754,25 @@ def test_json_adapter_requires_distilled_for_every_write() -> None:
         assert output["receipt"]["direct_attempted"] is False
 
 
-def test_json_adapter_rejects_metadata_scope_and_config_overrides() -> None:
-    payloads = [
-        request_payload(
-            "capture",
-            distilled=True,
-            content="distilled event",
-            metadata={"namespace": "other"},
-        ),
+def test_json_adapter_tolerates_metadata_but_rejects_authority_overrides() -> None:
+    top_level_metadata = request_payload(
+        "capture",
+        distilled=True,
+        content="distilled event",
+        metadata={"namespace": "other"},
+    )
+    authority_overrides = [
         request_payload("capture", distilled=True, content="event"),
         request_payload("capture", distilled=True, content="event"),
     ]
-    payloads[1]["scope"]["namespace"] = "other"
-    payloads[2]["config"]["fallback_command"] = ["other-command"]
+    authority_overrides[0]["scope"]["namespace"] = "other"
+    authority_overrides[1]["config"]["fallback_command"] = ["other-command"]
 
-    for payload in payloads:
+    tolerated = execute_json(top_level_metadata, transport=LaneAwareTransport())
+    assert tolerated["receipt"]["status"] == "saved"
+    assert tolerated["receipt"]["ignored_optional_key_count"] == 1
+
+    for payload in authority_overrides:
         output = execute_json(payload, transport=LaneAwareTransport())
         assert output["receipt"]["status"] == "failed"
         assert output["receipt"]["direct_attempted"] is False

--- a/python/openbrain-memory/tests/test_runtime_reflex.py
+++ b/python/openbrain-memory/tests/test_runtime_reflex.py
@@ -391,7 +391,7 @@ def test_reflex_cli_returns_validated_envelope_with_content_free_receipt() -> No
     assert "context" not in output
 
 
-def test_reflex_cli_rejects_unsupported_and_body_bearing_input() -> None:
+def test_reflex_cli_ignores_unknown_top_level_but_rejects_body_bearing_input() -> None:
     transport = LaneAwareTransport()
 
     unsupported_key = execute_json(
@@ -411,10 +411,20 @@ def test_reflex_cli_rejects_unsupported_and_body_bearing_input() -> None:
         transport=transport,
     )
 
-    assert unsupported_key["receipt"]["status"] == "failed"
+    assert unsupported_key["receipt"]["status"] == "direct"
+    assert (
+        unsupported_key["receipt"]["compatibility_note"]
+        == "ignored_optional_request_keys"
+    )
+    assert unsupported_key["receipt"]["ignored_optional_key_count"] == 1
     assert body_bearing["receipt"]["status"] == "failed"
     assert non_object_reference["receipt"]["status"] == "failed"
-    assert tool_calls(transport) == []
+    calls = tool_calls(transport)
+    assert [call["params"]["name"] for call in calls] == [
+        "get_contract",
+        "agent_reflex_pointers",
+    ]
+    assert "requested_sections" not in calls[1]["params"]["arguments"]
 
 
 # --- Finding #1: reflex requires the published contract tool version ---------

--- a/python/openbrain-memory/uv.lock
+++ b/python/openbrain-memory/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- openbrain-memory 0.1.18: unknown OPTIONAL top-level operation keys are now ignored (tolerant projection) instead of failing the request
- content-free receipt fields `compatibility_note` + `ignored_optional_key_count`; unknown keys are never forwarded to runtime/server code
- strictly fail-closed unchanged: unknown operations, scope/config authority keys, reflex `prior_context` body fields, required-field and type validation
- new N-1 compatibility suite both directions with immutable 0.1.17 request fixtures

Implements the operator no-pin/tolerant-client mandate (see reconciliation report; supersedes lockstep adapter/CLI updates).

## Validation

- `uv sync` / `uv run mypy src/openbrain_memory` / `uv run ruff check src tests`: clean
- `uv run pytest -q`: 515 passed, 9 skipped
- `OPENBRAIN_RUN_0_1_17_CLI_COMPAT=1 uv run pytest -q tests/test_cli_compatibility.py`: 14 passed against the real 0.1.17 wheel (all old-CLI failures were transport/runtime, never unsupported-key)
- pre-push contract parity: 13 fixtures across 8 capabilities; remote checks `check`, `contract-parity`, `db-integration`, `python-package` green

## Downstream rollout classification

Python client behavior change (tolerant reader). Hosted MCP contract unchanged. Downstream floor-install rollout (Claude/Claudex adapter) tracked in rodaddy/development#58 and `feat/ob-provider-no-pin`; Hermes policy untouched.

Critical self-review:
- Highest-risk behavior: tolerance accidentally extending to authority-bearing keys — mitigated: scope/config/prior_context validation untouched and covered by tests.
- Assumptions that could be wrong: receipt v1 accepts additive optional fields downstream; 0.1.17 adapter validation verified to accept-and-omit.
- Missing/weak tests: 0.1.17-CLI direction is env-gated for CI portability; proven locally (14/14) with receipt in lane report.
- Security/permission risk: none new; unknown keys never forwarded, names/values never echoed.
- Migration/deploy risk: version bump only; no schema/transport change.
- Downstream client/runtime risk: 0.1.17 CLI cannot accept genuinely new optional request fields — adapter emission must stay capability-gated while 0.1.17 is the floor (documented).
- Rollback/cleanup concern: revert to 0.1.17 restores strict rejection; no data-shape change.
- Fixes made before PR: contract fixture version refresh 0.1.17→0.1.18.
- Known residual risk: additive receipt fields on v1 (accepted-and-omitted by older adapters).

Lane report: /Volumes/ThunderBolt/_tmp/Development/claudex-ob-dogfood/recon/lane-1-tolerant-reader.md
