### PR TITLE
fix(contracts): derive the rewrite's contract declaration from what it registers

### DIFF
--- a/contracts/check-parity.ts
+++ b/contracts/check-parity.ts
@@ -167,12 +167,21 @@ for (const entry of manifest.capabilities ?? []) {
   }
 }
 
-// Every server implementation declares the same reviewed contract identity.
-// The running src/ provider derives it from buildContract; the rewrite provider
-// is declaration-only until its real schemas and handlers arrive.
+// Every server implementation declares the same reviewed contract identity, and
+// BOTH providers now derive it from buildContract rather than asserting it. The
+// rewrite's declaration used to be two string literals, so the fixture
+// comparison below matched a constant against itself and reported green no
+// matter what the rewrite had actually built.
+//
+// Deriving the identity makes that comparison honest but also makes it weak:
+// two derived values agree by construction. The identity check is therefore no
+// longer the load-bearing assertion for the rewrite -- `satisfaction` is. A
+// contract is a promise about tools, so the question worth failing on is
+// whether the provider REGISTERS what its contract names.
 const serverDeclarations = SERVER_CONTRACT_PROVIDERS.map((provider) => ({
   provider,
   declaration: provider.declaration("1970-01-01T00:00:00.000Z"),
+  satisfaction: provider.satisfaction?.("1970-01-01T00:00:00.000Z"),
 }));
 
 const fixtureGlob = new Bun.Glob("*.fixture.json");
@@ -337,7 +346,6 @@ for (const pending of manifest.not_yet_extracted ?? []) {
     );
   }
 }
-
 const providerIds = serverDeclarations.map(({ provider }) => provider.id);
 if (JSON.stringify(serverManifest.providers) !== JSON.stringify(providerIds)) {
   errors.push(
@@ -366,6 +374,7 @@ for (const providerId of providerIds) {
 const observedServerFixtureIds = new Set<string>();
 const observedServerCapabilities = new Set<string>();
 const observedServerTools = new Set<string>();
+const serverFixtures: ServerFixture[] = [];
 let serverFixtureCount = 0;
 const serverFixtureGlob = new Bun.Glob("*.fixture.json");
 for await (const name of serverFixtureGlob.scan({
@@ -374,6 +383,7 @@ for await (const name of serverFixtureGlob.scan({
 })) {
   serverFixtureCount += 1;
   const fixture = await readJson<ServerFixture>(new URL(name, serverFixtureDir));
+  serverFixtures.push(fixture);
   const prefix = `server/${name}:`;
   observedServerFixtureIds.add(fixture.id);
   observedServerCapabilities.add(fixture.capability);
@@ -424,6 +434,89 @@ for (const id of expectedServerFixtureIds) {
 for (const capability of serverCapabilities) {
   if (!observedServerCapabilities.has(capability)) {
     errors.push(`server/parity-manifest.json: capability '${capability}' has no fixture`);
+  }
+}
+
+// Does each provider's registered tool set satisfy the contract it declares?
+//
+// This is the assertion the old gate was missing. It compared the rewrite's
+// hardcoded {contractVersion, schemaHash} literals to buildContract() -- a
+// constant against itself -- so it stayed green regardless of what the rewrite
+// had actually built.
+//
+// The predicate is LEDGER-AWARE rather than absolute, and that is the design
+// decision. `contracts/README.md` says parity-manifest.json "declares the
+// current implementation asymmetry", and the server manifest already records
+// per capability which provider has really built it (`implemented`) versus only
+// declared it (`scaffold-declared`). The rewrite carries 6 scaffold-declared
+// capabilities today, `citation-recall` among them. A gate that ignored that
+// ledger would not measure drift; it would re-litigate a port schedule the repo
+// has already written down, and the only way to green it would be to lie in the
+// manifest. So this reads the declared asymmetry instead of overriding it:
+//
+//   - a tool whose capability the provider claims `implemented` MUST be
+//     registered. Claiming it and not registering it is drift -- exactly the
+//     failure the literals hid.
+//   - a tool whose capability is `scaffold-declared` may be absent, and is
+//     REPORTED so the remaining port surface stays visible instead of silent.
+//
+// Registering MORE than the contract requires is allowed: the rewrite carries
+// `record_skill_usage`/`skill_usage_report` (#469), which the frozen contract
+// never named. Only a shortfall against a claim can break a client.
+const satisfactionNotes: string[] = [];
+for (const { provider, satisfaction } of serverDeclarations) {
+  if (!satisfaction) continue;
+  if (satisfaction.registeredTools.length === 0) {
+    errors.push(
+      `${provider.id}: registry walk returned zero tools -- the walk is broken, not the registry empty`,
+    );
+    continue;
+  }
+
+  const statuses = serverManifest.provider_capability_status?.[provider.id] ?? {};
+  // Map each tool to the capability the server fixtures file it under, so a
+  // missing tool can be judged against that capability's declared status.
+  const toolCapability = new Map<string, string>();
+  for (const fixture of serverFixtures) {
+    for (const step of fixture.steps ?? []) {
+      if (step.tool && !toolCapability.has(step.tool)) {
+        toolCapability.set(step.tool, fixture.capability);
+      }
+    }
+  }
+
+  const claimedMissing: string[] = [];
+  const scaffoldMissing: string[] = [];
+  for (const tool of satisfaction.missingTools) {
+    const capability = toolCapability.get(tool);
+    // No mapping means no fixture files this tool at all, so nothing has
+    // declared it deferred -- treat it as claimed and fail rather than excuse it.
+    if (capability && statuses[capability] === "scaffold-declared") {
+      scaffoldMissing.push(`${tool} (${capability})`);
+    } else {
+      claimedMissing.push(
+        capability ? `${tool} (${capability})` : `${tool} (unmapped)`,
+      );
+    }
+  }
+
+  if (claimedMissing.length > 0) {
+    errors.push(
+      `${provider.id}: registry does not satisfy the contract it declares -- ${claimedMissing.length} of ${satisfaction.requiredTools.length} required tool(s) missing while their capability is claimed implemented: ${claimedMissing.join(", ")}`,
+    );
+  }
+  if (scaffoldMissing.length > 0) {
+    satisfactionNotes.push(
+      `${provider.id}: ${scaffoldMissing.length} contract-required tool(s) still unported, each covered by a scaffold-declared capability: ${scaffoldMissing.join(", ")}`,
+    );
+  }
+  const extra = satisfaction.registeredTools.filter(
+    (tool) => !satisfaction.requiredTools.includes(tool),
+  );
+  if (extra.length > 0) {
+    satisfactionNotes.push(
+      `${provider.id}: registers ${extra.length} tool(s) beyond the frozen contract (allowed): ${extra.join(", ")}`,
+    );
   }
 }
 
@@ -502,6 +595,17 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
+for (const note of satisfactionNotes) console.log(`note: ${note}`);
+
+const satisfactionSummary = serverDeclarations
+  .filter((entry) => entry.satisfaction)
+  .map((entry) => {
+    const { registeredTools, requiredTools, missingTools } = entry.satisfaction!;
+    const met = requiredTools.length - missingTools.length;
+    return `${entry.provider.id} registers ${registeredTools.length} tools covering ${met}/${requiredTools.length} contract-required${missingTools.length > 0 ? ` (${missingTools.length} scaffold-declared, not yet ported)` : ""}`;
+  })
+  .join("; ");
+
 console.log(
-  `Contract parity check passed: ${fixtureCount + serverFixtureCount} fixtures across ${capabilityMap.size + serverCapabilities.size} capabilities and ${serverDeclarations.length} server providers; ${observedServerTools.size}/${registeredServerTools.size} current-src MCP tools fixture-covered with ${declaredGapTools.size} explicit gaps.`,
+  `Contract parity check passed: ${fixtureCount + serverFixtureCount} fixtures across ${capabilityMap.size + serverCapabilities.size} capabilities and ${serverDeclarations.length} server providers; ${observedServerTools.size}/${registeredServerTools.size} current-src MCP tools fixture-covered with ${declaredGapTools.size} explicit gaps${satisfactionSummary ? `; ${satisfactionSummary}` : ""}.`,
 );

--- a/contracts/server-contract-providers.ts
+++ b/contracts/server-contract-providers.ts
@@ -1,5 +1,9 @@
 import { buildContract } from "../src/contract.ts";
-import { SERVER_CONTRACT_DECLARATION } from "../server/contracts/declaration.ts";
+import {
+  rewriteContractSatisfaction,
+  serverContractDeclaration,
+  type RewriteContractSatisfaction,
+} from "../server/contracts/declaration.ts";
 
 export interface ContractDeclarationProvider {
   id: "current-src" | "server-rewrite-scaffold";
@@ -8,6 +12,14 @@ export interface ContractDeclarationProvider {
     contractVersion: string;
     schemaHash: string;
   };
+  /**
+   * Whether this provider's REGISTERED tools satisfy the contract it declares.
+   *
+   * Optional because it only means something for a provider whose registry the
+   * checker can walk in-process. `current-src` already has an equivalent, and
+   * stricter, invariant in the tool gap map.
+   */
+  satisfaction?(generatedAt: string): RewriteContractSatisfaction;
 }
 
 export const SERVER_CONTRACT_PROVIDERS: readonly ContractDeclarationProvider[] = [
@@ -25,8 +37,16 @@ export const SERVER_CONTRACT_PROVIDERS: readonly ContractDeclarationProvider[] =
   {
     id: "server-rewrite-scaffold",
     state: "partial-implementation",
-    declaration() {
-      return SERVER_CONTRACT_DECLARATION;
+    // DERIVED, not asserted. This was a pair of hardcoded literals, so the
+    // parity check compared a constant to itself and reported green while the
+    // rewrite registry was short of the contract. Identity now comes from the
+    // same builder the running provider uses; `satisfaction` is what proves the
+    // rewrite has earned the identity it declares.
+    declaration(generatedAt) {
+      return serverContractDeclaration(generatedAt);
+    },
+    satisfaction(generatedAt) {
+      return rewriteContractSatisfaction(generatedAt);
     },
   },
 ];

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1531,3 +1531,56 @@ no-op. Nothing is dropped and nothing is stored twice.
   cannot fail on the oversized input, it is not proving the path.
 - On a send failure, does the watermark (or any resume cursor) stay put so the
   region re-reads, and is the re-send idempotent on the server's dedupe key?
+
+## [2026-08-02] A gate that compares a constant to itself has no failing input
+
+**Severity:** HIGH
+**Source:** PR (this change), `contracts/check-parity.ts`, `server/contracts/declaration.ts`
+**Scope:** any parity/compatibility gate that compares a declared value to a computed one
+**Status:** active
+
+### Pattern
+
+`server/contracts/declaration.ts` declared the rewrite's contract identity as
+two hardcoded string literals, and `contracts/check-parity.ts` asserted those
+literals equalled `buildContract()`. Both sides were fixed text that a human had
+already made match, so the assertion could not fail for any state of the code it
+claimed to police. Contract parity reported GREEN across every run while the
+rewrite registry was missing a tool the frozen contract requires.
+
+The gate was not weak, it was VACUOUS: it proved the `src` side (which really
+derives from the builder) and merely echoed the server side back. The same
+report line carried both, so the honest half lent its credibility to the half
+that measured nothing.
+
+Two second-order traps came with it. First, deriving both sides fixes the lie
+but produces a comparison that passes by construction -- correct and still
+worthless -- so the real assertion has to move to something the identity string
+cannot express: does the implementation REGISTER what its contract promises.
+Second, the obvious way to enumerate a registry (regex the source for
+`registerTool(`) silently found ZERO tools in `server/tools`, because `src`
+writes the tool name on the same line as the call and `server` writes it on the
+next. A shortfall check over an empty set reports success, which would have
+replaced one vacuous gate with another. Running the real registrar against a
+recording stand-in cannot lie about what is registered; a zero-tool result now
+throws rather than passing.
+
+The final predicate reads the ledger the repo already keeps
+(`provider_capability_status`: `implemented` vs `scaffold-declared`) so it fails
+on the false CLAIM rather than on the unfinished port -- otherwise the only way
+to green it is to lie in the manifest.
+
+### Review Questions
+
+- For every equality assertion in a gate: can BOTH sides change independently?
+  If one is a literal a human keeps in sync with the other, the check has no
+  failing input and proves nothing. Ask what edit would make it red.
+- When a check is made honest by deriving a previously-hardcoded value, does the
+  comparison still assert anything, or do the two sides now agree by
+  construction? Derivation removes the lie; it does not by itself restore the
+  signal.
+- Does any registry/inventory scan report a plausible-looking ZERO or a suspicious
+  count? Print the count and assert a floor. A pattern that matches nothing makes
+  every downstream "nothing is missing" conclusion vacuous.
+- Was the gate proven RED by fault injection on the real tree, or only observed
+  green? A green gate is evidence of nothing until something has made it fail.

--- a/server/contracts/declaration.test.ts
+++ b/server/contracts/declaration.test.ts
@@ -16,7 +16,7 @@ import {
   rewriteContractSatisfaction,
   serverContractDeclaration,
 } from "./declaration.ts";
-import { REWRITE_REGISTERED_TOOLS } from "./registered-tools.ts";
+import { rewriteRegisteredTools } from "./registered-tools.ts";
 
 const GENERATED_AT = "1970-01-01T00:00:00.000Z";
 
@@ -103,11 +103,28 @@ describe("the live rewrite registry", () => {
     // the tool name on the same line as `registerTool(` while `server/tools`
     // puts it on the next, so the src-side single-line pattern finds ZERO
     // rewrite tools -- and a shortfall check over an empty set reports success.
-    expect(REWRITE_REGISTERED_TOOLS.length).toBeGreaterThan(50);
-    expect(REWRITE_REGISTERED_TOOLS).toContain("get_contract");
-    expect(new Set(REWRITE_REGISTERED_TOOLS).size).toBe(
-      REWRITE_REGISTERED_TOOLS.length,
-    );
+    const registered = rewriteRegisteredTools();
+    expect(registered.length).toBeGreaterThan(50);
+    expect(registered).toContain("get_contract");
+    expect(new Set(registered).size).toBe(registered.length);
+  });
+
+  test("resolves through the get_contract import cycle without a TDZ error", () => {
+    // `registered-tools` and `tools/get-contract` import each other. Computing
+    // the set at module load made whichever side loaded second read the other's
+    // binding while still in its temporal dead zone -- 69 server tests failed in
+    // CI on `Cannot access 'REWRITE_REGISTERED_TOOLS' before initialization`
+    // while passing locally on a luckier module order. Importing the tool module
+    // FIRST here reproduces the order that broke, so this fails if the walk ever
+    // goes eager again.
+    const registrar = require("../tools/get-contract.ts");
+    expect(typeof registrar.registerGetContractTool).toBe("function");
+    expect(() => rewriteRegisteredTools()).not.toThrow();
+    expect(rewriteRegisteredTools()).toContain("get_contract");
+  });
+
+  test("caches the walk instead of re-running the registrar per call", () => {
+    expect(rewriteRegisteredTools()).toBe(rewriteRegisteredTools());
   });
 
   test("registers every contract-required tool whose port has landed", () => {

--- a/server/contracts/declaration.test.ts
+++ b/server/contracts/declaration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The rewrite's contract declaration is DERIVED, not asserted.
+ *
+ * These tests exist because the thing they replace could not fail. The
+ * declaration used to be two hardcoded string literals, and
+ * `contracts/check-parity.ts` compared them to `buildContract()` -- so parity
+ * reported green while the rewrite registry was materially short of the
+ * contract it claimed to implement. A check that compares a constant to itself
+ * has no failing input, which is exactly why nothing caught it.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildContract } from "../../src/contract.ts";
+import {
+  contractRequiredTools,
+  evaluateRewriteContractSatisfaction,
+  rewriteContractSatisfaction,
+  serverContractDeclaration,
+} from "./declaration.ts";
+import { REWRITE_REGISTERED_TOOLS } from "./registered-tools.ts";
+
+const GENERATED_AT = "1970-01-01T00:00:00.000Z";
+
+describe("serverContractDeclaration", () => {
+  test("derives the identity from buildContract rather than restating it", () => {
+    const contract = buildContract(GENERATED_AT);
+    expect(serverContractDeclaration(GENERATED_AT)).toEqual({
+      contractVersion: contract.contract_version,
+      schemaHash: contract.schema_hash,
+    });
+  });
+
+  test("still reports the reviewed frozen identity", () => {
+    // Pinned independently of `src/contract.test.ts`: deriving the value must
+    // not quietly change what the rewrite tells downstream clients.
+    expect(serverContractDeclaration(GENERATED_AT)).toEqual({
+      contractVersion: "2026-07-23.memory-tools.v23",
+      schemaHash:
+        "4b69e9b437c96175531b049b6e3c2782f383334e9e1931e96e73835599e4a4a8",
+    });
+  });
+});
+
+describe("contractRequiredTools", () => {
+  test("unions tool_contracts keys with kind:'tool' capabilities", () => {
+    const required = contractRequiredTools({
+      tool_contracts: { alpha: {}, beta: {} },
+      capabilities: [
+        { name: "beta", kind: "tool" },
+        { name: "gamma", kind: "tool" },
+        { name: "some_payload", kind: "schema" },
+        { name: "streamable_http", kind: "transport" },
+      ],
+    });
+    // gamma comes from the capability list alone, so a contract that names a
+    // tool without a schema entry is still demanded.
+    expect(required).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("excludes schema and transport capabilities, which are not tools", () => {
+    const required = contractRequiredTools({
+      tool_contracts: {},
+      capabilities: [
+        { name: "receipt_contract", kind: "schema" },
+        { name: "streamable_http_auth", kind: "transport" },
+      ],
+    });
+    expect(required).toEqual([]);
+  });
+});
+
+describe("evaluateRewriteContractSatisfaction", () => {
+  test("names every required tool the registry does not register", () => {
+    const result = evaluateRewriteContractSatisfaction(
+      ["alpha", "beta", "gamma"],
+      ["alpha"],
+    );
+    expect(result.satisfied).toBe(false);
+    expect(result.missingTools).toEqual(["beta", "gamma"]);
+  });
+
+  test("allows registering more than the contract requires", () => {
+    // The rewrite deliberately carries record_skill_usage/skill_usage_report
+    // (#469), which the frozen contract never named. Extra surface cannot break
+    // a client holding the contract; only a shortfall can.
+    const result = evaluateRewriteContractSatisfaction(
+      ["alpha"],
+      ["alpha", "record_skill_usage"],
+    );
+    expect(result.satisfied).toBe(true);
+    expect(result.missingTools).toEqual([]);
+  });
+
+  test("an empty registry does not vacuously satisfy a real contract", () => {
+    const result = evaluateRewriteContractSatisfaction(["alpha"], []);
+    expect(result.satisfied).toBe(false);
+    expect(result.missingTools).toEqual(["alpha"]);
+  });
+});
+
+describe("the live rewrite registry", () => {
+  test("is walked by running the real registrar, not by scanning source", () => {
+    // Guards the failure mode a regex has and this does not: `src/tools` puts
+    // the tool name on the same line as `registerTool(` while `server/tools`
+    // puts it on the next, so the src-side single-line pattern finds ZERO
+    // rewrite tools -- and a shortfall check over an empty set reports success.
+    expect(REWRITE_REGISTERED_TOOLS.length).toBeGreaterThan(50);
+    expect(REWRITE_REGISTERED_TOOLS).toContain("get_contract");
+    expect(new Set(REWRITE_REGISTERED_TOOLS).size).toBe(
+      REWRITE_REGISTERED_TOOLS.length,
+    );
+  });
+
+  test("registers every contract-required tool whose port has landed", () => {
+    const result = rewriteContractSatisfaction(GENERATED_AT);
+    // Asserted as a set difference rather than `satisfied === true`: the port is
+    // still in flight, and `contracts/check-parity.ts` is what judges each
+    // remaining gap against its capability's declared status. Anything missing
+    // here that is NOT a known scaffold-declared capability is drift.
+    const KNOWN_UNPORTED = ["citation_recall"];
+    expect(
+      result.missingTools.filter((tool) => !KNOWN_UNPORTED.includes(tool)),
+    ).toEqual([]);
+  });
+});

--- a/server/contracts/declaration.ts
+++ b/server/contracts/declaration.ts
@@ -1,9 +1,91 @@
+import { buildContract } from "../../src/contract.ts";
+import { REWRITE_REGISTERED_TOOLS } from "./registered-tools.ts";
+
 export interface ServerContractDeclaration {
   contractVersion: string;
   schemaHash: string;
 }
 
-export const SERVER_CONTRACT_DECLARATION: ServerContractDeclaration = {
-  contractVersion: "2026-07-23.memory-tools.v23",
-  schemaHash: "4b69e9b437c96175531b049b6e3c2782f383334e9e1931e96e73835599e4a4a8",
-};
+/**
+ * What the frozen contract REQUIRES any server implementation to register.
+ *
+ * `tool_contracts` keys and the `kind: "tool"` capability names are the same 21
+ * names today, but they are two independent statements in the contract and are
+ * unioned rather than assumed equal -- if a later contract adds a tool
+ * capability without a schema entry (or the reverse), this still demands both.
+ * `kind: "schema"` and `kind: "transport"` capabilities are excluded: they name
+ * payload shapes and the HTTP transport, not registered MCP tools.
+ */
+export function contractRequiredTools(contract: {
+  tool_contracts: Record<string, unknown>;
+  capabilities: ReadonlyArray<{ name: string; kind: string }>;
+}): string[] {
+  const required = new Set<string>(Object.keys(contract.tool_contracts));
+  for (const capability of contract.capabilities) {
+    if (capability.kind === "tool") required.add(capability.name);
+  }
+  return [...required].sort();
+}
+
+export interface RewriteContractSatisfaction {
+  requiredTools: string[];
+  registeredTools: string[];
+  missingTools: string[];
+  satisfied: boolean;
+}
+
+/**
+ * Does the rewrite registry satisfy the frozen contract?
+ *
+ * Registering MORE than the contract requires is not a violation -- the rewrite
+ * deliberately carries `record_skill_usage`/`skill_usage_report` (#469), which
+ * the contract never promised. Registering LESS is: a client holding this
+ * contract would call a tool the rewrite does not answer.
+ */
+export function evaluateRewriteContractSatisfaction(
+  requiredTools: readonly string[],
+  registeredTools: readonly string[],
+): RewriteContractSatisfaction {
+  const registered = new Set(registeredTools);
+  const missingTools = requiredTools.filter((tool) => !registered.has(tool));
+  return {
+    requiredTools: [...requiredTools],
+    registeredTools: [...registeredTools].sort(),
+    missingTools,
+    satisfied: missingTools.length === 0,
+  };
+}
+
+/**
+ * The rewrite's contract identity, DERIVED -- not asserted.
+ *
+ * This used to be two hardcoded string literals, which made
+ * `contracts/check-parity.ts` compare a constant to itself: parity stayed green
+ * while the rewrite registry was materially short of the contract it claimed to
+ * implement. The gate proved the src side and merely echoed the server side.
+ *
+ * The identity now comes from the same `buildContract()` the running src
+ * provider derives from, so the two can no longer drift apart by editing a
+ * string. Whether the rewrite actually HONORS that identity is a separate
+ * question, answered by `rewriteContractSatisfaction()` and enforced by the
+ * checker -- an identity is a claim, and the claim is only worth what the
+ * registry backs.
+ */
+export function serverContractDeclaration(
+  generatedAt: string,
+): ServerContractDeclaration {
+  const contract = buildContract(generatedAt);
+  return {
+    contractVersion: contract.contract_version,
+    schemaHash: contract.schema_hash,
+  };
+}
+
+export function rewriteContractSatisfaction(
+  generatedAt: string,
+): RewriteContractSatisfaction {
+  return evaluateRewriteContractSatisfaction(
+    contractRequiredTools(buildContract(generatedAt)),
+    REWRITE_REGISTERED_TOOLS,
+  );
+}

--- a/server/contracts/declaration.ts
+++ b/server/contracts/declaration.ts
@@ -1,5 +1,5 @@
 import { buildContract } from "../../src/contract.ts";
-import { REWRITE_REGISTERED_TOOLS } from "./registered-tools.ts";
+import { rewriteRegisteredTools } from "./registered-tools.ts";
 
 export interface ServerContractDeclaration {
   contractVersion: string;
@@ -86,6 +86,6 @@ export function rewriteContractSatisfaction(
 ): RewriteContractSatisfaction {
   return evaluateRewriteContractSatisfaction(
     contractRequiredTools(buildContract(generatedAt)),
-    REWRITE_REGISTERED_TOOLS,
+    rewriteRegisteredTools(),
   );
 }

--- a/server/contracts/registered-tools.ts
+++ b/server/contracts/registered-tools.ts
@@ -1,0 +1,61 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerMemoryTools } from "../tools/index.ts";
+import type { MemoryToolDependencies } from "../tools/types.ts";
+
+/**
+ * The tool names the rewrite ACTUALLY registers, observed by running the real
+ * registrar.
+ *
+ * This drives `registerMemoryTools()` -- the same function `server/index.ts`
+ * calls -- against a recording stand-in for `McpServer`, rather than scanning
+ * `server/tools/*.ts` for a `registerTool(` string. Source scanning is what the
+ * src-side gap map does, and it is load-bearing there because it also has to
+ * attribute a tool to a file; here it would be a second, weaker model of the
+ * registry that a regex detail can silently falsify. That is not hypothetical:
+ * `src/tools` puts the tool name on the same line as `registerTool(` while
+ * `server/tools` puts it on the next line, so the existing single-line pattern
+ * finds ZERO rewrite tools. A check that reports "nothing missing" because its
+ * regex matched nothing is the exact failure this whole change exists to remove.
+ *
+ * Registration is pure name/schema/handler bookkeeping -- no handler runs and
+ * nothing touches the pool -- so the dependencies are never dereferenced.
+ */
+function collectRegisteredTools(): string[] {
+  const names: string[] = [];
+  const recorder = {
+    registerTool(name: string) {
+      names.push(name);
+      // The SDK hands back a live tool handle; registrars may chain off it.
+      return {
+        enable() {},
+        disable() {},
+        remove() {},
+        update() {},
+      };
+    },
+  };
+
+  registerMemoryTools(
+    recorder as unknown as McpServer,
+    // Never dereferenced: registration stores handlers, it does not invoke them.
+    {} as unknown as MemoryToolDependencies,
+  );
+
+  const unique = [...new Set(names)].sort();
+  if (unique.length !== names.length) {
+    const seen = new Set<string>();
+    const duplicates = [...new Set(names.filter((n) => !seen.add(n)))].sort();
+    throw new Error(
+      `server/tools registers duplicate tool name(s): ${duplicates.join(", ")}`,
+    );
+  }
+  if (unique.length === 0) {
+    throw new Error(
+      "server/tools registered zero tools -- the registry walk is broken, not empty",
+    );
+  }
+  return unique;
+}
+
+export const REWRITE_REGISTERED_TOOLS: readonly string[] =
+  collectRegisteredTools();

--- a/server/contracts/registered-tools.ts
+++ b/server/contracts/registered-tools.ts
@@ -20,6 +20,28 @@ import type { MemoryToolDependencies } from "../tools/types.ts";
  * Registration is pure name/schema/handler bookkeeping -- no handler runs and
  * nothing touches the pool -- so the dependencies are never dereferenced.
  */
+let cached: readonly string[] | undefined;
+
+/**
+ * Resolved on FIRST CALL, never at module load.
+ *
+ * This module and `../tools/get-contract.ts` import each other: get-contract
+ * needs the registered set to report a shortfall, and the registry walk needs
+ * the tool module that registers it. Computing this eagerly made the value a
+ * module-init constant, so whichever side of the cycle loaded second saw the
+ * other's binding still in its temporal dead zone -- `ReferenceError: Cannot
+ * access 'REWRITE_REGISTERED_TOOLS' before initialization`, which took down
+ * `registerMemoryTools` and with it 69 server tests in CI while passing locally
+ * on a luckier module order.
+ *
+ * Deferring to call time breaks the cycle without breaking the layering: by the
+ * time anything asks, both modules are fully evaluated.
+ */
+export function rewriteRegisteredTools(): readonly string[] {
+  cached ??= collectRegisteredTools();
+  return cached;
+}
+
 function collectRegisteredTools(): string[] {
   const names: string[] = [];
   const recorder = {
@@ -56,6 +78,3 @@ function collectRegisteredTools(): string[] {
   }
   return unique;
 }
-
-export const REWRITE_REGISTERED_TOOLS: readonly string[] =
-  collectRegisteredTools();

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,7 +4,7 @@ export {
   rewriteContractSatisfaction,
   serverContractDeclaration,
 } from "./contracts/declaration.ts";
-export { REWRITE_REGISTERED_TOOLS } from "./contracts/registered-tools.ts";
+export { rewriteRegisteredTools } from "./contracts/registered-tools.ts";
 export { DATABASE_BOUNDARY } from "./db/index.ts";
 export { DOMAIN_BOUNDARY } from "./domain/index.ts";
 export { OBSERVABILITY_BOUNDARY } from "./observability/index.ts";

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,10 @@
 export { APPLICATION_BOUNDARY } from "./application/index.ts";
 export { CONFIG_BOUNDARY } from "./config/index.ts";
-export { SERVER_CONTRACT_DECLARATION } from "./contracts/declaration.ts";
+export {
+  rewriteContractSatisfaction,
+  serverContractDeclaration,
+} from "./contracts/declaration.ts";
+export { REWRITE_REGISTERED_TOOLS } from "./contracts/registered-tools.ts";
 export { DATABASE_BOUNDARY } from "./db/index.ts";
 export { DOMAIN_BOUNDARY } from "./domain/index.ts";
 export { OBSERVABILITY_BOUNDARY } from "./observability/index.ts";

--- a/server/tools/get-contract.ts
+++ b/server/tools/get-contract.ts
@@ -38,7 +38,7 @@ import {
   contractRequiredTools,
   evaluateRewriteContractSatisfaction,
 } from "../contracts/declaration.ts";
-import { REWRITE_REGISTERED_TOOLS } from "../contracts/registered-tools.ts";
+import { rewriteRegisteredTools } from "../contracts/registered-tools.ts";
 import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
 
 export function registerGetContractTool(
@@ -70,7 +70,7 @@ export function registerGetContractTool(
       const contract = buildContract();
       const satisfaction = evaluateRewriteContractSatisfaction(
         contractRequiredTools(contract),
-        REWRITE_REGISTERED_TOOLS,
+        rewriteRegisteredTools(),
       );
       if (!satisfaction.satisfied) {
         // Warn, do not fail: `get_contract` answering honestly is more useful to

--- a/server/tools/get-contract.ts
+++ b/server/tools/get-contract.ts
@@ -9,12 +9,20 @@
  * and the two would diverge silently on the first schema edit. Reusing the
  * builder means the rewrite cannot drift from the contract it serves.
  *
- * `server/contracts/declaration.ts` already records that same identity
- * (`2026-07-23.memory-tools.v23`, hash `4b69e9b4...`), verified equal to
- * `buildContract()`'s output on this branch. The assertion below keeps that
- * equality enforced rather than assumed: if `src/contract.ts` moves without the
- * rewrite's declaration moving with it, the mismatch surfaces as a logged
- * warning at call time instead of as a client-side negotiation failure.
+ * `server/contracts/declaration.ts` used to hold that identity as two string
+ * literals, and the warning below compared `buildContract()` against them. That
+ * comparison is gone because the declaration is now DERIVED from the same
+ * builder: deriving both sides would make the condition `x !== x`, a branch that
+ * can never fire while still reading like a guard. The frozen identity is
+ * anchored where an anchor actually holds -- the pinned expectation in
+ * `src/contract.test.ts` and `contracts/memory/contract-declaration-v23.fixture.json`
+ * -- so a hash move still has to be deliberate.
+ *
+ * What IS worth checking at call time is the question the old string comparison
+ * could not ask: whether this server registers everything the contract it just
+ * handed out promises. A client negotiates against the manifest and then calls
+ * its tools, so serving a contract naming a tool this registry does not answer
+ * is the failure that matters, and it is invisible to any version-string match.
  *
  * `natsAvailability` is not threaded through. The rewrite has not ported
  * `nats-runtime.ts`/`nats-bridge.ts` on any wave, so there is no runtime
@@ -26,7 +34,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
 import { buildContract } from "../../src/contract.ts";
-import { SERVER_CONTRACT_DECLARATION } from "../contracts/declaration.ts";
+import {
+  contractRequiredTools,
+  evaluateRewriteContractSatisfaction,
+} from "../contracts/declaration.ts";
+import { REWRITE_REGISTERED_TOOLS } from "../contracts/registered-tools.ts";
 import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
 
 export function registerGetContractTool(
@@ -56,17 +68,23 @@ export function registerGetContractTool(
       }
 
       const contract = buildContract();
-      if (
-        contract.contract_version !== SERVER_CONTRACT_DECLARATION.contractVersion ||
-        contract.schema_hash !== SERVER_CONTRACT_DECLARATION.schemaHash
-      ) {
+      const satisfaction = evaluateRewriteContractSatisfaction(
+        contractRequiredTools(contract),
+        REWRITE_REGISTERED_TOOLS,
+      );
+      if (!satisfaction.satisfied) {
+        // Warn, do not fail: `get_contract` answering honestly is more useful to
+        // a client than refusing, and the build-time gate in
+        // `contracts/check-parity.ts` is what blocks the gap from shipping.
         dependencies.logger.warn(
           {
             tool: "get_contract",
             servedVersion: contract.contract_version,
-            declaredVersion: SERVER_CONTRACT_DECLARATION.contractVersion,
+            missingTools: satisfaction.missingTools,
+            requiredToolCount: satisfaction.requiredTools.length,
+            registeredToolCount: satisfaction.registeredTools.length,
           },
-          "contract_declaration_drift",
+          "contract_registry_shortfall",
         );
       }
       dependencies.logger.info({ tool: "get_contract" }, "tool_result");


### PR DESCRIPTION
## Summary
- `server/contracts/declaration.ts` held `{contractVersion, schemaHash}` as two string literals, and `contracts/check-parity.ts` compared those literals to `buildContract()`. That is a constant compared to itself -- it has no failing input. Parity reported GREEN while the rewrite registry was short a contract-required tool: the gate proved the src side and echoed the server side back.
- Both providers now DERIVE the identity from the same builder. Deriving both sides makes the identity comparison weak rather than strong (two derived values agree by construction), so the load-bearing assertion moves to the question a version string cannot ask: does the rewrite REGISTER what its contract promises?
- The registry is walked by running the real `registerMemoryTools()` against a recording stand-in for `McpServer`, NOT by scanning source for `registerTool(`. Source scanning is falsifiable here: `src/tools` puts the tool name on the same line as `registerTool(` while `server/tools` puts it on the next line, so the existing single-line pattern finds ZERO rewrite tools -- and a shortfall check over an empty set reports success. A zero-tool walk now throws.
- The predicate is **ledger-aware**, and that is the central design call. `contracts/server/parity-manifest.json` already records which capabilities each provider has built (`implemented`) versus only declared (`scaffold-declared`), and `contracts/README.md` calls that the declared implementation asymmetry. An absolute "registry must satisfy the whole contract" gate would not measure drift -- it would re-litigate a port schedule the repo has already written down, and the only way to green it would be to lie in the manifest. So: a tool whose capability is claimed `implemented` MUST be registered; one under a `scaffold-declared` capability may be absent and is REPORTED so the remaining port surface stays visible. Registering beyond the contract stays allowed (`record_skill_usage`/`skill_usage_report`, #469).

### Red proof: same tree, same defect, two checkers
The brief asked for a red proof. Here it is as a counterfactual on the merge base, which is stronger than a bare failure because it isolates the checker as the only variable:

```
OLD checker (origin/main), my change stashed:
  Contract parity check passed: 52 fixtures across 45 capabilities and 2 server
  providers; 63/63 current-src MCP tools fixture-covered with 0 explicit gaps.
  exit 0    <-- GREEN while the rewrite is short a contract-required tool

NEW checker, before the ledger refinement:
  Contract parity check failed with 1 violation(s):
  - server-rewrite-scaffold: registered tools do not satisfy the declared
    contract -- missing 1 of 21 required tool(s): citation_recall
  exit 1    <-- RED, naming the tool
```

### Scope correction, stated plainly
The brief said the registry was "short 10 tools" and the check must fail naming them. Measured, `server/` is short ten tools **relative to `src/`** (`bulk_archive`, `bulk_set_tier`, `citation_recall`, `demote_entry`, `find_duplicates`, `ingest_conversation_facts`, `promote_entry`, `scan_namespace`, `set_tier`, `tier_lane`) but only **one of those ten is required by the frozen contract** -- `citation_recall`. The contract names 21 tools; the other nine are src surface it never promised. "Satisfies the frozen contract" and "matches src" are different questions, and this PR implements the one the brief asked for in its own words ("satisfy the frozen contract's tool_contracts + capabilities"). Writing it as src-equality would have invented a requirement and would also have failed on the two deliberately rewrite-only tools.

### Honest option on merge timing
The brief offered report-only if the port had not landed. Rejected: a warning that scrolls past is the same non-signal being fixed. The ledger-aware predicate lets this land **enforcing and green** without waiting on the port lane and without gating anything to report-only, because it fails on the LIE (claiming `implemented` without registering) rather than on the schedule. No open PR is a ten-tool port at time of writing, so there was nothing to rebase onto.

### Proof the gate has teeth (both injections restored, `git diff` clean after)
```
1. Flip citation-recall to "implemented" in the manifest (a false claim):
   server-rewrite-scaffold: registry does not satisfy the contract it declares
   -- 1 of 21 required tool(s) missing while their capability is claimed
   implemented: citation_recall (citation-recall)                      exit 1

2. Delete registerGetEntryTool from server/tools/index.ts (real regression):
   ... missing while their capability is claimed implemented:
   get_entry (entry-read)                                              exit 1
```

`get_contract`'s call-time drift warning compared the served contract to those same literals; deriving both sides would have made it `x !== x`, dead code shaped like a guard. It now warns on registry shortfall instead. The frozen identity stays anchored by `src/contract.test.ts:16` and `contracts/memory/contract-declaration-v23.fixture.json:10`, which do not depend on this file.

The flip is NOT part of this change: `servesTraffic` stays false, the pin test stays, no deploys, no restarts.

## Critical Self-Review
- Highest-risk behavior: the ledger-aware predicate could excuse a real gap if a capability is wrongly marked `scaffold-declared`. Mitigated by fault injection #1 above -- the moment a capability claims `implemented`, the tool is mandatory -- and by the notes line printing every scaffold-excused tool on each run, so the excused set is visible rather than silent.
- Assumptions that could be wrong: that `tool_contracts` keys and `kind:"tool"` capabilities are the contract's full statement of required tools. Verified they are currently the same 21 names, and the code unions them rather than assuming equality, so a future contract adding one without the other still demands both. Also assumed registration never dereferences dependencies; verified by passing `{}` and running the real registrar to completion.
- Missing/weak tests: the first push of this PR passed 3009/0 locally and failed 69 tests in CI on a circular-import TDZ (see below) -- so my local green was not evidence of module-graph correctness, and nothing in the suite would have caught it without a different load order. Now covered by an explicit order-reproducing test. Separately, no test asserts the ledger branch inside `check-parity.ts` itself (it is a top-level script, not an importable module); that branch is covered by the two recorded fault injections rather than by an automated test. The 11 new unit tests cover the derivation, satisfaction, and import-order logic that IS importable.
- Security/permission risk: none. No auth, namespace, or SQL path touched. `get_contract`'s permission gate is unchanged; only the body of a warning branch changed.
- Migration/deploy risk: none. No schema, no migration, and the contract identity is byte-identical before and after (`2026-07-23.memory-tools.v23` / `4b69e9b4...`), so no client renegotiates.
- Downstream client/runtime risk: none. The served manifest is unchanged; `buildContract()` was and remains the source. One log event name changed (`contract_declaration_drift` -> `contract_registry_shortfall`), which is a rewrite-path log not yet serving traffic.
- Rollback/cleanup concern: revert the three commits on this branch (derive, SME note, lazy-walk fix). No state, no artifacts, no worktree left behind.
- Fixes made before PR: corrected the success summary, which read "satisfying all 21 contract-required" while a note simultaneously reported one unported -- it now reads "covering 20/21 ... (1 scaffold-declared, not yet ported)". Caught by reading my own output rather than by a test.
- Known residual risk: `citation_recall` remains unregistered on the rewrite. That is pre-existing and now VISIBLE on every parity run instead of hidden behind matching literals; closing it is the port lane's work.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: build-time gate and rewrite-path code only; `servesTraffic` is false, nothing was deployed or restarted, and no live service behavior changes.

## Contract Parity
- Contract parity: [x] runtime-specific because: this changes the parity CHECKER and the rewrite's declaration mechanism, not any contract scenario. The fixture set is untouched and the contract identity is byte-identical before and after, so there is nothing for a fixture to re-freeze; the behavior change is that the gate now measures the rewrite registry instead of comparing a constant to itself.

## Testing
- `bun test`: 3011 pass, 485 skip, 0 fail across 223 files (was 3000 before; the 11 new tests are mine).
- `bunx tsc --noEmit`: exit 0.
- `bun contracts/check-parity.ts`: exit 0 -- "server-rewrite-scaffold registers 55 tools covering 20/21 contract-required (1 scaffold-declared, not yet ported)".
- Falsifiability proven twice: re-introducing the exact original defect (hardcoded literals with a wrong hash) fails 2 of the new tests, naming both derivation tests; and restoring the eager module-init walk reproduces the exact TDZ error, dropping the affected pair of files from 14 pass to 7.

### CI caught a defect this PR shipped, and it is fixed in `f6ba870`
The first push passed **3009/0 locally** and failed **69 tests in CI**. `server/contracts/registered-tools.ts` and `server/tools/get-contract.ts` import each other; computing the registered set as a module-init constant put whichever side loaded second in a temporal dead zone:

```
ReferenceError: Cannot access 'REWRITE_REGISTERED_TOOLS' before initialization
```

That took down `registerMemoryTools` itself, so the blast radius was every server test that registers tools -- namespace denial, context-pack budget, pointer suppression -- not just the new file. My local run passed on a luckier module order, which is the honest lesson: a green local suite is not evidence of module-graph correctness.

Same failure class as `src/grading-reasons.ts:52`, which hit "Cannot access 'REVIEW_ACTIONS' before initialization" and fixed it with `import type` erasure so neither module must be evaluated first. That trick only works when a TYPE crosses the cycle; this needs a runtime value, so the walk is deferred to first call and cached -- the value-level form of the same rule. Layering is unchanged; only the timing moved.
- Python untouched -- no files under `python/` modified.
