### PR TITLE
fix(docs): purge the retired .49 DB host and make clone restart obvious

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ Repo-specific rules below this line override the copies when stricter.
 - **Database:** PostgreSQL 18 + pgvector (halfvec 768)
 - **Embeddings:** Any OpenAI-compatible endpoint via `EMBEDDING_BASE_URL` (prod: local MLX server on 127.0.0.1:8791, `embeddinggemma-300m-8bit`). Hosted prod sets `EMBEDDING_WATCHDOG_RESTART_SCRIPT` so repeated provider failures bounce the local MLX embedding daemon.
 - **Auth:** Per-consumer Bearer tokens (admin, agent, discord, ob-admin, promoter, readonly)
-- **Deploy:** core01 Mac Mini via launchd `com.rico.open-brain` (10.71.1.21:3100). Source lives in `/Volumes/ThunderBolt/Development/open-brain`; the running app lives in `/Volumes/ThunderBolt/open-brain/app`; qmd runtime/index lives in `/Volumes/ThunderBolt/qmd`. LXC 208 decommissioned 2026-06-11; its Postgres (10.71.20.49) retained as a pre-cutover snapshot.
+- **Deploy:** core01 Mac Mini via launchd `com.rico.open-brain` (10.71.1.21:3100). Source lives in `/Volumes/ThunderBolt/Development/open-brain`; the running app lives in `/Volumes/ThunderBolt/open-brain/app`; qmd runtime/index lives in `/Volumes/ThunderBolt/qmd`.
+- **Hosts:** There are exactly two. This machine while developing, and core01 when the dev work is done. No other database or service host is valid for Open Brain — do not reintroduce retired LXC addresses.
+- **Local dogfood clone:** If you see `OB ✗ gate unavailable`, or nothing is listening on `127.0.0.1:3100`, the local clone is just not running. Read the restart section at the top of `docs/local-clone-dogfood.md` and run `bun run scripts/local-clone.ts --verify && bun run scripts/local-clone.ts --start` after sourcing `/Volumes/ThunderBolt/open-brain-local/local-clone.env`. The config and all six auth tokens already exist in that file — do not write a new `.env` or generate tokens, and do not use the repo `.env` for the clone.
 
 ## Commands
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -295,9 +295,8 @@ export OPENBRAIN_BASE_URL="http://10.71.1.21:3100"
 export OPENBRAIN_ALLOW_INSECURE_HTTP=1
 ```
 
-`10.71.20.49` is a retained pre-cutover snapshot, not the active production
-Open Brain endpoint. Use `https://open-brain.rodaddy.live` or direct
-`10.71.1.21:3100` for current host canaries.
+Use `https://open-brain.rodaddy.live` or direct `10.71.1.21:3100` for current
+host canaries.
 
 For full package usage, schema helper, live canary, and Hermes integration
 guidance, see [`python/openbrain-memory/README.md`](../python/openbrain-memory/README.md).

--- a/docs/local-clone-dogfood.md
+++ b/docs/local-clone-dogfood.md
@@ -1,5 +1,42 @@
 # Local Clone Dogfood
 
+## RESTART THE LOCAL CLONE (start here)
+
+If you saw `OB ✗ gate unavailable`, or
+`Open Brain lane memory unavailable`, or nothing is listening on
+`127.0.0.1:3100`, the clone is simply not running. **Do not create a clone, do
+not write a new `.env`, and do not invent tokens — they already exist.** Run:
+
+```zsh
+cd /Volumes/ThunderBolt/Development/open-brain
+set -a && source /Volumes/ThunderBolt/open-brain-local/local-clone.env && set +a
+bun run scripts/local-clone.ts --verify   # read-only preflight, must pass first
+bun run scripts/local-clone.ts --start
+```
+
+Then confirm: `curl -s http://127.0.0.1:3100/health` returns
+`"status":"healthy"` with `database.connected` and `embedding.connected` true.
+
+Facts worth knowing before you go looking for them:
+
+- The config is `/Volumes/ThunderBolt/open-brain-local/local-clone.env` (mode
+  600). It already holds the DB target and all six auth tokens.
+- The repo `.env` is **not** used for the local clone. Ignore it here.
+- `AUTH_TOKEN_USER_RICO` in that file is the same token the Claude memory
+  adapter sends, which is what makes `OB ✓ gate passed` work.
+- The clone DB is `open_brain_local_20260724`, owner `open_brain_local_clone`,
+  on local Postgres 18.
+- The MLX embedding server on `127.0.0.1:8791` must be up; the preflight fails
+  loudly if it is not.
+- Only two hosts are ever valid: this machine for dev, core01 when dev is done.
+- The launcher is the supported path. Starting `src/index.ts` by hand skips the
+  preflight that proves you are attached to the clone and not another database.
+
+The rest of this document is for **creating or refreshing** a clone from a
+backup set. You do not need it to restart one.
+
+---
+
 This runbook creates and operates a loopback-only Open Brain clone from one
 encrypted, verified backup set. It is an operator procedure, not replication:
 the launcher never creates or drops a database, rotates tokens, reads a

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -114,9 +114,6 @@ export OPENBRAIN_BASE_URL="http://10.71.1.21:3100"
 export OPENBRAIN_ALLOW_INSECURE_HTTP="1"
 ```
 
-Do not use retained pre-cutover LXC snapshots such as `10.71.20.49` for current
-host canaries.
-
 For trusted lab-only HTTP endpoints, such as `http://10.71.1.21:3100`, opt in
 explicitly:
 

--- a/src/tools/__tests__/agent-context-pack-guidance-repo-facts.test.ts
+++ b/src/tools/__tests__/agent-context-pack-guidance-repo-facts.test.ts
@@ -201,7 +201,7 @@ describe("defined empty and degraded states", () => {
     const pool = {
       query: async (sql: string) => {
         if (sql.includes("candidate_type")) {
-          throw new Error("connection reset to 10.71.20.49");
+          throw new Error("connection reset to db.internal.invalid");
         }
         return { rows: [] };
       },
@@ -217,7 +217,7 @@ describe("defined empty and degraded states", () => {
         reason: "database_unavailable",
       });
       // No dependency/error detail leaks into the envelope.
-      expect(raw).not.toContain("10.71.20.49");
+      expect(raw).not.toContain("db.internal.invalid");
       expect(raw).not.toContain("connection reset");
     } finally {
       await cleanup();

--- a/src/tools/__tests__/agent-context-pack-repo-facts.test.ts
+++ b/src/tools/__tests__/agent-context-pack-repo-facts.test.ts
@@ -245,7 +245,7 @@ describe("repo_facts budgets, order, and degradation", () => {
       { namespace: "rico", repo: "rodaddy/open-brain", nowMs: NOW },
       {
         query: async () => {
-          throw new Error("statement timeout on 10.71.20.49");
+          throw new Error("statement timeout on db.internal.invalid");
         },
       },
     );
@@ -253,6 +253,6 @@ describe("repo_facts budgets, order, and degradation", () => {
     expect(frag.degradedSources).toEqual([
       { source: "repo_facts", reason: "database_unavailable" },
     ]);
-    expect(JSON.stringify(frag)).not.toContain("10.71.20.49");
+    expect(JSON.stringify(frag)).not.toContain("db.internal.invalid");
   });
 });


### PR DESCRIPTION
## Summary

Purges the retired LXC 208 Postgres host (`10.71.20.49`) from the repo and
makes restarting the local dogfood clone obvious.

There are exactly two valid Open Brain hosts: this machine while developing,
and core01 when the dev work is done. The retired host was still referenced in
seven places, including a live `DB_HOST` in the repo `.env` carrying a real
password for a box that no longer exists.

The second half fixes what that confusion cost. When the local clone is not
running, the failure reads `OB ✗ gate unavailable`, which says nothing about
the cause or the fix. The recovery was three commands on line 188 of a runbook
written for *creating* a clone from an encrypted backup — so a restart looked
like a provisioning job. This session nearly hand-wrote a `.env` and generated
auth tokens that already existed in `local-clone.env`.

Changes:

- `AGENTS.md` — state the two-host rule; point at the clone restart keyed to
  the exact symptom string an agent will see.
- `docs/local-clone-dogfood.md` — restart section at the very top, before the
  create-from-backup procedure, stating plainly that the config and all six
  tokens already exist and must not be regenerated.
- `docs/README.md`, `python/openbrain-memory/README.md` — drop warnings against
  a host that no longer exists.
- Two test files — the four remaining hits were fixture data inside a thrown DB
  error, asserting the host never leaks into agent-facing output. Swapped to
  `db.internal.invalid` so the assertion survives with no dead host named.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bun test` on both edited files: 32 pass, 0 fail
- [x] Python package checks passed or are not applicable — only a README line removed, no source touched
- [x] Live Open Brain smoke passed or is not applicable — local clone restarted via the documented launcher, preflight `status: verified`, `/health` healthy with database and embedding connected, and `OB ✓ gate passed` confirmed through the memory adapter

## Critical Self-Review

- Highest-risk behavior: weakening a security regression test. The four test
  hits were not stale config — they prove an internal DB host never reaches
  agent-facing output. Deleting the string would have silently removed the
  assertion.
- Assumptions that could be wrong: that no runtime still resolves the retired
  host. Verified by grep across the repo (0 matches after the change) and
  across `/Volumes/ThunderBolt/Development` outside this repo (0 matches).
- Missing/weak tests: none added, and none needed — no behavior changed. The
  existing leak assertions were mutation-proven rather than assumed: inverting
  `not.toContain` to `toContain` fails (12 pass / 1 fail), restoring it passes
  (13 pass / 0 fail).
- Security/permission risk: the repo `.env` contained a plaintext password for
  the retired host. It is gitignored and never tracked, so this PR does not
  remove it from history — it was not in history. The file was backed up
  outside the repo before edit and restored unchanged; no secret is added,
  logged, or committed here.
- Migration/deploy risk: none. Docs and test fixtures only, no schema, no
  runtime path.
- Downstream client/runtime risk: none. No contract, tool schema, or client
  behavior changes.
- Rollback/cleanup concern: none — revert the commit. The scratch artifacts live
  under `/Volumes/collab/open-brain/_scratch/` and are outside the repo.
- Fixes made before PR: initially started the clone by hand with `nohup`, which
  bypasses the preflight that proves the server is attached to the clone
  database rather than another one. Stopped it and relaunched through
  `scripts/local-clone.ts --start`; that lesson is now written into the doc.
- Known residual risk: `AGENTS.md` still references `/Volumes/ThunderBolt/open-brain/app`
  as the running app path, which does not exist on this machine — the real
  directory is `/Volumes/ThunderBolt/open-brain-local`. Left unchanged because
  that line describes the core01 deploy, not the local clone, and I have not
  verified core01's layout from here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a stale-config and documentation fix, not a review finding about a code pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime surface changed; the clone restart above was verification of the documented procedure, not of this diff.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or tool surface changes.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] cache/skill refresh is complete or not applicable — not applicable, no tool schema change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- Mutation proof of the leak assertion: inverted → 12 pass / 1 fail; restored →
  13 pass / 0 fail.
- Post-change grep for the retired host across the repo: 0 matches.
- Local clone preflight receipt: `openbrain.local_clone_verify_receipt.v1`,
  `status: verified`, Postgres major 18, pgvector installed, embedding model
  verified at 768 dimensions.
