### PR TITLE
fix(deploy): fail closed on local clone restart

### DIFF
--- a/_plans/local-clone-deploy-runbook-2026-08-01.md
+++ b/_plans/local-clone-deploy-runbook-2026-08-01.md
@@ -254,10 +254,25 @@ WRITTEN.
 
 ### Step 5 — dogfood smoke (optional, normal production traffic)
 
-A capture/checkpoint/reflex through the installed provider is normal dogfood
-traffic (writes an `ob_raw_turns` row via the running service, not DDL). If the
-operator wants a live round-trip proof, fire one normal capture and confirm the
-count increments. This is production write behavior, not a schema mutation.
+A provider capture is normal dogfood traffic and persists a distilled event in
+`ob_session_events`; it does **not** ingest a row into `ob_raw_turns`. If the
+operator wants a live round-trip proof, fire one normal capture, require a
+`saved` / `durable` receipt, retain its `event_id`, and verify that exact row:
+
+```bash
+set -a; . /Volumes/ThunderBolt/Development/open-brain/.env; set +a
+psql -At -d open_brain_local_20260724 -c \
+  "SELECT id, event_type, created_at FROM ob_session_events WHERE id = '<event_id-from-receipt>';"
+```
+
+Keep `ob_raw_turns` checks for smokes that actually exercise raw-turn ingestion;
+a distilled provider capture is not one of those operations. This is production
+write behavior, not a schema mutation.
+
+**Corrected from live evidence 2026-08-02:** the capture receipt reported
+`saved` / `durable`, `ob_raw_turns` changed by 0, and the persisted event was
+present in `ob_session_events` as
+`2496e009-a2a3-48af-9aa5-6ea1996c9c1a`.
 
 ### Step 6 — rollback (if anything is wrong)
 

--- a/scripts/local-clone-deploy.sh
+++ b/scripts/local-clone-deploy.sh
@@ -50,8 +50,11 @@ fatal() { printf 'FATAL: %s\n' "$1" >&2; exit 1; }
 
 restart_service() {
   [[ -n "$SERVICE_LABEL" ]] || { log "no service label set; not restarting"; return 0; }
+  local uid
+  uid="$(id -u)"
   log "restarting ${SERVICE_LABEL}"
-  launchctl kickstart -k "$SERVICE_LABEL" || log "WARN: could not restart ${SERVICE_LABEL}"
+  launchctl kickstart -k "gui/${uid}/${SERVICE_LABEL}" \
+    || fatal "could not restart ${SERVICE_LABEL}"
 }
 
 # Health is checked against the port the CLONE env declares, not a hardcoded


### PR DESCRIPTION
## Summary

- Fix local-clone deploy restarts to target the actual per-user LaunchAgent service.
- Fail the deploy immediately when `launchctl kickstart` fails, preventing an old process from producing a false post-deploy health receipt.
- Correct the provider-capture smoke to verify `ob_session_events`, with the 2026-08-02 live receipt recorded.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence:
- `/opt/homebrew/bin/bash -n scripts/local-clone-deploy.sh`
- `shellcheck scripts/local-clone-deploy.sh`
- Extracted production `restart_service` failure-path test: mocked uid `777`, mocked `launchctl` exit `42`; observed script exit `1` and target `gui/777/com.example.test`.
- Full pre-push gate: TypeScript passed; 2,855 Bun tests passed, 308 skipped, 0 failed; Python and contract-parity gates correctly skipped because their paths were unchanged.
- Live read-only LaunchAgent lookup resolved `gui/501/com.rico.open-brain-local-clone`.
- Live read-only DB lookup found capture event `2496e009-a2a3-48af-9aa5-6ea1996c9c1a` in `ob_session_events` as event type `fact`.
- No deploy or service restart was performed by this PR run.

## Critical Self-Review

- Highest-risk behavior: A failed kickstart must terminate before health can observe the old process; the failure-path test observed exit 1 from the exact production function.
- Assumptions that could be wrong: The configured label is a per-user LaunchAgent; `launchctl print gui/501/com.rico.open-brain-local-clone` verified that domain and label live.
- Missing/weak tests: There is no dedicated checked-in test harness for `local-clone-deploy.sh`; validation used shell syntax/lint plus an extracted-function failure-path test.
- Security/permission risk: The script derives the current uid with `id -u` and does not broaden privileges or use `sudo`.
- Migration/deploy risk: Restart failure now stops immediately after the runtime swap instead of entering the health loop; rollback remains operator-invoked for this failure class.
- Downstream client/runtime risk: No MCP, transport, schema, Python client, or agent-facing contract changed.
- Rollback/cleanup concern: The script's existing `--rollback` path remains available; the temporary worktree will be removed after PR creation.
- Fixes made before PR: Corrected the service target, removed warn-and-continue behavior, and replaced the raw-turn capture assertion with exact event-row verification.
- Known residual risk: The corrected behavior is source-validated and not deployed in this PR run.
- SME review-memory update: [x] not applicable because: no MEDIUM+ reusable review finding was produced beyond the live evidence now recorded in the runbook.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: only the local launchd deploy script and its operator runbook changed; no public/client contract changed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is not applicable: no MCP tool/schema/protocol, transport, migration, Python client, generated skill, or Hermes-facing behavior changed.
- Live deploy receipt that exposed Fix 1: `2026-08-02T04:12:18Z`, `Unrecognized target specifier, did you mean gui/501/com.rico.open-brain-local-clone`.
- Live capture receipt that exposed Fix 2: provider returned `saved` / `durable`; `ob_raw_turns` delta was `0`; `ob_session_events.id` was `2496e009-a2a3-48af-9aa5-6ea1996c9c1a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
