### PR TITLE
feat(provider): port the PreToolUse guard to Python, verdict-for-verdict

### DIFF
--- a/python/openbrain-provider/pyproject.toml
+++ b/python/openbrain-provider/pyproject.toml
@@ -17,18 +17,24 @@ dependencies = [
     "openbrain-memory",
 ]
 
-# [project.scripts] is deliberately absent until PROV-9 (#418) adds
-# `cli_provider.py`. A declared entry point whose target module does not exist
-# still installs an executable shim into .venv/bin; it just dies with
-# ModuleNotFoundError when anything runs it. No lint, type, or test gate looks
-# at entry-point targets, so a broken script ships green.
+# A declared entry point whose target module does not exist still installs an
+# executable shim into .venv/bin; it just dies with ModuleNotFoundError when
+# anything runs it, and no lint, type, or test gate looks at entry-point
+# targets -- so a broken script ships green. `tests/test_packaging.py` closes
+# that: it parses this table and imports every declared `module:attr`.
 #
-# Planned, once the module lands:
-#   [project.scripts]
-#   ob-memory-provider = "openbrain_provider.cli_provider:main"
+# Each script is declared only once its module exists. The remaining names from
+# the epic's "Home and shape" section -- `ob-memory-provider`,
+# `ob-claude-hook`, `ob-context-budget-gate` -- arrive with their modules.
 #
 # The stable command name is the point: it replaces hook entries that hardcode
-# absolute paths into a content-addressed `sha256-<hash>` install dir (#420).
+# an absolute script path.
+[project.scripts]
+# Replaces `bun /Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider/guard.ts`,
+# the PreToolUse/Bash registration in both the Claude and Codex-sol profiles.
+# The port is behaviour-preserving; whether PreToolUse should observe or
+# enforce remains OPEN as open-brain#451.
+ob-guard = "openbrain_provider.cli_guard:main"
 
 [tool.uv.sources]
 openbrain-memory = { workspace = true }
@@ -61,8 +67,10 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests document themselves through their names; a docstring on every test
-# function is noise that trains people to write empty ones.
-"tests/*" = ["D100", "D103"]
+# function is noise that trains people to write empty ones. The same applies
+# to a class used purely to group related tests -- and to a nested helper
+# stub, which is why D101/D102 are here too.
+"tests/*" = ["D100", "D101", "D102", "D103"]
 
 [build-system]
 requires = ["hatchling"]

--- a/python/openbrain-provider/src/openbrain_provider/README.md
+++ b/python/openbrain-provider/src/openbrain_provider/README.md
@@ -24,10 +24,15 @@ Architecture:
     declared once here rather than restated per call site -- the duplication
     that produced two divergent copies in #412.
 
-    Incremental by design (#409): configuration, observability, and vocabulary
-    are present. Request parsing, receipt construction, dispatch, reflex, and
-    observation land in later slices. Nothing here is a placeholder; what is
-    exported works, and what is absent is absent.
+    Incremental by design (#409): configuration, observability, vocabulary, and
+    the ``ob-guard`` PreToolUse guard are present. Request parsing, receipt
+    construction, dispatch, reflex, and observation land in later slices.
+    Nothing here is a placeholder; what is exported works, and what is absent
+    is absent.
+
+    The guard is deliberately NOT re-exported here. It is an enforcement tool
+    invoked as a process by a hook, not a capability another module composes
+    with, and importing it would imply a coupling that does not exist.
 
 Key Components:
     - load_config / ProviderConfig: validated settings, read once at start
@@ -35,6 +40,9 @@ Key Components:
     - ConfigError: raised at boot on a bad setting, never at first use
     - configure_observability / logger: the single configured logging entry
     - EVENT_TYPES / is_valid_event_type: the one event vocabulary
+    - guard / shell_lexer / cli_guard: the ``ob-guard`` PreToolUse guard, a
+      standalone enforcement tool reached through its console script rather
+      than this package's importable surface
 
 Pattern/Convention:
     Configuration is read in ``config`` and nowhere else. A module that needs a

--- a/python/openbrain-provider/src/openbrain_provider/__init__.py
+++ b/python/openbrain-provider/src/openbrain_provider/__init__.py
@@ -20,10 +20,15 @@ Architecture:
     declared once here rather than restated per call site -- the duplication
     that produced two divergent copies in #412.
 
-    Incremental by design (#409): configuration, observability, and vocabulary
-    are present. Request parsing, receipt construction, dispatch, reflex, and
-    observation land in later slices. Nothing here is a placeholder; what is
-    exported works, and what is absent is absent.
+    Incremental by design (#409): configuration, observability, vocabulary, and
+    the ``ob-guard`` PreToolUse guard are present. Request parsing, receipt
+    construction, dispatch, reflex, and observation land in later slices.
+    Nothing here is a placeholder; what is exported works, and what is absent
+    is absent.
+
+    The guard is deliberately NOT re-exported here. It is an enforcement tool
+    invoked as a process by a hook, not a capability another module composes
+    with, and importing it would imply a coupling that does not exist.
 
 Key Components:
     - load_config / ProviderConfig: validated settings, read once at start
@@ -31,6 +36,9 @@ Key Components:
     - ConfigError: raised at boot on a bad setting, never at first use
     - configure_observability / logger: the single configured logging entry
     - EVENT_TYPES / is_valid_event_type: the one event vocabulary
+    - guard / shell_lexer / cli_guard: the ``ob-guard`` PreToolUse guard, a
+      standalone enforcement tool reached through its console script rather
+      than this package's importable surface
 
 Pattern/Convention:
     Configuration is read in ``config`` and nowhere else. A module that needs a

--- a/python/openbrain-provider/src/openbrain_provider/cli_guard.py
+++ b/python/openbrain-provider/src/openbrain_provider/cli_guard.py
@@ -1,0 +1,87 @@
+"""The ``ob-guard`` console script: the ``PreToolUse`` guard entrypoint.
+
+Purpose:
+    Read one hook payload from stdin, ask ``guard`` for a verdict, write it to
+    stdout, exit 0. Replaces ``bun _ob/scripts/ob-memory-provider/guard.ts``
+    with a stable command name, per the epic's "Home and shape" section
+    (``_plans/issues/409-*.md``), which names ``ob-guard`` as one of the four
+    console scripts that retire the hardcoded paths.
+
+Architecture:
+    An entrypoint and nothing else -- parse stdin, call one capability, write
+    stdout. No business logic here; the decision is entirely ``guard.py``'s.
+
+Pattern/Convention:
+    ALWAYS EXIT 0, ALWAYS FAIL OPEN. The block is expressed in the stdout
+    payload, never in the exit code, and any unexpected failure writes nothing
+    rather than taking out unrelated tool use. ``guard.ts:487-493`` swallows
+    its own errors for exactly this reason and says so in a comment; that is a
+    documented intentional fail-open, not a bare except by accident.
+
+    Reads at most ``MAX_INPUT_BYTES + 1`` bytes: one byte past the threshold is
+    all the verdict needs, and it means a huge payload cannot make the hook sit
+    reading inside the operator's 5-second timeout. ``guard.ts:471-485``.
+
+    Not registered in ``openbrain.apps.hooks``. The capture app's
+    ``PreToolUse`` module is a deliberate stub whose docstring says not to
+    conflate observation with enforcement; this guard is the separate
+    enforcement tool that stub refers to. Keeping them apart is what leaves
+    open-brain#451 open.
+
+Example:
+    >>> import io
+    >>> main(io.BytesIO(b'{"tool_name":"Read"}'), io.StringIO())
+    0
+
+See Also:
+    - ``guard`` - the verdict
+    - open-brain#451 - the OPEN observation-vs-enforcement decision
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import IO, TextIO
+
+from openbrain_provider.guard import MAX_INPUT_BYTES, guard_claude_command
+
+
+def read_bounded_stdin(stream: IO[bytes]) -> bytes:
+    """Read up to one byte past the parse threshold from ``stream``.
+
+    Args:
+        stream: The binary stream to read, normally ``sys.stdin.buffer``.
+
+    Returns:
+        The bytes read. Never more than ``MAX_INPUT_BYTES + 1``, which is
+        enough for the verdict because the guard only needs to know that the
+        payload exceeded the threshold, not by how much.
+    """
+    return stream.read(MAX_INPUT_BYTES + 1) or b""
+
+
+def main(stream: IO[bytes] | None = None, out: TextIO | None = None) -> int:
+    """Run the guard over one hook payload.
+
+    Args:
+        stream: Binary input; defaults to ``sys.stdin.buffer``.
+        out: Text output; defaults to ``sys.stdout``.
+
+    Returns:
+        Always 0. A blocked call is expressed in stdout, and any failure is
+        swallowed so the guard cannot break unrelated tool use.
+    """
+    try:
+        source = sys.stdin.buffer if stream is None else stream
+        sink = sys.stdout if out is None else out
+        sink.write(guard_claude_command(read_bounded_stdin(source)))
+        sink.flush()
+    except Exception:  # noqa: BLE001 - intentional: see the module docstring.
+        # The guard is deliberately narrow and does not break unrelated tool
+        # use. Mirrors `guard.ts:487-493`, which swallows for the same reason.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/openbrain-provider/src/openbrain_provider/guard.py
+++ b/python/openbrain-provider/src/openbrain_provider/guard.py
@@ -1,0 +1,638 @@
+"""Decide whether a Bash payload invokes the blocked Open Brain CLI route.
+
+Purpose:
+    Claude reaches Open Brain through the direct ``openbrain-memory`` provider.
+    The executable ``mcp2cli open-brain`` route is retired for Claude and this
+    guard refuses it at ``PreToolUse``, while leaving ``qmd`` and every other
+    ``mcp2cli`` service alone.
+
+Architecture:
+    A behaviour-identical port of
+    ``_ob/scripts/ob-memory-provider/guard.ts`` (493 lines, 1 live
+    registration on ``PreToolUse``/``Bash`` in both the Claude and Codex-sol
+    profiles). Lexing lives in ``shell_lexer``; this module is policy only and
+    performs no I/O. ``cli_guard`` is the entrypoint shell around it.
+
+Pattern/Convention:
+    LANGUAGE PORT ONLY -- no design change. Every verdict, including the ones
+    that look like gaps, matches the TypeScript byte for byte, proven against
+    fixtures recorded from the running script rather than re-derived from its
+    source. Two known gaps are deliberately preserved: ``( cmd )`` and
+    ``if ...; then cmd; fi`` are NOT blocked, because ``(`` and ``then`` lex
+    as the executable token. Closing either would change live enforcement.
+
+    Whether ``PreToolUse`` should observe or enforce is open-brain#451 and is
+    HITL. This port answers nothing about it: it preserves today's behaviour
+    exactly so the decision stays open and stays the operator's.
+
+    The guard fails OPEN by design. Malformed input, an unreadable payload, or
+    any unexpected shape returns an empty response rather than a block, because
+    a guard scoped to one command must never take out unrelated tool use.
+
+Example:
+    >>> guard_claude_command(b'{"tool_name":"Read","tool_input":{}}')
+    ''
+    >>> guard_claude_command(b'not json at all')
+    ''
+
+See Also:
+    - ``shell_lexer`` - the tokenizer this reasons over
+    - ``cli_guard`` - the ``ob-guard`` console script
+    - open-brain#451 - the OPEN observation-vs-enforcement decision
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Final
+
+from openbrain_provider.shell_lexer import (
+    Segment,
+    Token,
+    executable_substitutions,
+    tokenize_shell_detailed,
+)
+
+#: Largest stdin payload the guard parses as JSON, in bytes.
+#: ``guard.ts:8``: `const MAX_INPUT_BYTES = 64 * 1024`. Structural, and it is a
+#: FAIL-CLOSED threshold rather than a content bound: nothing is shortened or
+#: dropped. Above it the payload is not parsed, and a shell tool is blocked
+#: rather than waved through, so an oversized body cannot be used to smuggle a
+#: forbidden command past the guard. Reproduced exactly because raising or
+#: lowering it changes which payloads block.
+MAX_INPUT_BYTES: Final[int] = 64 * 1024
+
+#: Interpreters whose ``-c`` argument is scanned as a nested command.
+#: ``guard.ts:9``.
+SHELLS: Final[frozenset[str]] = frozenset({"sh", "bash", "zsh", "dash", "ksh"})
+
+#: Wrappers that pass through to the command that follows them.
+#: ``guard.ts:10``.
+PREFIXES: Final[frozenset[str]] = frozenset({"command", "exec", "nohup"})
+
+#: ``sudo`` options that take a separate value argument. ``guard.ts:11-14``.
+SUDO_OPTIONS_WITH_VALUES: Final[frozenset[str]] = frozenset(
+    {
+        "-C",
+        "-D",
+        "-g",
+        "-h",
+        "-p",
+        "-R",
+        "-T",
+        "-u",
+        "--chdir",
+        "--close-from",
+        "--group",
+        "--host",
+        "--other-user",
+        "--prompt",
+        "--role",
+        "--type",
+        "--user",
+    }
+)
+
+#: The refusal text handed back to the agent. ``guard.ts:15-16``, verbatim --
+#: the agent reads its replacement out of this string, so it is a contract, not
+#: a message.
+BLOCK_REASON: Final[str] = (
+    "Claude uses the direct openbrain-memory adapter; executable mcp2cli "
+    "open-brain commands are blocked. qmd and other mcp2cli services remain "
+    "allowed."
+)
+
+#: Tool names whose payload carries a shell command. ``guard.ts:37``.
+_SHELL_TOOL_NAMES: Final[frozenset[str]] = frozenset({"Bash", "Shell"})
+
+#: How deep nested-command scanning recurses. ``guard.ts:44``: `depth > 3`.
+#: Structural: it terminates the recursion that ``$(...)``, ``eval``, and
+#: ``sh -c`` would otherwise make unbounded.
+_MAX_NESTING_DEPTH: Final[int] = 3
+
+#: ``find`` primaries that run a command. ``guard.ts:125``.
+_FIND_EXEC_PRIMARIES: Final[frozenset[str]] = frozenset(
+    {"-exec", "-execdir", "-ok", "-okdir"}
+)
+
+#: ``env`` options taking a separate value. ``guard.ts:79``.
+_ENV_OPTIONS_WITH_VALUES: Final[frozenset[str]] = frozenset(
+    {"-u", "--unset", "-C", "--chdir"}
+)
+
+#: ``env`` options whose value is a whole nested command. ``guard.ts:83``.
+_ENV_SPLIT_STRING_OPTIONS: Final[frozenset[str]] = frozenset({"-S", "--split-string"})
+
+#: The retired CLI binary. ``guard.ts:447``.
+_BLOCKED_EXECUTABLE: Final[str] = "mcp2cli"
+
+#: The retired service argument. ``guard.ts:449``.
+_BLOCKED_SERVICE: Final[str] = "open-brain"
+
+_ASSIGNMENT: Final[re.Pattern[str]] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*=")
+_ASSIGNMENT_PARTS: Final[re.Pattern[str]] = re.compile(
+    r"^([a-zA-Z_][a-zA-Z0-9_]*)=(.*)$", re.DOTALL
+)
+_BARE_VARIABLE: Final[re.Pattern[str]] = re.compile(r"^\$([a-zA-Z_][a-zA-Z0-9_]*)$")
+_BRACED_VARIABLE: Final[re.Pattern[str]] = re.compile(
+    r"^\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}$"
+)
+_VARIABLE_MENTION: Final[re.Pattern[str]] = re.compile(r"\$\{?[a-zA-Z_]")
+_SHELL_COMMAND_FLAG: Final[re.Pattern[str]] = re.compile(r"^-[a-zA-Z]*c[a-zA-Z]*$")
+_QUOTE_OR_EXPANSION: Final[re.Pattern[str]] = re.compile(r"[$`]")
+
+
+def guard_claude_command(raw_input: bytes) -> str:
+    """Decide the guard's stdout for one ``PreToolUse`` payload.
+
+    Args:
+        raw_input: The raw stdin bytes of the hook event.
+
+    Returns:
+        The JSON block response with a trailing newline when the payload
+        invokes the blocked route, or an empty string to allow it.
+    """
+    if len(raw_input) > MAX_INPUT_BYTES:
+        return _oversized_response(raw_input)
+    try:
+        parsed = json.loads(raw_input.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        return ""
+    if not _is_record(parsed):
+        return ""
+    if parsed.get("tool_name") not in _SHELL_TOOL_NAMES:
+        return ""
+    tool_input = parsed.get("tool_input")
+    if not _is_record(tool_input):
+        return ""
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return ""
+    if not contains_forbidden_open_brain_command(command):
+        return ""
+    return _block_response()
+
+
+def _oversized_response(raw_input: bytes) -> str:
+    """Answer a payload too large to parse, without parsing it.
+
+    The prefix is scanned for a top-level ``tool_name`` only. A payload that
+    names a non-shell tool is allowed; anything else -- including one whose
+    ``tool_name`` sits past the prefix -- is blocked, because the command
+    cannot be inspected and waving it through would make oversizing the way
+    around the guard. ``guard.ts:22-28``.
+
+    Args:
+        raw_input: The raw stdin bytes.
+
+    Returns:
+        An empty string to allow, or the block response.
+    """
+    prefix = raw_input[:MAX_INPUT_BYTES].decode("utf-8", errors="replace")
+    tool_name = _top_level_string_property(prefix, "tool_name")
+    if tool_name and tool_name not in _SHELL_TOOL_NAMES:
+        return ""
+    return _block_response()
+
+
+def contains_forbidden_open_brain_command(command: str, depth: int = 0) -> bool:
+    """Report whether ``command`` would execute the blocked route.
+
+    Scans command substitutions first, then every segment, resolving simple
+    variable assignments that a previous segment made in the same shell.
+
+    Args:
+        command: The shell command text.
+        depth: Current nesting depth; recursion stops past
+            ``_MAX_NESTING_DEPTH``.
+
+    Returns:
+        True when some part of the command invokes the blocked route.
+    """
+    if not command or len(command) > MAX_INPUT_BYTES or depth > _MAX_NESTING_DEPTH:
+        return False
+    for nested in executable_substitutions(command):
+        if contains_forbidden_open_brain_command(nested, depth + 1):
+            return True
+    assignments: dict[str, str] = {}
+    segment_is_in_pipeline = False
+    for segment in tokenize_shell_detailed(command):
+        if _segment_is_forbidden(segment, assignments, depth):
+            return True
+        if not segment_is_in_pipeline and segment.terminator not in ("|", "&"):
+            _record_persistent_assignments(segment.tokens, assignments)
+        segment_is_in_pipeline = segment.terminator == "|"
+    return False
+
+
+def _segment_is_forbidden(
+    segment: Segment, assignments: dict[str, str], depth: int
+) -> bool:
+    """Check one segment both with and without assignment resolution.
+
+    The unresolved pass matters: a variable the guard could not resolve still
+    counts as dynamic, so ``$tool $service`` blocks even when nothing recorded
+    a value for either. ``guard.ts:52-55``.
+
+    Args:
+        segment: The segment to inspect.
+        assignments: Variable values recorded by earlier segments.
+        depth: Current nesting depth.
+
+    Returns:
+        True when either reading of the segment invokes the blocked route.
+    """
+    values = [token.value for token in segment.tokens]
+    resolved = [_resolve_assigned_token(token, assignments) for token in segment.tokens]
+    assignments_resolved = resolved != values
+    if _segment_invokes_open_brain(resolved, depth):
+        return True
+    return not assignments_resolved and _segment_invokes_open_brain(values, depth)
+
+
+def _segment_invokes_open_brain(tokens: list[str], depth: int) -> bool:
+    """Report whether a token list invokes the blocked route.
+
+    Walks past leading assignments, ``env``, pass-through prefixes, and
+    ``sudo`` to find the executable token, then checks it and the wrappers
+    that carry a command in an argument. ``guard.ts:64-137``.
+
+    Args:
+        tokens: The segment's token values.
+        depth: Current nesting depth.
+
+    Returns:
+        True when the segment invokes the blocked route.
+    """
+    index = 0
+    while index < len(tokens) and _is_assignment(_at(tokens, index)):
+        index += 1
+    if _at(tokens, index) == "env":
+        env_result = _skip_env_options(tokens, index + 1, depth)
+        if isinstance(env_result, bool):
+            return env_result
+        index = env_result
+    while _at(tokens, index) in PREFIXES:
+        index += 1
+        if _at(tokens, index) == "--":
+            index += 1
+    if _at(tokens, index) == "sudo":
+        index = _skip_sudo_options(tokens, index + 1)
+    executable_token = _at(tokens, index)
+    executable = _basename(executable_token)
+    if tokens_invoke_open_brain(executable_token, _at(tokens, index + 1)):
+        return True
+    return _wrapper_invokes_open_brain(executable, tokens, index, depth)
+
+
+def _wrapper_invokes_open_brain(
+    executable: str, tokens: list[str], index: int, depth: int
+) -> bool:
+    """Check the wrappers that carry a command in an argument.
+
+    ``eval``, ``xargs``, ``find -exec``, and ``sh -c`` each run something the
+    executable token alone does not reveal. ``guard.ts:115-135``.
+
+    Args:
+        executable: Basename of the executable token.
+        tokens: The segment's token values.
+        index: Index of the executable token.
+        depth: Current nesting depth.
+
+    Returns:
+        True when the wrapped command invokes the blocked route.
+    """
+    if executable == "eval":
+        nested = " ".join(tokens[index + 1 :])
+        return bool(nested) and contains_forbidden_open_brain_command(nested, depth + 1)
+    if executable == "xargs":
+        for candidate in range(index + 1, len(tokens) - 1):
+            if tokens_invoke_open_brain(tokens[candidate], tokens[candidate + 1]):
+                return True
+    if executable == "find":
+        exec_index = next(
+            (
+                i
+                for i, token in enumerate(tokens)
+                if i > index and token in _FIND_EXEC_PRIMARIES
+            ),
+            -1,
+        )
+        if exec_index >= 0 and tokens_invoke_open_brain(
+            _at(tokens, exec_index + 1), _at(tokens, exec_index + 2)
+        ):
+            return True
+    if executable in SHELLS:
+        command_flag = next(
+            (
+                i
+                for i, token in enumerate(tokens)
+                if i > index
+                and (_SHELL_COMMAND_FLAG.match(token) or token == "--command")
+            ),
+            -1,
+        )
+        nested = tokens[command_flag + 1] if 0 <= command_flag < len(tokens) - 1 else ""
+        if nested and contains_forbidden_open_brain_command(nested, depth + 1):
+            return True
+    return False
+
+
+def _skip_env_options(tokens: list[str], index: int, depth: int) -> int | bool:
+    """Advance past ``env`` options to the command it runs.
+
+    Args:
+        tokens: The segment's token values.
+        index: Index just after the ``env`` token.
+        depth: Current nesting depth.
+
+    Returns:
+        The index of the command token, or a bool verdict when ``env -S``
+        supplied the whole command as one argument.
+    """
+    while index < len(tokens):
+        token = _at(tokens, index)
+        if _is_assignment(token):
+            index += 1
+            continue
+        if token == "--":
+            return index + 1
+        if token in _ENV_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token in _ENV_SPLIT_STRING_OPTIONS:
+            nested = tokens[index + 1] if index + 1 < len(tokens) else ""
+            return bool(nested) and contains_forbidden_open_brain_command(
+                nested, depth + 1
+            )
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    return index
+
+
+def _skip_sudo_options(tokens: list[str], index: int) -> int:
+    """Advance past ``sudo`` options to the command it runs.
+
+    Args:
+        tokens: The segment's token values.
+        index: Index just after the ``sudo`` token.
+
+    Returns:
+        The index of the command token.
+    """
+    while index < len(tokens):
+        token = _at(tokens, index)
+        if token == "--":
+            return index + 1
+        if not token.startswith("-"):
+            break
+        index += 2 if token in SUDO_OPTIONS_WITH_VALUES else 1
+    return index
+
+
+def tokens_invoke_open_brain(executable_token: str, first_argument: str) -> bool:
+    """Report whether an executable/argument pair reaches the blocked route.
+
+    A token that could expand at runtime counts as possibly matching, so
+    ``$tool $service`` blocks even though neither word is literal. That is
+    what makes the guard resistant to trivially indirecting around it.
+    ``guard.ts:445-456``.
+
+    Args:
+        executable_token: The token in command position, path included.
+        first_argument: The token directly after it.
+
+    Returns:
+        True when the pair invokes, or may invoke, the blocked route.
+    """
+    executable = _basename(executable_token)
+    executable_is_cli = executable == _BLOCKED_EXECUTABLE
+    executable_may_be_cli = executable_is_cli or _dynamic_token_mentions(
+        executable_token, _BLOCKED_EXECUTABLE
+    )
+    argument_is_service = first_argument == _BLOCKED_SERVICE
+    argument_may_be_service = (
+        argument_is_service
+        or _dynamic_token_mentions(first_argument, _BLOCKED_SERVICE)
+        or (executable_may_be_cli and _is_dynamic_shell_token(first_argument))
+    )
+    return (
+        (executable_may_be_cli and argument_may_be_service)
+        or (_is_dynamic_shell_token(executable_token) and argument_is_service)
+        or (
+            _is_dynamic_shell_token(executable_token)
+            and _is_dynamic_shell_token(first_argument)
+        )
+    )
+
+
+def _resolve_assigned_token(token: Token, assignments: dict[str, str]) -> str:
+    """Substitute a recorded value for a bare ``$name`` token.
+
+    A token with any single-quoted part cannot expand, so its ``$`` and
+    backtick characters are stripped instead -- that is what stops
+    ``'$tool' '$service'`` from being read as an invocation.
+    ``guard.ts:271-276``.
+
+    Args:
+        token: The token to resolve.
+        assignments: Variable values recorded by earlier segments.
+
+    Returns:
+        The resolved token value.
+    """
+    if token.has_single_quoted_part:
+        return _QUOTE_OR_EXPANSION.sub("", token.value)
+    match = _BARE_VARIABLE.match(token.value) or _BRACED_VARIABLE.match(token.value)
+    name = match.group(1) if match else None
+    if name and name in assignments:
+        return assignments[name]
+    return token.value
+
+
+def _record_persistent_assignments(
+    tokens: tuple[Token, ...], assignments: dict[str, str]
+) -> None:
+    """Record assignments from a segment that is nothing but assignments.
+
+    A segment that also runs a command sets those variables only for that
+    command, so it is skipped. An empty or dynamic value forgets the variable
+    rather than recording something the guard cannot reason about.
+    ``guard.ts:278-288``.
+
+    Args:
+        tokens: The segment's tokens.
+        assignments: The map to update in place.
+    """
+    if not tokens or not all(_is_assignment(token.value) for token in tokens):
+        return
+    for token in tokens:
+        match = _ASSIGNMENT_PARTS.match(token.value)
+        if not match:
+            continue
+        name, value = match.group(1), match.group(2)
+        if not name:
+            continue
+        if not value or _is_dynamic_shell_token(value):
+            assignments.pop(name, None)
+        else:
+            assignments[name] = value
+
+
+def _dynamic_token_mentions(token: str, marker: str) -> bool:
+    """Report whether a runtime-expanding token names ``marker``."""
+    return _is_dynamic_shell_token(token) and marker in token
+
+
+def _is_dynamic_shell_token(token: str) -> bool:
+    """Report whether a token could expand to something else at runtime."""
+    return "$(" in token or "`" in token or bool(_VARIABLE_MENTION.search(token))
+
+
+def _is_assignment(token: str) -> bool:
+    """Report whether a token is a ``NAME=value`` assignment."""
+    return bool(_ASSIGNMENT.match(token))
+
+
+def _basename(path: str) -> str:
+    """Return the last ``/``-separated component of a token.
+
+    ``os.path.basename`` is deliberately not used: it returns ``""`` for a
+    trailing slash where ``guard.ts:462-465`` returns the empty final
+    component, and the guard's verdicts are pinned to the latter.
+    """
+    return path.split("/")[-1]
+
+
+def _at(tokens: list[str], index: int) -> str:
+    """Return ``tokens[index]``, or ``""`` when the index is out of range.
+
+    Mirrors the ``tokens[index] ?? ""`` idiom the TypeScript relies on; a
+    Python ``IndexError`` there would change a verdict into a crash.
+    """
+    return tokens[index] if 0 <= index < len(tokens) else ""
+
+
+def _block_response() -> str:
+    """Build the refusal payload, byte-identical to ``guard.ts:290-292``."""
+    payload = json.dumps(
+        {"decision": "block", "reason": BLOCK_REASON}, separators=(",", ":")
+    )
+    return f"{payload}\n"
+
+
+def _top_level_string_property(text: str, prop: str) -> str | None:
+    """Find a top-level string property in possibly-invalid JSON text.
+
+    Scans rather than parses, because the text is a prefix of an oversized
+    payload and will not parse. ``guard.ts:294-322``.
+
+    Args:
+        text: The JSON prefix to scan.
+        prop: The property name to find.
+
+    Returns:
+        The property's string value, or None when it is absent, nested, or
+        not a string.
+    """
+    depth = 0
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char == "{":
+            depth += 1
+            index += 1
+            continue
+        if char == "}":
+            depth -= 1
+            index += 1
+            continue
+        if char != '"':
+            index += 1
+            continue
+        token = _read_json_string(text, index)
+        if token is None:
+            return None
+        if depth == 1:
+            matched, value = _value_after_key(text, token, prop)
+            if matched:
+                return value
+        index = token[1] + 1
+    return None
+
+
+def _value_after_key(
+    text: str, token: tuple[str, int], prop: str
+) -> tuple[bool, str | None]:
+    """Read the value following a key token when the key matches ``prop``.
+
+    The match flag is separate from the value because "this key was not the
+    one" and "the key matched but its value is not a string" are different
+    answers, and the second one stops the scan. ``guard.ts:309-317`` expresses
+    the same split with an early ``return null``.
+
+    Args:
+        text: The JSON prefix being scanned.
+        token: The ``(value, end_index)`` pair of the key just read.
+        prop: The property name being sought.
+
+    Returns:
+        ``(False, None)`` when this key is not the one, otherwise ``(True,
+        value)`` where value is the string or None when it is not a string.
+    """
+    value, end = token
+    cursor = end + 1
+    while cursor < len(text) and _is_json_space(text[cursor]):
+        cursor += 1
+    if cursor >= len(text) or text[cursor] != ":" or value != prop:
+        return (False, None)
+    cursor += 1
+    while cursor < len(text) and _is_json_space(text[cursor]):
+        cursor += 1
+    if cursor >= len(text) or text[cursor] != '"':
+        return (True, None)
+    found = _read_json_string(text, cursor)
+    return (True, found[0] if found else None)
+
+
+def _read_json_string(text: str, start: int) -> tuple[str, int] | None:
+    """Read one JSON string literal beginning at ``start``.
+
+    Args:
+        text: The JSON prefix being scanned.
+        start: Index of the opening quote.
+
+    Returns:
+        The decoded value and the index of the closing quote, or None when the
+        literal never closes or does not decode.
+    """
+    escaped = False
+    for index in range(start + 1, len(text)):
+        char = text[index]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char != '"':
+            continue
+        try:
+            decoded = json.loads(text[start : index + 1])
+        except ValueError:
+            return None
+        return (decoded, index) if isinstance(decoded, str) else None
+    return None
+
+
+def _is_json_space(char: str) -> bool:
+    r"""Report whether a character is whitespace by JavaScript's ``\s``."""
+    return bool(re.match(r"\s", char))
+
+
+def _is_record(value: object) -> bool:
+    """Report whether a decoded JSON value is a non-array object."""
+    return isinstance(value, dict)

--- a/python/openbrain-provider/src/openbrain_provider/shell_lexer.py
+++ b/python/openbrain-provider/src/openbrain_provider/shell_lexer.py
@@ -1,0 +1,445 @@
+"""Shell lexing primitives the guard reasons over.
+
+Purpose:
+    Break a shell command string into segments of tokens, and find the
+    command substitutions inside it, closely enough that a guard can tell
+    which token is the executable being invoked.
+
+Architecture:
+    Pure functions over a string. No I/O, no state, no knowledge of what is
+    being guarded -- ``guard.py`` owns every policy decision and this module
+    owns none. Ported byte-for-byte in behaviour from
+    ``_ob/scripts/ob-memory-provider/guard.ts`` lines 139-269 and 346-435.
+
+Pattern/Convention:
+    This is deliberately NOT a shell parser and must not become one. It is a
+    scanner sized for one question -- "which word is the command?" -- and its
+    known gaps are part of the contract the TypeScript established: ``(`` and
+    ``then`` are ordinary token characters, so ``( cmd )`` lexes with ``(``
+    glued to ``cmd``. Recorded parity fixtures pin those gaps; closing one
+    would change live enforcement behaviour, which is open-brain#451's
+    decision to make and not this module's.
+
+    ``shlex`` is the obvious library answer and was rejected on measurement,
+    not on taste: ``shlex.split`` discards the segment terminators (``;``,
+    ``|``, ``&``) the guard needs to scope variable assignments, drops the
+    single-quoted-part provenance that decides whether ``$tool`` may expand,
+    and raises on unbalanced quotes where the guard must fail open. Matching
+    the recorded fixtures through it would mean re-deriving all three on top.
+
+Example:
+    >>> [s.terminator for s in tokenize_shell_detailed("a; b | c")]
+    [';', '|', None]
+    >>> [t.value for t in tokenize_shell_detailed("echo 'a b'")[0].tokens]
+    ['echo', 'a b']
+
+See Also:
+    - ``guard.py`` - the policy that consumes these tokens
+    - ``_ob/scripts/ob-memory-provider/guard.ts`` - the source of truth ported
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+#: Escapes ``$'...'`` (ANSI-C quoting) understands as a single character.
+#: Mirrors the map at ``guard.ts:357-361``.
+_ANSI_C_SIMPLE_ESCAPES: Final[dict[str, str]] = {
+    "a": "\x07",
+    "b": "\b",
+    "e": "\x1b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+}
+
+#: Digit width per numeric ``$'...'`` escape prefix. ``guard.ts:367``.
+_ANSI_C_HEX_WIDTHS: Final[dict[str, int]] = {"x": 2, "u": 4, "U": 8}
+
+#: Highest code point ``String.fromCodePoint`` accepts. ``guard.ts:372``.
+#: A Unicode fact, not a policy choice: this is the end of the code space.
+_MAX_CODE_POINT: Final[int] = 0x10FFFF
+
+_HEX_DIGITS: Final[re.Pattern[str]] = re.compile(r"^[a-fA-F0-9]+$")
+_OCTAL_RUN: Final[re.Pattern[str]] = re.compile(r"^[0-7]{1,3}")
+_WHITESPACE: Final[re.Pattern[str]] = re.compile(r"\s")
+
+#: Characters that end a segment. ``guard.ts:259``.
+_SEGMENT_TERMINATORS: Final[frozenset[str]] = frozenset({";", "|", "&"})
+
+
+@dataclass(frozen=True)
+class Token:
+    """One shell word, with whether any part of it was single-quoted.
+
+    Attributes:
+        value: The word with quoting removed.
+        has_single_quoted_part: True when any character came from inside
+            ``'...'`` or ``$'...'``. The guard uses this to decide that a
+            ``$name`` inside the word could not have expanded.
+    """
+
+    value: str
+    has_single_quoted_part: bool
+
+
+@dataclass(frozen=True)
+class Segment:
+    r"""One run of tokens up to a separator.
+
+    Attributes:
+        tokens: The words in this segment, in order.
+        terminator: The separator that ended it (``;``, ``|``, ``||``, ``&``,
+            ``&&``, ``\n``), or None at end of input.
+    """
+
+    tokens: tuple[Token, ...]
+    terminator: str | None
+
+
+@dataclass(frozen=True)
+class _Span:
+    """A parsed sub-string and the index of its final character."""
+
+    value: str
+    end: int
+
+
+def read_ansi_c_string(command: str, start: int) -> _Span | None:
+    """Read a ``$'...'`` ANSI-C quoted string starting at ``start``.
+
+    Args:
+        command: The full command text.
+        start: Index of the ``$``.
+
+    Returns:
+        The decoded value and the index of the closing quote, or None when
+        the string is never closed.
+    """
+    value = ""
+    index = start + 2
+    while index < len(command):
+        char = command[index]
+        if char == "'":
+            return _Span(value, index)
+        if char != "\\":
+            value += char
+            index += 1
+            continue
+        if index + 1 >= len(command):
+            return None
+        escaped = command[index + 1]
+        simple = _ANSI_C_SIMPLE_ESCAPES.get(escaped)
+        if simple is not None:
+            value += simple
+            index += 2
+            continue
+        decoded = _read_numeric_escape(command, index, escaped)
+        if decoded is not None:
+            value += decoded.value
+            index = decoded.end
+            continue
+        value += escaped
+        index += 2
+    return None
+
+
+def _read_numeric_escape(command: str, index: int, escaped: str) -> _Span | None:
+    r"""Decode a ``\xNN``/``\uNNNN``/``\UNNNNNNNN``/``\NNN`` escape.
+
+    Args:
+        command: The full command text.
+        index: Index of the backslash.
+        escaped: The character directly after the backslash.
+
+    Returns:
+        The decoded text and the next index to scan, or None when this is not
+        a numeric escape.
+    """
+    width = _ANSI_C_HEX_WIDTHS.get(escaped, 0)
+    if width:
+        digits = command[index + 2 : index + 2 + width]
+        if len(digits) == width and _HEX_DIGITS.match(digits):
+            code_point = int(digits, 16)
+            # `String.fromCodePoint` throws above this and guard.ts lets the
+            # throw escape into its outer catch; the value is simply dropped.
+            text = chr(code_point) if code_point <= _MAX_CODE_POINT else ""
+            return _Span(text, index + width + 2)
+        return None
+    if escaped in "01234567":
+        match = _OCTAL_RUN.match(command[index + 1 :])
+        digits = match.group(0) if match else escaped
+        return _Span(chr(int(digits, 8)), index + 1 + len(digits))
+    return None
+
+
+def read_command_substitution(command: str, start: int) -> _Span | None:
+    """Read a ``$(...)`` substitution starting at ``start``.
+
+    Args:
+        command: The full command text.
+        start: Index of the ``$``.
+
+    Returns:
+        The whole ``$(...)`` text and the index of its closing paren, or None
+        when it is never closed.
+    """
+    depth = 1
+    quote: str | None = None
+    escaped = False
+    for index in range(start + 2, len(command)):
+        char = command[index]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char == "(":
+            depth += 1
+        if char == ")":
+            depth -= 1
+            if depth == 0:
+                return _Span(command[start : index + 1], index)
+    return None
+
+
+def read_backtick_substitution(command: str, start: int) -> _Span | None:
+    """Read a `` `...` `` substitution starting at ``start``.
+
+    Args:
+        command: The full command text.
+        start: Index of the opening backtick.
+
+    Returns:
+        The whole backtick text and the index of the closing backtick, or None
+        when it is never closed.
+    """
+    escaped = False
+    for index in range(start + 1, len(command)):
+        char = command[index]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "`":
+            return _Span(command[start : index + 1], index)
+    return None
+
+
+def executable_substitutions(command: str) -> list[str]:
+    """Collect the bodies of substitutions that would actually execute.
+
+    A substitution inside single quotes is literal text and is skipped, which
+    is what keeps ``echo '$(...)'`` from being treated as an invocation.
+
+    Args:
+        command: The full command text.
+
+    Returns:
+        The inner text of each executing ``$(...)`` and `` `...` ``, in order.
+    """
+    nested: list[str] = []
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote == "'":
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if char == "'":
+            quote = "'"
+            index += 1
+            continue
+        if char == '"':
+            quote = None if quote == '"' else '"'
+            index += 1
+            continue
+        if char == "$" and command[index + 1 : index + 2] == "(":
+            parsed = read_command_substitution(command, index)
+            if parsed:
+                nested.append(command[index + 2 : parsed.end])
+                index = parsed.end
+            index += 1
+            continue
+        if char == "`":
+            parsed = read_backtick_substitution(command, index)
+            if parsed:
+                nested.append(command[index + 1 : parsed.end])
+                index = parsed.end
+        index += 1
+    return nested
+
+
+class _SegmentAccumulator:
+    """Builds tokens and segments as the scanner walks the command.
+
+    Split out because the scanner loop would otherwise carry five mutable
+    locals through every branch, which is how a token gets flushed on one path
+    and forgotten on another.
+    """
+
+    def __init__(self) -> None:
+        """Start with no tokens and no completed segments."""
+        self.segments: list[Segment] = []
+        self._tokens: list[Token] = []
+        self._token = ""
+        self._token_has_single_quoted_part = False
+
+    def add(self, text: str, *, single_quoted: bool = False) -> None:
+        """Append text to the token under construction."""
+        self._token += text
+        if single_quoted:
+            self._token_has_single_quoted_part = True
+
+    def mark_single_quoted(self) -> None:
+        """Record that this token touched a single-quoted region."""
+        self._token_has_single_quoted_part = True
+
+    @property
+    def token_is_empty(self) -> bool:
+        """True when no characters have been added to the current token."""
+        return not self._token
+
+    def finish_token(self) -> None:
+        """Close the current token, discarding it when it is empty."""
+        if self._token:
+            self._tokens.append(Token(self._token, self._token_has_single_quoted_part))
+        self._token = ""
+        self._token_has_single_quoted_part = False
+
+    def finish_segment(self, terminator: str | None) -> None:
+        """Close the current token and segment, discarding an empty segment."""
+        self.finish_token()
+        if self._tokens:
+            self.segments.append(Segment(tuple(self._tokens), terminator))
+        self._tokens = []
+
+
+def tokenize_shell_detailed(command: str) -> list[Segment]:
+    """Split a command into segments of tokens.
+
+    Quotes are removed, ``$'...'``/``$(...)``/`` `...` `` are folded into the
+    surrounding token, comments run to end of line, and ``;``/``|``/``&`` (and
+    their doubled forms) end a segment.
+
+    Args:
+        command: The full command text.
+
+    Returns:
+        The segments in order. Empty segments are dropped.
+    """
+    state = _SegmentAccumulator()
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            state.add(char)
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            else:
+                state.add(char, single_quoted=quote == "'")
+            index += 1
+            continue
+        consumed = _consume_expansion(command, index, state)
+        if consumed is not None:
+            index = consumed
+            continue
+        if char in ("'", '"'):
+            quote = char
+            if char == "'":
+                state.mark_single_quoted()
+            index += 1
+            continue
+        if char == "#" and state.token_is_empty:
+            while index < len(command) and command[index] != "\n":
+                index += 1
+            state.finish_segment("\n")
+            index += 1
+            continue
+        if _WHITESPACE.match(char):
+            if char == "\n":
+                state.finish_segment("\n")
+            else:
+                state.finish_token()
+            index += 1
+            continue
+        if char in _SEGMENT_TERMINATORS:
+            doubled = command[index + 1 : index + 2] == char and char != ";"
+            state.finish_segment(f"{char}{char}" if doubled else char)
+            index += 2 if doubled else 1
+            continue
+        state.add(char)
+        index += 1
+    state.finish_segment(None)
+    return state.segments
+
+
+def _consume_expansion(
+    command: str, index: int, state: _SegmentAccumulator
+) -> int | None:
+    """Fold a ``$'...'``, ``$(...)``, or `` `...` `` span into the token.
+
+    Args:
+        command: The full command text.
+        index: Index of the character starting the span.
+        state: The accumulator to append the span's text to.
+
+    Returns:
+        The next index to scan, or None when nothing was consumed.
+    """
+    char = command[index]
+    following = command[index + 1 : index + 2]
+    if char == "$" and following == "'":
+        parsed = read_ansi_c_string(command, index)
+        if parsed:
+            state.add(parsed.value)
+            return parsed.end + 1
+    if char == "$" and following == "(":
+        parsed = read_command_substitution(command, index)
+        if parsed:
+            state.add(parsed.value)
+            return parsed.end + 1
+    if char == "`":
+        parsed = read_backtick_substitution(command, index)
+        if parsed:
+            state.add(parsed.value)
+            return parsed.end + 1
+    return None

--- a/python/openbrain-provider/tests/fixtures/guard_parity.json
+++ b/python/openbrain-provider/tests/fixtures/guard_parity.json
@@ -1,0 +1,684 @@
+[
+  {
+    "name": "ts-block-000",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-001",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"/Users/rico/.local/bin/mcp2cli open-brain get_entity --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-002",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"OPENBRAIN_TEST=1 mcp2cli open-brain session_load --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-003",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env TEST_MODE=1 mcp2cli open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-004",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo ready && mcp2cli open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-005",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"zsh -c 'mcp2cli open-brain search_all --params {}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-006",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bash -lc 'mcp2cli open-brain search_all --params {}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-007",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sudo -u root -- mcp2cli open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-008",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"command -- mcp2cli open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-009",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"eval 'mcp2cli open-brain search_all --params {}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-010",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"printf '%s\\\\n' item | xargs mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-011",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"find . -exec mcp2cli open-brain search_all ;\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-012",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"$(mcp2cli open-brain search_all --params '{}')\\\"\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-013",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli $'open-brain' search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-014",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$'mcp2cli' open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-015",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"zsh -c $'mcp2cli open-brain search_all --params {}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-016",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$(printf mcp2cli) open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-017",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli $(printf open-brain) search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-018",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"${tool:-mcp2cli} open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-019",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli ${service:-open-brain} search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-020",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli; service=open-brain; $tool $service search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-021",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool='mcp2cli'; service='open-brain'; \\\"$tool\\\" \\\"$service\\\" search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-022",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli\\nservice=open-brain\\n${tool} ${service} search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-023",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli $service search --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-024",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$tool open-brain search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-025",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$tool $service search_all --params '{}'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-block-026",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli | service=open-brain; $tool $service search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "ts-allow-027",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli qmd search --params '{}'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-028",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli n8n list_workflows --params '{}'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-029",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo 'mcp2cli open-brain search_all'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-030",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rg 'mcp2cli open-brain' _ob\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-031",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"printf '%s' 'mcp2cli open-brain'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-032",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"printf '%s' $'mcp2cli open-brain'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-033",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rg $'mcp2cli open-brain' _ob\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-034",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo '$(mcp2cli open-brain search_all)'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-035",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"printf '%s' '`mcp2cli open-brain search_all`'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-036",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli $'qmd' search --params '{}'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-037",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$(printf mcp2cli) qmd search --params '{}'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-038",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli; service=qmd; $tool $service search --params '{}'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-039",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=printf; service=open-brain; $tool '%s' $service\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-040",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli; service=open-brain; echo '$tool $service search_all'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-041",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli; service=open-brain; rg '$tool $service' _ob\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "ts-allow-042",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli; service=open-brain; '$tool' '$service' search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-block-043",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli   open-brain   search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-044",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"nohup mcp2cli open-brain search_all &\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-045",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env -u FOO mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-046",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env -S 'mcp2cli open-brain search_all'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-047",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env FOO=1 -- mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-048",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"exec mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-049",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sudo --user root mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-050",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sudo -n mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-051",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sh -c 'sh -c \\\"mcp2cli open-brain search_all\\\"'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-052",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hi; mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-053",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hi || mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-054",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"true & mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-055",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"`mcp2cli open-brain search_all`\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-056",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"find . -execdir mcp2cli open-brain search_all ;\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-057",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"find . -ok mcp2cli open-brain search_all ;\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-058",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"find . -okdir mcp2cli open-brain search_all ;\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-059",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"printf x | xargs -I{} mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-060",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"zsh --command 'mcp2cli open-brain search_all'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-061",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ksh -c 'mcp2cli open-brain search_all'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-062",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"dash -c 'mcp2cli open-brain search_all'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-063",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bash -xc 'mcp2cli open-brain search_all'\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-064",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli \\\"open-brain\\\" search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-065",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"'mcp2cli' 'open-brain' search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-066",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"/usr/local/bin/mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-067",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"tool=mcp2cli\\nservice=open-brain\\n$tool $service search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-068",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli open-brain\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-069",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all | head -5\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-070",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"if true; then mcp2cli open-brain search_all; fi\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-block-071",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all > out.txt\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "extra-block-072",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"( mcp2cli open-brain search_all )\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-073",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status --short\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-074",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bun test\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-075",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"ls -la /Volumes/ThunderBolt\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-076",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rg -n 'open-brain' --glob '*.ts'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-077",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"aqmd \\\"how does the guard work\\\"\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-078",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-079",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli open-brainx search\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-080",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2clix open-brain search\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-081",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"MCP2CLI=1 echo open-brain\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-082",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"# mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-083",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo a # mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-084",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd /Volumes && echo hi\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-085",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-086",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"   \"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-087",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sudo mcp2cli qmd search\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-088",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"nohup mcp2cli qmd search &\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-089",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env -u FOO mcp2cli qmd search\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-090",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env -S 'mcp2cli qmd search'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-091",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"xargs echo < list.txt\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-092",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"find . -name '*.ts'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-093",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sh -c 'echo hi'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-094",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"eval 'echo hi'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-095",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo open-brain\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-096",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli vaultwarden-secrets get --params '{}'\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-097",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"openbrain-capture-stop\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "extra-allow-098",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"uv run pytest -q\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "shelltool-099",
+    "stdin": "{\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all\"}}",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "shelltool-100",
+    "stdin": "{\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"echo safe\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "nonshell-101",
+    "stdin": "{\"tool_name\":\"Read\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "nonshell-102",
+    "stdin": "{\"tool_name\":\"Edit\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "nonshell-103",
+    "stdin": "{\"tool_name\":\"Task\",\"tool_input\":{\"prompt\":\"mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-104",
+    "stdin": "{\"tool_name\":\"Bash\"}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-105",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{}}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-106",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":42}}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-107",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":\"mcp2cli open-brain search_all\"}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-108",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":null}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-109",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":[\"mcp2cli open-brain search_all\"]}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-110",
+    "stdin": "{\"tool_input\":{\"command\":\"mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-111",
+    "stdin": "{\"tool_name\":7,\"tool_input\":{\"command\":\"mcp2cli open-brain search_all\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "shape-112",
+    "stdin": "{}",
+    "stdout": ""
+  },
+  {
+    "name": "raw-notjson-113",
+    "stdin": "not-json",
+    "stdout": ""
+  },
+  {
+    "name": "raw-empty-114",
+    "stdin": "",
+    "stdout": ""
+  },
+  {
+    "name": "raw-array-115",
+    "stdin": "[1,2,3]",
+    "stdout": ""
+  },
+  {
+    "name": "raw-string-116",
+    "stdin": "\"hello\"",
+    "stdout": ""
+  },
+  {
+    "name": "raw-number-117",
+    "stdin": "12",
+    "stdout": ""
+  },
+  {
+    "name": "raw-null-118",
+    "stdin": "null",
+    "stdout": ""
+  },
+  {
+    "name": "raw-unterminated-119",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo",
+    "stdout": ""
+  },
+  {
+    "name": "raw-oversize-safe-120",
+    "stdin_parts": [
+      "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo safe\",\"padding\":\"",
+      {
+        "repeat": "x",
+        "count": 70000
+      },
+      "\"}}"
+    ],
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "raw-oversize-hidden-toolname-121",
+    "stdin_parts": [
+      "{\"padding\":\"",
+      {
+        "repeat": "x",
+        "count": 70000
+      },
+      "\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"mcp2cli open-brain search_all\"}}"
+    ],
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "raw-oversize-read-122",
+    "stdin_parts": [
+      "{\"tool_name\":\"Read\",\"tool_input\":{\"path\":\"/safe\",\"padding\":\"",
+      {
+        "repeat": "x",
+        "count": 70000
+      },
+      "\"}}"
+    ],
+    "stdout": ""
+  },
+  {
+    "name": "raw-oversize-nested-toolname-only-123",
+    "stdin_parts": [
+      "{\"padding\":\"",
+      {
+        "repeat": "x",
+        "count": 70000
+      },
+      "\",\"nested\":{\"tool_name\":\"Read\"},\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo safe\"}}"
+    ],
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "raw-oversize-notoolname-124",
+    "stdin_parts": [
+      "{\"padding\":\"",
+      {
+        "repeat": "x",
+        "count": 70000
+      },
+      "\",\"tool_input\":{\"command\":\"echo safe\"}}"
+    ],
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Claude uses the direct openbrain-memory adapter; executable mcp2cli open-brain commands are blocked. qmd and other mcp2cli services remain allowed.\"}\n"
+  },
+  {
+    "name": "raw-oversize-read-first-125",
+    "stdin_parts": [
+      "{\"tool_name\":\"Read\",\"padding\":\"",
+      {
+        "repeat": "x",
+        "count": 70000
+      },
+      "\",\"tool_input\":{\"command\":\"echo safe\"}}"
+    ],
+    "stdout": ""
+  },
+  {
+    "name": "raw-nonascii-126",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo é — ✓\"}}",
+    "stdout": ""
+  },
+  {
+    "name": "raw-at-threshold-127",
+    "stdin": "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo safe\"}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ",
+    "stdout": ""
+  }
+]

--- a/python/openbrain-provider/tests/test_guard.py
+++ b/python/openbrain-provider/tests/test_guard.py
@@ -1,0 +1,302 @@
+"""Behaviour tests for the guard's own units.
+
+The parity suite proves the whole thing matches the TypeScript. These prove the
+individual rules directly, so a failure names the rule that broke instead of
+only the case that noticed.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from openbrain_provider.cli_guard import main, read_bounded_stdin
+from openbrain_provider.guard import (
+    MAX_INPUT_BYTES,
+    contains_forbidden_open_brain_command,
+    guard_claude_command,
+    tokens_invoke_open_brain,
+)
+from openbrain_provider.shell_lexer import (
+    executable_substitutions,
+    read_ansi_c_string,
+    tokenize_shell_detailed,
+)
+
+CLI = "mcp2cli"
+SVC = "open-brain"
+FORBIDDEN = f"{CLI} {SVC} search_all"
+
+
+def _payload(tool_name: str, command: str) -> bytes:
+    return json.dumps(
+        {"tool_name": tool_name, "tool_input": {"command": command}}
+    ).encode()
+
+
+def _is_block(output: str) -> bool:
+    return output != "" and json.loads(output)["decision"] == "block"
+
+
+class TestTheBlockedRoute:
+    def test_a_direct_invocation_is_blocked(self) -> None:
+        assert contains_forbidden_open_brain_command(FORBIDDEN)
+
+    def test_an_absolute_path_does_not_evade_it(self) -> None:
+        assert contains_forbidden_open_brain_command(f"/usr/local/bin/{FORBIDDEN}")
+
+    @pytest.mark.parametrize("service", ["qmd", "n8n", "vaultwarden-secrets"])
+    def test_other_services_stay_allowed(self, service: str) -> None:
+        assert not contains_forbidden_open_brain_command(
+            f"{CLI} {service} search --params '{{}}'"
+        )
+
+    def test_the_name_in_quoted_text_is_not_an_invocation(self) -> None:
+        assert not contains_forbidden_open_brain_command(f"echo '{FORBIDDEN}'")
+
+    def test_a_near_miss_binary_is_allowed(self) -> None:
+        assert not contains_forbidden_open_brain_command(f"{CLI}x {SVC} search")
+
+    def test_a_near_miss_service_is_allowed(self) -> None:
+        assert not contains_forbidden_open_brain_command(f"{CLI} {SVC}x search")
+
+
+class TestIndirection:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            f"sudo -u root -- {FORBIDDEN}",
+            f"command -- {FORBIDDEN}",
+            f"env TEST=1 {FORBIDDEN}",
+            f"nohup {FORBIDDEN} &",
+            f"exec {FORBIDDEN}",
+            f"eval '{FORBIDDEN}'",
+            f"bash -lc '{FORBIDDEN}'",
+            f"zsh -c $'{FORBIDDEN}'",
+            f"printf x | xargs {FORBIDDEN}",
+            f"find . -exec {FORBIDDEN} ;",
+            f'echo "$({FORBIDDEN})"',
+            f"`{FORBIDDEN}`",
+        ],
+    )
+    def test_wrappers_do_not_evade_the_guard(self, command: str) -> None:
+        assert contains_forbidden_open_brain_command(command), command
+
+    def test_a_variable_holding_the_binary_is_resolved(self) -> None:
+        assert contains_forbidden_open_brain_command(
+            f"tool={CLI}; service={SVC}; $tool $service search_all"
+        )
+
+    def test_two_unresolvable_variables_still_block(self) -> None:
+        """Unknown expansion is treated as possibly matching, by design."""
+        assert contains_forbidden_open_brain_command("$tool $service search_all")
+
+    def test_a_single_quoted_variable_cannot_expand_and_is_allowed(self) -> None:
+        assert not contains_forbidden_open_brain_command(
+            f"tool={CLI}; service={SVC}; '$tool' '$service' search_all"
+        )
+
+    def test_a_variable_reassigned_to_another_service_is_allowed(self) -> None:
+        assert not contains_forbidden_open_brain_command(
+            f"tool={CLI}; service=qmd; $tool $service search"
+        )
+
+    def test_recursion_is_bounded_and_returns_a_verdict(self) -> None:
+        """Deep nesting terminates rather than recursing forever."""
+        deep = FORBIDDEN
+        for _ in range(8):
+            deep = f"sh -c '{deep}'"
+        assert contains_forbidden_open_brain_command(deep) in (True, False)
+
+
+class TestKnownGapsArePinned:
+    """These allow-verdicts are the TypeScript's, preserved on purpose.
+
+    Both are lexing artefacts: ``(`` glues to the following word and ``then``
+    lands in command position, so neither reaches the executable check.
+    Changing them would change live enforcement -- open-brain#451's call.
+    """
+
+    def test_a_subshell_is_not_blocked(self) -> None:
+        assert not contains_forbidden_open_brain_command(f"( {FORBIDDEN} )")
+
+    def test_an_if_branch_is_not_blocked(self) -> None:
+        assert not contains_forbidden_open_brain_command(
+            f"if true; then {FORBIDDEN}; fi"
+        )
+
+
+class TestPayloadHandling:
+    def test_only_shell_tools_are_inspected(self) -> None:
+        assert guard_claude_command(_payload("Bash", FORBIDDEN)) != ""
+        assert guard_claude_command(_payload("Shell", FORBIDDEN)) != ""
+        assert guard_claude_command(_payload("Read", FORBIDDEN)) == ""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            b"not-json",
+            b"",
+            b"[1,2,3]",
+            b'"text"',
+            b"12",
+            b"null",
+            b'{"tool_name":"Bash"',
+        ],
+    )
+    def test_unparseable_input_fails_open(self, raw: bytes) -> None:
+        assert guard_claude_command(raw) == ""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"tool_name": "Bash"},
+            {"tool_name": "Bash", "tool_input": {}},
+            {"tool_name": "Bash", "tool_input": {"command": 42}},
+            {"tool_name": "Bash", "tool_input": None},
+            {"tool_name": "Bash", "tool_input": [FORBIDDEN]},
+            {"tool_input": {"command": FORBIDDEN}},
+            {},
+        ],
+    )
+    def test_a_malformed_shape_fails_open(self, payload: dict[str, object]) -> None:
+        assert guard_claude_command(json.dumps(payload).encode()) == ""
+
+    def test_invalid_utf8_fails_open(self) -> None:
+        assert (
+            guard_claude_command(
+                b'{"tool_name":"Bash","tool_input":{"command":"\xff\xfe"}}'
+            )
+            == ""
+        )
+
+    def test_non_ascii_is_handled_without_blocking(self) -> None:
+        assert guard_claude_command(_payload("Bash", "echo é — ✓")) == ""
+
+
+class TestOversizedPayloads:
+    """Past the parse threshold the guard fails CLOSED for shell tools.
+
+    Nothing is shortened or dropped: the payload is simply not parsed, and a
+    shell call it cannot read is refused rather than waved through, so an
+    oversized body is not a way around the guard.
+    """
+
+    def _oversized(self, **fields: object) -> bytes:
+        return json.dumps({**fields, "padding": "x" * 70_000}).encode()
+
+    def test_a_shell_tool_is_blocked_even_when_its_command_is_safe(self) -> None:
+        raw = self._oversized(tool_name="Bash", tool_input={"command": "echo safe"})
+        assert _is_block(guard_claude_command(raw))
+
+    def test_a_non_shell_tool_is_still_allowed(self) -> None:
+        raw = self._oversized(tool_name="Read", tool_input={"path": "/safe"})
+        assert guard_claude_command(raw) == ""
+
+    def test_a_tool_name_past_the_prefix_is_blocked(self) -> None:
+        raw = json.dumps(
+            {
+                "padding": "x" * 70_000,
+                "tool_name": "Read",
+                "tool_input": {"command": "echo safe"},
+            }
+        ).encode()
+        assert _is_block(guard_claude_command(raw))
+
+    def test_a_nested_tool_name_does_not_count_as_the_top_level_one(self) -> None:
+        raw = json.dumps(
+            {
+                "nested": {"tool_name": "Read"},
+                "padding": "x" * 70_000,
+                "tool_name": "Bash",
+            }
+        ).encode()
+        assert _is_block(guard_claude_command(raw))
+
+    def test_an_absent_tool_name_is_blocked(self) -> None:
+        raw = self._oversized(tool_input={"command": "echo safe"})
+        assert _is_block(guard_claude_command(raw))
+
+
+class TestTokensInvokeOpenBrain:
+    def test_a_literal_pair_matches(self) -> None:
+        assert tokens_invoke_open_brain(CLI, SVC)
+
+    def test_a_dynamic_executable_with_the_literal_service_matches(self) -> None:
+        assert tokens_invoke_open_brain("$tool", SVC)
+
+    def test_two_dynamic_tokens_match(self) -> None:
+        assert tokens_invoke_open_brain("$tool", "$service")
+
+    def test_a_literal_pair_naming_another_service_does_not(self) -> None:
+        assert not tokens_invoke_open_brain(CLI, "qmd")
+
+    def test_an_unrelated_binary_with_a_dynamic_argument_does_not(self) -> None:
+        assert not tokens_invoke_open_brain("printf", "$service")
+
+
+class TestShellLexer:
+    def test_segments_carry_their_terminator(self) -> None:
+        assert [s.terminator for s in tokenize_shell_detailed("a; b | c && d")] == [
+            ";",
+            "|",
+            "&&",
+            None,
+        ]
+
+    def test_quotes_are_removed_and_recorded(self) -> None:
+        tokens = tokenize_shell_detailed("echo 'a b' \"c d\"")[0].tokens
+        assert [t.value for t in tokens] == ["echo", "a b", "c d"]
+        assert [t.has_single_quoted_part for t in tokens] == [False, True, False]
+
+    def test_a_comment_ends_the_segment(self) -> None:
+        segments = tokenize_shell_detailed("echo hi # a comment\necho bye")
+        assert [t.value for t in segments[0].tokens] == ["echo", "hi"]
+
+    def test_ansi_c_escapes_decode(self) -> None:
+        parsed = read_ansi_c_string(r"$'a\tb\x41\101'", 0)
+        assert parsed is not None
+        assert parsed.value == "a\tbAA"
+
+    def test_an_unterminated_ansi_c_string_is_not_a_span(self) -> None:
+        assert read_ansi_c_string("$'never closed", 0) is None
+
+    def test_substitutions_inside_single_quotes_do_not_execute(self) -> None:
+        assert executable_substitutions("echo '$(whoami)'") == []
+
+    def test_substitutions_outside_quotes_do_execute(self) -> None:
+        assert executable_substitutions('echo "$(whoami)"') == ["whoami"]
+
+    def test_nested_parens_close_correctly(self) -> None:
+        assert executable_substitutions("$(echo $(id))") == ["echo $(id)"]
+
+
+class TestTheEntrypoint:
+    def test_it_writes_the_verdict_and_exits_zero(self) -> None:
+        out = io.StringIO()
+        assert main(io.BytesIO(_payload("Bash", FORBIDDEN)), out) == 0
+        assert json.loads(out.getvalue())["decision"] == "block"
+
+    def test_an_allowed_call_writes_nothing(self) -> None:
+        out = io.StringIO()
+        assert main(io.BytesIO(_payload("Bash", "git status")), out) == 0
+        assert out.getvalue() == ""
+
+    def test_a_broken_stream_still_exits_zero_and_writes_nothing(self) -> None:
+        class Exploding(io.RawIOBase):
+            def read(self, size: int = -1) -> bytes:
+                raise OSError("stdin went away")
+
+        out = io.StringIO()
+        assert main(Exploding(), out) == 0  # type: ignore[arg-type]
+        assert out.getvalue() == ""
+
+    def test_it_stops_reading_one_byte_past_the_threshold(self) -> None:
+        """A huge payload must not make the hook sit reading inside its timeout."""
+        raw = read_bounded_stdin(io.BytesIO(b"x" * (MAX_INPUT_BYTES * 4)))
+        assert len(raw) == MAX_INPUT_BYTES + 1
+
+    def test_an_empty_stream_reads_as_empty_bytes(self) -> None:
+        assert read_bounded_stdin(io.BytesIO(b"")) == b""

--- a/python/openbrain-provider/tests/test_guard_parity.py
+++ b/python/openbrain-provider/tests/test_guard_parity.py
@@ -1,0 +1,114 @@
+"""Prove the Python guard emits the same bytes as the TypeScript it replaces.
+
+The fixture is a RECORDING, not a set of expectations someone wrote down: each
+case was fed to the running ``_ob/scripts/ob-memory-provider/guard.ts`` as a
+subprocess, exactly the way the ``PreToolUse`` hook feeds it, and its stdout
+captured byte for byte. That is what makes this a parity test rather than a
+restatement of the port's own logic.
+
+The corpus reproduces every case named by ``guard.test.ts`` (27 block, 16
+allow) and adds live-hook shapes that suite does not name: the ``Shell`` tool,
+non-shell tools, malformed payload shapes, and raw byte payloads including the
+oversized fast path.
+
+Two recorded ALLOW cases -- ``( cmd )`` and ``if ...; then cmd; fi`` -- look
+like gaps and are pinned deliberately. Byte-identical means identical including
+the gaps; changing either would change live enforcement, which is
+open-brain#451's decision and not this port's.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openbrain_provider.cli_guard import main
+from openbrain_provider.guard import BLOCK_REASON, guard_claude_command
+
+FIXTURE = Path(__file__).parent / "fixtures" / "guard_parity.json"
+
+
+def _rebuild_stdin(row: dict[str, Any]) -> str:
+    """Reconstruct a case's exact stdin text.
+
+    Long padding runs are stored as a repeat directive so the fixture stays
+    readable; the reconstruction is byte-exact and was asserted equal to the
+    original recording when the fixture was written.
+
+    Args:
+        row: One fixture record.
+
+    Returns:
+        The stdin text the TypeScript guard was fed.
+    """
+    if "stdin" in row:
+        text: str = row["stdin"]
+        return text
+    parts: list[str] = []
+    for part in row["stdin_parts"]:
+        parts.append(part if isinstance(part, str) else part["repeat"] * part["count"])
+    return "".join(parts)
+
+
+def _load_cases() -> list[tuple[str, str, str]]:
+    """Load the recorded cases as ``(name, stdin, expected_stdout)``."""
+    rows = json.loads(FIXTURE.read_text())
+    return [(row["name"], _rebuild_stdin(row), row["stdout"]) for row in rows]
+
+
+CASES = _load_cases()
+
+
+@pytest.mark.parametrize(
+    ("name", "stdin_text", "expected"), CASES, ids=[c[0] for c in CASES]
+)
+def test_guard_matches_recorded_typescript_output(
+    name: str, stdin_text: str, expected: str
+) -> None:
+    assert guard_claude_command(stdin_text.encode("utf-8")) == expected, name
+
+
+@pytest.mark.parametrize(
+    ("name", "stdin_text", "expected"), CASES, ids=[c[0] for c in CASES]
+)
+def test_cli_matches_recorded_typescript_output(
+    name: str, stdin_text: str, expected: str
+) -> None:
+    out = io.StringIO()
+    assert main(io.BytesIO(stdin_text.encode("utf-8")), out) == 0, name
+    assert out.getvalue() == expected, name
+
+
+def test_the_corpus_covers_both_verdicts() -> None:
+    blocked = [c for c in CASES if c[2]]
+    allowed = [c for c in CASES if not c[2]]
+    assert len(blocked) == 60
+    assert len(allowed) == 68
+
+
+def test_every_block_is_the_same_single_payload() -> None:
+    payloads = {c[2] for c in CASES if c[2]}
+    assert payloads == {
+        json.dumps({"decision": "block", "reason": BLOCK_REASON}, separators=(",", ":"))
+        + "\n"
+    }
+
+
+def test_the_recorded_block_reason_is_the_live_one() -> None:
+    """Pin the refusal text: the agent reads its replacement out of it."""
+    recorded = next(c[2] for c in CASES if c[2])
+    assert json.loads(recorded)["reason"] == BLOCK_REASON
+    assert "qmd" in BLOCK_REASON
+
+
+def test_the_fixture_reproduces_the_typescript_suite_labels() -> None:
+    """A ``ts-block``/``ts-allow`` case disagreeing means the oracle is wrong."""
+    for name, _stdin, expected in CASES:
+        if name.startswith("ts-block"):
+            assert expected, name
+        if name.startswith("ts-allow"):
+            assert expected == "", name


### PR DESCRIPTION
## Summary

Ports `_ob/scripts/ob-memory-provider/guard.ts` to Python as `ob-guard`, the console script the epic's "Home and shape" section (`_plans/issues/409-*.md`) already named for it. It is the last enforcement hook with no Python answer: one live `PreToolUse`/`Bash` registration, present in both `~/.claude/settings.json` and the Codex-sol profile.

**Language port only. No design change.** Every verdict is the TypeScript's, including the ones that look like gaps.

### Proven against a recording, not against expectations

Each of 128 payloads was fed to the *running* `guard.ts` as a subprocess, exactly the way the hook feeds it, and its stdout captured byte for byte. That recording is the fixture. The corpus reproduces all 43 cases `guard.test.ts` names (27 block, 16 allow) and adds the shapes it does not: the `Shell` tool, non-shell tools, nine malformed payload shapes, and raw byte payloads including the oversized fast path.

Recording rather than reasoning paid for itself immediately: **two cases I predicted as blocks are actually allows**, and the oracle said so before the code did.

### Two known gaps, pinned on purpose

`( cmd )` and `if ...; then cmd; fi` are **not** blocked by the TypeScript, because `(` and `then` lex into command position. Both are reproduced and pinned by name in `TestKnownGapsArePinned`. Byte-identical means identical including the gaps — closing either would change live enforcement, and that is **#451's decision to make, not this port's**.

### #451 stays open by construction

This is deliberately **not** wired into `openbrain.apps.hooks`. That package's `pre_tool_use.py` is an explicit stub whose docstring says not to conflate observation with enforcement; this is the separate enforcement tool it refers to. Nothing here decides whether the *capture* app owns any `PreToolUse` behaviour.

### Shape

Three modules, split by job per the port sequence's tight-units rule: `shell_lexer` tokenizes and owns no policy, `guard` decides and performs no I/O, `cli_guard` parses stdin and writes stdout and decides nothing.

`shlex` was measured and rejected, with the reason recorded in the module docstring: it discards the segment terminators the guard needs to scope assignments, drops the single-quoted-part provenance that decides whether `$tool` may expand, and raises where the guard must fail open.

Also corrects `pyproject.toml`'s "`[project.scripts]` is deliberately absent until PROV-9" comment. PROV-9 shipped 2026-08-01 and declared its scripts in a *different* package, so the note had been false since; this PR adds the table it claimed was absent.

### Receipts

| gate | result |
|---|---|
| `uv run ruff check --no-cache src tests` | All checks passed |
| `uv run ruff format --check` | 16 files already formatted |
| `uv run mypy src/openbrain_provider` | Success, 8 source files |
| `uv run pytest -q` | **425 passed** |
| sibling `openbrain` | 386 passed, 17 deselected |
| sibling `openbrain-memory` | 550 passed, 9 skipped |

**Proof the suite can fail** — six defects forged one at a time into `guard.py`, each reverted before the next:

| forged defect | failures caught |
|---|---|
| parse threshold 64 KiB → 128 KiB | 10 |
| nesting depth 3 → 1 | 2 |
| `nohup` dropped from `PREFIXES` | 3 |
| block-reason wording changed | 122 |
| dynamic-executable rule removed | 3 |
| single-quote provenance ignored | 3 |

Source restored and verified byte-identical afterwards (`diff -q` clean).

**Proof the shipped artifact works** — `uv sync` installs the shim, then all 128 payloads run through **both real executables**, `bun guard.ts` and `.venv/bin/ob-guard`:

```
cases compared: 128
stdout mismatches (live TS vs installed ob-guard): 0
non-zero ob-guard exits: 0 []
```

This also re-verified zero fixture drift, so the oracle has not gone stale.

**Latency**, 10 invocations each: ~76 ms for the Python against ~20 ms for bun. Both are well inside the registered `"timeout": 5`; the ~4x is interpreter startup, stated rather than omitted.

### Settings replacement line (controller's call, not applied here)

Nothing under `~/.claude` or `~/.claudex` was touched. The registration that would replace the current `bun .../guard.ts` entry, once the package is installed to the standard location:

```
sh /Users/rico/.local/share/openbrain-memory/env/openbrain-hook-env ob-guard
```

## Critical Self-Review

- Highest-risk behavior: a verdict that differs from the TypeScript on a shape the corpus does not cover, silently weakening or over-applying a live `PreToolUse` guard. Mitigated by recording the oracle from the running script rather than reasoning from its source, by covering all 43 cases its own suite names plus 85 more, and by the two-executable differential probe.
- Assumptions that could be wrong: that 128 payloads represent the live event space. They are representative, not exhaustive — a shell construct nobody wrote down could differ. The gaps I found were found by recording, which is exactly the class of error reasoning would have missed.
- Missing/weak tests: no test drives the guard through a real Claude Code `PreToolUse` event; the probe synthesises the payload shape from captured fixtures. There is no live-DB gate here because the guard touches no database, no network, and no state.
- Security/permission risk: this IS a security control, so a false negative is the risk that matters. Fail-open on malformed input is preserved deliberately and matches the TypeScript; the oversized path fails CLOSED for shell tools, and five tests pin that direction specifically so a future edit cannot quietly turn it into an escape hatch.
- Migration/deploy risk: none in this PR. It adds a console script and changes no registration; the live TS guard stays registered and functional, and the settings swap is a separate operator action.
- Downstream client/runtime risk: none. Nothing imports these modules, `__init__.py` deliberately does not re-export them, and no contract, schema, or client surface changes.
- Rollback/cleanup concern: revert the single commit. Nothing is installed to a shared location and no live registration is touched, so a revert is complete on its own.
- Fixes made before PR: replaced a sentinel-object return that mypy strict rejected with an explicit `(matched, value)` tuple; corrected three docstrings to raw strings; widened the tests' pydocstyle per-file-ignore to cover grouping classes; updated `__init__.py` and regenerated the package README after the docs `--check` gate caught the drift.
- Known residual risk: the two preserved gaps (`( cmd )`, `if/then`) are real evasions of a real guard. They are pre-existing live behaviour, not introduced here, and closing them is a behaviour change belonging to #451. Second: `generate_package_docs.py --check` prints its failure but exits 0, so it cannot fail CI as written — noticed while running it, out of scope here, worth its own issue.
- SME review-memory update: [x] not applicable because: no reviewer-lane pattern changed. This is a behaviour-preserving port whose findings are about this one file, and the transferable lesson (record the oracle, do not reason it) is already the port sequence's stated method.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: the guard performs no I/O, touches no database, contract, or service surface, and reaches Open Brain not at all — it only inspects a command string and writes a verdict to stdout.

## Contract Parity

- Contract parity: [x] runtime-specific because: no contract, schema, MCP tool, or client-facing surface is touched. The guard is a runtime enforcement hook that inspects a command string and writes a verdict to stdout; it has no contract fixtures to update.

## Testing

- Label: 425 in-process tests (256 of them parity assertions over recorded TS output), a six-defect forge pass proving the suite fails, and a 128-case differential probe across both real executables with 0 mismatches.

Refs #451, #409
