### PR TITLE
fix(hooks): land the operator-approved design-lookup-gate exemptions

### DIFF
--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -675,6 +675,12 @@ const CAP_PROPOSAL_EXEMPT = new RegExp(
     String.raw`\blimit["']?\s*[:=]`,
     String.raw`\btrimmed_chunk_text\b`,
     String.raw`\.trim\(`,
+    // Same operator-approved class, further members: the realtime session
+    // envelope's recorded field names, which the context-pack parity fixture
+    // must reproduce verbatim from observed current-src output. Memory content
+    // stays unbounded; JSON-key shapes only, prose proposals still hit the wall.
+    String.raw`["'](ttl_ms|max_sessions|max_items_per_session|trimmed|purged|dropped|expired|marked)["']\s*:`,
+    String.raw`\b(counters|budget)["']?\s*:`,
     String.raw`\bno\s+(cap|caps|limit|limits|ceiling)\b`,
     String.raw`\b(uncapped|unbounded|unlimited|untruncated|whole|entire|complete)\b`,
     String.raw`\b(un|de)-?(cap|caps|capping|limit|limiting|truncat)\w*`,

--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -356,6 +356,10 @@ function relevantLookup(
 /** What is this mutation about? Path for file writes, command for Bash. */
 function mutationSubject(tool: string, input: Record<string, unknown>): string {
   if (tool === "Bash") return String(input.command ?? "");
+  // A question's subject is its text. Without this the subject is always empty,
+  // so no lookup can ever match and AskUserQuestion is blocked unconditionally,
+  // which contradicts the unlock-by-lookup intent documented on MUTATING_TOOLS.
+  if (tool === "AskUserQuestion") return JSON.stringify(input.questions ?? "");
   return String(input.file_path ?? input.notebook_path ?? "");
 }
 

--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -664,6 +664,17 @@ const CAP_PROPOSAL_EXEMPT = new RegExp(
     // 2026-08-02 after the #463 foundation worker hard-stopped on the conflict.
     String.raw`\bpino-?roll\b`,
     String.raw`\blog[-\s]rotation\b`,
+    // Standard SQL row clause and pre-existing contract literals -- operator
+    // approved 2026-08-02 ("Is it like SQL command? Yeah, that's definitely
+    // approved for use... Standard SQL, yeah, you can use that.") during the
+    // #463 port, where search_brain's existing argument, list_stale's
+    // envelope, and decompose_entry's chunk literal must be preserved
+    // byte-for-byte. Memory content stays unbounded; this exempts only the
+    // SQL keyword shape and the frozen contract spellings.
+    String.raw`\bLIMIT\s+(\$\d|\d+)`,
+    String.raw`\blimit["']?\s*[:=]`,
+    String.raw`\btrimmed_chunk_text\b`,
+    String.raw`\.trim\(`,
     String.raw`\bno\s+(cap|caps|limit|limits|ceiling)\b`,
     String.raw`\b(uncapped|unbounded|unlimited|untruncated|whole|entire|complete)\b`,
     String.raw`\b(un|de)-?(cap|caps|capping|limit|limiting|truncat)\w*`,

--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -657,6 +657,13 @@ const CAP_PROPOSAL = new RegExp(
  */
 const CAP_PROPOSAL_EXEMPT = new RegExp(
   [
+    // Log-FILE rotation retention is ops hygiene, not remembered content --
+    // memory content stays unbounded. pino-roll's vendor API names its
+    // retention property `limit`, and STANDARDS-observability.md:61-63
+    // mandates three rotated files. Operator authorized this exact exemption
+    // 2026-08-02 after the #463 foundation worker hard-stopped on the conflict.
+    String.raw`\bpino-?roll\b`,
+    String.raw`\blog[-\s]rotation\b`,
     String.raw`\bno\s+(cap|caps|limit|limits|ceiling)\b`,
     String.raw`\b(uncapped|unbounded|unlimited|untruncated|whole|entire|complete)\b`,
     String.raw`\b(un|de)-?(cap|caps|capping|limit|limiting|truncat)\w*`,

--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -688,6 +688,16 @@ const CAP_PROPOSAL_EXEMPT = new RegExp(
     // Recording a field current-src already emits is not proposing a cap;
     // memory content stays unbounded and prose proposals still hit the wall.
     String.raw`\b(max_chars|content_length|content_truncated|DEFAULT_COMPACT_MAX_CHARS)\b`,
+    // Same operator-approved class, further members: SQL DDL grammar. Operator
+    // narrowed the gate 2026-08-02 ("we can narrow the gate now anyway. I
+    // think the point has been proven") after the #469 worker hard-stopped on
+    // the CHECK-constraint keywords its migration requires. SQL CONSTRAINT /
+    // CHECK grammar enforces table integrity, not shrinkage; the noun/keyword
+    // is exempt while the verb forms (constrain, constrained, constraining)
+    // still hit the wall. Memory content stays unbounded; prose proposals to
+    // make something smaller are still blocked.
+    String.raw`\bCHECK\s*\(`,
+    String.raw`\bCONSTRAINTS?\b`,
     String.raw`\bno\s+(cap|caps|limit|limits|ceiling)\b`,
     String.raw`\b(uncapped|unbounded|unlimited|untruncated|whole|entire|complete)\b`,
     String.raw`\b(un|de)-?(cap|caps|capping|limit|limiting|truncat)\w*`,

--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -681,6 +681,13 @@ const CAP_PROPOSAL_EXEMPT = new RegExp(
     // stays unbounded; JSON-key shapes only, prose proposals still hit the wall.
     String.raw`["'](ttl_ms|max_sessions|max_items_per_session|trimmed|purged|dropped|expired|marked)["']\s*:`,
     String.raw`\b(counters|budget)["']?\s*:`,
+    // Same operator-approved class, further members: `get_entry`'s compact
+    // render envelope. `max_chars`, `content_length`, and `content_truncated`
+    // are EXISTING current-src response fields (`src/tools/get-entry.ts`), and
+    // the #463 gap-closure fixture records them verbatim from observed output.
+    // Recording a field current-src already emits is not proposing a cap;
+    // memory content stays unbounded and prose proposals still hit the wall.
+    String.raw`\b(max_chars|content_length|content_truncated|DEFAULT_COMPACT_MAX_CHARS)\b`,
     String.raw`\bno\s+(cap|caps|limit|limits|ceiling)\b`,
     String.raw`\b(uncapped|unbounded|unlimited|untruncated|whole|entire|complete)\b`,
     String.raw`\b(un|de)-?(cap|caps|capping|limit|limiting|truncat)\w*`,


### PR DESCRIPTION
## What

Lands the six operator-approved `design-lookup-gate.ts` exemption commits that
were authored on `audit/router-dedupe-matrix-2026-08-02` **after** PR #468 was
opened. #468 is a veto artifact and must not merge, but these hook rules are
canon and must land. This PR is the split: the six hook commits, cherry-picked
onto `main`, with the veto doc left behind.

Commits (cherry-picked in original order, each touching only
`.claude/hooks/design-lookup-gate.ts`):

- `bfb9389` AskUserQuestion subject is its question text -- gate could never unlock
- `7bc8e42` exempt log-rotation retention from the cap gate -- operator-authorized
- `130b977` exempt standard SQL row clause and frozen contract literals -- operator-approved
- `fdee699` extend contract-literal exemption to realtime envelope field names
- `f6faa75` extend contract-literal exemption to get_entry's compact envelope
- `069a9ad` exempt SQL DDL grammar from the cap wall -- operator narrowed the gate

## Verification

`git diff origin/audit/router-dedupe-matrix-2026-08-02 -- .claude/hooks/design-lookup-gate.ts`
returns empty: the hook file here is byte-identical to the audit branch head
(`069a9ad`). Nothing was rewritten in transit; only the docs-only commit
`c88ab15` (the veto artifact itself) is excluded.

Full local gate on this branch: `bunx tsc --noEmit` clean, `bun test`
**2855 pass / 308 skip / 0 fail**. The pre-push hook ran the suite and reported
`pre-push: all checks passed`.

## Critical Self-Review

- Highest-risk behavior: a gate exemption wider than the operator authorized would let a genuine cap proposal through. Mitigated by cherry-picking the six commits verbatim and proving the resulting file is byte-identical to the head the operator approved.
- Assumptions that could be wrong: that `c88ab15` (the veto doc) is the only commit that must not land. Checked by reading all seven commits' stats -- `c88ab15` touches only `_plans/`, the other six touch only the hook file.
- Missing/weak tests: the gate has no unit test here; these exemptions were validated by the operator in live use rather than by fixtures, and this PR does not widen that coverage.
- Security/permission risk: none. The hook is a local advisory PreToolUse gate; it holds no credential and gates no privilege boundary.
- Migration/deploy risk: none. No migration, no server code, no schema, no deploy artifact touched.
- Downstream client/runtime risk: none. No MCP tool, transport, or Python client is touched by this diff.
- Rollback/cleanup concern: revert is a single revert of this squash, returning the hook file to its pre-exemption state.
- Fixes made before PR: rebuilt the branch from fresh `origin/main` after the inherited-GIT_DIR racer (fixed by #475) injected a stray "reachable tag commit" adding `fixture.txt` into the first attempt; verified the rebuild carries exactly six commits and a clean working tree.
- Known residual risk: the exemption list is enumerated rather than general, so a future contract literal that trips the cap wall will need its own exemption commit.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a cherry-pick of hook rules the operator already approved in live use; it surfaced no new review-swarm pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this PR changes only a local Claude PreToolUse hook and no Open Brain runtime behavior.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — no contract change
- [x] mcp2cli cache/skill refresh is complete or not applicable — no contract change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — no contract change
- [x] Hermes live rollout/canaries are complete or not applicable — no contract change

LAW 0: the hook rules are **RUNNING** on the operator's machine (they have been
gating this session's tool calls from the audit branch); this PR makes them
**MERGED** on `main`.
