### PR TITLE
fix(canon): render canon whole as plain text, stop episodic at startup (#450)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,18 +3,6 @@
     "TMPDIR": "/mnt/ThunderBolt/_tmp/open-brain/_scratch"
   },
   "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup|resume|clear",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"/Volumes/ThunderBolt/Development/_ob/skills/brain/scripts/resume.py\" --limit 200 2>/dev/null || true",
-            "timeout": 30
-          }
-        ]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Write|Edit|NotebookEdit|Bash|Grep|Glob|AskUserQuestion",

--- a/_plans/canon-always-known.md
+++ b/_plans/canon-always-known.md
@@ -241,3 +241,35 @@ Ordered by dependency. Each mutation needs explicit operator authorization.
   machines and goes stale the moment a port moves.
 - **Auto-loading episodic context** — contaminates unrelated work and forecloses
   a deliberate fresh start.
+
+## Cold-loader fixes (2026-08-01, #450)
+
+The #450 prototype ran the cold-session test: content passed, the *mechanism*
+failed twice. Both were loader-transport bugs, not canon-content bugs.
+
+1. **Canon pack was diverted to a preview.** `openbrain-session-start` dumped
+   the raw `agent_context_pack` JSON envelope (~30 KB of nested items, ids,
+   citations, confidences, warnings) into `additionalContext`, and Claude Code
+   persisted a payload that large to a file it surfaced as only a ~2 KB preview
+   — the session saw 2–3 of 31 items and could not name the sections. **Fix:**
+   `session_start.render_pack` now renders plain text — a one-line header
+   (schema, namespace, per-section counts) then every item on its own line
+   (`[<lane>] <scope-key>: <rule text in full>`), all 31 items, whole rule text.
+   This is formatting (dropping the JSON envelope/metadata bulk), **not** content
+   reduction; the rules still arrive whole. The plain-text render of the real
+   31-item pack is a few KB, small enough to land inline.
+
+2. **Episodic history was injected at startup, against the canon-only ruling.**
+   The 57.8 KB `Lane: dev:open-brain (200 events)` block at SessionStart was
+   **not** from the repo canon hook. It came from a *second* SessionStart hook in
+   this repo's own `.claude/settings.json`, matching `startup|resume|clear` and
+   running `_ob/skills/brain/scripts/resume.py --limit 200`. That directly
+   violates canon-only. **Fix:** the `SessionStart` block was removed from
+   `.claude/settings.json`; lane history is no longer injected at startup.
+
+**Episodic is now explicit-on-request — the recap vocabulary is the door.** To
+pull lane history deliberately, run the resume flow: `resume.py` directly
+(`"$RESUME"`, `--brief` for a human), or say "session recap" / "where were we" /
+"continue" to trigger the `brain` skill's resume. Canon (rules/profile/repo
+facts) still auto-loads every session via `openbrain-session-start`; only the
+back-history stopped auto-loading.

--- a/python/openbrain/src/openbrain/apps/hooks/session_start.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session_start.py
@@ -43,9 +43,22 @@ Pattern/Convention:
 
     The injecting response is one JSON object on stdout:
     ``{"hookSpecificOutput": {"hookEventName": "SessionStart",
-    "additionalContext": "<pack>"}}`` -- the documented SessionStart contract.
-    ``additionalContext`` is a string, so the assembled canon pack is serialised
-    into it verbatim.
+    "additionalContext": "<rendered>"}}`` -- the documented SessionStart
+    contract. ``additionalContext`` is a string, so the assembled canon pack is
+    RENDERED into it as plain text.
+
+    WHY PLAIN TEXT, NOT THE RAW PACK JSON. Measured 2026-08-01 against the #450
+    cold-session prototype: dumping the raw ``agent_context_pack`` JSON envelope
+    put ~30 KB of nested objects, ids, citations, confidences, and warnings into
+    ``additionalContext``, and Claude Code diverted a payload that large to a
+    file it surfaced only as a ~2 KB preview -- the session saw 2-3 of 31 items
+    and could not name the sections. The canon-only design requires the RULES
+    themselves front-of-mind, whole. So this renders every item to its own line
+    -- scope key, the rule text IN FULL, lane -- and drops the JSON envelope and
+    per-item metadata that carried the bulk. This is FORMATTING, not content
+    reduction: no rule text is shortened or omitted (``docs/CODING_STANDARDS.md``
+    section 6). If a choice ever arises between dropping content and a large
+    injection, the injection stays whole and large.
 
 Example:
     >>> import io
@@ -132,19 +145,114 @@ def inject_canon_with(
         )
 
 
+def render_pack(pack: Any) -> str:
+    """Render a canon ``agent_context_pack`` payload to front-of-mind plain text.
+
+    Args:
+        pack: The decoded ``agent_context_pack.v1`` payload the server assembled
+            -- ``schema``, ``scope``, ``sections`` (each a labelled block of
+            ``items``), and ``warnings``.
+
+    Returns:
+        One header line then every item on its own line, the rule text WHOLE. The
+        header names the schema, the resolved namespace, and the per-section
+        counts so the session can state what it was given. Each item line is
+        ``[<lane>] <scope-key>: <rule text in full>`` -- the lane is the item's
+        candidate/fact type, the scope-key is its stable name, and the rule text
+        is the item's ``guidance`` (profile/process items) or ``fact`` (repo
+        facts), never shortened.
+
+    This drops the JSON envelope and per-item metadata (ids, citations,
+    confidences, promotion timestamps, the ``warnings`` block) that carried the
+    bulk without carrying a rule. That is the whole point: it is the RULES the
+    session must hold, and only removing the scaffolding around them keeps the
+    injection small enough that Claude Code presents it inline instead of
+    diverting it to a preview file. No rule text is bounded, shortened, or
+    dropped (``docs/CODING_STANDARDS.md`` section 6).
+
+    Defensive by construction: a section, an item field, or the whole pack being
+    absent or the wrong type must not raise -- the entrypoint swallows, but a
+    partial pack should still render what it does carry rather than nothing. A
+    non-dict pack renders to an empty string, which the entrypoint treats as
+    "nothing to inject".
+    """
+    if not isinstance(pack, dict):
+        return ""
+
+    sections = pack.get("sections")
+    sections = sections if isinstance(sections, dict) else {}
+
+    schema = pack.get("schema") or "openbrain.agent_context_pack.v1"
+    scope = pack.get("scope")
+    namespace = ""
+    if isinstance(scope, dict):
+        namespace = str(scope.get("namespace") or "")
+
+    counts: list[str] = []
+    lines: list[str] = []
+    for label, section in sections.items():
+        if not isinstance(section, dict):
+            continue
+        items = section.get("items")
+        items = items if isinstance(items, list) else []
+        counts.append(f"{label}={len(items)}")
+        for item in items:
+            lines.append(_render_item(label, item))
+
+    header_bits = [f"CANON ({schema})"]
+    if namespace:
+        header_bits.append(f"namespace={namespace}")
+    header_bits.append("sections: " + ", ".join(counts) if counts else "sections: (none)")
+    header = " | ".join(header_bits)
+
+    return "\n".join([header, "", *lines])
+
+
+def _render_item(label: str, item: Any) -> str:
+    """Render one canon item to a single ``[<lane>] <key>: <rule text>`` line.
+
+    Two item shapes reach here from ``agent_context_pack``: guidance items
+    (``profile_guidance``/``process_guidance``) carry ``scope_key``,
+    ``guidance``, and ``candidate_type``; fact items (``repo_facts``) carry
+    ``subject``, ``fact``, and ``fact_type``. The lane falls back to the section
+    ``label`` when an item names no type, and the key falls back to empty; the
+    rule TEXT is whatever the item carries, in full, and is never dropped.
+    """
+    if not isinstance(item, dict):
+        return f"[{label}] {item}"
+
+    text = item.get("guidance")
+    if text is None:
+        text = item.get("fact")
+    text = "" if text is None else str(text)
+
+    key = item.get("scope_key")
+    if key is None:
+        key = item.get("subject")
+    key = "" if key is None else str(key)
+
+    lane = item.get("candidate_type") or item.get("fact_type") or label
+
+    prefix = f"[{lane}] "
+    if key:
+        return f"{prefix}{key}: {text}"
+    return f"{prefix}{text}"
+
+
 def _injection_envelope(pack: Any) -> str:
-    """Serialise the canon pack into the ``additionalContext`` response envelope.
+    """Wrap the rendered canon in the ``additionalContext`` response envelope.
 
     The SessionStart contract carries the injection as a STRING on
-    ``hookSpecificOutput.additionalContext``, so the assembled pack -- a JSON
-    object -- is serialised into that string verbatim. Nothing is bounded,
-    shortened, or dropped: the pack is injected WHOLE.
+    ``hookSpecificOutput.additionalContext``. The pack is RENDERED to plain text
+    (:func:`render_pack`) rather than dumped as raw JSON so it arrives whole and
+    front-of-mind instead of being diverted to a preview file; nothing in the
+    rendered rules is bounded, shortened, or dropped.
     """
     return json.dumps(
         {
             "hookSpecificOutput": {
                 "hookEventName": _HOOK_EVENT_NAME,
-                "additionalContext": json.dumps(pack, ensure_ascii=False),
+                "additionalContext": render_pack(pack),
             }
         }
     )

--- a/python/openbrain/tests/test_capture_hooks.py
+++ b/python/openbrain/tests/test_capture_hooks.py
@@ -1231,26 +1231,147 @@ def _write_injection(pack: object, out: io.StringIO) -> None:
     out.write(session_start._injection_envelope(pack))
 
 
+#: A fixture pack shaped exactly like the live ``agent_context_pack.v1``: the two
+#: real item shapes (guidance items with ``scope_key``/``guidance``/
+#: ``candidate_type``; fact items with ``subject``/``fact``/``fact_type``) and the
+#: envelope fields the renderer reads. Every rule text is a distinct sentinel so a
+#: test can assert it survived verbatim.
+_FIXTURE_PACK = {
+    "schema": "openbrain.agent_context_pack.v1",
+    "scope": {"namespace": "rico", "agent": "claude"},
+    "sections": {
+        "profile_guidance": {
+            "label": "profile_guidance",
+            "item_count": 2,
+            "items": [
+                {
+                    "scope_key": "profile.who",
+                    "guidance": "Rico is the operator; PROFILE-RULE-ONE in full.",
+                    "candidate_type": "profile_fact",
+                },
+                {
+                    "scope_key": "profile.adhd",
+                    "guidance": "Lead with the next action; PROFILE-RULE-TWO in full.",
+                    "candidate_type": "profile_fact",
+                },
+            ],
+        },
+        "process_guidance": {
+            "label": "process_guidance",
+            "item_count": 1,
+            "items": [
+                {
+                    "scope_key": "process.no_tmp",
+                    "guidance": "Never /tmp; PROCESS-RULE-ONE in full.",
+                    "candidate_type": "process_rule",
+                },
+            ],
+        },
+        "repo_facts": {
+            "label": "repo_facts",
+            "item_count": 1,
+            "items": [
+                {
+                    "subject": "repo.two_hosts",
+                    "fact": "Exactly two hosts; REPO-FACT-ONE in full.",
+                    "fact_type": "gotcha",
+                },
+            ],
+        },
+    },
+    "warnings": {"scope_denials": [], "degraded_sources": [], "truncation": []},
+}
+
+
+class TestSessionStartRendersCanonAsPlainText:
+    """render_pack renders every rule WHOLE as plain text -- no JSON envelope."""
+
+    def test_every_items_rule_text_appears_verbatim(self) -> None:
+        rendered = session_start.render_pack(_FIXTURE_PACK)
+        # Every rule sentinel from every section survives, IN FULL.
+        for section in _FIXTURE_PACK["sections"].values():
+            for item in section["items"]:
+                text = item.get("guidance") or item.get("fact")
+                assert text in rendered
+
+    def test_every_scope_key_and_lane_appears(self) -> None:
+        rendered = session_start.render_pack(_FIXTURE_PACK)
+        assert "profile.who" in rendered
+        assert "process.no_tmp" in rendered
+        assert "repo.two_hosts" in rendered  # a fact item keys on ``subject``
+        # The lane is the item's candidate/fact type, rendered as a ``[lane]`` tag.
+        assert "[process_rule]" in rendered
+        assert "[gotcha]" in rendered
+
+    def test_the_counts_line_is_correct(self) -> None:
+        rendered = session_start.render_pack(_FIXTURE_PACK)
+        header = rendered.splitlines()[0]
+        # The header names the schema, namespace, and per-section counts.
+        assert "openbrain.agent_context_pack.v1" in header
+        assert "namespace=rico" in header
+        assert "profile_guidance=2" in header
+        assert "process_guidance=1" in header
+        assert "repo_facts=1" in header
+
+    def test_one_line_per_item_after_the_header(self) -> None:
+        rendered = session_start.render_pack(_FIXTURE_PACK)
+        lines = rendered.splitlines()
+        # header, blank, then exactly one line per item (4 items here).
+        assert lines[1] == ""
+        item_lines = [ln for ln in lines[2:] if ln]
+        total = sum(len(s["items"]) for s in _FIXTURE_PACK["sections"].values())
+        assert len(item_lines) == total == 4
+
+    def test_the_raw_json_envelope_is_gone(self) -> None:
+        rendered = session_start.render_pack(_FIXTURE_PACK)
+        # The metadata bulk that diverted the injection to a preview must not be
+        # in the rendered text: no citation/confidence keys, no warnings block.
+        assert "citation_id" not in rendered
+        assert "candidate_type" not in rendered  # rendered as a lane tag, not a key
+        assert "scope_denials" not in rendered
+
+    def test_a_non_dict_pack_renders_empty(self) -> None:
+        assert session_start.render_pack("not a pack") == ""
+        assert session_start.render_pack(None) == ""
+
+    def test_a_missing_field_does_not_raise(self) -> None:
+        # A partial pack (no scope, an item missing its key) still renders its
+        # rule text rather than raising.
+        partial = {"sections": {"process_guidance": {"items": [{"guidance": "R"}]}}}
+        rendered = session_start.render_pack(partial)
+        assert "R" in rendered
+
+
 class TestSessionStartEntrypointWritesTheInjection:
-    """The additionalContext envelope carries the pack, WHOLE, on the happy path."""
+    """The additionalContext envelope carries the rendered canon on the happy path."""
 
     def test_the_envelope_shape_is_the_sessionstart_contract(self) -> None:
-        pack = {"sections": {"repo_facts": {"items": [{"fact": "two hosts only"}]}}}
         out = io.StringIO()
-        _write_injection(pack, out)
+        _write_injection(_FIXTURE_PACK, out)
 
         envelope = json.loads(out.getvalue())
         assert set(envelope) == {"hookSpecificOutput"}
         specific = envelope["hookSpecificOutput"]
         assert specific["hookEventName"] == "SessionStart"
-        # additionalContext is a STRING carrying the pack verbatim.
+        # additionalContext is a STRING carrying the RENDERED canon, not raw JSON.
         assert isinstance(specific["additionalContext"], str)
-        assert json.loads(specific["additionalContext"]) == pack
+        assert specific["additionalContext"] == session_start.render_pack(
+            _FIXTURE_PACK
+        )
+        # And it is plain text, not a re-parseable pack object.
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(specific["additionalContext"])
 
-    def test_the_injected_pack_is_whole(self) -> None:
-        # A large section body survives into additionalContext with no bound.
+    def test_the_injected_rule_text_is_whole(self) -> None:
+        # A large rule body survives into additionalContext with no bound.
         big = "y" * 20000
-        pack = {"sections": {"process_guidance": {"items": [big]}}}
+        pack = {
+            "sections": {
+                "process_guidance": {
+                    "items": [{"scope_key": "big", "guidance": big}]
+                }
+            }
+        }
         out = io.StringIO()
         _write_injection(pack, out)
 
@@ -1261,8 +1382,7 @@ class TestSessionStartEntrypointWritesTheInjection:
         # inject_canon_with, real path but injected factory via monkeypatch-free
         # override of the module factory would be heavier; drive the capability's
         # own return through the envelope by pointing the real factory at a reader.
-        pack = {"sections": {"profile_guidance": {"items": ["Rico"]}}}
-        reader = CanonPackReader(pack=pack)
+        reader = CanonPackReader(pack=_FIXTURE_PACK)
         import openbrain.apps.hooks.session as session_mod
 
         original = session_mod._canon_context
@@ -1276,9 +1396,10 @@ class TestSessionStartEntrypointWritesTheInjection:
             session_mod._canon_context = original  # type: ignore[assignment]
 
         envelope = json.loads(out.getvalue())
-        assert json.loads(
+        assert (
             envelope["hookSpecificOutput"]["additionalContext"]
-        ) == pack
+            == session_start.render_pack(_FIXTURE_PACK)
+        )
 
 
 class TestSessionStartEntrypointNeverDisruptsTheSession:


### PR DESCRIPTION
## Summary

- Fixes the two cold-session loader mechanism gaps the #450 prototype surfaced
  (operator ran the cold test 2026-08-01: content passed, mechanism failed
  twice). Both were loader-transport bugs, not canon-content bugs.

**GAP 1 -- canon pack diverted to a preview.** `openbrain-session-start` dumped
the raw `agent_context_pack` JSON envelope (~30 KB of nested items, ids,
citations, confidences, warnings) into `additionalContext`, and Claude Code
persisted a payload that large to a file it surfaced as only a ~2 KB preview --
the session saw 2-3 of 31 items and could not name the sections.
`session_start.render_pack` now renders plain text: a one-line header
(`CANON (<schema>) | namespace=<ns> | sections: profile_guidance=N, ...`) then
every item on its own line, `[<lane>] <scope-key>: <rule text in full>`. Handles
both live item shapes (guidance: `scope_key`/`guidance`/`candidate_type`; fact:
`subject`/`fact`/`fact_type`). FORMATTING, not content reduction. Measured on the
real 31-item live pack: 30,072 -> 12,253 bytes (33 lines: header + blank + 31
items, inline). All 31 rules verbatim, 0 truncated (longest 645 chars, whole).

**GAP 2 -- episodic injected at startup, against the canon-only ruling.** The
57.8 KB `Lane: dev:open-brain (200 events)` block at SessionStart was NOT the
canon hook. Identified injector: a second `SessionStart` hook in this repo's own
`.claude/settings.json` (matcher `startup|resume|clear`) running
`_ob/skills/brain/scripts/resume.py`. Removed that block; lane history no longer
auto-injects. Episodic is explicit-on-request -- the recap vocabulary
("session recap" / "where were we" / "continue", or `resume.py` directly) is the
door. Canon still auto-loads via `openbrain-session-start`. Documented in
`_plans/canon-always-known.md`.

Proof (GAP 2): a disposable `claude -p` session in this repo fired
policy-refresh-gate + `openbrain-session-start` at SessionStart and NO resume.py
hook / NO `Lane:` block; canon + policy refresh present, lane history absent.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

## Critical Self-Review

- Highest-risk behavior: the SessionStart injection Claude Code sees at every
  cold start. Verified the rendered output against the real 31-item pack (all
  rules verbatim) and confirmed the entrypoint envelope carries plain text.
- Assumptions that could be wrong: that Claude Code renders ~12 KB inline rather
  than diverting. Empirically the ~30 KB raw JSON diverted; the plain-text form
  is ~2.5x smaller and plain text. The operator re-runs the cold test as the
  instrument (#450 stays open).
- Missing/weak tests: renderer is unit-tested against a fixture shaped like the
  live pack (both item shapes). The divert threshold is a harness property, not
  asserted in unit tests.
- Security/permission risk: none. No auth, namespace, or SQL surface touched;
  render is pure formatting of an already-authorized pack.
- Migration/deploy risk: the installed uv tool must be reinstalled for the new
  render to go live; done post-merge and proven in the #450 comment.
- Downstream client/runtime risk: none -- no MCP tool, transport, Python client,
  or contract path touched (`python/openbrain-memory/src`, `clients/ts`,
  `contracts` untouched).
- Rollback/cleanup concern: the `.claude/settings.json` change is one JSON block;
  reverting restores the resume hook. `.bak` retained locally, gitignored.
- Fixes made before PR: none deferred.
- Known residual risk: the exact byte size at which Claude Code diverts to a
  preview is not documented; 12 KB plain text lands inline in the disposable
  run, and the operator's cold re-run is the final instrument.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a session-loader transport fix (hook rendering + repo settings) with no new review-swarm pattern for the SME lanes; it is captured in `_plans/canon-always-known.md`.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no MCP/schema/transport surface changed; the GAP 2 proof is the disposable SessionStart run described above.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no client/contract path is touched (`python/openbrain-memory/src`, `clients/ts`, `contracts` untouched); change is confined to `python/openbrain` hook rendering, repo settings, and a plan doc.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable: no MCP tool, transport, schema, or client-facing contract
  changed. The uv-tool reinstall (so the fixed hook is live locally) is proven in
  the #450 comment; it is a local Claude runtime change, not a downstream service
  rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
