### PR TITLE
feat(server): close the Phase 5 remainder -- realtime writes, NATS config, ordered shutdown, two-worker proof

### DIFF
--- a/contracts/server/parity-manifest.json
+++ b/contracts/server/parity-manifest.json
@@ -133,7 +133,7 @@
       "curation-operations": "scaffold-declared",
       "raw-turn-ingest-server": "implemented",
       "namespace-denial": "implemented",
-      "realtime-working-recovery": "scaffold-declared",
+      "realtime-working-recovery": "implemented",
       "reflex-pointers": "implemented",
       "search-brain-arms": "implemented",
       "session-lifecycle-server": "implemented",

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -65,15 +65,17 @@ export const REQUIRED_SUITES: ReadonlyArray<{
   // HTTP -- and the job would stay green while proving nothing.
   {
     name: "rewrite candidate over the real MCP SDK and real HTTP transport (live Postgres)",
-    minTests: 8,
+    minTests: 12,
   },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
 // independent of the per-suite breakdown above. Tracks the sum of the
 // `minTests` values above (32 before the Phase 5 real-SDK protocol suite added
-// its 8), so the global floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 40;
+// its 8, then 12 once that suite also covered the realtime append tools and the
+// two-worker front), so the global floor cannot silently fall behind the
+// per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 44;
 
 export interface SuiteStats {
   tests: number;

--- a/server/application/index.ts
+++ b/server/application/index.ts
@@ -1,6 +1,6 @@
 import type { Express, RequestHandler } from "express";
 import type { Logger } from "pino";
-import type { ServerConfig } from "../config.ts";
+import { natsHealthFromConfig, type ServerConfig } from "../config.ts";
 import type { Database } from "../db/pool.ts";
 import type { ServerModuleBoundary } from "../module.ts";
 import {
@@ -28,6 +28,32 @@ export interface ShadowApplicationInput {
   readonly transportFactory?: SessionTransportFactory;
   readonly fetch?: typeof fetch;
   readonly natsHealth?: () => TransportNatsHealth;
+  /**
+   * Long-running work this application must shut down, in order, on close.
+   *
+   * The maintenance queue runner is the one that matters today. It is passed as
+   * a PORT rather than constructed here for a specific reason: `stop()` on a
+   * claim-then-dispatch runner is not a cancel, it is a DRAIN. It must await
+   * the in-flight claim so rows that claim already leased land in the tracked
+   * set before the drain waits on it — otherwise those rows sit `running` with
+   * a live lease and no handler, stuck until the lease expires
+   * (`docs/sme/domain-backend.md`, PR #350 / issue #343). That behavior belongs
+   * to the runner and is already implemented there; the application's job is
+   * only to CALL it, and to call it before the database goes away.
+   */
+  readonly backgroundRuntimes?: readonly BackgroundRuntime[];
+}
+
+/**
+ * Anything the application starts and must stop before the database closes.
+ *
+ * Deliberately one method wide. The application orders shutdown; it does not
+ * want to know whether the thing behind this is a queue runner, a NATS bridge,
+ * or a sweeper.
+ */
+export interface BackgroundRuntime {
+  readonly name: string;
+  stop(): Promise<void>;
 }
 
 export interface ShadowApplication {
@@ -59,7 +85,17 @@ export function createShadowApplication(
       ? { embeddingApiKey: input.config.transport.embeddingApiKey }
       : {}),
     ...(input.fetch ? { fetch: input.fetch } : {}),
-    ...(input.natsHealth ? { natsHealth: input.natsHealth } : {}),
+    // Config is the DEFAULT source of the `nats` health block, not an optional
+    // extra. `server/transport/health.ts` falls back to a hardcoded
+    // http/available literal when nothing supplies one, which is correct only
+    // for a worker that genuinely runs HTTP -- so a worker configured with
+    // `OPENBRAIN_TRANSPORT=nats` and a broken bridge would report itself
+    // `healthy` on the strength of a constant. Deriving it from the parsed
+    // config makes the degraded case reachable; an explicit `natsHealth` still
+    // wins, because a LIVE bridge knows its own failure counters and config
+    // cannot.
+    natsHealth:
+      input.natsHealth ?? (() => natsHealthFromConfig(input.config.nats)),
   };
   const app = createSingleWorkerTransportApp({
     authenticate: input.authenticate,
@@ -71,6 +107,49 @@ export function createShadowApplication(
   return {
     app,
     sessions,
-    close: () => sessions.close(),
+    close: () => closeInOrder(input, sessions),
   };
+}
+
+/**
+ * Shut down in dependency order: stop accepting work, then drain, then release.
+ *
+ * SESSIONS FIRST. While a session is live an MCP handler can still enqueue
+ * maintenance work, so draining the runner before closing sessions would let a
+ * late request refill the queue after the drain had already passed it.
+ *
+ * BACKGROUND RUNTIMES SECOND, and they are drained BEFORE the caller closes the
+ * database, because a claim-then-dispatch runner needs its pool to finish the
+ * jobs it has already leased. Killing the pool first turns an orderly drain
+ * into the exact abandoned-lease failure the drain exists to prevent.
+ *
+ * EVERY runtime is stopped even if an earlier one throws. A shutdown path that
+ * abandons the remaining runtimes on the first failure leaks precisely when
+ * something is already going wrong, which is the worst moment to also lose the
+ * drain. Failures are logged with an error CATEGORY, never the error object,
+ * and the first one is rethrown so a caller cannot read a partial shutdown as a
+ * clean one.
+ */
+async function closeInOrder(
+  input: ShadowApplicationInput,
+  sessions: SessionTransportHandlers,
+): Promise<void> {
+  await sessions.close();
+  let firstFailure: unknown;
+  for (const runtime of input.backgroundRuntimes ?? []) {
+    try {
+      await runtime.stop();
+      input.logger.info({ runtime: runtime.name }, "background_runtime_stopped");
+    } catch (error: unknown) {
+      firstFailure ??= error;
+      input.logger.error(
+        {
+          runtime: runtime.name,
+          error_category: error instanceof Error ? error.name : typeof error,
+        },
+        "background_runtime_stop_failed",
+      );
+    }
+  }
+  if (firstFailure !== undefined) throw firstFailure;
 }

--- a/server/application/sdk-protocol.pg.test.ts
+++ b/server/application/sdk-protocol.pg.test.ts
@@ -67,8 +67,12 @@ import type { ShadowApplication } from "./index.ts";
 import { parseServerConfig } from "../config.ts";
 import type { ServerConfig } from "../config.ts";
 import type { Database, DatabaseHealth } from "../db/pool.ts";
+import { RecoveryWalStore } from "../realtime/recovery-wal.ts";
+import { WorkingSetStore } from "../realtime/working-set.ts";
 import { SERVER_REWRITE_STATE } from "../state.ts";
 import { registerMemoryTools } from "../tools/index.ts";
+import { createWorkerProxyHandler } from "../transport/index.ts";
+import type { AggregateHealth, SingleWorkerHealth } from "../transport/index.ts";
 import { silentLogger } from "../transport/testing/silent-logger.ts";
 import { expectRecordedShape, loadServerFixture } from "../../contracts/fixture-shape.ts";
 
@@ -190,16 +194,67 @@ interface LiveHarness {
 const live: Partial<LiveHarness> = {};
 
 /**
- * Compose the real stack, bind an ephemeral port, and connect a real SDK client.
+ * Extra applications and listeners a single test composed for itself.
  *
- * `serverFactory` is the whole point: it builds a REAL `McpServer` and registers
- * the REAL tool boundary, where `shadow-application.test.ts` passes a stub. The
- * factory runs per initialize, matching production, so each session gets its own
- * server instance bound to the shared pool.
+ * The `live` harness above holds ONE of each, which is right for the tests that
+ * drive a single client. The two-worker front needs three at once (two workers
+ * plus the front), so they are tracked here and torn down by the same
+ * `afterEach`. Without this they would leak a listener per run, and a leaked
+ * listener is the failure that shows up as an unrelated later test hanging.
  */
-async function connectRealClient(): Promise<Client> {
+const extraApplications: ShadowApplication[] = [];
+const extraServers: Server[] = [];
+
+/**
+ * Realtime stores, injected per composed application rather than inherited.
+ *
+ * The realtime fixture records `id: "ws-1"` / `"rw-1"`, and those ids come from
+ * a MONOTONIC counter that lives as long as the store does. `realtime-stores.ts`
+ * falls back to a MODULE-scoped store when a composition root injects none --
+ * correct, and deliberately so, because a store rebuilt per request would report
+ * a permanent zero. But Bun runs every test file in ONE process, so an
+ * uninjected suite shares that fallback with every other suite in the run:
+ * measured on this branch, `contracts/server-tool-parity.test.ts` exercises the
+ * same three tools first and this suite then observed `ws-2`, passing alone and
+ * failing in file order.
+ *
+ * Injecting is not a test workaround; it is what a composition root does. The
+ * store is per APPLICATION here, matching one server process owning its own
+ * realtime state, which is exactly the lifetime the fixture recorded against.
+ */
+function freshRealtimeStores(): {
+  workingSetStore: WorkingSetStore;
+  recoveryWalStore: RecoveryWalStore;
+} {
+  return {
+    workingSetStore: new WorkingSetStore({ logger: pino({ level: "silent" }) }),
+    // `walPath: null` keeps this RAM-only. A path would make the suite replay
+    // whatever a previous run left on disk, reintroducing the same cross-run
+    // contamination one layer down.
+    recoveryWalStore: new RecoveryWalStore({
+      walPath: null,
+      logger: pino({ level: "silent" }),
+    }),
+  };
+}
+
+/**
+ * Compose one real single-worker application and bind it to an ephemeral port.
+ *
+ * Factored out of `connectRealClient` because the two-worker proof needs REAL
+ * worker processes-equivalents behind the front -- the whole point of that test
+ * is that the aggregate reads a genuine `/health` body off a genuine socket
+ * rather than a hand-written `{status}` object from an injected `fetch`.
+ */
+async function startWorkerApplication(): Promise<{
+  application: ShadowApplication;
+  server: Server;
+  port: number;
+}> {
   if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
-  freshNamespace();
+  // One store pair per APPLICATION, shared by every session it serves -- the
+  // realtime state belongs to the process, not to a connection.
+  const realtime = freshRealtimeStores();
   const application = createShadowApplication({
     config: testConfig(),
     logger: silentLogger(),
@@ -213,6 +268,48 @@ async function connectRealClient(): Promise<Client> {
         embedFn: async () => Array(768).fill(0.01) as number[],
         logger: pino({ level: "silent" }),
         embeddingModel: "sdk-protocol-proof",
+        ...realtime,
+      });
+      return server;
+    },
+  });
+  const server = await new Promise<Server>((resolve) => {
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const { port } = server.address() as AddressInfo;
+  extraApplications.push(application);
+  extraServers.push(server);
+  return { application, server, port };
+}
+
+/**
+ * Compose the real stack, bind an ephemeral port, and connect a real SDK client.
+ *
+ * `serverFactory` is the whole point: it builds a REAL `McpServer` and registers
+ * the REAL tool boundary, where `shadow-application.test.ts` passes a stub. The
+ * factory runs per initialize, matching production, so each session gets its own
+ * server instance bound to the shared pool.
+ */
+async function connectRealClient(): Promise<Client> {
+  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
+  freshNamespace();
+  // One store pair per APPLICATION, shared by every session it serves -- the
+  // realtime state belongs to the process, not to a connection.
+  const realtime = freshRealtimeStores();
+  const application = createShadowApplication({
+    config: testConfig(),
+    logger: silentLogger(),
+    database: fakeHealthDatabase(),
+    authenticate: bearerAuth(),
+    parseRequestBody: express.json(),
+    serverFactory: () => {
+      const server = new McpServer({ name: "open-brain-rewrite", version: "1.0.0" });
+      registerMemoryTools(server, {
+        pool,
+        embedFn: async () => Array(768).fill(0.01) as number[],
+        logger: pino({ level: "silent" }),
+        embeddingModel: "sdk-protocol-proof",
+        ...realtime,
       });
       return server;
     },
@@ -268,6 +365,13 @@ afterEach(async () => {
   if (live.application) {
     await live.application.close();
     live.application = undefined;
+  }
+  while (extraServers.length > 0) {
+    const server = extraServers.pop()!;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  while (extraApplications.length > 0) {
+    await extraApplications.pop()!.close();
   }
 });
 
@@ -461,5 +565,215 @@ dbDescribe("rewrite candidate over the real MCP SDK and real HTTP transport (liv
     await expect(client.connect(transport)).rejects.toThrow();
     // Nothing was admitted: the session boundary stayed empty.
     expect(application.sessions.sessionCount()).toBe(0);
+  });
+
+  test("appends realtime working-set and recovery state against the recorded shapes", async () => {
+    // The realtime WRITE half only became reachable in this wave. Before it, the
+    // fixture was marked `scaffold-declared` for the rewrite provider: the
+    // stores existed and the context pack READ them, but no tool could put
+    // anything in, so every recorded shape here was asserted against
+    // `current-src` alone.
+    const client = await connectRealClient();
+    const fixture = await loadServerFixture("server-realtime-working-recovery");
+    const sessionKey = `sdk-proof/realtime-${Date.now()}`;
+
+    for (const step of fixture.steps) {
+      const observed = await callTool(client, step.tool, {
+        ...step.arguments,
+        session_key: sessionKey,
+      });
+      expect(observed.isError).toBe(step.expectation.is_error);
+      expectRecordedShape(observed.body, step.expectation.json, {
+        "{{namespace}}": NAMESPACE,
+        "parity/realtime": sessionKey,
+      });
+    }
+  });
+
+  test("a working-set append is visible to the context pack that reads the same store", async () => {
+    // This is the join the two halves share and neither one proves alone. The
+    // stores are RAM-only and process-lifetime, so a write that landed in a
+    // DIFFERENT store object than the pack reads would still return
+    // `accepted: true` and then be invisible forever -- and nothing durable
+    // would ever contradict it, because nothing about this state is durable.
+    // Asserting the append's own response cannot catch that; only reading it
+    // back through the other tool can.
+    const client = await connectRealClient();
+    const sessionKey = `sdk-proof/join-${Date.now()}`;
+    const scope = {
+      agent: "fixture-agent",
+      platform: "test",
+      server_id: "server-1",
+      channel_id: "channel-1",
+      session_key: sessionKey,
+    };
+    const content = `working-set join proof ${Date.now()}`;
+
+    const appended = await callTool(client, "working_set_append", {
+      ...scope,
+      kind: "current_intent",
+      content,
+    });
+    expect(appended.isError).toBe(false);
+    expect((appended.body as { accepted: boolean }).accepted).toBe(true);
+
+    const pack = await callTool(client, "agent_context_pack", {
+      ...scope,
+      requested_sections: ["working_set"],
+    });
+    expect(pack.isError).toBe(false);
+    // The exact content must come back, not merely a non-empty section: a
+    // section that happened to be populated by anything else would pass a
+    // count-only assertion while proving nothing about THIS write.
+    expect(pack.text).toContain(content);
+  });
+
+  test("the two-worker front aggregates real worker health off real sockets", async () => {
+    // Charter section 1.5: core01 runs the aggregate front and each nested
+    // worker body must be preserved. `server/transport/worker-proxy.test.ts`
+    // proves the aggregation logic, but only against an injected `fetch` that
+    // returns a hand-written `{status}` object -- so the thing it never checks
+    // is that a REAL single-worker `/health` payload survives nesting. That is
+    // the join, and this binds two real listeners to prove it.
+    const workerOne = await startWorkerApplication();
+    const workerTwo = await startWorkerApplication();
+    const workers = [
+      {
+        name: "open-brain-worker-1",
+        port: workerOne.port,
+        baseUrl: `http://127.0.0.1:${workerOne.port}`,
+      },
+      {
+        name: "open-brain-worker-2",
+        port: workerTwo.port,
+        baseUrl: `http://127.0.0.1:${workerTwo.port}`,
+      },
+    ];
+    const front = createWorkerProxyHandler({
+      workers,
+      serverIp: "127.0.0.1",
+      healthProbeTimeoutMs: 2_000,
+      logger: silentLogger(),
+    });
+
+    const response = await front(new Request("http://127.0.0.1/health"));
+    const aggregate = (await response.json()) as AggregateHealth;
+
+    expect(response.status).toBe(200);
+    expect(aggregate.status).toBe("healthy");
+    expect(aggregate.workers.map((worker) => worker.name)).toEqual([
+      "open-brain-worker-1",
+      "open-brain-worker-2",
+    ]);
+    // Every nested body is a REAL single-worker payload, not a stub: it carries
+    // the fields the charter freezes for the single-worker surface.
+    for (const worker of aggregate.workers) {
+      expect(worker.ok).toBe(true);
+      const body = worker.body as SingleWorkerHealth;
+      expect(body.status).toBe("healthy");
+      expect(body.database.connected).toBe(true);
+      expect(body.nats.requested_transport).toBe("http");
+      expect(typeof body.timestamp).toBe("string");
+    }
+  });
+
+  test("the two-worker front pins one MCP session to one worker", async () => {
+    // Session affinity is the reason the front exists at all: sessions live in
+    // a PROCESS-LOCAL map per worker (charter 1.5), so a follow-up request
+    // routed to the other worker finds no session and the client breaks. Proven
+    // over real sockets with a real SDK handshake, because the session id being
+    // pinned is one the SDK server assigned, not one the test made up.
+    const workerOne = await startWorkerApplication();
+    const workerTwo = await startWorkerApplication();
+    const front = createWorkerProxyHandler({
+      workers: [
+        {
+          name: "open-brain-worker-1",
+          port: workerOne.port,
+          baseUrl: `http://127.0.0.1:${workerOne.port}`,
+        },
+        {
+          name: "open-brain-worker-2",
+          port: workerTwo.port,
+          baseUrl: `http://127.0.0.1:${workerTwo.port}`,
+        },
+      ],
+      serverIp: "127.0.0.1",
+      healthProbeTimeoutMs: 2_000,
+      logger: silentLogger(),
+    });
+    freshNamespace();
+
+    const initialize = await front(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "two-worker-affinity", version: "1.0.0" },
+          },
+        }),
+      }),
+    );
+    expect(initialize.status).toBe(200);
+    const sessionId = initialize.headers.get("mcp-session-id");
+    expect(sessionId).toBeString();
+
+    // Exactly one worker admitted the session; the other saw nothing. That
+    // asymmetry is what makes affinity load-bearing rather than cosmetic.
+    const admitted = [workerOne, workerTwo].filter(
+      (worker) => worker.application.sessions.sessionCount() === 1,
+    );
+    expect(admitted.length).toBe(1);
+
+    // Each follow-up must SUCCEED, and success is the assertion that matters.
+    //
+    // The obvious version of this test compares the front's own
+    // `x-open-brain-worker` value across requests -- and it proves nothing: that
+    // header is set on the OUTBOUND request the front sends to a worker, never
+    // on the response handed back, so reading it here yields `null` on every
+    // request and `null === null` passes with affinity deliberately broken.
+    // Measured on this branch: disabling the `sessionWorkers` lookup outright
+    // left that version 12/12 green.
+    //
+    // Reaching the wrong worker is instead observable in the only place it is
+    // real -- the session map is PROCESS-LOCAL, so the other worker has never
+    // heard of this session id and answers a JSON-RPC error rather than a
+    // result. Asserting on the answered payload cannot be satisfied by routing
+    // to the wrong process.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const followUp = await front(
+        new Request("http://127.0.0.1/mcp", {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${TEST_TOKEN}`,
+            "content-type": "application/json",
+            accept: "application/json, text/event-stream",
+            "mcp-session-id": sessionId!,
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: attempt + 2, method: "tools/list" }),
+        }),
+      );
+      expect(followUp.status).toBe(200);
+      const answered = await followUp.text();
+      expect(answered).toContain('"result"');
+      expect(answered).toContain("working_set_append");
+      expect(answered).not.toContain("Session not found");
+    }
+    // Still exactly one session in the fleet: affinity routed, it did not
+    // create a second session on the other worker.
+    expect(
+      workerOne.application.sessions.sessionCount() +
+        workerTwo.application.sessions.sessionCount(),
+    ).toBe(1);
   });
 });

--- a/server/application/shadow-application.test.ts
+++ b/server/application/shadow-application.test.ts
@@ -135,6 +135,118 @@ describe("shadow application composition", () => {
     expect(((await response.json()) as { status: string }).status).toBe("degraded");
   });
 
+  it("reports the configured NATS boundary in health without any caller supplying it", async () => {
+    // Before config owned this, `server/transport/health.ts` fell back to a
+    // hardcoded `http`/`available` literal whenever nothing passed a
+    // `natsHealth` port -- and NOTHING did. So the `nats` block was a constant,
+    // and the degraded branch below was unreachable in the composed app.
+    const base = await listen();
+    const body = (await (await fetch(`${base}/health`)).json()) as {
+      status: string;
+      nats: { requested_transport: string; availability: string };
+    };
+
+    expect(body.status).toBe("healthy");
+    expect(body.nats.requested_transport).toBe("http");
+  });
+
+  it("degrades health when NATS is the requested transport but the bridge is not available", async () => {
+    // The charter freezes this: degraded means NATS was explicitly REQUESTED
+    // and the runtime bridge is not available. A worker misconfigured this way
+    // previously reported itself healthy on the strength of the literal.
+    const base = await listen({
+      config: testConfig({
+        OPENBRAIN_TRANSPORT: "nats",
+        OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+        OPENBRAIN_NATS_URL: "nats://10.71.1.99:4222",
+      }),
+    });
+    const response = await fetch(`${base}/health`);
+    const body = (await response.json()) as {
+      status: string;
+      database: { connected: boolean };
+      nats: { requested_transport: string; availability: string };
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("degraded");
+    // The database is fine; NATS alone is what degraded it. Asserting this
+    // keeps the test from passing for the unrelated reason the suite above
+    // already covers.
+    expect(body.database.connected).toBe(true);
+    expect(body.nats.requested_transport).toBe("nats");
+    expect(body.nats.availability).toBe("not_runtime_available");
+  });
+
+  it("drains background runtimes on close, after the session boundary", async () => {
+    // The application boundary DECLARES it owns "shutdown ordering", and until
+    // this port existed `close()` closed sessions and nothing else -- so a
+    // maintenance runner composed into this application was never stopped at
+    // all. Order is the assertion, not merely that stop ran: while a session is
+    // live an MCP handler can still enqueue maintenance work, so draining
+    // before sessions close lets a late request refill the queue behind the
+    // drain.
+    const order: string[] = [];
+    const application = createShadowApplication({
+      config: testConfig(),
+      logger: silentLogger(),
+      database: fakeDatabase(),
+      authenticate: bearerAuth(),
+      parseRequestBody: express.json(),
+      serverFactory: () => ({ connect: async () => {} }) as never,
+      backgroundRuntimes: [
+        {
+          name: "maintenance",
+          stop: async () => {
+            order.push("maintenance");
+          },
+        },
+      ],
+    });
+    const originalSessionClose = application.sessions.close.bind(application.sessions);
+    (application.sessions as { close: () => Promise<void> }).close = async () => {
+      order.push("sessions");
+      await originalSessionClose();
+    };
+
+    await application.close();
+
+    expect(order).toEqual(["sessions", "maintenance"]);
+  });
+
+  it("stops every background runtime even when an earlier one throws", async () => {
+    // A shutdown that abandons the remaining runtimes on the first failure
+    // leaks exactly when something is already wrong. The failure is still
+    // surfaced -- a partial shutdown must not read as a clean one.
+    const stopped: string[] = [];
+    const application = createShadowApplication({
+      config: testConfig(),
+      logger: silentLogger(),
+      database: fakeDatabase(),
+      authenticate: bearerAuth(),
+      parseRequestBody: express.json(),
+      serverFactory: () => ({ connect: async () => {} }) as never,
+      backgroundRuntimes: [
+        {
+          name: "broken",
+          stop: async () => {
+            stopped.push("broken");
+            throw new Error("stop failed");
+          },
+        },
+        {
+          name: "maintenance",
+          stop: async () => {
+            stopped.push("maintenance");
+          },
+        },
+      ],
+    });
+
+    await expect(application.close()).rejects.toThrow("stop failed");
+    expect(stopped).toEqual(["broken", "maintenance"]);
+  });
+
   it("requires authentication on every /mcp method", async () => {
     const base = await listen();
     for (const method of ["POST", "GET", "DELETE"]) {

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,6 +7,16 @@
  * here and passed inward as typed data.
  */
 import { z } from "zod";
+import {
+  parseMaintenanceConfig,
+  type MaintenanceConfig,
+} from "./config/maintenance.ts";
+import { parseNatsConfig, type NatsConfig } from "./config/nats.ts";
+
+export type { MaintenanceConfig } from "./config/maintenance.ts";
+export { parseMaintenanceConfig } from "./config/maintenance.ts";
+export type { NatsConfig } from "./config/nats.ts";
+export { natsHealthFromConfig, parseNatsConfig } from "./config/nats.ts";
 
 const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 const ROLE_NAMES = [
@@ -105,6 +115,8 @@ export interface ServerConfig {
     readonly embeddingBaseUrl?: string;
     readonly embeddingApiKey?: string;
   };
+  readonly nats: NatsConfig;
+  readonly maintenance: MaintenanceConfig;
   readonly sharedNamespace: "shared-kb";
 }
 
@@ -187,6 +199,15 @@ function buildConfig(parsed: ParsedEnvironment, userTokens: AuthTokenConfig[]): 
         ? { embeddingApiKey: parsed.EMBEDDING_API_KEY }
         : {}),
     },
+    // The schema's `.catchall` keeps every unlisted key as an optional string,
+    // so the NATS variables survive parsing and this reads them from the SAME
+    // validated object rather than reaching back into `process.env`. That is
+    // the whole point of the config boundary: one env read, at the composition
+    // root, and no module behind it touching global state.
+    nats: parseNatsConfig(parsed as Record<string, string | undefined>),
+    maintenance: parseMaintenanceConfig(
+      parsed as Record<string, string | undefined>,
+    ),
     sharedNamespace: parsed.SHARED_NAMESPACE_CANONICAL,
   };
 }

--- a/server/config/maintenance.test.ts
+++ b/server/config/maintenance.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Maintenance settings at the config boundary.
+ *
+ * Design authority: `src/maintenance-bootstrap.ts` is the behavior being
+ * preserved (`maintenanceQueueEnabled` plus the three optional tuning reads);
+ * `_plans/463-server-rewrite-charter.md` section 3 is why the parsing moves to
+ * `server/config/`. No rule changes here — only ownership.
+ */
+import { describe, expect, it } from "bun:test";
+import { parseMaintenanceConfig } from "./maintenance.ts";
+
+describe("maintenance config boundary", () => {
+  it("is enabled when the variable is absent", () => {
+    // The default has to be ON. The variable is unset in essentially every
+    // environment, so an OFF default would silently stop maintenance fleetwide.
+    expect(parseMaintenanceConfig({}).enabled).toBe(true);
+  });
+
+  it("opts a process out on either recorded off value", () => {
+    for (const value of ["0", "false", "FALSE", " false "]) {
+      expect(
+        parseMaintenanceConfig({ OPEN_BRAIN_MAINTENANCE_ENABLED: value }).enabled,
+      ).toBe(false);
+    }
+  });
+
+  it("treats any other value as enabled rather than guessing", () => {
+    for (const value of ["1", "true", "yes", "no"]) {
+      expect(
+        parseMaintenanceConfig({ OPEN_BRAIN_MAINTENANCE_ENABLED: value }).enabled,
+      ).toBe(true);
+    }
+  });
+
+  it("passes through the optional tuning values when they are usable", () => {
+    const config = parseMaintenanceConfig({
+      OPEN_BRAIN_MAINTENANCE_CONCURRENCY: "4",
+      OPEN_BRAIN_MAINTENANCE_POLL_MS: "1500",
+      OPEN_BRAIN_MAINTENANCE_LEASE_MS: "45000",
+    });
+    expect(config.concurrency).toBe(4);
+    expect(config.pollIntervalMs).toBe(1_500);
+    expect(config.leaseMs).toBe(45_000);
+  });
+
+  it("omits an unusable tuning value so the runner's own default applies", () => {
+    // Absent, not zero, and not a startup failure. These are optional knobs;
+    // the current behavior is that a bad value falls back to the runner default
+    // and the process still starts.
+    const config = parseMaintenanceConfig({
+      OPEN_BRAIN_MAINTENANCE_CONCURRENCY: "0",
+      OPEN_BRAIN_MAINTENANCE_POLL_MS: "not-a-number",
+      OPEN_BRAIN_MAINTENANCE_LEASE_MS: "  ",
+    });
+    expect(config).not.toHaveProperty("concurrency");
+    expect(config).not.toHaveProperty("pollIntervalMs");
+    expect(config).not.toHaveProperty("leaseMs");
+  });
+
+  it("omits a negative value rather than passing it to the runner", () => {
+    expect(
+      parseMaintenanceConfig({ OPEN_BRAIN_MAINTENANCE_CONCURRENCY: "-2" }),
+    ).not.toHaveProperty("concurrency");
+  });
+});

--- a/server/config/maintenance.ts
+++ b/server/config/maintenance.ts
@@ -1,0 +1,71 @@
+/**
+ * Maintenance queue runtime settings, owned by the config layer.
+ *
+ * Design authority: `_plans/463-server-rewrite-charter.md` section 3 puts ALL
+ * env parsing in `server/config/`. The behavior preserved is
+ * `src/maintenance-bootstrap.ts`'s `maintenanceQueueEnabled` and the three
+ * `envPositiveInt` reads that feed `MaintenanceQueueRunner`.
+ *
+ * SCOPE. This module owns the SETTINGS ONLY. The queue, the runner, and the
+ * handler map stay where they are: the runner's stop path is a DRAIN with a
+ * lease-boundary rule that took a review swarm to get right
+ * (`docs/sme/domain-backend.md`, PR #350 / issue #343 -- a stop observed
+ * between a claim committing its leases and those jobs being tracked abandons
+ * leased rows until lease expiry). Reimplementing that here to "complete the
+ * rewrite" would fork the one component whose failure mode is invisible: rows
+ * sit `running` with a live lease and nothing errors.
+ *
+ * ENABLED BY DEFAULT. `OPEN_BRAIN_MAINTENANCE_ENABLED=0`/`false` opts a process
+ * out, so a worker that must not poll can be configured rather than patched.
+ * Absent means ON, matching current behavior -- the inverse default would
+ * silently stop maintenance everywhere the variable is unset, which is
+ * everywhere.
+ */
+
+export interface MaintenanceConfig {
+  readonly enabled: boolean;
+  /**
+   * Absent means "the runner's own default", not zero. These are deliberately
+   * `undefined` rather than defaulted here so one owner keeps the defaults:
+   * duplicating them would let config and runner disagree, and the runner would
+   * silently win.
+   */
+  readonly concurrency?: number;
+  readonly pollIntervalMs?: number;
+  readonly leaseMs?: number;
+}
+
+type Environment = Record<string, string | undefined>;
+
+/**
+ * Read a positive integer, or `undefined` when unset, blank, or unusable.
+ *
+ * A non-numeric or non-positive value reads as absent rather than throwing,
+ * which is the current behavior: the runner then applies its own default and
+ * the process still starts. Failing startup on a typo in an optional tuning
+ * knob would be a behavior change this rewrite is not authorized to make.
+ */
+function positiveInteger(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim() === "") return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function parseMaintenanceConfig(
+  environment: Environment,
+): MaintenanceConfig {
+  const raw = environment.OPEN_BRAIN_MAINTENANCE_ENABLED?.trim().toLowerCase();
+  const concurrency = positiveInteger(
+    environment.OPEN_BRAIN_MAINTENANCE_CONCURRENCY,
+  );
+  const pollIntervalMs = positiveInteger(
+    environment.OPEN_BRAIN_MAINTENANCE_POLL_MS,
+  );
+  const leaseMs = positiveInteger(environment.OPEN_BRAIN_MAINTENANCE_LEASE_MS);
+  return {
+    enabled: raw !== "0" && raw !== "false",
+    ...(concurrency !== undefined ? { concurrency } : {}),
+    ...(pollIntervalMs !== undefined ? { pollIntervalMs } : {}),
+    ...(leaseMs !== undefined ? { leaseMs } : {}),
+  };
+}

--- a/server/config/nats.test.ts
+++ b/server/config/nats.test.ts
@@ -1,0 +1,138 @@
+/**
+ * NATS runtime boundary, at the config layer.
+ *
+ * Design authority: `docs/nats-jetstream-foundation.md` ("Python Client
+ * Status") is the rule set being preserved -- NATS is opt-in and advertises
+ * availability only when explicitly enabled; HTTP workers keep
+ * `OPENBRAIN_TRANSPORT=http` with the bridge off even on a host that has a
+ * local broker; and a remote plaintext `nats://` URL is NOT runtime-available
+ * unless the explicit lab override is set. `_plans/463-server-rewrite-charter.md`
+ * section 3 moves the DERIVATION of that rule set into `server/config/`, which
+ * is the only delta: the rules themselves are unchanged from
+ * `src/nats-runtime.ts`.
+ *
+ * The one addition is `unavailableReason`. Availability alone collapses "the
+ * operator did not ask for NATS" and "the operator asked and the broker URL is
+ * a typo" into the same silent `not_runtime_available`, which is exactly the
+ * indistinguishability the src implementation logs a warning about.
+ */
+import { describe, expect, it } from "bun:test";
+import { natsHealthFromConfig, parseNatsConfig } from "./nats.ts";
+
+const NATS_ON = {
+  OPENBRAIN_TRANSPORT: "nats",
+  OPENBRAIN_NATS_ENABLE_BRIDGE: "true",
+  OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+};
+
+describe("nats config boundary", () => {
+  it("defaults an HTTP worker to http transport with the bridge unavailable", () => {
+    const config = parseNatsConfig({});
+    expect(config.requestedTransport).toBe("http");
+    expect(config.availability).toBe("not_runtime_available");
+    expect(config.unavailableReason).toBe("transport_not_requested");
+    expect(config.fallbackTransport).toBe("http_mcp");
+    // Fallback to HTTP/MCP is the default and must stay on unless switched off.
+    expect(config.fallbackHttp).toBe(true);
+  });
+
+  it("reports available only when transport, bridge, and a local url all agree", () => {
+    const config = parseNatsConfig(NATS_ON);
+    expect(config.availability).toBe("available");
+    expect(config.unavailableReason).toBeNull();
+  });
+
+  it("keeps the bridge unavailable on an http worker that has a local broker", () => {
+    // The design doc requires exactly this: an HTTP worker on a host that also
+    // runs a broker and a NATS worker still advertises nothing.
+    const config = parseNatsConfig({
+      ...NATS_ON,
+      OPENBRAIN_TRANSPORT: "http",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+    });
+    expect(config.availability).toBe("not_runtime_available");
+    expect(config.unavailableReason).toBe("transport_not_requested");
+  });
+
+  it("names a disabled bridge separately from an unrequested transport", () => {
+    const config = parseNatsConfig({
+      ...NATS_ON,
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+    });
+    expect(config.unavailableReason).toBe("bridge_disabled");
+  });
+
+  it("refuses a remote plaintext broker url by default", () => {
+    const config = parseNatsConfig({
+      ...NATS_ON,
+      OPENBRAIN_NATS_URL: "nats://10.71.1.99:4222",
+    });
+    expect(config.availability).toBe("not_runtime_available");
+    expect(config.unavailableReason).toBe("url_remote_not_allowed");
+  });
+
+  it("allows a remote broker url only under the explicit lab override", () => {
+    const config = parseNatsConfig({
+      ...NATS_ON,
+      OPENBRAIN_NATS_URL: "nats://10.71.1.99:4222",
+      OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE: "true",
+    });
+    expect(config.availability).toBe("available");
+    expect(config.unavailableReason).toBeNull();
+  });
+
+  it("fails closed on an unparseable url and says so", () => {
+    // The distinguishing case. Before `unavailableReason`, a typo here was
+    // indistinguishable from a deliberate configuration choice, so an operator
+    // debugging a silent bridge had no signal pointing at the URL.
+    const config = parseNatsConfig({ ...NATS_ON, OPENBRAIN_NATS_URL: "not a url" });
+    expect(config.availability).toBe("not_runtime_available");
+    expect(config.unavailableReason).toBe("url_unparseable");
+  });
+
+  it("forces the namespace override off whenever auth is required", () => {
+    // Mutually exclusive by design: the override is a local-trust affordance,
+    // so an authenticated caller must not additionally be able to name any
+    // namespace it likes.
+    const config = parseNatsConfig({
+      ...NATS_ON,
+      OPENBRAIN_NATS_REQUIRE_AUTH: "true",
+      OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE: "true",
+    });
+    expect(config.requireAuth).toBe(true);
+    expect(config.allowNamespaceOverride).toBe(false);
+  });
+
+  it("resolves the env-prefixed subject and honors the explicit override", () => {
+    expect(parseNatsConfig({}).contextPackSubject).toBe("dev.ob.memory.context_pack");
+    expect(parseNatsConfig({ OPENBRAIN_NATS_ENV: "prod" }).contextPackSubject).toBe(
+      "prod.ob.memory.context_pack",
+    );
+    expect(
+      parseNatsConfig({ OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT: "ob.custom" })
+        .contextPackSubject,
+    ).toBe("ob.custom");
+  });
+
+  it("never puts the broker url into the health projection", () => {
+    // `/health` is unauthenticated and the broker url may carry credentials.
+    const config = parseNatsConfig({
+      ...NATS_ON,
+      OPENBRAIN_NATS_URL: "nats://user:secret@127.0.0.1:4222",
+    });
+    const health = natsHealthFromConfig(config);
+    const serialized = JSON.stringify(health);
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("user");
+    expect(health.requested_transport).toBe("nats");
+  });
+
+  it("redacts a live bridge error rather than reporting it", () => {
+    const health = natsHealthFromConfig(parseNatsConfig(NATS_ON), {
+      consecutiveFailures: 3,
+      lastError: true,
+    });
+    expect(health.consecutive_failures).toBe(3);
+    expect(health.last_error).toBe("redacted");
+  });
+});

--- a/server/config/nats.ts
+++ b/server/config/nats.ts
@@ -1,0 +1,186 @@
+/**
+ * NATS runtime boundary, owned by the config layer.
+ *
+ * Design authority: `_plans/463-server-rewrite-charter.md` section 3 —
+ * `server/config/` owns ALL env parsing and startup validation, replacing the
+ * 18 scattered `process.env` readers the charter counts in `src/`. The behavior
+ * being preserved is `src/nats-runtime.ts`'s `readNatsRuntimeBoundary`, and the
+ * `/health` `nats` block it feeds (`src/index.ts` health payload), both frozen
+ * by the charter's `/health` row.
+ *
+ * WHY THIS IS CONFIG AND NOT TRANSPORT. Everything here is a decision about the
+ * ENVIRONMENT: which transport was requested, whether a bridge was enabled,
+ * whether the broker URL is one this process may talk to. None of it needs a
+ * socket, and `server/transport/health.ts` already takes the answer through its
+ * `natsHealth` port rather than deriving it. Putting the derivation here is what
+ * lets health stay a pure reporter — the charter's stated reason for the config
+ * boundary existing at all.
+ *
+ * THE URL RULE IS A SECURITY RULE, NOT A CONVENIENCE. NATS here is a
+ * plaintext, possibly auth-bearing transport, so the runtime is available only
+ * for a LOCAL broker unless an explicit remote override is set, and an
+ * UNPARSEABLE url fails closed rather than being treated as local
+ * (`docs/sme/security.md` records this). An unparseable URL and a deliberately
+ * remote one produce the same `not_runtime_available`, so the reason is reported
+ * separately rather than being inferred from the availability alone — a typo in
+ * the broker URL used to be indistinguishable from a configuration choice.
+ */
+import { obContextPackSubject } from "../../src/nats-subjects.ts";
+
+/** Hosts treated as a local broker for the plaintext-transport rule. */
+const LOCAL_NATS_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+const DEFAULT_NATS_ENV = "dev";
+
+export type NatsAvailability = "available" | "not_runtime_available";
+
+/**
+ * Why the runtime is not available, when it is not.
+ *
+ * `null` when it IS available. This is the field that separates "the operator
+ * did not ask for NATS" from "the operator asked and the broker URL is a typo",
+ * which the availability flag alone collapses into one silent answer.
+ */
+export type NatsUnavailableReason =
+  | "transport_not_requested"
+  | "bridge_disabled"
+  | "url_missing"
+  | "url_unparseable"
+  | "url_remote_not_allowed"
+  | null;
+
+export interface NatsConfig {
+  readonly requestedTransport: "http" | "nats";
+  readonly fallbackTransport: "http_mcp";
+  readonly availability: NatsAvailability;
+  readonly unavailableReason: NatsUnavailableReason;
+  /** Never logged and never emitted in `/health`; it may carry credentials. */
+  readonly url: string | null;
+  readonly contextPackSubject: string;
+  readonly fallbackHttp: boolean;
+  readonly requireAuth: boolean;
+  readonly allowNamespaceOverride: boolean;
+}
+
+type Environment = Record<string, string | undefined>;
+
+function readEnv(value: string | undefined): string | null {
+  const cleaned = value?.trim();
+  return cleaned ? cleaned : null;
+}
+
+function isTrue(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+/**
+ * Decide whether the configured broker URL may be used by this runtime.
+ *
+ * Returns the failure REASON rather than a boolean so the caller can report
+ * which of the three distinct situations occurred. Fails closed on a parse
+ * error: the URL may carry credentials, so it is never included in the answer.
+ */
+function urlAvailability(
+  url: string | null,
+  environment: Environment,
+): Exclude<NatsUnavailableReason, "transport_not_requested" | "bridge_disabled"> {
+  if (!url) return "url_missing";
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return "url_unparseable";
+  }
+  if (LOCAL_NATS_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+  return isTrue(environment.OPENBRAIN_NATS_ALLOW_INSECURE_REMOTE)
+    ? null
+    : "url_remote_not_allowed";
+}
+
+/**
+ * Resolve the env-prefixed context-pack subject, or the explicit override.
+ *
+ * The subject is reported in `/health` even when the runtime is unavailable,
+ * because it tells an operator which lane the bridge WOULD use — which is the
+ * question being asked when the bridge is not working.
+ */
+export function resolveContextPackSubject(environment: Environment): string {
+  const override = readEnv(environment.OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT);
+  if (override) return override;
+  return obContextPackSubject(
+    readEnv(environment.OPENBRAIN_NATS_ENV) ?? DEFAULT_NATS_ENV,
+  );
+}
+
+/** Derive the whole NATS boundary from an explicit environment-shaped input. */
+export function parseNatsConfig(environment: Environment): NatsConfig {
+  const requestedTransport =
+    environment.OPENBRAIN_TRANSPORT?.trim().toLowerCase() === "nats"
+      ? "nats"
+      : "http";
+  const url = readEnv(environment.OPENBRAIN_NATS_URL);
+  const bridgeEnabled = isTrue(environment.OPENBRAIN_NATS_ENABLE_BRIDGE);
+
+  // Auth is OFF by default (trusted local bus). When REQUIRE_AUTH is set the
+  // bearer gate is re-enabled AND the namespace override is force-disabled:
+  // they are mutually exclusive, because the override is a local-trust
+  // affordance and an authenticated caller must not also be able to name any
+  // namespace it likes.
+  const requireAuth = isTrue(environment.OPENBRAIN_NATS_REQUIRE_AUTH);
+  const allowNamespaceOverride =
+    !requireAuth &&
+    environment.OPENBRAIN_NATS_ALLOW_NAMESPACE_OVERRIDE?.trim().toLowerCase() !==
+      "false";
+
+  // Order matters and is the reported reason: not requested beats disabled
+  // beats a URL problem, so an operator is told the FIRST thing to fix rather
+  // than a downstream symptom of a switch that was never turned on.
+  const unavailableReason: NatsUnavailableReason =
+    requestedTransport !== "nats"
+      ? "transport_not_requested"
+      : !bridgeEnabled
+        ? "bridge_disabled"
+        : urlAvailability(url, environment);
+
+  return {
+    requestedTransport,
+    fallbackTransport: "http_mcp",
+    availability: unavailableReason === null ? "available" : "not_runtime_available",
+    unavailableReason,
+    url,
+    contextPackSubject: resolveContextPackSubject(environment),
+    fallbackHttp:
+      environment.OPENBRAIN_NATS_FALLBACK_HTTP?.trim().toLowerCase() !== "false",
+    requireAuth,
+    allowNamespaceOverride,
+  };
+}
+
+/**
+ * Project the config onto the frozen `/health` `nats` block.
+ *
+ * The URL is deliberately absent and `last_error` is the literal `"redacted"`
+ * or `null`: `/health` is unauthenticated, and the broker URL may carry
+ * credentials. `consecutive_failures` comes from a live bridge, so it is a
+ * parameter rather than something config could know.
+ */
+export function natsHealthFromConfig(
+  config: NatsConfig,
+  live: { consecutiveFailures?: number; lastError?: boolean } = {},
+): {
+  requested_transport: "http" | "nats";
+  availability: NatsAvailability;
+  context_pack_subject: string;
+  fallback_http: boolean;
+  consecutive_failures: number;
+  last_error: "redacted" | null;
+} {
+  return {
+    requested_transport: config.requestedTransport,
+    availability: config.availability,
+    context_pack_subject: config.contextPackSubject,
+    fallback_http: config.fallbackHttp,
+    consecutive_failures: live.consecutiveFailures ?? 0,
+    last_error: live.lastError ? "redacted" : null,
+  };
+}

--- a/server/tools/agent-context-pack.ts
+++ b/server/tools/agent-context-pack.ts
@@ -33,12 +33,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AuthIdentity } from "../auth/types.ts";
 import { canRead } from "../auth/permissions.ts";
+import type { RecoveryWalContextPackFragment } from "../realtime/recovery-wal.ts";
 import {
-  RecoveryWalStore,
-  type RecoveryWalContextPackFragment,
-} from "../realtime/recovery-wal.ts";
-import {
-  WorkingSetStore,
   normalizeWorkingSetScope,
   type WorkingSetContextPackFragment,
   type WorkingSetScope,
@@ -83,6 +79,7 @@ import {
 import { loadRepoFactsSection } from "./context-pack-repo-facts.ts";
 import type { SectionFragment } from "./context-pack-sections.ts";
 import { canReadNamespace } from "./read-scope.ts";
+import { recoveryWalStoreFor, workingSetStoreFor } from "./realtime-stores.ts";
 import { physicalNamespace } from "./shared-namespace.ts";
 import { authIdentity, errorResult, textResult } from "./types.ts";
 import type { MemoryToolDependencies } from "./types.ts";
@@ -93,39 +90,6 @@ export { CONTEXT_PACK_SECTION_PRIORITY };
 export interface AgentContextPackBuildResult {
   payload: unknown;
   isError: boolean;
-}
-
-/**
- * Process-lifetime store fallbacks.
- *
- * When a composition root registers no realtime stores, the pack still has to
- * emit its defined `working_set`/`recovery` envelopes. These module-level
- * defaults give it stable, empty ones. They are module-scoped rather than
- * per-call for the same reason the injected stores exist: a store rebuilt on
- * every request reports a permanent zero that looks exactly like real emptiness.
- */
-let fallbackWorkingSetStore: WorkingSetStore | undefined;
-let fallbackRecoveryWalStore: RecoveryWalStore | undefined;
-
-function workingSetStoreFor(
-  dependencies: MemoryToolDependencies,
-): WorkingSetStore {
-  if (dependencies.workingSetStore) return dependencies.workingSetStore;
-  fallbackWorkingSetStore ??= new WorkingSetStore({
-    logger: dependencies.logger,
-  });
-  return fallbackWorkingSetStore;
-}
-
-function recoveryWalStoreFor(
-  dependencies: MemoryToolDependencies,
-): RecoveryWalStore {
-  if (dependencies.recoveryWalStore) return dependencies.recoveryWalStore;
-  fallbackRecoveryWalStore ??= new RecoveryWalStore({
-    walPath: process.env.OPENBRAIN_RECOVERY_WAL_PATH ?? null,
-    logger: dependencies.logger,
-  });
-  return fallbackRecoveryWalStore;
 }
 
 export async function buildAgentContextPackPayload(

--- a/server/tools/index.ts
+++ b/server/tools/index.ts
@@ -18,6 +18,7 @@ import { registerListRecentTool } from "./list-recent.ts";
 import { registerOperatorDoctorTool } from "./operator-doctor.ts";
 import { registerPeopleTools } from "./people.ts";
 import { registerPromotionTools } from "./promotion.ts";
+import { registerRealtimeAppendTools } from "./realtime-append.ts";
 import { registerReportingTools } from "./reporting.ts";
 import { registerRepoFactTools } from "./repo-facts.ts";
 import { registerResolveEntryTool } from "./resolve-entry.ts";
@@ -75,6 +76,12 @@ export function registerMemoryTools(
   // `agent_context_pack`, not a second implementation of it.
   registerAgentContextPackTool(server, dependencies);
   registerAgentReflexPointersTool(server, dependencies);
+  // The realtime WRITE half. It registers alongside the pack deliberately: both
+  // halves resolve their stores through `realtime-stores.ts`, so an append and
+  // the `working_set`/`recovery` sections that read it always address one
+  // object. Registering the writes without the pack would accept content
+  // nothing could ever read back.
+  registerRealtimeAppendTools(server, dependencies);
   // Service-metadata surfaces. Neither is namespaced memory: `get_contract`
   // reports what this server promises downstream clients, `operator_doctor`
   // reports how the deployment is doing, and both reuse the single existing

--- a/server/tools/realtime-append.ts
+++ b/server/tools/realtime-append.ts
@@ -1,0 +1,291 @@
+/**
+ * `working_set_append`, `recovery_wal_append`, `recovery_wal_mark` — the write
+ * half of the realtime surface.
+ *
+ * Design authority: the same one the stores already cite —
+ * `docs/decisions/realtime-working-set.md`, recorded as observed behavior in
+ * `contracts/server/server-realtime-working-recovery.fixture.json`.
+ *
+ * These three tools are ADAPTERS AND NOTHING ELSE. Every rule about what may be
+ * appended, how long it lives, when it is trimmed, and what a near-miss scope is
+ * allowed to reveal already lives in `server/realtime/working-set.ts` and
+ * `server/realtime/recovery-wal.ts`, which the read half
+ * (`agent_context_pack`'s `working_set` and `recovery` sections) has been going
+ * through since it was written. Re-deciding any of that here would give the
+ * write path a second opinion about a store the read path already governs, and
+ * the two would drift in exactly the place where drift is invisible: RAM state
+ * nothing persists and no migration would catch.
+ *
+ * So the adapter owns three things only — the MCP schema, the authorization
+ * gate, and the response envelope — and the store owns the rest. In particular
+ * `isError` is `!result.accepted`: a rejected append is a real error to the
+ * caller, and a `not_found` mark is the fixture's recorded error case rather
+ * than a silent no-op.
+ *
+ * The stores are taken from `dependencies`, never constructed here. They are
+ * process-lifetime state; a store built inside a handler would accept a write
+ * into an object the next request cannot see, and the append would report
+ * success for content that had already ceased to exist.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  RECOVERY_WAL_ACTIONS,
+  RECOVERY_WAL_STATUSES,
+} from "../realtime/recovery-wal.ts";
+import {
+  WORKING_SET_ITEM_KINDS,
+  type WorkingSetScope,
+} from "../realtime/working-set.ts";
+import { scopeInputSchema } from "./context-pack-args.ts";
+import { recoveryWalStoreFor, workingSetStoreFor } from "./realtime-stores.ts";
+import { authorize } from "./memory-helpers.ts";
+import { authIdentity, type MemoryToolDependencies } from "./types.ts";
+
+/**
+ * Arguments carrying the seven scope coordinates, as `scopeInputSchema` parses
+ * them. `namespace` is excluded: the scope's namespace is the AUTHORIZED one,
+ * not the requested one, so the caller-supplied value is consumed by the
+ * permission gate and never reaches the store.
+ */
+interface ScopeArguments {
+  readonly agent: string;
+  readonly platform: string;
+  readonly server_id: string;
+  readonly channel_id: string;
+  readonly thread_id?: string | undefined;
+  readonly session_key: string;
+}
+
+/**
+ * Build the store scope from the AUTHORIZED namespace plus the caller's six
+ * remaining coordinates.
+ *
+ * The namespace argument is the one `authorize()` returned, not `args.namespace`.
+ * Passing the requested value would let a caller name a namespace it was denied
+ * and still land the write in it — the check would have run and changed nothing,
+ * which is the failure mode namespace isolation exists to prevent.
+ */
+function storeScope(namespace: string, args: ScopeArguments): WorkingSetScope {
+  return {
+    namespace,
+    agent: args.agent,
+    platform: args.platform,
+    server_id: args.server_id,
+    channel_id: args.channel_id,
+    thread_id: args.thread_id ?? null,
+    session_key: args.session_key,
+  };
+}
+
+/** Emit a store result as the recorded JSON envelope, error-flagged on rejection. */
+function realtimeResult(
+  payload: Record<string, unknown>,
+  accepted: boolean,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
+} {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+    isError: !accepted,
+  };
+}
+
+export function registerRealtimeAppendTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "working_set_append",
+    {
+      description:
+        "Append one RAM-only scoped working-set item for the exact active " +
+        "namespace/agent/platform/server/channel/thread/session. This does " +
+        "not write durable memory or shared-kb.",
+      inputSchema: {
+        ...scopeInputSchema,
+        kind: z.enum(WORKING_SET_ITEM_KINDS).describe("Working-set item kind"),
+        content: z
+          .string()
+          .min(1)
+          .max(4000)
+          .describe("Bounded working context content, not durable memory"),
+        confidence: z.number().min(0).max(1).optional(),
+        stale_at: z.string().max(100).optional(),
+        trace_id: z.string().max(500).optional(),
+        source_ref: z.string().max(1000).optional(),
+        durable_ref: z
+          .object({
+            table: z.string().min(1).max(100),
+            id: z.string().min(1).max(200),
+          })
+          .optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      },
+      annotations: {
+        title: "Working Set Append",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args, extra) => {
+      const auth = authorize(
+        authIdentity(extra.authInfo),
+        "write",
+        "sessions",
+        "cannot write working set",
+        args.namespace,
+      );
+      if (!auth.ok) return auth.response;
+
+      const result = workingSetStoreFor(dependencies).append(
+        storeScope(auth.namespace, args),
+        {
+          kind: args.kind,
+          content: args.content,
+          confidence: args.confidence,
+          stale_at: args.stale_at ?? null,
+          trace_id: args.trace_id ?? null,
+          source_ref: args.source_ref ?? null,
+          durable_ref: args.durable_ref ?? null,
+          metadata: args.metadata,
+        },
+      );
+
+      return realtimeResult(
+        {
+          accepted: result.accepted,
+          reason: result.reason ?? null,
+          item: result.item ?? null,
+          counters: result.counters,
+          not_durable_memory: true,
+        },
+        result.accepted,
+      );
+    },
+  );
+
+  server.registerTool(
+    "recovery_wal_append",
+    {
+      description:
+        "Append one quarantined recovery WAL record for the exact active " +
+        "namespace/agent/platform/server/channel/thread/session. Recovery " +
+        "records are unreviewed, not durable memory, and not searchable recall.",
+      inputSchema: {
+        ...scopeInputSchema,
+        content: z
+          .string()
+          .min(1)
+          .max(8000)
+          .describe("Bounded quarantined recovery content, not durable memory"),
+        status: z.enum(RECOVERY_WAL_STATUSES).optional(),
+        trace_id: z.string().max(500).optional(),
+        source_ref: z.string().max(1000).optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      },
+      annotations: {
+        title: "Recovery WAL Append",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    async (args, extra) => {
+      const auth = authorize(
+        authIdentity(extra.authInfo),
+        "write",
+        "sessions",
+        "cannot write recovery WAL",
+        args.namespace,
+      );
+      if (!auth.ok) return auth.response;
+
+      const result = recoveryWalStoreFor(dependencies).append(
+        storeScope(auth.namespace, args),
+        {
+          content: args.content,
+          status: args.status,
+          trace_id: args.trace_id ?? null,
+          source_ref: args.source_ref ?? null,
+          metadata: args.metadata,
+        },
+      );
+
+      return realtimeResult(
+        {
+          accepted: result.accepted,
+          reason: result.reason ?? null,
+          item: result.item ?? null,
+          counters: result.counters,
+          not_durable_memory: true,
+          not_searchable_recall: true,
+          unreviewed_quarantine: true,
+        },
+        result.accepted,
+      );
+    },
+  );
+
+  server.registerTool(
+    "recovery_wal_mark",
+    {
+      description:
+        "Mark or purge one exact-scope quarantined recovery WAL record after " +
+        "review. This never promotes recovery content into durable memory.",
+      inputSchema: {
+        ...scopeInputSchema,
+        id: z.string().min(1).max(200),
+        action: z.enum(RECOVERY_WAL_ACTIONS),
+        status: z.enum(RECOVERY_WAL_STATUSES),
+        purge: z
+          .boolean()
+          .optional()
+          .describe("When true, remove the exact recovery record after review"),
+      },
+      annotations: {
+        title: "Recovery WAL Mark",
+        readOnlyHint: false,
+        // A purge deletes a record outright, so the whole tool is annotated
+        // destructive even though `purge` defaults false: the hint describes
+        // what the tool CAN do, and a client that gates destructive calls must
+        // gate this one before it learns which argument was sent.
+        destructiveHint: true,
+        idempotentHint: false,
+      },
+    },
+    async (args, extra) => {
+      const auth = authorize(
+        authIdentity(extra.authInfo),
+        "write",
+        "sessions",
+        "cannot mark recovery WAL",
+        args.namespace,
+      );
+      if (!auth.ok) return auth.response;
+
+      const result = recoveryWalStoreFor(dependencies).mark(
+        storeScope(auth.namespace, args),
+        args.id,
+        args.action,
+        args.status,
+        { purge: args.purge ?? false },
+      );
+
+      return realtimeResult(
+        {
+          accepted: result.accepted,
+          reason: result.reason ?? null,
+          item: result.item ?? null,
+          purged: result.purged ?? false,
+          counters: result.counters,
+          not_durable_memory: true,
+          not_searchable_recall: true,
+        },
+        result.accepted,
+      );
+    },
+  );
+}

--- a/server/tools/realtime-stores.ts
+++ b/server/tools/realtime-stores.ts
@@ -1,0 +1,50 @@
+/**
+ * The single resolution point for the two process-lifetime realtime stores.
+ *
+ * Design authority: `docs/decisions/realtime-working-set.md` (RAM-only working
+ * context) as exercised by
+ * `contracts/server/server-realtime-working-recovery.fixture.json` and
+ * `contracts/server/server-context-pack-sections.fixture.json`.
+ *
+ * This module exists because the realtime surface has TWO halves that must see
+ * the SAME object: `working_set_append`/`recovery_wal_append`/`recovery_wal_mark`
+ * write, and `agent_context_pack`'s `working_set`/`recovery` sections read. When
+ * a composition root injects no store, each half needs a fallback — and if each
+ * half owned its own fallback, an append would land in one map while the pack
+ * read an empty one, and the pack would report a permanent, entirely convincing
+ * zero for content that was accepted moments earlier. Nothing persists this
+ * state, so no database check would ever contradict the wrong answer.
+ *
+ * The fallbacks are therefore MODULE-scoped and shared, for the same reason the
+ * injected stores are process-lifetime: a store rebuilt per call is empty on
+ * every request.
+ */
+import { RecoveryWalStore } from "../realtime/recovery-wal.ts";
+import { WorkingSetStore } from "../realtime/working-set.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+
+let fallbackWorkingSetStore: WorkingSetStore | undefined;
+let fallbackRecoveryWalStore: RecoveryWalStore | undefined;
+
+/** The injected working-set store, or the shared process-lifetime fallback. */
+export function workingSetStoreFor(
+  dependencies: MemoryToolDependencies,
+): WorkingSetStore {
+  if (dependencies.workingSetStore) return dependencies.workingSetStore;
+  fallbackWorkingSetStore ??= new WorkingSetStore({
+    logger: dependencies.logger,
+  });
+  return fallbackWorkingSetStore;
+}
+
+/** The injected recovery WAL store, or the shared process-lifetime fallback. */
+export function recoveryWalStoreFor(
+  dependencies: MemoryToolDependencies,
+): RecoveryWalStore {
+  if (dependencies.recoveryWalStore) return dependencies.recoveryWalStore;
+  fallbackRecoveryWalStore ??= new RecoveryWalStore({
+    walPath: process.env.OPENBRAIN_RECOVERY_WAL_PATH ?? null,
+    logger: dependencies.logger,
+  });
+  return fallbackRecoveryWalStore;
+}


### PR DESCRIPTION
Closes the Phase 5 remainder of `_plans/463-server-rewrite-charter.md` (lines 162-166). Stacked on #491.

## What #491 left open

PR #491 proved session lifecycle, capture, search, and `agent_context_pack` over the real MCP SDK and real HTTP. It explicitly did **not** cover five things, and the charter's Phase 5 gate names each of them: NATS wiring, the maintenance loop, health under the two-worker front, hook-consumer gates, and the realtime working/recovery append tools that were scaffold-declared in `server/realtime/`.

Each is closed here at the boundary the charter assigns it, not wherever it was easiest to bolt on.

## 1. The realtime append tools

`working_set_append`, `recovery_wal_append`, and `recovery_wal_mark` were the last three fixture-covered tools the rewrite could not answer. The situation was lopsided rather than empty: `server/realtime/working-set.ts` and `recovery-wal.ts` were fully implemented and `agent_context_pack` had been READING them since they were written — but nothing could write, so `contracts/server/server-realtime-working-recovery.fixture.json` was proven against `current-src` alone and marked `scaffold-declared` for the rewrite provider.

`server/tools/realtime-append.ts` adds the three adapters. They own exactly three things — the MCP schema, the authorization gate, and the response envelope — and nothing else. Every rule about what may be appended, how long it lives, when it is trimmed, and what a near-miss scope may reveal stays in the stores, because the read half already goes through them and a second opinion would drift precisely where drift is invisible: RAM state nothing persists and no migration would catch.

The store resolution moved out of `agent-context-pack.ts` into `server/tools/realtime-stores.ts` so both halves address **one** object. This is the load-bearing part. Had each half kept its own fallback, an append would land in one map while the pack read another, the append would still answer `accepted: true`, and the content would be invisible forever — with nothing durable to ever contradict it.

`realtime-working-recovery` is now `implemented` for `server-rewrite-scaffold`, and contract parity rises from 69/69 to **70/70**, with the rewrite provider's share going 31 → 32.

## 2. NATS

Per charter section 3 (`server/config/` owns all env parsing, replacing the 18 scattered readers), `server/config/nats.ts` takes over the derivation currently in `src/nats-runtime.ts`. The rules are preserved verbatim from that module and from `docs/nats-jetstream-foundation.md` (lines 255-292): NATS is opt-in, the bridge must be explicitly enabled, a remote plaintext `nats://` broker is refused without the explicit lab override, and an unparseable URL fails closed.

The one addition is `unavailableReason`. Availability alone collapsed "the operator did not ask for NATS" and "the operator asked and the broker URL is a typo" into the same silent `not_runtime_available` — which is the exact indistinguishability the src implementation logs a warning about.

The wiring change matters more than the move. `server/transport/health.ts` has always had a `natsHealth` port, and **nothing supplied it**, so the `nats` block in every composed-app health response was a hardcoded `http`/`available` literal and the degraded branch was unreachable. The application now defaults that port from the parsed config, so a worker configured `OPENBRAIN_TRANSPORT=nats` with a broken bridge correctly reports 503/degraded instead of `healthy` on the strength of a constant. An explicit `natsHealth` still wins, because a live bridge knows its own failure counters and config cannot.

## 3. Maintenance

`server/config/maintenance.ts` owns the four env reads (`maintenanceQueueEnabled` plus the three optional tuning values), with the enabled-by-default behavior preserved — the variable is unset nearly everywhere, so an off default would silently stop maintenance fleetwide.

The application boundary declared it owns "startup ordering, shutdown ordering" while `close()` closed sessions and nothing else, so a maintenance runner composed into it was never stopped. `close()` now drains a `backgroundRuntimes` port in dependency order: sessions first (while a session is live an MCP handler can still enqueue work, so draining first lets a late request refill the queue behind the drain), then each runtime, with every runtime stopped even when an earlier one throws and the first failure rethrown so a partial shutdown cannot read as a clean one.

**The queue and runner internals are deliberately not ported.** The runner's `stop()` is not a cancel but a drain with a lease-boundary rule that took a review swarm to get right (`docs/sme/domain-backend.md`, PR #350 / issue #343: a stop observed between a claim committing its leases and those jobs being tracked abandons leased rows until lease expiry). Reimplementing it here to "finish the rewrite" would fork the one component whose failure mode is silent.

## 4. Health under the two-worker front

`server/transport/worker-proxy.test.ts` proves the aggregation logic, but only against an injected `fetch` returning a hand-written `{ status }` object. So the thing it never checks is the thing the charter freezes in section 1.5: that a **real** single-worker `/health` payload survives nesting in the aggregate `workers` array.

The SDK-protocol suite now binds two real ephemeral listeners behind a real front and asserts each nested body is a genuine single-worker payload. A second test proves session affinity over a real SDK handshake — sessions live in a process-local map per worker, so a follow-up routed to the other worker finds nothing.

This is provable locally and was proven locally; it needs no core01 access, because what is under test is the front's routing and nesting, not core01's specific deployment.

## 5. Hook-consumer gates

The charter records the hook-consumer list as **UNVERIFIED as a complete list**. Resolved by census rather than left open: all nine hook events (`SessionStart`, `SessionEnd`, `PreCompact`, `PostCompact`, `SubagentStop`, `UserPromptSubmit`, `Stop`, `PreToolUse`, `PostToolUse`) appear in `python/openbrain/tests/`, and the suite is **302 passed**. This PR changes no Python, so the gate is green and unaffected rather than newly proven.

## Red-proven

Per `_DOCS/STANDARDS-testing.md`, each of the six new behaviors was mutated individually and observed failing:

| Mutation | Result |
|---|---|
| `recovery_wal_mark` never reports `isError` | realtime fixture test fails |
| `working_set_append` builds a per-call store | store-join test fails |
| aggregate nested `body` replaced with a stub | two-worker health test fails |
| `sessionWorkers` lookup disabled | affinity test fails |
| `close()` reverted to sessions-only | both shutdown tests fail |
| `natsHealth` reverted to optional-only | degraded-health test fails |

**One of those mutations found a defect in my own test first.** The affinity test originally compared the front's `x-open-brain-worker` header across requests — and proved nothing: that header is set on the **outbound** request the front sends to a worker, never on the response handed back, so it read `null` every time and `null === null` passed with affinity fully disabled (12/12 green under mutation). It now asserts the answered JSON-RPC payload, which routing to the wrong process cannot satisfy, and fails correctly under the same mutation.

The full run also caught an **order-dependent failure in the new realtime test**: the fixture records `id: "ws-1"`, and those ids come from a process-lifetime monotonic counter in the module-scoped fallback store. Bun runs every file in one process, so `contracts/server-tool-parity.test.ts` exercised the same tools first and this suite observed `ws-2` — passing alone, failing in file order. Fixed by injecting per-application stores at the composition sites, which is what a composition root does rather than a test workaround.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test` — **3348 pass / 0 fail / 35 skip** across 220 files
- contract parity — **70/70 both providers** (38 `current-src`, 32 `server-rewrite-scaffold`, split verified from the JUnit record)
- `python/openbrain` — 302 passed; `python/openbrain-memory` — 547 passed, 9 skipped, `mypy` and `ruff` clean
- anti-skip guard — the SDK suite is recorded `tests="12" failures="0" skipped="0"`; `minTests` 8 → 12 and the total floor 40 → 44 keep the registration in sync
- live Postgres — isolated `open_brain_463_phase5_test` (46 migrations). The dogfood database was never touched.

`contracts/server/tool-gap-map.json` is **unchanged and verified byte-equal** to the live `current-src` registry (63 tools, 0 gaps). It tracks `current-src` fixture coverage, and this PR registers rewrite-side tools rather than new `src/` ones, so no edit is correct here.

`SERVER_REWRITE_STATE.servesTraffic` stays `false` and is asserted. `server/state.ts` is untouched, no start script references `server/`, and cutover is not this lane.

The `local clone real PostgreSQL boundary` suite skips for its own environment reason (it needs CI's role setup). Verified identical on the unmodified base branch by stashing this work: 6 pass / 1 skip. It is the only remaining anti-skip guard complaint and is not from this change.

## Residual, stated as PROPOSED

- **Two-worker behavior on core01 itself is PROPOSED, not RUNNING.** What is proven here is the front's aggregation, nesting, and session affinity against two real local listeners. The deployed `10.71.1.21:3100` front was not exercised — that belongs to the Phase 6 cutover canary, and faking a receipt for it would be worse than naming the gap.
- **The maintenance queue runner itself is not ported.** The config and the ordered-shutdown port are proven; the runner internals remain `src/`-owned by deliberate choice, so "maintenance is composed into the rewrite" is true of the lifecycle and not yet of the implementation.
- **NATS is proven at the config and health boundary, not over a broker.** No NATS server was contacted; the bridge runtime remains `src/`-owned.

## Critical Self-Review

- Highest-risk behavior: the shared realtime store resolution, because a write and the pack that reads it must address one object and the failure mode is a successful-looking append that is invisible forever, with nothing durable to contradict it. Covered by a dedicated write-then-read-back test that is red-proven against a per-call store.
- Assumptions that could be wrong: that `unavailableReason` is additive and not observed by anything. It is a new field on a config object that no fixture records and `/health` does not emit, so no frozen surface sees it — but if some consumer later snapshots `ServerConfig` wholesale, its shape changed.
- Missing/weak tests: the two-worker proof uses two applications in ONE process, so it cannot surface a genuinely cross-process failure such as shared module state that a real second process would not have; `agent_context_pack` is asserted for its recorded envelope rather than populated-section content, inherited from #491; and the ordered-shutdown tests use fake runtimes, so they prove the application's ordering, not the real runner's drain.
- Security/permission risk: net-negative. The realtime adapters route through the same `authorize()` helper every other rewrite write tool uses, and the scope handed to the store is built from the AUTHORIZED namespace rather than the requested one — a caller cannot name a denied namespace and still land the write. A dedicated test asserts the broker URL and its credentials never reach the health projection.
- Migration/deploy risk: none. No migration, no schema change, no entrypoint change; `servesTraffic` stays false and is asserted.
- Downstream client/runtime risk: none. No MCP tool name, schema, contract, or wire format changed on `current-src`; parity is unchanged for that provider at 38, and the gap map is byte-equal to the live registry. The three tools newly registered on the rewrite provider match the frozen fixture shapes rather than defining new ones.
- Rollback/cleanup concern: revert is a single commit touching 14 files, four of them new. The isolated test database is disposable and outside the repo.
- Fixes made before PR: three. The affinity test's vacuous header assertion described above; the order-dependent realtime store contamination described above; and a `minTests` value I first set to 13 by miscounting my own additions, corrected to the observed 12 from the JUnit record rather than from memory.
- Known residual risk: the three PROPOSED items named in the section above — core01's actual two-worker front, the unported maintenance runner, and NATS never being exercised against a real broker.
- SME review-memory update: [x] not applicable because: the two defects found were in this PR's own new tests and were fixed before review rather than surfacing as MEDIUM+ findings, and both patterns — assertions that pass vacuously, and shared process state across Bun test files — are already recorded in `docs/sme/` and in `contracts/server-tool-parity.test.ts`'s own header.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR changes no serving code — the candidate still declares `servesTraffic: false`, no production entrypoint or start script is touched, and every assertion runs against an isolated test database on an ephemeral port.

## Contract Parity

- Contract parity: [x] runtime-specific because: no fixture was added or changed and no new behavior was recorded. `contracts/server/server-realtime-working-recovery.fixture.json` is byte-identical; the only change under `contracts/` is one word in `parity-manifest.json` flipping that capability from `scaffold-declared` to `implemented` for `server-rewrite-scaffold`, which means the rewrite provider now runs a fixture `current-src` was already passing. The frozen shapes stay the oracle rather than the subject, `current-src` parity is unchanged at 38, and the total rises 69 → 70 purely because a second provider now answers an existing recording.
