### PR TITLE
fix(capture): record both sides -- the agent's replies were a port regression (#447)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,63 @@ jobs:
           TMPDIR: ${{ runner.temp }}
         run: uv build --python "${PYTHON_VERSION}"
 
+  # THE CAPTURE PACKAGE HAD NO CI JOB AT ALL until 2026-08-03 (#447).
+  #
+  # `python-package` runs from `python/openbrain-memory` and `python-provider`
+  # from `python/openbrain-provider`; NOTHING ran `python/openbrain`, which owns
+  # the hook entrypoints and the whole capture path. So a change there could be
+  # merged on a fully green PR having had its tests, lint, and typing executed
+  # nowhere but the author's machine -- and #447 is exactly the defect class that
+  # slips through: the port silently stopped recording the assistant side of
+  # every conversation for six days while every check stayed green.
+  #
+  # Two sibling packages passing is not coverage of a third. Found by the
+  # opposite-harness pre-merge audit, which named it as the "green sibling
+  # package jobs do not cover the changed package" pattern in
+  # `docs/sme/gotcha-agent.md`.
+  python-capture:
+    runs-on: [self-hosted, Linux, rodaddy]
+    # Self-hosted runner: same trusted-source gate as the sibling package jobs.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PYTHON_VERSION: "3.13"
+    defaults:
+      run:
+        working-directory: python/openbrain
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Install Python ${{ env.PYTHON_VERSION }}
+        run: uv python install "${PYTHON_VERSION}"
+
+      - name: Lint capture package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" ruff check src tests
+
+      - name: Typecheck capture package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" mypy src
+
+      # The default `addopts` deselects `-m live`, so this is the in-process
+      # suite. The live gate needs a playground service and database that this
+      # runner does not have; it is run by the author against the local
+      # playground and its receipt goes in the PR. Deselecting it here is why
+      # the in-process suite must be strong on its own -- see the non-vacuity
+      # guards in `test_capture_both_sides.py`.
+      - name: Test capture package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv run --python "${PYTHON_VERSION}" pytest -q
+
+      - name: Build capture package
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: uv build --python "${PYTHON_VERSION}"
+
   contract-parity:
     runs-on: [self-hosted, Linux, rodaddy]
     # Self-hosted runner: same trusted-source gate as the existing validation jobs.
@@ -427,7 +484,18 @@ jobs:
         run: uv run --python "${PYTHON_VERSION}" pytest -q tests/test_contract_fixtures.py
 
   deploy:
-    needs: [check, db-integration, python-package, python-provider, contract-parity]
+    # `python-capture` added 2026-08-03 (#447): the capture package ships the
+    # hook entrypoints, so deploying without gating on it would ship the exact
+    # path that silently lost half of every conversation.
+    needs:
+      [
+        check,
+        db-integration,
+        python-package,
+        python-provider,
+        python-capture,
+        contract-parity,
+      ]
     runs-on: [self-hosted, macOS, core01]
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.deploy_core01 && github.ref == 'refs/heads/main') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,9 +384,17 @@ jobs:
       run:
         working-directory: python/openbrain
     steps:
-      - uses: actions/checkout@v6
+      # PINNED BY FULL COMMIT SHA, not a mutable tag: `_DOCS/STANDARDS-ci-
+      # security.md:11` requires it, and this job runs on a PERSISTENT
+      # self-hosted runner, so a retargeted tag would execute attacker-chosen
+      # code on shared infrastructure regardless of the trusted-source gate
+      # above. The SHAs are the ones already used by `contract-parity` in this
+      # same workflow, verified 2026-08-03 against the upstream tags they
+      # annotate. The sibling package jobs still use bare tags; that is
+      # pre-existing drift, not a precedent to copy.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install Python ${{ env.PYTHON_VERSION }}
         run: uv python install "${PYTHON_VERSION}"

--- a/docs/decisions/capture-never-drops-a-turn.md
+++ b/docs/decisions/capture-never-drops-a-turn.md
@@ -185,6 +185,20 @@ mechanics: compare typed-in-transcript against `is_human_prompt` rows in
 something not yet identified, and the instinct to measure window sizes should be
 resisted — that is what produced the retracted 58%.
 
+**Run it PER ROLE, not just for the operator.** As written above this check
+watches one speaker, and that blind spot is exactly how #447 went unnoticed for
+six days: the operator numbers stayed healthy the entire time the assistant side
+was at zero. Group by role and compare each against the transcript:
+
+```sql
+SELECT role, count(*) FROM ob_raw_turns
+WHERE namespace = 'rico' AND created_at > now() - interval '24 hours'
+GROUP BY role;
+```
+
+An `assistant` count near zero beside a healthy `user` count is a capture
+defect, not a quiet day.
+
 It assumed one turn is a handful of entries. True for plain conversation, false
 with tool calls: every call and every result is its own transcript line. Worse,
 the collection loop walks **backward**, so the 8 kept are the *newest* — the
@@ -260,6 +274,50 @@ PROV-9) must carry this decision forward — it is written into #418's acceptanc
 criteria — and the next wheel install will overwrite the deployed file. If
 capture starts silently shrinking again, check whether this decision survived
 the port.
+
+### It did not survive the port. Fixed 2026-08-03 (#447).
+
+The warning above was correct and the check it asks for was never run. The
+Python port carried the OPERATOR half of this decision and left the assistant
+half behind: its record parser returned a turn only for operator records, so
+every `type == "assistant"` line became `None`.
+
+Measured on the dogfood database, `ob_raw_turns` in namespace `rico`:
+
+| Day | assistant | tool | user | Path |
+|---|---|---|---|---|
+| 2026-07-27 | 5,773 | 3,022 | 495 | TypeScript adapter |
+| 2026-07-30 | 3,332 | 1,877 | 255 | TypeScript adapter |
+| 2026-08-02 | 13 | 0 | 365 | Python port |
+
+and all 13 of those assistant rows are `PostCompact` summaries, not replies. So
+"everything on screen goes in" held for one speaker for six days of sessions,
+and the corpus REM grades held the questions with none of the answers — which
+is what #447 was raised to name.
+
+**The fix is a restoration, not a new decision.** `records.py` now reads the
+`text` blocks off assistant records and attributes them `role=assistant`,
+`is_human_prompt=False`. No distillation step was added: this section's rule
+still holds, a filter here may TYPE a turn and may never decide whether to keep
+one, and a model-backed summarizer on the capture path would be exactly the
+drop-by-default filter that rule forbids.
+
+**What the fix did NOT resolve.** The OPEN question below — reasoning blocks,
+tool invocations, tool output — stays open, deliberately. `thinking` blocks are
+never stored (chain-of-thought, and the TypeScript reference skipped them for
+the same reason at `backfill-transcripts.ts:148`), and `tool_use` blocks are
+left to that question rather than answered by this fix. Reading speech now and
+leaving the machinery to a deliberate decision is the reversible order.
+
+**Why the gates did not catch it, recorded so the next port does better:** the
+port's tests were written from the port, so they asserted what it did. A
+`conftest.py` helper named `assistant_line` existed and was used only to prove
+an assistant record was correctly *declined*. The suite encoded the defect as
+intended behaviour. The health check this document already recommends —
+comparing stored rows against the transcript — would have caught it on day one;
+nobody ran it for the assistant side because the check as written only names
+`is_human_prompt`. It should be run per ROLE. The review pattern is captured in
+`docs/sme/gotcha-agent.md`, "A port is complete when the BEHAVIOUR matches".
 
 Verified at the time of the change, 9/9 functional cases: `yes`, `ok`, `no do
 it`, and `okay` all capture as `fact`; `use postgres not sqlite` still

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -898,3 +898,74 @@ it can actually open, and awaiting the thing under test collapses the window.**
 - Does a "drain proven" claim rest on a fake queue? Both invariants here fail
   silently in durable state, so only a real database read can distinguish a
   drained row from an abandoned one.
+
+---
+
+## A port is complete when the BEHAVIOUR matches, not when the tests pass
+
+**Provenance:** #447, found 2026-08-03 during the capture-both-sides fix.
+**Severity:** HIGH — silent, permanent data loss on the primary product path.
+**Status:** active.
+
+### Pattern
+
+The Python capture port replaced a TypeScript adapter and passed its own full
+suite — 453 tests, mypy clean, ruff clean, plus a live Postgres gate. It had
+also silently stopped recording half of every conversation.
+
+The old adapter captured the assistant's replies
+(`scripts/backfill-transcripts.ts:125`). The port's record parser only ever
+returned a turn for operator records, so every `type == "assistant"` line
+became `None`. Measured on the dogfood database, `ob_raw_turns`:
+
+| Day | assistant | tool | user | Path |
+|---|---|---|---|---|
+| 2026-07-27 | 5,773 | 3,022 | 495 | TypeScript adapter |
+| 2026-07-30 | 3,332 | 1,877 | 255 | TypeScript adapter |
+| 2026-08-02 | 13 | 0 | 365 | Python port |
+
+and all 13 of those were `PostCompact` summaries, not replies.
+
+**Why every gate stayed green.** The tests were written FROM the port, so they
+asserted what it did. A helper named `assistant_line` existed in `conftest.py`
+and was used only to prove an assistant record was *correctly declined*. The
+suite encoded the defect as intended behaviour, at which point no amount of
+coverage can surface it.
+
+**Why review missed it.** Nothing in the diff looked wrong. `is_operator_turn`
+is a correct predicate, `operator_text` is a correct accessor, and the module
+docstring described operator parsing accurately and in detail. The defect was
+not a bad line — it was an ABSENT branch, and absence does not appear in a
+diff. The one artifact that would have caught it was the governing decision doc
+sitting in the same repo, which had already settled the scope in one sentence:
+*"the operator's words and the assistant's replies, in full"*
+(`docs/decisions/capture-never-drops-a-turn.md:215`).
+
+**The corroborating signal that was already present.** The Codex adapter in the
+same package had captured both sides all along, and `test_bulk_ingest.py`
+asserted a `TurnRole.ASSISTANT` turn for it. One adapter satisfying a contract
+its sibling silently did not is a defect signal, not a style difference.
+
+### Review Questions
+
+- **Does a row count exist for before and after?** A port that changes what
+  reaches durable storage must be checked against the volume the old path
+  produced. "The tests pass" and "the same data lands" are different claims, and
+  only the second one is about the product. One `GROUP BY` answers it.
+- **Were the tests written from the new code or from the contract?** Tests
+  derived from the implementation cannot fail on a missing branch, because they
+  never knew to ask for it. Check that at least one assertion traces to a
+  decision doc, an issue, or the replaced implementation.
+- **Does a test helper exist whose only use is to prove something is DECLINED?**
+  That is where an unimplemented branch hides — the helper documents the gap as
+  if it were a rule. Ask what would use it if the branch existed.
+- **Is there a sibling adapter, client, or runtime that handles the same input?**
+  If one captures a field, a role, or a record type the other drops, name the
+  asymmetry and make someone justify it. Two implementations of one contract
+  disagreeing is the cheapest defect signal available and it is usually free.
+- **Does the replaced implementation still exist to diff against?** Read it for
+  branches, not for style. An absent branch is invisible in the new file and
+  obvious side by side.
+- **For a capture/ingest path specifically: does an end-to-end test assert a
+  COUNT, not just per-record shape?** Every per-record assertion in #447 passed.
+  Only "a two-speaker transcript delivers 2" fails on the defect.

--- a/python/openbrain/src/openbrain/apps/capture/records.py
+++ b/python/openbrain/src/openbrain/apps/capture/records.py
@@ -1,9 +1,10 @@
 """Turn one transcript record into a ``RawTurn``, or into nothing.
 
 Purpose:
-    A Claude Code transcript is JSONL, and most of its lines are not operator
-    turns. This module answers one question per line: did the operator say this,
-    and if so, what did they say.
+    A Claude Code transcript is JSONL, and most of its lines are neither half of
+    the conversation. This module answers one question per line: is this
+    something a participant SAID -- the operator typing, or the assistant
+    replying on screen -- and if so, what were the words.
 
 Architecture:
     **Pydantic owns the shape; this module owns the meaning.** The record is
@@ -41,9 +42,66 @@ Architecture:
         a ``str``; the list shape belongs to tool results and structured content
         blocks. A reader assuming one shape silently drops the other.
 
+    THE ASSISTANT SIDE IS ALWAYS THE LIST SHAPE (#447).
+        Measured 2026-08-03 on a live open-brain session transcript: all 134
+        ``type == "assistant"`` records carried a ``list``, none a ``str``, and
+        those lists held ``text`` (75) and ``tool_use`` (59) blocks. So the
+        operator's ``str``-only rule is exactly wrong for the assistant, and
+        reading its words needs the block walk in :func:`_assistant_text`.
+
+Both Sides (#447):
+    An earlier version of this module read the OPERATOR ONLY, and that was a
+    PORT REGRESSION, not an original gap. The governing decision already settled
+    the scope -- ``docs/decisions/capture-never-drops-a-turn.md:215``:
+
+        *"Settled: everything on screen goes in. The operator's words and the
+        assistant's replies, in full, no length test, no phrasing allowlist."*
+
+    The TypeScript adapter this package replaced honoured that
+    (``scripts/backfill-transcripts.ts:125``); the port carried the operator half
+    across and left the assistant half behind. Measured on the dogfood database,
+    ``ob_raw_turns`` in namespace ``rico``:
+
+    ==========  =========  ====  =====  ===================================
+    Day         assistant  tool  user   Path
+    ==========  =========  ====  =====  ===================================
+    2026-07-27  5,773      3,022 495    TypeScript adapter
+    2026-07-30  3,332      1,877 255    TypeScript adapter
+    2026-08-02  13         0     365    Python port -- and all 13 are
+                                        ``PostCompact`` summaries
+    ==========  =========  ====  =====  ===================================
+
+    So the corpus REM grades held one side of every conversation: the questions
+    and none of the answers. That is the defect #447 names, and restoring it here
+    -- at the parser that decides what a line WAS -- is the owning boundary. It
+    is not a distillation step: the raw lane is the corpus, distillation is a
+    later and reversible stage, and a filter on this path "may TYPE a turn, it
+    may never decide whether to keep one" (the same decision, line 12).
+
+    TWO BLOCK KINDS ARE ROUTED ELSEWHERE, each by a rule someone already made:
+
+    ``thinking`` blocks -- chain-of-thought.
+        Never stored. Not on screen, not something either participant said, and
+        the standing hard rule across every runtime is distilled events only,
+        never raw reasoning. The TypeScript reference skipped these for the same
+        stated reason (``backfill-transcripts.ts:148``), so this preserves the
+        settled behaviour rather than introducing anything new.
+
+    ``tool_use`` blocks -- the machinery underneath.
+        Left to the open question rather than answered here. The decision doc
+        parks it explicitly (``capture-never-drops-a-turn.md:213``) in terms that
+        bind this change: *"Do not resolve this by inference, and do not let it
+        be resolved by accident. The failure mode is a stage quietly starting to
+        filter on role."* Reading text now and leaving tool calls to that
+        question is the reversible order -- bringing tool volume in afterwards is
+        purely additive, whereas asserting here that it belongs would resolve by
+        accident exactly what the operator parked. Nothing is dropped from
+        anywhere: these records stay in the transcript, which remains their
+        source, and #417 tracks where execution traces land.
+
 Pattern/Convention:
-    A line that is not an operator turn returns ``None``, and so does a line that
-    is malformed. NEITHER IS AN ERROR -- a transcript legitimately contains
+    A line that neither participant spoke returns ``None``, and so does a line
+    that is malformed. NEITHER IS AN ERROR -- a transcript legitimately contains
     eleven record types, and the first three lines of every file
     (``last-prompt``, ``mode``, ``permission-mode``) carry no ``uuid`` at all.
     Raising on those would mean crashing on line 1 of every session.
@@ -58,8 +116,10 @@ Example:
     >>> turn = raw_turn_from_line(line)
     >>> turn.content
     'ok'
-    >>> raw_turn_from_line('{"type":"assistant","uuid":"a1"}') is None
-    True
+    >>> reply = '{"type":"assistant","uuid":"a1","message":{"content":'
+    >>> reply += '[{"type":"text","text":"the index was empty"}]}}'
+    >>> raw_turn_from_line(reply).content
+    'the index was empty'
 
 See Also:
     - ``openbrain.models.turn`` - the ``RawTurn`` shape produced here
@@ -80,6 +140,28 @@ from openbrain.models.turn import RawTurn, TurnRole
 #: Necessary but nowhere near sufficient: 2,561 records matched this and only
 #: 234 were the operator. See :class:`PromptSource`.
 USER_RECORD_TYPE = "user"
+
+#: The record type carrying the assistant's reply -- the agent side (#447).
+#:
+#: Unlike ``user``, this type needs no second discriminator: a record is either
+#: the assistant speaking or it is not. What it DOES need is the block walk, and
+#: for the same reason ``promptSource`` matters above -- the type alone says who
+#: authored the record, never which parts of it were on screen.
+ASSISTANT_RECORD_TYPE = "assistant"
+
+#: The content block holding words that appeared on screen.
+#:
+#: The ONLY block kind read off an assistant record. ``thinking`` is
+#: chain-of-thought and is never stored, and ``tool_use`` belongs to the open
+#: memory-versus-observability question -- both covered in the module docstring.
+TEXT_BLOCK_TYPE = "text"
+
+#: Separator between an assistant record's text blocks when it carries several.
+#:
+#: One record can hold prose, then a tool call, then more prose; the reply is the
+#: prose in order, and a newline is how it rendered on screen. Matches the
+#: TypeScript reference (``scripts/backfill-transcripts.ts:159``).
+BLOCK_JOINER = "\n"
 
 
 class PromptSource(StrEnum):
@@ -146,6 +228,18 @@ class TranscriptRecord(BaseModel):
         )
 
     @property
+    def is_assistant_turn(self) -> bool:
+        """Whether the assistant produced this record (#447).
+
+        No ``promptSource`` analogue is needed or available: that field
+        discriminates operator typing from injected text in the PROMPT position,
+        and nothing is injected into the assistant position. The narrowing that
+        matters for the assistant is which blocks it spoke, which is
+        :attr:`assistant_text`'s job, not this one's.
+        """
+        return self.record_type == ASSISTANT_RECORD_TYPE
+
+    @property
     def operator_text(self) -> str | None:
         """What the operator typed, or ``None`` if this is not their message.
 
@@ -159,6 +253,65 @@ class TranscriptRecord(BaseModel):
         content = self.message.content
         return content if isinstance(content, str) else None
 
+    @property
+    def assistant_text(self) -> str | None:
+        """What the assistant said on screen, or ``None`` when it said nothing.
+
+        Returns:
+            The record's ``text`` blocks joined in order, or ``None`` when the
+            record carries none -- a reply that was purely tool calls, which is
+            a real and ordinary record, not a malformed one.
+
+        Mirrors :attr:`operator_text` in contract and inverts it in mechanism:
+        the operator speaks in the ``str`` shape and the assistant in the
+        ``list`` shape (all 134 assistant records on a live transcript, measured
+        2026-08-03). A ``str`` is therefore NOT accepted here -- it has never
+        been observed on an assistant record, and quietly accepting one would
+        make an unmeasured shape look like a verified one.
+
+        Text is joined, never shortened, and never sampled: the whole reply is
+        the record of what was said (``capture-never-drops-a-turn.md``).
+        """
+        if self.message is None:
+            return None
+
+        content = self.message.content
+        if not isinstance(content, list):
+            return None
+
+        return _assistant_text(content)
+
+
+def _assistant_text(content: list[Any]) -> str | None:
+    """Join the ``text`` blocks of one assistant record, in order.
+
+    Args:
+        content: The record's ``message.content`` list, straight off the
+            transcript and therefore untrusted in shape.
+
+    Returns:
+        The spoken text, or ``None`` when the record held no usable text block.
+
+    Every block that is not :data:`TEXT_BLOCK_TYPE` is passed over rather than
+    rejected: a reply that interleaves prose with tool calls is the NORMAL shape
+    (59 of the 134 measured records carried a ``tool_use``), so treating an
+    unread block as malformed would decline the very records that carry the most
+    reasoning. Malformed entries -- a bare string, a null -- are passed over for
+    the same reason: this walk reports what it could read, never what it wished
+    the transcript looked like.
+    """
+    spoken = [
+        text
+        for block in content
+        if isinstance(block, dict)
+        and block.get("type") == TEXT_BLOCK_TYPE
+        and isinstance(text := block.get("text"), str)
+        and text.strip()
+    ]
+    if not spoken:
+        return None
+    return BLOCK_JOINER.join(spoken)
+
 
 def raw_turn_from_line(line: str) -> RawTurn | None:
     """Build a :class:`~openbrain.models.turn.RawTurn` from one JSONL line.
@@ -168,10 +321,12 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
             trailing newline.
 
     Returns:
-        A ``RawTurn`` when the line is an operator turn, otherwise ``None``.
-        ``None`` covers every ordinary non-turn case -- assistant messages, tool
-        results, mode markers, blank lines -- and also unparseable lines, which
-        a transcript being written concurrently can produce.
+        A ``RawTurn`` when the line is something a participant SAID -- the
+        operator typing or the assistant replying (#447) -- otherwise ``None``.
+        ``None`` covers every ordinary non-turn case -- tool results, mode
+        markers, an assistant record that was only tool calls, blank lines --
+        and also unparseable lines, which a transcript being written
+        concurrently can produce.
 
     Example:
         >>> raw_turn_from_line("") is None
@@ -188,20 +343,38 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
     except ValidationError:
         return None
 
-    if not record.is_operator_turn:
+    if not record.uuid:
         return None
 
-    content = record.operator_text
-    if content is None or not record.uuid:
+    # BOTH SIDES, and the branch order is not arbitrary: the operator test is
+    # the narrower one (a type AND a promptSource), so it is asked first and the
+    # assistant test never sees a record the operator test already claimed.
+    if record.is_operator_turn:
+        content = record.operator_text
+        role = TurnRole.USER
+        # The load-bearing flag: what a PERSON typed. It is what the health
+        # check in capture-never-drops-a-turn.md compares against the transcript,
+        # so an assistant turn must never set it -- doing so would make the agent
+        # side look like operator volume and hide a future operator-side loss.
+        is_human_prompt = True
+    elif record.is_assistant_turn:
+        content = record.assistant_text
+        role = TurnRole.ASSISTANT
+        is_human_prompt = False
+    else:
+        return None
+
+    if content is None:
         return None
 
     return RawTurn(
         turn_uuid=record.uuid,
         content=content,
-        # Explicit, not the model default: only the typed-shape path reaches
-        # here, so USER is a fact about this line, not a fallback.
-        role=TurnRole.USER,
-        is_human_prompt=True,
+        # Explicit per branch, never the model default: the role is a FACT about
+        # which side of the conversation this line was, and defaulting it is how
+        # the port came to record every turn as the operator's.
+        role=role,
+        is_human_prompt=is_human_prompt,
         # The transcript's own clock, verbatim. The server orders a session by
         # (session_ref, occurred_at); a backfill that dropped this left 20,535
         # rows unorderable (scripts/backfill-transcripts.ts:256).

--- a/python/openbrain/tests/conftest.py
+++ b/python/openbrain/tests/conftest.py
@@ -243,9 +243,28 @@ def thinking_block(text: str) -> dict[str, Any]:
     return {"type": "thinking", "thinking": text}
 
 
+#: A value placed inside a `tool_use` block's ARGUMENTS that must never persist.
+#:
+#: Distinct from the tool NAME and from the argument KEY, because those three can
+#: leak independently. An earlier version of the leak assertions checked the name
+#: and the key only, so a parser that persisted just the argument VALUE would
+#: have passed -- the reviewer's finding, 2026-08-03. A unique sentinel makes the
+#: value itself assertable.
+TOOL_ARGUMENT_SENTINEL = "ToolArgumentValueMustNotPersist"
+
+
 def tool_use_block(name: str) -> dict[str, Any]:
-    """An assistant ``tool_use`` block -- machinery, left to the open question."""
-    return {"type": "tool_use", "name": name, "input": {"command": "ls"}}
+    """An assistant ``tool_use`` block -- machinery, left to the open question.
+
+    Carries a NON-EMPTY argument holding :data:`TOOL_ARGUMENT_SENTINEL`, so a
+    test can assert the absence of the name, the key, AND the value. An empty
+    ``input`` would make the strongest of those three assertions unprovable.
+    """
+    return {
+        "type": "tool_use",
+        "name": name,
+        "input": {"command": TOOL_ARGUMENT_SENTINEL},
+    }
 
 
 def write_lines(path: Path, lines: list[str]) -> None:

--- a/python/openbrain/tests/conftest.py
+++ b/python/openbrain/tests/conftest.py
@@ -197,8 +197,55 @@ def operator_line(
 
 
 def assistant_line(uuid: str) -> str:
-    """Build one assistant transcript line -- not an operator turn."""
+    """Build one assistant line that SAID NOTHING -- no text blocks at all.
+
+    Still not a captured turn after #447 restored the agent side, and for a
+    reason worth keeping distinct: it is declined for holding no spoken text,
+    NOT for being the assistant. Use :func:`assistant_says` for a reply that
+    actually speaks.
+    """
     return json.dumps({"type": "assistant", "uuid": uuid, "message": {"content": []}})
+
+
+def assistant_says(
+    uuid: str,
+    *blocks: dict[str, Any],
+    session: str = "s1",
+    timestamp: str = TIMESTAMP,
+) -> str:
+    """Build one assistant line carrying the given content blocks (#447).
+
+    The assistant's half is ALWAYS the list shape -- measured 2026-08-03 across
+    134 live assistant records, none of which used a bare string -- so blocks are
+    passed through exactly as the transcript writes them and callers build the
+    mix they mean to test (``text``, ``tool_use``, ``thinking``).
+    """
+    return json.dumps(
+        {
+            "type": "assistant",
+            "uuid": uuid,
+            "sessionId": session,
+            "cwd": "/repo",
+            "parentUuid": None,
+            "timestamp": timestamp,
+            "message": {"role": "assistant", "content": list(blocks)},
+        }
+    )
+
+
+def text_block(text: str) -> dict[str, Any]:
+    """An assistant ``text`` block -- words that appeared on screen."""
+    return {"type": "text", "text": text}
+
+
+def thinking_block(text: str) -> dict[str, Any]:
+    """An assistant ``thinking`` block -- chain-of-thought, never stored."""
+    return {"type": "thinking", "thinking": text}
+
+
+def tool_use_block(name: str) -> dict[str, Any]:
+    """An assistant ``tool_use`` block -- machinery, left to the open question."""
+    return {"type": "tool_use", "name": name, "input": {"command": "ls"}}
 
 
 def write_lines(path: Path, lines: list[str]) -> None:

--- a/python/openbrain/tests/test_bulk_ingest.py
+++ b/python/openbrain/tests/test_bulk_ingest.py
@@ -44,15 +44,36 @@ CODEX_FIXTURE = (
     Path(__file__).parent / "fixtures" / "bulk" / "codex-rollout-sanitized.jsonl"
 )
 
-#: The operator turns the fixture contains, in order, with their exact text. The
-#: fixture also carries markers, an assistant line, a tool result, a system
-#: prompt, and a compaction summary -- none of which is an operator turn -- so a
-#: run that returns exactly these three has declined all the non-turns correctly.
+#: The CONVERSATION the fixture contains, in file order, with exact text.
+#:
+#: BOTH SIDES since #447: the operator's three turns and the assistant's one
+#: reply. The bulk ingester shares ``raw_turn_from_line`` with the live capture
+#: path, so restoring the agent side there restored it here too -- which is the
+#: point. A bulk-ingested corpus that held only the operator's half would grade
+#: the same one-sided material the live path was producing.
+#:
+#: The fixture also carries markers, a tool result, a system-injected prompt, and
+#: a compaction summary -- none of which either participant SAID -- so a run
+#: returning exactly these four has declined all the non-turns correctly.
 EXPECTED_TURNS = (
     ("op-1", "port the bulk ingester from the spec"),
+    ("as-1", "working on it"),
     ("op-2", "y"),
     ("op-3", "use SQLite staging, not an in-memory list, and yield each turn whole"),
 )
+
+#: How each expected turn is attributed: ``(role, is_human_prompt)`` by uuid.
+#:
+#: Asserted separately from the text because #447's defect was never that content
+#: was wrong -- it was that a whole speaker was missing, and a restored speaker
+#: mislabelled as the operator would corrupt the health check that watches for
+#: operator-side loss (``docs/decisions/capture-never-drops-a-turn.md``).
+EXPECTED_ATTRIBUTION = {
+    "op-1": (TurnRole.USER, True),
+    "as-1": (TurnRole.ASSISTANT, False),
+    "op-2": (TurnRole.USER, True),
+    "op-3": (TurnRole.USER, True),
+}
 
 
 class TurnRejectedError(RuntimeError):
@@ -97,10 +118,10 @@ def stage_fixture(tmp_path: Path) -> StagingStore:
     return store
 
 
-class TestEveryOperatorTurnReachesTheLane:
-    """A giant file in, every operator turn out -- and nothing that is not one."""
+class TestEveryTurnReachesTheLane:
+    """A giant file in, the whole conversation out -- and nothing that is not it."""
 
-    def test_all_operator_turns_land_in_file_order(self, tmp_path: Path) -> None:
+    def test_all_turns_land_in_file_order(self, tmp_path: Path) -> None:
         store = stage_fixture(tmp_path)
         lane = RecordingLane()
 
@@ -111,11 +132,26 @@ class TestEveryOperatorTurnReachesTheLane:
         landed = [(turn["turn_uuid"], turn["content"]) for turn in lane.turns]
         assert landed == list(EXPECTED_TURNS)
 
-    def test_non_operator_records_are_declined_not_stored(
+    def test_each_turn_is_attributed_to_the_side_that_said_it(
         self, tmp_path: Path
     ) -> None:
-        # The fixture's tool result, assistant line, system prompt, markers, and
-        # compaction summary must all be absent -- staging carries only turns.
+        """Both speakers land, and each is labelled as itself (#447)."""
+        store = stage_fixture(tmp_path)
+        lane = RecordingLane()
+
+        ingest(store, lane)
+
+        attribution = {
+            turn["turn_uuid"]: (turn["role"], turn["is_human_prompt"])
+            for turn in lane.turns
+        }
+        assert attribution == EXPECTED_ATTRIBUTION
+
+    def test_records_neither_side_said_are_declined_not_stored(
+        self, tmp_path: Path
+    ) -> None:
+        # The fixture's tool result, system-injected prompt, markers, and
+        # compaction summary must all be absent -- staging carries only speech.
         store = stage_fixture(tmp_path)
         assert store.counts().staged == len(EXPECTED_TURNS)
         landed_ids = {turn.turn_uuid for turn in store.pending()}
@@ -180,12 +216,14 @@ class TestResumeDoesNotResend:
         self, tmp_path: Path
     ) -> None:
         store = stage_fixture(tmp_path)
-        # First run rejects op-2: op-1 lands, op-2 quarantines, op-3 still lands.
+        # First run rejects op-2: everything before and after it still lands,
+        # including the assistant's reply -- quarantine is per turn, and it is
+        # not allowed to take a whole speaker down with it.
         rejecting = RejectingLane(reject_uuid="op-2")
         first = ingest(store, rejecting)
-        assert first.sent == 2
+        assert first.sent == len(EXPECTED_TURNS) - 1
         assert first.quarantined == 1
-        assert rejecting.accepted == ["op-1", "op-3"]
+        assert rejecting.accepted == ["op-1", "as-1", "op-3"]
 
         # A resume with an accepting lane sends ONLY the still-pending op-2 --
         # the two already-sent turns are not re-sent.
@@ -204,7 +242,7 @@ class TestRejectedTurnsAreQuarantinedNotDropped:
         store = stage_fixture(tmp_path)
         result = ingest(store, RejectingLane(reject_uuid="op-2"))
 
-        assert result.sent == 2
+        assert result.sent == len(EXPECTED_TURNS) - 1
         assert result.quarantined == 1
         quarantined = list(store.quarantined())
         assert len(quarantined) == 1

--- a/python/openbrain/tests/test_capture_both_sides.py
+++ b/python/openbrain/tests/test_capture_both_sides.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conftest import (
+    TOOL_ARGUMENT_SENTINEL,
     RecordingLane,
     assistant_line,
     assistant_says,
@@ -176,14 +177,23 @@ class TestReasoningIsNeverStored:
 
         ``capture-never-drops-a-turn.md``: "Do not resolve this by inference,
         and do not let it be resolved by accident."
+
+        A tool call can leak in THREE independent ways -- its name, its argument
+        key, and its argument VALUE -- so all three are asserted. An earlier
+        version checked the first two only, which a parser persisting just the
+        value would have satisfied (reviewer finding, 2026-08-03).
         """
         turn = raw_turn_from_line(
             assistant_says("a1", text_block(FINDING), tool_use_block("Bash"))
         )
 
         assert turn is not None
+        # Non-vacuity: the assertions below are only meaningful because this
+        # record DID produce a turn with content to search.
+        assert turn.content == FINDING
         assert "Bash" not in turn.content
         assert "command" not in turn.content
+        assert TOOL_ARGUMENT_SENTINEL not in turn.content
 
     def test_an_empty_assistant_record_is_not_a_turn(self) -> None:
         """Declined for saying nothing, not for being the assistant."""
@@ -292,7 +302,17 @@ class TestBothSidesReachTheLane:
 
     @pytest.mark.asyncio
     async def test_no_reasoning_reaches_the_lane(self, tmp_path: Path) -> None:
-        """End-to-end guarantee, not just a parser property."""
+        """End-to-end guarantee, not just a parser property.
+
+        NON-VACUITY IS ASSERTED FIRST, and that ordering is the point. An
+        absence assertion over an empty corpus passes for the wrong reason:
+        under the pre-#447 parser both records below yield nothing, `delivered`
+        is the empty string, and every `not in` check is trivially true. That is
+        precisely the shape `docs/sme/correctness.md` warns about -- "a green
+        gate is evidence of nothing until something has made it fail" -- and it
+        was caught here by the opposite-harness review on 2026-08-03. So this
+        proves the material ARRIVED before it proves what was left out.
+        """
         transcript = tmp_path / "session.jsonl"
         write_lines(
             transcript,
@@ -306,11 +326,22 @@ class TestBothSidesReachTheLane:
         lane = RecordingLane()
         store = WatermarkStore(tmp_path / "watermark.sqlite")
 
-        await deliver_new_turns(transcript, "s1", store, lane)
+        delivery = await deliver_new_turns(transcript, "s1", store, lane)
+
+        # THE NON-VACUITY GUARD. Exactly one turn: the record that spoke. The
+        # tool-only record is correctly declined, so a2 contributes nothing --
+        # which is why the count is 1 and not 2.
+        assert delivery.delivered == 1, (
+            "nothing was delivered, so the absence checks below would pass "
+            "against an empty corpus and prove nothing"
+        )
+        assert len(lane.turns) == 1
+        assert lane.turns[0]["content"] == FINDING
 
         delivered = " ".join(turn["content"] for turn in lane.turns)
         assert "SECRET REASONING" not in delivered
         assert "Bash" not in delivered
+        assert TOOL_ARGUMENT_SENTINEL not in delivered
 
     @pytest.mark.asyncio
     async def test_the_watermark_advances_over_both_sides(

--- a/python/openbrain/tests/test_capture_both_sides.py
+++ b/python/openbrain/tests/test_capture_both_sides.py
@@ -1,0 +1,335 @@
+"""Capture records BOTH sides of the work, not just the operator's half (#447).
+
+The defect these pin is a PORT REGRESSION, and the red-proof is stated in terms
+of it: every test in :class:`TestTheAgentSideIsCaptured` fails on the pre-#447
+parser, which returned ``None`` for every ``type == "assistant"`` record, and
+passes on the restored one. Measured on the dogfood database before the fix --
+389 operator turns against 15 assistant rows, all 15 of them ``PostCompact``
+summaries rather than replies -- so the corpus REM grades held the questions and
+none of the answers.
+
+Organised by the claim each group makes, so a failure names the rule that broke:
+
+    TestTheAgentSideIsCaptured   the reply lands, whole, as the assistant
+    TestReasoningIsNeverStored   thinking/tool blocks stay out, by their own rules
+    TestTheOperatorSideIsIntact  the half that already worked still works
+    TestBothSidesReachTheLane    the spine delivers the conversation in order
+
+The last group is the one that actually answers #447's title: a single
+transcript, read once, yields both speakers in the order they spoke.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conftest import (
+    RecordingLane,
+    assistant_line,
+    assistant_says,
+    operator_line,
+    text_block,
+    thinking_block,
+    tool_use_block,
+    write_lines,
+)
+from openbrain.apps.capture.deliver import deliver_new_turns
+from openbrain.apps.capture.records import raw_turn_from_line
+from openbrain.apps.capture.watermark import WatermarkStore
+from openbrain.models.turn import TurnRole
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: A finding phrased the way the agent actually phrases one. Deliberately NOT a
+#: word any classifier pattern would match: #447 is about whether the agent side
+#: is stored at all, and a fixture that happened to look like a "decision" would
+#: pass for the wrong reason.
+FINDING = "The fleet index is 20% third-party code and buzz's checkout is dirty."
+
+
+class TestTheAgentSideIsCaptured:
+    """An assistant record becomes a turn. THE RED-PROOF GROUP (#447)."""
+
+    def test_an_assistant_reply_becomes_a_turn(self) -> None:
+        """The core regression: before #447 this returned None, silently."""
+        turn = raw_turn_from_line(assistant_says("a1", text_block(FINDING)))
+
+        assert turn is not None, (
+            "the assistant side was dropped -- this is the #447 regression, "
+            "where a session recorded the questions and none of the answers"
+        )
+        assert turn.content == FINDING
+
+    def test_the_reply_is_attributed_to_the_assistant(self) -> None:
+        """Role is a FACT per branch, never the model's USER default."""
+        turn = raw_turn_from_line(assistant_says("a1", text_block(FINDING)))
+
+        assert turn is not None
+        assert turn.role is TurnRole.ASSISTANT
+
+    def test_the_agent_side_is_not_counted_as_a_human_prompt(self) -> None:
+        """``is_human_prompt`` stays the operator-only health-check signal.
+
+        ``capture-never-drops-a-turn.md`` compares typed-in-transcript against
+        ``is_human_prompt`` rows to detect operator-side loss. An assistant turn
+        setting it would inflate that count and hide exactly what it watches for.
+        """
+        turn = raw_turn_from_line(assistant_says("a1", text_block(FINDING)))
+
+        assert turn is not None
+        assert turn.is_human_prompt is False
+
+    def test_a_reply_carries_its_transcript_metadata(self) -> None:
+        """Ordering and provenance are populated for the agent side too.
+
+        ``occurred_at`` is THE ordering key -- the server sequences a session by
+        ``(session_ref, occurred_at)`` -- so an assistant turn without it is
+        stored but unorderable, which is how 20,535 backfilled rows were lost to
+        sequencing once already.
+        """
+        turn = raw_turn_from_line(
+            assistant_says("a1", text_block(FINDING), session="s9")
+        )
+
+        assert turn is not None
+        assert turn.occurred_at is not None
+        assert turn.session_ref == "s9"
+        assert turn.turn_uuid == "a1"
+
+    def test_several_text_blocks_are_joined_in_order(self) -> None:
+        """One record can speak more than once; all of it is the reply."""
+        turn = raw_turn_from_line(
+            assistant_says("a1", text_block("first"), text_block("second"))
+        )
+
+        assert turn is not None
+        assert turn.content == "first\nsecond"
+
+    def test_prose_around_a_tool_call_is_kept_whole(self) -> None:
+        """The interleaved shape is NORMAL -- 59 of 134 measured records.
+
+        Declining a record because it also called a tool would drop precisely
+        the replies that carry the most reasoning.
+        """
+        turn = raw_turn_from_line(
+            assistant_says(
+                "a1",
+                text_block("before"),
+                tool_use_block("Bash"),
+                text_block("after"),
+            )
+        )
+
+        assert turn is not None
+        assert turn.content == "before\nafter"
+
+    def test_a_long_reply_is_stored_byte_for_byte(self) -> None:
+        """No length floor and no shortening on the agent side either."""
+        long_finding = FINDING * 500
+        turn = raw_turn_from_line(assistant_says("a1", text_block(long_finding)))
+
+        assert turn is not None
+        assert turn.content == long_finding
+
+    def test_a_one_character_reply_is_stored(self) -> None:
+        """"ok" from the agent is as capturable as "ok" from the operator."""
+        turn = raw_turn_from_line(assistant_says("a1", text_block("k")))
+
+        assert turn is not None
+        assert turn.content == "k"
+
+
+class TestReasoningIsNeverStored:
+    """Chain-of-thought and machinery stay out -- each by its own settled rule."""
+
+    def test_a_thinking_block_is_not_stored(self) -> None:
+        """The hard rule: distilled events only, never raw reasoning."""
+        turn = raw_turn_from_line(
+            assistant_says("a1", thinking_block("let me work through this"))
+        )
+
+        assert turn is None, "chain-of-thought must never reach the lane"
+
+    def test_thinking_beside_speech_contributes_nothing(self) -> None:
+        """The spoken half lands; the reasoning half is not part of it."""
+        turn = raw_turn_from_line(
+            assistant_says(
+                "a1", thinking_block("private reasoning"), text_block(FINDING)
+            )
+        )
+
+        assert turn is not None
+        assert turn.content == FINDING
+        assert "private reasoning" not in turn.content
+
+    def test_a_reply_that_only_called_tools_is_not_a_turn(self) -> None:
+        """No spoken text is a real, ordinary record -- declined, not an error."""
+        turn = raw_turn_from_line(assistant_says("a1", tool_use_block("Read")))
+
+        assert turn is None
+
+    def test_a_tool_call_never_contributes_its_arguments(self) -> None:
+        """The open memory-versus-observability question stays open.
+
+        ``capture-never-drops-a-turn.md``: "Do not resolve this by inference,
+        and do not let it be resolved by accident."
+        """
+        turn = raw_turn_from_line(
+            assistant_says("a1", text_block(FINDING), tool_use_block("Bash"))
+        )
+
+        assert turn is not None
+        assert "Bash" not in turn.content
+        assert "command" not in turn.content
+
+    def test_an_empty_assistant_record_is_not_a_turn(self) -> None:
+        """Declined for saying nothing, not for being the assistant."""
+        assert raw_turn_from_line(assistant_line("a1")) is None
+
+    def test_a_whitespace_only_block_is_not_speech(self) -> None:
+        """There is no length floor, but blank is still nothing said."""
+        assert raw_turn_from_line(assistant_says("a1", text_block("   "))) is None
+
+    @pytest.mark.parametrize(
+        "malformed",
+        [
+            {"type": "text"},
+            {"type": "text", "text": None},
+            {"type": "text", "text": 12},
+        ],
+        ids=["no-text-key", "null-text", "non-string-text"],
+    )
+    def test_a_malformed_block_is_passed_over(self, malformed: dict) -> None:
+        """Report what was readable; never crash on a shape not seen before."""
+        turn = raw_turn_from_line(assistant_says("a1", malformed, text_block(FINDING)))
+
+        assert turn is not None
+        assert turn.content == FINDING
+
+    def test_an_assistant_record_with_no_uuid_is_declined(self) -> None:
+        """No uuid means no server dedupe key, so there is nothing to store."""
+        line = '{"type":"assistant","message":{"content":[{"type":"text","text":"x"}]}}'
+
+        assert raw_turn_from_line(line) is None
+
+
+class TestTheOperatorSideIsIntact:
+    """The half that already worked is unchanged -- #447 adds, never trades."""
+
+    def test_an_operator_turn_is_still_captured(self) -> None:
+        turn = raw_turn_from_line(operator_line("u1", "roll that back a bit"))
+
+        assert turn is not None
+        assert turn.role is TurnRole.USER
+        assert turn.is_human_prompt is True
+
+    def test_a_tool_result_is_still_not_a_turn(self) -> None:
+        """Type ``user`` without ``promptSource`` is machinery replayed as user.
+
+        The measurement that forced the operator rule: 2,561 ``user`` records,
+        only 234 typed by a person.
+        """
+        line = (
+            '{"type":"user","uuid":"t1","sessionId":"s1",'
+            '"message":{"content":[{"type":"tool_result","content":"output"}]}}'
+        )
+
+        assert raw_turn_from_line(line) is None
+
+    def test_injected_system_text_is_still_not_the_operator(self) -> None:
+        """``promptSource: system`` is text the operator never wrote."""
+        line = operator_line("u1", "injected").replace('"typed"', '"system"')
+
+        assert raw_turn_from_line(line) is None
+
+    def test_a_mode_marker_is_still_not_a_turn(self) -> None:
+        """The first lines of every transcript carry no uuid at all."""
+        assert raw_turn_from_line('{"type":"mode","mode":"default"}') is None
+
+
+class TestBothSidesReachTheLane:
+    """#447's actual claim: one read yields the conversation, both speakers."""
+
+    @pytest.mark.asyncio
+    async def test_a_conversation_delivers_both_speakers_in_order(
+        self, tmp_path: Path
+    ) -> None:
+        """THE PRODUCT PROOF at the spine boundary.
+
+        Before #447 this delivered 2 turns -- the operator's two questions and
+        neither answer. It now delivers 4, alternating, which is what makes the
+        next session inherit what this one learned.
+        """
+        transcript = tmp_path / "session.jsonl"
+        write_lines(
+            transcript,
+            [
+                operator_line("u1", "why is the index empty?"),
+                assistant_says("a1", text_block(FINDING)),
+                operator_line("u2", "fix it"),
+                assistant_says("a2", thinking_block("plan"), text_block("Fixed.")),
+            ],
+        )
+        lane = RecordingLane()
+        store = WatermarkStore(tmp_path / "watermark.sqlite")
+
+        delivery = await deliver_new_turns(transcript, "s1", store, lane)
+
+        assert delivery.delivered == 4, (
+            "a conversation is both speakers -- delivering 2 is the #447 "
+            "regression, where resume replays the questions and none of the "
+            "answers"
+        )
+        assert [(turn["role"], turn["content"]) for turn in lane.turns] == [
+            ("user", "why is the index empty?"),
+            ("assistant", FINDING),
+            ("user", "fix it"),
+            ("assistant", "Fixed."),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_reaches_the_lane(self, tmp_path: Path) -> None:
+        """End-to-end guarantee, not just a parser property."""
+        transcript = tmp_path / "session.jsonl"
+        write_lines(
+            transcript,
+            [
+                assistant_says(
+                    "a1", thinking_block("SECRET REASONING"), text_block(FINDING)
+                ),
+                assistant_says("a2", tool_use_block("Bash")),
+            ],
+        )
+        lane = RecordingLane()
+        store = WatermarkStore(tmp_path / "watermark.sqlite")
+
+        await deliver_new_turns(transcript, "s1", store, lane)
+
+        delivered = " ".join(turn["content"] for turn in lane.turns)
+        assert "SECRET REASONING" not in delivered
+        assert "Bash" not in delivered
+
+    @pytest.mark.asyncio
+    async def test_the_watermark_advances_over_both_sides(
+        self, tmp_path: Path
+    ) -> None:
+        """A second Stop re-delivers neither speaker's turns."""
+        transcript = tmp_path / "session.jsonl"
+        write_lines(
+            transcript,
+            [
+                operator_line("u1", "go"),
+                assistant_says("a1", text_block(FINDING)),
+            ],
+        )
+        lane = RecordingLane()
+        store = WatermarkStore(tmp_path / "watermark.sqlite")
+
+        first = await deliver_new_turns(transcript, "s1", store, lane)
+        second = await deliver_new_turns(transcript, "s1", store, lane)
+
+        assert first.delivered == 2
+        assert second.delivered == 0

--- a/python/openbrain/tests/test_capture_deliver_live.py
+++ b/python/openbrain/tests/test_capture_deliver_live.py
@@ -84,6 +84,13 @@ THINKING_MARKER = "PRIVATE-CHAIN-OF-THOUGHT-MUST-NOT-PERSIST"
 #: observability question stays open on the live path too, not just in-process.
 TOOL_MARKER = "ToolNameMustNotPersist"
 
+#: A tool ARGUMENT VALUE that must never appear. Separate from the name because
+#: the two leak independently: a parser that persisted only `input` would still
+#: satisfy an assertion about the name. The live fixture previously sent an
+#: EMPTY `input`, which made this the one leak the round trip could not disprove
+#: (reviewer finding, 2026-08-03).
+TOOL_ARGUMENT_MARKER = "ToolArgumentValueMustNotPersistLive"
+
 
 def assistant_line(turn_uuid: str, text: str, session: str) -> str:
     """One assistant transcript line, in the shape Claude Code actually writes.
@@ -107,7 +114,13 @@ def assistant_line(turn_uuid: str, text: str, session: str) -> str:
                 "content": [
                     {"type": "thinking", "thinking": THINKING_MARKER},
                     {"type": "text", "text": text},
-                    {"type": "tool_use", "name": TOOL_MARKER, "input": {}},
+                    {
+                        "type": "tool_use",
+                        "name": TOOL_MARKER,
+                        # NON-EMPTY on purpose: an empty input cannot prove the
+                        # argument value stays out of Postgres.
+                        "input": {"command": TOOL_ARGUMENT_MARKER},
+                    },
                 ],
             },
         }
@@ -344,6 +357,10 @@ class TestBothSidesReachPostgres:
 
         assert rows, "nothing was stored, so this proves nothing about leaking"
         stored = "\n".join(str(row[0]) for row in rows)
+        # Non-vacuity beyond "a row exists": the SPOKEN text must be the thing
+        # that arrived, or the absence checks below could pass over some other
+        # row entirely.
+        assert "the measured answer" in stored
         assert THINKING_MARKER not in stored, (
             "chain-of-thought reached durable storage -- the standing hard rule "
             "is distilled events only, never raw reasoning"
@@ -351,4 +368,8 @@ class TestBothSidesReachPostgres:
         assert TOOL_MARKER not in stored, (
             "a tool name reached durable storage, resolving by accident the "
             "memory-versus-observability question the decision doc parks"
+        )
+        assert TOOL_ARGUMENT_MARKER not in stored, (
+            "a tool ARGUMENT VALUE reached durable storage -- the name staying "
+            "out is not sufficient, they leak independently"
         )

--- a/python/openbrain/tests/test_capture_deliver_live.py
+++ b/python/openbrain/tests/test_capture_deliver_live.py
@@ -75,6 +75,45 @@ def operator_line(turn_uuid: str, content: str, session: str) -> str:
     )
 
 
+#: Text placed in a `thinking` block that must NEVER appear in any stored row.
+#: A literal marker rather than a shape test: the assertion is a substring search
+#: over what Postgres actually holds, so a leak anywhere in the round trip fails.
+THINKING_MARKER = "PRIVATE-CHAIN-OF-THOUGHT-MUST-NOT-PERSIST"
+
+#: A tool name that must never appear either -- the open memory-versus-
+#: observability question stays open on the live path too, not just in-process.
+TOOL_MARKER = "ToolNameMustNotPersist"
+
+
+def assistant_line(turn_uuid: str, text: str, session: str) -> str:
+    """One assistant transcript line, in the shape Claude Code actually writes.
+
+    The list content shape is not a stylistic choice: all 134 assistant records
+    on a live transcript measured 2026-08-03 used it and none used a bare
+    string, so a fixture written the operator's way would prove nothing about
+    the path #447 restored. The `thinking` and `tool_use` blocks are present
+    deliberately -- their markers are what the leak assertions search for.
+    """
+    return json.dumps(
+        {
+            "type": "assistant",
+            "uuid": turn_uuid,
+            "sessionId": session,
+            "cwd": "/repo/spine-live",
+            "parentUuid": None,
+            "timestamp": "2026-07-31T06:00:01.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": THINKING_MARKER},
+                    {"type": "text", "text": text},
+                    {"type": "tool_use", "name": TOOL_MARKER, "input": {}},
+                ],
+            },
+        }
+    )
+
+
 def fetch_row(database_url: str, turn_uuid: str) -> tuple[str, object] | None:
     """The row as Postgres holds it: (content, occurred_at)."""
     import psycopg
@@ -85,6 +124,28 @@ def fetch_row(database_url: str, turn_uuid: str) -> tuple[str, object] | None:
             (turn_uuid,),
         ).fetchone()
     return None if row is None else (str(row[0]), row[1])
+
+
+def fetch_attribution(database_url: str, turn_uuid: str) -> tuple[str, bool] | None:
+    """How Postgres attributed the row: (role, is_human_prompt).
+
+    A separate query rather than a wider :func:`fetch_row`, because the two
+    answer different questions: whether the turn survived, and whether the
+    SERVER agreed about who said it. `role` is validated server-side
+    (`src/tools/ingest-raw-turn.ts`: `z.enum(["user","assistant","tool"])`), and
+    `_plans/python-port-sequence.md` records that the live gate is precisely
+    where such contract facts surfaced -- "the server requires `role` +
+    `turn_index`" was learned here, not in-process. So this is the only proof
+    that an `assistant` turn is neither coerced nor refused on the wire.
+    """
+    import psycopg
+
+    with psycopg.connect(database_url) as connection:
+        row = connection.execute(
+            "SELECT role, is_human_prompt FROM ob_raw_turns WHERE turn_uuid = %s",
+            (turn_uuid,),
+        ).fetchone()
+    return None if row is None else (str(row[0]), bool(row[1]))
 
 
 def started_memory(live_env: dict[str, str], session: str) -> Any:
@@ -193,3 +254,101 @@ class TestOneTurnEndToEnd:
 
         replay = await deliver_new_turns(path, session, store, memory)
         assert replay.delivered == 0
+
+
+class TestBothSidesReachPostgres:
+    """#447 on the real wire: the conversation lands, the reasoning does not."""
+
+    async def test_a_conversation_lands_with_each_side_attributed(
+        self, live_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        """THE PRODUCT PROOF, end to end.
+
+        In-process tests prove the parser reads the agent side; only this proves
+        the server ACCEPTS it. That distinction is load-bearing here: `role` is
+        server-validated, so an `assistant` turn could in principle be refused
+        or coerced on the wire, and the in-process suite could not tell.
+        """
+        session = f"spine-bothsides-{uuid.uuid4()}"
+        operator_id, assistant_id = f"u-{uuid.uuid4()}", f"a-{uuid.uuid4()}"
+        question = "why is the fleet index 20% third-party code?"
+        finding = "buzz's checkout is dirty and was never rebuilt after the move."
+        path = tmp_path / "conversation.jsonl"
+        path.write_text(
+            operator_line(operator_id, question, session)
+            + "\n"
+            + assistant_line(assistant_id, finding, session)
+            + "\n",
+            encoding="utf-8",
+        )
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+        memory = started_memory(live_env, session)
+
+        result = await deliver_new_turns(path, session, store, memory)
+
+        assert result.delivered == 2, (
+            "a conversation is both speakers -- delivering 1 is the #447 "
+            "regression, where the corpus holds the question and not the answer"
+        )
+
+        database_url = live_env["OPENBRAIN_TEST_DATABASE_URL"]
+        stored_question = fetch_row(database_url, operator_id)
+        stored_finding = fetch_row(database_url, assistant_id)
+
+        assert stored_question is not None
+        assert stored_question[0] == question
+        assert stored_finding is not None, (
+            "the agent's finding never reached Postgres -- the session's "
+            "answers are exactly what #447 says get lost"
+        )
+        assert stored_finding[0] == finding
+        # The ordering key on BOTH rows: without it the two sides are stored but
+        # cannot be sequenced back into a conversation.
+        assert stored_question[1] is not None
+        assert stored_finding[1] is not None
+
+        # The server AGREED about who said what -- role is its own enum, and
+        # is_human_prompt must stay the operator-only health-check signal.
+        assert fetch_attribution(database_url, operator_id) == ("user", True)
+        assert fetch_attribution(database_url, assistant_id) == ("assistant", False)
+
+    async def test_no_reasoning_or_tool_name_is_ever_persisted(
+        self, live_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        """The hard rule, proven against the column rather than the parser.
+
+        Searches the WHOLE session's stored content, not just the turn under
+        test, so a leak through any row -- a future block kind, a re-encoding --
+        fails here.
+        """
+        import psycopg
+
+        session = f"spine-noreasoning-{uuid.uuid4()}"
+        assistant_id = f"a-{uuid.uuid4()}"
+        path = tmp_path / "reasoning.jsonl"
+        path.write_text(
+            assistant_line(assistant_id, "the measured answer", session) + "\n",
+            encoding="utf-8",
+        )
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+        memory = started_memory(live_env, session)
+
+        await deliver_new_turns(path, session, store, memory)
+
+        database_url = live_env["OPENBRAIN_TEST_DATABASE_URL"]
+        with psycopg.connect(database_url) as connection:
+            rows = connection.execute(
+                "SELECT content FROM ob_raw_turns WHERE session_ref = %s",
+                (session,),
+            ).fetchall()
+
+        assert rows, "nothing was stored, so this proves nothing about leaking"
+        stored = "\n".join(str(row[0]) for row in rows)
+        assert THINKING_MARKER not in stored, (
+            "chain-of-thought reached durable storage -- the standing hard rule "
+            "is distilled events only, never raw reasoning"
+        )
+        assert TOOL_MARKER not in stored, (
+            "a tool name reached durable storage, resolving by accident the "
+            "memory-versus-observability question the decision doc parks"
+        )


### PR DESCRIPTION
Closes #447. Part of the #443 map.

## The decision, and why the question as posed had a wrong premise

#447 asks us to "decide: distill in the capture path, capture both sides, or
change the rule." The answer is **capture both sides** — and the reason the
other two are wrong is that the rule was never ambiguous. It was already
decided, and the port broke it.

`docs/decisions/capture-never-drops-a-turn.md:215`:

> **Settled: everything on screen goes in.** The operator's words and the
> assistant's replies, in full, no length test, no phrasing allowlist.

So this is a **port regression**, not an open design question. Measured on the
dogfood database, `ob_raw_turns` in namespace `rico`:

| Day | assistant | tool | user | Path |
|---|---|---|---|---|
| 2026-07-27 | 5,773 | 3,022 | 495 | TypeScript adapter |
| 2026-07-30 | 3,332 | 1,877 | 255 | TypeScript adapter |
| 2026-08-02 | **13** | **0** | 365 | Python port |

…and all 13 of those assistant rows begin `<analysis>` — they are `PostCompact`
summaries, not replies. The agent side was not thin. It was **absent**, and
`ob_session_events` showed zero assistant-side rows exactly as the issue says.

The same document had already predicted this failure, in its own words:

> "If capture starts silently shrinking again, check whether this decision
> survived the port."

It did not, and nobody ran the check.

### Rejected alternatives

**Rejected: a model-backed distillation step on the capture path.** This is the
option the issue floats and the map records as open, and it is wrong at this
boundary for three independent reasons:

1. **It is the exact filter the governing decision forbids.** Same document,
   line 12: *"A filter on the capture path may TYPE a turn. It may never decide
   whether to keep one."* A summarizer decides what survives. That inversion has
   already been found twice in this codebase — `SIGNALS` returning null, and
   `distill-window.ts` — and both times it was a silent permanent drop.
2. **It cannot fit the budget.** The Stop hook has a hard 5-second harness
   deadline, and the per-request timeout is *derived* from it, not chosen:
   `apps/hooks/session.py:87-139` pins five round trips at 0.7s plus 0.5s
   overhead = 4.0s, with an `assert` at import time enforcing the arithmetic. An
   LLM call does not fit, and a killed hook cannot honour the exit-0 contract.
3. **The raw lane is the corpus, not the product.** Distillation is a later,
   reversible stage that reads this lane. Distilling on write destroys the
   building blocks — which is the operator's stated reason for keeping
   everything in the first place (same doc, "we can't start cutting things out
   of the building blocks").

Because no model-backed step is added, the env-first model-choice and
loud-fallback requirements in the brief do not arise: **there is no model on
this path, and no silent fallback, because there is nothing to fall back from.**
No infrastructure decision is needed and none is being asked for.

**Rejected: reading `last_assistant_message` off the Stop payload.** It is
present (confirmed on both captured fixtures), and it is the *final* message
only — the fixture's value is literally `"ok"`. Capturing that would record the
sign-off and discard the findings, which is the same defect with better
optics. The transcript holds the whole reply, so the transcript is the source.

**Rejected: changing the rule.** Nothing was found to justify it, and the
operator's standing position is the opposite.

## What changed

`records.py` — the parser that decides what a transcript line *was*, so the
owning boundary — now returns a turn for `type == "assistant"` records,
reading the `text` blocks off the list-shaped content, attributed
`role=assistant`, `is_human_prompt=False`.

**Measured this session** on a live open-brain transcript: all 134 assistant
records use the LIST content shape, none a `str`, holding `text` (75) and
`tool_use` (59) blocks. That is why `operator_text`'s `isinstance(str)` rule
could never have reached them — two independent gates were dropping the agent
side, so a one-line relaxation would not have worked.

### What stays out, and why each is someone else's settled rule

- **`thinking` blocks — chain-of-thought. Never stored.** The standing hard rule
  is distilled events only, never raw reasoning. The TypeScript reference
  skipped these for the same stated reason
  (`scripts/backfill-transcripts.ts:148`), so this preserves settled behaviour.
- **`tool_use` blocks — left to the open question, not answered here.** The
  decision doc parks memory-vs-observability explicitly (line 213) in terms that
  bind this PR: *"Do not resolve this by inference, and do not let it be
  resolved by accident. The failure mode is a stage quietly starting to filter
  on role."* Reading speech now and leaving machinery to a deliberate decision
  is the reversible order — adding tool volume later is purely additive.
  Nothing is deleted: those records remain in the transcript, and #417 tracks
  where execution traces land.

## Evidence

**Red-proof.** `git stash` of `records.py` back to `origin/main`, then the new
suite: **15 of 25 fail**, including the product proof —
`test_a_conversation_delivers_both_speakers_in_order` delivers **1 turn instead
of 2**. Restored: 25/25 pass.

**Gates.** `uv run mypy src` → clean (46 files). `uv run ruff check src tests` →
clean. `uv run pytest -q` → **458 passed, 1 skipped**.

**Playground round-trip** (`pytest -m live`, 4 passed). Target verified *before*
writing: `:3101` serves `open_brain_local_play`, not the dogfood database. Two
new tests read `role` and `is_human_prompt` **out of Postgres** — `role` is
server-validated (`z.enum(["user","assistant","tool"])`), so this is the only
proof the server does not refuse or coerce an assistant turn — plus a marker
substring search over every stored row proving no reasoning or tool name
persists.

**THE PRODUCT PATH — one live capture through the real hook entrypoint.**
Invoked `openbrain-capture-stop` in the exact shape `~/.claude/settings.json`
uses it (the `env -i` clean-child wrapper, only `PATH`/`HOME`/
`OPENBRAIN_BASE_URL`/`OPENBRAIN_TOKEN`), with a real Stop payload on stdin,
against the playground:

```
exit code                     0        (fail-open observer contract honoured)
rows in ob_raw_turns          2
  user      | is_human_prompt=t | occurred_at set | "what did the measurement actually show?"
  assistant | is_human_prompt=f | occurred_at set | "Assistant rows fell from 3332/day to 13..."
chain-of-thought leaks        0
tool-name leaks               0
current_database()            open_brain_local_play   (playground)
rows leaked into dogfood      0                       (checked explicitly)
```

Both sides land through the real product path.

## Blast radius

Five `test_bulk_ingest.py` tests failed on the new behaviour, and that is
correct: the bulk ingester **shares this parser**, so restoring the agent side
restored it there too — which is the point, since a bulk-ingested corpus holding
only the operator's half would grade the same one-sided material. Expectations
move from 3 operator turns to the 4-turn conversation, with new per-speaker
attribution assertions.

Notably `test_bulk_ingest.py` has asserted a `TurnRole.ASSISTANT` turn for the
**Codex** adapter all along. Codex captured both sides the whole time; the
Claude adapter was the odd one out. That asymmetry was a free defect signal
sitting in the suite.

## Docs and SME

- `capture-never-drops-a-turn.md` records the outcome of its own warning, with
  the measurement.
- **Its health check is corrected.** As written it compared transcript against
  `is_human_prompt` rows — *one speaker* — which is precisely why nothing fired:
  operator numbers stayed healthy the entire six days the assistant side sat at
  zero. It now says group by role, with the query.
- `docs/sme/gotcha-agent.md` gains *"A port is complete when the BEHAVIOUR
  matches, not when the tests pass."*

## Critical Self-Review

- Highest-risk behavior: capture volume rises substantially, since assistant records historically outnumber operator ones roughly 10:1. This RESTORES prior behavior rather than exceeding it (the TypeScript adapter sustained 5,773 assistant rows/day), and the operator's standing instruction is that size is not a concern before correctness.
- Assumptions that could be wrong: that `text` blocks are the whole of what appeared on screen. Measured across 134 live assistant records; a future block kind would be passed over silently rather than crashing, which is the safe direction but would under-capture. Mitigated by the per-role health check now documented in the decision doc.
- Missing/weak tests: no test asserts behavior for an assistant record carrying a `str` content shape, because none has ever been observed in 134 measured records; the code declines it deliberately rather than guessing, and the docstring says so.
- Security/permission risk: none new. No namespace, auth, or predicate logic is touched and namespace stays token-derived server-side. The one genuine exposure question, reasoning reaching durable storage, is tested against the Postgres column on the live path rather than only in-process.
- Migration/deploy risk: none. No schema change; `role` and `is_human_prompt` are existing columns the server already validates via `z.enum(["user","assistant","tool"])`.
- Downstream client/runtime risk: the bulk ingester shares this parser and changes behavior by design, covered in Blast radius above. No MCP tool, schema, or wire contract changed, so `docs/downstream-rollout.md` classification is not applicable: this is a client-side reader change against an unchanged server contract.
- Rollback/cleanup concern: revert is a single-file revert of `records.py`; rows already written remain valid and correctly attributed, so no data cleanup is implied.
- Fixes made before PR: joined multi-block replies in order rather than taking only the first block; excluded `thinking` before writing any test that could have made storing it look acceptable; verified the playground target served `open_brain_local_play` before the first live write.
- Known residual risk: the uv-installed tool is still v0.9.0 (pre-fix), so this machine's live capture keeps dropping the agent side until the post-merge reinstall. Nothing in this PR changes that, and the reinstall is deliberately sequenced after merge.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Live checks, all run this session and reported in Evidence above:

- Playground round-trip: `pytest -m live` on `test_capture_deliver_live.py`, 4 passed, against `:3101` / `open_brain_local_play`.
- Product path: the real `openbrain-capture-stop` entrypoint invoked in the installed hook's `env -i` shape wrote 2 rows (one per speaker), 0 chain-of-thought leaks, 0 tool-name leaks, and 0 rows into the dogfood database.

LAW-0 state: the code is WRITTEN and pushed, not yet merged; the behavior is RUNNING against the playground through the real hook entrypoint; it is NOT running on this machine's live capture until the post-merge reinstall.
