### PR TITLE
fix(server): restore session_context event bounds dropped in the port (#515)

### DIFF
--- a/server/tools/session-lifecycle.pg.test.ts
+++ b/server/tools/session-lifecycle.pg.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Live-Postgres behavior tests for the ported session lifecycle tools.
+ *
+ * Regression coverage for #515: the port dropped `session_context`'s
+ * `event_limit` argument (src/tools/session-context.ts:49, default 50) and
+ * `session_start`'s `LIMIT 50` (src/tools/session-start.ts:237), so both
+ * returned every event in the lane. A lane with enough history made the
+ * response larger than clients read, and every resume died. These tests seed
+ * more events than the bounds and prove the row counts, so the old behavior
+ * fails them.
+ *
+ * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
+ * unset. It must point at an isolated test/playground database, never the
+ * dogfood database.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import pino from "pino";
+import { Pool } from "pg";
+import { registerSessionLifecycleTools } from "./session-lifecycle.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+
+const NAMESPACE = `session-lifecycle-pg-${process.pid}`;
+const SESSION_KEY = `${NAMESPACE}-lane`;
+const EVENT_COUNT = 55;
+
+interface ContextEnvelope {
+  lane: { id: string; session_key: string } | null;
+  events: Array<{ event_type: string; content: string }>;
+  event_count: number;
+}
+
+interface StartEnvelope {
+  lane: { id: string; session_key: string };
+  events: Array<{ event_type: string; content: string }>;
+  events_returned: number;
+  is_new: boolean;
+}
+
+async function callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
+  const server = new McpServer({ name: "session-lifecycle-test", version: "1.0.0" });
+  registerSessionLifecycleTools(server, {
+    pool,
+    embedFn: async () => null,
+    logger: pino({ level: "silent" }),
+  });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    originalSend(message, {
+      ...options,
+      authInfo: { role: "agent", clientId: NAMESPACE, namespaceSource: "token" },
+    } as never);
+  const client = new Client({ name: "session-lifecycle-test", version: "1.0.0" });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  const result = await client.callTool({ name, arguments: args });
+  const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+  await client.close();
+  return JSON.parse(text);
+}
+
+dbDescribe("session lifecycle event bounds (#515)", () => {
+  let laneId: string;
+
+  beforeAll(async () => {
+    if (!pool) return;
+    const lane = await pool.query(
+      `INSERT INTO ob_session_lanes
+         (session_key, namespace, status, metadata, created_by)
+       VALUES ($1, $2, 'active', '{}'::jsonb, $3)
+       RETURNING id`,
+      [SESSION_KEY, NAMESPACE, NAMESPACE],
+    );
+    laneId = lane.rows[0].id;
+    for (let i = 0; i < EVENT_COUNT; i++) {
+      await pool.query(
+        `INSERT INTO ob_session_events
+           (lane_id, event_type, content, importance, metadata, created_by, created_at)
+         VALUES ($1, $2, $3, 'warm', '{}'::jsonb, $4, now() + make_interval(secs => $5))`,
+        [laneId, i % 5 === 0 ? "decision" : "fact", `event ${i}`, NAMESPACE, i],
+      );
+    }
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DELETE FROM ob_session_events WHERE lane_id = $1`, [laneId]);
+    await pool.query(`DELETE FROM ob_session_lanes WHERE id = $1`, [laneId]);
+    await pool.end();
+  });
+
+  test("session_context honors event_limit", async () => {
+    const ctx = (await callTool("session_context", {
+      session_key: SESSION_KEY,
+      include_events: true,
+      event_limit: 3,
+    })) as ContextEnvelope;
+    expect(ctx.lane?.session_key).toBe(SESSION_KEY);
+    expect(ctx.events.length).toBe(3);
+    expect(ctx.event_count).toBe(3);
+    // Newest first
+    expect(ctx.events[0]?.content).toBe(`event ${EVENT_COUNT - 1}`);
+  });
+
+  test("session_context defaults to 50 events, not the whole lane", async () => {
+    const ctx = (await callTool("session_context", {
+      session_key: SESSION_KEY,
+      include_events: true,
+    })) as ContextEnvelope;
+    expect(ctx.events.length).toBe(50);
+  });
+
+  test("session_context filters by event_types", async () => {
+    const ctx = (await callTool("session_context", {
+      session_key: SESSION_KEY,
+      event_types: ["decision"],
+      event_limit: 200,
+    })) as ContextEnvelope;
+    expect(ctx.events.length).toBe(Math.ceil(EVENT_COUNT / 5));
+    for (const event of ctx.events) expect(event.event_type).toBe("decision");
+  });
+
+  test("session_start returns the 50 newest events for an existing lane", async () => {
+    const started = (await callTool("session_start", {
+      session_key: SESSION_KEY,
+    })) as StartEnvelope;
+    expect(started.is_new).toBe(false);
+    expect(started.events_returned).toBe(50);
+    expect(started.events[0]?.content).toBe(`event ${EVENT_COUNT - 1}`);
+  });
+});

--- a/server/tools/session-lifecycle.ts
+++ b/server/tools/session-lifecycle.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
-import { authorize, contentHash, embeddingFields, sessionEmbedText } from "./memory-helpers.ts";
+import {
+  authorize,
+  contentHash,
+  embeddingFields,
+  EVENT_TYPES,
+  IMPORTANCE_LEVELS,
+  sessionEmbedText,
+} from "./memory-helpers.ts";
 
 const startLaneFields = `id, session_key, namespace, status, agent, source, channel_id,
   thread_id, project, topic, current_context_md, metadata, created_at, updated_at, ended_at`;
@@ -59,7 +66,7 @@ function registerSessionStart(server: McpServer, dependencies: MemoryToolDepende
       if (existing.rows[0]) {
         const events = await dependencies.pool.query(
           `SELECT ${eventFields} FROM ob_session_events
-            WHERE lane_id = $1 ORDER BY created_at DESC`,
+            WHERE lane_id = $1 ORDER BY created_at DESC LIMIT 50`,
           [existing.rows[0].id],
         );
         return textResult({
@@ -110,6 +117,9 @@ function registerSessionContext(server: McpServer, dependencies: MemoryToolDepen
         channel_id: z.string().max(500).optional(),
         thread_id: z.string().max(500).optional(),
         include_events: z.boolean().optional(),
+        event_limit: z.number().int().min(1).max(200).optional(),
+        event_types: z.array(z.enum(EVENT_TYPES)).optional(),
+        importance: z.enum(IMPORTANCE_LEVELS).optional(),
       },
       annotations: {
         title: "Session Context",
@@ -151,13 +161,25 @@ function registerSessionContext(server: McpServer, dependencies: MemoryToolDepen
       );
       const lane = lanes.rows[0];
       if (!lane) return textResult({ lane: null, events: [], event_count: 0 });
-      const events = args.include_events === false
-        ? { rows: [] }
-        : await dependencies.pool.query(
-            `SELECT ${eventFields} FROM ob_session_events
-              WHERE lane_id = $1 ORDER BY created_at DESC`,
-            [lane.id],
-          );
+      let events: { rows: unknown[] } = { rows: [] };
+      if (args.include_events !== false) {
+        const eventConditions = ["lane_id = $1"];
+        const eventValues: unknown[] = [lane.id, args.event_limit ?? 50];
+        if (args.event_types && args.event_types.length > 0) {
+          eventValues.push(args.event_types);
+          eventConditions.push(`event_type = ANY($${eventValues.length})`);
+        }
+        if (args.importance) {
+          eventValues.push(args.importance);
+          eventConditions.push(`importance = $${eventValues.length}`);
+        }
+        events = await dependencies.pool.query(
+          `SELECT ${eventFields} FROM ob_session_events
+            WHERE ${eventConditions.join(" AND ")}
+            ORDER BY created_at DESC LIMIT $2`,
+          eventValues,
+        );
+      }
       return textResult({ lane, events: events.rows, event_count: events.rows.length });
     },
   );


### PR DESCRIPTION
Closes #515.

## What

The rewrite's `session_context` lost the `event_limit` argument the frozen contract declares (`src/tools/session-context.ts:49`, default 50, applied at `:200`), plus the `event_types`/`importance` filters, and `session_start` lost its `LIMIT 50` (`src/tools/session-start.ts:237`). Both returned every event in the lane. The MCP schema silently ignores unknown arguments, so clients passing `event_limit` got the whole lane anyway.

Measured on the live dogfood clone: lane `dev:open-brain` returned 1,256 events / 3.2MB for a request asking for 3 — past what the Python client reads in one response (`client.py:29`) — so **every `resume.py` in every session died**. Post-reboot, no agent on the machine could recover its context; that is how it was found. #514 (capture both sides) makes lanes grow ~2x faster, so this was worsening hourly.

## Fix

Contract parity restoration only, no new behavior: `event_limit` (default 50, 1..200), `event_types`, `importance` back on the schema and applied in the query as current-src does; `session_start`'s existing-lane read gets `LIMIT 50` back.

## Evidence

- Regression tests (`server/tools/session-lifecycle.pg.test.ts`) against live Postgres (playground clone), seeded past both bounds. **Red-proven: 0 pass / 4 fail on pre-fix code, 4/4 with fix.**
- `bunx tsc --noEmit` clean; pre-push full suite 3060 pass / 0 fail.
- The 16 pre-existing `server/` pg failures on the playground (telemetry migration 046 postdates the 08-01 clone; known shared-kb fixture collision) are identical with and without this change.

## Critical Self-Review
- Highest-risk behavior: the dynamic WHERE assembly for event_types/importance; parameter indices are derived from array length after push, and the LIMIT parameter is pinned at $2. Covered by the filter test.
- Assumptions that could be wrong: default 50 matches current-src exactly (cited); no client depended on the unbounded dump (the only affected clients are the ones currently broken by it).
- Missing/weak tests: importance filter has no dedicated assertion (event_types path covers the same code shape); channel_id-lookup path untouched and untested here.
- Security/permission risk: none new — auth/namespace predicate unchanged, all values parameterized.
- Migration/deploy risk: none — no schema change; local-clone redeploy per SOP with app.previous rollback.
- Downstream client/runtime risk: schema widens (adds optional args) — additive, no consumer sends what it removes. Downstream rollout classification: dogfood-only until core01 swap-back; hosted steps N/A today.
- Rollback/cleanup concern: none; revert is a clean single-commit revert.
- Fixes made before PR: strict-null test nits found by tsc.
- Known residual risk: session_start's 50 is a fixed contract constant, not caller-tunable — same as current-src; parity preserved deliberately.

State: WRITTEN + tested against playground; deploy to the local dogfood clone follows as its own step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review Gate
Merge was operator-directed 2026-08-03 ("yes, redeploy, let's fucking go" — direct instruction to land and redeploy the #515 fix), satisfying the merge gate's operator arm. CI code checks green on both runs (check, db-integration, python-capture/package/provider); the validate failure was this body's missing section headers, corrected here post-merge for the record.