### PR TITLE
docs(router): dedupe Claude-only canon rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,7 @@ those when stricter or more specific.
   The local dogfood service is the real one for this machine while in dev mode;
   `mcp2cli`/core01 is not. Endpoint and token come from
   `$OPENBRAIN_BASE_URL` / `$OPENBRAIN_TOKEN`
-  (`~/.local/share/openbrain-memory/env/claudex-observation.env`). Never
-  hardcode a host — not `10.71.1.21`, not `127.0.0.1`.
+  (`~/.local/share/openbrain-memory/env/claudex-observation.env`).
 - **The retired operator CLI bridge is hook-blocked for Claude.** Durable writes
   use the direct `openbrain-memory` provider commands advertised in the
   SessionStart context. Those recipes remain valid for Codex and operators.
@@ -36,10 +35,9 @@ those when stricter or more specific.
   mutations behind a subject-relevant design lookup, blocks tree-search as a
   first move, and refuses writes to the shared `/Volumes/collab` volume. A
   denial means adjust, not retry with a different spelling.
-- **Search this repo before asking.** `aqmd search "<word>"` (~0.1s) then
-  `aqmd "<question>"`. `grep`/`find` are denied; use `rg`, `fd`, `mdfind`.
-  Development-wide `_DOCS`/`_ob` are not yet in any index (#440), so procedures
-  living there are currently unreachable by search.
+- **Search this repo before asking.** Use `aqmd search "<word>"`, then
+  `aqmd "<question>"`. Development-wide `_DOCS`/`_ob` are not yet in any index
+  (#440), so procedures living there are currently unreachable by search.
 - **Skills are thin adapters.** Canonical content lives in
   `_ob/skills/<slug>/`; `~/.claude/skills/<slug>/` may only carry trigger text,
   paths, OB ref status, and a runtime caveat (≤2400 bytes). Editing an adapter


### PR DESCRIPTION
## Summary

- remove the repo `CLAUDE.md` host-hardcoding restatement now carried by live `repo.no_hardcoded_host` canon
- remove the fast-tool ladder restatement now carried by live `process.fast_tools` canon while preserving the repo-search command pointer
- leave `@AGENTS.md`, shared `AGENTS.md`, hooks, and the standards banner untouched

Implements only the Open Brain Claude-only SAFE-NOW slice approved from the router dedupe plan in PR #468. Related to #450.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — Python paths unchanged
- [x] Live Open Brain smoke passed or is not applicable — documentation-only Claude shim change
- `bunx tsc --noEmit`
- `bun test` — 2,855 pass, 308 skip, 0 fail
- pre-push gate — all checks passed
- staged/committed file set: `CLAUDE.md` only
- live canon spot-checks: `repo.no_hardcoded_host`, `process.fast_tools`

## Critical Self-Review

- Highest-risk behavior: Removing a rule before its canon replacement is live could starve Claude; both removed rules were queried live from the dogfood database before editing.
- Assumptions that could be wrong: SessionStart continues to inject the canon pack; this PR does not alter that path.
- Missing/weak tests: No behavioral code changed; the full repository pre-push gate passed.
- Security/permission risk: No shared router, auth, namespace, or permission surface changed.
- Migration/deploy risk: Documentation-only Claude shim change; no migration or deploy path changed.
- Downstream client/runtime risk: No MCP, transport, client, or protocol contract changed.
- Rollback/cleanup concern: Revert commit `bad95cd`; no data migration or persistent runtime mutation.
- Fixes made before PR: Preserved `@AGENTS.md`, kept the `aqmd` search pointer, and removed only the exact canon-backed duplicate clauses.
- Known residual risk: Claude-only startup now relies on the already-running canon injection for these two rules.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this mechanical docs-only dedupe introduced no new review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this PR changes only Claude router prose and no runtime behavior.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — no contract change
- [x] mcp2cli cache/skill refresh is complete or not applicable — no contract change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — no contract change
- [x] Hermes live rollout/canaries are complete or not applicable — no contract change

Notes/evidence:

- `repo.no_hardcoded_host` and `process.fast_tools` were read from the live local canon store before the edit.
- PR remains intentionally open and unmerged per operator instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)