### PR TITLE
chore(release): v0.9.0 -- one release number across the server and all three Python packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-brain",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,

--- a/python/openbrain-memory/pyproject.toml
+++ b/python/openbrain-memory/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-memory"
-version = "0.1.18"
+version = "0.9.0"
 description = "Python client for remote Open Brain memory service"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain-memory/tests/test_contract.py
+++ b/python/openbrain-memory/tests/test_contract.py
@@ -161,8 +161,8 @@ def test_manifest_requires_current_package_without_overstating_legacy_compatibil
         client_version=PREVIOUS_CLIENT_VERSION,
     )
 
-    assert CURRENT_CLIENT_VERSION == "0.1.18"
-    assert manifest["min_client_versions"]["openbrain-memory"] == "0.1.18"
+    assert CURRENT_CLIENT_VERSION == "0.9.0"
+    assert manifest["min_client_versions"]["openbrain-memory"] == "0.9.0"
     assert manifest["compatible_client_ranges"]["openbrain-memory"] == (
         ">=0.1.15 <1.0.0"
     )

--- a/python/openbrain-provider/pyproject.toml
+++ b/python/openbrain-provider/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain-provider"
-version = "0.1.0"
+version = "0.9.0"
 description = "Runtime lifecycle provider for Open Brain: session start, capture, checkpoint, reflex, and the agent hooks that drive them."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/python/openbrain/pyproject.toml
+++ b/python/openbrain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbrain"
-version = "0.1.0"
+version = "0.9.0"
 description = "Open Brain: the shared core, configuration, models, and capability modules that every Open Brain Python process is built from."
 # The package README is GENERATED from the src/openbrain/__init__.py docstring
 # by scripts/pytools/generate_package_docs.py. Pointing at the generated file

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -202,7 +202,7 @@ wheels = [
 
 [[package]]
 name = "openbrain"
-version = "0.1.0"
+version = "0.9.0"
 source = { editable = "openbrain" }
 dependencies = [
     { name = "loguru" },
@@ -239,7 +239,7 @@ dev = [
 
 [[package]]
 name = "openbrain-memory"
-version = "0.1.18"
+version = "0.9.0"
 source = { editable = "openbrain-memory" }
 
 [package.optional-dependencies]
@@ -267,7 +267,7 @@ dev = [
 
 [[package]]
 name = "openbrain-provider"
-version = "0.1.0"
+version = "0.9.0"
 source = { editable = "openbrain-provider" }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
## Summary

The TS server and the three Python packages carried four different version
numbers (`0.1.0`, `0.1.18`, `0.1.0`, `0.1.0`), so no artifact said which release
it belonged to. This sets one number, `0.9.0`, across all four manifests.

There is no changelog file in this repo and this PR does not invent one. The
release evidence is below, per `docs/local-release-deploy-sop.md`.

| Manifest | Before | After |
|---|---|---|
| `package.json` | 0.1.0 | 0.9.0 |
| `python/openbrain-memory` | 0.1.18 | 0.9.0 |
| `python/openbrain-provider` | 0.1.0 | 0.9.0 |
| `python/openbrain` | 0.1.0 | 0.9.0 |
| `python/uv.lock` | — | regenerated by `uv` for all three |

### What is deliberately NOT changed

`min_client_versions` in `src/contract.ts` stays at `openbrain-memory: 0.1.15`.
It is a **deprecation floor**, not a mirror of the current package version:

- `0.9.0` already satisfies the declared range `>=0.1.15 <1.0.0`, so no client
  is newly incompatible.
- The floor sits **inside** the hashed contract payload, so raising it changes
  `schema_hash`.
- `docs/compatibility-matrix.md` requires any rise to ship with updated parity
  fixtures, and states that raising the minimum **is** the deprecation
  mechanism — older clients then fail contract validation loudly at session
  start.

Raising it here would deprecate every 0.1.x client for a version bump that
breaks nothing. Live `get_contract` on the release candidate confirms the served
floor is unchanged.

One tripwire did have to move: `python/openbrain-memory/tests/test_contract.py`
sets `CURRENT_CLIENT_VERSION = PACKAGE_VERSION` and then asserted the literal
`"0.1.18"`. That assertion tracks the package version by design, so it moves
with the bump or CI fails.

## Release Evidence

```text
Release:
- Version: v0.9.0 (tag NOT pushed — see "Tag disposition")
- Commit: 61975c7 on release/v0.9.0, branched from origin/main 2e0a2b9
- PRs included: #493 (canon/lens reconciler, merged today at 2e0a2b9) on top of
  the already-merged rewrite batch through a55c804 (#495, #496, #489)
- Local full suite: bun install --frozen-lockfile OK (140 packages);
  bunx tsc --noEmit exit 0; bun run migrate applied 47 migrations;
  bun test = 3358 pass / 35 skip / 0 fail, 17007 expect() calls,
  221 files, 37.00s — run with OPENBRAIN_TEST_DATABASE_URL set, so the
  Postgres-backed suites executed rather than silently skipping
- Python package checks:
  - openbrain-memory: mypy 17 files OK, ruff OK, pytest 550 passed / 9 skipped,
    uv build -> openbrain_memory-0.9.0 (wheel + sdist)
  - openbrain-provider: ruff format --check OK, ruff check OK, mypy src + tests
    OK, pytest 98 passed, uv build -> openbrain_provider-0.9.0
  - openbrain: ruff OK, mypy 40 files OK, pytest 386 passed / 17 deselected,
    uv build -> openbrain-0.9.0
  All six built artifacts carry 0.9.0, which proves the bump reaches the
  artifacts and is not just a manifest edit.
- Local runtime port: 13100 (isolated release-test env, non-production)
- Health result: status "healthy"; database.connected true;
  embedding.configured true; embedding.connected true (local MLX
  embeddinggemma-300m-8bit); nats availability not_runtime_available with
  fallback_http true
- REST smoke: POST /api/v1/thoughts with the test admin token ->
  {"embedded":true}; GET /api/v1/search returned that exact id with vector
  distance 0.3267 — real embedded write and semantic recall, not a stub
- MCP/client smoke: MCP SDK StreamableHTTPClientTransport against
  127.0.0.1:13100/mcp with an ISOLATED temp HOME/XDG_CONFIG_HOME (the
  operator's real client config was not touched, per the SOP). Connected;
  63 tools listed; log_thought write returned embedded:true; search_brain
  returned the written record; get_contract returned
  contract_version 2026-07-23.memory-tools.v23, schema_version 1,
  schema_hash 4b69e9b437c96175531b049b6e3c2782f383334e9e1931e96e73835599e4a4a8
- Downstream rollout classification: CONTRACT-CHANGING, downstream DEFERRED
  (full reasoning below)
- Deploy trigger: NONE. No tag pushed, no workflow_dispatch. core01 untouched.
- Core01 health: NOT CHECKED — deliberately. core01 is out of scope by operator
  policy while this box is in dev mode; the SOP's core01 verification section
  belongs to the swap-back event.
- Residual risk: listed under "Known residual risk" below
```

The release-test environment lives outside the repo at
`/Users/rico/.config/open-brain/env.release-test` (mode 0600, created for this
gate). It points at a dedicated `open_brain_release_test` database owned by a
dedicated non-superuser role, with generated throwaway credentials. It is not
the dogfood database and carries no production values. Variable **names** only
are recorded here; no value is reproduced anywhere.

## Downstream Rollout Classification

Per `docs/downstream-rollout.md`.

**Classification: contract-changing. Downstream steps 3-7 explicitly DEFERRED
to the core01 swap-back event.**

### Why contract-changing

Measured against the last release tag (`v0.1.0-rc.4`), the contract-bearing
paths (`src/contract.ts`, `src/contract-schemas.ts`, `contracts/`,
`python/openbrain-memory/`, `clients/ts/`) changed across 111 files. In
`src/contract.ts` specifically:

- `CONTRACT_VERSION` `2026-07-17.memory-tools.v22` → `2026-07-23.memory-tools.v23`
- a new served tool contract, `agent_reflex_pointers`
- `min_client_versions["openbrain-memory"]` `0.1.8` → `0.1.15`, and the
  compatible range `>=0.1.8` → `>=0.1.15`

That last one is a real deprecation of 0.1.8–0.1.14 clients. It landed in an
earlier merged PR, not in this one, but it has never been rolled out to the
fleet, so it is this release's obligation to carry.

### Correction to the assumed scope

The release was described to me as adding the MCP tools `record_skill_usage`
and `skill_usage_report` plus realtime appends. **Observed on the running
release candidate, that is not the case for the served surface**, and I am
recording what I measured rather than what was assumed:

- `listTools` over the live MCP transport returned **63 tools; neither
  `record_skill_usage` nor `skill_usage_report` is among them.**
- Both exist only in `server/tools/skill-usage.ts` — the rewrite scaffold that
  landed in #495 — and in `python/openbrain/apps/hooks/`.
- Nothing under `src/` imports `server/`; `src/index.ts` imports `./server.ts`,
  a different file.
- `server/state.ts` pins `SERVER_REWRITE_STATE = { law0: "WRITTEN", phase:
  "partial-implementation", servesTraffic: false, cutoverStarted: false }`.
- `server/` is not listed in `contracts/parity-paths.txt`.

So the rewrite scaffold is **WRITTEN, not RUNNING**, and it changes no served
contract in this release. The contract change above is the real one, and it
comes from the merged v23 surface.

### Step-by-step disposition

1. **Open Brain local verification — COMPLETE.** Full suite, typecheck,
   migrations, all three Python package suites, runtime health, REST smoke, and
   an MCP-path smoke, all recorded above against an isolated database.
2. **Open Brain hosted verification — DEFERRED.** core01 is untouched by
   operator policy while this box is in dev mode. No tag, no dispatch.
3. **rtech-mcps handoff — DEFERRED.**
4. **Client pull, cache verification, generated skill refresh — DEFERRED.**
5. **rtech-hermes Python runtime/plugin check — DEFERRED.**
6. **Hermes live rollout — DEFERRED.**
7. **Live agent canaries — DEFERRED.**

Steps 3-7 are not merely skipped: `docs/downstream-rollout.md` orders hosted
verification (step 2) **before** them, so they are **blocked by a prerequisite
this release deliberately does not meet**. They belong to the core01 swap-back
event, together with the v23 contract rollout and the `min_client_versions`
floor rise, and this release is not done in the fleet sense until then.

## Tag disposition — v0.9.0 tag NOT pushed

Requested check: determine exactly what a pushed `v0.9.0` tag triggers before
creating one.

`.github/workflows/ci.yml` is the only workflow that can deploy
(`codex-review.yml` and `pr-body.yml` cannot). Its `deploy` job:

```yaml
# .github/workflows/ci.yml
on:
  push:
    tags: ["v*"]            # line 6

deploy:                      # line 429
  needs: [check, db-integration, python-package, python-provider, contract-parity]
  runs-on: [self-hosted, macOS, core01]      # line 431
  if: |                                      # lines 432-434
    (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||
    (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
  steps:
    - run: /opt/homebrew/bin/bash scripts/core01-deploy-local.sh   # line 447
```

A pushed `v0.9.0` tag satisfies the **second** disjunct on line 434
unconditionally. The job then runs **on the core01 macOS runner** and executes
`scripts/core01-deploy-local.sh`, which stages the runtime, runs migrations,
swaps `/Volumes/ThunderBolt/open-brain/app`, and restarts the
`com.rico.open-brain` LaunchAgent.

The ref gate does not save this. `verify_deploy_ref()` in
`scripts/core01-deploy-local.sh` is a no-op outside CI, and inside CI it
**allows** a `v*` tag reachable from `main` — which is exactly what this tag
would be. The gate authorizes the deploy rather than blocking it.

**Therefore the tag was not created and not pushed.** I could not prove the tag
push cannot reach core01; the workflow proves the opposite.

Options, for the operator to choose:

1. **Hold the tag until swap-back day** (recommended, and what this PR does).
   Tag then, with the core01 deploy as the intended, attended event, and run
   the SOP's Core01 Deploy Verification plus downstream steps 3-7 at that time.
2. **Gate the workflow first**, then tag — e.g. require `deploy_core01` for the
   tag path too, or add an environment protection rule. This is a workflow
   change with its own review, not a release-day edit.
3. **Tag knowing the core01 deploy fires.** This contradicts the current
   operator policy and is recorded only for completeness.

The version bump does not depend on the tag. `0.9.0` is in the manifests and in
the built artifacts either way.

## Contract Parity

- Contract parity: [x] runtime-specific because: this PR changes only package
  version strings and the one test literal that tracks `PACKAGE_VERSION`. It
  touches no request shape, response shape, tool schema, or contract field. The
  parity fixtures pin the compatibility FLOOR (`contracts/server/server-contract-discovery.fixture.json`
  declares `min_client_versions["openbrain-memory"] = "0.1.15"` and the range
  `>=0.1.15 <1.0.0`), and this PR deliberately does not move that floor, so the
  fixtures remain exactly correct. No fixture pins the current package version.
  The `contract-parity` CI job passed on this branch, which is the machine
  confirmation of the same claim.

## Critical Self-Review

- Highest-risk behavior: the `min_client_versions` decision — bumping the package to 0.9.0 while leaving the floor at 0.1.15. If that call were wrong, clients would validate against a stale floor. Checked against `src/contract.ts:567`, the declared range `>=0.1.15 <1.0.0`, the policy in `docs/compatibility-matrix.md`, and live `get_contract` output from the running candidate; 0.9.0 sits inside the range.
- Assumptions that could be wrong: that no external consumer pins `openbrain-memory==0.1.18` exactly, since a 0.1.18 to 0.9.0 jump would break such a pin. Nothing in this repo pins it exactly (only the test tripwire, updated here), but consumers outside this repo were not audited and cannot be while the downstream rollout is deferred.
- Missing/weak tests: no test asserts that the four manifests agree with one another, so nothing prevents them drifting apart again at the next bump — that drift is exactly what this PR fixes by hand.
- Security/permission risk: none introduced. The release-test env file was created at mode 0600 outside the repo with generated throwaway credentials, on a dedicated non-superuser role and isolated database. No value is printed in this PR, the journal, or any log, and no production credential was read or used.
- Migration/deploy risk: no schema change in this PR; 47 migrations applied cleanly to a fresh isolated database, which exercises the migration chain from empty — the path a new deployment takes.
- Downstream client/runtime risk: real but deferred, and the deferral is written into this PR rather than left implicit. The v23 contract and the raised client floor still owe the fleet a rollout at the core01 swap-back.
- Rollback/cleanup concern: rollback is reverting one commit, since nothing is deployed or installed by merging it. The RC worktree is removed after merge; the `open_brain_release_test` database and role persist deliberately so the gate is repeatable, and hold only smoke rows.
- Fixes made before PR: found and fixed the `test_contract.py` version tripwire that would otherwise have failed CI after the bump, and confirmed `uv.lock` regenerated for all three packages rather than leaving a stale lock.
- Known residual risk: the release is verified local-only. Nothing here is RUNNING on core01, the hosted contract there is still the pre-v23 surface until swap-back, and the `server/` rewrite scaffold ships in the tree with `servesTraffic: false` having never served a request.
- SME review-memory update: [x] not applicable because: the one reusable pattern (a version-bump tripwire asserting a literal package version) is already recorded in `docs/sme/domain-backend.md`, which is what led me to check for it.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Live checks were run against an isolated local release candidate on port 13100:
health (`status: healthy`, `embedding.connected: true`), a REST write/read
round-trip returning `embedded: true` with vector distance 0.3267, and an MCP
write/read plus `get_contract` returning contract version
`2026-07-23.memory-tools.v23`. All receipts are in the Release Evidence block
above. Hosted/core01 checks were intentionally not run — see tag disposition.
