### PR TITLE
feat(provider): port both hook gates to Python -- byte-parity, and #419's deadlock actually fixed

### DIFF
--- a/python/openbrain-provider/pyproject.toml
+++ b/python/openbrain-provider/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
 # that: it parses this table and imports every declared `module:attr`.
 #
 # Each script is declared only once its module exists. The remaining names from
-# the epic's "Home and shape" section -- `ob-memory-provider`,
-# `ob-claude-hook`, `ob-context-budget-gate` -- arrive with their modules.
+# the epic's "Home and shape" section -- `ob-memory-provider` and
+# `ob-claude-hook` -- arrive with their modules.
 #
 # The stable command name is the point: it replaces hook entries that hardcode
 # an absolute script path.
@@ -35,6 +35,12 @@ dependencies = [
 # The port is behaviour-preserving; whether PreToolUse should observe or
 # enforce remains OPEN as open-brain#451.
 ob-guard = "openbrain_provider.cli_guard:main"
+# The two hook gates (#419, PROV-10). These replace the six
+# `context-budget-gate.ts` and four `policy-refresh-gate.ts` registrations.
+# PROV-9's capture/lifecycle scripts live in the sibling `openbrain` package,
+# not here.
+openbrain-context-budget-gate = "openbrain_provider.context_budget_gate:_cli"
+openbrain-policy-refresh-gate = "openbrain_provider.policy_refresh_gate:_cli"
 
 [tool.uv.sources]
 openbrain-memory = { workspace = true }

--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -425,7 +425,7 @@ def _default_gate_script_path() -> str:
     name the `.ts` entry, and refusing that spelling would block the repair
     command the gate itself printed.
     """
-    return "/Volumes/ThunderBolt/Development/_ob/scripts/context-budget-gate.ts"
+    return str(development_root() / "_ob" / "scripts" / "context-budget-gate.ts")
 
 
 def _handle_user_prompt_submit(gate: _Gate) -> int:

--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -197,9 +197,7 @@ def _build_parser(env: dict[str, str]) -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--repair-reason", default="")
-    parser.add_argument(
-        "--repair-minutes", type=int, default=_DEFAULT_REPAIR_MINUTES
-    )
+    parser.add_argument("--repair-minutes", type=int, default=_DEFAULT_REPAIR_MINUTES)
     parser.add_argument(
         "--gate-script-path",
         default="",
@@ -725,9 +723,7 @@ def main(
         a non-zero exit means the hook itself failed.
     """
     environment = dict(os.environ) if env is None else env
-    args = _build_parser(environment).parse_args(
-        sys.argv[1:] if argv is None else argv
-    )
+    args = _build_parser(environment).parse_args(sys.argv[1:] if argv is None else argv)
     event = read_hook_event(stdin)
     gate = _Gate(args, event, stdout)
     handler = _HANDLERS[gate.event_name]

--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -1,0 +1,748 @@
+"""The context-budget gate entrypoint: one event in, one verdict out.
+
+Purpose:
+    Automatic-compaction discipline. Token pressure is ADVISORY before a
+    compaction. After one, task mutation waits for an exact-cycle direct recall
+    receipt -- and that requirement self-releases after fifteen minutes, with an
+    explicit expiring repair mode that admits Bash, Write, and Edit while the
+    recall plumbing itself is being fixed.
+
+Architecture:
+    A dispatch shell. Argument parsing, state loading, and event routing live
+    here; every decision lives in a module underneath -- ``gate_state`` for what
+    is owed, ``gate_shell`` for what a blocked session may still run,
+    ``gate_presentation`` for the text, ``gate_transcript`` for token pressure,
+    ``receipt_state`` for the evidence. One handler per event, none of them
+    sharing a branch with another.
+
+Pattern/Convention:
+    THE GATE MUST NOT DEADLOCK ON WHAT IT GATES. Issue #419 exists because the
+    documented self-release did not fire, so the gate blocked Bash and Write
+    until an Open Brain recall succeeded while the broken recall was the thing
+    needing repair. Two mechanisms answer it, both tested: the timed
+    self-release in ``gate_state._release_timed_out_readback``, and the bounded
+    repair window entered with ``--event repair-enter``.
+
+    EVERY BRANCH RECORDS A NAMED TRANSITION. Silence is a signal (#419
+    acceptance): a state change nobody can grep for later is a state change
+    nobody can debug.
+
+Example:
+    >>> import io
+    >>> main(["--event", "status", "--session-id", "s1"],
+    ...      stdin=io.StringIO("{}"), stdout=io.StringIO())
+    0
+
+See Also:
+    - ``_plans/issues/419-prov-10-context-budget-gate-with-a-repair-mode-escape.md``
+    - ``_ob/scripts/context-budget-gate.ts`` - the TypeScript this replaces
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from .development_scope import resolve_development_scope
+from .gate_presentation import (
+    PresentationContext,
+    capture_banner,
+    gate_status_line,
+    nag_banner,
+    readback_banner,
+    transition_message,
+)
+from .gate_shell import ShellGateContext, is_checkpoint_activity, is_repair_capable_tool
+from .gate_state import (
+    CHECKPOINT_MAX_AGE_SECONDS,
+    enter_repair_mode,
+    exit_repair_mode,
+    fresh_session_state,
+    hydrate_session_state,
+    load_state,
+    reconcile_gate_state,
+    record_transition,
+    repair_mode_is_active,
+    save_session_state,
+    verified_checkpoint,
+)
+from .gate_transcript import read_context_tokens, turn_did_work
+from .hook_io import HookEvent, emit, emit_json, read_hook_event
+from .receipt_state import (
+    current_compact_cycle,
+    default_receipt_state_path,
+    gate_compact_cycle,
+)
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+__all__ = ["main"]
+
+#: Advisory notice thresholds. These are notice points, not blocks: crossing
+#: them prints a line and nothing else (``nag_banner`` says so in its own text).
+_DEFAULT_NAG_TOKENS: Final[int] = 200_000
+_DEFAULT_ADVISORY_TOKENS: Final[int] = 250_000
+
+#: context-budget-gate.ts:75 -- how much the count must climb before the same
+#: advisory is repeated, so one long session does not print it every turn.
+_RENAG_STEP: Final[int] = 15_000
+
+#: context-budget-gate.ts:77-78. A repair window is minutes, and the longest one
+#: is the same fifteen minutes the read-back self-releases in -- an escape hatch
+#: that outlived the requirement it escapes would just be the gate switched off.
+_DEFAULT_REPAIR_MINUTES: Final[int] = 5
+_LONGEST_REPAIR_MINUTES: Final[int] = 15
+
+#: context-budget-gate.ts:79 -- the agent key the policy state file is scoped by.
+_POLICY_STATE_AGENT: Final[str] = "claude"
+
+#: context-budget-gate.ts:80 -- how much of an auxiliary state file to inspect
+#: before answering "unknown" instead. An unbounded read of an arbitrary file on
+#: the hook's critical path is the failure this avoids; the answer when it trips
+#: is `None`, which the status line renders as unknown rather than as healthy.
+_MAX_STATE_SCAN_BYTES: Final[int] = 8 * 1024 * 1024
+
+#: Every event this gate answers.
+_EVENTS: Final[tuple[str, ...]] = (
+    "user-prompt-submit",
+    "pre-tool-use",
+    "pre-compact",
+    "post-compact",
+    "session-start",
+    "checkpoint-done",
+    "repair-enter",
+    "repair-exit",
+    "stop",
+    "status",
+)
+
+
+def _iso_now() -> str:
+    """Return the current instant the way the TypeScript writer spells it."""
+    utc = datetime.now(UTC)
+    return f"{utc.strftime('%Y-%m-%dT%H:%M:%S')}.{utc.microsecond // 1000:03d}Z"
+
+
+def _state_home(env: dict[str, str]) -> Path:
+    """Return ``$XDG_STATE_HOME`` or its documented default."""
+    configured = env.get("XDG_STATE_HOME", "").strip()
+    return Path(configured) if configured else Path.home() / ".local" / "state"
+
+
+def _build_parser(env: dict[str, str]) -> argparse.ArgumentParser:
+    """Build the argument parser with environment-aware defaults.
+
+    Args:
+        env: Environment mapping, so defaults are testable without exporting.
+
+    Returns:
+        The parser. Every path is overridable, which is what lets the parity
+        tests run against scratch files instead of the operator's live state.
+    """
+    state_home = _state_home(env)
+    parser = argparse.ArgumentParser(
+        prog="openbrain-context-budget-gate", add_help=True
+    )
+    parser.add_argument("--event", default="status", choices=_EVENTS)
+    parser.add_argument("--session-id", default="")
+    parser.add_argument("--project", default="")
+    parser.add_argument(
+        "--nag-tokens",
+        type=int,
+        default=int(env.get("CONTEXT_BUDGET_NAG") or _DEFAULT_NAG_TOKENS),
+    )
+    parser.add_argument(
+        "--hard-tokens",
+        type=int,
+        default=int(env.get("CONTEXT_BUDGET_HARD") or _DEFAULT_ADVISORY_TOKENS),
+    )
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=state_home / "agent-runtime" / "context-budget" / "state.json",
+    )
+    parser.add_argument(
+        "--receipt-state-path", type=Path, default=default_receipt_state_path(env)
+    )
+    parser.add_argument(
+        "--settings-path",
+        type=Path,
+        default=Path.home() / ".claude" / "settings.json",
+    )
+    parser.add_argument(
+        "--policy-state-path",
+        type=Path,
+        default=Path.home()
+        / ".local"
+        / "state"
+        / "agent-policy-refresh"
+        / "state.json",
+    )
+    parser.add_argument(
+        "--spool-path",
+        type=Path,
+        default=Path(
+            env.get("OPENBRAIN_SPOOL_PATH")
+            or Path.home()
+            / ".local"
+            / "state"
+            / "openbrain-memory"
+            / "claude-spool.jsonl"
+        ),
+    )
+    parser.add_argument("--repair-reason", default="")
+    parser.add_argument(
+        "--repair-minutes", type=int, default=_DEFAULT_REPAIR_MINUTES
+    )
+    parser.add_argument(
+        "--gate-script-path",
+        default="",
+        help="Path a repair-enter/repair-exit command must name to be allowed.",
+    )
+    parser.add_argument(
+        "--provider-script-path",
+        default="/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider.ts",
+        help="Path a direct provider command must name to be allowed.",
+    )
+    return parser
+
+
+class _Gate:
+    """One invocation's resolved inputs, state, and handlers.
+
+    Grouped into an object because every handler needs the same six things and
+    threading them through ten function signatures would be noise. The class
+    holds no behaviour a function could not -- it is the invocation's scope.
+    """
+
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        event: HookEvent,
+        stdout: TextIO | None,
+    ) -> None:
+        """Resolve state and context for one invocation.
+
+        Args:
+            args: Parsed arguments.
+            event: The parsed hook stdin.
+            stdout: Where the verdict goes.
+        """
+        self.args = args
+        self.event = event
+        self.stdout = stdout
+        self.now = _iso_now()
+        self.event_name: str = args.event
+        self.session_id = args.session_id or event.session_id or "unknown-session"
+        self.state_file, self.raw_sessions = load_state(args.state_path)
+        self.state = hydrate_session_state(
+            self.raw_sessions.get(self.session_id), self.session_id, self.now
+        )
+        self._set_project()
+        tokens = read_context_tokens(event.transcript_path)
+        if tokens > 0:
+            self.state.context_tokens = tokens
+        reconcile_gate_state(
+            self.state, receipt_state_path=args.receipt_state_path, now=self.now
+        )
+        self.presentation = PresentationContext(
+            advisory_tokens=args.hard_tokens,
+            provider_script_path=args.provider_script_path,
+            settings_path=args.settings_path,
+            cwd=self._development_cwd(),
+        )
+        self.shell = ShellGateContext(
+            state=self.state,
+            gate_script_path=args.gate_script_path or _default_gate_script_path(),
+            provider_script_path=args.provider_script_path,
+            settings_path=args.settings_path,
+        )
+        self._policy_stale: bool | None | _Unset = _UNSET
+        self._spool_pending: int | None | _Unset = _UNSET
+
+    def _set_project(self) -> None:
+        """Resolve the project this session is scoped to.
+
+        An explicit ``--project`` wins; otherwise the cwd is resolved. A cwd
+        outside Development leaves the project as it was, so a hook fired from
+        elsewhere mid-session does not silently re-scope the state.
+        """
+        if self.args.project:
+            self.state.project = self.args.project
+            return
+        if not self.event.cwd:
+            return
+        scope = resolve_development_scope(self.event.cwd)
+        if scope is not None:
+            self.state.project = scope.project
+
+    def _development_cwd(self) -> str:
+        """Return the cwd a recovery command should carry."""
+        if self.event.cwd and resolve_development_scope(self.event.cwd) is not None:
+            return self.event.cwd
+        project = self.state.project or ""
+        return f"/Volumes/ThunderBolt/Development/{project}".rstrip("/")
+
+    def save(self) -> None:
+        """Persist this session's state."""
+        save_session_state(self.args.state_path, self.raw_sessions, self.state)
+
+    def consume_notices(self) -> list[str]:
+        """Take the queued one-time notices and persist the empty queue.
+
+        Persisting immediately is what makes a notice survive a still-blocked
+        call: it is removed only once something has actually displayed it.
+
+        Returns:
+            The notices that were queued.
+        """
+        notices = list(self.state.pending_cleared_notices)
+        self.state.pending_cleared_notices = []
+        self.save()
+        return notices
+
+    def policy_stale(self) -> bool | None:
+        """Report policy-refresh staleness for this session, or None.
+
+        Returns:
+            True/False from the policy gate's own state file, or None when that
+            file is absent, oversized, or unreadable. None is rendered as
+            unknown, never as healthy.
+        """
+        if not isinstance(self._policy_stale, _Unset):
+            return self._policy_stale
+        self._policy_stale = self._read_policy_state()
+        return self._policy_stale
+
+    def _read_policy_state(self) -> bool | None:
+        """Read `refreshRequired` for this session from the policy state file."""
+        path: Path = self.args.policy_state_path
+        try:
+            if not path.is_file() or path.stat().st_size > _MAX_STATE_SCAN_BYTES:
+                return None
+            parsed = json.loads(path.read_text(encoding="utf8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        sessions = parsed.get("sessions")
+        if not isinstance(sessions, dict):
+            return None
+        entry = sessions.get(f"{_POLICY_STATE_AGENT}:{self.session_id}")
+        if not isinstance(entry, dict):
+            return None
+        return bool(entry.get("refreshRequired"))
+
+    def spool_pending(self) -> int | None:
+        """Report how many entries are waiting in the durability spool."""
+        if not isinstance(self._spool_pending, _Unset):
+            return self._spool_pending
+        self._spool_pending = self._read_spool_pending()
+        return self._spool_pending
+
+    def _read_spool_pending(self) -> int | None:
+        """Count JSON-object lines in the spool file."""
+        path: Path = self.args.spool_path
+        try:
+            if not path.exists():
+                return 0
+            size = path.stat().st_size
+            if size == 0:
+                return 0
+            if size > _MAX_STATE_SCAN_BYTES:
+                return None
+            text = path.read_text(encoding="utf8")
+        except OSError:
+            return None
+        return sum(1 for line in text.split("\n") if _is_json_object_line(line))
+
+    def status_line(self) -> str:
+        """Render the per-turn status line."""
+        return gate_status_line(self.state, self.policy_stale(), self.spool_pending())
+
+    def emit(self, text: str) -> None:
+        """Write plain text to the return channel."""
+        emit(text, self.stdout)
+
+    def emit_json(self, payload: dict[str, Any]) -> None:
+        """Write a JSON verdict to the return channel."""
+        emit_json(payload, self.stdout)
+
+
+class _Unset:
+    """Sentinel type distinguishing "not computed yet" from a computed None."""
+
+
+_UNSET: Final[_Unset] = _Unset()
+
+
+def _is_json_object_line(line: str) -> bool:
+    """Report whether a line is a JSON object.
+
+    Args:
+        line: One spool line.
+
+    Returns:
+        True only for a parseable JSON object; blanks and fragments are not
+        pending entries.
+    """
+    if not line.strip():
+        return False
+    try:
+        parsed = json.loads(line)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(parsed, dict)
+
+
+def _default_gate_script_path() -> str:
+    """Return the TypeScript gate path a repair command may still name.
+
+    During the changeover the operator's muscle memory and every banner still
+    name the `.ts` entry, and refusing that spelling would block the repair
+    command the gate itself printed.
+    """
+    return "/Volumes/ThunderBolt/Development/_ob/scripts/context-budget-gate.ts"
+
+
+def _handle_user_prompt_submit(gate: _Gate) -> int:
+    """Emit the per-turn status line, plus a banner when one is owed."""
+    gate.save()
+    banner = ""
+    state = gate.state
+    if state.readback_required:
+        banner = readback_banner(state, gate.presentation)
+    elif (
+        state.context_tokens >= gate.args.nag_tokens
+        and state.context_tokens >= state.last_nag_at_tokens + _RENAG_STEP
+    ):
+        state.last_nag_at_tokens = state.context_tokens
+        gate.save()
+        banner = nag_banner(state, gate.presentation)
+
+    if not state.project:
+        # Outside Development the gate reports nothing at all; a banner would be
+        # the only output, and this hook has no authority in another repo.
+        if banner:
+            gate.emit(banner)
+        return 0
+
+    notices = gate.consume_notices()
+    lines = [f"OB ✓ {' · '.join(notices)}"] if notices else []
+    lines.append(gate.status_line())
+    payload: dict[str, Any] = {"systemMessage": "\n".join(lines)}
+    if banner:
+        payload["hookSpecificOutput"] = {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": banner,
+        }
+    gate.emit_json(payload)
+    return 0
+
+
+def _handle_pre_tool_use(gate: _Gate) -> int:
+    """Allow, allow-under-repair, or block one tool call."""
+    tool_name = gate.event.tool_name.lower()
+    tool_input = gate.event.tool_input
+    state = gate.state
+
+    if repair_mode_is_active(state, gate.now) and is_repair_capable_tool(tool_name):
+        gate.save()
+        gate.emit_json(
+            {
+                "systemMessage": transition_message(
+                    "repair-active-tool-allowed",
+                    f"{tool_name} permitted until {state.repair_mode_expires_at}",
+                )
+            }
+        )
+        return 0
+
+    if state.capture_required and not is_checkpoint_activity(
+        tool_name, tool_input, gate.shell
+    ):
+        return _block(
+            gate, "capture-required", capture_banner(state, gate.presentation)
+        )
+    if state.readback_required and not is_checkpoint_activity(
+        tool_name, tool_input, gate.shell
+    ):
+        return _block(
+            gate, "readback-required", readback_banner(state, gate.presentation)
+        )
+
+    notices = gate.consume_notices()
+    gate.save()
+    if notices:
+        gate.emit_json({"systemMessage": f"OB ✓ {' · '.join(notices)}"})
+    return 0
+
+
+def _block(gate: _Gate, reason: str, banner: str) -> int:
+    """Emit a block verdict and record that it happened.
+
+    Args:
+        gate: The invocation.
+        reason: Short machine-readable reason.
+        banner: The operator-facing text carrying the command that clears it.
+
+    Returns:
+        ``0``. A BLOCK is carried in the verdict JSON, not in the exit code --
+        a non-zero exit is a hook failure, which is a different thing entirely.
+    """
+    record_transition(gate.state, "still-blocking-with-reason", gate.now, reason)
+    gate.save()
+    gate.emit_json(
+        {
+            "decision": "block",
+            "reason": banner,
+            "systemMessage": transition_message("still-blocking-with-reason", reason),
+        }
+    )
+    return 0
+
+
+def _handle_checkpoint_done(gate: _Gate) -> int:
+    """Accept an operator's checkpoint claim only against a real receipt."""
+    evidence = verified_checkpoint(
+        gate.state, gate.args.receipt_state_path, CHECKPOINT_MAX_AGE_SECONDS
+    )
+    if evidence is None:
+        gate.emit(
+            "REFUSED: no fresh verified-remote provider checkpoint receipt exists "
+            "for this session/project. Run the direct ob-memory-provider checkpoint "
+            "command and retry; spooled, failed, and lost writes do not count."
+        )
+        return 1
+    state = gate.state
+    state.checkpoint_required = False
+    state.checkpoint_required_at = ""
+    state.checkpoint_at_tokens = state.context_tokens
+    state.checkpoint_at = evidence.recorded_at
+    state.last_nag_at_tokens = state.context_tokens
+    gate.save()
+    gate.emit(
+        "\n".join(
+            [
+                f"Checkpoint verified remotely at "
+                f"~{round(state.context_tokens / 1000)}k tokens.",
+                "Task tools remain available; automatic compaction handles rollover.",
+            ]
+        )
+    )
+    return 0
+
+
+def _handle_repair_enter(gate: _Gate) -> int:
+    """Open a bounded repair window, or refuse and say exactly why."""
+    reason = gate.args.repair_reason
+    minutes = gate.args.repair_minutes
+    if not reason or minutes < 1 or minutes > _LONGEST_REPAIR_MINUTES:
+        gate.emit(
+            "REFUSED: repair-enter requires --repair-reason and --repair-minutes "
+            f"between 1 and {_LONGEST_REPAIR_MINUTES}."
+        )
+        return 1
+    enter_repair_mode(gate.state, gate.now, timedelta(minutes=minutes), reason)
+    gate.save()
+    gate.emit(
+        transition_message(
+            "repair-entered",
+            f"expires at {gate.state.repair_mode_expires_at}; {reason}",
+        )
+    )
+    return 0
+
+
+def _handle_repair_exit(gate: _Gate) -> int:
+    """Close the repair window explicitly."""
+    exit_repair_mode(
+        gate.state, gate.now, gate.args.repair_reason or "explicit repair exit"
+    )
+    gate.save()
+    gate.emit(transition_message("repair-exited", "normal enforcement resumed"))
+    return 0
+
+
+def _handle_stop(gate: _Gate) -> int:
+    """Arm the capture requirement when the turn landed uncaptured work."""
+    if not turn_did_work(gate.event.transcript_path, gate.state.last_write_at):
+        gate.save()
+        return 0
+    gate.state.capture_required = True
+    gate.state.capture_required_at = gate.now
+    record_transition(
+        gate.state, "armed", gate.now, "capture required after uncaptured work"
+    )
+    gate.save()
+    gate.emit(capture_banner(gate.state, gate.presentation))
+    return 0
+
+
+def _handle_pre_compact(gate: _Gate) -> int:
+    """Persist state before context is discarded; decide nothing."""
+    gate.save()
+    return 0
+
+
+def _handle_compact_lifecycle(gate: _Gate) -> int:
+    """Arm the post-compact read-back, or reset for a genuinely new session."""
+    state = gate.state
+    if gate.event_name == "session-start" and gate.event.source:
+        if gate.event.source != "compact":
+            if state.repair_mode_active:
+                record_transition(
+                    state, "repair-exited", gate.now, "fresh session reset"
+                )
+            gate.state = fresh_session_state(state)
+            gate.save()
+            return 0
+
+    state.checkpoint_required = False
+    state.checkpoint_required_at = ""
+    state.readback_required = True
+    state.last_nag_at_tokens = 0
+    state.context_tokens = 0
+    cycle_id, started_at = _compact_cycle_for_event(gate)
+    state.readback_required_at = started_at
+    state.readback_correlation_id = cycle_id
+    record_transition(
+        state, "armed", gate.now, f"post-compact read-back cycle {cycle_id}"
+    )
+    if gate.event_name == "session-start":
+        reconcile_gate_state(
+            state, receipt_state_path=gate.args.receipt_state_path, now=gate.now
+        )
+    gate.save()
+    return 0
+
+
+def _compact_cycle_for_event(gate: _Gate) -> tuple[str, str]:
+    """Return the compaction cycle this read-back is correlated to.
+
+    ``post-compact`` always joins-or-opens: it IS the compaction, so if no cycle
+    exists the gate opens one rather than arming with no correlation id. A
+    ``session-start`` prefers an existing cycle and only opens one when there is
+    none, because a session-start that follows a compaction should attach to the
+    cycle that compaction already opened
+    (``context-budget-gate.ts:280-286``).
+
+    Args:
+        gate: The invocation.
+
+    Returns:
+        ``(correlation_id, started_at)``. An empty id means the cycle could not
+        be read or written; the read-back still arms and still blocks, and
+        ``_recover_legacy_correlation`` adopts the real id as soon as one exists.
+    """
+    if gate.event_name != "post-compact":
+        existing = current_compact_cycle(
+            gate.args.receipt_state_path,
+            session_id=gate.session_id,
+            project=gate.state.project,
+        )
+        if existing is not None:
+            return existing.id, existing.started_at
+    cycle = gate_compact_cycle(
+        gate.args.receipt_state_path,
+        session_id=gate.session_id,
+        project=gate.state.project,
+    )
+    if cycle is not None:
+        return cycle.id, cycle.started_at
+    return "", gate.now
+
+
+def _handle_status(gate: _Gate) -> int:
+    """Print the whole gate state as JSON, for a human or a test."""
+    gate.save()
+    state = gate.state
+    payload = {
+        "sessionId": gate.session_id,
+        "project": state.project or None,
+        "contextTokens": state.context_tokens,
+        "nagAt": gate.args.nag_tokens,
+        "hardAt": gate.args.hard_tokens,
+        "checkpointRequired": False,
+        "preCompactTaskBlocking": False,
+        "readbackRequired": state.readback_required,
+        "captureRequired": state.capture_required,
+        "repairModeActive": state.repair_mode_active,
+        "repairModeEnteredAt": state.repair_mode_entered_at or None,
+        "repairModeExpiresAt": state.repair_mode_expires_at or None,
+        "lastWriteAt": state.last_write_at or None,
+        "checkpointAt": state.checkpoint_at or None,
+        "policyStale": gate.policy_stale(),
+        "spoolPending": gate.spool_pending(),
+        "statusLine": gate.status_line() if state.project else None,
+        "pendingClearedNotices": state.pending_cleared_notices,
+        "transitions": [entry.to_json() for entry in state.transition_log],
+    }
+    gate.emit(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+#: Event name to handler. A table rather than a branch chain: adding an event is
+#: one row, and no handler can reach another's locals.
+_HANDLERS: Final[dict[str, Any]] = {
+    "user-prompt-submit": _handle_user_prompt_submit,
+    "pre-tool-use": _handle_pre_tool_use,
+    "checkpoint-done": _handle_checkpoint_done,
+    "repair-enter": _handle_repair_enter,
+    "repair-exit": _handle_repair_exit,
+    "stop": _handle_stop,
+    "pre-compact": _handle_pre_compact,
+    "post-compact": _handle_compact_lifecycle,
+    "session-start": _handle_compact_lifecycle,
+    "status": _handle_status,
+}
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Run one gate invocation.
+
+    Args:
+        argv: Command-line arguments. Defaults to ``sys.argv[1:]``.
+        stdin: The hook's stdin. Defaults to ``sys.stdin``.
+        stdout: The return channel. Defaults to ``sys.stdout``.
+        env: Environment mapping for defaults. Defaults to ``os.environ``.
+
+    Returns:
+        The process exit code: ``0`` for every verdict including a block, and
+        ``1`` only for a REFUSED operator command. A block is data on stdout;
+        a non-zero exit means the hook itself failed.
+    """
+    environment = dict(os.environ) if env is None else env
+    args = _build_parser(environment).parse_args(
+        sys.argv[1:] if argv is None else argv
+    )
+    event = read_hook_event(stdin)
+    gate = _Gate(args, event, stdout)
+    handler = _HANDLERS[gate.event_name]
+    result = handler(gate)
+    return int(result)
+
+
+def _cli() -> int:
+    """Console-script entrypoint.
+
+    Returns:
+        The exit code.
+    """
+    return main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -48,7 +48,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
-from .development_scope import resolve_development_scope
+from .development_scope import development_root, resolve_development_scope
 from .gate_presentation import (
     PresentationContext,
     capture_banner,
@@ -205,7 +205,10 @@ def _build_parser(env: dict[str, str]) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--provider-script-path",
-        default="/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider.ts",
+        # Derived from the resolved root rather than written as an independent
+        # literal: this path and the recovery command's cwd have to agree, and
+        # two literals agree only by luck.
+        default=str(development_root() / "_ob" / "scripts" / "ob-memory-provider.ts"),
         help="Path a direct provider command must name to be allowed.",
     )
     return parser
@@ -281,11 +284,27 @@ class _Gate:
             self.state.project = scope.project
 
     def _development_cwd(self) -> str:
-        """Return the cwd a recovery command should carry."""
+        """Return the cwd a recovery command should carry.
+
+        The fallback composes `<root>/<project>`, EXCEPT when the project is the
+        root's own name. A hook fired from the Development repository itself
+        reports project `Development`, and the naive composition then yields
+        `/Volumes/ThunderBolt/Development/Development`, which does not exist --
+        so the recovery command the banner tells the operator to paste fails,
+        and the block never clears. That is the #419 deadlock arriving through
+        the escape hatch meant to resolve it.
+
+        `context-budget-gate.ts:352-355` has this defect. It is fixed here
+        rather than there, per the port's rule that bugs are fixed by being
+        written correctly in Python.
+        """
         if self.event.cwd and resolve_development_scope(self.event.cwd) is not None:
             return self.event.cwd
         project = self.state.project or ""
-        return f"/Volumes/ThunderBolt/Development/{project}".rstrip("/")
+        root = development_root()
+        if not project or project == root.name:
+            return str(root)
+        return str(root / project)
 
     def save(self) -> None:
         """Persist this session's state."""

--- a/python/openbrain-provider/src/openbrain_provider/development_scope.py
+++ b/python/openbrain-provider/src/openbrain_provider/development_scope.py
@@ -1,0 +1,222 @@
+"""Decide whether a working directory is inside the Development lane.
+
+The gate enforces nothing outside `/Volumes/ThunderBolt/Development` and the
+approved temp worktree roots. A cwd that resolves to neither yields no project,
+and a gate with no project emits nothing — that is what keeps the hook silent in
+somebody else's repository.
+
+Ported from `ob-memory-provider.ts:336-338` (`resolveDevelopmentScope`) and its
+helpers at `:1455-1534`, which is the only piece of that 2,046-line module the
+gates actually import.
+
+What this module does NOT do: it does not read config, contact a server, or
+decide anything about memory. It answers one question about one path.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+__all__ = [
+    "APPROVED_TEMP_WORKTREE_ROOTS",
+    "DEVELOPMENT_ROOT",
+    "DevelopmentScope",
+    "approved_temp_worktree_path",
+    "resolve_development_scope",
+]
+
+#: ob-memory-provider.ts:143. The one lane root.
+DEVELOPMENT_ROOT: Final[Path] = Path("/Volumes/ThunderBolt/Development")
+
+#: ob-memory-provider.ts:144-147. A worktree under one of these still counts as
+#: Development work, but only when git agrees it is the same repository — see
+#: :func:`resolve_development_scope`.
+APPROVED_TEMP_WORKTREE_ROOTS: Final[tuple[Path, ...]] = (
+    Path("/Volumes/ThunderBolt/_tmp"),
+    Path("/mnt/collab/tmp_space"),
+)
+
+#: ob-memory-provider.ts:1508 — anything outside this becomes a hyphen, so a
+#: project slug is always safe to embed in a state-file key or a shell string.
+_UNSAFE_SLUG_CHARS: Final[re.Pattern[str]] = re.compile(r"[^a-zA-Z0-9._-]")
+
+#: A git call that hangs would hang the hook, and the hook is on the agent's
+#: critical path. Two seconds matches ob-memory-provider.ts:1520.
+_GIT_TIMEOUT_SECONDS: Final[float] = 2.0
+
+
+@dataclass(frozen=True)
+class DevelopmentScope:
+    """A resolved Development working directory.
+
+    Attributes:
+        cwd: The canonicalised directory.
+        project: The project slug the gate scopes state by.
+    """
+
+    cwd: Path
+    project: str
+
+
+def _canonical_directory(path: str | Path) -> Path | None:
+    """Resolve a path to a real existing directory.
+
+    Args:
+        path: Candidate path.
+
+    Returns:
+        The fully-resolved directory, or None when it does not exist or is not a
+        directory. Symlinks are followed, so two spellings of one directory
+        compare equal.
+    """
+    try:
+        resolved = Path(path).resolve()
+    except OSError:
+        return None
+    try:
+        return resolved if resolved.is_dir() else None
+    except OSError:
+        return None
+
+
+def _git_path(cwd: Path, selector: str) -> Path | None:
+    """Ask git for an absolute path, or None when git cannot answer.
+
+    Args:
+        cwd: Directory to ask from.
+        selector: ``--show-toplevel`` or ``--git-common-dir``.
+
+    Returns:
+        The canonicalised path git reported, or None on any failure. Every
+        failure mode is the same answer here: git missing, not a repository,
+        timed out, or a path that no longer exists.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(cwd), "rev-parse", "--path-format=absolute", selector],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    reported = completed.stdout.strip()
+    if not reported:
+        return None
+    try:
+        resolved = Path(reported).resolve()
+    except OSError:
+        return None
+    return resolved if resolved.exists() else None
+
+
+def _same_git_repository(left: Path, right: Path) -> bool:
+    """Report whether two directories share one git object store.
+
+    ``--git-common-dir`` is the right question rather than ``--show-toplevel``:
+    a linked worktree has its own toplevel but the same common dir, which is
+    exactly the case this exists to accept.
+
+    Args:
+        left: One directory.
+        right: The other.
+
+    Returns:
+        True when both resolve to the same common git directory.
+    """
+    left_common = _git_path(left, "--git-common-dir")
+    right_common = _git_path(right, "--git-common-dir")
+    return left_common is not None and left_common == right_common
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    """Report whether ``candidate`` is ``root`` or lives under it."""
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def approved_temp_worktree_path(candidate: Path) -> bool:
+    """Report whether a path is an approved temp worktree location.
+
+    The shape is fixed: ``<temp root>/<area>/_worktrees/<name>[/...]``. Requiring
+    the ``_worktrees`` bucket is what stops an arbitrary scratch directory from
+    inheriting Development enforcement just by sitting on the same volume.
+
+    Args:
+        candidate: Directory to test.
+
+    Returns:
+        True when the path matches that shape under an approved root.
+    """
+    try:
+        absolute = candidate.resolve()
+    except OSError:
+        return False
+    for temp_root in APPROVED_TEMP_WORKTREE_ROOTS:
+        try:
+            relative = absolute.relative_to(temp_root.resolve())
+        except (OSError, ValueError):
+            continue
+        parts = relative.parts
+        if len(parts) < 3:
+            continue
+        if parts[1] != "_worktrees":
+            continue
+        if any(part in ("", ".", "..") for part in parts):
+            continue
+        return True
+    return False
+
+
+def _project_slug(cwd: Path) -> str:
+    """Return the project slug for a Development directory.
+
+    Args:
+        cwd: A canonicalised Development directory.
+
+    Returns:
+        The git toplevel's basename, sanitised. A directory inside the
+        Development repository ITSELF reports ``Development`` rather than a
+        subdirectory name, so every hook in that repo shares one state key.
+    """
+    toplevel = _git_path(cwd, "--show-toplevel")
+    development = _canonical_directory(DEVELOPMENT_ROOT)
+    if toplevel is not None and development is not None:
+        if _same_git_repository(toplevel, development):
+            return development.name
+    source = toplevel if toplevel is not None else cwd
+    return _UNSAFE_SLUG_CHARS.sub("-", source.name) or "development"
+
+
+def resolve_development_scope(cwd: str | Path | None) -> DevelopmentScope | None:
+    """Resolve a working directory to a Development scope, or None.
+
+    Args:
+        cwd: The hook's reported working directory.
+
+    Returns:
+        The scope when the directory is inside Development, or inside an
+        approved temp worktree of the SAME repository. None otherwise — and None
+        is what makes the gate silent outside its lane.
+    """
+    if cwd is None:
+        return None
+    root = _canonical_directory(DEVELOPMENT_ROOT)
+    candidate = _canonical_directory(cwd)
+    if root is None or candidate is None:
+        return None
+    if _is_within(candidate, root):
+        return DevelopmentScope(cwd=candidate, project=_project_slug(candidate))
+    if approved_temp_worktree_path(candidate) and _same_git_repository(candidate, root):
+        return DevelopmentScope(cwd=candidate, project=_project_slug(candidate))
+    return None

--- a/python/openbrain-provider/src/openbrain_provider/development_scope.py
+++ b/python/openbrain-provider/src/openbrain_provider/development_scope.py
@@ -15,6 +15,7 @@ decide anything about memory. It answers one question about one path.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from dataclasses import dataclass
@@ -23,14 +24,44 @@ from typing import Final
 
 __all__ = [
     "APPROVED_TEMP_WORKTREE_ROOTS",
-    "DEVELOPMENT_ROOT",
+    "DEFAULT_DEVELOPMENT_ROOT",
+    "development_root",
     "DevelopmentScope",
     "approved_temp_worktree_path",
     "resolve_development_scope",
 ]
 
-#: ob-memory-provider.ts:143. The one lane root.
-DEVELOPMENT_ROOT: Final[Path] = Path("/Volumes/ThunderBolt/Development")
+#: ob-memory-provider.ts:143. The one lane root, as shipped. Public because the
+#: parity fixtures were recorded against it and have to recognise it by name.
+DEFAULT_DEVELOPMENT_ROOT: Final[Path] = Path("/Volumes/ThunderBolt/Development")
+
+
+def development_root() -> Path:
+    """Return the Development lane root.
+
+    Read per call rather than frozen at import, and overridable via
+    `OPENBRAIN_DEVELOPMENT_ROOT`, for one reason: this module answers by asking
+    the FILESYSTEM -- `_canonical_directory` requires the path to exist and be a
+    directory. On any machine without this exact macOS volume (a Linux CI
+    runner, a container) every scope resolves to None, the gate correctly falls
+    silent, and every test depending on a resolved scope then asserts against
+    silence. That shipped green locally and failed 11 tests on CI.
+
+    A module constant could not fix it: it is evaluated when the module is first
+    imported, which under pytest happens during collection -- before a conftest
+    can set the variable. A function has no such ordering to get wrong.
+
+    The TypeScript already threads `developmentRoot` as a parameter through its
+    helpers (`ob-memory-provider.ts:1455-1469`) and pins it only at the entry
+    point; this is that same seam.
+
+    Returns:
+        The override when set and non-empty, else the shipped default. The
+        default is unchanged, so production behaviour is identical.
+    """
+    override = os.environ.get("OPENBRAIN_DEVELOPMENT_ROOT", "").strip()
+    return Path(override) if override else DEFAULT_DEVELOPMENT_ROOT
+
 
 #: ob-memory-provider.ts:144-147. A worktree under one of these still counts as
 #: Development work, but only when git agrees it is the same repository — see
@@ -190,7 +221,7 @@ def _project_slug(cwd: Path) -> str:
         subdirectory name, so every hook in that repo shares one state key.
     """
     toplevel = _git_path(cwd, "--show-toplevel")
-    development = _canonical_directory(DEVELOPMENT_ROOT)
+    development = _canonical_directory(development_root())
     if toplevel is not None and development is not None:
         if _same_git_repository(toplevel, development):
             return development.name
@@ -211,7 +242,7 @@ def resolve_development_scope(cwd: str | Path | None) -> DevelopmentScope | None
     """
     if cwd is None:
         return None
-    root = _canonical_directory(DEVELOPMENT_ROOT)
+    root = _canonical_directory(development_root())
     candidate = _canonical_directory(cwd)
     if root is None or candidate is None:
         return None

--- a/python/openbrain-provider/src/openbrain_provider/gate_presentation.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_presentation.py
@@ -1,0 +1,240 @@
+"""Render the gate's operator-visible text.
+
+Every string here is byte-identical to what the TypeScript gate emits, and that
+is load-bearing rather than cosmetic: the recovery command printed in a banner is
+the SAME command :mod:`openbrain_provider.gate_shell` accepts as checkpoint
+activity. A banner that reworded the command would print an instruction the gate
+then refuses — which is the deadlock #419 is about, arriving by a different door.
+
+What this module does NOT do: it makes no decisions and touches no state. It
+turns a state into text.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .gate_shell import activated_provider_script_paths, shell_quote
+from .gate_state import SessionState
+
+__all__ = [
+    "PresentationContext",
+    "capture_banner",
+    "gate_status_line",
+    "nag_banner",
+    "readback_banner",
+    "transition_message",
+]
+
+
+@dataclass(frozen=True)
+class PresentationContext:
+    """What rendering needs besides the session state.
+
+    Attributes:
+        advisory_tokens: The advisory high-water mark quoted in the nag.
+        provider_script_path: Provider path used in a recovery command.
+        settings_path: Settings scanned for an activated adapter generation.
+        cwd: Development cwd embedded in a recovery payload.
+    """
+
+    advisory_tokens: int
+    provider_script_path: str
+    settings_path: Path
+    cwd: str
+
+
+def _format_thousands(value: int) -> str:
+    """Render a token count the way the banners do.
+
+    Args:
+        value: Token count.
+
+    Returns:
+        e.g. ``250k``. Rounded, matching `Math.round(value / 1000)`.
+    """
+    return f"{round(value / 1000)}k"
+
+
+def _provider_payload_command(
+    event_name: str, payload: dict[str, Any], context: PresentationContext
+) -> str:
+    """Build the exact executable recovery command.
+
+    An activated adapter generation wins over the sibling path when one is
+    installed and the sibling is not, so the printed command names the provider
+    that is actually wired up.
+
+    Args:
+        event_name: `session-start`, `capture`, or `checkpoint`.
+        payload: The JSON payload to pipe in.
+        context: Provider paths.
+
+    Returns:
+        A single-line shell command.
+    """
+    activated = activated_provider_script_paths(context.settings_path)
+    preferred = (
+        activated[0]
+        if activated and context.provider_script_path not in activated
+        else context.provider_script_path
+    )
+    # `separators` reproduces JSON.stringify's spacing exactly; a space after a
+    # colon would change the quoted payload and make the printed command stop
+    # matching the one the allowance accepts.
+    encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    return (
+        f"printf '%s' {shell_quote(encoded)} | bun {shell_quote(preferred)} "
+        f"--runtime claude --event {event_name}"
+    )
+
+
+def capture_banner(state: SessionState, context: PresentationContext) -> str:
+    """Render the banner shown when durable capture is owed.
+
+    Args:
+        state: Session state.
+        context: Rendering context.
+
+    Returns:
+        The multi-line banner, including the exact command that clears it.
+    """
+    command = _provider_payload_command(
+        "capture",
+        {
+            "cwd": context.cwd,
+            "session_id": state.session_id,
+            "distilled": {
+                "content": "<distilled durable action only>",
+                "event_type": "action",
+            },
+        },
+        context,
+    )
+    return "\n".join(
+        [
+            "<!-- OB Capture Gate -->",
+            "Work landed last turn but nothing was written to Open Brain."
+            " Task tools are",
+            "BLOCKED until you capture it — if it isn't in OB, it might as well"
+            " not have",
+            "happened. Replace the placeholder with distilled durable content and run:",
+            f"  {command}",
+            "A direct saved receipt or durable spool clears capture."
+            " Read-only tools and",
+            "provider activity remain available; canonical ritual:"
+            " _ob/skills/ob-checkpoint.",
+            "<!-- End OB Capture Gate -->",
+        ]
+    )
+
+
+def nag_banner(state: SessionState, context: PresentationContext) -> str:
+    """Render the advisory context-pressure notice.
+
+    Advisory by design: it reports the number and explicitly says no manual
+    action is required, because automatic compaction handles rollover.
+
+    Args:
+        state: Session state.
+        context: Rendering context.
+
+    Returns:
+        The multi-line notice.
+    """
+    return "\n".join(
+        [
+            "<!-- Context Budget Warning -->",
+            f"Context is ~{_format_thousands(state.context_tokens)} tokens "
+            f"(advisory high-water mark {_format_thousands(context.advisory_tokens)}).",
+            "Continue task work; automatic compaction handles rollover. "
+            "No manual /compact is required.",
+            "<!-- End Context Budget Warning -->",
+        ]
+    )
+
+
+def readback_banner(state: SessionState, context: PresentationContext) -> str:
+    """Render the banner shown when a post-compact recall is owed.
+
+    Args:
+        state: Session state.
+        context: Rendering context.
+
+    Returns:
+        The multi-line banner, including the exact correlated recall command.
+    """
+    command = _provider_payload_command(
+        "session-start",
+        {
+            "cwd": context.cwd,
+            "session_id": state.session_id,
+            "source": "compact",
+            "correlation_id": state.readback_correlation_id,
+        },
+        context,
+    )
+    return "\n".join(
+        [
+            "<!-- Context Budget: forced post-compact read-back -->",
+            "A compact just happened. Task tools are BLOCKED until a fresh"
+            " direct recall",
+            "receipt proves Open Brain was read (the built-in summary is not enough).",
+            "SessionStart:compact normally runs this automatically."
+            " If it did not, run:",
+            f"  {command}",
+            "A direct receipt unblocks the next gate check; "
+            "fallback/failed recall does not.",
+            "<!-- End Context Budget -->",
+        ]
+    )
+
+
+def gate_status_line(
+    state: SessionState, policy_stale: bool | None, spool_pending: int | None
+) -> str:
+    """Render the one-line per-turn status.
+
+    Args:
+        state: Session state.
+        policy_stale: Policy refresh staleness, or None when unknown.
+        spool_pending: Pending spool entries, or None when unreadable.
+
+    Returns:
+        A single line. Unknown is rendered as a distinct marker rather than as
+        "ok", because reporting an unread file as healthy is the failure mode
+        this line exists to make visible.
+    """
+    failing = state.readback_required or state.capture_required or policy_stale is True
+    if policy_stale is None:
+        policy = "—"
+    else:
+        policy = "STALE" if policy_stale else "ok"
+    segments = [
+        f"recall {'DUE' if state.readback_required else 'ok'}",
+        f"policy {policy}",
+        f"capture {'DUE' if state.capture_required else 'ok'}",
+        f"spool {'?' if spool_pending is None else spool_pending}",
+    ]
+    if state.repair_mode_active:
+        segments.append(f"repair ACTIVE until {state.repair_mode_expires_at}")
+    if state.context_tokens > 0:
+        segments.append(f"ctx ~{_format_thousands(state.context_tokens)}")
+    marker = "✗" if failing else "✓"
+    return f"OB {marker} {' · '.join(segments)}"
+
+
+def transition_message(name: str, reason: str) -> str:
+    """Render a transition as a greppable one-liner.
+
+    Args:
+        name: Transition name.
+        reason: Why it happened.
+
+    Returns:
+        ``context-budget-gate transition=<name> reason=<reason>``.
+    """
+    return f"context-budget-gate transition={name} reason={reason}"

--- a/python/openbrain-provider/src/openbrain_provider/gate_shell.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_shell.py
@@ -1,0 +1,635 @@
+"""Classify a tool call as checkpoint activity, repair-capable, or neither.
+
+This is the module that decides what a BLOCKED session may still do. Two
+separate allowances live here and must not be confused:
+
+* **Checkpoint activity** — what is permitted while the gate is blocking,
+  because it is either read-only or it is the exact command that clears the
+  block. This is the escape hatch: a gate that blocks the repair of the
+  subsystem it gates on is the defect issue #419 names.
+* **Repair-capable** — the broader set (bash, write, edit) that an explicitly
+  opened, expiring repair window admits.
+
+The shell parser is deliberately strict and fails closed. It parses a simple
+pipeline of quoted words and REFUSES on any character that could redirect,
+substitute, or chain (``;``, ``&``, ``>``, `` ` ``, ``$``). A command it cannot
+prove safe is not allowed. That is the correct direction for an allowance: a
+parser that guessed would turn "read-only" into an arbitrary-execution hole.
+
+What this module does NOT do: it holds no state and reads no receipts. It
+answers questions about a command string and a session's current requirements.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from .development_scope import resolve_development_scope
+from .gate_state import SessionState
+
+__all__ = [
+    "READONLY_BASH",
+    "ShellGateContext",
+    "activated_provider_script_paths",
+    "is_checkpoint_activity",
+    "is_repair_capable_tool",
+    "shell_quote",
+]
+
+#: context-budget-gate-shell.ts:5-11, byte-identical. Commands that read and do
+#: not write. `sed` and `find` are here but are re-checked below for their
+#: mutating flags, because the binary alone does not settle it.
+READONLY_BASH: Final[frozenset[str]] = frozenset(
+    {
+        "ls", "cat", "head", "tail", "grep", "rg", "egrep", "fgrep", "find", "fd",
+        "wc", "stat", "file", "du", "df", "tree", "realpath", "dirname", "basename",
+        "echo", "printf", "pwd", "whoami", "id", "date", "hostname", "uname",
+        "which", "type", "printenv", "sort", "uniq", "cut", "tr", "column",
+        "jq", "diff", "sed", "awk", "test", "sw_vers", "uuidgen",
+    }
+)
+
+#: context-budget-gate-shell.ts:29 — tools that cannot mutate anything, so they
+#: are permitted regardless of gate state.
+_ALWAYS_ALLOWED_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "read", "grep", "glob", "tasklist", "taskget",
+        "askuserquestion", "skill", "toolsearch",
+    }
+)
+
+#: context-budget-gate-shell.ts:21 — what an open repair window admits.
+_REPAIR_CAPABLE_TOOLS: Final[frozenset[str]] = frozenset(
+    {"bash", "shell", "write", "edit"}
+)
+
+_SHELL_TOOLS: Final[frozenset[str]] = frozenset({"bash", "shell"})
+_FILE_TOOLS: Final[frozenset[str]] = frozenset({"write", "edit"})
+
+#: The interpreters a maintenance command may be spelled with.
+_BUN_BINARIES: Final[frozenset[str]] = frozenset({"bun", "/opt/homebrew/bin/bun"})
+
+#: context-budget-gate-shell.ts:153 — the provider events a maintenance command
+#: may name at all.
+_PROVIDER_EVENTS: Final[frozenset[str]] = frozenset(
+    {"session-start", "capture", "checkpoint", "wrap"}
+)
+
+#: context-budget-gate-shell.ts:193 — the activated-adapter path shape.
+_ACTIVATED_PROVIDER_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"([^'\"\s]+/adapters/versions/sha256-[0-9a-f]{64})"
+    r"/(?:context-budget-gate|ob-memory-provider)\.ts"
+)
+
+#: Characters that make a command something other than a simple pipeline.
+_UNSAFE_SHELL_CHARS: Final[frozenset[str]] = frozenset({";", "&", ">", "<", "`", "$"})
+
+
+@dataclass(frozen=True)
+class ShellGateContext:
+    """Everything command classification needs besides the command itself.
+
+    Attributes:
+        state: The session's current requirements.
+        gate_script_path: Path a `repair-enter`/`repair-exit` command must name.
+        provider_script_path: Path a direct provider command must name.
+        settings_path: Settings file scanned for activated adapter generations.
+    """
+
+    state: SessionState
+    gate_script_path: str
+    provider_script_path: str
+    settings_path: Path
+
+
+def shell_quote(value: str) -> str:
+    """Return a single-quoted shell word.
+
+    Args:
+        value: Raw value.
+
+    Returns:
+        The value wrapped in single quotes with embedded quotes escaped the
+        POSIX way, byte-identical to context-budget-gate-shell.ts:59-61 so the
+        command the banner prints is the command the allowance accepts.
+    """
+    escaped = value.replace("'", "'\"'\"'")
+    return f"'{escaped}'"
+
+
+def is_repair_capable_tool(tool_name: str) -> bool:
+    """Report whether an open repair window admits this tool.
+
+    Args:
+        tool_name: Lowercased tool name.
+
+    Returns:
+        True for bash, shell, write, and edit.
+    """
+    return tool_name in _REPAIR_CAPABLE_TOOLS
+
+
+def _parse_shell_pipeline(command: str) -> list[list[str]] | None:
+    """Parse a simple quoted pipeline into segments of words.
+
+    Fails closed. Any construct beyond quoting, escaping, and a single ``|``
+    returns None, and every caller treats None as "not allowed".
+
+    Args:
+        command: The raw command string.
+
+    Returns:
+        A list of pipeline segments, each a list of words, or None when the
+        command is not a simple pipeline.
+    """
+    pipeline: list[list[str]] = [[]]
+    word = ""
+    started = False
+    quote = ""
+    index = 0
+    length = len(command)
+
+    while index < length:
+        char = command[index]
+        if quote:
+            consumed = _consume_quoted(command, index, quote, word)
+            if consumed is None:
+                return None
+            index, quote, word = consumed
+            started = True
+            index += 1
+            continue
+        if char.isspace():
+            if started:
+                pipeline[-1].append(word)
+                word, started = "", False
+            index += 1
+            continue
+        if char in ("'", '"'):
+            quote, started = char, True
+            index += 1
+            continue
+        if char == "|":
+            if index + 1 < length and command[index + 1] == "|":
+                return None
+            if started:
+                pipeline[-1].append(word)
+                word, started = "", False
+            if not pipeline[-1]:
+                return None
+            pipeline.append([])
+            index += 1
+            continue
+        if char in _UNSAFE_SHELL_CHARS:
+            return None
+        if char == "\\":
+            if index + 1 >= length:
+                return None
+            escaped = command[index + 1]
+            word += "" if escaped == "\n" else escaped
+            started = True
+            index += 2
+            continue
+        word += char
+        started = True
+        index += 1
+
+    if quote:
+        return None
+    if started:
+        pipeline[-1].append(word)
+    return pipeline if all(segment for segment in pipeline) else None
+
+
+def _consume_quoted(
+    command: str, index: int, quote: str, word: str
+) -> tuple[int, str, str] | None:
+    """Consume one character inside a quoted run.
+
+    Args:
+        command: The full command.
+        index: Index of the character to consume.
+        quote: The open quote character.
+        word: The word built so far.
+
+    Returns:
+        ``(index, quote, word)`` after consuming, or None when the character is
+        not permitted inside that quote. Inside double quotes ``$`` and
+        `` ` `` are refused, because both still substitute there.
+    """
+    char = command[index]
+    if char == quote:
+        return index, "", word
+    if quote == '"' and char in ("$", "`"):
+        return None
+    if quote != '"' or char != "\\":
+        return index, quote, word + char
+    if index + 1 >= len(command):
+        return None
+    escaped = command[index + 1]
+    if escaped not in ('"', "\\"):
+        return None
+    return index + 1, quote, word + escaped
+
+
+def activated_provider_script_paths(settings_path: Path) -> list[str]:
+    """Return provider paths from activated adapter generations in settings.
+
+    Args:
+        settings_path: A Claude settings file.
+
+    Returns:
+        Every existing `ob-memory-provider.ts` reachable from a `sha256-<hash>`
+        adapter path named in a hook command. Empty on any read or parse
+        failure — malformed settings fail closed, they do not widen the
+        allowance.
+    """
+    try:
+        parsed = json.loads(settings_path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    hooks = parsed.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+
+    candidates: list[str] = []
+    for event_hooks in hooks.values():
+        if not isinstance(event_hooks, list):
+            continue
+        for event_hook in event_hooks:
+            if not isinstance(event_hook, dict):
+                continue
+            commands = event_hook.get("hooks")
+            if not isinstance(commands, list):
+                continue
+            for hook in commands:
+                _collect_provider_path(hook, candidates)
+    return candidates
+
+
+def _collect_provider_path(hook: object, candidates: list[str]) -> None:
+    """Append any existing provider path named by one hook command."""
+    if not isinstance(hook, dict):
+        return
+    command = hook.get("command")
+    if not isinstance(command, str):
+        return
+    for match in _ACTIVATED_PROVIDER_PATTERN.finditer(command):
+        candidate = f"{match.group(1)}/ob-memory-provider.ts"
+        try:
+            if Path(candidate).is_file() and candidate not in candidates:
+                candidates.append(candidate)
+        except OSError:
+            continue
+
+
+def is_checkpoint_activity(
+    tool_name: str, tool_input: dict[str, Any], context: ShellGateContext
+) -> bool:
+    """Report whether a blocked session may still run this tool call.
+
+    Args:
+        tool_name: Lowercased tool name.
+        tool_input: The tool's arguments.
+        context: Session requirements and the paths a maintenance command may
+            name.
+
+    Returns:
+        True when the call is read-only, is memory-file bookkeeping, or is one
+        of the exact maintenance commands that clears or repairs the gate.
+    """
+    if tool_name in _ALWAYS_ALLOWED_TOOLS:
+        return True
+    if tool_name in _FILE_TOOLS:
+        path = str(tool_input.get("file_path") or "")
+        return "/.claude/projects/" in path and "/memory/" in path
+    if tool_name not in _SHELL_TOOLS:
+        return False
+
+    command = str(tool_input.get("command") or "").strip()
+    maintenance = (
+        _is_direct_provider_command(command, context)
+        or _is_maintenance_command(command, "context-budget-gate.ts", "checkpoint-done")
+        or _is_gate_repair_command(command, "repair-enter", context.gate_script_path)
+        or _is_gate_repair_command(command, "repair-exit", context.gate_script_path)
+        or _is_maintenance_command(command, "policy-refresh-gate.ts", "refresh")
+    )
+    return maintenance or _is_read_only_bash(command)
+
+
+def _is_maintenance_command(
+    command: str, script_name: str, required_event: str
+) -> bool:
+    """Report whether a command is `bun <…/script> … --event <required>`.
+
+    Args:
+        command: The raw command.
+        script_name: Filename the command must name.
+        required_event: The event it must request.
+
+    Returns:
+        True only for a single unchained invocation naming both.
+    """
+    if re.search(r"[>`;&|]|\$\(", command):
+        return False
+    escaped = re.escape(script_name)
+    pattern = (
+        r"^\s*(?:bun|/opt/homebrew/bin/bun)(?:\s+run)?\s+"
+        rf"(?:'|\")?[^\s'\"]*/{escaped}(?:'|\")?\s+.*"
+        rf"--event\s+{re.escape(required_event)}(?:\s|$).*$"
+    )
+    return re.match(pattern, command, re.DOTALL) is not None
+
+
+def _is_gate_repair_command(
+    command: str, required_event: str, gate_script_path: str
+) -> bool:
+    """Report whether a command is this exact gate's repair-enter/exit call.
+
+    The gate script path must match exactly. A repair command naming some other
+    gate script would open a window in a state file this process does not own.
+
+    Args:
+        command: The raw command.
+        required_event: ``repair-enter`` or ``repair-exit``.
+        gate_script_path: The path this process is running as.
+
+    Returns:
+        True only for a single-segment invocation naming both.
+    """
+    pipeline = _parse_shell_pipeline(command)
+    if pipeline is None or len(pipeline) != 1:
+        return False
+    words = pipeline[0]
+    index = 0
+    if index >= len(words) or words[index] not in _BUN_BINARIES:
+        return False
+    index += 1
+    if index < len(words) and words[index] == "run":
+        index += 1
+    if index >= len(words) or words[index] != gate_script_path:
+        return False
+    try:
+        event_index = words.index("--event", index + 1)
+    except ValueError:
+        return False
+    return (
+        event_index + 1 < len(words) and words[event_index + 1] == required_event
+    )
+
+
+def _provider_events_allowed_by_state(state: SessionState) -> frozenset[str]:
+    """Return the provider events permitted by the session's current block.
+
+    A read-back block is cleared ONLY by a recall (`session-start`), and a
+    capture block ONLY by a durable write. Allowing the other one would let an
+    agent satisfy a block with a command that cannot possibly produce the
+    evidence the block is waiting for.
+
+    Args:
+        state: Session state.
+
+    Returns:
+        The allowed provider event names.
+    """
+    if state.readback_required:
+        return frozenset({"session-start"})
+    if state.capture_required:
+        return frozenset({"capture", "checkpoint", "wrap"})
+    return frozenset({"session-start", "capture", "checkpoint", "wrap"})
+
+
+def _is_direct_provider_command(command: str, context: ShellGateContext) -> bool:
+    """Report whether a command is the exact direct provider call this gate wants.
+
+    Args:
+        command: The raw command.
+        context: Session requirements and provider paths.
+
+    Returns:
+        True for a one- or two-segment pipeline whose last segment is a valid
+        provider invocation for an allowed event, and whose payload (when a
+        payload is piped in) matches this session, project, and cycle.
+    """
+    allowed = _provider_events_allowed_by_state(context.state)
+    pipeline = _parse_shell_pipeline(command)
+    if pipeline is None or len(pipeline) > 2:
+        return False
+    event = _parse_provider_invocation(pipeline[-1], context)
+    if event is None or event not in allowed:
+        return False
+    if len(pipeline) == 1:
+        # A session-start recall must carry a correlated payload, so the bare
+        # form cannot satisfy a read-back block.
+        return event != "session-start"
+    return _valid_provider_payload(pipeline[0], event, context.state)
+
+
+def _valid_provider_payload(
+    words: list[str], provider_event: str, state: SessionState
+) -> bool:
+    """Report whether the piped payload belongs to THIS session and cycle.
+
+    Args:
+        words: The producing segment's words, expected `printf %s <json>`.
+        provider_event: The provider event the payload feeds.
+        state: Session state the payload must match.
+
+    Returns:
+        True only when the JSON names this session, resolves to this project,
+        and — for a recall — quotes the exact correlation id the gate is
+        waiting on.
+    """
+    if len(words) != 3 or words[0] != "printf" or words[1] != "%s":
+        return False
+    try:
+        payload = json.loads(words[2])
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("session_id") != state.session_id:
+        return False
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str):
+        return False
+    scope = resolve_development_scope(cwd)
+    if scope is None or scope.project != state.project:
+        return False
+    if provider_event != "session-start":
+        distilled = payload.get("distilled")
+        return isinstance(distilled, dict)
+    return (
+        payload.get("source") == "compact"
+        and bool(state.readback_correlation_id)
+        and payload.get("correlation_id") == state.readback_correlation_id
+    )
+
+
+def _parse_provider_invocation(
+    words: list[str], context: ShellGateContext
+) -> str | None:
+    """Return the provider event a segment invokes, or None.
+
+    Args:
+        words: One pipeline segment's words.
+        context: Provider paths this gate accepts.
+
+    Returns:
+        The event name, or None when the segment is not a provider invocation
+        naming a path this gate recognises.
+    """
+    index = 0
+    if index >= len(words) or words[index] not in _BUN_BINARIES:
+        return None
+    index += 1
+    if index < len(words) and words[index] == "run":
+        index += 1
+    if index >= len(words):
+        return None
+    path = words[index]
+    activated = activated_provider_script_paths(context.settings_path)
+    if path != context.provider_script_path and path not in activated:
+        return None
+    return _parse_provider_flags(words, index + 1)
+
+
+def _parse_provider_flags(words: list[str], start: int) -> str | None:
+    """Parse `--runtime`/`--event` flags, refusing anything else.
+
+    A repeated flag is refused: two `--event` values make the effective event
+    ambiguous, and ambiguity in an allowance is a hole.
+
+    Args:
+        words: The segment's words.
+        start: Index of the first flag.
+
+    Returns:
+        The event, or None when the flags are unrecognised, duplicated, or the
+        runtime is not `claude`.
+    """
+    index = start
+    runtime = ""
+    event = ""
+    while index < len(words):
+        parsed = _parse_flag(words, index)
+        if parsed is None:
+            return None
+        name, value, index = parsed
+        if name == "runtime":
+            if runtime:
+                return None
+            runtime = value
+        if name == "event":
+            if event:
+                return None
+            event = value
+    if runtime != "claude" or event not in _PROVIDER_EVENTS:
+        return None
+    return event
+
+
+def _parse_flag(words: list[str], index: int) -> tuple[str, str, int] | None:
+    """Parse one `--runtime`/`--event` flag in either spelling.
+
+    Args:
+        words: The segment's words.
+        index: Index to parse at.
+
+    Returns:
+        ``(name, value, next_index)``, or None for any other word.
+    """
+    word = words[index]
+    for name in ("runtime", "event"):
+        flag = f"--{name}"
+        if word == flag and index + 1 < len(words):
+            return name, words[index + 1], index + 2
+        if word.startswith(f"{flag}="):
+            return name, word[len(flag) + 1 :], index + 1
+    return None
+
+
+def _is_read_only_bash(command: str) -> bool:
+    """Report whether every segment of a command is read-only.
+
+    Args:
+        command: The raw command.
+
+    Returns:
+        True only when the command has no redirect or substitution and every
+        chained segment is a read-only binary or a read-only git subcommand.
+    """
+    if not command or re.search(r"[>`]|\$\(", command):
+        return False
+    segments = [
+        segment.strip()
+        for segment in re.split(r"\|\||&&|[;|&]", command)
+        if segment.strip()
+    ]
+    if not segments:
+        return False
+    return all(_is_read_only_segment(segment) for segment in segments)
+
+
+def _is_read_only_segment(segment: str) -> bool:
+    """Report whether one chained segment is read-only.
+
+    Args:
+        segment: One segment of a chained command.
+
+    Returns:
+        True for a read-only binary used read-only. `sed -i` and `find -delete`
+        are refused because the binary alone does not settle it.
+    """
+    parts = segment.split()
+    if not parts:
+        return False
+    head, rest = parts[0], parts[1:]
+    if head == "git":
+        return _is_read_only_git(rest)
+    if head not in READONLY_BASH:
+        return False
+    if head == "sed" and any(
+        arg.startswith("-i") or arg.startswith("--in-place") for arg in rest
+    ):
+        return False
+    if head == "find" and any(
+        arg in ("-delete", "-exec", "-execdir", "-fprint") for arg in rest
+    ):
+        return False
+    return True
+
+
+def _is_read_only_git(args: list[str]) -> bool:
+    """Report whether a git invocation only reads.
+
+    Args:
+        args: Arguments after `git`.
+
+    Returns:
+        True for the read-only subcommands, and for `git branch` only with
+        listing flags — `git branch -D` deletes.
+    """
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--no-pager":
+            index += 1
+            continue
+        following = args[index + 1] if index + 1 < len(args) else "-"
+        if arg == "-C" and not following.startswith("-"):
+            index += 2
+            continue
+        break
+    subcommand = args[index] if index < len(args) else ""
+    if subcommand != "branch":
+        return subcommand in ("status", "log", "diff", "show", "rev-parse", "ls-files")
+    flags = args[index + 1 :]
+    listing = {"-a", "--all", "-r", "--remotes", "-v", "-vv", "--show-current"}
+    return not flags or all(flag in listing for flag in flags)

--- a/python/openbrain-provider/src/openbrain_provider/gate_shell.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_shell.py
@@ -45,11 +45,48 @@ __all__ = [
 #: mutating flags, because the binary alone does not settle it.
 READONLY_BASH: Final[frozenset[str]] = frozenset(
     {
-        "ls", "cat", "head", "tail", "grep", "rg", "egrep", "fgrep", "find", "fd",
-        "wc", "stat", "file", "du", "df", "tree", "realpath", "dirname", "basename",
-        "echo", "printf", "pwd", "whoami", "id", "date", "hostname", "uname",
-        "which", "type", "printenv", "sort", "uniq", "cut", "tr", "column",
-        "jq", "diff", "sed", "awk", "test", "sw_vers", "uuidgen",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "rg",
+        "egrep",
+        "fgrep",
+        "find",
+        "fd",
+        "wc",
+        "stat",
+        "file",
+        "du",
+        "df",
+        "tree",
+        "realpath",
+        "dirname",
+        "basename",
+        "echo",
+        "printf",
+        "pwd",
+        "whoami",
+        "id",
+        "date",
+        "hostname",
+        "uname",
+        "which",
+        "type",
+        "printenv",
+        "sort",
+        "uniq",
+        "cut",
+        "tr",
+        "column",
+        "jq",
+        "diff",
+        "sed",
+        "awk",
+        "test",
+        "sw_vers",
+        "uuidgen",
     }
 )
 
@@ -57,8 +94,14 @@ READONLY_BASH: Final[frozenset[str]] = frozenset(
 #: are permitted regardless of gate state.
 _ALWAYS_ALLOWED_TOOLS: Final[frozenset[str]] = frozenset(
     {
-        "read", "grep", "glob", "tasklist", "taskget",
-        "askuserquestion", "skill", "toolsearch",
+        "read",
+        "grep",
+        "glob",
+        "tasklist",
+        "taskget",
+        "askuserquestion",
+        "skill",
+        "toolsearch",
     }
 )
 
@@ -379,9 +422,7 @@ def _is_gate_repair_command(
         event_index = words.index("--event", index + 1)
     except ValueError:
         return False
-    return (
-        event_index + 1 < len(words) and words[event_index + 1] == required_event
-    )
+    return event_index + 1 < len(words) and words[event_index + 1] == required_event
 
 
 def _provider_events_allowed_by_state(state: SessionState) -> frozenset[str]:

--- a/python/openbrain-provider/src/openbrain_provider/gate_state.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_state.py
@@ -1,0 +1,690 @@
+"""Per-session context-budget gate state, and every transition it can make.
+
+This module owns WHAT THE GATE BELIEVES: whether a post-compact read-back is
+still owed, whether an uncaptured turn is still owed, whether repair mode is
+open, and the log of how it got there. It reads receipt evidence through
+:mod:`openbrain_provider.receipt_state` and never writes it.
+
+Two properties here are the reason issue #419 exists, and both are asserted by
+tests rather than left to a comment:
+
+* **The read-back requirement self-releases.** After
+  :data:`READBACK_TIMEOUT_SECONDS` the gate stops blocking on its own, because a
+  gate that waits forever on a subsystem is a gate that blocks the repair of
+  that subsystem. It releases by RECORDING that it released — it never
+  manufactures a recall receipt that did not happen.
+* **Repair mode expires.** An escape hatch that stays open is not an escape
+  hatch, it is the gate being off.
+
+What this module does NOT do: it does not read stdin, decide a verdict, or
+render a banner. Those are `gate_shell`, `gate.py`, and `gate_presentation`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Final
+
+from .receipt_state import (
+    ReceiptEvidence,
+    current_compact_cycle,
+    find_fresh_receipt,
+    has_verified_compact_recall,
+    parse_iso,
+)
+
+__all__ = [
+    "CHECKPOINT_MAX_AGE_SECONDS",
+    "READBACK_TIMEOUT_SECONDS",
+    "GateTransition",
+    "SessionState",
+    "StateFile",
+    "enter_repair_mode",
+    "exit_repair_mode",
+    "fresh_session_state",
+    "hydrate_session_state",
+    "load_state",
+    "queue_notice",
+    "reconcile_gate_state",
+    "record_transition",
+    "repair_mode_is_active",
+    "save_session_state",
+    "verified_checkpoint",
+]
+
+#: context-budget-gate-state.ts:10. THE self-release. The documented 15 minutes
+#: did not actually fire in the revision issue #419 was filed against; here the
+#: release is a named transition with its own test, so a regression is a failing
+#: test rather than a session that silently never unblocks.
+READBACK_TIMEOUT_SECONDS: Final[float] = 15 * 60.0
+
+#: context-budget-gate.ts:76 — how fresh a checkpoint receipt must be to satisfy
+#: an explicit `checkpoint-done`.
+CHECKPOINT_MAX_AGE_SECONDS: Final[float] = 20 * 60.0
+
+#: context-budget-gate-state.ts:172 — the window for "has this session written
+#: anything durable lately", used only to date `lastWriteAt`.
+LATEST_WRITE_MAX_AGE_SECONDS: Final[float] = 24 * 60 * 60.0
+
+#: context-budget-gate-state.ts:217 — how far back a legacy correlation may be
+#: recovered from.
+LEGACY_CORRELATION_MAX_AGE_SECONDS: Final[float] = 24 * 60 * 60.0
+
+#: context-budget-gate-state.ts:223 — how closely a recovered cycle's start must
+#: match the moment the read-back was armed to be the SAME compaction.
+LEGACY_CORRELATION_SKEW_SECONDS: Final[float] = 2 * 60.0
+
+#: context-budget-gate-state.ts:204 — a verified recall older than this does not
+#: clear the read-back.
+VERIFIED_RECALL_MAX_AGE_SECONDS: Final[float] = 2 * 60.0
+
+#: Every transition the gate can make. A closed set, because "silence is a
+#: signal" (#419 acceptance): an unnamed state change is one nobody can grep
+#: for after the fact.
+TRANSITION_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "armed",
+        "cleared-by-recall",
+        "cleared-by-capture",
+        "repair-entered",
+        "repair-exited",
+        "repair-expired",
+        "self-released-after-timeout",
+        "still-blocking-with-reason",
+    }
+)
+
+_WRITE_OPERATIONS: Final[tuple[str, ...]] = ("capture", "checkpoint", "wrap")
+_DURABLE_MODES: Final[tuple[str, ...]] = ("verified-remote", "durable-spool")
+
+
+@dataclass(frozen=True)
+class GateTransition:
+    """One recorded state change.
+
+    Attributes:
+        name: One of :data:`TRANSITION_NAMES`.
+        at: When it happened, ISO-8601.
+        reason: Why, in operator-readable prose.
+    """
+
+    name: str
+    at: str
+    reason: str
+
+    def to_json(self) -> dict[str, str]:
+        """Return the on-disk shape the TypeScript reader expects."""
+        return {"name": self.name, "at": self.at, "reason": self.reason}
+
+
+@dataclass
+class SessionState:
+    """Everything the gate remembers about one session.
+
+    Field names mirror the on-disk camelCase keys through
+    :meth:`to_json`/:meth:`from_json`, because the state file is shared with the
+    TypeScript gate during the changeover and must stay readable by both.
+    """
+
+    session_id: str
+    project: str = ""
+    context_tokens: int = 0
+    last_nag_at_tokens: int = 0
+    checkpoint_required: bool = False
+    checkpoint_required_at: str = ""
+    readback_required: bool = False
+    readback_required_at: str = ""
+    readback_correlation_id: str = ""
+    capture_required: bool = False
+    capture_required_at: str = ""
+    pending_cleared_notices: list[str] = field(default_factory=list)
+    last_write_at: str = ""
+    checkpoint_at_tokens: int = 0
+    checkpoint_at: str = ""
+    repair_mode_active: bool = False
+    repair_mode_entered_at: str = ""
+    repair_mode_expires_at: str = ""
+    transition_log: list[GateTransition] = field(default_factory=list)
+    updated_at: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the camelCase on-disk representation."""
+        return {
+            "sessionId": self.session_id,
+            "project": self.project,
+            "contextTokens": self.context_tokens,
+            "lastNagAtTokens": self.last_nag_at_tokens,
+            "checkpointRequired": self.checkpoint_required,
+            "checkpointRequiredAt": self.checkpoint_required_at,
+            "readbackRequired": self.readback_required,
+            "readbackRequiredAt": self.readback_required_at,
+            "readbackCorrelationId": self.readback_correlation_id,
+            "captureRequired": self.capture_required,
+            "captureRequiredAt": self.capture_required_at,
+            "pendingClearedNotices": list(self.pending_cleared_notices),
+            "lastWriteAt": self.last_write_at,
+            "checkpointAtTokens": self.checkpoint_at_tokens,
+            "checkpointAt": self.checkpoint_at,
+            "repairModeActive": self.repair_mode_active,
+            "repairModeEnteredAt": self.repair_mode_entered_at,
+            "repairModeExpiresAt": self.repair_mode_expires_at,
+            "transitionLog": [entry.to_json() for entry in self.transition_log],
+            "updatedAt": self.updated_at,
+        }
+
+
+@dataclass
+class StateFile:
+    """The whole state file: one entry per session.
+
+    Attributes:
+        sessions: Session id to state.
+    """
+
+    sessions: dict[str, SessionState] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the on-disk representation."""
+        return {
+            "sessions": {
+                key: value.to_json() for key, value in sorted(self.sessions.items())
+            }
+        }
+
+
+def _string(value: object, fallback: str = "") -> str:
+    """Return a string field, or the fallback when the stored value is not one."""
+    return value if isinstance(value, str) else fallback
+
+
+def _integer(value: object, fallback: int = 0) -> int:
+    """Return an int field, or the fallback for a non-numeric stored value."""
+    if isinstance(value, bool):
+        return fallback
+    return value if isinstance(value, int) else fallback
+
+
+def _boolean(value: object, fallback: bool = False) -> bool:
+    """Return a bool field, or the fallback for a non-boolean stored value."""
+    return value if isinstance(value, bool) else fallback
+
+
+def _string_list(value: object) -> list[str]:
+    """Return only the string members of a stored list."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _transition_list(value: object) -> list[GateTransition]:
+    """Return only the well-formed transitions from a stored list."""
+    if not isinstance(value, list):
+        return []
+    transitions: list[GateTransition] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        name, at, reason = item.get("name"), item.get("at"), item.get("reason")
+        if not (
+            isinstance(name, str) and isinstance(at, str) and isinstance(reason, str)
+        ):
+            continue
+        transitions.append(GateTransition(name=name, at=at, reason=reason))
+    return transitions
+
+
+def hydrate_session_state(
+    stored: dict[str, Any] | None, session_id: str, now: str
+) -> SessionState:
+    """Build a session state from whatever the file held.
+
+    Every field is read defensively: a state file half-written by a killed
+    process, or written by an older revision, must produce a usable state rather
+    than an exception, because an exception here would break the session the
+    gate is supposed to protect.
+
+    ``checkpointRequired`` is deliberately forced to False regardless of what is
+    stored (context-budget-gate-state.ts:78-80): pre-compact token pressure is
+    advisory now, and an old state file still carrying a required checkpoint
+    would otherwise resurrect a retired block.
+
+    Args:
+        stored: Raw stored entry, or None for a session with no history.
+        session_id: The session this state belongs to.
+        now: Current instant, ISO-8601.
+
+    Returns:
+        A usable session state.
+    """
+    source: dict[str, Any] = stored if isinstance(stored, dict) else {}
+    return SessionState(
+        session_id=session_id,
+        project=_string(source.get("project")),
+        context_tokens=_integer(source.get("contextTokens")),
+        last_nag_at_tokens=_integer(source.get("lastNagAtTokens")),
+        checkpoint_required=False,
+        checkpoint_required_at="",
+        readback_required=_boolean(source.get("readbackRequired")),
+        readback_required_at=_string(source.get("readbackRequiredAt")),
+        readback_correlation_id=_string(source.get("readbackCorrelationId")),
+        capture_required=_boolean(source.get("captureRequired")),
+        capture_required_at=_string(source.get("captureRequiredAt")),
+        pending_cleared_notices=_string_list(source.get("pendingClearedNotices")),
+        last_write_at=_string(source.get("lastWriteAt")),
+        checkpoint_at_tokens=_integer(source.get("checkpointAtTokens")),
+        checkpoint_at=_string(source.get("checkpointAt")),
+        repair_mode_active=_boolean(source.get("repairModeActive")),
+        repair_mode_entered_at=_string(source.get("repairModeEnteredAt")),
+        repair_mode_expires_at=_string(source.get("repairModeExpiresAt")),
+        transition_log=_transition_list(source.get("transitionLog")),
+        updated_at=now,
+    )
+
+
+def load_state(state_path: Path) -> tuple[StateFile, dict[str, Any]]:
+    """Read the gate state file.
+
+    Args:
+        state_path: The gate's own state file.
+
+    Returns:
+        A tuple of the parsed state file and the raw sessions mapping. The raw
+        mapping is returned because :func:`hydrate_session_state` needs the
+        untouched entry, and re-serialising a hydrated one first would lose any
+        field this revision does not know about.
+    """
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        # A corrupt state file must not break the session; the gate rebuilds it.
+        return StateFile(), {}
+    if not isinstance(raw, dict):
+        return StateFile(), {}
+    sessions = raw.get("sessions")
+    if not isinstance(sessions, dict):
+        return StateFile(), {}
+    return StateFile(), sessions
+
+
+def save_session_state(
+    state_path: Path, raw_sessions: dict[str, Any], state: SessionState
+) -> None:
+    """Write the state file with this session's entry replaced.
+
+    Other sessions' raw entries are written back untouched. Rehydrating them
+    would silently rewrite state the running TypeScript gate owns for a
+    different session, which during the changeover is somebody else's data.
+
+    Args:
+        state_path: The gate's own state file.
+        raw_sessions: The raw sessions mapping as it was read.
+        state: The session state to store.
+    """
+    raw_sessions[state.session_id] = state.to_json()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"sessions": raw_sessions}, indent=2, ensure_ascii=False),
+        encoding="utf8",
+    )
+
+
+def record_transition(
+    state: SessionState, name: str, now: str, reason: str
+) -> None:
+    """Append one named transition to the session's log.
+
+    Args:
+        state: Session state to record into.
+        name: One of :data:`TRANSITION_NAMES`.
+        now: When, ISO-8601.
+        reason: Why, in operator-readable prose.
+
+    Raises:
+        ValueError: If the name is not a declared transition. An invented name
+            is a silent hole in the audit trail, so it fails loudly here rather
+            than being written and never found.
+    """
+    if name not in TRANSITION_NAMES:
+        raise ValueError(f"unknown gate transition {name!r}")
+    state.transition_log.append(GateTransition(name=name, at=now, reason=reason))
+
+
+def queue_notice(state: SessionState, notice: str) -> None:
+    """Queue a one-time notice for the next surface that can display one.
+
+    Deduped, because the same clear can be reconciled on several consecutive
+    events before anything is displayed.
+
+    Args:
+        state: Session state.
+        notice: The message.
+    """
+    if notice not in state.pending_cleared_notices:
+        state.pending_cleared_notices.append(notice)
+
+
+def repair_mode_is_active(state: SessionState, now: str) -> bool:
+    """Report whether repair mode is open right now.
+
+    Expiry is evaluated on read as well as on reconcile, so a stale
+    ``repairModeActive`` flag left by a killed process cannot keep the gate open.
+
+    Args:
+        state: Session state.
+        now: Current instant, ISO-8601.
+
+    Returns:
+        True only when the flag is set AND the expiry is in the future.
+    """
+    if not state.repair_mode_active:
+        return False
+    expires = parse_iso(state.repair_mode_expires_at)
+    current = parse_iso(now)
+    if expires is None or current is None:
+        return False
+    return current < expires
+
+
+def enter_repair_mode(
+    state: SessionState, now: str, duration: timedelta, reason: str
+) -> None:
+    """Open a bounded repair window.
+
+    Args:
+        state: Session state.
+        now: Current instant, ISO-8601.
+        duration: How long the window stays open.
+        reason: Operator-supplied reason, required by the caller.
+    """
+    entered = parse_iso(now) or datetime.now(UTC)
+    state.repair_mode_active = True
+    state.repair_mode_entered_at = now
+    state.repair_mode_expires_at = _iso(entered + duration)
+    record_transition(state, "repair-entered", now, reason)
+
+
+def exit_repair_mode(state: SessionState, now: str, reason: str) -> None:
+    """Close the repair window explicitly.
+
+    Recording the exit even when nothing was open is deliberate: an operator who
+    runs `repair-exit` gets a receipt either way, so "did that take effect" is
+    answerable from the transition log.
+
+    Args:
+        state: Session state.
+        now: Current instant, ISO-8601.
+        reason: Why it was closed.
+    """
+    was_active = state.repair_mode_active
+    _clear_repair_mode(state)
+    record_transition(
+        state,
+        "repair-exited",
+        now,
+        reason if was_active else f"{reason}; already inactive",
+    )
+
+
+def verified_checkpoint(
+    state: SessionState,
+    receipt_state_path: Path,
+    max_age_seconds: float = CHECKPOINT_MAX_AGE_SECONDS,
+    now: datetime | None = None,
+) -> ReceiptEvidence | None:
+    """Return a fresh verified-remote checkpoint receipt for this session.
+
+    ``verified-remote`` only. A spooled checkpoint is durable but has not been
+    confirmed by the server, and `checkpoint-done` is the one place the operator
+    is explicitly asserting the remote write happened.
+
+    Args:
+        state: Session state.
+        receipt_state_path: Shared receipt state file.
+        max_age_seconds: Freshness window.
+        now: Reference time; defaults to the current instant.
+
+    Returns:
+        The receipt, or None when no qualifying evidence exists.
+    """
+    return find_fresh_receipt(
+        receipt_state_path,
+        session_id=state.session_id,
+        project=state.project or None,
+        operations=("checkpoint",),
+        modes=("verified-remote",),
+        after=state.checkpoint_required_at or None,
+        max_age_seconds=max_age_seconds,
+        now=now,
+    )
+
+
+def reconcile_gate_state(
+    state: SessionState, *, receipt_state_path: Path, now: str
+) -> None:
+    """Bring the gate's beliefs in line with the evidence on disk.
+
+    Runs before every verdict. Order matters only in that expiry and self-release
+    come last, so a requirement cleared by real evidence is recorded as cleared
+    by that evidence rather than as a timeout.
+
+    Args:
+        state: Session state to update in place.
+        receipt_state_path: Shared receipt state file.
+        now: Current instant, ISO-8601.
+    """
+    reference = parse_iso(now) or datetime.now(UTC)
+    _reconcile_latest_write(state, receipt_state_path, reference)
+    _reconcile_capture(state, receipt_state_path, now, reference)
+    _reconcile_compact_recall(state, receipt_state_path, now, reference)
+    _expire_repair_mode(state, now, reference)
+    _release_timed_out_readback(state, now, reference)
+
+
+def fresh_session_state(previous: SessionState) -> SessionState:
+    """Return a reset state for a brand-new session.
+
+    Project, last write, and the transition log survive; every requirement and
+    every counter is cleared. A fresh session inherits no block from the last
+    one — that block belonged to a context that no longer exists.
+
+    Args:
+        previous: The state being reset.
+
+    Returns:
+        A new state with requirements cleared.
+    """
+    return SessionState(
+        session_id=previous.session_id,
+        project=previous.project,
+        context_tokens=0,
+        last_nag_at_tokens=0,
+        checkpoint_required=False,
+        checkpoint_required_at="",
+        readback_required=False,
+        readback_required_at="",
+        readback_correlation_id="",
+        capture_required=False,
+        capture_required_at="",
+        pending_cleared_notices=[],
+        last_write_at=previous.last_write_at,
+        checkpoint_at_tokens=previous.checkpoint_at_tokens,
+        checkpoint_at=previous.checkpoint_at,
+        repair_mode_active=False,
+        repair_mode_entered_at="",
+        repair_mode_expires_at="",
+        transition_log=list(previous.transition_log),
+        updated_at=previous.updated_at,
+    )
+
+
+def _iso(moment: datetime) -> str:
+    """Render an instant the way the TypeScript writer does.
+
+    Args:
+        moment: The instant.
+
+    Returns:
+        ISO-8601 in UTC with millisecond precision and a Z suffix, matching
+        JavaScript's `toISOString()`. The state file is read by both runtimes
+        during the changeover, so the spelling has to agree.
+    """
+    utc = moment.astimezone(UTC)
+    return f"{utc.strftime('%Y-%m-%dT%H:%M:%S')}.{utc.microsecond // 1000:03d}Z"
+
+
+def _clear_readback(state: SessionState) -> None:
+    """Clear the read-back requirement and its correlation."""
+    state.readback_required = False
+    state.readback_required_at = ""
+    state.readback_correlation_id = ""
+
+
+def _clear_repair_mode(state: SessionState) -> None:
+    """Clear repair mode and its timestamps."""
+    state.repair_mode_active = False
+    state.repair_mode_entered_at = ""
+    state.repair_mode_expires_at = ""
+
+
+def _reconcile_latest_write(
+    state: SessionState, receipt_state_path: Path, now: datetime
+) -> None:
+    """Advance ``lastWriteAt`` to the newest durable write receipt."""
+    latest = find_fresh_receipt(
+        receipt_state_path,
+        session_id=state.session_id,
+        project=state.project or None,
+        operations=_WRITE_OPERATIONS,
+        modes=_DURABLE_MODES,
+        max_age_seconds=LATEST_WRITE_MAX_AGE_SECONDS,
+        now=now,
+    )
+    if latest is None:
+        return
+    recorded = latest.recorded_at_time
+    known = parse_iso(state.last_write_at)
+    if recorded is not None and known is not None and recorded <= known:
+        return
+    state.last_write_at = latest.recorded_at
+
+
+def _reconcile_capture(
+    state: SessionState, receipt_state_path: Path, now: str, reference: datetime
+) -> None:
+    """Clear the capture requirement when a durable write landed after it armed."""
+    if not state.capture_required:
+        return
+    captured = find_fresh_receipt(
+        receipt_state_path,
+        session_id=state.session_id,
+        project=state.project or None,
+        operations=_WRITE_OPERATIONS,
+        modes=_DURABLE_MODES,
+        after=state.capture_required_at or None,
+        now=reference,
+    )
+    if captured is None:
+        return
+    state.capture_required = False
+    state.capture_required_at = ""
+    state.last_write_at = captured.recorded_at
+    record_transition(
+        state, "cleared-by-capture", now, "durable write receipt verified"
+    )
+    queue_notice(state, "capture cleared · durable write receipt verified")
+
+
+def _reconcile_compact_recall(
+    state: SessionState, receipt_state_path: Path, now: str, reference: datetime
+) -> None:
+    """Clear the read-back when the EXACT cycle has a fresh verified recall."""
+    if not state.readback_required:
+        return
+    _recover_legacy_correlation(state, receipt_state_path, reference)
+    if not state.readback_correlation_id:
+        return
+    verified = has_verified_compact_recall(
+        receipt_state_path,
+        session_id=state.session_id,
+        project=state.project,
+        correlation_id=state.readback_correlation_id,
+        max_age_seconds=VERIFIED_RECALL_MAX_AGE_SECONDS,
+        now=reference,
+    )
+    if not verified:
+        return
+    _clear_readback(state)
+    record_transition(state, "cleared-by-recall", now, "direct recall receipt verified")
+    queue_notice(state, "read-back cleared · direct recall receipt verified")
+
+
+def _recover_legacy_correlation(
+    state: SessionState, receipt_state_path: Path, reference: datetime
+) -> None:
+    """Adopt the live cycle id when a stored state armed without one.
+
+    Only from the MATCHING compaction window: the cycle's start must be within
+    :data:`LEGACY_CORRELATION_SKEW_SECONDS` of when the read-back armed.
+    Adopting any recent cycle would let an unrelated compaction's verified
+    recall clear this one.
+    """
+    if state.readback_correlation_id:
+        return
+    cycle = current_compact_cycle(
+        receipt_state_path,
+        session_id=state.session_id,
+        project=state.project,
+        max_age_seconds=LEGACY_CORRELATION_MAX_AGE_SECONDS,
+        now=reference,
+    )
+    if cycle is None:
+        return
+    required = parse_iso(state.readback_required_at)
+    started = parse_iso(cycle.started_at)
+    if required is None or started is None:
+        return
+    if abs((required - started).total_seconds()) > LEGACY_CORRELATION_SKEW_SECONDS:
+        return
+    state.readback_correlation_id = cycle.id
+    state.readback_required_at = cycle.started_at
+
+
+def _expire_repair_mode(state: SessionState, now: str, reference: datetime) -> None:
+    """Close repair mode once its window has elapsed."""
+    if not state.repair_mode_active:
+        return
+    expires = parse_iso(state.repair_mode_expires_at)
+    if expires is not None and reference < expires:
+        return
+    _clear_repair_mode(state)
+    record_transition(state, "repair-expired", now, "bounded repair window elapsed")
+    queue_notice(state, "repair-expired · normal enforcement resumed")
+
+
+def _release_timed_out_readback(
+    state: SessionState, now: str, reference: datetime
+) -> None:
+    """Self-release the read-back after :data:`READBACK_TIMEOUT_SECONDS`.
+
+    THE fix behind #419. The gate stops blocking on its own, and says so — it
+    does not fabricate the recall receipt it never got, because that would make
+    the next gate believe a recall happened.
+    """
+    if not state.readback_required:
+        return
+    required = parse_iso(state.readback_required_at)
+    if required is None:
+        return
+    if (reference - required).total_seconds() < READBACK_TIMEOUT_SECONDS:
+        return
+    _clear_readback(state)
+    record_transition(
+        state,
+        "self-released-after-timeout",
+        now,
+        "15-minute read-back timeout elapsed",
+    )
+    queue_notice(state, "self-released-after-timeout · no recall receipt manufactured")

--- a/python/openbrain-provider/src/openbrain_provider/gate_state.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_state.py
@@ -331,9 +331,7 @@ def save_session_state(
     )
 
 
-def record_transition(
-    state: SessionState, name: str, now: str, reason: str
-) -> None:
+def record_transition(state: SessionState, name: str, now: str, reason: str) -> None:
     """Append one named transition to the session's log.
 
     Args:

--- a/python/openbrain-provider/src/openbrain_provider/gate_transcript.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_transcript.py
@@ -1,0 +1,204 @@
+"""Read two facts out of a session transcript: token pressure, and did-work.
+
+Both are read from the TAIL of the file. A transcript is append-only and can be
+tens of megabytes; the gate runs on the agent's critical path, so it seeks to
+the end rather than reading the whole file. The read sizes below are I/O sizes,
+not bounds on content — nothing here shortens, stores, or rewrites a transcript.
+
+What this module does NOT do: it does not capture, store, or forward anything
+from the transcript. It returns a number and a boolean.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Final
+
+from .receipt_state import parse_iso
+
+__all__ = ["read_context_tokens", "turn_did_work"]
+
+#: How much of the tail to read when looking for the latest usage record.
+#: context-budget-gate.ts:442.
+_TOKEN_SCAN_BYTES: Final[int] = 2 * 1024 * 1024
+
+#: How much of the tail to read when looking for work in the current turn.
+#: context-budget-gate.ts:411.
+_WORK_SCAN_BYTES: Final[int] = 512 * 1024
+
+#: context-budget-gate.ts:422 — the timestamp field on a transcript record.
+_TIMESTAMP_PATTERN: Final[re.Pattern[str]] = re.compile(r'"timestamp":"([^"]+)"')
+
+#: context-budget-gate.ts:424-428. Mutating tool activity, and the git commands
+#: that constitute work even though Bash itself is not a mutating tool.
+_TOOL_EVENT_PATTERN: Final[re.Pattern[str]] = re.compile(r'"(tool_use|tool_result)"')
+_MUTATING_TOOL_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r'"(Edit|Write|NotebookEdit|Task|Agent)"'
+)
+_ERROR_PATTERN: Final[re.Pattern[str]] = re.compile(r'"is_error":true')
+_BASH_PATTERN: Final[re.Pattern[str]] = re.compile(r'"Bash"')
+_GIT_WORK_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"(git commit|git push|gh pr create|gh pr merge)"
+)
+
+
+def _read_tail_lines(path: Path, scan_bytes: int) -> list[str]:
+    """Read the last ``scan_bytes`` of a file and split it into lines.
+
+    Args:
+        path: Transcript file.
+        scan_bytes: How many trailing bytes to read.
+
+    Returns:
+        The decoded lines. The first line may be a partial record, which every
+        caller tolerates: a partial line simply fails to parse and is skipped.
+    """
+    with path.open("rb") as handle:
+        size = handle.seek(0, 2)
+        handle.seek(max(0, size - scan_bytes))
+        payload = handle.read()
+    return payload.decode("utf8", errors="replace").split("\n")
+
+
+def _usage_tokens(line: str) -> int | None:
+    """Return the total context tokens a transcript line reports, or None.
+
+    Cache reads and cache creation are added to input tokens, because all three
+    occupy the context window. Counting only `input_tokens` under-reports a
+    cached session by the size of its cache, which is most of it.
+
+    Args:
+        line: One transcript line.
+
+    Returns:
+        The token total, or None when the line carries no usable usage record.
+    """
+    if '"usage"' not in line or '"isSidechain":true' in line:
+        return None
+    try:
+        entry = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(entry, dict) or entry.get("isSidechain"):
+        return None
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    input_tokens = usage.get("input_tokens")
+    if not isinstance(input_tokens, int) or isinstance(input_tokens, bool):
+        return None
+    total = input_tokens
+    for key in ("cache_read_input_tokens", "cache_creation_input_tokens"):
+        value = usage.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            total += value
+    return total
+
+
+def read_context_tokens(transcript_path: str) -> int:
+    """Return the newest reported context-token total, or 0.
+
+    Args:
+        transcript_path: The hook's reported transcript path.
+
+    Returns:
+        The most recent usage total, or 0 when the file is absent, unreadable,
+        or carries no usage record in the scanned tail. Zero is "unknown", and
+        the caller treats it as such by not overwriting a known value with it.
+    """
+    if not transcript_path:
+        return 0
+    path = Path(transcript_path)
+    try:
+        if not path.is_file():
+            return 0
+        lines = _read_tail_lines(path, _TOKEN_SCAN_BYTES)
+    except OSError:
+        return 0
+    for line in reversed(lines):
+        tokens = _usage_tokens(line)
+        if tokens is not None:
+            return tokens
+    return 0
+
+
+def _latest_user_boundary(lines: list[str]) -> int:
+    """Return the index of the most recent real operator turn.
+
+    Sidechain records are subagent traffic, not the operator, so they do not
+    open a turn.
+
+    Args:
+        lines: Transcript lines.
+
+    Returns:
+        The index, or 0 when no boundary is found in the scanned tail.
+    """
+    for index in range(len(lines) - 1, -1, -1):
+        line = lines[index]
+        if '"type":"user"' in line and '"isSidechain":true' not in line:
+            return index
+    return 0
+
+
+def _is_work_line(line: str, last_write: datetime | None) -> bool:
+    """Report whether one line records work worth capturing.
+
+    Args:
+        line: One transcript line.
+        last_write: When this session last wrote durably, or None.
+
+    Returns:
+        True for a successful mutating tool call, or a git/gh command that lands
+        work. A record at or before ``last_write`` is not new work — it was
+        already captured.
+    """
+    if not line:
+        return False
+    match = _TIMESTAMP_PATTERN.search(line)
+    if match and last_write is not None:
+        recorded = parse_iso(match.group(1))
+        if recorded is not None and recorded <= last_write:
+            return False
+    tool_work = (
+        _TOOL_EVENT_PATTERN.search(line) is not None
+        and _MUTATING_TOOL_PATTERN.search(line) is not None
+        and _ERROR_PATTERN.search(line) is None
+    )
+    git_work = (
+        _BASH_PATTERN.search(line) is not None
+        and _GIT_WORK_PATTERN.search(line) is not None
+    )
+    return tool_work or git_work
+
+
+def turn_did_work(transcript_path: str, last_write_at: str) -> bool:
+    """Report whether the current turn landed uncaptured work.
+
+    Args:
+        transcript_path: The hook's reported transcript path.
+        last_write_at: When this session last wrote durably, ISO-8601 or empty.
+
+    Returns:
+        True when work happened since the last operator boundary and since the
+        last durable write. False on any read failure — an unreadable transcript
+        must not arm a block the operator cannot clear.
+    """
+    if not transcript_path:
+        return False
+    path = Path(transcript_path)
+    try:
+        if not path.is_file():
+            return False
+        lines = _read_tail_lines(path, _WORK_SCAN_BYTES)
+    except OSError:
+        return False
+    boundary = _latest_user_boundary(lines)
+    last_write = parse_iso(last_write_at) if last_write_at else None
+    return any(_is_work_line(line, last_write) for line in lines[boundary:])

--- a/python/openbrain-provider/src/openbrain_provider/hook_io.py
+++ b/python/openbrain-provider/src/openbrain_provider/hook_io.py
@@ -1,0 +1,164 @@
+"""The hook wire protocol: stdin JSON in, verdict JSON out, exit code.
+
+Purpose:
+    Both gates speak one protocol, so it is defined once here instead of twice.
+    A hook is handed its event as JSON on stdin and answers on stdout; this
+    module is the only place in the package that touches either.
+
+Architecture:
+    No decisions live here. It reads, it writes, it returns. The gates decide.
+    The shape follows ``openbrain.apps.hooks`` in the sibling package -- a
+    ``main(stream) -> int`` entrypoint taking its stream so tests drive it with
+    an in-memory buffer -- so the two packages' hooks read the same way.
+
+Pattern/Convention:
+    Three rules, each of which has already cost a session when broken.
+
+    STDIN IS FAIL-OPEN. Absent, empty, or malformed stdin yields an empty
+    event. A hook that raised on bad stdin would take the turn down with it,
+    and a gate exists to shape a turn, not to end one.
+
+    STDOUT IS THE RETURN CHANNEL. Nothing but the verdict goes there. Log
+    records go to a file or stderr (``observability``); one stray line on
+    stdout is a corrupted response, not noise.
+
+    AN ALLOW IS SILENCE. Both runtimes treat empty stdout as allow, and a
+    top-level ``decision: "allow"`` is INVALID and makes the hook report a JSON
+    failure (``policy-refresh-gate.ts:502-505``). So an allowance emits nothing.
+
+Example:
+    >>> import io
+    >>> read_hook_event(io.StringIO('{"session_id":"s1"}')).session_id
+    's1'
+    >>> read_hook_event(io.StringIO("not json")).session_id
+    ''
+
+See Also:
+    - ``python/openbrain/tests/fixtures/captured_hooks/README.md`` - the
+      captured proof that empty stdout with exit 0 is the accepted response
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+__all__ = [
+    "HookEvent",
+    "emit",
+    "emit_json",
+    "read_hook_event",
+]
+
+#: Compact separators, matching ``JSON.stringify`` with no spacing. The verdicts
+#: are compared byte-for-byte against recordings of the TypeScript gates, so the
+#: spelling is part of the contract, not a formatting preference.
+_COMPACT: Final[tuple[str, str]] = (",", ":")
+
+
+class HookEvent(dict[str, Any]):
+    """One hook invocation's parsed stdin.
+
+    A dict subclass rather than a model: the harness adds fields between
+    releases, and a strict model would reject an event the gate could otherwise
+    handle. The accessors read the fields this package uses and coerce
+    defensively, so a field arriving with the wrong type reads as absent rather
+    than raising.
+    """
+
+    @property
+    def session_id(self) -> str:
+        """Return the session id, or an empty string."""
+        value = self.get("session_id")
+        return value if isinstance(value, str) else ""
+
+    @property
+    def transcript_path(self) -> str:
+        """Return the transcript path, or an empty string."""
+        value = self.get("transcript_path")
+        return value if isinstance(value, str) else ""
+
+    @property
+    def cwd(self) -> str:
+        """Return the working directory, or an empty string."""
+        value = self.get("cwd")
+        return value if isinstance(value, str) else ""
+
+    @property
+    def source(self) -> str:
+        """Return the SessionStart source, or an empty string."""
+        value = self.get("source")
+        return value if isinstance(value, str) else ""
+
+    @property
+    def tool_name(self) -> str:
+        """Return the tool name, accepting either spelling the runtimes send."""
+        for key in ("tool_name", "toolName"):
+            value = self.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return ""
+
+    @property
+    def tool_input(self) -> dict[str, Any]:
+        """Return the tool arguments, accepting either spelling."""
+        for key in ("tool_input", "toolInput"):
+            value = self.get(key)
+            if isinstance(value, dict):
+                return value
+        return {}
+
+
+def read_hook_event(stream: TextIO | None = None) -> HookEvent:
+    """Read and parse the hook's stdin.
+
+    Args:
+        stream: Text stream to read. Defaults to ``sys.stdin``.
+
+    Returns:
+        The parsed event, or an empty one. Every failure -- no stdin, a closed
+        pipe, empty input, malformed JSON, or a JSON scalar where an object was
+        expected -- is the same answer, because in all of them the gate has no
+        event to act on and must not break the turn.
+    """
+    source = sys.stdin if stream is None else stream
+    try:
+        text = source.read()
+    except (OSError, ValueError):
+        return HookEvent()
+    if not isinstance(text, str) or not text.strip():
+        return HookEvent()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return HookEvent()
+    return HookEvent(parsed) if isinstance(parsed, dict) else HookEvent()
+
+
+def emit(text: str, stream: TextIO | None = None) -> None:
+    """Write one line to the hook's return channel.
+
+    Args:
+        text: The line. An empty string writes NOTHING -- an allowance is
+            silence, and a bare newline is not silence.
+        stream: Text stream to write to. Defaults to ``sys.stdout``.
+    """
+    if not text:
+        return
+    target = sys.stdout if stream is None else stream
+    target.write(f"{text}\n")
+    target.flush()
+
+
+def emit_json(payload: dict[str, Any], stream: TextIO | None = None) -> None:
+    """Write one compact JSON verdict to the return channel.
+
+    Args:
+        payload: The verdict object.
+        stream: Text stream to write to. Defaults to ``sys.stdout``.
+    """
+    emit(json.dumps(payload, separators=_COMPACT, ensure_ascii=False), stream)

--- a/python/openbrain-provider/src/openbrain_provider/policy_context.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_context.py
@@ -1,0 +1,242 @@
+"""The policy text the refresh gate injects.
+
+Purpose:
+    The startup block, the stale-context notice, the post-compact standing
+    requirements, and the refresh confirmation — the four pieces of prose this
+    gate exists to put in front of an agent at the right moment.
+
+Architecture:
+    Text only. No state, no decisions. The one non-trivial function reads the
+    runtime fast-path block out of a source-owned ``AGENTS.md`` for non-Claude
+    runtimes, so that block has ONE home and this gate quotes it rather than
+    keeping a second copy that drifts.
+
+Pattern/Convention:
+    Byte-identical to ``policy-refresh-gate.ts:539-633``. These strings are
+    compared against recordings of the live gate, so an edit here is a
+    behaviour change, not a wording change.
+
+See Also:
+    - ``_ob/scripts/policy-refresh-gate.ts`` — the TypeScript this ports
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+__all__ = [
+    "post_compact_requirements",
+    "refresh_context",
+    "stale_context",
+    "startup_context",
+]
+
+#: The markers delimiting the fast-path block inside a source-owned AGENTS.md.
+_FAST_PATH_START: Final[str] = "<!-- runtime-fast-path:start -->"
+_FAST_PATH_END: Final[str] = "<!-- runtime-fast-path:end -->"
+
+#: Runtimes whose startup hydration is already done by the Python adapter.
+_DIRECT_HYDRATION_RUNTIMES: Final[frozenset[str]] = frozenset({"claude", "claudex"})
+
+_DEVELOPMENT_AGENTS: Final[Path] = Path("/Volumes/ThunderBolt/Development/AGENTS.md")
+
+
+def _runtime_fast_path_block(command_cwd: str, runtime: str) -> str:
+    """Return the runtime-specific fast-path section.
+
+    Args:
+        command_cwd: The session's working directory.
+        runtime: The active runtime.
+
+    Returns:
+        The section, or an empty string when no source supplies one.
+
+    For Claude/Claudex the answer is fixed, because hydration is already done by
+    the package-owned SessionStart adapter and the visible ``OB ✓ gate passed``
+    line is the proof. For every other runtime the block is READ from the
+    source-owned ``AGENTS.md`` rather than restated here — a second copy of a
+    startup recipe is a copy that will be stale the first time the real one
+    changes.
+    """
+    if runtime in _DIRECT_HYDRATION_RUNTIMES:
+        return "\n".join(
+            [
+                "",
+                "## Runtime Fast Path",
+                "Claude/Claudex startup memory hydration is already performed by "
+                "the package-owned direct Open Brain SessionStart adapter.",
+                "- Do not run `mcp2cli open-brain`; that operational path is "
+                "retired and blocked for Claude.",
+                "- Treat the visible `OB ✓ gate passed` line as the direct-recall "
+                "proof.",
+                "- Use `/Volumes/ThunderBolt/Development/_ob/repo-context/"
+                "development.md` only when direct recall is missing, stale, or "
+                "reports `OB ✗ gate unavailable`.",
+            ]
+        )
+
+    candidates = [Path(command_cwd) / "AGENTS.md", _DEVELOPMENT_AGENTS]
+    for path in candidates:
+        try:
+            text = path.read_text(encoding="utf8")
+        except OSError:
+            continue
+        start = text.find(_FAST_PATH_START)
+        end = text.find(_FAST_PATH_END)
+        if start < 0 or end <= start:
+            continue
+        block = text[start : end + len(_FAST_PATH_END)]
+        return "\n".join(
+            [
+                "",
+                "## Runtime Fast Path",
+                "This block was loaded from the source-owned AGENTS.md. For "
+                "startup hydration, run its direct UUID recipe before any help, "
+                "schema, semantic search, or broad filesystem discovery; then run "
+                "its validator and proceed with the user's action.",
+                block,
+            ]
+        )
+    return ""
+
+
+def startup_context(command_cwd: str, runtime: str) -> str:
+    """Render the session-start policy block.
+
+    Args:
+        command_cwd: The session's working directory.
+        runtime: The active runtime.
+
+    Returns:
+        The multi-line block.
+
+    Critical mode is deliberately NOT injected as a default. It is an INVOKED
+    command precisely because a mode that is always on stops being a mode — the
+    challenge degrades into a required field, and invoking it then buys nothing
+    because there is no contrast to switch into. What stays on is the part that
+    should never be a toggle: verify before asserting, and do not agree
+    reflexively.
+    """
+    fast_path = _runtime_fast_path_block(command_cwd, runtime)
+    # NOTE: no blank line after the heading. The TypeScript builds this array
+    # with a `""` separator and then calls `.filter(Boolean)` to drop an absent
+    # fast-path block -- which drops the separator too. That is emitted
+    # behaviour, verified against a recording of the live gate, so reinstating
+    # the "obviously intended" blank line would be a parity failure.
+    lines = [
+        "<!-- Development Policy Refresh: session-start -->",
+        "## Development Policy Refresh",
+        "- Pony style is active by default: identify the owning boundary, make "
+        "the smallest correct owned change, preserve callers/invariants, and "
+        "verify.",
+        '- Say what you mean: verify before asserting. Every factual claim about '
+        "the system comes from something checked this session, not memory or "
+        'inference. Name the exact object. "I don\'t know yet" is a complete '
+        "answer; a guess in the grammar of a fact is not. Do not agree "
+        "reflexively, and do not manufacture a concern to look rigorous.",
+        "- ADHD output shaping is active by default for user-facing responses: "
+        "lead with the next concrete action, number multi-step work, restate "
+        "state each turn, suppress tangents, give task-only time estimates, and "
+        "make wins visible (`_ob/skills/adhd-mode/_DOCS/procedure.md`).",
+        "- Source-of-truth order: live/source files and current system state beat "
+        "OB/qmd, which beat compacted memory or recalled summaries.",
+        "- Hard local rules: no `/bin/bash` on macOS, no system Python for "
+        "project processes, temp work under `{temp_workspace}/{project-or-repo}/"
+        "...` with stale artifacts moved to `_archive/`, temp has no lifetime "
+        "persistence guarantee, no raw `rm -f`/`rm -rf` temp cleanup, no secrets "
+        "in logs/git, no protected-branch mutation.",
+        "- After compaction, resume, or phase change, reread the active router "
+        "and triggered SOPs before risky action.",
+        "- Model routing: the head/controller is Claude Opus 5 at high effort and "
+        "is also the normal Claude workhorse; every worker runs as a Workflow "
+        "`agent()` node, with Claude workers as direct native Workflow models and "
+        "Codex Luna/Sol/Terra through the Workflow-owned non-native "
+        "`codex:codex-rescue` integration; runners own code swarms, highly "
+        "parallel mutation, clean repro, dirty experiments, heavy dependencies, "
+        "detached jobs, and best-of-N; Sonnet max medium; Fable only as an "
+        "explicit non-default low/medium/high route; never Ultra or reasoning "
+        "above high.",
+    ]
+    if fast_path:
+        lines.append(fast_path)
+    lines.append("<!-- End Development Policy Refresh -->")
+    return "\n".join(lines)
+
+
+def stale_context(reason: str) -> str:
+    """Render the stale-policy notice.
+
+    Args:
+        reason: Why policy went stale.
+
+    Returns:
+        The multi-line notice.
+    """
+    return "\n".join(
+        [
+            "<!-- Development Policy Refresh Required -->",
+            "Policy refresh is required before risky action.",
+            f"Reason: {reason}.",
+            "Reread the active router plus triggered SOPs, then restate Pony "
+            "style, critical mode, source order, and next action.",
+            "<!-- End Development Policy Refresh Required -->",
+        ]
+    )
+
+
+def post_compact_requirements() -> str:
+    """Render the requirements that survive a compaction.
+
+    Returns:
+        The multi-line block. These are restated because a compaction summary
+        keeps whatever it keeps, and "the summary probably mentioned it" is not
+        a control.
+    """
+    return "\n".join(
+        [
+            "<!-- Post-Compact Standing Requirements -->",
+            "## Post-Compact Standing Requirements",
+            "",
+            "These requirements survive compaction regardless of what the summary "
+            "retained:",
+            "",
+            "- The pre-merge review gauntlet is MANDATORY at every PR boundary for "
+            "non-trivial behavior/logic changes. Do not mark a PR ready, merge, or "
+            "declare a slice complete without it.",
+            "- Canonical procedure: `/Volumes/ThunderBolt/Development/_ob/skills/"
+            "pre-merge-gauntlet/SKILL.md` (registry: `_ob/skills/registry.json`). "
+            "Reread it before the next PR-boundary action -- do not run the "
+            "gauntlet from memory of the pre-compact context.",
+            "- Reviews run at PR boundaries only; review weight is tiered by blast "
+            "radius (full gauntlet for repo-set/deploy-path code; lighter "
+            "single-review tier for dev tooling/docs). The skill defines the "
+            "current ordering.",
+            "<!-- End Post-Compact Standing Requirements -->",
+        ]
+    )
+
+
+def refresh_context(refreshed: int) -> str:
+    """Render the confirmation printed after an explicit refresh.
+
+    Args:
+        refreshed: How many session states were marked refreshed.
+
+    Returns:
+        The multi-line confirmation, including what must be restated.
+    """
+    plural = "" if refreshed == 1 else "s"
+    return "\n".join(
+        [
+            f"Policy refresh marked complete for {refreshed} session state{plural}.",
+            "",
+            "Restate before acting:",
+            "- Pony: owning boundary, smallest correct owned change, verify.",
+            "- Critical: challenge assumptions, surface risk, ask if ambiguity "
+            "matters.",
+            "- Source order: source/live state > OB/qmd > memory/summary.",
+            "- Next action must name the controlling SOPs and concrete "
+            "verification.",
+        ]
+    )

--- a/python/openbrain-provider/src/openbrain_provider/policy_context.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_context.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Final
 
+from .development_scope import development_root
+
 __all__ = [
     "post_compact_requirements",
     "refresh_context",
@@ -39,7 +41,19 @@ _FAST_PATH_END: Final[str] = "<!-- runtime-fast-path:end -->"
 #: Runtimes whose startup hydration is already done by the Python adapter.
 _DIRECT_HYDRATION_RUNTIMES: Final[frozenset[str]] = frozenset({"claude", "claudex"})
 
-_DEVELOPMENT_AGENTS: Final[Path] = Path("/Volumes/ThunderBolt/Development/AGENTS.md")
+
+def _development_agents() -> Path:
+    """Return the source-owned Development ``AGENTS.md``.
+
+    Derived from `development_root()` rather than written as a literal, so it
+    follows the same root everything else resolves against instead of pinning a
+    path that exists on exactly one machine.
+
+    Returns:
+        The path. It need not exist -- the caller treats an unreadable candidate
+        as simply not supplying a block.
+    """
+    return development_root() / "AGENTS.md"
 
 
 def _runtime_fast_path_block(command_cwd: str, runtime: str) -> str:
@@ -76,7 +90,7 @@ def _runtime_fast_path_block(command_cwd: str, runtime: str) -> str:
             ]
         )
 
-    candidates = [Path(command_cwd) / "AGENTS.md", _DEVELOPMENT_AGENTS]
+    candidates = [Path(command_cwd) / "AGENTS.md", _development_agents()]
     for path in candidates:
         try:
             text = path.read_text(encoding="utf8")

--- a/python/openbrain-provider/src/openbrain_provider/policy_context.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_context.py
@@ -130,7 +130,7 @@ def startup_context(command_cwd: str, runtime: str) -> str:
         "- Pony style is active by default: identify the owning boundary, make "
         "the smallest correct owned change, preserve callers/invariants, and "
         "verify.",
-        '- Say what you mean: verify before asserting. Every factual claim about '
+        "- Say what you mean: verify before asserting. Every factual claim about "
         "the system comes from something checked this session, not memory or "
         'inference. Name the exact object. "I don\'t know yet" is a complete '
         "answer; a guess in the grammar of a fact is not. Do not agree "
@@ -236,7 +236,6 @@ def refresh_context(refreshed: int) -> str:
             "- Critical: challenge assumptions, surface risk, ask if ambiguity "
             "matters.",
             "- Source order: source/live state > OB/qmd > memory/summary.",
-            "- Next action must name the controlling SOPs and concrete "
-            "verification.",
+            "- Next action must name the controlling SOPs and concrete verification.",
         ]
     )

--- a/python/openbrain-provider/src/openbrain_provider/policy_refresh_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_refresh_gate.py
@@ -400,8 +400,7 @@ def _stale_block_reason(gate: _Gate) -> str:
             "Policy refresh is required before risky task action.",
             f"Reason: {reason}.",
             "",
-            "Before continuing, reread the active router and triggered SOPs, "
-            "then run:",
+            "Before continuing, reread the active router and triggered SOPs, then run:",
             command,
             "",
             "Refresh must restate Pony style, critical mode, source-of-truth "

--- a/python/openbrain-provider/src/openbrain_provider/policy_refresh_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_refresh_gate.py
@@ -1,0 +1,574 @@
+"""The policy-refresh gate entrypoint: keep the router in front of risky work.
+
+Purpose:
+    A session's policy goes stale at a compaction, because the summary keeps
+    what it keeps. This gate marks that, injects the router text, and refuses
+    RISKY tool calls until an explicit refresh — while allowing everything
+    harmless and, critically, allowing the refresh command itself.
+
+Architecture:
+    A dispatch shell over one handler per event. Safety refusals live in
+    ``policy_safety``, injected prose in ``policy_context``, the wire protocol in
+    ``hook_io``. Nothing here decides what a command means or what the text says.
+
+Pattern/Convention:
+    THE UNBLOCK MUST BE REACHABLE. A stale session may always run the exact
+    refresh command, checked by ``_is_policy_refresh_tool``. A gate whose escape
+    is itself gated is the deadlock class issue #419 names, arriving through
+    this gate instead of the budget one.
+
+    SAFETY FIRST, STALENESS SECOND. Safety refusals are unconditional and are
+    evaluated before staleness, so a `git reset --hard` is refused whether or
+    not policy is fresh.
+
+Example:
+    >>> import io
+    >>> main(["--event", "user-prompt-submit", "--session-id", "s1",
+    ...       "--state-path", "/dev/null"],
+    ...      stdin=io.StringIO("{}"), stdout=io.StringIO())
+    0
+
+See Also:
+    - ``_ob/scripts/policy-refresh-gate.ts`` — the TypeScript this replaces
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from .hook_io import HookEvent, emit, emit_json, read_hook_event
+from .policy_context import (
+    post_compact_requirements,
+    refresh_context,
+    stale_context,
+    startup_context,
+)
+from .policy_safety import (
+    SHELL_TOOLS,
+    is_risky_tool,
+    pre_tool_advisory,
+    pre_tool_safety_block_reason,
+)
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+__all__ = ["main"]
+
+#: Every event this gate answers.
+_EVENTS: Final[tuple[str, ...]] = (
+    "session-start",
+    "user-prompt-submit",
+    "pre-tool-use",
+    "pre-compact",
+    "post-compact",
+    "refresh",
+)
+
+#: policy-refresh-gate.ts:496-499 — the shape a refresh command must have to be
+#: allowed through a stale block. Deliberately strict: no chaining, no
+#: substitution, no redirect, because "a command that CONTAINS the refresh call"
+#: is not the same thing as "the refresh call".
+_REFRESH_SHELL_UNSAFE: Final[re.Pattern[str]] = re.compile(r"[;&|`$<>]")
+_REFRESH_BUN: Final[re.Pattern[str]] = re.compile(r"(?:^|\s)(?:timeout \d+\s+)?bun\s+")
+_REFRESH_EVENT: Final[re.Pattern[str]] = re.compile(
+    r"(?:^|\s)--event\s+refresh(?:\s|$)"
+)
+
+#: policy-refresh-gate.ts:221-222 — a state file whose block came from a retired
+#: turn/tool threshold resumes clean, because that mechanism no longer exists and
+#: the stored reason would otherwise block forever with no way to satisfy it.
+_LEGACY_THRESHOLD_REASON: Final[re.Pattern[str]] = re.compile(
+    r"^(?:turn|tool) threshold reached:"
+)
+
+
+def _iso_now() -> str:
+    """Return the current instant, ISO-8601 with a Z suffix."""
+    utc = datetime.now(UTC)
+    return f"{utc.strftime('%Y-%m-%dT%H:%M:%S')}.{utc.microsecond // 1000:03d}Z"
+
+
+@dataclass
+class PolicySessionState:
+    """One session's policy-refresh state.
+
+    Attributes:
+        sessionId: The session id.
+        agent: Which agent the state belongs to.
+        cwd: The session's working directory.
+        turnCount: Turns since the last refresh.
+        toolCount: Tool calls since the last refresh.
+        refreshRequired: Whether risky work is currently blocked.
+        reason: Why, when it is.
+        updatedAt: When this entry last changed.
+        totalTurnCount: Turns across the whole session.
+        lastRefreshAt: When policy was last refreshed.
+        lastRefreshEvent: What refreshed it.
+        lastPromptAt: When the last prompt arrived.
+
+    Field names are the on-disk camelCase ones. The file is shared with the
+    running TypeScript gate during the changeover, and the context-budget gate
+    reads ``refreshRequired`` out of it by that exact name
+    (``context-budget-gate.ts:373``), so renaming them here would silently make
+    the status line report unknown forever.
+    """
+
+    sessionId: str  # noqa: N815 -- on-disk key, shared with the TypeScript gate
+    agent: str
+    cwd: str
+    turnCount: int = 0  # noqa: N815
+    toolCount: int = 0  # noqa: N815
+    refreshRequired: bool = False  # noqa: N815
+    reason: str = ""
+    updatedAt: str = ""  # noqa: N815
+    totalTurnCount: int | None = None  # noqa: N815
+    lastRefreshAt: str | None = None  # noqa: N815
+    lastRefreshEvent: str | None = None  # noqa: N815
+    lastPromptAt: str | None = None  # noqa: N815
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the on-disk representation, omitting unset optionals."""
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+@dataclass
+class PolicyStateFile:
+    """The whole policy state file.
+
+    Attributes:
+        sessions: ``<agent>:<session>`` to state.
+    """
+
+    sessions: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def _load_state(state_path: Path) -> PolicyStateFile:
+    """Read the policy state file, or an empty one.
+
+    Args:
+        state_path: The gate's state file.
+
+    Returns:
+        The parsed file. A corrupt file resets rather than raising: this gate
+        runs on every tool call, and an exception here would break every one.
+    """
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        return PolicyStateFile()
+    if not isinstance(raw, dict):
+        return PolicyStateFile()
+    sessions = raw.get("sessions")
+    if not isinstance(sessions, dict):
+        return PolicyStateFile()
+    return PolicyStateFile(sessions=sessions)
+
+
+def _write_state(state_path: Path, state_file: PolicyStateFile) -> None:
+    """Write the policy state file.
+
+    Args:
+        state_path: The gate's state file.
+        state_file: The state to write.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"sessions": state_file.sessions}, indent=2, ensure_ascii=False),
+        encoding="utf8",
+    )
+
+
+def _hydrate(
+    stored: dict[str, Any] | None, session_id: str, agent: str, cwd: str, now: str
+) -> PolicySessionState:
+    """Build a session state from whatever the file held.
+
+    Args:
+        stored: Raw stored entry, or None.
+        session_id: The session id.
+        agent: The agent key.
+        cwd: The session's working directory.
+        now: Current instant.
+
+    Returns:
+        A usable state, with counters coerced to integers and a legacy
+        threshold block cleared.
+    """
+    source = stored if isinstance(stored, dict) else {}
+
+    def integer(key: str) -> int:
+        value = source.get(key)
+        if isinstance(value, bool) or not isinstance(value, int):
+            return 0
+        return value
+
+    def text(key: str) -> str | None:
+        value = source.get(key)
+        return value if isinstance(value, str) else None
+
+    state = PolicySessionState(
+        sessionId=session_id,
+        agent=agent,
+        cwd=cwd,
+        turnCount=integer("turnCount"),
+        toolCount=integer("toolCount"),
+        refreshRequired=bool(source.get("refreshRequired")),
+        reason=text("reason") or "",
+        updatedAt=now,
+        totalTurnCount=integer("totalTurnCount"),
+        lastRefreshAt=text("lastRefreshAt"),
+        lastRefreshEvent=text("lastRefreshEvent"),
+        lastPromptAt=text("lastPromptAt"),
+    )
+    if state.refreshRequired and _LEGACY_THRESHOLD_REASON.match(state.reason):
+        state.refreshRequired = False
+        state.reason = ""
+    return state
+
+
+def _is_policy_refresh_tool(name: str, tool_input: dict[str, Any]) -> bool:
+    """Report whether a call is the exact refresh command, and nothing more.
+
+    Args:
+        name: Tool name in any casing.
+        tool_input: The tool's arguments.
+
+    Returns:
+        True only for a single, unchained `bun … policy-refresh-gate.ts …
+        --event refresh` invocation. This allowance is the ONLY way out of a
+        stale block, so it is checked strictly: a chained or substituted command
+        that merely contains the refresh call is not the refresh call.
+    """
+    if name.lower() not in SHELL_TOOLS:
+        return False
+    for key in ("command", "cmd", "cmdline"):
+        value = tool_input.get(key)
+        if value:
+            command = str(value)
+            break
+    else:
+        return False
+    normalized = re.sub(r"\s+", " ", command.strip())
+    if not normalized or "\n" in normalized:
+        return False
+    if _REFRESH_SHELL_UNSAFE.search(normalized):
+        return False
+    return bool(
+        _REFRESH_BUN.search(normalized)
+        and "policy-refresh-gate.ts" in normalized
+        and _REFRESH_EVENT.search(normalized)
+    )
+
+
+@dataclass
+class _Gate:
+    """One invocation's resolved inputs and state."""
+
+    args: argparse.Namespace
+    event: HookEvent
+    stdout: TextIO | None
+    now: str
+    cwd: str
+    session_id: str
+    state_key: str
+    state_file: PolicyStateFile
+    state: PolicySessionState
+
+    def save(self) -> None:
+        """Persist this session's entry."""
+        self.state_file.sessions[self.state_key] = self.state.to_json()
+        _write_state(self.args.state_path, self.state_file)
+
+    def emit(self, text: str) -> None:
+        """Write plain text to the return channel."""
+        emit(text, self.stdout)
+
+    def emit_json(self, payload: dict[str, Any]) -> None:
+        """Write a JSON verdict to the return channel."""
+        emit_json(payload, self.stdout)
+
+    def save_and_output(self, content: str, *, inject: bool) -> None:
+        """Persist, then emit content in the shape this runtime expects.
+
+        Args:
+            content: The text to inject.
+            inject: Whether this content is an injection rather than a notice.
+
+        Codex takes injected content as a `hookSpecificOutput` envelope; every
+        other runtime takes plain text.
+        """
+        self.save()
+        if not content:
+            return
+        if self.args.runtime == "codex" and inject:
+            self.emit_json(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "SessionStart",
+                        "additionalContext": content,
+                    }
+                }
+            )
+            return
+        self.emit(content)
+
+
+def _handle_session_start(gate: _Gate) -> int:
+    """Reset the session's counters and inject the startup policy block."""
+    state = gate.state
+    state.turnCount = 0
+    state.totalTurnCount = 0
+    state.toolCount = 0
+    state.refreshRequired = False
+    state.reason = ""
+    state.lastRefreshAt = gate.now
+    state.lastRefreshEvent = "session-start"
+    gate.save_and_output(startup_context(gate.cwd, gate.args.runtime), inject=True)
+    return 0
+
+
+def _handle_user_prompt_submit(gate: _Gate) -> int:
+    """Count the turn. Emit nothing: a prompt is not a risky action."""
+    state = gate.state
+    state.turnCount += 1
+    state.totalTurnCount = (state.totalTurnCount or 0) + 1
+    state.lastPromptAt = gate.now
+    gate.save()
+    return 0
+
+
+def _handle_pre_tool_use(gate: _Gate) -> int:
+    """Refuse unsafe calls, refuse risky ones while stale, allow the rest."""
+    gate.state.toolCount += 1
+    gate.save()
+
+    tool_name = gate.event.tool_name
+    tool_input = gate.event.tool_input
+
+    safety = pre_tool_safety_block_reason(tool_name, tool_input, gate.cwd)
+    if safety is not None:
+        gate.emit_json({"decision": "block", "reason": safety})
+        return 0
+
+    # Advisory only, and deliberately NOT an early exit in the blocking sense: a
+    # native Agent call is allowed, but it must still pass the staleness check
+    # below when policy IS stale.
+    advisory = pre_tool_advisory(tool_name, gate.args.runtime)
+    if advisory is not None and not gate.state.refreshRequired:
+        gate.emit_json(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": advisory,
+                }
+            }
+        )
+        return 0
+
+    if gate.state.refreshRequired and _is_policy_refresh_tool(tool_name, tool_input):
+        return 0
+    if gate.state.refreshRequired and is_risky_tool(tool_name, tool_input):
+        gate.emit_json({"decision": "block", "reason": _stale_block_reason(gate)})
+    return 0
+
+
+def _shell_quote(value: str) -> str:
+    """Return a single-quoted shell word."""
+    escaped = value.replace("'", "'\\''")
+    return f"'{escaped}'"
+
+
+def _stale_block_reason(gate: _Gate) -> str:
+    """Render the refusal text, including the exact command that clears it."""
+    reason = gate.state.reason or "refresh marked stale"
+    command = (
+        "bun /Volumes/ThunderBolt/Development/_ob/scripts/policy-refresh-gate.ts "
+        f"--event refresh --agent {gate.args.agent} "
+        f"--session-id {_shell_quote(gate.session_id)}"
+    )
+    return "\n".join(
+        [
+            "Policy refresh is required before risky task action.",
+            f"Reason: {reason}.",
+            "",
+            "Before continuing, reread the active router and triggered SOPs, "
+            "then run:",
+            command,
+            "",
+            "Refresh must restate Pony style, critical mode, source-of-truth "
+            "order, and the next concrete action.",
+        ]
+    )
+
+
+def _handle_compact(gate: _Gate) -> int:
+    """Mark policy stale, and say what survives the compaction."""
+    gate.state.refreshRequired = True
+    gate.state.reason = f"{gate.args.event} marked context as stale"
+    if gate.args.event == "post-compact":
+        content = "\n".join(
+            [stale_context(gate.state.reason), post_compact_requirements()]
+        )
+    else:
+        content = stale_context(gate.state.reason)
+    gate.save_and_output(content, inject=gate.args.event == "post-compact")
+    return 0
+
+
+def _handle_refresh(gate: _Gate) -> int:
+    """Mark policy refreshed and print what must be restated."""
+    refreshed = _refresh_matching_states(gate)
+    _write_state(gate.args.state_path, gate.state_file)
+    gate.emit(refresh_context(refreshed))
+    return 0
+
+
+def _refresh_matching_states(gate: _Gate) -> int:
+    """Refresh this session, or every session for this agent and cwd.
+
+    Args:
+        gate: The invocation.
+
+    Returns:
+        How many states were marked refreshed.
+
+    A refresh naming a session refreshes only that one. A refresh with no
+    session named refreshes every session for the same agent in the same
+    directory, because the operator running it in a terminal cannot know which
+    session id they are in.
+    """
+    explicit = bool(gate.args.session_id or gate.event.session_id)
+    if explicit:
+        keys = [gate.state_key]
+    else:
+        keys = [
+            key
+            for key, candidate in gate.state_file.sessions.items()
+            if isinstance(candidate, dict)
+            and candidate.get("agent") == gate.args.agent
+            and candidate.get("cwd") == gate.cwd
+        ] or [gate.state_key]
+
+    for key in keys:
+        stored = gate.state_file.sessions.get(key)
+        target = (
+            _hydrate(stored, gate.session_id, gate.args.agent, gate.cwd, gate.now)
+            if isinstance(stored, dict)
+            else gate.state
+        )
+        _mark_refreshed(target, gate.now)
+        gate.state_file.sessions[key] = target.to_json()
+
+    if gate.state_key not in keys:
+        _mark_refreshed(gate.state, gate.now)
+    return len(keys)
+
+
+def _mark_refreshed(state: PolicySessionState, now: str) -> None:
+    """Clear a session's staleness and reset its counters."""
+    state.turnCount = 0
+    state.toolCount = 0
+    state.refreshRequired = False
+    state.reason = ""
+    state.lastRefreshAt = now
+    state.lastRefreshEvent = "manual-refresh"
+    state.updatedAt = now
+
+
+#: Event name to handler. A table, not a branch chain.
+_HANDLERS: Final[dict[str, Any]] = {
+    "session-start": _handle_session_start,
+    "user-prompt-submit": _handle_user_prompt_submit,
+    "pre-tool-use": _handle_pre_tool_use,
+    "pre-compact": _handle_compact,
+    "post-compact": _handle_compact,
+    "refresh": _handle_refresh,
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser.
+
+    Returns:
+        The parser. ``--runtime`` defaults to ``--agent`` when unset, matching
+        policy-refresh-gate.ts:47-48.
+    """
+    parser = argparse.ArgumentParser(prog="openbrain-policy-refresh-gate")
+    parser.add_argument("--event", default="session-start", choices=_EVENTS)
+    parser.add_argument("--agent", default="agent")
+    parser.add_argument("--runtime", default="")
+    parser.add_argument("--session-id", default="")
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=Path.home()
+        / ".local"
+        / "state"
+        / "agent-policy-refresh"
+        / "state.json",
+    )
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+) -> int:
+    """Run one gate invocation.
+
+    Args:
+        argv: Command-line arguments. Defaults to ``sys.argv[1:]``.
+        stdin: The hook's stdin. Defaults to ``sys.stdin``.
+        stdout: The return channel. Defaults to ``sys.stdout``.
+
+    Returns:
+        ``0``. This gate never fails a hook: a block is data on stdout.
+    """
+    args = _build_parser().parse_args(sys.argv[1:] if argv is None else argv)
+    if not args.runtime:
+        args.runtime = args.agent
+    event = read_hook_event(stdin)
+    now = _iso_now()
+    cwd = event.cwd or os.getcwd()
+    session_id = args.session_id or event.session_id or f"{args.agent}:{cwd}"
+    state_key = f"{args.agent}:{session_id}"
+    state_file = _load_state(args.state_path)
+    state = _hydrate(
+        state_file.sessions.get(state_key), session_id, args.agent, cwd, now
+    )
+    gate = _Gate(
+        args=args,
+        event=event,
+        stdout=stdout,
+        now=now,
+        cwd=cwd,
+        session_id=session_id,
+        state_key=state_key,
+        state_file=state_file,
+        state=state,
+    )
+    return int(_HANDLERS[args.event](gate))
+
+
+def _cli() -> int:
+    """Console-script entrypoint.
+
+    Returns:
+        The exit code.
+    """
+    return main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/python/openbrain-provider/src/openbrain_provider/policy_safety.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_safety.py
@@ -1,0 +1,432 @@
+"""The unconditional safety blocks the policy gate enforces on every tool call.
+
+Purpose:
+    These refusals do not depend on policy staleness, on a session, or on any
+    state at all. They are hard blocks on a small set of operations that have
+    each already cost real work, and each one carries the incident that put it
+    here.
+
+Architecture:
+    Pure functions over a tool name and its arguments. No state, no I/O except
+    one `git` call to read the current branch. Split out of the entrypoint
+    because a safety refusal and a staleness refusal are different mechanisms
+    with different triggers, and mixing them in one function is how one hides
+    the other (`_plans/python-port-sequence.md`, the two-mechanisms-in-one-file
+    finding).
+
+Pattern/Convention:
+    A block returns a REASON STRING; allow returns ``None``. The reason is
+    operator-facing text naming the correct action, not just the refusal —
+    "there is no such path, use this one" leaves nothing to route around,
+    where a bare "denied" invites a rephrase.
+
+See Also:
+    - ``_ob/scripts/policy-refresh-gate.ts:375-479`` — the TypeScript this ports
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import Any, Final
+
+__all__ = [
+    "SHELL_TOOLS",
+    "is_risky_tool",
+    "pre_tool_advisory",
+    "pre_tool_safety_block_reason",
+    "tmp_write_block_reason",
+]
+
+#: Every spelling of "run a command" across the runtimes.
+SHELL_TOOLS: Final[frozenset[str]] = frozenset(
+    {"bash", "shell", "exec_command", "functions.exec_command"}
+)
+
+#: Every spelling of "write a file".
+_FILE_TOOLS: Final[frozenset[str]] = frozenset({"write", "edit", "notebookedit"})
+
+#: policy-refresh-gate.ts:264-277 — tools whose use is risky while policy is
+#: stale, in every spelling the runtimes send.
+_RISKY_FILE_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "write",
+        "edit",
+        "notebookedit",
+        "apply_patch",
+        "function.apply_patch",
+        "functions.apply_patch",
+        "function.write",
+        "functions.write",
+        "function.edit",
+        "functions.edit",
+        "function.notebookedit",
+        "functions.notebookedit",
+    }
+)
+
+#: policy-refresh-gate.ts:285-287 — shell commands that mutate something.
+_RISKY_COMMAND_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\b(git\s+(commit|push|merge|rebase|checkout|switch|reset)|rm\s+-|mv\s+|cp\s+"
+    r"|scp\s+|ssh\s+|sudo\s+|bun\s+run|npm\s+|pnpm\s+|uv\s+|python\d?\s+|psql\s+"
+    r"|launchctl\s+|brew\s+(install|upgrade|services))\b"
+)
+
+#: policy-refresh-gate.ts:316-321. Stated as ABSENCE, not prohibition: a rule
+#: invites negotiation, "there is no such path" does not. The message names the
+#: real location so the next attempt is correct rather than merely different.
+_TMP_REMEDY: Final[str] = (
+    "There is no writable system temp directory on this machine. $TMPDIR is "
+    "already pointed at this repo's temp workspace, so just use it, or write to "
+    "{temp_workspace}/{project-or-repo}/_scratch/ directly "
+    "(/Volumes/ThunderBolt/_tmp on this Mac, /mnt/collab/tmp_space on cc-* boxes). "
+    "Temp policy: _DOCS/CODING_STANDARDS.md ## Workspace Hygiene."
+)
+
+#: policy-refresh-gate.ts:355. `$TMPDIR` is deliberately NOT matched: every repo
+#: now points it at its own temp-workspace bucket, so writing there is the
+#: CORRECT behaviour and flagging it would punish the right answer. Only literal
+#: system temp paths are refused.
+_TMP_PATH: Final[str] = r"(?:/private)?/tmp/|/var/tmp/"
+_TMP_FILE_PATH: Final[re.Pattern[str]] = re.compile(
+    r"^/(?:private/)?tmp(?:/|$)|^/var/tmp(?:/|$)"
+)
+_TMP_ANYWHERE: Final[re.Pattern[str]] = re.compile(_TMP_PATH)
+_TMP_REDIRECT: Final[re.Pattern[str]] = re.compile(
+    rf"(?:^|[^>\d])\d?>>?\s*[\"']?(?:{_TMP_PATH})"
+)
+_TMP_WRITER: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|(])"
+    r"(?:cp|mv|rsync|touch|mkdir|install|tee|dd|curl|wget|git\s+clone|tar|unzip|zip)"
+    rf"\b[^\n;|&]*?(?:{_TMP_PATH})"
+)
+
+#: policy-refresh-gate.ts:419-436 — the git and gh operations that need an
+#: explicit human decision.
+_GIT_RESET_HARD: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|()])git\s+reset\s+--hard(?:\s|$)", re.IGNORECASE
+)
+_GIT_CHECKOUT_DISCARD: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|()])git\s+checkout\s+--(?:\s|$)", re.IGNORECASE
+)
+_GIT_SWITCH_PROTECTED: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|()])git\s+(?:checkout|switch)\s+(?:main|master)(?:\s|$)", re.IGNORECASE
+)
+_CLAUDE_WORKTREE: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|()])claude\s+(?:(?![#\n]).)*--worktree(?:[=\s]|$)"
+)
+_GH_PR_MERGE: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|()])gh\s+pr\s+merge(?:\s|$)"
+)
+_GH_MERGE_AUTOMATIC: Final[re.Pattern[str]] = re.compile(
+    r"(?:^|\s)--(?:admin|auto)(?:\s|$)"
+)
+_GIT_MUTATES_HISTORY: Final[re.Pattern[str]] = re.compile(
+    r"(^|[\s;&|()])git\s+(?:commit|push)(?:\s|$)", re.IGNORECASE
+)
+_PROTECTED_REF: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:origin\s+)?(?:main|master)(?::|(?:\s|$))", re.IGNORECASE
+)
+_DOUBLE_QUOTED: Final[re.Pattern[str]] = re.compile(r'"(?:[^"\\]|\\.)*"')
+_SINGLE_QUOTED: Final[re.Pattern[str]] = re.compile(r"'[^']*'")
+
+#: policy-refresh-gate.ts:466-473 — the transient image-output directory.
+_GENERATED_DIR: Final[str] = (
+    r"(?:~/\.codex/generated_images/|/Users/rico/\.codex/generated_images/"
+    r"|\$HOME/\.codex/generated_images/|\$\{HOME\}/\.codex/generated_images/)"
+)
+_WRITES_INTO_GENERATED: Final[re.Pattern[str]] = re.compile(
+    rf"(?:>|>>|\b(?:cp|mv|rsync|curl|wget|touch|mkdir|install|tee|dd)\b)"
+    rf"[^\n;|]*?{_GENERATED_DIR}"
+)
+_GENERATED_EGRESS: Final[re.Pattern[str]] = re.compile(
+    rf"^\s*(?:cp|mv)\s+(?:--\s+)?[\"']?{_GENERATED_DIR}[^\s\"']+[\"']?\s+"
+    rf"[\"']?(?!/Users/rico/\.codex(?:/|$))/[^\s\"']+[\"']?\s*$"
+)
+
+#: A branch read that hangs would hang the hook.
+_GIT_TIMEOUT_SECONDS: Final[float] = 0.5
+
+
+def _command_of(tool_input: dict[str, Any]) -> str:
+    """Return the command a shell tool call carries, in any spelling."""
+    for key in ("command", "cmd", "cmdline"):
+        value = tool_input.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _file_path_of(tool_input: dict[str, Any]) -> str:
+    """Return the path a file tool call targets, in any spelling."""
+    for key in ("file_path", "filePath", "path"):
+        value = tool_input.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def tmp_write_block_reason(
+    normalized_name: str, tool_input: dict[str, Any]
+) -> str | None:
+    """Refuse a WRITE into a system temp path, and only a write.
+
+    Args:
+        normalized_name: Lowercased tool name.
+        tool_input: The tool's arguments.
+
+    Returns:
+        The refusal text, or None.
+
+    WHY THIS IS A HOOK AND NOT A RULE. It is the single most-repeated
+    instruction in this repo set and it kept being violated anyway, usually as a
+    one-line redirect buried inside a larger task. `/tmp` is on the small main
+    disk, and on macOS it is per-process sandbox-local: an artifact written
+    there is invisible to runners and to the operator, so "I saved it to /tmp"
+    silently means the work is gone.
+
+    READS ARE ALLOWED. Only writes are refused. Plenty of legitimate work reads
+    system-owned paths under `/tmp` (sockets, other processes' files), and
+    blocking those would break real tasks and teach agents to route around the
+    guard.
+    """
+    if normalized_name in _FILE_TOOLS:
+        path = _file_path_of(tool_input)
+        if _TMP_FILE_PATH.search(path):
+            return (
+                "That path does not exist as an agent-writable location. "
+                f"{_TMP_REMEDY}"
+            )
+        return None
+
+    if normalized_name not in SHELL_TOOLS:
+        return None
+
+    command = _command_of(tool_input)
+    if not command or not _TMP_ANYWHERE.search(command):
+        return None
+
+    # `mktemp` is deliberately allowed: it resolves through $TMPDIR, which every
+    # repo points at its own temp-workspace bucket. `mktemp -p /tmp` still trips
+    # the literal-path check.
+    if _TMP_REDIRECT.search(command) or _TMP_WRITER.search(command):
+        return (
+            "That path is not an agent-writable location: it is on the small main "
+            "disk and is sandbox-local, so anything written there is invisible to "
+            f"runners and to the operator. {_TMP_REMEDY}"
+        )
+    return None
+
+
+def _agent_tool_block_reason(env: dict[str, str]) -> str | None:
+    """Refuse a direct Agent/Task call only under a proxied session.
+
+    Args:
+        env: Environment mapping.
+
+    Returns:
+        The refusal text under Claudex, or None on a native session.
+
+    The failure this prevents is proxy-specific. Under Claudex,
+    `ANTHROPIC_BASE_URL` points at CLIProxyAPI, and an unrouted Agent call
+    silently collapses the worker to the head model -- a Sol session reviewing
+    its own work while the record says Opus did. A native session talks to
+    Anthropic directly and cannot reach that failure mode, so blocking there
+    would refuse a safe operation to prevent an impossible one.
+
+    `--runtime claude` is NOT the test: it is true for both cases. The proxy
+    variable is the honest signal. This block used to be unconditional, and the
+    cost was not just a refused call -- a native session that hits it infers it
+    must be under the Claudex contract and then defends that belief, because a
+    hook that BEHAVES like Claudex is more persuasive than prose saying it is not.
+    """
+    if not env.get("ANTHROPIC_BASE_URL"):
+        return None
+    return (
+        "Direct Agent and Task tools are disabled under Claudex: ANTHROPIC_BASE_URL "
+        "routes through CLIProxyAPI, where an unrouted call collapses the worker to "
+        "the head model. Launch workers only through a Workflow `agent()` node with "
+        "the model and effort pinned per _DOCS/MODEL_ROUTING.md."
+    )
+
+
+def _git_history_block_reason(command: str, command_cwd: str) -> str | None:
+    """Refuse a commit or push that would land on a protected branch.
+
+    Args:
+        command: The shell command.
+        command_cwd: Directory the command would run in.
+
+    Returns:
+        The refusal text, or None.
+    """
+    if not _GIT_MUTATES_HISTORY.search(command):
+        return None
+    # Test the ref pattern only OUTSIDE quoted strings: a commit message
+    # containing the English word "main" is not a push to main. Refspecs
+    # (`git push origin main`) are unquoted and still match.
+    outside_quotes = _SINGLE_QUOTED.sub("''", _DOUBLE_QUOTED.sub('""', command))
+    if _PROTECTED_REF.search(outside_quotes):
+        return (
+            "Codex git guard: do not commit or push directly to main/master "
+            "without explicit approval."
+        )
+    try:
+        completed = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=command_cwd or None,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (
+            "Codex git guard: unable to verify the current branch; commit/push is "
+            "blocked until branch state is readable."
+        )
+    branch = completed.stdout.strip()
+    if branch in ("main", "master"):
+        return (
+            f"Codex git guard: current branch is {branch}; do not commit or push "
+            "from a protected branch."
+        )
+    return None
+
+
+def _shell_safety_block_reason(command: str, command_cwd: str) -> str | None:
+    """Refuse the shell commands that need an explicit human decision.
+
+    Args:
+        command: The shell command.
+        command_cwd: Directory the command would run in.
+
+    Returns:
+        The refusal text, or None.
+    """
+    if _GIT_RESET_HARD.search(command):
+        return "Codex git guard: `git reset --hard` needs explicit user approval."
+    if _GIT_CHECKOUT_DISCARD.search(command):
+        return (
+            "Codex git guard: `git checkout --` can discard work and needs "
+            "explicit user approval."
+        )
+    if _GIT_SWITCH_PROTECTED.search(command):
+        return (
+            "Codex git guard: do not switch to main/master for work; use a "
+            "focused work branch."
+        )
+    if _CLAUDE_WORKTREE.search(command):
+        return (
+            "Do not use `claude --worktree` directly. Use `gwt \"name\"` with the "
+            "intended runtime."
+        )
+    if _GH_PR_MERGE.search(command) and _GH_MERGE_AUTOMATIC.search(command):
+        return (
+            "Codex merge guard: do not use `gh pr merge --admin/--auto`. Inspect "
+            "checks and merge deliberately."
+        )
+
+    history = _git_history_block_reason(command, command_cwd)
+    if history is not None:
+        return history
+
+    if _WRITES_INTO_GENERATED.search(command) and not _GENERATED_EGRESS.search(command):
+        return (
+            "Treat ~/.codex/generated_images as transient output. Move the selected "
+            "image to /Volumes/ThunderBolt/_tmp/_image-gen2/ or the user-requested "
+            "destination."
+        )
+    return None
+
+
+def pre_tool_safety_block_reason(
+    name: str,
+    tool_input: dict[str, Any],
+    command_cwd: str,
+    env: dict[str, str] | None = None,
+) -> str | None:
+    """Return the reason this tool call is refused outright, or None.
+
+    Args:
+        name: Tool name in any casing.
+        tool_input: The tool's arguments.
+        command_cwd: Directory the command would run in.
+        env: Environment mapping. Defaults to ``os.environ``.
+
+    Returns:
+        Operator-facing refusal text, or None to allow.
+    """
+    environment = dict(os.environ) if env is None else env
+    normalized = name.lower()
+
+    tmp_write = tmp_write_block_reason(normalized, tool_input)
+    if tmp_write is not None:
+        return tmp_write
+
+    if normalized in ("agent", "task"):
+        return _agent_tool_block_reason(environment)
+    if normalized == "enterworktree":
+        if tool_input.get("path"):
+            return None
+        return (
+            "Enter only an existing user-approved worktree path; do not create "
+            "nested .claude worktrees."
+        )
+    if normalized not in SHELL_TOOLS:
+        return None
+
+    return _shell_safety_block_reason(_command_of(tool_input), command_cwd)
+
+
+def pre_tool_advisory(
+    name: str, runtime: str, env: dict[str, str] | None = None
+) -> str | None:
+    """Return non-blocking guidance for a direct Agent/Task call, or None.
+
+    Args:
+        name: Tool name in any casing.
+        runtime: The active runtime.
+        env: Environment mapping. Defaults to ``os.environ``.
+
+    Returns:
+        Advisory text, or None.
+
+    A native session MAY use Agent/Task; the Workflow route is still preferred
+    because it pins model and effort. That is guidance, not a safety rule, so it
+    rides `additionalContext` instead of blocking. Codex is excluded: its
+    PreToolUse honours only the FIRST verdict and treats plain stdout as allow,
+    so emitting this there risks eating a real decision.
+    """
+    environment = dict(os.environ) if env is None else env
+    if runtime == "codex":
+        return None
+    if environment.get("ANTHROPIC_BASE_URL"):
+        return None
+    if name.lower() not in ("agent", "task"):
+        return None
+    return (
+        "Native session (no ANTHROPIC_BASE_URL): direct Agent/Task is permitted. "
+        "Prefer a Workflow `agent()` node with model and effort pinned per "
+        "_DOCS/MODEL_ROUTING.md when the work is a delegated worker rather than a "
+        "one-off search."
+    )
+
+
+def is_risky_tool(name: str, tool_input: dict[str, Any]) -> bool:
+    """Report whether this call is risky enough to need fresh policy.
+
+    Args:
+        name: Tool name in any casing.
+        tool_input: The tool's arguments.
+
+    Returns:
+        True for a file mutation, or a shell command that mutates something.
+    """
+    normalized = name.lower()
+    if normalized in _RISKY_FILE_TOOLS:
+        return True
+    if normalized not in SHELL_TOOLS:
+        return False
+    return _RISKY_COMMAND_PATTERN.search(_command_of(tool_input)) is not None

--- a/python/openbrain-provider/src/openbrain_provider/policy_safety.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_safety.py
@@ -195,8 +195,7 @@ def tmp_write_block_reason(
         path = _file_path_of(tool_input)
         if _TMP_FILE_PATH.search(path):
             return (
-                "That path does not exist as an agent-writable location. "
-                f"{_TMP_REMEDY}"
+                f"That path does not exist as an agent-writable location. {_TMP_REMEDY}"
             )
         return None
 
@@ -319,7 +318,7 @@ def _shell_safety_block_reason(command: str, command_cwd: str) -> str | None:
         )
     if _CLAUDE_WORKTREE.search(command):
         return (
-            "Do not use `claude --worktree` directly. Use `gwt \"name\"` with the "
+            'Do not use `claude --worktree` directly. Use `gwt "name"` with the '
             "intended runtime."
         )
     if _GH_PR_MERGE.search(command) and _GH_MERGE_AUTOMATIC.search(command):

--- a/python/openbrain-provider/src/openbrain_provider/receipt_state.py
+++ b/python/openbrain-provider/src/openbrain_provider/receipt_state.py
@@ -1,0 +1,706 @@
+"""Read the provider receipt state both runtimes share.
+
+`~/.local/state/agent-runtime/openbrain-memory/receipts.json` is the ONE file
+the context-budget gate reads to decide whether a durable write or a
+post-compact recall actually happened. Its schema is owned by
+`_ob/scripts/ob-memory-provider/receipt-state.ts`; this module is a reader of
+that same file, not a second definition of it.
+
+**This module reads receipts and writes exactly one thing: the compact cycle
+the gate itself participates in.** Receipts are written by the provider
+capture/checkpoint/recall paths (PROV-6, #415), which are a different lane, and
+nothing here constructs one. The gate must be able to OPEN a compact cycle
+because the correlation id is what the read-back banner prints and what the
+clear path compares against — arming with no id would print an uncorrelated
+command that the allowance then refuses, which is the deadlock this port exists
+to remove (`context-budget-gate.ts:280-286`, `gateCompactCycle`).
+
+That one write uses the same exclusive-create lock protocol and the same atomic
+temp-file rename as the TypeScript writer (`receipt-state.ts:466-498`), so the
+two can run concurrently during the changeover without either seeing a partial
+file.
+
+The schema constants below are transcribed from the TypeScript with line
+citations so a drift is a diff rather than a mystery.
+
+What it does NOT do: it does not decide what the gate should do with the
+evidence (that is `gate_state.py`), and it does not construct receipts.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+from uuid import uuid4
+
+__all__ = [
+    "MEMORY_CONTRACT",
+    "MEMORY_CONTRACT_SCHEMA_HASH",
+    "MEMORY_CONTRACT_SCHEMA_VERSION",
+    "RECEIPT_STATE_SCHEMA",
+    "CompactCycle",
+    "ReceiptEvidence",
+    "current_compact_cycle",
+    "default_receipt_state_path",
+    "find_fresh_receipt",
+    "gate_compact_cycle",
+    "has_verified_compact_recall",
+    "is_correlation_id",
+    "parse_iso",
+]
+
+#: receipt-state.ts:417 — a file declaring any other schema is read as empty.
+RECEIPT_STATE_SCHEMA: Final[str] = "development.openbrain-memory-receipts.v1"
+
+#: receipt-state.ts:92-95. A receipt whose contract triple does not match
+#: exactly is ignored (receipt-state.ts:337-339): an old receipt written under a
+#: superseded contract is not evidence about the current one.
+MEMORY_CONTRACT: Final[str] = "2026-07-23.memory-tools.v23"
+MEMORY_CONTRACT_SCHEMA_VERSION: Final[int] = 1
+MEMORY_CONTRACT_SCHEMA_HASH: Final[str] = (
+    "4b69e9b437c96175531b049b6e3c2782f383334e9e1931e96e73835599e4a4a8"
+)
+
+#: receipt-state.ts:98 — a compact cycle older than this is not the current one.
+COMPACT_CYCLE_MAX_AGE_SECONDS: Final[float] = 20 * 60.0
+#: receipt-state.ts:99 — a verified recall older than this no longer clears.
+VERIFIED_RECALL_MAX_AGE_SECONDS: Final[float] = 2 * 60.0
+#: receipt-state.ts:328 — the default freshness window for a receipt query.
+DEFAULT_RECEIPT_MAX_AGE_SECONDS: Final[float] = 20 * 60.0
+
+#: receipt-state.ts:586. A correlation id that is not a v4 UUID is refused
+#: rather than compared, so a hand-typed or truncated id can never accidentally
+#: equal a cycle id.
+_CORRELATION_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def default_receipt_state_path(env: dict[str, str] | None = None) -> Path:
+    """Return the receipt state path the TypeScript writer uses.
+
+    Args:
+        env: Environment mapping. Defaults to ``os.environ``.
+
+    Returns:
+        ``$XDG_STATE_HOME/agent-runtime/openbrain-memory/receipts.json``, falling
+        back to ``~/.local/state`` — byte-identical to receipt-state.ts:105-108.
+    """
+    import os
+
+    source = dict(os.environ) if env is None else env
+    state_home = source.get("XDG_STATE_HOME", "").strip()
+    root = Path(state_home) if state_home else Path.home() / ".local" / "state"
+    return root / "agent-runtime" / "openbrain-memory" / "receipts.json"
+
+
+def is_correlation_id(value: object) -> bool:
+    """Report whether a value is a well-formed v4 correlation id.
+
+    Args:
+        value: Candidate id.
+
+    Returns:
+        True only for a lowercase v4 UUID string.
+    """
+    return isinstance(value, str) and bool(_CORRELATION_ID_PATTERN.match(value))
+
+
+def parse_iso(value: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp the way ``Date.parse`` does for our writers.
+
+    Args:
+        value: Candidate timestamp, normally ``...Z``.
+
+    Returns:
+        An aware datetime, or None when the value is absent or unparseable. The
+        TypeScript treats an unparseable timestamp as "not fresh" rather than
+        raising, and every caller here does the same.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class ReceiptEvidence:
+    """One recorded provider receipt.
+
+    Attributes:
+        operation: ``recall``, ``capture``, ``checkpoint``, or ``wrap``.
+        mode: ``verified-remote``, ``durable-spool``, or ``failed``.
+        status: The writer's own status word.
+        project: Development project slug the receipt belongs to.
+        session_id: Session the receipt belongs to.
+        trigger: What caused the write.
+        recorded_at: When the writer recorded it.
+        correlation_id: Compact-cycle id, when the receipt is part of one.
+    """
+
+    operation: str
+    mode: str
+    status: str
+    project: str
+    session_id: str
+    trigger: str
+    recorded_at: str
+    correlation_id: str | None = None
+
+    @property
+    def recorded_at_time(self) -> datetime | None:
+        """Return ``recorded_at`` parsed, or None when it is unusable."""
+        return parse_iso(self.recorded_at)
+
+
+@dataclass(frozen=True)
+class CompactCycle:
+    """One compaction, shared by every hook that participates in it.
+
+    Attributes:
+        id: The correlation id every participant quotes.
+        project: Development project slug.
+        session_id: Session the compaction happened in.
+        started_at: When the cycle was opened.
+        verified_recall_at: When a verified recall landed, if one has.
+    """
+
+    id: str
+    project: str
+    session_id: str
+    started_at: str
+    verified_recall_at: str | None = None
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    """Read the receipt state file, or an empty state.
+
+    A corrupt, foreign-schema, or unreadable file reads as empty rather than
+    raising: this state is evidence, and absent evidence is a normal answer
+    (receipt-state.ts:410-434). The gate then keeps enforcing, which is the
+    fail-closed direction for a gate.
+
+    Args:
+        path: Receipt state file.
+
+    Returns:
+        The parsed state, or ``{}`` when it cannot be used.
+    """
+    try:
+        raw = path.read_text(encoding="utf8")
+    except OSError:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    if parsed.get("schema") != RECEIPT_STATE_SCHEMA:
+        return {}
+    if not isinstance(parsed.get("sessions"), dict):
+        return {}
+    return parsed
+
+
+def _evidence_from(entry: object) -> ReceiptEvidence | None:
+    """Build a :class:`ReceiptEvidence` from a raw JSON entry.
+
+    Contract-triple and `fallbackAttempted` checks live here rather than at the
+    query, so an entry that fails them is never constructed at all.
+
+    Args:
+        entry: A raw receipt object from the state file.
+
+    Returns:
+        The evidence, or None when the entry is malformed or off-contract.
+    """
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("contract") != MEMORY_CONTRACT:
+        return None
+    if entry.get("contractSchemaVersion") != MEMORY_CONTRACT_SCHEMA_VERSION:
+        return None
+    if entry.get("contractSchemaHash") != MEMORY_CONTRACT_SCHEMA_HASH:
+        return None
+    # receipt-state.ts:336 — `!== false` rejects a missing field too, so a
+    # receipt that never recorded the flag is not treated as if it had.
+    if entry.get("fallbackAttempted") is not False:
+        return None
+    required = ("operation", "mode", "status", "project", "sessionId", "trigger")
+    if any(not isinstance(entry.get(field), str) for field in required):
+        return None
+    recorded_at = entry.get("recordedAt")
+    if not isinstance(recorded_at, str):
+        return None
+    correlation = entry.get("correlationId")
+    return ReceiptEvidence(
+        operation=str(entry["operation"]),
+        mode=str(entry["mode"]),
+        status=str(entry["status"]),
+        project=str(entry["project"]),
+        session_id=str(entry["sessionId"]),
+        trigger=str(entry["trigger"]),
+        recorded_at=recorded_at,
+        correlation_id=correlation if isinstance(correlation, str) else None,
+    )
+
+
+def _session_candidates(
+    state: dict[str, Any], session_id: str
+) -> list[ReceiptEvidence]:
+    """Collect every usable receipt recorded for one session.
+
+    Both stores are read — the per-operation `sessions` map and the
+    `triggerReceipts` map — because the writer records into both and the newer
+    evidence can be in either (receipt-state.ts:320-324).
+
+    Args:
+        state: Parsed receipt state.
+        session_id: Session to collect for.
+
+    Returns:
+        Every parseable receipt for that session, unsorted.
+    """
+    candidates: list[ReceiptEvidence] = []
+    sessions = state.get("sessions")
+    if isinstance(sessions, dict):
+        operations = sessions.get(session_id)
+        if isinstance(operations, dict):
+            candidates.extend(
+                evidence
+                for entry in operations.values()
+                if (evidence := _evidence_from(entry)) is not None
+            )
+    trigger_receipts = state.get("triggerReceipts")
+    if isinstance(trigger_receipts, dict):
+        session_triggers = trigger_receipts.get(session_id)
+        if isinstance(session_triggers, dict):
+            candidates.extend(
+                evidence
+                for entry in session_triggers.values()
+                if (evidence := _evidence_from(entry)) is not None
+            )
+    return candidates
+
+
+def find_fresh_receipt(
+    path: Path,
+    *,
+    session_id: str,
+    modes: tuple[str, ...],
+    operations: tuple[str, ...],
+    project: str | None = None,
+    trigger: str | None = None,
+    after: str | None = None,
+    max_age_seconds: float = DEFAULT_RECEIPT_MAX_AGE_SECONDS,
+    now: datetime | None = None,
+) -> ReceiptEvidence | None:
+    """Return the newest receipt matching every constraint, or None.
+
+    Args:
+        path: Receipt state file.
+        session_id: Session the receipt must belong to.
+        modes: Acceptable modes. A `failed` receipt is evidence of a failure,
+            never of a write, so callers pass only the modes they accept.
+        operations: Acceptable operations.
+        project: Project the receipt must belong to, when scoping matters.
+        trigger: Trigger the receipt must carry, when it matters.
+        after: Only receipts recorded at or after this instant count. This is
+            what stops a receipt written BEFORE the gate armed from clearing it.
+        max_age_seconds: How old a receipt may be and still count.
+        now: Reference time; defaults to the current instant.
+
+    Returns:
+        The newest qualifying receipt, or None when there is no evidence.
+    """
+    state = _load_state(path)
+    reference = now or datetime.now(UTC)
+    after_time = parse_iso(after) if after else None
+
+    qualifying: list[tuple[datetime, ReceiptEvidence]] = []
+    for evidence in _session_candidates(state, session_id):
+        if evidence.operation not in operations:
+            continue
+        recorded = evidence.recorded_at_time
+        if recorded is None:
+            continue
+        if after_time is not None and recorded < after_time:
+            continue
+        if (reference - recorded).total_seconds() > max_age_seconds:
+            continue
+        if project and evidence.project != project:
+            continue
+        if evidence.mode not in modes:
+            continue
+        if trigger and evidence.trigger != trigger:
+            continue
+        qualifying.append((recorded, evidence))
+
+    if not qualifying:
+        return None
+    qualifying.sort(key=lambda pair: pair[0], reverse=True)
+    return qualifying[0][1]
+
+
+def _cycle_from(entry: object) -> CompactCycle | None:
+    """Build a :class:`CompactCycle` from a raw JSON entry.
+
+    Args:
+        entry: Raw cycle object.
+
+    Returns:
+        The cycle, or None when the entry is malformed.
+    """
+    if not isinstance(entry, dict):
+        return None
+    required = ("id", "project", "sessionId", "startedAt")
+    if any(not isinstance(entry.get(field), str) for field in required):
+        return None
+    verified = entry.get("verifiedRecallAt")
+    return CompactCycle(
+        id=str(entry["id"]),
+        project=str(entry["project"]),
+        session_id=str(entry["sessionId"]),
+        started_at=str(entry["startedAt"]),
+        verified_recall_at=verified if isinstance(verified, str) else None,
+    )
+
+
+def current_compact_cycle(
+    path: Path,
+    *,
+    session_id: str,
+    project: str,
+    max_age_seconds: float = COMPACT_CYCLE_MAX_AGE_SECONDS,
+    now: datetime | None = None,
+) -> CompactCycle | None:
+    """Return the session's live compact cycle, or None.
+
+    Args:
+        path: Receipt state file.
+        session_id: Session to look up.
+        project: Project the cycle must belong to; a cycle from another project
+            is a different piece of work and never matches.
+        max_age_seconds: How old the cycle may be and still be current.
+        now: Reference time; defaults to the current instant.
+
+    Returns:
+        The cycle, or None when there is none, it belongs elsewhere, or it has
+        aged out.
+    """
+    state = _load_state(path)
+    cycles = state.get("compactCycles")
+    if not isinstance(cycles, dict):
+        return None
+    cycle = _cycle_from(cycles.get(session_id))
+    if cycle is None or cycle.project != project:
+        return None
+    started = parse_iso(cycle.started_at)
+    if started is None:
+        return None
+    reference = now or datetime.now(UTC)
+    if (reference - started).total_seconds() > max_age_seconds:
+        return None
+    return cycle
+
+
+def has_verified_compact_recall(
+    path: Path,
+    *,
+    session_id: str,
+    project: str,
+    correlation_id: str,
+    max_age_seconds: float = VERIFIED_RECALL_MAX_AGE_SECONDS,
+    now: datetime | None = None,
+) -> bool:
+    """Report whether the EXACT named compact cycle has a fresh verified recall.
+
+    The exactness is the point. A previous compaction's verified recall must not
+    satisfy a new one, which is why the correlation id is compared rather than
+    just looking for any recent recall (receipt-state.ts:236-244).
+
+    Args:
+        path: Receipt state file.
+        session_id: Session to look up.
+        project: Project the cycle must belong to.
+        correlation_id: The cycle id the gate is waiting on.
+        max_age_seconds: How old the recall may be and still count.
+        now: Reference time; defaults to the current instant.
+
+    Returns:
+        True only when this session's current cycle IS that id and carries a
+        fresh ``verifiedRecallAt``.
+    """
+    if not is_correlation_id(correlation_id):
+        return False
+    state = _load_state(path)
+    cycles = state.get("compactCycles")
+    if not isinstance(cycles, dict):
+        return False
+    cycle = _cycle_from(cycles.get(session_id))
+    if cycle is None or cycle.project != project or cycle.id != correlation_id:
+        return False
+    if cycle.verified_recall_at is None:
+        return False
+    recalled = parse_iso(cycle.verified_recall_at)
+    if recalled is None:
+        return False
+    reference = now or datetime.now(UTC)
+    return (reference - recalled).total_seconds() <= max_age_seconds
+
+
+#: receipt-state.ts:100-102 — how long to wait for another writer's lock, and
+#: when to treat a lock nobody released as abandoned. These are the TypeScript
+#: writer's own values; both processes must agree or one will reclaim a lock the
+#: other still holds.
+_LOCK_WAIT_SECONDS: Final[float] = 5.0
+_STALE_LOCK_SECONDS: Final[float] = 30.0
+_LOCK_RETRY_SECONDS: Final[float] = 0.01
+
+
+def _iso(moment: datetime) -> str:
+    """Render an instant the way JavaScript's ``toISOString`` does.
+
+    Args:
+        moment: The instant.
+
+    Returns:
+        UTC, millisecond precision, ``Z`` suffix. The file is read by both
+        runtimes, so the spelling has to agree.
+    """
+    utc = moment.astimezone(UTC)
+    return f"{utc.strftime('%Y-%m-%dT%H:%M:%S')}.{utc.microsecond // 1000:03d}Z"
+
+
+def _write_state(path: Path, state: dict[str, Any]) -> None:
+    """Write the receipt state atomically and privately.
+
+    Args:
+        path: Receipt state file.
+        state: The whole state to write.
+
+    A temp file in the same directory, fsynced, then renamed: a reader either
+    sees the old file or the new one, never a half-written one. Mode 0600
+    throughout, matching receipt-state.ts:471-481, because this state names
+    sessions and projects.
+    """
+    import os
+
+    encoded = json.dumps(state, indent=2, ensure_ascii=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    temporary = path.with_name(f"{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    descriptor = os.open(
+        temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    temporary.replace(path)
+    path.chmod(0o600)
+
+
+@contextmanager
+def _receipt_lock(path: Path) -> Iterator[None]:
+    """Hold the receipt state's cross-process lock.
+
+    Args:
+        path: Receipt state file.
+
+    Yields:
+        Control, with the lock held.
+
+    Raises:
+        TimeoutError: When another writer holds the lock past
+            :data:`_LOCK_WAIT_SECONDS`. The caller treats that as "no cycle",
+            which keeps the gate blocking rather than arming with a wrong id.
+
+    The lock is an exclusively-created sibling file holding an owner token, the
+    same protocol as receipt-state.ts:483-498. A lock whose mtime is older than
+    :data:`_STALE_LOCK_SECONDS` is reclaimed, because a process killed mid-write
+    would otherwise wedge every later hook.
+    """
+    import os
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f"{path.name}.lock")
+    token = f"{os.getpid()}:{time.time_ns()}:{uuid4()}"
+    deadline = time.monotonic() + _LOCK_WAIT_SECONDS
+
+    while not _create_owned_lock(lock_path, token):
+        if _lock_is_stale(lock_path):
+            lock_path.unlink(missing_ok=True)
+            continue
+        if time.monotonic() >= deadline:
+            raise TimeoutError("receipt state lock timed out")
+        time.sleep(_LOCK_RETRY_SECONDS)
+    try:
+        yield
+    finally:
+        _release_owned_lock(lock_path, token)
+
+
+def _create_owned_lock(lock_path: Path, token: str) -> bool:
+    """Create the lock file exclusively and stamp it with an owner token.
+
+    Args:
+        lock_path: The lock file.
+        token: This process's owner token.
+
+    Returns:
+        True when this process created it; False when someone else holds it.
+    """
+    import os
+
+    try:
+        descriptor = os.open(
+            lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+        )
+    except FileExistsError:
+        return False
+    except OSError:
+        return False
+    with os.fdopen(descriptor, "w", encoding="utf8") as handle:
+        handle.write(token)
+        handle.flush()
+        os.fsync(handle.fileno())
+    return True
+
+
+def _lock_is_stale(lock_path: Path) -> bool:
+    """Report whether a lock has been held longer than any writer should need."""
+    try:
+        age = time.time() - lock_path.stat().st_mtime
+    except OSError:
+        return False
+    return age > _STALE_LOCK_SECONDS
+
+
+def _release_owned_lock(lock_path: Path, token: str) -> None:
+    """Remove the lock only if this process still owns it.
+
+    Args:
+        lock_path: The lock file.
+        token: This process's owner token.
+
+    Checking the token first is what stops a process whose lock was reclaimed as
+    stale from deleting the NEW owner's lock on its way out.
+    """
+    try:
+        if lock_path.read_text(encoding="utf8") == token:
+            lock_path.unlink(missing_ok=True)
+    except OSError:
+        return
+
+
+def gate_compact_cycle(
+    path: Path,
+    *,
+    session_id: str,
+    project: str,
+    now: datetime | None = None,
+    max_age_seconds: float = COMPACT_CYCLE_MAX_AGE_SECONDS,
+) -> CompactCycle | None:
+    """Join the session's live compact cycle, or open one as the gate.
+
+    This is the ONE write this module makes, and it exists because the
+    correlation id is what the read-back banner prints and what the clear path
+    compares. Arming a read-back with no id would print a command the allowance
+    refuses (`gate_shell._valid_provider_payload`), which is precisely the
+    self-inflicted deadlock #419 is about.
+
+    Args:
+        path: Receipt state file.
+        session_id: Session opening or joining the cycle.
+        project: Project the cycle belongs to.
+        now: Reference time; defaults to the current instant.
+        max_age_seconds: How old an existing cycle may be and still be joined.
+
+    Returns:
+        The joined or newly-opened cycle, or None when the lock could not be
+        taken. None keeps the gate blocking without a correlation id rather than
+        inventing one that no provider will ever match.
+    """
+    reference = now or datetime.now(UTC)
+    try:
+        with _receipt_lock(path):
+            state = _load_state(path)
+            if not state:
+                state = {
+                    "schema": RECEIPT_STATE_SCHEMA,
+                    "sessions": {},
+                    "compactCycles": {},
+                }
+            cycles = state.get("compactCycles")
+            if not isinstance(cycles, dict):
+                cycles = {}
+                state["compactCycles"] = cycles
+
+            existing = _cycle_from(cycles.get(session_id))
+            if existing is not None and existing.project == project:
+                started = parse_iso(existing.started_at)
+                fresh = (
+                    started is not None
+                    and (reference - started).total_seconds() <= max_age_seconds
+                )
+                if fresh:
+                    _record_attempt(cycles[session_id], "gate")
+                    _write_state(path, state)
+                    return existing
+
+            cycle = CompactCycle(
+                id=str(uuid4()),
+                project=project,
+                session_id=session_id,
+                started_at=_iso(reference),
+            )
+            cycles[session_id] = {
+                "id": cycle.id,
+                "project": cycle.project,
+                "sessionId": cycle.session_id,
+                "startedAt": cycle.started_at,
+                "participants": [],
+                "attemptedParticipants": ["gate"],
+            }
+            _write_state(path, state)
+            return cycle
+    except (TimeoutError, OSError):
+        return None
+
+
+def _record_attempt(entry: object, participant: str) -> None:
+    """Note that a participant tried to join an existing cycle.
+
+    Args:
+        entry: The raw cycle object being joined.
+        participant: The participant name.
+
+    The TypeScript tracks attempted participants separately from successful ones
+    (receipt-state.ts:188-194), and the difference is diagnostic: a hook that
+    attempted and never succeeded is exactly what a stuck cycle looks like.
+    """
+    if not isinstance(entry, dict):
+        return
+    attempted = entry.get("attemptedParticipants")
+    if not isinstance(attempted, list):
+        attempted = []
+        entry["attemptedParticipants"] = attempted
+    if participant not in attempted:
+        attempted.append(participant)

--- a/python/openbrain-provider/src/openbrain_provider/receipt_state.py
+++ b/python/openbrain-provider/src/openbrain_provider/receipt_state.py
@@ -502,9 +502,7 @@ def _write_state(path: Path, state: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.parent.chmod(0o700)
     temporary = path.with_name(f"{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
-    descriptor = os.open(
-        temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
-    )
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         with os.fdopen(descriptor, "w", encoding="utf8") as handle:
             handle.write(encoded)
@@ -570,9 +568,7 @@ def _create_owned_lock(lock_path: Path, token: str) -> bool:
     import os
 
     try:
-        descriptor = os.open(
-            lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
-        )
+        descriptor = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError:
         return False
     except OSError:

--- a/python/openbrain-provider/tests/conftest.py
+++ b/python/openbrain-provider/tests/conftest.py
@@ -8,14 +8,62 @@ appears in every run gets read as normal and stops being informative.
 
 Removing every sink around each test makes sink state per-test rather than
 per-session.
+
+This module also provisions the Development root the gate scopes by, BEFORE
+`openbrain_provider` is imported anywhere -- see `_install_development_root`.
 """
 
 from __future__ import annotations
 
+import os
+import subprocess
+import tempfile
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 from loguru import logger
+
+
+def _install_development_root() -> None:
+    """Point `OPENBRAIN_DEVELOPMENT_ROOT` at a real directory for this run.
+
+    `resolve_development_scope` asks the FILESYSTEM: the root must exist, be a
+    directory, and share a git object store with the cwd under test. On Rico's
+    Mac `/Volumes/ThunderBolt/Development` satisfies that by accident of where
+    the work happens, so the suite passed locally and 11 tests failed on the
+    Linux CI runner where the path does not exist -- every scope resolved to
+    None and the gate correctly fell silent, which reads as a broken gate.
+
+    Depending on a machine-specific absolute path is the defect. When the real
+    root is absent, this creates a git repository named `Development` and points
+    the override at it, so the project slug and every banner string stay
+    identical to the local run.
+
+    Runs at import time because `DEVELOPMENT_ROOT` is read when
+    `openbrain_provider.development_scope` is first imported, which a fixture
+    would be too late for.
+    """
+    if os.environ.get("OPENBRAIN_DEVELOPMENT_ROOT"):
+        return
+    default = Path("/Volumes/ThunderBolt/Development")
+    if default.is_dir():
+        return
+
+    # Not the temp-workspace rule's business: this is CI's own scratch, chosen
+    # by the runner, and it must not be a path on Rico's machine.
+    root = Path(tempfile.mkdtemp(prefix="openbrain-dev-root-")) / "Development"
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", str(root)],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    os.environ["OPENBRAIN_DEVELOPMENT_ROOT"] = str(root)
+
+
+_install_development_root()
 
 
 @pytest.fixture(autouse=True)

--- a/python/openbrain-provider/tests/fixtures/ts_gate_parity/README.md
+++ b/python/openbrain-provider/tests/fixtures/ts_gate_parity/README.md
@@ -1,0 +1,47 @@
+# Recorded TypeScript-gate I/O — the parity fixtures
+
+`recorded.json` is 33 real invocations of the LIVE TypeScript gates
+(`_ob/scripts/context-budget-gate.ts` and `_ob/scripts/policy-refresh-gate.ts`),
+captured 2026-08-02 by running `record-from-typescript.ts` against them. Each
+entry holds the exact arguments, the exact stdin, and the **byte-exact stdout,
+stderr, and exit code** the gate produced.
+
+## Why these exist
+
+The hook contract IS the bytes. A `decision` key spelled differently is an
+unenforced gate; a recovery command rendered differently is a command the gate
+then refuses. So "behaves similarly" is not the bar for this port — the bar is
+the same bytes on the same input, and only a recording of the real thing can
+state that.
+
+They already earned it once: the recordings caught a blank line. `startup_context`
+looked like it should have one after the `## Development Policy Refresh` heading,
+and the TypeScript emits none — it builds the array with a `""` separator and
+then calls `.filter(Boolean)`, which drops the separator along with an absent
+fast-path block. Nobody would have written that from the source by eye.
+
+## The cases are a SEQUENCE, not a set
+
+Half of them only mean anything in order: a `post-compact` arms a session and the
+next case proves the block. `test_ts_parity.py` replays the whole list against one
+state directory for exactly that reason. Replaying each in a fresh directory would
+test a different program.
+
+## What is normalised
+
+Only two things, because only two things differ between two runs of the *same*
+program: ISO-8601 instants and freshly-generated v4 UUIDs (the compact-cycle
+correlation id). Scratch paths are rewritten to the run's own temp directory.
+Everything else — every word, every separator, every exit code — is compared
+literally. A normaliser that reached further would hide the drift these exist to
+catch.
+
+## Re-recording
+
+```bash
+bun run record-from-typescript.ts
+```
+
+Writes `recorded.json` next to itself. Only re-record when the TypeScript gate's
+behaviour has deliberately changed; re-recording to make a failing test pass
+inverts what the fixture is for.

--- a/python/openbrain-provider/tests/fixtures/ts_gate_parity/record-from-typescript.ts
+++ b/python/openbrain-provider/tests/fixtures/ts_gate_parity/record-from-typescript.ts
@@ -1,0 +1,110 @@
+// Record byte-exact stdin -> stdout/exit fixtures from the LIVE TS gates.
+// These recordings ARE the parity fixtures for the Python port.
+import { mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const OUT = "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gateport-fixtures";
+const SCRIPTS = "/Volumes/ThunderBolt/Development/_ob/scripts";
+mkdirSync(OUT, { recursive: true });
+const scratch = mkdtempSync(join("/Volumes/ThunderBolt/_tmp/open-brain/_scratch", "gaterec-"));
+const settings = join(scratch, "settings.json");
+writeFileSync(settings, "{}");
+
+type Probe = { name: string; script: string; argv: string[]; stdin: Record<string, unknown> };
+
+const budgetState = join(scratch, "budget-state.json");
+const receipts = join(scratch, "receipts.json");
+const policyState = join(scratch, "policy-state.json");
+const spool = join(scratch, "spool.jsonl");
+
+function budgetArgs(event: string, sessionId: string, project: string | null = "Development"): string[] {
+  const a = [
+    join(SCRIPTS, "context-budget-gate.ts"),
+    "--event", event,
+    "--state-path", budgetState,
+    "--receipt-state-path", receipts,
+    "--settings-path", settings,
+    "--policy-state-path", policyState,
+    "--spool-path", spool,
+    "--session-id", sessionId,
+    "--nag-tokens", "200000",
+    "--hard-tokens", "250000",
+  ];
+  if (project) a.push("--project", project);
+  return a;
+}
+
+function policyArgs(event: string, sessionId: string, extra: string[] = []): string[] {
+  return [
+    join(SCRIPTS, "policy-refresh-gate.ts"),
+    "--event", event,
+    "--state-path", join(scratch, "policy-own-state.json"),
+    "--agent", "claude",
+    "--runtime", "claude",
+    "--session-id", sessionId,
+    ...extra,
+  ];
+}
+
+const cwd = "/Volumes/ThunderBolt/Development";
+const probes: Probe[] = [
+  // --- context-budget-gate ---
+  { name: "budget-status-fresh", script: "budget", argv: budgetArgs("status", "rec-1"), stdin: { session_id: "rec-1", cwd } },
+  { name: "budget-user-prompt-submit-clean", script: "budget", argv: budgetArgs("user-prompt-submit", "rec-1"), stdin: { session_id: "rec-1", cwd } },
+  { name: "budget-pre-tool-use-clean", script: "budget", argv: budgetArgs("pre-tool-use", "rec-1"), stdin: { session_id: "rec-1", cwd, tool_name: "Read", tool_input: { file_path: "/x" } } },
+  { name: "budget-session-start-startup", script: "budget", argv: budgetArgs("session-start", "rec-1"), stdin: { session_id: "rec-1", cwd, source: "startup" } },
+  { name: "budget-pre-compact", script: "budget", argv: budgetArgs("pre-compact", "rec-1"), stdin: { session_id: "rec-1", cwd } },
+  { name: "budget-post-compact-arms", script: "budget", argv: budgetArgs("post-compact", "rec-2"), stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-blocked-pre-tool-use", script: "budget", argv: budgetArgs("pre-tool-use", "rec-2"), stdin: { session_id: "rec-2", cwd, tool_name: "Write", tool_input: { file_path: "/x/y" } } },
+  { name: "budget-blocked-user-prompt-submit", script: "budget", argv: budgetArgs("user-prompt-submit", "rec-2"), stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-blocked-allows-read", script: "budget", argv: budgetArgs("pre-tool-use", "rec-2"), stdin: { session_id: "rec-2", cwd, tool_name: "Read", tool_input: { file_path: "/x" } } },
+  { name: "budget-status-blocked", script: "budget", argv: budgetArgs("status", "rec-2"), stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-repair-enter", script: "budget", argv: [...budgetArgs("repair-enter", "rec-2"), "--repair-reason", "recall is broken", "--repair-minutes", "5"], stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-repair-active-bash", script: "budget", argv: budgetArgs("pre-tool-use", "rec-2"), stdin: { session_id: "rec-2", cwd, tool_name: "Bash", tool_input: { command: "echo hi >> notes.txt" } } },
+  { name: "budget-repair-exit", script: "budget", argv: [...budgetArgs("repair-exit", "rec-2"), "--repair-reason", "done"], stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-repair-enter-refused", script: "budget", argv: [...budgetArgs("repair-enter", "rec-2"), "--repair-minutes", "5"], stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-checkpoint-done-refused", script: "budget", argv: budgetArgs("checkpoint-done", "rec-2"), stdin: { session_id: "rec-2", cwd } },
+  { name: "budget-stop-no-work", script: "budget", argv: budgetArgs("stop", "rec-3"), stdin: { session_id: "rec-3", cwd } },
+  { name: "budget-outside-development", script: "budget", argv: budgetArgs("user-prompt-submit", "rec-4", null), stdin: { session_id: "rec-4", cwd: "/Users/rico" } },
+  { name: "budget-empty-stdin", script: "budget", argv: budgetArgs("status", "rec-5"), stdin: {} },
+  // --- policy-refresh-gate ---
+  { name: "policy-session-start", script: "policy", argv: policyArgs("session-start", "pol-1"), stdin: { session_id: "pol-1", cwd } },
+  { name: "policy-user-prompt-submit", script: "policy", argv: policyArgs("user-prompt-submit", "pol-1"), stdin: { session_id: "pol-1", cwd } },
+  { name: "policy-pre-tool-use-harmless", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Read", tool_input: { file_path: "/x" } } },
+  { name: "policy-pre-tool-use-tmp-write", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Write", tool_input: { file_path: "/tmp/evil.txt" } } },
+  { name: "policy-pre-tool-use-tmp-redirect", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Bash", tool_input: { command: "echo hi > /tmp/x.txt" } } },
+  { name: "policy-pre-tool-use-git-reset-hard", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Bash", tool_input: { command: "git reset --hard origin/main" } } },
+  { name: "policy-pre-tool-use-git-checkout-main", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Bash", tool_input: { command: "git checkout main" } } },
+  { name: "policy-pre-tool-use-pr-merge-admin", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Bash", tool_input: { command: "gh pr merge --admin 12" } } },
+  { name: "policy-pre-tool-use-agent", script: "policy", argv: policyArgs("pre-tool-use", "pol-1"), stdin: { session_id: "pol-1", cwd, tool_name: "Agent", tool_input: {} } },
+  { name: "policy-post-compact", script: "policy", argv: policyArgs("post-compact", "pol-2"), stdin: { session_id: "pol-2", cwd } },
+  { name: "policy-pre-compact", script: "policy", argv: policyArgs("pre-compact", "pol-3"), stdin: { session_id: "pol-3", cwd } },
+  { name: "policy-blocked-risky-write", script: "policy", argv: policyArgs("pre-tool-use", "pol-2"), stdin: { session_id: "pol-2", cwd, tool_name: "Write", tool_input: { file_path: "/Volumes/ThunderBolt/Development/x.md" } } },
+  { name: "policy-blocked-allows-refresh-cmd", script: "policy", argv: policyArgs("pre-tool-use", "pol-2"), stdin: { session_id: "pol-2", cwd, tool_name: "Bash", tool_input: { command: "bun /Volumes/ThunderBolt/Development/_ob/scripts/policy-refresh-gate.ts --event refresh --agent claude" } } },
+  { name: "policy-refresh", script: "policy", argv: policyArgs("refresh", "pol-2"), stdin: { session_id: "pol-2", cwd } },
+  { name: "policy-empty-stdin", script: "policy", argv: policyArgs("user-prompt-submit", "pol-9"), stdin: {} },
+];
+
+const recorded: unknown[] = [];
+for (const probe of probes) {
+  const stdin = JSON.stringify(probe.stdin);
+  const result = spawnSync("bun", ["run", ...probe.argv], {
+    input: stdin,
+    encoding: "utf8",
+    shell: false,
+    env: { ...process.env, ANTHROPIC_BASE_URL: "" },
+  });
+  recorded.push({
+    name: probe.name,
+    script: probe.script,
+    argv: probe.argv.slice(1),
+    stdin: probe.stdin,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    status: result.status,
+  });
+  console.log(`${probe.name}: exit=${result.status} stdout=${result.stdout.length}b`);
+}
+writeFileSync(join(OUT, "recorded.json"), JSON.stringify(recorded, null, 2));
+console.log(`\nwrote ${recorded.length} recordings; scratch=${scratch}`);

--- a/python/openbrain-provider/tests/fixtures/ts_gate_parity/recorded.json
+++ b/python/openbrain-provider/tests/fixtures/ts_gate_parity/recorded.json
@@ -1,0 +1,992 @@
+[
+  {
+    "name": "budget-status-fresh",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "status",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-1",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-1",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "{\n  \"sessionId\": \"rec-1\",\n  \"project\": \"Development\",\n  \"contextTokens\": 0,\n  \"nagAt\": 200000,\n  \"hardAt\": 250000,\n  \"checkpointRequired\": false,\n  \"preCompactTaskBlocking\": false,\n  \"readbackRequired\": false,\n  \"captureRequired\": false,\n  \"repairModeActive\": false,\n  \"repairModeEnteredAt\": null,\n  \"repairModeExpiresAt\": null,\n  \"lastWriteAt\": null,\n  \"checkpointAt\": null,\n  \"policyStale\": null,\n  \"spoolPending\": 0,\n  \"statusLine\": \"OB ✓ recall ok · policy — · capture ok · spool 0\",\n  \"pendingClearedNotices\": [],\n  \"transitions\": []\n}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-user-prompt-submit-clean",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "user-prompt-submit",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-1",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-1",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "{\"systemMessage\":\"OB ✓ recall ok · policy — · capture ok · spool 0\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-pre-tool-use-clean",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-1",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Read",
+      "tool_input": {
+        "file_path": "/x"
+      }
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-session-start-startup",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "session-start",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-1",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "source": "startup"
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-pre-compact",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "pre-compact",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-1",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-1",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-post-compact-arms",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "post-compact",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-blocked-pre-tool-use",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/x/y"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"<!-- Context Budget: forced post-compact read-back -->\\nA compact just happened. Task tools are BLOCKED until a fresh direct recall\\nreceipt proves Open Brain was read (the built-in summary is not enough).\\nSessionStart:compact normally runs this automatically. If it did not, run:\\n  printf '%s' '{\\\"cwd\\\":\\\"/Volumes/ThunderBolt/Development\\\",\\\"session_id\\\":\\\"rec-2\\\",\\\"source\\\":\\\"compact\\\",\\\"correlation_id\\\":\\\"1c4be25b-7866-4913-b45b-a168f192984a\\\"}' | bun '/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider.ts' --runtime claude --event session-start\\nA direct receipt unblocks the next gate check; fallback/failed recall does not.\\n<!-- End Context Budget -->\",\"systemMessage\":\"context-budget-gate transition=still-blocking-with-reason reason=readback-required\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-blocked-user-prompt-submit",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "user-prompt-submit",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "{\"systemMessage\":\"OB ✗ recall DUE · policy — · capture ok · spool 0\",\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"<!-- Context Budget: forced post-compact read-back -->\\nA compact just happened. Task tools are BLOCKED until a fresh direct recall\\nreceipt proves Open Brain was read (the built-in summary is not enough).\\nSessionStart:compact normally runs this automatically. If it did not, run:\\n  printf '%s' '{\\\"cwd\\\":\\\"/Volumes/ThunderBolt/Development\\\",\\\"session_id\\\":\\\"rec-2\\\",\\\"source\\\":\\\"compact\\\",\\\"correlation_id\\\":\\\"1c4be25b-7866-4913-b45b-a168f192984a\\\"}' | bun '/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider.ts' --runtime claude --event session-start\\nA direct receipt unblocks the next gate check; fallback/failed recall does not.\\n<!-- End Context Budget -->\"}}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-blocked-allows-read",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Read",
+      "tool_input": {
+        "file_path": "/x"
+      }
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-status-blocked",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "status",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "{\n  \"sessionId\": \"rec-2\",\n  \"project\": \"Development\",\n  \"contextTokens\": 0,\n  \"nagAt\": 200000,\n  \"hardAt\": 250000,\n  \"checkpointRequired\": false,\n  \"preCompactTaskBlocking\": false,\n  \"readbackRequired\": true,\n  \"captureRequired\": false,\n  \"repairModeActive\": false,\n  \"repairModeEnteredAt\": null,\n  \"repairModeExpiresAt\": null,\n  \"lastWriteAt\": null,\n  \"checkpointAt\": null,\n  \"policyStale\": null,\n  \"spoolPending\": 0,\n  \"statusLine\": \"OB ✗ recall DUE · policy — · capture ok · spool 0\",\n  \"pendingClearedNotices\": [],\n  \"transitions\": [\n    {\n      \"name\": \"armed\",\n      \"at\": \"2026-08-03T00:48:35.180Z\",\n      \"reason\": \"post-compact read-back cycle 1c4be25b-7866-4913-b45b-a168f192984a\"\n    },\n    {\n      \"name\": \"still-blocking-with-reason\",\n      \"at\": \"2026-08-03T00:48:35.230Z\",\n      \"reason\": \"readback-required\"\n    }\n  ]\n}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-repair-enter",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "repair-enter",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development",
+      "--repair-reason",
+      "recall is broken",
+      "--repair-minutes",
+      "5"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "context-budget-gate transition=repair-entered reason=expires at 2026-08-03T00:53:35.430Z; recall is broken\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-repair-active-bash",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "echo hi >> notes.txt"
+      }
+    },
+    "stdout": "{\"systemMessage\":\"context-budget-gate transition=repair-active-tool-allowed reason=bash permitted until 2026-08-03T00:53:35.430Z\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-repair-exit",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "repair-exit",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development",
+      "--repair-reason",
+      "done"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "context-budget-gate transition=repair-exited reason=normal enforcement resumed\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-repair-enter-refused",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "repair-enter",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development",
+      "--repair-minutes",
+      "5"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "REFUSED: repair-enter requires --repair-reason and --repair-minutes between 1 and 15.\n",
+    "stderr": "",
+    "status": 1
+  },
+  {
+    "name": "budget-checkpoint-done-refused",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "checkpoint-done",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-2",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "REFUSED: no fresh verified-remote provider checkpoint receipt exists for this session/project. Run the direct ob-memory-provider checkpoint command and retry; spooled, failed, and lost writes do not count.\n",
+    "stderr": "",
+    "status": 1
+  },
+  {
+    "name": "budget-stop-no-work",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "stop",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-3",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {
+      "session_id": "rec-3",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-outside-development",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "user-prompt-submit",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-4",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000"
+    ],
+    "stdin": {
+      "session_id": "rec-4",
+      "cwd": "/Users/rico"
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "budget-empty-stdin",
+    "script": "budget",
+    "argv": [
+      "--event",
+      "status",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/budget-state.json",
+      "--receipt-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/receipts.json",
+      "--settings-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/settings.json",
+      "--policy-state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-state.json",
+      "--spool-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/spool.jsonl",
+      "--session-id",
+      "rec-5",
+      "--nag-tokens",
+      "200000",
+      "--hard-tokens",
+      "250000",
+      "--project",
+      "Development"
+    ],
+    "stdin": {},
+    "stdout": "{\n  \"sessionId\": \"rec-5\",\n  \"project\": \"Development\",\n  \"contextTokens\": 0,\n  \"nagAt\": 200000,\n  \"hardAt\": 250000,\n  \"checkpointRequired\": false,\n  \"preCompactTaskBlocking\": false,\n  \"readbackRequired\": false,\n  \"captureRequired\": false,\n  \"repairModeActive\": false,\n  \"repairModeEnteredAt\": null,\n  \"repairModeExpiresAt\": null,\n  \"lastWriteAt\": null,\n  \"checkpointAt\": null,\n  \"policyStale\": null,\n  \"spoolPending\": 0,\n  \"statusLine\": \"OB ✓ recall ok · policy — · capture ok · spool 0\",\n  \"pendingClearedNotices\": [],\n  \"transitions\": []\n}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-session-start",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "session-start",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "<!-- Development Policy Refresh: session-start -->\n## Development Policy Refresh\n- Pony style is active by default: identify the owning boundary, make the smallest correct owned change, preserve callers/invariants, and verify.\n- Say what you mean: verify before asserting. Every factual claim about the system comes from something checked this session, not memory or inference. Name the exact object. \"I don't know yet\" is a complete answer; a guess in the grammar of a fact is not. Do not agree reflexively, and do not manufacture a concern to look rigorous.\n- ADHD output shaping is active by default for user-facing responses: lead with the next concrete action, number multi-step work, restate state each turn, suppress tangents, give task-only time estimates, and make wins visible (`_ob/skills/adhd-mode/_DOCS/procedure.md`).\n- Source-of-truth order: live/source files and current system state beat OB/qmd, which beat compacted memory or recalled summaries.\n- Hard local rules: no `/bin/bash` on macOS, no system Python for project processes, temp work under `{temp_workspace}/{project-or-repo}/...` with stale artifacts moved to `_archive/`, temp has no lifetime persistence guarantee, no raw `rm -f`/`rm -rf` temp cleanup, no secrets in logs/git, no protected-branch mutation.\n- After compaction, resume, or phase change, reread the active router and triggered SOPs before risky action.\n- Model routing: the head/controller is Claude Opus 5 at high effort and is also the normal Claude workhorse; every worker runs as a Workflow `agent()` node, with Claude workers as direct native Workflow models and Codex Luna/Sol/Terra through the Workflow-owned non-native `codex:codex-rescue` integration; runners own code swarms, highly parallel mutation, clean repro, dirty experiments, heavy dependencies, detached jobs, and best-of-N; Sonnet max medium; Fable only as an explicit non-default low/medium/high route; never Ultra or reasoning above high.\n\n## Runtime Fast Path\nClaude/Claudex startup memory hydration is already performed by the package-owned direct Open Brain SessionStart adapter.\n- Do not run `mcp2cli open-brain`; that operational path is retired and blocked for Claude.\n- Treat the visible `OB ✓ gate passed` line as the direct-recall proof.\n- Use `/Volumes/ThunderBolt/Development/_ob/repo-context/development.md` only when direct recall is missing, stale, or reports `OB ✗ gate unavailable`.\n<!-- End Development Policy Refresh -->\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-user-prompt-submit",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "user-prompt-submit",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-harmless",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Read",
+      "tool_input": {
+        "file_path": "/x"
+      }
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-tmp-write",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/tmp/evil.txt"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"That path does not exist as an agent-writable location. There is no writable system temp directory on this machine. $TMPDIR is already pointed at this repo's temp workspace, so just use it, or write to {temp_workspace}/{project-or-repo}/_scratch/ directly (/Volumes/ThunderBolt/_tmp on this Mac, /mnt/collab/tmp_space on cc-* boxes). Temp policy: _DOCS/CODING_STANDARDS.md ## Workspace Hygiene.\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-tmp-redirect",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "echo hi > /tmp/x.txt"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"That path is not an agent-writable location: it is on the small main disk and is sandbox-local, so anything written there is invisible to runners and to the operator. There is no writable system temp directory on this machine. $TMPDIR is already pointed at this repo's temp workspace, so just use it, or write to {temp_workspace}/{project-or-repo}/_scratch/ directly (/Volumes/ThunderBolt/_tmp on this Mac, /mnt/collab/tmp_space on cc-* boxes). Temp policy: _DOCS/CODING_STANDARDS.md ## Workspace Hygiene.\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-git-reset-hard",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "git reset --hard origin/main"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Codex git guard: `git reset --hard` needs explicit user approval.\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-git-checkout-main",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "git checkout main"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Codex git guard: do not switch to main/master for work; use a focused work branch.\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-pr-merge-admin",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "gh pr merge --admin 12"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Codex merge guard: do not use `gh pr merge --admin/--auto`. Inspect checks and merge deliberately.\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-tool-use-agent",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-1"
+    ],
+    "stdin": {
+      "session_id": "pol-1",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Agent",
+      "tool_input": {}
+    },
+    "stdout": "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"Native session (no ANTHROPIC_BASE_URL): direct Agent/Task is permitted. Prefer a Workflow `agent()` node with model and effort pinned per _DOCS/MODEL_ROUTING.md when the work is a delegated worker rather than a one-off search.\"}}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-post-compact",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "post-compact",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-2"
+    ],
+    "stdin": {
+      "session_id": "pol-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "<!-- Development Policy Refresh Required -->\nPolicy refresh is required before risky action.\nReason: post-compact marked context as stale.\nReread the active router plus triggered SOPs, then restate Pony style, critical mode, source order, and next action.\n<!-- End Development Policy Refresh Required -->\n<!-- Post-Compact Standing Requirements -->\n## Post-Compact Standing Requirements\n\nThese requirements survive compaction regardless of what the summary retained:\n\n- The pre-merge review gauntlet is MANDATORY at every PR boundary for non-trivial behavior/logic changes. Do not mark a PR ready, merge, or declare a slice complete without it.\n- Canonical procedure: `/Volumes/ThunderBolt/Development/_ob/skills/pre-merge-gauntlet/SKILL.md` (registry: `_ob/skills/registry.json`). Reread it before the next PR-boundary action -- do not run the gauntlet from memory of the pre-compact context.\n- Reviews run at PR boundaries only; review weight is tiered by blast radius (full gauntlet for repo-set/deploy-path code; lighter single-review tier for dev tooling/docs). The skill defines the current ordering.\n<!-- End Post-Compact Standing Requirements -->\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-pre-compact",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-compact",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-3"
+    ],
+    "stdin": {
+      "session_id": "pol-3",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "<!-- Development Policy Refresh Required -->\nPolicy refresh is required before risky action.\nReason: pre-compact marked context as stale.\nReread the active router plus triggered SOPs, then restate Pony style, critical mode, source order, and next action.\n<!-- End Development Policy Refresh Required -->\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-blocked-risky-write",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-2"
+    ],
+    "stdin": {
+      "session_id": "pol-2",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/Volumes/ThunderBolt/Development/x.md"
+      }
+    },
+    "stdout": "{\"decision\":\"block\",\"reason\":\"Policy refresh is required before risky task action.\\nReason: post-compact marked context as stale.\\n\\nBefore continuing, reread the active router and triggered SOPs, then run:\\nbun /Volumes/ThunderBolt/Development/_ob/scripts/policy-refresh-gate.ts --event refresh --agent claude --session-id 'pol-2'\\n\\nRefresh must restate Pony style, critical mode, source-of-truth order, and the next concrete action.\"}\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-blocked-allows-refresh-cmd",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "pre-tool-use",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-2"
+    ],
+    "stdin": {
+      "session_id": "pol-2",
+      "cwd": "/Volumes/ThunderBolt/Development",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "bun /Volumes/ThunderBolt/Development/_ob/scripts/policy-refresh-gate.ts --event refresh --agent claude"
+      }
+    },
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-refresh",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "refresh",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-2"
+    ],
+    "stdin": {
+      "session_id": "pol-2",
+      "cwd": "/Volumes/ThunderBolt/Development"
+    },
+    "stdout": "Policy refresh marked complete for 1 session state.\n\nRestate before acting:\n- Pony: owning boundary, smallest correct owned change, verify.\n- Critical: challenge assumptions, surface risk, ask if ambiguity matters.\n- Source order: source/live state > OB/qmd > memory/summary.\n- Next action must name the controlling SOPs and concrete verification.\n",
+    "stderr": "",
+    "status": 0
+  },
+  {
+    "name": "policy-empty-stdin",
+    "script": "policy",
+    "argv": [
+      "--event",
+      "user-prompt-submit",
+      "--state-path",
+      "/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gaterec-6Rlo8p/policy-own-state.json",
+      "--agent",
+      "claude",
+      "--runtime",
+      "claude",
+      "--session-id",
+      "pol-9"
+    ],
+    "stdin": {},
+    "stdout": "",
+    "stderr": "",
+    "status": 0
+  }
+]

--- a/python/openbrain-provider/tests/gate_harness.py
+++ b/python/openbrain-provider/tests/gate_harness.py
@@ -161,15 +161,24 @@ def run_gate(
     stdin_payload.setdefault("session_id", session_id)
     stdin_payload.setdefault("cwd", DEVELOPMENT_CWD)
     argv = [
-        "--event", event,
-        "--state-path", str(paths.state),
-        "--receipt-state-path", str(paths.receipts),
-        "--settings-path", str(paths.settings),
-        "--policy-state-path", str(paths.policy_state),
-        "--spool-path", str(paths.spool),
-        "--session-id", str(stdin_payload["session_id"]),
-        "--nag-tokens", "200000",
-        "--hard-tokens", "250000",
+        "--event",
+        event,
+        "--state-path",
+        str(paths.state),
+        "--receipt-state-path",
+        str(paths.receipts),
+        "--settings-path",
+        str(paths.settings),
+        "--policy-state-path",
+        str(paths.policy_state),
+        "--spool-path",
+        str(paths.spool),
+        "--session-id",
+        str(stdin_payload["session_id"]),
+        "--nag-tokens",
+        "200000",
+        "--hard-tokens",
+        "250000",
     ]
     if project:
         argv += ["--project", project]
@@ -212,11 +221,16 @@ def run_policy_gate(
     stdin_payload.setdefault("session_id", session_id)
     stdin_payload.setdefault("cwd", DEVELOPMENT_CWD)
     argv = [
-        "--event", event,
-        "--state-path", str(state_path),
-        "--agent", agent,
-        "--runtime", runtime,
-        "--session-id", str(stdin_payload["session_id"]),
+        "--event",
+        event,
+        "--state-path",
+        str(state_path),
+        "--agent",
+        agent,
+        "--runtime",
+        runtime,
+        "--session-id",
+        str(stdin_payload["session_id"]),
     ] + (extra or [])
     stdout = io.StringIO()
     code = policy_refresh_gate.main(

--- a/python/openbrain-provider/tests/gate_harness.py
+++ b/python/openbrain-provider/tests/gate_harness.py
@@ -33,6 +33,7 @@ from typing import Any
 from uuid import uuid4
 
 from openbrain_provider import context_budget_gate, policy_refresh_gate
+from openbrain_provider.development_scope import development_root
 from openbrain_provider.receipt_state import (
     MEMORY_CONTRACT,
     MEMORY_CONTRACT_SCHEMA_HASH,
@@ -59,8 +60,13 @@ __all__ = [
 
 #: The Development directory every test claims to run from, so the gate resolves
 #: a real project rather than falling silent outside its lane.
-DEVELOPMENT_CWD = "/Volumes/ThunderBolt/Development"
-PROJECT = "Development"
+#:
+#: Read from the production constant rather than repeated as a literal: on a
+#: machine without Rico's volume, `conftest.py` provisions a stand-in root and
+#: points the override at it, and a second hardcoded copy here would send the
+#: gate a cwd outside the root it actually resolved against.
+DEVELOPMENT_CWD = str(development_root())
+PROJECT = development_root().name
 SESSION = "gate-session"
 
 

--- a/python/openbrain-provider/tests/gate_harness.py
+++ b/python/openbrain-provider/tests/gate_harness.py
@@ -1,0 +1,425 @@
+"""Drive the gates the way a hook does, and write the receipts they read.
+
+Purpose:
+    The behaviour tests need three things the gates do not provide: a scratch
+    state directory, a way to invoke a gate with one event and read its answer,
+    and a way to PUT a provider receipt on disk so the gate has evidence to
+    reconcile against.
+
+Architecture:
+    A helper module, not a test. ``record_receipt`` is the only writer of a
+    receipt anywhere in this package -- the gates read receipts and never write
+    one -- so it lives here, in the tests, rather than being a production
+    function with only test callers.
+
+Pattern/Convention:
+    ``run_gate`` calls ``main()`` in-process with explicit streams rather than
+    spawning a subprocess. Same code path, no interpreter start per case, and a
+    failure surfaces as a Python traceback instead of an exit code.
+
+See Also:
+    - ``_ob/scripts/context-budget-gate-test-helpers.ts`` -- the TypeScript
+      equivalent these are ported from
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from openbrain_provider import context_budget_gate, policy_refresh_gate
+from openbrain_provider.receipt_state import (
+    MEMORY_CONTRACT,
+    MEMORY_CONTRACT_SCHEMA_HASH,
+    MEMORY_CONTRACT_SCHEMA_VERSION,
+    RECEIPT_STATE_SCHEMA,
+)
+
+__all__ = [
+    "PROJECT",
+    "SESSION",
+    "GatePaths",
+    "GateResult",
+    "arm_readback",
+    "gate_paths",
+    "iso",
+    "read_session_state",
+    "receipt_mode",
+    "record_receipt",
+    "run_gate",
+    "run_policy_gate",
+    "start_compact_cycle",
+    "write_session_state",
+]
+
+#: The Development directory every test claims to run from, so the gate resolves
+#: a real project rather than falling silent outside its lane.
+DEVELOPMENT_CWD = "/Volumes/ThunderBolt/Development"
+PROJECT = "Development"
+SESSION = "gate-session"
+
+
+def iso(moment: datetime) -> str:
+    """Render an instant the way the gates do."""
+    utc = moment.astimezone(UTC)
+    return f"{utc.strftime('%Y-%m-%dT%H:%M:%S')}.{utc.microsecond // 1000:03d}Z"
+
+
+def minutes_ago(minutes: float) -> str:
+    """Return an instant that many minutes in the past."""
+    return iso(datetime.now(UTC) - timedelta(minutes=minutes))
+
+
+@dataclass(frozen=True)
+class GatePaths:
+    """The scratch files one test's gate invocations share."""
+
+    root: Path
+    state: Path
+    receipts: Path
+    settings: Path
+    policy_state: Path
+    spool: Path
+
+
+def gate_paths(root: Path) -> GatePaths:
+    """Create a scratch directory with the files a gate expects.
+
+    Args:
+        root: A pytest tmp directory.
+
+    Returns:
+        The paths, with an empty settings file already written.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    settings = root / "settings.json"
+    settings.write_text("{}", encoding="utf8")
+    return GatePaths(
+        root=root,
+        state=root / "gate.json",
+        receipts=root / "receipts.json",
+        settings=settings,
+        policy_state=root / "policy-state.json",
+        spool=root / "spool.jsonl",
+    )
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """One gate invocation's answer."""
+
+    stdout: str
+    code: int
+
+    @property
+    def json(self) -> dict[str, Any]:
+        """Return stdout parsed as JSON.
+
+        Raises:
+            AssertionError: If stdout is not JSON -- which in a test asserting
+                on a verdict means the gate emitted something else entirely.
+        """
+        try:
+            return dict(json.loads(self.stdout))
+        except json.JSONDecodeError as error:
+            raise AssertionError(f"stdout is not JSON: {self.stdout!r}") from error
+
+    @property
+    def blocked(self) -> bool:
+        """Report whether this answer is a block verdict."""
+        return '"decision":"block"' in self.stdout
+
+
+def run_gate(
+    paths: GatePaths,
+    event: str,
+    payload: dict[str, Any] | None = None,
+    extra: list[str] | None = None,
+    *,
+    project: str | None = PROJECT,
+    session_id: str = SESSION,
+) -> GateResult:
+    """Invoke the context-budget gate once.
+
+    Args:
+        paths: The scratch paths.
+        event: The gate event.
+        payload: The hook stdin. Defaults to a Development session.
+        extra: Extra arguments.
+        project: Explicit project, or None to let the cwd decide.
+        session_id: Session the event belongs to.
+
+    Returns:
+        The answer.
+    """
+    stdin_payload = payload if payload is not None else {}
+    stdin_payload.setdefault("session_id", session_id)
+    stdin_payload.setdefault("cwd", DEVELOPMENT_CWD)
+    argv = [
+        "--event", event,
+        "--state-path", str(paths.state),
+        "--receipt-state-path", str(paths.receipts),
+        "--settings-path", str(paths.settings),
+        "--policy-state-path", str(paths.policy_state),
+        "--spool-path", str(paths.spool),
+        "--session-id", str(stdin_payload["session_id"]),
+        "--nag-tokens", "200000",
+        "--hard-tokens", "250000",
+    ]
+    if project:
+        argv += ["--project", project]
+    argv += extra or []
+    stdout = io.StringIO()
+    code = context_budget_gate.main(
+        argv,
+        stdin=io.StringIO(json.dumps(stdin_payload)),
+        stdout=stdout,
+        env={"HOME": str(paths.root)},
+    )
+    return GateResult(stdout=stdout.getvalue(), code=code)
+
+
+def run_policy_gate(
+    state_path: Path,
+    event: str,
+    payload: dict[str, Any] | None = None,
+    extra: list[str] | None = None,
+    *,
+    agent: str = "claude",
+    runtime: str = "claude",
+    session_id: str = SESSION,
+) -> GateResult:
+    """Invoke the policy-refresh gate once.
+
+    Args:
+        state_path: The policy gate's own state file.
+        event: The gate event.
+        payload: The hook stdin.
+        extra: Extra arguments.
+        agent: The agent key.
+        runtime: The runtime.
+        session_id: Session the event belongs to.
+
+    Returns:
+        The answer.
+    """
+    stdin_payload = payload if payload is not None else {}
+    stdin_payload.setdefault("session_id", session_id)
+    stdin_payload.setdefault("cwd", DEVELOPMENT_CWD)
+    argv = [
+        "--event", event,
+        "--state-path", str(state_path),
+        "--agent", agent,
+        "--runtime", runtime,
+        "--session-id", str(stdin_payload["session_id"]),
+    ] + (extra or [])
+    stdout = io.StringIO()
+    code = policy_refresh_gate.main(
+        argv, stdin=io.StringIO(json.dumps(stdin_payload)), stdout=stdout
+    )
+    return GateResult(stdout=stdout.getvalue(), code=code)
+
+
+def read_session_state(paths: GatePaths, session_id: str = SESSION) -> dict[str, Any]:
+    """Read one session's stored gate state.
+
+    Args:
+        paths: The scratch paths.
+        session_id: Session to read.
+
+    Returns:
+        The raw stored entry.
+    """
+    stored = json.loads(paths.state.read_text(encoding="utf8"))
+    return dict(stored["sessions"][session_id])
+
+
+def write_session_state(
+    paths: GatePaths, state: dict[str, Any], session_id: str = SESSION
+) -> None:
+    """Overwrite one session's stored gate state.
+
+    Args:
+        paths: The scratch paths.
+        state: The entry to store.
+        session_id: Session to write.
+
+    This is how a test ages a timestamp: rewriting the stored instant is the
+    only way to prove a fifteen-minute release without waiting fifteen minutes,
+    and it exercises the same code path a real stale state would.
+    """
+    stored = json.loads(paths.state.read_text(encoding="utf8"))
+    stored["sessions"][session_id] = state
+    paths.state.write_text(json.dumps(stored, indent=2), encoding="utf8")
+
+
+def receipt_mode(
+    operation: str, status: str, durable: bool, direct_attempted: bool
+) -> str:
+    """Return the mode a receipt with these properties carries.
+
+    Args:
+        operation: The provider operation.
+        status: The writer's status word.
+        durable: Whether the write is durable.
+        direct_attempted: Whether a direct send was attempted.
+
+    Returns:
+        ``verified-remote``, ``durable-spool``, or ``failed``. Ported from
+        receipt-state.ts:110-124 so the tests build receipts the same way the
+        real writer does, rather than hand-picking a mode that happens to pass.
+    """
+    if operation == "recall":
+        direct = status == "direct" and direct_attempted
+        return "verified-remote" if direct else "failed"
+    if status == "saved" and durable and direct_attempted:
+        return "verified-remote"
+    if status == "spooled" and durable:
+        return "durable-spool"
+    return "failed"
+
+
+def record_receipt(
+    receipts_path: Path,
+    operation: str,
+    status: str,
+    durable: bool,
+    trigger: str = "explicit",
+    recorded_at: str | None = None,
+    correlation_id: str | None = None,
+    *,
+    project: str = PROJECT,
+    session_id: str = SESSION,
+) -> None:
+    """Write one provider receipt into the shared receipt state.
+
+    Args:
+        receipts_path: The receipt state file.
+        operation: The provider operation.
+        status: The writer's status word.
+        durable: Whether the write is durable.
+        trigger: What caused it.
+        recorded_at: When, defaulting to now.
+        correlation_id: Compact cycle id, when it belongs to one.
+        project: Project the receipt belongs to.
+        session_id: Session the receipt belongs to.
+
+    A verified compact recall also stamps ``verifiedRecallAt`` on the matching
+    cycle, mirroring recordProviderReceipt (receipt-state.ts:293-297). Without
+    that the gate would have a receipt and still no cleared read-back, which is
+    a state the real writer cannot produce.
+    """
+    direct_attempted = status != "failed"
+    mode = receipt_mode(operation, status, durable, direct_attempted)
+    moment = recorded_at or iso(datetime.now(UTC))
+
+    try:
+        state = json.loads(receipts_path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    if not isinstance(state, dict) or state.get("schema") != RECEIPT_STATE_SCHEMA:
+        state = {"schema": RECEIPT_STATE_SCHEMA, "sessions": {}, "compactCycles": {}}
+    state.setdefault("sessions", {})
+    state.setdefault("compactCycles", {})
+
+    evidence: dict[str, Any] = {
+        "operation": operation,
+        "mode": mode,
+        "status": status,
+        "project": project,
+        "sessionId": session_id,
+        "trigger": trigger,
+        "directAttempted": direct_attempted,
+        "fallbackAttempted": False,
+        "recordedAt": moment,
+        "contract": MEMORY_CONTRACT,
+        "contractSchemaVersion": MEMORY_CONTRACT_SCHEMA_VERSION,
+        "contractSchemaHash": MEMORY_CONTRACT_SCHEMA_HASH,
+    }
+    if correlation_id:
+        evidence["correlationId"] = correlation_id
+
+    session = state["sessions"].setdefault(session_id, {})
+    session[operation] = evidence
+
+    triggers = state.setdefault("triggerReceipts", {}).setdefault(session_id, {})
+    triggers[f"{operation}:{trigger}:{correlation_id or 'uncorrelated'}"] = evidence
+
+    cycle = state["compactCycles"].get(session_id)
+    if (
+        isinstance(cycle, dict)
+        and correlation_id
+        and cycle.get("id") == correlation_id
+        and cycle.get("project") == project
+        and operation == "recall"
+        and trigger == "compact"
+        and mode == "verified-remote"
+    ):
+        cycle["verifiedRecallAt"] = moment
+
+    receipts_path.parent.mkdir(parents=True, exist_ok=True)
+    receipts_path.write_text(json.dumps(state, indent=2), encoding="utf8")
+
+
+def start_compact_cycle(
+    receipts_path: Path,
+    *,
+    project: str = PROJECT,
+    session_id: str = SESSION,
+    now: datetime | None = None,
+) -> str:
+    """Open a compact cycle as the PROVIDER, before the gate ever runs.
+
+    Args:
+        receipts_path: The receipt state file.
+        project: Project the cycle belongs to.
+        session_id: Session the cycle belongs to.
+        now: When the cycle opened, defaulting to the current instant.
+
+    Returns:
+        The new cycle's correlation id.
+
+    Distinct from ``gate_compact_cycle``: this models the ordering where the
+    provider's PostCompact hook opens the cycle first and the gate joins it,
+    which is the normal live sequence and the one the ordering tests exercise.
+    """
+    moment = now or datetime.now(UTC)
+    try:
+        state = json.loads(receipts_path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    if not isinstance(state, dict) or state.get("schema") != RECEIPT_STATE_SCHEMA:
+        state = {"schema": RECEIPT_STATE_SCHEMA, "sessions": {}, "compactCycles": {}}
+    state.setdefault("sessions", {})
+    cycles = state.setdefault("compactCycles", {})
+    cycle_id = str(uuid4())
+    cycles[session_id] = {
+        "id": cycle_id,
+        "project": project,
+        "sessionId": session_id,
+        "startedAt": iso(moment),
+        "participants": [],
+        "attemptedParticipants": ["post-compact"],
+    }
+    receipts_path.parent.mkdir(parents=True, exist_ok=True)
+    receipts_path.write_text(json.dumps(state, indent=2), encoding="utf8")
+    return cycle_id
+
+
+def arm_readback(paths: GatePaths) -> str:
+    """Fire a post-compact so the read-back requirement is armed.
+
+    Args:
+        paths: The scratch paths.
+
+    Returns:
+        The correlation id the gate armed against.
+    """
+    result = run_gate(paths, "post-compact")
+    assert result.code == 0
+    return str(read_session_state(paths)["readbackCorrelationId"])

--- a/python/openbrain-provider/tests/parity_runner.py
+++ b/python/openbrain-provider/tests/parity_runner.py
@@ -1,0 +1,152 @@
+"""Replay recorded TypeScript-gate I/O through the Python gates.
+
+Purpose:
+    The parity bar for this port is not "similar behaviour", it is the SAME
+    bytes on the same input. The fixtures in ``tests/fixtures/ts_gate_parity/``
+    are recordings of the live TypeScript gates, so this replays each one and
+    compares.
+
+Architecture:
+    A helper, not a test module -- ``test_ts_parity.py`` drives it. Kept
+    separate because the normalisation rules below are the interesting part and
+    they should be readable without the test scaffolding around them.
+
+Pattern/Convention:
+    NORMALISE ONLY WHAT IS GENUINELY NON-DETERMINISTIC. Timestamps and UUIDs
+    differ between two runs of the SAME gate, so comparing them would prove
+    nothing. Everything else -- every word, every separator, every exit code --
+    is compared literally. A normaliser that reached further would hide exactly
+    the drift these fixtures exist to catch.
+
+See Also:
+    - ``tests/fixtures/ts_gate_parity/README.md`` -- how the fixtures were made
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+from pathlib import Path
+from typing import Any, Final
+
+from openbrain_provider import context_budget_gate, policy_refresh_gate
+
+__all__ = ["ParityCase", "load_cases", "normalise", "run_case"]
+
+#: An ISO-8601 instant. Two runs of one gate differ here by construction.
+_TIMESTAMP: Final[re.Pattern[str]] = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"
+)
+
+#: A v4 UUID -- the compact-cycle correlation id, freshly generated per cycle.
+_UUID: Final[re.Pattern[str]] = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+)
+
+#: Scratch paths baked into a recording's arguments.
+_SCRATCH_PATH: Final[re.Pattern[str]] = re.compile(
+    r"/Volumes/ThunderBolt/_tmp/open-brain/_scratch/gate[a-zA-Z0-9-]+"
+)
+
+
+class ParityCase(dict[str, Any]):
+    """One recorded invocation: arguments, stdin, and the observed answer."""
+
+    @property
+    def name(self) -> str:
+        """Return the case name."""
+        return str(self["name"])
+
+    @property
+    def script(self) -> str:
+        """Return which gate produced it: ``budget`` or ``policy``."""
+        return str(self["script"])
+
+    @property
+    def argv(self) -> list[str]:
+        """Return the recorded arguments, minus the script path."""
+        return [str(item) for item in self["argv"]]
+
+    @property
+    def stdin(self) -> dict[str, Any]:
+        """Return the recorded stdin object."""
+        value = self["stdin"]
+        return value if isinstance(value, dict) else {}
+
+    @property
+    def stdout(self) -> str:
+        """Return the recorded stdout."""
+        return str(self["stdout"])
+
+    @property
+    def status(self) -> int:
+        """Return the recorded exit code."""
+        return int(self["status"])
+
+
+def load_cases(fixture: Path) -> list[ParityCase]:
+    """Read the recorded cases.
+
+    Args:
+        fixture: The recordings file.
+
+    Returns:
+        Every recorded case, in order.
+    """
+    raw = json.loads(fixture.read_text(encoding="utf8"))
+    return [ParityCase(entry) for entry in raw]
+
+
+def normalise(text: str, scratch: Path) -> str:
+    """Replace only the genuinely non-deterministic parts of an answer.
+
+    Args:
+        text: Recorded or produced output.
+        scratch: The scratch directory this run used.
+
+    Returns:
+        The text with timestamps, UUIDs, and scratch paths replaced by stable
+        markers. Nothing else is touched.
+    """
+    replaced = _TIMESTAMP.sub("<TIME>", text)
+    replaced = _UUID.sub("<UUID>", replaced)
+    replaced = replaced.replace(str(scratch), "<SCRATCH>")
+    return _SCRATCH_PATH.sub("<SCRATCH>", replaced)
+
+
+def _rewrite_argv(argv: list[str], scratch: Path) -> list[str]:
+    """Point a recording's path arguments at this run's scratch directory.
+
+    Args:
+        argv: The recorded arguments.
+        scratch: This run's scratch directory.
+
+    Returns:
+        The arguments with every recorded scratch path rewritten, and the
+        TypeScript-only ``--gate-script-path`` default preserved so the repair
+        allowances compare like for like.
+    """
+    return [_SCRATCH_PATH.sub(str(scratch), argument) for argument in argv]
+
+
+def run_case(case: ParityCase, scratch: Path) -> tuple[str, int]:
+    """Run one recorded case through the Python gate.
+
+    Args:
+        case: The recorded invocation.
+        scratch: This run's scratch directory.
+
+    Returns:
+        ``(stdout, exit_code)`` from the Python gate.
+    """
+    argv = _rewrite_argv(case.argv, scratch)
+    stdin = io.StringIO(json.dumps(case.stdin))
+    stdout = io.StringIO()
+    if case.script == "budget":
+        code = context_budget_gate.main(
+            argv, stdin=stdin, stdout=stdout, env={"HOME": str(scratch)}
+        )
+    else:
+        code = policy_refresh_gate.main(argv, stdin=stdin, stdout=stdout)
+    return stdout.getvalue(), code

--- a/python/openbrain-provider/tests/parity_runner.py
+++ b/python/openbrain-provider/tests/parity_runner.py
@@ -31,6 +31,10 @@ from pathlib import Path
 from typing import Any, Final
 
 from openbrain_provider import context_budget_gate, policy_refresh_gate
+from openbrain_provider.development_scope import (
+    DEFAULT_DEVELOPMENT_ROOT,
+    development_root,
+)
 
 __all__ = ["ParityCase", "load_cases", "normalise", "run_case"]
 
@@ -106,13 +110,20 @@ def normalise(text: str, scratch: Path) -> str:
         scratch: The scratch directory this run used.
 
     Returns:
-        The text with timestamps, UUIDs, and scratch paths replaced by stable
-        markers. Nothing else is touched.
+        The text with timestamps, UUIDs, scratch paths, and the Development root
+        replaced by stable markers. Nothing else is touched.
     """
     replaced = _TIMESTAMP.sub("<TIME>", text)
     replaced = _UUID.sub("<UUID>", replaced)
     replaced = replaced.replace(str(scratch), "<SCRATCH>")
-    return _SCRATCH_PATH.sub("<SCRATCH>", replaced)
+    replaced = _SCRATCH_PATH.sub("<SCRATCH>", replaced)
+    # The recordings were made on Rico's Mac, where the Development root is
+    # `/Volumes/ThunderBolt/Development`. On a machine without that volume the
+    # suite runs against a provisioned stand-in root, so the root is environment
+    # exactly like a scratch path is -- NOT behaviour. Both spellings collapse to
+    # one marker, which keeps every other byte of the banner compared literally.
+    replaced = replaced.replace(str(development_root()), "<DEV_ROOT>")
+    return replaced.replace(str(DEFAULT_DEVELOPMENT_ROOT), "<DEV_ROOT>")
 
 
 def _rewrite_argv(argv: list[str], scratch: Path) -> list[str]:

--- a/python/openbrain-provider/tests/test_gate_allowance.py
+++ b/python/openbrain-provider/tests/test_gate_allowance.py
@@ -158,9 +158,7 @@ def test_the_recovery_command_is_accepted_in_every_equivalent_spelling(
             id="no-payload",
         ),
         pytest.param(
-            lambda command: command.replace(
-                "--event session-start", "--event capture"
-            ),
+            lambda command: command.replace("--event session-start", "--event capture"),
             id="wrong-event",
         ),
         pytest.param(
@@ -438,7 +436,7 @@ def test_the_read_only_allowance_admits_reading(tmp_path: Path, command: str) ->
     "command",
     [
         "mcp2cli qmd search --params '{}'",
-        "mcp2cli open-brain session_load --params '{\"project\":\"Development\"}'",
+        'mcp2cli open-brain session_load --params \'{"project":"Development"}\'',
     ],
 )
 def test_another_tools_memory_command_is_not_this_gates_evidence(

--- a/python/openbrain-provider/tests/test_gate_allowance.py
+++ b/python/openbrain-provider/tests/test_gate_allowance.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 from gate_harness import (
+    DEVELOPMENT_CWD,
     PROJECT,
     SESSION,
     GatePaths,
@@ -30,10 +31,18 @@ from gate_harness import (
 )
 from test_gate_receipts import _recovery_command
 
+from openbrain_provider.development_scope import development_root
 from openbrain_provider.gate_shell import shell_quote
 
-SIBLING_PROVIDER = "/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider.ts"
-DEVELOPMENT_CWD = "/Volumes/ThunderBolt/Development"
+#: The provider script the gate's `--provider-script-path` default names. Built
+#: from the resolved root for the same reason `gate_harness` builds its cwd that
+#: way -- a hardcoded second copy disagrees with the root the gate resolved
+#: against on any machine that is not Rico's Mac.
+#:
+#: `DEVELOPMENT_CWD` is deliberately NOT redefined here: it is imported from
+#: `gate_harness` above, and shadowing it with a literal is what made five of
+#: these tests pass locally and fail on CI.
+SIBLING_PROVIDER = str(development_root() / "_ob" / "scripts" / "ob-memory-provider.ts")
 
 
 def _bash(command: str) -> dict[str, object]:
@@ -127,6 +136,29 @@ def test_the_printed_recovery_command_is_the_one_the_gate_accepts(
     assert command.endswith("--runtime claude --event session-start")
 
     assert run_gate(paths, "pre-tool-use", _bash(command)).stdout == ""
+
+
+def test_the_fallback_cwd_is_a_directory_that_exists(tmp_path: Path) -> None:
+    # When the hook reports no usable cwd, the banner composes one from the
+    # project. For the Development repo itself the project IS `Development`, and
+    # composing `<root>/<project>` yields `/Volumes/ThunderBolt/Development/
+    # Development` -- a path that does not exist, so the command the operator is
+    # told to paste fails and the block never clears. That is the #419 deadlock
+    # reappearing through the escape hatch meant to resolve it.
+    #
+    # `context-budget-gate.ts:352-355` still composes it that way; this is one of
+    # the bugs the port fixes by writing it correctly rather than porting it.
+    paths = gate_paths(tmp_path)
+    record_receipt(paths.receipts, "recall", "failed", False, "compact")
+    run_gate(paths, "session-start", {"source": "compact", "cwd": DEVELOPMENT_CWD})
+
+    # No cwd on this event: the fallback is what renders.
+    prompted = run_gate(paths, "user-prompt-submit", {"cwd": ""})
+    command = _recovery_command(prompted.stdout)
+
+    assert f'"cwd":"{DEVELOPMENT_CWD}"' in command
+    # The defect's signature: the root's own name appearing twice in a row.
+    assert f"{PROJECT}/{PROJECT}" not in command
 
 
 def test_the_recovery_command_is_accepted_in_every_equivalent_spelling(

--- a/python/openbrain-provider/tests/test_gate_allowance.py
+++ b/python/openbrain-provider/tests/test_gate_allowance.py
@@ -1,0 +1,454 @@
+"""The allowance boundary: exactly what a blocked session may still run.
+
+This is the highest-risk surface in the gate. Every case here is an attempt to
+get a mutating command past a block by dressing it as the escape hatch, and each
+one must be refused -- while the REAL escape hatch, the exact command the gate
+itself printed, must be allowed. Both halves matter: an allowance that is too
+tight is the deadlock #419 names, and one that is too loose is no gate at all.
+
+Ported from `context-budget-gate-provider.test.ts`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from gate_harness import (
+    PROJECT,
+    SESSION,
+    GatePaths,
+    gate_paths,
+    iso,
+    read_session_state,
+    record_receipt,
+    run_gate,
+    start_compact_cycle,
+)
+from test_gate_receipts import _recovery_command
+
+from openbrain_provider.gate_shell import shell_quote
+
+SIBLING_PROVIDER = "/Volumes/ThunderBolt/Development/_ob/scripts/ob-memory-provider.ts"
+DEVELOPMENT_CWD = "/Volumes/ThunderBolt/Development"
+
+
+def _bash(command: str) -> dict[str, object]:
+    """Build a Bash tool call."""
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _recall_command(provider_path: str, correlation: str) -> str:
+    """Build the exact correlated recall command for a provider path."""
+    payload = json.dumps(
+        {
+            "cwd": DEVELOPMENT_CWD,
+            "session_id": SESSION,
+            "source": "compact",
+            "correlation_id": correlation,
+        },
+        separators=(",", ":"),
+    )
+    return (
+        f"printf '%s' {shell_quote(payload)} | bun {shell_quote(provider_path)} "
+        "--runtime claude --event session-start"
+    )
+
+
+def _activated_adapter(root: Path, create_provider: bool = True) -> tuple[str, Path]:
+    """Write a settings file naming an installed sha256 adapter generation.
+
+    Args:
+        root: Scratch directory.
+        create_provider: Whether the provider file actually exists on disk.
+
+    Returns:
+        ``(provider_path, settings_path)``.
+    """
+    adapter_dir = root / "adapters" / "versions" / f"sha256-{'a' * 64}"
+    provider = adapter_dir / "ob-memory-provider.ts"
+    if create_provider:
+        adapter_dir.mkdir(parents=True, exist_ok=True)
+        provider.write_text("// test provider stub\n", encoding="utf8")
+    settings = root / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        f"bun run '{adapter_dir}"
+                                        "/context-budget-gate.ts' "
+                                        "--event pre-tool-use"
+                                    ),
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf8",
+    )
+    return str(provider), settings
+
+
+def test_the_printed_recovery_command_is_the_one_the_gate_accepts(
+    tmp_path: Path,
+) -> None:
+    # The single most important property in this file. If the banner printed a
+    # command the allowance then refused, the operator would be told to run the
+    # one thing that cannot work -- a deadlock with an instruction attached.
+    paths = gate_paths(tmp_path)
+    record_receipt(paths.receipts, "recall", "failed", False, "compact")
+
+    started = run_gate(paths, "session-start", {"source": "compact"})
+    assert started.stdout == ""
+
+    prompted = run_gate(paths, "user-prompt-submit")
+    command = _recovery_command(prompted.stdout)
+
+    # Exactly ONE command is offered. Two would make the operator choose, and a
+    # retired one (`mcp2cli open-brain`) is blocked for Claude entirely.
+    assert len(re.findall(r"ob-memory-provider\.ts", prompted.stdout)) == 1
+    assert "mcp2cli open-brain" not in prompted.stdout
+    assert f'"session_id":"{SESSION}"' in command
+    assert '"source":"compact"' in command
+    assert re.search(r'"correlation_id":"[0-9a-f-]{36}"', command)
+    assert shell_quote(SIBLING_PROVIDER) in command
+    assert command.endswith("--runtime claude --event session-start")
+
+    assert run_gate(paths, "pre-tool-use", _bash(command)).stdout == ""
+
+
+def test_the_recovery_command_is_accepted_in_every_equivalent_spelling(
+    tmp_path: Path,
+) -> None:
+    # An operator does not retype the command byte for byte. `bun run`, the
+    # absolute bun path, and `--flag=value` are the same invocation, and
+    # refusing them would refuse the escape hatch on a technicality.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+    command = _recovery_command(run_gate(paths, "user-prompt-submit").stdout)
+
+    respelled = command.replace(" | bun ", "\n| /opt/homebrew/bin/bun run ").replace(
+        "--runtime claude --event session-start",
+        "--event='session-start' --runtime=\"claude\"",
+    )
+
+    assert run_gate(paths, "pre-tool-use", _bash(respelled)).stdout == ""
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(
+            lambda command: (
+                f"bun {shell_quote(SIBLING_PROVIDER)} "
+                "--runtime claude --event session-start"
+            ),
+            id="no-payload",
+        ),
+        pytest.param(
+            lambda command: command.replace(
+                "--event session-start", "--event capture"
+            ),
+            id="wrong-event",
+        ),
+        pytest.param(
+            lambda command: re.sub(
+                r'"correlation_id":"[0-9a-f-]{36}"',
+                '"correlation_id":"00000000-0000-4000-8000-000000000000"',
+                command,
+            ),
+            id="wrong-cycle",
+        ),
+        pytest.param(
+            lambda command: command.replace(
+                f'"session_id":"{SESSION}"', '"session_id":"someone-else"'
+            ),
+            id="wrong-session",
+        ),
+        pytest.param(lambda command: f"{command} && git push", id="chained"),
+    ],
+)
+def test_a_near_miss_recovery_command_is_refused(
+    tmp_path: Path, mutate: object
+) -> None:
+    # Each of these is one edit away from the real command. A payload-free call
+    # recalls nothing correlated; the wrong event, cycle, or session proves
+    # somebody else's work; and a chained `&& git push` smuggles a mutation in
+    # behind a command the gate approves of.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+    command = _recovery_command(run_gate(paths, "user-prompt-submit").stdout)
+
+    assert callable(mutate)
+    blocked = run_gate(paths, "pre-tool-use", _bash(mutate(command)))
+
+    assert blocked.blocked
+    assert read_session_state(paths)["readbackRequired"] is True
+
+
+def test_the_currently_activated_provider_is_accepted_and_an_impostor_is_not(
+    tmp_path: Path,
+) -> None:
+    # A deployed adapter generation lives at a `sha256-<hash>` path, and that is
+    # the provider actually wired into settings. It is accepted BECAUSE settings
+    # names it -- not because it sits in an adapters directory, which is what
+    # the impostor case proves.
+    paths = gate_paths(tmp_path)
+    provider, settings = _activated_adapter(tmp_path)
+    paths = GatePaths(
+        root=paths.root,
+        state=paths.state,
+        receipts=paths.receipts,
+        settings=settings,
+        policy_state=paths.policy_state,
+        spool=paths.spool,
+    )
+    correlation = start_compact_cycle(paths.receipts)
+    run_gate(paths, "post-compact")
+
+    allowed = run_gate(
+        paths, "pre-tool-use", _bash(_recall_command(provider, correlation))
+    )
+    assert allowed.code == 0
+    assert allowed.stdout == ""
+
+    impostor_dir = tmp_path / "adapters" / "versions" / "evil"
+    impostor_dir.mkdir(parents=True, exist_ok=True)
+    impostor = impostor_dir / "ob-memory-provider.ts"
+    impostor.write_text("// test provider stub\n", encoding="utf8")
+
+    blocked = run_gate(
+        paths, "pre-tool-use", _bash(_recall_command(str(impostor), correlation))
+    )
+    assert blocked.blocked
+
+
+def test_the_hint_names_the_activated_provider_when_the_sibling_is_not_wired(
+    tmp_path: Path,
+) -> None:
+    # The printed command has to name the provider that is actually installed,
+    # or the operator runs a path that is not on the hook chain.
+    paths = gate_paths(tmp_path)
+    provider, settings = _activated_adapter(tmp_path)
+    paths = GatePaths(
+        root=paths.root,
+        state=paths.state,
+        receipts=paths.receipts,
+        settings=settings,
+        policy_state=paths.policy_state,
+        spool=paths.spool,
+    )
+    run_gate(paths, "post-compact")
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    command = _recovery_command(blocked.stdout)
+
+    assert shell_quote(provider) in command
+    assert shell_quote(SIBLING_PROVIDER) not in command
+
+
+@pytest.mark.parametrize(
+    ("name", "malformed", "create_provider"),
+    [("invalid-json", True, True), ("missing-generation", False, False)],
+)
+def test_unreadable_settings_fail_closed(
+    tmp_path: Path, name: str, malformed: bool, create_provider: bool
+) -> None:
+    # Settings that cannot be read, or that name a generation which is not
+    # installed, must NARROW the allowance rather than widen it. Falling back to
+    # "allow any adapter path" on a parse error would make a corrupt file the
+    # way in.
+    root = tmp_path / name
+    root.mkdir(parents=True, exist_ok=True)
+    paths = gate_paths(root)
+    provider, settings = _activated_adapter(root, create_provider)
+    if malformed:
+        settings.write_text("{not-json", encoding="utf8")
+    paths = GatePaths(
+        root=paths.root,
+        state=paths.state,
+        receipts=paths.receipts,
+        settings=settings,
+        policy_state=paths.policy_state,
+        spool=paths.spool,
+    )
+    correlation = start_compact_cycle(paths.receipts)
+    run_gate(paths, "post-compact")
+
+    activated = run_gate(
+        paths, "pre-tool-use", _bash(_recall_command(provider, correlation))
+    )
+    assert activated.blocked
+
+    # The sibling path is still accepted: it is this gate's own configured
+    # provider, so it does not depend on settings being readable at all.
+    sibling = run_gate(
+        paths, "pre-tool-use", _bash(_recall_command(SIBLING_PROVIDER, correlation))
+    )
+    assert sibling.stdout == ""
+
+
+def test_a_realistic_quoted_checkpoint_payload_passes_the_capture_gate(
+    tmp_path: Path,
+) -> None:
+    # A real distilled payload contains quotes, pipes, and a literal
+    # `printf '%s' … | bun` example. The parser must handle the operator's own
+    # content without either refusing it or being fooled by the pipe inside it.
+    paths = gate_paths(tmp_path)
+    transcript = tmp_path / "work.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "implement"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "tool_use", "name": "Write"}]},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf8",
+    )
+    stopped = run_gate(paths, "stop", {"transcript_path": str(transcript)})
+    assert "OB Capture Gate" in stopped.stdout
+
+    payload = json.dumps(
+        {
+            "cwd": DEVELOPMENT_CWD,
+            "session_id": SESSION,
+            "distilled": {
+                "summary": (
+                    "Preserve the user's literal printf '%s' payload | bun "
+                    "recovery example."
+                ),
+                "key_decisions": ["Automatic compaction owns rollover"],
+                "next_steps": [],
+                "receipt_refs": [],
+            },
+        },
+        separators=(",", ":"),
+    )
+    command = (
+        f"printf '%s' {shell_quote(payload)} | bun {shell_quote(SIBLING_PROVIDER)} "
+        "--runtime claude --event checkpoint"
+    )
+
+    assert run_gate(paths, "pre-tool-use", _bash(command)).stdout == ""
+    assert run_gate(paths, "pre-tool-use", _bash(f"{command} && git push")).blocked
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"session_id": SESSION, "project": PROJECT, "age_minutes": 3},
+        {"session_id": "other-session", "project": PROJECT, "age_minutes": 0},
+        {"session_id": SESSION, "project": "other-project", "age_minutes": 0},
+    ],
+    ids=["stale", "cross-session", "cross-project"],
+)
+def test_recall_evidence_outside_this_compaction_never_clears_it(
+    tmp_path: Path, case: dict[str, object]
+) -> None:
+    paths = gate_paths(tmp_path)
+    record_receipt(
+        paths.receipts,
+        "recall",
+        "direct",
+        False,
+        "compact",
+        iso(datetime.now(UTC) - timedelta(minutes=float(str(case["age_minutes"])))),
+        project=str(case["project"]),
+        session_id=str(case["session_id"]),
+    )
+
+    started = run_gate(paths, "session-start", {"source": "compact"})
+
+    assert started.stdout == ""
+    assert read_session_state(paths)["readbackRequired"] is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "env git push",
+        "env rm blocked.ts",
+        "git config user.name changed",
+        "git remote add unsafe example.invalid/repo.git",
+        "git branch unsafe-new-branch",
+        "git -C /some/worktree push",
+        "git -C /some/worktree commit -m x",
+        "git --no-pager -C /some/worktree branch unsafe-new-branch",
+        "git -C --force status",
+    ],
+)
+def test_the_read_only_allowance_does_not_admit_a_mutation(
+    tmp_path: Path, command: str
+) -> None:
+    # `env` prefixes a mutation with a read-only-looking word; `git config`,
+    # `git remote add`, and `git branch <name>` all mutate under a subcommand
+    # whose read-only spelling IS allowed. `git -C --force status` is the parser
+    # test: `-C` taking a flag as its argument must not shift the subcommand.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+
+    assert run_gate(paths, "pre-tool-use", _bash(command)).blocked
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git status --short",
+        "git branch",
+        "git branch --show-current",
+        "printenv HOME",
+        "git -C /some/worktree status",
+        "git -C /some/worktree log --oneline -3",
+        "git --no-pager -C /some/worktree diff",
+        "git -C /some/worktree branch --show-current",
+    ],
+)
+def test_the_read_only_allowance_admits_reading(tmp_path: Path, command: str) -> None:
+    # A blocked session must still be able to LOOK at things. Refusing these
+    # would make the block a total stop, and the operator could not even
+    # diagnose what the gate is waiting for.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+
+    assert run_gate(paths, "pre-tool-use", _bash(command)).stdout == ""
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "mcp2cli qmd search --params '{}'",
+        "mcp2cli open-brain session_load --params '{\"project\":\"Development\"}'",
+    ],
+)
+def test_another_tools_memory_command_is_not_this_gates_evidence(
+    tmp_path: Path, command: str
+) -> None:
+    # These commands may well read Open Brain. They do not produce the receipt
+    # this gate reconciles against, so accepting them would clear a block on the
+    # strength of a side effect nobody verified.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+
+    assert run_gate(paths, "pre-tool-use", _bash(command)).blocked
+    assert read_session_state(paths)["readbackRequired"] is True

--- a/python/openbrain-provider/tests/test_gate_lifecycle.py
+++ b/python/openbrain-provider/tests/test_gate_lifecycle.py
@@ -1,0 +1,261 @@
+"""What the operator SEES, and what the gate remembers between events.
+
+The status line is the gate's whole visible surface. If it reports "ok" for a
+file it could not read, or drops a cleared-notice because the same call was
+blocked for a different reason, the operator is being told the system is
+healthier than it is -- which is the failure the line exists to prevent.
+
+Ported from `context-budget-gate-lifecycle.test.ts`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gate_harness import (
+    SESSION,
+    gate_paths,
+    read_session_state,
+    record_receipt,
+    run_gate,
+)
+
+
+def _work_transcript(root: Path) -> str:
+    """Write a transcript whose latest turn contains a successful Write."""
+    path = root / "work.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "implement"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [{"type": "tool_use", "name": "Write"}]
+                        },
+                    }
+                ),
+            ]
+        ),
+        encoding="utf8",
+    )
+    return str(path)
+
+
+def _policy_state(paths: object, refresh_required: object) -> None:
+    """Write a policy state file the gate will read for this session."""
+    assert hasattr(paths, "policy_state")
+    paths.policy_state.write_text(  # type: ignore[attr-defined]
+        json.dumps(
+            {"sessions": {f"claude:{SESSION}": {"refreshRequired": refresh_required}}}
+        ),
+        encoding="utf8",
+    )
+
+
+def test_token_accounting_includes_cache_reads_and_creation(tmp_path: Path) -> None:
+    # Counting only `input_tokens` under-reports a cached session by the size of
+    # its cache, which is most of it -- so the advisory would fire far too late,
+    # or never.
+    paths = gate_paths(tmp_path)
+    transcript = tmp_path / "tokens.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "usage": {
+                        "input_tokens": 11_000,
+                        "cache_read_input_tokens": 22_000,
+                        "cache_creation_input_tokens": 33_000,
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf8",
+    )
+
+    run_gate(paths, "status", {"transcript_path": str(transcript)})
+
+    assert read_session_state(paths)["contextTokens"] == 66_000
+
+
+def test_a_durable_spool_clears_capture_without_claiming_a_remote_write(
+    tmp_path: Path,
+) -> None:
+    # A spooled write IS durable -- the spool replays it -- so it clears the
+    # capture requirement. The notice says "durable write receipt", not
+    # "verified remotely", because those are different claims and only one of
+    # them is true here.
+    paths = gate_paths(tmp_path)
+    stopped = run_gate(paths, "stop", {"transcript_path": _work_transcript(tmp_path)})
+    assert "OB Capture Gate" in stopped.stdout
+
+    record_receipt(paths.receipts, "capture", "spooled", True)
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+
+    assert '"decision"' not in allowed.stdout
+    assert (
+        allowed.json["systemMessage"]
+        == "OB ✓ capture cleared · durable write receipt verified"
+    )
+    assert read_session_state(paths)["captureRequired"] is False
+
+
+def test_the_status_line_reports_every_gate_every_turn(tmp_path: Path) -> None:
+    paths = gate_paths(tmp_path)
+    _policy_state(paths, False)
+
+    clear = run_gate(paths, "user-prompt-submit")
+    assert clear.json["systemMessage"] == (
+        "OB ✓ recall ok · policy ok · capture ok · spool 0"
+    )
+    assert "hookSpecificOutput" not in clear.json
+
+    run_gate(paths, "session-start", {"source": "compact"})
+    # A truthy non-boolean must read as STALE: the policy gate itself enforces
+    # on truthiness, so reading only `is True` here would disagree with the gate
+    # that owns the field.
+    _policy_state(paths, 1)
+    # The unparseable line is not a pending entry. Counting it would report work
+    # waiting that the spool will never replay.
+    paths.spool.write_text('{"entry":1}\nnot-json\n{"entry":2}\n', encoding="utf8")
+
+    armed = run_gate(paths, "user-prompt-submit")
+    assert (
+        armed.json["systemMessage"]
+        == "OB ✗ recall DUE · policy STALE · capture ok · spool 2"
+    )
+    assert armed.json["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert (
+        "forced post-compact read-back"
+        in armed.json["hookSpecificOutput"]["additionalContext"]
+    )
+
+    status = run_gate(paths, "status").json
+    assert status["policyStale"] is True
+    assert status["spoolPending"] == 2
+    assert status["statusLine"] == (
+        "OB ✗ recall DUE · policy STALE · capture ok · spool 2"
+    )
+
+
+def test_unknown_is_shown_as_unknown_and_the_gate_is_silent_outside_development(
+    tmp_path: Path,
+) -> None:
+    # An absent policy state file is UNKNOWN, not healthy. Rendering it as "ok"
+    # would report a check that never ran as a check that passed -- the same
+    # class of defect as a test suite that skips silently.
+    paths = gate_paths(tmp_path)
+
+    no_policy = run_gate(paths, "user-prompt-submit")
+    assert (
+        no_policy.json["systemMessage"]
+        == "OB ✓ recall ok · policy — · capture ok · spool 0"
+    )
+
+    outside = run_gate(
+        paths,
+        "user-prompt-submit",
+        {"session_id": "outside", "cwd": "/"},
+        project=None,
+        session_id="outside",
+    )
+    assert outside.stdout == ""
+
+
+def test_a_cleared_notice_waits_for_a_surface_that_displays_it(
+    tmp_path: Path,
+) -> None:
+    # `status` observes the clear but must not consume the notice: it is a
+    # diagnostic command, not something the operator is watching. Consuming it
+    # there would mean the one turn that reported the clear was a debug run
+    # nobody saw.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+    correlation = read_session_state(paths)["readbackCorrelationId"]
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+
+    expected = ["read-back cleared · direct recall receipt verified"]
+    assert run_gate(paths, "status").json["pendingClearedNotices"] == expected
+    assert run_gate(paths, "status").json["pendingClearedNotices"] == expected
+
+    prompted = run_gate(paths, "user-prompt-submit")
+    assert prompted.json["systemMessage"] == (
+        "OB ✓ read-back cleared · direct recall receipt verified\n"
+        "OB ✓ recall ok · policy — · capture ok · spool 0"
+    )
+    assert read_session_state(paths)["pendingClearedNotices"] == []
+
+    again = run_gate(paths, "user-prompt-submit")
+    assert again.json["systemMessage"] == (
+        "OB ✓ recall ok · policy — · capture ok · spool 0"
+    )
+
+
+def test_a_notice_queued_during_a_block_survives_to_the_next_allowed_call(
+    tmp_path: Path,
+) -> None:
+    # Two independent gates can be armed at once. When one clears on a call the
+    # OTHER still blocks, the clear must not be swallowed by the block path --
+    # otherwise the operator fixes something and is never told it worked.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "stop", {"transcript_path": _work_transcript(tmp_path)})
+    run_gate(paths, "session-start", {"source": "compact"})
+    correlation = read_session_state(paths)["readbackCorrelationId"]
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    assert blocked.blocked
+    assert read_session_state(paths)["pendingClearedNotices"] == [
+        "read-back cleared · direct recall receipt verified"
+    ]
+
+    record_receipt(paths.receipts, "capture", "spooled", True)
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+    assert allowed.json["systemMessage"] == (
+        "OB ✓ read-back cleared · direct recall receipt verified · "
+        "capture cleared · durable write receipt verified"
+    )
+    assert read_session_state(paths)["pendingClearedNotices"] == []
+
+
+def test_stop_does_not_arm_capture_when_the_turn_did_no_work(tmp_path: Path) -> None:
+    # An advisory turn -- reading, answering a question -- has nothing to
+    # capture. Arming there would block the next tool call over a turn that
+    # produced nothing worth storing.
+    paths = gate_paths(tmp_path)
+    transcript = tmp_path / "idle.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "what is this"}}),
+                json.dumps({"type": "assistant", "message": {"content": "a gate"}}),
+            ]
+        ),
+        encoding="utf8",
+    )
+
+    stopped = run_gate(paths, "stop", {"transcript_path": str(transcript)})
+
+    assert stopped.stdout == ""
+    assert read_session_state(paths)["captureRequired"] is False

--- a/python/openbrain-provider/tests/test_gate_lifecycle.py
+++ b/python/openbrain-provider/tests/test_gate_lifecycle.py
@@ -32,9 +32,7 @@ def _work_transcript(root: Path) -> str:
                 json.dumps(
                     {
                         "type": "assistant",
-                        "message": {
-                            "content": [{"type": "tool_use", "name": "Write"}]
-                        },
+                        "message": {"content": [{"type": "tool_use", "name": "Write"}]},
                     }
                 ),
             ]

--- a/python/openbrain-provider/tests/test_gate_lifecycle.py
+++ b/python/openbrain-provider/tests/test_gate_lifecycle.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from gate_harness import (
     SESSION,
+    GatePaths,
     gate_paths,
     read_session_state,
     record_receipt,
@@ -42,10 +43,14 @@ def _work_transcript(root: Path) -> str:
     return str(path)
 
 
-def _policy_state(paths: object, refresh_required: object) -> None:
-    """Write a policy state file the gate will read for this session."""
-    assert hasattr(paths, "policy_state")
-    paths.policy_state.write_text(  # type: ignore[attr-defined]
+def _policy_state(paths: GatePaths, refresh_required: object) -> None:
+    """Write a policy state file the gate will read for this session.
+
+    `refresh_required` is deliberately `object`: the field arrives from JSON on
+    disk, so a truthy non-bool is a real input the gate has to handle, and one
+    caller below passes `1` to prove it.
+    """
+    paths.policy_state.write_text(
         json.dumps(
             {"sessions": {f"claude:{SESSION}": {"refreshRequired": refresh_required}}}
         ),

--- a/python/openbrain-provider/tests/test_gate_receipts.py
+++ b/python/openbrain-provider/tests/test_gate_receipts.py
@@ -1,0 +1,434 @@
+"""What counts as evidence, and what does not.
+
+The gate's whole authority rests on one judgement: whether a receipt on disk
+proves the thing the block is waiting for. These tests are the boundary of that
+judgement -- the wrong session, the wrong project, the wrong compaction, or an
+old one all look like receipts and none of them count.
+
+Ported from `context-budget-gate.test.ts`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from gate_harness import (
+    PROJECT,
+    SESSION,
+    gate_paths,
+    iso,
+    read_session_state,
+    record_receipt,
+    run_gate,
+    start_compact_cycle,
+)
+
+from openbrain_provider.development_scope import resolve_development_scope
+
+
+def _usage_transcript(root: Path, tokens: int) -> str:
+    """Write a one-line transcript reporting a token total."""
+    path = root / "tokens.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "usage": {
+                        "input_tokens": tokens,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf8",
+    )
+    return str(path)
+
+
+def test_the_project_comes_from_the_git_toplevel(tmp_path: Path) -> None:
+    # The project scopes every piece of state and every receipt query, so a
+    # nested directory inside Development must resolve to the SAME project as
+    # its root -- otherwise a hook fired from a subdirectory would look at an
+    # empty state file and enforce nothing.
+    nested = "/Volumes/ThunderBolt/Development/_ob/scripts"
+    scope = resolve_development_scope(nested)
+    assert scope is not None
+    assert scope.project == PROJECT
+
+    paths = gate_paths(tmp_path)
+    result = run_gate(
+        paths, "status", {"session_id": "nested", "cwd": nested}, project=None
+    )
+    assert result.code == 0
+    assert result.json["project"] == scope.project
+
+
+def test_checkpoint_done_accepts_only_a_verified_remote_receipt(
+    tmp_path: Path,
+) -> None:
+    paths = gate_paths(tmp_path)
+    transcript = _usage_transcript(tmp_path, 260_000)
+
+    warned = run_gate(
+        paths, "user-prompt-submit", {"transcript_path": transcript}
+    )
+    payload = warned.json
+    assert str(payload["systemMessage"]).startswith("OB ")
+    assert "automatic compaction" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "BLOCKED" not in warned.stdout
+    assert read_session_state(paths)["lastNagAtTokens"] == 260_000
+
+    # The same pressure does not nag twice: the count has to climb before the
+    # advisory repeats, or one long session prints it every turn and it becomes
+    # noise nobody reads.
+    renagged = run_gate(paths, "user-prompt-submit", {"transcript_path": transcript})
+    assert "hookSpecificOutput" not in renagged.json
+
+    # Spooled, failed, and lost are all "we did not confirm a remote write".
+    for status, durable in (("spooled", True), ("failed", False), ("lost", False)):
+        record_receipt(paths.receipts, "checkpoint", status, durable)
+        refused = run_gate(paths, "checkpoint-done")
+        assert refused.code == 1, status
+        assert "REFUSED" in refused.stdout, status
+
+    record_receipt(paths.receipts, "checkpoint", "saved", True)
+    accepted = run_gate(paths, "checkpoint-done")
+    assert accepted.code == 0
+    assert "verified remotely" in accepted.stdout
+    assert read_session_state(paths)["checkpointRequired"] is False
+
+
+def test_checkpoint_evidence_is_scoped_and_fresh(tmp_path: Path) -> None:
+    # Three different receipts that all LOOK valid. Each is refused for its own
+    # reason, and each reason is a real leak if it were accepted: another
+    # session's work, another project's work, and work old enough that the
+    # context it proved is gone.
+    paths = gate_paths(tmp_path)
+    cases = [
+        {"session_id": "other-session", "project": PROJECT, "recorded_at": None},
+        {"session_id": SESSION, "project": "other-project", "recorded_at": None},
+        {
+            "session_id": SESSION,
+            "project": PROJECT,
+            "recorded_at": iso(datetime.now(UTC) - timedelta(minutes=21)),
+        },
+    ]
+    for case in cases:
+        record_receipt(
+            paths.receipts,
+            "checkpoint",
+            "saved",
+            True,
+            "explicit",
+            case["recorded_at"],
+            project=str(case["project"]),
+            session_id=str(case["session_id"]),
+        )
+        refused = run_gate(paths, "checkpoint-done")
+        assert refused.code == 1, case
+        assert "REFUSED" in refused.stdout, case
+
+
+def test_a_direct_recall_clears_the_readback_and_a_failed_one_does_not(
+    tmp_path: Path,
+) -> None:
+    paths = gate_paths(tmp_path)
+    armed = run_gate(paths, "session-start", {"source": "compact"})
+    assert armed.stdout == ""
+    correlation = read_session_state(paths)["readbackCorrelationId"]
+    assert correlation
+
+    # A FAILED recall is a receipt. It is not evidence of a recall.
+    record_receipt(
+        paths.receipts, "recall", "failed", False, "compact", None, correlation
+    )
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    assert blocked.blocked
+
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+    assert '"decision"' not in allowed.stdout
+    assert (
+        allowed.json["systemMessage"]
+        == "OB ✓ read-back cleared · direct recall receipt verified"
+    )
+    assert run_gate(paths, "status").json["readbackRequired"] is False
+
+
+def test_a_recall_recorded_before_the_gate_ran_still_counts(tmp_path: Path) -> None:
+    # Hook ordering is not guaranteed. The provider's recall can land before the
+    # gate's own hook fires, and requiring the gate to observe the arming first
+    # would block a session whose recall demonstrably succeeded.
+    paths = gate_paths(tmp_path)
+    correlation = start_compact_cycle(paths.receipts)
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+
+    started = run_gate(paths, "session-start", {"source": "compact"})
+
+    assert started.code == 0
+    assert started.stdout == ""
+    assert read_session_state(paths)["readbackRequired"] is False
+
+
+def test_a_post_compact_gate_accepts_the_same_cycles_earlier_recall(
+    tmp_path: Path,
+) -> None:
+    paths = gate_paths(tmp_path)
+    correlation = start_compact_cycle(paths.receipts)
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+
+    compacted = run_gate(paths, "post-compact")
+    assert compacted.code == 0
+    assert read_session_state(paths)["readbackRequired"] is True
+
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": "bun -e 'process.exit(0)'"}},
+    )
+    assert '"decision"' not in allowed.stdout
+    assert "read-back cleared" in allowed.stdout
+    assert read_session_state(paths)["readbackRequired"] is False
+
+
+def test_a_legacy_correlation_is_recovered_only_from_the_matching_window(
+    tmp_path: Path,
+) -> None:
+    # A state file written by an older revision can carry an armed read-back
+    # with no correlation id. Adopting the live cycle is right ONLY when the
+    # timings say it is the same compaction; adopting any recent cycle would let
+    # an unrelated compaction's recall clear this block.
+    paths = gate_paths(tmp_path)
+    started_at = datetime.now(UTC) - timedelta(minutes=5)
+    correlation = start_compact_cycle(paths.receipts, now=started_at)
+
+    _write_legacy_state(paths.state, iso(started_at + timedelta(seconds=1)))
+    prompted = run_gate(paths, "user-prompt-submit")
+    command = _recovery_command(prompted.stdout)
+    assert f'"correlation_id":"{correlation}"' in command
+
+    allowed = run_gate(
+        paths, "pre-tool-use", {"tool_name": "Bash", "tool_input": {"command": command}}
+    )
+    assert allowed.stdout == ""
+
+    # Same command, but the stored arming instant no longer matches the cycle:
+    # a different compaction, so the correlation is not adopted and the command
+    # no longer proves anything.
+    _write_legacy_state(paths.state, iso(datetime.now(UTC)))
+    mismatched = run_gate(
+        paths, "pre-tool-use", {"tool_name": "Bash", "tool_input": {"command": command}}
+    )
+    assert mismatched.blocked
+
+
+def test_post_compact_blocks_until_the_exact_cycle_recall_arrives(
+    tmp_path: Path,
+) -> None:
+    paths = gate_paths(tmp_path)
+    correlation = start_compact_cycle(paths.receipts)
+    run_gate(paths, "post-compact")
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    assert blocked.blocked
+
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+    assert '"decision"' not in allowed.stdout
+    assert "read-back cleared" in allowed.stdout
+    assert read_session_state(paths)["readbackRequired"] is False
+
+
+def test_a_prior_cycles_verified_recall_does_not_satisfy_a_new_compaction(
+    tmp_path: Path,
+) -> None:
+    # The exactness of the correlation id is the whole mechanism. If any recent
+    # verified recall counted, a session that compacts twice in a minute would
+    # have its second compaction cleared by its first, and the second context
+    # would never actually be read back.
+    paths = gate_paths(tmp_path)
+    prior = start_compact_cycle(
+        paths.receipts, now=datetime.now(UTC) - timedelta(seconds=9)
+    )
+    record_receipt(paths.receipts, "recall", "direct", False, "compact", None, prior)
+    current = start_compact_cycle(paths.receipts)
+    assert current != prior
+
+    started = run_gate(paths, "session-start", {"source": "compact"})
+    assert started.stdout == ""
+    assert read_session_state(paths)["readbackRequired"] is True
+
+
+def test_an_uncorrelated_recall_never_satisfies_a_compaction(tmp_path: Path) -> None:
+    # A recall with no correlation id at all is the pre-compaction one. It
+    # proves the OLD context was read, which is exactly the context the
+    # compaction discarded.
+    paths = gate_paths(tmp_path)
+    record_receipt(
+        paths.receipts,
+        "recall",
+        "direct",
+        False,
+        "compact",
+        iso(datetime.now(UTC) - timedelta(seconds=30)),
+    )
+    armed = run_gate(paths, "session-start", {"source": "compact"})
+    assert armed.stdout == ""
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    assert blocked.blocked
+
+
+def test_token_pressure_is_advisory_and_never_blocks(tmp_path: Path) -> None:
+    # Pre-compaction pressure used to block. It does not any more, and an old
+    # state file still carrying `checkpointRequired` must not resurrect that:
+    # automatic compaction handles rollover, so blocking on the way there just
+    # stops work for no gain.
+    paths = gate_paths(tmp_path)
+    paths.state.write_text(
+        json.dumps(
+            {
+                "sessions": {
+                    SESSION: {
+                        "checkpointRequired": True,
+                        "checkpointRequiredAt": iso(datetime.now(UTC)),
+                    }
+                }
+            }
+        ),
+        encoding="utf8",
+    )
+    transcript = _usage_transcript(tmp_path, 260_000)
+
+    warned = run_gate(paths, "user-prompt-submit", {"transcript_path": transcript})
+    assert "Continue task work" in warned.stdout
+
+    write = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+    bash = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": "bun -e 'process.exit(0)'"}},
+    )
+    assert write.stdout == ""
+    assert bash.stdout == ""
+    assert read_session_state(paths)["checkpointRequired"] is False
+
+    status = run_gate(paths, "status").json
+    assert status["nagAt"] == 200_000
+    assert status["hardAt"] == 250_000
+    assert status["checkpointRequired"] is False
+    assert status["preCompactTaskBlocking"] is False
+
+
+def test_a_fresh_session_start_clears_a_previous_sessions_block(
+    tmp_path: Path,
+) -> None:
+    # A block belongs to a context. A genuinely new session -- source is not
+    # `compact` -- inherits no requirement, because the work that armed it is
+    # gone and there is nothing the new session could do to satisfy it.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "post-compact")
+    assert read_session_state(paths)["readbackRequired"] is True
+
+    run_gate(paths, "session-start", {"source": "startup"})
+
+    state = read_session_state(paths)
+    assert state["readbackRequired"] is False
+    assert state["captureRequired"] is False
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+    assert not allowed.blocked
+
+
+def _write_legacy_state(state_path: Path, required_at: str) -> None:
+    """Write an armed read-back carrying no correlation id."""
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessions": {
+                    SESSION: {
+                        "sessionId": SESSION,
+                        "project": PROJECT,
+                        "readbackRequired": True,
+                        "readbackRequiredAt": required_at,
+                        "readbackCorrelationId": "",
+                    }
+                }
+            }
+        ),
+        encoding="utf8",
+    )
+
+
+def _recovery_command(output: str) -> str:
+    """Extract the executable recovery command from a gate answer.
+
+    Args:
+        output: The gate's stdout.
+
+    Returns:
+        The `printf … | bun …` line.
+
+    Raises:
+        AssertionError: If no such line is present -- which means the banner
+            printed no way out, and a banner with no way out is the deadlock.
+    """
+    banner = output
+    try:
+        parsed = json.loads(output)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        if isinstance(parsed.get("reason"), str):
+            banner = parsed["reason"]
+        else:
+            hook_output = parsed.get("hookSpecificOutput")
+            if isinstance(hook_output, dict) and isinstance(
+                hook_output.get("additionalContext"), str
+            ):
+                banner = hook_output["additionalContext"]
+    for line in banner.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("printf '%s' ") and "ob-memory-provider.ts" in stripped:
+            return stripped
+    raise AssertionError(f"no executable recovery command in:\n{output}")

--- a/python/openbrain-provider/tests/test_gate_receipts.py
+++ b/python/openbrain-provider/tests/test_gate_receipts.py
@@ -74,9 +74,7 @@ def test_checkpoint_done_accepts_only_a_verified_remote_receipt(
     paths = gate_paths(tmp_path)
     transcript = _usage_transcript(tmp_path, 260_000)
 
-    warned = run_gate(
-        paths, "user-prompt-submit", {"transcript_path": transcript}
-    )
+    warned = run_gate(paths, "user-prompt-submit", {"transcript_path": transcript})
     payload = warned.json
     assert str(payload["systemMessage"]).startswith("OB ")
     assert "automatic compaction" in payload["hookSpecificOutput"]["additionalContext"]

--- a/python/openbrain-provider/tests/test_gate_receipts.py
+++ b/python/openbrain-provider/tests/test_gate_receipts.py
@@ -26,7 +26,10 @@ from gate_harness import (
     start_compact_cycle,
 )
 
-from openbrain_provider.development_scope import resolve_development_scope
+from openbrain_provider.development_scope import (
+    development_root,
+    resolve_development_scope,
+)
 
 
 class WrongReceipt(NamedTuple):
@@ -65,7 +68,12 @@ def test_the_project_comes_from_the_git_toplevel(tmp_path: Path) -> None:
     # nested directory inside Development must resolve to the SAME project as
     # its root -- otherwise a hook fired from a subdirectory would look at an
     # empty state file and enforce nothing.
-    nested = "/Volumes/ThunderBolt/Development/_ob/scripts"
+    # Built from the resolved root, not written as a literal: the scope check
+    # requires the directory to EXIST, so a hardcoded macOS path resolves to
+    # None anywhere else and this asserts against a gate that fell silent.
+    nested_path = development_root() / "_ob" / "scripts"
+    nested_path.mkdir(parents=True, exist_ok=True)
+    nested = str(nested_path)
     scope = resolve_development_scope(nested)
     assert scope is not None
     assert scope.project == PROJECT

--- a/python/openbrain-provider/tests/test_gate_receipts.py
+++ b/python/openbrain-provider/tests/test_gate_receipts.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import NamedTuple
 
 from gate_harness import (
     PROJECT,
@@ -26,6 +27,15 @@ from gate_harness import (
 )
 
 from openbrain_provider.development_scope import resolve_development_scope
+
+
+class WrongReceipt(NamedTuple):
+    """A receipt that looks valid but must not clear the gate."""
+
+    session_id: str
+    project: str
+    #: `None` means "now" -- only the age case sets an explicit instant.
+    recorded_at: str | None
 
 
 def _usage_transcript(root: Path, tokens: int) -> str:
@@ -108,13 +118,9 @@ def test_checkpoint_evidence_is_scoped_and_fresh(tmp_path: Path) -> None:
     # context it proved is gone.
     paths = gate_paths(tmp_path)
     cases = [
-        {"session_id": "other-session", "project": PROJECT, "recorded_at": None},
-        {"session_id": SESSION, "project": "other-project", "recorded_at": None},
-        {
-            "session_id": SESSION,
-            "project": PROJECT,
-            "recorded_at": iso(datetime.now(UTC) - timedelta(minutes=21)),
-        },
+        WrongReceipt("other-session", PROJECT, None),
+        WrongReceipt(SESSION, "other-project", None),
+        WrongReceipt(SESSION, PROJECT, iso(datetime.now(UTC) - timedelta(minutes=21))),
     ]
     for case in cases:
         record_receipt(
@@ -123,9 +129,9 @@ def test_checkpoint_evidence_is_scoped_and_fresh(tmp_path: Path) -> None:
             "saved",
             True,
             "explicit",
-            case["recorded_at"],
-            project=str(case["project"]),
-            session_id=str(case["session_id"]),
+            case.recorded_at,
+            project=case.project,
+            session_id=case.session_id,
         )
         refused = run_gate(paths, "checkpoint-done")
         assert refused.code == 1, case

--- a/python/openbrain-provider/tests/test_gate_repair.py
+++ b/python/openbrain-provider/tests/test_gate_repair.py
@@ -25,7 +25,10 @@ from gate_harness import (
     write_session_state,
 )
 
-TS_GATE = "/Volumes/ThunderBolt/Development/_ob/scripts/context-budget-gate.ts"
+from openbrain_provider.development_scope import development_root
+
+#: Derived, not a literal, so it follows the same root the gate resolved against.
+TS_GATE = str(development_root() / "_ob" / "scripts" / "context-budget-gate.ts")
 
 
 def test_a_stale_readback_self_releases_after_fifteen_minutes(tmp_path: Path) -> None:

--- a/python/openbrain-provider/tests/test_gate_repair.py
+++ b/python/openbrain-provider/tests/test_gate_repair.py
@@ -1,0 +1,271 @@
+"""The gate must not deadlock on the subsystem it gates. Issue #419's acceptance.
+
+Two independent escapes are proven here, because one is not enough: the read-back
+requirement self-releases on time WITHOUT anybody doing anything, and an operator
+can open a bounded repair window to fix the recall plumbing by hand. Each is
+tested for firing, for being recorded, and for ending.
+
+Ported from `context-budget-gate-repair.test.ts`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from gate_harness import (
+    PROJECT,
+    SESSION,
+    arm_readback,
+    gate_paths,
+    iso,
+    read_session_state,
+    record_receipt,
+    run_gate,
+    write_session_state,
+)
+
+TS_GATE = "/Volumes/ThunderBolt/Development/_ob/scripts/context-budget-gate.ts"
+
+
+def test_a_stale_readback_self_releases_after_fifteen_minutes(tmp_path: Path) -> None:
+    # THE #419 BUG. The documented fifteen-minute self-release did not fire, so
+    # the gate blocked Write while the broken recall was the thing needing
+    # repair. This asserts it fires, that it unblocks, and that it says so.
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+
+    state = read_session_state(paths)
+    state["readbackRequiredAt"] = iso(
+        datetime.now(UTC) - timedelta(minutes=15, seconds=1)
+    )
+    write_session_state(paths, state)
+
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+
+    assert allowed.code == 0
+    assert not allowed.blocked
+    assert "self-released-after-timeout" in allowed.stdout
+
+    released = read_session_state(paths)
+    assert released["readbackRequired"] is False
+    assert released["readbackCorrelationId"] == ""
+    assert released["transitionLog"][-1]["name"] == "self-released-after-timeout"
+    assert (
+        released["transitionLog"][-1]["reason"] == "15-minute read-back timeout elapsed"
+    )
+
+
+def test_the_release_never_manufactures_a_recall_receipt(tmp_path: Path) -> None:
+    # The release must not fake the evidence it never got. If it wrote a recall
+    # receipt to unblock itself, the NEXT gate would read that receipt and
+    # believe a recall happened -- a self-inflicted false clear that no later
+    # check could distinguish from a real one.
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+    state = read_session_state(paths)
+    state["readbackRequiredAt"] = iso(datetime.now(UTC) - timedelta(minutes=16))
+    write_session_state(paths, state)
+
+    answer = run_gate(paths, "pre-tool-use", {"tool_name": "Read", "tool_input": {}})
+
+    # No recall receipt anywhere in the shared state.
+    receipts = paths.receipts.read_text(encoding="utf8")
+    assert '"operation": "recall"' not in receipts
+
+    # And the release SAYS it did not manufacture one, on the surface that
+    # displays it. The notice is consumed by this same allowed call, which is
+    # why it is asserted on the output rather than on the stored queue.
+    assert "no recall receipt manufactured" in answer.stdout
+    released = read_session_state(paths)
+    assert released["readbackRequired"] is False
+    assert any(
+        entry["name"] == "self-released-after-timeout"
+        for entry in released["transitionLog"]
+    )
+
+
+def test_a_real_recall_clears_by_recall_not_by_timeout(tmp_path: Path) -> None:
+    # A gate that cleared everything by timeout would look identical from the
+    # outside. The transition name is what distinguishes "recall worked" from
+    # "we gave up waiting", and only one of those is healthy.
+    paths = gate_paths(tmp_path)
+    correlation = arm_readback(paths)
+    record_receipt(
+        paths.receipts, "recall", "direct", False, "compact", None, correlation
+    )
+
+    allowed = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+
+    assert "read-back cleared" in allowed.stdout
+    names = [entry["name"] for entry in read_session_state(paths)["transitionLog"]]
+    assert "cleared-by-recall" in names
+    assert "self-released-after-timeout" not in names
+
+
+def test_the_blocked_gate_permits_the_exact_repair_enter_command(
+    tmp_path: Path,
+) -> None:
+    # The escape hatch has to be REACHABLE from inside the block, or it is not
+    # an escape hatch. And it has to be the exact command -- a repair-enter
+    # naming some other gate script would open a window in a state file this
+    # process does not own.
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+    command = (
+        f"bun '{TS_GATE}' --event repair-enter --session-id {SESSION} "
+        f"--project {PROJECT} --state-path '{paths.state}' "
+        f"--receipt-state-path '{paths.receipts}' --repair-minutes 5 "
+        "--repair-reason 'repair provider plumbing'"
+    )
+
+    allowed = run_gate(
+        paths, "pre-tool-use", {"tool_name": "Bash", "tool_input": {"command": command}}
+    )
+    assert allowed.code == 0
+    assert allowed.stdout == ""
+
+    impostor = command.replace(TS_GATE, str(tmp_path / "context-budget-gate.ts"))
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": impostor}},
+    )
+    assert blocked.blocked
+
+
+def test_repair_mode_admits_bash_write_and_edit(tmp_path: Path) -> None:
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+
+    for tool in ("Bash", "Write", "Edit"):
+        blocked = run_gate(paths, "pre-tool-use", _tool_call(tool, tmp_path))
+        assert blocked.blocked, tool
+
+    entered = run_gate(
+        paths,
+        "repair-enter",
+        None,
+        ["--repair-minutes", "5", "--repair-reason", "repair provider plumbing"],
+    )
+    assert entered.code == 0
+    assert "transition=repair-entered" in entered.stdout
+    assert read_session_state(paths)["repairModeActive"] is True
+
+    status = run_gate(paths, "status")
+    assert status.json["repairModeActive"] is True
+    assert "repair ACTIVE until" in status.json["statusLine"]
+
+    for tool in ("Bash", "Write", "Edit"):
+        allowed = run_gate(paths, "pre-tool-use", _tool_call(tool, tmp_path))
+        assert not allowed.blocked, tool
+        assert "repair-active-tool-allowed" in allowed.stdout, tool
+
+
+def test_repair_mode_does_not_admit_everything(tmp_path: Path) -> None:
+    # The window is bounded in WHAT as well as in time. A tool outside the
+    # repair-capable set gets no free pass, because "repair the recall plumbing"
+    # does not require arbitrary tool access.
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+    run_gate(
+        paths,
+        "repair-enter",
+        None,
+        ["--repair-minutes", "5", "--repair-reason", "repair provider plumbing"],
+    )
+
+    blocked = run_gate(
+        paths, "pre-tool-use", {"tool_name": "NotebookEdit", "tool_input": {}}
+    )
+    assert blocked.blocked
+
+
+def test_repair_expiry_restores_enforcement(tmp_path: Path) -> None:
+    # An escape hatch that stays open is the gate switched off. Expiry is what
+    # makes it an escape hatch rather than a disable switch.
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+    run_gate(
+        paths,
+        "repair-enter",
+        None,
+        ["--repair-minutes", "1", "--repair-reason", "repair provider plumbing"],
+    )
+    state = read_session_state(paths)
+    state["repairModeExpiresAt"] = iso(datetime.now(UTC) - timedelta(seconds=1))
+    write_session_state(paths, state)
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "c.ts")}},
+    )
+
+    assert blocked.blocked
+    expired = read_session_state(paths)
+    assert expired["repairModeActive"] is False
+    assert expired["readbackRequired"] is True
+    assert [entry["name"] for entry in expired["transitionLog"][-2:]] == [
+        "repair-expired",
+        "still-blocking-with-reason",
+    ]
+
+
+def test_repair_mode_can_be_exited_early(tmp_path: Path) -> None:
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+    run_gate(
+        paths, "repair-enter", None, ["--repair-reason", "repair provider plumbing"]
+    )
+
+    exited = run_gate(
+        paths, "repair-exit", None, ["--repair-reason", "repair complete"]
+    )
+
+    assert exited.code == 0
+    assert "transition=repair-exited" in exited.stdout
+    state = read_session_state(paths)
+    assert state["repairModeActive"] is False
+    assert state["transitionLog"][-1]["name"] == "repair-exited"
+
+
+def test_repair_enter_refuses_without_a_reason_or_a_sane_window(
+    tmp_path: Path,
+) -> None:
+    # A repair window with no stated reason is an untraceable disable. And a
+    # window longer than the read-back timeout it escapes would outlive the
+    # requirement entirely.
+    paths = gate_paths(tmp_path)
+    arm_readback(paths)
+
+    no_reason = run_gate(paths, "repair-enter", None, ["--repair-minutes", "5"])
+    assert no_reason.code == 1
+    assert no_reason.stdout.startswith("REFUSED:")
+
+    too_long = run_gate(
+        paths, "repair-enter", None, ["--repair-minutes", "60", "--repair-reason", "x"]
+    )
+    assert too_long.code == 1
+    assert read_session_state(paths)["repairModeActive"] is False
+
+
+def _tool_call(tool: str, root: Path) -> dict[str, object]:
+    """Build a representative call for a repair-capable tool."""
+    if tool == "Bash":
+        return {
+            "tool_name": tool,
+            "tool_input": {"command": "bun -e 'process.exit(0)'"},
+        }
+    return {
+        "tool_name": tool,
+        "tool_input": {"file_path": str(root / f"{tool.lower()}.ts")},
+    }

--- a/python/openbrain-provider/tests/test_hook_protocol.py
+++ b/python/openbrain-provider/tests/test_hook_protocol.py
@@ -1,0 +1,240 @@
+"""The wire protocol itself: stdin in, verdict out, exit code, and the scripts.
+
+Separate from the behaviour tests because these are about the CONTRACT rather
+than the policy: what happens with no stdin at all, and what an allow looks like
+on the wire.
+
+Whether every declared `[project.scripts]` target actually imports is checked ONCE,
+generically, by `test_packaging.py::test_every_declared_console_script_resolves`.
+This file asserts only that the two GATE commands are declared at all -- the fact
+that specific to this port. A second generic resolver here would be a second
+implementation of a rule that already exists, which is the defect the port plan
+names on sight (`_plans/consolidation-2026-07-30.md:99`).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+from gate_harness import gate_paths, run_gate, run_policy_gate
+
+from openbrain_provider import context_budget_gate, policy_refresh_gate
+from openbrain_provider.hook_io import HookEvent, emit, emit_json, read_hook_event
+
+PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def test_both_gate_console_scripts_are_declared() -> None:
+    # A hook registration names one of these commands. If the declaration were
+    # dropped, `test_packaging.py` would still pass -- it checks that what IS
+    # declared resolves, not that these two exist.
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf8"))
+    scripts = data.get("project", {}).get("scripts", {})
+
+    assert scripts.get("openbrain-context-budget-gate") == (
+        "openbrain_provider.context_budget_gate:_cli"
+    )
+    assert scripts.get("openbrain-policy-refresh-gate") == (
+        "openbrain_provider.policy_refresh_gate:_cli"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", "not json", "[1,2,3]", '"a string"', "null", "{"],
+)
+def test_unusable_stdin_reads_as_an_empty_event(raw: str) -> None:
+    # Fail-open. A hook that raised on bad stdin would take the agent's turn
+    # down with it, and a gate exists to shape a turn, not to end one.
+    event = read_hook_event(io.StringIO(raw))
+
+    assert isinstance(event, HookEvent)
+    assert event.session_id == ""
+    assert event.tool_name == ""
+    assert event.tool_input == {}
+
+
+def test_a_closed_stdin_reads_as_an_empty_event() -> None:
+    stream = io.StringIO("{}")
+    stream.close()
+
+    assert read_hook_event(stream) == HookEvent()
+
+
+def test_both_tool_field_spellings_are_accepted() -> None:
+    # Claude sends `tool_name`/`tool_input`; Codex sends `toolName`/`toolInput`.
+    # Reading only one spelling makes the gate silently unenforced on the other
+    # runtime -- which looks exactly like a gate that is working.
+    claude = read_hook_event(
+        io.StringIO(
+            json.dumps({"tool_name": "Write", "tool_input": {"file_path": "a"}})
+        )
+    )
+    codex = read_hook_event(
+        io.StringIO(
+            json.dumps({"toolName": "Write", "toolInput": {"file_path": "a"}})
+        )
+    )
+
+    assert claude.tool_name == codex.tool_name == "Write"
+    assert claude.tool_input == codex.tool_input == {"file_path": "a"}
+
+
+def test_a_field_with_the_wrong_type_reads_as_absent() -> None:
+    event = read_hook_event(
+        io.StringIO(json.dumps({"session_id": 12, "tool_input": "not-a-dict"}))
+    )
+
+    assert event.session_id == ""
+    assert event.tool_input == {}
+
+
+def test_an_empty_emit_writes_nothing_at_all() -> None:
+    # Not a newline. Both runtimes read empty stdout as allow, and a bare
+    # newline is not empty.
+    stream = io.StringIO()
+    emit("", stream)
+
+    assert stream.getvalue() == ""
+
+
+def test_a_json_verdict_is_compact_and_newline_terminated() -> None:
+    stream = io.StringIO()
+    emit_json({"decision": "block", "reason": "x"}, stream)
+
+    assert stream.getvalue() == '{"decision":"block","reason":"x"}\n'
+
+
+def test_non_ascii_survives_the_verdict_encoding() -> None:
+    # The status line uses `✓`, `✗`, and `·`. Escaping them would still be valid
+    # JSON but would put `✓` in front of the operator.
+    stream = io.StringIO()
+    emit_json({"systemMessage": "OB ✓ recall ok · spool 0"}, stream)
+
+    assert "OB ✓ recall ok · spool 0" in stream.getvalue()
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        "status",
+        "user-prompt-submit",
+        "pre-tool-use",
+        "pre-compact",
+        "post-compact",
+        "session-start",
+        "stop",
+    ],
+)
+def test_the_budget_gate_survives_an_empty_event(tmp_path: Path, event: str) -> None:
+    # Every event, with nothing on stdin. None of them may raise: a hook that
+    # throws is a hook failure the harness reports, on a turn the operator was
+    # in the middle of.
+    paths = gate_paths(tmp_path / event)
+    stdout = io.StringIO()
+    code = context_budget_gate.main(
+        [
+            "--event", event,
+            "--state-path", str(paths.state),
+            "--receipt-state-path", str(paths.receipts),
+            "--settings-path", str(paths.settings),
+            "--policy-state-path", str(paths.policy_state),
+            "--spool-path", str(paths.spool),
+        ],
+        stdin=io.StringIO(""),
+        stdout=stdout,
+        env={"HOME": str(paths.root)},
+    )
+
+    assert code == 0
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        "session-start",
+        "user-prompt-submit",
+        "pre-tool-use",
+        "pre-compact",
+        "post-compact",
+        "refresh",
+    ],
+)
+def test_the_policy_gate_survives_an_empty_event(tmp_path: Path, event: str) -> None:
+    stdout = io.StringIO()
+    code = policy_refresh_gate.main(
+        ["--event", event, "--state-path", str(tmp_path / f"{event}.json")],
+        stdin=io.StringIO(""),
+        stdout=stdout,
+    )
+
+    assert code == 0
+
+
+def test_an_unknown_event_name_is_refused_at_the_boundary(tmp_path: Path) -> None:
+    # Not silently treated as `status`. A registration with a typo would then
+    # look like it worked while enforcing nothing, and the exit code is the only
+    # place that mistake can surface.
+    with pytest.raises(SystemExit) as raised:
+        context_budget_gate.main(
+            ["--event", "post-compct", "--state-path", str(tmp_path / "s.json")],
+            stdin=io.StringIO("{}"),
+            stdout=io.StringIO(),
+        )
+    assert raised.value.code != 0
+
+    with pytest.raises(SystemExit) as policy_raised:
+        policy_refresh_gate.main(
+            ["--event", "sesion-start", "--state-path", str(tmp_path / "p.json")],
+            stdin=io.StringIO("{}"),
+            stdout=io.StringIO(),
+        )
+    assert policy_raised.value.code != 0
+
+
+def test_a_corrupt_state_file_does_not_break_the_turn(tmp_path: Path) -> None:
+    # State is a cache of belief, not a source of truth. A file half-written by
+    # a killed process must rebuild, because the alternative is a session that
+    # cannot run a single tool until somebody deletes a file by hand.
+    paths = gate_paths(tmp_path)
+    paths.state.write_text("{ this is not json", encoding="utf8")
+
+    result = run_gate(paths, "status")
+
+    assert result.code == 0
+    assert result.json["readbackRequired"] is False
+
+
+def test_a_corrupt_policy_state_file_does_not_break_the_turn(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    state_path.write_text("{ this is not json", encoding="utf8")
+
+    result = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Read", "tool_input": {"file_path": "a"}},
+    )
+
+    assert result.code == 0
+    assert result.stdout == ""
+
+
+def test_a_corrupt_receipt_file_keeps_the_gate_blocking(tmp_path: Path) -> None:
+    # Absent evidence is not evidence of a write. A receipt file that cannot be
+    # read must leave the block standing -- failing OPEN here would mean any
+    # session could clear a gate by corrupting a file.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "post-compact")
+    paths.receipts.write_text("{ not json", encoding="utf8")
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+
+    assert blocked.blocked

--- a/python/openbrain-provider/tests/test_hook_protocol.py
+++ b/python/openbrain-provider/tests/test_hook_protocol.py
@@ -75,9 +75,7 @@ def test_both_tool_field_spellings_are_accepted() -> None:
         )
     )
     codex = read_hook_event(
-        io.StringIO(
-            json.dumps({"toolName": "Write", "toolInput": {"file_path": "a"}})
-        )
+        io.StringIO(json.dumps({"toolName": "Write", "toolInput": {"file_path": "a"}}))
     )
 
     assert claude.tool_name == codex.tool_name == "Write"
@@ -138,12 +136,18 @@ def test_the_budget_gate_survives_an_empty_event(tmp_path: Path, event: str) -> 
     stdout = io.StringIO()
     code = context_budget_gate.main(
         [
-            "--event", event,
-            "--state-path", str(paths.state),
-            "--receipt-state-path", str(paths.receipts),
-            "--settings-path", str(paths.settings),
-            "--policy-state-path", str(paths.policy_state),
-            "--spool-path", str(paths.spool),
+            "--event",
+            event,
+            "--state-path",
+            str(paths.state),
+            "--receipt-state-path",
+            str(paths.receipts),
+            "--settings-path",
+            str(paths.settings),
+            "--policy-state-path",
+            str(paths.policy_state),
+            "--spool-path",
+            str(paths.spool),
         ],
         stdin=io.StringIO(""),
         stdout=stdout,

--- a/python/openbrain-provider/tests/test_policy_gate.py
+++ b/python/openbrain-provider/tests/test_policy_gate.py
@@ -1,0 +1,444 @@
+"""The policy-refresh gate: what goes stale, what that blocks, and what clears it.
+
+Ported from `policy-refresh-gate.test.ts`, with three assertions deliberately
+NOT transcribed. That file is red today against its own source (verified
+2026-08-02: 6 pass, 3 fail): it still expects `OB ✓ gate passed` and a
+`source_validator:` line the gate no longer emits -- both moved into the
+source-owned `AGENTS.md` -- and it expects an UNCONDITIONAL Agent/Task block
+that the gate deliberately made conditional on `ANTHROPIC_BASE_URL`.
+
+Those three are stale expectations, not gate defects. Copying them across would
+import a false red. The tests below assert what the SOURCE does, and the Agent
+rule is tested on BOTH branches so the conditionality is pinned rather than
+assumed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from gate_harness import SESSION, run_policy_gate
+
+DEVELOPMENT_CWD = "/Volumes/ThunderBolt/Development"
+
+
+def _state(state_path: Path, agent: str = "claude") -> dict[str, object]:
+    """Read one session's stored policy state."""
+    stored = json.loads(state_path.read_text(encoding="utf8"))
+    return dict(stored["sessions"][f"{agent}:{SESSION}"])
+
+
+def test_claude_startup_points_at_the_direct_adapter_not_the_retired_cli(
+    tmp_path: Path,
+) -> None:
+    # The `mcp2cli open-brain` path is retired and hook-blocked for Claude. A
+    # startup block still naming it would send every session to a command that
+    # is refused before it runs.
+    started = run_policy_gate(tmp_path / "state.json", "session-start")
+
+    assert started.code == 0
+    assert "package-owned direct Open Brain SessionStart adapter" in started.stdout
+    assert "mcp2cli open-brain get_entity" not in started.stdout
+
+
+def test_claudex_startup_uses_the_same_direct_hydration(tmp_path: Path) -> None:
+    started = run_policy_gate(
+        tmp_path / "state.json", "session-start", agent="claudex", runtime="claudex"
+    )
+
+    assert started.code == 0
+    assert "package-owned direct Open Brain SessionStart adapter" in started.stdout
+    assert "mcp2cli open-brain get_entity" not in started.stdout
+
+
+def test_codex_startup_quotes_the_source_owned_fast_path(tmp_path: Path) -> None:
+    # Codex keeps the UUID recipe, and the gate READS it out of AGENTS.md rather
+    # than restating it -- a second copy would be stale the first time the real
+    # one changed. The envelope is Codex's `hookSpecificOutput` shape.
+    started = run_policy_gate(
+        tmp_path / "state.json", "session-start", agent="codex", runtime="codex"
+    )
+
+    assert started.code == 0
+    payload = started.json
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert "runtime-fast-path:start" in context
+    assert "repo_fact_uuid" in context
+    assert "loaded from the source-owned AGENTS.md" in context
+
+
+def test_startup_names_the_current_model_routing(tmp_path: Path) -> None:
+    started = run_policy_gate(tmp_path / "state.json", "session-start")
+
+    assert started.code == 0
+    assert "Claude Opus 5" in started.stdout
+    assert "Workflow `agent()` node" in started.stdout
+    assert "codex:codex-rescue" in started.stdout
+    assert "Sonnet max medium" in started.stdout
+    assert "explicit non-default" in started.stdout
+
+
+def test_startup_does_not_declare_critical_mode_active(tmp_path: Path) -> None:
+    # Critical mode is INVOKED, not defaulted. A mode that is always on stops
+    # being a mode, so injecting it every session would quietly override the
+    # design that made it a command.
+    started = run_policy_gate(tmp_path / "state.json", "session-start")
+
+    assert "critical mode is active" not in started.stdout.lower()
+    assert "Say what you mean" in started.stdout
+
+
+def test_ordinary_turns_and_many_harmless_tools_never_go_stale(
+    tmp_path: Path,
+) -> None:
+    # The retired turn/tool thresholds are why this test exists: volume alone is
+    # not staleness, and a gate that blocked on a counter interrupted long
+    # sessions that had done nothing wrong.
+    state_path = tmp_path / "state.json"
+    started = run_policy_gate(state_path, "session-start")
+    assert started.code == 0
+    assert "Development Policy Refresh" in started.stdout
+
+    for _ in range(30):
+        prompt = run_policy_gate(state_path, "user-prompt-submit")
+        assert prompt.code == 0
+        assert prompt.stdout == ""
+
+    for _ in range(81):
+        harmless = run_policy_gate(
+            state_path,
+            "pre-tool-use",
+            {"tool_name": "Read", "tool_input": {"file_path": str(tmp_path / "a.txt")}},
+        )
+        assert harmless.code == 0
+        assert harmless.stdout == ""
+
+    state = _state(state_path)
+    assert state["turnCount"] == 30
+    assert state["totalTurnCount"] == 30
+    assert state["toolCount"] == 81
+    assert state["refreshRequired"] is False
+    assert state["reason"] == ""
+
+    risky = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    assert risky.code == 0
+    assert risky.stdout == ""
+
+
+def test_post_compact_stays_stale_until_an_explicit_refresh(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    assert run_policy_gate(state_path, "session-start").code == 0
+
+    compacted = run_policy_gate(state_path, "post-compact")
+    assert compacted.code == 0
+    assert "post-compact marked context as stale" in compacted.stdout
+    state = _state(state_path)
+    assert state["refreshRequired"] is True
+    assert state["reason"] == "post-compact marked context as stale"
+
+    blocked = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "b.ts")}},
+    )
+    assert blocked.blocked
+    assert "post-compact marked context as stale" in blocked.stdout
+
+    refreshed = run_policy_gate(state_path, "refresh")
+    assert refreshed.code == 0
+    assert "Policy refresh marked complete" in refreshed.stdout
+    cleared = _state(state_path)
+    assert cleared["refreshRequired"] is False
+    assert cleared["reason"] == ""
+
+    allowed = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+    assert allowed.code == 0
+    assert allowed.stdout == ""
+
+
+def test_post_compact_restates_what_survives_the_compaction(tmp_path: Path) -> None:
+    # A compaction summary keeps what it keeps. "The summary probably mentioned
+    # the review gauntlet" is not a control, so the requirement is restated
+    # every time rather than trusted to survive.
+    compacted = run_policy_gate(tmp_path / "state.json", "post-compact")
+
+    assert "Post-Compact Standing Requirements" in compacted.stdout
+    assert "pre-merge review gauntlet is MANDATORY" in compacted.stdout
+
+
+def test_a_stale_session_can_always_run_the_refresh_command(tmp_path: Path) -> None:
+    # THE escape. A gate whose unblock is itself gated is a deadlock, and the
+    # refusal text prints this exact command -- so it must be accepted.
+    state_path = tmp_path / "state.json"
+    run_policy_gate(state_path, "post-compact")
+
+    command = (
+        "bun /Volumes/ThunderBolt/Development/_ob/scripts/policy-refresh-gate.ts "
+        "--event refresh --agent claude"
+    )
+    allowed = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": command}},
+    )
+    assert allowed.stdout == ""
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "bun .../policy-refresh-gate.ts --event refresh && git push",
+        "echo x; bun .../policy-refresh-gate.ts --event refresh",
+        "bun .../policy-refresh-gate.ts --event refresh > out.txt",
+        "bun .../policy-refresh-gate.ts --event session-start",
+    ],
+)
+def test_a_command_that_merely_contains_the_refresh_call_is_not_the_refresh_call(
+    tmp_path: Path, command: str
+) -> None:
+    # The allowance is the way out of a block, so it is the thing worth
+    # smuggling a mutation through. Chaining, redirecting, and naming a
+    # different event are all refused.
+    state_path = tmp_path / "state.json"
+    run_policy_gate(state_path, "post-compact")
+
+    result = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": f"{command} && rm -rf x"}},
+    )
+    assert result.blocked
+
+
+def test_a_direct_agent_call_is_blocked_under_a_proxied_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Under Claudex an unrouted Agent call silently collapses the worker to the
+    # head model -- a Sol session reviewing its own work while the record says
+    # Opus did. That is the failure the block exists for.
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:7180")
+    state_path = tmp_path / "state.json"
+    assert run_policy_gate(state_path, "session-start").code == 0
+
+    for tool in ("Agent", "agent", "Task", "task"):
+        result = run_policy_gate(
+            state_path,
+            "pre-tool-use",
+            {"tool_name": tool, "tool_input": {"model": "claude-opus-5"}},
+        )
+        assert result.blocked, tool
+        assert "Workflow `agent()` node" in result.stdout
+        assert "MODEL_ROUTING.md" in result.stdout
+
+
+def test_a_direct_agent_call_is_advised_not_blocked_on_a_native_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A native session talks to Anthropic directly and cannot reach that failure
+    # mode, so blocking would refuse a safe operation to prevent an impossible
+    # one -- and worse, a hook that BEHAVES like Claudex convinces a native
+    # session it is under the Claudex contract.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    state_path = tmp_path / "state.json"
+    assert run_policy_gate(state_path, "session-start").code == 0
+
+    result = run_policy_gate(
+        state_path, "pre-tool-use", {"tool_name": "Agent", "tool_input": {}}
+    )
+
+    assert not result.blocked
+    context = result.json["hookSpecificOutput"]["additionalContext"]
+    assert "direct Agent/Task is permitted" in context
+    assert "MODEL_ROUTING.md" in context
+
+
+def test_the_agent_advisory_is_suppressed_for_codex(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Codex PreToolUse honours only the FIRST verdict and reads plain stdout as
+    # allow, so emitting an advisory there risks eating a real decision.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    state_path = tmp_path / "state.json"
+
+    result = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Agent", "tool_input": {}},
+        agent="codex",
+        runtime="codex",
+    )
+
+    assert result.stdout == ""
+
+
+def test_safety_blocks_fire_even_when_policy_is_fresh(tmp_path: Path) -> None:
+    # Safety and staleness are different mechanisms. A `git reset --hard` is not
+    # safer because the router was reread five seconds ago.
+    state_path = tmp_path / "state.json"
+    assert run_policy_gate(state_path, "session-start").code == 0
+
+    blocked = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": "git reset --hard"}},
+    )
+
+    assert blocked.blocked
+    assert "git reset --hard" in blocked.stdout
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input"),
+    [
+        ("Write", {"file_path": "/tmp/evil.txt"}),
+        ("Edit", {"file_path": "/private/tmp/evil.txt"}),
+        ("Bash", {"command": "echo hi > /tmp/x.txt"}),
+        ("Bash", {"command": "cp a.txt /var/tmp/b.txt"}),
+    ],
+)
+def test_a_write_into_system_temp_is_refused(
+    tmp_path: Path, tool_name: str, tool_input: dict[str, str]
+) -> None:
+    # `/tmp` is sandbox-local, so an artifact written there is invisible to
+    # runners and to the operator: "I saved it to /tmp" silently means gone.
+    blocked = run_policy_gate(
+        tmp_path / "state.json",
+        "pre-tool-use",
+        {"tool_name": tool_name, "tool_input": tool_input},
+    )
+
+    assert blocked.blocked
+    assert "temp workspace" in blocked.stdout
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["cat /tmp/some.sock", "ls /tmp", "rg pattern /var/tmp/log.txt"],
+)
+def test_reading_from_system_temp_is_allowed(tmp_path: Path, command: str) -> None:
+    # Only writes are refused. Plenty of legitimate work reads system-owned
+    # paths there, and blocking those would teach agents to route around the
+    # guard rather than obey it.
+    result = run_policy_gate(
+        tmp_path / "state.json",
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": command}},
+    )
+
+    assert not result.blocked
+
+
+def test_a_commit_message_mentioning_main_is_not_a_push_to_main(
+    tmp_path: Path,
+) -> None:
+    # The protected-ref test runs OUTSIDE quoted strings, so the English word
+    # "main" in a message is not a refspec. Getting this wrong would refuse a
+    # correct commit for its prose.
+    result = run_policy_gate(
+        tmp_path / "state.json",
+        "pre-tool-use",
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": 'git commit -m "align the main flow with the router"'
+            },
+        },
+    )
+
+    # It may still be refused for the branch check -- what must NOT happen is
+    # the protected-REF refusal, which would be reading the message as a target.
+    assert "do not commit or push directly to main/master" not in result.stdout
+
+
+def test_an_unquoted_push_to_main_is_refused(tmp_path: Path) -> None:
+    blocked = run_policy_gate(
+        tmp_path / "state.json",
+        "pre-tool-use",
+        {"tool_name": "Bash", "tool_input": {"command": "git push origin main"}},
+    )
+
+    assert blocked.blocked
+    assert "do not commit or push directly to main/master" in blocked.stdout
+
+
+def test_a_legacy_threshold_block_resumes_without_a_refresh(tmp_path: Path) -> None:
+    # The turn/tool threshold mechanism no longer exists, so a state file still
+    # carrying its block would wait forever for a condition nothing can satisfy.
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessions": {
+                    f"claude:{SESSION}": {
+                        "sessionId": SESSION,
+                        "agent": "claude",
+                        "cwd": DEVELOPMENT_CWD,
+                        "turnCount": 24,
+                        "totalTurnCount": 24,
+                        "toolCount": 81,
+                        "refreshRequired": True,
+                        "reason": "tool threshold reached: 81/80",
+                        "updatedAt": "2026-07-19T00:00:00.000Z",
+                    }
+                }
+            }
+        ),
+        encoding="utf8",
+    )
+
+    allowed = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+
+    assert allowed.code == 0
+    assert allowed.stdout == ""
+    state = _state(state_path)
+    assert state["toolCount"] == 82
+    assert state["refreshRequired"] is False
+    assert state["reason"] == ""
+
+
+def test_a_real_stale_block_is_not_cleared_by_the_legacy_migration(
+    tmp_path: Path,
+) -> None:
+    # The migration must only drop the RETIRED reason. A post-compact block
+    # carries a different reason and has to survive, or every stored block would
+    # be cleared on read.
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessions": {
+                    f"claude:{SESSION}": {
+                        "sessionId": SESSION,
+                        "agent": "claude",
+                        "cwd": DEVELOPMENT_CWD,
+                        "refreshRequired": True,
+                        "reason": "post-compact marked context as stale",
+                        "updatedAt": "2026-07-19T00:00:00.000Z",
+                    }
+                }
+            }
+        ),
+        encoding="utf8",
+    )
+
+    blocked = run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {"tool_name": "Write", "tool_input": {"file_path": str(tmp_path / "a.ts")}},
+    )
+
+    assert blocked.blocked

--- a/python/openbrain-provider/tests/test_policy_gate.py
+++ b/python/openbrain-provider/tests/test_policy_gate.py
@@ -21,7 +21,11 @@ from pathlib import Path
 import pytest
 from gate_harness import SESSION, run_policy_gate
 
-DEVELOPMENT_CWD = "/Volumes/ThunderBolt/Development"
+from openbrain_provider.development_scope import development_root
+
+# Derived, not a literal: a second hardcoded copy of the root disagrees with
+# the one the gate resolved against on any machine but Rico's Mac.
+DEVELOPMENT_CWD = str(development_root())
 
 
 def _state(state_path: Path, agent: str = "claude") -> dict[str, object]:
@@ -57,8 +61,35 @@ def test_codex_startup_quotes_the_source_owned_fast_path(tmp_path: Path) -> None
     # Codex keeps the UUID recipe, and the gate READS it out of AGENTS.md rather
     # than restating it -- a second copy would be stale the first time the real
     # one changed. The envelope is Codex's `hookSpecificOutput` shape.
+    #
+    # The AGENTS.md is written HERE rather than relying on the real one: reading
+    # Rico's file made this pass on his Mac and fail on CI, and it also meant the
+    # assertions were checking his file's contents instead of the extraction this
+    # test is actually about. The fixture is minimal and deliberately unlike the
+    # real file, so a pass means the markers were honoured.
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(
+        "\n".join(
+            [
+                "# Fixture router",
+                "Text before the block is not extracted.",
+                "<!-- runtime-fast-path:start -->",
+                "```yaml",
+                "repo_fact_uuid: 0c0a4e94-84bc-424f-b396-bf7d0ad62083",
+                "```",
+                "<!-- runtime-fast-path:end -->",
+                "Text after the block is not extracted either.",
+            ]
+        ),
+        encoding="utf8",
+    )
+
     started = run_policy_gate(
-        tmp_path / "state.json", "session-start", agent="codex", runtime="codex"
+        tmp_path / "state.json",
+        "session-start",
+        {"cwd": str(tmp_path)},
+        agent="codex",
+        runtime="codex",
     )
 
     assert started.code == 0
@@ -67,6 +98,9 @@ def test_codex_startup_quotes_the_source_owned_fast_path(tmp_path: Path) -> None
     assert "runtime-fast-path:start" in context
     assert "repo_fact_uuid" in context
     assert "loaded from the source-owned AGENTS.md" in context
+    # Only the marked span, not the whole file.
+    assert "Text before the block" not in context
+    assert "Text after the block" not in context
 
 
 def test_startup_names_the_current_model_routing(tmp_path: Path) -> None:

--- a/python/openbrain-provider/tests/test_ts_parity.py
+++ b/python/openbrain-provider/tests/test_ts_parity.py
@@ -1,0 +1,113 @@
+"""Byte-parity with the live TypeScript gates, on their own recorded I/O.
+
+Every case here is a recording of the TypeScript gate answering a real event.
+The Python gate is fed the same stdin and arguments and must produce the same
+stdout and the same exit code, modulo the two things that differ between any two
+runs of the same program: instants and freshly-generated UUIDs.
+
+THE CASES REPLAY IN ORDER, AGAINST ONE STATE DIRECTORY, because that is how they
+were recorded. Half of them only mean anything as a sequence -- a `post-compact`
+arms a session and the next case proves the block, so replaying each in a fresh
+directory would test a different program. The whole sequence runs once in a
+session fixture and every case then asserts against its own recorded answer.
+
+A failure here is not a formatting nit. The hook contract IS the bytes: a
+`decision` key spelled differently is an unenforced gate, and a recovery command
+rendered differently is a command the gate then refuses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+from parity_runner import ParityCase, load_cases, normalise, run_case
+
+FIXTURE = Path(__file__).parent / "fixtures" / "ts_gate_parity" / "recorded.json"
+CASES = load_cases(FIXTURE)
+
+
+class Replay(NamedTuple):
+    """One case's recorded answer beside the answer Python produced."""
+
+    case: ParityCase
+    produced: str
+    code: int
+    scratch: Path
+
+
+@pytest.fixture(scope="module")
+def replays(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Replay]:
+    """Replay every recorded case, in order, against one state directory.
+
+    Args:
+        tmp_path_factory: pytest's per-module temp directory factory.
+
+    Returns:
+        Each case's produced answer, keyed by case name.
+    """
+    scratch = tmp_path_factory.mktemp("ts-parity")
+    results: dict[str, Replay] = {}
+    for case in CASES:
+        produced, code = run_case(case, scratch)
+        results[case.name] = Replay(case, produced, code, scratch)
+    return results
+
+
+def test_the_recordings_exist_and_cover_both_gates() -> None:
+    # A fixture file that silently became empty would make every parity test
+    # below pass while proving nothing -- the same class of defect as a live
+    # test that skips without its database.
+    assert len(CASES) >= 30
+    assert {case.script for case in CASES} == {"budget", "policy"}
+
+
+@pytest.mark.parametrize("name", [case.name for case in CASES])
+def test_matches_the_typescript_gate(name: str, replays: dict[str, Replay]) -> None:
+    replay = replays[name]
+    assert normalise(replay.produced, replay.scratch) == normalise(
+        replay.case.stdout, replay.scratch
+    ), name
+    assert replay.code == replay.case.status, name
+
+
+def test_a_block_is_json_with_a_reason_and_exit_zero(
+    replays: dict[str, Replay],
+) -> None:
+    # The shape a runtime actually enforces on: a block is DATA on stdout, and
+    # the exit code stays 0. A non-zero exit means the hook itself failed, which
+    # the harness handles differently.
+    blocked = [
+        replay
+        for replay in replays.values()
+        if replay.case.stdout.startswith("{") and '"decision"' in replay.case.stdout
+    ]
+    assert blocked, "no recorded block to compare against"
+    for replay in blocked:
+        payload = json.loads(replay.produced)
+        assert payload["decision"] == "block", replay.case.name
+        assert isinstance(payload["reason"], str) and payload["reason"]
+        assert replay.code == 0, replay.case.name
+
+
+def test_an_allow_emits_nothing_at_all(replays: dict[str, Replay]) -> None:
+    # Not an empty JSON object, not a newline: NOTHING. Both runtimes read empty
+    # stdout as allow, and a top-level `decision: "allow"` is invalid.
+    allowed = [replay for replay in replays.values() if replay.case.stdout == ""]
+    assert allowed, "no recorded allow to compare against"
+    for replay in allowed:
+        assert replay.produced == "", replay.case.name
+        assert replay.code == 0, replay.case.name
+
+
+def test_a_refusal_exits_one_and_says_why(replays: dict[str, Replay]) -> None:
+    # A REFUSED operator command is the one case that exits non-zero, because
+    # the operator asked for something and did not get it. It must also say what
+    # to do instead -- an exit code alone is not an error message.
+    refused = [replay for replay in replays.values() if replay.case.status == 1]
+    assert refused, "no recorded refusal to compare against"
+    for replay in refused:
+        assert replay.code == 1, replay.case.name
+        assert replay.produced.startswith("REFUSED:"), replay.case.name


### PR DESCRIPTION
## Summary
- PROV-10 (#419) as the epic specifies it: **the bugs are fixed by being written correctly in Python, not fixed in TypeScript first** (`_plans/issues/409-…md:41`). Ports `_ob/scripts/context-budget-gate.ts` (+ its `-shell`/`-state`/`-presentation` modules as merged by Development PR #75) and `_ob/scripts/policy-refresh-gate.ts` into `python/openbrain-provider`, which had stalled at PROV-3.
- **Byte parity is the bar, not similar behaviour.** The hook contract IS the bytes: a `decision` key spelled differently is an unenforced gate, and a recovery command rendered differently is a command the gate then refuses. The live TS gates were invoked with 33 representative events and their exact stdin/stdout/exit recorded (`tests/fixtures/ts_gate_parity/`); `test_ts_parity.py` replays them **in sequence against one state directory**, because half of them only mean anything in order — a `post-compact` arms a session and the next case proves the block.
- The fixtures earned their keep on the first run: the startup block emits **no** blank line after its heading, because the TS builds the array with a `""` separator and then `.filter(Boolean)` drops the separator along with an absent fast-path block. Nobody writes that from source by eye.
- **#419's acceptance is met and proven to be met.** The 15-minute read-back self-release fires, is a named transition, and never manufactures the recall receipt it did not get. Mutation-proven: disabling the release branch makes the test FAIL and restoring it returns green — which is exactly what the issue demands ("must fail against the current behavior").
- Ships `openbrain-context-budget-gate` and `openbrain-policy-refresh-gate` as `[project.scripts]`, invocable through the same `openbrain-hook-env` wrapper as the other hooks.
- **NOTHING IS REGISTERED.** The live TS gates stay on the hook chain and stay functional (verified this session: `--event status` exit 0, valid JSON). The `settings.json` swap is a separate, deliberate act.

## Critical Self-Review
- Highest-risk behavior: the **allowance boundary** in `gate_shell.py` — what a blocked session may still run. Too tight is the deadlock #419 names; too loose is no gate at all. Mitigated by 34 parametrised cases covering both directions: the exact printed recovery command is accepted in every equivalent spelling (`bun run`, absolute bun path, `--flag=value`), while five near-misses (no payload, wrong event, wrong cycle, wrong session, chained `&& git push`) are each refused, and `git config`/`git remote add`/`git branch <name>`/`env git push` are refused while their read-only spellings pass. The shell parser fails CLOSED on any character it cannot prove safe.
- Assumptions that could be wrong: (1) that `_ob`'s receipt-state schema stays stable — mitigated by transcribing the contract triple and schema string with line citations, so a drift is a diff rather than a mystery, and by ignoring any receipt whose triple does not match exactly; (2) that the TS gate's `gateCompactCycle` write is required rather than optional — verified from the recordings, where the read-back banner embeds a real correlation id that the clear path then compares.
- Missing/weak tests: no live-Postgres test, because **these gates touch no database** — they read and write local JSON state only, so a live gate would prove nothing this suite does not. Concurrency of the one write path is argued from protocol equivalence with the TS writer (same exclusive-create lock, same stale-lock reclaim, same fsync-and-rename), **not** measured under contention; that is the honest residual below.
- Security/permission risk: this is an enforcement surface, so a parser hole IS the risk. Addressed structurally — the pipeline parser refuses `;`, `&`, `>`, `` ` ``, `$`, refuses `$`/`` ` `` inside double quotes, refuses a repeated `--event`/`--runtime` flag as ambiguous, and requires the payload to name THIS session and resolve to THIS project. Malformed settings **narrow** the allowance rather than widening it (tested both for invalid JSON and for a named-but-missing adapter generation). State files are written 0600 under a 0700 parent, matching the TS writer.
- Migration/deploy risk: none in this PR — nothing is registered and no hook command changes. The registration lines are output for the controller to apply as a separate act, so the swap is reversible by not applying them.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python-client surface is touched; `python/openbrain` and `python/openbrain-memory` are unmodified and still green (386 and 550 tests). Per `docs/downstream-rollout.md` this is not a contract-changing change.
- Rollback/cleanup concern: one commit, additive to a package with no current consumers. Reverting removes two console-script declarations and eleven new modules; nothing else in the repo imports them.
- Fixes made before PR: the parity fixture caught the `startup_context` blank line (fixed, and commented so it is not "corrected" back); an unused `_unused_typing_anchor` helper was deleted rather than shipped, per the plan's review question about abstractions with no caller.
- Known residual risk: (1) the compact-cycle write is protocol-equivalent to the TS writer but **not measured under real concurrent contention** — the failure mode is a `TimeoutError` that the gate swallows into "no cycle", which keeps it blocking rather than arming with a wrong id, so it fails in the safe direction; (2) three assertions in `policy-refresh-gate.test.ts` are deliberately **not** transcribed because that file is red today against its own source (verified this session: 6 pass, 3 fail — it expects `OB ✓ gate passed` and a `source_validator:` line that moved into `AGENTS.md`, and an unconditional Agent/Task block the gate made conditional on `ANTHROPIC_BASE_URL`). Copying them would import a false red; the port tests what the source does and covers BOTH branches of the Agent rule explicitly. That upstream staleness is reported, not fixed here — it is Development's repo, not this one.
- SME review-memory update: [x] not applicable because: no new reviewer-lane pattern surfaced; the findings here (byte-parity fixtures as the port bar, and stale upstream tests) are recorded in the session journal and in `tests/fixtures/ts_gate_parity/README.md`, which is where the next porter will actually look.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: these gates never contact the Open Brain service — they read local receipt/state JSON and emit a verdict. No endpoint, token, or namespace is touched, so there is nothing to check live.

## Contract Parity
- Disposition: not applicable because: no MCP tool, schema, transport, or client-facing contract path is touched. The one shared contract this code reads — the receipt-state schema string and its contract triple — is consumed unchanged and asserted by constant, not redefined.

## Testing
- Label: `uv run ruff check` clean, `uv run mypy` clean (16 files), `uv run pytest` **258 passed** in `python/openbrain-provider`.
- Byte-parity: 33 recorded live-TS invocations replayed, all matching stdout and exit code.
- Mutation proof for #419: disabling the self-release branch → `test_a_stale_readback_self_releases_after_fifteen_minutes` FAILS (2 failed / 7 passed); restoring → 9 passed.
- Untouched-green: `bun test` **3060 pass / 500 skip / 0 fail**, `bunx tsc --noEmit` exit 0; `python/openbrain` 386 passed; `python/openbrain-memory` 550 passed.
- Live TS gates confirmed still functional after the change (`context-budget-gate.ts --event status` → exit 0, valid JSON).
