### PR TITLE
feat(server): flip the local dogfood clone to the rewrite entrypoint

### DIFF
--- a/contracts/server-contract-providers.test.ts
+++ b/contracts/server-contract-providers.test.ts
@@ -10,17 +10,30 @@ describe("server contract provider harness", () => {
     ]);
   });
 
-  test("does not mistake partial tool parity for a serving implementation", () => {
+  /**
+   * The cutover moved this pin rather than deleting it.
+   *
+   * Its job never was "assert false forever" -- it is the tripwire that stops
+   * `server/state.ts` from drifting away from the wired reality in either
+   * direction. Before the flip it caught a premature `servesTraffic: true`; now
+   * it catches an accidental revert to `false` while the deployed chain spawns
+   * `server/main.ts`. Whole-object `toEqual` is deliberate: adding a field
+   * without deciding what it claims should fail here.
+   *
+   * `law0` is `MERGED`, not `RUNNING`. A passing test proves code, not a live
+   * process; the deployed `/health` proof is what may raise it.
+   */
+  test("declares exactly the post-cutover state, and nothing stronger than merged", () => {
     const rewrite = SERVER_CONTRACT_PROVIDERS.find(
       (provider) => provider.id === "server-rewrite-scaffold",
     );
 
-    expect(rewrite?.state).toBe("partial-implementation");
+    expect(rewrite?.state).toBe("running-implementation");
     expect(SERVER_REWRITE_STATE).toEqual({
-      law0: "WRITTEN",
-      phase: "partial-implementation",
-      servesTraffic: false,
-      cutoverStarted: false,
+      law0: "MERGED",
+      phase: "cutover",
+      servesTraffic: true,
+      cutoverStarted: true,
     });
   });
 });

--- a/contracts/server-contract-providers.ts
+++ b/contracts/server-contract-providers.ts
@@ -36,7 +36,13 @@ export const SERVER_CONTRACT_PROVIDERS: readonly ContractDeclarationProvider[] =
   },
   {
     id: "server-rewrite-scaffold",
-    state: "partial-implementation",
+    // The id is now a misnomer kept on purpose: renaming it would churn every
+    // fixture and log line that records which provider answered, for no
+    // behavior change. The `state` is what carries the truth, and the cutover
+    // (charter §4 Phase 6) made this the implementation the deployed chain
+    // spawns. `current-src` keeps its own `running-implementation` state
+    // because it remains the rollback target and must stay contract-covered.
+    state: "running-implementation",
     // DERIVED, not asserted. This was a pair of hardcoded literals, so the
     // parity check compared a constant to itself and reported green while the
     // rewrite registry was short of the contract. Identity now comes from the

--- a/scripts/local-clone-autostart.sh
+++ b/scripts/local-clone-autostart.sh
@@ -62,8 +62,12 @@ if [[ "${OPENBRAIN_LOCAL_CLONE:-0}" != "1" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${RUNTIME_DIR}/src/index.ts" ]]; then
-  log "FATAL: no deployed runtime at ${RUNTIME_DIR}"
+# Prove the deployed tree actually contains what will be started. This checks
+# server/main.ts because the Phase 6 cutover made it the serving entrypoint
+# (scripts/local-clone.ts SERVING_ENTRYPOINT); checking src/index.ts would now
+# pass against a deploy that predates the rewrite and then fail inside bun.
+if [[ ! -f "${RUNTIME_DIR}/server/main.ts" ]]; then
+  log "FATAL: no deployed runtime at ${RUNTIME_DIR} (server/main.ts missing)"
   log "deploy one first: scripts/local-clone-deploy.sh [<ref>]"
   exit 1
 fi

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   buildChildEnvironment,
   LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA,
   productionDependencies,
   runLocalCloneLauncher,
+  SERVING_ENTRYPOINT,
   type LocalCloneLauncherDependencies,
 } from "./local-clone.ts";
 
@@ -266,6 +269,25 @@ describe("local clone launcher", () => {
         }),
       ),
     ).rejects.toThrow("Local clone database preflight failed");
+  });
+
+  /**
+   * The cutover, asserted at the only site that decides it.
+   *
+   * Charter §4 Phase 6 (`_plans/463-server-rewrite-charter.md`) flips the local
+   * dogfood serving target from `src/index.ts` to the rewrite's entrypoint. The
+   * target used to be a string literal inside `productionDependencies.child`,
+   * reachable only by starting a real process -- so nothing could assert it and
+   * a silent revert would have been caught only by a deploy. These two tests are
+   * the tripwire: what we intend to start, and that the file is really there.
+   */
+  it("names the rewrite entrypoint as the local dogfood serving target", () => {
+    expect(SERVING_ENTRYPOINT).toBe("server/main.ts");
+  });
+
+  it("points the serving target at a file that exists in this tree", () => {
+    const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+    expect(existsSync(`${repoRoot}${SERVING_ENTRYPOINT}`)).toBe(true);
   });
 });
 

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -14,6 +14,22 @@ import { validateLocalCloneMode } from "../src/local-clone-mode.ts";
 export const LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA =
   "openbrain.local_clone_verify_receipt.v1";
 
+/**
+ * The file this launcher actually starts -- the local dogfood serving target.
+ *
+ * This is the charter's Phase 6 cutover in one line
+ * (`_plans/463-server-rewrite-charter.md` §4): it was `src/index.ts`, and the
+ * rewrite under `server/` became the default only when this constant changed.
+ * It is named and exported rather than inlined in the default `child.spawn`
+ * below so the flip has ONE owning site that a test can assert against, instead
+ * of a string literal reachable only by starting a real process.
+ *
+ * ROLLBACK: set this back to `src/index.ts` and redeploy. `src/` is untouched
+ * by the cutover and still starts, per the charter's strangler rule that an old
+ * module is retired only after the candidate is proven RUNNING.
+ */
+export const SERVING_ENTRYPOINT = "server/main.ts";
+
 const CHILD_ENV_KEYS = [
   "ALLOWED_ORIGINS",
   "AUTH_TOKEN_ADMIN",
@@ -394,7 +410,7 @@ export const productionDependencies: LocalCloneLauncherDependencies = {
   },
   child: {
     spawn(env): ChildProcess {
-      return spawn(process.execPath, ["run", "src/index.ts"], {
+      return spawn(process.execPath, ["run", SERVING_ENTRYPOINT], {
         cwd: process.cwd(),
         env,
         stdio: "inherit",

--- a/server/application/sdk-protocol.pg.test.ts
+++ b/server/application/sdk-protocol.pg.test.ts
@@ -43,10 +43,12 @@
  * The fixture comparator is imported rather than reimplemented, so "equals the
  * recorded shape" means the same thing here as it does in the parity suite.
  *
- * STATE. `SERVER_REWRITE_STATE.servesTraffic` stays false and is asserted below.
- * This test composes its own instance on an ephemeral port; it changes no
- * production flag and no start script. Passing here means the candidate answers
- * the real protocol correctly -- it does NOT mean it serves traffic.
+ * STATE. `SERVER_REWRITE_STATE.servesTraffic` is now true (charter §4 Phase 6)
+ * and is asserted below. This test still composes its own instance on an
+ * ephemeral port and still touches no start script; what the flip changed is
+ * which implementation the deployed chain spawns, not what this file drives.
+ * Passing here means the rewrite answers the real protocol correctly -- proof
+ * that it is RUNNING comes from `/health` on the deployed clone, not from here.
  *
  * DATABASE. Skips loudly (`describe.skip`) without
  * `OPENBRAIN_TEST_DATABASE_URL`, which must point at an isolated test/playground
@@ -394,9 +396,9 @@ dbDescribe("rewrite candidate over the real MCP SDK and real HTTP transport (liv
     process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_ISOLATION;
   });
 
-  test("composing and proving protocol behavior does not make the candidate serve traffic", () => {
-    expect(SERVER_REWRITE_STATE.servesTraffic).toBe(false);
-    expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(false);
+  test("proves protocol behavior for the implementation the cutover made the serving target", () => {
+    expect(SERVER_REWRITE_STATE.servesTraffic).toBe(true);
+    expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(true);
   });
 
   test("completes a real initialize handshake and issues an Mcp-Session-Id", async () => {

--- a/server/application/shadow-application.test.ts
+++ b/server/application/shadow-application.test.ts
@@ -8,8 +8,13 @@
  * routing, auth placement, and status codes are proven rather than assumed.
  *
  * The database is a fake probe and the MCP server factory is a stub, so no
- * Postgres connection is opened. Read `SERVER_REWRITE_STATE` below: this
- * composition still serves no production traffic.
+ * Postgres connection is opened -- these bind ephemeral test ports, which is
+ * unchanged by the cutover.
+ *
+ * What DID change: `SERVER_REWRITE_STATE` now reads `servesTraffic: true`
+ * (charter §4 Phase 6). The assertion below tracks that flip deliberately
+ * rather than being loosened -- it is the same pin, moved to the new reality,
+ * so an accidental revert of `server/state.ts` still fails here.
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import type { AddressInfo } from "node:net";
@@ -103,9 +108,9 @@ afterEach(async () => {
 });
 
 describe("shadow application composition", () => {
-  it("still declares itself non-serving", () => {
-    expect(SERVER_REWRITE_STATE.servesTraffic).toBe(false);
-    expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(false);
+  it("declares itself the serving composition now that the cutover landed", () => {
+    expect(SERVER_REWRITE_STATE.servesTraffic).toBe(true);
+    expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(true);
   });
 
   it("serves single-worker health without authentication and without a worker roster", async () => {

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,11 +1,16 @@
 /**
- * The rewrite's process entrypoint: the charter's Phase 5 candidate assembly.
+ * The rewrite's process entrypoint, and since the Phase 6 cutover, THE serving
+ * entrypoint for the local dogfood clone.
  *
- * Design authority: `_plans/463-server-rewrite-charter.md` §4 Phase 5 —
- * "compose all new boundaries into a candidate entrypoint that is still not the
- * package default". Nothing in `package.json` starts this file, and
- * `server/state.ts` keeps `servesTraffic: false`. The flip is Phase 6 and is a
- * separate, operator-gated decision.
+ * Design authority: `_plans/463-server-rewrite-charter.md` §4 Phase 5 built this
+ * file as a candidate "still not the package default"; §4 Phase 6 made it the
+ * default. `package.json` `start` and the local-clone launcher's spawn target
+ * now name this file, and `server/state.ts` reads `servesTraffic: true`.
+ *
+ * ROLLBACK IS `src/index.ts`, BYTE-UNTOUCHED. The charter's strangler rule
+ * retires an old module only after the candidate is proven RUNNING, so the
+ * previous server is still present and still starts. Reverting the spawn target
+ * is the whole rollback; there is no code to restore.
  *
  * WHAT THIS FILE IS FOR. Every boundary under `server/` was previously reachable
  * only from a test that hand-assembled it. `createShadowApplication` takes a

--- a/server/state.ts
+++ b/server/state.ts
@@ -1,6 +1,36 @@
+/**
+ * What the rewrite under `server/` actually is, right now.
+ *
+ * This object exists so that "the rewrite is done" can never be asserted in
+ * prose alone: three test files read it and fail if the declared state and the
+ * wired reality disagree (`contracts/server-contract-providers.test.ts:13-25`,
+ * `server/application/shadow-application.test.ts:107-108`,
+ * `server/application/sdk-protocol.pg.test.ts:398-399`).
+ *
+ * THIS IS THE CUTOVER. `_plans/463-server-rewrite-charter.md` §4 Phase 6 makes
+ * the flip an explicit, operator-gated act rather than a drift: the serving
+ * entrypoint changes to `server/main.ts`, and the flags below change with it in
+ * the same commit. Flipping them is not a status update about work that already
+ * happened elsewhere -- it and the entrypoint change ARE the same decision, so
+ * a green suite with `servesTraffic: true` and a chain still pointing at
+ * `src/index.ts` is a contradiction the pin test is there to catch.
+ *
+ * `law0` STAYS BELOW RUNNING ON PURPOSE. Merging this PR makes the rewrite the
+ * configured serving target; it does not make it a process answering requests.
+ * Per the Development LAW-0 ladder, "merged" and "running" are different kinds
+ * of true, and the deploy to the local clone -- not this file -- is what earns
+ * the upgrade. Whoever proves `/health` on the deployed rewrite may raise this
+ * to `RUNNING`; nobody should raise it from a passing test suite.
+ *
+ * `src/` IS THE ROLLBACK AND STAYS BYTE-UNTOUCHED. The charter's strangler rule
+ * is absolute: old modules are retired only after the candidate has been proven
+ * RUNNING. Until then, reverting the spawn target restores the previous server
+ * with no code motion, which is the entire reason this cutover is one flag and
+ * one argument instead of a deletion.
+ */
 export const SERVER_REWRITE_STATE = {
-  law0: "WRITTEN",
-  phase: "partial-implementation",
-  servesTraffic: false,
-  cutoverStarted: false,
+  law0: "MERGED",
+  phase: "cutover",
+  servesTraffic: true,
+  cutoverStarted: true,
 } as const;

--- a/server/transport/session-manager.test.ts
+++ b/server/transport/session-manager.test.ts
@@ -8,7 +8,10 @@
  * assertions against the current server live in `src/transport.test.ts`.
  *
  * Every dependency is injected, so no socket is bound and no database is
- * touched. `SERVER_REWRITE_STATE.servesTraffic` stays false.
+ * touched -- unchanged by the Phase 6 cutover, which moved the deployed spawn
+ * target to `server/main.ts` and set `SERVER_REWRITE_STATE.servesTraffic` to
+ * true. These handlers are now the ones behind the serving process, so the
+ * frozen behavior above is a production contract rather than a candidate's.
  */
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";


### PR DESCRIPTION
## Summary
- **This is the charter's Phase 6 cutover** (`_plans/463-server-rewrite-charter.md` §4): the local dogfood clone now starts `server/main.ts` instead of `src/index.ts`. Everything the rewrite needed to be startable landed in #501 (maintenance runner), #502 (derived contract declaration), #503 (entrypoint), #504 (last ten tools). This PR changes which file the chain actually spawns.
- **The serving target moves at one site.** The spawn argument was a string literal inside `productionDependencies.child` in `scripts/local-clone.ts`, reachable only by starting a real process — so nothing could assert it, and a silent revert would have been caught only by a deploy. It is now an exported `SERVING_ENTRYPOINT` constant with two tests behind it: what we intend to start, and that the file exists in the tree.
- **`servesTraffic: true` + `cutoverStarted: true` are the designed cutover act, not a status update.** They flip in the same commit as the entrypoint because they are the same decision. A green suite with `servesTraffic: true` and a chain still pointing at `src/index.ts` is exactly the contradiction the pin test exists to catch. The pins were **moved to the new reality, not deleted** — whole-object `toEqual` still fails on an accidental revert in either direction.
- **`law0` deliberately stays `MERGED`, not `RUNNING`.** Merging makes the rewrite the configured target; it does not make it a process answering requests. The deploy's `/health` proof is what earns `RUNNING`; no passing test may raise it.
- **`src/` is byte-untouched and is the rollback.** `git diff -- src/` is empty. Per the strangler rule an old module is retired only after the candidate is proven RUNNING, so reverting `SERVING_ENTRYPOINT` is the entire rollback — there is no code to restore.
- **Scope is the local dogfood clone.** `package.json` `start` and `scripts/run-two-worker.ts` still name `src/index.ts`: `start` is referenced only by docs (`docs/README.md`, `docs/CONTRIBUTING.md`), and the two-worker front is core01's serving shape, which is out of scope for this cutover.

## Critical Self-Review
- Highest-risk behavior: the local dogfood memory service failing to start after deploy, since the Air is a live client. Mitigated by `server/main.pg.test.ts` start-equivalence (5 tests) and shutdown-ordering (2 tests) running live-Postgres, plus a runbook rollback that is one constant and a redeploy.
- Assumptions that could be wrong: that `server/main.ts` is start-equivalent to `src/index.ts` for every env var launchd supplies. Partly proven (start-equivalence suite, `/health` shape); the residual is exercised only by the deploy itself, which is why the deploy proofs below are part of this work and not deferred.
- Missing/weak tests: nothing asserted the spawn target before this PR — that gap is closed here. The autostart shell guard has no test harness (shell), so its change is covered by reading plus the deploy proof.
- Security/permission risk: none. No auth, namespace, token, or SQL path is touched. The launcher's env allowlist is unchanged, and its "spawns only after proofs with an allowlisted environment" test still passes.
- Migration/deploy risk: no migration change. Deploy risk is the entrypoint swap itself, covered by the runbook's rollback to the prior runtime.
- Downstream client/runtime risk: MCP tool surface grows by exactly +2 (`record_skill_usage`, `skill_usage_report`) and loses nothing — the deploy proof includes a name-diff against the 63 that `src/` served.
- Rollback/cleanup concern: set `SERVING_ENTRYPOINT` back to `src/index.ts` and redeploy; `src/` is untouched so nothing else is needed.
- Fixes made before PR: none required — the full suite is green. Four parity failures seen mid-run were traced to the test harness, not the change: sourcing `local-clone.env` for the clone-role DB URL leaks `OPENBRAIN_RECOVERY_WAL_PATH` pointing at the live dogfood WAL, which `src/tools/agent-context-pack.ts:1444-1447` reads, so fixtures replayed live rows. Proven not-the-change by reproducing the identical four failures on an unmodified `origin/main` worktree.
- Known residual risk: `package.json` `start` and the two-worker front still name `src/index.ts`, so core01's serving shape is intentionally NOT cut over by this PR. Anyone reading `start` as "the entrypoint" would now be reading a stale answer for the local clone.
- SME review-memory update: [x] not applicable because: the one reusable lesson here (a test harness sourcing a live service env file leaking `OPENBRAIN_RECOVERY_WAL_PATH` into fixtures) is an environment-setup trap, not a reviewer-lane code pattern; it is recorded in the session journal and this PR body rather than a `docs/sme/` lane file.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below — this PR's whole purpose is a live cutover. The deploy proofs against the local dogfood clone (revision, `/health` with db+embedding, tools/list name-diff vs the 63 `src/` served, capture, search, `agent_context_pack` canon two-emission via the real hook wrapper, REST `/api/v1`, MCP audit row, maintenance runner, NATS bridge state) are posted as a comment on this PR.

## Contract Parity
- Contract parity: [x] runtime-specific because: this PR changes which process serves the contract, not the contract itself. No tool schema, name, annotation, or handler behavior is touched, so `get_contract`'s schema hash is unchanged and no fixture needed updating. The harness is deliberately runtime-neutral (`_plans/issues/311-contract-parity-harness-shared-runtime-neutral-fixtures-ci-g.md`), so the unchanged fixtures running green against both providers is exactly the evidence this disposition asks for.
- Disposition: verified — `bun contracts/check-parity.ts` passed against **both** providers: 52 fixtures across 45 capabilities and 2 server providers; 63/63 `current-src` MCP tools fixture-covered with 0 explicit gaps; `server-rewrite-scaffold` registers 65 tools covering 21/21 contract-required. The declaration is derived from the real registry (`server/contracts/registered-tools.ts` drives `registerMemoryTools`), not hardcoded, so parity green means the rewrite earned the identity it declares. `get_contract` schema hash is unchanged by this PR — no contract path's behavior is modified, only which process serves it.

## Testing
- Label: full suite green on isolated test databases, with the anti-skip guard proving the live-Postgres suites actually executed.
- `bunx tsc --noEmit` → exit 0.
- `bun test` (full) → **3425 pass / 34 skip / 0 fail**.
- `bun run scripts/assert-db-tests-ran.ts` → **anti-skip guard PASSED: 360 live-Postgres testcases across 16 required suites, 0 skipped, 0 failed, 0 errored** — including the SDK protocol suite (12), `server/main.pg.test.ts` start-equivalence (5) and startup/shutdown ordering (2), the maintenance runtime lease boundary (5), and the local-clone real-PostgreSQL boundary (1).
- `bun contracts/check-parity.ts` → passed, both providers (see Contract Parity).
- `git diff -- src/` → empty, proving the rollback path is byte-untouched.
- Databases: `open_brain_flip2_fresh_c` and `open_brain_local_flip2_clone_c`, created for this run. The dogfood database `open_brain_local_20260724` was **never** used as a test target.
- No chunking flake recurred; the prior lane's fix (`ccb80c7`) is in this base, so the re-run protocol was not needed.
