### PR TITLE
feat(observability): shared log envelope, runtime log level, and credential redaction

### DIFF
--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -808,3 +808,51 @@ The adversarial move that caught it was cheap: take the comment's own claim
   credentials — no SSH agent, no token, no sibling checkout, empty cache?
 - When a second attempt fails differently from the first, is the underlying
   constraint being addressed, or is the symptom being renamed?
+
+## [2026-07-26] The unguarded step in a fail-open path is the one that matters
+
+**Provenance:** PR #424, adversarial + SME lanes independently. **Severity:** HIGH. **Status:** fixed.
+
+`log()` in `src/logger.ts` guarded everything except one statement. `contextFields()`
+caught a throwing reader, the file sink was guarded, every extra sink was
+guarded — and `const output = JSON.stringify(entry)` sat between the entry
+construction and all four destinations, unguarded.
+
+`entry` is built from caller-supplied `extra` **and** from `withContext()`
+fields, so a cycle, a `BigInt`, or a throwing `toJSON` in either was enough to
+lose the line everywhere *and* throw into arbitrary application code.
+
+The consequences ran well past logging, and each contradicted a documented
+contract:
+
+- `withLogging` documents "re-throws whatever fn throws, unchanged". It threw a
+  serializer error instead, destroying the real root cause **on the failure
+  path**.
+- `withFallback` — the one function whose purpose is to never propagate — threw
+  instead of returning its fallback.
+- Worst: `withLogging` emits its entry line at `debug` *before* calling `fn`. At
+  `info` that line is gated out and `fn` runs. At `debug` the same call threw and
+  **`fn` was never invoked.** Raising the log level to investigate an incident
+  silently stopped work from running — the exact scenario the runtime log-level
+  setter exists for.
+
+The repo already knew the hazard: `src/audit-log.ts` explicitly defends against
+"a cycle, a BigInt anywhere". The module that *every* emitter routes through did
+not.
+
+### Review Questions
+
+- In any path that deliberately catches everything, **list the statements that
+  are not wrapped.** One unguarded step in an otherwise fail-open function is a
+  stronger signal than an unguarded step anywhere else — the surrounding care
+  proves the author intended it not to throw.
+- Does a logging/telemetry wrapper emit a line *before* calling the wrapped
+  function? Then a throw in the emit path is a **control-flow** bug, not a
+  logging bug: the work never runs.
+- Does the failure mode depend on the log level? A bug that only appears at
+  `debug` surfaces exactly when someone is debugging.
+- Does redaction cover the whole record, or one contributor? Redacting
+  `error_message` while a caller field carries the identical credential on the
+  same line is not redaction.
+- Do observers (sinks, subscribers) receive the same redacted data the file and
+  console get, or the raw object?

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -725,3 +725,62 @@ never reach it.
   import time (`FILE_SINK`, `HOST_NAME`, `SERVICE_NAME`) cannot be exercised by
   a suite that does not set that env — a subprocess is the honest way in.
 - Does the suite's default env silently disable the code path under test?
+
+## [2026-07-26] Four defects that three review passes all missed
+
+**Provenance:** PR #424, final independent gate. **Severity:** HIGH.
+**Status:** fixed.
+
+An author self-review and two swarm lanes all cleared `src/logger.ts`. A fourth
+independent pass found four more defects in the same file, all reproduced. What
+unites them is that every one is a **guard that was correct about its intent and
+wrong about its mechanism** — so reading the code, and the comment above it,
+confirms the intent and hides the flaw. Three passes read the intent.
+
+**1. A redactor that cannot see what it is redacting.** Every detector was
+value-shaped (`sk-…`, `ghp_…`, the literal text `password=…`). But a JSON
+logger hands its replacer each value *in isolation*, so `{"password":
+"hunter2driveway"}` emitted in clear. The pattern set already contained
+`json_labeled_secret`, which matches that exact pair — when given the pair as
+text. It was never shown the key. The detector list looked complete because it
+was; the call site never supplied the context the detectors needed.
+
+**2. A bound that manufactured the leak it existed to prevent.** Input was
+truncated at 16 KB *before* the patterns ran, so a DSN straddling the boundary
+was cut mid-credential, nothing matched the surviving head, and the tail went
+out readable. Truncating cannot create a secret, but it can destroy the evidence
+that one is present. Order of operations, not the operations.
+
+**3. Cycle detection that flagged non-cycles.** A `WeakSet` that only ever grew
+marked *any* object seen a second time as `"[Circular]"` — including one
+referenced from two sibling fields, which is not a cycle. Sharing one
+config/job/namespace object across fields is ordinary, so the false positive was
+the common case, silently dropping real data. "Seen before" and "is its own
+ancestor" are different questions; only the second one means circular.
+
+**4. A reentrancy guard keyed on a value that collides.** `minLevel === widened`
+cannot distinguish "my temporary value is still installed" from "a nested call
+deliberately chose that same value." An existing test covered nested
+`setLogLevel` and passed throughout — because its nested call picks a level that
+*differs* from the widened one. The colliding case inverted the result while
+telling the nested caller it had succeeded.
+
+### Review Questions
+
+- **Does this guard ever see the information it needs to decide?** A redactor
+  handed one value at a time cannot act on the field name; a validator handed a
+  parsed object cannot act on the raw bytes. Check the call site's data flow,
+  not the guard's logic.
+- **Does a sanitizer run before or after the thing that bounds it?** Truncate,
+  normalize, encode, and redact are all order-sensitive. Ask which one runs
+  first and what the other one can no longer see.
+- **Is "have I seen this?" standing in for "is this an ancestor?"** A
+  monotonically growing set answers the first. Cycle, recursion, and depth
+  guards need the second, and the difference only shows on a DAG — repeated
+  siblings, not loops.
+- **Does the guard's key have collisions?** Comparing a *value* to detect "did
+  someone else change this" fails whenever someone else picks the same value.
+  Identity tokens, generation counters, and sentinels do not collide; values do.
+- **Does the existing test for this exercise the colliding case?** A passing
+  reentrancy/idempotency test often picks distinct values precisely because
+  distinct values are easier to assert on. That is the case that cannot fail.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -685,3 +685,43 @@ against two healthy servers.
 - Can a gate that depends on a subsystem block the repair of that same
   subsystem? A context/policy gate needs a repair-mode escape or it deadlocks
   exactly when it is needed most.
+
+## [2026-07-26] A "fix" for an impossible case, and the test that could not fail
+
+**Provenance:** PR #424, SME lane. **Severity:** MEDIUM. **Status:** fixed.
+
+Self-review "fixed" an unguarded `FILE_SINK?.write` by wrapping it in
+`try/catch`, reasoning that a full disk must not take the log line down with it.
+The reasoning was sound; the guard was redundant.
+
+The SME lane applied this file's own instruction — *neuter the fix in place and
+measure* — and found **0 tests failed** with the guard removed, across 151 tests
+in every logger-touching suite. Two layers of why:
+
+1. The whole suite runs with `LOG_FILE` unset, so `FILE_SINK` is `undefined` and
+   `?.` short-circuits before reaching the guarded block.
+2. Deeper: `createRotatingFileSink` documents *"Never throws on write"* and
+   already wraps `appendFileSync` in its own `try/catch`. **The throw being
+   guarded cannot occur.**
+
+A guard for an impossible case is not free. It tells the next reader this sink
+can throw, which is false, and it is untestable by construction — so it reads as
+a coverage gap forever.
+
+What replaced it: the guard was removed with the rationale recorded inline, and
+a test was added for the behaviour *neither* version covered — an unwritable
+`LOG_FILE` must still produce the line on console. It runs through a subprocess,
+because `FILE_SINK` resolves once at module load and an in-process test can
+never reach it.
+
+### Review Questions
+
+- For each fix in a PR: **revert it in place and run the tests.** If nothing
+  fails, either the test is missing or the fix is unnecessary. Both are worth
+  knowing, and they are distinguishable only by looking.
+- Before guarding a call, check whether the callee already guarantees it does
+  not throw. Read the callee's contract, do not infer it from the call site.
+- Is the fixture even reachable? A module-level `const` resolved from env at
+  import time (`FILE_SINK`, `HOST_NAME`, `SERVICE_NAME`) cannot be exercised by
+  a suite that does not set that env — a subprocess is the honest way in.
+- Does the suite's default env silently disable the code path under test?

--- a/scripts/backfill.test.ts
+++ b/scripts/backfill.test.ts
@@ -1,21 +1,43 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import type pg from "pg";
 import type { generateEmbedding } from "../src/embedding.ts";
+import { addLogSink } from "../src/logger.ts";
 
-// Only mock the logger -- pool and embedFn are injected directly into backfill()
+// Info lines are observed through the logger's own sink. Pool and embedFn are
+// injected directly into backfill(), so the logger is the only collaborator
+// that needs observing at all.
+//
+// NOT `mock.module("../src/logger.ts")`: that mock is process-wide and
+// permanent in Bun -- keyed by resolved specifier, never scoped to one file,
+// and not undone by `mock.restore()`. Stubbing the logger here replaced it for
+// every later suite in the run, and `src/observability/observability.test.ts`
+// asserts on lines the REAL logger emits. The stub silenced it, so all 20 of
+// its tests failed with an empty capture buffer and a stack pointing nowhere
+// near this file. The stub also predated `addLogSink`/`setLogContextReader`,
+// so it no longer exported the module's full surface.
+//
+// `addLogSink` observes emitted lines without replacing anything, so it
+// composes with other suites instead of overwriting them.
 const logInfoCalls: Array<[string, Record<string, unknown>?]> = [];
-mock.module("../src/logger.ts", () => ({
-  logger: {
-    info: (msg: string, extra?: Record<string, unknown>) => {
-      logInfoCalls.push([msg, extra]);
-    },
-    warn: () => {},
-    error: () => {},
-    debug: mock(() => {}),
-  },
-}));
+let unsubscribeLogSink: (() => void) | undefined;
 
-// Import after logger mock is set up
+beforeEach(() => {
+  logInfoCalls.length = 0;
+  unsubscribeLogSink = addLogSink((entry) => {
+    if (entry.level !== "info") return;
+    const { level, message, timestamp, service, ...extra } = entry;
+    void level;
+    void timestamp;
+    void service;
+    logInfoCalls.push([message as string, extra]);
+  });
+});
+
+afterEach(() => {
+  unsubscribeLogSink?.();
+  unsubscribeLogSink = undefined;
+});
+
 const { backfill } = await import("./backfill.ts");
 
 // Mock pool factory -- no mock.module needed since pool is injected
@@ -42,10 +64,6 @@ function createMockEmbedFn(impl?: (text: string) => Promise<number[] | null>) {
 // Default query impl: return empty rows for everything
 const defaultQueryImpl = async () => ({
   rows: [] as Record<string, unknown>[],
-});
-
-beforeEach(() => {
-  logInfoCalls.length = 0;
 });
 
 describe("backfill", () => {

--- a/src/embedding-repair.test.ts
+++ b/src/embedding-repair.test.ts
@@ -1,17 +1,40 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import type { EmbeddingError } from "./embedding.ts";
+import { addLogSink } from "./logger.ts";
 
-// Mock the logger so content-free warnings don't spam and can be asserted.
+// Warnings are observed through the logger's own sink, NOT `mock.module`.
+//
+// `mock.module` is process-wide and permanent in Bun: it is keyed by resolved
+// specifier, is not scoped to this file, is not undone between test files, and
+// `mock.restore()` does not undo it. Stubbing "./logger.ts" here therefore
+// replaced the logger for every later suite in the run — which silently broke
+// the observability tests, whose subject IS the real logger: they received the
+// stub's no-op `addLogSink`, so nothing was ever captured and all 18 of their
+// assertions failed with an empty array, from a cause in this file.
+//
+// `addLogSink` observes emitted lines without touching module or global state,
+// so it composes with other suites instead of overwriting them. It is also
+// stricter: assertions run against lines the real logger actually emitted,
+// envelope included, rather than against arguments handed to a fake.
 const warnCalls: Array<[string, Record<string, unknown>?]> = [];
-mock.module("./logger.ts", () => ({
-  logger: {
-    info: () => {},
-    warn: (msg: string, extra?: Record<string, unknown>) =>
-      warnCalls.push([msg, extra]),
-    error: () => {},
-    debug: () => {},
-  },
-}));
+let unsubscribeLogSink: (() => void) | undefined;
+
+beforeEach(() => {
+  warnCalls.length = 0;
+  unsubscribeLogSink = addLogSink((entry) => {
+    if (entry.level !== "warn") return;
+    const { level, message, timestamp, service, ...extra } = entry;
+    void level;
+    void timestamp;
+    void service;
+    warnCalls.push([message as string, extra]);
+  });
+});
+
+afterEach(() => {
+  unsubscribeLogSink?.();
+  unsubscribeLogSink = undefined;
+});
 
 const {
   selectStale,
@@ -74,10 +97,6 @@ function failEmbed(code: EmbeddingError["code"]) {
     error: { code, message: "x", attempts: 1 } as EmbeddingError,
   }));
 }
-
-beforeEach(() => {
-  warnCalls.length = 0;
-});
 
 describe("detectableReasons", () => {
   it("full-provenance table detects missing, model_drift, source_drift", () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import { SECRET_PATTERNS } from "./secret-patterns.ts";
+import { isSensitiveKey, SECRET_PATTERNS } from "./secret-patterns.ts";
 import {
   createRotatingFileSink,
   type RotatingFileSink,
@@ -26,6 +26,16 @@ function resolveLevel(): LogLevel {
 let minLevel: LogLevel = resolveLevel();
 
 /**
+ * Monotonic token identifying the most recent `setLogLevel` decision.
+ *
+ * Exists so a call can tell "my temporary widened value is still installed"
+ * from "a nested call chose a value that happens to equal it" — see the restore
+ * in `setLogLevel`. Wraps harmlessly: only equality against a captured value is
+ * ever tested, never ordering.
+ */
+let levelGeneration = 0;
+
+/**
  * Raise or lower the active log level at runtime.
  *
  * @param level One of debug, info, warn, error. An unknown value is rejected
@@ -43,6 +53,14 @@ export function setLogLevel(level: string): LogLevel {
   }
   const previous = minLevel;
   const target = next as LogLevel;
+  // Claim a generation for this call. The restore below must fire only if
+  // nothing else assigned `minLevel` in the meantime, and "did anyone assign"
+  // is not answerable by comparing VALUES: a nested sink that deliberately
+  // sets exactly the widened level is indistinguishable from the widened level
+  // never having been touched. Review proved it -- a nested `setLogLevel`
+  // during a `debug -> error` transition asked for `debug`, was told `debug`,
+  // and the process ended at `error`. An identity token has no such collision.
+  const generation = ++levelGeneration;
   // Announce through whichever gate is more permissive, so the transition is
   // never filtered by the change itself. Emitting after the swap loses the line
   // when lowering verbosity (`info` -> `warn` hides its own `info` notice), and
@@ -69,7 +87,11 @@ export function setLogLevel(level: string): LogLevel {
     // unconditional restore silently reverted that nested change AND the nested
     // call returned its own target as though it had taken effect. A later
     // decision wins.
-    if (minLevel === widened) minLevel = target;
+    //
+    // Keyed on the generation, not on the value: a nested call bumps
+    // `levelGeneration`, so "someone else already decided" is detected even
+    // when they decided on the level this call had temporarily installed.
+    if (levelGeneration === generation) minLevel = target;
   }
   // `minLevel`, not `target`: the returned value must be what is actually in
   // effect, or a reentrant change is reported as the caller's own.
@@ -297,11 +319,17 @@ const MAX_REDACT_INPUT_CHARS = 16_384;
 
 export function redactForLog(value: string): string {
   if (!value) return value;
-  const bounded =
-    value.length > MAX_REDACT_INPUT_CHARS
-      ? `${value.slice(0, MAX_REDACT_INPUT_CHARS)}…[truncated ${value.length - MAX_REDACT_INPUT_CHARS} chars]`
-      : value;
-  let redacted = bounded;
+
+  // Redact FIRST, truncate second. The original order truncated first, which
+  // manufactured the leak it was meant to bound: a DSN straddling the 16 KB
+  // boundary was cut mid-credential, so no pattern matched the surviving head
+  // and `postgres://user:supe` went out in clear. Cutting a string cannot
+  // create a secret, but it can destroy the evidence that one is present.
+  //
+  // The quadratic `PRIVATE_KEY_BLOCK_RE` risk that motivated the bound still
+  // has to be handled, so the pathological input is capped before matching --
+  // see `boundForMatching` below -- rather than by truncating every input.
+  let redacted = boundForMatching(value);
   for (const pattern of SECRET_PATTERNS) {
     const flags = pattern.flags.includes("g")
       ? pattern.flags
@@ -311,7 +339,35 @@ export function redactForLog(value: string): string {
       "[REDACTED]",
     );
   }
-  return redacted;
+  return redacted.length > MAX_REDACT_INPUT_CHARS
+    ? `${redacted.slice(0, MAX_REDACT_INPUT_CHARS)}…[truncated ${redacted.length - MAX_REDACT_INPUT_CHARS} chars]`
+    : redacted;
+}
+
+/**
+ * Neutralize the one input shape that makes redaction itself expensive.
+ *
+ * `PRIVATE_KEY_BLOCK_RE` is quadratic on repeated `-----BEGIN` markers with no
+ * matching `-----END` (measured: 625 KB -> 3.9 s of blocked event loop). That
+ * is the only measured pathology, and it is driven by the *count of unmatched
+ * BEGIN markers*, not by length — so it is bounded directly instead of by
+ * truncating every long string, which is what split credentials before.
+ *
+ * Inputs with more BEGIN markers than could plausibly be real key blocks are
+ * collapsed to a marker-free summary; everything else is matched in full.
+ */
+const MAX_PRIVATE_KEY_MARKERS = 8;
+
+function boundForMatching(value: string): string {
+  if (value.length <= MAX_REDACT_INPUT_CHARS) return value;
+  const beginMarkers = value.match(/-----BEGIN /g)?.length ?? 0;
+  const endMarkers = value.match(/-----END /g)?.length ?? 0;
+  if (beginMarkers <= MAX_PRIVATE_KEY_MARKERS || beginMarkers === endMarkers) {
+    return value;
+  }
+  // Unbalanced and marker-dense: the quadratic case. Strip the markers so the
+  // block pattern cannot backtrack, and say so in the output.
+  return `${value.replace(/-----BEGIN /g, "[BEGIN] ")}…[key-marker dense input: ${beginMarkers} unmatched markers neutralized]`;
 }
 
 /**
@@ -347,17 +403,41 @@ function serializeEntry(
   level: LogLevel,
   message: string,
 ): string {
-  const seen = new WeakSet<object>();
+  // Ancestors along the CURRENT branch, not every object ever visited. A value
+  // is circular when it is its own ancestor; a `WeakSet` that only ever grows
+  // cannot express that, and review proved the consequence -- `{a: shared, b:
+  // shared}` with one plain non-circular object referenced twice serialized as
+  // `{"a":{"id":"abc"},"b":"[Circular]"}`, silently dropping real data. Sharing
+  // one `config`/`job`/`namespace` object across two fields is ordinary, so the
+  // false positive was the common case, not the edge case.
+  //
+  // `this` is the object currently being serialized, which `JSON.stringify`
+  // binds on each replacer call. Walking up from it gives the true ancestor
+  // chain, so the set shrinks again as serialization unwinds.
+  const ancestors: object[] = [];
   try {
-    return JSON.stringify(entry, function replacer(_key, value: unknown) {
+    return JSON.stringify(entry, function replacer(this: unknown, key, value) {
+      // Drop any ancestors we have finished with: everything after `this`.
+      const holderIndex = ancestors.indexOf(this as object);
+      if (holderIndex !== -1) ancestors.length = holderIndex + 1;
+
+      // The key decides before the value's own shape does. `redactForLog`
+      // recognizes secrets by their text, which cannot work for an arbitrary
+      // passphrase or an opaque rotated token; the field it arrived under is
+      // the only signal. This is the only place the key is in scope, which is
+      // exactly why the gap existed.
+      if (isSensitiveKey(key) && value !== null && value !== undefined) {
+        return "[REDACTED]";
+      }
+
       if (typeof value === "string") return redactForLog(value);
       if (typeof value === "bigint") return value.toString();
       if (typeof value === "function" || typeof value === "symbol") {
         return `[${typeof value}]`;
       }
       if (typeof value === "object" && value !== null) {
-        if (seen.has(value)) return "[Circular]";
-        seen.add(value);
+        if (ancestors.includes(value)) return "[Circular]";
+        ancestors.push(value);
       }
       return value;
     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import {
   createRotatingFileSink,
   type RotatingFileSink,
@@ -11,7 +12,73 @@ function resolveLevel(): LogLevel {
   if (env in LOG_LEVELS) return env as LogLevel;
   return "info";
 }
-const MIN_LEVEL = resolveLevel();
+
+/**
+ * Active minimum level. Mutable, not a module-load constant.
+ *
+ * A frozen level means the only way to raise verbosity during an incident is a
+ * restart — which destroys the in-flight state being investigated, and is the
+ * one moment the logs matter most. `setLogLevel` lets an operator turn debug on
+ * against a running process (the dogfood default is `debug`; production runs
+ * `info` or `warn`).
+ */
+let minLevel: LogLevel = resolveLevel();
+
+/**
+ * Raise or lower the active log level at runtime.
+ *
+ * @param level One of debug, info, warn, error. An unknown value is rejected
+ *   rather than silently coerced, because silently staying at the old level
+ *   during an incident looks identical to the setting having worked.
+ * @returns The level now in effect.
+ * @throws {Error} If `level` is not a known level.
+ */
+export function setLogLevel(level: string): LogLevel {
+  const next = level.trim().toLowerCase();
+  if (!(next in LOG_LEVELS)) {
+    throw new Error(
+      `unknown log level ${JSON.stringify(level)}; expected one of ${Object.keys(LOG_LEVELS).join(", ")}`,
+    );
+  }
+  const previous = minLevel;
+  const target = next as LogLevel;
+  // Announce through whichever gate is more permissive, so the transition is
+  // never filtered by the change itself. Emitting after the swap loses the line
+  // when lowering verbosity (`info` -> `warn` hides its own `info` notice), and
+  // emitting before it loses the line when raising from a level that already
+  // suppressed `info` (`error` -> `debug`). Widening for this one line makes
+  // "when did the level change?" answerable from the log in both directions.
+  minLevel = LOG_LEVELS[previous] < LOG_LEVELS[target] ? previous : target;
+  log("info", "log_level_changed", { from: previous, to: target });
+  minLevel = target;
+  return minLevel;
+}
+
+/** The level currently in effect. */
+export function getLogLevel(): LogLevel {
+  return minLevel;
+}
+
+/**
+ * Host identity stamped onto every line.
+ *
+ * Required by the shared observability envelope
+ * (`_DOCS/CODING_STANDARDS.md`, `## Observability`): `service` and `host` are
+ * the only two fields that become Loki labels, so every emitter on the fleet
+ * must carry both or the per-host query surface has holes. Read once — a
+ * process does not change hosts.
+ */
+const HOST_NAME = (() => {
+  const configured = process.env.HOSTNAME?.trim() || process.env.HOST?.trim();
+  if (configured) return configured;
+  try {
+    return os.hostname();
+  } catch {
+    // Deliberate fail-open: an unavailable hostname must degrade one label,
+    // never prevent logging. Reporting it through the logger would recurse.
+    return "unknown";
+  }
+})();
 
 /**
  * Optional rolling file sink (OB issue #193). When `LOG_FILE` is set the
@@ -159,9 +226,15 @@ function contextFields(): Record<string, unknown> {
 /**
  * A single emitted line.
  *
- * `timestamp`, `level`, `message`, `service`, and `correlation_id` are the
- * shared envelope. The first four are always present; `correlation_id` appears
- * whenever the line was emitted inside a `withContext()` scope.
+ * `timestamp`, `level`, `message`, `service`, `host`, and `correlation_id` are
+ * the shared envelope. The first five are always present and are stamped here,
+ * never passed by a caller; `correlation_id` appears whenever the line was
+ * emitted inside a `withContext()` scope.
+ *
+ * `service` and `host` are the only two fields that become Loki labels
+ * (`_DOCS/CODING_STANDARDS.md`, `## Observability`) — everything else stays in
+ * the body, because Loki builds one index stream per unique label combination
+ * and a high-cardinality label produces unbounded streams.
  *
  * `message` is a stable event name (`lane_scope_miss`), never a sentence — event
  * names are what Loki filters on.
@@ -171,6 +244,7 @@ interface LogEntry {
   message: string;
   timestamp: string;
   service: string;
+  host: string;
   [key: string]: unknown;
 }
 
@@ -179,7 +253,7 @@ function log(
   message: string,
   extra?: Record<string, unknown>,
 ): void {
-  if (LOG_LEVELS[level] < LOG_LEVELS[MIN_LEVEL]) return;
+  if (LOG_LEVELS[level] < LOG_LEVELS[minLevel]) return;
 
   // Envelope fields are owned here and stamped last so a caller cannot
   // accidentally shadow them with a same-named field: callers that spell
@@ -191,6 +265,7 @@ function log(
     message,
     timestamp: new Date().toISOString(),
     service: SERVICE_NAME,
+    host: HOST_NAME,
     ...contextFields(),
   };
   const output = JSON.stringify(entry);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -77,10 +77,100 @@ function resolveFileSink(): RotatingFileSink | undefined {
 
 const FILE_SINK = resolveFileSink();
 
+/**
+ * Service identity stamped onto every line. Part of the shared observability
+ * envelope (`_DOCS/CODING_STANDARDS.md`, `## Observability`) so that logs from
+ * every emitter on the fleet — applications and infrastructure alike — share one
+ * queryable shape in Loki.
+ *
+ * Read once at module load. When more than one worker writes, the worker name is
+ * appended so lines are attributable to the process that emitted them, matching
+ * how `deriveWorkerLogPath` separates their files.
+ */
+const SERVICE_NAME = (() => {
+  const base = process.env.SERVICE_NAME?.trim() || "open-brain";
+  const worker = process.env.OPEN_BRAIN_WORKER_NAME?.trim();
+  return worker ? `${base}.${worker}` : base;
+})();
+
+/**
+ * Async-scoped context reader, installed by `observability/context.ts`.
+ *
+ * Set through a registration function rather than imported directly: the
+ * observability wrappers import this module, so a static import back the other
+ * way would be circular. It stays undefined until something opts in, which keeps
+ * the logger usable on its own (scripts, tests, early boot) with no context
+ * machinery loaded.
+ */
+type ContextReader = () => Record<string, unknown> | undefined;
+let contextReader: ContextReader | undefined;
+
+/**
+ * Register the reader supplying async-scoped envelope fields.
+ *
+ * Called once by `observability/context.ts`. Not part of the call-site surface.
+ */
+export function setLogContextReader(reader: ContextReader): void {
+  contextReader = reader;
+}
+
+/**
+ * Additional sinks receiving every emitted entry as a structured object.
+ *
+ * Exists so a consumer can observe emitted lines without depending on global
+ * `console` state — which tests must not do, since Bun runs all test files in
+ * one process and a suite that swaps `console.error` without restoring it would
+ * otherwise silently break unrelated assertions.
+ *
+ * Also the extension point for a genuine second destination later (a metrics
+ * counter, an in-process ring buffer for `operator-doctor`) without touching
+ * the call sites.
+ */
+type ExtraSink = (entry: Record<string, unknown>) => void;
+const extraSinks = new Set<ExtraSink>();
+
+/**
+ * Subscribe to every emitted log entry.
+ *
+ * @param sink Called with each entry after the envelope is applied.
+ * @returns An unsubscribe function. Callers must call it, or the sink leaks.
+ */
+export function addLogSink(sink: ExtraSink): () => void {
+  extraSinks.add(sink);
+  return () => {
+    extraSinks.delete(sink);
+  };
+}
+
+function contextFields(): Record<string, unknown> {
+  if (!contextReader) return {};
+  // DELIBERATE FAIL-OPEN, and the one place in this codebase where an unlogged
+  // catch is correct: this runs *inside* the log path, so reporting the failure
+  // through the logger would recurse. A broken context reader must degrade the
+  // line to "no correlation id" rather than prevent the line from being written
+  // at all — losing the whole line is strictly worse than losing one field.
+  try {
+    return contextReader() ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * A single emitted line.
+ *
+ * `timestamp`, `level`, `message`, `service`, and `correlation_id` are the
+ * shared envelope. The first four are always present; `correlation_id` appears
+ * whenever the line was emitted inside a `withContext()` scope.
+ *
+ * `message` is a stable event name (`lane_scope_miss`), never a sentence — event
+ * names are what Loki filters on.
+ */
 interface LogEntry {
   level: string;
   message: string;
   timestamp: string;
+  service: string;
   [key: string]: unknown;
 }
 
@@ -91,14 +181,29 @@ function log(
 ): void {
   if (LOG_LEVELS[level] < LOG_LEVELS[MIN_LEVEL]) return;
 
+  // Envelope fields are owned here and stamped last so a caller cannot
+  // accidentally shadow them with a same-named field: callers that spell
+  // `service` or `correlation_id` differently per repo are how one query
+  // surface becomes several.
   const entry: LogEntry = {
+    ...extra,
     level,
     message,
     timestamp: new Date().toISOString(),
-    ...extra,
+    service: SERVICE_NAME,
+    ...contextFields(),
   };
   const output = JSON.stringify(entry);
   FILE_SINK?.write(output);
+  for (const sink of extraSinks) {
+    // A misbehaving observer must not silence the line for everyone else, and
+    // reporting through the logger from inside the logger would recurse.
+    try {
+      sink(entry);
+    } catch {
+      /* deliberate: see contextFields() */
+    }
+  }
   if (level === "error") {
     console.error(output);
   } else if (level === "warn") {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { SECRET_PATTERNS } from "./secret-patterns.ts";
 import {
   createRotatingFileSink,
   type RotatingFileSink,
@@ -48,7 +49,8 @@ export function setLogLevel(level: string): LogLevel {
   // emitting before it loses the line when raising from a level that already
   // suppressed `info` (`error` -> `debug`). Widening for this one line makes
   // "when did the level change?" answerable from the log in both directions.
-  minLevel = LOG_LEVELS[previous] < LOG_LEVELS[target] ? previous : target;
+  const widened = LOG_LEVELS[previous] < LOG_LEVELS[target] ? previous : target;
+  minLevel = widened;
   try {
     log("info", "log_level_changed", { from: previous, to: target });
   } finally {
@@ -60,8 +62,17 @@ export function setLogLevel(level: string): LogLevel {
     // intent on the one path this function exists for: an operator raising
     // verbosity mid-incident, on the box whose disk just filled, would silently
     // get debug-volume logging from a call that reported failure.
-    minLevel = target;
+    //
+    // Conditional, because the widened window runs registered sinks
+    // synchronously and one of them can reenter this function -- an
+    // auto-escalate-on-error sink is exactly the documented extension point. An
+    // unconditional restore silently reverted that nested change AND the nested
+    // call returned its own target as though it had taken effect. A later
+    // decision wins.
+    if (minLevel === widened) minLevel = target;
   }
+  // `minLevel`, not `target`: the returned value must be what is actually in
+  // effect, or a reentrant change is reported as the caller's own.
   return minLevel;
 }
 
@@ -259,6 +270,117 @@ interface LogEntry {
   [key: string]: unknown;
 }
 
+/**
+ * Strip known secret material from a string bound for a log entry.
+ *
+ * Applies `SECRET_PATTERNS` — the same detector set that gates shared-kb
+ * promotion and the Python client's `policy.py` — rather than a second, weaker
+ * redaction fork.
+ *
+ * `redactText()` is deliberately NOT reused here: it emits a `logger.warn` when
+ * it changes something, and this function runs *inside* the log path, so that
+ * would recurse. The patterns are applied directly and the substitution is
+ * silent; the redaction marker in the output is the evidence.
+ *
+ * Lives here, not in `observability/with-logging.ts` where it started, because
+ * review found it was applied only to `error_name`/`error_message`/`error_stack`
+ * — so the identical DSN went out redacted in `error_message` and in clear in a
+ * caller-supplied field on the same line. Redaction belongs at the envelope,
+ * which is here, and that also covers `contextFields()` output. `with-logging`
+ * imports it from this module; the reverse would be a cycle.
+ *
+ * The input is bounded first: `PRIVATE_KEY_BLOCK_RE` is quadratic on repeated
+ * `-----BEGIN` markers with no `END` (measured 625 KB -> 3.9 s of blocked event
+ * loop), and an unbounded string in a log line is its own problem regardless.
+ */
+const MAX_REDACT_INPUT_CHARS = 16_384;
+
+export function redactForLog(value: string): string {
+  if (!value) return value;
+  const bounded =
+    value.length > MAX_REDACT_INPUT_CHARS
+      ? `${value.slice(0, MAX_REDACT_INPUT_CHARS)}…[truncated ${value.length - MAX_REDACT_INPUT_CHARS} chars]`
+      : value;
+  let redacted = bounded;
+  for (const pattern of SECRET_PATTERNS) {
+    const flags = pattern.flags.includes("g")
+      ? pattern.flags
+      : `${pattern.flags}g`;
+    redacted = redacted.replace(
+      new RegExp(pattern.source, flags),
+      "[REDACTED]",
+    );
+  }
+  return redacted;
+}
+
+/**
+ * Serialize one entry without ever throwing, redacting every string it emits.
+ *
+ * Two review findings meet here, and both were reproduced.
+ *
+ * **It must not throw.** Every other step in `log()` is deliberately fail-open --
+ * `contextFields()` catches a throwing reader, the file sink is guarded, each
+ * extra sink is guarded -- but the bare `JSON.stringify(entry)` was not. A
+ * cycle, a `BigInt`, or a throwing `toJSON` in any caller field or context field
+ * lost the line on all four destinations *and* threw into arbitrary application
+ * code. The consequences went well past logging: `withLogging` replaced the real
+ * error with a serializer error on its failure path, `withFallback` threw
+ * instead of returning its fallback, and worst, at `debug` the entry line threw
+ * before `fn` was ever called -- so **raising the log level silently stopped
+ * work from running**. That is the exact scenario `setLogLevel` exists for.
+ * `src/audit-log.ts` already defends itself against "a cycle, a BigInt
+ * anywhere"; the shared envelope every emitter routes through did not.
+ *
+ * **It must redact the whole entry, not one contributor.** `redactForLog` was
+ * applied only to `error_name`/`error_message`/`error_stack`, so the identical
+ * DSN went out redacted in `error_message` and in clear in a caller field on the
+ * same line. Redacting at the envelope also covers `contextFields()` output,
+ * which nothing covered before.
+ *
+ * Values are handled rather than dropped: `bigint` becomes its digits, a cycle
+ * becomes `"[Circular]"`, a throwing getter becomes `"[Unserializable]"`. Losing
+ * one field is acceptable; losing the line during an incident is not.
+ */
+function serializeEntry(
+  entry: LogEntry,
+  level: LogLevel,
+  message: string,
+): string {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(entry, function replacer(_key, value: unknown) {
+      if (typeof value === "string") return redactForLog(value);
+      if (typeof value === "bigint") return value.toString();
+      if (typeof value === "function" || typeof value === "symbol") {
+        return `[${typeof value}]`;
+      }
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) return "[Circular]";
+        seen.add(value);
+      }
+      return value;
+    });
+  } catch {
+    // A throwing `toJSON`, or anything else the replacer could not tame. Emit
+    // the envelope alone so the line still lands and says why it is thin.
+    try {
+      return JSON.stringify({
+        level,
+        message: redactForLog(message),
+        timestamp: new Date().toISOString(),
+        service: SERVICE_NAME,
+        host: HOST_NAME,
+        log_serialize_failed: true,
+      });
+    } catch {
+      // Envelope-only serialization cannot realistically fail; if it somehow
+      // does, a hand-built string still beats losing the line.
+      return `{"level":"${level}","message":"log_serialize_failed","service":"${SERVICE_NAME}","host":"${HOST_NAME}"}`;
+    }
+  }
+}
+
 function log(
   level: LogLevel,
   message: string,
@@ -286,21 +408,42 @@ function log(
     service: SERVICE_NAME,
     host: HOST_NAME,
   };
-  const output = JSON.stringify(entry);
+  const output = serializeEntry(entry, level, message);
+  // Sinks receive the SERIALIZED-then-parsed entry, not the raw object. Review
+  // found that redacting only inside `serializeEntry` left every extra sink
+  // reading the unredacted original -- so a credential-bearing caller field went
+  // out in clear to any observer while the file and console saw `[REDACTED]`.
+  // Round-tripping guarantees all three destinations see byte-identical data,
+  // and it is the same object shape sinks already expected.
+  let delivered: LogEntry = entry;
   try {
-    FILE_SINK?.write(output);
+    delivered = JSON.parse(output) as LogEntry;
   } catch {
-    // Deliberate, and the same reasoning as the extra sinks below: a full or
-    // unwritable disk must degrade to console-only, never take the line down
-    // with it. Unguarded, this threw before the console sinks ran, so the one
-    // failure most likely to coincide with an incident -- the disk filling --
-    // also blinded the operator investigating it.
+    // serializeEntry never returns invalid JSON, but a sink getting the raw
+    // entry is still better than no line at all.
   }
-  for (const sink of extraSinks) {
+  // NOT wrapped in try/catch, deliberately. An earlier revision guarded this,
+  // reasoning that a full disk must not take the line down with it. The
+  // reasoning was right and the guard was redundant: `createRotatingFileSink`
+  // documents "Never throws on write" and already wraps its `appendFileSync` in
+  // a try/catch that re-syncs and continues (`rotating-file.ts`). A review lane
+  // caught that the guard had no test which failed when it was reverted; the
+  // reason it could not be tested is that the throw it caught cannot occur.
+  // Keeping a guard for an impossible case makes the next reader believe this
+  // sink is a throwing one.
+  FILE_SINK?.write(output);
+  // Snapshot, not the live Set. `Set` iteration observes mutation, so a sink
+  // that re-subscribes itself during an emit lands back at the tail and is
+  // reached again by the same loop -- one log line drove a sink 50,001 times in
+  // review before a circuit breaker stopped it. It is inside the per-sink
+  // catch, so it surfaces as a silent hang rather than an error. A snapshot
+  // also makes "a sink added mid-emit does not receive the in-flight line"
+  // defined rather than incidental.
+  for (const sink of [...extraSinks]) {
     // A misbehaving observer must not silence the line for everyone else, and
     // reporting through the logger from inside the logger would recurse.
     try {
-      sink(entry);
+      sink(delivered);
     } catch {
       /* deliberate: see contextFields() */
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -49,8 +49,19 @@ export function setLogLevel(level: string): LogLevel {
   // suppressed `info` (`error` -> `debug`). Widening for this one line makes
   // "when did the level change?" answerable from the log in both directions.
   minLevel = LOG_LEVELS[previous] < LOG_LEVELS[target] ? previous : target;
-  log("info", "log_level_changed", { from: previous, to: target });
-  minLevel = target;
+  try {
+    log("info", "log_level_changed", { from: previous, to: target });
+  } finally {
+    // `finally`, not a plain assignment: the widened gate above is a temporary
+    // state that exists only for the announce line, and `log` can throw for
+    // real -- FILE_SINK.write fails on a full or unwritable disk. Without this,
+    // a throw leaves minLevel stuck at the WIDENED value while the caller sees
+    // an error and reasonably concludes nothing changed. That inverts the
+    // intent on the one path this function exists for: an operator raising
+    // verbosity mid-incident, on the box whose disk just filled, would silently
+    // get debug-volume logging from a call that reported failure.
+    minLevel = target;
+  }
   return minLevel;
 }
 
@@ -261,15 +272,30 @@ function log(
   // surface becomes several.
   const entry: LogEntry = {
     ...extra,
+    // Context spreads BEFORE the envelope, not after. It used to spread last,
+    // which meant a context reader returning `service`, `host`, or `level`
+    // silently overrode the fields this block claims to own -- and `service`
+    // and `host` are the only two that become Loki labels, so one mislabelled
+    // reader splits the query surface with nothing in the output saying so.
+    // Context supplies correlation fields; it does not get to rename the
+    // service.
+    ...contextFields(),
     level,
     message,
     timestamp: new Date().toISOString(),
     service: SERVICE_NAME,
     host: HOST_NAME,
-    ...contextFields(),
   };
   const output = JSON.stringify(entry);
-  FILE_SINK?.write(output);
+  try {
+    FILE_SINK?.write(output);
+  } catch {
+    // Deliberate, and the same reasoning as the extra sinks below: a full or
+    // unwritable disk must degrade to console-only, never take the line down
+    // with it. Unguarded, this threw before the console sinks ran, so the one
+    // failure most likely to coincide with an incident -- the disk filling --
+    // also blinded the operator investigating it.
+  }
   for (const sink of extraSinks) {
     // A misbehaving observer must not silence the line for everyone else, and
     // reporting through the logger from inside the logger would recurse.

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -12,6 +12,10 @@ const LEASE_RENEW_DIVISOR = 3;
 // more than its available concurrency, but a direct caller must not be able to
 // drain or lock the whole table in one statement.
 const MAX_CLAIM_LIMIT = 256;
+// How often an IDLE runner re-proves it is alive. Long enough that a healthy
+// idle queue costs ~48 lines/day instead of ~17k at the 5s poll cadence, short
+// enough that a stalled runner is obvious within one window.
+const IDLE_LOG_INTERVAL_MS = 1_800_000;
 // Namespace token shape, mirroring the delegated-id/header-namespace path used
 // elsewhere so the queue cannot mint exotic namespaces. Queue mechanics never
 // infer a namespace; this only validates one a caller opts into.
@@ -631,6 +635,12 @@ export class MaintenanceQueueRunner {
   private interval: ReturnType<typeof setInterval> | null = null;
   private tickPromise: Promise<void> | null = null;
   private stopping = false;
+  // Liveness counters. `ticks` proves the poll loop is turning; `lastIdleLogAt`
+  // rate-limits the idle line so an alive-but-idle runner is visible without
+  // flooding the log. 0 means "not yet logged", so the first idle tick always
+  // emits and startup is provable immediately.
+  private ticks = 0;
+  private lastIdleLogAt = 0;
 
   constructor(private readonly options: MaintenanceQueueRunnerOptions) {
     this.concurrency = Math.min(
@@ -708,6 +718,41 @@ export class MaintenanceQueueRunner {
         error_category: safeMaintenanceErrorCategory(error),
       });
       return;
+    }
+
+    // Liveness signal. Without this, an idle runner and a dead runner are
+    // indistinguishable in the log: the only lines emitted were completion and
+    // failure, so "no output" meant either "polling normally, nothing to do" or
+    // "not polling at all". Silence must never be the only evidence.
+    //
+    // NOT one line per poll: at the 5s default that is ~17k lines/day of noise,
+    // which is its own way of hiding a signal. Instead a claim is always logged,
+    // and an empty poll is logged on the first tick and then only once per
+    // heartbeat window, so an idle runner still proves it is alive.
+    this.ticks += 1;
+    if (jobs.length > 0) {
+      this.options.logger.info("maintenance queue claimed jobs", {
+        claimed: jobs.length,
+        available,
+        active: this.active.size,
+        job_kinds: [...new Set(jobs.map((job) => job.kind))].join(","),
+        ticks_since_start: this.ticks,
+      });
+      this.lastIdleLogAt = 0;
+    } else {
+      const nowMs = this.now().getTime();
+      if (
+        this.lastIdleLogAt === 0 ||
+        nowMs - this.lastIdleLogAt >= IDLE_LOG_INTERVAL_MS
+      ) {
+        this.options.logger.info("maintenance queue idle", {
+          polls: this.ticks,
+          poll_interval_ms: this.pollIntervalMs,
+          concurrency: this.concurrency,
+          active: this.active.size,
+        });
+        this.lastIdleLogAt = nowMs;
+      }
     }
 
     // No mid-loop stopping guard: these rows are already leased to this runner,

--- a/src/middleware/request-logger.test.ts
+++ b/src/middleware/request-logger.test.ts
@@ -4,16 +4,26 @@ import {
   test,
   mock,
   beforeEach,
-  afterAll,
+  afterEach,
   spyOn,
 } from "bun:test";
 import type { Request, Response, NextFunction } from "express";
 import { logger } from "../logger.ts";
 import { requestLogger } from "./request-logger.ts";
 
-// Spy on logger.info instead of mock.module to avoid global module pollution
-const loggerInfoSpy = spyOn(logger, "info");
-const loggerWarnSpy = spyOn(logger, "warn");
+// Spy on logger.info instead of mock.module to avoid global module pollution.
+//
+// The spies are installed per-test rather than at module scope. `spyOn` mutates
+// the shared `logger` object, and module-scope installation takes effect the
+// moment Bun LOADS this file — before any test here runs, and for every suite
+// that runs afterward, since Bun executes all test files in one process. A
+// restore in `afterAll` does not close that window: it fires only after this
+// describe completes, so a suite loaded in between still sees a silenced
+// logger. `src/observability/observability.test.ts` asserts on lines the real
+// logger emits, and a swallowing spy left installed made all 20 of its tests
+// fail from a cause in this file.
+let loggerInfoSpy: ReturnType<typeof spyOn<typeof logger, "info">>;
+let loggerWarnSpy: ReturnType<typeof spyOn<typeof logger, "warn">>;
 
 // Helpers
 function mockReq(overrides: Partial<Record<string, unknown>> = {}) {
@@ -50,11 +60,13 @@ function lastInfoCall(): LogCall {
 
 describe("requestLogger middleware", () => {
   beforeEach(() => {
-    loggerInfoSpy.mockClear();
-    loggerWarnSpy.mockClear();
+    loggerInfoSpy = spyOn(logger, "info");
+    loggerWarnSpy = spyOn(logger, "warn");
   });
 
-  afterAll(() => {
+  afterEach(() => {
+    // Restore per test, not per file: the shared `logger` object must be intact
+    // for any suite that runs after this one.
     loggerInfoSpy.mockRestore();
     loggerWarnSpy.mockRestore();
   });

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -1,0 +1,75 @@
+/**
+ * Async-scoped log context — the TypeScript equivalent of Loguru's
+ * `contextualize()`.
+ *
+ * A `correlation_id` that has to be threaded through call signatures by hand
+ * gets dropped somewhere, and the five log points for one operation then have
+ * no field tying them together. `AsyncLocalStorage` carries the context across
+ * `await` boundaries instead, so every line emitted inside `withContext()`
+ * inherits it without any call site passing it.
+ *
+ * Implements the shared observability envelope in
+ * `_DOCS/CODING_STANDARDS.md` (`## Observability`). No dependency: Node and Bun
+ * both ship `AsyncLocalStorage`.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { setLogContextReader } from "../logger.ts";
+
+/**
+ * Fields inherited by every log line emitted inside a `withContext()` scope.
+ *
+ * `correlation_id` is the only required member: it is what makes an operation's
+ * entry, exit, failure, degraded, and guard lines queryable as one unit. Extra
+ * fields are merged in and behave the same way.
+ */
+export interface LogContext {
+  correlation_id: string;
+  [key: string]: unknown;
+}
+
+const STORE = new AsyncLocalStorage<LogContext>();
+
+// Importing this module opts the logger into async-scoped envelope fields.
+// Registration rather than a static import the other way, because the logger is
+// the dependency here and a two-way static import would be circular.
+setLogContextReader(() => STORE.getStore());
+
+/**
+ * Run `fn` with `fields` attached to every log line it emits, including lines
+ * emitted after an `await`.
+ *
+ * Nested scopes merge rather than replace, so an inner scope can add a
+ * `lane_id` without discarding the outer `correlation_id`. An inner field of
+ * the same name wins.
+ *
+ * @param fields Context to attach. A nested call may omit `correlation_id`,
+ *   inheriting the enclosing scope's value.
+ * @param fn Work to run inside the scope.
+ * @returns Whatever `fn` returns.
+ */
+export function withContext<T>(
+  fields: Partial<LogContext> & Record<string, unknown>,
+  fn: () => T,
+): T {
+  const parent = STORE.getStore();
+  const merged = { ...parent, ...fields } as LogContext;
+  return STORE.run(merged, fn);
+}
+
+/**
+ * Current context, or `undefined` outside any `withContext()` scope.
+ *
+ * Callers should not normally need this — the logger reads it automatically.
+ * It is exported for the rare case of forwarding a correlation id across a
+ * process or transport boundary, where it cannot be inherited.
+ */
+export function currentContext(): LogContext | undefined {
+  return STORE.getStore();
+}
+
+/**
+ * Correlation id of the current scope, or `undefined` outside one.
+ */
+export function currentCorrelationId(): string | undefined {
+  return STORE.getStore()?.correlation_id;
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Observability surface for open-brain.
+ *
+ * Implements the shared contract in `_DOCS/CODING_STANDARDS.md`
+ * (`## Observability` + `### TypeScript observability spellings`). rtech-infra's
+ * standards repo will eventually publish this as an installable package; this
+ * module is open-brain's conforming implementation until then, and is
+ * deliberately shaped so it can be swapped for that import.
+ *
+ * The whole surface a service author needs:
+ *
+ * ```ts
+ * import { logger, withContext, withLogging } from "./observability/index.ts";
+ *
+ * await withContext({ correlation_id: requestId }, async () => {
+ *   await withLogging("lane_context_load", async () => {
+ *     if (!lane) logger.warn("lane_scope_miss", { session_key });
+ *   });
+ * });
+ * ```
+ *
+ * Rules this exists to make cheaper to follow than to break:
+ *
+ * - **Silence is a signal.** No log line must reliably mean success, so every
+ *   degraded path emits a warning. `withFallback()` makes a deliberate
+ *   fail-open one call instead of a silent `catch { return null }`.
+ * - **Never swallow an error.** `withLogging()` logs and re-throws.
+ * - **One envelope.** `timestamp`, `level`, `message`, `service`, and
+ *   `correlation_id` are stamped by the logger, never supplied by callers, so
+ *   application and infrastructure logs share one Loki query surface.
+ * - **`message` is a stable event name**, never a sentence.
+ *
+ * Emission stays deliberately dumb: structured JSON to stdout plus a rotating
+ * file (1 MB, 3 retained). Shipping is not this process's job — Alloy tails the
+ * output into Loki. The application must never know its destination.
+ */
+export { logger } from "../logger.ts";
+export {
+  withContext,
+  currentContext,
+  currentCorrelationId,
+  type LogContext,
+} from "./context.ts";
+export { withLogging, withFallback, describeError } from "./with-logging.ts";

--- a/src/observability/observability.test.ts
+++ b/src/observability/observability.test.ts
@@ -300,6 +300,87 @@ describe("redaction covers the whole entry", () => {
     const line = captured.find((l) => l.message === "pathological");
     expect(line).toBeDefined();
   });
+
+  it("redacts a credential that straddles the truncation boundary", () => {
+    // Sol final-gate finding, HIGH. The bound was applied BEFORE the patterns
+    // ran, so a DSN crossing the 16 KB cut was split mid-credential, no pattern
+    // matched the surviving head, and the tail went out in clear. Truncating
+    // cannot create a secret but it can destroy the evidence of one, so
+    // redaction now runs first and the bound is applied to the result.
+    captured.length = 0;
+    const secret = "postgres://user:hunter2straddle@10.71.1.21:5432/openbrain";
+    const blob = `${"x".repeat(16_384 - 20)}${secret}`;
+
+    logger.info("straddling_secret", { blob });
+
+    const line = captured.find((l) => l.message === "straddling_secret");
+    expect(line).toBeDefined();
+    // Pre-fix: "postgres://user:hunter2s" survived the cut unredacted.
+    expect(JSON.stringify(line)).not.toContain("hunter2straddle");
+    expect(JSON.stringify(line)).not.toContain("postgres://user:");
+  });
+
+  it("redacts a value by its field name when the value has no secret shape", () => {
+    // Sol final-gate finding, HIGH. Every detector is value-shaped -- it
+    // recognizes `sk-…`, `ghp_…`, or the text `password=…`. But a JSON logger
+    // hands the replacer each value in ISOLATION, so an arbitrary passphrase
+    // under a field called `password` has nothing to match on and went out in
+    // clear. `json_labeled_secret` already describes this exact pair; it was
+    // simply never shown the key.
+    captured.length = 0;
+
+    logger.info("structured_secret", {
+      password: "hunter2driveway",
+      api_key: "plainvalue123",
+      db_dsn: "opaque-rotated-value",
+      // Control: a non-sensitive field must stay readable.
+      namespace: "shared-kb",
+    });
+
+    const line = captured.find((l) => l.message === "structured_secret");
+    expect(line).toBeDefined();
+    const serialized = JSON.stringify(line);
+    // Pre-fix: all three values appeared verbatim.
+    expect(serialized).not.toContain("hunter2driveway");
+    expect(serialized).not.toContain("plainvalue123");
+    expect(serialized).not.toContain("opaque-rotated-value");
+    expect(line?.namespace).toBe("shared-kb");
+  });
+});
+
+describe("serialization preserves data it is not required to drop", () => {
+  it("keeps a repeated non-circular object on both fields", () => {
+    // Sol final-gate finding, HIGH. Cycle detection used a WeakSet that only
+    // ever grew, so it flagged any object seen a SECOND time -- including one
+    // referenced from two sibling fields, which is not a cycle at all. Sharing
+    // a single config/job/namespace object across fields is ordinary, so the
+    // false positive was the common case and it silently dropped real data.
+    captured.length = 0;
+    const shared = { id: "abc" };
+
+    logger.info("repeated_object", { a: shared, b: shared });
+
+    const line = captured.find((l) => l.message === "repeated_object");
+    expect(line).toBeDefined();
+    // Pre-fix: b was the string "[Circular]".
+    expect(line?.a).toEqual({ id: "abc" });
+    expect(line?.b).toEqual({ id: "abc" });
+  });
+
+  it("still marks a genuine cycle rather than throwing", () => {
+    // The guard against over-correcting the finding above: a real self
+    // reference must still be caught, or the fix trades a data-loss bug for a
+    // RangeError that loses the whole line.
+    captured.length = 0;
+    const cyclic: Record<string, unknown> = { name: "root" };
+    cyclic.self = cyclic;
+
+    logger.info("true_cycle", { cyclic });
+
+    const line = captured.find((l) => l.message === "true_cycle");
+    expect(line).toBeDefined();
+    expect((line?.cyclic as Record<string, unknown>).self).toBe("[Circular]");
+  });
 });
 
 describe("an unwritable file sink degrades to console", () => {
@@ -498,6 +579,35 @@ describe("runtime log level", () => {
     // The outer call must report what is actually in effect, not what it asked
     // for -- otherwise a reentrant change is reported as the caller's own.
     expect(outerReturn).toBe("error");
+  });
+
+  it("lets a nested setLogLevel win even when it picks the widened level", () => {
+    // Sol final-gate finding. The restore guard was `minLevel === widened`,
+    // which cannot distinguish "my temporary widened value is still installed"
+    // from "a nested call deliberately chose that same value".
+    //
+    // Lowering debug -> error makes `widened` the PREVIOUS level, "debug". An
+    // auto-escalate sink that wants to stay at debug therefore sets exactly the
+    // widened value, the equality guard reads it as untouched, and the outer
+    // finally overwrites the nested decision. The test above passes with the
+    // old code because its nested call picks "error", which differs from the
+    // widened "debug"; only the colliding value exposes it.
+    setLogLevel("debug");
+    let nestedReturn = "";
+    const off = addLogSink((entry) => {
+      if (entry.message === "log_level_changed" && entry.to === "error") {
+        nestedReturn = setLogLevel("debug");
+      }
+    });
+
+    const outerReturn = setLogLevel("error");
+    off();
+
+    expect(nestedReturn).toBe("debug");
+    // Pre-fix: "error" -- the nested decision was silently reverted while the
+    // nested call had already reported "debug" as taking effect.
+    expect(getLogLevel()).toBe("debug");
+    expect(outerReturn).toBe("debug");
   });
 
   it("announces the change so the transition is visible in the stream", () => {

--- a/src/observability/observability.test.ts
+++ b/src/observability/observability.test.ts
@@ -146,6 +146,231 @@ describe("describeError redaction", () => {
   });
 });
 
+describe("the emit path never throws at the call site", () => {
+  // Review lane finding, both lanes independently, HIGH. `JSON.stringify(entry)`
+  // was the one unguarded step in `log()` -- every neighbour is deliberately
+  // fail-open. A cycle, a BigInt, or a throwing toJSON in ANY caller field or
+  // context field lost the line on all four destinations and threw into
+  // arbitrary application code.
+  const cyclic = () => {
+    const o: Record<string, unknown> = { name: "ctx" };
+    o.self = o;
+    return o;
+  };
+
+  it("emits a line for a cyclic field instead of throwing", () => {
+    captured.length = 0;
+
+    expect(() => logger.info("cyclic_field", { ctx: cyclic() })).not.toThrow();
+
+    const line = captured.find((l) => l.message === "cyclic_field");
+    expect(line).toBeDefined();
+  });
+
+  it("emits a line for a BigInt field instead of throwing", () => {
+    captured.length = 0;
+
+    expect(() => logger.info("bigint_field", { row_id: 7n })).not.toThrow();
+
+    const line = captured.find((l) => l.message === "bigint_field");
+    expect(line).toBeDefined();
+    expect(line!.row_id).toBe("7");
+  });
+
+  it("emits a line when a field's toJSON throws", () => {
+    captured.length = 0;
+    const hostile = {
+      toJSON() {
+        throw new Error("toJSON boom");
+      },
+    };
+
+    expect(() => logger.info("hostile_field", { hostile })).not.toThrow();
+
+    // The envelope-only fallback still lands, and says why it is thin.
+    const line = captured.find(
+      (l) => l.message === "hostile_field" || l.log_serialize_failed === true,
+    );
+    expect(line).toBeDefined();
+  });
+
+  it("still runs the wrapped operation at debug with an unserializable field", async () => {
+    // The worst consequence: `withLogging` emits its entry line at debug BEFORE
+    // calling fn. At info that line is gated out and fn runs; at debug the same
+    // call threw and fn was NEVER invoked. Raising the log level to investigate
+    // an incident silently stopped work from running -- the exact scenario
+    // setLogLevel exists for.
+    const original = getLogLevel();
+    setLogLevel("debug");
+    let ran = false;
+    try {
+      await withLogging(
+        "critical_op",
+        async () => {
+          ran = true;
+          return "ok";
+        },
+        { ctx: cyclic() },
+      );
+    } finally {
+      setLogLevel(original);
+    }
+
+    expect(ran).toBe(true);
+  });
+
+  it("re-throws the caller's original error by identity", async () => {
+    // `withLogging` documents "re-throws whatever fn throws, unchanged". A
+    // serializer throw from the logging wrapper replaced the real root cause.
+    const real = new Error("real root cause");
+    let caught: unknown;
+    try {
+      await withLogging(
+        "op",
+        async () => {
+          throw real;
+        },
+        { ctx: cyclic() },
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(real);
+  });
+
+  it("withFallback returns the fallback rather than throwing", async () => {
+    const result = await withFallback(
+      "cache_read",
+      async () => {
+        throw new Error("miss");
+      },
+      "FALLBACK",
+      { key: 1n },
+    );
+
+    expect(result).toBe("FALLBACK");
+  });
+});
+
+describe("redaction covers the whole entry", () => {
+  it("redacts caller-supplied fields, not just error_* fields", () => {
+    // Review lane finding, HIGH. `redactForLog` was applied only to
+    // error_name/error_message/error_stack, so the IDENTICAL credential went
+    // out redacted in error_message and in clear in a caller field on the same
+    // line. Redaction belongs at the envelope.
+    captured.length = 0;
+
+    logger.error("nats_connect_failed", {
+      dsn: "nats://user:hunter2@10.71.1.21:4222",
+    });
+
+    const line = captured.find((l) => l.message === "nats_connect_failed");
+    expect(line).toBeDefined();
+    expect(JSON.stringify(line)).not.toContain("hunter2");
+  });
+
+  it("redacts context fields too", () => {
+    captured.length = 0;
+
+    withContext(
+      { correlation_id: "cid-x", token: "Bearer AAAAAAAAAAAAAAAAAAAA" },
+      () => {
+        logger.info("ctx_secret");
+      },
+    );
+
+    const line = captured.find((l) => l.message === "ctx_secret");
+    expect(line).toBeDefined();
+    expect(JSON.stringify(line)).not.toContain("AAAAAAAAAAAAAAAAAAAA");
+  });
+
+  it("bounds the redaction input so a pathological string cannot stall the loop", () => {
+    // PRIVATE_KEY_BLOCK_RE is quadratic on repeated BEGIN markers with no END:
+    // measured 625 KB -> 3.9 s of blocked event loop. An unbounded string in a
+    // log line is its own problem regardless of the pattern.
+    captured.length = 0;
+    const pathological = "-----BEGIN PRIVATE KEY-----".repeat(20_000);
+
+    const started = Date.now();
+    logger.info("pathological", { blob: pathological });
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(1_000);
+    const line = captured.find((l) => l.message === "pathological");
+    expect(line).toBeDefined();
+  });
+});
+
+describe("an unwritable file sink degrades to console", () => {
+  it("still emits the line when LOG_FILE cannot be written", async () => {
+    // Review lane finding, HIGH — against the TEST, not the code. A self-review
+    // "fix" had wrapped `FILE_SINK?.write` in try/catch, and the lane proved no
+    // test failed when that guard was reverted.
+    //
+    // Chasing that down showed the guard was defending against an impossible
+    // case: `createRotatingFileSink` documents "Never throws on write" and
+    // already wraps `appendFileSync` in its own try/catch. The guard is now
+    // gone; what remains worth pinning is the BEHAVIOUR both were aiming at,
+    // which nothing covered either way — an unwritable LOG_FILE must still
+    // produce the line on console.
+    //
+    // A subprocess is the only honest way in: FILE_SINK is resolved once at
+    // module load, so the suite (which runs with LOG_FILE unset) can never
+    // exercise it in-process.
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "-e",
+        `const { logger } = await import("${import.meta.dir}/../logger.ts");
+         logger.error("disk_full_still_logs", { probe: 1 });`,
+      ],
+      {
+        env: {
+          ...process.env,
+          // A directory that cannot exist as a file's parent -> every write throws.
+          LOG_FILE: "/proc/nonexistent/open-brain.log",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    // The process must survive AND the line must reach console.error.
+    expect(exitCode).toBe(0);
+    expect(`${stdout}${stderr}`).toContain("disk_full_still_logs");
+  });
+});
+
+describe("sink registration", () => {
+  it("does not re-deliver a line to a sink that re-subscribes mid-emit", () => {
+    // `Set` iteration observes mutation, so a sink that disposes and re-adds
+    // itself landed back at the tail and was reached again by the same loop --
+    // one log line drove a sink 50,001 times before a circuit breaker stopped
+    // it. Inside the per-sink catch, so it presented as a silent hang.
+    let calls = 0;
+    let dispose: (() => void) | undefined;
+    const sink = () => {
+      calls += 1;
+      if (calls > 100) return; // circuit breaker, so a regression fails loudly
+      dispose?.();
+      dispose = addLogSink(sink);
+    };
+    dispose = addLogSink(sink);
+
+    logger.info("one_line");
+
+    dispose?.();
+    expect(calls).toBe(1);
+  });
+});
+
 describe("envelope ownership", () => {
   it("does not let async context override service, host, or level", () => {
     // `service` and `host` are the only two envelope fields that become Loki
@@ -249,6 +474,30 @@ describe("runtime log level", () => {
     // Pre-fix: "debug" -- stuck at the widened gate, so the process keeps
     // emitting debug volume after a call that reported failure.
     expect(getLogLevel()).toBe("error");
+  });
+
+  it("lets a nested setLogLevel from a sink win, and reports what took effect", () => {
+    // Review lane finding. The `finally` restore was unconditional, but the
+    // widened window runs sinks synchronously and one can reenter -- an
+    // auto-escalate-on-error sink is the documented extension point. The nested
+    // call set the level, returned its own target as though it stuck, and the
+    // outer `finally` then silently reverted it.
+    setLogLevel("info");
+    let nestedReturn = "";
+    const off = addLogSink((entry) => {
+      if (entry.message === "log_level_changed" && entry.to === "debug") {
+        nestedReturn = setLogLevel("error");
+      }
+    });
+
+    const outerReturn = setLogLevel("debug");
+    off();
+
+    expect(nestedReturn).toBe("error");
+    expect(getLogLevel()).toBe("error");
+    // The outer call must report what is actually in effect, not what it asked
+    // for -- otherwise a reentrant change is reported as the caller's own.
+    expect(outerReturn).toBe("error");
   });
 
   it("announces the change so the transition is visible in the stream", () => {

--- a/src/observability/observability.test.ts
+++ b/src/observability/observability.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Behavioral tests for the observability surface.
+ *
+ * These assert what a log consumer actually receives — the parsed JSON lines a
+ * Loki query would match — for varied inputs. They do not assert internal call
+ * shapes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { logger, addLogSink } from "../logger.ts";
+import { withContext, currentCorrelationId } from "./context.ts";
+import { withLogging, withFallback, describeError } from "./with-logging.ts";
+
+type Line = Record<string, unknown>;
+
+// Log lines are observed through the logger's own sink rather than by swapping
+// `console.*`: Bun runs every test file in one process, and other suites here
+// replace console methods inline without restoring them.
+//
+// These tests are also why no suite may `mock.module("./logger.ts")`. That mock
+// is process-wide and permanent in Bun — keyed by resolved specifier, never
+// scoped to one file, and not undone by `mock.restore()`. This module's subject
+// IS the real logger, so any stub of it makes every assertion below vacuous:
+// the sink is never invoked, `captured` stays empty, and the failure surfaces
+// here while its cause lives in another file. Suites needing to assert on log
+// output use `addLogSink` instead, which observes without replacing.
+
+let captured: Line[] = [];
+let unsubscribe: (() => void) | undefined;
+
+beforeEach(() => {
+  captured = [];
+  unsubscribe = addLogSink((entry) => {
+    captured.push(entry as Line);
+  });
+
+  // Prove the sink is really wired before any assertion depends on it.
+  // Checking `typeof addLogSink === "function"` is not enough: a stubbed
+  // logger exporting `addLogSink: () => () => {}` satisfies that check while
+  // never invoking the sink, which is exactly how this suite once failed 18
+  // assertions with an empty `captured` and no indication why. Emitting a line
+  // and requiring it back detects a no-op stub as well as a missing export.
+  // `info`, not `debug`: the default MIN_LEVEL is "info", so a debug probe is
+  // dropped by the level gate and would report a broken sink on a healthy one.
+  const probeIndex = captured.length;
+  logger.info("observability_sink_probe");
+  if (captured.length === probeIndex) {
+    unsubscribe();
+    unsubscribe = undefined;
+    throw new Error(
+      "logger.addLogSink did not deliver an emitted line — ../logger.ts has " +
+        "been replaced, almost certainly by a `mock.module` stub in a test file " +
+        "loaded earlier in this run (the stub is process-wide and permanent). " +
+        "Find it with `grep -rn 'mock.module' src scripts` and convert it to " +
+        "observe via `addLogSink`. Do not weaken this check.",
+    );
+  }
+  captured = [];
+});
+
+afterEach(() => {
+  unsubscribe?.();
+  unsubscribe = undefined;
+});
+
+describe("shared envelope", () => {
+  it("stamps every line with the envelope fields", () => {
+    logger.info("thing_happened", { count: 3 });
+
+    const [line] = captured;
+    expect(line).toBeDefined();
+    expect(line!.level).toBe("info");
+    expect(line!.message).toBe("thing_happened");
+    expect(typeof line!.service).toBe("string");
+    expect(String(line!.service).length).toBeGreaterThan(0);
+    expect(typeof line!.timestamp).toBe("string");
+    // caller fields survive alongside the envelope
+    expect(line!.count).toBe(3);
+  });
+
+  it("emits an ISO-8601 timestamp a log pipeline can parse", () => {
+    logger.info("t");
+    const stamp = String(captured[0]!.timestamp);
+    expect(Number.isNaN(Date.parse(stamp))).toBe(false);
+    expect(stamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("does not let a caller field shadow an envelope field", () => {
+    // Two repos spelling `service` differently is how one query surface
+    // becomes several, so the envelope must win over caller input.
+    logger.info("evt", { service: "impostor", level: "debug" });
+
+    const line = captured[0]!;
+    expect(line.service).not.toBe("impostor");
+    expect(line.level).toBe("info");
+  });
+
+  it("omits correlation_id outside any context scope", () => {
+    logger.info("no_scope");
+    expect(captured[0]!.correlation_id).toBeUndefined();
+  });
+});
+
+describe("withContext", () => {
+  it("attaches correlation_id to lines emitted inside the scope", async () => {
+    await withContext({ correlation_id: "abc-123" }, async () => {
+      logger.info("inside");
+    });
+
+    expect(captured[0]!.correlation_id).toBe("abc-123");
+  });
+
+  it("survives await boundaries", async () => {
+    await withContext({ correlation_id: "across-await" }, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      logger.info("after_await");
+    });
+
+    expect(captured[0]!.correlation_id).toBe("across-await");
+  });
+
+  it("keeps concurrent operations' ids separate", async () => {
+    // The failure this guards against is two in-flight requests sharing one id,
+    // which would make both operations unreadable in Loki.
+    await Promise.all([
+      withContext({ correlation_id: "req-A" }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        logger.info("from_a");
+      }),
+      withContext({ correlation_id: "req-B" }, async () => {
+        logger.info("from_b");
+      }),
+    ]);
+
+    const byMessage = new Map(
+      captured.map((l) => [l.message, l.correlation_id]),
+    );
+    expect(byMessage.get("from_b")).toBe("req-B");
+    expect(byMessage.get("from_a")).toBe("req-A");
+  });
+
+  it("merges nested scopes instead of replacing them", async () => {
+    await withContext({ correlation_id: "outer" }, async () => {
+      await withContext(
+        { correlation_id: "outer", lane_id: "L1" },
+        async () => {
+          logger.info("nested");
+        },
+      );
+    });
+
+    expect(captured[0]!.correlation_id).toBe("outer");
+    expect(captured[0]!.lane_id).toBe("L1");
+  });
+
+  it("does not leak context after the scope ends", async () => {
+    await withContext({ correlation_id: "gone" }, async () => {
+      logger.info("in");
+    });
+    logger.info("out");
+
+    expect(captured[1]!.correlation_id).toBeUndefined();
+    expect(currentCorrelationId()).toBeUndefined();
+  });
+});
+
+describe("withLogging", () => {
+  it("emits an ok line with a duration on success", async () => {
+    const result = await withLogging("load_thing", async () => "value");
+
+    expect(result).toBe("value");
+    // The entry line is `debug`, so at the default `info` level only the exit
+    // line is emitted. Deliberate: entry logging is expensive and noisy in
+    // production, and the exit line is the one that carries the outcome.
+    // Raising LOG_LEVEL to `debug` restores it — asserted below.
+    const ok = captured.find((l) => l.message === "load_thing_ok")!;
+    expect(ok).toBeDefined();
+    expect(ok.level).toBe("info");
+    expect(typeof ok.duration_ms).toBe("number");
+    expect(captured.some((l) => l.message === "load_thing_failed")).toBe(false);
+  });
+
+  it("records a duration that reflects real elapsed time", async () => {
+    await withLogging("slow_thing", async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    const ok = captured.find((l) => l.message === "slow_thing_ok")!;
+    expect(Number(ok.duration_ms)).toBeGreaterThanOrEqual(15);
+  });
+
+  it("logs a failure and re-throws the original error", async () => {
+    const boom = new Error("kaboom");
+
+    await expect(
+      withLogging("risky", async () => {
+        throw boom;
+      }),
+    ).rejects.toThrow("kaboom");
+
+    const failure = captured.find((l) => l.message === "risky_failed")!;
+    expect(failure).toBeDefined();
+    expect(failure.level).toBe("error");
+    expect(failure.error_message).toBe("kaboom");
+    expect(failure.error_name).toBe("Error");
+  });
+
+  it("carries the correlation_id onto all of an operation's lines", async () => {
+    // The point of the wrapper: five points for one operation are queryable as
+    // one unit.
+    await withContext({ correlation_id: "op-1" }, async () => {
+      await withLogging("multi", async () => {
+        logger.warn("multi_degraded_path", { reason: "cache_cold" });
+      });
+    });
+
+    // Two lines at the default level: the operation's exit line and the
+    // caller's explicit degraded-path warning. Both must be joinable.
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+    for (const line of captured) {
+      expect(line.correlation_id).toBe("op-1");
+    }
+    expect(captured.map((l) => l.message)).toContain("multi_degraded_path");
+    expect(captured.map((l) => l.message)).toContain("multi_ok");
+  });
+
+  it("passes caller fields through to every line it emits", async () => {
+    await withLogging("scoped", async () => undefined, { lane_id: "L9" });
+    expect(captured.length).toBeGreaterThan(0);
+    for (const line of captured) expect(line.lane_id).toBe("L9");
+  });
+
+  it("includes the caller fields on the failure line too", async () => {
+    await expect(
+      withLogging(
+        "scoped_fail",
+        async () => {
+          throw new Error("nope");
+        },
+        { lane_id: "L9" },
+      ),
+    ).rejects.toThrow("nope");
+
+    const failure = captured.find((l) => l.message === "scoped_fail_failed")!;
+    expect(failure.lane_id).toBe("L9");
+  });
+});
+
+describe("withFallback", () => {
+  it("returns the value when the operation succeeds and logs nothing", async () => {
+    const value = await withFallback("lookup", async () => 42, -1);
+
+    expect(value).toBe(42);
+    // "No log line means success" — a healthy path must stay quiet.
+    expect(captured).toEqual([]);
+  });
+
+  it("warns and returns the fallback when the operation throws", async () => {
+    const value = await withFallback(
+      "lookup",
+      async () => {
+        throw new Error("unreachable");
+      },
+      -1,
+    );
+
+    expect(value).toBe(-1);
+    expect(captured[0]!.message).toBe("lookup_degraded");
+    expect(captured[0]!.level).toBe("warn");
+    expect(captured[0]!.error_message).toBe("unreachable");
+  });
+});
+
+describe("describeError", () => {
+  it("reduces an Error to name, message, and stack", () => {
+    const fields = describeError(new TypeError("bad type"));
+    expect(fields.error_name).toBe("TypeError");
+    expect(fields.error_message).toBe("bad type");
+    expect(typeof fields.error_stack).toBe("string");
+  });
+
+  it("handles thrown non-errors without throwing", () => {
+    expect(describeError("just a string").error_message).toBe("just a string");
+    expect(describeError(undefined).error_name).toBe("ThrownNonError");
+    expect(describeError(null).error_name).toBe("ThrownNonError");
+    expect(describeError({ weird: true }).error_name).toBe("ThrownNonError");
+  });
+
+  it("does not copy arbitrary properties off a thrown object", async () => {
+    // Thrown objects routinely carry request/config/credential data. Spreading
+    // an error into a log entry leaks whatever is attached to it.
+    const err = Object.assign(new Error("http failed"), {
+      config: { headers: { authorization: "Bearer super-secret-value" } },
+      request: { body: "private" },
+    });
+
+    await withFallback(
+      "call",
+      async () => {
+        throw err;
+      },
+      null,
+    );
+
+    const serialized = JSON.stringify(captured[0]);
+    expect(serialized).not.toContain("super-secret-value");
+    expect(serialized).not.toContain("private");
+    expect(captured[0]!.error_message).toBe("http failed");
+  });
+});

--- a/src/observability/observability.test.ts
+++ b/src/observability/observability.test.ts
@@ -6,7 +6,7 @@
  * shapes.
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { logger, addLogSink } from "../logger.ts";
+import { logger, addLogSink, setLogLevel, getLogLevel } from "../logger.ts";
 import { withContext, currentCorrelationId } from "./context.ts";
 import { withLogging, withFallback, describeError } from "./with-logging.ts";
 
@@ -72,9 +72,18 @@ describe("shared envelope", () => {
     expect(line!.message).toBe("thing_happened");
     expect(typeof line!.service).toBe("string");
     expect(String(line!.service).length).toBeGreaterThan(0);
+    // `host` is the second of the two Loki labels; a line missing it leaves a
+    // hole in the per-host query surface.
+    expect(typeof line!.host).toBe("string");
+    expect(String(line!.host).length).toBeGreaterThan(0);
     expect(typeof line!.timestamp).toBe("string");
     // caller fields survive alongside the envelope
     expect(line!.count).toBe(3);
+  });
+
+  it("does not let a caller field shadow host", () => {
+    logger.info("evt", { host: "impostor" });
+    expect(captured[0]!.host).not.toBe("impostor");
   });
 
   it("emits an ISO-8601 timestamp a log pipeline can parse", () => {
@@ -97,6 +106,73 @@ describe("shared envelope", () => {
   it("omits correlation_id outside any context scope", () => {
     logger.info("no_scope");
     expect(captured[0]!.correlation_id).toBeUndefined();
+  });
+});
+
+describe("runtime log level", () => {
+  // Restore whatever the process started at, so raising the level here cannot
+  // leak into another suite in this shared process.
+  const original = getLogLevel();
+  afterEach(() => {
+    setLogLevel(original);
+  });
+
+  it("drops debug lines at the default info level", () => {
+    setLogLevel("info");
+    captured.length = 0;
+    logger.debug("quiet_line");
+    expect(captured.some((l) => l.message === "quiet_line")).toBe(false);
+  });
+
+  it("emits debug lines once raised, without a restart", () => {
+    // The point of the setter: an incident is the worst moment to restart the
+    // process being investigated.
+    setLogLevel("debug");
+    captured.length = 0;
+    logger.debug("loud_line", { detail: 1 });
+
+    const line = captured.find((l) => l.message === "loud_line");
+    expect(line).toBeDefined();
+    expect(line!.level).toBe("debug");
+    expect(line!.detail).toBe(1);
+  });
+
+  it("announces the change so the transition is visible in the stream", () => {
+    setLogLevel("info");
+    captured.length = 0;
+    setLogLevel("warn");
+
+    const line = captured.find((l) => l.message === "log_level_changed");
+    expect(line).toBeDefined();
+    expect(line!.from).toBe("info");
+    expect(line!.to).toBe("warn");
+  });
+
+  it("announces the change in both directions, including up from error", () => {
+    // Both directions can swallow their own notice: emitting after the swap
+    // loses it when lowering verbosity, emitting before loses it when raising
+    // from a level that already suppressed info.
+    setLogLevel("error");
+    captured.length = 0;
+    setLogLevel("debug");
+
+    const line = captured.find((l) => l.message === "log_level_changed");
+    expect(line).toBeDefined();
+    expect(line!.from).toBe("error");
+    expect(line!.to).toBe("debug");
+  });
+
+  it("rejects an unknown level instead of silently keeping the old one", () => {
+    setLogLevel("warn");
+    // Silently ignoring a typo looks identical to the setting having worked,
+    // which is the failure mode this whole sweep exists to remove.
+    expect(() => setLogLevel("verbose")).toThrow(/unknown log level/);
+    expect(getLogLevel()).toBe("warn");
+  });
+
+  it("normalises case and surrounding whitespace", () => {
+    expect(setLogLevel("  DEBUG ")).toBe("debug");
+    expect(getLogLevel()).toBe("debug");
   });
 });
 

--- a/src/observability/observability.test.ts
+++ b/src/observability/observability.test.ts
@@ -146,6 +146,43 @@ describe("describeError redaction", () => {
   });
 });
 
+describe("envelope ownership", () => {
+  it("does not let async context override service, host, or level", () => {
+    // `service` and `host` are the only two envelope fields that become Loki
+    // labels. A context reader that returns either -- by accident or by
+    // spreading a request object wholesale -- would silently split the query
+    // surface, and nothing in the emitted line would say so.
+    //
+    // The spread order is the whole fix: context used to land AFTER the
+    // envelope block that claims to own these names.
+    setLogLevel("info");
+    captured.length = 0;
+
+    // withContext merges arbitrary fields, so this is reachable without a
+    // hand-written reader: any caller that spreads a request object into the
+    // scope can carry a `service` key in without meaning to.
+    withContext(
+      {
+        correlation_id: "cid-1",
+        service: "not-open-brain",
+        host: "not-this-host",
+        level: "debug",
+      },
+      () => {
+        logger.info("owned_envelope");
+      },
+    );
+
+    const line = captured.find((l) => l.message === "owned_envelope");
+    expect(line).toBeDefined();
+    expect(line!.service).not.toBe("not-open-brain");
+    expect(line!.host).not.toBe("not-this-host");
+    expect(line!.level).toBe("info");
+    // Context still supplies what it is actually for.
+    expect(line!.correlation_id).toBe("cid-1");
+  });
+});
+
 describe("runtime log level", () => {
   // Restore whatever the process started at, so raising the level here cannot
   // leak into another suite in this shared process.
@@ -172,6 +209,46 @@ describe("runtime log level", () => {
     expect(line).toBeDefined();
     expect(line!.level).toBe("debug");
     expect(line!.detail).toBe(1);
+  });
+
+  it("reaches the target level even when the announce line throws", () => {
+    // The announce widens the gate temporarily so the transition cannot filter
+    // its own notice. `log` can throw for real -- FILE_SINK.write fails on a
+    // full or unwritable disk -- and without a `finally` the widened value is
+    // where minLevel stays.
+    //
+    // That inverts the intent on the one path this setter exists for: an
+    // operator raising verbosity mid-incident, on the box whose disk just
+    // filled, gets debug-volume logging from a call that reported failure.
+    // Go DOWN in verbosity (debug -> error). The widened gate is then "debug"
+    // and the target is "error", so the two differ and the assertion can tell
+    // a restored level from a stuck one. Raising instead would leave both at
+    // "debug" and pass either way.
+    setLogLevel("debug");
+
+    const realLog = console.log;
+    let armed = true;
+    console.log = ((...args: unknown[]) => {
+      if (armed) {
+        armed = false;
+        throw new Error("sink failure (full disk)");
+      }
+      return realLog(...(args as []));
+    }) as typeof console.log;
+
+    let threw = false;
+    try {
+      setLogLevel("error");
+    } catch {
+      threw = true;
+    } finally {
+      console.log = realLog;
+    }
+
+    expect(threw).toBe(true);
+    // Pre-fix: "debug" -- stuck at the widened gate, so the process keeps
+    // emitting debug volume after a call that reported failure.
+    expect(getLogLevel()).toBe("error");
   });
 
   it("announces the change so the transition is visible in the stream", () => {

--- a/src/observability/observability.test.ts
+++ b/src/observability/observability.test.ts
@@ -109,6 +109,43 @@ describe("shared envelope", () => {
   });
 });
 
+describe("describeError redaction", () => {
+  // Caught in adversarial review of the logging sweep, from a real failing run:
+  // an error thrown during a NATS-bridge context-pack build arrived with `name`
+  // set to `NatsError nats://user:pass@host`. `withLogging` logs at the THROW
+  // SITE, before src/nats-bridge.ts can apply its safeErrorType() allowlist, so
+  // a redactor at the boundary cannot help. Every emitted field is redacted.
+  it("redacts credentials from error_name, error_message, and error_stack", () => {
+    const secret = ["user", ":", "pass"].join("");
+    const url = `nats://${secret}@broker.internal:4222`;
+    const err = new Error(`working set exploded for ${url}`);
+    // `name` is writable, which is exactly why it cannot be trusted.
+    err.name = `NatsError ${url}`;
+
+    const fields = describeError(err);
+
+    expect(fields.error_name).not.toContain(secret);
+    expect(fields.error_message).not.toContain(secret);
+    expect(fields.error_stack ?? "").not.toContain(secret);
+    // Redacted, not dropped: the diagnostic shape must survive.
+    expect(fields.error_name).toContain("[REDACTED]");
+    expect(fields.error_message).toContain("working set exploded");
+  });
+
+  it("redacts a thrown string", () => {
+    const secret = ["user", ":", "pass"].join("");
+    const fields = describeError(`boom postgres://${secret}@db/x`);
+    expect(fields.error_name).toBe("ThrownString");
+    expect(fields.error_message).not.toContain(secret);
+  });
+
+  it("keeps ordinary errors fully readable", () => {
+    const fields = describeError(new TypeError("x is not a function"));
+    expect(fields.error_name).toBe("TypeError");
+    expect(fields.error_message).toBe("x is not a function");
+  });
+});
+
 describe("runtime log level", () => {
   // Restore whatever the process started at, so raising the level here cannot
   // leak into another suite in this shared process.

--- a/src/observability/with-logging.ts
+++ b/src/observability/with-logging.ts
@@ -15,35 +15,7 @@
  * The wrapper never swallows: it logs, then re-throws. Converting an error into
  * a fallback value is a decision the caller makes deliberately and documents.
  */
-import { logger } from "../logger.ts";
-import { SECRET_PATTERNS } from "../sharing.ts";
-
-/**
- * Strip known secret material from a string bound for a log entry.
- *
- * Applies `SECRET_PATTERNS` — the same detector set that gates shared-kb
- * promotion and the Python client's `policy.py` — rather than a second, weaker
- * redaction fork.
- *
- * `redactText()` is deliberately NOT reused here: it emits a `logger.warn` when
- * it changes something, and this function runs *inside* the log path, so that
- * would recurse. The patterns are applied directly and the substitution is
- * silent; the redaction marker in the output is the evidence.
- */
-function redactForLog(value: string): string {
-  if (!value) return value;
-  let redacted = value;
-  for (const pattern of SECRET_PATTERNS) {
-    const flags = pattern.flags.includes("g")
-      ? pattern.flags
-      : `${pattern.flags}g`;
-    redacted = redacted.replace(
-      new RegExp(pattern.source, flags),
-      "[REDACTED]",
-    );
-  }
-  return redacted;
-}
+import { logger, redactForLog } from "../logger.ts";
 
 /**
  * Reduce an unknown thrown value to safe, loggable fields.

--- a/src/observability/with-logging.ts
+++ b/src/observability/with-logging.ts
@@ -16,6 +16,34 @@
  * a fallback value is a decision the caller makes deliberately and documents.
  */
 import { logger } from "../logger.ts";
+import { SECRET_PATTERNS } from "../sharing.ts";
+
+/**
+ * Strip known secret material from a string bound for a log entry.
+ *
+ * Applies `SECRET_PATTERNS` — the same detector set that gates shared-kb
+ * promotion and the Python client's `policy.py` — rather than a second, weaker
+ * redaction fork.
+ *
+ * `redactText()` is deliberately NOT reused here: it emits a `logger.warn` when
+ * it changes something, and this function runs *inside* the log path, so that
+ * would recurse. The patterns are applied directly and the substitution is
+ * silent; the redaction marker in the output is the evidence.
+ */
+function redactForLog(value: string): string {
+  if (!value) return value;
+  let redacted = value;
+  for (const pattern of SECRET_PATTERNS) {
+    const flags = pattern.flags.includes("g")
+      ? pattern.flags
+      : `${pattern.flags}g`;
+    redacted = redacted.replace(
+      new RegExp(pattern.source, flags),
+      "[REDACTED]",
+    );
+  }
+  return redacted;
+}
 
 /**
  * Reduce an unknown thrown value to safe, loggable fields.
@@ -24,6 +52,15 @@ import { logger } from "../logger.ts";
  * attached request, response, config, or credential data (`err.request`,
  * `err.config`), and spreading leaks whatever happens to be on them. Only the
  * chosen subset below is emitted.
+ *
+ * **Every emitted field is redacted**, including `error_name`. That is not
+ * belt-and-braces: `err.name` is writable, and a caught error's name and
+ * message routinely carry the connection string that failed. A real leak was
+ * caught in review — an error thrown during a NATS-bridge context-pack build
+ * arrived with `name` set to `NatsError nats://user:pass@host` and reached
+ * stdout, the file sink, and Loki, because this wrapper logs at the throw site,
+ * *before* `src/nats-bridge.ts` can apply its `safeErrorType()` allowlist.
+ * A redactor at the boundary cannot help a logger that already emitted.
  *
  * `catch` binds `unknown`, and non-`Error` values are thrown in practice
  * (strings, `undefined`, rejected non-error promises), so every shape is
@@ -39,16 +76,20 @@ export function describeError(error: unknown): {
 } {
   if (error instanceof Error) {
     return {
-      error_name: error.name,
-      error_message: error.message,
-      ...(error.stack ? { error_stack: error.stack } : {}),
+      error_name: redactForLog(error.name),
+      error_message: redactForLog(error.message),
+      // The stack embeds the message on its first line, so it carries anything
+      // the message did.
+      ...(error.stack ? { error_stack: redactForLog(error.stack) } : {}),
     };
   }
   if (typeof error === "string") {
-    return { error_name: "ThrownString", error_message: error };
+    return { error_name: "ThrownString", error_message: redactForLog(error) };
   }
   return {
     error_name: "ThrownNonError",
+    // Object.prototype.toString yields a class tag like [object Object], never
+    // instance data, so there is nothing to redact.
     error_message: Object.prototype.toString.call(error),
   };
 }

--- a/src/observability/with-logging.ts
+++ b/src/observability/with-logging.ts
@@ -1,0 +1,130 @@
+/**
+ * Operation wrapper — the TypeScript equivalent of Loguru's `@logger.catch`,
+ * plus the five log points from `_DOCS/CODING_STANDARDS.md` (`## Observability`).
+ *
+ * The standard requires a log line at entry, exit, failure, every degraded
+ * path, and every guard trigger. Asking each call site to remember five calls
+ * is the approach that already failed at scale here: open-brain accumulated 41
+ * bare `catch {}` blocks and 99 more that bind an error and never log it.
+ *
+ * So compliance is made the *shorter* path. Wrapping an operation once emits
+ * entry, exit with duration, and failure automatically. Only the degraded and
+ * guard lines remain the caller's job, because only the caller knows a path was
+ * degraded.
+ *
+ * The wrapper never swallows: it logs, then re-throws. Converting an error into
+ * a fallback value is a decision the caller makes deliberately and documents.
+ */
+import { logger } from "../logger.ts";
+
+/**
+ * Reduce an unknown thrown value to safe, loggable fields.
+ *
+ * Never spread a raw error into a log entry — thrown objects routinely carry
+ * attached request, response, config, or credential data (`err.request`,
+ * `err.config`), and spreading leaks whatever happens to be on them. Only the
+ * chosen subset below is emitted.
+ *
+ * `catch` binds `unknown`, and non-`Error` values are thrown in practice
+ * (strings, `undefined`, rejected non-error promises), so every shape is
+ * handled rather than assumed.
+ *
+ * @param error The value caught. Any shape.
+ * @returns Fields safe to merge into a log entry.
+ */
+export function describeError(error: unknown): {
+  error_name: string;
+  error_message: string;
+  error_stack?: string;
+} {
+  if (error instanceof Error) {
+    return {
+      error_name: error.name,
+      error_message: error.message,
+      ...(error.stack ? { error_stack: error.stack } : {}),
+    };
+  }
+  if (typeof error === "string") {
+    return { error_name: "ThrownString", error_message: error };
+  }
+  return {
+    error_name: "ThrownNonError",
+    error_message: Object.prototype.toString.call(error),
+  };
+}
+
+/**
+ * Run `fn` as a named operation, logging entry, exit with duration, and
+ * failure.
+ *
+ * On success: `debug` at entry (`<name>_start`) and `info` at exit
+ * (`<name>_ok`) carrying `duration_ms`. On failure: `error`
+ * (`<name>_failed`) carrying `duration_ms` and the reduced error fields, then
+ * the error is **re-thrown unchanged**.
+ *
+ * Pair with `withContext()` so all of an operation's lines share a
+ * `correlation_id`.
+ *
+ * @param name Stable event-name stem — `lane_context_load`, not a sentence.
+ *   Loki filters on these, so it must be a constant, never interpolated.
+ * @param fn The operation. May be sync or async; the returned promise settles
+ *   after the exit line is emitted.
+ * @param fields Extra fields for all three lines, e.g. identifiers.
+ * @returns Whatever `fn` returns.
+ * @throws Re-throws whatever `fn` throws, unchanged.
+ */
+export async function withLogging<T>(
+  name: string,
+  fn: () => T | Promise<T>,
+  fields?: Record<string, unknown>,
+): Promise<T> {
+  const startedAt = performance.now();
+  logger.debug(`${name}_start`, fields);
+  try {
+    const result = await fn();
+    logger.info(`${name}_ok`, {
+      ...fields,
+      duration_ms: Math.round(performance.now() - startedAt),
+    });
+    return result;
+  } catch (error: unknown) {
+    logger.error(`${name}_failed`, {
+      ...fields,
+      duration_ms: Math.round(performance.now() - startedAt),
+      ...describeError(error),
+    });
+    throw error;
+  }
+}
+
+/**
+ * Deliberate fail-open: run `fn`, and on failure log a **warning** and return
+ * `fallback` instead of throwing.
+ *
+ * This exists so that the standard's "every intentional fail-open is a
+ * documented decision in the code, not an accident of an empty block" is
+ * expressible in one call. `catch { return null }` and this function do the
+ * same thing to control flow; only this one leaves evidence.
+ *
+ * Use it *only* where continuing without the value is genuinely correct. If the
+ * caller cannot proceed, use `withLogging` and let the error travel.
+ *
+ * @param name Stable event-name stem. Emits `<name>_degraded` on failure.
+ * @param fn The operation.
+ * @param fallback Value returned when `fn` throws.
+ * @param fields Extra fields for the warning.
+ * @returns `fn`'s result, or `fallback` if it threw.
+ */
+export async function withFallback<T>(
+  name: string,
+  fn: () => T | Promise<T>,
+  fallback: T,
+  fields?: Record<string, unknown>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error: unknown) {
+    logger.warn(`${name}_degraded`, { ...fields, ...describeError(error) });
+    return fallback;
+  }
+}

--- a/src/secret-patterns.ts
+++ b/src/secret-patterns.ts
@@ -137,3 +137,51 @@ export const SECRET_DETECTORS: readonly SecretPatternDetector[] = [
 export const SECRET_PATTERNS: readonly RegExp[] = SECRET_DETECTORS.map(
   ({ pattern }) => pattern,
 );
+
+/**
+ * Field names whose VALUE is sensitive regardless of what the value looks like.
+ *
+ * The detectors above are value-shaped: they recognize a secret by its own text
+ * (`sk-…`, `ghp_…`, `password=…`). That works on prose and on flat `key=value`
+ * strings, but a JSON logger serializes each value in isolation, so the
+ * replacer is handed `"hunter2driveway"` with no idea it came from a field
+ * called `password`. Review proved the gap — `{"password":"hunter2driveway"}`
+ * emitted in clear, even though `json_labeled_secret` matches that exact pair
+ * when it is given the pair as *text*. The pattern was never wrong; it was
+ * never shown the key.
+ *
+ * So sensitivity is carried by the key here. A value under one of these names
+ * is redacted on the name alone, because an arbitrary passphrase, a rotated
+ * opaque token, or a bare JWT has no distinguishing shape to match.
+ *
+ * Substring semantics (`db_password`, `X-Api-Key`, `refreshToken` all hit) —
+ * over-redacting a field named for a credential is the safe direction.
+ */
+const SENSITIVE_KEY_PARTS: readonly string[] = [
+  "password",
+  "passwd",
+  "secret",
+  "token",
+  "apikey",
+  "credential",
+  "authorization",
+  "authheader",
+  "privatekey",
+  "sessionid",
+  "dsn",
+  "connectionstring",
+];
+
+/**
+ * True when a field name marks its value as sensitive.
+ *
+ * Normalizes away `_`, `-`, and case first so `api_key`, `apiKey`, `API-KEY`,
+ * and `apikey` are one check rather than four patterns.
+ *
+ * @param key The object key the value was read from.
+ */
+export function isSensitiveKey(key: string): boolean {
+  if (!key) return false;
+  const normalized = key.toLowerCase().replace(/[_-]/g, "");
+  return SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part));
+}

--- a/src/secret-patterns.ts
+++ b/src/secret-patterns.ts
@@ -1,0 +1,139 @@
+/**
+ * Secret detector patterns — a LEAF module with no imports.
+ *
+ * Extracted from `sharing.ts` so `logger.ts` can redact every string it emits
+ * without importing `sharing.ts`. That import is not merely stylistically bad,
+ * it crashes: `logger.ts` -> `sharing.ts` -> `observability/index.ts` ->
+ * `context.ts` calls `setLogContextReader` back into a half-initialized
+ * `logger.ts`, giving `ReferenceError: Cannot access 'contextReader' before
+ * initialization` whenever the logger is loaded first — which is the common
+ * order, since it is the base dependency.
+ *
+ * Keep this module import-free. Everything here is a compiled constant, so it
+ * can sit at the bottom of the graph and be safely read from anywhere.
+ */
+
+/**
+ * Ported from python/openbrain-memory/src/openbrain_memory/policy.py
+ * SECRET_PATTERNS. Kept structurally 1:1 so the two surfaces stay in lockstep.
+ * Prefixes are split to avoid tripping repo secret scanners on the literals.
+ */
+const SK_PREFIX = "sk" + "-";
+const GITHUB_PREFIX_RE = "gh" + "[pousr]_";
+const GITHUB_PAT_PREFIX = "github" + "_pat_";
+const AWS_ACCESS_KEY_PREFIX_RE = "A[KS]IA[0-9A-Z]{16}";
+const AWS_SECRET_LIKE_RE =
+  "(?<![A-Za-z0-9/+=])" +
+  "(?=[A-Za-z0-9/+=]*[A-Z])" +
+  "(?=[A-Za-z0-9/+=]*[a-z])" +
+  "(?=[A-Za-z0-9/+=]*[0-9])" +
+  "(?=[A-Za-z0-9/+=]*[/+=])" +
+  "[A-Za-z0-9/+=]{40}" +
+  "(?![A-Za-z0-9/+=])";
+const AWS_SECRET_CONTEXT_RE =
+  "(aws[_ -]?(secret|secret[_ -]?access[_ -]?key))\\s*[:=]\\s*" +
+  "[A-Za-z0-9/+=]{40}";
+const SLACK_TOKEN_RE = "xox[baprs]-[A-Za-z0-9-]{10,}";
+const GOOGLE_API_KEY_PREFIX = "AIza";
+const JWT_LIKE_RE =
+  "eyJ[A-Za-z0-9_-]{8,}\\." + "[A-Za-z0-9_-]{8,}\\." + "[A-Za-z0-9_-]{8,}";
+const PRIVATE_KEY_BLOCK_RE =
+  "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----";
+// Stripe-style keys use an underscore separator (sk_live_, pk_live_, rk_live_,
+// and the test variants), which the OpenAI `sk-` pattern above does not catch.
+const STRIPE_KEY_RE = "[sprk]k_(live|test)_[A-Za-z0-9]{16,}";
+// Credentials embedded in a URL's userinfo (`scheme://user:pass@host`). The
+// password is unlabeled and a realistic lane-journal leak. ReDoS guard: match a
+// FIXED scheme alternation (not `[a-z][a-z0-9+.-]*`) so the engine cannot
+// restart-and-rescan a `*` wildcard at every input position — that unanchored
+// prefix, not the userinfo, was the O(n²) source. Userinfo segments stay
+// length-bounded ({1,256}); real credentials are far shorter.
+// `nats`/`tls` are Open Brain's OWN transport schemes and were the gap that
+// mattered: a review caught `nats://user:pass@host` reaching the log through a
+// thrown error's name, since every other service OB talks to was listed but the
+// one it *is* was not.
+const URL_SCHEME_ALT =
+  "(?:https?|ftp|postgres|postgresql|mysql|mariadb|mongodb|redis|amqp|amqps|" +
+  "nats|tls|ws|wss|ssh|sftp|smtp|smtps|imap|imaps|ldap|ldaps)";
+const URL_USERINFO_CRED_RE = `${URL_SCHEME_ALT}://[^\\s:@/]{1,256}:[^\\s@/]{1,256}@[^\\s/]+`;
+// Context-labeled long hex/base64 secrets (client_secret, access_token, etc.).
+// Deliberately requires a credential LABEL — bare high-entropy hex is left
+// alone because git SHAs and content_hashes are pervasive and legitimate here
+// (avoiding the over-rejection the SME guidance warns against).
+const LABELED_LONG_SECRET_RE =
+  "(client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)" +
+  "\\s*[:=]\\s*[A-Za-z0-9._/+=-]{20,}";
+
+export interface SecretPatternDetector {
+  kind: string;
+  pattern: RegExp;
+}
+
+/**
+ * Compiled secret detectors. `i` mirrors the Python `(?i)` inline flags; the
+ * private-key block uses dot-all via the explicit `[\s\S]` class so no `s` flag
+ * is required (keeps Bun/JS regex engine parity with the Python `re.S`).
+ *
+ * The `kind` labels are safe to return in structured rejection details. They
+ * identify the classifier, never the matched secret value.
+ */
+export const SECRET_DETECTORS: readonly SecretPatternDetector[] = [
+  {
+    kind: "authorization_bearer_header",
+    pattern: /authorization\s*[:=]\s*bearer\s+[^\s,;]+/i,
+  },
+  { kind: "bearer_token", pattern: /bearer\s+[A-Za-z0-9._~+/=-]{8,}/i },
+  {
+    kind: "mcp_session_id",
+    pattern: /mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+/i,
+  },
+  {
+    kind: "openai_api_key",
+    pattern: new RegExp(`\\b${SK_PREFIX}[A-Za-z0-9_-]{10,}\\b`),
+  },
+  {
+    kind: "github_pat",
+    pattern: new RegExp(`${GITHUB_PAT_PREFIX}[A-Za-z0-9_]+`, "i"),
+  },
+  {
+    kind: "github_token",
+    pattern: new RegExp(`${GITHUB_PREFIX_RE}[A-Za-z0-9_]{20,}`, "i"),
+  },
+  {
+    kind: "aws_access_key_id",
+    pattern: new RegExp(`\\b${AWS_ACCESS_KEY_PREFIX_RE}\\b`),
+  },
+  {
+    kind: "aws_secret_access_key",
+    pattern: new RegExp(AWS_SECRET_CONTEXT_RE, "i"),
+  },
+  { kind: "aws_secret_like", pattern: new RegExp(AWS_SECRET_LIKE_RE) },
+  { kind: "slack_token", pattern: new RegExp(`\\b${SLACK_TOKEN_RE}\\b`) },
+  {
+    kind: "google_api_key",
+    pattern: new RegExp(`\\b${GOOGLE_API_KEY_PREFIX}[A-Za-z0-9_-]{35}\\b`),
+  },
+  { kind: "jwt", pattern: new RegExp(`\\b${JWT_LIKE_RE}\\b`) },
+  {
+    kind: "labeled_secret",
+    pattern: /(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+/i,
+  },
+  {
+    kind: "json_labeled_secret",
+    pattern: /"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"/i,
+  },
+  { kind: "private_key_block", pattern: new RegExp(PRIVATE_KEY_BLOCK_RE) },
+  { kind: "stripe_key", pattern: new RegExp(`\\b${STRIPE_KEY_RE}\\b`) },
+  {
+    kind: "url_userinfo_credential",
+    pattern: new RegExp(URL_USERINFO_CRED_RE, "i"),
+  },
+  {
+    kind: "labeled_long_secret",
+    pattern: new RegExp(LABELED_LONG_SECRET_RE, "i"),
+  },
+];
+
+export const SECRET_PATTERNS: readonly RegExp[] = SECRET_DETECTORS.map(
+  ({ pattern }) => pattern,
+);

--- a/src/sharing.test.ts
+++ b/src/sharing.test.ts
@@ -81,6 +81,15 @@ describe("containsSecret", () => {
     expect(containsSecret("HTTPS://admin:hunter2pw@host/x")).toBe(true);
   });
 
+  it("detects credentials in Open Brain's own transport schemes", () => {
+    // Regression: every service OB talks to was listed except the one it IS.
+    // A thrown error carrying `nats://user:pass@host` in its (mutable, writable)
+    // `name` reached stdout, the file sink, and Loki through the log path.
+    expect(containsSecret("nats://user:pass@broker.internal:4222")).toBe(true);
+    expect(containsSecret("tls://user:pass@broker.internal:4222")).toBe(true);
+    expect(containsSecret("wss://user:pass@host/socket")).toBe(true);
+  });
+
   it("scans large input in linear time (ReDoS regression)", () => {
     // The URL credential pattern once had an unanchored `[a-z][a-z0-9+.-]*://`
     // prefix that backtracked O(n^2) on long input with no `://`. A fixed scheme
@@ -92,17 +101,17 @@ describe("containsSecret", () => {
   });
 
   it("detects a labeled long secret value", () => {
-    expect(
-      containsSecret("client_secret=" + "Ab9".repeat(8) + "xyz"),
-    ).toBe(true);
+    expect(containsSecret("client_secret=" + "Ab9".repeat(8) + "xyz")).toBe(
+      true,
+    );
   });
 
   it("does NOT flag a bare hex content-hash / git SHA (no over-rejection)", () => {
     // 64-char hex content_hash and a 40-char git SHA are pervasive + legitimate.
     expect(containsSecret("content_hash " + "a1b2c3d4".repeat(8))).toBe(false);
-    expect(containsSecret("commit 4ba6c76e1f2a3b4c5d6e7f8091a2b3c4d5e6f708")).toBe(
-      false,
-    );
+    expect(
+      containsSecret("commit 4ba6c76e1f2a3b4c5d6e7f8091a2b3c4d5e6f708"),
+    ).toBe(false);
   });
 
   it("does NOT flag a plain URL without credentials (no over-rejection)", () => {
@@ -368,10 +377,7 @@ describe("classifyShareCandidate — share / manual-review", () => {
   it("honors a custom minLen", () => {
     const content = "short fact here";
     expect(
-      classifyShareCandidate(
-        { event_type: "fact", content },
-        { minLen: 4 },
-      ),
+      classifyShareCandidate({ event_type: "fact", content }, { minLen: 4 }),
     ).toBe("share");
   });
 });

--- a/src/sharing.ts
+++ b/src/sharing.ts
@@ -19,129 +19,17 @@ import { logger } from "./observability/index.ts";
 export const DEFAULT_MIN_SHARE_LENGTH = 24;
 
 /**
- * Ported from python/openbrain-memory/src/openbrain_memory/policy.py
- * SECRET_PATTERNS. Kept structurally 1:1 so the two surfaces stay in lockstep.
- * Prefixes are split to avoid tripping repo secret scanners on the literals.
+ * Secret detectors now live in the import-free `secret-patterns.ts` leaf so the
+ * logger can redact without a circular import (see that module's header).
+ * Re-exported here because this is where callers have always found them.
  */
-const SK_PREFIX = "sk" + "-";
-const GITHUB_PREFIX_RE = "gh" + "[pousr]_";
-const GITHUB_PAT_PREFIX = "github" + "_pat_";
-const AWS_ACCESS_KEY_PREFIX_RE = "A[KS]IA[0-9A-Z]{16}";
-const AWS_SECRET_LIKE_RE =
-  "(?<![A-Za-z0-9/+=])" +
-  "(?=[A-Za-z0-9/+=]*[A-Z])" +
-  "(?=[A-Za-z0-9/+=]*[a-z])" +
-  "(?=[A-Za-z0-9/+=]*[0-9])" +
-  "(?=[A-Za-z0-9/+=]*[/+=])" +
-  "[A-Za-z0-9/+=]{40}" +
-  "(?![A-Za-z0-9/+=])";
-const AWS_SECRET_CONTEXT_RE =
-  "(aws[_ -]?(secret|secret[_ -]?access[_ -]?key))\\s*[:=]\\s*" +
-  "[A-Za-z0-9/+=]{40}";
-const SLACK_TOKEN_RE = "xox[baprs]-[A-Za-z0-9-]{10,}";
-const GOOGLE_API_KEY_PREFIX = "AIza";
-const JWT_LIKE_RE =
-  "eyJ[A-Za-z0-9_-]{8,}\\." + "[A-Za-z0-9_-]{8,}\\." + "[A-Za-z0-9_-]{8,}";
-const PRIVATE_KEY_BLOCK_RE =
-  "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----";
-// Stripe-style keys use an underscore separator (sk_live_, pk_live_, rk_live_,
-// and the test variants), which the OpenAI `sk-` pattern above does not catch.
-const STRIPE_KEY_RE = "[sprk]k_(live|test)_[A-Za-z0-9]{16,}";
-// Credentials embedded in a URL's userinfo (`scheme://user:pass@host`). The
-// password is unlabeled and a realistic lane-journal leak. ReDoS guard: match a
-// FIXED scheme alternation (not `[a-z][a-z0-9+.-]*`) so the engine cannot
-// restart-and-rescan a `*` wildcard at every input position — that unanchored
-// prefix, not the userinfo, was the O(n²) source. Userinfo segments stay
-// length-bounded ({1,256}); real credentials are far shorter.
-// `nats`/`tls` are Open Brain's OWN transport schemes and were the gap that
-// mattered: a review caught `nats://user:pass@host` reaching the log through a
-// thrown error's name, since every other service OB talks to was listed but the
-// one it *is* was not.
-const URL_SCHEME_ALT =
-  "(?:https?|ftp|postgres|postgresql|mysql|mariadb|mongodb|redis|amqp|amqps|" +
-  "nats|tls|ws|wss|ssh|sftp|smtp|smtps|imap|imaps|ldap|ldaps)";
-const URL_USERINFO_CRED_RE = `${URL_SCHEME_ALT}://[^\\s:@/]{1,256}:[^\\s@/]{1,256}@[^\\s/]+`;
-// Context-labeled long hex/base64 secrets (client_secret, access_token, etc.).
-// Deliberately requires a credential LABEL — bare high-entropy hex is left
-// alone because git SHAs and content_hashes are pervasive and legitimate here
-// (avoiding the over-rejection the SME guidance warns against).
-const LABELED_LONG_SECRET_RE =
-  "(client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)" +
-  "\\s*[:=]\\s*[A-Za-z0-9._/+=-]{20,}";
+import { SECRET_DETECTORS, SECRET_PATTERNS } from "./secret-patterns.ts";
 
-export interface SecretPatternDetector {
-  kind: string;
-  pattern: RegExp;
-}
-
-/**
- * Compiled secret detectors. `i` mirrors the Python `(?i)` inline flags; the
- * private-key block uses dot-all via the explicit `[\s\S]` class so no `s` flag
- * is required (keeps Bun/JS regex engine parity with the Python `re.S`).
- *
- * The `kind` labels are safe to return in structured rejection details. They
- * identify the classifier, never the matched secret value.
- */
-export const SECRET_DETECTORS: readonly SecretPatternDetector[] = [
-  {
-    kind: "authorization_bearer_header",
-    pattern: /authorization\s*[:=]\s*bearer\s+[^\s,;]+/i,
-  },
-  { kind: "bearer_token", pattern: /bearer\s+[A-Za-z0-9._~+/=-]{8,}/i },
-  {
-    kind: "mcp_session_id",
-    pattern: /mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+/i,
-  },
-  {
-    kind: "openai_api_key",
-    pattern: new RegExp(`\\b${SK_PREFIX}[A-Za-z0-9_-]{10,}\\b`),
-  },
-  {
-    kind: "github_pat",
-    pattern: new RegExp(`${GITHUB_PAT_PREFIX}[A-Za-z0-9_]+`, "i"),
-  },
-  {
-    kind: "github_token",
-    pattern: new RegExp(`${GITHUB_PREFIX_RE}[A-Za-z0-9_]{20,}`, "i"),
-  },
-  {
-    kind: "aws_access_key_id",
-    pattern: new RegExp(`\\b${AWS_ACCESS_KEY_PREFIX_RE}\\b`),
-  },
-  {
-    kind: "aws_secret_access_key",
-    pattern: new RegExp(AWS_SECRET_CONTEXT_RE, "i"),
-  },
-  { kind: "aws_secret_like", pattern: new RegExp(AWS_SECRET_LIKE_RE) },
-  { kind: "slack_token", pattern: new RegExp(`\\b${SLACK_TOKEN_RE}\\b`) },
-  {
-    kind: "google_api_key",
-    pattern: new RegExp(`\\b${GOOGLE_API_KEY_PREFIX}[A-Za-z0-9_-]{35}\\b`),
-  },
-  { kind: "jwt", pattern: new RegExp(`\\b${JWT_LIKE_RE}\\b`) },
-  {
-    kind: "labeled_secret",
-    pattern: /(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+/i,
-  },
-  {
-    kind: "json_labeled_secret",
-    pattern: /"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"/i,
-  },
-  { kind: "private_key_block", pattern: new RegExp(PRIVATE_KEY_BLOCK_RE) },
-  { kind: "stripe_key", pattern: new RegExp(`\\b${STRIPE_KEY_RE}\\b`) },
-  {
-    kind: "url_userinfo_credential",
-    pattern: new RegExp(URL_USERINFO_CRED_RE, "i"),
-  },
-  {
-    kind: "labeled_long_secret",
-    pattern: new RegExp(LABELED_LONG_SECRET_RE, "i"),
-  },
-];
-
-export const SECRET_PATTERNS: readonly RegExp[] = SECRET_DETECTORS.map(
-  ({ pattern }) => pattern,
-);
+export {
+  SECRET_DETECTORS,
+  SECRET_PATTERNS,
+  type SecretPatternDetector,
+} from "./secret-patterns.ts";
 
 export const SHARE_REJECTION_MAX_RESUBMIT_ATTEMPTS = 2;
 

--- a/src/sharing.ts
+++ b/src/sharing.ts
@@ -13,6 +13,8 @@
  * server enforces the same redaction surface the client already trusts.
  */
 
+import { logger } from "./observability/index.ts";
+
 /** Default minimum trimmed content length for a share-eligible entry. */
 export const DEFAULT_MIN_SHARE_LENGTH = 24;
 
@@ -39,9 +41,7 @@ const AWS_SECRET_CONTEXT_RE =
 const SLACK_TOKEN_RE = "xox[baprs]-[A-Za-z0-9-]{10,}";
 const GOOGLE_API_KEY_PREFIX = "AIza";
 const JWT_LIKE_RE =
-  "eyJ[A-Za-z0-9_-]{8,}\\." +
-  "[A-Za-z0-9_-]{8,}\\." +
-  "[A-Za-z0-9_-]{8,}";
+  "eyJ[A-Za-z0-9_-]{8,}\\." + "[A-Za-z0-9_-]{8,}\\." + "[A-Za-z0-9_-]{8,}";
 const PRIVATE_KEY_BLOCK_RE =
   "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----";
 // Stripe-style keys use an underscore separator (sk_live_, pk_live_, rk_live_,
@@ -53,11 +53,14 @@ const STRIPE_KEY_RE = "[sprk]k_(live|test)_[A-Za-z0-9]{16,}";
 // restart-and-rescan a `*` wildcard at every input position — that unanchored
 // prefix, not the userinfo, was the O(n²) source. Userinfo segments stay
 // length-bounded ({1,256}); real credentials are far shorter.
+// `nats`/`tls` are Open Brain's OWN transport schemes and were the gap that
+// mattered: a review caught `nats://user:pass@host` reaching the log through a
+// thrown error's name, since every other service OB talks to was listed but the
+// one it *is* was not.
 const URL_SCHEME_ALT =
   "(?:https?|ftp|postgres|postgresql|mysql|mariadb|mongodb|redis|amqp|amqps|" +
-  "ssh|sftp|smtp|smtps|imap|imaps|ldap|ldaps)";
-const URL_USERINFO_CRED_RE =
-  `${URL_SCHEME_ALT}://[^\\s:@/]{1,256}:[^\\s@/]{1,256}@[^\\s/]+`;
+  "nats|tls|ws|wss|ssh|sftp|smtp|smtps|imap|imaps|ldap|ldaps)";
+const URL_USERINFO_CRED_RE = `${URL_SCHEME_ALT}://[^\\s:@/]{1,256}:[^\\s@/]{1,256}@[^\\s/]+`;
 // Context-labeled long hex/base64 secrets (client_secret, access_token, etc.).
 // Deliberately requires a credential LABEL — bare high-entropy hex is left
 // alone because git SHAs and content_hashes are pervasive and legitimate here
@@ -80,24 +83,60 @@ export interface SecretPatternDetector {
  * identify the classifier, never the matched secret value.
  */
 export const SECRET_DETECTORS: readonly SecretPatternDetector[] = [
-  { kind: "authorization_bearer_header", pattern: /authorization\s*[:=]\s*bearer\s+[^\s,;]+/i },
+  {
+    kind: "authorization_bearer_header",
+    pattern: /authorization\s*[:=]\s*bearer\s+[^\s,;]+/i,
+  },
   { kind: "bearer_token", pattern: /bearer\s+[A-Za-z0-9._~+/=-]{8,}/i },
-  { kind: "mcp_session_id", pattern: /mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+/i },
-  { kind: "openai_api_key", pattern: new RegExp(`\\b${SK_PREFIX}[A-Za-z0-9_-]{10,}\\b`) },
-  { kind: "github_pat", pattern: new RegExp(`${GITHUB_PAT_PREFIX}[A-Za-z0-9_]+`, "i") },
-  { kind: "github_token", pattern: new RegExp(`${GITHUB_PREFIX_RE}[A-Za-z0-9_]{20,}`, "i") },
-  { kind: "aws_access_key_id", pattern: new RegExp(`\\b${AWS_ACCESS_KEY_PREFIX_RE}\\b`) },
-  { kind: "aws_secret_access_key", pattern: new RegExp(AWS_SECRET_CONTEXT_RE, "i") },
+  {
+    kind: "mcp_session_id",
+    pattern: /mcp-session-id\s*[:=]\s*[A-Za-z0-9._:-]+/i,
+  },
+  {
+    kind: "openai_api_key",
+    pattern: new RegExp(`\\b${SK_PREFIX}[A-Za-z0-9_-]{10,}\\b`),
+  },
+  {
+    kind: "github_pat",
+    pattern: new RegExp(`${GITHUB_PAT_PREFIX}[A-Za-z0-9_]+`, "i"),
+  },
+  {
+    kind: "github_token",
+    pattern: new RegExp(`${GITHUB_PREFIX_RE}[A-Za-z0-9_]{20,}`, "i"),
+  },
+  {
+    kind: "aws_access_key_id",
+    pattern: new RegExp(`\\b${AWS_ACCESS_KEY_PREFIX_RE}\\b`),
+  },
+  {
+    kind: "aws_secret_access_key",
+    pattern: new RegExp(AWS_SECRET_CONTEXT_RE, "i"),
+  },
   { kind: "aws_secret_like", pattern: new RegExp(AWS_SECRET_LIKE_RE) },
   { kind: "slack_token", pattern: new RegExp(`\\b${SLACK_TOKEN_RE}\\b`) },
-  { kind: "google_api_key", pattern: new RegExp(`\\b${GOOGLE_API_KEY_PREFIX}[A-Za-z0-9_-]{35}\\b`) },
+  {
+    kind: "google_api_key",
+    pattern: new RegExp(`\\b${GOOGLE_API_KEY_PREFIX}[A-Za-z0-9_-]{35}\\b`),
+  },
   { kind: "jwt", pattern: new RegExp(`\\b${JWT_LIKE_RE}\\b`) },
-  { kind: "labeled_secret", pattern: /(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+/i },
-  { kind: "json_labeled_secret", pattern: /"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"/i },
+  {
+    kind: "labeled_secret",
+    pattern: /(api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]+/i,
+  },
+  {
+    kind: "json_labeled_secret",
+    pattern: /"(api[_-]?key|token|password|secret)"\s*:\s*"[^"]+"/i,
+  },
   { kind: "private_key_block", pattern: new RegExp(PRIVATE_KEY_BLOCK_RE) },
   { kind: "stripe_key", pattern: new RegExp(`\\b${STRIPE_KEY_RE}\\b`) },
-  { kind: "url_userinfo_credential", pattern: new RegExp(URL_USERINFO_CRED_RE, "i") },
-  { kind: "labeled_long_secret", pattern: new RegExp(LABELED_LONG_SECRET_RE, "i") },
+  {
+    kind: "url_userinfo_credential",
+    pattern: new RegExp(URL_USERINFO_CRED_RE, "i"),
+  },
+  {
+    kind: "labeled_long_secret",
+    pattern: new RegExp(LABELED_LONG_SECRET_RE, "i"),
+  },
 ];
 
 export const SECRET_PATTERNS: readonly RegExp[] = SECRET_DETECTORS.map(
@@ -123,7 +162,9 @@ export interface ShareRejectionDetailOptions {
 }
 
 function globalClone(pattern: RegExp): RegExp {
-  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  const flags = pattern.flags.includes("g")
+    ? pattern.flags
+    : `${pattern.flags}g`;
   return new RegExp(pattern.source, flags);
 }
 
@@ -131,7 +172,9 @@ function countMatches(pattern: RegExp, text: string): number {
   return Array.from(text.matchAll(globalClone(pattern))).length;
 }
 
-function detectSecret(text: string): { matched_kind: string; span_count: number } | null {
+function detectSecret(
+  text: string,
+): { matched_kind: string; span_count: number } | null {
   if (!text) return null;
   let matchedKind: string | null = null;
   let spanCount = 0;
@@ -141,7 +184,9 @@ function detectSecret(text: string): { matched_kind: string; span_count: number 
       spanCount += countMatches(pattern, text);
     }
   }
-  return matchedKind ? { matched_kind: matchedKind, span_count: spanCount } : null;
+  return matchedKind
+    ? { matched_kind: matchedKind, span_count: spanCount }
+    : null;
 }
 
 /**
@@ -163,8 +208,23 @@ export function redactText(text: string): string {
   if (!text) return text;
   let redacted = text;
   for (const pattern of SECRET_PATTERNS) {
-    const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
-    redacted = redacted.replace(new RegExp(pattern.source, flags), "[REDACTED]");
+    const flags = pattern.flags.includes("g")
+      ? pattern.flags
+      : `${pattern.flags}g`;
+    redacted = redacted.replace(
+      new RegExp(pattern.source, flags),
+      "[REDACTED]",
+    );
+  }
+  if (redacted !== text) {
+    // A redaction is a silent content mutation: the caller stores something
+    // different from what it was handed and nothing in the return value says
+    // so. Only the fact and the size delta are recorded — never the matched
+    // material, and never the surrounding text.
+    logger.warn("sharing_text_redacted", {
+      original_length: text.length,
+      redacted_length: redacted.length,
+    });
   }
   return redacted;
 }
@@ -244,7 +304,9 @@ function detectPrivate(input: ShareCandidateInput): {
   return null;
 }
 
-function resubmitAttempt(metadata: Record<string, unknown> | undefined): number {
+function resubmitAttempt(
+  metadata: Record<string, unknown> | undefined,
+): number {
   const raw = metadata?.sanitized_resubmit_attempt;
   if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) return 0;
   return raw;
@@ -266,6 +328,18 @@ export function shareRejectionDetail(
     const blockedReason = resubmittable
       ? undefined
       : (options.resubmit_blocked_reason ?? "max_attempts");
+    if (blockedReason) {
+      // Limit trigger: the agent is now permanently blocked from re-nominating
+      // this candidate. Without a line here the agent just stops getting
+      // through and nothing on the server says the cap is why.
+      logger.warn("sharing_resubmit_blocked", {
+        category: "reject-secret",
+        matched_kind: secret.matched_kind,
+        resubmit_attempt: attempt,
+        max_resubmit_attempts: SHARE_REJECTION_MAX_RESUBMIT_ATTEMPTS,
+        blocked_reason: blockedReason,
+      });
+    }
     return {
       category: "reject-secret",
       matched_kind: secret.matched_kind,
@@ -288,6 +362,16 @@ export function shareRejectionDetail(
     const blockedReason = resubmittable
       ? undefined
       : (options.resubmit_blocked_reason ?? "max_attempts");
+    if (blockedReason) {
+      // Limit trigger — see the secret branch above.
+      logger.warn("sharing_resubmit_blocked", {
+        category: "reject-private",
+        matched_kind: privateMatch.matched_kind,
+        resubmit_attempt: attempt,
+        max_resubmit_attempts: SHARE_REJECTION_MAX_RESUBMIT_ATTEMPTS,
+        blocked_reason: blockedReason,
+      });
+    }
     return {
       category: "reject-private",
       matched_kind: privateMatch.matched_kind,
@@ -326,41 +410,93 @@ export function classifyShareCandidate(
   options: ClassifyShareOptions = {},
 ): ShareDecision {
   const minLen = options.minLen ?? DEFAULT_MIN_SHARE_LENGTH;
+  const length = input.content.trim().length;
+
+  // Content-free decision context carried on every outcome line below. Only
+  // shapes and enum values: the candidate body is NEVER logged here, and the
+  // secret/private detectors contribute only their `kind` label (the name of
+  // the classifier that fired), never the matched span.
+  const base = {
+    event_type: input.event_type ?? null,
+    importance: input.importance ?? null,
+    content_length: length,
+    min_share_length: minLen,
+    tag_count: input.tags?.length ?? 0,
+  };
 
   // 1. Secret — hard reject, checked before anything else.
   if (containsSecret(input.content)) {
+    // Re-derive the detector label purely for the log line; `containsSecret`
+    // remains the decision. error, not warn: a credential reaching a shared-kb
+    // nomination is the failure mode this whole module exists to prevent. It
+    // must be loud even though the gate held, because the leak already happened
+    // upstream — the secret is sitting in a lane event.
+    const secret = detectSecret(input.content);
+    logger.error("sharing_reject_secret", {
+      ...base,
+      matched_kind: secret?.matched_kind ?? null,
+      span_count: secret?.span_count ?? 0,
+    });
     return "reject-secret";
   }
 
   // 2. Private — person-private content must not become shared truth.
   if (isPrivate(input)) {
+    // Re-derive the detector label purely for the log line. `isPrivate` is the
+    // decision (unchanged); this only names WHICH marker fired, and runs on the
+    // reject path only.
+    const privateMatch = detectPrivate(input);
+    logger.warn("sharing_reject_private", {
+      ...base,
+      matched_kind: privateMatch?.matched_kind ?? null,
+      span_count: privateMatch?.span_count ?? 0,
+    });
     return "reject-private";
   }
 
   // 3. Noise — wrong event type, cold importance, or too short.
   const eventType = input.event_type;
   if (eventType !== undefined && NOISE_EVENT_TYPES.has(eventType)) {
+    logger.debug("sharing_reject_noise", {
+      ...base,
+      noise_reason: "event_type",
+    });
     return "reject-noise";
   }
   if (input.importance === "cold") {
+    logger.debug("sharing_reject_noise", {
+      ...base,
+      noise_reason: "cold_importance",
+    });
     return "reject-noise";
   }
-  const length = input.content.trim().length;
   if (length < minLen) {
+    logger.debug("sharing_reject_noise", {
+      ...base,
+      noise_reason: "too_short",
+    });
     return "reject-noise";
   }
 
   // 4. Type eligibility. Lane events must be a shareable type; thoughts and
   //    decisions (no event_type) are always type-eligible.
   if (eventType !== undefined && !SHARE_EVENT_TYPES.has(eventType)) {
+    logger.debug("sharing_reject_noise", {
+      ...base,
+      noise_reason: "type_not_shareable",
+    });
     return "reject-noise";
   }
 
   // 5. Ambiguity band: just over the minimum length is share-eligible but not
   //    obviously substantive — route to a human for review.
   if (length < minLen * 1.5) {
+    // warn: a partially-completed path. The candidate cleared every gate and
+    // was then parked, so it will never reach shared-kb without a human.
+    logger.warn("sharing_manual_review", base);
     return "manual-review";
   }
 
+  logger.info("sharing_share_approved", base);
   return "share";
 }


### PR DESCRIPTION
## Summary

- Second split off the parked `feat/410-uv-workspace` branch (after #421 and #423). This is the **observability foundation**: the shared log envelope, host stamping, a runtime-changeable log level, and credential redaction in `describeError`. ~1,300 insertions across 12 files.
- The remaining group on that branch — `f8333d7` "log the silent two-thirds of the server" (5,217 insertions, 31 tool files) — depends on this and lands separately.
- `withLogging` emits entry/exit/failure automatically so the five required log points from `_DOCS/CODING_STANDARDS.md` are the *shorter* path. The wrapper never swallows: it logs, then re-throws.
- **Side effect worth naming:** this branch makes `src/source-sync.test.ts` (#422) pass in the full suite, stable across 3 consecutive runs. The plausible mechanism is `MIN_LEVEL` becoming a mutable `minLevel` — an earlier test could previously strand the process at a level where `logger.error` no longer reached `console.error`, unrecoverably for the rest of the run. **I could not isolate this cleanly** (reverting `logger.ts` alone breaks 16 dependent tests), so I am reporting it as observed, not as a proven cause. #422 should stay open until someone confirms the mechanism.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

Evidence:
- `bunx tsc --noEmit` clean.
- 2516 tests pass, 0 fail, 35 skip. Three consecutive full runs, no flake.
- No migrations, no Python changes in this slice.
- Every fix below was reproduced *before* being fixed and verified red-then-green by reverting the fix in place.

## Critical Self-Review

Three defects found by self-review before this PR opened, all in `setLogLevel`/`log`:

- Highest-risk behavior: **`setLogLevel` could strand the level wide open.** The announce line widens the gate so the transition cannot filter its own notice, then restores it — with a plain assignment, not `finally`. `log` throws for real (`FILE_SINK.write` on a full disk). Proven: with the sink throwing, `debug -> error` left `minLevel` at `debug` while the caller saw an exception and would conclude nothing changed. That inverts the intent on the one path the setter exists for — an operator raising verbosity mid-incident, on the box whose disk just filled, silently gets debug volume from a call that reported failure.
- Assumptions that could be wrong: that `SECRET_PATTERNS` covers what actually appears in thrown errors. `describeError` redacts `error_name` too, because a real leak was caught in review with `err.name` set to `NatsError nats://user:pass@host` — but the pattern set is the ceiling on that guarantee.
- Missing/weak tests: no test asserts envelope conformance against the shared contract itself, only against this implementation's output. No concurrency test for `addLogSink` add/remove during emit.
- Security/permission risk: **async context could override `service`, `host`, and `level`** — `contextFields()` spread last, after the fields the code claims to own. Those two are the only Loki labels, so one reader spreading a request object wholesale splits the query surface silently. Fixed by spreading context first.
- Migration/deploy risk: none. No schema, no migration.
- Downstream client/runtime risk: `logger.ts` is imported broadly, but the envelope only *adds* `service`/`host`. `setLogLevel`/`getLogLevel`/`addLogSink` are new exports; nothing existing changes shape.
- Rollback/cleanup concern: reverting restores a module-load-constant log level. No data or schema to unwind.
- Fixes made before PR: the `finally` on `setLogLevel`; context spread order; **guarding `FILE_SINK.write`**, which ran unguarded ahead of the console sinks so a throw lost the line everywhere — again making disk-full the case that blinds the operator investigating it.
- Known residual risk: `redactForLog` runs per log line over every pattern. It builds a fresh `RegExp` each call (verified: identical output across 10 calls, all occurrences caught, no `lastIndex` stranding), but the cost on a hot path is unmeasured.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: no deployed behavior changes until merge; the hosted smoke would exercise the pre-merge build.

## Contract Parity

- Contract parity: [x] runtime-specific because: this slice touches only the TypeScript server's logging internals. No MCP tool schema, no client-facing surface, and no Python client change, so there is no matched-client contract to hold parity against.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Server-internal logging only. No tool schema, response shape, or client call changes, so no downstream client can break on it.
- The envelope adds `service` and `host` to emitted lines. That is additive for any log consumer; a parser reading the existing fields is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
