### PR TITLE
feat(server): port the maintenance runner -- one runner, composed, drained in order

### DIFF
--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -842,3 +842,59 @@ hazard.
   reverted. The child must signal *itself* immediately after the last record.
 - Is `signal.default_int_handler` treated as "already claimed"? It is a
   *callable*, so a plain `if callable(previous)` guard skips SIGINT every time.
+
+## [2026-08-02] A drain test that awaits the worker proves nothing about the drain
+
+**Severity:** MEDIUM
+**Source:** PR for the maintenance-runner port onto `server/`, red-proof pass
+**Scope:** any test asserting that `stop()`/`close()`/`shutdown()` DRAINS rather
+than cancels; `server/maintenance/maintenance.pg.test.ts`
+**Status:** fixed before review
+
+### Pattern
+
+Two independent mistakes made a lease-drain test pass under the exact defect it
+existed to catch. Both are invisible in review because the test reads correctly
+and the assertions are about real durable state.
+
+**1. Awaiting the work before asserting.** The test did:
+
+```ts
+await stopping;
+await tick;          // <- this is the bug
+const row = await readRow(job.id);
+expect(row.state).toBe("succeeded");
+```
+
+Awaiting the tick guarantees the handler finished no matter what `stop()` did,
+so the row reads terminal even under a `stop()` that abandoned it. Deleting
+`await this.tickPromise` from the runner — the literal PR #350 defect — still
+passed 5/5. The assertion must bind to the moment `stop()` RESOLVES: read the
+state immediately after `await stopping`, and join the worker only afterwards
+so the test leaves nothing running.
+
+**2. Opening the window at the wrong boundary.** The first version blocked
+inside the HANDLER and called `stop()` once the handler had started. That proves
+nothing either: a dispatched job is already tracked in the runner's `active`
+set, and every implementation waits on that set. The recorded defect lives one
+step EARLIER — between a claim committing its leases and those rows being
+tracked. Reaching it requires `stop()` to be entered while `claimDueJobs` is
+still in flight, which means wrapping the claim (let the real one commit, then
+park it) rather than blocking the handler.
+
+The general shape: **a lifecycle test is only as strong as the narrowest window
+it can actually open, and awaiting the thing under test collapses the window.**
+
+### Review Questions
+
+- Does the test `await` the worker/tick/promise before reading the state that is
+  supposed to prove the drain? If so it cannot fail, and it should be re-checked
+  under a mutation before being trusted.
+- Is the shutdown window opened at the point the defect actually occupies, or at
+  a later point every implementation already handles? For claim-then-dispatch,
+  handler-start is too late; the claim must be the seam.
+- Was the assertion observed FAILING under a mutation that reintroduces the
+  original defect, by name — not merely under some mutation?
+- Does a "drain proven" claim rest on a fake queue? Both invariants here fail
+  silently in durable state, so only a real database read can distinguish a
+  drained row from an abandoned one.

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -74,6 +74,13 @@ export const REQUIRED_SUITES: ReadonlyArray<{
   // across the namespace boundary. `skill_usage_log` has no namespace column, so
   // that boundary lives entirely in a join this suite is what checks.
   { name: "skill usage telemetry (live Postgres)", minTests: 9 },
+  // The maintenance queue runner's lease boundary, proven through the composed
+  // `server/` runtime. This entry matters more than most: both invariants it
+  // covers fail SILENTLY -- a row sits `running` under a live lease with no
+  // handler, nothing throws, and nothing is logged -- so a skipped run and a
+  // passing run look identical from the outside. That is precisely the shape
+  // this guard exists for.
+  { name: "maintenance runtime lease boundary (live Postgres)", minTests: 5 },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -81,9 +88,9 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // `minTests` values above (32 before the Phase 5 real-SDK protocol suite added
 // its 8, then 12 once that suite also covered the realtime append tools and the
 // two-worker front, then 44 -> 53 when the #469 skill-usage telemetry suite
-// added its 9), so the global floor cannot silently fall behind the per-suite
-// one.
-export const MIN_TOTAL_LIVE_TESTCASES = 53;
+// added its 9, then 53 -> 58 when the maintenance lease-boundary suite added
+// its 5), so the global floor cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 58;
 
 export interface SuiteStats {
   tests: number;

--- a/server/application/index.ts
+++ b/server/application/index.ts
@@ -3,6 +3,8 @@ import type { Logger } from "pino";
 import { natsHealthFromConfig, type ServerConfig } from "../config.ts";
 import type { Database } from "../db/pool.ts";
 import type { ServerModuleBoundary } from "../module.ts";
+import { createMaintenanceRuntime } from "../maintenance/index.ts";
+import type { MaintenanceJobHandler } from "../../src/maintenance-queue.ts";
 import {
   createSingleWorkerTransportApp,
   createSessionTransportHandlers,
@@ -42,6 +44,30 @@ export interface ShadowApplicationInput {
    * only to CALL it, and to call it before the database goes away.
    */
   readonly backgroundRuntimes?: readonly BackgroundRuntime[];
+  /**
+   * Job kinds this process can dispatch. Supplying it composes the maintenance
+   * queue runner from `config.maintenance` and appends it to the shutdown order.
+   *
+   * This is what turned the `backgroundRuntimes` port from a declared shape into
+   * a wired one: before it, the port's only suppliers were test fakes, so the
+   * ordered shutdown above was proven against runtimes that had no leases to
+   * drain. Composing here rather than making every caller assemble a queue keeps
+   * "maintenance is running" and "maintenance is in the shutdown order" the same
+   * decision — they cannot disagree, which is the failure the drain exists to
+   * prevent.
+   *
+   * Omitted means this process dispatches nothing, which is correct for a test
+   * composition and for any worker deliberately not running maintenance. It is
+   * NOT the same as `config.maintenance.enabled: false`, which is an operator
+   * opting a process out; both end with no runtime in the shutdown order.
+   */
+  readonly maintenanceHandlers?: ReadonlyMap<string, MaintenanceJobHandler>;
+  /**
+   * Start maintenance polling immediately (default true). `false` composes the
+   * runner and its shutdown wiring without a timer, for tests that drive ticks
+   * deterministically.
+   */
+  readonly maintenanceAutoStart?: boolean;
 }
 
 /**
@@ -59,6 +85,13 @@ export interface BackgroundRuntime {
 export interface ShadowApplication {
   readonly app: Express;
   readonly sessions: SessionTransportHandlers;
+  /**
+   * Everything this application will stop on close, in the order it will stop
+   * it. Exposed so a caller (and a test) can see the composed shutdown order
+   * rather than infer it — a runtime that is running but absent from this list
+   * is the abandoned-lease bug, and it should be observable, not silent.
+   */
+  readonly backgroundRuntimes: readonly BackgroundRuntime[];
   close(): Promise<void>;
 }
 
@@ -104,10 +137,35 @@ export function createShadowApplication(
     health,
     logger: transportLogger,
   });
+  // Compose maintenance BEFORE returning, so the runner and its place in the
+  // shutdown order are created together. `createMaintenanceRuntime` returns
+  // undefined when the operator disabled maintenance for this process, and a
+  // process that dispatches no job kinds composes none at all.
+  //
+  // Caller-supplied runtimes stop first, then maintenance. The queue runner is
+  // the drain that needs the database longest -- it must finish jobs it has
+  // already leased -- so it sits closest to the database in the ordering.
+  const maintenance = input.maintenanceHandlers
+    ? createMaintenanceRuntime({
+        config: input.config.maintenance,
+        logger: input.logger.child({ component: "maintenance" }),
+        pool: input.database.pool,
+        handlers: input.maintenanceHandlers,
+        ...(input.maintenanceAutoStart !== undefined
+          ? { autoStart: input.maintenanceAutoStart }
+          : {}),
+      })
+    : undefined;
+  const backgroundRuntimes: readonly BackgroundRuntime[] = [
+    ...(input.backgroundRuntimes ?? []),
+    ...(maintenance ? [maintenance] : []),
+  ];
+
   return {
     app,
     sessions,
-    close: () => closeInOrder(input, sessions),
+    backgroundRuntimes,
+    close: () => closeInOrder(input.logger, sessions, backgroundRuntimes),
   };
 }
 
@@ -121,7 +179,9 @@ export function createShadowApplication(
  * BACKGROUND RUNTIMES SECOND, and they are drained BEFORE the caller closes the
  * database, because a claim-then-dispatch runner needs its pool to finish the
  * jobs it has already leased. Killing the pool first turns an orderly drain
- * into the exact abandoned-lease failure the drain exists to prevent.
+ * into the exact abandoned-lease failure the drain exists to prevent. The
+ * composed maintenance runner is last in this list for that reason: it is the
+ * runtime that needs the database for the longest.
  *
  * EVERY runtime is stopped even if an earlier one throws. A shutdown path that
  * abandons the remaining runtimes on the first failure leaks precisely when
@@ -131,18 +191,19 @@ export function createShadowApplication(
  * clean one.
  */
 async function closeInOrder(
-  input: ShadowApplicationInput,
+  logger: Logger,
   sessions: SessionTransportHandlers,
+  backgroundRuntimes: readonly BackgroundRuntime[],
 ): Promise<void> {
   await sessions.close();
   let firstFailure: unknown;
-  for (const runtime of input.backgroundRuntimes ?? []) {
+  for (const runtime of backgroundRuntimes) {
     try {
       await runtime.stop();
-      input.logger.info({ runtime: runtime.name }, "background_runtime_stopped");
+      logger.info({ runtime: runtime.name }, "background_runtime_stopped");
     } catch (error: unknown) {
       firstFailure ??= error;
-      input.logger.error(
+      logger.error(
         {
           runtime: runtime.name,
           error_category: error instanceof Error ? error.name : typeof error,

--- a/server/application/shadow-application.test.ts
+++ b/server/application/shadow-application.test.ts
@@ -214,6 +214,74 @@ describe("shadow application composition", () => {
     expect(order).toEqual(["sessions", "maintenance"]);
   });
 
+  it("composes the maintenance runner into the shutdown order, last", async () => {
+    // The port used to have NO production supplier: every proof of ordered
+    // shutdown above runs against a fake runtime, so "the application drains
+    // maintenance" was true of a shape and not of a runner. This asserts the
+    // real composition -- supplying handlers builds a queue runner and places it
+    // in the shutdown order.
+    //
+    // LAST is the assertion, not merely present. The queue runner is the drain
+    // that needs the database for the longest, because it must finish jobs it
+    // has already leased; anything stopped after it would be stopped while it
+    // was still using the pool.
+    const application = createShadowApplication({
+      config: testConfig(),
+      logger: silentLogger(),
+      database: fakeDatabase(),
+      authenticate: bearerAuth(),
+      parseRequestBody: express.json(),
+      serverFactory: () => ({ connect: async () => {} }) as never,
+      backgroundRuntimes: [{ name: "other", stop: async () => {} }],
+      maintenanceHandlers: new Map([["noop.kind", async () => {}]]),
+      // No timer: this test asserts composition, not polling, and a live poller
+      // would query the fake database.
+      maintenanceAutoStart: false,
+    });
+
+    expect(application.backgroundRuntimes.map((runtime) => runtime.name)).toEqual([
+      "other",
+      "maintenance",
+    ]);
+    await application.close();
+  });
+
+  it("composes no maintenance runner when the operator disabled it", async () => {
+    // An operator opting a worker out must leave NOTHING in the shutdown order,
+    // not an idle runner that still holds a pool connection to poll with.
+    const application = createShadowApplication({
+      config: testConfig({ OPEN_BRAIN_MAINTENANCE_ENABLED: "0" }),
+      logger: silentLogger(),
+      database: fakeDatabase(),
+      authenticate: bearerAuth(),
+      parseRequestBody: express.json(),
+      serverFactory: () => ({ connect: async () => {} }) as never,
+      maintenanceHandlers: new Map([["noop.kind", async () => {}]]),
+      maintenanceAutoStart: false,
+    });
+
+    expect(application.backgroundRuntimes).toEqual([]);
+    await application.close();
+  });
+
+  it("composes no maintenance runner when the process dispatches no job kinds", async () => {
+    // Distinct from the disabled case above and deliberately so: this process
+    // was never given a dispatch surface, so there is nothing for a runner to
+    // run. Both end with an empty shutdown order, but only one of them is an
+    // operator decision.
+    const application = createShadowApplication({
+      config: testConfig(),
+      logger: silentLogger(),
+      database: fakeDatabase(),
+      authenticate: bearerAuth(),
+      parseRequestBody: express.json(),
+      serverFactory: () => ({ connect: async () => {} }) as never,
+    });
+
+    expect(application.backgroundRuntimes).toEqual([]);
+    await application.close();
+  });
+
   it("stops every background runtime even when an earlier one throws", async () => {
     // A shutdown that abandons the remaining runtimes on the first failure
     // leaks exactly when something is already wrong. The failure is still

--- a/server/maintenance/index.ts
+++ b/server/maintenance/index.ts
@@ -1,0 +1,195 @@
+/**
+ * Maintenance runtime boundary: the queue runner as a composed, ordered-shutdown
+ * background runtime.
+ *
+ * Design authority: `_plans/463-server-rewrite-charter.md` Phase 5 names
+ * "maintenance" as a gate the candidate must answer. `server/config/maintenance.ts`
+ * already owns the four env reads. `server/application/index.ts` already owns
+ * ordered shutdown through its `backgroundRuntimes` port. The piece between them
+ * — the thing that actually CONSTRUCTS a runner and hands it to that port — did
+ * not exist, so the port had no production supplier and every proof of ordered
+ * shutdown ran against a fake runtime.
+ *
+ * WHAT THIS OWNS: composition and lifecycle adaptation. Constructing the durable
+ * queue over the application's pool, composing the handler map, starting bounded
+ * polling when the config enables it, and presenting the whole thing as one
+ * `BackgroundRuntime` the application can stop in dependency order.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT OWN: the lease semantics. `MaintenanceQueue`
+ * and `MaintenanceQueueRunner` are imported from `src/`, not reimplemented here,
+ * and that is the load-bearing decision in this module.
+ *
+ * WHY IMPORTING IS THE PORT, AND COPYING WOULD BE THE FORK. PR #494 declined to
+ * port the runner because "reimplementing it here would fork the one component
+ * whose failure mode is silent" — rows sitting `running` under a live lease with
+ * no handler, and nothing erroring. That reasoning is preserved exactly, not
+ * overridden: the fix for it is to have ONE implementation reachable from both
+ * compositions, which is what this module does. Two copies would need the same
+ * two lease invariants re-proven forever, and would drift precisely where drift
+ * is invisible.
+ *
+ * The two invariants that must survive this port, both from the PR #350 /
+ * issue #343 review swarm, and both proven through THIS boundary in
+ * `maintenance.pg.test.ts` against a real database rather than assumed from the
+ * fact that the import compiles:
+ *
+ *  1. STOP IS A DRAIN, NOT A CANCEL (`docs/sme/domain-backend.md`). A claim
+ *     already in flight when `stop()` is called has leased rows in the database.
+ *     Those rows are owned work: they must be dispatched and tracked, and
+ *     `stop()` must await the in-flight tick before draining, or they sit
+ *     `running` until lease expiry. This is why `stop()` on the returned runtime
+ *     is `runner.stop()` and not a timer clear.
+ *
+ *  2. THE RETRY BOUND APPLIES TO THE EXPIRY PATH TOO (`docs/sme/correctness.md`).
+ *     An expired `running` row that has already consumed `max_attempts`
+ *     executions dead-letters inside the claim statement rather than being
+ *     reclaimed forever.
+ *
+ * `src/maintenance-queue.ts` imports nothing but `pg` types, so reaching it from
+ * here pulls in no `src/` composition — this is the same strangler-direction
+ * import `server/config/nats.ts` and `server/tools/source-registry.ts` already
+ * use, and it leaves the eventual `src/` retirement a file move rather than a
+ * reconciliation of two divergent runners.
+ */
+import type pg from "pg";
+import type { Logger } from "pino";
+import type { ServerModuleBoundary } from "../module.ts";
+import type { MaintenanceConfig } from "../config/maintenance.ts";
+import type { BackgroundRuntime } from "../application/index.ts";
+import {
+  MaintenanceQueue,
+  MaintenanceQueueRunner,
+  type MaintenanceJobHandler,
+  type MaintenanceQueueLogger,
+} from "../../src/maintenance-queue.ts";
+
+export const MAINTENANCE_BOUNDARY: ServerModuleBoundary = {
+  name: "maintenance",
+  owns: ["queue composition", "handler registration", "runner lifecycle"],
+  excludes: ["lease semantics", "retry policy", "SQL", "handler behavior"],
+};
+
+/** The name this runtime reports in ordered-shutdown logs. */
+export const MAINTENANCE_RUNTIME_NAME = "maintenance";
+
+export interface MaintenanceRuntimeInput {
+  readonly config: MaintenanceConfig;
+  readonly logger: Logger;
+  readonly pool: Pick<pg.Pool, "query" | "connect">;
+  /**
+   * The dispatch surface. A job kind absent from this map can never run, however
+   * many jobs are enqueued under it, so registration is the whole contract
+   * between an enqueuer and a worker.
+   *
+   * Passed IN rather than composed here: the handlers reach embedding providers,
+   * the graph deriver, and the DREAM pipeline, each with its own auth identity
+   * and its own reasons. This boundary owns the runner's lifecycle, not what the
+   * jobs do.
+   */
+  readonly handlers: ReadonlyMap<string, MaintenanceJobHandler>;
+  /**
+   * Start polling immediately (default true). `false` composes the runtime
+   * without a timer, which is what a test wants when it drives `runOnce()`
+   * itself and needs the tick boundary to be deterministic.
+   */
+  readonly autoStart?: boolean;
+}
+
+/**
+ * A composed maintenance runtime: the queue, the runner, and the
+ * `BackgroundRuntime` adaptation the application shuts down.
+ */
+export interface MaintenanceRuntime extends BackgroundRuntime {
+  readonly queue: MaintenanceQueue;
+  readonly runner: MaintenanceQueueRunner;
+}
+
+/**
+ * Adapt a pino logger to the queue's content-free logger shape.
+ *
+ * The queue logs `(message, fields)` where every field value is already a string
+ * or number — it never passes an error object or a payload. Pino takes the
+ * object first, so the two are swapped here and nothing else: no field is added,
+ * renamed, or dropped, because the queue's field names are what its own log
+ * assertions and any operator grep are written against.
+ */
+function queueLogger(logger: Logger): MaintenanceQueueLogger {
+  return {
+    info: (message, fields) => logger.info(fields, message),
+    warn: (message, fields) => logger.warn(fields, message),
+    error: (message, fields) => logger.error(fields, message),
+  };
+}
+
+/**
+ * Compose the maintenance queue runner as a background runtime.
+ *
+ * Returns `undefined` when the config disables maintenance for this process, so
+ * a disabled worker composes NO runner at all rather than an idle one: an
+ * opted-out process should hold no pool connection for polling and should emit
+ * no maintenance lines. The caller spreads the result into `backgroundRuntimes`,
+ * so "disabled" and "absent from the shutdown order" are the same state and
+ * cannot disagree.
+ *
+ * The three tuning values are forwarded ONLY when the config supplies them.
+ * `MaintenanceConfig` deliberately leaves them `undefined` rather than
+ * defaulting, so that the runner stays the single owner of its own defaults;
+ * passing an explicit `undefined` through would be equivalent here, but spelling
+ * it as omission keeps that ownership visible at the call site. The runner
+ * clamps whatever it receives to its own safe bounds regardless.
+ */
+export function createMaintenanceRuntime(
+  input: MaintenanceRuntimeInput,
+): MaintenanceRuntime | undefined {
+  if (!input.config.enabled) {
+    input.logger.info(
+      { runtime: MAINTENANCE_RUNTIME_NAME },
+      "maintenance_runtime_disabled",
+    );
+    return undefined;
+  }
+
+  const logger = queueLogger(input.logger);
+  const queue = new MaintenanceQueue(input.pool);
+  const runner = new MaintenanceQueueRunner({
+    queue,
+    handlers: input.handlers,
+    logger,
+    ...(input.config.concurrency !== undefined
+      ? { concurrency: input.config.concurrency }
+      : {}),
+    ...(input.config.pollIntervalMs !== undefined
+      ? { pollIntervalMs: input.config.pollIntervalMs }
+      : {}),
+    ...(input.config.leaseMs !== undefined
+      ? { leaseMs: input.config.leaseMs }
+      : {}),
+  });
+
+  // `start()` throws on an empty handler map rather than polling a queue whose
+  // every claim would dead-letter as `unsupported_job_kind`. Let it throw: a
+  // process composed with no handlers is mis-wired, and failing at startup is
+  // strictly better than discovering it as a growing dead-letter table.
+  if (input.autoStart !== false) runner.start();
+
+  let stopped = false;
+  return {
+    name: MAINTENANCE_RUNTIME_NAME,
+    queue,
+    runner,
+    // `runner.stop()` is a DRAIN (invariant 1 above): it awaits the in-flight
+    // tick so any rows that tick's claim leased are tracked, then waits for
+    // every tracked handler to finish. The application calls this BEFORE
+    // closing the database, because a drain needs the pool to complete the work
+    // it has already leased.
+    //
+    // Idempotent: the application stops each runtime once, but a shutdown path
+    // that can be entered twice (a signal arriving during shutdown) must not
+    // turn the second entry into a second drain.
+    stop: async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      await runner.stop();
+    },
+  };
+}

--- a/server/maintenance/maintenance.pg.test.ts
+++ b/server/maintenance/maintenance.pg.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Real-PostgreSQL lease proof for the maintenance runtime composed at the
+ * `server/` boundary (charter Phase 5 "maintenance" gate).
+ *
+ * WHY THIS FILE HAS TO USE A REAL DATABASE. Both invariants under test are
+ * statements about DURABLE ROW STATE observed across a concurrency boundary, and
+ * both fail SILENTLY: a row sits `running` with a live lease, no handler
+ * attached, and nothing throws. A fake queue cannot prove either one, because a
+ * fake is free to report whatever the test wants — the whole failure mode is
+ * that the in-memory story and the row disagree. So every assertion below reads
+ * `maintenance_jobs` back with SQL after the fact.
+ *
+ * This complements rather than duplicates `src/maintenance-queue.pg.test.ts`:
+ * that file proves the queue in isolation, this one proves the invariants
+ * SURVIVE the composition — the runtime built by `createMaintenanceRuntime` and
+ * stopped through the application's ordered shutdown. A port that kept the code
+ * and lost the wiring would pass there and fail here.
+ *
+ * THE TWO INVARIANTS, both from the PR #350 / issue #343 review swarm:
+ *
+ *  1. `docs/sme/domain-backend.md` — stop is a DRAIN. A claim in flight when
+ *     `stop()` is called has already leased rows; every one of them must be
+ *     dispatched, tracked, and completed before `stop()` resolves. The recorded
+ *     defect was a mid-loop `if (stopping) return` that abandoned them until
+ *     lease expiry.
+ *
+ *  2. `docs/sme/correctness.md` — the retry bound governs the EXPIRY path too.
+ *     An expired `running` row that has consumed `max_attempts` executions
+ *     dead-letters inside the claim statement instead of being reclaimed
+ *     forever, and never appears to the runner as claimed work.
+ *
+ * DATABASE. Skips loudly without `OPENBRAIN_TEST_DATABASE_URL`, which must point
+ * at an isolated test database. Never the dogfood database. Each test uses its
+ * own job-kind prefix and deletes only its own rows, so a shared test database
+ * stays usable and no test can observe another's jobs.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import pg from "pg";
+import pino from "pino";
+import {
+  MaintenanceTerminalError,
+  type MaintenanceJob,
+  type MaintenanceJobHandler,
+} from "../../src/maintenance-queue.ts";
+import { createMaintenanceRuntime } from "./index.ts";
+import type { MaintenanceConfig } from "../config/maintenance.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const pool = DB_URL ? new pg.Pool({ connectionString: DB_URL }) : null;
+
+/** Job kinds are namespaced per run so concurrent suites cannot collide. */
+const KIND_PREFIX = `maint.port.${process.pid}`;
+
+function silentLogger() {
+  return pino({ level: "silent" });
+}
+
+function config(overrides: Partial<MaintenanceConfig> = {}): MaintenanceConfig {
+  return { enabled: true, ...overrides };
+}
+
+async function db(): Promise<pg.Pool> {
+  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
+  return pool;
+}
+
+/** Read a row back by id. The durable row is the oracle, never the job object. */
+async function readRow(id: string): Promise<{
+  state: string;
+  attempts: number;
+  max_attempts: number;
+  lease_token: string | null;
+  lease_until: Date | null;
+  last_error_category: string | null;
+  terminal_at: Date | null;
+  dead_lettered_at: Date | null;
+}> {
+  const client = await db();
+  const result = await client.query(
+    `SELECT state, attempts, max_attempts, lease_token, lease_until,
+            last_error_category, terminal_at, dead_lettered_at
+       FROM maintenance_jobs WHERE id = $1`,
+    [id],
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error(`maintenance job ${id} not found`);
+  return row;
+}
+
+async function deleteKind(kind: string): Promise<void> {
+  const client = await db();
+  await client.query(`DELETE FROM maintenance_jobs WHERE job_kind = $1`, [kind]);
+}
+
+afterAll(async () => {
+  if (!pool) return;
+  await pool.query(`DELETE FROM maintenance_jobs WHERE job_kind LIKE $1`, [
+    `${KIND_PREFIX}%`,
+  ]);
+  await pool.end();
+});
+
+// The "(live Postgres)" marker is REQUIRED, not decorative: the anti-skip guard
+// (`scripts/assert-db-tests-ran.ts`) matches suites by this name, and without it
+// a CI Postgres misconfiguration would silently skip the ONE suite that proves
+// the lease invariants survive the port -- leaving the job green while proving
+// nothing about the failure mode that never throws.
+dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
+  beforeEach(async () => {
+    if (!pool) return;
+    await pool.query(`DELETE FROM maintenance_jobs WHERE job_kind LIKE $1`, [
+      `${KIND_PREFIX}%`,
+    ]);
+  });
+
+  it("drains a job whose claim was already in flight when stop() began", async () => {
+    // INVARIANT 1, and the reason this whole port had to be proven rather than
+    // asserted. The window is real and narrow: stop() flips `stopping` while a
+    // claim is mid-COMMIT. The claim still leases its rows, so those rows are
+    // this runner's owned work; a runner that checks `stopping` AFTER the claim
+    // returns drops them on the floor, and they stay `running` under a live
+    // lease with no handler until expiry -- with nothing logged and nothing
+    // thrown.
+    //
+    // THE WINDOW IS THE CLAIM, NOT THE HANDLER. This is the whole subtlety, and
+    // getting it wrong is how this test first passed under the very mutation it
+    // exists to catch. Once a job has been dispatched it is already tracked in
+    // the runner's `active` set, and `stop()` waits on that set -- so a stop
+    // observed at handler-start is drained by any implementation and proves
+    // nothing. The defect lives EARLIER: between the claim committing its leases
+    // and those rows being tracked. To reach it, `stop()` must be entered while
+    // `claimDueJobs` is still in flight.
+    //
+    // The queue is therefore wrapped so the test controls exactly when the claim
+    // returns. The real claim runs first (the leases are genuinely committed in
+    // PostgreSQL), then the wrapper holds the resolved rows until the test has
+    // called stop(). The rows are real, leased, and not yet tracked -- the
+    // recorded defect's exact state.
+    const kind = `${KIND_PREFIX}.drain`;
+    let claimReached!: () => void;
+    const claimInFlight = new Promise<void>((resolve) => {
+      claimReached = resolve;
+    });
+    let releaseClaim!: () => void;
+    const claimMayReturn = new Promise<void>((resolve) => {
+      releaseClaim = resolve;
+    });
+    const seen: string[] = [];
+
+    const handler: MaintenanceJobHandler = async (job: MaintenanceJob) => {
+      seen.push(job.id);
+    };
+
+    const runtime = createMaintenanceRuntime({
+      config: config({ concurrency: 1, leaseMs: 60_000 }),
+      logger: silentLogger(),
+      pool: await db(),
+      handlers: new Map([[kind, handler]]),
+      // No timer: the tick boundary must be exact for this window to be a
+      // window rather than a race.
+      autoStart: false,
+    });
+    if (!runtime) throw new Error("maintenance runtime should be composed");
+
+    const job = await runtime.queue.enqueue({
+      kind,
+      version: 1,
+      payload: { proof: "drain" },
+      idempotencyKey: "drain-1",
+    });
+
+    const realClaim = runtime.queue.claimDueJobs.bind(runtime.queue);
+    (runtime.queue as { claimDueJobs: typeof realClaim }).claimDueJobs = async (
+      request,
+    ) => {
+      const claimed = await realClaim(request);
+      claimReached();
+      await claimMayReturn;
+      return claimed;
+    };
+
+    // Drive one tick; do NOT await it. The claim commits real leases and then
+    // parks, so the tick sits precisely in the defect's window.
+    const tick = runtime.runner.runOnce();
+    await claimInFlight;
+
+    // The row is leased to this runner right now, and no handler has seen it:
+    // that is what makes the assertion after the drain meaningful.
+    const leased = await readRow(job.id);
+    expect(leased.state).toBe("running");
+    expect(leased.lease_token).not.toBeNull();
+    expect(seen).toEqual([]);
+
+    // Enter stop() while the claim is still parked, then let the claim return.
+    // The runner now observes `stopping === true` holding rows it has already
+    // leased: it must treat them as owned work and dispatch them anyway.
+    const stopping = runtime.stop();
+    releaseClaim();
+
+    // THE ASSERTION BINDS TO stop() RESOLVING, and deliberately does NOT await
+    // the tick first. Awaiting the tick here is what makes this test vacuous:
+    // it guarantees the dispatch finished regardless of what stop() did, so the
+    // row would read terminal even under a stop() that abandoned it. Observed
+    // during red-proof: with `await tick` before this read, deleting
+    // `await this.tickPromise` from the runner's stop() still passed 5/5.
+    //
+    // Read the row the instant stop() resolves. A stop that is a DRAIN cannot
+    // resolve until the leased job is complete; a stop that abandons the
+    // in-flight claim resolves with the row still `running` under a live lease.
+    await stopping;
+    const drained = await readRow(job.id);
+    expect(seen).toEqual([job.id]);
+    expect(drained.state).toBe("succeeded");
+    expect(drained.lease_token).toBeNull();
+    expect(drained.lease_until).toBeNull();
+    expect(drained.terminal_at).not.toBeNull();
+
+    // Only now is the tick joined, so the test leaves nothing running.
+    await tick;
+    await deleteKind(kind);
+  });
+
+  it("refuses to begin a new claim once stopping, leaving queued work untouched", async () => {
+    // The other half of invariant 1. Refusing to BEGIN a claim is what keeps
+    // shutdown bounded: a claim mutates durable state, so starting one during
+    // stop would lease rows this process is about to stop being able to run.
+    // A queued row must therefore still be `queued`, unleased, and at attempts
+    // 0 after a stop -- available to the next worker rather than stranded.
+    const kind = `${KIND_PREFIX}.noclaim`;
+    const seen: string[] = [];
+    const runtime = createMaintenanceRuntime({
+      config: config({ concurrency: 1 }),
+      logger: silentLogger(),
+      pool: await db(),
+      handlers: new Map([
+        [
+          kind,
+          async (job: MaintenanceJob) => {
+            seen.push(job.id);
+          },
+        ],
+      ]),
+      autoStart: false,
+    });
+    if (!runtime) throw new Error("maintenance runtime should be composed");
+
+    const job = await runtime.queue.enqueue({
+      kind,
+      version: 1,
+      payload: { proof: "noclaim" },
+      idempotencyKey: "noclaim-1",
+    });
+
+    await runtime.stop();
+    // A tick attempted after stop must claim nothing at all.
+    await runtime.runner.runOnce();
+
+    expect(seen).toEqual([]);
+    const untouched = await readRow(job.id);
+    expect(untouched.state).toBe("queued");
+    expect(untouched.attempts).toBe(0);
+    expect(untouched.lease_token).toBeNull();
+
+    await deleteKind(kind);
+  });
+
+  it("dead-letters an expired lease that has consumed its attempts instead of reclaiming it", async () => {
+    // INVARIANT 2. A handler that hangs or crashes never calls complete/fail, so
+    // the ONLY path that ever revisits its row is the expiry reclaim. If that
+    // path ignores max_attempts the job is re-executed forever past its bound --
+    // the retry cap enforced on one exit and not the other.
+    //
+    // The expired state is constructed durably (a past lease_until on a row that
+    // has already consumed its attempts) rather than by waiting out a real lease,
+    // so the assertion is about the claim statement's rule and not about timing.
+    const kind = `${KIND_PREFIX}.expired`;
+    const seen: string[] = [];
+    const runtime = createMaintenanceRuntime({
+      config: config({ concurrency: 4 }),
+      logger: silentLogger(),
+      pool: await db(),
+      handlers: new Map([
+        [
+          kind,
+          async (job: MaintenanceJob) => {
+            seen.push(job.id);
+          },
+        ],
+      ]),
+      autoStart: false,
+    });
+    if (!runtime) throw new Error("maintenance runtime should be composed");
+
+    const exhausted = await runtime.queue.enqueue({
+      kind,
+      version: 1,
+      payload: { proof: "expired" },
+      idempotencyKey: "expired-1",
+      retry: { maxAttempts: 2 },
+    });
+    // A second job with budget REMAINING, expired the same way. It proves the
+    // rule terminates only the bounded row and does not simply stop reclaiming
+    // expired leases altogether -- a "fix" that stalled every recoverable job
+    // would otherwise pass the first assertion.
+    const recoverable = await runtime.queue.enqueue({
+      kind,
+      version: 1,
+      payload: { proof: "recoverable" },
+      idempotencyKey: "expired-2",
+      retry: { maxAttempts: 5 },
+    });
+
+    const client = await db();
+    await client.query(
+      `UPDATE maintenance_jobs
+          SET state = 'running',
+              lease_token = gen_random_uuid(),
+              lease_until = now() - interval '1 minute',
+              attempts = max_attempts
+        WHERE id = $1`,
+      [exhausted.id],
+    );
+    await client.query(
+      `UPDATE maintenance_jobs
+          SET state = 'running',
+              lease_token = gen_random_uuid(),
+              lease_until = now() - interval '1 minute',
+              attempts = 1
+        WHERE id = $1`,
+      [recoverable.id],
+    );
+
+    await runtime.runner.runOnce();
+
+    // The exhausted row terminated in the claim statement: it was never handed
+    // to a handler, and it satisfies every migration CHECK for a terminal row.
+    expect(seen).not.toContain(exhausted.id);
+    const dead = await readRow(exhausted.id);
+    expect(dead.state).toBe("dead_letter");
+    expect(dead.last_error_category).toBe("lease_expired");
+    expect(dead.lease_token).toBeNull();
+    expect(dead.lease_until).toBeNull();
+    expect(dead.terminal_at).not.toBeNull();
+    expect(dead.dead_lettered_at).not.toBeNull();
+    // attempts stays at the number of leases actually consumed; the sweep must
+    // not inflate the counter that gates the bound.
+    expect(dead.attempts).toBe(dead.max_attempts);
+
+    // The row with budget left was reclaimed and run normally.
+    expect(seen).toContain(recoverable.id);
+    const recovered = await readRow(recoverable.id);
+    expect(recovered.state).toBe("succeeded");
+
+    await deleteKind(kind);
+  });
+
+  it("dead-letters a terminal handler failure on this attempt and keeps bounded retry otherwise", async () => {
+    // The runner's failure classification, proven through the composed runtime.
+    // A handler declaring its own failure non-retryable must dead-letter NOW
+    // regardless of remaining budget, while an ordinary throw must go back to
+    // `queued` with a future run_after -- the two must not collapse into one
+    // policy, because that is how a permanent failure burns three retries or a
+    // transient one is discarded after the first.
+    const kind = `${KIND_PREFIX}.terminal`;
+    const ordinaryKind = `${KIND_PREFIX}.ordinary`;
+    const runtime = createMaintenanceRuntime({
+      config: config({ concurrency: 4 }),
+      logger: silentLogger(),
+      pool: await db(),
+      handlers: new Map<string, MaintenanceJobHandler>([
+        [
+          kind,
+          async () => {
+            throw new MaintenanceTerminalError("not retryable");
+          },
+        ],
+        [
+          ordinaryKind,
+          async () => {
+            throw new Error("transient");
+          },
+        ],
+      ]),
+      autoStart: false,
+    });
+    if (!runtime) throw new Error("maintenance runtime should be composed");
+
+    const terminal = await runtime.queue.enqueue({
+      kind,
+      version: 1,
+      payload: { proof: "terminal" },
+      idempotencyKey: "terminal-1",
+      retry: { maxAttempts: 3 },
+    });
+    const ordinary = await runtime.queue.enqueue({
+      kind: ordinaryKind,
+      version: 1,
+      payload: { proof: "ordinary" },
+      idempotencyKey: "ordinary-1",
+      retry: { maxAttempts: 3, backoffBaseMs: 60_000, backoffMaxMs: 120_000 },
+    });
+
+    await runtime.runner.runOnce();
+    await runtime.stop();
+
+    const dead = await readRow(terminal.id);
+    expect(dead.state).toBe("dead_letter");
+    expect(dead.last_error_category).toBe("terminal");
+    // Dead-lettered on attempt 1 of 3: the budget was NOT consumed first.
+    expect(dead.attempts).toBe(1);
+    expect(dead.max_attempts).toBe(3);
+
+    const retried = await readRow(ordinary.id);
+    expect(retried.state).toBe("queued");
+    expect(retried.last_error_category).toBe("error");
+    expect(retried.lease_token).toBeNull();
+    expect(retried.terminal_at).toBeNull();
+
+    await deleteKind(kind);
+    await deleteKind(ordinaryKind);
+  });
+
+  it("composes no runtime when the operator disabled maintenance", async () => {
+    // A disabled process must hold no poller at all. Returning `undefined`
+    // rather than an idle runner is what keeps "disabled" and "absent from the
+    // shutdown order" the same state -- they cannot disagree.
+    const runtime = createMaintenanceRuntime({
+      config: config({ enabled: false }),
+      logger: silentLogger(),
+      pool: await db(),
+      handlers: new Map([[`${KIND_PREFIX}.disabled`, async () => {}]]),
+    });
+    expect(runtime).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last named gap before the dogfood entrypoint flip: the maintenance
queue runner now runs inside the rewrite server and is drained by its ordered
shutdown.

PR #494 built the `backgroundRuntimes` port and deliberately stopped at its
edge. Its stated reason is worth quoting, because this PR does not overturn it:

> The queue and runner internals are deliberately not ported. The runner's
> `stop()` is not a cancel but a drain with a lease-boundary rule that took a
> review swarm to get right. Reimplementing it here to "finish the rewrite"
> would fork the one component whose failure mode is silent.

That is correct, so the port here is a **composition, not a copy**.
`src/maintenance-queue.ts` imports nothing but `pg` types (verified: one import
line in 952). It is already a standalone module, not an entangled one — so
there is exactly one runner, reachable from both compositions, and the eventual
`src/` retirement stays a file move rather than a reconciliation of two
divergent implementations. Copying 952 lines into `server/` would have created
precisely the second copy #494 warned about, and both would have needed the same
lease invariants re-proven forever.

## What was actually missing

The pieces on either side already existed and had never been joined:

- `server/config/maintenance.ts:54` parses the four env values. Its own header
  says it owns "the SETTINGS ONLY."
- `server/application/index.ts:54` declares `BackgroundRuntime` and drains it in
  order.

Nothing constructed a runner and handed it to that port. So the port had **no
production supplier at all** — every existing proof of ordered shutdown runs
against a fake runtime with no leases to drain, which is a proof about a shape
rather than about a runner.

`server/maintenance/index.ts` is that missing piece. It builds the queue and
runner from the already-parsed config, and presents them as one
`BackgroundRuntime`. The application composes it whenever a process supplies a
handler map, and places it **last** in the shutdown order: the queue runner is
the drain that needs the database longest, because it must finish jobs it has
already leased. Anything stopped after it would be stopped while it was still
using the pool.

Two states deliberately produce an empty shutdown order, and they are distinct:
`OPEN_BRAIN_MAINTENANCE_ENABLED=0` is an operator opting a worker out, while an
absent handler map means the process was never given a dispatch surface. Both
compose no runner, so "maintenance is running" and "maintenance is in the
shutdown order" cannot disagree — which is the failure the drain exists to
prevent.

## The lease invariants, proven rather than inherited

Both invariants fail **silently**: a row sits `running` under a live lease with
no handler attached, nothing throws, and nothing is logged. A fake queue cannot
prove either one, because the entire failure mode is that the in-memory story
and the durable row disagree. So `server/maintenance/maintenance.pg.test.ts`
reads `maintenance_jobs` back with SQL after every assertion, against a real
isolated database.

1. **Stop is a DRAIN, not a cancel** (PR #350 / issue #343,
   `docs/sme/domain-backend.md`). A claim in flight when `stop()` is called has
   already leased rows; they are owned work and must be dispatched, tracked, and
   completed before `stop()` resolves.
2. **The retry bound governs the expiry path too** (`docs/sme/correctness.md`).
   An expired `running` row that has consumed `max_attempts` dead-letters inside
   the claim statement instead of being reclaimed forever, and never reaches the
   runner as claimed work.

## Red-proven

Eight mutations, each observed failing, each hitting its own test:

| Mutation | Result |
|---|---|
| delete `await this.tickPromise` from runner `stop()` | drain test fails |
| reinstate the mid-loop `if (this.stopping) return` (the literal PR #350 defect) | drain test fails |
| drop `WHERE state='queued' OR attempts < max_attempts` from the reclaim CTE | expired-lease test fails |
| `const terminal = false` in `queue.fail()` | terminal-vs-retry test fails |
| bypass the disabled-config branch | disabled-composition test fails (both suites) |
| move maintenance first in the shutdown array | ordering test fails |
| compose a runner for a process with no handler map | no-handlers test fails |

`src/` was restored byte-clean after every mutation; `git diff --stat src/` is
empty in the merged result.

## The red-proof found a defect in this PR's own test first

The drain test originally passed under the exact mutation it exists to catch —
5/5 green with `await this.tickPromise` deleted from the runner. Two independent
mistakes, both invisible on reading:

**It awaited the work before asserting.** `await stopping; await tick;` then
reading the row guarantees the handler finished regardless of what `stop()` did,
so the row read terminal even under a `stop()` that abandoned it. The assertion
now binds to the instant `stop()` resolves, and joins the tick only afterwards.

**It opened the window at the wrong boundary.** The first version blocked inside
the handler and called `stop()` at handler-start — but a dispatched job is
already tracked in the runner's `active` set, and every implementation waits on
that set. The recorded defect lives one step earlier, between a claim committing
its leases and those rows being tracked. Reaching it required wrapping
`claimDueJobs` so the real claim commits and then parks, leaving rows genuinely
leased and not yet tracked.

Both are fixed, and the pattern is written into `docs/sme/gotcha-agent.md` so
the next swarm checks for it.

## Anti-skip guard

The new suite is registered in `scripts/assert-db-tests-ran.ts` and named with
the required `(live Postgres)` marker. This registration matters more than most:
because both invariants fail silently, a skipped run and a passing run look
identical from the outside — exactly what the guard exists for. Total floor
53 → 58.

JUnit receipt: `tests="5" failures="0" skipped="0"`.

The guard's only complaint is the pre-existing `local clone real PostgreSQL
boundary` skip, which needs CI's role setup. Verified identical on the base
branch by stashing this work: 6 pass / 1 skip / 0 fail. It is not from this
change.

## Testing

- `bunx tsc --noEmit` — clean
- `bun test` — **3366 pass / 0 fail / 35 skip** across 222 files
- contract parity — 52 fixtures across 45 capabilities and 2 server providers;
  63/63 `current-src` MCP tools fixture-covered, 0 explicit gaps
- new lease suite — 5 pass / 31 expect() calls, stable across 5 consecutive runs
- live Postgres — isolated `open_brain_maint_runner_test`, 47 migrations. The
  dogfood database `open_brain_local_20260724` was never written to; `.env` was
  read only for host and role.
- `python/` — untouched, `git status --short python/` empty

## Critical Self-Review

- Highest-risk behavior: the shutdown ORDER, because getting it wrong is silent. If maintenance stopped after something that closes the pool, an orderly drain becomes the abandoned-lease failure the drain exists to prevent — and the symptom is rows stuck `running`, not an error. Covered by an ordering assertion red-proven against moving maintenance first, and by the real-database drain test that reads the row the instant `stop()` resolves.
- Assumptions that could be wrong: that composing maintenance inside `createShadowApplication` is the right owner rather than leaving it to a future entrypoint. If a worker ever needs two differently-configured runners, this shape composes one; the `backgroundRuntimes` input still accepts extras, so the escape hatch exists, but the composed one is not individually addressable.
- Missing/weak tests: the application-level composition tests use a fake database and `maintenanceAutoStart: false`, so they prove placement and suppression but never that a composed runner actually polls in the assembled application — the polling proof lives in the pg suite against a directly-composed runtime. Nothing here exercises a real handler doing real work; the handlers are `src/`-owned and unchanged, but the join between this composition and the real handler map is therefore PROPOSED, not proven.
- Security/permission risk: none introduced. This composes existing components and adds no auth decision, no SQL, and no namespace predicate. The pino-to-queue logger adapter swaps argument order only — no field is added, renamed, or dropped — and the queue's fields were already content-free (counts, job ids, kinds, stable status tokens), so no payload or error text reaches a log through this path.
- Migration/deploy risk: none. No migration, no schema change, no entrypoint change. `SERVER_REWRITE_STATE.servesTraffic` stays `false` and `server/state.ts` is untouched, so nothing composed here serves traffic on merge.
- Downstream client/runtime risk: none. No MCP tool, schema, contract, or wire format changed; `contracts/` is byte-unchanged and the gap map still matches the live `current-src` registry at 63 tools with 0 gaps, which is correct because this registers no new `src/` tool. Per `docs/downstream-rollout.md` this is not a contract-changing change, so no rtech-mcps, mcp2cli, or Hermes step applies.
- Rollback/cleanup concern: revert is a single commit touching six files, two of them new, and `src/` is not among them. The isolated test database is disposable and outside the repo; the worktree is removed after merge.
- Fixes made before PR: two, both in this PR's own new tests and both found by the red-proof rather than by reading — the vacuous drain assertion and the wrong-boundary shutdown window, described in full above. Also renamed the suite to carry the `(live Postgres)` marker after finding it would otherwise never be counted by the anti-skip guard.
- Known residual risk: this is MERGED-not-RUNNING. The composition is proven against an isolated database and an unassembled application; nothing here has run in the dogfood entrypoint or on core01, and the entrypoint flip is a separate lane. The handler map is supplied by the caller and no caller supplies one yet in production, so a real end-to-end maintenance job through the rewrite server remains PROPOSED.
- SME review-memory update: [x] `docs/sme/` updated — the vacuous drain assertion is a new MEDIUM pattern not previously recorded, added to `docs/sme/gotcha-agent.md`: a lifecycle test that awaits the thing under test collapses the window it exists to open, and passes under the exact defect it targets.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR changes no serving code — `servesTraffic` stays `false`, no production entrypoint or start script is touched, no caller supplies a handler map in production, and every assertion runs against an isolated test database.

## Contract Parity

- Contract parity: [x] runtime-specific because: no fixture was added or changed and no tool behavior was recorded. `contracts/` is byte-unchanged — `git diff --stat contracts/` is empty — and the gap map still matches the live `current-src` registry at 63 tools with 0 gaps, which is the correct state for a change that registers no new `src/` tool and alters no MCP surface. This is composition and lifecycle wiring inside the rewrite candidate; the frozen shapes stay the oracle and neither provider's parity count moves.
