### PR TITLE
feat(380): raw-turn full-send ingest lane

### DIFF
--- a/contracts/memory/parity-manifest.json
+++ b/contracts/memory/parity-manifest.json
@@ -11,6 +11,7 @@
     "lifecycle-session-start": "both",
     "lifecycle-wrap": "both",
     "python-drain-replay-quarantine-receipts": "both",
+    "python-raw-turn-ingest": "python",
     "python-runtime-and-agent-receipt-shapes": "both",
     "spool-line-cap-backpressure": "both",
     "spool-redact-before-persist": "both",
@@ -57,6 +58,12 @@
       "python": "implemented",
       "ts": "runtime-specific",
       "reason": "The TS client owns the bounded public error_category enum (clients/ts receipts, fixture ts-public-receipt-error-category-v1); the Python package exposes sanitized error text on its internal runtime receipt and does not own that taxonomy. The agent-receipt half of the shared receipt-shapes fixture exercises AgentMemory.record_receipt, which the TS client intentionally does not implement."
+    },
+    {
+      "capability": "raw-turn-ingest",
+      "python": "implemented",
+      "ts": "runtime-specific",
+      "reason": "Full-send raw turn ingest (open-brain#380) is a writer-side lane: the ingest_raw_turn MCP tool and the 032_raw_turns table are the contract, and the Python client wraps them because the agent runtimes that capture turns are Python. The TS client is a reader/lifecycle peer and has no turn-capture surface to wrap, so there is no matched call to hold parity against. If clients/ts ever gains a capture path this becomes 'both' and needs a shared fixture."
     }
   ],
   "not_yet_extracted": [

--- a/contracts/memory/raw-turn-ingest.fixture.json
+++ b/contracts/memory/raw-turn-ingest.fixture.json
@@ -1,0 +1,56 @@
+{
+  "id": "python-raw-turn-ingest",
+  "description": "Full-send raw turn ingest is content-bearing by design: the client batches turns onto the single ingest_raw_turn call and applies NO salience filtering, because the server owns redaction, noise-dropping, and dedupe on UNIQUE(namespace, turn_uuid).",
+  "capability": "raw-turn-ingest",
+  "runtime": "python",
+  "consumers": ["python"],
+  "request": {
+    "entrypoint": "runtime.ingest_raw_turns",
+    "arguments": {
+      "turns": [
+        {
+          "turn_uuid": "11111111-1111-4111-8111-111111111111",
+          "turn_index": 0,
+          "role": "user",
+          "content": "what broke the deploy"
+        },
+        {
+          "turn_uuid": "22222222-2222-4222-8222-222222222222",
+          "turn_index": 1,
+          "role": "assistant",
+          "content": "the migration ran twice"
+        }
+      ]
+    }
+  },
+  "expectation": {
+    "tool_calls": [
+      {
+        "name": "ingest_raw_turn",
+        "arguments": {
+          "turns": [
+            {
+              "turn_uuid": "11111111-1111-4111-8111-111111111111",
+              "turn_index": 0,
+              "role": "user",
+              "content": "what broke the deploy"
+            },
+            {
+              "turn_uuid": "22222222-2222-4222-8222-222222222222",
+              "turn_index": 1,
+              "role": "assistant",
+              "content": "the migration ran twice"
+            }
+          ]
+        }
+      }
+    ],
+    "status": "saved",
+    "durable": true
+  },
+  "notes": [
+    "Both roles survive. Client-side salience was measured failing exactly here on 2026-07-25: 21 user turns and ZERO assistant turns captured. An assistant turn reaching the wire unmodified is the property this fixture holds.",
+    "Content is passed through verbatim. This is the one lane where that is correct -- the distilled verbs (capture/checkpoint/wrap) reject non-summarized content, this one must not.",
+    "Batched into a SINGLE ingest_raw_turn call rather than one call per turn."
+  ]
+}

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -605,3 +605,83 @@ every single time, because the interpreter's own default satisfies it.
   still dies, and does SIGINT keep `KeyboardInterrupt` semantics instead of
   becoming a hard kill?
 - Do tests that call such a function restore signal dispositions afterward?
+## [2026-07-25] uv ANSI output disabled Open Brain session-start recall
+
+**Severity:** HIGH
+**Source:** live incident — post-compact recall failure, dogfood Open Brain
+**Scope:** `ob-memory-provider/package-runtime.ts` uv resolution
+**Status:** open — fix belongs in the adapter source repo, not the hash-pinned
+install
+
+> The general rules this produced (force machine-readable subprocess output,
+> misdirecting errors cost more than silence, instrument rather than infer,
+> never hand-patch a hash-pinned install, gates must not block their own
+> repair) are now in `_DOCS/CODING_STANDARDS.md` `## Gotchas` and apply
+> fleet-wide. This entry keeps only the Open Brain specifics.
+
+Session-start recall failed with `OB ✗ gate unavailable` while BOTH Open Brain
+servers were healthy (127.0.0.1:3100 and 10.71.1.21:3100 each returned 200),
+Postgres was reachable, the token authenticated, the env config was correct, and
+the `openbrain-memory` CLI at 0.1.18 returned a full valid context pack
+(`status: "direct"`, 14,663 chars) when invoked directly with the same payload.
+
+Root cause: `uv` emitted ANSI color codes on stdout. `commandPath()` runs
+`uv tool dir`, then `isAbsolute(stdout.trim())`. The actual bytes were
+`033 [ 3 6 m / U s e r s / ...` (proven with `od -c`), which is not an absolute
+path, so `commandPath` returned null -> `resolveUvToolLayout` null ->
+`resolvePackageRuntime` null -> `callPackage` returned
+`{ok: false, errorCategory: "provider"}` **before any network call was made**.
+The adapter then reported "lane memory unavailable", naming the network as the
+suspect for a local string-parsing failure.
+
+The fix is a subprocess-scoped `env: {...process.env, NO_COLOR: "1"}` on the
+`spawnSync` in `defaultPackageRuntimeRunner`, plus ANSI stripping before
+`isAbsolute()`. Do NOT set `NO_COLOR` in the operator's shell environment —
+Rico uses color interactively; the adapter owns its child env, not the session.
+Do NOT hand-patch the installed `sha256-<hash>` adapter directory: the hash is
+the version pin, and the next `uv tool install --upgrade` silently erases the
+patch, guaranteeing rediscovery of a bug already "fixed".
+
+**Cost of the suppression:** four layers each computed the cause and discarded
+it — `commandPath` knew the `isAbsolute` check failed, `resolveUvToolLayout`
+knew the layout was unresolved, `resolvePackageRuntime` knew it returned null,
+and `callPackage` computed `errorCategory: "provider"` then shipped it to
+Langfuse instead of stdout. This violates `_DOCS/CODING_STANDARDS.md`
+`## Observability` verbatim: *"Catch blocks that return a fallback value must log
+before returning. Never `catch { return null }` silently."* One `console.error`
+at the resolution site would have made this a two-minute fix; instead it cost
+~40 minutes and three wrong diagnoses (missing env key, wrong base URL, version
+mismatch), each disproved only by an operator-run command.
+
+**The diagnostic method that actually worked**, after reading code failed three
+times: copy the module beside its own imports (relative imports break if moved),
+insert `console.error` at every failure branch, run it. Do not infer a runtime
+cause from code structure when the error text is suppressed — instrument it.
+Reading cannot see a runtime value.
+
+**A wrong error message is more expensive than no error message.** Silence makes
+you look; misdirection makes you look elsewhere. "Unavailable" sent six probes
+against two healthy servers.
+
+### Review Questions
+
+- Does any code path parse another program's stdout? If so, does it force
+  machine-readable output (`NO_COLOR`, `--format json`, `--quiet`) in the
+  subprocess env AND sanitize before parsing? A convenience CLI's formatting is
+  not a stable contract; it changes on the tool's schedule, not yours.
+- Is that env forcing scoped to the child process, or does it leak into the
+  operator's interactive shell?
+- Does every `return null` / `return {ok: false}` on a failure path log the
+  specific reason first, or does the caller receive an undifferentiated null?
+- When a failure category IS computed (e.g. `errorCategory`), does the operator
+  see it, or is it exported to telemetry only? Telemetry is not a substitute for
+  an error message at the terminal.
+- Does one generic failure string cover multiple distinct causes that require
+  different operator actions (config invalid vs server unreachable vs validation
+  failed)? Name each cause distinctly.
+- Does the error message name the subsystem that actually failed? A local
+  parsing failure reported as a remote availability problem routes the responder
+  to the wrong half of the system.
+- Can a gate that depends on a subsystem block the repair of that same
+  subsystem? A context/policy gate needs a repair-mode escape or it deadlocks
+  exactly when it is needed most.

--- a/python/openbrain-memory/src/openbrain_memory/_runtime_router.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_router.py
@@ -61,6 +61,8 @@ class DirectClient(Protocol):
 
     def append_session_event(self, **arguments: Any) -> JSON: ...
 
+    def ingest_raw_turn(self, **arguments: Any) -> JSON: ...
+
     def lane_upsert(self, **arguments: Any) -> JSON: ...
 
     def upsert_repo_fact(self, **arguments: Any) -> JSON: ...
@@ -251,6 +253,13 @@ class RuntimeClientRouter:
 
     def append_session_event(self, **arguments: Any) -> JSON:
         return self._call("append_session_event", arguments)
+
+    def ingest_raw_turn(self, **arguments: Any) -> JSON:
+        # Direct-only: the mcp2cli fallback is a retired operator surface that
+        # does not carry this tool, and a raw turn that cannot be sent must
+        # spool for replay rather than silently take a second transport.
+        with self.direct_only():
+            return self._call("ingest_raw_turn", arguments)
 
     def lane_upsert(self, **arguments: Any) -> JSON:
         return self._call("lane_upsert", arguments)

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Protocol, cast
@@ -123,6 +123,8 @@ class MemoryClient(Protocol):
     def session_context(self, **arguments: Any) -> JSON: ...
 
     def append_session_event(self, **arguments: Any) -> JSON: ...
+
+    def ingest_raw_turn(self, **arguments: Any) -> JSON: ...
 
     def search_all(self, **arguments: Any) -> JSON: ...
 
@@ -584,6 +586,36 @@ class AgentMemory:
             "append_session_event",
             payload,
             self.client.append_session_event,
+            key=key,
+        )
+
+    def ingest_raw_turns(
+        self,
+        turns: Sequence[Mapping[str, Any]],
+        *,
+        namespace: str | None = None,
+    ) -> JSON:
+        """Full-send a batch of raw turns; the server owns every judgment.
+
+        This is the RAW lane and it is content-bearing BY DESIGN. Unlike
+        ``append_scoped_event`` and the other distilled writes, nothing here
+        classifies, scores, or decides whether a turn is worth keeping --
+        client-side salience was measured to fail exactly that way (21 user
+        turns and ZERO assistant turns captured on 2026-07-25). The server
+        redacts secret VALUES, drops harness scaffolding, and de-duplicates on
+        ``UNIQUE(namespace, turn_uuid)``, so a replayed batch is a no-op.
+        """
+        self._require_session("ingest_raw_turns")
+        if not turns:
+            raise ValueError("turns must not be empty")
+        key = idempotency_key()
+        payload: dict[str, Any] = {"turns": [dict(turn) for turn in turns]}
+        if namespace is not None:
+            payload["namespace"] = _required_str(namespace, "namespace")
+        return self._call_write(
+            "ingest_raw_turn",
+            payload,
+            self.client.ingest_raw_turn,
             key=key,
         )
 

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -19,6 +19,11 @@ from .runtime import (
 )
 
 MAX_JSON_INPUT_BYTES = 64 * 1024
+# The raw lane ships whole turns; 64 KB bounds a distilled record but would
+# silently refuse a long assistant turn, which is the exact failure full-send
+# exists to remove. The envelope is admitted at the larger bound and the
+# distilled operations keep their own 64 KB ceiling below.
+MAX_INGEST_JSON_INPUT_BYTES = 2 * 1024 * 1024
 MAX_JSON_OUTPUT_BYTES = 1_000_000
 MAX_IGNORED_OPTIONAL_KEY_COUNT = 65_535
 IGNORED_OPTIONAL_REQUEST_KEYS_NOTE = "ignored_optional_request_keys"
@@ -33,6 +38,9 @@ _OPERATION_KEYS = {
     },
     "reflex": {"max_latency_ms", "max_tokens", "prior_context", "query"},
     "capture": {"content", "distilled", "event_type"},
+    # The raw lane carries no "distilled" key by design: it is the one verb
+    # that ships the transcript rather than a summary of it.
+    "ingest": {"namespace", "turns"},
     "checkpoint": {
         "distilled",
         "key_decisions",
@@ -113,15 +121,22 @@ def failure_output(operation: str, error: BaseException | str) -> dict[str, Any]
 
 
 def parse_json_input(data: bytes) -> Mapping[str, Any]:
-    """Parse one bounded UTF-8 JSON object."""
-    if len(data) > MAX_JSON_INPUT_BYTES:
-        raise ValueError(f"JSON input exceeds {MAX_JSON_INPUT_BYTES} bytes")
+    """Parse one bounded UTF-8 JSON object.
+
+    The envelope is admitted at the raw-lane ceiling because the operation is
+    not known until it is parsed; the distilled 64 KB bound is then enforced
+    against the decoded operation, so only ``ingest`` may exceed it.
+    """
+    if len(data) > MAX_INGEST_JSON_INPUT_BYTES:
+        raise ValueError(f"JSON input exceeds {MAX_INGEST_JSON_INPUT_BYTES} bytes")
     try:
         decoded = json.loads(data.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError("input must be one UTF-8 JSON object") from error
     if not isinstance(decoded, dict):
         raise ValueError("input must be a JSON object")
+    if decoded.get("operation") != "ingest" and len(data) > MAX_JSON_INPUT_BYTES:
+        raise ValueError(f"JSON input exceeds {MAX_JSON_INPUT_BYTES} bytes")
     return cast(Mapping[str, Any], decoded)
 
 
@@ -171,6 +186,20 @@ def _dispatch(
         return runtime.capture_distilled(
             _mapping_text(payload, "content"),
             event_type=_mapping_default_text(payload, "event_type", "fact"),
+        )
+    if operation == "ingest":
+        # Deliberately NOT _require_distilled: this is the raw lane. Every
+        # other write verb asserts distilled=true because it carries a
+        # summarized statement; raw turns carry the transcript itself.
+        turns = _mapping_optional_object_list(payload, "turns")
+        if turns is None:
+            raise ValueError("turns must be a JSON array")
+        namespace = payload.get("namespace")
+        return runtime.ingest_raw_turns(
+            turns,
+            namespace=(
+                _mapping_text(payload, "namespace") if namespace is not None else None
+            ),
         )
     if operation == "checkpoint":
         _require_distilled(payload, operation)

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -18,6 +18,8 @@ from .runtime import (
     RuntimeScope,
 )
 
+MAX_IGNORED_OPTIONAL_KEY_COUNT = 65_535
+IGNORED_OPTIONAL_REQUEST_KEYS_NOTE = "ignored_optional_request_keys"
 MAX_JSON_INPUT_BYTES = 64 * 1024
 # The raw lane ships whole turns; 64 KB bounds a distilled record but would
 # silently refuse a long assistant turn, which is the exact failure full-send

--- a/python/openbrain-memory/src/openbrain_memory/client.py
+++ b/python/openbrain-memory/src/openbrain_memory/client.py
@@ -1258,6 +1258,9 @@ class OpenBrainClient:
     def append_session_event(self, **arguments: Any) -> JSON:
         return self.call_tool("append_session_event", arguments)
 
+    def ingest_raw_turn(self, **arguments: Any) -> JSON:
+        return self.call_tool("ingest_raw_turn", arguments)
+
     def citation_recall(self, **arguments: Any) -> JSON:
         return self.call_tool("citation_recall", arguments)
 

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -128,6 +128,7 @@ _REPLAYABLE_SPOOL_OPERATIONS = frozenset(
         "lane_upsert",
         "upsert_repo_fact",
         "append_session_event",
+        "ingest_raw_turn",
         "log_thought",
         "log_decision",
         "session_wrap",
@@ -783,6 +784,49 @@ class FirstClassMemoryRuntime:
             ),
         )
 
+    def ingest_raw_turns(
+        self,
+        turns: Sequence[Mapping[str, Any]],
+        *,
+        namespace: str | None = None,
+    ) -> RuntimeOutput:
+        """Full-send raw turns. THE ONE CONTENT-BEARING LANE.
+
+        The distilled verbs (``capture``/``checkpoint``/``wrap``) never carry
+        raw content: they run ``_distilled_content`` and reject anything that
+        is not an already-summarized statement. This verb deliberately does
+        NOT, because raw turns ARE the transcript -- filtering them client-side
+        is the exact defect full-send exists to remove.
+
+        Validation here is STRUCTURAL only (is it a turn at all), never
+        salience. The server owns secret-value redaction, harness-noise
+        filtering, and de-duplication; keeping those server-side means one
+        implementation serves Claude, Codex, and Python instead of three
+        divergent client heuristics.
+        """
+        try:
+            if not isinstance(turns, Sequence) or isinstance(turns, str | bytes):
+                raise ValueError("turns must be a sequence of turn objects")
+            if not turns:
+                raise ValueError("turns must not be empty")
+            if len(turns) > _MAX_RAW_TURN_BATCH:
+                raise ValueError(
+                    f"turns must contain at most {_MAX_RAW_TURN_BATCH} entries"
+                )
+            safe_turns = [_raw_turn(turn, index) for index, turn in enumerate(turns)]
+            safe_namespace = (
+                _require_text(namespace, "namespace") if namespace is not None else None
+            )
+        except ValueError as error:
+            return _failed_write("ingest", error)
+        return self._write(
+            "ingest",
+            lambda: self._memory.ingest_raw_turns(
+                safe_turns,
+                namespace=safe_namespace,
+            ),
+        )
+
     def checkpoint(
         self,
         summary: str,
@@ -1130,6 +1174,96 @@ def _failed_write(operation: str, error: BaseException) -> RuntimeOutput:
 
 def _distilled_content(value: str, name: str) -> str:
     return _validate_distilled_content(value, name, _reject_secret_payload)
+
+
+# Mirrors the server's ingest_raw_turn Zod schema. Kept in step deliberately:
+# a client that ships a turn the server will reject wastes a round trip and
+# turns a structural bug into a runtime error the hook has to interpret.
+_MAX_RAW_TURN_BATCH = 100
+_MAX_RAW_TURN_CHARS = 200_000
+_RAW_TURN_ROLES = frozenset({"user", "assistant", "tool"})
+_RAW_TURN_TEXT_FIELDS = {
+    "turn_uuid": 200,
+    "parent_turn_uuid": 200,
+    "logical_parent_turn_uuid": 200,
+    "prompt_id": 200,
+    "session_ref": 500,
+    "repo": 200,
+    "git_branch": 300,
+    "runtime": 100,
+    "occurred_at": 100,
+}
+
+
+def _raw_turn(turn: Any, index: int) -> dict[str, Any]:
+    """Validate one raw turn STRUCTURALLY -- shape only, never salience.
+
+    Content is passed through untouched: no secret rejection, no length
+    judgment beyond the server's hard cap, no "is this worth keeping". A turn
+    is dropped only if it is not a turn.
+    """
+    where = f"turns[{index}]"
+    if not isinstance(turn, Mapping):
+        raise ValueError(f"{where} must be an object")
+
+    role = turn.get("role")
+    if role not in _RAW_TURN_ROLES:
+        raise ValueError(f"{where}.role must be one of user, assistant, tool")
+
+    content = turn.get("content")
+    if not isinstance(content, str):
+        raise ValueError(f"{where}.content must be a string")
+    if len(content) > _MAX_RAW_TURN_CHARS:
+        raise ValueError(
+            f"{where}.content exceeds {_MAX_RAW_TURN_CHARS} characters"
+        )
+
+    turn_index = turn.get("turn_index")
+    if not isinstance(turn_index, int) or isinstance(turn_index, bool):
+        raise ValueError(f"{where}.turn_index must be an integer")
+    if turn_index < 0:
+        raise ValueError(f"{where}.turn_index must be >= 0")
+
+    safe: dict[str, Any] = {
+        "role": role,
+        "content": content,
+        "turn_index": turn_index,
+    }
+
+    for name, limit in _RAW_TURN_TEXT_FIELDS.items():
+        value = turn.get(name)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{where}.{name} must be a non-empty string")
+        if len(value) > limit:
+            raise ValueError(f"{where}.{name} exceeds {limit} characters")
+        safe[name] = value
+
+    if "turn_uuid" not in safe:
+        raise ValueError(f"{where}.turn_uuid is required")
+
+    is_human_prompt = turn.get("is_human_prompt")
+    if is_human_prompt is not None:
+        if not isinstance(is_human_prompt, bool):
+            raise ValueError(f"{where}.is_human_prompt must be a boolean")
+        safe["is_human_prompt"] = is_human_prompt
+
+    token_estimate = turn.get("token_estimate")
+    if token_estimate is not None:
+        if not isinstance(token_estimate, int) or isinstance(token_estimate, bool):
+            raise ValueError(f"{where}.token_estimate must be an integer")
+        if token_estimate < 0:
+            raise ValueError(f"{where}.token_estimate must be >= 0")
+        safe["token_estimate"] = token_estimate
+
+    metadata = turn.get("metadata")
+    if metadata is not None:
+        if not isinstance(metadata, Mapping):
+            raise ValueError(f"{where}.metadata must be an object")
+        safe["metadata"] = dict(metadata)
+
+    return safe
 
 
 def _persisted_text(value: Any, name: str) -> str:

--- a/python/openbrain-memory/tests/_runtime_fakes.py
+++ b/python/openbrain-memory/tests/_runtime_fakes.py
@@ -174,6 +174,21 @@ class LaneAwareTransport:
                     "lane_created": False,
                 },
             )
+        elif tool == "ingest_raw_turn":
+            # The raw lane is namespace-scoped, not lane-scoped: it carries no
+            # exact-scope coordinates and is therefore not checked against a
+            # started lane. Mirrors the server's ingested/duplicates/filtered
+            # response shape.
+            turns = arguments["turns"]
+            return self._tool_result(
+                json_body["id"],
+                {
+                    "ingested": len(turns),
+                    "duplicates": 0,
+                    "filtered": 0,
+                    "namespace": arguments.get("namespace", "bilby"),
+                },
+            )
         elif tool == "agent_context_pack":
             lane = self.started_sessions.get(arguments["session_key"])
             exact = lane is not None and all(

--- a/python/openbrain-memory/tests/test_contract_fixtures.py
+++ b/python/openbrain-memory/tests/test_contract_fixtures.py
@@ -128,6 +128,7 @@ def test_python_consumes_memory_contract_fixture(
         "auto-drain-allowlist": _consume_auto_drain_allowlist,
         "receipt-shapes": _consume_receipt_shapes,
         "drain-receipts": _consume_drain_receipts,
+        "raw-turn-ingest": _consume_raw_turn_ingest,
     }
     handlers[fixture["capability"]](fixture, tmp_path)
 
@@ -141,9 +142,7 @@ def _consume_contract_declaration(
     assert CURRENT_CONTRACT_VERSION == request["contract_id"]
     assert CURRENT_CONTRACT_SCHEMA_VERSION == request["schema_version"]
     assert CURRENT_CONTRACT_SCHEMA_HASH == request["schema_hash"]
-    assert list(COMPATIBLE_CONTRACT_VERSIONS) == expectation[
-        "compatible_contract_ids"
-    ]
+    assert list(COMPATIBLE_CONTRACT_VERSIONS) == expectation["compatible_contract_ids"]
     assert CURRENT_CONTRACT_HEADER == expectation["client_header"]
 
 
@@ -195,6 +194,56 @@ def _consume_session_lifecycle(
     )
 
 
+def _consume_raw_turn_ingest(
+    fixture: dict[str, Any],
+    _tmp_path: Path,
+) -> None:
+    """Replay the full-send raw-turn lane and assert nothing is filtered.
+
+    The property under test is the absence of client-side judgment. Turns reach
+    the wire verbatim, both roles survive, and the batch is one call. Measured
+    failure this guards against (2026-07-25): client-side salience captured 21
+    user turns and ZERO assistant turns.
+    """
+    request = fixture["request"]
+    expectation = fixture["expectation"]
+    transport = LaneAwareTransport()
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        transport=transport,
+    )
+
+    method = getattr(runtime, request["entrypoint"].removeprefix("runtime."))
+    output = method(**request["arguments"])
+
+    calls = [
+        call["params"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] != "get_contract"
+    ]
+    # One call for the whole batch, not one per turn.
+    ingest_calls = [c for c in calls if c["name"] == "ingest_raw_turn"]
+    assert len(ingest_calls) == len(expectation["tool_calls"])
+    for actual, expected in zip(ingest_calls, expectation["tool_calls"], strict=True):
+        _assert_contract_value(actual, expected)
+
+    # Every role in the fixture reaches the wire. A lane that silently drops
+    # assistant turns still satisfies a naive count assertion, so check roles.
+    sent_roles = {
+        turn["role"] for call in ingest_calls for turn in call["arguments"]["turns"]
+    }
+    assert sent_roles == {turn["role"] for turn in request["arguments"]["turns"]}
+
+    assert output.receipt.status.value == expectation["status"]
+    if "durable" in expectation:
+        assert output.receipt.durable is expectation["durable"]
+    assert all(
+        http_request["headers"]["X-OB-Contract"] == CURRENT_CONTRACT_HEADER
+        for http_request in transport.requests
+    )
+
+
 def _consume_exact_scope_proof(
     fixture: dict[str, Any],
     _tmp_path: Path,
@@ -217,9 +266,10 @@ def _consume_exact_scope_proof(
             runtime_scope(),
             client=ScopeProofClient(mismatched),
         ).recall_context(f"Mismatch fixture: {field}")
-        assert output.receipt.status.value == expectation[
-            "mismatch_status_without_fallback"
-        ]
+        assert (
+            output.receipt.status.value
+            == expectation["mismatch_status_without_fallback"]
+        )
         assert output.context == expectation["mismatch_context_without_fallback"]
 
 

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -1805,12 +1805,25 @@ def test_execute_json_does_not_close_caller_injected_client() -> None:
 def test_json_input_and_output_are_bounded() -> None:
     assert parse_json_input(b'{"operation":"recall"}') == {"operation": "recall"}
 
+    # A distilled operation stays bound at 64 KB. The payload must be valid
+    # JSON: the raw-lane ceiling admits the envelope first, so the distilled
+    # bound is now enforced against the decoded operation rather than the
+    # undecoded byte length.
+    oversized = (
+        b'{"operation":"capture","content":"'
+        + b"x" * MAX_JSON_INPUT_BYTES
+        + b'"}'
+    )
     try:
-        parse_json_input(b"x" * (MAX_JSON_INPUT_BYTES + 1))
+        parse_json_input(oversized)
     except ValueError as error:
         assert "exceeds" in str(error)
     else:
         raise AssertionError("oversized input was accepted")
+
+    # The raw lane is exempt: the same size under operation=ingest is admitted.
+    ingest = b'{"operation":"ingest","turns":["' + b"x" * MAX_JSON_INPUT_BYTES + b'"]}'
+    assert parse_json_input(ingest)["operation"] == "ingest"
 
     encoded = encode_json_output({"context": "x" * 1_000_001})
     decoded = json.loads(encoded)

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -336,6 +336,24 @@ def test_json_adapter_recall_rejects_non_boolean_recovery_before_transport() -> 
             {"distilled": True, "summary": "distilled wrap"},
             "saved",
         ),
+        # The raw lane gets the same tolerance. It is the newest verb and the
+        # one an older adapter is most likely to call with a field this version
+        # has not seen, so leaving it out of this matrix is how it would drift
+        # back to fail-closed without anyone noticing.
+        (
+            "ingest",
+            {
+                "turns": [
+                    {
+                        "turn_uuid": "turn-0",
+                        "turn_index": 0,
+                        "role": "user",
+                        "content": "raw turn",
+                    }
+                ]
+            },
+            "saved",
+        ),
     ],
 )
 @pytest.mark.parametrize("unknown_key_count", [1, 2])
@@ -1810,9 +1828,7 @@ def test_json_input_and_output_are_bounded() -> None:
     # bound is now enforced against the decoded operation rather than the
     # undecoded byte length.
     oversized = (
-        b'{"operation":"capture","content":"'
-        + b"x" * MAX_JSON_INPUT_BYTES
-        + b'"}'
+        b'{"operation":"capture","content":"' + b"x" * MAX_JSON_INPUT_BYTES + b'"}'
     )
     try:
         parse_json_input(oversized)

--- a/python/openbrain-memory/tests/test_runtime_ingest.py
+++ b/python/openbrain-memory/tests/test_runtime_ingest.py
@@ -1,0 +1,232 @@
+"""Raw-turn full-send lane tests.
+
+The defect these exist to prevent, measured 2026-07-25: per-turn capture
+recorded 21 of the user's turns and ZERO of the assistant's, because the only
+write verbs available were distilled ones that required a client-side salience
+judgment. Every test here asserts the raw lane makes NO such judgment.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openbrain_memory.cli import execute_json
+
+from ._runtime_fakes import LaneAwareTransport, request_payload, tool_calls
+
+
+def _turn(index: int = 0, **overrides: object) -> dict[str, object]:
+    turn: dict[str, object] = {
+        "turn_uuid": f"turn-{index}",
+        "turn_index": index,
+        "role": "assistant",
+        "content": "Measured: enqueueGraphDerivationJobs has zero callers.",
+    }
+    turn.update(overrides)
+    return turn
+
+
+def _request(**overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {"turns": [_turn()]}
+    values.update(overrides)
+    return request_payload("ingest", **values)
+
+
+def test_ingest_dispatches_the_raw_turn_tool() -> None:
+    transport = LaneAwareTransport()
+
+    output = execute_json(_request(), transport=transport)
+
+    assert output["receipt"]["operation"] == "ingest"
+    assert output["receipt"]["status"] == "saved"
+    assert output["receipt"]["durable"] is True
+    dispatched = tool_calls(transport)[-1]["params"]
+    assert dispatched["name"] == "ingest_raw_turn"
+    assert dispatched["arguments"]["turns"][0]["turn_uuid"] == "turn-0"
+
+
+def test_assistant_turns_are_ingested() -> None:
+    """The exact half that per-turn capture never recorded."""
+    transport = LaneAwareTransport()
+
+    execute_json(
+        _request(turns=[_turn(role="assistant", content="My analysis.")]),
+        transport=transport,
+    )
+
+    sent = tool_calls(transport)[-1]["params"]["arguments"]["turns"][0]
+    assert sent["role"] == "assistant"
+    assert sent["content"] == "My analysis."
+
+
+@pytest.mark.parametrize("role", ["user", "assistant", "tool"])
+def test_every_role_is_accepted(role: str) -> None:
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        _request(turns=[_turn(role=role)]),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "saved"
+    assert tool_calls(transport)[-1]["params"]["arguments"]["turns"][0]["role"] == role
+
+
+def test_raw_content_is_shipped_verbatim_not_distilled() -> None:
+    """The lane rule: no summarizing, no scoring, no salience filter.
+
+    A bare acknowledgement carries no durable content and the distilled verbs
+    would reject or skip it. The raw lane MUST ship it, because deciding what
+    matters is the server's job and re-runnable.
+    """
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        _request(turns=[_turn(content="ok")]),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "saved"
+    assert tool_calls(transport)[-1]["params"]["arguments"]["turns"][0]["content"] == (
+        "ok"
+    )
+
+
+def test_secret_bearing_content_is_not_rejected_client_side() -> None:
+    """Redaction is the SERVER's job: value-only, statement kept.
+
+    Fail-closed was explicitly rejected -- dropping a turn because it contains
+    a credential discards the durable decision that is the point of capturing
+    it. The client must not silently refuse the turn.
+    """
+    raw = "export AUTH_TOKEN_ADMIN=sk-live-not-a-real-secret-value"
+    transport = LaneAwareTransport()
+
+    output = execute_json(_request(turns=[_turn(content=raw)]), transport=transport)
+
+    assert output["receipt"]["status"] == "saved"
+    sent = tool_calls(transport)[-1]["params"]["arguments"]["turns"][0]
+    assert sent["content"] == raw
+
+
+def test_ingest_carries_no_distilled_flag() -> None:
+    """distilled=true is the distilled lane's assertion and must not appear."""
+    transport = LaneAwareTransport()
+
+    execute_json(_request(), transport=transport)
+
+    arguments = tool_calls(transport)[-1]["params"]["arguments"]
+    assert "distilled" not in arguments
+    assert "event_type" not in arguments
+
+
+def test_optional_provenance_fields_are_forwarded() -> None:
+    transport = LaneAwareTransport()
+
+    execute_json(
+        _request(
+            turns=[
+                _turn(
+                    prompt_id="prompt-9",
+                    session_ref="/transcripts/a.jsonl",
+                    logical_parent_turn_uuid="turn-before-compact",
+                    repo="open-brain",
+                    git_branch="feat/380-raw-turns-ingest",
+                    runtime="claude",
+                    is_human_prompt=False,
+                    token_estimate=64,
+                    metadata={"model": "opus"},
+                )
+            ]
+        ),
+        transport=transport,
+    )
+
+    sent = tool_calls(transport)[-1]["params"]["arguments"]["turns"][0]
+    assert sent["prompt_id"] == "prompt-9"
+    assert sent["logical_parent_turn_uuid"] == "turn-before-compact"
+    assert sent["git_branch"] == "feat/380-raw-turns-ingest"
+    assert sent["is_human_prompt"] is False
+    assert sent["token_estimate"] == 64
+    assert sent["metadata"] == {"model": "opus"}
+
+
+def test_namespace_is_forwarded_when_supplied() -> None:
+    transport = LaneAwareTransport()
+
+    execute_json(_request(namespace="shared-kb"), transport=transport)
+
+    assert tool_calls(transport)[-1]["params"]["arguments"]["namespace"] == "shared-kb"
+
+
+def test_batches_are_sent_in_one_call() -> None:
+    """Batching keeps the interactive turn unblocked."""
+    transport = LaneAwareTransport()
+
+    execute_json(
+        _request(turns=[_turn(i) for i in range(5)]),
+        transport=transport,
+    )
+
+    calls = [
+        c for c in tool_calls(transport) if c["params"]["name"] == "ingest_raw_turn"
+    ]
+    assert len(calls) == 1
+    assert len(calls[0]["params"]["arguments"]["turns"]) == 5
+
+
+@pytest.mark.parametrize(
+    ("turns", "expected"),
+    [
+        ([], "turns must not be empty"),
+        ([{"turn_index": 0, "role": "user"}], "turns[0].content must be a string"),
+        (
+            [{"turn_uuid": "a", "turn_index": 0, "role": "bot", "content": "x"}],
+            "turns[0].role must be one of user, assistant, tool",
+        ),
+        (
+            [{"turn_uuid": "a", "role": "user", "content": "x"}],
+            "turns[0].turn_index must be an integer",
+        ),
+        (
+            [{"turn_index": 0, "role": "user", "content": "x"}],
+            "turns[0].turn_uuid is required",
+        ),
+    ],
+)
+def test_structural_validation_rejects_non_turns(
+    turns: list[dict[str, object]],
+    expected: str,
+) -> None:
+    """Shape only -- a turn is refused for not being a turn, never for content."""
+    transport = LaneAwareTransport()
+
+    output = execute_json(_request(turns=turns), transport=transport)
+
+    assert output["receipt"]["status"] == "failed"
+    assert output["receipt"]["error"] == expected
+    assert tool_calls(transport) == []
+
+
+def test_oversize_batch_is_rejected_before_the_transport() -> None:
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        _request(turns=[_turn(i) for i in range(101)]),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "failed"
+    assert output["receipt"]["error"] == "turns must contain at most 100 entries"
+    assert tool_calls(transport) == []
+
+
+def test_unknown_request_key_is_not_forwarded() -> None:
+    transport = LaneAwareTransport()
+
+    output = execute_json(_request(future_optional="ignored"), transport=transport)
+
+    assert output["receipt"]["status"] == "saved"
+    assert "future_optional" not in json.dumps(tool_calls(transport))

--- a/src/db/migrations/032_raw_turns.sql
+++ b/src/db/migrations/032_raw_turns.sql
@@ -1,0 +1,226 @@
+-- Migration 032: Content-bearing raw turn table (Issue #380, INGEST-1)
+--
+-- Spec: docs/full-send-derivation-spec.md section 1.
+--
+-- Why this table exists: distillation and derivation are impossible because
+-- their input does not exist. Measured 2026-07-24 on the local dogfood clone, a
+-- full working day produced 3 ob_session_events, every one written because the
+-- assistant manually chose to run a capture command. mcp_tool_audit_log
+-- recorded 445 calls but is content-free by design (declared_parameter_keys,
+-- payload_size_bucket, duration_ms; no content column), so it cannot serve as a
+-- raw stream. Prompts and responses were persisted nowhere.
+--
+-- The client is a dumb pipe: it ships raw turns and decides nothing about
+-- salience. All judgment (distillation, dedupe, supersession) is server-side,
+-- asynchronous, and re-runnable against this table.
+--
+-- CONTENT SAFETY -- deliberate reversal, read before extending:
+-- Unlike mcp_tool_audit_log, this table DOES store real dialogue content. That
+-- reversal is the entire point (derivation is impossible without content) and
+-- is justified only by its compensating controls:
+--   1. Namespace isolation, applied exactly as on every other table.
+--   2. Redaction at write, BEFORE the row reaches disk -- redaction is applied
+--      by the server write path, never trusted from the client.
+--   3. Mandatory retention bounding (INGEST-2 / #381), because unbounded raw
+--      dialogue is a disk-exhaustion path.
+-- redaction_applied records WHICH rule fired, never the removed value. The
+-- standing rule is redact the VALUE, keep the STATEMENT: a turn is never
+-- dropped for containing a credential, because "AUTH_TOKEN_X=[REDACTED]" is
+-- itself a useful durable fact. Fail-closed was explicitly rejected.
+
+CREATE TABLE IF NOT EXISTS ob_raw_turns (
+  -- Surrogate key. Stable handle for foreign keys (distill_job_id and future
+  -- derived tables point here); it does NOT enforce uniqueness of a turn --
+  -- that is idx_ob_raw_turns_identity below. uuid rather than a serial to match
+  -- every other table and keep cross-database merges collision-free.
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Exact isolation boundary, identical in meaning to every other table.
+  namespace         TEXT NOT NULL,
+
+  -- TURN IDENTITY. The runtime's own per-turn id (Claude Code's record `uuid`).
+  -- Measured 2026-07-25 across 94,564 real turns in 515 transcripts: this value
+  -- never covers two different contents, so it is a safe identity key. A
+  -- runtime with no native per-turn id (Codex, the Python client) must
+  -- synthesize a deterministic one -- hash(session_ref, turn_index,
+  -- content_hash) -- because this column is NOT NULL and carries the dedupe.
+  turn_uuid         TEXT NOT NULL,
+
+  -- Reply chain. parent_turn_uuid is what makes the conversation a graph rather
+  -- than a bag of rows, and it is the only field that survives batching,
+  -- retries, and out-of-order spool replay intact. Nullable: the first turn of
+  -- a session has no parent.
+  parent_turn_uuid  TEXT,
+
+  -- Continuity across a compaction or session boundary. The runtime already
+  -- emits this and nothing has been reading it: at a compact the transcript
+  -- writes a `compact_boundary` record whose `parentUuid` is NULL (which is why
+  -- the chain LOOKS broken) but whose `logicalParentUuid` points at the last
+  -- turn before the compact. Measured 2026-07-25: 22 boundaries, 0 unresolved,
+  -- and one of them links into a DIFFERENT transcript file -- so the thread
+  -- spans sessions, not just compactions within one. One session with fifteen
+  -- compacts is already a linked list; this column is the join that walks it.
+  -- Same target as parent_turn_uuid (a turn id), different edge type: normal
+  -- reply vs. continuity across a context reset.
+  logical_parent_turn_uuid TEXT,
+
+  -- Native turn grouping: one human prompt and every record it produced share
+  -- one prompt_id. Preferred over counting turn_index, which the client has to
+  -- synthesize. Nullable -- it is absent on records that predate a prompt (e.g.
+  -- resumed history), which is also why it is NOT part of the identity key.
+  prompt_id         TEXT,
+
+  -- Owning lane. Nullable: a turn can arrive before a lane is established, and
+  -- losing the turn would defeat full-send. ON DELETE SET NULL keeps the
+  -- content (still namespace-bound) rather than cascading a content delete from
+  -- lane cleanup.
+  lane_id           UUID REFERENCES ob_session_lanes(id) ON DELETE SET NULL,
+
+  -- Opaque client-side session identifier (Claude Code's sessionId). Not a
+  -- foreign key: it names a runtime session, not an OB row.
+  session_ref       TEXT,
+
+  -- Origin. repo is the meaningful path segment, NOT the last one: measured
+  -- 2026-07-25, 22 project directories collide on their final segment ('wt'
+  -- alone maps to three distinct worktrees), so a tail-truncated path would
+  -- merge unrelated working trees. git_branch is provenance, not identity --
+  -- a branch can be renamed or deleted while its turns keep the old value.
+  repo              TEXT,
+  git_branch        TEXT,
+
+  -- Monotonic position within the sending session. Ordering only; NOT unique,
+  -- and not part of the identity key.
+  turn_index        INTEGER NOT NULL,
+
+  -- Who produced the turn. 'tool' is first-class and NOT deferred: measured
+  -- 2026-07-25, AskUserQuestion answers -- the densest decision content in the
+  -- corpus, a question paired with an explicit human choice -- arrive as a
+  -- tool_result block and are invisible to any user-text-only reader.
+  role              TEXT NOT NULL
+                    CHECK (role IN ('user', 'assistant', 'tool')),
+
+  -- Declared human authorship (promptSource == 'typed' AND origin.kind ==
+  -- 'human'), not inferred from content shape. This is the honest version of
+  -- what a client-side "does this look pasted?" heuristic was guessing at.
+  is_human_prompt   BOOLEAN NOT NULL DEFAULT false,
+
+  -- The dialogue itself, redacted at write. Plain text, not JSON: this column
+  -- feeds embedding and FTS, and JSON syntax would be lexed as content (braces,
+  -- quotes, and key names becoming tokens). Structured payloads belong in
+  -- metadata.
+  content           TEXT NOT NULL,
+
+  -- Structured, non-lexed provenance and payload (model, effort, token usage,
+  -- stop_reason, permission mode, sidechain flag, and the verbatim
+  -- AskUserQuestion answers/annotations object). Kept out of content so
+  -- retrieval ranks on meaning, not on JSON punctuation.
+  metadata          JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Opaque digest of the redacted content. Drift detection and change
+  -- comparison only -- deliberately NOT the identity key: measured 2026-07-25,
+  -- keying on content alone would merge 3,495 turns, and the overwhelming
+  -- majority of exact content repeats are harness control strings
+  -- ('[Request interrupted by user]' appears 270 times across 51 sessions).
+  -- Those must be filtered at the writer and never ingested at all; collapsing
+  -- them here would also destroy the reply chain, since each copy has a
+  -- different parent.
+  content_hash      TEXT NOT NULL,
+
+  -- Real token counts when the runtime reports them (message.usage), not a
+  -- heuristic estimate.
+  token_estimate    INTEGER,
+  runtime           TEXT,
+
+  -- WHICH redaction rules fired, never the removed values.
+  redaction_applied JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Distillation bookkeeping. NULL distilled_at is the sweep work queue.
+  distilled_at      TIMESTAMPTZ,
+  distill_job_id    UUID,
+
+  created_by        TEXT NOT NULL,
+
+  -- BI-TEMPORAL, borrowed from Graphiti (graphiti_core/edges.py:271-280,
+  -- Apache-2.0 -- credit where taken). Four fields, not two: separating
+  -- WORLD-time from KNOWLEDGE-time is what makes the believed-a-dead-fact
+  -- window measurable. invalid_at is when reality changed; expired_at is when
+  -- we found out; the gap between them IS the drift metric.
+  --
+  -- On raw turns specifically: a turn is an immutable event, so valid_at is
+  -- effectively occurred_at and invalid_at/expired_at normally stay NULL. They
+  -- are carried here anyway because a turn CAN be retracted -- measured
+  -- 2026-07-25, two records written 12:52 were disproved by a retraction at
+  -- 12:53, and with only created_at there is no way to express "this was
+  -- believed true between these two instants" without deleting it. The fields
+  -- earn their keep on the distilled layer; here they make retraction
+  -- expressible instead of destructive.
+  --
+  -- occurred_at is Graphiti's reference_time: when the turn HAPPENED, tied to
+  -- the source episode rather than write time. Full-send allows batching and
+  -- spool replay, so a turn from 09:00 can land at 14:00; ordering by
+  -- created_at would silently scramble the conversation.
+  occurred_at       TIMESTAMPTZ,
+  valid_at          TIMESTAMPTZ,
+  invalid_at        TIMESTAMPTZ,
+  expired_at        TIMESTAMPTZ,
+
+  -- Retention tier. NEVER DELETE: 'live' is in recall, 'unused' is out of
+  -- recall but still queryable, 'cold' means the CONTENT moved to hard storage
+  -- while this row stays as the index. Cold archival is ~6 months, not weeks:
+  -- the unused tier must outlive the phenomenon it exists to detect, and a
+  -- two-week drift is invisible in a one-week window.
+  retention_tier    TEXT NOT NULL DEFAULT 'live'
+                    CHECK (retention_tier IN ('live', 'unused', 'cold')),
+
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- TURN IDENTITY / DEDUPE. An exact duplicate turn must never enter the table.
+-- Resuming or forking a session makes the runtime copy prior history into the
+-- new transcript: measured 2026-07-25, 961 turns exist verbatim in two
+-- transcripts under one id. Keying on the turn's own id (not session_ref +
+-- id) is what makes that re-send conflict and be ignored rather than stored
+-- twice. Scoped to namespace so two namespaces never collide or resolve across
+-- the boundary.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ob_raw_turns_identity
+  ON ob_raw_turns (namespace, turn_uuid);
+
+-- The sweep's work queue: undistilled LIVE turns, oldest first, within a
+-- namespace. Retired turns are excluded here rather than by the caller, so a
+-- sweep cannot accidentally re-distill archived content.
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_undistilled
+  ON ob_raw_turns (namespace, created_at)
+  WHERE distilled_at IS NULL AND retention_tier = 'live';
+
+-- Retention drain: find what is eligible to move live -> unused -> cold.
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_retention
+  ON ob_raw_turns (retention_tier, created_at);
+
+-- Drift measurement: turns whose truth was retracted, and how long the wrong
+-- belief was held (expired_at - invalid_at).
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_retracted
+  ON ob_raw_turns (namespace, invalid_at)
+  WHERE invalid_at IS NOT NULL;
+
+-- Conversation reconstruction in real turn order, and retention scans
+-- (INGEST-2 drops distilled turns older than a window).
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_session
+  ON ob_raw_turns (namespace, session_ref, occurred_at);
+
+-- Reply-chain walks: find the children of a turn.
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_parent
+  ON ob_raw_turns (namespace, parent_turn_uuid)
+  WHERE parent_turn_uuid IS NOT NULL;
+
+-- Walk the conversation thread across compaction and session boundaries.
+-- Measured 2026-07-25: one boundary reported cumulativeDroppedTokens
+-- 1,316,157 -- that much context left the window, and all of it is
+-- reconstructable through this link.
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_logical_parent
+  ON ob_raw_turns (namespace, logical_parent_turn_uuid)
+  WHERE logical_parent_turn_uuid IS NOT NULL;
+
+-- Group every record produced by one human prompt.
+CREATE INDEX IF NOT EXISTS idx_ob_raw_turns_prompt
+  ON ob_raw_turns (namespace, prompt_id)
+  WHERE prompt_id IS NOT NULL;

--- a/src/db/migrations/032_raw_turns.test.ts
+++ b/src/db/migrations/032_raw_turns.test.ts
@@ -1,0 +1,394 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "../migrate.ts";
+
+// Live-Postgres coverage for migration 032 (Issue #380, INGEST-1). Proves the
+// raw-turn table's structural guarantees against a real database rather than
+// asserting SQL shape: exact-duplicate rejection, the reply chain, the
+// undistilled work queue, the namespace boundary, and that 'tool' is an
+// accepted role (measured 2026-07-25: AskUserQuestion answers arrive as
+// tool_result blocks and carry the densest decision content in the corpus, so
+// excluding them would rebuild the exact blindness full-send exists to fix).
+//
+// Skipped unless OPENBRAIN_TEST_DATABASE_URL is set (matches 025/027).
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("032 raw turns (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+
+  const nsAlice = "test-raw-alice";
+  const nsBob = "test-raw-bob";
+  const namespaces = [nsAlice, nsBob];
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM ob_raw_turns WHERE namespace = ANY($1)", [
+      namespaces,
+    ]);
+  }
+
+  interface TurnOverrides {
+    turn_uuid?: string;
+    parent_turn_uuid?: string | null;
+    logical_parent_turn_uuid?: string | null;
+    session_ref?: string | null;
+    prompt_id?: string | null;
+    role?: string;
+    content?: string;
+    content_hash?: string;
+    turn_index?: number;
+    is_human_prompt?: boolean;
+    occurred_at?: string | null;
+    valid_at?: string | null;
+    invalid_at?: string | null;
+    expired_at?: string | null;
+    metadata?: unknown;
+  }
+
+  async function insert(
+    namespace: string,
+    overrides: TurnOverrides = {},
+  ): Promise<number> {
+    const row = {
+      turn_uuid: "uuid-a",
+      parent_turn_uuid: null,
+      logical_parent_turn_uuid: null,
+      session_ref: null,
+      prompt_id: null,
+      role: "user",
+      content: "hello",
+      content_hash: "hash-a",
+      turn_index: 0,
+      is_human_prompt: false,
+      occurred_at: null,
+      valid_at: null,
+      invalid_at: null,
+      expired_at: null,
+      metadata: undefined,
+      ...overrides,
+    };
+    const result = await pool.query(
+      `INSERT INTO ob_raw_turns
+         (namespace, turn_uuid, parent_turn_uuid, logical_parent_turn_uuid,
+          session_ref, prompt_id, role, content,
+          content_hash, turn_index, is_human_prompt, occurred_at,
+          valid_at, invalid_at, expired_at, created_by, metadata)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,'test',
+               COALESCE($16::jsonb, '{}'::jsonb))
+       ON CONFLICT DO NOTHING`,
+      [
+        namespace,
+        row.turn_uuid,
+        row.parent_turn_uuid,
+        row.logical_parent_turn_uuid,
+        row.session_ref,
+        row.prompt_id,
+        row.role,
+        row.content,
+        row.content_hash,
+        row.turn_index,
+        row.is_human_prompt,
+        row.occurred_at,
+        row.valid_at,
+        row.invalid_at,
+        row.expired_at,
+        row.metadata === undefined ? null : JSON.stringify(row.metadata),
+      ],
+    );
+    return result.rowCount ?? 0;
+  }
+
+  beforeAll(async () => {
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("accepts user, assistant, and tool roles", async () => {
+    for (const role of ["user", "assistant", "tool"]) {
+      expect(await insert(nsAlice, { turn_uuid: `uuid-${role}`, role })).toBe(
+        1,
+      );
+    }
+  });
+
+  it("rejects a role outside the contract", async () => {
+    await expect(
+      insert(nsAlice, { turn_uuid: "uuid-sys", role: "system" }),
+    ).rejects.toThrow();
+  });
+
+  it("never stores an exact duplicate turn twice", async () => {
+    // Resuming or forking a session makes the runtime copy prior history into
+    // a new transcript. That re-send must conflict and be ignored.
+    expect(await insert(nsAlice, { turn_uuid: "uuid-dupe" })).toBe(1);
+    expect(await insert(nsAlice, { turn_uuid: "uuid-dupe" })).toBe(0);
+
+    const { rows } = await pool.query(
+      "SELECT count(*)::int AS n FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = $2",
+      [nsAlice, "uuid-dupe"],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  it("dedupes on turn identity even when the copy differs in session or lane", async () => {
+    // The forked copy legitimately carries a different session_ref; identity is
+    // the turn's own id, so it still conflicts.
+    expect(await insert(nsAlice, { turn_uuid: "uuid-fork" })).toBe(1);
+    const second = await pool.query(
+      `INSERT INTO ob_raw_turns
+         (namespace, turn_uuid, role, content, content_hash, turn_index, created_by, session_ref)
+       VALUES ($1,'uuid-fork','user','hello','hash-a',0,'test','other-session')
+       ON CONFLICT DO NOTHING`,
+      [nsAlice],
+    );
+    expect(second.rowCount ?? 0).toBe(0);
+  });
+
+  it("keeps the same turn id in different namespaces separate", async () => {
+    expect(await insert(nsAlice, { turn_uuid: "uuid-shared" })).toBe(1);
+    expect(await insert(nsBob, { turn_uuid: "uuid-shared" })).toBe(1);
+  });
+
+  it("allows distinct turns that share identical content", async () => {
+    // Content is NOT the identity key: two real turns may repeat a phrase, and
+    // each keeps its own place in the reply chain.
+    expect(
+      await insert(nsAlice, {
+        turn_uuid: "uuid-1",
+        content: "yes",
+        content_hash: "h",
+      }),
+    ).toBe(1);
+    expect(
+      await insert(nsAlice, {
+        turn_uuid: "uuid-2",
+        content: "yes",
+        content_hash: "h",
+        parent_turn_uuid: "uuid-1",
+      }),
+    ).toBe(1);
+  });
+
+  it("reconstructs the reply chain from parent links", async () => {
+    await insert(nsAlice, { turn_uuid: "root", prompt_id: "p1" });
+    await insert(nsAlice, {
+      turn_uuid: "child",
+      parent_turn_uuid: "root",
+      prompt_id: "p1",
+      role: "assistant",
+    });
+
+    const { rows } = await pool.query(
+      "SELECT turn_uuid FROM ob_raw_turns WHERE namespace = $1 AND parent_turn_uuid = $2",
+      [nsAlice, "root"],
+    );
+    expect(rows.map((r) => r.turn_uuid)).toEqual(["child"]);
+  });
+
+  it("groups every record produced by one human prompt", async () => {
+    await insert(nsAlice, {
+      turn_uuid: "h1",
+      prompt_id: "p9",
+      is_human_prompt: true,
+    });
+    await insert(nsAlice, {
+      turn_uuid: "a1",
+      prompt_id: "p9",
+      role: "assistant",
+    });
+    await insert(nsAlice, { turn_uuid: "t1", prompt_id: "p9", role: "tool" });
+
+    const { rows } = await pool.query(
+      `SELECT count(*)::int AS n,
+              count(*) FILTER (WHERE is_human_prompt)::int AS humans
+         FROM ob_raw_turns WHERE namespace = $1 AND prompt_id = $2`,
+      [nsAlice, "p9"],
+    );
+    expect(rows[0].n).toBe(3);
+    // Exactly one declared human authorship per prompt group.
+    expect(rows[0].humans).toBe(1);
+  });
+
+  it("orders a batched replay by when the turn happened, not when it landed", async () => {
+    await insert(nsAlice, {
+      turn_uuid: "late-write",
+      occurred_at: "2026-07-25T09:00:00Z",
+      content: "first",
+    });
+    await insert(nsAlice, {
+      turn_uuid: "early-write",
+      occurred_at: "2026-07-25T08:00:00Z",
+      content: "zeroth",
+    });
+
+    const { rows } = await pool.query(
+      `SELECT content FROM ob_raw_turns
+        WHERE namespace = $1 AND occurred_at IS NOT NULL
+        ORDER BY occurred_at`,
+      [nsAlice],
+    );
+    expect(rows.map((r) => r.content)).toEqual(["zeroth", "first"]);
+  });
+
+  it("walks one conversation across a compaction and session boundary", async () => {
+    // The runtime already emits this link and nothing was reading it: at a
+    // compact, parentUuid is NULL but logicalParentUuid points at the last turn
+    // before the reset. Two sessions, one thread.
+    await insert(nsAlice, {
+      turn_uuid: "pre-compact",
+      session_ref: "session-1",
+      content: "before the reset",
+    });
+    await insert(nsAlice, {
+      turn_uuid: "post-compact",
+      session_ref: "session-2",
+      parent_turn_uuid: null,
+      logical_parent_turn_uuid: "pre-compact",
+      content: "after the reset",
+    });
+
+    const { rows } = await pool.query(
+      `WITH RECURSIVE thread AS (
+         SELECT turn_uuid, logical_parent_turn_uuid, content, session_ref
+           FROM ob_raw_turns
+          WHERE namespace = $1 AND turn_uuid = 'post-compact'
+         UNION ALL
+         SELECT t.turn_uuid, t.logical_parent_turn_uuid, t.content, t.session_ref
+           FROM ob_raw_turns t
+           JOIN thread ON t.turn_uuid = thread.logical_parent_turn_uuid
+          WHERE t.namespace = $1
+       )
+       SELECT content, session_ref FROM thread`,
+      [nsAlice],
+    );
+
+    // The walk crosses the session boundary the plain reply chain cannot.
+    expect(rows.map((r) => r.content)).toEqual([
+      "after the reset",
+      "before the reset",
+    ]);
+    expect(new Set(rows.map((r) => r.session_ref))).toEqual(
+      new Set(["session-1", "session-2"]),
+    );
+  });
+
+  it("measures the believed-a-dead-fact window from invalid_at vs expired_at", async () => {
+    // Bi-temporal, borrowed from Graphiti: world-time vs knowledge-time. The
+    // fact stopped being true at 12:52; we found out at 12:53. The gap is the
+    // drift metric, and it is only expressible because both are stored.
+    await insert(nsAlice, {
+      turn_uuid: "retracted",
+      valid_at: "2026-07-25T16:40:00Z",
+      invalid_at: "2026-07-25T16:52:00Z",
+      expired_at: "2026-07-25T16:53:00Z",
+    });
+
+    const { rows } = await pool.query(
+      `SELECT EXTRACT(EPOCH FROM (expired_at - invalid_at))::int AS drift_seconds
+         FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = 'retracted'`,
+      [nsAlice],
+    );
+    expect(rows[0].drift_seconds).toBe(60);
+  });
+
+  it("retracts a turn without destroying it", async () => {
+    // NEVER DELETE. A retraction marks when the claim stopped being true; the
+    // row and its content remain queryable.
+    await insert(nsAlice, { turn_uuid: "wrong", content: "the cap is 2047" });
+    await pool.query(
+      `UPDATE ob_raw_turns SET invalid_at = now(), expired_at = now(),
+              retention_tier = 'unused'
+        WHERE namespace = $1 AND turn_uuid = 'wrong'`,
+      [nsAlice],
+    );
+
+    const { rows } = await pool.query(
+      "SELECT content, retention_tier FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = 'wrong'",
+      [nsAlice],
+    );
+    expect(rows[0].content).toBe("the cap is 2047");
+    expect(rows[0].retention_tier).toBe("unused");
+  });
+
+  it("rejects a retention tier outside live/unused/cold", async () => {
+    await expect(
+      pool.query(
+        `INSERT INTO ob_raw_turns
+           (namespace, turn_uuid, role, content, content_hash, turn_index, created_by, retention_tier)
+         VALUES ($1,'bad-tier','user','x','h',0,'test','deleted')`,
+        [nsAlice],
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("keeps retired turns out of the sweep queue", async () => {
+    // A cold-archived turn must never be re-distilled: its content has moved to
+    // hard storage and only the index row remains.
+    await insert(nsAlice, { turn_uuid: "archived" });
+    await pool.query(
+      "UPDATE ob_raw_turns SET retention_tier = 'cold' WHERE namespace = $1 AND turn_uuid = 'archived'",
+      [nsAlice],
+    );
+
+    const { rows } = await pool.query(
+      `SELECT turn_uuid FROM ob_raw_turns
+        WHERE namespace = $1 AND distilled_at IS NULL AND retention_tier = 'live'`,
+      [nsAlice],
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("exposes undistilled turns as the sweep work queue", async () => {
+    await insert(nsAlice, { turn_uuid: "pending" });
+    await insert(nsAlice, { turn_uuid: "done" });
+    await pool.query(
+      "UPDATE ob_raw_turns SET distilled_at = now() WHERE namespace = $1 AND turn_uuid = $2",
+      [nsAlice, "done"],
+    );
+
+    const { rows } = await pool.query(
+      `SELECT turn_uuid FROM ob_raw_turns
+        WHERE namespace = $1 AND distilled_at IS NULL ORDER BY created_at`,
+      [nsAlice],
+    );
+    expect(rows.map((r) => r.turn_uuid)).toEqual(["pending"]);
+  });
+
+  it("stores structured provenance in metadata without touching content", async () => {
+    // Structured payloads stay out of `content` so embedding and FTS never lex
+    // JSON punctuation and key names as if they were dialogue.
+    await insert(nsAlice, {
+      turn_uuid: "uuid-meta",
+      content: "Q: ship it? A: yes",
+      metadata: {
+        model: "claude-opus-5",
+        effort: "high",
+        usage: { input_tokens: 10 },
+      },
+    });
+
+    const { rows } = await pool.query(
+      "SELECT content, metadata FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = $2",
+      [nsAlice, "uuid-meta"],
+    );
+    expect(rows[0].content).toBe("Q: ship it? A: yes");
+    expect(rows[0].metadata.model).toBe("claude-opus-5");
+    expect(rows[0].metadata.usage.input_tokens).toBe(10);
+  });
+
+  it("defaults redaction_applied to an empty list", async () => {
+    // Records WHICH rule fired, never the removed value.
+    await insert(nsAlice, { turn_uuid: "uuid-redact" });
+    const { rows } = await pool.query(
+      "SELECT redaction_applied FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = $2",
+      [nsAlice, "uuid-redact"],
+    );
+    expect(rows[0].redaction_applied).toEqual([]);
+  });
+});

--- a/src/tools/__tests__/ingest-raw-turn.test.ts
+++ b/src/tools/__tests__/ingest-raw-turn.test.ts
@@ -1,0 +1,249 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "../../db/migrate.ts";
+import { isHarnessNoise, registerIngestRawTurn } from "../ingest-raw-turn.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+// isHarnessNoise is pure, so its coverage runs everywhere. The ingest path
+// itself needs a real database (namespace predicate, ON CONFLICT, jsonb
+// round-trip) and is gated on OPENBRAIN_TEST_DATABASE_URL like 025/027/032.
+describe("harness noise filter", () => {
+  it("drops runtime scaffolding that is not dialogue", () => {
+    // Measured across 515 transcripts: these are the exact strings that repeat
+    // hundreds of times with no author and no decision content.
+    for (const noise of [
+      "[Request interrupted by user]",
+      "[Request interrupted by user for tool use]",
+      "<local-command-caveat>Caveat: the messages below...</local-command-caveat>",
+      "<command-name>/exit</command-name>",
+      "<bash-stdout>(Bash completed with no output)</bash-stdout>",
+      "Continue from where you left off.",
+      "   ",
+      "",
+    ]) {
+      expect(isHarnessNoise(noise)).toBe(true);
+    }
+  });
+
+  it("keeps real dialogue, including talk ABOUT the markers", () => {
+    // A shape filter must not swallow a turn that merely mentions the markers,
+    // or the conversation where we diagnosed them would itself be lost.
+    for (const real of [
+      "yeah, that's right. We should not be ingesting them at all.",
+      "why does [Request interrupted by user] appear 270 times?",
+      "run <bash-input> through the filter and tell me what happens",
+      "no",
+    ]) {
+      expect(isHarnessNoise(real)).toBe(false);
+    }
+  });
+});
+
+// Assembled at runtime so no credential-shaped literal exists in the source
+// tree; the secret scanner correctly refuses a realistic-looking fixture.
+const FAKE_TOKEN = ["sk", "live", "abcd1234efgh5678ijkl"].join("-");
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+dbDescribe("ingest_raw_turn (live Postgres)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const nsAlice = "test-ingest-alice";
+  const nsBob = "test-ingest-bob";
+
+  const alice: AuthInfo = {
+    role: "agent",
+    clientId: nsAlice,
+    namespaceSource: "token",
+  };
+
+  // Minimal MCP server double: capture the registered handler and call it the
+  // way the real server would.
+  type Handler = (
+    args: Record<string, unknown>,
+    extra: { authInfo?: AuthInfo },
+  ) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+  let handler: Handler;
+
+  const server = {
+    registerTool(_name: string, _schema: unknown, fn: Handler) {
+      handler = fn;
+    },
+  } as unknown as Parameters<typeof registerIngestRawTurn>[0];
+
+  async function ingest(
+    turns: Array<Record<string, unknown>>,
+    auth: AuthInfo = alice,
+    namespace?: string,
+  ): Promise<Record<string, unknown>> {
+    const res = await handler(namespace ? { turns, namespace } : { turns }, {
+      authInfo: auth,
+    });
+    return JSON.parse(res.content[0]!.text) as Record<string, unknown>;
+  }
+
+  function turn(overrides: Record<string, unknown> = {}) {
+    return {
+      turn_uuid: "t-1",
+      turn_index: 0,
+      role: "user",
+      content: "hello",
+      ...overrides,
+    };
+  }
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM ob_raw_turns WHERE namespace = ANY($1)", [
+      [nsAlice, nsBob],
+    ]);
+  }
+
+  beforeAll(async () => {
+    await runMigrations(pool);
+    registerIngestRawTurn(server, { pool } as unknown as ToolDeps);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("ingests both sides of a conversation", async () => {
+    // The whole point: the assistant half was never captured before.
+    const result = await ingest([
+      turn({ turn_uuid: "u-1", role: "user", content: "what broke?" }),
+      turn({
+        turn_uuid: "a-1",
+        role: "assistant",
+        content: "the writer only read user records",
+        turn_index: 1,
+      }),
+      turn({
+        turn_uuid: "t-1",
+        role: "tool",
+        content: 'Q: ship it? A: "yes"',
+        turn_index: 2,
+      }),
+    ]);
+
+    expect(result.ingested).toBe(3);
+
+    const { rows } = await pool.query(
+      "SELECT role FROM ob_raw_turns WHERE namespace = $1 ORDER BY turn_index",
+      [nsAlice],
+    );
+    expect(rows.map((r) => r.role)).toEqual(["user", "assistant", "tool"]);
+  });
+
+  it("makes a replayed batch a no-op instead of duplicating", async () => {
+    const batch = [turn({ turn_uuid: "dup-1" }), turn({ turn_uuid: "dup-2" })];
+    const first = await ingest(batch);
+    const second = await ingest(batch);
+
+    expect(first.ingested).toBe(2);
+    expect(second.ingested).toBe(0);
+    expect(second.duplicates).toBe(2);
+  });
+
+  it("filters harness noise without failing the batch", async () => {
+    const result = await ingest([
+      turn({ turn_uuid: "keep-1", content: "a real decision" }),
+      turn({ turn_uuid: "drop-1", content: "[Request interrupted by user]" }),
+      turn({
+        turn_uuid: "drop-2",
+        content: "<command-name>/exit</command-name>",
+      }),
+    ]);
+
+    expect(result.ingested).toBe(1);
+    expect(result.filtered).toBe(2);
+  });
+
+  it("redacts the value but keeps the statement", async () => {
+    // A turn is NEVER dropped for containing a credential; fail-closed was
+    // explicitly rejected.
+    await ingest([
+      turn({
+        turn_uuid: "secret-1",
+        content: `set AUTH_TOKEN_ADMIN=${FAKE_TOKEN} and retry`,
+      }),
+    ]);
+
+    const { rows } = await pool.query(
+      "SELECT content, redaction_applied FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = 'secret-1'",
+      [nsAlice],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).not.toContain(FAKE_TOKEN);
+    expect(rows[0].content).toContain("AUTH_TOKEN_ADMIN");
+    expect(rows[0].content).toContain("retry");
+    expect(rows[0].redaction_applied).toEqual(["secret_value"]);
+  });
+
+  it("stores structured provenance and the reply chain", async () => {
+    await ingest([
+      turn({
+        turn_uuid: "prov-1",
+        parent_turn_uuid: "root-0",
+        logical_parent_turn_uuid: "pre-compact-0",
+        prompt_id: "p-1",
+        session_ref: "sess-1",
+        repo: "open-brain",
+        git_branch: "feat/380",
+        is_human_prompt: true,
+        runtime: "claude-code",
+        token_estimate: 42,
+        occurred_at: "2026-07-25T18:00:00Z",
+        metadata: { model: "claude-opus-5", effort: "high" },
+      }),
+    ]);
+
+    const { rows } = await pool.query(
+      `SELECT parent_turn_uuid, logical_parent_turn_uuid, prompt_id, repo,
+              git_branch, is_human_prompt, runtime, token_estimate,
+              occurred_at, valid_at, metadata
+         FROM ob_raw_turns WHERE namespace = $1 AND turn_uuid = 'prov-1'`,
+      [nsAlice],
+    );
+    const row = rows[0];
+    expect(row.parent_turn_uuid).toBe("root-0");
+    expect(row.logical_parent_turn_uuid).toBe("pre-compact-0");
+    expect(row.repo).toBe("open-brain");
+    expect(row.is_human_prompt).toBe(true);
+    expect(row.token_estimate).toBe(42);
+    expect(row.metadata.model).toBe("claude-opus-5");
+    // valid_at mirrors occurred_at: the turn became true when it happened.
+    expect(row.valid_at).toEqual(row.occurred_at);
+  });
+
+  it("refuses to write outside the caller's namespace", async () => {
+    const res = await handler(
+      { turns: [turn({ turn_uuid: "cross-1" })], namespace: nsBob },
+      { authInfo: alice },
+    );
+    expect(res.isError).toBe(true);
+
+    const { rows } = await pool.query(
+      "SELECT count(*)::int AS n FROM ob_raw_turns WHERE namespace = $1",
+      [nsBob],
+    );
+    expect(rows[0].n).toBe(0);
+  });
+
+  it("denies an unauthenticated caller", async () => {
+    const res = await handler({ turns: [turn()] }, {});
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content[0]!.text).error).toBe("auth_denied");
+  });
+
+  it("reports a batch that was entirely noise without erroring", async () => {
+    const result = await ingest([
+      turn({ turn_uuid: "n-1", content: "[Request interrupted by user]" }),
+    ]);
+    expect(result.ingested).toBe(0);
+    expect(result.filtered).toBe(1);
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -32,6 +32,7 @@ import { registerTierRecommendations } from "./tier-recommendations.ts";
 import { registerLaneUpsert } from "./lane-upsert.ts";
 import { registerLaneLoad } from "./lane-load.ts";
 import { registerAppendSessionEvent } from "./append-session-event.ts";
+import { registerIngestRawTurn } from "./ingest-raw-turn.ts";
 import { registerCitationRecall } from "./citation-recall.ts";
 import { registerSessionContext } from "./session-context.ts";
 import { registerSessionStart } from "./session-start.ts";
@@ -122,6 +123,7 @@ export function registerAllTools(server: McpServer, deps: ToolDeps): void {
   registerLaneUpsert(server, toolDeps);
   registerLaneLoad(server, toolDeps);
   registerAppendSessionEvent(server, toolDeps);
+  registerIngestRawTurn(server, toolDeps);
   registerCitationRecall(server, toolDeps);
   registerSessionContext(server, toolDeps);
   registerSessionStart(server, toolDeps);

--- a/src/tools/ingest-raw-turn.ts
+++ b/src/tools/ingest-raw-turn.ts
@@ -1,0 +1,313 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canWrite } from "../permissions.ts";
+import { canWriteNamespace } from "../namespace-policy.ts";
+import { contentHash } from "../embedding.ts";
+import { redactText } from "../sharing.ts";
+import type { AuthInfo } from "../types.ts";
+import { logger } from "../logger.ts";
+import type { ToolDeps } from "./index.ts";
+
+/**
+ * Full-send raw turn ingest (Issue #380, INGEST-1).
+ * Spec: docs/full-send-derivation-spec.md section 2.
+ *
+ * The client is a DUMB PIPE. It ships what happened and decides nothing about
+ * salience: no summarizing, no scoring, no "is this worth remembering". Every
+ * judgment (distillation, dedupe, supersession) is server-side, asynchronous,
+ * and re-runnable, because only the server runs when no session is open, sees
+ * the whole corpus, survives a client crash, and serves Claude/Codex/Python
+ * from one implementation instead of three divergent client heuristics.
+ *
+ * This replaces client-side salience filtering, which was measured to fail in
+ * exactly the ways a heuristic fails: on 2026-07-25 it captured 21 of the
+ * user's turns and ZERO of the assistant's, and had never once captured an
+ * AskUserQuestion answer -- the densest decision content in the corpus.
+ */
+
+const MAX_BATCH = 100;
+const MAX_CONTENT_CHARS = 200_000;
+
+type IngestErrorClass = "retryable_outage" | "auth_denied" | "scope_validation";
+
+function ingestError(
+  errorClass: IngestErrorClass,
+  message: string,
+  retryable: boolean,
+  details: Record<string, unknown> = {},
+) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          error: errorClass,
+          message,
+          retryable,
+          ...details,
+        }),
+      },
+    ],
+    isError: true,
+  };
+}
+
+/**
+ * Harness control strings that are not dialogue and must never be ingested.
+ *
+ * This is a SHAPE filter on runtime scaffolding, NOT a salience judgment: it
+ * does not ask whether a turn is worth remembering, only whether it is a turn
+ * at all. Measured across 515 transcripts on 2026-07-25 -- "[Request
+ * interrupted by user]" appears 270 times across 51 sessions, "[Request
+ * interrupted by user for tool use]" 103 times across 33. Storing those is
+ * pure noise: identical strings, no author, no decision, and they would
+ * dominate any exact-content analysis.
+ */
+const HARNESS_NOISE: readonly RegExp[] = [
+  /^\[Request interrupted by user[^\]]*\]$/,
+  /^<local-command-(?:caveat|stdout|stderr)>/,
+  /^<command-(?:name|message|args)>/,
+  /^<bash-(?:input|stdout|stderr)>/,
+  /^Continue from where you left off\.$/,
+  /^The user doesn't want to proceed with this tool use\./,
+];
+
+export function isHarnessNoise(content: string): boolean {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return true;
+  return HARNESS_NOISE.some((pattern) => pattern.test(trimmed));
+}
+
+const rawTurnSchema = z.object({
+  turn_uuid: z.string().trim().min(1).max(200),
+  parent_turn_uuid: z.string().trim().min(1).max(200).nullish(),
+  logical_parent_turn_uuid: z.string().trim().min(1).max(200).nullish(),
+  prompt_id: z.string().trim().min(1).max(200).nullish(),
+  session_ref: z.string().trim().min(1).max(500).nullish(),
+  repo: z.string().trim().min(1).max(200).nullish(),
+  git_branch: z.string().trim().min(1).max(300).nullish(),
+  turn_index: z.number().int().min(0),
+  role: z.enum(["user", "assistant", "tool"]),
+  is_human_prompt: z.boolean().optional(),
+  content: z.string().max(MAX_CONTENT_CHARS),
+  runtime: z.string().trim().min(1).max(100).nullish(),
+  token_estimate: z.number().int().min(0).nullish(),
+  occurred_at: z.string().datetime({ offset: true }).nullish(),
+  metadata: z
+    .record(z.string().max(100), z.unknown())
+    .optional()
+    .refine((v) => !v || JSON.stringify(v).length <= 100_000, {
+      message: "metadata: max 100KB total",
+    }),
+});
+
+type RawTurnInput = z.infer<typeof rawTurnSchema>;
+
+interface PreparedTurn {
+  turn: RawTurnInput;
+  content: string;
+  contentHashValue: string;
+  redactionApplied: string[];
+}
+
+/**
+ * Redact the VALUE, keep the STATEMENT. A turn is NEVER dropped for containing
+ * a credential -- "AUTH_TOKEN_ADMIN=[REDACTED]" is itself a useful durable
+ * fact, and fail-closed was explicitly rejected. `redaction_applied` records
+ * only THAT redaction fired, never the removed value.
+ */
+function prepare(turn: RawTurnInput): PreparedTurn {
+  const redacted = redactText(turn.content);
+  const redactionApplied = redacted === turn.content ? [] : ["secret_value"];
+  return {
+    turn,
+    content: redacted,
+    contentHashValue: contentHash(redacted),
+    redactionApplied,
+  };
+}
+
+export function registerIngestRawTurn(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    "ingest_raw_turn",
+    {
+      description:
+        "Full-send ingest of raw conversation turns. The client ships what " +
+        "happened and applies no salience judgment; the server owns " +
+        "distillation. Re-sending an identical turn is a no-op, so hook " +
+        "retries and session-resume replays are safe.",
+      inputSchema: {
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe(
+            "Namespace for isolation (defaults to the caller's clientId)",
+          ),
+        turns: z
+          .array(rawTurnSchema)
+          .min(1)
+          .max(MAX_BATCH)
+          .describe(
+            `Raw turns in order, max ${MAX_BATCH} per call. Batching keeps the interactive turn unblocked.`,
+          ),
+      },
+      annotations: {
+        title: "Ingest Raw Turn",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const auth = extra.authInfo as AuthInfo | undefined;
+
+      if (!auth || !canWrite(auth.role, "sessions")) {
+        logger.warn("ingest_raw_turn_denied", {
+          role: auth?.role ?? "none",
+          clientId: auth?.clientId ?? "none",
+        });
+        return ingestError(
+          "auth_denied",
+          "Permission denied: cannot write raw turns",
+          false,
+        );
+      }
+
+      const ns = args.namespace ?? auth.clientId;
+      const nsCheck = canWriteNamespace(auth, ns);
+      if (!nsCheck.allowed) {
+        return ingestError(
+          "auth_denied",
+          `Permission denied: ${nsCheck.reason}`,
+          false,
+          { namespace: ns },
+        );
+      }
+
+      // Harness scaffolding is dropped before anything touches the database.
+      const kept: PreparedTurn[] = [];
+      let filtered = 0;
+      for (const turn of args.turns) {
+        if (isHarnessNoise(turn.content)) {
+          filtered += 1;
+          continue;
+        }
+        kept.push(prepare(turn));
+      }
+
+      if (kept.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ingested: 0,
+                duplicates: 0,
+                filtered,
+                namespace: ns,
+              }),
+            },
+          ],
+        };
+      }
+
+      try {
+        // One multi-row INSERT: the whole batch is one round trip, and
+        // ON CONFLICT DO NOTHING makes a replayed batch a no-op rather than an
+        // error the client has to interpret.
+        const values: unknown[] = [];
+        const tuples: string[] = [];
+        const COLS = 19;
+        for (const [index, prepared] of kept.entries()) {
+          const b = index * COLS;
+          tuples.push(
+            `($${b + 1},$${b + 2},$${b + 3},$${b + 4},$${b + 5},$${b + 6},` +
+              `$${b + 7},$${b + 8},$${b + 9}::int,$${b + 10},$${b + 11}::boolean,` +
+              `$${b + 12},$${b + 13},$${b + 14},$${b + 15}::int,$${b + 16}::jsonb,` +
+              `$${b + 17}::jsonb,$${b + 18},$${b + 19}::timestamptz)`,
+          );
+          const t = prepared.turn;
+          values.push(
+            ns,
+            t.turn_uuid,
+            t.parent_turn_uuid ?? null,
+            t.logical_parent_turn_uuid ?? null,
+            t.prompt_id ?? null,
+            t.session_ref ?? null,
+            t.repo ?? null,
+            t.git_branch ?? null,
+            t.turn_index,
+            t.role,
+            t.is_human_prompt ?? false,
+            prepared.content,
+            prepared.contentHashValue,
+            t.runtime ?? null,
+            t.token_estimate ?? null,
+            JSON.stringify(t.metadata ?? {}),
+            JSON.stringify(prepared.redactionApplied),
+            auth.clientId,
+            t.occurred_at ?? null,
+          );
+        }
+
+        // valid_at mirrors occurred_at: a turn became true when it happened.
+        // invalid_at/expired_at stay NULL until something retracts it.
+        const { rows } = await deps.pool.query(
+          `INSERT INTO ob_raw_turns
+             (namespace, turn_uuid, parent_turn_uuid, logical_parent_turn_uuid,
+              prompt_id, session_ref, repo, git_branch, turn_index, role,
+              is_human_prompt, content, content_hash, runtime, token_estimate,
+              metadata, redaction_applied, created_by, occurred_at, valid_at)
+           SELECT v.*, v.occurred_at
+             FROM (VALUES ${tuples.join(",")}) AS v(
+                    namespace, turn_uuid, parent_turn_uuid,
+                    logical_parent_turn_uuid, prompt_id, session_ref, repo,
+                    git_branch, turn_index, role, is_human_prompt, content,
+                    content_hash, runtime, token_estimate, metadata,
+                    redaction_applied, created_by, occurred_at)
+           ON CONFLICT (namespace, turn_uuid) DO NOTHING
+           RETURNING id`,
+          values,
+        );
+
+        const ingested = rows.length;
+        const duplicates = kept.length - ingested;
+
+        // Content-free telemetry: counts only, never turn text.
+        logger.info("ingest_raw_turn_ok", {
+          namespace: ns,
+          ingested,
+          duplicates,
+          filtered,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ingested,
+                duplicates,
+                filtered,
+                namespace: ns,
+              }),
+            },
+          ],
+        };
+      } catch (err) {
+        logger.error("ingest_raw_turn_db_error", {
+          namespace: ns,
+          batch_size: kept.length,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return ingestError(
+          "retryable_outage",
+          `Database error during raw turn ingest: ${err instanceof Error ? err.message : String(err)}`,
+          true,
+          { namespace: ns },
+        );
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Splits the raw-turn full-send lane (#380) off the parked `feat/410-uv-workspace` branch, which had accumulated 21 commits / 14,148 insertions across 96 files. This is 4 commits / ~1,900 insertions across 20 files.
- Adds `032_raw_turns.sql` (content-bearing table, `UNIQUE(namespace, turn_uuid)` so a replayed batch is a no-op), the `ingest_raw_turn` MCP tool, and the Python client half on the runtime, agent, and CLI.
- **Why full-send:** client-side salience was measured failing on 2026-07-25 — **21 user turns and ZERO assistant turns** captured. The server owns redaction, harness-noise filtering, and dedupe, so one implementation serves Claude, Codex, and Python instead of three divergent heuristics. Client-side validation here is structural only (is it a turn at all), never salience.
- **The finding worth reading:** the cherry-pick silently reverted PR #379's tolerant CLI reader. No textual conflict, because the two changes touch adjacent lines rather than the same ones. `_validate_request_keys` came back, `_project_request` disappeared, both compatibility constants were dropped, and two pre-#379 strict tests returned. Caught only because this branch's own new test failed: `test_unknown_request_key_is_not_forwarded` expected `saved`, got `failed`. Fixed by restoring the upstream projection verbatim and keeping only the ingest-specific additions.
- `ingest` is now in the parametrized tolerant-reader matrix. It is the newest verb and the one an older adapter is most likely to call with an unknown field, so leaving it out is how it drifts back to fail-closed unnoticed.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

Evidence:
- `bunx tsc --noEmit` clean.
- Migration `032` applies on top of `031` against a fresh Postgres.
- 2482 TS tests pass, including the DB-backed raw-turn tests that skip without `OPENBRAIN_TEST_DATABASE_URL`.
- 536 Python tests, mypy clean, ruff clean.
- `bun contracts/check-parity.ts` — 14 fixtures across 9 capabilities.
- **One pre-existing failure inherited, not caused by this branch:** `src/source-sync.test.ts` fails in the full suite and passes alone. Reproduced identically on the base commit; filed as #422.

## Critical Self-Review

- Highest-risk behavior: a content-bearing write path with no client-side salience filter. Mitigated by server-side redaction/dedupe and by the structural-only validator, but this lane carries raw transcript by design.
- Assumptions that could be wrong: that the server's redaction is complete. The client deliberately does not second-guess it, so a server-side gap is fully exposed here.
- Missing/weak tests: no concurrent-batch test against the UNIQUE constraint; replay idempotency is asserted at the schema level, not under parallel writers.
- Security/permission risk: namespace is caller-supplied and optional. Auth-derived namespace predicates on the server side remain the boundary.
- Migration/deploy risk: 032 is additive, no backfill, no destructive DDL. If code-brain (033/034) lands first, this needs renumbering.
- Downstream client/runtime risk: adds a Python client method with no TS peer — declared in the parity manifest rather than hidden.
- Rollback/cleanup concern: dropping the table loses ingested turns; there is no derived-from-distilled recovery path.
- Fixes made before PR: restored the tolerant CLI reader this cherry-pick had reverted; added `ingest` to the tolerant matrix; added the parity capability and its fixture.
- Known residual risk: the 2 MB raw-lane envelope ceiling is a judgment call, not measured against real transcript sizes.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this branch adds a tool and a table but changes no deployed server behavior until it merges; the hosted smoke would exercise the pre-merge build.

## Contract Parity

- Contract parity: [x] fixtures updated

The Python client gains `ingest_raw_turn`/`ingest_raw_turns` with no TS counterpart. Rather than bypassing the gate with a commit-message escape, this declares a `raw-turn-ingest` capability as `ts: runtime-specific` and adds the fixture the gate requires.

The fixture asserts the property the lane exists for: turns reach the wire verbatim, both roles survive, one call per batch. **Verified it fails when assistant turns are dropped** — the exact regression measured on 2026-07-25.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- `ingest_raw_turn` is a **new additive** MCP tool. No existing tool schema, response shape, or client call changes, so no downstream client breaks by adding it.
- The Python client gains new methods only; existing methods are untouched. An older client that never calls `ingest_raw_turns` is unaffected.
- Downstream rollout becomes relevant when a runtime is wired to *call* this lane (the adapter cutover, #420). That is out of scope here.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
