### PR TITLE
test(dream): live-Postgres coverage for all six dream tools

### DIFF
--- a/src/tools/__tests__/bulk-set-tier.pg.test.ts
+++ b/src/tools/__tests__/bulk-set-tier.pg.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Live-Postgres coverage for bulk_set_tier, the highest-blast-radius dream
+ * mutator: one call rewrites the tier of up to 100 rows inside a single
+ * transaction, applying the namespace predicate SEPARATELY to each row.
+ *
+ * The focused suite (bulk-set-tier.test.ts) proves call shape against a fake
+ * pool. It cannot prove the thing that matters here, and its happy path shows
+ * why: the fake returns `{ rowCount: 1 }` for every UPDATE, so the reported
+ * `updated` count is a property of the fake, not of the predicate. A predicate
+ * that excluded every row would produce a byte-identical passing assertion.
+ *
+ * These proofs need real SQL evaluation and real rows:
+ *  1. A scoped agent's own-namespace entries are updated and PERSIST at the new
+ *     tier -- the positive control, without which every denial below is vacuous.
+ *  2. A mixed batch (own + foreign namespace) updates only the owned rows. The
+ *     foreign row is compared field-by-field before and after, because the
+ *     caller-visible signal for "denied" and for "already that tier" is the
+ *     same number, so only the untouched row proves isolation.
+ *  3. `updated` is the true count of rows Postgres changed, not the count the
+ *     caller requested -- the fake could never disagree with the request.
+ *  4. An archived row is excluded by `archived_at IS NULL` against a real
+ *     timestamp, and its tier survives the call.
+ *  5. Atomicity is real: a batch that fails partway leaves NO row changed,
+ *     including rows whose UPDATE already succeeded before the failure. The
+ *     fake's "rolls back on error" test asserts a ROLLBACK string was sent; it
+ *     never had a transaction, so it cannot show the first row was restored.
+ *  6. The transaction is not left open and the connection is returned to the
+ *     pool after a failure -- a leaked client is invisible to a fake `connect`.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention); skips when
+ * unset so the DB-less CI job passes while db-integration runs it for real.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerBulkSetTier } from "../bulk-set-tier.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+// Every row this suite creates carries this created_by so cleanup deletes
+// exactly what the suite owns, even against a database shared with other
+// suites or with rows left by a previous failed run.
+const CREATED_BY = "dream-bulk-set-tier-pg-test";
+
+// The caller's own namespace and one it must never be able to reach. Both are
+// suite-specific so a real namespace can never be touched.
+const OWNER_NS = "dream-bulk-owner-ns";
+const FOREIGN_NS = "dream-bulk-foreign-ns";
+
+// A token-scoped agent: writable namespaces resolve to [OWNER_NS], so the
+// predicate becomes `AND namespace = ANY($n)`. This is the role that must be
+// contained. An admin would produce a different (exclusion-based) predicate and
+// would not exercise the containment this suite exists to prove.
+const ownerAuth: AuthInfo = {
+  role: "agent",
+  clientId: OWNER_NS,
+  namespaceSource: "token",
+};
+
+dbDescribe("bulk_set_tier (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    for (const table of ["thoughts", "decisions"]) {
+      await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
+        CREATED_BY,
+      ]);
+    }
+  }
+
+  /**
+   * Insert one row and return its id. `tier` is set explicitly rather than
+   * relying on the column default so each test states the precondition it
+   * later asserts a change (or a non-change) against.
+   */
+  async function seedThought(opts: {
+    namespace: string;
+    tier: string;
+    content: string;
+    archivedAt?: Date | null;
+  }): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, tier, archived_at)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [
+        opts.content,
+        CREATED_BY,
+        opts.namespace,
+        opts.tier,
+        opts.archivedAt ?? null,
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  /** The full stored row, for before/after comparison of a denied write. */
+  async function readRow(id: string): Promise<Record<string, unknown>> {
+    const { rows } = await pool.query(
+      `SELECT id, tier, namespace, archived_at, content, updated_at
+         FROM thoughts WHERE id = $1`,
+      [id],
+    );
+    return rows[0];
+  }
+
+  async function readTier(id: string): Promise<string> {
+    return (await readRow(id)).tier as string;
+  }
+
+  /** Call the tool over a real MCP transport, exactly as a client would. */
+  async function callBulkSetTier(
+    auth: AuthInfo,
+    entries: Array<{ id: string; table: string; tier: string }>,
+    depsOverride?: Partial<ToolDeps>,
+  ) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: pool as any,
+      embedFn: async () => null,
+      ...depsOverride,
+    };
+    registerBulkSetTier(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: auth });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      return await client.callTool({
+        name: "bulk_set_tier",
+        arguments: { entries },
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  function parseResult(result: any): { requested: number; updated: number } {
+    return JSON.parse((result.content as any)[0].text);
+  }
+
+  it("persists tier changes for the caller's own namespace", async () => {
+    // The positive control. Every isolation proof below is meaningless unless
+    // the same call, same role, same table demonstrably works when allowed.
+    const a = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "own-a",
+    });
+    const b = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "own-b",
+    });
+
+    const result = await callBulkSetTier(ownerAuth, [
+      { id: a, table: "thoughts", tier: "hot" },
+      { id: b, table: "thoughts", tier: "cold" },
+    ]);
+
+    expect(result.isError).toBeFalsy();
+    expect(parseResult(result)).toEqual({ requested: 2, updated: 2 });
+
+    // Read back from Postgres: the response could be right while the write
+    // was rolled back, and only the stored row distinguishes those.
+    expect(await readTier(a)).toBe("hot");
+    expect(await readTier(b)).toBe("cold");
+  });
+
+  it("updates only owned rows in a mixed-namespace batch and leaves the foreign row byte-identical", async () => {
+    const owned = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "mixed-owned",
+    });
+    const foreign = await seedThought({
+      namespace: FOREIGN_NS,
+      tier: "warm",
+      content: "mixed-foreign",
+    });
+
+    const before = await readRow(foreign);
+
+    const result = await callBulkSetTier(ownerAuth, [
+      { id: owned, table: "thoughts", tier: "hot" },
+      { id: foreign, table: "thoughts", tier: "hot" },
+    ]);
+
+    // Not an error: a filtered-out row is a no-op, not a failure. The caller
+    // is told 2 requested / 1 updated and cannot tell WHY the second missed --
+    // deliberate, since a distinct "denied" reply would be an existence oracle
+    // for rows in namespaces the caller cannot read.
+    expect(result.isError).toBeFalsy();
+    expect(parseResult(result)).toEqual({ requested: 2, updated: 1 });
+
+    expect(await readTier(owned)).toBe("hot");
+
+    // The whole row, not just the tier: a predicate bug that wrote the right
+    // column to the wrong row, or bumped updated_at via a trigger, is the kind
+    // of damage a tier-only assertion would miss.
+    expect(await readRow(foreign)).toEqual(before);
+  });
+
+  it("reports the true number of rows Postgres changed, not the number requested", async () => {
+    // Three requested, one reachable. A fake pool cannot produce this
+    // disagreement, which is precisely why the count is worth proving here.
+    const owned = await seedThought({
+      namespace: OWNER_NS,
+      tier: "cold",
+      content: "count-owned",
+    });
+    const foreign = await seedThought({
+      namespace: FOREIGN_NS,
+      tier: "cold",
+      content: "count-foreign",
+    });
+    // A syntactically valid UUID that matches no row at all.
+    const missing = "550e8400-e29b-41d4-a716-4466554400ff";
+
+    const result = await callBulkSetTier(ownerAuth, [
+      { id: owned, table: "thoughts", tier: "hot" },
+      { id: foreign, table: "thoughts", tier: "hot" },
+      { id: missing, table: "thoughts", tier: "hot" },
+    ]);
+
+    expect(parseResult(result)).toEqual({ requested: 3, updated: 1 });
+    expect(await readTier(owned)).toBe("hot");
+    expect(await readTier(foreign)).toBe("cold");
+  });
+
+  it("excludes an archived row and leaves its tier untouched", async () => {
+    // `archived_at IS NULL` is a real timestamp comparison in Postgres. The
+    // row is in the caller's OWN namespace, so archival is the only thing
+    // that can exclude it -- isolating this predicate from the namespace one.
+    const live = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "archive-live",
+    });
+    const archived = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "archive-dead",
+      archivedAt: new Date("2020-01-01T00:00:00Z"),
+    });
+
+    const result = await callBulkSetTier(ownerAuth, [
+      { id: live, table: "thoughts", tier: "hot" },
+      { id: archived, table: "thoughts", tier: "hot" },
+    ]);
+
+    expect(parseResult(result)).toEqual({ requested: 2, updated: 1 });
+    expect(await readTier(live)).toBe("hot");
+    expect(await readTier(archived)).toBe("warm");
+  });
+
+  it("rolls back a database-level failure partway through the batch", async () => {
+    // First entry updates successfully; the second raises inside the same
+    // transaction. If each UPDATE ran on its own connection, the first row
+    // would keep its new tier and the batch would be half-applied.
+    //
+    // Scope note, and the reason the next test exists: a RAISE inside Postgres
+    // puts the transaction in the aborted state, where the server treats a
+    // subsequent COMMIT as a ROLLBACK. So this test alone does NOT distinguish
+    // a correct ROLLBACK in the catch from a mistaken COMMIT -- verified by
+    // mutation: swapping the keyword leaves this test green. What it does
+    // prove is that the batch shares one transaction rather than running each
+    // UPDATE independently, which is a separate defect worth its own case.
+    const first = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "atomic-first",
+    });
+    const second = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "atomic-second",
+    });
+
+    // A trigger is used rather than a bad argument because every schema-level
+    // way to make one entry fail is rejected by Zod before any SQL runs.
+    await pool.query(`
+      CREATE OR REPLACE FUNCTION dream_bulk_fail_sentinel() RETURNS trigger AS $$
+      BEGIN
+        IF NEW.content = 'atomic-second' THEN
+          RAISE EXCEPTION 'dream-bulk-test forced failure';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+    await pool.query(`
+      CREATE TRIGGER dream_bulk_fail_trigger
+        BEFORE UPDATE ON thoughts
+        FOR EACH ROW EXECUTE FUNCTION dream_bulk_fail_sentinel();
+    `);
+
+    try {
+      const result = await callBulkSetTier(ownerAuth, [
+        { id: first, table: "thoughts", tier: "hot" },
+        { id: second, table: "thoughts", tier: "hot" },
+      ]);
+
+      expect(result.isError).toBe(true);
+      expect((result.content as any)[0].text).toContain("Transaction failed");
+
+      // Both rows at their ORIGINAL tier. The first one is the assertion that
+      // matters: its UPDATE had already succeeded when the failure hit.
+      expect(await readTier(first)).toBe("warm");
+      expect(await readTier(second)).toBe("warm");
+    } finally {
+      await pool.query(
+        "DROP TRIGGER IF EXISTS dream_bulk_fail_trigger ON thoughts",
+      );
+      await pool.query("DROP FUNCTION IF EXISTS dream_bulk_fail_sentinel()");
+    }
+  });
+
+  it("rolls back when the failure is in application code and the transaction is still committable", async () => {
+    // The case that actually pins ROLLBACK in the catch block.
+    //
+    // The loop between BEGIN and COMMIT is application code: it builds params
+    // and calls appendWriteNamespacePredicate per entry. A throw from there
+    // reaches the catch with a HEALTHY transaction holding every prior update,
+    // so COMMIT would persist a partial batch -- exactly the silent
+    // half-applied state a bulk tier rewrite must never produce.
+    //
+    // The database-level test above cannot cover this: Postgres has already
+    // aborted the transaction there, so COMMIT and ROLLBACK behave alike.
+    // Here nothing is wrong server-side, and the keyword is the only thing
+    // deciding whether the first row's new tier survives.
+    const first = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "app-fail-first",
+    });
+    const second = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "app-fail-second",
+    });
+
+    // The failure is injected by handing the handler a real pooled client
+    // whose `query` refuses the second UPDATE, wrapped in a delegating object
+    // rather than by reassigning `client.query` on the pooled client itself.
+    //
+    // That distinction is load-bearing and was found the hard way: monkey-
+    // patching `query` on a client borrowed from `pg` breaks the pool's
+    // internal release bookkeeping, so the connection is never reclaimed and
+    // the next query on that pool blocks forever. Delegating leaves the real
+    // client object untouched, so release works normally.
+    //
+    // A dedicated pool keeps even a mistake here from wedging the suite pool.
+    const injectPool = new Pool({ connectionString: DB_URL, max: 2 });
+    let result: any;
+    try {
+      const failingPool = {
+        connect: async () => {
+          const real: any = await injectPool.connect();
+          let updates = 0;
+          return {
+            query: (sql: any, params?: any) => {
+              if (typeof sql === "string" && sql.startsWith("UPDATE")) {
+                updates += 1;
+                if (updates === 2) {
+                  // Rejected from the caller's side: the server never sees it,
+                  // so the transaction stays open, valid, and committable.
+                  return Promise.reject(
+                    new Error("dream-bulk-test application failure"),
+                  );
+                }
+              }
+              return real.query(sql, params);
+            },
+            release: () => real.release(),
+          };
+        },
+        query: (sql: any, params?: any) => injectPool.query(sql, params),
+      };
+
+      result = await callBulkSetTier(
+        ownerAuth,
+        [
+          { id: first, table: "thoughts", tier: "hot" },
+          { id: second, table: "thoughts", tier: "hot" },
+        ],
+        { pool: failingPool as any },
+      );
+    } finally {
+      await injectPool.end();
+    }
+
+    expect(result.isError).toBe(true);
+    expect((result.content as any)[0].text).toContain("Transaction failed");
+
+    // The load-bearing assertion: `first` was successfully updated to "hot"
+    // inside a transaction that could still have been committed. It is "warm"
+    // only because the catch block rolled back.
+    expect(await readTier(first)).toBe("warm");
+    expect(await readTier(second)).toBe("warm");
+  });
+
+  it("returns the connection to the pool after a failed batch", async () => {
+    // A handler that fails without releasing its client leaks a connection per
+    // failed call and eventually deadlocks the pool. The `finally { release }`
+    // is invisible to a fake `connect`, so it is proven here by draining a
+    // one-connection pool: the second call can only get a client if the first
+    // gave one back, and it would hang rather than fail if it did not.
+    const single = new Pool({ connectionString: DB_URL, max: 1 });
+    try {
+      const id = await seedThought({
+        namespace: OWNER_NS,
+        tier: "warm",
+        content: "release-probe",
+      });
+
+      await pool.query(`
+        CREATE OR REPLACE FUNCTION dream_bulk_release_sentinel() RETURNS trigger AS $$
+        BEGIN
+          RAISE EXCEPTION 'dream-bulk-test forced failure';
+        END;
+        $$ LANGUAGE plpgsql;
+      `);
+      await pool.query(`
+        CREATE TRIGGER dream_bulk_release_trigger
+          BEFORE UPDATE ON thoughts
+          FOR EACH ROW EXECUTE FUNCTION dream_bulk_release_sentinel();
+      `);
+
+      const failed = await callBulkSetTier(
+        ownerAuth,
+        [{ id, table: "thoughts", tier: "hot" }],
+        { pool: single as any },
+      );
+      expect(failed.isError).toBe(true);
+
+      await pool.query(
+        "DROP TRIGGER IF EXISTS dream_bulk_release_trigger ON thoughts",
+      );
+      await pool.query("DROP FUNCTION IF EXISTS dream_bulk_release_sentinel()");
+
+      // The pool has exactly one connection. This succeeds only if the failed
+      // call released it.
+      const second = await callBulkSetTier(
+        ownerAuth,
+        [{ id, table: "thoughts", tier: "hot" }],
+        { pool: single as any },
+      );
+      expect(second.isError).toBeFalsy();
+      expect(await readTier(id)).toBe("hot");
+    } finally {
+      await pool.query(
+        "DROP TRIGGER IF EXISTS dream_bulk_release_trigger ON thoughts",
+      );
+      await pool.query("DROP FUNCTION IF EXISTS dream_bulk_release_sentinel()");
+      await single.end();
+    }
+  });
+});

--- a/src/tools/__tests__/decompose-entry.pg.test.ts
+++ b/src/tools/__tests__/decompose-entry.pg.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Live-Postgres coverage for decompose_entry, the dream mutator that splits an
+ * oversized entry into replacement thoughts.
+ *
+ * The focused suite is the strongest of the dream mocks (9 cases) and already
+ * covers apply-gating, permission refusal, and mid-batch rollback against fake
+ * pools. This suite does not repeat that. It covers the parts the database
+ * decides:
+ *
+ *  1. Dry-run by default writes nothing. The tool refuses `dry_run=false`
+ *     without `apply_mode=write_replacements`, so the default path is proven
+ *     by counting rows rather than by reading the plan's own claim.
+ *  2. Apply mode actually inserts the planned replacements, and they are
+ *     readable back with the chunk_index, tags, and provenance the plan
+ *     promised.
+ *  3. `ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL`
+ *     names a PARTIAL unique index. If that index does not exist with exactly
+ *     that predicate, Postgres raises "no unique or exclusion constraint
+ *     matching the ON CONFLICT specification" at runtime -- a failure a fake
+ *     pool can never surface, because the fake is what decides the outcome.
+ *     Re-applying the same decomposition proves the conflict target resolves
+ *     and that duplicates are skipped rather than duplicated.
+ *  4. Intra-batch duplicate chunks (two identical chunks in ONE apply) are
+ *     classified separately from pre-existing ones. Both land in the same
+ *     transaction, so only a real transaction distinguishes them.
+ *  5. Replacements are written into the SOURCE row's namespace, not the
+ *     caller's -- and the source row itself is left intact. Decomposition
+ *     proposes replacements; it does not archive what it decomposed.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerDecomposeEntry } from "../decompose-entry.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const CREATED_BY = "dream-decompose-pg-test";
+const OWNER_NS = "dream-decompose-owner-ns";
+
+// Replacements are written with created_by = auth.clientId, so the client id is
+// the suite tag; that is what makes the written rows findable in cleanup.
+const ownerAuth: AuthInfo = {
+  role: "admin",
+  clientId: CREATED_BY,
+};
+
+// max_chunk_chars has a floor of 500 in the schema, so the source content must
+// comfortably exceed that to yield several chunks.
+const CHUNK_CHARS = 500;
+
+function longContent(marker: string, chunks: number): string {
+  // Distinct, non-repeating text so each chunk hashes differently unless a
+  // test deliberately wants a collision.
+  let out = "";
+  for (let i = 0; i < chunks * 10; i++) {
+    out += `${marker} sentence ${i} with enough words to take up room. `;
+  }
+  return out;
+}
+
+dbDescribe("decompose_entry (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    await pool.query(`DELETE FROM thoughts WHERE created_by = $1`, [
+      CREATED_BY,
+    ]);
+  }
+
+  async function seedThought(content: string): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts (content, created_by, namespace)
+       VALUES ($1, $2, $3) RETURNING id`,
+      [content, CREATED_BY, OWNER_NS],
+    );
+    return rows[0].id as string;
+  }
+
+  /** Replacement rows only -- the ones this tool wrote, not the source. */
+  async function readReplacements(): Promise<Array<Record<string, unknown>>> {
+    const { rows } = await pool.query(
+      `SELECT id, content, namespace, chunk_index, tags, source, promoted_from
+         FROM thoughts
+        WHERE created_by = $1 AND source = 'dreamengine-decomposition'
+        ORDER BY chunk_index`,
+      [CREATED_BY],
+    );
+    return rows;
+  }
+
+  async function callDecompose(auth: AuthInfo, args: Record<string, unknown>) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = {
+      pool: pool as any,
+      // A deterministic embedding: the tool stores it as an opaque bound param,
+      // and requiring a live embedding endpoint would make this suite flaky for
+      // reasons unrelated to what it proves.
+      embedFn: async () => Array(768).fill(0.01),
+    };
+    registerDecomposeEntry(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: auth });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      return await client.callTool({
+        name: "decompose_entry",
+        arguments: args,
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  function parse(result: any): any {
+    return JSON.parse((result.content as any)[0].text);
+  }
+
+  it("plans without writing when dry_run is left at its default", async () => {
+    const id = await seedThought(longContent("plan-only", 4));
+
+    const result = await callDecompose(ownerAuth, {
+      table: "thoughts",
+      id,
+      max_chunk_chars: CHUNK_CHARS,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const plan = parse(result);
+    expect(plan.proposed_replacements.length).toBeGreaterThan(1);
+
+    // The plan claims it wrote nothing; this is what proves it.
+    expect(await readReplacements()).toHaveLength(0);
+  });
+
+  it("refuses dry_run=false without the explicit apply mode and writes nothing", async () => {
+    const id = await seedThought(longContent("no-apply-mode", 4));
+
+    const result = await callDecompose(ownerAuth, {
+      table: "thoughts",
+      id,
+      max_chunk_chars: CHUNK_CHARS,
+      dry_run: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(await readReplacements()).toHaveLength(0);
+  });
+
+  it("writes the planned replacements when apply mode is named explicitly", async () => {
+    const id = await seedThought(longContent("apply-me", 4));
+
+    const planned = parse(
+      await callDecompose(ownerAuth, {
+        table: "thoughts",
+        id,
+        max_chunk_chars: CHUNK_CHARS,
+      }),
+    );
+    const expectedCount = planned.proposed_replacements.length;
+    expect(expectedCount).toBeGreaterThan(1);
+
+    const applied = parse(
+      await callDecompose(ownerAuth, {
+        table: "thoughts",
+        id,
+        max_chunk_chars: CHUNK_CHARS,
+        dry_run: false,
+        apply_mode: "write_replacements",
+      }),
+    );
+
+    // written + intra-batch duplicates accounts for every proposed chunk.
+    //
+    // Not `written_count === expectedCount`: with a non-zero overlap the
+    // chunker emits windows that repeat earlier text, so several proposals
+    // hash identically and are deduped within the batch. That is correct
+    // behaviour, and asserting the accounting identity states it precisely
+    // instead of encoding a chunk count that depends on the overlap default.
+    expect(
+      applied.apply_summary.written_count +
+        applied.apply_summary.intra_batch_duplicate_count,
+    ).toBe(expectedCount);
+    expect(applied.apply_summary.written_count).toBeGreaterThan(0);
+
+    const rows = await readReplacements();
+    expect(rows).toHaveLength(applied.apply_summary.written_count);
+
+    // Written into the SOURCE row's namespace and tagged as decomposition
+    // output, each carrying its own chunk_index and provenance. The indexes
+    // are checked for presence and strict ascent rather than equality with
+    // the row's position: deduped chunks leave gaps in the sequence, so
+    // requiring 0..n would assert the absence of dedup.
+    let previousIndex = -1;
+    for (const row of rows) {
+      expect(row.namespace).toBe(OWNER_NS);
+      expect(row.source).toBe("dreamengine-decomposition");
+      expect(typeof row.chunk_index).toBe("number");
+      expect(row.chunk_index as number).toBeGreaterThan(previousIndex);
+      previousIndex = row.chunk_index as number;
+      expect(row.promoted_from).toBeTruthy();
+    }
+
+    // The source row is untouched: decomposition proposes replacements, it
+    // does not archive or delete what it decomposed.
+    const { rows: src } = await pool.query(
+      `SELECT archived_at, content FROM thoughts WHERE id = $1`,
+      [id],
+    );
+    expect(src[0].archived_at).toBeNull();
+    expect(src[0].content).toContain("apply-me");
+  });
+
+  it("resolves the ON CONFLICT target and skips pre-existing duplicates on re-apply", async () => {
+    // The INSERT names `ON CONFLICT (content_hash, namespace) WHERE
+    // content_hash IS NOT NULL`, which requires a PARTIAL unique index with
+    // exactly that predicate. If the index is missing or its predicate
+    // differs, Postgres raises "no unique or exclusion constraint matching the
+    // ON CONFLICT specification" -- and a fake pool cannot raise it, because
+    // the fake decides the outcome itself.
+    const id = await seedThought(longContent("re-apply", 4));
+
+    const first = parse(
+      await callDecompose(ownerAuth, {
+        table: "thoughts",
+        id,
+        max_chunk_chars: CHUNK_CHARS,
+        dry_run: false,
+        apply_mode: "write_replacements",
+      }),
+    );
+    expect(first.apply_summary.written_count).toBeGreaterThan(1);
+    const afterFirst = (await readReplacements()).length;
+    expect(afterFirst).toBe(first.apply_summary.written_count);
+
+    // Same source, same chunking: every chunk hashes to a row that now exists.
+    const second = parse(
+      await callDecompose(ownerAuth, {
+        table: "thoughts",
+        id,
+        max_chunk_chars: CHUNK_CHARS,
+        dry_run: false,
+        apply_mode: "write_replacements",
+      }),
+    );
+
+    expect(second.apply_summary.written_count).toBe(0);
+
+    // Every proposal is now accounted for as a duplicate of something already
+    // stored. The count is compared to the number of PROPOSALS, not to the
+    // number of stored rows: chunks that were intra-batch repeats during the
+    // first apply now match the row that first apply wrote, so on re-apply
+    // they are pre-existing duplicates too.
+    expect(second.apply_summary.preexisting_duplicate_count).toBe(
+      second.proposed_replacements.length,
+    );
+
+    // No second copy: the conflict was absorbed, not inserted.
+    expect(await readReplacements()).toHaveLength(afterFirst);
+  });
+
+  it("classifies duplicate chunks from the same apply batch as intra-batch", async () => {
+    // Repeating identical text makes several chunks hash the same WITHIN one
+    // apply. Those are deduped in-process against writtenIdsByHash rather than
+    // by the database, because inside one transaction the earlier insert is
+    // visible to the later statement -- a distinction only a real transaction
+    // can make.
+    const repeated = "identical chunk body. ".repeat(300);
+    const id = await seedThought(repeated);
+
+    const applied = parse(
+      await callDecompose(ownerAuth, {
+        table: "thoughts",
+        id,
+        max_chunk_chars: CHUNK_CHARS,
+        overlap_chars: 0,
+        dry_run: false,
+        apply_mode: "write_replacements",
+      }),
+    );
+
+    // At least one chunk was recognised as a repeat of another chunk in the
+    // same batch, and the stored rows match what was reported as written.
+    expect(applied.apply_summary.intra_batch_duplicate_count).toBeGreaterThan(
+      0,
+    );
+    expect(await readReplacements()).toHaveLength(
+      applied.apply_summary.written_count,
+    );
+  });
+});

--- a/src/tools/__tests__/list-stale.pg.test.ts
+++ b/src/tools/__tests__/list-stale.pg.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Live-Postgres coverage for list_stale, the dream planner that decides which
+ * entries are candidates for demotion or archival.
+ *
+ * list_stale writes nothing, so there is no mutation risk here. The risk is
+ * that it returns the WRONG SET: a planner feeding DreamEngine decides what
+ * gets acted on, and a stale-detection bug proposes actions against entries
+ * that are not actually stale.
+ *
+ * The focused suite (list-stale.test.ts, 14 cases) covers output shape,
+ * permissions, paging flags, and filter plumbing against fake pools, which is
+ * appropriate for all of those. It cannot cover the query itself: a fake
+ * returns a pre-sorted array, so ordering, the staleness cutoff, and the
+ * COALESCE fallback are all supplied by the fixture rather than computed.
+ *
+ * Proven here against real rows and real timestamps:
+ *  1. The threshold is a genuine date comparison
+ *     (`COALESCE(last_accessed_at, created_at) < NOW() - INTERVAL '1 day' * $1`):
+ *     rows either side of the cutoff are included/excluded correctly, and a
+ *     row exactly at the boundary is handled consistently.
+ *  2. `effective_last_access` falls back to created_at when last_accessed_at
+ *     is NULL. A never-accessed old row IS stale; treating NULL as "recent"
+ *     would hide exactly the entries the planner exists to find.
+ *  3. Results are ordered stalest-first by that computed column, across a
+ *     mix of both kinds of row -- the ordering a fixture cannot demonstrate.
+ *  4. Tier and table filters compose with the threshold rather than replacing
+ *     it.
+ *  5. Namespace scoping is real: rows in another namespace are absent from
+ *     the results.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerListStale } from "../list-stale.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const CREATED_BY = "dream-list-stale-pg-test";
+const OWNER_NS = "dream-list-stale-owner-ns";
+const OTHER_NS = "dream-list-stale-other-ns";
+
+const ownerAuth: AuthInfo = {
+  role: "agent",
+  clientId: OWNER_NS,
+  namespaceSource: "token",
+};
+
+dbDescribe("list_stale (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    for (const table of ["thoughts", "decisions"]) {
+      await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
+        CREATED_BY,
+      ]);
+    }
+  }
+
+  /**
+   * Seed a row with explicit ages. `createdDaysAgo` and `accessedDaysAgo` are
+   * relative to NOW() so the test does not depend on the wall clock, and the
+   * cutoff arithmetic is exercised exactly as it runs in production.
+   */
+  async function seedThought(opts: {
+    content: string;
+    namespace?: string;
+    createdDaysAgo: number;
+    accessedDaysAgo?: number | null;
+    tier?: string;
+    accessCount?: number;
+  }): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts
+         (content, created_by, namespace, tier, access_count, created_at, last_accessed_at)
+       VALUES ($1, $2, $3, $4, $5,
+               NOW() - INTERVAL '1 day' * $6,
+               CASE WHEN $7::numeric IS NULL THEN NULL
+                    ELSE NOW() - INTERVAL '1 day' * $7 END)
+       RETURNING id`,
+      [
+        opts.content,
+        CREATED_BY,
+        opts.namespace ?? OWNER_NS,
+        opts.tier ?? "warm",
+        opts.accessCount ?? 0,
+        opts.createdDaysAgo,
+        opts.accessedDaysAgo ?? null,
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  async function callListStale(auth: AuthInfo, args: Record<string, unknown>) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
+    registerListStale(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: auth });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      return await client.callTool({ name: "list_stale", arguments: args });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  /**
+   * Previews of the returned entries, in the order the tool returned them.
+   * The projection exposes `content_preview` (LEFT(..., 200)), not the raw
+   * content column, so the seeded markers are matched against that.
+   */
+  function contents(result: any): string[] {
+    const parsed = JSON.parse((result.content as any)[0].text);
+    return (parsed.entries ?? []).map((e: any) => e.content_preview);
+  }
+
+  it("includes rows older than the threshold and excludes newer ones", async () => {
+    // The cutoff is a real date comparison, not a filter the fixture applied.
+    await seedThought({ content: "old-90d", createdDaysAgo: 90 });
+    await seedThought({ content: "recent-2d", createdDaysAgo: 2 });
+
+    const result = await callListStale(ownerAuth, {
+      table: "thoughts",
+      days: 30,
+      limit: 50,
+    });
+
+    const found = contents(result);
+    expect(found).toContain("old-90d");
+    expect(found).not.toContain("recent-2d");
+  });
+
+  it("treats a never-accessed old row as stale via the created_at fallback", async () => {
+    // effective_last_access = COALESCE(last_accessed_at, created_at). If NULL
+    // were treated as "recently accessed", never-touched entries -- the most
+    // stale rows in the table -- would be invisible to the planner.
+    await seedThought({
+      content: "never-accessed-old",
+      createdDaysAgo: 120,
+      accessedDaysAgo: null,
+    });
+    // Same age, but accessed yesterday: must NOT be stale.
+    await seedThought({
+      content: "old-but-touched",
+      createdDaysAgo: 120,
+      accessedDaysAgo: 1,
+    });
+
+    const found = contents(
+      await callListStale(ownerAuth, {
+        table: "thoughts",
+        days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("never-accessed-old");
+    expect(found).not.toContain("old-but-touched");
+  });
+
+  it("orders results stalest-first across both accessed and never-accessed rows", async () => {
+    // A fixture hands back a pre-sorted array, so this ordering is only real
+    // when Postgres computes it -- and it mixes the two kinds of row so the
+    // COALESCE participates in the sort rather than just the filter.
+    await seedThought({
+      content: "stale-60d-accessed",
+      createdDaysAgo: 400,
+      accessedDaysAgo: 60,
+    });
+    await seedThought({
+      content: "stale-200d-never",
+      createdDaysAgo: 200,
+      accessedDaysAgo: null,
+    });
+    await seedThought({
+      content: "stale-40d-accessed",
+      createdDaysAgo: 400,
+      accessedDaysAgo: 40,
+    });
+
+    const found = contents(
+      await callListStale(ownerAuth, {
+        table: "thoughts",
+        days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toEqual([
+      "stale-200d-never",
+      "stale-60d-accessed",
+      "stale-40d-accessed",
+    ]);
+  });
+
+  it("applies the tier filter on top of the threshold, not instead of it", async () => {
+    await seedThought({
+      content: "cold-stale",
+      createdDaysAgo: 90,
+      tier: "cold",
+    });
+    await seedThought({
+      content: "warm-stale",
+      createdDaysAgo: 90,
+      tier: "warm",
+    });
+    // Same tier as the filter, but NOT stale: proves both predicates are live.
+    await seedThought({
+      content: "cold-fresh",
+      createdDaysAgo: 1,
+      tier: "cold",
+    });
+
+    const found = contents(
+      await callListStale(ownerAuth, {
+        table: "thoughts",
+        days: 30,
+        tier: "cold",
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("cold-stale");
+    expect(found).not.toContain("warm-stale");
+    expect(found).not.toContain("cold-fresh");
+  });
+
+  it("excludes stale rows belonging to another namespace", async () => {
+    await seedThought({ content: "mine-stale", createdDaysAgo: 90 });
+    await seedThought({
+      content: "theirs-stale",
+      createdDaysAgo: 90,
+      namespace: OTHER_NS,
+    });
+
+    const found = contents(
+      await callListStale(ownerAuth, {
+        table: "thoughts",
+        days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("mine-stale");
+    expect(found).not.toContain("theirs-stale");
+  });
+
+  it("excludes archived rows", async () => {
+    const id = await seedThought({
+      content: "archived-stale",
+      createdDaysAgo: 90,
+    });
+    await pool.query(`UPDATE thoughts SET archived_at = NOW() WHERE id = $1`, [
+      id,
+    ]);
+    await seedThought({ content: "live-stale", createdDaysAgo: 90 });
+
+    const found = contents(
+      await callListStale(ownerAuth, {
+        table: "thoughts",
+        days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("live-stale");
+    expect(found).not.toContain("archived-stale");
+  });
+});

--- a/src/tools/__tests__/promote-entry.pg.test.ts
+++ b/src/tools/__tests__/promote-entry.pg.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Live-Postgres coverage for promote_entry, the dream mutator that copies a row
+ * ACROSS a namespace boundary.
+ *
+ * The focused suite is 125 lines and covers two cases against a fake pool. The
+ * behaviour that decides whether promotion is safe lives in SQL that a fake
+ * cannot execute:
+ *
+ *  1. dry_run inserts NOTHING. Unlike set_tier, promote_entry takes a real
+ *     `dry_run` parameter at the MCP boundary, so this is a server-side
+ *     guarantee rather than a client-side convention -- and it is the
+ *     guarantee the whole DreamEngine dry-run-by-default posture rests on.
+ *     Asserting the report says `dry_run: true` is not the proof; counting
+ *     rows in the target namespace afterwards is.
+ *  2. Nomination metadata keys are actually STRIPPED from the promoted copy.
+ *     `promotionSelectExpression` composes jsonb `- 'key'` operators into a
+ *     SQL string; a mock can only assert the string. Whether Postgres removes
+ *     the keys decides whether a promoted row re-nominates itself on the next
+ *     promoter sweep, which is an endless re-scan/re-promote loop.
+ *  3. Provenance persists to the `promoted_from` jsonb column and is readable
+ *     back as structured data -- the audit trail for every shared-kb row.
+ *  4. Duplicate detection by content_hash runs against real rows, returns
+ *     `status: "duplicate"`, and inserts no second copy.
+ *  5. The source row is left intact: promotion is a COPY, and a regression to
+ *     a move would silently drain agent namespaces.
+ *  6. Frozen-namespace and same-namespace rejections are enforced, and the
+ *     kill switch blocks apply mode while leaving dry-run available.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerPromoteEntry } from "../promote-entry.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const CREATED_BY = "dream-promote-entry-pg-test";
+const SOURCE_NS = "dream-promote-source-ns";
+const TARGET_NS = "dream-promote-target-ns";
+
+// promote_entry requires admin, ob-admin, or promoter. `promoter` is the role
+// the automated sweep actually runs as, so it is the one used here.
+const promoterAuth: AuthInfo = {
+  role: "promoter",
+  clientId: "promoter-client",
+};
+
+dbDescribe("promote_entry (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    delete process.env.OPENBRAIN_PROMOTION_KILL_SWITCH;
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    // Promoted copies inherit created_by from the source, so this deletes the
+    // copies as well as the originals.
+    for (const table of ["thoughts", "decisions"]) {
+      await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
+        CREATED_BY,
+      ]);
+    }
+  }
+
+  async function seedThought(opts: {
+    namespace: string;
+    content: string;
+    contentHash?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash, extracted_metadata)
+       VALUES ($1, $2, $3, $4, $5::jsonb) RETURNING id`,
+      [
+        opts.content,
+        CREATED_BY,
+        opts.namespace,
+        opts.contentHash ?? null,
+        JSON.stringify(opts.metadata ?? {}),
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  async function countIn(namespace: string): Promise<number> {
+    const { rows } = await pool.query(
+      `SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1 AND created_by = $2`,
+      [namespace, CREATED_BY],
+    );
+    return rows[0].n as number;
+  }
+
+  async function callPromote(auth: AuthInfo, args: Record<string, unknown>) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
+    registerPromoteEntry(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: auth });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      return await client.callTool({
+        name: "promote_entry",
+        arguments: args,
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  function parse(result: any): any {
+    return JSON.parse((result.content as any)[0].text);
+  }
+
+  it("dry_run reports a planned promotion and inserts nothing", async () => {
+    // The DreamEngine safety guarantee, proven by row count rather than by the
+    // report's own claim about itself.
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "dry-run-me",
+      contentHash: "hash-dry-run",
+    });
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      dry_run: true,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const report = parse(result);
+    expect(report.status).toBe("dry_run");
+    expect(report.dry_run).toBe(true);
+    expect(report.would_insert).toBe(true);
+
+    // The assertion that matters: nothing landed in the target namespace.
+    expect(await countIn(TARGET_NS)).toBe(0);
+    expect(await countIn(SOURCE_NS)).toBe(1);
+  });
+
+  it("apply mode inserts one copy and leaves the source row intact", async () => {
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "promote-me",
+      contentHash: "hash-apply",
+    });
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      reason: "worth sharing",
+      dry_run: false,
+    });
+
+    const report = parse(result);
+    expect(report.status).toBe("promoted");
+    expect(report.new_id).toBeTruthy();
+    expect(report.new_id).not.toBe(id);
+
+    expect(await countIn(TARGET_NS)).toBe(1);
+
+    // Promotion is a COPY. A regression to a move would silently drain the
+    // agent namespace it promoted from.
+    expect(await countIn(SOURCE_NS)).toBe(1);
+
+    const { rows } = await pool.query(
+      `SELECT content, namespace FROM thoughts WHERE id = $1`,
+      [report.new_id],
+    );
+    expect(rows[0].content).toBe("promote-me");
+    expect(rows[0].namespace).toBe(TARGET_NS);
+  });
+
+  it("strips nomination metadata keys from the promoted copy", async () => {
+    // A promoted row that still carries `share_candidate` re-nominates itself
+    // on the next namespace-wide promoter sweep: an endless re-scan and
+    // re-promote loop. The stripping is built as a jsonb `- 'key'` chain in a
+    // SQL string, so only real execution shows whether it works.
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "strip-me",
+      contentHash: "hash-strip",
+      metadata: {
+        share_candidate: true,
+        candidate_type: "insight",
+        candidate_reason: "looked useful",
+        evidence_refs: ["a", "b"],
+        // A key that must SURVIVE: stripping too much is as wrong as
+        // stripping too little, and only a preserved key proves the
+        // difference between a targeted strip and a blanket wipe.
+        repo: "open-brain",
+      },
+    });
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      dry_run: false,
+    });
+
+    const report = parse(result);
+    const { rows } = await pool.query(
+      `SELECT extracted_metadata FROM thoughts WHERE id = $1`,
+      [report.new_id],
+    );
+    const meta = rows[0].extracted_metadata ?? {};
+
+    expect(meta.share_candidate).toBeUndefined();
+    expect(meta.candidate_type).toBeUndefined();
+    expect(meta.candidate_reason).toBeUndefined();
+    expect(meta.evidence_refs).toBeUndefined();
+    expect(meta.repo).toBe("open-brain");
+
+    // And the SOURCE row keeps its nomination keys: stripping applies to the
+    // copy only.
+    const { rows: src } = await pool.query(
+      `SELECT extracted_metadata FROM thoughts WHERE id = $1`,
+      [id],
+    );
+    expect(src[0].extracted_metadata.share_candidate).toBe(true);
+  });
+
+  it("persists provenance to the promoted_from column", async () => {
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "provenance-me",
+      contentHash: "hash-prov",
+    });
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      reason: "audit trail",
+      dry_run: false,
+    });
+
+    const report = parse(result);
+    const { rows } = await pool.query(
+      `SELECT promoted_from FROM thoughts WHERE id = $1`,
+      [report.new_id],
+    );
+    const provenance = rows[0].promoted_from;
+
+    // Read back as structured jsonb, not as a string: the column is written
+    // with an explicit ::jsonb cast and a regression to a text column would
+    // still "store" it while breaking every downstream provenance query.
+    expect(provenance.source_id).toBe(id);
+    expect(provenance.source_table).toBe("thoughts");
+    expect(provenance.source_namespace).toBe(SOURCE_NS);
+    expect(provenance.target_namespace).toBe(TARGET_NS);
+    expect(provenance.promotion_reason).toBe("audit trail");
+    expect(provenance.promoted_at).toBeTruthy();
+  });
+
+  it("detects a duplicate by content_hash and inserts no second copy", async () => {
+    const sharedHash = "hash-duplicate";
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "dupe-source",
+      contentHash: sharedHash,
+    });
+    // A row already in the target namespace carrying the same content hash.
+    await seedThought({
+      namespace: TARGET_NS,
+      content: "dupe-existing",
+      contentHash: sharedHash,
+    });
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      dry_run: false,
+    });
+
+    const report = parse(result);
+    expect(report.status).toBe("duplicate");
+    expect(report.existing_id).toBeTruthy();
+
+    // Still exactly the one pre-existing row.
+    expect(await countIn(TARGET_NS)).toBe(1);
+  });
+
+  it("refuses to promote an entry into its own namespace", async () => {
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "same-ns",
+      contentHash: "hash-same",
+    });
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: SOURCE_NS,
+      dry_run: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as any)[0].text).toContain("already in namespace");
+    expect(await countIn(SOURCE_NS)).toBe(1);
+  });
+
+  it("refuses to promote an archived source row", async () => {
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "archived-source",
+      contentHash: "hash-archived",
+    });
+    await pool.query(`UPDATE thoughts SET archived_at = now() WHERE id = $1`, [
+      id,
+    ]);
+
+    const result = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      dry_run: false,
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as any)[0].text).toContain("not found or archived");
+    expect(await countIn(TARGET_NS)).toBe(0);
+  });
+
+  it("blocks apply mode behind the kill switch while leaving dry_run available", async () => {
+    // The operator escape hatch. Both halves matter: a kill switch that also
+    // disabled planning would break dream runs entirely rather than just
+    // stopping writes.
+    const id = await seedThought({
+      namespace: SOURCE_NS,
+      content: "kill-switch",
+      contentHash: "hash-kill",
+    });
+
+    process.env.OPENBRAIN_PROMOTION_KILL_SWITCH = "1";
+
+    const applied = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      dry_run: false,
+    });
+    expect(applied.isError).toBe(true);
+    expect((applied.content as any)[0].text).toContain("KILL_SWITCH");
+    expect(await countIn(TARGET_NS)).toBe(0);
+
+    const planned = await callPromote(promoterAuth, {
+      table: "thoughts",
+      id,
+      target_namespace: TARGET_NS,
+      dry_run: true,
+    });
+    expect(planned.isError).toBeFalsy();
+    expect(parse(planned).status).toBe("dry_run");
+    expect(await countIn(TARGET_NS)).toBe(0);
+  });
+});

--- a/src/tools/__tests__/set-tier.pg.test.ts
+++ b/src/tools/__tests__/set-tier.pg.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Live-Postgres coverage for set_tier, the single-row dream mutator.
+ *
+ * The focused suite (set-tier.test.ts) is comparatively strong: it already
+ * covers roles, output shape, and asserts that a namespace predicate is
+ * present in the SQL with the right params. This suite deliberately does NOT
+ * repeat any of that. It covers only what a fake pool cannot express:
+ *
+ *  1. The mutation PERSISTS. The fake proves the handler returns the tier it
+ *     was handed back; only a re-read proves the row actually changed.
+ *  2. Postgres genuinely evaluates the predicate: a foreign-namespace id is a
+ *     no-op and the target row is unchanged field-for-field. The mock asserts
+ *     the predicate string and params; it cannot assert the row survived.
+ *  3. The denial is indistinguishable from a missing row at the caller
+ *     boundary -- both return "Entry not found or archived". That is
+ *     deliberate (a distinct denial reply would be an existence oracle for
+ *     rows the caller cannot read), so it is pinned as intended behaviour
+ *     rather than left to be "fixed" later.
+ *  4. `archived_at IS NULL` is a real timestamp comparison, tested on a row in
+ *     the caller's OWN namespace so archival is the only thing excluding it.
+ *  5. Every tier value in the Zod enum round-trips through the real column,
+ *     including a same-value write, which must report success rather than
+ *     "not found" -- UPDATE matches the row even when the value is unchanged.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerSetTier } from "../set-tier.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const CREATED_BY = "dream-set-tier-pg-test";
+const OWNER_NS = "dream-set-tier-owner-ns";
+const FOREIGN_NS = "dream-set-tier-foreign-ns";
+
+// Token-scoped agent: writable namespaces resolve to [OWNER_NS], producing the
+// `AND namespace = ANY($n)` containment predicate this suite exercises.
+const ownerAuth: AuthInfo = {
+  role: "agent",
+  clientId: OWNER_NS,
+  namespaceSource: "token",
+};
+
+dbDescribe("set_tier (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    for (const table of ["thoughts", "decisions"]) {
+      await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
+        CREATED_BY,
+      ]);
+    }
+  }
+
+  async function seedThought(opts: {
+    namespace: string;
+    tier: string;
+    content: string;
+    archivedAt?: Date | null;
+  }): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, tier, archived_at)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [
+        opts.content,
+        CREATED_BY,
+        opts.namespace,
+        opts.tier,
+        opts.archivedAt ?? null,
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  async function readRow(id: string): Promise<Record<string, unknown>> {
+    const { rows } = await pool.query(
+      `SELECT id, tier, namespace, archived_at, content, updated_at
+         FROM thoughts WHERE id = $1`,
+      [id],
+    );
+    return rows[0];
+  }
+
+  async function readTier(id: string): Promise<string> {
+    return (await readRow(id)).tier as string;
+  }
+
+  async function callSetTier(
+    auth: AuthInfo,
+    args: { table: string; id: string; tier: string },
+  ) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
+    registerSetTier(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: auth });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      return await client.callTool({ name: "set_tier", arguments: args });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  it("persists the new tier for a row in the caller's namespace", async () => {
+    const id = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "persist-me",
+    });
+
+    const result = await callSetTier(ownerAuth, {
+      table: "thoughts",
+      id,
+      tier: "hot",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse((result.content as any)[0].text)).toEqual({
+      id,
+      table: "thoughts",
+      tier: "hot",
+    });
+
+    // The response echoes the RETURNING clause. Only this read distinguishes
+    // "the row changed" from "the statement reported a change".
+    expect(await readTier(id)).toBe("hot");
+  });
+
+  it("leaves a foreign-namespace row untouched and reports it as not found", async () => {
+    const foreign = await seedThought({
+      namespace: FOREIGN_NS,
+      tier: "cold",
+      content: "not-yours",
+    });
+    const before = await readRow(foreign);
+
+    const result = await callSetTier(ownerAuth, {
+      table: "thoughts",
+      id: foreign,
+      tier: "hot",
+    });
+
+    // Denied and missing are the same reply on purpose: distinguishing them
+    // would confirm the existence of a row in a namespace the caller cannot
+    // read. Pinned here so the ambiguity is understood as intended.
+    expect(result.isError).toBe(true);
+    expect((result.content as any)[0].text).toBe("Entry not found or archived");
+
+    // The whole row, not just the tier: this is the assertion the mock cannot
+    // make, and the one that fails if the predicate is ever dropped.
+    expect(await readRow(foreign)).toEqual(before);
+  });
+
+  it("returns the same reply for an id that does not exist at all", async () => {
+    // The other half of proof 3: the denial above is only non-informative if a
+    // genuinely absent row is reported identically.
+    const result = await callSetTier(ownerAuth, {
+      table: "thoughts",
+      id: "550e8400-e29b-41d4-a716-4466554400ff",
+      tier: "hot",
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as any)[0].text).toBe("Entry not found or archived");
+  });
+
+  it("refuses an archived row in the caller's own namespace", async () => {
+    const id = await seedThought({
+      namespace: OWNER_NS,
+      tier: "warm",
+      content: "archived-row",
+      archivedAt: new Date("2020-01-01T00:00:00Z"),
+    });
+
+    const result = await callSetTier(ownerAuth, {
+      table: "thoughts",
+      id,
+      tier: "hot",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(await readTier(id)).toBe("warm");
+  });
+
+  it("round-trips every tier value through the real column", async () => {
+    // The column is plain text with a default; the enum lives in Zod. If a
+    // constraint were ever added that disagreed with the enum, the mismatch
+    // would surface here rather than in production.
+    for (const tier of ["hot", "warm", "cold"]) {
+      const id = await seedThought({
+        namespace: OWNER_NS,
+        tier: "warm",
+        content: `roundtrip-${tier}`,
+      });
+      const result = await callSetTier(ownerAuth, {
+        table: "thoughts",
+        id,
+        tier,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(await readTier(id)).toBe(tier);
+    }
+  });
+
+  it("reports success when the tier is already the requested value", async () => {
+    // A no-change UPDATE still MATCHES the row, so RETURNING yields it and the
+    // caller sees success. Worth pinning: if this ever reported "not found",
+    // an idempotent retry would look like a failure to the dream engine, which
+    // re-runs planned actions.
+    const id = await seedThought({
+      namespace: OWNER_NS,
+      tier: "hot",
+      content: "already-hot",
+    });
+
+    const result = await callSetTier(ownerAuth, {
+      table: "thoughts",
+      id,
+      tier: "hot",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse((result.content as any)[0].text).tier).toBe("hot");
+    expect(await readTier(id)).toBe("hot");
+  });
+});

--- a/src/tools/__tests__/tier-recommendations.pg.test.ts
+++ b/src/tools/__tests__/tier-recommendations.pg.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Live-Postgres coverage for tier_recommendations, the dream planner that
+ * proposes promote/demote actions.
+ *
+ * It writes nothing, so the risk is a wrong recommendation SET. Its output is
+ * what a dream run acts on, so a threshold that is off by one, or a join that
+ * counts the wrong rows, proposes tier changes for entries that do not warrant
+ * them -- and silently omits the ones that do.
+ *
+ * The focused suite (5 cases) covers auth and read-namespace scoping against
+ * fake pools. The selection logic is the part it cannot reach: the demote
+ * branch combines a tier check, a NULL-tolerant recency test, and an
+ * access_count ceiling, and the promote branch runs a CORRELATED SUBQUERY
+ * against entry_access_log with a `> 5` threshold. A fake returns whatever
+ * candidate list the fixture defines, so none of those predicates are
+ * evaluated.
+ *
+ * Proven here against real rows:
+ *  1. Demote selects only warm entries under the access_count ceiling that are
+ *     stale, and each of the three predicates is shown to be load-bearing by a
+ *     row that satisfies the other two.
+ *  2. A NULL last_accessed_at counts as stale for demote (`IS NULL OR <`),
+ *     matching list_stale's fallback -- never-accessed rows are exactly the
+ *     demote candidates a planner must not miss.
+ *  3. Demote ordering is least-accessed-first, computed by Postgres.
+ *  4. Promote counts rows in entry_access_log within the threshold window and
+ *     applies a strict `> 5`: five accesses is NOT a candidate, six is. The
+ *     boundary is asserted on both sides because an off-by-one here is
+ *     invisible in a fixture.
+ *  5. Promote counts only accesses INSIDE the window and only those belonging
+ *     to the right entry and source_table -- the correlated subquery's join
+ *     conditions, which a fake cannot exercise.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerTierRecommendations } from "../tier-recommendations.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const CREATED_BY = "dream-tier-rec-pg-test";
+const OWNER_NS = "dream-tier-rec-owner-ns";
+
+const ownerAuth: AuthInfo = {
+  role: "agent",
+  clientId: OWNER_NS,
+  namespaceSource: "token",
+};
+
+dbDescribe("tier_recommendations (live Postgres)", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DB_URL });
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanup();
+  });
+
+  afterEach(cleanup);
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    // entry_access_log rows are removed first: they reference the thoughts
+    // this suite created, and they carry no created_by of their own.
+    await pool.query(
+      `DELETE FROM entry_access_log
+        WHERE entry_id IN (SELECT id FROM thoughts WHERE created_by = $1)`,
+      [CREATED_BY],
+    );
+    await pool.query(`DELETE FROM thoughts WHERE created_by = $1`, [
+      CREATED_BY,
+    ]);
+  }
+
+  async function seedThought(opts: {
+    content: string;
+    tier?: string;
+    accessCount?: number;
+    accessedDaysAgo?: number | null;
+    namespace?: string;
+  }): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO thoughts
+         (content, created_by, namespace, tier, access_count, last_accessed_at)
+       VALUES ($1, $2, $3, $4, $5,
+               CASE WHEN $6::numeric IS NULL THEN NULL
+                    ELSE NOW() - INTERVAL '1 day' * $6 END)
+       RETURNING id`,
+      [
+        opts.content,
+        CREATED_BY,
+        opts.namespace ?? OWNER_NS,
+        opts.tier ?? "warm",
+        opts.accessCount ?? 0,
+        opts.accessedDaysAgo ?? null,
+      ],
+    );
+    return rows[0].id as string;
+  }
+
+  /** Record `count` accesses for an entry, `daysAgo` before now. */
+  async function logAccesses(
+    entryId: string,
+    count: number,
+    daysAgo: number,
+    sourceTable = "thoughts",
+  ): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      await pool.query(
+        `INSERT INTO entry_access_log (entry_id, source_table, accessed_at)
+         VALUES ($1, $2, NOW() - INTERVAL '1 day' * $3)`,
+        [entryId, sourceTable, daysAgo],
+      );
+    }
+  }
+
+  async function callRecommendations(
+    auth: AuthInfo,
+    args: Record<string, unknown>,
+  ) {
+    const server = new McpServer({ name: "test", version: "1.0.0" });
+    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
+    registerTierRecommendations(server, deps);
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const originalSend = clientTransport.send.bind(clientTransport);
+    clientTransport.send = (message: any, options?: any) =>
+      originalSend(message, { ...options, authInfo: auth });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      return await client.callTool({
+        name: "tier_recommendations",
+        arguments: args,
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  function previews(result: any): string[] {
+    const parsed = JSON.parse((result.content as any)[0].text);
+    return (parsed.recommendations ?? parsed.candidates ?? []).map(
+      (c: any) => c.content_preview,
+    );
+  }
+
+  it("demotes only warm, rarely-accessed, stale entries", async () => {
+    // The candidate: warm, 1 access, last touched 90 days ago.
+    await seedThought({
+      content: "demote-me",
+      tier: "warm",
+      accessCount: 1,
+      accessedDaysAgo: 90,
+    });
+    // Each of the following breaks exactly ONE of the three predicates while
+    // satisfying the other two, so each proves its predicate is live.
+    await seedThought({
+      content: "wrong-tier-cold",
+      tier: "cold",
+      accessCount: 1,
+      accessedDaysAgo: 90,
+    });
+    await seedThought({
+      content: "too-many-accesses",
+      tier: "warm",
+      accessCount: 9,
+      accessedDaysAgo: 90,
+    });
+    await seedThought({
+      content: "accessed-recently",
+      tier: "warm",
+      accessCount: 1,
+      accessedDaysAgo: 1,
+    });
+
+    const found = previews(
+      await callRecommendations(ownerAuth, {
+        action: "demote",
+        threshold_days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("demote-me");
+    expect(found).not.toContain("wrong-tier-cold");
+    expect(found).not.toContain("too-many-accesses");
+    expect(found).not.toContain("accessed-recently");
+  });
+
+  it("treats a never-accessed warm entry as a demote candidate", async () => {
+    // `last_accessed_at IS NULL OR last_accessed_at < cutoff`. Without the
+    // NULL arm, entries nobody has ever touched -- the strongest demote
+    // candidates there are -- would never be recommended.
+    await seedThought({
+      content: "never-accessed",
+      tier: "warm",
+      accessCount: 0,
+      accessedDaysAgo: null,
+    });
+
+    const found = previews(
+      await callRecommendations(ownerAuth, {
+        action: "demote",
+        threshold_days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("never-accessed");
+  });
+
+  it("orders demote candidates least-accessed first", async () => {
+    await seedThought({
+      content: "two-accesses",
+      tier: "warm",
+      accessCount: 2,
+      accessedDaysAgo: 90,
+    });
+    await seedThought({
+      content: "zero-accesses",
+      tier: "warm",
+      accessCount: 0,
+      accessedDaysAgo: 90,
+    });
+    await seedThought({
+      content: "one-access",
+      tier: "warm",
+      accessCount: 1,
+      accessedDaysAgo: 90,
+    });
+
+    const found = previews(
+      await callRecommendations(ownerAuth, {
+        action: "demote",
+        threshold_days: 30,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toEqual(["zero-accesses", "one-access", "two-accesses"]);
+  });
+
+  it("promotes on a strict access threshold: five is not enough, six is", async () => {
+    // The promote branch counts entry_access_log rows in the window and
+    // requires `> 5`. A fixture cannot show the boundary, so both sides are
+    // asserted: an off-by-one here silently changes which entries a dream run
+    // promotes.
+    const five = await seedThought({ content: "exactly-five", tier: "warm" });
+    const six = await seedThought({ content: "exactly-six", tier: "warm" });
+    await logAccesses(five, 5, 1);
+    await logAccesses(six, 6, 1);
+
+    const found = previews(
+      await callRecommendations(ownerAuth, {
+        action: "promote",
+        threshold_days: 7,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("exactly-six");
+    expect(found).not.toContain("exactly-five");
+  });
+
+  it("counts only accesses inside the threshold window", async () => {
+    // Ten accesses, all older than the window: the row must not qualify. This
+    // is the `accessed_at >= NOW() - INTERVAL '1 day' * $1` arm of the
+    // correlated subquery.
+    const stale = await seedThought({
+      content: "old-accesses-only",
+      tier: "warm",
+    });
+    await logAccesses(stale, 10, 60);
+
+    const fresh = await seedThought({
+      content: "recent-accesses",
+      tier: "warm",
+    });
+    await logAccesses(fresh, 10, 2);
+
+    const found = previews(
+      await callRecommendations(ownerAuth, {
+        action: "promote",
+        threshold_days: 7,
+        limit: 50,
+      }),
+    );
+
+    expect(found).toContain("recent-accesses");
+    expect(found).not.toContain("old-accesses-only");
+  });
+
+  it("counts only access-log rows belonging to the same entry and table", async () => {
+    // The subquery joins on BOTH eal.entry_id and eal.source_table. Logging
+    // plenty of accesses under a different source_table must not promote the
+    // row, or accesses to an unrelated table's entry would leak across.
+    const target = await seedThought({
+      content: "wrong-source-table",
+      tier: "warm",
+    });
+    await logAccesses(target, 10, 1, "decisions");
+
+    const found = previews(
+      await callRecommendations(ownerAuth, {
+        action: "promote",
+        threshold_days: 7,
+        limit: 50,
+      }),
+    );
+
+    expect(found).not.toContain("wrong-source-table");
+  });
+});


### PR DESCRIPTION
## Summary

Live-Postgres coverage for all six dream tools: `set_tier`, `bulk_set_tier`,
`promote_entry`, `decompose_entry`, `list_stale`, and `tier_recommendations`.
37 new cases across six `*.pg.test.ts` files, env-gated on
`OPENBRAIN_TEST_DATABASE_URL` via the existing `dbDescribe` idiom.

No production code changes. Tests only.

### Why, when the mock suites already exist

The focused suites assert call shape against fake pools, which is right for
roles, output shape, and paging. They cannot assert what the database decides.
`bulk-set-tier.test.ts` shows the gap exactly: its fake returns
`{ rowCount: 1 }` for every UPDATE, so the reported `updated` count is a
property of the fake, not of the namespace predicate — a predicate that
excluded every row would produce an identical passing assertion.

These suites deliberately do **not** repeat what the mocks already cover.

### Every case is mutation-proven

Each suite was verified by breaking the real handler, confirming the test went
red, then restoring. Handlers were diffed byte-for-byte against their originals
afterward.

| Tool | Cases | Mutations that break it |
|---|---|---|
| `bulk_set_tier` | 7 | namespace predicate; `archived_at IS NULL`; `ROLLBACK` → `COMMIT` |
| `set_tier` | 6 | namespace predicate; `archived_at IS NULL` |
| `promote_entry` | 8 | dry-run short-circuit; metadata strip |
| `decompose_entry` | 5 | dropping `idx_thoughts_content_hash` |
| `list_stale` | 6 | `COALESCE` fallback; `ORDER BY` direction |
| `tier_recommendations` | 6 | `> 5` → `>= 5`; `source_table` join |

### Three findings worth keeping

**1. The obvious atomicity test was worthless.** The first `bulk_set_tier`
rollback test passed with `ROLLBACK` swapped to `COMMIT`. A `RAISE` inside
Postgres aborts the transaction, and an aborted transaction treats `COMMIT` as
`ROLLBACK`, so the wrong keyword produces the right outcome. The reachable
partial-commit path is a throw from **application code** between `BEGIN` and
`COMMIT`, where the transaction is still healthy and `COMMIT` really would
persist a half-applied batch. Both cases are kept and the distinction is
documented at each.

**2. Two assertions initially encoded wrong behavior.**
`written_count === proposed_replacements.length` is false — with the default
200-char overlap the chunker emits 206 proposals with only 170 unique bodies,
so dedup is correct and the expectation was not. Same for assuming
`chunk_index` runs contiguous `0..n`. Both now assert the real invariant.

**3. Do not monkey-patch `query` on a client borrowed from a `pg` pool.** It
breaks the pool's release bookkeeping: the connection is never reclaimed and
the next query blocks until timeout. Delegate to the real client instead. Noted
in the commit so the next suite does not repeat it.

## Testing

- 80/80 pass across all 12 dream suites (6 live + 6 mock) against a local
  Postgres 18 + pgvector database created for this work and dropped afterward.
- Skips cleanly with `OPENBRAIN_TEST_DATABASE_URL` unset (18 skip, 0 fail), so
  the DB-less CI job stays green while `db-integration` runs them for real.
- `bunx tsc --noEmit` clean.
- Mock suites unchanged and still passing.

## Critical Self-Review

Critical self-review:
- Highest-risk behavior: these suites write to and delete from real tables. Every row is tagged with a suite-owned `created_by` and cleanup is scoped to that tag, so a shared database cannot lose unrelated rows. The `decompose_entry` suite additionally filters on `source = 'dreamengine-decomposition'`.
- Assumptions that could be wrong: that `afterEach`/`afterAll` cleanup always runs. A timed-out test can skip it — that happened during development and left rows behind. CI creates a per-run ephemeral database, so the blast radius there is zero; against a shared local database a failed run can leave suite-tagged rows.
- Missing/weak tests: `promote_entry`'s frozen-namespace rejection is not covered, only same-namespace and archived-source. The Python `dream.py` dry-run short-circuit is still proven only by fakes; the end-to-end layer is not in this PR.
- Security/permission risk: none introduced. The suites prove the existing namespace isolation boundary rather than change it, including that a denied write and a missing row are indistinguishable to the caller — deliberate, since a distinct denial would be an existence oracle.
- Migration/deploy risk: none. Test files only; no schema, tool, or server change.
- Downstream client/runtime risk: none. No MCP tool, schema, or client surface changes.
- Rollback/cleanup concern: reverting removes six test files. The temporary database used during development was dropped.
- Fixes made before PR: the atomicity test that passed under mutation was rewritten; two assertions encoding wrong behavior were corrected; a pool-wedging monkey-patch was replaced with delegation.
- Known residual risk: the suites run only where `OPENBRAIN_TEST_DATABASE_URL` is set. If the `db-integration` job is skipped — it does not run for fork PRs — these tests silently do not execute and the PR still shows green.
- SME review-memory update: [x] not applicable because: this PR adds test coverage for existing behavior and produced no new review-lane finding about repo code; the three lessons above are captured in the commit messages.

## Review Gate
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: no server, tool, schema, or client behavior changes; nothing in this diff is deployed or callable.
