### PR TITLE
fix(canon): bind repo_facts to the repo the session is in, not a literal (#517)

### DIFF
--- a/python/openbrain/src/openbrain/apps/canon/run.py
+++ b/python/openbrain/src/openbrain/apps/canon/run.py
@@ -159,6 +159,10 @@ def provenance_from(
     """
     if not (args.repo_source_commit and args.repo_source_url and args.repo_verified_at):
         return None
+    if settings.repo is None:
+        # Same all-or-nothing rule: a fact cannot bind without a repo, and the
+        # cwd-derived None (#517) must never become a half-filled provenance.
+        return None
     return FactProvenance(
         repo=settings.repo,
         source_commit=args.repo_source_commit,

--- a/python/openbrain/src/openbrain/apps/hooks/session.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session.py
@@ -858,6 +858,31 @@ class CanonContext(BaseModel):
     close: Callable[[], None]
 
 
+def _derive_repo_slug(cwd: str | Path | None) -> str | None:
+    """Resolve the ``repo_facts`` binding from the session's working directory.
+
+    Walks up from ``cwd`` to the nearest directory containing ``.git`` (the
+    repository root -- a plain directory for a checkout, a file for a worktree)
+    and returns its basename, lowercased. That is the slug convention the
+    existing fact rows already use (``open-brain``, ``king-core``); rows bound
+    under other shapes are rebind work, not a fallback here.
+
+    Returns ``None`` when no repository contains ``cwd``. The server then
+    serves the defined empty state for ``repo_facts`` -- never another repo's
+    facts (``src/tools/agent-context-pack-repo-facts.ts``).
+    """
+    if not cwd:
+        return None
+    try:
+        path = Path(cwd).resolve()
+    except OSError:
+        return None
+    for candidate in (path, *path.parents):
+        if (candidate / ".git").exists():
+            return candidate.name.lower()
+    return None
+
+
 async def run_session_start(
     payload: SessionStartHook,
     settings: CanonSettings,
@@ -899,6 +924,11 @@ async def run_session_start(
     """
     if not settings.sections:
         return None
+    # Bind repo_facts to the repo the session is ACTUALLY in. An explicit
+    # OPENBRAIN_CANON_REPO always wins; otherwise the literal default served
+    # open-brain's facts to every repo on the machine (#517).
+    if "repo" not in settings.model_fields_set:
+        settings = settings.model_copy(update={"repo": _derive_repo_slug(payload.cwd)})
     build = canon_factory if canon_factory is not None else _canon_context
     context = build(settings)
     try:

--- a/python/openbrain/src/openbrain/config.py
+++ b/python/openbrain/src/openbrain/config.py
@@ -487,7 +487,13 @@ class CanonSettings(_Base):
         default="dev:open-brain",
         validation_alias=AliasChoices("OPENBRAIN_CANON_SESSION_KEY"),
     )
-    repo: str = Field(
+    #: ``repo_facts`` binding. When NOT explicitly set via environment, the
+    #: session-start path derives it from the hook payload's ``cwd`` (git-root
+    #: basename, lowercased) so a session gets the facts of the repo it is
+    #: actually in -- the literal default served open-brain's facts to every
+    #: repo on the machine (#517). ``None`` (underivable) yields the server's
+    #: defined empty state, never another repo's facts.
+    repo: str | None = Field(
         default="open-brain",
         validation_alias=AliasChoices("OPENBRAIN_CANON_REPO"),
     )

--- a/python/openbrain/tests/test_capture_hooks.py
+++ b/python/openbrain/tests/test_capture_hooks.py
@@ -1448,6 +1448,72 @@ class TestSessionStartRequestsCanonOnly:
         assert returned is pack
 
 
+class TestSessionStartBindsRepoFromCwd:
+    """repo_facts binds to the repo the session is IN, not a literal (#517).
+
+    The regression: ``CanonSettings.repo`` defaulted to ``"open-brain"`` and the
+    hook never looked at ``cwd``, so every session on the machine -- Development
+    root, king repos, anywhere -- was served open-brain's repo facts. Proven
+    live 2026-08-03 against the dogfood DB (Development has 1 bound fact; the
+    emission returned open-brain's 7).
+    """
+
+    async def test_repo_is_derived_from_the_payload_cwd(self, tmp_path) -> None:
+        root = tmp_path / "King-Core"
+        (root / ".git").mkdir(parents=True)
+        nested = root / "src" / "deep"
+        nested.mkdir(parents=True)
+        reader = CanonPackReader()
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=nested)
+
+        await run_session_start(payload, canon_settings(), canon_factory=reader)
+
+        assert reader.requested[0].repo == "king-core"
+
+    async def test_an_explicit_repo_setting_wins_over_derivation(self, tmp_path) -> None:
+        root = tmp_path / "some-repo"
+        (root / ".git").mkdir(parents=True)
+        reader = CanonPackReader()
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=root)
+
+        await run_session_start(
+            payload, canon_settings(repo="pinned-repo"), canon_factory=reader
+        )
+
+        assert reader.requested[0].repo == "pinned-repo"
+
+    async def test_a_worktree_git_file_counts_as_the_repo_root(self, tmp_path) -> None:
+        root = tmp_path / "Some-Worktree"
+        root.mkdir()
+        (root / ".git").write_text("gitdir: elsewhere")
+        reader = CanonPackReader()
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=root)
+
+        await run_session_start(payload, canon_settings(), canon_factory=reader)
+
+        assert reader.requested[0].repo == "some-worktree"
+
+    async def test_outside_any_repo_requests_the_empty_state_not_a_fallback(
+        self, tmp_path
+    ) -> None:
+        # None is the honest binding: the server serves the defined empty state
+        # (agent-context-pack-repo-facts.ts), never another repo's facts.
+        reader = CanonPackReader()
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=tmp_path)
+
+        await run_session_start(payload, canon_settings(), canon_factory=reader)
+
+        assert reader.requested[0].repo is None
+
+    async def test_a_missing_cwd_requests_the_empty_state(self) -> None:
+        reader = CanonPackReader()
+        payload = SessionStartHook(session_id="sess", source="startup")
+
+        await run_session_start(payload, canon_settings(), canon_factory=reader)
+
+        assert reader.requested[0].repo is None
+
+
 def _write_injection(pack: object, out: io.StringIO) -> None:
     """Serialise a pack through the entrypoint's own envelope builder."""
     out.write(session_start._injection_envelope(pack))


### PR DESCRIPTION
Closes #517.

## Summary

- `CanonSettings.repo` defaulted to `"open-brain"` and the session-start hook never read the payload's `cwd` — every session on the machine got open-brain's repo facts at startup. Proven live: a controlled `openbrain-session-start-remaining` probe with `cwd=/Volumes/ThunderBolt/Development` returned `repo_facts=7`, all open-brain content, while Development has exactly 1 bound fact. The server was already correct (no cross-repo fallback, `agent-context-pack-repo-facts.ts:3-10`); the client never told it where the session was.
- Fix at the client boundary: when `OPENBRAIN_CANON_REPO` is not explicitly set, derive the binding from `payload.cwd` (walk to nearest `.git` dir-or-file, root basename lowercased — the slug convention 15/16 existing rows use). Underivable → `None` → the server's defined empty state, never another repo's facts. Explicit env always wins. Matching all-or-nothing guard in the reconciler's provenance builder.
- 5 regression tests (CanonPackReader pattern). **Red-proven: 4/5 fail on pre-fix code** (precedence passes both, correctly — it predates this).

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

pytest 463 pass / mypy clean / ruff clean (`python/openbrain`). Live probe evidence in #517. Post-merge: uv tool reinstall + live cwd probe before RUNNING is claimed.

## Critical Self-Review

- Highest-risk behavior: repos with nonconforming slug bindings (Development's fact under `rodaddy/development`) now show `repo_facts=0` honestly until rebound — deliberate; it is the visible signal for the seeding pass that follows.
- Assumptions that could be wrong: basename-lowercase is the canonical slug (15/16 rows agree; the outlier gets rebound in seeding).
- Missing/weak tests: no symlinked-cwd test; `Path.resolve()` handles it and the failure mode is the empty state, not wrong facts.
- Security/permission risk: none — read path; namespace handling untouched.
- Migration/deploy risk: none server-side; client requires `uv tool install --force` to take effect.
- Downstream client/runtime risk: dogfood-scoped; Hermes/mcp2cli do not use this hook stack.
- Rollback/cleanup concern: single-commit revert; `OPENBRAIN_CANON_REPO` env is the immediate escape hatch.
- Fixes made before PR: mypy caught the reconciler provenance site; guarded.
- Known residual risk: `session_key` still defaults to `dev:open-brain` for all repos — lane scoping is tracked as the startup-lane-resume work item.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: single-lane operator-directed fix, no swarm findings to promote; the port-drops-arguments pattern is already queued for `gotcha-agent.md` under the #515/#516 follow-up.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live checks: #517 carries the controlled probe + DB binding counts (RUNNING-verified 2026-08-03).

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: client-side scope resolution only; the `agent_context_pack` wire contract and section shapes are unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Dogfood-only client hook change; no MCP tool/schema/protocol surface moved, so downstream steps are not applicable. Operator-directed run ("go", 2026-08-03); merge on operator direction per the merge gate's operator arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)