### PR TITLE
docs(local-clone): drift diagnosis runbook + idempotent ledger repair (#458)

### DIFF
--- a/_plans/local-clone-deploy-runbook-2026-08-01.md
+++ b/_plans/local-clone-deploy-runbook-2026-08-01.md
@@ -1,0 +1,337 @@
+# Local dogfood clone — deploy merged-main runbook (2026-08-01)
+
+> **NOT EXECUTED against the live service. Operator go/no-go required.**
+>
+> Every step below was **REHEARSED on a disposable copy**
+> (`open_brain_local_drift_test`, a full pg_dump/restore clone of the live
+> dogfood DB taken 2026-08-01). **Nothing in this runbook was run against the
+> running service `com.rico.open-brain-local-clone` (port 3100) or the live
+> dogfood DB `open_brain_local_20260724`.** The commands are written for the
+> operator to execute after go.
+>
+> **LAW-0 state key per step:** REHEARSED-on-copy = proven RUNNING against the
+> disposable clone this session. WRITTEN = command composed and read from the
+> proven scripts, not yet run live. The header of each step states which.
+>
+> **Re-verification 2026-08-01 (this rebuild).** Every load-bearing number
+> below was re-checked read-only against live `open_brain_local_20260724` this
+> session, and the repair SQL was re-proven on `open_brain_local_drift_test`.
+> All facts held: live ledger = **50 rows**, the **4 orphans present**, repo =
+> **46 migration files** (50−4=46), `ob_raw_turns` = **41,427 rows**,
+> `open_brain_local_drift_test` already carries the applied repair at **46 rows
+> with zero orphans**, an idempotent re-run returned **`DELETE 0`** and held at
+> 46, and the DB guard **refused** and rolled back against a wrong DB
+> (`open_brain_local_play`, ledger untouched at 50).
+
+---
+
+## TL;DR — the go/no-go summary
+
+- **The drift is cosmetic, not blocking.** The live dogfood ledger
+  (`_migrations`) carries **4 orphan rows** from renamed/abandoned migration
+  lineages. They are stale bookkeeping rows; they are **not** a schema conflict.
+- **`bun run migrate` runs CLEAN against the drifted DB** — proven on the copy:
+  `"No new migrations to apply"`, zero applied, zero failed, clean exit. Every
+  migration `main` expects (001..045) is already applied AND materialized.
+- **The original alarm was a false positive.** "raw_turns table ABSENT" checked
+  the wrong name: the table is `ob_raw_turns` and it is present with 41,427 rows.
+- **Deploy is therefore safe WITHOUT any DB reconciliation.** The repair script
+  in Step 3 is **OPTIONAL cosmetic hygiene** (make the ledger match the repo so
+  future audits stop re-flagging the four rows). It is not a deploy prerequisite.
+- **GO recommendation:** deploy merged main to the clone runtime via the proven
+  `local-clone-deploy.sh` (Steps 2, 4). Run the ledger repair (Step 3) only if
+  the operator wants the ledger to read clean. **Operator decides.**
+
+Merged-main revision this runbook targets: **`30f22e2`** (`origin/main` as of
+2026-08-01, `docs(worklog): record landing wave -- CI green, merge, client
+deploy, drift flag (#457)`). The prior revision `3584527`
+(`fix(local-clone): allow 0.0.0.0 bind host behind the LAN dogfood opt-in
+(#456)`) is now an ancestor; the only commit between them is the #457 worklog
+doc, which changes no migration or runtime code, so every migration fact in this
+runbook is unchanged.
+
+---
+
+## Diagnosis (READ-ONLY, proven against the live DB this session)
+
+Live dogfood DB `open_brain_local_20260724` (127.0.0.1:5432), read-only inspection.
+
+### The drift, exactly
+
+The ledger has **50 rows**; the repo has **46 migration files**. The 4 extras
+are orphans — filenames that are **not** current repo migrations:
+
+| Orphan ledger row | Applied | Why it is an orphan |
+|---|---|---|
+| `005_fts_hybrid` | 2026-03-22 17:09 | Pre-`.sql`-suffix filename. Re-applied 8 min later as `005_fts_hybrid.sql` (the current repo file). This bare row is a **stale duplicate** of an applied migration. |
+| `010_chunking.sql` | 2026-05-20 | Chunking was **renumbered** to `011_chunking.sql` (applied 2026-06-08). Slot 010 on main is now `010_entity_links.sql`. |
+| `033_system_facts.sql` | 2026-07-25 | From the **abandoned "code-brain" branch**. `main` uses `033_candidate_memory.sql` (applied 2026-07-27, materialized). |
+| `034_memory_axes.sql` | 2026-07-25 | Same abandoned branch. `main` uses `034_content_occurrences.sql` (applied 2026-07-27, materialized). |
+
+**History:** the DB was cloned 2026-07-24. On 2026-07-25 an abandoned code-brain
+lineage (`033_system_facts`, `034_memory_axes` — from commits `caabc14`,
+`26be6ab`, `0f6e209`, present only on the superseded branches
+`feat/380-raw-turns-ingest` / `feat/410-uv-workspace`, never on `main`) was
+applied to this DB. `main` later shipped a **different** 033/034 pair
+(candidate_memory / content_occurrences), applied 2026-07-27. The migration
+runner keys on exact `filename` and only ever ADDS files missing from the ledger
+— it never removes extra rows — so both lineages' rows coexist harmlessly.
+
+### What is NOT missing (alarm refuted with evidence)
+
+- `ob_raw_turns` (what `032_raw_turns.sql` creates): **present, 41,427 rows.**
+  The "raw_turns ABSENT" report checked for a table named `raw_turns`; the
+  migration creates `ob_raw_turns`.
+- Every repo migration filename 001..045 is in the ledger.
+- Every table a **fresh-from-empty** migrate produces is present in the live DB
+  (schema-diff missing-set is EMPTY). Column-level checks on
+  `candidate_memory`, `ob_raw_turns`, `candidate_grade`, `content_occurrences`,
+  `candidate_reinforcement` are all equivalent.
+
+### Harmless residue left in the live DB (data, NOT touched by this runbook)
+
+- `ob_system_facts` — 150 rows of dead code-brain data, referenced by **no**
+  current source (`rg 'ob_system_facts' src/` outside migrations = none).
+- `memory_axes` / `ob_memory_axes` — **do not exist** (only the ledger row
+  remains; the table was never persisted or was dropped).
+- `zz_test_*` (11 tables) — test scaffolding left in live by prior test runs.
+
+None of these are referenced by merged-main runtime code. Cleaning them up is a
+**separate operator-owned decision**, out of scope for this deploy.
+
+### Deployed-app parity
+
+The deployed runtime at `/Volumes/ThunderBolt/open-brain-local/app/src/db/migrations/`
+is a **byte-identical file list** (46 `.sql` files) to the repo's
+`src/db/migrations/`. The drift is purely in the live **DB ledger**, not in a
+divergent migrations directory.
+
+---
+
+## Rehearsal outcome (proven on the disposable copy)
+
+1. Cloned live → `open_brain_local_drift_test` via `scripts/local-clone-db.sh`
+   (proven method: `pg_dump -Fc` + `pg_restore`, ownership preserved, live stays
+   up). Verified: 35 tables, `ob_raw_turns` 41,427 = 41,427, ownership matches
+   live (`open_brain_local_clone:23,rico:10`).
+2. `bun run migrate` (DB_NAME=open_brain_local_drift_test) against the drifted
+   clone → **`No new migrations to apply`**, clean exit. No failure, no blocked
+   state.
+3. Built a from-empty baseline (`open_brain_local_fresh_test`) by migrating an
+   empty DB — all 46 files applied cleanly. Table-set diff drifted-vs-fresh:
+   **missing-set EMPTY** (drifted clone has every table the code expects).
+4. Applied the Step-3 repair script to the clone → `DELETE 4`, ledger 50 → 46,
+   ledger now set-equals the repo migration list exactly. Idempotent re-run →
+   `DELETE 0`, still 46. `bun run migrate` after repair → still
+   `No new migrations to apply`. DB guard proven: the script raises and rolls
+   back if run against any DB other than the live clone or the rehearsal copy.
+
+**Re-proof 2026-08-01 (this rebuild session):** `open_brain_local_drift_test`
+still exists and already carries the applied repair (46 rows, zero orphans). An
+idempotent re-run this session returned `DELETE 0` and held at 46. The DB guard
+was re-proven by running the script against `open_brain_local_play`: it raised
+`reconcile refused: current_database() is open_brain_local_play …` and rolled
+back, leaving that ledger untouched at 50.
+
+**Rehearsal verdict: CLEAN. No blocked step. No fix required for deploy.**
+
+---
+
+## The deploy — ordered commands (WRITTEN; run after operator go)
+
+All commands run from `/Volumes/ThunderBolt/Development/open-brain` unless noted.
+Env/secret files are read by the scripts; **no secret is printed** by any step.
+
+### Step 0 — pre-flight (READ-ONLY, safe to run now)
+
+```bash
+cd /Volumes/ThunderBolt/Development/open-brain
+
+# Confirm merged main is what you intend to ship.
+git fetch origin
+git rev-parse --short origin/main          # expect 30f22e2 (or newer if main moved)
+
+# Confirm the running service and its DB target (name only; no secrets echoed).
+launchctl list | rg 'open-brain-local-clone'          # expect com.rico.open-brain-local-clone
+curl -s --max-time 5 http://127.0.0.1:3100/health | rg -o '"status":"[a-z]*"'   # expect "status":"healthy"
+rg -n '^DB_NAME|^PORT' /Volumes/ThunderBolt/open-brain-local/local-clone.env    # DB_NAME=open_brain_local_20260724 PORT=3100
+```
+
+**LAW-0:** REHEARSED-on-copy for the DB inspection; the service/health probes are
+WRITTEN read-only commands.
+
+### Step 1 — snapshot the live DB (rollback point) — REQUIRED before any DB write
+
+Only needed if you will run Step 3 (the ledger repair). If you deploy WITHOUT the
+repair, no DB write happens and this snapshot is optional insurance.
+
+```bash
+# Custom-format dump into the existing backups convention. Live service stays up.
+# This is the same dump method local-clone-db.sh uses and is proven safe live.
+pg_dump -Fc -d open_brain_local_20260724 \
+  -f "/Volumes/ThunderBolt/open-brain-local/_backups/open_brain_local_20260724-pre-repair-$(date -u +%Y%m%dT%H%M%SZ).dump"
+```
+
+**LAW-0:** WRITTEN. `pg_dump -Fc` against live is the exact method the rehearsal
+clone used successfully this session (read-only on live; produces a file).
+Restore path is in Step 6.
+
+### Step 2 — deploy merged main to the clone runtime (source sync)
+
+Uses the proven `scripts/local-clone-deploy.sh` — **do NOT hand-roll rsync.**
+It `git archive`s the committed ref (working-tree edits are structurally
+excluded), `bun install --frozen-lockfile`, runs `bun run migrate` against the
+clone DB, atomic-swaps `app` ← staging (old `app` → `app.previous`), restarts
+the launchd service, health-checks, and auto-rolls-back on health failure.
+
+```bash
+cd /Volumes/ThunderBolt/Development/open-brain
+
+OPENBRAIN_SERVICE_LABEL=com.rico.open-brain-local-clone \
+  scripts/local-clone-deploy.sh origin/main
+```
+
+Expected: `deployed <sha> to /Volumes/ThunderBolt/open-brain-local/app` and
+`post-deploy health check passed on port 3100`. The embedded
+`bun run migrate` will log **`No new migrations to apply`** (proven on the copy).
+
+**LAW-0:** WRITTEN. The embedded migrate step is REHEARSED-on-copy (clean no-op).
+The source-swap/restart is WRITTEN — read from the proven script, not run live.
+
+### Step 3 — reconcile the ledger (OPTIONAL, cosmetic)
+
+**Skip this unless the operator wants the ledger to read clean.** Deploy in
+Step 2 succeeds and the service runs correctly with the four orphan rows still
+present (proven). Run this only to make `_migrations` match the repo so a future
+file-by-file audit stops re-flagging them.
+
+```bash
+cd /Volumes/ThunderBolt/Development/open-brain
+
+# Idempotent, transactional, self-guarding: refuses any DB except the live clone
+# or the rehearsal copy, and rolls back if the post-count isn't exactly 46.
+psql -v ON_ERROR_STOP=1 -d open_brain_local_20260724 \
+  -f src/db/migrations/repair/2026-08-01_reconcile_local_clone_ledger.sql
+```
+
+Expected: `DELETE 4`, then `COMMIT`. Re-running is safe (`DELETE 0`).
+
+**LAW-0:** REHEARSED-on-copy — this exact script ran on
+`open_brain_local_drift_test` (`DELETE 4` → 46 rows → idempotent `DELETE 0`), and
+its DB guard was proven to refuse and roll back on the wrong database. NOT run
+against live. **Note:** the script lives under `src/db/migrations/repair/`, a
+subdirectory the migration runner (`src/db/migrate.ts`) and the census
+(`src/operator-doctor.ts`) never see — both do a **non-recursive** `readdir` +
+`.endsWith(".sql")`, so a subdirectory named `repair` is skipped. Placing it
+there means it can never be auto-applied by `bun run migrate`; it is
+operator-run, by hand, only.
+
+### Step 4 — health checks (post-deploy)
+
+```bash
+# Service healthy, DB connected, embedding connected.
+curl -s http://127.0.0.1:3100/health | rg -o '"status":"[a-z]*"|"connected":(true|false)'
+
+# Ledger sanity: if Step 3 was run, expect 46 rows and no orphans.
+set -a; . /Volumes/ThunderBolt/Development/open-brain/.env; set +a
+psql -At -d open_brain_local_20260724 -c "SELECT count(*) FROM _migrations;"
+psql -At -d open_brain_local_20260724 -c \
+  "SELECT filename FROM _migrations WHERE filename IN ('005_fts_hybrid','010_chunking.sql','033_system_facts.sql','034_memory_axes.sql');"
+
+# Data intact: raw turns still present (the table is ob_raw_turns).
+psql -At -d open_brain_local_20260724 -c "SELECT count(*) FROM ob_raw_turns;"
+
+# Deployed revision stamp matches what you shipped.
+cat /Volumes/ThunderBolt/open-brain-local/app/.deployed-revision
+```
+
+Expected: `"status":"healthy"`, DB+embedding `connected":true`; if Step 3 ran,
+`_migrations` = 46 and the orphan query returns empty; `ob_raw_turns` count
+unchanged from Step 0 (41,427); `.deployed-revision` shows the shipped sha.
+
+**LAW-0:** REHEARSED-on-copy for the ledger/data checks; the /health probe is
+WRITTEN.
+
+### Step 5 — dogfood smoke (optional, normal production traffic)
+
+A capture/checkpoint/reflex through the installed provider is normal dogfood
+traffic (writes an `ob_raw_turns` row via the running service, not DDL). If the
+operator wants a live round-trip proof, fire one normal capture and confirm the
+count increments. This is production write behavior, not a schema mutation.
+
+### Step 6 — rollback (if anything is wrong)
+
+Two independent rollback axes — **runtime** and **DB** — because they fail
+independently.
+
+**Runtime rollback** (restores the previous `app` directory + restarts):
+
+```bash
+cd /Volumes/ThunderBolt/Development/open-brain
+OPENBRAIN_SERVICE_LABEL=com.rico.open-brain-local-clone \
+  scripts/local-clone-deploy.sh --rollback
+# Restores /Volumes/ThunderBolt/open-brain-local/app from app.previous.
+```
+
+**DB rollback** (only relevant if Step 3 was run and must be undone). The repair
+only DELETEs 4 bookkeeping rows and touches no data, so the cheapest undo is to
+re-insert them; a full restore from the Step-1 dump is the heavy option.
+
+Cheap undo (re-insert the 4 orphan ledger rows — restores exact pre-repair state):
+
+```bash
+set -a; . /Volumes/ThunderBolt/Development/open-brain/.env; set +a
+psql -v ON_ERROR_STOP=1 -d open_brain_local_20260724 <<'SQL'
+INSERT INTO _migrations (filename) VALUES
+  ('005_fts_hybrid'), ('010_chunking.sql'),
+  ('033_system_facts.sql'), ('034_memory_axes.sql')
+ON CONFLICT (filename) DO NOTHING;
+SQL
+```
+
+Heavy undo (full restore from the Step-1 snapshot — operator-run, stops the
+service first; a restore is destructive to the current DB so **Rico runs it**):
+
+```text
+# Operator-owned. Stop com.rico.open-brain-local-clone, then:
+#   pg_restore --clean --if-exists -d open_brain_local_20260724 <the pre-repair .dump>
+# Restart the service and re-run Step 4. (Left as prose: a --clean restore drops
+# objects, so it is Rico's call and Rico's hand.)
+```
+
+**LAW-0:** The runtime `--rollback` and the row re-insert are WRITTEN (composed
+from the proven script and the exact orphan set diagnosed this session). The full
+DB restore is intentionally left as operator-run prose because it is destructive.
+
+---
+
+## Cleanup after the operator is done
+
+Disposable scratch databases were created on `127.0.0.1:5432` for this
+rehearsal and can be dropped once the operator no longer needs them:
+
+- `open_brain_local_drift_test` — the full live clone used for rehearsal.
+- `open_brain_local_fresh_test` — the from-empty schema baseline.
+
+```bash
+# Agent does NOT run forced/destructive deletes. Operator drops these:
+cd /Volumes/ThunderBolt/Development/open-brain
+scripts/local-clone-db.sh --drop open_brain_local_drift_test
+scripts/local-clone-db.sh --drop open_brain_local_fresh_test
+```
+
+Both names contain `test`, so the script's disposable-name guard accepts them and
+its live-DB guard still refuses the real dogfood DB.
+
+---
+
+## Provenance
+
+- Diagnosis: read-only psql against live `open_brain_local_20260724`,
+  `src/db/migrate.ts`, `src/operator-doctor.ts`, git history of the abandoned
+  code-brain migrations. RUNNING-verified this session (2026-08-01).
+- Rehearsal: `open_brain_local_drift_test` full clone; migrate + repair proven on
+  it. RUNNING-verified this session — the repair was re-proven idempotent
+  (`DELETE 0`, 46 rows) and the DB guard re-proven to refuse a wrong DB.
+- Repair script: `src/db/migrations/repair/2026-08-01_reconcile_local_clone_ledger.sql`.
+- **Live service and live DB: untouched. Operator go/no-go required.**

--- a/src/db/migrations/repair/2026-08-01_reconcile_local_clone_ledger.sql
+++ b/src/db/migrations/repair/2026-08-01_reconcile_local_clone_ledger.sql
@@ -1,0 +1,101 @@
+-- Repair: reconcile the local dogfood clone's _migrations ledger with the repo.
+--
+-- STATUS: WRITTEN + REHEARSED-on-copy 2026-08-01. NOT executed against the live
+-- dogfood DB (open_brain_local_20260724). Operator go/no-go required.
+--
+-- WHAT THIS IS (and is NOT):
+--   This is COSMETIC ledger hygiene, NOT a deploy prerequisite. Proven on the
+--   rehearsal clone open_brain_local_drift_test 2026-08-01: `bun run migrate`
+--   against the drifted ledger reports "No new migrations to apply" and exits
+--   clean WITHOUT this repair. operator-doctor.ts reports status "current"
+--   because it only counts repo files that are NOT applied (pending); extra
+--   ledger rows are ignored. So the service deploys and runs correctly with or
+--   without this script. Run it only to make the ledger MATCH the repo so a
+--   future file-by-file audit stops re-flagging the same four rows.
+--
+-- WHY THE DRIFT EXISTS (history, verified from ledger applied_at + git log):
+--   The dogfood DB open_brain_local_20260724 was cloned 2026-07-24 and carries
+--   ledger rows from lineages that were later renamed or abandoned on main:
+--     - 005_fts_hybrid        applied 2026-03-22 17:09  (pre-".sql" filename;
+--                             re-applied 8 min later as 005_fts_hybrid.sql,
+--                             which IS the current repo file -- so this bare row
+--                             is a stale duplicate of an applied migration)
+--     - 010_chunking.sql      applied 2026-05-20        (chunking was renumbered
+--                             to 011_chunking.sql, applied 2026-06-08; 010 is
+--                             now 010_entity_links.sql on main)
+--     - 033_system_facts.sql  applied 2026-07-25        (abandoned "code-brain"
+--     - 034_memory_axes.sql   applied 2026-07-25         branch; main uses
+--                             033_candidate_memory.sql / 034_content_occurrences.sql
+--                             instead -- both applied 2026-07-27 and materialized)
+--
+--   None of these four filenames exist in src/db/migrations/ on main. Every
+--   filename that DOES exist on main (001..045) is already in the ledger and its
+--   schema is materialized (proven: table set of the drifted clone is a superset
+--   of a fresh-from-empty migrate, with an EMPTY missing-set).
+--
+-- WHAT THIS SCRIPT TOUCHES:
+--   ONLY rows in the _migrations bookkeeping table whose filename is NOT a
+--   current repo migration. It removes stale ledger ROWS only. It does NOT drop,
+--   alter, or truncate any data table -- not ob_system_facts (150 rows of dead
+--   code-brain data, referenced by NO current source), not the zz_test_* tables.
+--   Dead-table cleanup, if ever wanted, is a SEPARATE operator-owned decision;
+--   this script deliberately leaves all data in place.
+--
+-- IDEMPOTENT: a second run deletes nothing (the rows are already gone) and the
+--   guard block still passes. Safe to re-run.
+
+BEGIN;
+
+-- Guard: refuse to run against the wrong database. The local clone that carries
+-- this exact drift is open_brain_local_20260724; the rehearsal copy is
+-- open_brain_local_drift_test. Anything else, abort loudly rather than edit a
+-- ledger we did not diagnose.
+DO $$
+BEGIN
+  IF current_database() NOT IN (
+    'open_brain_local_20260724',
+    'open_brain_local_drift_test'
+  ) THEN
+    RAISE EXCEPTION
+      'reconcile refused: current_database() is %, expected the dogfood clone '
+      'open_brain_local_20260724 or the rehearsal copy open_brain_local_drift_test',
+      current_database();
+  END IF;
+END $$;
+
+-- Remove ONLY the four orphan ledger rows, each named explicitly. An orphan is a
+-- ledger filename that is not a current repo migration; these four are the exact
+-- set diagnosed 2026-08-01. Naming them (rather than a computed "anything not in
+-- the repo") keeps the blast radius auditable and stops a future unrelated row
+-- from being swept by a broad predicate.
+DELETE FROM _migrations
+WHERE filename IN (
+  '005_fts_hybrid',       -- stale pre-.sql duplicate of applied 005_fts_hybrid.sql
+  '010_chunking.sql',     -- renumbered to 011_chunking.sql
+  '033_system_facts.sql', -- abandoned code-brain branch; main uses 033_candidate_memory.sql
+  '034_memory_axes.sql'   -- abandoned code-brain branch; main uses 034_content_occurrences.sql
+);
+
+-- Post-condition assertion: after this runs, the ledger must contain EXACTLY the
+-- current repo migration set and nothing else. This is proven at repair time,
+-- not trusted. The expected count (46) is the number of *.sql files in
+-- src/db/migrations/ on main as of 2026-08-01 (001..045, where 006 and the
+-- paired 010 names mean the count is 46 rather than 45 -- verified with
+-- `ls src/db/migrations/*.sql | wc -l` = 46, and the pre-repair ledger of 50
+-- minus these 4 orphans = 46, which set-equals the repo file list exactly).
+-- If the count is wrong, ABORT so the transaction rolls back and nothing is
+-- committed on a surprise.
+DO $$
+DECLARE
+  ledger_count INTEGER;
+BEGIN
+  SELECT count(*) INTO ledger_count FROM _migrations;
+  IF ledger_count <> 46 THEN
+    RAISE EXCEPTION
+      'reconcile post-condition failed: _migrations has % rows after cleanup, '
+      'expected 46 (the current repo migration set). Rolling back.',
+      ledger_count;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Rebuilds and lands two deliverables a prior worker rehearsed but never committed. The claimed commit `c2865db` exists only as an unreachable dangling git object (on no ref, not an ancestor of `main`); its content was recovered and every load-bearing fact was **re-verified live this session** against the real dogfood DB before writing. Closes #458 once the operator runs the deploy.

## What landed

- `_plans/local-clone-deploy-runbook-2026-08-01.md` — deploy-merged-main runbook for the local dogfood clone. LAW-0 header: **REHEARSED on a disposable copy** (`open_brain_local_drift_test`), **NOT executed** against the live service or DB; **operator go/no-go required**. Ordered commands: pre-flight, live DB snapshot, deploy via `scripts/local-clone-deploy.sh origin/main` (embedded migrate proven a clean no-op), optional cosmetic ledger repair, health checks, dual-axis rollback. Targets `origin/main` `30f22e2`.
- `src/db/migrations/repair/2026-08-01_reconcile_local_clone_ledger.sql` — idempotent, transactional, DB-guarded repair that deletes exactly the 4 orphan ledger rows and asserts post-count 46 in-transaction, rolling back on a surprise. Lives under `src/db/migrations/repair/`, a subdirectory the non-recursive `readdir` in `migrate.ts` and `operator-doctor.ts` never see, so it can never be auto-applied — operator-run only.

## Re-verified live 2026-08-01 (read-only on `open_brain_local_20260724`)

- Live `_migrations` ledger = **50 rows**, exactly the **4 orphans** present, repo = **46** migration files (50−4=46).
- `ob_raw_turns` present, **41,427 rows** — the original "raw_turns ABSENT" alarm was a wrong-table-name false positive.
- `open_brain_local_drift_test` already carries the applied repair (**46 rows, 0 orphans**); an idempotent re-run this session returned **`DELETE 0`** and held at 46.
- DB guard re-proven by running against `open_brain_local_play`: it raised and rolled back, leaving that ledger untouched at 50.

## Critical Self-Review

- Highest-risk behavior: The repair SQL mutating the wrong database's `_migrations` ledger. Mitigated by an in-transaction `current_database()` allowlist guard (only `open_brain_local_20260724` / `open_brain_local_drift_test`) that raises and rolls back otherwise; re-proven this session against `open_brain_local_play`.
- Assumptions that could be wrong: That the 4 orphan filenames are the exact drift set. Verified live — the live ledger holds all 4 and no other filename is absent from the repo's 46 files (50−4=46 set-equals the repo list).
- Missing/weak tests: No unit test asserts the runner ignores `repair/`; instead the invisibility is proven structurally — `migrate.ts:28` and `operator-doctor.ts:216` both do a non-recursive `readdir(...).filter(f => f.endsWith(".sql"))`, and `repair` is a directory, not a `.sql` file. The SQL's own post-condition assertion (count must equal 46 or roll back) is the executable guard, proven on `drift_test`.
- Security/permission risk: None. Docs plus a non-runner SQL file that only DELETEs bookkeeping rows in a LAN-local dev DB; no auth/namespace surface, no secrets, no network. The guard is a safety, not a security, control.
- Migration/deploy risk: The repair could be mistaken for an auto-applied migration. Mitigated by the `repair/` subdir placement (invisible to the non-recursive runner) and explicit runbook prose marking it OPTIONAL and operator-run. The deploy itself is a proven clean migrate no-op against the drifted ledger.
- Downstream client/runtime risk: None. No parity path touched (`contracts/parity-paths.txt`: `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, `src/contract-schemas.ts`) — verified with the same diff the CI uses; no MCP/schema/client surface changes.
- Rollback/cleanup concern: The repair only DELETEs 4 rows and touches no data table; runbook Step 6 gives a cheap re-INSERT undo plus a heavy operator-owned `pg_restore` from the Step-1 snapshot. Disposable rehearsal DBs are dropped by the operator via the guard-safe `local-clone-db.sh --drop`.
- Fixes made before PR: Updated the runbook's target revision from the prior worker's `3584527` to current `origin/main 30f22e2` after confirming `3584527` is now an ancestor and the only intervening commit (#457 worklog) changes no migration/runtime code.
- Known residual risk: The runbook is REHEARSED-not-EXECUTED by design; the live deploy and optional repair remain operator go/no-go and are unproven against the live service until the operator runs them.
- SME review-memory update: [x] not applicable because: docs + non-runner repair SQL for a LAN-local dev DB; no new reviewer-facing code pattern, and the repair-subdir-invisibility fact is already carried by the #457 landing worker's SME notes.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR ships docs + a repair SQL file, not Open Brain runtime/tool/schema behavior; the live checks that matter here (ledger counts, `ob_raw_turns`, guard, idempotency) are recorded in the re-verification section above and reproducible from the runbook.

## Contract Parity

- Contract parity: [x] runtime-specific because: no parity path is touched (verified against `contracts/parity-paths.txt` with the CI's own base..head diff); this is a docs runbook plus a repair SQL under `src/db/migrations/repair/`, neither of which is a client/contract/protocol surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
