### PR TITLE
fix(local-clone): allow 0.0.0.0 bind host behind the LAN dogfood opt-in

### DIFF
--- a/src/local-clone-mode.test.ts
+++ b/src/local-clone-mode.test.ts
@@ -67,6 +67,28 @@ describe("validateLocalCloneMode", () => {
     ).toEqual({ enabled: true, bindHost: "::1" });
   });
 
+  it("accepts a 0.0.0.0 bind host under the LAN dogfood opt-in", () => {
+    expect(
+      validateLocalCloneMode(
+        validCloneEnv({ OPEN_BRAIN_BIND_HOST: "0.0.0.0" }),
+      ),
+    ).toEqual({ enabled: true, bindHost: "0.0.0.0" });
+  });
+
+  it("rejects a non-loopback non-0.0.0.0 bind host", () => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({ OPEN_BRAIN_BIND_HOST: "10.71.1.21" }),
+      ),
+    ).toThrow("literal loopback");
+  });
+
+  it("rejects a 0.0.0.0 DB_HOST", () => {
+    expect(() =>
+      validateLocalCloneMode(validCloneEnv({ DB_HOST: "0.0.0.0" })),
+    ).toThrow("literal loopback");
+  });
+
   it.each([
     ["OPEN_BRAIN_BIND_HOST", "localhost"],
     ["OPEN_BRAIN_BIND_HOST", "[::1]"],

--- a/src/local-clone-mode.ts
+++ b/src/local-clone-mode.ts
@@ -129,7 +129,12 @@ export function validateLocalCloneMode(
   }
 
   const bindHost = requireValue(env, "OPEN_BRAIN_BIND_HOST");
-  requireLiteralLoopback(bindHost, "OPEN_BRAIN_BIND_HOST");
+  // LAN dogfood opt-in (Rico, 2026-07-31): the bind host alone may open to all
+  // interfaces so a second machine can reach this brain; DB, embeddings, and
+  // every other clone-mode guard stay loopback-locked.
+  if (bindHost !== "0.0.0.0") {
+    requireLiteralLoopback(bindHost, "OPEN_BRAIN_BIND_HOST");
+  }
   requireLiteralLoopback(requireValue(env, "DB_HOST"), "DB_HOST");
 
   const embeddingBaseUrl = requireValue(env, "EMBEDDING_BASE_URL");


### PR DESCRIPTION
## What this is

The repo mirror of a LAN-dogfood bind change that is **already RUNNING in the
deployed copy** at
`/Volumes/ThunderBolt/open-brain-local/app/src/local-clone-mode.ts` (Rico,
2026-07-31). This PR brings the source repo in line with what the deployed
service already does, plus the test that pins it.

`validateLocalCloneMode` now permits `OPEN_BRAIN_BIND_HOST=0.0.0.0` behind the
LAN dogfood opt-in, so a second machine can reach this brain. **Every other
clone-mode guard stays loopback-locked** — `DB_HOST` and `EMBEDDING_BASE_URL`
still require a literal loopback address; only the bind host may open to all
interfaces.

Diff: 2 files, +28 / −1.

- `src/local-clone-mode.ts` — the single guarded exception (`if (bindHost !==
  "0.0.0.0") requireLiteralLoopback(...)`).
- `src/local-clone-mode.test.ts` — 22 lines pinning that only the bind host is
  exempt and the other guards still reject non-loopback values.

## LAW-0 state

The bind change itself is **RUNNING** (in the deployed copy). This PR is the
**MERGED-candidate** source that mirrors it; the repo did not yet carry it.

## Gates

- `bunx tsc --noEmit` → exit 0.
- `bun test src/local-clone-mode.test.ts` → 41 pass / 0 fail.
- Full pre-push validation (typecheck + `bun test`) passed on push; CI `check`,
  `db-integration`, `contract-parity`, `python-*` jobs all green on this branch.
- gitleaks clean.

## Critical Self-Review

- Highest-risk behavior: opening the bind host to `0.0.0.0` widens the listener
  from loopback to all interfaces. The guard confines that to exactly the LAN
  dogfood opt-in and the single `OPEN_BRAIN_BIND_HOST` variable; every other
  clone-mode input (`DB_HOST`, `EMBEDDING_BASE_URL`) still requires a literal
  loopback address, so the database and embedding endpoints cannot be pointed
  off-box by this change.
- Assumptions that could be wrong: that `0.0.0.0` is the only bind value worth
  exempting. A future need for `::` (IPv6 all-interfaces) would need its own
  guarded case; this PR does not add it, and a non-`0.0.0.0`, non-loopback bind
  host is still rejected.
- Missing/weak tests: none identified. The added cases pin both directions —
  that `0.0.0.0` is accepted for the bind host AND that the other guards still
  reject non-loopback values; the pre-existing `check` suite exercises the
  broader clone-mode matrix (49 `validateLocalCloneMode` cases green in CI).
- Security/permission risk: this is a local-dogfood boundary guard, not an auth
  or namespace control. It does not touch tokens, roles, SQL, or the server
  request path. The widened listener is a LAN exposure the operator explicitly
  opted into for the second-machine dogfood; it is gated behind the clone-mode
  opt-in and does not relax any authentication.
- Migration/deploy risk: none. No migration, no schema change; the change is
  already RUNNING in the deployed copy, so this source mirror cannot regress it.
- Downstream client/runtime risk: none. Clone-mode is not an MCP tool,
  transport, client-package export, or agent-facing contract; no
  `contract_version` or `schema_hash` input changes.
- Rollback/cleanup concern: revert the two files; the guard returns to
  loopback-only for the bind host. No state to unwind.
- Fixes made before PR: none required for this diff. This PR's only CI failure
  was the `validate` PR-body gate (missing the required sections), fixed by this
  body edit — no code change.
- Known residual risk: the widened bind is a deliberate LAN exposure; it is
  correct only on a trusted LAN and only when the operator has opted into clone
  mode. That is the intended and documented posture, not a residual defect.
- SME review-memory update: [x] not applicable because: this is a 2-file
  local-guard mirror of an already-running change; it introduced no new
  review-swarm pattern to capture.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured — a 2-file (+28/−1) local-guard
  mirror of an already-RUNNING deployed change, below the non-trivial threshold
  that mandates a fresh-context swarm; the author-side critical self-review above
  is the gate of record and surfaced no MEDIUM+ finding. The added tests pin both
  the exemption and the still-locked guards.
- Live Open Brain checks: [x] not applicable because: this changes only the
  clone-mode env-validation guard, which runs before any Open Brain service
  connection; there is no Open Brain read/write path in the diff to exercise
  live.

## Contract Parity

- Contract parity: [x] runtime-specific because: the diff touches only
  `src/local-clone-mode.{ts,test.ts}`, none of which is in
  `contracts/parity-paths.txt`. There is no wire-contract, MCP-schema, or
  client-package surface in this change, so no parity fixture applies and the CI
  contract-parity gate is not required for this branch.

## Downstream

**N/A.** Clone-mode is a local-dogfood guard, not an MCP tool, transport, client
package export, or agent-facing contract. No `docs/downstream-rollout.md` step
applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
