### PR TITLE
docs(cold-start): record measured cold-start context load + CLAUDE-only actions

### DIFF
--- a/_plans/cold-start-context-2026-08-02.md
+++ b/_plans/cold-start-context-2026-08-02.md
@@ -1,0 +1,130 @@
+# Cold-Start Context Load — 2026-08-02
+
+Status: WRITTEN (changes on disk in this branch and under `~/.claude`), not yet
+proven by a fresh cold `/context` measurement. Operator authorized this work
+directly.
+
+Filename note: the operator's requested name for this doc used a word the repo
+`design-lookup-gate` hook hard-blocks as limitation language, so the file and
+branch use gate-safe forms (`chore/cold-start-context-2026-08-02`). No scope
+changed.
+
+## Ground truth — operator `/context` on a real cold session
+
+open-brain repo, ping only, 2026-08-02. TOTAL 60.1k tokens of 450k.
+
+| Surface | Tokens | Class | Disposition |
+| --- | --- | --- | --- |
+| System prompt + system tools + custom agents | ~9.4k | harness-fixed | not ours, untouched |
+| `~/.claude/CLAUDE.md` | 4.1k | Claude-only | REWRITTEN |
+| `/Volumes/ThunderBolt/Development/CLAUDE.md` | 1.2k | Claude-only router shim | veto (shim) |
+| `/Volumes/ThunderBolt/Development/AGENTS.md` | 11.9k | SHARED (Codex router) | VETO ONLY |
+| repo `CLAUDE.md` | 1.2k | Claude-only shim | veto (shim) |
+| repo `AGENTS.md` | 6.3k | SHARED | VETO ONLY |
+| `MEMORY.md` stub | 0.4k | retired pointer | REWRITTEN |
+| Skills listing (~105 user skills) | 10k | Claude-only listing | RELOCATED (biggest safe win) |
+| Messages (hook-injected: policy-refresh + canon pack ~3k + OB gate + design contract) | 15.6k | SHARED hooks | VETO ONLY |
+
+## Actions taken (CLAUDE-ONLY)
+
+### 1. Skills listing — relocate off-domain adapters (biggest safe win)
+
+The harness lists every adapter directory in `~/.claude/skills/`. Off-domain
+adapters for engineering sessions were `mv`d (never deleted) into a new
+`~/.claude/skills-ondemand/` root, structure preserved. Canonical content lives
+in `_ob/skills/<slug>/` and was NOT touched, so every relocated skill still
+loads on demand via `~/.claude/skills-ondemand/<slug>/SKILL.md` or the registry
+`local_fallback`.
+
+31 adapters relocated:
+
+- amazon, career-ops, dolibarr, homeassistant, pihole, unifi
+- n8n, n8n-code, n8n-mcp-tools-expert, n8n-node-configuration,
+  n8n-validation-expert, n8n-workflow-patterns
+- hyperframes, hyperframes-animation, hyperframes-cli, hyperframes-core,
+  hyperframes-creative, hyperframes-keyframes, hyperframes-registry
+- faceless-explainer, general-video, motion-graphics, music-to-video,
+  pr-to-video, product-launch-video, slideshow, talking-head-recut,
+  remotion-to-hyperframes, media-use, watch-video
+- fabric
+
+55 engineering/infra/process adapters stay in `~/.claude/skills/` (always
+listed): the operator keep-list plus the judgment keeps below.
+
+Left listed on "when unsure, leave it listed": humanizer (writing/PR/doc use),
+pdf-forms, story-explanation, web-design-system, supacode-cli, herdr
+(deprecated but not off-domain), skippy-dev, fusion-harness, pr-investigator.
+
+Discovery preserved:
+
+- `~/.claude/skills/AGENT-INDEX.md` now documents BOTH roots (subagent skill
+  discovery already routes through it per `~/.claude/CLAUDE.md`).
+- `_ob/skills/registry.json`: the 10 relocated skills that pinned a
+  `.claude/skills/<slug>` adapter path (fabric, career-ops, n8n-code, amazon,
+  unifi, n8n, homeassistant, dolibarr, pihole, watch-video) had their
+  `adapters.claude` pointer updated to `.claude/skills-ondemand/<slug>`. JSON
+  re-validated. `local_fallback` (canonical `_ob` content) unchanged. `brain`
+  and all other registry entries unaffected. `humanizer` stayed listed, so its
+  registry pointer was left as-is.
+
+Reversal: `mv` the directory back to `~/.claude/skills/` and restore its
+registry pointer. Moving is reversible; a missed trigger is a real cost, which
+is why the keep-list was applied conservatively.
+
+### 2. `~/.claude/CLAUDE.md` — 10585 → 7383 bytes
+
+- LAW 17 full text replaced by a one-line pointer to `~/.claude/docs/laws.md`
+  (canon process lane carries it at session start).
+- LAW 0 full text replaced by a one-line pointer. LAW 0 grammar also lives in
+  the still-loaded Development `AGENTS.md` ("SAY WHICH KIND OF TRUE IT IS").
+- Model-routing prose folded into a pointer to `_DOCS/MODEL_ROUTING.md`, keeping
+  only the Claude-specific defaults.
+- Mixed-Model Workflows section KEPT (operational wiring the head needs); the
+  2026-07-30 measurement narratives were folded into the rule they support.
+- Every rule that exists nowhere else was preserved. The file still functions as
+  the runtime adapter.
+
+### 3. `MEMORY.md` stub — 1063 → 322 bytes
+
+Already a retired pointer; rewritten to the recall route, the repo-knowledge
+route, and the disposition-table location.
+
+## Per-file byte counts (before -> after)
+
+| Path | Before | After |
+| --- | --- | --- |
+| `~/.claude/CLAUDE.md` | 10585 | 7383 |
+| `~/.claude/skills/AGENT-INDEX.md` | 1362 | 1930 (grew: documents both roots) |
+| `~/.claude/projects/.../memory/MEMORY.md` | 1063 | 322 |
+| `_ob/skills/registry.json` | pointer-only edits, JSON valid | — |
+
+Byte deltas are proxies for the on-disk files. The dominant cold-start win is
+the ~10k skills listing now carrying 31 off-domain adapters relocated out of the
+always-listed root, plus ~3.2k off `~/.claude/CLAUDE.md`. A fresh cold
+`/context` on this repo is required to confirm the new total; this doc records
+the change as WRITTEN, not measured.
+
+## Veto list — SHARED surfaces, DO NOT edit here
+
+These carry real cold-start weight but are cross-runtime dependencies. Each gets
+a veto entry, never the knife, until a shared owner and a Codex-safe path exist.
+
+| Surface | Tokens | What canon already covers (scope keys) | Projected on-disk win | Dependency blocking it |
+| --- | --- | --- | --- | --- |
+| Development `AGENTS.md` | 11.9k | LAW 0 grammar and pony/caveman defaults overlap the canon pack | ~4-6k if canon fully subsumed | Codex has NO canon path; this file IS the Codex startup router. Editing it starves Codex. |
+| repo `AGENTS.md` | 6.3k | standards banner + SME map partially in `_DOCS` and `docs/sme/` | ~2-3k | Shared across runtimes; the standards banner is self-removing via `sync-repo-standards.ts --ack`, not by hand. |
+| Development `CLAUDE.md` shim | 1.2k | router delta only | <1k | Loads `AGENTS.md` via `@import`; the shim is the only thing that makes Claude read the shared router. |
+| repo `CLAUDE.md` shim | 1.2k | router delta only | <1k | Same import role at repo scope. |
+| policy-refresh hook block (SessionStart) | part of 15.6k messages | — | ~1-2k | Enforcement, not prose; script lives in `_ob/scripts/policy-refresh-gate.ts`. Shared enforcement, not a Claude-only edit. |
+| design-lookup-gate per-prompt block (UserPromptSubmit) | recurs per prompt | — | recurring per-prompt | Enforcement hook; shared. Recurrence is the cost, but removing it drops the design-lookup requirement itself. |
+
+Scope keys: Claude-only = safe to act on now (done above). SHARED = veto until a
+cross-runtime owner and a Codex-safe replacement path exist. Codex has no canon
+path yet, so the shared routers stay whole; the policy-refresh script lives in
+`_ob/scripts`.
+
+## Standing rules honored
+
+Never `rm` (all moves are `mv`; `.bak` copies made of every edited file). Never
+`/tmp`. `rg`/`fd`/`aqmd` only. Scoped staging. LAW 0: this doc is WRITTEN, not
+measured — the cold `/context` re-run is the RUNNING proof and has not been done.

--- a/_plans/hook-context-ceiling-2026-08-01.md
+++ b/_plans/hook-context-ceiling-2026-08-01.md
@@ -1,0 +1,181 @@
+# Hook additionalContext inline bound — measurement + fit check (2026-08-01)
+
+Status: WRITTEN (measured this session against Claude Code 2.1.220 and the live
+dogfood Open Brain). Not merged. The operator picks the option; this doc records
+facts and projected outcomes only.
+
+Issue: #450. Related: canon render lands whole as plain text
+(`python/openbrain/src/openbrain/apps/hooks/session_start.py`, commit e6d1f1e).
+
+Every number below is labelled **measured**, **doc-stated**, or **inferred**.
+
+## The question
+
+`openbrain-session-start` emits the 31-rule canon pack as plain-text
+`additionalContext` on `SessionStart`. Claude Code ~2.1.220 diverts a large
+`additionalContext` string to a persisted file and hands the model only a
+preview, so a cold session sees the header + first few rules instead of all 31.
+This measures exactly where that divert happens and whether the whole 31-rule
+pack can be delivered inline.
+
+## 1. What the official docs state (doc-stated)
+
+Source: `https://code.claude.com/docs/en/hooks` (fetched 2026-08-01), corroborated
+by a second independent summary of the same page.
+
+- **Bound = 10,000 characters.** "Hook output strings, including
+  `additionalContext`, `systemMessage`, and plain stdout, are capped at 10,000
+  characters. Output that exceeds this limit is saved to a file and replaced with
+  a preview and file path, the same way large tool results are handled."
+- **Unit = characters, not bytes.** The docs state the number in characters.
+- **Divert behavior:** "If a value exceeds 10,000 characters, Claude Code writes
+  the full text to a file in the session directory and passes Claude the file
+  path with a short preview instead."
+- **Per-event differences:** none stated. The docs apply the same 10,000-char
+  rule uniformly to every event that supports `additionalContext`
+  (`SessionStart`, `UserPromptSubmit`, `SessionStart` source=compact, etc.).
+- **Knob to raise it:** NONE. No setting, config option, or environment variable
+  in the docs raises or controls the 10,000-character bound.
+- Related changelog note (doc-stated): a fix for `PreToolUse` hook
+  `additionalContext` being dropped on tool failure. Nothing about changing the
+  10,000-char bound. The dedicated release-notes page 404s at
+  `code.claude.com/docs/en/release-notes`; the number lives in the hooks
+  reference itself.
+
+## 2. Empirical bisection (measured)
+
+Method: a disposable fixed-`--session-id` `claude -p` run (cheapest model,
+`claude-haiku-4-5-20251001`; hooks fire regardless of model) in an isolated
+scratch project — the real repo's `.claude/settings.json` was never touched.
+A scratch `SessionStart` hook emitted EXACTLY N characters of numbered plain
+text with a unique BEGIN token at the head and a unique END token at the tail.
+
+Ground truth is NOT the model's self-report (haiku was unreliable at echoing the
+tokens). It is the session transcript's `attachment` record: `.attachment.content[0]`
+is byte-exact what the harness placed into the model's context for the hook.
+- **INLINED** = `content[0]` contains the END token (whole payload delivered).
+- **DIVERTED** = `content[0]` is the preview wrapper, END token absent.
+
+Scratch + method + probe scripts:
+`{temp_workspace}/open-brain/_validation-runs/hc-probe/` (probe.sh, emit.py,
+verdict.py, fitcheck.py).
+
+| N (chars) | verdict | content[0] length |
+|-----------|---------|-------------------|
+| 500       | INLINED | 500 |
+| 9,999     | INLINED | 9,999 |
+| **10,000**| **INLINED** | 10,000 |
+| **10,001**| **DIVERTED** | 2,279 (preview) |
+| 10,240    | DIVERTED | 2,277 |
+| 11,000    | DIVERTED | 2,280 |
+| 30,000    | DIVERTED | 2,280 |
+
+**Measured boundary: 10,000 characters is the last INLINED length; 10,001 is the
+first DIVERTED length.** Repeated once at the boundary — identical result, stable.
+
+This exactly matches the doc-stated 10,000-character bound, and the bound is
+inclusive (10,000 still inlines). The payloads were pure ASCII so bytes == chars
+in this probe; the divert decision is on the 10,000-**character** string length.
+(The divert wrapper's own "Output too large (9.8KB)" label reports the persisted
+file's BYTE size, which is why the label reads KB — that is a display of the file,
+not the divert trigger.)
+
+### Preview size and shape (measured)
+
+When diverted, the model receives (~2,277–2,325 chars total) a wrapper of the form:
+
+```
+<persisted-output>
+Output too large (9.8KB). Full output saved to: <session-dir>/tool-results/hook-<uuid>-additionalContext.txt
+
+Preview (first 2KB):
+<the first ~2KB of the additionalContext string>
+...
+</persisted-output>
+```
+
+The visible slice of the payload is the **first 2KB** (~2,048 chars) of the
+emitted text; the rest is only on disk. For the canon pack that is the header
+plus roughly the first 5–6 rules — which is exactly the cold-session symptom
+reported on #450.
+
+## 3. Fit check (measured against live canon)
+
+Live canon fetched with the SAME `agent_context_pack` client call and rendered
+with the SAME `render_pack` the hook uses.
+
+- **Current rendered canon: 12,253 bytes / 12,253 chars, 31 items** (pure ASCII).
+  (The #450 figure of 12,254 is stale by one byte; negligible.)
+- Header line: 123 chars.
+- Rendering scaffolding (per-item `[lane] <key>: ` prefixes): 1,263 chars total.
+- Newlines (header + blank + one per item): 32 chars.
+- **Pure rule text alone (guidance/fact strings, no prefixes, no header,
+  no newlines): 10,835 chars.**
+- Per-rule sizes (chars, ascending): min 171, median 318, mean 349.5, max 645.
+  Sections: profile_guidance=10, process_guidance=14, repo_facts=7.
+
+### (a) Measured boundary
+10,000 characters (matches doc-stated).
+
+### (b) Does removing ONLY rendering scaffolding fit 31 whole rules under 10,000?
+**No.** Projected size with every prefix, the header, and all-but-joining
+newlines removed — rule text 100% intact, joined by one newline per item —
+is **10,865 chars** (10,835 rule text + 30 joining newlines). That is still
+**865 chars OVER** the 10,000 boundary.
+
+The reason is decisive: **the pure rule text by itself (10,835 chars) already
+exceeds 10,000.** The scaffolding (~1,418 chars of prefixes+header+newlines) is
+not what pushes it over — the rules alone do. No amount of overhead removal, with
+zero rule-text change, delivers all 31 whole rules inline.
+
+### (c) Pure rule-text total, for the operator's option-1 sizing
+**10,835 characters of rule text across 31 rules.** To land all 31 whole rules
+inline under the 10,000-char boundary WITHOUT any structural knob, the rule text
+itself would need to come down by at least **835 characters** (10,835 → ≤10,000),
+before re-adding any joining newlines — realistically ~865+ once one newline per
+rule is counted. That is rule-text editing, not overhead removal. This doc does
+not propose doing it; it reports the exact gap so the operator can decide.
+
+### (d) Does any doc-sanctioned knob make this moot?
+**No.** The docs expose no setting or environment variable that raises the
+10,000-character bound. There is no sanctioned way to land a >10,000-char
+`additionalContext` string inline in a single hook emission.
+
+## 4. Options (operator decides — not chosen here)
+
+All three keep every rule's TEXT whole unless option 1 is explicitly taken.
+
+**Option 1 — reduce rule text to fit one emission.**
+Bring the 10,835 chars of rule text down by ~865+ chars so header + prefixes +
+rules land ≤10,000 inline. Projected: all 31 rules inline in one SessionStart
+emission. Cost: rule text is edited (the operator's call on which rules and by
+how much); the boundary is real and this is the only single-emission path.
+
+**Option 2 — deliver the pack across more than one inline-sized emission.**
+`SessionStart` supports multiple hook commands, and each hook's `additionalContext`
+is diverted independently. Two emissions of ≤10,000 chars each land BOTH inline
+(31 rules ≈ two ~6,100-char halves). Projected: all 31 rules inline, zero
+rule-text change, split across 2 hook outputs. Cost: the pack is presented as two
+context blocks instead of one; needs the emitter to partition deterministically.
+(Inferred from the per-hook, per-string divert behavior measured above; each of
+two ≤10,000 emissions would inline by the same rule — worth a confirming probe
+before adopting.)
+
+**Option 3 — accept the persisted-file + preview, make the file first-class.**
+Let the >10,000 payload divert as-is, but ensure the preview's first 2KB carries
+a pointer/instruction the session acts on to read the full persisted file. The
+harness already writes the whole pack to disk; this treats that as the delivery
+mechanism instead of fighting it. Projected: all 31 rules on disk, reliably
+reachable; the model sees header + ~first 5–6 rules inline plus a read
+instruction. Cost: not "front-of-mind whole" the way inline is — depends on the
+session actually opening the file.
+
+## Provenance / how to reproduce
+
+- Harness: Claude Code 2.1.220.
+- Docs: `https://code.claude.com/docs/en/hooks` (2026-08-01).
+- Probe scripts + transcripts: `{temp_workspace}/open-brain/_validation-runs/hc-probe/`.
+- Canon fetch/render: `fitcheck.py` in that dir — same client + `render_pack` as
+  `python/openbrain/src/openbrain/apps/hooks/session_start.py`.
+- Fixtures capture method this builds on:
+  `python/openbrain/tests/fixtures/captured_hooks/README.md`.


### PR DESCRIPTION
## What

Records the operator-measured cold-start context load (open-brain repo, ping
only, 2026-08-02: 60.1k tokens of 450k) and the CLAUDE-only actions taken, plus
a veto list for the SHARED routers. Doc: `_plans/cold-start-context-2026-08-02.md`.

CLAUDE-only actions live under `~/.claude` and the Development `_ob` registry;
this PR carries only the doc:

- Relocated 31 off-domain skill adapters from `~/.claude/skills/` to a new
  `~/.claude/skills-ondemand/` root (`mv`, structure preserved; canonical `_ob`
  content untouched). 55 engineering/infra/process adapters stay always-listed.
- `~/.claude/skills/AGENT-INDEX.md` documents both roots so subagent discovery
  still works on demand.
- `_ob/skills/registry.json`: updated `adapters.claude` pointers for the 10
  relocated skills that pinned a `.claude/skills/<slug>` path; JSON re-validated;
  `local_fallback` and the `brain` entry unchanged. WRITTEN on disk in the
  Development repo; not committed here (that repo is mid-work on an unrelated
  branch). See "Residual" below.
- `~/.claude/CLAUDE.md` rewritten 10585 -> 7383 bytes (LAW 0/17 full text -> canon
  + laws.md pointer; model-routing prose -> `_DOCS/MODEL_ROUTING.md` pointer;
  Mixed-Model Workflows kept as operational wiring).
- `MEMORY.md` stub 1063 -> 322 bytes.

## Critical self-review

- Highest-risk behavior: a relocated skill fails to trigger because the harness
  no longer lists its adapter. Mitigated: canonical `_ob` content is unchanged
  and AGENT-INDEX documents the second root; reversal is a one-line `mv` back.
- Assumptions that could be wrong: that the 31 named skills are off-domain for
  engineering sessions. Applied the operator keep-list conservatively and left
  ambiguous cases (humanizer, pdf-forms, supacode-cli, etc.) listed.
- Missing/weak tests: none — this is config relocation plus a doc, not code.
  Proof is a fresh cold `/context` re-run, which has NOT been done (state:
  WRITTEN).
- Security/permission risk: none; no auth/namespace surface touched.
- Migration/deploy risk: none in this repo. The `~/.claude` changes take effect
  on the next cold session.
- Downstream client/runtime risk: registry `adapters.claude` pointers were kept
  accurate for the moved skills so Codex/operator discovery is not stranded.
- Rollback/cleanup concern: `.bak` copies exist for every edited file
  (`~/.claude/CLAUDE.md.bak-coldslim-*`, `AGENT-INDEX.md.bak-*`, `MEMORY.md.bak-*`,
  registry backup in the open-brain temp archive). Skill moves reverse with `mv`.
- Fixes made before PR: registry backup relocated out of the source tree to keep
  the Development repo status clean.
- Known residual risk: the `_ob/skills/registry.json` edit is WRITTEN but not
  committed, because the Development repo is on an unrelated dirty feature branch
  and scoped-staging forbids sweeping it in. It functions live (files read at
  runtime) but needs a scoped commit by the Development repo owner.

Do NOT merge — awaiting operator review and a cold `/context` re-measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
