### PR TITLE
fix(provider): move signal ownership out of the logging module

### DIFF
--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -784,3 +784,61 @@ telling the nested caller it had succeeded.
 - **Does the existing test for this exercise the colliding case?** A passing
   reentrancy/idempotency test often picks distinct values precisely because
   distinct values are easier to assert on. That is the case that cannot fail.
+## [2026-07-26] Derived a logging design instead of reading the working one
+
+**Severity:** MEDIUM (process, not code). **Status:** fixed — canonical rules now
+in `_DOCS/CODING_STANDARDS.md` `### Logging (non-negotiable)`.
+
+I built `openbrain-provider`'s loguru setup from the observability contract plus
+first principles: a `_usable_log_dir` probe-and-fallback chain, sink reset on
+every `configure_observability` call, and a **process-global SIGTERM/SIGINT
+handler installed from library code**.
+
+Rico: *"can you not look at my other python project to see how the
+config/logging/etc work rather than guessing. i've NEVER had an issue with
+logging via loguru in any other project."*
+
+The reference — `WorkStuff/b1x-message-coordinator/src/message_coordinator/utils/logging_config.py`
+— answers every question I had been deriving, and answers two of them
+differently:
+
+| | what I derived | what the working project does |
+|---|---|---|
+| repeat setup | `logger.remove()` every call | module-level `_logging_initialized` flag |
+| unwritable sink | probe dir, fallback chain | `try/except` around each `logger.add`, degrade |
+| signals | installed inside the logging module | **only in each service's `__main__`** |
+| stdout vs stderr | stderr (agreed) | stderr |
+
+### The technical content worth keeping
+
+The record loss I measured was real and reproduces in the plain reference style
+with no project code: **clean exit 200/200, abrupt SIGTERM ~100/200**, newest
+records lost. But that reconciles with "never had an issue" rather than
+contradicting it, and the reconciliation is the actual rule:
+
+- A **long-running daemon** exits through its own `signal_handler` → normal exit
+  → loguru's `atexit` drains the queue. It can run for years and never lose a
+  line.
+- A **short-lived hook** gets killed mid-run. No graceful shutdown, no `atexit`,
+  so it needs an explicit drain — but as an **entrypoint opt-in**, not something
+  `configure_observability` does to its caller.
+
+So the fix was warranted; I had built it in the wrong layer. A separate review
+lane independently flagged the same library-installed handler as a reentrancy
+hazard.
+
+### Review Questions
+
+- Does this repo (or a sibling under `Development/`) already solve this exact
+  problem in production? **Search before deriving.** A working implementation
+  answers questions a spec cannot — especially "which layer owns this."
+- Does a library function install a process-global signal handler, `atexit` hook,
+  or other process-wide state? That belongs in the entrypoint. If it must be
+  offered, offer it as an opt-in the entrypoint calls.
+- Is `enqueue=True` used in a **short-lived** process? Then the queue can outlive
+  it. Long-running services are fine; hooks and CLIs are not.
+- Does the durability test give the async writer a drain window? A ready-file
+  plus parent poll hands it ~10 ms and reports a clean pass with the fix
+  reverted. The child must signal *itself* immediately after the last record.
+- Is `signal.default_int_handler` treated as "already claimed"? It is a
+  *callable*, so a plain `if callable(previous)` guard skips SIGINT every time.

--- a/python/openbrain-provider/src/openbrain_provider/observability.py
+++ b/python/openbrain-provider/src/openbrain_provider/observability.py
@@ -50,6 +50,7 @@ __all__ = [
     "TOP_LEVEL_FIELDS",
     "configure_observability",
     "flush_logs",
+    "install_signal_flush",
     "logger",
     "resolve_log_file",
 ]
@@ -233,18 +234,24 @@ def flush_logs() -> None:
     logger.remove()
 
 
-def _install_signal_flush() -> None:
+def install_signal_flush() -> None:
     """Drain the log queue on SIGTERM and SIGINT before exiting.
 
-    loguru registers an `atexit` hook, which covers a clean exit: measured 200
-    of 200 records surviving. It does NOT cover a signal. Measured on SIGTERM
-    with no handler: **130 of 200 records reached disk**, the missing 70 being
-    the newest ones still queued.
+    **Call this from an entrypoint, not from library code.** It is deliberately
+    opt-in: `configure_observability` does not call it. Installing a
+    process-global signal handler is the entrypoint's decision, because the
+    entrypoint is the only layer that knows whether something else already owns
+    shutdown. `b1x-message-coordinator` -- a long-running loguru service that has
+    never had a logging problem -- puts its `signal_handler` in each service's
+    `__main__` and keeps the logging module free of signals. Same split here.
 
-    That is the wrong way round for a hook. The records worth having are the
-    ones written just before something tore the process down, and those are
-    exactly the ones sitting in the queue. A hook killed mid-session would lose
-    its own explanation.
+    Why a hook needs it when that service does not: loguru's `atexit` hook drains
+    the queue on a **clean** exit, which is how a daemon shutting down through
+    its own handler exits. Measured, with plain `enqueue=True` and no handler at
+    all: clean exit 200/200, abrupt SIGTERM ~100/200. A daemon never hits the
+    second case. A hook is a short-lived process the runtime can kill mid-run, so
+    it hits exactly that case, and the records it loses are the newest ones --
+    the ones explaining whatever killed it.
 
     Only installs a handler when none is set, and chains to any previous one, so
     this never silently overrides a caller's own shutdown logic. Signal handlers
@@ -333,8 +340,7 @@ def configure_observability(
         # channel, the one place a log line must never land.
         logger.add(sys.stderr, level=level, format=sink_format, enqueue=True)
 
-    # After the sink exists, so a signal arriving mid-configure drains a real
-    # queue rather than a sink that has not been attached yet.
-    _install_signal_flush()
-
+    # NOTE: no signal handler is installed here. Configuring logging must not
+    # claim a process-global signal on the caller's behalf -- see
+    # `install_signal_flush`, which an entrypoint calls explicitly.
     return log_file

--- a/python/openbrain-provider/tests/test_observability.py
+++ b/python/openbrain-provider/tests/test_observability.py
@@ -26,10 +26,10 @@ from openbrain_provider.config import LogConfig, ProviderConfig, load_config
 from openbrain_provider.observability import (
     SERVICE_NAME,
     TOP_LEVEL_FIELDS,
-    _install_signal_flush,
     _usable_log_dir,
     configure_observability,
     flush_logs,
+    install_signal_flush,
     logger,
     resolve_log_file,
 )
@@ -359,7 +359,7 @@ def test_known_contract_fields_stay_at_the_top_level(tmp_path: Path) -> None:
 #: `ready` file and sleep while the parent polled and then signalled. That
 #: handed the writer roughly ten milliseconds -- enough to finish the queue --
 #: so it reported 200/200 with the fix reverted and proved nothing. Verified:
-#: this shape gives 133/200 with `_install_signal_flush()` disabled and 200/200
+#: this shape gives 133/200 with `install_signal_flush()` not called and 200/200
 #: with it enabled.
 #:
 #: `%s` rather than str.format: the source contains dict literals, and every
@@ -367,9 +367,15 @@ def test_known_contract_fields_stay_at_the_top_level(tmp_path: Path) -> None:
 _SIGTERM_PROBE = """
 import os, signal, sys
 from openbrain_provider.config import load_config
-from openbrain_provider.observability import configure_observability, logger
+from openbrain_provider.observability import (
+    configure_observability,
+    install_signal_flush,
+    logger,
+)
 
 configure_observability(load_config({"LOG_LEVEL": "info", "LOG_FILE": sys.argv[1]}))
+# An entrypoint opts in; the logging module never claims the signal itself.
+install_signal_flush()
 for i in range(%s):
     logger.info("record", record_index=i)
 os.kill(os.getpid(), signal.SIGTERM)
@@ -448,7 +454,7 @@ def test_a_caller_installed_signal_handler_is_not_replaced() -> None:
     previous = signal.getsignal(signal.SIGTERM)
     signal.signal(signal.SIGTERM, caller_handler)
     try:
-        _install_signal_flush()
+        install_signal_flush()
 
         assert signal.getsignal(signal.SIGTERM) is caller_handler
     finally:


### PR DESCRIPTION
## Summary

- `configure_observability` was installing a process-global SIGTERM/SIGINT handler on its caller's behalf. Configuring logging must not claim a process-wide signal — the entrypoint is the only layer that knows whether something else already owns shutdown. A review lane independently flagged the same construct as a reentrancy hazard.
- `_install_signal_flush` becomes the public, opt-in `install_signal_flush()`, called by an entrypoint rather than as a side effect of configuring logging.
- The pattern comes from a working loguru service rather than from first principles: `WorkStuff/b1x-message-coordinator` keeps signal handling in each service's `__main__` and its logging module free of signals. It has never had a logging problem, which is the point.

**Why the handler is needed at all.** loguru's `enqueue=True` writes on a background thread. `atexit` drains it on a clean exit; a signal does not. A daemon exits through its own handler → normal exit → `atexit` drains, so the same setting looks fine there. A hook process is killed mid-run and never reaches `atexit`. Same setting, opposite outcome — which is why "we've never had an issue with loguru" and "records are lost here" are both true.

**Also fixed: `signal.default_int_handler` is a callable.** A plain `if callable(previous)` "already claimed" guard skips SIGINT every time, because the interpreter's own SIGINT default *is* a callable. The guard now excludes it explicitly.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

`uv run pytest -q` → 85 passed. `uv run mypy src/openbrain_provider` → no issues in 4 files. `uv run ruff check src tests` → all checks passed.

**Red-then-green proof.** Commenting out the single `install_signal_flush()` call in the probe:

```
AssertionError: lost 58 of 200 records
assert 142 == 200
FAILED tests/test_observability.py::test_queued_records_survive_sigterm
```

Restored → 85 passed. The test binds to the behavior, not to the shape of the code.

## Critical Self-Review

- Highest-risk behavior: installing a process-global signal handler. That is exactly what this PR stops doing implicitly; the opt-in call is now the entrypoint's explicit decision.
- Assumptions that could be wrong: that no current entrypoint depended on the handler being installed as a side effect of `configure_observability`. Checked — the handler was only reachable through that call, and the probe is the only in-repo caller that needs it.
- Missing/weak tests: the SIGINT path is covered for disposition/restore but not for record survival; only SIGTERM has the 200-record probe. Deliberate — the SIGINT variant needs an interactive terminal to be honest, and a fake one would be the drain-window mistake again.
- Security/permission risk: none. No auth, namespace, or credential surface touched.
- Migration/deploy risk: none. No schema, no migration.
- Downstream client/runtime risk: `install_signal_flush` is newly public API. Nothing outside this package calls it yet, so no consumer breaks; the previously implicit behavior is the one that changed, and it changed to "does nothing unless asked".
- Rollback/cleanup concern: reverting restores the implicit handler. The test fixture now restores signal dispositions, so a revert cannot leak handlers into the pytest process the way the original did.
- Fixes made before PR: the `callable(previous)` guard that silently skipped SIGINT; the pytest fixture that leaked handlers between tests; and an earlier version of this test that used a ready-file/parent-poll handshake, gave the writer ~10 ms, and reported a clean 200/200 **with the fix reverted**. It now self-signals with no drain window.
- Known residual risk: `flush_logs()` is `logger.remove()`, so a handler that fires mid-flush during an already-draining shutdown gets a no-op rather than a second drain. Acceptable: the first drain is the one that matters, and the alternative is a lock in a signal handler.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this is a logging-lifecycle change inside the Python provider package, with no server, transport, or MCP tool surface.

`docs/sme/gotcha-agent.md` gains "Derived a logging design instead of reading the working one" — the process failure was mine: I reasoned about loguru from the contract doc instead of reading a project that already had this solved.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no capability, tool, or wire-format surface changes. `bun contracts/check-parity.ts` passes unchanged (14 fixtures / 9 capabilities).

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing surface changes. The only new symbol is `install_signal_flush`, which is internal to `openbrain-provider` and has no external callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

