### PR TITLE
feat(canon): emission two carries the repo lane's resume (#519)

### DIFF
--- a/python/openbrain-memory/tests/test_event_vocabulary.py
+++ b/python/openbrain-memory/tests/test_event_vocabulary.py
@@ -247,6 +247,14 @@ def test_vocabulary_is_declared_exactly_where_expected() -> None:
         # surface above has its own per-surface drift test. Listed here so the
         # census still trips on an EIGHTH, undocumented declaration.
         "python/openbrain/src/openbrain/models/turn.py",
+        # NOT a vocabulary declaration: the startup lane resume (#519) SELECTS
+        # the intent subset -- decision/blocker/correction/checkpoint/handoff,
+        # fact excluded for noise, the same selection resume.py --brief makes.
+        # A subset filter names members without declaring the vocabulary; the
+        # authority stays openbrain_memory.EVENT_TYPES, and an unknown name in
+        # that set simply never matches an event. Listed so the census keeps
+        # tripping on genuinely new declarations.
+        "python/openbrain/src/openbrain/apps/hooks/session_start.py",
     }
     result = subprocess.run(
         ["git", "grep", "-l", "-E", r'"blocker"', "--", "*.py", "*.ts"],

--- a/python/openbrain/src/openbrain/apps/hooks/session_start.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session_start.py
@@ -8,16 +8,19 @@ Purpose:
     it through two independently registered ``additionalContext`` hook outputs:
     profile/process guidance first, then repo facts and any remaining sections.
 
-    CANON ONLY. The injection is the always-known layer -- who Rico is
-    (``profile_guidance``), the rules/LAWs/standards/persona
-    (``process_guidance``), and this repo's facts (``repo_facts``) -- and NOTHING
-    episodic. No lane history, no session events, no working-set dump: knowing
-    that back-information poisons what the session is trying to do next. Back
-    history stays explicit-on-request (the resume flow), the way session start
-    used to be a direct command. Operator ruling 2026-08-01, superseding the
-    "stays stub" row in ``_plans/rewrite-gotchas.md``; the canon-vs-episodic model
-    it enforces is ``_ob/skills/brain/workflows/canon.md`` and
-    ``_plans/canon-always-known.md``.
+    CANON, PLUS THIS REPO'S OWN LANE. The injection is the always-known layer
+    -- who Rico is (``profile_guidance``), the rules/LAWs/standards/persona
+    (``process_guidance``), and this repo's facts (``repo_facts``) -- plus one
+    REPO-SCOPED lane resume in emission two (#519): the lane's checkpoint and
+    its most recent day's intent events, so a session opens knowing where the
+    repo's work left off without anyone typing a resume command. Operator
+    amendment 2026-08-03 ("startup should already know most of this stuff"),
+    amending the 2026-08-01 canon-only ruling by scope, not by reversal:
+    CROSS-lane history and deeper digs stay explicit-on-request (the resume
+    flow), because loading ANOTHER lane's history poisons what the session is
+    trying to do next -- the same contamination rule, now enforced by scoping
+    the auto-load to the repo the session is in. The canon-vs-episodic model is
+    ``_ob/skills/brain/workflows/canon.md`` and ``_plans/canon-always-known.md``.
 
 Non-goals:
     This does NOT load back-history -- that is the resume flow, which already
@@ -82,7 +85,12 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from openbrain.apps.hooks.session import SessionStartHook, run_session_start
+from openbrain.apps.hooks.session import (
+    CANON_REQUEST_TIMEOUT_SECONDS,
+    SessionStartHook,
+    _derive_repo_slug,
+    run_session_start,
+)
 from openbrain.config import load_canon_settings
 
 if TYPE_CHECKING:
@@ -170,8 +178,23 @@ def _inject_canon_with(
         pack = asyncio.run(run_session_start(payload, selected))
         if pack is None:
             return
+        trailer = None
+        if emission is CanonEmission.REMAINING:
+            try:
+                trailer = _lane_resume_text(payload, canon)
+            except Exception as error:  # noqa: BLE001 -- the lane read must not cost the pack
+                # Same content-free rule as the outer handler: class name only.
+                logger.warning(
+                    "SessionStart lane resume failed ({}); canon emitted without it",
+                    type(error).__name__,
+                )
         out.write(
-            _injection_envelope(pack, emission=emission, requested_sections=sections)
+            _injection_envelope(
+                pack,
+                emission=emission,
+                requested_sections=sections,
+                trailer=trailer,
+            )
         )
     except Exception as error:  # noqa: BLE001 -- an observer must never break its subject
         # Content-free BY CONSTRUCTION: only the exception class name is passed,
@@ -292,21 +315,116 @@ def _render_item(label: str, item: Any) -> str:
     return f"{prefix}{text}"
 
 
+def _resolve_lane_key(payload: SessionStartHook, canon: CanonSettings) -> str | None:
+    """The lane the startup resume reads: explicit setting, else ``dev:<repo>``.
+
+    An explicitly configured ``OPENBRAIN_CANON_SESSION_KEY`` always wins, the
+    same precedence rule the ``repo`` binding uses (#517). Otherwise the lane is
+    ``dev:<git-root basename>`` derived from the payload's cwd. ``None`` --
+    outside any repo -- means no lane is read at all: the scoping IS the
+    contamination guard, so there is no fallback lane.
+    """
+    if "session_key" in canon.model_fields_set:
+        return canon.session_key
+    repo = _derive_repo_slug(payload.cwd)
+    return None if repo is None else f"dev:{repo}"
+
+
+#: The event types the startup lane resume renders -- the intent lanes
+#: ``resume.py --brief`` shows. ``fact`` is excluded there for noise, the same
+#: reason it is excluded here.
+_LANE_RESUME_EVENT_TYPES = frozenset(
+    {"decision", "blocker", "correction", "checkpoint", "handoff"}
+)
+
+
+def _render_lane_resume(lane_key: str, context: Any) -> str:
+    """Render one lane's recent state in the ``resume.py --brief`` shape.
+
+    Header, the lane checkpoint's first line, then the newest calendar day's
+    intent events (newest last, so reading order matches time order). Every
+    rendered event body is carried whole -- formatting, not content reduction.
+    An empty lane says so in one line; it never borrows another lane's events.
+    """
+    header = f"LANE RESUME ({lane_key}) | openbrain.session_context"
+    lane = context.get("lane") if isinstance(context, dict) else None
+    events = (context.get("events") or []) if isinstance(context, dict) else []
+    if not lane:
+        return f"{header}\nNo lane history for this repo yet."
+    lines = [header]
+    checkpoint = str(lane.get("current_context_md") or "").strip()
+    if checkpoint:
+        lines.append(f"Checkpoint: {checkpoint.splitlines()[0]}")
+    intent = [
+        event
+        for event in events
+        if event.get("event_type") in _LANE_RESUME_EVENT_TYPES
+        and event.get("created_at")
+    ]
+    if not intent:
+        lines.append("No recent decisions or blockers recorded.")
+        return "\n".join(lines)
+    newest_day = str(intent[0]["created_at"])[:10]
+    day_events = [e for e in intent if str(e["created_at"])[:10] == newest_day]
+    lines.append(f"{newest_day} — {len(day_events)} recent intent events:")
+    for event in reversed(day_events):
+        stamp = str(event["created_at"])[11:16]
+        body = str(event.get("content") or "").strip()
+        lines.append(f"- {stamp} {event['event_type']}: {body}")
+    return "\n".join(lines)
+
+
+def _lane_resume_text(payload: SessionStartHook, canon: CanonSettings) -> str | None:
+    """Read and render the repo lane's recent state for emission two (#519).
+
+    One ``session_context`` call on the same client configuration the canon
+    read uses: single attempt, the canon timeout, token-scoped namespace. Any
+    failure propagates to the caller, which logs content-free and emits the
+    pack without the trailer -- the lane read must never cost the canon.
+    """
+    lane_key = _resolve_lane_key(payload, canon)
+    if lane_key is None or canon.base_url is None or canon.token is None:
+        return None
+
+    from openbrain_memory.client import OpenBrainClient
+    from openbrain_memory.policy import RetryPolicy
+
+    client = OpenBrainClient(
+        base_url=canon.base_url,
+        token=canon.token.get_secret_value(),
+        namespace=canon.agent,
+        agent_id=canon.agent,
+        timeout=CANON_REQUEST_TIMEOUT_SECONDS,
+        retry_policy=RetryPolicy(attempts=1),
+    )
+    try:
+        context = client.session_context(
+            session_key=lane_key, include_events=True, event_limit=50
+        )
+    finally:
+        client.close()
+    return _render_lane_resume(lane_key, context)
+
+
 def _injection_envelope(
     pack: Any,
     *,
     emission: CanonEmission | None = None,
     requested_sections: tuple[str, ...] | None = None,
+    trailer: str | None = None,
 ) -> str:
     """Wrap one rendered canon emission in the SessionStart response envelope."""
+    rendered = render_pack(
+        pack,
+        emission=emission,
+        requested_sections=requested_sections,
+    )
+    if trailer:
+        rendered = f"{rendered}\n\n{trailer}"
     return json.dumps({
         "hookSpecificOutput": {
             "hookEventName": _HOOK_EVENT_NAME,
-            "additionalContext": render_pack(
-                pack,
-                emission=emission,
-                requested_sections=requested_sections,
-            ),
+            "additionalContext": rendered,
         }
     })
 

--- a/python/openbrain/tests/test_capture_hooks.py
+++ b/python/openbrain/tests/test_capture_hooks.py
@@ -1514,6 +1514,105 @@ class TestSessionStartBindsRepoFromCwd:
         assert reader.requested[0].repo is None
 
 
+class TestStartupLaneResume:
+    """Emission two carries the repo lane's recent state (#519).
+
+    Operator amendment 2026-08-03 to the canon-only ruling: a REPO-SCOPED lane
+    resume auto-loads at session start; cross-lane history stays
+    explicit-on-request. Scope is the contamination guard, so an unresolvable
+    repo reads no lane at all -- there is no fallback lane.
+    """
+
+    def test_lane_key_derives_from_cwd(self, tmp_path) -> None:
+        root = tmp_path / "Some-Repo"
+        (root / ".git").mkdir(parents=True)
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=root)
+
+        assert (
+            session_start._resolve_lane_key(payload, canon_settings())
+            == "dev:some-repo"
+        )
+
+    def test_an_explicit_session_key_wins(self, tmp_path) -> None:
+        root = tmp_path / "some-repo"
+        (root / ".git").mkdir(parents=True)
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=root)
+
+        key = session_start._resolve_lane_key(
+            payload, canon_settings(session_key="dev:pinned")
+        )
+
+        assert key == "dev:pinned"
+
+    def test_outside_a_repo_reads_no_lane(self, tmp_path) -> None:
+        payload = SessionStartHook(session_id="sess", source="startup", cwd=tmp_path)
+
+        assert session_start._resolve_lane_key(payload, canon_settings()) is None
+
+    def test_an_empty_lane_says_so_in_one_line(self) -> None:
+        text = session_start._render_lane_resume(
+            "dev:new-repo", {"lane": None, "events": [], "event_count": 0}
+        )
+
+        assert "No lane history for this repo yet." in text
+        assert "dev:new-repo" in text
+
+    def test_renders_only_the_newest_day_of_intent_events_whole(self) -> None:
+        context = {
+            "lane": {"current_context_md": "Checkpoint line one.\nMore detail."},
+            "events": [
+                # Newest first, as session_context returns them.
+                {
+                    "event_type": "decision",
+                    "content": "today decision body carried whole",
+                    "created_at": "2026-08-03T04:01:20+00:00",
+                },
+                {
+                    "event_type": "fact",
+                    "content": "facts are noise here",
+                    "created_at": "2026-08-03T03:00:00+00:00",
+                },
+                {
+                    "event_type": "blocker",
+                    "content": "today blocker",
+                    "created_at": "2026-08-03T01:00:00+00:00",
+                },
+                {
+                    "event_type": "decision",
+                    "content": "yesterday decision must not render",
+                    "created_at": "2026-08-02T22:00:00+00:00",
+                },
+            ],
+            "event_count": 4,
+        }
+
+        text = session_start._render_lane_resume("dev:open-brain", context)
+
+        assert "Checkpoint: Checkpoint line one." in text
+        assert "today decision body carried whole" in text
+        assert "today blocker" in text
+        assert "facts are noise here" not in text
+        assert "yesterday decision must not render" not in text
+        # Reading order matches time order: blocker (01:00) before decision (04:01).
+        assert text.index("today blocker") < text.index("today decision body")
+
+    def test_the_envelope_appends_the_trailer_after_the_pack(self) -> None:
+        envelope = json.loads(
+            session_start._injection_envelope(
+                _FIXTURE_PACK, trailer="LANE RESUME (dev:x)\nline"
+            )
+        )
+
+        context = envelope["hookSpecificOutput"]["additionalContext"]
+        assert context.endswith("LANE RESUME (dev:x)\nline")
+
+    def test_no_trailer_leaves_the_envelope_unchanged(self) -> None:
+        with_none = session_start._injection_envelope(_FIXTURE_PACK, trailer=None)
+        plain = session_start._injection_envelope(_FIXTURE_PACK)
+
+        assert with_none == plain
+
+
 def _write_injection(pack: object, out: io.StringIO) -> None:
     """Serialise a pack through the entrypoint's own envelope builder."""
     out.write(session_start._injection_envelope(pack))


### PR DESCRIPTION
Closes #519.

## Summary

- Operator amendment 2026-08-03 to the canon-only ruling, by scope not reversal: a **repo-scoped** lane resume auto-loads at session start; cross-lane history stays explicit-on-request. Scope IS the contamination guard — an unresolvable repo reads no lane, never a fallback.
- Lane key follows #517's precedence: explicit `OPENBRAIN_CANON_SESSION_KEY` wins, else `dev:<git-root basename>` from cwd. One `session_context` call (the `event_limit` #516 restored) on the canon client shape; a failed lane read logs content-free and the pack emits WITHOUT the trailer — the lane never costs the canon.
- Rendered `resume.py --brief` shape: checkpoint first line + newest day's intent events (fact excluded), bodies whole, time order. Empty lane says so in one line.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

pytest 470 pass / mypy clean / ruff clean. Live-probed pre-merge via branch-installed tool: open-brain probe ends with `LANE RESUME (dev:open-brain)` carrying today's decisions; Development probe returns `dev:development`'s own Codex checkpoints (the provider write side already lanes per repo — the read side now matches).

## Critical Self-Review

- Highest-risk behavior: emission-two size when a day is decision-heavy; bodies are carried whole by the no-reduction rule, and oversized additionalContext degrades to the harness's persisted-file path rather than breaking. Watched item, not a code guard, per the standing content rule.
- Assumptions that could be wrong: `dev:<repo>` is the lane convention — confirmed for open-brain and development live; other repos accrete lanes as they capture.
- Missing/weak tests: `_lane_resume_text`'s client construction is untested live-path (same stance as `_canon_context`); renderer and key resolution are fully covered.
- Security/permission risk: read-only, token-scoped namespace, no delegation.
- Migration/deploy risk: none server-side; client is `uv tool install --force` (already installed from this branch on the dogfood box).
- Downstream client/runtime risk: dogfood-scoped; #511/#512 adapters inherit the behavior when they adopt this hook stack.
- Rollback/cleanup concern: single-commit revert + tool reinstall; setting `OPENBRAIN_CANON_SESSION_KEY` pins the old behavior immediately.
- Fixes made before PR: fixture-name mismatch in tests caught on first run.
- Known residual risk: the docstring's amended ruling and canon.md/`_plans/canon-always-known.md` now diverge — the model docs need a follow-up line recording the 2026-08-03 amendment.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: operator-directed single-lane feature; the #515/#516 port-parity pattern for `gotcha-agent.md` is already queued separately.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live checks: probes recorded in the commit body; #519 carries the design and its evidence trail.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: client-side rendering and scope resolution only; `session_context` and `agent_context_pack` wire contracts unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Dogfood-only client hook change; no MCP surface moved. Operator-directed run ("go", 2026-08-03); merge on operator direction per the merge gate's operator arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)