### PR TITLE
fix(hooks): split canon SessionStart emissions

### DIFF
--- a/docs/420-cutover-rollback.md
+++ b/docs/420-cutover-rollback.md
@@ -9,7 +9,7 @@ absent, and restoring the previous settings in one command.
 `~/.claude/settings.json` is OUTSIDE this repo, so it is not versioned here. The
 backup taken before the cutover, the installed console scripts, and the env
 wrapper are all outside the repo too. What lives in the repo: this doc, the
-`openbrain-session-start` console-script declaration
+two `openbrain-session-start*` console-script declarations
 (`python/openbrain/pyproject.toml`), and the surviving TS the settings now point
 at (`_ob/scripts/...`, a separate repo).
 
@@ -21,7 +21,7 @@ at (`_ob/scripts/...`, a separate repo).
 | `SubagentStop` | (not wired) | `sh …/openbrain-hook-env openbrain-capture-subagent-stop` |
 | `SessionEnd` | `bun … claude-hook.ts` | `sh …/openbrain-hook-env openbrain-session-end` |
 | `PostCompact` | `bun … claude-hook.ts` | `sh …/openbrain-hook-env openbrain-post-compact` |
-| `SessionStart` | `bun … claude-hook.ts` | `sh …/openbrain-hook-env openbrain-session-start` |
+| `SessionStart` | `bun … claude-hook.ts` | two entries: `sh …/openbrain-hook-env openbrain-session-start` and `sh …/openbrain-hook-env openbrain-session-start-remaining` |
 | `UserPromptSubmit` / `PreCompact` | `bun … claude-hook.ts` (no-op) | removed |
 | `context-budget-gate.ts` (7 events) | `sha256-…/context-budget-gate.ts` | `/Volumes/ThunderBolt/Development/_ob/scripts/context-budget-gate.ts` |
 | `guard.ts` (PreToolUse Bash) | `sha256-…/ob-memory-provider/guard.ts` | `/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider/guard.ts` |
@@ -37,11 +37,13 @@ The provider is installed as a `uv tool` from `python/openbrain/`:
 uv tool install --force /Volumes/ThunderBolt/Development/open-brain/python/openbrain
 ```
 
-This links five console scripts into `~/.local/bin/` (on the settings `PATH`):
-`openbrain-capture-stop`, `openbrain-capture-subagent-stop`,
-`openbrain-session-end`, `openbrain-post-compact`, `openbrain-session-start`.
-No `sha256-` path is involved; a `uv tool install --upgrade` re-bakes the same
-stable names.
+This links six hook console scripts into `~/.local/bin/` (on the settings
+`PATH`): `openbrain-capture-stop`, `openbrain-capture-subagent-stop`,
+`openbrain-session-end`, `openbrain-post-compact`, `openbrain-session-start`, and
+`openbrain-session-start-remaining`. Claude settings register the two
+`SessionStart` scripts as separate hook entries so each `additionalContext` is
+handled independently. No `sha256-` path is involved; a `uv tool install
+--upgrade` re-bakes the same stable names.
 
 ### Env delivery
 

--- a/python/openbrain/pyproject.toml
+++ b/python/openbrain/pyproject.toml
@@ -47,9 +47,10 @@ dependencies = [
 # `stop` (delivers the main transcript), `subagent-stop` (the same spine over the
 # subagent transcript), `session-end` (releases the server session slot),
 # `post-compact` (records the compaction summary the Stop spine drops --
-# `_plans/rewrite-gotchas.md`), and `session-start` (injects the CANON pack at
-# session open -- the operator ruling 2026-08-01 that superseded its "stays stub"
-# row, so the module now does real work and earns a script). The remaining event
+# `_plans/rewrite-gotchas.md`), and the two `session-start` emissions (inject the
+# one CANON pack through independently registered hook outputs at session open --
+# the operator ruling 2026-08-01 that superseded its "stays stub" row). The
+# remaining event
 # modules are explicit stubs whose capabilities are undecided, and `dispatch.py`
 # is a table with no stdin-reading entrypoint of its own -- so there is nothing
 # else to point a real, non-shim script at yet. A stub, or any dispatch
@@ -67,6 +68,7 @@ openbrain-capture-subagent-stop = "openbrain.apps.hooks.subagent_stop:main"
 openbrain-session-end = "openbrain.apps.hooks.session_end:main"
 openbrain-post-compact = "openbrain.apps.hooks.post_compact:main"
 openbrain-session-start = "openbrain.apps.hooks.session_start:main"
+openbrain-session-start-remaining = "openbrain.apps.hooks.session_start:main_remaining"
 # The bulk ingester (#454): the second application, operator-run over a giant
 # session file. Its module does REAL work -- stage a whole file, yield every
 # turn to the raw lane -- so it earns a script by the same rule the hook

--- a/python/openbrain/src/openbrain/apps/hooks/session_start.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session_start.py
@@ -5,8 +5,8 @@ Purpose:
     ``startup``/``resume``/``clear``/``compact``/``fork``) and hands it the event
     as JSON on stdin. It reads that payload, reads the CANON-tier context pack
     through the same ``openbrain_memory`` client the capture hooks use, and writes
-    the pack back to the harness as ``hookSpecificOutput.additionalContext`` on
-    stdout so it lands in front of the model for the whole session.
+    it through two independently registered ``additionalContext`` hook outputs:
+    profile/process guidance first, then repo facts and any remaining sections.
 
     CANON ONLY. The injection is the always-known layer -- who Rico is
     (``profile_guidance``), the rules/LAWs/standards/persona
@@ -27,11 +27,12 @@ Non-goals:
     or retry mechanism.
 
 Architecture:
-    A parse-and-exit shell. Reading stdin, loading settings, choosing a
-    capability, and serialising the response is all this module does; the
-    capability that builds the client and reads ``agent_context_pack`` is
-    ``session.run_session_start``, so there is no business logic here
-    (``_plans/418-prov-9-hook-entrypoints.md``).
+    Two parse-and-exit console scripts share this module and partition the
+    configured section names before calling the unchanged whole-pack capability.
+    Claude Code registers both scripts as separate ``SessionStart`` hooks because
+    ``additionalContext`` delivery is independent per hook. The capability that
+    builds the client and reads ``agent_context_pack`` remains
+    ``session.run_session_start`` (``_plans/418-prov-9-hook-entrypoints.md``).
 
 Pattern/Convention:
     FAIL OPEN. A hook that opens a session must never block or break one. Every
@@ -41,11 +42,11 @@ Pattern/Convention:
     (``tests/fixtures/captured_hooks/README.md``). The session opens uninjured
     either way; a missing injection is a degraded start, not a broken one.
 
-    The injecting response is one JSON object on stdout:
+    Each registered script writes one JSON object on stdout:
     ``{"hookSpecificOutput": {"hookEventName": "SessionStart",
     "additionalContext": "<rendered>"}}`` -- the documented SessionStart
-    contract. ``additionalContext`` is a string, so the assembled canon pack is
-    RENDERED into it as plain text.
+    contract. Both headers identify their section set and name the two outputs as
+    one canon pack; every rule body is copied whole into exactly one output.
 
     WHY PLAIN TEXT, NOT THE RAW PACK JSON. Measured 2026-08-01 against the #450
     cold-session prototype: dumping the raw ``agent_context_pack`` JSON envelope
@@ -53,12 +54,12 @@ Pattern/Convention:
     ``additionalContext``, and Claude Code diverted a payload that large to a
     file it surfaced only as a ~2 KB preview -- the session saw 2-3 of 31 items
     and could not name the sections. The canon-only design requires the RULES
-    themselves front-of-mind, whole. So this renders every item to its own line
-    -- scope key, the rule text IN FULL, lane -- and drops the JSON envelope and
-    per-item metadata that carried the bulk. This is FORMATTING, not content
-    reduction: no rule text is shortened or omitted (``docs/CODING_STANDARDS.md``
-    section 6). If a choice ever arises between dropping content and a large
-    injection, the injection stays whole and large.
+    themselves front-of-mind, whole. The two hook emissions therefore render one
+    exact rule body per line and put section identity in each emission's header,
+    dropping the JSON envelope and per-item metadata that carried the bulk. The
+    unsplit renderer keeps scope keys and lanes for diagnostic callers. This is
+    FORMATTING, not content reduction: no rule text is shortened or omitted
+    (``docs/CODING_STANDARDS.md`` section 6).
 
 Example:
     >>> import io
@@ -76,6 +77,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -92,49 +94,85 @@ if TYPE_CHECKING:
 #: the injection to the event by this exact string.
 _HOOK_EVENT_NAME = "SessionStart"
 
+#: The sections that always belong to the first of the two canon emissions.
+_PROFILE_PROCESS_SECTIONS = frozenset({"profile_guidance", "process_guidance"})
 
-def inject_canon(stream: TextIO, out: TextIO) -> None:
-    """Read one ``SessionStart`` payload and write its canon injection, swallowing all.
+
+class CanonEmission(StrEnum):
+    """Which independently registered ``SessionStart`` hook output is rendered."""
+
+    PROFILE_PROCESS = "1/2"
+    REMAINING = "2/2"
+
+
+def sections_for_emission(
+    configured: tuple[str, ...], emission: CanonEmission
+) -> tuple[str, ...]:
+    """Partition configured canon sections between the two hook emissions.
 
     Args:
-        stream: The hook's stdin. Read whole; a ``SessionStart`` payload is one
-            JSON object.
-        out: Where the injection is written -- the hook's stdout. Nothing is
-            written on any failure or when there is no pack, so the session opens
-            with an empty stdout, the "proceed normally" response.
+        configured: The operator-configured section order.
+        emission: Which registered hook output is being built.
 
-    Loads the ``canon`` settings itself. Takes the streams rather than reading
-    ``sys.stdin`` / writing ``sys.stdout`` directly so a test drives it with
-    in-memory buffers. Every exception is caught -- an observer must never break
-    the session it opens.
+    Returns:
+        The sections for that emission, preserving configured order. Profile and
+        process guidance always belong to emission one; every other configured
+        section, including repo facts, belongs to emission two.
     """
+    if emission is CanonEmission.PROFILE_PROCESS:
+        return tuple(
+            section for section in configured if section in _PROFILE_PROCESS_SECTIONS
+        )
+    return tuple(
+        section for section in configured if section not in _PROFILE_PROCESS_SECTIONS
+    )
+
+
+def inject_canon(stream: TextIO, out: TextIO) -> None:
+    """Write profile and process guidance as the first canon emission."""
     inject_canon_with(stream, out, None)
+
+
+def inject_canon_remaining(stream: TextIO, out: TextIO) -> None:
+    """Write repo facts and all other configured sections as emission two."""
+    inject_canon_remaining_with(stream, out, None)
 
 
 def inject_canon_with(
     stream: TextIO, out: TextIO, settings: CanonSettings | None
 ) -> None:
-    """Inject one ``SessionStart`` payload's canon with a given (or loaded) config.
+    """Inject emission one with a given (or loaded) canon configuration."""
+    _inject_canon_with(stream, out, settings, CanonEmission.PROFILE_PROCESS)
 
-    Args:
-        stream: The hook's stdin.
-        out: The hook's stdout.
-        settings: The ``canon`` configuration, or ``None`` to load it. Injected
-            so a test exercises the swallow with an explicit config -- e.g. an
-            unconfigured one -- without reaching ``load_canon_settings``.
 
-    The swallow lives here so BOTH the entrypoint and tests get it: any failure,
-    including a missing config or an unreachable server, is logged and eaten with
-    nothing written to stdout.
-    """
+def inject_canon_remaining_with(
+    stream: TextIO, out: TextIO, settings: CanonSettings | None
+) -> None:
+    """Inject emission two with a given (or loaded) canon configuration."""
+    _inject_canon_with(stream, out, settings, CanonEmission.REMAINING)
+
+
+def _inject_canon_with(
+    stream: TextIO,
+    out: TextIO,
+    settings: CanonSettings | None,
+    emission: CanonEmission,
+) -> None:
+    """Inject one partition of canon and swallow every observer failure."""
     try:
         raw = stream.read()
         payload = SessionStartHook.model_validate_json(raw)
         canon = settings if settings is not None else load_canon_settings()
-        pack = asyncio.run(run_session_start(payload, canon))
+        sections = sections_for_emission(canon.sections, emission)
+        if not sections:
+            return
+        selected = canon.model_copy(update={"sections": sections})
+        pack = asyncio.run(run_session_start(payload, selected))
         if pack is None:
             return
-        out.write(_injection_envelope(pack))
+        out.write(
+            _injection_envelope(pack, emission=emission, requested_sections=sections)
+        )
     except Exception as error:  # noqa: BLE001 -- an observer must never break its subject
         # Content-free BY CONSTRUCTION: only the exception class name is passed,
         # never the exception object, so no payload text or token reaches the
@@ -145,67 +183,82 @@ def inject_canon_with(
         )
 
 
-def render_pack(pack: Any) -> str:
-    """Render a canon ``agent_context_pack`` payload to front-of-mind plain text.
+def render_pack(
+    pack: Any,
+    *,
+    emission: CanonEmission | None = None,
+    requested_sections: tuple[str, ...] | None = None,
+) -> str:
+    """Render selected canon sections as plain text with every rule whole.
 
     Args:
-        pack: The decoded ``agent_context_pack.v1`` payload the server assembled
-            -- ``schema``, ``scope``, ``sections`` (each a labelled block of
-            ``items``), and ``warnings``.
+        pack: The decoded ``agent_context_pack.v1`` payload.
+        emission: The registered hook output, or ``None`` for the unsplit renderer.
+        requested_sections: The exact sections this emission owns. ``None`` renders
+            every section present in the pack.
 
     Returns:
-        One header line then every item on its own line, the rule text WHOLE. The
-        header names the schema, the resolved namespace, and the per-section
-        counts so the session can state what it was given. Each item line is
-        ``[<lane>] <scope-key>: <rule text in full>`` -- the lane is the item's
-        candidate/fact type, the scope-key is its stable name, and the rule text
-        is the item's ``guidance`` (profile/process items) or ``fact`` (repo
-        facts), never shortened.
-
-    This drops the JSON envelope and per-item metadata (ids, citations,
-    confidences, promotion timestamps, the ``warnings`` block) that carried the
-    bulk without carrying a rule. That is the whole point: it is the RULES the
-    session must hold, and only removing the scaffolding around them keeps the
-    injection small enough that Claude Code presents it inline instead of
-    diverting it to a preview file. No rule text is bounded, shortened, or
-    dropped (``docs/CODING_STANDARDS.md`` section 6).
-
-    Defensive by construction: a section, an item field, or the whole pack being
-    absent or the wrong type must not raise -- the entrypoint swallows, but a
-    partial pack should still render what it does carry rather than nothing. A
-    non-dict pack renders to an empty string, which the entrypoint treats as
-    "nothing to inject".
+        One header line, a blank line, then every selected item on its own line.
+        Rule text is copied in full from ``guidance`` or ``fact`` and is never
+        shortened or split.
     """
     if not isinstance(pack, dict):
         return ""
 
     sections = pack.get("sections")
     sections = sections if isinstance(sections, dict) else {}
-
-    schema = pack.get("schema") or "openbrain.agent_context_pack.v1"
-    scope = pack.get("scope")
-    namespace = ""
-    if isinstance(scope, dict):
-        namespace = str(scope.get("namespace") or "")
+    labels = tuple(sections) if requested_sections is None else requested_sections
 
     counts: list[str] = []
     lines: list[str] = []
-    for label, section in sections.items():
+    for label in labels:
+        section = sections.get(label)
         if not isinstance(section, dict):
             continue
         items = section.get("items")
         items = items if isinstance(items, list) else []
         counts.append(f"{label}={len(items)}")
-        for item in items:
-            lines.append(_render_item(label, item))
+        renderer = _render_item if emission is None else _render_rule_text
+        lines.extend(renderer(label, item) for item in items)
 
-    header_bits = [f"CANON ({schema})"]
-    if namespace:
-        header_bits.append(f"namespace={namespace}")
-    header_bits.append("sections: " + ", ".join(counts) if counts else "sections: (none)")
-    header = " | ".join(header_bits)
+    header_bits = _header_bits(pack, emission, labels)
+    header_bits.append(
+        "sections: " + ", ".join(counts) if counts else "sections: (none)"
+    )
+    return "\n".join([" | ".join(header_bits), "", *lines])
 
-    return "\n".join([header, "", *lines])
+
+def _header_bits(
+    pack: dict[str, Any],
+    emission: CanonEmission | None,
+    labels: tuple[str, ...],
+) -> list[str]:
+    """Build the canon header, identifying the shared pack and held sections."""
+    schema = pack.get("schema") or "openbrain.agent_context_pack.v1"
+    title = f"CANON ({schema})"
+    if emission is not None:
+        title = f"CANON PACK {emission.value} ({schema})"
+
+    bits = [title]
+    if emission is not None:
+        bits.append("one pack across two SessionStart emissions")
+        held = ", ".join(labels) if labels else "(none)"
+        bits.append(f"this emission sections: {held}")
+
+    scope = pack.get("scope")
+    if isinstance(scope, dict) and scope.get("namespace"):
+        bits.append(f"namespace={scope['namespace']}")
+    return bits
+
+
+def _render_rule_text(_label: str, item: Any) -> str:
+    """Render only one item's exact rule body for an inline hook emission."""
+    if not isinstance(item, dict):
+        return str(item)
+    text = item.get("guidance")
+    if text is None:
+        text = item.get("fact")
+    return "" if text is None else str(text)
 
 
 def _render_item(label: str, item: Any) -> str:
@@ -239,38 +292,34 @@ def _render_item(label: str, item: Any) -> str:
     return f"{prefix}{text}"
 
 
-def _injection_envelope(pack: Any) -> str:
-    """Wrap the rendered canon in the ``additionalContext`` response envelope.
-
-    The SessionStart contract carries the injection as a STRING on
-    ``hookSpecificOutput.additionalContext``. The pack is RENDERED to plain text
-    (:func:`render_pack`) rather than dumped as raw JSON so it arrives whole and
-    front-of-mind instead of being diverted to a preview file; nothing in the
-    rendered rules is bounded, shortened, or dropped.
-    """
-    return json.dumps(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": _HOOK_EVENT_NAME,
-                "additionalContext": render_pack(pack),
-            }
+def _injection_envelope(
+    pack: Any,
+    *,
+    emission: CanonEmission | None = None,
+    requested_sections: tuple[str, ...] | None = None,
+) -> str:
+    """Wrap one rendered canon emission in the SessionStart response envelope."""
+    return json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": _HOOK_EVENT_NAME,
+            "additionalContext": render_pack(
+                pack,
+                emission=emission,
+                requested_sections=requested_sections,
+            ),
         }
-    )
+    })
 
 
 def main(stream: TextIO | None = None) -> int:
-    """Run the ``SessionStart`` canon injection over stdin and always report success.
-
-    Args:
-        stream: The hook's stdin. Defaults to ``sys.stdin``; the argument keeps
-            the signature uniform with the other entrypoints so ``dispatch``
-            holds one table of them.
-
-    Returns:
-        ``0``, unconditionally. The return value is the exit code, and a hook
-        that opens a session may never fail it.
-    """
+    """Run profile/process canon emission one and always report success."""
     inject_canon(sys.stdin if stream is None else stream, sys.stdout)
+    return 0
+
+
+def main_remaining(stream: TextIO | None = None) -> int:
+    """Run repo/remaining canon emission two and always report success."""
+    inject_canon_remaining(sys.stdin if stream is None else stream, sys.stdout)
     return 0
 
 

--- a/python/openbrain/tests/test_capture_hooks.py
+++ b/python/openbrain/tests/test_capture_hooks.py
@@ -1342,6 +1342,88 @@ class TestSessionStartRendersCanonAsPlainText:
         assert "R" in rendered
 
 
+class TestSessionStartSplitsCanonAcrossTwoEmissions:
+    """The two hook outputs partition one pack without changing any rule text."""
+
+    def test_default_sections_are_partitioned_without_overlap(self) -> None:
+        configured = ("profile_guidance", "process_guidance", "repo_facts")
+
+        first = session_start.sections_for_emission(
+            configured, session_start.CanonEmission.PROFILE_PROCESS
+        )
+        second = session_start.sections_for_emission(
+            configured, session_start.CanonEmission.REMAINING
+        )
+
+        assert first == ("profile_guidance", "process_guidance")
+        assert second == ("repo_facts",)
+        assert set(first).isdisjoint(second)
+        assert first + second == configured
+
+    def test_widened_sections_land_in_the_remaining_emission(self) -> None:
+        configured = (
+            "profile_guidance",
+            "process_guidance",
+            "repo_facts",
+            "working_set",
+        )
+
+        second = session_start.sections_for_emission(
+            configured, session_start.CanonEmission.REMAINING
+        )
+
+        assert second == ("repo_facts", "working_set")
+
+    def test_each_header_names_its_sections_and_one_shared_pack(self) -> None:
+        first_sections = ("profile_guidance", "process_guidance")
+        second_sections = ("repo_facts",)
+        first = session_start.render_pack(
+            _FIXTURE_PACK,
+            emission=session_start.CanonEmission.PROFILE_PROCESS,
+            requested_sections=first_sections,
+        )
+        second = session_start.render_pack(
+            _FIXTURE_PACK,
+            emission=session_start.CanonEmission.REMAINING,
+            requested_sections=second_sections,
+        )
+
+        assert "CANON PACK 1/2" in first.splitlines()[0]
+        assert "this emission sections: profile_guidance, process_guidance" in first
+        assert "CANON PACK 2/2" in second.splitlines()[0]
+        assert "this emission sections: repo_facts" in second
+        assert "one pack across two SessionStart emissions" in first
+        assert "one pack across two SessionStart emissions" in second
+
+    def test_every_rule_appears_whole_in_exactly_one_emission(self) -> None:
+        first = session_start.render_pack(
+            _FIXTURE_PACK,
+            emission=session_start.CanonEmission.PROFILE_PROCESS,
+            requested_sections=("profile_guidance", "process_guidance"),
+        )
+        second = session_start.render_pack(
+            _FIXTURE_PACK,
+            emission=session_start.CanonEmission.REMAINING,
+            requested_sections=("repo_facts",),
+        )
+
+        for section in _FIXTURE_PACK["sections"].values():
+            for item in section["items"]:
+                text = item.get("guidance") or item.get("fact")
+                assert (text in first) != (text in second)
+
+        expected_first = [
+            item["guidance"]
+            for label in ("profile_guidance", "process_guidance")
+            for item in _FIXTURE_PACK["sections"][label]["items"]
+        ]
+        expected_second = [
+            item["fact"] for item in _FIXTURE_PACK["sections"]["repo_facts"]["items"]
+        ]
+        assert first.splitlines()[2:] == expected_first
+        assert second.splitlines()[2:] == expected_second
+
+
 class TestSessionStartEntrypointWritesTheInjection:
     """The additionalContext envelope carries the rendered canon on the happy path."""
 
@@ -1355,9 +1437,7 @@ class TestSessionStartEntrypointWritesTheInjection:
         assert specific["hookEventName"] == "SessionStart"
         # additionalContext is a STRING carrying the RENDERED canon, not raw JSON.
         assert isinstance(specific["additionalContext"], str)
-        assert specific["additionalContext"] == session_start.render_pack(
-            _FIXTURE_PACK
-        )
+        assert specific["additionalContext"] == session_start.render_pack(_FIXTURE_PACK)
         # And it is plain text, not a re-parseable pack object.
         with pytest.raises(json.JSONDecodeError):
             json.loads(specific["additionalContext"])
@@ -1367,9 +1447,7 @@ class TestSessionStartEntrypointWritesTheInjection:
         big = "y" * 20000
         pack = {
             "sections": {
-                "process_guidance": {
-                    "items": [{"scope_key": "big", "guidance": big}]
-                }
+                "process_guidance": {"items": [{"scope_key": "big", "guidance": big}]}
             }
         }
         out = io.StringIO()
@@ -1396,10 +1474,40 @@ class TestSessionStartEntrypointWritesTheInjection:
             session_mod._canon_context = original  # type: ignore[assignment]
 
         envelope = json.loads(out.getvalue())
-        assert (
-            envelope["hookSpecificOutput"]["additionalContext"]
-            == session_start.render_pack(_FIXTURE_PACK)
+        context = envelope["hookSpecificOutput"]["additionalContext"]
+        assert context == session_start.render_pack(
+            _FIXTURE_PACK,
+            emission=session_start.CanonEmission.PROFILE_PROCESS,
+            requested_sections=("profile_guidance", "process_guidance"),
         )
+        assert "PROFILE-RULE-ONE in full." in context
+        assert "PROCESS-RULE-ONE in full." in context
+        assert "REPO-FACT-ONE in full." not in context
+
+    def test_the_remaining_entrypoint_writes_repo_facts(self) -> None:
+        reader = CanonPackReader(pack=_FIXTURE_PACK)
+        import openbrain.apps.hooks.session as session_mod
+
+        original = session_mod._canon_context
+        session_mod._canon_context = reader  # type: ignore[assignment]
+        try:
+            out = io.StringIO()
+            session_start.inject_canon_remaining_with(
+                io.StringIO(fixture_bytes("SessionStart")), out, canon_settings()
+            )
+        finally:
+            session_mod._canon_context = original  # type: ignore[assignment]
+
+        envelope = json.loads(out.getvalue())
+        context = envelope["hookSpecificOutput"]["additionalContext"]
+        assert context == session_start.render_pack(
+            _FIXTURE_PACK,
+            emission=session_start.CanonEmission.REMAINING,
+            requested_sections=("repo_facts",),
+        )
+        assert "REPO-FACT-ONE in full." in context
+        assert "PROFILE-RULE-ONE in full." not in context
+        assert "PROCESS-RULE-ONE in full." not in context
 
 
 class TestSessionStartEntrypointNeverDisruptsTheSession:


### PR DESCRIPTION
## Summary

- split package-owned canon startup injection into two independently registered `SessionStart` console scripts
- emission 1 carries `profile_guidance` + `process_guidance`; emission 2 carries `repo_facts` + every other configured section
- preserve each rule body byte-for-byte and identify both outputs as one canon pack in their headers
- document the uv-tool install and two-entry Claude settings wiring

## Validator

Live local-service validation used the installed uv tool through the production `openbrain-hook-env` wrapper and ran both entry points over the same captured-shape `SessionStart` payload.

- live section counts: `profile_guidance=10`, `process_guidance=15`, `repo_facts=7` (`32` total)
- emission 1 `additionalContext`: `9,327` characters / `9,327` UTF-8 bytes
- emission 2 `additionalContext`: `2,422` characters / `2,422` UTF-8 bytes
- serialized envelope files: `9,443` bytes and `2,514` bytes
- whole-rule check: `32/32` exact UTF-8 rule bodies found exactly once across the two decoded `additionalContext` strings and only in the expected emission
- headers: both identify one shared pack; emission 1 names `profile_guidance, process_guidance`; emission 2 names `repo_facts`
- test mutation proof: the new split tests were run before implementation and failed on missing `CanonEmission` / `sections_for_emission`, then passed after implementation

## Gates

- `uv run ruff check src tests` — passed
- `uv run mypy src/openbrain` — passed (`35` source files)
- `uv run pytest -q` — passed (`308 passed, 17 deselected`)
- repository pre-push gate — passed: TypeScript typecheck, Bun tests, path-sensitive openbrain mypy/ruff/pytest, generated-package-doc check, and applicable parity classification
- live Claude settings JSON parsed successfully and contains two `openbrain-session-start*` command entries

## Critical self-review

- Highest-risk behavior: emission 1 initially measured `10,412` characters; fixed by removing per-item metadata scaffolding from emitted blocks while retaining every rule body unchanged. Final live measurement is `9,327` characters.
- Assumptions that could be wrong: the two independently invoked hooks make separate live pack reads; a canon mutation between those reads could make the pair represent adjacent pack states.
- Missing/weak tests: this branch directly validates both installed entry points against the local service, but does not repeat the already-proven full Claude cold-start transcript experiment for multiple hook outputs.
- Security/permission risk: token delivery remains exclusively in `openbrain-hook-env`; no token or endpoint was added to settings, source, logs, or PR text.
- Migration/deploy risk: the installed uv tool and local Claude settings are already activated from this branch. Rollback is reinstalling from the prior source and removing the second `SessionStart` command entry.
- Downstream client/runtime risk: not applicable to MCP schema, transport, or Python client contracts; the changed consumer boundary is the local Claude hook registration.
- Rollback/cleanup concern: the uv tool was baked from the required temporary worktree; removing the worktree does not remove the installed wheel, but the recorded local source path will no longer exist for a future implicit upgrade. The documented reinstall command remains the explicit upgrade path.
- Fixes made before PR: added exact partition tests, console-script resolution coverage, compact whole-rule emission rendering, runbook wiring, live two-output validator, and settings registration.
- Known residual risk: two service reads can briefly observe different canon revisions during concurrent writes; each individual output remains internally whole and fail-open.
- SME review-memory update: [x] not applicable because: the self-review found no reusable MEDIUM+ review pattern beyond the behavior tests and runbook updates already committed.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below
  - `32/32` live rules verified byte-exact across the two outputs; measured contexts were `9,327` and `2,422` characters.

## State

OPEN for review. **Do not merge until the wider code effort is complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
