### PR TITLE
fix(hooks): exempt git worktree prune from the cap wall

### DIFF
--- a/.claude/hooks/design-lookup-gate.ts
+++ b/.claude/hooks/design-lookup-gate.ts
@@ -698,6 +698,12 @@ const CAP_PROPOSAL_EXEMPT = new RegExp(
     // make something smaller are still blocked.
     String.raw`\bCHECK\s*\(`,
     String.raw`\bCONSTRAINTS?\b`,
+    // Same operator-approved class, further member: the git subcommand that
+    // clears stale worktree REGISTRATIONS. AGENTS.md mandates running it at
+    // cleanup; on 2026-08-02 the cap wall refused it mid-wave (the "prun" stem
+    // is limitation vocabulary, but this is a command name, not a proposal).
+    // Memory content stays unbounded; only the exact git spelling is exempt.
+    String.raw`\bgit\s+worktree\s+prune\b`,
     String.raw`\bno\s+(cap|caps|limit|limits|ceiling)\b`,
     String.raw`\b(uncapped|unbounded|unlimited|untruncated|whole|entire|complete)\b`,
     String.raw`\b(un|de)-?(cap|caps|capping|limit|limiting|truncat)\w*`,


### PR DESCRIPTION
## Summary
- Adds the exact `git worktree prune` spelling to the gate's operator-approved technical-vocabulary exemption class (same class as the SQL DDL narrowing landed via #496). Memory content stays unbounded; prose uses of the stem still blocked.
- Trigger: the merge-day worktree wave was refused running a command AGENTS.md mandates; verified moot in that instance (zero stale registrations) but a standing false positive.
- Proven both directions by direct hook invocation: the git spelling passes; "prune the events table down" prose still blocked.

## Critical Self-Review
- Highest-risk behavior: widening the cap wall too far; mitigated by exempting only the exact three-word git spelling, with a block receipt proving prose still refused.
- Assumptions that could be wrong: none material; the pattern is an anchored word-boundary literal.
- Missing/weak tests: the gate has no test harness; receipts are direct hook invocations recorded in the session journal.
- Security/permission risk: none; hook-only, no auth or data paths.
- Migration/deploy risk: none; not deployed code.
- Downstream client/runtime risk: none; local hook.
- Rollback/cleanup concern: revert the single commit.
- Fixes made before PR: none needed beyond the exemption itself.
- Known residual risk: other mandated commands containing walled stems may surface later; each gets its own narrow member per operator direction.
- SME review-memory update: [x] not applicable because: gate false-positive handling is already recorded in docs/GOTCHAS.md by the merge-day scribe entries; no reviewer-lane pattern changed.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: hook-only change with no service, contract, or client surface; nothing to check live.

## Contract Parity
- Disposition: not applicable because: hook-only change, no contract paths touched.

## Testing
- Label: direct hook invocation both directions; allow and block receipts in the session journal.