### PR TITLE
fix(openbrain-memory): expose provider operation vocabulary

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/__main__.py
+++ b/python/openbrain-memory/src/openbrain_memory/__main__.py
@@ -10,7 +10,9 @@ from .cli import (
     encode_json_output,
     execute_json,
     failure_output,
+    operation_names,
     parse_json_input,
+    usage_output,
 )
 from .runtime import ReceiptStatus
 
@@ -18,10 +20,14 @@ from .runtime import ReceiptStatus
 def main(argv: Sequence[str] | None = None) -> int:
     """Read one JSON object from stdin and emit one JSON object to stdout."""
     arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments == ["--help"]:
+        sys.stdout.buffer.write(encode_json_output(usage_output()))
+        return 0
     if arguments:
         output = failure_output(
             "input",
-            "arguments are not supported; provide bounded JSON on stdin",
+            "arguments are not supported; use --help or provide bounded JSON "
+            f"on stdin; valid operations: {', '.join(operation_names())}",
         )
         sys.stdout.buffer.write(encode_json_output(output))
         return 2

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -42,32 +42,62 @@ MAX_JSON_OUTPUT_BYTES = 1_000_000
 MAX_IGNORED_OPTIONAL_KEY_COUNT = 65_535
 IGNORED_OPTIONAL_REQUEST_KEYS_NOTE = "ignored_optional_request_keys"
 _COMMON_KEYS = {"config", "operation", "scope"}
-_OPERATION_KEYS = {
-    "recall": {
-        "include_unreviewed_recovery",
-        "max_latency_ms",
-        "max_tokens",
-        "query",
-        "requested_sections",
-    },
-    "reflex": {"max_latency_ms", "max_tokens", "prior_context", "query"},
-    "capture": {"content", "distilled", "event_type"},
+_OPERATION_SPECS = {
+    "help": ("List provider operations and an example request.", set()),
+    "recall": (
+        "Load context for a query.",
+        {
+            "include_unreviewed_recovery",
+            "max_latency_ms",
+            "max_tokens",
+            "query",
+            "requested_sections",
+        },
+    ),
+    "reflex": (
+        "Load body-free reflex pointers for a query.",
+        {"max_latency_ms", "max_tokens", "prior_context", "query"},
+    ),
+    "capture": (
+        "Persist one distilled memory event.",
+        {"content", "distilled", "event_type"},
+    ),
     # The raw lane carries no "distilled" key by design: it is the one verb
     # that ships the transcript rather than a summary of it.
-    "ingest": {"namespace", "turns"},
-    "checkpoint": {
-        "distilled",
-        "key_decisions",
-        "next_steps",
-        "receipt_refs",
-        "summary",
-    },
-    "wrap": {
-        "distilled",
-        "key_decisions",
-        "next_steps",
-        "receipt_refs",
-        "summary",
+    "ingest": ("Persist raw conversation turns.", {"namespace", "turns"}),
+    "checkpoint": (
+        "Persist distilled session progress.",
+        {
+            "distilled",
+            "key_decisions",
+            "next_steps",
+            "receipt_refs",
+            "summary",
+        },
+    ),
+    "wrap": (
+        "Persist a distilled session wrap.",
+        {
+            "distilled",
+            "key_decisions",
+            "next_steps",
+            "receipt_refs",
+            "summary",
+        },
+    ),
+}
+_OPERATION_KEYS = {name: keys for name, (_, keys) in _OPERATION_SPECS.items()}
+_OPERATION_NAMES = tuple(_OPERATION_SPECS)
+_OPERATION_VOCABULARY = ", ".join(_OPERATION_NAMES)
+_HELP_EXAMPLE = {
+    "operation": "recall",
+    "query": "current task",
+    "scope": {
+        "agent": "agent-name",
+        "channel_id": "channel-id",
+        "platform": "runtime-name",
+        "server_id": "server-id",
+        "session_key": "session-key",
     },
 }
 
@@ -86,24 +116,27 @@ def execute_json(
     runtime: FirstClassMemoryRuntime | None = None
     ignored_optional_key_count = 0
     try:
-        operation = _mapping_text(payload, "operation")
+        operation = _operation_text(payload)
         projected, ignored_optional_key_count = _project_request(payload, operation)
-        scope_value = projected.get("scope")
-        config_value = projected.get("config", {})
-        if not isinstance(scope_value, Mapping):
-            raise ValueError("scope must be a JSON object")
-        if not isinstance(config_value, Mapping):
-            raise ValueError("config must be a JSON object")
-        runtime = FirstClassMemoryRuntime(
-            RuntimeConfig.from_sources(config_value, environ=environ),
-            RuntimeScope.from_mapping(scope_value),
-            transport=transport,
-            client=client,
-            client_factory=client_factory,
-            fallback_runner=fallback_runner,
-            spool=spool,
-        )
-        output = _dispatch(runtime, operation, projected).as_dict()
+        if operation == "help":
+            output = usage_output()
+        else:
+            scope_value = projected.get("scope")
+            config_value = projected.get("config", {})
+            if not isinstance(scope_value, Mapping):
+                raise ValueError("scope must be a JSON object")
+            if not isinstance(config_value, Mapping):
+                raise ValueError("config must be a JSON object")
+            runtime = FirstClassMemoryRuntime(
+                RuntimeConfig.from_sources(config_value, environ=environ),
+                RuntimeScope.from_mapping(scope_value),
+                transport=transport,
+                client=client,
+                client_factory=client_factory,
+                fallback_runner=fallback_runner,
+                spool=spool,
+            )
+            output = _dispatch(runtime, operation, projected).as_dict()
     except Exception as error:
         output = failure_output(_safe_operation(payload.get("operation")), error)
     _attach_compatibility_receipt(output, ignored_optional_key_count)
@@ -132,6 +165,31 @@ def failure_output(operation: str, error: BaseException | str) -> dict[str, Any]
             error=error_text,
         )
     ).as_dict()
+
+
+def usage_output() -> dict[str, Any]:
+    """Build the structured provider operation reference."""
+    return RuntimeOutput(
+        receipt=RuntimeReceipt(
+            operation="help",
+            status=ReceiptStatus.DIRECT,
+            durable=False,
+            direct_attempted=False,
+            fallback_attempted=False,
+        ),
+        result={
+            "operations": [
+                {"name": name, "description": description}
+                for name, (description, _) in _OPERATION_SPECS.items()
+            ],
+            "example": _HELP_EXAMPLE,
+        },
+    ).as_dict()
+
+
+def operation_names() -> tuple[str, ...]:
+    """Return every operation accepted by the JSON router."""
+    return _OPERATION_NAMES
 
 
 def parse_json_input(data: bytes) -> Mapping[str, Any]:
@@ -237,7 +295,10 @@ def _dispatch(
             next_steps=_mapping_optional_str_list(payload, "next_steps"),
             receipt_refs=_mapping_optional_str_list(payload, "receipt_refs"),
         )
-    raise ValueError(f"unsupported operation: {_safe_text(operation)}")
+    raise ValueError(
+        f"unsupported operation: {_safe_text(operation)}; "
+        f"valid operations: {_OPERATION_VOCABULARY}"
+    )
 
 
 def _project_request(
@@ -246,7 +307,10 @@ def _project_request(
 ) -> tuple[dict[str, Any], int]:
     allowed = _OPERATION_KEYS.get(operation)
     if allowed is None:
-        raise ValueError(f"unsupported operation: {_safe_text(operation)}")
+        raise ValueError(
+            f"unsupported operation: {_safe_text(operation)}; "
+            f"valid operations: {_OPERATION_VOCABULARY}"
+        )
     known_keys = _COMMON_KEYS | allowed
     projected = {key: value for key, value in payload.items() if key in known_keys}
     ignored_count = min(
@@ -272,6 +336,16 @@ def _attach_compatibility_receipt(
 def _require_distilled(payload: Mapping[str, Any], operation: str) -> None:
     if payload.get("distilled") is not True:
         raise ValueError(f"{operation} requires distilled=true")
+
+
+def _operation_text(value: Mapping[str, Any]) -> str:
+    item = value.get("operation")
+    if not isinstance(item, str) or not item.strip():
+        raise ValueError(
+            "operation must be a non-empty string; "
+            f"valid operations: {_OPERATION_VOCABULARY}"
+        )
+    return item.strip()
 
 
 def _mapping_text(value: Mapping[str, Any], name: str) -> str:

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -27,6 +27,7 @@ from openbrain_memory._runtime_spool import PARKED_NAMESPACE_KEY, TrackingSpool
 from openbrain_memory.cli import (
     encode_json_output,
     execute_json,
+    operation_names,
     parse_json_input,
 )
 
@@ -1889,6 +1890,49 @@ def test_main_returns_nonzero_when_output_bound_replaces_success() -> None:
     emitted = json.loads(stdout_buffer.getvalue())
     assert emitted["receipt"]["status"] == "failed"
     assert emitted["receipt"]["operation"] == "output"
+
+
+def test_unknown_and_missing_operation_errors_name_complete_vocabulary() -> None:
+    outputs = (
+        execute_json({"operation": "not-an-operation"}),
+        execute_json({}),
+    )
+
+    assert outputs[0]["receipt"]["error"].startswith(
+        "unsupported operation: not-an-operation;"
+    )
+    for output in outputs:
+        assert output["receipt"]["status"] == "failed"
+        error = output["receipt"]["error"]
+        for operation in operation_names():
+            assert operation in error
+
+
+def test_help_lists_every_routed_operation() -> None:
+    output = execute_json({"operation": "help"})
+
+    assert output["receipt"]["status"] == "direct"
+    operations = output["result"]["operations"]
+    assert [entry["name"] for entry in operations] == list(operation_names())
+    assert all(entry["description"] for entry in operations)
+    assert output["result"]["example"]["operation"] in operation_names()
+
+
+def test_module_entry_point_supports_help_argument() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "openbrain_memory", "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    output = json.loads(completed.stdout)
+    assert [entry["name"] for entry in output["result"]["operations"]] == list(
+        operation_names()
+    )
 
 
 def test_module_entry_point_emits_json_for_malformed_input() -> None:


### PR DESCRIPTION
## Summary

- make missing/unknown provider operation failures name the complete operation vocabulary
- add structured help through both `--help` and `{"operation":"help"}` stdin requests
- derive help and error vocabulary from the same operation router metadata

Related to #413 and #464. The issue search found no exact duplicate: #413 is the closest fail-loud umbrella, while #464 is a distinct silent-key-drop defect in the same provider family.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable — not applicable; this is local CLI discovery and does not call or change the service

Evidence:

- `uv run mypy src/openbrain_memory` — success, 17 source files
- `uv run ruff check src tests` — all checks passed
- `uv run pytest -q` — 550 passed, 9 skipped
- pre-push root suite — 2,855 passed, 308 skipped, 0 failed
- contract parity — 14 fixtures across 9 capabilities; 14 tests passed
- red proof: temporarily removed `wrap` from the exported operation-name view; `test_help_lists_every_routed_operation` failed because help still contained `wrap`, then the mutation was restored

## Critical Self-Review

- Highest-risk behavior: help uses the existing successful read-style `direct` receipt status while truthfully leaving `direct_attempted=false`; no transport is contacted.
- Assumptions that could be wrong: consumers accept an additive `help` operation and additive `result.operations` payload without treating it as a runtime memory call.
- Missing/weak tests: the installed uv tool was intentionally not reinstalled; source-level console subprocess tests and exact pre/post invocation receipts cover the candidate instead.
- Security/permission risk: none identified; output is static operation metadata and contains no config, token, namespace, or memory content.
- Migration/deploy risk: no database or server migration; cutover requires upgrading the installed uv tool after merge.
- Downstream client/runtime risk: existing operation behavior and output shapes are unchanged; only unknown/missing-operation errors gain vocabulary and help is additive.
- Rollback/cleanup concern: revert commit `1397db9`; no durable data or service state was changed.
- Fixes made before PR: centralized operation descriptions/keys, added missing-operation vocabulary, added stdin and flag help, and proved the new router-parity test goes red.
- Known residual risk: the live installed binary remains on the old behavior until the explicit uv tool upgrade cutover.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this change introduces no new MEDIUM+ review finding or post-merge missed pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no server, schema, auth, transport, or persistence behavior changed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is the Python provider console surface only; the existing parity gate passed unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable; no MCP registry/schema/tool change
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable; no hosted MCP contract change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable; no runtime/plugin call-shape change
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable; no Hermes behavior change

Notes/evidence:

- Python package cutover is intentionally deferred until after merge; the operator-directed reinstall command is documented in the delivery report.
- The PR is open and must remain unmerged until the wider code effort is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
