### PR TITLE
feat(412): one event vocabulary, imported not duplicated

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/__init__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .agent import (
+    EVENT_TYPES,
     AgentMemory,
     MemoryClient,
     MemoryContext,
@@ -79,6 +80,7 @@ from .turn_concepts import (
 )
 
 __all__ = [
+    "EVENT_TYPES",
     "AgentMemory",
     "DEFAULT_MAX_KEYS",
     "TurnConcepts",

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -32,6 +32,25 @@ logger = logging.getLogger(__name__)
 # (entities before concepts), first-seen wins.
 DERIVED_QUERY_MAX_KEYS = 8
 
+#: The session-event vocabulary. THE definition — every other surface imports or
+#: is checked against this one, never redeclares it (#412).
+#:
+#: The authority is ultimately the database: `ob_session_events.event_type`
+#: carries a CHECK constraint listing exactly these values. A value that is not
+#: in the constraint is rejected by Postgres, so a set that drifts *wider* than
+#: the constraint produces the failure this vocabulary was consolidated to
+#: prevent — the caller passes validation here, the insert is refused, and the
+#: symptom is a silent no-row write rather than a named error. `event_type:
+#: "finding"` did exactly that: exit 0, no output, no row.
+#:
+#: Because it is duplicated across languages by necessity (Python, the TS
+#: client, the TS server, and SQL cannot share one literal), the guard is a test
+#: rather than an import: `test_event_vocabulary.py` asserts every surface
+#: agrees, and fails if any one of them adds or drops a value.
+#:
+#: Widening this set therefore means widening the CHECK constraint in the same
+#: change. Adding a value here alone does not make it usable; it makes it
+#: silently unwritable.
 EVENT_TYPES = {
     "fact",
     "decision",

--- a/python/openbrain-memory/tests/test_event_vocabulary.py
+++ b/python/openbrain-memory/tests/test_event_vocabulary.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import re
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -49,6 +49,15 @@ def _extract_quoted_block(source: str, anchor: str) -> set[str]:
     the thing it guards, and a malformed anchor fails loudly as an empty set
     rather than silently matching too much.
     """
+    if anchor not in source:
+        # A rename upstream is the likely cause, and a bare
+        # `ValueError: substring not found` from `str.index` does not say so.
+        # It fails either way -- the point of naming it is that the next reader
+        # knows the declaration moved rather than the vocabulary changed.
+        pytest.fail(
+            f"anchor {anchor!r} not found; the declaration was renamed or moved. "
+            "Update this guard to the new spelling -- do not delete the check."
+        )
     start = source.index(anchor)
     tail = source[start + len(anchor) :]
     end = min(
@@ -58,6 +67,17 @@ def _extract_quoted_block(source: str, anchor: str) -> set[str]:
     if end == -1:  # pragma: no cover - only on a malformed source file
         pytest.fail(f"no closing bracket after anchor: {anchor!r}")
     return set(re.findall(r'"([a-z_]+)"', tail[:end]))
+
+
+def _extract_union(source: str, anchor: str) -> set[str]:
+    """Return the quoted members of a TypeScript union starting at `anchor`."""
+    if anchor not in source:
+        pytest.fail(
+            f"anchor {anchor!r} not found; the union was renamed or moved. "
+            "Update this guard to the new spelling -- do not delete the check."
+        )
+    start = source.index(anchor)
+    return set(re.findall(r'"([a-z_]+)"', source[start : source.index(";", start)]))
 
 
 def _drift(surface: str, found: set[str]) -> str:
@@ -119,9 +139,7 @@ def test_mcp_tool_schema_matches_python() -> None:
 def test_tiering_union_matches_python() -> None:
     """`src/tiering.ts` `EventType` matches; it decides what gets promoted."""
     source = (REPO_ROOT / "src" / "tiering.ts").read_text()
-    start = source.index("export type EventType")
-    union = source[start : source.index(";", start)]
-    found = set(re.findall(r'"([a-z_]+)"', union))
+    found = _extract_union(source, "export type EventType")
     assert found == EVENT_TYPES, _drift("tiering EventType", found)
 
 
@@ -141,9 +159,7 @@ def test_typescript_server_union_type_matches_python() -> None:
     rather than a silent write, which is why it is checked separately.
     """
     source = (REPO_ROOT / "src" / "agent-memory.ts").read_text()
-    start = source.index("export type MemoryEventType")
-    union = source[start : source.index(";", start)]
-    found = set(re.findall(r'"([a-z_]+)"', union))
+    found = _extract_union(source, "export type MemoryEventType")
     assert found == EVENT_TYPES, _drift("MemoryEventType union", found)
 
 
@@ -185,12 +201,33 @@ def test_database_constraint_matches_python() -> None:
     )
 
 
+def _is_test_path(path: str) -> bool:
+    """True for a test file, matched on path COMPONENTS, not substrings.
+
+    `"test" in path` was the first version and it silently excluded
+    `latest.ts`, `manifest.ts`, and `attestation.ts` from the sweep below --
+    every one of which could hold a real declaration. A guard whose filter
+    hides files is worse than no guard, because it reports success over the
+    gap. Matched on segment boundaries instead.
+    """
+    parts = PurePosixPath(path).parts
+    return any(
+        part in {"tests", "__tests__"} or part.startswith(("test_", "test."))
+        for part in parts
+    ) or PurePosixPath(path).name.endswith((".test.ts", "_test.py"))
+
+
 def test_vocabulary_is_declared_exactly_where_expected() -> None:
-    """No fifth copy appears without this guard being updated to cover it.
+    """No seventh copy appears without this guard being updated to cover it.
 
     The point of the slice is one definition; a new redeclaration somewhere
     else would be invisible to the assertions above, which only compare the
     surfaces they already know about.
+
+    Scope note: `git grep` searches TRACKED files, so a brand-new untracked
+    file is not seen. That is the right boundary for CI (which runs on
+    committed code) but means this cannot catch a declaration mid-edit before
+    it is staged.
     """
     known = {
         "python/openbrain-memory/src/openbrain_memory/agent.py",
@@ -210,7 +247,7 @@ def test_vocabulary_is_declared_exactly_where_expected() -> None:
     found = {
         line
         for line in result.stdout.splitlines()
-        if line and "test" not in line and "_tmp" not in line
+        if line and not _is_test_path(line) and not line.startswith("_tmp/")
     }
     unexpected = found - known
     assert not unexpected, (

--- a/python/openbrain-memory/tests/test_event_vocabulary.py
+++ b/python/openbrain-memory/tests/test_event_vocabulary.py
@@ -1,0 +1,220 @@
+"""The session-event vocabulary is defined once and never redeclared (#412).
+
+The vocabulary necessarily appears in six places -- this package, the
+TypeScript client, the TypeScript server set, the `MemoryEventType` union, the
+MCP tool schema, `table-constants.ts`, and a SQL CHECK constraint -- because
+those languages cannot share one literal. So "one definition" is enforced by
+this test rather than by an import: `openbrain_memory.EVENT_TYPES` is the
+definition, and every other surface is asserted equal to it.
+
+The issue that prompted this named two copies. Writing the guard found four
+more, which is the argument for the guard: nobody can hold six declarations in
+their head, and the `test_vocabulary_is_declared_exactly_where_expected` check
+below exists so a seventh cannot appear unnoticed.
+
+Why this is worth a test instead of a comment: the two Python/TypeScript copies
+had already drifted once. `question` was valid in Python and missing from the
+TypeScript adapter, and nothing reported it -- sending an event the other side
+did not know about produced exit 0, no output, and no row. A silent no-op is
+the worst possible failure for a memory write, because the caller has every
+reason to believe it succeeded.
+
+The SQL constraint is included deliberately, and it is the one that actually
+matters. Postgres is the final authority: a value in the code sets but missing
+from the CHECK constraint is accepted by every layer of validation and then
+refused at the insert, reproducing exactly the silent-write symptom above. A
+code set that drifts *wider* than the database is therefore not a cosmetic
+inconsistency; it is that bug.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from openbrain_memory import EVENT_TYPES
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _extract_quoted_block(source: str, anchor: str) -> set[str]:
+    """Return the quoted string literals in the block opened at `anchor`.
+
+    Reads to the first closing bracket after the anchor, which is what every
+    declaration here looks like (a set/array literal of bare strings). This is
+    deliberately dumb: a real parser for two languages would be more code than
+    the thing it guards, and a malformed anchor fails loudly as an empty set
+    rather than silently matching too much.
+    """
+    start = source.index(anchor)
+    tail = source[start + len(anchor) :]
+    end = min(
+        (tail.index(c) for c in ("]", "}") if c in tail),
+        default=-1,
+    )
+    if end == -1:  # pragma: no cover - only on a malformed source file
+        pytest.fail(f"no closing bracket after anchor: {anchor!r}")
+    return set(re.findall(r'"([a-z_]+)"', tail[:end]))
+
+
+def _drift(surface: str, found: set[str]) -> str:
+    """A failure message naming which side has which value.
+
+    A bare `assert found == EVENT_TYPES` reports two sorted sets and leaves the
+    reader to diff nine strings by eye. Naming the difference is the whole
+    value of the message when this fires months from now.
+    """
+    return (
+        f"{surface} vocabulary drifted from openbrain_memory.EVENT_TYPES; "
+        f"missing={sorted(EVENT_TYPES - found)} "
+        f"unexpected={sorted(found - EVENT_TYPES)}"
+    )
+
+
+def test_python_vocabulary_is_the_public_surface() -> None:
+    """`EVENT_TYPES` is importable from the package root, not just `agent`."""
+    from openbrain_memory import agent
+
+    assert EVENT_TYPES is agent.EVENT_TYPES
+    assert "EVENT_TYPES" in __import__("openbrain_memory").__all__
+
+
+def test_typescript_client_matches_python() -> None:
+    """`clients/ts/src/runtime.ts` carries the same set."""
+    source = (REPO_ROOT / "clients" / "ts" / "src" / "runtime.ts").read_text()
+    found = _extract_quoted_block(source, "export const EVENT_TYPES")
+    assert found == EVENT_TYPES, _drift("TypeScript client", found)
+
+
+def test_typescript_server_matches_python() -> None:
+    """`src/agent-memory.ts` carries the same set."""
+    source = (REPO_ROOT / "src" / "agent-memory.ts").read_text()
+    found = _extract_quoted_block(
+        source, "const EVENT_TYPES = new Set<MemoryEventType>"
+    )
+    assert found == EVENT_TYPES, _drift("TypeScript server", found)
+
+
+def test_mcp_tool_schema_matches_python() -> None:
+    """The `append_session_event` tool schema advertises the same set.
+
+    This one is wire-visible: the schema is what every MCP client is told it
+    may send. A value here that the server rejects produces a request the
+    client had every reason to believe was valid, and a value missing here is
+    unreachable through the tool even though the server would accept it.
+    """
+    source = (REPO_ROOT / "src" / "contract-schemas.ts").read_text()
+    # Anchor on this property's own `values: [`, found by seeking forward from
+    # the `event_type` key. A bare `values: [` matches a different enum earlier
+    # in the file, and anchoring on `event_type: {` alone picks up the
+    # `type: "enum"` line before the list starts.
+    prop = source.index("event_type: {")
+    found = _extract_quoted_block(source[prop:], "values: [")
+    assert found == EVENT_TYPES, _drift("MCP tool schema", found)
+
+
+def test_tiering_union_matches_python() -> None:
+    """`src/tiering.ts` `EventType` matches; it decides what gets promoted."""
+    source = (REPO_ROOT / "src" / "tiering.ts").read_text()
+    start = source.index("export type EventType")
+    union = source[start : source.index(";", start)]
+    found = set(re.findall(r'"([a-z_]+)"', union))
+    assert found == EVENT_TYPES, _drift("tiering EventType", found)
+
+
+def test_table_constants_match_python() -> None:
+    """`src/tools/table-constants.ts` matches; it gates the SQL write path."""
+    source = (REPO_ROOT / "src" / "tools" / "table-constants.ts").read_text()
+    found = _extract_quoted_block(source, "export const EVENT_TYPES = [")
+    assert found == EVENT_TYPES, _drift("table-constants", found)
+
+
+def test_typescript_server_union_type_matches_python() -> None:
+    """The `MemoryEventType` union matches the runtime set it types.
+
+    The union and the `Set` are two separate declarations in the same file, so
+    they can disagree with each other as easily as with Python -- and a union
+    that is missing a value makes the corresponding `Set` entry a type error
+    rather than a silent write, which is why it is checked separately.
+    """
+    source = (REPO_ROOT / "src" / "agent-memory.ts").read_text()
+    start = source.index("export type MemoryEventType")
+    union = source[start : source.index(";", start)]
+    found = set(re.findall(r'"([a-z_]+)"', union))
+    assert found == EVENT_TYPES, _drift("MemoryEventType union", found)
+
+
+def _migration_check_constraint() -> set[str] | None:
+    """The event_type CHECK constraint as declared in the migrations."""
+    migrations = REPO_ROOT / "src" / "db" / "migrations"
+    if not migrations.is_dir():
+        return None
+    # `CHECK (event_type IN ('fact', 'decision', ...))` as declared in
+    # 013_session_events.sql. Matching the IN-list specifically rather than any
+    # CHECK containing `event_type` keeps a neighbouring constraint on the same
+    # column from being picked up instead.
+    pattern = re.compile(
+        r"CHECK\s*\(\s*event_type\s+IN\s*\((.*?)\)\s*\)", re.IGNORECASE | re.DOTALL
+    )
+    for path in sorted(migrations.iterdir()):
+        if path.suffix != ".sql":
+            continue
+        match = pattern.search(path.read_text())
+        if match:
+            return set(re.findall(r"'([a-z_]+)'", match.group(1)))
+    return None
+
+
+def test_database_constraint_matches_python() -> None:
+    """The SQL CHECK constraint carries the same set.
+
+    Postgres is the authority. A value the code accepts but the constraint
+    rejects is accepted by every validation layer and then refused at the
+    insert -- the caller sees success and no row appears.
+    """
+    declared = _migration_check_constraint()
+    if declared is None:
+        pytest.skip("no event_type CHECK constraint found in migrations/")
+    assert declared is not None  # narrows for the type checker after skip
+    assert declared == EVENT_TYPES, (
+        _drift("database CHECK constraint", declared)
+        + ". A code value missing from the constraint is a silent no-row write."
+    )
+
+
+def test_vocabulary_is_declared_exactly_where_expected() -> None:
+    """No fifth copy appears without this guard being updated to cover it.
+
+    The point of the slice is one definition; a new redeclaration somewhere
+    else would be invisible to the assertions above, which only compare the
+    surfaces they already know about.
+    """
+    known = {
+        "python/openbrain-memory/src/openbrain_memory/agent.py",
+        "clients/ts/src/runtime.ts",
+        "src/agent-memory.ts",
+        "src/contract-schemas.ts",
+        "src/tiering.ts",
+        "src/tools/table-constants.ts",
+    }
+    result = subprocess.run(
+        ["git", "grep", "-l", "-E", r'"blocker"', "--", "*.py", "*.ts"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    found = {
+        line
+        for line in result.stdout.splitlines()
+        if line and "test" not in line and "_tmp" not in line
+    }
+    unexpected = found - known
+    assert not unexpected, (
+        f"event vocabulary appears in unexpected files: {sorted(unexpected)}. "
+        "Either import it from openbrain_memory.EVENT_TYPES, or add the file to "
+        "this guard so drift there is caught too."
+    )

--- a/python/openbrain-provider/src/openbrain_provider/__init__.py
+++ b/python/openbrain-provider/src/openbrain_provider/__init__.py
@@ -16,14 +16,17 @@ from .config import (
     load_config,
 )
 from .observability import SERVICE_NAME, configure_observability, logger
+from .vocabulary import EVENT_TYPES, is_valid_event_type
 
 __all__ = [
+    "EVENT_TYPES",
     "SERVICE_NAME",
     "ConfigError",
     "DispatchConfig",
     "LogConfig",
     "ProviderConfig",
     "configure_observability",
+    "is_valid_event_type",
     "load_config",
     "logger",
 ]

--- a/python/openbrain-provider/src/openbrain_provider/vocabulary.py
+++ b/python/openbrain-provider/src/openbrain_provider/vocabulary.py
@@ -1,0 +1,49 @@
+"""Domain vocabulary, imported from `openbrain-memory` rather than redeclared.
+
+There is no vocabulary defined in this module and there must never be one. The
+provider validates the same event types the memory package does, so it consumes
+that package's definition through the workspace dependency; a second literal
+here would be a fourth copy of a set that has already drifted once in this
+codebase.
+
+That drift is the reason this module exists. `question` was valid in the Python
+package and missing from the TypeScript adapter, and the mismatch surfaced as
+nothing at all: sending an event type the other side did not know about
+produced exit 0, no output, and no row. For a memory write that is the worst
+available failure, because the caller has every reason to believe it worked.
+
+`openbrain_memory.EVENT_TYPES` is the definition. Six surfaces necessarily
+restate it -- Python, the TS client, the TS server, the MCP tool schema, the
+tiering union, the SQL CHECK constraint -- because no single literal can be
+shared across those languages. Those are held together by
+`test_event_vocabulary.py` in the memory package, which fails if any one of
+them adds or drops a value. This module is the one place that does NOT need
+that guard, because it does not restate anything.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from openbrain_memory import EVENT_TYPES as _MEMORY_EVENT_TYPES
+
+#: Accepted session-event types.
+#:
+#: Re-exported, not redefined: this name is an alias for
+#: `openbrain_memory.EVENT_TYPES` and is `frozenset` only to make the provider's
+#: copy immutable at the boundary. Adding a value means editing the memory
+#: package (and the CHECK constraint alongside it), never editing this file.
+EVENT_TYPES: Final[frozenset[str]] = frozenset(_MEMORY_EVENT_TYPES)
+
+
+def is_valid_event_type(value: str) -> bool:
+    """True when `value` is an accepted session-event type.
+
+    A predicate rather than a bare set membership check at each call site, so
+    the rejection path has one place to grow a named reason (#413) instead of
+    nine scattered `in` tests.
+    """
+    return value in EVENT_TYPES
+
+
+__all__ = ["EVENT_TYPES", "is_valid_event_type"]

--- a/python/openbrain-provider/tests/test_vocabulary.py
+++ b/python/openbrain-provider/tests/test_vocabulary.py
@@ -1,0 +1,79 @@
+"""The provider consumes the memory package's vocabulary; it never keeps its own.
+
+The assertion that matters is `test_provider_set_is_the_memory_set`: it fails
+if either side adds or removes a value. Without it the two copies re-diverge
+silently, which is precisely how `question` came to be valid in Python and
+invalid in the TypeScript adapter -- a mismatch that produced exit 0, no
+output, and no row rather than an error anyone could act on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from openbrain_memory import EVENT_TYPES as MEMORY_EVENT_TYPES
+
+from openbrain_provider import EVENT_TYPES, is_valid_event_type
+
+PROVIDER_SRC = Path(__file__).resolve().parents[1] / "src" / "openbrain_provider"
+
+
+def test_provider_set_is_the_memory_set() -> None:
+    """The drift guard. Fails the moment either side changes independently."""
+    assert set(EVENT_TYPES) == set(MEMORY_EVENT_TYPES), (
+        "provider vocabulary diverged from openbrain_memory.EVENT_TYPES; "
+        f"provider-only={sorted(set(EVENT_TYPES) - set(MEMORY_EVENT_TYPES))} "
+        f"memory-only={sorted(set(MEMORY_EVENT_TYPES) - set(EVENT_TYPES))}"
+    )
+
+
+def test_question_is_accepted() -> None:
+    """`question` is valid today and the TypeScript adapter rejected it.
+
+    Named explicitly rather than covered only by the set comparison above: this
+    is the value whose absence was the reported bug, so it gets an assertion
+    that says so.
+    """
+    assert is_valid_event_type("question")
+
+
+@pytest.mark.parametrize("event_type", sorted(MEMORY_EVENT_TYPES))
+def test_every_memory_event_type_is_accepted(event_type: str) -> None:
+    """Each value individually, so a failure names the value that broke."""
+    assert is_valid_event_type(event_type)
+
+
+def test_unknown_event_type_is_rejected() -> None:
+    """`finding` is the value from the bug report: accepted by nothing, silently.
+
+    The provider must return False rather than pass it through. Reporting the
+    rejection loudly is #413; refusing it is this slice.
+    """
+    assert not is_valid_event_type("finding")
+    assert not is_valid_event_type("")
+    assert not is_valid_event_type("FACT")  # the set is lowercase, exactly
+
+
+def test_provider_declares_no_vocabulary_of_its_own() -> None:
+    """No literal event-type set is written anywhere in the provider package.
+
+    The point of the slice is one definition. A helpful-looking local copy
+    added later would satisfy every other test in this file while reintroducing
+    exactly the duplication that caused the bug, so the absence of a second
+    literal is asserted directly rather than assumed.
+    """
+    offenders: list[str] = []
+    for path in PROVIDER_SRC.rglob("*.py"):
+        text = path.read_text()
+        # `vocabulary.py` names one value in prose; a redeclaration would need
+        # several literals together, so require two distinct ones to flag.
+        hits = sum(
+            1 for value in ("fact", "blocker", "handoff") if f'"{value}"' in text
+        )
+        if hits >= 2:
+            offenders.append(str(path.relative_to(PROVIDER_SRC)))
+    assert not offenders, (
+        f"event-type literals found in provider source: {offenders}. "
+        "Import openbrain_memory.EVENT_TYPES instead of restating it."
+    )


### PR DESCRIPTION
## Summary

Closes #412.

The provider now imports `EVENT_TYPES` from `openbrain-memory` through the workspace dependency instead of carrying a literal of its own, and `EVENT_TYPES` is promoted to that package's public surface so consuming it does not mean reaching into `agent.py`.

**Two findings changed the shape of the slice.**

**1. The drift the issue reports is already repaired.** Python, the TS client, and the TS server all carry the same nine values today, and `question` is present in every one. So the durable deliverable is not a repair — it is the guard the issue itself calls for: *"the drift guard; without it the two copies re-diverge silently."*

**2. There were not two copies. There are six, plus SQL.** Writing the guard immediately found four the issue never named:

| Surface | File |
|---|---|
| Python (the definition) | `openbrain_memory/agent.py` |
| TS client | `clients/ts/src/runtime.ts` |
| TS server set | `src/agent-memory.ts` |
| `MemoryEventType` union | `src/agent-memory.ts` |
| **MCP tool schema** | `src/contract-schemas.ts` |
| tiering `EventType` union | `src/tiering.ts` |
| SQL write path | `src/tools/table-constants.ts` |
| **CHECK constraint** | `src/db/migrations/013_session_events.sql` |

That is the argument for a test rather than a convention — nobody holds six declarations in their head. A final assertion fails if a seventh appears, so the guard cannot silently stop covering what it guards.

**The SQL constraint is included and matters most.** Postgres is the authority, so a code set drifting *wider* than the constraint reproduces the exact reported symptom: validation passes, the insert is refused, and the caller sees exit 0 with no row. That is the worst failure available to a memory write, because success is indistinguishable from a no-op.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Memory 545 pass, provider 98 pass, TS 2386 pass / 0 fail, `bunx tsc --noEmit` clean, mypy and ruff clean on both packages.

**Mutation-verified.** Removing `question` — the value from the original bug — from each of the six surfaces in turn fails exactly that surface's assertion:

```
RED  test_typescript_client_matches_python      <- clients/ts/src/runtime.ts
RED  test_typescript_server_matches_python      <- src/agent-memory.ts
RED  test_mcp_tool_schema_matches_python        <- src/contract-schemas.ts
RED  test_tiering_union_matches_python          <- src/tiering.ts
RED  test_table_constants_match_python          <- src/tools/table-constants.ts
RED  test_database_constraint_matches_python    <- 013_session_events.sql
```

Re-run after refactoring the shared failure message, to confirm the extraction did not quietly unbind the assertions. Provider-side, replacing the re-export with a literal fails four tests including the no-redeclaration check and the `question` acceptance criterion.

## Acceptance criteria

- [x] Exactly one definition across both packages — the provider re-exports, and `test_provider_declares_no_vocabulary_of_its_own` fails if a literal is added there.
- [x] A test asserts the provider's set equals `openbrain_memory`'s and fails if either side changes — `test_provider_set_is_the_memory_set`.
- [x] `question` is accepted by the provider — asserted by name, since it is the value whose absence was the bug.

## Critical Self-Review

- Highest-risk behavior: the guard parses TypeScript and SQL with regex anchors. A refactor that renames a declaration makes the anchor miss. Mitigated by `_extract_quoted_block` failing loudly on a missing bracket and by the equality assertion reporting an empty set rather than passing vacuously — a missed anchor fails, it does not silently succeed.
- Assumptions that could be wrong: that all six surfaces should be identical. Checked — each gates a different stage of the same write path, so a value valid at one and not another is by definition a bug.
- Missing/weak tests: `IMPORTANCE_LEVELS` and `CANDIDATE_TYPES` are duplicated the same way and are not guarded here. Deliberate — out of scope for #412, and worth its own issue rather than silently widening this one.
- Security/permission risk: none. No auth, namespace, or credential surface.
- Migration/deploy risk: none. The migration is read, never modified.
- Downstream client/runtime risk: `EVENT_TYPES` is newly public in `openbrain-memory`. Additive only — no existing import path changed, so no consumer breaks.
- Rollback/cleanup concern: reverting drops the guard and the re-export; nothing depends on either yet, since the provider has no dispatch path until #414.
- Fixes made before PR: my first anchor for the tool schema matched a different enum earlier in `contract-schemas.ts`, and the second picked up `type: "enum"` before the list. Both caught because the test failed loudly rather than matching nothing. Also corrected the migrations path (`src/db/migrations`, not `migrations/`), which was silently skipping the constraint check — the assertion that matters most was not running.
- Known residual risk: the no-seventh-copy check greps for `"blocker"`, so a new declaration that happens to omit that value would not be flagged. Chose a real value over a sentinel because a sentinel drifts too.
- SME review-memory update: [x] not applicable because: no review findings yet; this is the implementing PR.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: no server, transport, or MCP tool behavior changes — the tool schema is read by a test, never modified.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no wire or capability surface changed. `git diff origin/main...HEAD --name-only` is six Python files; nothing under `src/`, `contracts/`, or `clients/ts/`. The pre-push gate matched the `openbrain-memory` path rather than an actual contract edit.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no tool, schema, protocol, or client-facing change. The only new public symbols are `openbrain_memory.EVENT_TYPES` (additive) and `openbrain_provider.vocabulary`, which has no external callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
