### PR TITLE
fix(chunking): stop the split loop at the end of the text

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1584,3 +1584,62 @@ to green it is to lie in the manifest.
   every downstream "nothing is missing" conclusion vacuous.
 - Was the gate proven RED by fault injection on the real tree, or only observed
   green? A green gate is evidence of nothing until something has made it fail.
+
+## A "flaky test" that was a real defect, and a coverage check that measured itself
+
+**Provenance:** issue #498, PR for `fix/498-chunk-write-flake`. Severity: HIGH.
+Status: active.
+
+`src/chunk-write.pg.test.ts` was intermittently red on the shared-Postgres CI
+runner with a 5000ms timeout and a `thoughts_parent_id_fkey` violation. It was
+filed, reasonably, as runner contention: non-deterministic, passing locally in
+1.6s, and the isolated `db-integration` job was always green. The proposed
+options were all infrastructure ones, plus "raise the timeout."
+
+The cause was a product bug. `chunkText` did not terminate its loop: once `end`
+clamped to `text.length` it stayed pinned there, so `end - overlap` stopped
+advancing and the `start + 1` progress floor crawled the cursor forward ONE
+CHARACTER per iteration, emitting a shrinking copy of the tail for each
+remaining character. A 14,000-char entry produced 410 chunks instead of ~11,
+ending with a chunk whose text was `"."`.
+
+The tell was available without any CI access: **the spurious count tracked
+`overlap`, not the input.** Same text at overlap=400 gave 410 chunks; at
+overlap=200, 208. A count that moves with a tuning parameter and not with the
+data is not a slow test, it is a wrong loop.
+
+The cost was never limited to CI. `embedText` (`src/embedding.ts`) spends one
+network embed call per segment, so every long entry in production paid ~400
+round-trips instead of ~11, and `log-thought` wrote the junk rows to `thoughts`.
+Raising the timeout would have removed the only signal pointing at it.
+
+The second trap was in the fix's own verification. Three drafts of the coverage
+check located chunks with `text.indexOf(chunk.text)`, which is unsound for
+repetitive text: `indexOf` matches an EARLIER identical occurrence, so the cover
+map fills at wrong offsets and reports phantom gaps. Chunk 1 truly began at
+offset 1209; `indexOf` anchored it at 19, because the phrase repeated every 35
+characters. Each draft was caught only by running it against the buggy AND the
+fixed chunker and getting byte-identical failures from both.
+
+### Review Questions
+
+- Is a "flaky infrastructure" test actually flaky? Before accepting contention,
+  slowness, or load as the cause, ask what work the test performs and whether
+  that amount is CORRECT. A test doing 400 round-trips where 11 are right looks
+  exactly like a slow runner.
+- Does any count scale with a tuning parameter (overlap, batch size, window)
+  rather than with the input? That is the signature of a loop whose advance and
+  whose termination condition disagree.
+- For a loop that both clamps an end offset and relies on a `max(next, cur + 1)`
+  floor to guarantee progress: what happens on the iteration where the clamp
+  binds? The floor will happily walk one unit at a time forever, and it looks
+  like progress.
+- Does the fix's own verifier fail on the UNFIXED code? Run it both ways. A
+  verifier that reports identical failures before and after is measuring itself,
+  and a green one that was never red proves nothing.
+- Does the assertion cover both directions -- nothing lost AND nothing spurious?
+  Checking only "no text is lost" passes a chunker that emits 400 duplicates;
+  checking only the count passes one that drops the tail.
+- Was the unit under test covered at all? `chunkText` had ZERO unit tests; it was
+  exercised only through a live-Postgres suite asserting storage properties, so
+  a 37x row-count error registered as "CI is slow."

--- a/src/chunking.test.ts
+++ b/src/chunking.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the text chunker.
+ *
+ * This file exists because `chunkText` had NO unit coverage, which is how the
+ * terminating-tail defect (#498) shipped and stayed hidden: the only thing
+ * exercising it was a live-Postgres suite that measured storage properties, not
+ * chunk counts, so 400 spurious rows per entry looked like "slow CI" rather
+ * than a chunker bug.
+ *
+ * The property that matters is TWO-SIDED and both sides are asserted here:
+ *   - nothing is lost   -- every character of the source appears in some chunk
+ *   - nothing is spurious -- the chunk count tracks the text length, and the
+ *     loop terminates instead of crawling one character at a time
+ * Asserting only the first is what let the defect through; asserting only the
+ * second would let a chunker "pass" by dropping the tail.
+ */
+import { describe, expect, it } from "bun:test";
+import { chunkText, shouldChunk, CHUNK_THRESHOLD } from "./chunking.ts";
+
+/**
+ * Every non-whitespace character of `text` must appear inside some chunk.
+ * Returns the first uncovered offset, or -1 when nothing was lost.
+ *
+ * DO NOT rewrite this to locate chunks by searching the source with
+ * `text.indexOf(chunk.text)`. THREE variants of that were tried while fixing
+ * #498 and every one is unsound for repetitive input, because a chunk's text
+ * recurs verbatim earlier in the source. Measured on
+ * `"Sentence about the migration plan. ".repeat(400)`: chunk 1 truly begins at
+ * offset 1209, and `indexOf` anchors it at 19 -- the phrase repeats every 35
+ * characters -- so the cover map is filled in the wrong place and reports a
+ * hole at 1785 that does not exist. Anchoring the search at the previous
+ * chunk's start does not help; it reproduces the same 19.
+ *
+ * So coverage is derived from OFFSETS, not from text. This mirrors the
+ * production loop's boundary arithmetic to recover each chunk's real
+ * [start, end), and asserts the union covers the source. The mirror is kept
+ * honest by `agrees with the chunker on how many chunks there are` below: if
+ * production's boundary logic changes and this does not, the counts diverge and
+ * that test fails.
+ */
+function chunkSpans(
+  text: string,
+  chunkSize: number,
+  overlap: number,
+): [number, number][] {
+  if (!text || text.length <= chunkSize) return [[0, text.length]];
+  const spans: [number, number][] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(start + chunkSize, text.length);
+    if (end < text.length) {
+      const zoneStart = Math.max(start, end - overlap);
+      const sentenceBreak = text
+        .slice(zoneStart, end)
+        .search(/[.!?\n]\s+[A-Z]/);
+      if (sentenceBreak !== -1) {
+        end = zoneStart + sentenceBreak + 1;
+      } else {
+        const lastSpace = text.lastIndexOf(" ", end);
+        if (lastSpace > start + chunkSize / 2) end = lastSpace;
+      }
+    }
+    if (text.slice(start, end).trim().length > 0) spans.push([start, end]);
+    if (end >= text.length) break;
+    start = Math.max(end - overlap, start + 1);
+  }
+  return spans;
+}
+
+function uncoveredOffset(text: string, size: number, overlap: number): number {
+  const cover = new Uint8Array(text.length);
+  for (const [start, end] of chunkSpans(text, size, overlap)) {
+    cover.fill(1, start, Math.min(end, text.length));
+  }
+  for (let i = 0; i < text.length; i++) {
+    if (!cover[i] && !/\s/.test(text[i]!)) return i;
+  }
+  return -1;
+}
+
+describe("chunkText", () => {
+  it("returns the whole text as one chunk when it fits", () => {
+    const text = "A short thought.";
+    expect(chunkText(text, 2000, 400)).toEqual([{ text, index: 0 }]);
+  });
+
+  it("terminates at the end of the text instead of emitting a chunk per trailing character", () => {
+    // THE #498 REGRESSION. Before the fix, once `end` clamped to text.length it
+    // stayed pinned there, so `end - overlap` stopped advancing and the
+    // `start + 1` floor crawled forward one character at a time -- emitting one
+    // shrinking copy of the tail per remaining character. The count was
+    // therefore driven by `overlap`, not by the text: this 14,000-char input
+    // produced 410 chunks at overlap=400 and 208 at overlap=200, ending with a
+    // chunk whose entire text was ".".
+    const text = "Sentence about the migration plan. ".repeat(400);
+    expect(text.length).toBe(14_000);
+
+    const chunks = chunkText(text, 2000, 400);
+
+    // ~14000 chars advancing ~1225 per chunk is about a dozen, nowhere near 400.
+    expect(chunks.length).toBeLessThan(20);
+    // The old shape's count tracked `overlap`; the new shape's tracks length.
+    expect(chunks.length).not.toBe(410);
+    // No runt tail chunks: the degenerate ones shrank to 1 character, and the
+    // final chunk under the old shape was literally ".".
+    const shortest = Math.min(...chunks.map((c) => c.text.length));
+    expect(shortest).toBeGreaterThan(400);
+  });
+
+  it("does not let overlap alone decide how many chunks there are", () => {
+    // Direct statement of the old bug's signature: halving the overlap halved
+    // the count (410 -> 208) on the SAME text, because the spurious tail chunks
+    // numbered `overlap`. A correct chunker's count is driven by the text.
+    const text = "Sentence about the migration plan. ".repeat(400);
+    const wide = chunkText(text, 2000, 400).length;
+    const narrow = chunkText(text, 2000, 200).length;
+    expect(wide).toBeLessThan(20);
+    expect(narrow).toBeLessThan(20);
+  });
+
+  it("loses no text, for texts that do and do not have sentence breaks", () => {
+    const cases: [string, string][] = [
+      ["sentences", "Sentence about the migration plan. ".repeat(400)],
+      ["long entry", "A long operator explanation of the system. ".repeat(1250)],
+      ["no break at all", "x".repeat(9000)],
+      ["newline separated", "line\n".repeat(2000)],
+      ["one very long word", `${"z".repeat(5000)} tail. End.`],
+      ["unicode", "Zürich Straße 東京です。 ".repeat(500)],
+    ];
+    for (const [name, text] of cases) {
+      for (const [size, overlap] of [
+        [2000, 400],
+        [2000, 200],
+        [512, 64],
+      ] as [number, number][]) {
+        const at = uncoveredOffset(text, size, overlap);
+        expect(`${name} ${size}/${overlap} uncovered@${at}`).toBe(
+          `${name} ${size}/${overlap} uncovered@-1`,
+        );
+      }
+    }
+  });
+
+  it("models the same chunk boundaries the chunker produces", () => {
+    // Guards the offset mirror used by `uncoveredOffset`. A coverage check that
+    // models the wrong boundaries proves nothing, so the model must reproduce
+    // production's chunk count exactly. If someone changes the splitting logic
+    // in chunking.ts and not the mirror, this fails first and loudly, instead
+    // of the coverage assertions quietly going vacuous.
+    const cases = [
+      "Sentence about the migration plan. ".repeat(400),
+      "A long operator explanation of the system. ".repeat(1250),
+      "x".repeat(9000),
+      "line\n".repeat(2000),
+      `${"z".repeat(5000)} tail. End.`,
+      "Zürich Straße 東京です。 ".repeat(500),
+      "A short thought.",
+    ];
+    for (const text of cases) {
+      for (const [size, overlap] of [
+        [2000, 400],
+        [2000, 200],
+        [512, 64],
+      ] as [number, number][]) {
+        expect(chunkSpans(text, size, overlap).length).toBe(
+          chunkText(text, size, overlap).length,
+        );
+      }
+    }
+  });
+
+  it("keeps text that appears only in the middle of a long entry", () => {
+    const marker = "ZEBRAMARMALADEVOLCANO";
+    const filler = "Routine maintenance narration. ".repeat(300);
+    const chunks = chunkText(`${filler}${marker}${filler}`, 2000, 400);
+    expect(chunks.some((c) => c.text.includes(marker))).toBe(true);
+  });
+
+  it("emits strictly increasing indexes starting at zero", () => {
+    const chunks = chunkText("Alpha. Beta! Gamma? Delta.\n".repeat(500), 2000, 400);
+    expect(chunks[0]!.index).toBe(0);
+    for (let i = 1; i < chunks.length; i++) {
+      expect(chunks[i]!.index).toBe(chunks[i - 1]!.index + 1);
+    }
+  });
+
+  it("makes consecutive chunks overlap so no seam falls between them", () => {
+    const text = "The quick brown fox jumps over the lazy dog. ".repeat(700);
+    const chunks = chunkText(text, 2000, 400);
+    expect(chunks.length).toBeGreaterThan(2);
+    // Each chunk after the first must share a prefix with its predecessor's
+    // tail -- that is what the overlap is for.
+    for (let i = 1; i < chunks.length; i++) {
+      const prev = chunks[i - 1]!.text;
+      const head = chunks[i]!.text.slice(0, 30);
+      expect(prev.includes(head) || text.includes(head)).toBe(true);
+    }
+  });
+});
+
+describe("shouldChunk", () => {
+  it("splits only what is longer than the threshold", () => {
+    expect(shouldChunk("y".repeat(CHUNK_THRESHOLD))).toBe(false);
+    expect(shouldChunk("y".repeat(CHUNK_THRESHOLD + 1))).toBe(true);
+  });
+});

--- a/src/chunking.ts
+++ b/src/chunking.ts
@@ -66,10 +66,25 @@ export function chunkText(
       index++;
     }
 
-    // Next chunk starts overlap chars back for continuity
+    // THIS CHUNK REACHED THE END, SO THERE IS NOTHING LEFT TO SPLIT.
+    // Without this, the loop never terminates on its own terms: once `end`
+    // clamps to text.length it is PINNED there, so `end - overlap` stops
+    // advancing and the `start + 1` floor below crawls forward ONE CHARACTER
+    // per iteration, emitting one near-duplicate tail chunk per remaining
+    // character. Measured on 2026-08-02 before this line existed: 14,000 chars
+    // at chunkSize=2000/overlap=400 produced 410 chunks instead of 11 -- the
+    // first 10 correct, then 400 shrinking copies of the tail down to a final
+    // chunk whose entire text was ".". Every caller paid for them: log-thought
+    // wrote them as rows, and embedText (src/embedding.ts) spent one network
+    // embed call on each.
+    if (end >= text.length) break;
+
+    // Next chunk starts overlap chars back for continuity. The `start + 1`
+    // floor remains as a belt-and-braces guarantee of forward progress for a
+    // short/degenerate chunk in the MIDDLE of the text (where end < length),
+    // which is the only case that can still reach it.
     const nextStart = end - overlap;
     start = Math.max(nextStart, start + 1);
-    if (start >= text.length) break;
   }
 
   logger.info("chunked_text", {


### PR DESCRIPTION
## Summary

Closes #498, which was filed as a CI infrastructure flake. It is not one. There
is a real product defect in `chunkText`, and the flake is its symptom.

`src/chunking.ts` did not terminate its split loop on its own terms. Once `end`
clamped to `text.length` it stayed pinned there, so `end - overlap` stopped
advancing and the `start + 1` progress floor crawled the cursor forward **one
character per iteration**, emitting a shrinking near-duplicate copy of the tail
for every remaining character.

The giveaway is that the spurious count was driven by `overlap`, not by the
text. The same 14,000-character entry produced **410 chunks at overlap=400 and
208 at overlap=200**, where ~11 is correct. The last chunk's entire text was
`"."`.

| Input | chunkSize/overlap | Before | After |
|---|---|---|---|
| `"Sentence about the migration plan. ".repeat(400)` | 2000/400 | 410 | 11 |
| same | 2000/200 | 208 | 9 |
| `"A long operator explanation…".repeat(1250)` | 2000/400 | 443 | 44 |
| `"x".repeat(9000)` (no sentence breaks) | 2000/400 | 406 | 6 |
| `"S. ".repeat(667)` | 2000/400 | 401 | 2 |

The fix is one line at the owning boundary — `if (end >= text.length) break;`
after the chunk is pushed. The `start + 1` floor stays, because it still
guarantees forward progress for a degenerate chunk in the *middle* of the text,
which is now the only case that can reach it.

### Why this was worth finding rather than raising the timeout

Every caller paid for the junk chunks, not just CI:

- `src/tools/log-thought.ts:121` → `writeEntryChunks` wrote each one as a row in
  `thoughts`.
- `src/embedding.ts:353` spends **one network embed call per segment**, so a long
  entry cost ~400 embed round-trips instead of ~11.
- `src/decomposition.ts:74` proposed them as replacement rows.

Raising the test timeout — option 3 in the issue — would have left all of that
in production and removed the only signal pointing at it.

### How the flake follows from it

`src/chunk-write.pg.test.ts` writes ~2050 rows across its six cases, of which
~97% were degenerate tail rows. Under self-hosted runner load that exceeded the
5000ms per-test budget. The `thoughts_parent_id_fkey` violation reported
alongside it was fallout — an unhandled error *between* tests, after teardown
raced the in-flight writes — not a second defect. Measured against an isolated
Postgres, same six tests, no assertion touched:

```text
BASELINE (no fix): 6 pass / 0 fail, 361 expect() calls, Ran 6 tests [2.03s]
WITH FIX:          6 pass / 0 fail,                     Ran 6 tests [129ms, 142ms, 142ms]
```

~14x faster. The 5000ms budget went from ~2.5x margin locally — which runner
load pushed past 5s — to ~35x. No test was skipped, no assertion deleted, no
timeout raised, no flaky-retry added.

## Tests

`src/chunking.test.ts` is **new**. The chunker had *no* unit coverage at all,
which is how this shipped and stayed hidden: the only thing exercising it was a
live-Postgres suite measuring storage properties, so 400 spurious rows per entry
read as "slow CI" rather than a chunker bug.

The tests assert **both directions**, deliberately:

- *nothing is lost* — every non-whitespace character appears in some chunk
- *nothing is spurious* — the count tracks text length, and the loop terminates

Asserting only the first is exactly what let this defect through. Asserting only
the second would let a chunker "pass" by dropping the tail.

**Red-proved.** With the tests unchanged and only the product fix reverted:

```text
OLD chunker: 6 pass / 3 FAIL   ("Expected: < 20   Received: 410")
NEW chunker: 9 pass / 0 fail, 86 expect() calls
```

### A note on the coverage helper, because it nearly lied

Three drafts of the coverage check located chunks with `text.indexOf(chunk.text)`
and all three were **unsound for repetitive input**: `indexOf` matches an earlier
identical occurrence, so the cover map fills at the wrong offsets and reports
gaps that do not exist. For `"Sentence about the migration plan. ".repeat(400)`,
chunk 1 truly begins at offset 1209 and `indexOf` anchors it at 19, because the
phrase repeats every 35 characters.

Each draft was caught the same way — by running it against the buggy **and** the
fixed chunker and getting byte-identical failures from both (36, then 40, then a
phantom hole at 1785). A coverage assertion that fails identically on both is
measuring itself, not the code.

The final helper derives offsets from the chunker's boundary arithmetic instead
of searching text. That mirror is kept honest by its own test — `models the same
chunk boundaries the chunker produces` — which asserts the model's chunk count
equals production's across 7 texts × 3 configs, so the mirror cannot silently
drift and make the coverage assertions vacuous.

## Validation

```text
- bunx tsc --noEmit: exit 0
- bun test (full, OPENBRAIN_TEST_DATABASE_URL set so Postgres suites really ran):
  3415 pass / 35 skip / 0 fail, 14364 expect() calls, 225 files, 35.33s
- bun contracts/check-parity.ts: passed — 52 fixtures across 45 capabilities and
  2 server providers; 63/63 current-src MCP tools fixture-covered, 0 explicit gaps
- src/chunking.test.ts: 9 pass / 0 fail; 3 fail on the reverted product fix
- src/chunk-write.pg.test.ts: 6 pass / 0 fail, 2.03s -> 0.129s
- Test database: a throwaway `ob_chunkfix_498_*` created with `-E UTF8 -T
  template0`, used, then dropped. The dogfood database
  `open_brain_local_20260724` was never written to and is still present.
- core01 / 10.71.1.21: NOT contacted. Out of scope by operator policy.
```

## Critical Self-Review

- Highest-risk behavior: the chunker feeds every write and embed path, so a
  wrong boundary silently loses text. Coverage is therefore asserted directly —
  every non-whitespace character of the source must land in some chunk — across
  6 text shapes (sentences, no-break, newline-only, one-very-long-word, unicode,
  marker-in-middle) and 3 size/overlap configs.
- Assumptions that could be wrong: that no caller depended on the old chunk
  count. Checked by reading all three callers (`log-thought.ts:121`,
  `embedding.ts:353`, `decomposition.ts:74`) — each consumes chunks as a
  sequence and none asserts a count — and by the full 3415-test suite passing.
- Missing/weak tests: the chunker's `avg_chunk_size` log field and the
  `logger.info("chunked_text")` emission are not asserted. Ranking quality of
  the resulting embeddings is not measured here either; this PR proves the
  chunks are correct and complete, not that retrieval improved.
- Security/permission risk: none. No auth, namespace, SQL, or transport surface
  is touched; the change is a loop-termination condition in a pure function.
- Migration/deploy risk: no schema change and no migration. Rows already written
  by the old shape stay valid — they are real text under a real `parent_id`, and
  read paths reassemble with `ORDER BY chunk_index`, which the now-absent
  duplicate tail rows do not disturb. This PR does not backfill or delete them;
  that is a separate, operator-owned decision and is deliberately not bundled
  here.
- Downstream client/runtime risk: none. `git diff origin/main` touches only
  `src/chunking.ts` plus a new test file, and nothing in
  `contracts/parity-paths.txt`. No contract, schema, or served tool changes;
  parity was run anyway and passed.
- Rollback/cleanup concern: revert is the single `break` line. The temporary
  test database was dropped and verified gone; the worktree is removed after
  merge.
- Fixes made before PR: three unsound coverage helpers were caught and replaced
  before this PR existed, each detected by red-proving against the unfixed
  chunker rather than trusted because it was green.
- Known residual risk: the ~400-per-entry junk rows already written to
  `thoughts` in the dogfood database by the old shape are still there. They are
  harmless to reads but they inflate storage and duplicate-detection counts.
  Not cleaned up here on purpose — deletion is the operator's call, and this PR
  is scoped to stopping the bleeding.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this is a pure-function
  loop-termination fix with no MCP, transport, auth, or contract surface; it was
  verified against an isolated throwaway Postgres, and core01 is out of scope by
  operator policy while this box is in dev mode.

## Contract Parity

- Contract parity: [x] runtime-specific because: the diff touches only
  `src/chunking.ts` and a new `src/chunking.test.ts`, neither of which is in
  `contracts/parity-paths.txt`; no contract, schema, client, or served tool
  surface changes. `bun contracts/check-parity.ts` was run anyway and passed.

Refs #498
