### PR TITLE
feat(receipts): the Python hooks write the gate state, breaking the circularity

### DIFF
--- a/python/openbrain-provider/pyproject.toml
+++ b/python/openbrain-provider/pyproject.toml
@@ -27,6 +27,26 @@ dependencies = [
 # the epic's "Home and shape" section -- `ob-memory-provider`,
 # `ob-claude-hook`, `ob-context-budget-gate` -- arrive with their modules.
 #
+# THE LIFECYCLE HOOKS ARE NOT AMONG THEM, and that is the part this file used to
+# get wrong. PROV-9 (#418) shipped on 2026-08-01 in the SIBLING package: the
+# console scripts `~/.claude/settings.json` actually runs after the #420 cutover
+# are declared in `python/openbrain/pyproject.toml` and implemented in
+# `openbrain/apps/hooks/` --
+#
+#   openbrain-session-start           = "openbrain.apps.hooks.session_start:main"
+#   openbrain-session-start-remaining = "...session_start:main_remaining"
+#   openbrain-post-compact            = "openbrain.apps.hooks.post_compact:main"
+#   openbrain-capture-stop            = "openbrain.apps.hooks.stop:main"
+#   openbrain-capture-subagent-stop   = "openbrain.apps.hooks.subagent_stop:main"
+#   openbrain-session-end             = "openbrain.apps.hooks.session_end:main"
+#
+# So the capture/lifecycle work did not stall here -- it RELOCATED. An earlier
+# version of this comment promised a `cli_provider.py` that is not coming, and
+# was left uncorrected when the work moved. What this package owns is `config`,
+# `constants`, `observability`, `vocabulary` (PROV-1..PROV-3) and the guard
+# below; #413-#417 remain open against it, and `docs/architecture.md` carries
+# the honest per-component state.
+#
 # The stable command name is the point: it replaces hook entries that hardcode
 # an absolute script path.
 [project.scripts]

--- a/python/openbrain/src/openbrain/apps/hooks/receipts.py
+++ b/python/openbrain/src/openbrain/apps/hooks/receipts.py
@@ -1,0 +1,313 @@
+"""Write the gate's unblock receipts at the lifecycle moments that earn them.
+
+Purpose:
+    The capabilities in ``apps.hooks.session`` do the WORK -- read canon, record a
+    compaction summary, deliver a turn. This module records the EVIDENCE that the
+    work happened, in the file the TypeScript context-budget gate reads. Keeping
+    it separate means a capability's own logic never has to know a gate exists,
+    and a change to the gate's protocol touches one file.
+
+Architecture:
+    Three functions, one per lifecycle moment the gate cares about.
+
+        ``note_compaction``      PostCompact opens the cycle
+        ``note_verified_recall`` SessionStart's successful canon read closes it
+        ``note_capture``         Stop's delivery clears the capture block
+
+    ``note_verified_recall_for_current_cycle`` is the form the ``SessionStart``
+    capability actually calls: it JOINS the session's live cycle to learn the id
+    the gate is waiting on, then records the recall against it, so the caller does
+    not have to carry a correlation id across two separate hook processes.
+
+    Each takes the hook payload's ``cwd`` and derives the project slug the same
+    way the gate does (``receipts.scope``). A ``cwd`` that is not Development work
+    resolves to nothing and nothing is written -- correctly, because the gate
+    tracks no block for such a session either.
+
+Pattern/Convention:
+    A RECEIPT IS NEVER WORTH BREAKING A HOOK FOR. Every function here returns
+    quietly on any failure and logs content-free. The receipt is evidence of work
+    that has ALREADY succeeded; failing the hook because the evidence could not be
+    filed would discard the work to protect the note about it. The worst case of a
+    swallowed failure is a gate that stays blocked, which self-releases on its own
+    timer and which the operator can clear explicitly.
+
+    THE RECEIPT IS WRITTEN AFTER THE WORK, NEVER BEFORE. Each caller invokes these
+    only on a path where the operation already returned successfully. A receipt
+    written first would be a claim rather than evidence, and the gate exists
+    precisely because claims were being trusted.
+
+See Also:
+    - ``openbrain.receipts`` - the writer and the schema
+    - ``openbrain.apps.hooks.session`` - the capabilities these observe
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from openbrain.receipts import (
+    ProviderReceiptEvidence,
+    default_receipt_state_path,
+    ensure_compact_cycle,
+    receipt_mode,
+    record_provider_receipt,
+    resolve_development_scope,
+    start_compact_cycle,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+def note_compaction(
+    session_id: str | None,
+    cwd: str | Path | None,
+    *,
+    state_path: Path | None = None,
+) -> str | None:
+    """Open the compaction cycle a later recall must name, after ``PostCompact``.
+
+    Args:
+        session_id: The session that was compacted.
+        cwd: The hook payload's working directory, used to derive the project.
+        state_path: The receipt file, defaulting to the shared one. Injected by
+            tests so they never touch the running session's state.
+
+    Returns:
+        The cycle's correlation id, or ``None`` when nothing was written.
+
+    This is the half of the lifecycle that ARMS the gate rather than releasing it:
+    the gate reads the cycle this opens, stores its id, and then blocks task
+    mutation until a recall naming that exact id arrives.
+    """
+    return _guarded(
+        "PostCompact",
+        lambda project, path: start_compact_cycle(
+            path, session_id=_required(session_id), project=project
+        ).id,
+        cwd,
+        state_path,
+    )
+
+
+def note_verified_recall(
+    session_id: str | None,
+    cwd: str | Path | None,
+    correlation_id: str,
+    *,
+    state_path: Path | None = None,
+) -> None:
+    """Record that ``SessionStart`` read canon back, releasing the gate's read-back.
+
+    Args:
+        session_id: The session that read canon.
+        cwd: The hook payload's working directory.
+        correlation_id: The compaction cycle this read belongs to. It MUST be the
+            id the gate is waiting on; a recall naming any other cycle is
+            correctly ignored.
+        state_path: The receipt file, defaulting to the shared one.
+
+    This is THE unblock. The receipt is graded through
+    :func:`~openbrain.receipts.receipt_mode` rather than asserted, so a read that
+    did not actually reach the service cannot present as a verified one.
+    """
+    _guarded(
+        "SessionStart",
+        lambda project, path: _record_recall(
+            path, project, _required(session_id), correlation_id
+        ),
+        cwd,
+        state_path,
+    )
+
+
+def _record_recall(
+    path: Path, project: str, session_id: str, correlation_id: str
+) -> str:
+    """File the verified-recall receipt that releases the gate's read-back.
+
+    ``mode`` is derived through :func:`~openbrain.receipts.receipt_mode` rather
+    than written as the literal ``verified-remote``. The grading is what makes the
+    receipt honest, and this is the one receipt whose only job is to say a read
+    really reached the service.
+    """
+    return record_provider_receipt(
+        path,
+        ProviderReceiptEvidence(
+            operation="recall",
+            mode=receipt_mode(
+                "recall",
+                "direct",
+                durable=False,
+                direct_attempted=True,
+                fallback_attempted=False,
+            ),
+            status="direct",
+            project=project,
+            session_id=session_id,
+            trigger="compact",
+            direct_attempted=True,
+            recorded_at=_now(),
+            correlation_id=correlation_id,
+        ),
+    ).recorded_at
+
+
+def note_verified_recall_for_current_cycle(
+    session_id: str | None,
+    cwd: str | Path | None,
+    *,
+    state_path: Path | None = None,
+) -> None:
+    """Join the session's live compaction cycle and record the recall against it.
+
+    Args:
+        session_id: The session that read canon.
+        cwd: The hook payload's working directory.
+        state_path: The receipt file, defaulting to the shared one.
+
+    The ``SessionStart`` hook is a SEPARATE PROCESS from the ``PostCompact`` that
+    opened the cycle, so it cannot be handed the correlation id -- it has to read
+    it back out of the shared file. :func:`~openbrain.receipts.ensure_compact_cycle`
+    is exactly that read: it returns the live cycle when one exists and opens a
+    fresh one when it does not.
+
+    Opening one when none exists is deliberate rather than a fallback. If the gate
+    has not armed a block, the cycle and receipt are simply unread and cost
+    nothing; if the gate armed one from its own side without a ``PostCompact``
+    hook having run, this is what lets the session clear it.
+    """
+    _guarded(
+        "SessionStart",
+        lambda project, path: _record_recall(
+            path, project, _required(session_id), _joined_cycle_id(path, project, session_id)
+        ),
+        cwd,
+        state_path,
+    )
+
+
+def _joined_cycle_id(path: Path, project: str, session_id: str | None) -> str:
+    """The id of the session's live compaction cycle, joining or opening one."""
+    return ensure_compact_cycle(
+        path, session_id=_required(session_id), project=project
+    ).id
+
+
+def note_capture(
+    session_id: str | None,
+    cwd: str | Path | None,
+    *,
+    state_path: Path | None = None,
+) -> None:
+    """Record that a turn was written durably, clearing the gate's capture block.
+
+    Args:
+        session_id: The session whose turn was delivered.
+        cwd: The hook payload's working directory.
+        state_path: The receipt file, defaulting to the shared one.
+
+    Called only after the lane has ACCEPTED the delivery, which is what makes
+    ``saved`` and ``durable`` honest here. A delivery that raised never reaches
+    this, so a failed write leaves the block standing -- which is the behaviour
+    the gate is for.
+    """
+    _guarded(
+        "Stop",
+        lambda project, path: record_provider_receipt(
+            path,
+            ProviderReceiptEvidence(
+                operation="capture",
+                mode=receipt_mode(
+                    "capture",
+                    "saved",
+                    durable=True,
+                    direct_attempted=True,
+                    fallback_attempted=False,
+                ),
+                status="saved",
+                project=project,
+                session_id=_required(session_id),
+                trigger="explicit",
+                direct_attempted=True,
+                recorded_at=_now(),
+            ),
+        ).recorded_at,
+        cwd,
+        state_path,
+    )
+
+
+def _guarded(
+    event: str,
+    write: Callable[[str, Path], str],
+    cwd: str | Path | None,
+    state_path: Path | None,
+) -> str | None:
+    """Resolve the project, run ``write``, and swallow every failure.
+
+    Args:
+        event: The hook name, for the log line only.
+        write: Takes the project slug and the state path and performs the write.
+        cwd: The hook payload's working directory.
+        state_path: The receipt file, or ``None`` for the shared default.
+
+    Returns:
+        Whatever ``write`` returned, or ``None`` when the directory was out of
+        scope or the write failed.
+
+    The whole swallow lives in one place so no caller can forget it and so the
+    log line is identical for every event.
+    """
+    scope = resolve_development_scope(cwd)
+    if scope is None:
+        return None
+
+    try:
+        path = state_path if state_path is not None else default_receipt_state_path()
+        return write(scope.project, path)
+    except Exception as error:  # noqa: BLE001 -- evidence must never break the work
+        # Content-free BY CONSTRUCTION: only the class name is passed, never the
+        # exception object, so no payload text or path reaches the sink even under
+        # loguru's diagnose (the rule ``stop.capture_stop_with`` documents).
+        logger.warning(
+            "{} receipt not recorded ({}); the context-budget gate may stay blocked",
+            event,
+            type(error).__name__,
+        )
+        return None
+
+
+class _NoSessionError(ValueError):
+    """The hook payload carried no session id, so there is nothing to file against.
+
+    Raised inside :func:`_guarded` rather than checked by each caller, so every
+    "nothing was written" outcome takes the one swallowed path instead of being
+    split across two shapes.
+    """
+
+    def __init__(self) -> None:
+        """State the missing field. There is no value to name."""
+        super().__init__("the hook payload carried no session id")
+
+
+def _required(session_id: str | None) -> str:
+    """The session id, or raise so :func:`_guarded` swallows it as one failure."""
+    if session_id is None:
+        raise _NoSessionError
+    return session_id
+
+
+def _now() -> str:
+    """The current moment in the shape the gate parses.
+
+    UTC with an explicit ``Z``, milliseconds -- matching JavaScript's
+    ``toISOString``. Every freshness window the gate applies is measured from this
+    value, so a naive datetime here would read as an arbitrarily old receipt.
+    """
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/python/openbrain/src/openbrain/apps/hooks/session.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session.py
@@ -60,8 +60,24 @@ from pydantic import BaseModel, ConfigDict, SkipValidation
 
 from openbrain.apps.capture.deliver import Delivery, RawLane, deliver_new_turns
 from openbrain.apps.capture.watermark import WatermarkStore
+from openbrain.apps.hooks.receipts import (
+    note_capture,
+    note_compaction,
+    note_verified_recall_for_current_cycle,
+)
 from openbrain.config import CanonSettings, CaptureSettings, ConfigurationError
 from openbrain.models.turn import RawTurn, TurnRole
+
+#: The ``SessionStart`` ``source`` value that means "a compaction just finished".
+#:
+#: The one start that is a post-compaction read-back. A ``startup``, ``resume``,
+#: ``clear``, or ``fork`` start reads canon too, but it is not what the
+#: context-budget gate armed its block against, and recording a ``compact`` recall
+#: receipt for one would clear a block a real compaction had every right to hold.
+#: Observed on the captured ``compact`` variant of the fixture, which carries
+#: ``prompt_id`` and ``model`` the ``startup`` variant lacks
+#: (``tests/fixtures/captured_hooks/README.md``).
+COMPACT_SESSION_SOURCE = "compact"
 
 #: The Stop harness deadline, in seconds. NOT a content bound -- this is a TIME
 #: budget tied to an EXTERNAL limit: Claude Code kills a Stop hook that has not
@@ -180,13 +196,20 @@ class SessionStartHook(BaseModel):
     ``source`` is READ but does not gate injection: the ruling is that canon --
     the always-known layer -- loads on every session start regardless of trigger.
     Back-history is what varies by source, and back-history is explicit-on-request
-    (the resume flow), never auto-loaded here.
+    (the resume flow), never auto-loaded here. It DOES gate the receipt: only a
+    ``compact`` start is the post-compaction read-back the gate is waiting for.
+
+    ``cwd`` is carried for the receipt alone. Canon does not use it -- its scope is
+    configured -- but the context-budget gate files every receipt under a project
+    slug derived from this directory, so a receipt written without it is filed
+    where the gate never looks.
     """
 
     model_config = ConfigDict(extra="ignore")
 
     session_id: str | None = None
     source: str | None = None
+    cwd: Path | None = None
 
 
 class StopHook(BaseModel):
@@ -198,12 +221,18 @@ class StopHook(BaseModel):
     do-nothing outcome, not a parse failure. ``extra="ignore"`` because the real
     payload carries many more fields (``stop_hook_active``, ``effort``, ...)
     that capture has no interest in.
+
+    ``cwd`` is carried for the capture receipt alone -- the context-budget gate
+    files receipts under a project slug derived from it, so a receipt written
+    without it is filed where the gate never looks. Delivery itself does not use
+    it; the namespace stays token-derived server-side.
     """
 
     model_config = ConfigDict(extra="ignore")
 
     transcript_path: Path | None = None
     session_id: str | None = None
+    cwd: Path | None = None
 
 
 class SubagentStopHook(BaseModel):
@@ -274,7 +303,12 @@ class PostCompactHook(BaseModel):
     recorded, and it takes it straight from this payload rather than the
     transcript. All fields optional -- a hook can fire before one exists, a
     do-nothing outcome, not a parse failure -- and ``extra="ignore"`` drops
-    ``trigger``, ``cwd``, and the rest.
+    ``trigger`` and the rest.
+
+    ``cwd`` is carried for the compaction-cycle receipt alone. Recording the
+    summary does not need it, but the context-budget gate keys the cycle this hook
+    opens on a project slug derived from this directory, and that cycle is what
+    the following ``SessionStart`` recall must name to release the gate.
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -283,6 +317,7 @@ class PostCompactHook(BaseModel):
     session_id: str | None = None
     prompt_id: str | None = None
     timestamp: str | None = None
+    cwd: Path | None = None
 
 
 class PostToolUseHook(BaseModel):
@@ -422,7 +457,7 @@ async def run_stop(
     store = WatermarkStore(settings.watermark_path)
 
     try:
-        return await deliver_new_turns(
+        delivery = await deliver_new_turns(
             payload.transcript_path, payload.session_id, store, started.lane
         )
     finally:
@@ -431,6 +466,14 @@ async def run_stop(
         # its own transport errors (``openbrain_memory.client.close``), so it
         # cannot itself break the delivery's outcome.
         started.close()
+
+    # Only reached when the delivery RETURNED, so the receipt is evidence rather
+    # than a claim: a raised delivery leaves the watermark unadvanced and skips
+    # this, which correctly leaves the gate's capture block standing. Written for
+    # a delivery of zero turns too -- the gate's question is "did this session
+    # reach Open Brain", and a turn with nothing new to send did.
+    note_capture(payload.session_id, payload.cwd)
+    return delivery
 
 
 async def run_subagent_stop(
@@ -584,6 +627,13 @@ async def run_post_compact(
         # same lifecycle rule run_stop and run_session_end own. The closer
         # swallows its own transport errors, so it cannot mask a send failure.
         started.close()
+
+    # AFTER the summary is stored, never before: this opens the compaction cycle
+    # the context-budget gate then blocks on, and arming that block for a
+    # compaction whose summary was never recorded would block the session over
+    # work that did not happen. It writes nothing and raises nothing when the cwd
+    # is out of scope or the receipt file is unwritable.
+    note_compaction(payload.session_id, payload.cwd)
     return True
 
 
@@ -852,12 +902,21 @@ async def run_session_start(
     build = canon_factory if canon_factory is not None else _canon_context
     context = build(settings)
     try:
-        return context.pack
+        pack = context.pack
     finally:
         # The read holds a server session slot; release it on every path, the
         # same lifecycle rule the capture capabilities own. The closer is
         # content-free and swallows its own transport errors.
         context.close()
+
+    # THE UNBLOCK, and only on a compaction restart. A ``startup`` or ``resume``
+    # start is not what the gate armed its read-back against, and writing a
+    # ``compact`` recall receipt for one would clear a block that a real
+    # compaction had every right to hold. Reached only after the read RETURNED,
+    # so the receipt is evidence the session really read canon back.
+    if payload.source == COMPACT_SESSION_SOURCE:
+        note_verified_recall_for_current_cycle(payload.session_id, payload.cwd)
+    return pack
 
 
 def _canon_context(settings: CanonSettings) -> CanonContext:

--- a/python/openbrain/src/openbrain/receipts/README.md
+++ b/python/openbrain/src/openbrain/receipts/README.md
@@ -1,4 +1,8 @@
-"""The gate's unblock state, written from Python instead of only read from TypeScript.
+# receipts
+
+<!-- generated from __init__.py -- do not edit by hand -->
+
+The gate's unblock state, written from Python instead of only read from TypeScript.
 
 Purpose:
     A live TypeScript hook -- ``_ob/scripts/context-budget-gate.ts``, registered
@@ -47,58 +51,9 @@ See Also:
     - ``_ob/scripts/ob-memory-provider/receipt-state.ts`` - the specification
     - ``_ob/scripts/context-budget-gate-state.ts`` - the reader that unblocks
     - ``_plans/issues/415-prov-6-receipt-construction-and-receipt-state.md``
-"""
 
-from __future__ import annotations
+---
 
-from openbrain.receipts.evidence import (
-    MEMORY_CONTRACT,
-    MEMORY_CONTRACT_SCHEMA_HASH,
-    MEMORY_CONTRACT_SCHEMA_VERSION,
-    RECEIPT_STATE_SCHEMA,
-    CompactCycleEvidence,
-    CompactCycleParticipant,
-    ProviderReceiptEvidence,
-    ReceiptMode,
-    ReceiptOperation,
-    ReceiptStatus,
-    ReceiptTrigger,
-    receipt_mode,
-)
-from openbrain.receipts.scope import (
-    DevelopmentScope,
-    resolve_development_scope,
-)
-from openbrain.receipts.state import (
-    ReceiptStateError,
-    attach_compact_cycle,
-    default_receipt_state_path,
-    ensure_compact_cycle,
-    open_compact_cycle,
-    record_provider_receipt,
-    start_compact_cycle,
-)
-
-__all__ = [
-    "MEMORY_CONTRACT",
-    "MEMORY_CONTRACT_SCHEMA_HASH",
-    "MEMORY_CONTRACT_SCHEMA_VERSION",
-    "RECEIPT_STATE_SCHEMA",
-    "CompactCycleEvidence",
-    "CompactCycleParticipant",
-    "DevelopmentScope",
-    "ProviderReceiptEvidence",
-    "ReceiptMode",
-    "ReceiptOperation",
-    "ReceiptStateError",
-    "ReceiptStatus",
-    "ReceiptTrigger",
-    "attach_compact_cycle",
-    "default_receipt_state_path",
-    "ensure_compact_cycle",
-    "open_compact_cycle",
-    "receipt_mode",
-    "record_provider_receipt",
-    "resolve_development_scope",
-    "start_compact_cycle",
-]
+Generated from the module docstring in `__init__.py`. To change this
+file, edit that docstring and run
+`python scripts/pytools/generate_package_docs.py --write`.

--- a/python/openbrain/src/openbrain/receipts/__init__.py
+++ b/python/openbrain/src/openbrain/receipts/__init__.py
@@ -1,0 +1,104 @@
+"""The gate's unblock state, written from Python instead of only read from TypeScript.
+
+Purpose:
+    A live TypeScript hook -- ``_ob/scripts/context-budget-gate.ts``, registered
+    on six Claude Code events -- blocks task mutation after a compaction until it
+    finds a fresh receipt in a shared JSON file. Before this package, only
+    TypeScript could write that file, and the #420 settings cutover removed every
+    hook registration that invoked the TypeScript writer. The reader stayed
+    registered; its writers did not. This package is the missing half: the Python
+    hooks that now own the lifecycle write the receipts the TypeScript gate reads.
+
+Architecture:
+    Two modules, one job each.
+
+        ``evidence``   the shapes -- what a receipt and a compact cycle ARE
+        ``state``      the file -- how they are read, merged, locked, and written
+        ``filelock``   the cross-language advisory lock the write protocol needs
+        ``scope``      which project slug a hook's ``cwd`` files receipts under
+
+    The split is the boundary between "what the gate expects to find" and "how
+    two languages share one file without corrupting it". A change to the schema
+    touches only ``evidence``; a change to the write protocol touches only
+    ``state``.
+
+    ``scope`` is separate because it is the part with no JSON in it and the part
+    most easily got wrong: the gate filters receipts by project slug, so a slug
+    derived any other way produces a valid receipt filed where nothing looks for
+    it.
+
+Pattern/Convention:
+    THE TYPESCRIPT MODULE IS THE SPECIFICATION, not a reference implementation to
+    improve on. ``_ob/scripts/ob-memory-provider/receipt-state.ts`` defines the
+    file's path, its schema literal, every field name and value, the freshness
+    windows the reader applies, the advisory lock protocol, and the atomic-replace
+    write. Python reproduces all of it byte-for-byte. Where a Python idiom would
+    differ from the TypeScript behaviour, the TypeScript behaviour wins -- an
+    "improvement" here is a file the gate cannot read, which fails CLOSED into a
+    session that can no longer edit or commit.
+
+    That is also why this does not reach for a storage library the way
+    ``apps.capture.watermark`` reaches for SQLite. Watermarks are ours end to end;
+    receipts are shared, and the solved problem was solved by the TypeScript
+    module. Any other engine would be a different protocol and would not
+    interoperate.
+
+See Also:
+    - ``_ob/scripts/ob-memory-provider/receipt-state.ts`` - the specification
+    - ``_ob/scripts/context-budget-gate-state.ts`` - the reader that unblocks
+    - ``_plans/issues/415-prov-6-receipt-construction-and-receipt-state.md``
+"""
+
+from __future__ import annotations
+
+from openbrain.receipts.evidence import (
+    MEMORY_CONTRACT,
+    MEMORY_CONTRACT_SCHEMA_HASH,
+    MEMORY_CONTRACT_SCHEMA_VERSION,
+    RECEIPT_STATE_SCHEMA,
+    CompactCycleEvidence,
+    CompactCycleParticipant,
+    ProviderReceiptEvidence,
+    ReceiptMode,
+    ReceiptOperation,
+    ReceiptStatus,
+    ReceiptTrigger,
+    receipt_mode,
+)
+from openbrain.receipts.scope import (
+    DevelopmentScope,
+    resolve_development_scope,
+)
+from openbrain.receipts.state import (
+    ReceiptStateError,
+    attach_compact_cycle,
+    default_receipt_state_path,
+    ensure_compact_cycle,
+    open_compact_cycle,
+    record_provider_receipt,
+    start_compact_cycle,
+)
+
+__all__ = [
+    "MEMORY_CONTRACT",
+    "MEMORY_CONTRACT_SCHEMA_HASH",
+    "MEMORY_CONTRACT_SCHEMA_VERSION",
+    "RECEIPT_STATE_SCHEMA",
+    "CompactCycleEvidence",
+    "CompactCycleParticipant",
+    "DevelopmentScope",
+    "ProviderReceiptEvidence",
+    "ReceiptMode",
+    "ReceiptOperation",
+    "ReceiptStateError",
+    "ReceiptStatus",
+    "ReceiptTrigger",
+    "attach_compact_cycle",
+    "default_receipt_state_path",
+    "ensure_compact_cycle",
+    "open_compact_cycle",
+    "receipt_mode",
+    "record_provider_receipt",
+    "resolve_development_scope",
+    "start_compact_cycle",
+]

--- a/python/openbrain/src/openbrain/receipts/evidence.py
+++ b/python/openbrain/src/openbrain/receipts/evidence.py
@@ -1,0 +1,308 @@
+"""The exact shapes the TypeScript gate expects to find in ``receipts.json``.
+
+Purpose:
+    Every field name, literal value, and enum member here is copied from
+    ``_ob/scripts/ob-memory-provider/receipt-state.ts``. The gate does not
+    negotiate: it filters candidate receipts on ``contract``,
+    ``contractSchemaVersion``, ``contractSchemaHash``, ``mode``, ``trigger``, and
+    ``fallbackAttempted`` (``receipt-state.ts`` ``findFreshReceipt``), so a
+    receipt that differs in any one of them is silently skipped and the gate
+    stays blocked.
+
+Architecture:
+    pydantic models with ``alias_generator`` doing the camelCase translation.
+    The Python attribute names stay snake_case, as the rest of the package is;
+    the SERIALISED names are camelCase, as TypeScript wrote them. Declaring the
+    mapping once on the model beats writing a hand-maintained field-name table,
+    which is the shape that drifts.
+
+Pattern/Convention:
+    THE CONTRACT TRIPLE IS NOT A PARAMETER. ``contract``,
+    ``contract_schema_version``, and ``contract_schema_hash`` are fixed defaults
+    that no caller may set: they identify WHICH memory-tools contract produced
+    the receipt, and a caller that could vary them could write a receipt claiming
+    a contract it does not implement. The TypeScript writer treats them the same
+    way -- ``recordProviderReceipt`` takes an ``Omit<..., "contract" | ...>`` and
+    fills them itself.
+
+    Likewise ``fallback_attempted`` is the literal ``False``. The gate rejects any
+    receipt where it is not exactly ``false``: the field records that no
+    second-choice write path was used, so a durable receipt earned through a
+    fallback is not evidence of the direct write the gate is waiting for.
+
+See Also:
+    - ``openbrain.receipts.state`` - the file this shape is written into
+    - ``_ob/scripts/ob-memory-provider/receipt-state.ts`` - the specification
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+#: The ``schema`` literal at the top of the file. The TypeScript reader compares
+#: it exactly and returns an EMPTY state on any mismatch, so a wrong value here
+#: does not corrupt the gate -- it silently erases every receipt in the file from
+#: the gate's view (``receipt-state.ts`` ``loadReceiptState``).
+RECEIPT_STATE_SCHEMA: Final = "development.openbrain-memory-receipts.v1"
+
+#: Which memory-tools contract produced a receipt. Part of the triple the gate
+#: filters on; a receipt naming a different contract is skipped.
+#:
+#: Typed ``Final`` rather than left to inference so it stays a ``Literal`` and can
+#: BE the model field's default. Inferred as a plain ``str`` it could not, and the
+#: constant and the field would drift into two independent copies of the same
+#: value -- exactly the split this triple exists to detect.
+MEMORY_CONTRACT: Final = "2026-07-23.memory-tools.v23"
+
+#: The contract's schema version, filtered on alongside :data:`MEMORY_CONTRACT`.
+MEMORY_CONTRACT_SCHEMA_VERSION: Final = 1
+
+#: The contract's schema hash, filtered on alongside :data:`MEMORY_CONTRACT`.
+#: A literal, never recomputed here: it identifies the TypeScript-side contract
+#: definition, and deriving it locally would let the two sides drift apart while
+#: both looked self-consistent.
+MEMORY_CONTRACT_SCHEMA_HASH: Final = (
+    "4b69e9b437c96175531b049b6e3c2782f383334e9e1931e96e73835599e4a4a8"
+)
+
+#: What the receipt is evidence OF. ``recall`` is a read; the other three are
+#: writes. The gate asks for different sets depending on which block it is
+#: clearing (``context-budget-gate-state.ts``: capture clears on any of
+#: capture/checkpoint/wrap, the post-compaction read-back clears only on recall).
+ReceiptOperation = Literal["recall", "capture", "checkpoint", "wrap"]
+
+#: How well the operation went, in the only three grades the gate distinguishes.
+#: ``verified-remote`` means the service accepted it directly; ``durable-spool``
+#: means it is queued on disk and will survive; ``failed`` is neither and never
+#: unblocks anything.
+ReceiptMode = Literal["verified-remote", "durable-spool", "failed"]
+
+#: The raw outcome the transport reported, before :func:`receipt_mode` grades it.
+ReceiptStatus = Literal["direct", "saved", "spooled", "failed", "lost"]
+
+#: What caused the operation. ``compact`` is the one the post-compaction
+#: read-back requires: ``recordProviderReceipt`` sets a cycle's
+#: ``verifiedRecallAt`` only for a ``recall``/``compact``/``verified-remote``
+#: receipt, and that timestamp is the whole unblock.
+ReceiptTrigger = Literal[
+    "compact", "pre-compact", "post-compact", "session-end", "explicit"
+]
+
+#: Which lifecycle hook joined a compaction cycle. ``gate`` is the TypeScript
+#: gate itself, which opens a cycle when no hook has.
+CompactCycleParticipant = Literal[
+    "pre-compact", "post-compact", "session-start", "gate"
+]
+
+
+class _CamelModel(BaseModel):
+    """Serialise as the TypeScript writer did: camelCase keys, no extra fields.
+
+    ``populate_by_name`` lets Python construct with snake_case attribute names
+    while ``by_alias=True`` dumps camelCase, so the two sides of the file agree
+    without either language writing the other's naming convention by hand.
+    ``extra="allow"`` on the reading path is deliberately NOT set here: these
+    models are what Python WRITES, and writing a field the gate does not know
+    about is how a shared file grows junk.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+
+class ProviderReceiptEvidence(_CamelModel):
+    """One durable-memory operation's receipt, in the gate's exact shape.
+
+    Attributes:
+        operation: What the receipt is evidence of.
+        mode: The graded outcome -- see :func:`receipt_mode`, which is the only
+            correct way to derive it.
+        status: The raw transport outcome the mode was graded from.
+        project: The Development project slug the session was working in. The
+            gate filters on this, so a receipt filed under the wrong slug is
+            invisible to it even when everything else matches.
+        session_id: The Claude Code session id.
+        trigger: What caused the operation.
+        direct_attempted: Whether the direct (non-spool) path was tried. A
+            ``recall`` receipt is only ``verified-remote`` when it was.
+        recorded_at: When the operation completed, ISO-8601 with an explicit UTC
+            offset. Every freshness window the gate applies is measured from
+            here, so a naive or local-time value silently ages the receipt.
+        correlation_id: The compaction cycle this belongs to, when it belongs to
+            one. It must equal the cycle's ``id`` for the read-back to clear.
+        fallback_attempted: Always ``False``, never settable.
+        contract: Always :data:`MEMORY_CONTRACT`, never settable.
+        contract_schema_version: Always
+            :data:`MEMORY_CONTRACT_SCHEMA_VERSION`, never settable.
+        contract_schema_hash: Always :data:`MEMORY_CONTRACT_SCHEMA_HASH`, never
+            settable.
+    """
+
+    operation: ReceiptOperation
+    mode: ReceiptMode
+    status: ReceiptStatus
+    project: str
+    session_id: str
+    trigger: ReceiptTrigger
+    direct_attempted: bool
+    recorded_at: str
+    correlation_id: str | None = None
+
+    # The four constants below are what the gate filters on to decide a receipt
+    # was written by something implementing the contract it expects. They are
+    # declared as single-value Literals so a caller CANNOT vary them: passing a
+    # different value is a validation error, not a receipt that lies.
+    fallback_attempted: Literal[False] = False
+    contract: Literal["2026-07-23.memory-tools.v23"] = MEMORY_CONTRACT
+    contract_schema_version: Literal[1] = MEMORY_CONTRACT_SCHEMA_VERSION
+    contract_schema_hash: Literal[
+        "4b69e9b437c96175531b049b6e3c2782f383334e9e1931e96e73835599e4a4a8"
+    ] = MEMORY_CONTRACT_SCHEMA_HASH
+
+    def trigger_key(self) -> str:
+        """The key this receipt is filed under in ``triggerReceipts``.
+
+        Returns:
+            ``"<operation>:<trigger>:<correlationId or 'uncorrelated'>"``, the
+            join ``recordProviderReceipt`` builds (``receipt-state.ts``). The
+            literal ``"uncorrelated"`` is part of the format, not a placeholder:
+            an uncorrelated receipt of the same operation and trigger must
+            overwrite the previous uncorrelated one rather than accumulate.
+        """
+        correlation = self.correlation_id or "uncorrelated"
+        return f"{self.operation}:{self.trigger}:{correlation}"
+
+
+class CompactCycleEvidence(_CamelModel):
+    """One compaction, and which lifecycle hooks took part in it.
+
+    A compaction spans several hook invocations in different processes:
+    ``PreCompact`` before the context is discarded, ``PostCompact`` after the
+    summary exists, and ``SessionStart`` when the harness reopens. This record is
+    what gives all of them ONE identity, so the gate can require that the recall
+    it is waiting for belongs to THIS compaction rather than an older one.
+
+    Attributes:
+        id: The correlation id, a UUID4. A receipt's ``correlation_id`` must
+            equal this for the read-back to clear.
+        project: The Development project slug.
+        session_id: The Claude Code session id, which is also this cycle's key in
+            the file.
+        started_at: When the cycle was opened, ISO-8601 with a UTC offset. The
+            gate treats a cycle older than its window as absent.
+        participants: The hooks that SUCCEEDED -- appended by
+            :func:`~openbrain.receipts.state.record_provider_receipt` when a
+            non-failed receipt arrives carrying this cycle's id.
+        attempted_participants: The hooks that RAN, successful or not. Kept apart
+            from ``participants`` because the TypeScript writer decides whether a
+            repeat invocation opens a NEW cycle from this list -- a second
+            ``pre-compact`` attempt means a second compaction, not a retry.
+        verified_recall_at: When a ``recall``/``compact``/``verified-remote``
+            receipt named this cycle. This single field is what clears the gate's
+            post-compaction read-back block.
+    """
+
+    id: str
+    project: str
+    session_id: str
+    started_at: str
+    participants: list[CompactCycleParticipant] = Field(default_factory=list)
+    attempted_participants: list[CompactCycleParticipant] = Field(
+        default_factory=list
+    )
+    verified_recall_at: str | None = None
+
+    # These lists are REPLACED, never appended to in place: the model is frozen
+    # so a participant is added by rebuilding the record with `model_copy`.
+    # Mutating a shared list is how two hook processes reading the same state end
+    # up writing each other's participants.
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="forbid",
+        frozen=True,
+    )
+
+    def with_participant(
+        self, participant: CompactCycleParticipant, *, attempted: bool
+    ) -> CompactCycleEvidence:
+        """Return this cycle with ``participant`` recorded, or itself unchanged.
+
+        Args:
+            participant: The hook to record.
+            attempted: ``True`` to record it in ``attempted_participants`` (it
+                ran), ``False`` to record it in ``participants`` (it succeeded).
+
+        Returns:
+            A new cycle carrying the participant, or ``self`` when it is already
+            listed -- the lists are sets by intent, and the TypeScript writer
+            guards the same way before appending.
+        """
+        current = self.attempted_participants if attempted else self.participants
+        if participant in current:
+            return self
+
+        field = "attempted_participants" if attempted else "participants"
+        return self.model_copy(update={field: [*current, participant]})
+
+
+def receipt_mode(
+    operation: ReceiptOperation,
+    status: ReceiptStatus,
+    *,
+    durable: bool,
+    direct_attempted: bool,
+    fallback_attempted: bool,
+) -> ReceiptMode:
+    """Grade a raw transport outcome into the mode the gate filters on.
+
+    Args:
+        operation: What was attempted.
+        status: What the transport reported.
+        durable: Whether the write is known to survive this process -- accepted
+            by the service, or committed to the on-disk spool.
+        direct_attempted: Whether the direct path was tried at all.
+        fallback_attempted: Whether a second-choice path was used.
+
+    Returns:
+        ``verified-remote`` when the service itself took it, ``durable-spool``
+        when it is queued and will survive, ``failed`` otherwise.
+
+    This is a straight port of ``receiptMode`` in ``receipt-state.ts`` and must
+    stay one. The grading is the honesty of the receipt: it is what stops a
+    spooled or failed write from reading as the verified one the gate is waiting
+    for. In particular a ``recall`` can never be ``durable-spool`` -- a read that
+    did not reach the service returned nothing, so there is no such thing as a
+    queued recall.
+
+    Example:
+        >>> receipt_mode("recall", "direct", durable=False,
+        ...              direct_attempted=True, fallback_attempted=False)
+        'verified-remote'
+        >>> receipt_mode("capture", "spooled", durable=True,
+        ...              direct_attempted=True, fallback_attempted=False)
+        'durable-spool'
+        >>> receipt_mode("capture", "saved", durable=True,
+        ...              direct_attempted=True, fallback_attempted=True)
+        'failed'
+    """
+    if fallback_attempted:
+        return "failed"
+
+    if operation == "recall":
+        return "verified-remote" if status == "direct" and direct_attempted else "failed"
+
+    if status == "saved" and durable and direct_attempted:
+        return "verified-remote"
+
+    if status == "spooled" and durable:
+        return "durable-spool"
+
+    return "failed"

--- a/python/openbrain/src/openbrain/receipts/filelock.py
+++ b/python/openbrain/src/openbrain/receipts/filelock.py
@@ -1,0 +1,247 @@
+"""The advisory lock two languages use to take turns on one JSON file.
+
+Purpose:
+    ``receipts.json`` is written by Python hooks and, today, still by the
+    TypeScript provider. Both must serialise against each other, and neither can
+    do that with a lock that lives inside one process. This module reproduces the
+    exact protocol ``withReceiptLock`` implements in
+    ``_ob/scripts/ob-memory-provider/receipt-state.ts`` so a Python writer and a
+    TypeScript writer contend correctly rather than interleaving.
+
+Architecture:
+    An ``O_CREAT | O_EXCL`` lockfile beside the state file. That flag pair is a
+    single atomic filesystem operation: exactly one of two racing processes gets
+    the file, the other gets ``EEXIST``. It is the cross-language part -- both
+    languages issue the same ``open(2)`` -- which a Python-only primitive
+    (``threading.Lock``, ``fcntl.flock`` semantics differing per platform, a
+    library's own scheme) would not be.
+
+Pattern/Convention:
+    A LOCK MUST BE RECLAIMABLE. A hook process killed between taking the lock and
+    releasing it would otherwise wedge the file permanently, and the gate would
+    then never see another receipt. So a lock whose mtime is old enough is
+    declared stale and stolen -- but only under a SECOND lock (``.lock.reclaim``),
+    so two processes cannot both decide to steal it and both believe they hold
+    it.
+
+    THE TOKEN IS WHY RELEASE IS SAFE. The holder writes ``pid:millis:uuid4`` into
+    the lockfile and, on release, only unlinks it if the content still matches. A
+    process whose lock was stolen while it was slow therefore cannot delete the
+    NEW holder's lock on its way out.
+
+    This module deliberately hand-writes what looks like a solved problem. The
+    solved problem is "lock a file in Python"; the actual problem is "use the
+    same lock the TypeScript module already uses", and only reproducing its
+    protocol solves that one.
+
+See Also:
+    - ``_ob/scripts/ob-memory-provider/receipt-state.ts`` - the specification
+    - ``openbrain.receipts.state`` - the only caller
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+#: How long a writer waits for another process's lock before giving up, matching
+#: ``LOCK_WAIT_MS`` in ``receipt-state.ts``. A receipt write is microseconds of
+#: work, so reaching this means the other holder is wedged, not merely busy.
+LOCK_WAIT_SECONDS = 5.0
+
+#: How old a lockfile must be before it is treated as abandoned, matching
+#: ``STALE_LOCK_MS``. Comfortably longer than any honest hold.
+STALE_LOCK_SECONDS = 30.0
+
+#: How long to sleep between attempts, matching ``LOCK_RETRY_MS``.
+RETRY_SECONDS = 0.01
+
+#: The permissions a lockfile is created with: owner-only, like the state file it
+#: guards. Receipts name sessions and projects, so the whole tree is private.
+_PRIVATE_FILE = 0o600
+
+
+class LockTimeoutError(TimeoutError):
+    """The lock was held by another process for longer than the wait allows.
+
+    Raised rather than silently proceeding: writing the state file without the
+    lock is what corrupts it, and a hook that cannot record a receipt should fail
+    into its caller's swallow rather than produce a file the gate then rejects.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Name the lock that could not be taken."""
+        super().__init__(f"receipt state lock timed out: {path}")
+
+
+@contextmanager
+def receipt_lock(state_path: Path) -> Iterator[None]:
+    """Hold the advisory lock for ``state_path`` for the duration of the block.
+
+    Args:
+        state_path: The state file being guarded. The lock itself is
+            ``<state_path>.lock``, the name the TypeScript writer uses.
+
+    Yields:
+        Nothing. The block runs with the lock held.
+
+    Raises:
+        LockTimeoutError: Another process held the lock past
+            :data:`LOCK_WAIT_SECONDS` and it was not stale enough to reclaim.
+        OSError: The lock directory could not be created or written.
+
+    Example:
+        >>> import tempfile, pathlib
+        >>> with tempfile.TemporaryDirectory() as directory:
+        ...     target = pathlib.Path(directory) / "receipts.json"
+        ...     with receipt_lock(target):
+        ...         (target.with_suffix(".json.lock")).exists()
+        True
+    """
+    lock_path = _lock_path(state_path)
+    token = _token()
+    _acquire(lock_path, token)
+    try:
+        yield
+    finally:
+        _release(lock_path, token)
+
+
+def ensure_private_parent(path: Path) -> None:
+    """Create ``path``'s directory owner-only, and keep it that way.
+
+    Args:
+        path: The file whose parent directory is being prepared.
+
+    ``mkdir`` applies its mode only when it CREATES the directory, so an existing
+    directory with looser permissions would keep them. The explicit ``chmod``
+    after is what makes the guarantee hold either way -- the same two-step the
+    TypeScript ``ensurePrivateParent`` performs.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    parent.chmod(0o700)
+
+
+def _lock_path(state_path: Path) -> Path:
+    """The lockfile guarding ``state_path``: its own name with ``.lock`` added.
+
+    Built by appending to the NAME rather than with ``with_suffix``, which would
+    replace ``.json`` instead of following it and would name a different file
+    from the one TypeScript locks.
+    """
+    return state_path.with_name(state_path.name + ".lock")
+
+
+def _token() -> str:
+    """A value unique to this holder: process, moment, and a random id.
+
+    All three matter. The pid alone repeats after a wrap; the timestamp alone
+    collides between two processes in the same millisecond; the uuid alone hides
+    who holds it when a wedged lock is being diagnosed by hand.
+    """
+    return f"{os.getpid()}:{int(time.time() * 1000)}:{uuid.uuid4()}"
+
+
+def _acquire(lock_path: Path, token: str) -> None:
+    """Take the lock, waiting for and if necessary reclaiming the current holder.
+
+    Raises:
+        LockTimeoutError: The wait elapsed with the lock still held by a holder
+            that was not stale.
+    """
+    ensure_private_parent(lock_path)
+    deadline = time.monotonic() + LOCK_WAIT_SECONDS
+    while not _create_owned_lock(lock_path, token):
+        if _lock_is_stale(lock_path) and _reclaim_stale_lock(lock_path, token):
+            return
+        if time.monotonic() >= deadline:
+            raise LockTimeoutError(lock_path)
+        time.sleep(RETRY_SECONDS)
+
+
+def _create_owned_lock(lock_path: Path, token: str) -> bool:
+    """Create the lockfile atomically and stamp it, or report it already exists.
+
+    Returns:
+        ``True`` when this process created it, ``False`` when another holds it.
+
+    ``O_EXCL`` is the whole mechanism: create-if-absent is one atomic syscall, so
+    two processes racing cannot both succeed. Everything after it is bookkeeping.
+    """
+    try:
+        descriptor = os.open(
+            lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, _PRIVATE_FILE
+        )
+    except FileExistsError:
+        return False
+
+    try:
+        os.write(descriptor, token.encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+    # `os.open`'s mode is masked by the process umask, so the file can land more
+    # permissive than asked. The explicit chmod is what actually guarantees it.
+    lock_path.chmod(_PRIVATE_FILE)
+    return True
+
+
+def _reclaim_stale_lock(lock_path: Path, token: str) -> bool:
+    """Steal an abandoned lock, under a second lock so only one stealer wins.
+
+    Returns:
+        ``True`` when this process now holds ``lock_path``.
+
+    Without the reclaim lock, two processes that both observed the same stale
+    lock would both unlink it and both create their own, and both would believe
+    they held it -- which is worse than the wedge being reclaimed, because it is
+    silent. Staleness is re-checked after taking the reclaim lock: by then the
+    original holder may have finished and a NEW holder taken it, and that one is
+    not abandoned.
+    """
+    reclaim_path = lock_path.with_name(lock_path.name + ".reclaim")
+    reclaim_token = _token()
+    if not _create_owned_lock(reclaim_path, reclaim_token):
+        return False
+
+    try:
+        if not _lock_is_stale(lock_path):
+            return False
+        lock_path.unlink(missing_ok=True)
+        return _create_owned_lock(lock_path, token)
+    finally:
+        _release(reclaim_path, reclaim_token)
+
+
+def _release(lock_path: Path, token: str) -> None:
+    """Unlink the lock, but only while this process is still its holder.
+
+    A lock that was reclaimed out from under a slow process now belongs to
+    someone else, and unlinking it would hand a third process a lock two of them
+    think they hold. Comparing the token before unlinking is what prevents that.
+    """
+    try:
+        if lock_path.read_text(encoding="utf-8") == token:
+            lock_path.unlink(missing_ok=True)
+    except FileNotFoundError:
+        return
+
+
+def _lock_is_stale(lock_path: Path) -> bool:
+    """Whether the lockfile is older than the abandonment window.
+
+    A lock that vanished between the failed create and this check is NOT stale --
+    it is gone, and the caller's next create attempt will simply succeed.
+    """
+    try:
+        age = time.time() - lock_path.stat().st_mtime
+    except FileNotFoundError:
+        return False
+
+    return age > STALE_LOCK_SECONDS

--- a/python/openbrain/src/openbrain/receipts/scope.py
+++ b/python/openbrain/src/openbrain/receipts/scope.py
@@ -246,7 +246,7 @@ def _git_path(cwd: Path, selector: str) -> Path | None:
             text=True,
             timeout=_GIT_TIMEOUT_SECONDS,
             check=False,
-            env=_git_environment(),
+            env=git_environment(),
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -258,7 +258,7 @@ def _git_path(cwd: Path, selector: str) -> Path | None:
     return Path(reported) if reported else None
 
 
-def _git_environment() -> dict[str, str]:
+def git_environment() -> dict[str, str]:
     """This process's environment with git's repository overrides removed.
 
     Returns:

--- a/python/openbrain/src/openbrain/receipts/scope.py
+++ b/python/openbrain/src/openbrain/receipts/scope.py
@@ -1,0 +1,245 @@
+"""Which Development project a hook's ``cwd`` belongs to, resolved as the gate does.
+
+Purpose:
+    Every receipt the gate reads is filed under a ``project`` slug, and the gate
+    filters on it. It derives that slug from the hook payload's ``cwd`` through
+    ``resolveDevelopmentScope`` in ``_ob/scripts/ob-memory-provider.ts``, so a
+    Python writer that derives it any other way files receipts under a key the
+    gate never looks up. The failure is silent -- a perfectly valid receipt that
+    unblocks nothing -- which makes this the least obvious and most load-bearing
+    part of the port.
+
+Architecture:
+    Two questions, in the order TypeScript asks them.
+
+        1. Is this ``cwd`` in scope at all?  ``scopedCwd``
+        2. If so, what is it called?          ``projectSlug``
+
+    Out of scope answers ``None``, and a caller with ``None`` writes no receipt:
+    the gate itself only tracks sessions whose ``cwd`` resolved, so a receipt for
+    an unscoped directory would have no block to clear.
+
+Pattern/Convention:
+    A WORKTREE IN THE TEMP WORKSPACE IS IN SCOPE, and that is not an edge case --
+    it is where the work happens. A directory outside ``Development`` still
+    resolves when it is a git worktree OF a Development repo and sits under an
+    approved temp root in the ``<repo>/_worktrees/<name>`` shape. Dropping that
+    branch would mean no receipt is ever written from a worktree, which is most
+    sessions.
+
+    THE SLUG COMES FROM GIT, NOT FROM THE PATH. ``git rev-parse --show-toplevel``
+    is what makes a worktree at ``_tmp/open-brain/_worktrees/x`` resolve to the
+    repo it belongs to rather than to the directory it sits in.
+
+See Also:
+    - ``_ob/scripts/ob-memory-provider.ts`` - ``resolveDevelopmentScope`` and below
+    - ``openbrain.receipts.state`` - what the slug is written into
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+#: The one directory tree Development work happens in. A literal, matching
+#: ``DEVELOPMENT_ROOT``; the gate has the same literal, and a configurable value
+#: on one side only would put the writer and the reader in different scopes.
+DEVELOPMENT_ROOT = Path("/Volumes/ThunderBolt/Development")
+
+#: Temp roots a Development worktree may legitimately live under, matching
+#: ``APPROVED_TEMP_WORKTREE_ROOTS``. The first is Rico's Mac, the second the
+#: cc-* boxes.
+APPROVED_TEMP_WORKTREE_ROOTS = (
+    Path("/Volumes/ThunderBolt/_tmp"),
+    Path("/mnt/collab/tmp_space"),
+)
+
+#: The slug used when no better name can be derived, matching ``projectSlug``.
+FALLBACK_PROJECT = "development"
+
+#: How long to wait for git before giving up on it, matching the TypeScript
+#: ``spawnSync`` timeout. A hook runs against a short deadline, and a wedged git
+#: must degrade to "no scope" rather than hold the session's hook open.
+_GIT_TIMEOUT_SECONDS = 2.0
+
+#: Characters a slug may keep; everything else becomes ``-``. Matches the
+#: TypeScript ``replace(/[^a-zA-Z0-9._-]/g, "-")``.
+_SLUG_UNSAFE = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+class DevelopmentScope(BaseModel):
+    """A resolved working directory and the project slug it belongs to.
+
+    Attributes:
+        cwd: The canonical (symlink-resolved) directory.
+        project: The slug receipts for this directory are filed under.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    cwd: Path
+    project: str
+
+
+def resolve_development_scope(cwd: str | Path | None) -> DevelopmentScope | None:
+    """Resolve a hook payload's ``cwd`` to the scope its receipts belong to.
+
+    Args:
+        cwd: The ``cwd`` field from the hook payload, or ``None`` when the
+            payload carried none.
+
+    Returns:
+        The scope, or ``None`` when this directory is not Development work. A
+        caller receiving ``None`` writes no receipt.
+
+    Example:
+        >>> resolve_development_scope("/nowhere-that-exists") is None
+        True
+        >>> resolve_development_scope(None) is None
+        True
+    """
+    if cwd is None:
+        return None
+
+    scoped = _scoped_cwd(Path(cwd))
+    if scoped is None:
+        return None
+
+    return DevelopmentScope(cwd=scoped, project=_project_slug(scoped))
+
+
+def _scoped_cwd(cwd: Path) -> Path | None:
+    """The canonical directory when it is in scope, else ``None``.
+
+    In scope means inside ``Development``, or -- for a worktree -- the same git
+    repository as ``Development`` AND under an approved temp root in the expected
+    shape. The git check is what stops an arbitrary directory that happens to sit
+    in the temp workspace from claiming Development scope.
+    """
+    root = _canonical_directory(DEVELOPMENT_ROOT)
+    candidate = _canonical_directory(cwd)
+    if root is None or candidate is None:
+        return None
+
+    if _is_within(candidate, root):
+        return candidate
+
+    if _same_git_repository(candidate, root) and _approved_temp_worktree(candidate):
+        return candidate
+
+    return None
+
+
+def _project_slug(cwd: Path) -> str:
+    """The slug this directory's receipts are filed under.
+
+    A directory belonging to the Development repository ITSELF -- the router, the
+    shared ``_ob`` tooling -- is named after that repository, not after whichever
+    subdirectory the session happened to open in. Anything else is named after
+    its own git top level, falling back to the directory when git says nothing.
+    """
+    top = _git_path(cwd, "--show-toplevel")
+    root = _canonical_directory(DEVELOPMENT_ROOT)
+    if top is not None and root is not None and _same_git_repository(top, root):
+        return root.name
+
+    named = top if top is not None else cwd
+    return _SLUG_UNSAFE.sub("-", named.name) or FALLBACK_PROJECT
+
+
+def _approved_temp_worktree(candidate: Path) -> bool:
+    """Whether ``candidate`` sits in the ``<repo>/_worktrees/<name>`` temp shape.
+
+    The shape is required, not just the root: it is what distinguishes a managed
+    worktree from a scratch directory someone left in the temp workspace, and the
+    gate applies the same test.
+    """
+    return any(
+        _worktree_shaped(_relative_parts(candidate, _canonical_directory(root)))
+        for root in APPROVED_TEMP_WORKTREE_ROOTS
+    )
+
+
+def _worktree_shaped(parts: tuple[str, ...] | None) -> bool:
+    """Whether a path relative to a temp root is ``<repo>/_worktrees/<name>...``."""
+    if parts is None or len(parts) < 3:
+        return False
+    return parts[1] == "_worktrees" and all(part not in {"", ".", ".."} for part in parts)
+
+
+def _relative_parts(candidate: Path, root: Path | None) -> tuple[str, ...] | None:
+    """``candidate``'s path segments below ``root``, or ``None`` when not below it."""
+    if root is None:
+        return None
+    try:
+        return candidate.relative_to(root).parts
+    except ValueError:
+        return None
+
+
+def _is_within(candidate: Path, root: Path) -> bool:
+    """Whether ``candidate`` is ``root`` itself or sits underneath it."""
+    return candidate == root or _relative_parts(candidate, root) is not None
+
+
+def _same_git_repository(left: Path, right: Path) -> bool:
+    """Whether two directories belong to the same git repository.
+
+    Compares ``--git-common-dir``, not ``--git-dir``: a worktree has its OWN git
+    dir but SHARES the common one with its main checkout, and sharing it is
+    exactly the relationship being tested.
+    """
+    left_common = _git_path(left, "--git-common-dir")
+    right_common = _git_path(right, "--git-common-dir")
+    return left_common is not None and left_common == right_common
+
+
+def _git_path(cwd: Path, selector: str) -> Path | None:
+    """Ask git for an absolute path from ``cwd``, or ``None`` when it cannot say.
+
+    Args:
+        cwd: Where to ask from.
+        selector: ``--show-toplevel`` or ``--git-common-dir``.
+
+    Returns:
+        The path git reported, or ``None`` for a non-repository, a missing git, a
+        timeout, or empty output.
+
+    Never raises. Scope resolution runs inside a hook, and a git that is absent or
+    slow must degrade to "no scope" rather than break the session.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 -- fixed argv, no shell, no user input in the command
+            ["git", "-C", str(cwd), "rev-parse", "--path-format=absolute", selector],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if completed.returncode != 0:
+        return None
+
+    reported = completed.stdout.strip()
+    return Path(reported) if reported else None
+
+
+def _canonical_directory(path: Path) -> Path | None:
+    """``path`` with symlinks resolved, or ``None`` when it is not a directory.
+
+    Symlinks are resolved on BOTH sides of every comparison in this module. A
+    containment test between a resolved path and an unresolved one silently
+    answers "no" for any directory reached through a symlink, which on a machine
+    with a symlinked volume means no receipts at all.
+    """
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return None
+
+    return resolved if resolved.is_dir() else None

--- a/python/openbrain/src/openbrain/receipts/scope.py
+++ b/python/openbrain/src/openbrain/receipts/scope.py
@@ -38,6 +38,7 @@ See Also:
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -68,6 +69,29 @@ _GIT_TIMEOUT_SECONDS = 2.0
 #: Characters a slug may keep; everything else becomes ``-``. Matches the
 #: TypeScript ``replace(/[^a-zA-Z0-9._-]/g, "-")``.
 _SLUG_UNSAFE = re.compile(r"[^a-zA-Z0-9._-]")
+
+#: Git environment variables that OVERRIDE ``git -C`` and must be cleared.
+#:
+#: This is not hypothetical tidiness -- it was measured. ``git push`` exports
+#: ``GIT_DIR`` and ``GIT_WORK_TREE`` to its hooks, and ``GIT_WORK_TREE`` beats
+#: ``-C``: inside a pre-push hook, ``git -C <any path> rev-parse --show-toplevel``
+#: answered ``/Volumes/ThunderBolt/Development`` for EVERY directory asked about.
+#: Every receipt in every repo would then be filed under the single project slug
+#: ``Development``, and the gate -- which keys its blocks per project -- would
+#: never match one.
+#:
+#: Caught 2026-08-03 by the scope tests failing under the pre-push hook while
+#: passing when run directly. Cleared rather than merely documented, because a
+#: hook is exactly where these hooks run.
+_OVERRIDING_GIT_ENV = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+)
 
 
 class DevelopmentScope(BaseModel):
@@ -210,6 +234,10 @@ def _git_path(cwd: Path, selector: str) -> Path | None:
 
     Never raises. Scope resolution runs inside a hook, and a git that is absent or
     slow must degrade to "no scope" rather than break the session.
+
+    Runs with :data:`_OVERRIDING_GIT_ENV` stripped, because those variables beat
+    ``-C`` and would make every directory answer with the invoking repository's
+    paths instead of its own.
     """
     try:
         completed = subprocess.run(  # noqa: S603 -- fixed argv, no shell, no user input in the command
@@ -218,6 +246,7 @@ def _git_path(cwd: Path, selector: str) -> Path | None:
             text=True,
             timeout=_GIT_TIMEOUT_SECONDS,
             check=False,
+            env=_git_environment(),
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -227,6 +256,24 @@ def _git_path(cwd: Path, selector: str) -> Path | None:
 
     reported = completed.stdout.strip()
     return Path(reported) if reported else None
+
+
+def _git_environment() -> dict[str, str]:
+    """This process's environment with git's repository overrides removed.
+
+    Returns:
+        A copy of ``os.environ`` without :data:`_OVERRIDING_GIT_ENV`.
+
+    A copy, not a mutation: this runs inside a hook whose parent process owns
+    those variables, and clearing them globally would change the behaviour of
+    anything else that shells out to git afterwards. Only the child sees them
+    gone.
+    """
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if name not in _OVERRIDING_GIT_ENV
+    }
 
 
 def _canonical_directory(path: Path) -> Path | None:

--- a/python/openbrain/src/openbrain/receipts/state.py
+++ b/python/openbrain/src/openbrain/receipts/state.py
@@ -1,0 +1,565 @@
+"""Read, merge, and atomically replace the receipt file the TypeScript gate reads.
+
+Purpose:
+    The write half of the shared state. A hook calls
+    :func:`record_provider_receipt` when an operation completes, or one of the
+    ``*_compact_cycle`` functions when it joins a compaction, and this module
+    merges that into ``receipts.json`` without losing what another writer -- in
+    either language -- put there.
+
+Architecture:
+    Read-modify-write under the shared lock, then replace the file atomically.
+
+        ``filelock.receipt_lock``   nobody else writes while we read and merge
+        ``os.replace``              a reader never sees a half-written file
+
+    Both halves are required. The lock alone still lets a reader observe a
+    partial write; the atomic replace alone still lets two writers each merge
+    into a stale copy and one lose. ``os.replace`` is POSIX ``rename(2)``, the
+    same call node's ``renameSync`` makes, so a TypeScript reader gets the same
+    all-or-nothing guarantee a Python one does.
+
+Pattern/Convention:
+    A FOREIGN OR CORRUPT FILE READS AS EMPTY, NEVER AS AN ERROR. That is the
+    TypeScript reader's behaviour (``loadReceiptState`` returns an empty state on
+    a parse failure or an unrecognised ``schema``) and it has to be matched: a
+    hook that raised on a malformed file would fail on every subsequent
+    invocation, and the file is exactly what a crashed writer might have
+    mangled.
+
+    UNKNOWN KEYS SURVIVE A ROUND TRIP. The file carries sections this package
+    does not model -- ``reflexSuppression`` is written by the TypeScript reflex
+    path -- and dropping them on write would silently delete another component's
+    state. They are read as opaque values and written straight back.
+
+    THIS MODULE PRUNES NOTHING. The TypeScript writer discards entries older than
+    its window on every write; Python does not, because the gate applies its own
+    freshness windows when reading and an old entry is therefore already inert.
+    Removing data is the operator's call, not a side effect of recording a
+    receipt.
+
+See Also:
+    - ``openbrain.receipts.evidence`` - the shapes written here
+    - ``openbrain.receipts.filelock`` - the cross-language lock
+    - ``_ob/scripts/context-budget-gate-state.ts`` - the reader that unblocks
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from openbrain.receipts.evidence import (
+    RECEIPT_STATE_SCHEMA,
+    CompactCycleEvidence,
+    CompactCycleParticipant,
+    ProviderReceiptEvidence,
+)
+from openbrain.receipts.filelock import ensure_private_parent, receipt_lock
+
+#: How long a compaction cycle stays current, matching ``COMPACT_CYCLE_MAX_AGE_MS``
+#: in ``receipt-state.ts``. A hook joining a cycle older than this opens a new one
+#: instead, because the gate would not have accepted the old one anyway.
+COMPACT_CYCLE_MAX_AGE_SECONDS = 20 * 60
+
+#: The permissions the state file carries. Receipts name sessions and projects,
+#: so the file is owner-only, as the TypeScript writer leaves it.
+_PRIVATE_FILE = 0o600
+
+#: The characters a session id or project slug may contain, matching
+#: ``safeCoordinate``. These values become JSON object KEYS and are compared by
+#: the gate, so anything outside this set is a coordinate that could not have
+#: come from the harness.
+_COORDINATE_ALPHABET = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:@/-"
+)
+
+#: The longest a coordinate may be, matching ``safeCoordinate``.
+_COORDINATE_LONGEST = 200
+
+
+class ReceiptStateError(ValueError):
+    """A receipt could not be recorded because its coordinates were unusable.
+
+    Raised for a session id or project slug that could not have come from the
+    harness -- empty, over-long, or carrying characters that have no place in a
+    JSON key the gate matches on. The alternative is filing the receipt under a
+    key the gate will never look up, which reads as "no receipt was written" and
+    is far harder to diagnose than a named error the entrypoint swallows.
+    """
+
+    def __init__(self, name: str) -> None:
+        """Name which coordinate was unusable.
+
+        The VALUE is deliberately absent from the message. A session id is not a
+        secret, but this error is raised from inside a hook whose logs are
+        content-free by construction, and naming the field is enough to find the
+        caller that passed it.
+        """
+        super().__init__(f"{name} is not a usable receipt coordinate")
+
+
+def default_receipt_state_path() -> Path:
+    """Where the shared receipt file lives, resolved exactly as TypeScript does.
+
+    Returns:
+        ``$XDG_STATE_HOME/agent-runtime/openbrain-memory/receipts.json``, falling
+        back to ``~/.local/state`` when the variable is unset or empty.
+
+    An empty ``XDG_STATE_HOME`` falls back rather than resolving to the current
+    directory: ``defaultReceiptStatePath`` uses a JavaScript ``||``, which treats
+    the empty string as absent, and a Python ``os.environ.get`` default would
+    not. Two languages disagreeing about this would put the writer and the reader
+    on different files, which presents as the gate simply never unblocking.
+    """
+    state_home = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(state_home) / "agent-runtime" / "openbrain-memory" / "receipts.json"
+
+
+def open_compact_cycle(
+    path: Path, *, session_id: str, project: str, now: datetime | None = None
+) -> CompactCycleEvidence:
+    """Open a compaction cycle from ``PreCompact``, the first participant.
+
+    Args:
+        path: The receipt state file.
+        session_id: The Claude Code session id.
+        project: The Development project slug.
+        now: The moment to record, defaulting to the current UTC time.
+
+    Returns:
+        The cycle this hook is part of -- a fresh one, or the current one it
+        joined.
+
+    ``PreCompact`` is the only participant that runs while the full pre-loss
+    context still exists, so it opens the cycle the later participants join. A
+    SECOND ``PreCompact`` attempt means a second compaction rather than a retry,
+    and starts a new cycle.
+    """
+    return attach_compact_cycle(
+        path, session_id=session_id, project=project, participant="pre-compact", now=now
+    )
+
+
+def start_compact_cycle(
+    path: Path, *, session_id: str, project: str, now: datetime | None = None
+) -> CompactCycleEvidence:
+    """Join or open a compaction cycle from ``PostCompact``.
+
+    Args:
+        path: The receipt state file.
+        session_id: The Claude Code session id.
+        project: The Development project slug.
+        now: The moment to record, defaulting to the current UTC time.
+
+    Returns:
+        The cycle this hook is part of.
+
+    ``PostCompact`` fires once per completed compaction. When it joins a cycle a
+    ``SessionStart`` has already completed, that cycle is finished and this is a
+    new compaction, so a new cycle is opened.
+    """
+    return attach_compact_cycle(
+        path, session_id=session_id, project=project, participant="post-compact", now=now
+    )
+
+
+def ensure_compact_cycle(
+    path: Path, *, session_id: str, project: str, now: datetime | None = None
+) -> CompactCycleEvidence:
+    """Join or open a compaction cycle from ``SessionStart``.
+
+    Args:
+        path: The receipt state file.
+        session_id: The Claude Code session id.
+        project: The Development project slug.
+        now: The moment to record, defaulting to the current UTC time.
+
+    Returns:
+        The cycle whose ``id`` a following recall receipt must carry to clear the
+        gate's post-compaction read-back.
+
+    This is the call that matters most to the unblock: the gate stores the
+    cycle's id as its ``readbackCorrelationId``, and clears only when a
+    ``recall``/``compact``/``verified-remote`` receipt names that exact id.
+    """
+    return attach_compact_cycle(
+        path,
+        session_id=session_id,
+        project=project,
+        participant="session-start",
+        now=now,
+    )
+
+
+def attach_compact_cycle(
+    path: Path,
+    *,
+    session_id: str,
+    project: str,
+    participant: CompactCycleParticipant,
+    now: datetime | None = None,
+) -> CompactCycleEvidence:
+    """Record ``participant`` against the session's cycle, opening one if needed.
+
+    Args:
+        path: The receipt state file.
+        session_id: The Claude Code session id.
+        project: The Development project slug.
+        participant: Which lifecycle hook is joining.
+        now: The moment to record, defaulting to the current UTC time.
+
+    Returns:
+        The cycle the participant is now attached to.
+
+    Raises:
+        ReceiptStateError: ``session_id`` or ``project`` is not a usable
+            coordinate.
+    """
+    session_id = _safe_coordinate(session_id, "session_id")
+    project = _safe_coordinate(project, "project")
+    moment = now if now is not None else datetime.now(UTC)
+
+    with receipt_lock(path):
+        state = _load(path)
+        cycles = _mapping(state.get("compactCycles"))
+        existing = _existing_cycle(cycles.get(session_id), project, moment)
+        cycle = (
+            existing.with_participant(participant, attempted=True)
+            if existing is not None and not _starts_new_cycle(existing, participant)
+            else _fresh_cycle(session_id, project, participant, moment)
+        )
+        cycles[session_id] = cycle.model_dump(by_alias=True, exclude_none=True)
+        state["compactCycles"] = cycles
+        _write(path, state)
+        return cycle
+
+
+def record_provider_receipt(
+    path: Path, receipt: ProviderReceiptEvidence
+) -> ProviderReceiptEvidence:
+    """File one receipt, and credit its compaction cycle when it names one.
+
+    Args:
+        path: The receipt state file.
+        receipt: The evidence to record. Build its ``mode`` with
+            :func:`~openbrain.receipts.evidence.receipt_mode` rather than by
+            hand -- an over-stated mode is a receipt that lies to the gate.
+
+    Returns:
+        The receipt as filed.
+
+    Raises:
+        ReceiptStateError: The receipt's session id or project is not a usable
+            coordinate.
+
+    The receipt lands in three places, all of which the gate reads:
+    ``sessions[sessionId][operation]`` (the latest of each operation),
+    ``triggerReceipts[sessionId][key]`` (kept per trigger and correlation, so a
+    compaction recall is not overwritten by an unrelated one), and -- when it
+    names a live cycle -- that cycle's ``participants``. A
+    ``recall``/``compact``/``verified-remote`` receipt additionally stamps the
+    cycle's ``verifiedRecallAt``, which IS the post-compaction unblock.
+    """
+    session_id = _safe_coordinate(receipt.session_id, "session_id")
+    project = _safe_coordinate(receipt.project, "project")
+    filed = receipt.model_copy(update={"session_id": session_id, "project": project})
+    encoded = filed.model_dump(by_alias=True, exclude_none=True)
+
+    with receipt_lock(path):
+        state = _load(path)
+        _file_receipt(state, filed, encoded)
+        _credit_cycle(state, filed)
+        _write(path, state)
+
+    return filed
+
+
+def _file_receipt(
+    state: dict[str, Any], receipt: ProviderReceiptEvidence, encoded: dict[str, Any]
+) -> None:
+    """Store the receipt under both the per-operation and per-trigger keys.
+
+    Two indexes because the gate asks two different questions. ``sessions`` keeps
+    only the newest receipt per operation, which answers "has anything been
+    captured lately"; ``triggerReceipts`` keeps one per operation/trigger/cycle,
+    which answers "did THIS compaction's recall happen" without an unrelated
+    later recall overwriting the answer.
+    """
+    sessions = _mapping(state.get("sessions"))
+    session = _mapping(sessions.get(receipt.session_id))
+    session[receipt.operation] = encoded
+    sessions[receipt.session_id] = session
+    state["sessions"] = sessions
+
+    trigger_receipts = _mapping(state.get("triggerReceipts"))
+    per_session = _mapping(trigger_receipts.get(receipt.session_id))
+    per_session[receipt.trigger_key()] = encoded
+    trigger_receipts[receipt.session_id] = per_session
+    state["triggerReceipts"] = trigger_receipts
+
+
+def _credit_cycle(state: dict[str, Any], receipt: ProviderReceiptEvidence) -> None:
+    """Add the receipt's participant to its cycle, and stamp a verified recall.
+
+    Does nothing unless the receipt carries a ``correlation_id`` matching a
+    stored cycle of the same project. That guard is the point of the correlation
+    id: a recall from an EARLIER compaction must not clear the read-back the
+    current one armed, and without the id check it would.
+    """
+    cycles = _mapping(state.get("compactCycles"))
+    stored = cycles.get(receipt.session_id)
+    cycle = _decode_cycle(stored)
+    if cycle is None or receipt.correlation_id != cycle.id:
+        return
+    if receipt.project != cycle.project:
+        return
+
+    participant = _compact_participant(receipt)
+    if participant is not None:
+        cycle = cycle.with_participant(participant, attempted=False)
+
+    if (
+        receipt.operation == "recall"
+        and receipt.trigger == "compact"
+        and receipt.mode == "verified-remote"
+    ):
+        cycle = cycle.model_copy(update={"verified_recall_at": receipt.recorded_at})
+
+    cycles[receipt.session_id] = cycle.model_dump(by_alias=True, exclude_none=True)
+    state["compactCycles"] = cycles
+
+
+def _compact_participant(
+    receipt: ProviderReceiptEvidence,
+) -> CompactCycleParticipant | None:
+    """Which cycle participant a SUCCESSFUL receipt proves ran.
+
+    Returns:
+        The participant, or ``None`` when the receipt proves nothing -- a failed
+        write, or an operation that is not part of a compaction.
+
+    A straight port of ``compactParticipant``. A failed receipt credits nobody:
+    ``participants`` records what actually happened, and the attempt is already
+    in ``attemptedParticipants``.
+    """
+    if receipt.mode == "failed":
+        return None
+    if receipt.operation == "checkpoint" and receipt.trigger == "pre-compact":
+        return "pre-compact"
+    if receipt.operation == "checkpoint" and receipt.trigger == "post-compact":
+        return "post-compact"
+    if receipt.operation == "recall" and receipt.trigger == "compact":
+        return "session-start"
+    return None
+
+
+def _existing_cycle(
+    stored: object, project: str, now: datetime
+) -> CompactCycleEvidence | None:
+    """The session's current cycle, or ``None`` when there is nothing to join.
+
+    ``None`` covers all four ways a stored cycle is not joinable: absent,
+    undecodable, belonging to another project, and older than the window the gate
+    would accept.
+    """
+    cycle = _decode_cycle(stored)
+    if cycle is None or cycle.project != project:
+        return None
+
+    started = _parse_moment(cycle.started_at)
+    if started is None:
+        return None
+    if (now - started).total_seconds() > COMPACT_CYCLE_MAX_AGE_SECONDS:
+        return None
+
+    return cycle
+
+
+def _starts_new_cycle(
+    existing: CompactCycleEvidence, participant: CompactCycleParticipant
+) -> bool:
+    """Whether this participant's arrival means a SECOND compaction, not a retry.
+
+    Two cases, both ported from ``attachCompactCycle``. A repeat ``pre-compact``
+    is a new compaction, because that hook fires once before each one. A repeat
+    ``post-compact`` is a new compaction only once a ``session-start`` has
+    succeeded in the current cycle -- until then the cycle is still mid-flight
+    and the repeat is the same compaction being re-observed.
+    """
+    if participant == "pre-compact":
+        return "pre-compact" in existing.attempted_participants
+    if participant == "post-compact":
+        return (
+            "post-compact" in existing.attempted_participants
+            and "session-start" in existing.participants
+        )
+    return False
+
+
+def _fresh_cycle(
+    session_id: str,
+    project: str,
+    participant: CompactCycleParticipant,
+    now: datetime,
+) -> CompactCycleEvidence:
+    """A newly opened cycle with this participant recorded as having run."""
+    return CompactCycleEvidence(
+        id=str(uuid.uuid4()),
+        project=project,
+        session_id=session_id,
+        started_at=_iso(now),
+        participants=[],
+        attempted_participants=[participant],
+    )
+
+
+def _decode_cycle(stored: object) -> CompactCycleEvidence | None:
+    """Parse a stored cycle, treating anything unrecognisable as absent.
+
+    A cycle written by a future version, or mangled by a crashed writer, must not
+    raise here: the caller would then be unable to open a NEW cycle and the
+    session would stay blocked on unreadable state forever. Returning ``None``
+    lets a fresh cycle replace it.
+    """
+    if not isinstance(stored, dict):
+        return None
+    try:
+        return CompactCycleEvidence.model_validate(stored)
+    except ValueError:
+        return None
+
+
+def _load(path: Path) -> dict[str, Any]:
+    """Read the state file, or an empty state when it is absent or unusable.
+
+    Mirrors ``loadReceiptState``: a missing file, unparseable JSON, a non-object
+    document, or a ``schema`` value this version does not recognise all read as
+    empty. Failing loudly instead would turn one bad write into a permanently
+    broken hook, and the file is exactly what a crashed writer may have mangled.
+
+    Keys this package does not model are kept as they were found, so a section
+    another component owns survives being written back.
+    """
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return _empty()
+
+    if not isinstance(document, dict):
+        return _empty()
+    if document.get("schema") != RECEIPT_STATE_SCHEMA:
+        return _empty()
+
+    state: dict[str, Any] = dict(document)
+    state["sessions"] = _mapping(state.get("sessions"))
+    state["compactCycles"] = _mapping(state.get("compactCycles"))
+    return state
+
+
+def _empty() -> dict[str, Any]:
+    """A state document carrying nothing but the schema the gate recognises."""
+    return {"schema": RECEIPT_STATE_SCHEMA, "sessions": {}, "compactCycles": {}}
+
+
+def _write(path: Path, state: dict[str, Any]) -> None:
+    """Replace the state file atomically, owner-only, with the caller's lock held.
+
+    Writes a staging file beside the target, flushes it to disk, then
+    ``os.replace``s it over the target. ``os.replace`` is POSIX ``rename(2)``:
+    within a filesystem it is atomic, so a concurrent reader -- in either
+    language -- sees either the whole old file or the whole new one and never a
+    truncated document.
+
+    The staging name carries the pid and the moment so two writers cannot collide
+    on it, matching the TypeScript writer's ``${path}.${pid}.${now}.tmp``, and it
+    is opened exclusively so an existing file is never silently overwritten.
+    """
+    ensure_private_parent(path)
+    staging = path.with_name(f"{path.name}.{os.getpid()}.{int(time.time() * 1000)}.tmp")
+    encoded = json.dumps(state, indent=2)
+
+    descriptor = os.open(
+        staging, os.O_CREAT | os.O_EXCL | os.O_WRONLY, _PRIVATE_FILE
+    )
+    try:
+        os.write(descriptor, encoded.encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+    # The open mode is masked by the umask, so the explicit chmod is what
+    # actually makes the file owner-only -- before it is put in place, so the
+    # target is never briefly readable.
+    staging.chmod(_PRIVATE_FILE)
+    os.replace(staging, path)
+    path.chmod(_PRIVATE_FILE)
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    """A stored sub-object as a mutable dict, or an empty one when it is not one."""
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _iso(moment: datetime) -> str:
+    """Format a moment the way the gate parses it: UTC, ``Z``-suffixed, millis.
+
+    ``Date.parse`` on the reader side accepts a ``+00:00`` offset too, but the
+    whole existing file is written with ``Z`` and matching it keeps a
+    hand-inspected file uniform. Millisecond precision matches
+    ``toISOString()``; Python's default microseconds would still parse, but the
+    two languages writing visibly different shapes into one file is the kind of
+    difference that gets mistaken for a bug later.
+    """
+    return (
+        moment.astimezone(UTC)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_moment(value: str) -> datetime | None:
+    """Parse a stored ISO timestamp, or ``None`` when it is not one.
+
+    Accepts the ``Z`` suffix that ``toISOString`` produces, which
+    ``datetime.fromisoformat`` handles natively from 3.11. A value that does not
+    parse is treated as absent rather than as an error, matching the reader's
+    ``Number.isFinite(Date.parse(...))`` guard.
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _safe_coordinate(value: str, name: str) -> str:
+    """Validate a value that becomes a JSON key the gate matches on.
+
+    Args:
+        value: The session id or project slug.
+        name: Which one, for the error message.
+
+    Returns:
+        The value, trimmed.
+
+    Raises:
+        ReceiptStateError: It is empty, over-long, or carries a character outside
+            the alphabet ``safeCoordinate`` allows.
+
+    The alphabet is not decoration. These strings are object keys the gate looks
+    up by exact match; one carrying a newline or a quote would either be filed
+    where nothing looks for it or make the document awkward to inspect by hand.
+    """
+    text = value.strip()
+    if not text or len(text) > _COORDINATE_LONGEST:
+        raise ReceiptStateError(name)
+    if not set(text) <= _COORDINATE_ALPHABET:
+        raise ReceiptStateError(name)
+    return text

--- a/python/openbrain/tests/test_capture_hooks_receipts.py
+++ b/python/openbrain/tests/test_capture_hooks_receipts.py
@@ -1,0 +1,288 @@
+"""The lifecycle wiring: which hook writes which receipt, and when it must not.
+
+``test_receipts_state`` proves the writer works and ``test_receipts_gate_crosslang``
+proves the gate accepts what it writes. Neither proves the hooks CALL it -- a
+correct writer nobody invokes leaves the gate exactly as blocked as no writer at
+all, which is the state the #420 cutover left behind and this change exists to
+end.
+
+These run the capabilities with injected lanes, so nothing here reaches a server
+or a database, and every receipt lands in a per-test temporary file rather than
+the running session's own state.
+
+See Also:
+    - ``openbrain.apps.hooks.receipts`` - the module being invoked
+    - ``openbrain.apps.hooks.session`` - the capabilities that invoke it
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from conftest import (
+    CanonPackReader,
+    LaneUnreachableError,
+    RecordingLane,
+    UnreachableLane,
+    operator_line,
+    write_lines,
+)
+from openbrain.apps.hooks import receipts as hook_receipts
+from openbrain.apps.hooks.session import (
+    PostCompactHook,
+    SessionStartHook,
+    StartedLane,
+    StopHook,
+    run_post_compact,
+    run_session_start,
+    run_stop,
+)
+from openbrain.config import CanonSettings, CaptureSettings
+from openbrain.receipts.scope import DEVELOPMENT_ROOT
+
+#: A directory the scope resolver accepts, so a receipt is actually written.
+IN_SCOPE_CWD = DEVELOPMENT_ROOT / "open-brain"
+
+#: A directory it does not, so nothing is.
+OUT_OF_SCOPE_CWD = Path.home()
+
+SESSION_ID = "wiring-session"
+
+pytestmark = pytest.mark.skipif(
+    not IN_SCOPE_CWD.is_dir(),
+    reason=(
+        "receipt wiring is keyed on a project slug resolved from the real "
+        "Development checkout; without it no receipt is written by design"
+    ),
+)
+
+
+@pytest.fixture
+def receipts_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the shared receipt file into this test's temporary directory.
+
+    The capabilities call the receipt helpers with no explicit path, so the only
+    way to keep them off the running session's state is to move the default. This
+    is also the honest shape: it exercises ``default_receipt_state_path`` rather
+    than bypassing it.
+    """
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    return (
+        tmp_path
+        / "state"
+        / "agent-runtime"
+        / "openbrain-memory"
+        / "receipts.json"
+    )
+
+
+def _document(path: Path) -> dict[str, Any]:
+    """The receipt file, decoded, or an empty document when nothing was written."""
+    if not path.exists():
+        return {}
+    decoded = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+def _capture_settings(tmp_path: Path) -> CaptureSettings:
+    """Capture config whose watermark store is per-test."""
+    return CaptureSettings(watermark_path=tmp_path / "watermarks.sqlite")
+
+
+def _lane_factory(lane: object) -> Any:
+    """A factory returning ``lane`` with a no-op closer, as the tests' spine does."""
+    return lambda _settings, _key: StartedLane(lane=lane, close=lambda: None)
+
+
+def _transcript(tmp_path: Path) -> Path:
+    """One operator turn on disk, the smallest thing a ``Stop`` can deliver."""
+    path = tmp_path / "transcript.jsonl"
+    write_lines(path, [operator_line("u1", "hello")])
+    return path
+
+
+def _stop(transcript: Path, cwd: Path, settings: CaptureSettings, lane: object) -> Any:
+    """Run one ``Stop`` through the real capability with an injected lane."""
+    return asyncio.run(
+        run_stop(
+            StopHook(transcript_path=transcript, session_id=SESSION_ID, cwd=cwd),
+            settings,
+            lane_factory=_lane_factory(lane),
+        )
+    )
+
+
+def test_stop_writes_a_capture_receipt(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """A delivered turn leaves the evidence the gate's capture block clears on."""
+    transcript = _transcript(tmp_path)
+
+    _stop(transcript, IN_SCOPE_CWD, _capture_settings(tmp_path), RecordingLane())
+
+    sessions = _document(receipts_path)["sessions"]
+    assert set(sessions[SESSION_ID]) == {"capture"}
+    assert sessions[SESSION_ID]["capture"]["mode"] == "verified-remote"
+
+
+def test_a_failed_delivery_writes_no_capture_receipt(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """A lane that raised produced no durable write, so it earns no evidence.
+
+    This is the property that makes the receipt worth reading. If a failed
+    delivery still filed one, the gate would clear its block on a turn that never
+    reached Open Brain -- which is precisely the claim-versus-evidence confusion
+    the gate exists to catch.
+    """
+    transcript = _transcript(tmp_path)
+
+    with pytest.raises(LaneUnreachableError):
+        _stop(transcript, IN_SCOPE_CWD, _capture_settings(tmp_path), UnreachableLane())
+
+    assert _document(receipts_path) == {}
+
+
+def test_an_out_of_scope_cwd_writes_no_receipt(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """A session outside Development files nothing -- the gate tracks no block for it."""
+    transcript = _transcript(tmp_path)
+
+    _stop(transcript, OUT_OF_SCOPE_CWD, _capture_settings(tmp_path), RecordingLane())
+
+    assert _document(receipts_path) == {}
+
+
+def test_post_compact_opens_the_cycle_the_gate_blocks_on(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """Recording the summary also arms the correlation the recall must later name."""
+    payload = PostCompactHook(
+        compact_summary="a summary",
+        session_id=SESSION_ID,
+        prompt_id="00000000-0000-4000-8000-000000000001",
+        cwd=IN_SCOPE_CWD,
+    )
+
+    asyncio.run(
+        run_post_compact(
+            payload, _capture_settings(tmp_path), lane_factory=_lane_factory(RecordingLane())
+        )
+    )
+
+    cycles = _document(receipts_path)["compactCycles"]
+    assert cycles[SESSION_ID]["attemptedParticipants"] == ["post-compact"]
+    assert "verifiedRecallAt" not in cycles[SESSION_ID]
+
+
+def test_a_post_compact_with_no_summary_opens_no_cycle(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """No summary recorded means no compaction to arm a block over.
+
+    Arming the gate for a compaction whose summary was never stored would block
+    the session over work that did not happen.
+    """
+    payload = PostCompactHook(session_id=SESSION_ID, cwd=IN_SCOPE_CWD)
+
+    asyncio.run(
+        run_post_compact(
+            payload, _capture_settings(tmp_path), lane_factory=_lane_factory(RecordingLane())
+        )
+    )
+
+    assert _document(receipts_path) == {}
+
+
+def test_a_compact_session_start_writes_the_verified_recall(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """The full arm-then-release pair, through the real capabilities.
+
+    ``PostCompact`` opens the cycle; the ``compact`` ``SessionStart`` reads canon
+    and stamps ``verifiedRecallAt`` on that SAME cycle. That stamp is what the
+    gate reads to unblock, so this is the wiring the whole change exists for.
+    """
+    settings = _capture_settings(tmp_path)
+    asyncio.run(
+        run_post_compact(
+            PostCompactHook(
+                compact_summary="a summary",
+                session_id=SESSION_ID,
+                prompt_id="00000000-0000-4000-8000-000000000001",
+                cwd=IN_SCOPE_CWD,
+            ),
+            settings,
+            lane_factory=_lane_factory(RecordingLane()),
+        )
+    )
+    opened = _document(receipts_path)["compactCycles"][SESSION_ID]["id"]
+
+    asyncio.run(
+        run_session_start(
+            SessionStartHook(session_id=SESSION_ID, source="compact", cwd=IN_SCOPE_CWD),
+            CanonSettings(),
+            canon_factory=CanonPackReader(),
+        )
+    )
+
+    cycle = _document(receipts_path)["compactCycles"][SESSION_ID]
+    assert cycle["id"] == opened, "the recall must join the cycle PostCompact opened"
+    assert "verifiedRecallAt" in cycle
+
+
+def test_a_startup_session_start_writes_no_recall_receipt(
+    tmp_path: Path, receipts_path: Path
+) -> None:
+    """An ordinary session start is not a post-compaction read-back.
+
+    Writing a ``compact`` recall receipt here would clear a read-back block that a
+    real compaction had every right to hold -- the gate would be released by a
+    session merely opening.
+    """
+    asyncio.run(
+        run_session_start(
+            SessionStartHook(session_id=SESSION_ID, source="startup", cwd=IN_SCOPE_CWD),
+            CanonSettings(),
+            canon_factory=CanonPackReader(),
+        )
+    )
+
+    assert _document(receipts_path) == {}
+
+
+def test_a_receipt_failure_does_not_break_the_capability(
+    tmp_path: Path, receipts_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The evidence is never worth failing the work it describes.
+
+    The turn is already delivered by the time the receipt is written. A hook that
+    raised because it could not file the note would discard a successful capture
+    to protect the record of it.
+    """
+
+    class UnwritableReceiptFileError(OSError):
+        """The receipt file could not be written -- the failure being swallowed."""
+
+        def __init__(self) -> None:
+            """State what failed. No path is named; the log line is content-free."""
+            super().__init__("the receipt file could not be written")
+
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise UnwritableReceiptFileError
+
+    monkeypatch.setattr(hook_receipts, "record_provider_receipt", explode)
+    transcript = _transcript(tmp_path)
+    lane = RecordingLane()
+
+    delivery = _stop(transcript, IN_SCOPE_CWD, _capture_settings(tmp_path), lane)
+
+    assert delivery is not None
+    assert lane.turns, "the turn must still have been delivered"

--- a/python/openbrain/tests/test_receipts_gate_crosslang.py
+++ b/python/openbrain/tests/test_receipts_gate_crosslang.py
@@ -1,0 +1,395 @@
+"""The cross-language proof: the real TypeScript gate unblocks on a Python receipt.
+
+This is the whole point of ``openbrain.receipts``, and it is the ONLY test here
+that can prove it. Every other test of this package checks that Python writes the
+JSON it meant to write -- which is worth nothing if the gate reads it differently.
+So this one runs the ACTUAL gate, ``_ob/scripts/context-budget-gate.ts``, as a
+subprocess under ``bun``, against a ``receipts.json`` that only Python has ever
+touched, and asserts on the gate's own decision.
+
+The existing TypeScript tests over this state
+(``_ob/scripts/ob-memory-provider/receipt-state.test.ts``,
+``.../claude-hook.test.ts``) all write the receipt from TypeScript, so none of
+them can catch a Python writer that produces a file the gate silently skips. The
+subprocess-with-every-path-redirected shape is borrowed from
+``_ob/scripts/context-budget-gate-test-helpers.ts``; writing the receipt from
+Python is the delta.
+
+WHY THE RED HALF IS NOT OPTIONAL. A test that only shows the gate unblocking
+proves nothing on its own: a gate that never blocks passes it. Each proof here
+therefore runs the same gate, over the same state, twice -- once where it must
+refuse and once where the Python receipt must release it -- so the pass is
+evidence the receipt did the work rather than evidence the block was absent.
+
+ISOLATION. Every path the gate touches is redirected into a temporary directory:
+its session state, the receipt file, the settings it scans, the policy state, and
+the spool. The live gate registrations and the real
+``~/.local/state/agent-runtime/openbrain-memory/receipts.json`` are never read or
+written by these tests, which matters because that file is the running session's
+own unblock state.
+
+See Also:
+    - ``openbrain.receipts.state`` - the writer under test
+    - ``_ob/scripts/context-budget-gate-state.ts`` - the reader being satisfied
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from openbrain.receipts import (
+    ProviderReceiptEvidence,
+    receipt_mode,
+    record_provider_receipt,
+    start_compact_cycle,
+)
+
+#: The gate under test, in the Development checkout it is registered from. An
+#: absolute path because that is where the LIVE hook runs it from -- pointing at a
+#: copy would prove a copy works.
+GATE_SCRIPT = Path(
+    "/Volumes/ThunderBolt/Development/_ob/scripts/context-budget-gate.ts"
+)
+
+#: A directory the gate resolves to a Development project. It only has to exist
+#: and be in scope; nothing is written to it.
+GATE_CWD = Path("/Volumes/ThunderBolt/Development/open-brain")
+
+#: The project slug the receipts are filed under. Passed to the gate explicitly
+#: with ``--project`` so the assertion does not depend on the git layout of
+#: whatever checkout the suite runs from.
+PROJECT = "open-brain"
+
+#: The session the proof runs under.
+SESSION_ID = "receipts-crosslang-session"
+
+#: How long to wait for the whole subprocess. Generous: this is a guard against a
+#: wedged gate hanging the suite, not a performance assertion.
+GATE_TIMEOUT_SECONDS = 60.0
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bun") is None or not GATE_SCRIPT.is_file(),
+    reason=(
+        "the cross-language proof needs bun and the Development checkout's "
+        f"{GATE_SCRIPT.name}; without both there is no gate to prove against"
+    ),
+)
+
+
+class Gate:
+    """The real gate, wired to a throwaway state directory.
+
+    Args:
+        root: A temporary directory. Every file the gate reads or writes is
+            placed inside it.
+    """
+
+    def __init__(self, root: Path) -> None:
+        """Lay out the isolated state files the gate will be pointed at."""
+        self.root = root
+        self.state_path = root / "gate.json"
+        self.receipts_path = root / "receipts.json"
+        self.settings_path = root / "settings.json"
+        self.settings_path.write_text("{}", encoding="utf-8")
+
+    def run(self, event: str, **payload: object) -> subprocess.CompletedProcess[str]:
+        """Invoke the gate for one event and return its completed process.
+
+        Args:
+            event: The ``--event`` value, e.g. ``post-compact`` or
+                ``pre-tool-use``.
+            **payload: Extra fields for the hook's stdin JSON. ``session_id`` and
+                ``cwd`` are supplied.
+
+        Returns:
+            The completed process, whose stdout is the gate's decision.
+        """
+        argv = [
+            "bun",
+            str(GATE_SCRIPT),
+            "--event",
+            event,
+            "--state-path",
+            str(self.state_path),
+            "--receipt-state-path",
+            str(self.receipts_path),
+            "--settings-path",
+            str(self.settings_path),
+            "--policy-state-path",
+            str(self.root / "policy.json"),
+            "--spool-path",
+            str(self.root / "spool.jsonl"),
+            "--session-id",
+            SESSION_ID,
+            "--project",
+            PROJECT,
+        ]
+        stdin = json.dumps({"session_id": SESSION_ID, "cwd": str(GATE_CWD), **payload})
+        return subprocess.run(  # noqa: S603 -- fixed argv built here, no shell
+            argv,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=GATE_TIMEOUT_SECONDS,
+            check=False,
+        )
+
+    def attempt_edit(self) -> dict[str, object]:
+        """Ask the gate to permit an ``Edit``, and return its decoded answer.
+
+        ``Edit`` is used because it is a plain mutating tool with no special
+        handling: the gate's checkpoint-activity allowance recognises certain
+        Bash commands, and using one of those would prove the allowance rather
+        than the receipt.
+        """
+        completed = self.run(
+            "pre-tool-use",
+            tool_name="Edit",
+            tool_input={"file_path": str(GATE_CWD / "x")},
+        )
+        if not completed.stdout.strip():
+            return {}
+        decoded = json.loads(completed.stdout)
+        assert isinstance(decoded, dict)
+        return decoded
+
+    def correlation_id(self) -> str:
+        """The cycle id the gate is currently waiting on a recall for."""
+        correlation = self._session_state()["readbackCorrelationId"]
+        assert isinstance(correlation, str)
+        return correlation
+
+    def readback_required(self) -> bool:
+        """Whether the gate still considers the post-compaction read-back open."""
+        return bool(self._session_state()["readbackRequired"])
+
+    def transitions(self) -> list[str]:
+        """The names of the gate's recorded state transitions, in order."""
+        log = self._session_state()["transitionLog"]
+        assert isinstance(log, list)
+        return [str(entry["name"]) for entry in log]
+
+    def _session_state(self) -> dict[str, object]:
+        """The gate's own persisted state for this session."""
+        document = json.loads(self.state_path.read_text(encoding="utf-8"))
+        session = document["sessions"][SESSION_ID]
+        assert isinstance(session, dict)
+        return session
+
+
+def _iso(moment: datetime) -> str:
+    """A timestamp in the shape the gate parses, matching ``toISOString``."""
+    return (
+        moment.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    )
+
+
+def _write_recall_receipt(
+    receipts_path: Path,
+    correlation_id: str,
+    *,
+    recorded_at: datetime | None = None,
+) -> ProviderReceiptEvidence:
+    """Write, from PYTHON ONLY, the receipt the gate's read-back waits for.
+
+    Args:
+        receipts_path: The isolated receipt file.
+        correlation_id: The cycle the gate is waiting on.
+        recorded_at: When the recall happened, defaulting to now. Overridden by
+            the staleness proof to place it outside the gate's window.
+
+    Returns:
+        The receipt as filed.
+
+    ``mode`` is derived through :func:`receipt_mode` rather than written as a
+    literal, because that is the call a real hook makes and grading is the part
+    that can lie.
+    """
+    moment = recorded_at if recorded_at is not None else datetime.now(UTC)
+    return record_provider_receipt(
+        receipts_path,
+        ProviderReceiptEvidence(
+            operation="recall",
+            mode=receipt_mode(
+                "recall",
+                "direct",
+                durable=False,
+                direct_attempted=True,
+                fallback_attempted=False,
+            ),
+            status="direct",
+            project=PROJECT,
+            session_id=SESSION_ID,
+            trigger="compact",
+            direct_attempted=True,
+            recorded_at=_iso(moment),
+            correlation_id=correlation_id,
+        ),
+    )
+
+
+def _armed_gate(tmp_path: Path) -> Gate:
+    """A gate that has seen a compaction and is blocking on the read-back.
+
+    The cycle is opened by :func:`start_compact_cycle` -- the PYTHON writer -- so
+    even the correlation id the gate ends up waiting on came from this package,
+    which is the ``PostCompact`` half of the lifecycle.
+    """
+    gate = Gate(tmp_path)
+    cycle = start_compact_cycle(
+        gate.receipts_path, session_id=SESSION_ID, project=PROJECT
+    )
+    gate.run("post-compact")
+
+    assert gate.readback_required(), "the gate should block after a compaction"
+    assert gate.correlation_id() == cycle.id, (
+        "the gate must adopt the cycle Python opened, not open its own -- "
+        "if it opens its own, PostCompact wrote a cycle the gate cannot see"
+    )
+    return gate
+
+
+def test_python_written_recall_receipt_unblocks_the_real_gate(tmp_path: Path) -> None:
+    """RED then GREEN: the gate refuses, Python writes a receipt, the gate releases.
+
+    This is the deliverable. Nothing in this test executes the TypeScript writer:
+    the compaction cycle and the recall receipt are both produced by
+    ``openbrain.receipts``, and the only TypeScript that runs is the gate itself,
+    reading them.
+    """
+    gate = _armed_gate(tmp_path)
+
+    blocked = gate.attempt_edit()
+    assert blocked.get("decision") == "block", (
+        "RED half failed: the gate did not block, so a later pass would prove "
+        "nothing about the receipt"
+    )
+
+    _write_recall_receipt(gate.receipts_path, gate.correlation_id())
+
+    released = gate.attempt_edit()
+    assert released.get("decision") != "block"
+    assert not gate.readback_required()
+    assert "cleared-by-recall" in gate.transitions()
+
+
+def test_absent_python_receipt_leaves_the_gate_blocking(tmp_path: Path) -> None:
+    """The red on its own: with no receipt written at all, the gate stays shut.
+
+    Separate from the round trip above so a regression that makes the gate
+    permissive -- rather than one that makes the receipt unreadable -- is
+    distinguishable in the failure output.
+    """
+    gate = _armed_gate(tmp_path)
+
+    first = gate.attempt_edit()
+    second = gate.attempt_edit()
+
+    assert first.get("decision") == "block"
+    assert second.get("decision") == "block"
+    assert gate.readback_required()
+    assert "cleared-by-recall" not in gate.transitions()
+
+
+def test_stale_python_receipt_does_not_unblock_the_gate(tmp_path: Path) -> None:
+    """A correctly-shaped receipt from too long ago is still a blocked gate.
+
+    The gate accepts a compaction recall only within a short window, because the
+    recall has to be evidence that THIS session just read Open Brain back -- an
+    hour-old one is not. This proves the Python writer's timestamp lands somewhere
+    the gate actually measures: a receipt written with a naive or wrongly-offset
+    ``recorded_at`` would read as fresh here and would pass a test that only ever
+    wrote "now".
+    """
+    gate = _armed_gate(tmp_path)
+    long_ago = datetime.now(UTC) - timedelta(hours=1)
+
+    _write_recall_receipt(
+        gate.receipts_path, gate.correlation_id(), recorded_at=long_ago
+    )
+
+    blocked = gate.attempt_edit()
+    assert blocked.get("decision") == "block"
+    assert gate.readback_required()
+
+
+def test_receipt_for_another_cycle_does_not_unblock_the_gate(tmp_path: Path) -> None:
+    """A recall belonging to a DIFFERENT compaction leaves this one blocked.
+
+    The correlation id is the reason the gate stores one at all: a recall from an
+    earlier compaction must not satisfy the read-back the current one armed. This
+    proves Python's ``correlation_id`` reaches the field the gate compares, rather
+    than being written somewhere it is merely present.
+    """
+    gate = _armed_gate(tmp_path)
+    foreign_cycle = "00000000-0000-4000-8000-000000000000"
+    assert foreign_cycle != gate.correlation_id()
+
+    _write_recall_receipt(gate.receipts_path, foreign_cycle)
+
+    blocked = gate.attempt_edit()
+    assert blocked.get("decision") == "block"
+    assert gate.readback_required()
+
+
+def test_python_capture_receipt_clears_the_gates_capture_block(tmp_path: Path) -> None:
+    """The other unblock path: a capture receipt releases the post-work capture block.
+
+    The gate arms ``captureRequired`` after a turn that did mutating work and
+    clears it on any durable write receipt -- a different query from the
+    compaction read-back (no correlation id, a wider set of operations, and
+    ``durable-spool`` accepted alongside ``verified-remote``). Proving only the
+    recall path would leave this one unproven, and it is the path a ``Stop`` hook
+    exercises on every turn.
+    """
+    gate = Gate(tmp_path)
+    gate.state_path.write_text(
+        json.dumps(
+            {
+                "sessions": {
+                    SESSION_ID: {
+                        "sessionId": SESSION_ID,
+                        "project": PROJECT,
+                        "captureRequired": True,
+                        "captureRequiredAt": _iso(
+                            datetime.now(UTC) - timedelta(seconds=5)
+                        ),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    blocked = gate.attempt_edit()
+    assert blocked.get("decision") == "block", "RED half failed: capture not blocking"
+
+    record_provider_receipt(
+        gate.receipts_path,
+        ProviderReceiptEvidence(
+            operation="capture",
+            mode=receipt_mode(
+                "capture",
+                "saved",
+                durable=True,
+                direct_attempted=True,
+                fallback_attempted=False,
+            ),
+            status="saved",
+            project=PROJECT,
+            session_id=SESSION_ID,
+            trigger="explicit",
+            direct_attempted=True,
+            recorded_at=_iso(datetime.now(UTC)),
+        ),
+    )
+
+    released = gate.attempt_edit()
+    assert released.get("decision") != "block"
+    assert "cleared-by-capture" in gate.transitions()

--- a/python/openbrain/tests/test_receipts_scope.py
+++ b/python/openbrain/tests/test_receipts_scope.py
@@ -1,0 +1,225 @@
+"""Project resolution, the part that fails silently when it is wrong.
+
+A receipt filed under the wrong project slug is a perfectly valid receipt that
+unblocks nothing: the gate filters on ``project``, so it simply never matches.
+Nothing logs, nothing raises, and the symptom is "the gate stopped working". That
+makes this the part of the port most worth testing directly.
+
+These tests run against the REAL Development checkout, because the resolver's
+answers depend on real git repository identity -- which directory shares a
+``--git-common-dir`` with which -- and a fabricated tree would prove the resolver
+works on a tree nobody uses. They skip when that checkout is absent.
+
+See Also:
+    - ``openbrain.receipts.scope`` - the module under test
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbrain.receipts.scope import (
+    DEVELOPMENT_ROOT,
+    FALLBACK_PROJECT,
+    resolve_development_scope,
+)
+
+#: A repository inside the Development tree, used as the "ordinary" case.
+REPO_INSIDE_DEVELOPMENT = DEVELOPMENT_ROOT / "open-brain"
+
+pytestmark = pytest.mark.skipif(
+    not REPO_INSIDE_DEVELOPMENT.is_dir(),
+    reason=(
+        "scope resolution answers questions about the real Development checkout; "
+        "without it there is nothing meaningful to resolve"
+    ),
+)
+
+
+def test_a_repo_inside_development_resolves_to_its_own_slug() -> None:
+    """The ordinary case: a checkout under Development is named after itself."""
+    scope = resolve_development_scope(REPO_INSIDE_DEVELOPMENT)
+
+    assert scope is not None
+    assert scope.project == "open-brain"
+
+
+def test_a_subdirectory_resolves_to_its_repository_not_itself() -> None:
+    """The slug comes from git's top level, so a subdirectory does not get its own.
+
+    Receipts for a session working in ``open-brain/python`` must be filed under
+    ``open-brain``, because that is the project the gate armed its block against.
+    """
+    scope = resolve_development_scope(REPO_INSIDE_DEVELOPMENT / "python")
+
+    assert scope is not None
+    assert scope.project == "open-brain"
+
+
+def test_the_development_repo_itself_is_named_development() -> None:
+    """Work in the Development repository is filed under Development, not a subfolder.
+
+    The router and the shared ``_ob`` tooling live in the Development repository
+    itself; naming a session there after whichever directory it opened in would
+    scatter its receipts across several slugs.
+    """
+    scope = resolve_development_scope(DEVELOPMENT_ROOT / "_ob")
+
+    assert scope is not None
+    assert scope.project == DEVELOPMENT_ROOT.name
+
+
+def test_a_directory_outside_development_does_not_resolve() -> None:
+    """Out of scope answers ``None``, and a caller with ``None`` writes no receipt.
+
+    The gate only tracks sessions whose ``cwd`` resolved, so a receipt for an
+    unscoped directory would have no block to clear.
+    """
+    assert resolve_development_scope(Path.home()) is None
+
+
+def test_a_missing_directory_does_not_resolve() -> None:
+    """A path that does not exist is not scope, and is not an error either.
+
+    A hook can fire with a ``cwd`` that has since been removed; that is a
+    do-nothing outcome, not a failure to report.
+    """
+    assert resolve_development_scope("/no/such/directory/anywhere") is None
+
+
+def test_an_absent_cwd_does_not_resolve() -> None:
+    """A payload carrying no ``cwd`` at all resolves to nothing, without raising."""
+    assert resolve_development_scope(None) is None
+
+
+def test_a_file_path_does_not_resolve() -> None:
+    """Only directories are scope. A file path is a caller error, not a project."""
+    marker = DEVELOPMENT_ROOT / "AGENTS.md"
+    if not marker.is_file():
+        pytest.skip("the Development router file is not present in this checkout")
+
+    assert resolve_development_scope(marker) is None
+
+
+def test_the_resolved_cwd_is_canonical() -> None:
+    """Symlinks are resolved, so containment comparisons are made on real paths.
+
+    A containment test between a resolved path and an unresolved one silently
+    answers "not in scope" for anything reached through a symlink, which on a
+    machine with a symlinked volume means no receipts are ever written.
+    """
+    scope = resolve_development_scope(REPO_INSIDE_DEVELOPMENT)
+
+    assert scope is not None
+    assert scope.cwd == scope.cwd.resolve()
+
+
+def test_a_worktree_of_a_nested_repo_does_not_resolve() -> None:
+    """A temp worktree of a repo INSIDE Development is out of scope, in both languages.
+
+    This is the surprising one, and it is the specification rather than a defect
+    in this port. The temp-workspace branch requires the candidate to share a git
+    repository with ``Development`` ITSELF -- ``--git-common-dir`` equal to
+    Development's own. A worktree of ``open-brain`` reports
+    ``Development/open-brain/.git``, which is a DIFFERENT repository from
+    ``Development/.git``, so it fails that test even though its path shape is
+    accepted.
+
+    Verified against the real resolver on 2026-08-03: ``resolveDevelopmentScope``
+    in ``_ob/scripts/ob-memory-provider.ts`` returns ``null`` for exactly this
+    path, while ``approvedTempWorktreePath`` returns ``true`` for it -- the shape
+    passes and the repository identity is what refuses. Python answering anything
+    else here would write receipts the gate does not expect to exist.
+
+    The consequence is worth stating plainly: a session working in a temp worktree
+    of a nested repo writes NO receipts, because the gate tracks no block for it
+    either. The two sides agree, which is what this test locks in.
+    """
+    worktree = Path(__file__).resolve().parents[3]
+    if not (worktree / ".git").exists():
+        pytest.skip("this test run is not inside a git worktree")
+    if "_worktrees" not in worktree.parts:
+        pytest.skip("this test run is not inside a temp-workspace worktree")
+
+    assert resolve_development_scope(worktree) is None
+
+
+def test_a_worktree_of_development_itself_resolves() -> None:
+    """The temp-worktree branch is reachable, not dead code.
+
+    The nested-repo case above proves the branch REFUSES; without this one, a
+    resolver that always refused would pass every test here and no receipt would
+    ever be written from a worktree. This creates a real worktree of the
+    Development repository itself -- the one repo whose ``--git-common-dir``
+    matches -- at the required ``<repo>/_worktrees/<name>`` path, and asserts it
+    resolves.
+
+    The worktree is removed with ``git worktree remove``, never a recursive
+    delete: that is a git operation which unregisters and removes together, and is
+    the one cleanup that must not be left behind.
+    """
+    import subprocess
+
+    if not (DEVELOPMENT_ROOT / ".git").exists():
+        pytest.skip("the Development repository is not present in this checkout")
+
+    root = Path("/Volumes/ThunderBolt/_tmp/Development/_worktrees")
+    if not root.parent.parent.is_dir():
+        pytest.skip("the temp workspace volume is not mounted")
+    root.mkdir(parents=True, exist_ok=True)
+    worktree = root / "receipts-scope-probe"
+
+    created = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "git", "-C", str(DEVELOPMENT_ROOT), "worktree", "add",
+            "--detach", str(worktree), "HEAD",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if created.returncode != 0:
+        pytest.skip(f"could not create a probe worktree: {created.stderr.strip()}")
+
+    try:
+        scope = resolve_development_scope(worktree)
+        assert scope is not None
+        assert scope.project == DEVELOPMENT_ROOT.name
+    finally:
+        subprocess.run(  # noqa: S603
+            [  # noqa: S607
+                "git", "-C", str(DEVELOPMENT_ROOT), "worktree", "remove",
+                "--force", str(worktree),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+
+def test_a_temp_directory_that_is_not_a_worktree_does_not_resolve(
+    tmp_path: Path,
+) -> None:
+    """Sitting in the temp workspace is not enough; the git relationship is required.
+
+    Otherwise any scratch directory someone left in the temp workspace could claim
+    Development scope and file receipts under a project it has nothing to do with.
+    """
+    assert resolve_development_scope(tmp_path) is None
+
+
+def test_the_fallback_slug_is_never_empty() -> None:
+    """Whatever happens, a resolved scope carries a usable slug.
+
+    An empty project would be rejected as a coordinate downstream, so the resolver
+    must not be able to produce one.
+    """
+    scope = resolve_development_scope(REPO_INSIDE_DEVELOPMENT)
+
+    assert scope is not None
+    assert scope.project
+    assert FALLBACK_PROJECT

--- a/python/openbrain/tests/test_receipts_scope.py
+++ b/python/openbrain/tests/test_receipts_scope.py
@@ -23,6 +23,7 @@ import pytest
 from openbrain.receipts.scope import (
     DEVELOPMENT_ROOT,
     FALLBACK_PROJECT,
+    git_environment,
     resolve_development_scope,
 )
 
@@ -159,6 +160,11 @@ def test_a_worktree_of_development_itself_resolves() -> None:
     The worktree is removed with ``git worktree remove``, never a recursive
     delete: that is a git operation which unregisters and removes together, and is
     the one cleanup that must not be left behind.
+
+    Both git calls run with the repository-overriding environment stripped, for
+    the same reason the resolver strips it: under a pre-push hook, an inherited
+    ``GIT_WORK_TREE`` makes ``worktree add`` operate on the invoking repository
+    rather than the one named by ``-C``.
     """
     import subprocess
 
@@ -180,6 +186,7 @@ def test_a_worktree_of_development_itself_resolves() -> None:
         text=True,
         timeout=120,
         check=False,
+        env=git_environment(),
     )
     if created.returncode != 0:
         pytest.skip(f"could not create a probe worktree: {created.stderr.strip()}")
@@ -198,6 +205,7 @@ def test_a_worktree_of_development_itself_resolves() -> None:
             text=True,
             timeout=120,
             check=False,
+            env=git_environment(),
         )
 
 

--- a/python/openbrain/tests/test_receipts_scope.py
+++ b/python/openbrain/tests/test_receipts_scope.py
@@ -212,6 +212,34 @@ def test_a_temp_directory_that_is_not_a_worktree_does_not_resolve(
     assert resolve_development_scope(tmp_path) is None
 
 
+def test_git_env_overrides_do_not_hijack_the_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook's inherited ``GIT_WORK_TREE`` must not rename every project.
+
+    MEASURED, not theoretical. ``git push`` exports ``GIT_DIR`` and
+    ``GIT_WORK_TREE`` to its hooks, and ``GIT_WORK_TREE`` BEATS ``git -C``: with
+    it set, ``rev-parse --show-toplevel`` answers the invoking repository for
+    every directory asked about. This test failed exactly that way inside the
+    pre-push hook on 2026-08-03 while passing when run directly -- ``open-brain``
+    resolved as ``Development``.
+
+    The consequence is the quiet kind: every repo's receipts would be filed under
+    one slug, and the gate -- which keys its blocks per project -- would match
+    none of them. Nothing would raise; the gate would simply stop unblocking.
+
+    Reproduces the hook's environment exactly, so it fails against the old
+    behaviour and passes only because the subprocess environment is stripped.
+    """
+    monkeypatch.setenv("GIT_DIR", str(DEVELOPMENT_ROOT / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(DEVELOPMENT_ROOT))
+
+    scope = resolve_development_scope(REPO_INSIDE_DEVELOPMENT)
+
+    assert scope is not None
+    assert scope.project == "open-brain"
+
+
 def test_the_fallback_slug_is_never_empty() -> None:
     """Whatever happens, a resolved scope carries a usable slug.
 

--- a/python/openbrain/tests/test_receipts_state.py
+++ b/python/openbrain/tests/test_receipts_state.py
@@ -1,0 +1,467 @@
+"""The receipt writer's own behaviour, without the gate in the loop.
+
+The cross-language proof (``test_receipts_gate_crosslang``) shows the gate accepts
+what this package writes. These tests cover what that one cannot: the properties
+that only matter when something ELSE has already written the file -- a TypeScript
+writer, a crashed process, a future version -- and which show up as a corrupted or
+silently-emptied shared file rather than as a failed assertion.
+
+See Also:
+    - ``openbrain.receipts.state`` - the module under test
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from openbrain.receipts import (
+    RECEIPT_STATE_SCHEMA,
+    ProviderReceiptEvidence,
+    ReceiptStateError,
+    default_receipt_state_path,
+    ensure_compact_cycle,
+    open_compact_cycle,
+    receipt_mode,
+    record_provider_receipt,
+    start_compact_cycle,
+)
+from openbrain.receipts.filelock import LockTimeoutError, receipt_lock
+
+SESSION_ID = "unit-session"
+PROJECT = "open-brain"
+
+
+def _now_iso() -> str:
+    """A timestamp in the shape the gate parses."""
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _capture_receipt(**overrides: object) -> ProviderReceiptEvidence:
+    """A well-formed capture receipt, with fields overridable per test."""
+    fields: dict[str, object] = {
+        "operation": "capture",
+        "mode": receipt_mode(
+            "capture",
+            "saved",
+            durable=True,
+            direct_attempted=True,
+            fallback_attempted=False,
+        ),
+        "status": "saved",
+        "project": PROJECT,
+        "session_id": SESSION_ID,
+        "trigger": "explicit",
+        "direct_attempted": True,
+        "recorded_at": _now_iso(),
+    }
+    fields.update(overrides)
+    return ProviderReceiptEvidence.model_validate(fields)
+
+
+def _document(path: Path) -> dict[str, object]:
+    """The state file, decoded."""
+    decoded = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+def _sessions(path: Path) -> dict[str, object]:
+    """The ``sessions`` index."""
+    sessions = _document(path)["sessions"]
+    assert isinstance(sessions, dict)
+    return sessions
+
+
+def _cycles(path: Path) -> dict[str, object]:
+    """The ``compactCycles`` index."""
+    cycles = _document(path)["compactCycles"]
+    assert isinstance(cycles, dict)
+    return cycles
+
+
+def test_default_path_follows_xdg_state_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The file location tracks ``XDG_STATE_HOME`` exactly as TypeScript's does."""
+    monkeypatch.setenv("XDG_STATE_HOME", "/somewhere/state")
+
+    assert default_receipt_state_path() == Path(
+        "/somewhere/state/agent-runtime/openbrain-memory/receipts.json"
+    )
+
+
+def test_empty_xdg_state_home_falls_back_to_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An EMPTY ``XDG_STATE_HOME`` means "unset", as JavaScript's ``||`` treats it.
+
+    An ``os.environ.get(..., default)`` would return the empty string here and
+    resolve the receipt file relative to the current directory, putting the Python
+    writer and the TypeScript reader on different files. That failure presents as
+    the gate simply never unblocking, with a perfectly valid receipt on disk.
+    """
+    monkeypatch.setenv("XDG_STATE_HOME", "")
+
+    assert default_receipt_state_path() == (
+        Path.home() / ".local/state/agent-runtime/openbrain-memory/receipts.json"
+    )
+
+
+def test_receipt_lands_in_both_indexes_the_gate_reads(tmp_path: Path) -> None:
+    """A receipt is filed per-operation AND per-trigger, the two queries the gate makes."""
+    path = tmp_path / "receipts.json"
+
+    record_provider_receipt(path, _capture_receipt())
+
+    document = _document(path)
+    assert document["schema"] == RECEIPT_STATE_SCHEMA
+
+    per_operation = _sessions(path)[SESSION_ID]
+    assert isinstance(per_operation, dict)
+    assert set(per_operation) == {"capture"}
+
+    trigger_receipts = document["triggerReceipts"]
+    assert isinstance(trigger_receipts, dict)
+    assert set(trigger_receipts[SESSION_ID]) == {"capture:explicit:uncorrelated"}
+
+
+def test_serialised_keys_are_camel_case(tmp_path: Path) -> None:
+    """Every field name on disk is the one the TypeScript reader looks up.
+
+    A snake_case key here is not a style difference: the gate reads
+    ``fallbackAttempted`` and ``contractSchemaHash`` by exact name, and a receipt
+    spelling them otherwise is skipped as not matching the contract.
+    """
+    path = tmp_path / "receipts.json"
+
+    record_provider_receipt(path, _capture_receipt())
+
+    stored = _sessions(path)[SESSION_ID]
+    assert isinstance(stored, dict)
+    capture = stored["capture"]
+    assert isinstance(capture, dict)
+    assert {
+        "sessionId",
+        "directAttempted",
+        "recordedAt",
+        "fallbackAttempted",
+        "contractSchemaVersion",
+        "contractSchemaHash",
+    } <= set(capture)
+    assert not [key for key in capture if "_" in key]
+
+
+def test_contract_triple_cannot_be_overridden_by_a_caller() -> None:
+    """A caller cannot claim a contract this package does not implement.
+
+    The triple is what the gate uses to decide a receipt came from something
+    speaking its protocol. If a caller could set it, a component could write a
+    receipt asserting compliance it does not have, and the gate would unblock on
+    it.
+    """
+    with pytest.raises(ValueError, match="contract"):
+        _capture_receipt(contract="something-else")
+
+    with pytest.raises(ValueError, match="fallbackAttempted|fallback_attempted"):
+        _capture_receipt(fallback_attempted=True)
+
+
+def test_unrecognised_sections_survive_a_write(tmp_path: Path) -> None:
+    """A section this package does not model is written back untouched.
+
+    ``reflexSuppression`` is written by the TypeScript reflex path into this same
+    file. Dropping it while recording an unrelated receipt would silently delete
+    another component's state, and nothing would report it.
+    """
+    path = tmp_path / "receipts.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": RECEIPT_STATE_SCHEMA,
+                "sessions": {},
+                "compactCycles": {},
+                "reflexSuppression": {
+                    "other-session": {
+                        "project": "elsewhere",
+                        "refs": ["brain_record:thought:" + "0" * 8 + "-0000-4000-8000-" + "0" * 12],
+                        "updatedAt": _now_iso(),
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record_provider_receipt(path, _capture_receipt())
+
+    assert "reflexSuppression" in _document(path)
+
+
+def test_existing_receipts_from_another_session_are_preserved(tmp_path: Path) -> None:
+    """Recording a receipt merges into the file rather than replacing it.
+
+    Two sessions share this file. A write that dropped the other session's
+    receipts would unblock nothing for it and would look like the gate spuriously
+    re-arming.
+    """
+    path = tmp_path / "receipts.json"
+    record_provider_receipt(path, _capture_receipt(session_id="first-session"))
+
+    record_provider_receipt(path, _capture_receipt(session_id="second-session"))
+
+    assert set(_sessions(path)) == {"first-session", "second-session"}
+
+
+def test_corrupt_file_is_replaced_rather_than_raising(tmp_path: Path) -> None:
+    """Unparseable JSON reads as empty, so one bad write does not wedge the hook.
+
+    The TypeScript reader behaves the same way. Raising instead would mean every
+    subsequent hook invocation failed on state a crashed writer left behind, with
+    no path back to a working file.
+    """
+    path = tmp_path / "receipts.json"
+    path.write_text("{not json at all", encoding="utf-8")
+
+    record_provider_receipt(path, _capture_receipt())
+
+    assert set(_sessions(path)) == {SESSION_ID}
+
+
+def test_foreign_schema_is_not_merged_into(tmp_path: Path) -> None:
+    """A file declaring a schema this version does not know reads as empty.
+
+    Matching ``loadReceiptState``: merging into a document whose shape is unknown
+    would produce a file neither version can read.
+    """
+    path = tmp_path / "receipts.json"
+    path.write_text(
+        json.dumps({"schema": "some.future.schema.v9", "sessions": {"old": {}}}),
+        encoding="utf-8",
+    )
+
+    record_provider_receipt(path, _capture_receipt())
+
+    document = _document(path)
+    assert document["schema"] == RECEIPT_STATE_SCHEMA
+    assert set(_sessions(path)) == {SESSION_ID}
+
+
+def test_state_file_and_parent_are_owner_only(tmp_path: Path) -> None:
+    """Receipts name sessions and projects, so nothing here is group- or world-readable."""
+    path = tmp_path / "nested" / "receipts.json"
+
+    record_provider_receipt(path, _capture_receipt())
+
+    assert path.stat().st_mode & 0o077 == 0
+    assert path.parent.stat().st_mode & 0o077 == 0
+
+
+def test_no_staging_files_are_left_behind(tmp_path: Path) -> None:
+    """The atomic write cleans up after itself, leaving only the state file.
+
+    A staging file surviving means ``os.replace`` did not run -- the write was not
+    atomic, and a reader could have seen a partial document.
+    """
+    path = tmp_path / "receipts.json"
+
+    record_provider_receipt(path, _capture_receipt())
+
+    assert sorted(entry.name for entry in tmp_path.iterdir()) == ["receipts.json"]
+
+
+def test_unusable_coordinates_are_refused(tmp_path: Path) -> None:
+    """A session id or project that could not be a JSON key the gate matches is refused.
+
+    Silently filing it would produce a receipt nothing ever looks up, which reads
+    as "no receipt was written" and is far harder to trace than a named error.
+    """
+    path = tmp_path / "receipts.json"
+
+    with pytest.raises(ReceiptStateError, match="session_id"):
+        record_provider_receipt(path, _capture_receipt(session_id="has a space"))
+
+    with pytest.raises(ReceiptStateError, match="project"):
+        record_provider_receipt(path, _capture_receipt(project=""))
+
+
+def test_lifecycle_hooks_share_one_cycle(tmp_path: Path) -> None:
+    """PreCompact, PostCompact, and SessionStart join a single correlation id.
+
+    That shared id is the whole mechanism: it is what lets the gate require the
+    recall it is waiting for to belong to THIS compaction rather than an earlier
+    one.
+    """
+    path = tmp_path / "receipts.json"
+
+    opened = open_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+    started = start_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+    ensured = ensure_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+
+    assert opened.id == started.id == ensured.id
+    assert set(ensured.attempted_participants) == {
+        "pre-compact",
+        "post-compact",
+        "session-start",
+    }
+
+
+def test_a_second_precompact_opens_a_second_cycle(tmp_path: Path) -> None:
+    """A repeated ``PreCompact`` is a NEW compaction, not a retry of the last one.
+
+    ``PreCompact`` fires once before each compaction, so seeing it twice means two
+    compactions. Reusing the cycle would let a recall for the first satisfy the
+    read-back armed by the second.
+    """
+    path = tmp_path / "receipts.json"
+    first = open_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+
+    second = open_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+
+    assert second.id != first.id
+
+
+def test_a_stale_cycle_is_not_joined(tmp_path: Path) -> None:
+    """A cycle older than the gate would accept is replaced rather than joined.
+
+    Joining it would hand the gate a correlation id it treats as expired, so the
+    read-back could never be cleared by a recall naming it.
+    """
+    path = tmp_path / "receipts.json"
+    long_ago = datetime.now(UTC) - timedelta(hours=2)
+    stale = ensure_compact_cycle(
+        path, session_id=SESSION_ID, project=PROJECT, now=long_ago
+    )
+
+    fresh = ensure_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+
+    assert fresh.id != stale.id
+
+
+def test_a_cycle_from_another_project_is_not_joined(tmp_path: Path) -> None:
+    """The same session id in a different project gets its own cycle."""
+    path = tmp_path / "receipts.json"
+    elsewhere = ensure_compact_cycle(
+        path, session_id=SESSION_ID, project="other-repo"
+    )
+
+    here = ensure_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+
+    assert here.id != elsewhere.id
+    assert here.project == PROJECT
+
+
+def test_verified_recall_is_stamped_only_by_a_matching_recall(tmp_path: Path) -> None:
+    """The cycle's ``verifiedRecallAt`` -- the unblock itself -- has four conditions.
+
+    Operation, trigger, mode, and correlation id must all line up. Each of the
+    three near-misses here would, if it stamped the field, let something that is
+    not a fresh direct recall of THIS compaction release the gate.
+    """
+    path = tmp_path / "receipts.json"
+    cycle = ensure_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+    near_misses = [
+        {"operation": "capture", "trigger": "compact", "mode": "verified-remote"},
+        {"operation": "recall", "trigger": "explicit", "mode": "verified-remote"},
+        {"operation": "recall", "trigger": "compact", "mode": "failed"},
+    ]
+
+    for fields in near_misses:
+        record_provider_receipt(
+            path,
+            _capture_receipt(status="direct", correlation_id=cycle.id, **fields),
+        )
+        stored = _cycles(path)[SESSION_ID]
+        assert isinstance(stored, dict)
+        assert "verifiedRecallAt" not in stored, fields
+
+    record_provider_receipt(
+        path,
+        _capture_receipt(
+            operation="recall",
+            trigger="compact",
+            mode="verified-remote",
+            status="direct",
+            correlation_id=cycle.id,
+        ),
+    )
+
+    stamped = _cycles(path)[SESSION_ID]
+    assert isinstance(stamped, dict)
+    assert "verifiedRecallAt" in stamped
+
+
+def test_a_failed_receipt_credits_no_participant(tmp_path: Path) -> None:
+    """``participants`` records what SUCCEEDED; the attempt is already recorded elsewhere."""
+    path = tmp_path / "receipts.json"
+    cycle = start_compact_cycle(path, session_id=SESSION_ID, project=PROJECT)
+
+    record_provider_receipt(
+        path,
+        _capture_receipt(
+            operation="checkpoint",
+            trigger="post-compact",
+            mode="failed",
+            status="failed",
+            correlation_id=cycle.id,
+        ),
+    )
+
+    stored = _cycles(path)[SESSION_ID]
+    assert isinstance(stored, dict)
+    assert stored["participants"] == []
+    assert stored["attemptedParticipants"] == ["post-compact"]
+
+
+def test_the_lock_is_released_when_the_block_raises(tmp_path: Path) -> None:
+    """A failure inside the lock must not leave the file wedged for every later hook."""
+    path = tmp_path / "receipts.json"
+
+    with pytest.raises(RuntimeError, match="deliberate"), receipt_lock(path):
+        raise RuntimeError("deliberate")
+
+    with receipt_lock(path):
+        pass
+
+
+def test_a_held_lock_blocks_a_second_writer(tmp_path: Path) -> None:
+    """The lock actually excludes, rather than being a file that is merely created.
+
+    Asserting the timeout rather than trusting the constant: a lock that does not
+    exclude is indistinguishable from one that does until two writers race, and by
+    then the symptom is a lost receipt.
+    """
+    path = tmp_path / "receipts.json"
+
+    def take_it_again() -> None:
+        """Contend for the lock the caller already holds.
+
+        A fresh lockfile is not yet stale, so this waits the full window and then
+        gives up -- which is why nothing else shares this test.
+        """
+        with receipt_lock(path):
+            pass
+
+    with receipt_lock(path):
+        pytest.raises(LockTimeoutError, take_it_again)
+
+
+def test_an_abandoned_lock_is_reclaimed(tmp_path: Path) -> None:
+    """A lock left by a killed process is stolen rather than wedging the file forever.
+
+    Without reclamation one crashed hook would stop every later receipt from being
+    written, and the gate would block a session with no way to clear it.
+    """
+    path = tmp_path / "receipts.json"
+    lock_path = path.with_name(path.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("someone-else:0:dead", encoding="utf-8")
+    long_ago = time.time() - 3600
+    os.utime(lock_path, (long_ago, long_ago))
+
+    record_provider_receipt(path, _capture_receipt())
+
+    assert set(_sessions(path)) == {SESSION_ID}


### PR DESCRIPTION
## Summary
- **Breaks the receipts circularity.** The #420 cutover removed every hook registration that invoked the TypeScript writer of `receipts.json`, but left the READER — `context-budget-gate.ts` — registered on six live events. The gate could block a session and nothing in the running hook chain could unblock it; the only writer left was the agent manually running the command the gate's own banner prints. `openbrain.receipts` makes the Python hooks, which now own the lifecycle, write the state the TypeScript gate reads.
- **The deliverable is a cross-language proof.** `tests/test_receipts_gate_crosslang.py` runs the REAL gate under `bun` against a `receipts.json` only Python has ever touched, and asserts the gate's own decision — red and green — on **both** unblock paths (post-compaction read-back, and the capture block). Every existing test of this state writes the receipt from TypeScript, so none of them could catch a Python writer the gate silently skips.
- **Lifecycle wiring:** `PostCompact` opens the compaction cycle after the summary is stored; a `compact` `SessionStart` stamps the verified recall on that same cycle after canon is read; `Stop` files a capture receipt after the delivery returns. Each runs only where the work already succeeded, so a receipt is evidence rather than a claim.
- **Hygiene:** corrects the false `openbrain-provider/pyproject.toml` comment that promised a `cli_provider.py` — PROV-9 shipped in the sibling package and nobody retracted the note.

Part of #409. Closes #415.

### Byte-compatibility is the whole design constraint
`_ob/scripts/ob-memory-provider/receipt-state.ts` is treated as the **specification**, not a reference implementation to improve on: the schema literal, camelCase field names, the contract triple, the `triggerReceipts` key format, the `O_CREAT|O_EXCL` advisory lock with its stale-reclaim protocol, and the fsync-then-rename atomic replace are all reproduced exactly. Both languages write this one file; a divergence is a receipt the gate skips, which fails CLOSED into a session that can no longer edit or commit.

This is also why the package does **not** reach for a storage library the way `apps/capture/watermark.py` reaches for SQLite. Watermarks are ours end to end; receipts are shared, and the solved problem was solved by the TypeScript module.

### A defect the pre-push gate caught, and it was mine
The scope tests passed when run directly and failed inside the pre-push hook. Root cause: `git push` exports `GIT_DIR`/`GIT_WORK_TREE` to its hooks, and **`GIT_WORK_TREE` beats `git -C`** — `rev-parse --show-toplevel` answered `/Volumes/ThunderBolt/Development` for every directory asked about, so every project resolved to the slug `Development`.

Had that shipped, every repo's receipts would be filed under one slug and the gate — which keys blocks per project — would match none of them. No raise, no log; indistinguishable from the bug this branch exists to fix. Since these hooks *run inside git hooks*, the polluted environment is the normal case. Fixed by running the git child with those variables stripped from a copy of the environment (`ee85c43`), with a regression test forged against the old behaviour.

## Critical Self-Review
- Highest-risk behavior: writing a shared file the live gate reads on six registrations. A malformed write blocks a session's ability to edit or commit. Mitigated by matching the TS lock and atomic-replace protocol exactly, by a tolerant reader that treats corrupt/foreign state as empty rather than raising, by preserving unmodelled sections (`reflexSuppression`) on write, and by the cross-language proof asserting the real gate's decision rather than the file's shape.
- Assumptions that could be wrong: two were, and both were checked against the real resolver rather than assumed. (1) I assumed a temp worktree of a nested repo resolves to that repo; `resolveDevelopmentScope` returns `null` for it in TypeScript too — the path shape passes, `--git-common-dir` identity is what refuses. The test was corrected to assert the real behaviour instead of bending the port to my belief. (2) I assumed both unblock paths validate the contract triple; only the capture path does — see residual risk.
- Missing/weak tests: the compaction-cycle *staleness* boundary is exercised at an hour, not at the exact window edge. The lock's stale-reclaim race between two real concurrent processes is proven only for the single-process abandoned-lock case; the exclusion itself is proven with a real timeout.
- Security/permission risk: receipts name sessions and projects, so the file is `0600` and its parent `0700`, both asserted; the staging file is created exclusively and chmod'd *before* being put in place, so the target is never briefly readable. No content, prompt, transcript text, or token is ever written — the receipt is coordinates and grades by construction. Every failure log passes the exception *class name* only, never the object, so nothing reaches a sink under loguru's diagnose.
- Migration/deploy risk: none. No settings change, no registration change, no schema version bump — the file format is unchanged because matching it is the point. Existing TypeScript-written receipts remain readable and are merged into, not replaced.
- Downstream client/runtime risk: none to the MCP contract, transport, or Python client. This adds a local state writer; no tool, schema, or client-facing surface changes.
- Rollback/cleanup concern: revert the branch. The receipt file is derived state the gate re-creates, and the pre-existing 15-minute self-release means a stale block clears itself even with no writer at all.
- Fixes made before PR: the `GIT_WORK_TREE` hijack (`ee85c43`), the same for the probe worktree's own git calls (`7ca2a0a`), the missing generated package README plus a docstring that claimed "two modules" for a four-module package (`9575e77`).
- Known residual risk: the two unblock paths do **not** validate equally. `findFreshReceipt` (`receipt-state.ts:337-339`, the capture path) rejects on any contract/version/hash mismatch; the recall path reads `verifiedRecallAt` off the cycle and never revalidates the triple. So a contract-drifted recall receipt still unblocks the read-back. That asymmetry exists in the TypeScript today; this port **reproduces it faithfully rather than correcting it**, because diverging would make the two writers behave differently against one reader. Flagged for a decision, not silently fixed. Separately, the TypeScript `projectSlug`/`gitPath` carries the same `GIT_WORK_TREE` flaw fixed here on the Python side — deliberately untouched, since the live gates must not be disturbed by this change.
- SME review-memory update: [x] not applicable because: the durable lessons here are cross-language file-protocol fidelity and git-env leakage inside hooks, both recorded in the session journal and in the module docstrings that are this repo's qmd retrieval surface; no existing reviewer-lane pattern changed.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this writes a local state file read by a local hook. No service, contract, or client surface is touched — the tests inject lanes and never reach a server, and the gate proof runs entirely against redirected paths.

## Contract Parity
- Disposition: not applicable because: no contract paths touched. This adds a local receipt writer and its hook wiring; no MCP tool, schema, transport, or client-facing surface changes.

## Testing
- `uv run pytest -q` → **433 passed**, 17 deselected (baseline before this branch: 424). Verified green **both with and without** `GIT_DIR`/`GIT_WORK_TREE` set, reproducing the pre-push hook's environment.
- `uv run mypy src/openbrain` → Success, no issues in 46 source files. `uv run ruff check src tests` → All checks passed.
- **Cross-language proof, 5 tests:** the real `context-budget-gate.ts` under `bun`, every path (`--state-path`, `--receipt-state-path`, `--settings-path`, `--policy-state-path`, `--spool-path`) redirected into `tmp_path`, so the live gate state is never touched. Red half asserted in every case, because a gate that never blocks would pass a green-only test.
- **Forged, both directions.** Flipping four bytes of the contract hash makes the capture proof fail (`assert 'block' != 'block'`); removing the git-env strip makes the hijack regression test fail. Restored, both pass.
- Full pre-push gauntlet green: bun 3060 pass / 0 fail across 226 files, plus mypy, ruff, pytest, and the docs `--check`.
