### PR TITLE
fix(deploy): empty optional secrets and a deploy that proves the new process

### DIFF
--- a/scripts/local-clone-deploy.sh
+++ b/scripts/local-clone-deploy.sh
@@ -20,6 +20,13 @@
 #      src/index.ts and re-exporting HEAD produced an archive with zero
 #      occurrences of it.
 #
+#   3. A REVISION PROOF, which core01's script does not have. The deploy only
+#      succeeds if the process LISTENING on the clone port changed pid, is
+#      running out of the runtime directory, and that directory is stamped with
+#      the revision this run shipped. Added 2026-08-02 after a deploy reported
+#      success while the previous process still held the port and served the
+#      previous revision; see `check_new_process_serving` for the receipt.
+#
 # Everything else -- staging dir, atomic swap, .previous rollback, health
 # check -- is the core01 shape, deliberately.
 #
@@ -73,13 +80,139 @@ wait_for_health() {
   return 1
 }
 
+# The pid of whatever is LISTENING on the clone port, or empty if nothing is.
+#
+# `lsof` on the port, deliberately, and not the two obvious alternatives:
+#   - `launchctl print ... | grep pid` reports the SUPERVISED pid, which here is
+#     the `local-clone.ts --start` wrapper, not the server that binds the socket
+#     (measured 2026-08-02: wrapper 2407, listener 2476, its child).
+#   - `pgrep -f 'bun run ...'` matches stray orphans from earlier sessions that
+#     hold no port (measured: pid 37600, running since the previous day).
+# The question this must answer is "who is serving :PORT", and only the socket
+# knows that.
+listening_pid() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null | head -1
+}
+
+# The working directory of a running process, used to prove the listener is
+# serving the tree we just swapped in rather than some other checkout.
+pid_cwd() {
+  local pid="$1"
+  lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1
+}
+
+deployed_short_sha() {
+  local dir="$1"
+  [[ -r "${dir}/.deployed-revision" ]] || return 1
+  sed -n 's/^short_sha=//p' "${dir}/.deployed-revision" | head -1
+}
+
+# Prove the NEW process is the one serving. THIS is the deploy's success
+# criterion; the health check below is a secondary liveness assertion.
+#
+# A health check the previous process can satisfy is not a proof. On 2026-08-02
+# this exact script reported a successful deploy while the OLD runtime was still
+# answering :3100: the restart was accepted, the new entrypoint threw on config
+# and died, launchd held the service down for its ThrottleInterval (30s here)
+# before retrying -- longer than the 15x2s health poll ran -- and `curl /health`
+# was answered by the process that had never stopped. The stamp on disk said one
+# revision; the running code was another. A deploy that cannot tell those apart
+# cannot fail, and one that cannot fail proves nothing when it passes.
+#
+# Three assertions, all required, all fatal:
+#   1. a listener exists and its pid DIFFERS from the pre-restart pid
+#      (the old process really went away and a new one really bound the port)
+#   2. that listener's cwd is the runtime directory
+#      (it is serving the tree we swapped, not another checkout)
+#   3. the runtime's .deployed-revision matches the sha this run deployed
+#      (the tree it is serving is the revision we asked for)
+# Returns 0 only if all three assertions hold; logs the exact reason otherwise.
+# Non-fatal by design so the deploy path can roll back on failure -- the callers
+# decide whether a failure is recoverable, and both of them treat it as loud.
+check_new_process_serving() {
+  local port="$1" previous_pid="$2" expected_short_sha="$3"
+  local pid="" cwd="" stamped=""
+
+  # Poll rather than sleep-once: bun install/migrate timing varies, and launchd
+  # may hold a restarted service down for ThrottleInterval (30s on this service)
+  # before the new process even starts. The polling window has to outlast that
+  # or a merely-delayed start reads as a permanent failure.
+  for _ in $(seq 1 30); do
+    pid="$(listening_pid "$port")"
+    if [[ -n "$pid" && "$pid" != "$previous_pid" ]]; then
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ -z "$pid" ]]; then
+    log "revision proof FAILED: nothing is listening on port ${port} after restart"
+    return 1
+  fi
+  if [[ "$pid" == "$previous_pid" ]]; then
+    log "revision proof FAILED: port ${port} is still held by the PRE-DEPLOY process (pid ${pid}); the new runtime never took over"
+    return 1
+  fi
+
+  cwd="$(pid_cwd "$pid")"
+  if [[ "$cwd" != "$RUNTIME_DIR" ]]; then
+    log "revision proof FAILED: listener pid ${pid} is serving '${cwd:-<unknown>}', not the deployed runtime ${RUNTIME_DIR}"
+    return 1
+  fi
+
+  if ! stamped="$(deployed_short_sha "$RUNTIME_DIR")"; then
+    log "revision proof FAILED: no .deployed-revision in ${RUNTIME_DIR}"
+    return 1
+  fi
+  if [[ "$stamped" != "$expected_short_sha" ]]; then
+    log "revision proof FAILED: runtime is stamped ${stamped} but this deploy shipped ${expected_short_sha}"
+    return 1
+  fi
+
+  log "revision proof PASSED: pid ${previous_pid:-<none>} -> ${pid}, cwd ${cwd}, revision ${stamped}"
+  return 0
+}
+
+# Fatal wrapper for callers with nowhere left to fall back to.
+assert_new_process_serving() {
+  check_new_process_serving "$@" \
+    || fatal "revision proof failed and there is no further fallback"
+}
+
 if [[ "${1:-}" == "--rollback" ]]; then
   [[ -d "$PREVIOUS_DIR" ]] || fatal "no previous runtime at ${PREVIOUS_DIR}"
+  [[ -r "$ENV_FILE" ]] || fatal "env file missing or unreadable: ${ENV_FILE}"
+  # Sourced here too, not only on the deploy path: the rollback needs the clone
+  # port to know which listener to prove. A rollback that cannot check the port
+  # is the same unfalsifiable success the deploy path used to report.
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+  ROLLBACK_PORT="${PORT:-3100}"
+
   log "rolling back to ${PREVIOUS_DIR}"
   rm -rf "${RUNTIME_DIR}.rollback-discard"
   [[ -d "$RUNTIME_DIR" ]] && mv "$RUNTIME_DIR" "${RUNTIME_DIR}.rollback-discard"
   mv "$PREVIOUS_DIR" "$RUNTIME_DIR"
+
+  PRE_ROLLBACK_PID="$(listening_pid "$ROLLBACK_PORT")"
+  log "pre-rollback listener on port ${ROLLBACK_PORT}: pid ${PRE_ROLLBACK_PID:-<none>}"
   restart_service
+
+  if [[ -n "$SERVICE_LABEL" ]]; then
+    # Same standard of proof as a deploy. Rolling back is exactly when a false
+    # success is most expensive: the operator stops looking because the log said
+    # the old revision is back, while the broken one is still serving.
+    assert_new_process_serving "$ROLLBACK_PORT" "$PRE_ROLLBACK_PID" \
+      "$(deployed_short_sha "$RUNTIME_DIR")"
+    wait_for_health "$ROLLBACK_PORT" "post-rollback" \
+      || fatal "health check failed after rollback; service is down"
+  else
+    log "NOTE: no service label set, so nothing was restarted and the rollback is UNVERIFIED."
+  fi
+
   log "rollback complete; discarded runtime kept at ${RUNTIME_DIR}.rollback-discard"
   exit 0
 fi
@@ -149,22 +282,48 @@ fi
 mv "$STAGING_DIR" "$RUNTIME_DIR"
 log "swapped ${SHORT_SHA} into ${RUNTIME_DIR}"
 
+# Read the OUTGOING listener before the restart. This is the value that makes
+# the proof below possible: without a "before", "something is answering" and
+# "the new thing is answering" are indistinguishable.
+PRE_RESTART_PID="$(listening_pid "$CLONE_PORT")"
+log "pre-restart listener on port ${CLONE_PORT}: pid ${PRE_RESTART_PID:-<none>}"
+
 restart_service
 
 if [[ -n "$SERVICE_LABEL" ]]; then
-  if ! wait_for_health "$CLONE_PORT" "post-deploy"; then
-    log "health check FAILED; rolling back"
+  # Order matters: prove the process FIRST, then check health. Reversing these
+  # is the 2026-08-02 failure -- health passed against the outgoing process and
+  # the deploy exited 0 with the old revision still serving.
+  deploy_ok=1
+  if ! check_new_process_serving "$CLONE_PORT" "$PRE_RESTART_PID" "$SHORT_SHA"; then
+    deploy_ok=0
+  elif ! wait_for_health "$CLONE_PORT" "post-deploy"; then
+    log "health check FAILED"
+    deploy_ok=0
+  fi
+
+  if [[ "$deploy_ok" -eq 0 ]]; then
+    log "deploy verification FAILED; rolling back"
     if [[ -d "$PREVIOUS_DIR" ]]; then
       rm -rf "${RUNTIME_DIR}.failed"
       mv "$RUNTIME_DIR" "${RUNTIME_DIR}.failed"
       mv "$PREVIOUS_DIR" "$RUNTIME_DIR"
+      rollback_pid="$(listening_pid "$CLONE_PORT")"
       restart_service
+      # The rollback gets the same standard of proof as the deploy. A rollback
+      # that "succeeded" because the failed process still held the port would
+      # leave the broken revision serving under a reassuring log line.
+      assert_new_process_serving "$CLONE_PORT" "$rollback_pid" \
+        "$(deployed_short_sha "$RUNTIME_DIR")"
       wait_for_health "$CLONE_PORT" "post-rollback" \
         || fatal "health check failed after rollback; service is down"
-      fatal "deploy of ${SHORT_SHA} failed health check and was rolled back"
+      fatal "deploy of ${SHORT_SHA} failed verification and was rolled back"
     fi
-    fatal "deploy of ${SHORT_SHA} failed health check and there was no previous runtime"
+    fatal "deploy of ${SHORT_SHA} failed verification and there was no previous runtime"
   fi
+else
+  log "NOTE: no service label set, so nothing was restarted and NO revision proof was possible."
+  log "NOTE: ${RUNTIME_DIR} now holds ${SHORT_SHA} but the running process is unverified."
 fi
 
 log "deployed ${SHORT_SHA} to ${RUNTIME_DIR}"

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -3,9 +3,9 @@
  * Design authority: `docs/code-brain-design.md` R3 and
  * `docs/decisions/shared-kb-canonical-namespace.md`.
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { parseServerConfig } from "./config.ts";
+import { OPTIONAL_SECRET_KEYS, parseServerConfig } from "./config.ts";
 
 const REQUIRED = {
   DB_HOST: "db.internal",
@@ -43,5 +43,102 @@ describe("server configuration boundary", () => {
       { role: "promoter", clientId: "openbrain-promoter" },
     ]);
     expect(result.config.sharedNamespace).toBe("shared-kb");
+  });
+});
+
+/**
+ * Present-but-EMPTY optional secrets.
+ *
+ * This is the shape that took the local dogfood service down on 2026-08-02.
+ * `/Volumes/ThunderBolt/open-brain-local/local-clone.env` legitimately sets
+ * `EMBEDDING_API_KEY=` (empty) because the local MLX embedding server needs no
+ * key, and `z.string().min(1).optional()` accepts ABSENT while REJECTING
+ * present-and-empty. The entrypoint threw
+ * `server_configuration_invalid: EMBEDDING_API_KEY: Too small` and launchd
+ * throttle-looped.
+ *
+ * The bar is start-equivalence with `src/`, so these assert the semantics the
+ * runtime env actually uses, read from the source of each consumer:
+ *   - `src/auth.ts` `if (!token) { warn; continue; }` — empty is skipped, not fatal
+ *   - `src/embedding.ts` `embeddingApiKey()` returns the raw env value
+ *   - `src/db/pool.ts` passes `process.env.DB_PASSWORD` straight to pg
+ * In every one of them an empty string behaves exactly as an unset variable.
+ *
+ * Parameterized over the WHOLE class rather than the one field that bit us:
+ * the defect is in the shared `optionalSecret` schema, so a test that pinned
+ * only `EMBEDDING_API_KEY` would leave the other seven able to fail the same
+ * way on the next environment that sets one to empty.
+ */
+describe("optional secrets that are present but empty", () => {
+  test.each([...OPTIONAL_SECRET_KEYS])("%s: empty string parses as absent", (key) => {
+    const result = parseServerConfig({ ...REQUIRED, [key]: "" });
+    if (!result.ok) {
+      throw new Error(
+        `empty ${key} must not fail the config boundary: ${JSON.stringify(result.issues)}`,
+      );
+    }
+  });
+
+  it("covers every field declared with the shared optional-secret schema", () => {
+    // Guards the parameterization above: a NEW optionalSecret field added to the
+    // schema without being listed here would otherwise go untested.
+    expect([...OPTIONAL_SECRET_KEYS].sort()).toEqual([
+      "AUTH_TOKEN_ADMIN",
+      "AUTH_TOKEN_AGENT",
+      "AUTH_TOKEN_DISCORD",
+      "AUTH_TOKEN_OB_ADMIN",
+      "AUTH_TOKEN_PROMOTER",
+      "AUTH_TOKEN_READONLY",
+      "DB_PASSWORD",
+      "EMBEDDING_API_KEY",
+    ]);
+  });
+
+  it("omits an empty database password rather than sending one", () => {
+    const result = parseServerConfig({ ...REQUIRED, DB_PASSWORD: "" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect("password" in result.config.database).toBe(false);
+  });
+
+  it("omits an empty embedding api key rather than sending one", () => {
+    const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: "" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect("embeddingApiKey" in result.config.transport).toBe(false);
+  });
+
+  it("skips an empty role token instead of registering a blank-token role", () => {
+    // `src/auth.ts` warns and continues on an empty role token. A blank token
+    // registered as a credential would be an auth hole, not a config nicety.
+    const result = parseServerConfig({
+      ...REQUIRED,
+      AUTH_TOKEN_ADMIN: "",
+      AUTH_TOKEN_AGENT: "configured-agent-token",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect(result.config.authTokens.map(({ role }) => role)).toEqual(["agent"]);
+  });
+
+  it("still parses when EVERY optional secret is empty at once", () => {
+    // The real clone environment sets several of these blank together; the
+    // per-field cases above would all pass even if the combination did not.
+    const empties = Object.fromEntries(OPTIONAL_SECRET_KEYS.map((key) => [key, ""]));
+    const result = parseServerConfig({ ...REQUIRED, ...empties });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect(result.config.authTokens).toEqual([]);
+    expect("password" in result.config.database).toBe(false);
+    expect("embeddingApiKey" in result.config.transport).toBe(false);
+  });
+
+  it("still rejects a present-but-empty REQUIRED field", () => {
+    // The empty-as-absent rule is scoped to OPTIONAL secrets. Widening it to
+    // required fields would turn `DB_HOST=` into a silent default.
+    const result = parseServerConfig({ ...REQUIRED, DB_HOST: "" });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected invalid configuration");
+    expect(result.issues.map((issue) => issue.path)).toEqual(["DB_HOST"]);
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -33,7 +33,52 @@ export type Role = z.infer<typeof roleSchema>;
 
 const positiveInteger = z.coerce.number().int().positive();
 const nonEmpty = z.string().trim().min(1);
-const optionalSecret = z.string().min(1).optional();
+/**
+ * Every field declared with the shared optional-secret schema below.
+ *
+ * Exported so the boundary tests can parameterize over the whole class rather
+ * than the single field that happened to break a deploy.
+ */
+export const OPTIONAL_SECRET_KEYS = [
+  "DB_PASSWORD",
+  "EMBEDDING_API_KEY",
+  "AUTH_TOKEN_ADMIN",
+  "AUTH_TOKEN_AGENT",
+  "AUTH_TOKEN_DISCORD",
+  "AUTH_TOKEN_OB_ADMIN",
+  "AUTH_TOKEN_PROMOTER",
+  "AUTH_TOKEN_READONLY",
+] as const;
+
+/**
+ * An optional secret: absent, or a non-empty value. **Present-and-empty counts
+ * as absent.**
+ *
+ * The `z.preprocess` is the whole point and is not decoration. Without it,
+ * `z.string().min(1).optional()` accepts an unset variable but REJECTS
+ * `FOO=`, and those are the same thing to every consumer of these fields:
+ * `src/auth.ts` skips a role token with `if (!token)`, `src/db/pool.ts` hands
+ * `process.env.DB_PASSWORD` straight to pg, and `src/embedding.ts`'s
+ * `embeddingApiKey()` returns the raw value. An empty string behaves as unset
+ * in all three.
+ *
+ * Shell environments produce empty rather than absent as a matter of course, so
+ * this is the normal case and not a malformed one. The local dogfood clone env
+ * sets `EMBEDDING_API_KEY=` because the local MLX embedding server needs no
+ * key; on 2026-08-02 that alone made the rewritten entrypoint throw
+ * `server_configuration_invalid` at startup and launchd throttle-looped it,
+ * while `src/index.ts` had always started fine on the identical environment.
+ *
+ * Normalizing HERE, at the parse boundary, rather than at each of the eight
+ * declaration sites, is what makes the rule hold for a field added later:
+ * everything typed `optionalSecret` gets it. Required fields keep rejecting
+ * empty — see `nonEmpty` — because there an empty value is a real misconfiguration
+ * rather than an omission.
+ */
+const optionalSecret = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  z.string().min(1).optional(),
+);
 const userTokenValue = z
   .string()
   .transform((value) => {

--- a/server/main.pg.test.ts
+++ b/server/main.pg.test.ts
@@ -244,6 +244,60 @@ dbDescribe("rewrite entrypoint start-equivalence (live Postgres)", () => {
 });
 
 dbDescribe("rewrite entrypoint startup and shutdown ordering (live Postgres)", () => {
+  test("starts on an environment whose optional secrets are present but empty", async () => {
+    // The 2026-08-02 deploy failure, as a live boot rather than a unit parse.
+    // `server/config.test.ts` pins the parse-boundary semantics for all eight
+    // optional-secret fields; this proves the ENTRYPOINT actually comes up on
+    // that environment, which is the claim start-equivalence makes and the one
+    // the previous fixtures never exercised — every env they built either set
+    // an optional secret to a real value or omitted the key entirely, so the
+    // shape that broke production (`EMBEDDING_API_KEY=`, empty) had no test.
+    const url = new URL(DB_URL!);
+    const result = parseServerConfig({
+      DB_HOST: url.hostname,
+      DB_PORT: url.port || "5432",
+      DB_NAME: url.pathname.replace(/^\//, ""),
+      DB_USER: decodeURIComponent(url.username) || "postgres",
+      LOG_FILE: "logs/open-brain-entrypoint-empty-secret-test.log",
+      OPEN_BRAIN_SERVER_IP: "127.0.0.1",
+      OPENBRAIN_MIGRATIONS_DIR: "src/db/migrations",
+      AUTH_TOKEN_AGENT: TOKEN,
+      // Exactly the local clone env's shape: the MLX embedding server needs no
+      // key, so the variable is exported empty rather than left unset.
+      EMBEDDING_API_KEY: "",
+      DB_PASSWORD: "",
+      AUTH_TOKEN_ADMIN: "",
+    });
+    if (!result.ok) {
+      throw new Error(
+        `empty optional secrets must not fail config: ${JSON.stringify(result.issues)}`,
+      );
+    }
+    const instance = await startServer({
+      config: result.config,
+      port: 0,
+      bindHost: "127.0.0.1",
+      logger: silentLogger(),
+      runMigrations: false,
+      allowedOrigins: [],
+    });
+    try {
+      // A real listener answering the real health route. 503 is acceptable
+      // because the embedding provider need not be up beside a test database.
+      expect([200, 503]).toContain(
+        (await fetch(`http://127.0.0.1:${instance.port}/health`)).status,
+      );
+      // The empty admin token must not have been registered as a credential:
+      // a blank bearer token accepted as `admin` would be an auth hole.
+      expect(result.config.authTokens.map(({ role }) => role)).toEqual(["agent"]);
+      // Empty password/key were dropped rather than passed to pg / the provider.
+      expect("password" in result.config.database).toBe(false);
+      expect("embeddingApiKey" in result.config.transport).toBe(false);
+    } finally {
+      await instance.shutdown();
+    }
+  });
+
   test("refuses to start, and opens no listener, without configured tokens", async () => {
     const config = testConfig();
     const tokenless: ServerConfig = { ...config, authTokens: [] };


### PR DESCRIPTION
## Summary

Fixes the two blockers that stopped the Phase 6 cutover deploy on 2026-08-02 (see the failure report on #506). Both are the same mistake in different clothes: a declaration treated as a state.

**1. `server/config.ts` — present-but-empty optional secrets, the whole 8-field class.**

`optionalSecret` was `z.string().min(1).optional()`. That accepts an ABSENT variable and rejects a PRESENT-AND-EMPTY one — but those are the same thing to every consumer of these fields, read from source:

- `src/auth.ts` skips a role token with `if (!token) { warn; continue; }`
- `src/db/pool.ts` hands `process.env.DB_PASSWORD` straight to pg
- `src/embedding.ts` `embeddingApiKey()` returns the raw env value

The local clone env legitimately sets `EMBEDDING_API_KEY=` (empty) because the local MLX embedding server needs no key. So the rewritten entrypoint threw `server_configuration_invalid: EMBEDDING_API_KEY: Too small` at startup and launchd restart-looped it, while `src/index.ts` had always started fine on that identical environment. That is exactly the start-equivalence bar `server/main.ts` claims to meet.

Normalized at the parse boundary with `z.preprocess("" -> undefined)`: **one site**, so the rule holds for any optional secret added later rather than for the one field that happened to bite. Required fields still reject empty — there an empty value is a real misconfiguration, not an omission.

**2. `scripts/local-clone-deploy.sh` — success criteria that could not fail.**

The post-deploy health check passed against the OLD process, which had never stopped. The restart was accepted, the new entrypoint died on the config throw, launchd held the service down for its `ThrottleInterval` (30s) — longer than the 15×2s health poll ran — and `curl /health` was answered by the previous revision. The script exited 0 with the stamp saying one revision and the running code being another.

The deploy now proves the NEW process is serving **before** it checks health. Three assertions, all required, all fatal:

1. the pid LISTENING on the clone port exists and DIFFERS from the pre-restart pid
2. that pid's cwd is the runtime directory (serving the tree we swapped)
3. the runtime's `.deployed-revision` matches the sha this run shipped

The listener comes from `lsof` on the port, deliberately — `launchctl print` reports the supervised *wrapper* pid, not the process that binds the socket (measured: wrapper 2407, listener 2476), and `pgrep` matches stray orphans holding no port (measured: pid 37600, from the previous day). Both alternatives are wrong for the question being asked, and the comment says so.

Rollback gets the same standard of proof. `--rollback` previously asserted nothing at all and just logged "rollback complete" — the same defect class, unreported, and most expensive exactly when it fires because the operator stops looking. The no-service-label path now states plainly that nothing was restarted and the running process is unverified, instead of reporting a deploy.

**The launchctl target spelling is NOT changed.** #472's `gui/$UID/` form is already merged and correct. `Unrecognized target specifier` is reproducibly the bare-label form (verified both spellings this session), which this script cannot emit — it came from a manual kickstart during the failed run, not from here. Editing a correct line to look responsive would have been the wrong repair.

## Critical Self-Review

- Highest-risk behavior: the `z.preprocess` widening acceptance too far — an empty REQUIRED field silently becoming a default. Bounded by scoping the change to `optionalSecret` only, with an explicit test that `DB_HOST: ""` still produces an issue.
- Assumptions that could be wrong: that empty-as-absent matches `src/` for all eight fields. Checked by reading each consumer rather than inferring — `src/auth.ts:33` and `:42`, `src/db/pool.ts:24`, `src/embedding.ts:262`. An empty `AUTH_TOKEN_*` could plausibly have been intended as fatal; `src/` warns and continues, so this matches it and pins that a blank token is never registered as a credential.
- Missing/weak tests: the deploy script has no automated test — bash, launchd, and a live port. Mitigated by probing all three new helpers against the running service (`listening_pid 3100` → 2476, `pid_cwd` → the runtime dir, `deployed_short_sha` → de4429b, empty-port probe → empty) and by the redeploy itself being the end-to-end exercise. The failure branches are reasoned, not executed, and that is stated as residual risk below.
- Security/permission risk: an empty `AUTH_TOKEN_ADMIN` must not become a usable blank bearer token. `roleTokenConfig` filters on `typeof token === "string"`, and preprocessing to `undefined` removes the key, so the role is dropped — asserted directly rather than assumed.
- Migration/deploy risk: no migrations touched. The deploy script is now strictly harder to satisfy, so the realistic failure mode is a deploy that refuses where it previously (falsely) passed. The polling window is 30×2s = 60s, chosen to outlast the 30s `ThrottleInterval` so a merely-delayed start is not misread as failure.
- Downstream client/runtime risk: none. `server/` does not serve traffic anywhere but this local dogfood clone, no MCP tool/schema/protocol surface changed, contract parity is unchanged at 65 tools, and core01 was never contacted.
- Rollback/cleanup concern: `src/` is byte-untouched (`git diff --stat -- src/` empty), so the documented rollback to the previous entrypoint remains available exactly as before.
- Fixes made before PR: corrected an assertion I had written against `instance.application.authTokens` — `rg` showed `authTokens` exists only on config (`server/main.ts:196,227,241`), never on `application`, so it now asserts the verified surface instead of a field I had not confirmed exists.
- Known residual risk: the deploy script's rollback-on-failure branches are reasoned rather than executed — inducing a real failed deploy against the live dogfood service to exercise them is not a safe thing to do to a live client. The happy path is proven end to end by the redeploy.
- SME review-memory update: [x] not applicable because: both defects are deploy/config-boundary issues rather than reviewer-lane patterns, and the durable lesson (a health check the previous process can satisfy is not a proof) is recorded as a comment at the check site in the script itself, where the next person to edit it will see it.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Live checks run against the local dogfood service; full proof battery posted as a PR comment after the redeploy.

## Contract Parity

- Contract parity: [x] runtime-specific because: no tool, schema, or protocol surface changed — this is a config-parse boundary and a deploy script. `bun contracts/check-parity.ts` passes unchanged at 52 fixtures / 45 capabilities / 2 providers, with the rewrite still registering 65 tools covering 21/21 contract-required.

## Testing

- `bunx tsc --noEmit` — clean, exit 0.
- `bun test` (full) — **3440 pass / 34 skip / 0 fail** across 226 files, on isolated databases (`open_brain_cutover_finish_test`, `open_brain_local_cutover_finish_test`). The dogfood database was never a target.
- Anti-skip guard — **PASSED: 361 live-Postgres testcases across 16 required suites, 0 skipped / 0 failed / 0 errored.** `rewrite entrypoint startup and shutdown ordering` now reports 3 tests where it reported 2, which is the new live boot test proving it actually ran rather than silently skipping.
- `bun contracts/check-parity.ts` — passed; 63/63 current-src tools fixture-covered, rewrite 65 tools 21/21 contract-required (+`record_skill_usage`, +`skill_usage_report`).
- **Red proof for the config fix:** with `OPTIONAL_SECRET_KEYS` exported but the `z.preprocess` not yet applied, `server/config.test.ts` ran **5 pass / 12 fail**. After the fix: **17 pass / 0 fail**. The new tests fail on the old code, which is what makes them worth having.
- Deploy script: `bash -n` clean; all three new helpers probed against the live service before being trusted in a deploy.
