### PR TITLE
feat(capture): Langfuse observation sink — second best-effort lane for captured turns (#523)

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -281,6 +281,30 @@ envelope; the environment is the fallback.
 `OPENBRAIN_TOKEN` accepting two spellings is a compatibility shim. New code
 writes `OPENBRAIN_TOKEN`.
 
+### Observation sink (#523) — Python `openbrain` hooks
+
+Read by `python/openbrain/src/openbrain/config.py` (`ObservationSettings`,
+`load_observation_settings`). The capture hooks ship the same turns they
+deliver to the raw lane to the fleet Langfuse server as content-ful session
+traces — secret-shaped values masked client-side
+(`apps/capture/redaction.py`), because Langfuse redacts nothing server-side.
+
+| variable | default | notes |
+|---|---|---|
+| `OPENBRAIN_OBSERVATION_ENABLED` | `false` | opt-in per host; off means the sink declines silently |
+| `OPENBRAIN_OBSERVATION_ENDPOINT` | — | Langfuse host; the `/api/public/ingestion` suffix the #372 lane uses is accepted and stripped |
+| `OPENBRAIN_OBSERVATION_PUBLIC_KEY` | — | Langfuse `pk-lf-...` |
+| `OPENBRAIN_OBSERVATION_SECRET_KEY` | — | Langfuse `sk-lf-...`, held as a `SecretStr` |
+| `OPENBRAIN_OBSERVATION_HMAC_SECRET` | — | reserved for the #372 content-free lane; declared so the provisioned variable is not rejected as a typo, read by nothing yet |
+
+**Deploy coupling:** the deployed `openbrain-hook-env` wrapper (see
+`docs/420-cutover-rollback.md`) passes hooks ONLY the variables the installed
+package declares. The wrapper may add the `OPENBRAIN_OBSERVATION_*`
+pass-throughs only at or after the moment the installed package includes
+`ObservationSettings` — passing them to an older install makes
+`unknown_prefixed_variables` reject the whole environment, which the hooks
+swallow into a silent zero capture.
+
 ### Live canary flags
 
 `OPENBRAIN_LIVE_CANARY`, `OPENBRAIN_LIVE_CANARY_WRITE`,

--- a/python/openbrain/pyproject.toml
+++ b/python/openbrain/pyproject.toml
@@ -34,6 +34,12 @@ dependencies = [
     # is a live import, so the dependency is real and is stated here. Resolved
     # from the workspace, not PyPI -- see `[tool.uv.sources]`.
     "openbrain-memory",
+    # The observation sink (#523): captured turns also ship to the fleet
+    # Langfuse server as content-ful session traces. v4 is the floor because
+    # the emitter uses the v4 surface (`propagate_attributes`,
+    # `start_as_current_observation`) -- v3 spells both differently, so an
+    # older resolve would import-error rather than misbehave.
+    "langfuse>=4",
 ]
 
 # The console scripts. Step 10 of `_plans/python-port-sequence.md`: declare an

--- a/python/openbrain/src/openbrain/apps/capture/langfuse_emitter.py
+++ b/python/openbrain/src/openbrain/apps/capture/langfuse_emitter.py
@@ -1,0 +1,167 @@
+"""The real observation emitter: one delivery's turns as one Langfuse trace.
+
+Purpose:
+    Implements :class:`~openbrain.apps.capture.observe.ObservationEmitter`
+    against the fleet Langfuse server. Each delivery becomes one trace whose
+    ``session_id`` is the session's own key, so the Langfuse session view
+    stitches every Stop of a conversation into one timeline.
+
+Architecture:
+    A thin mapping, nothing else: the spine already read, ordered, and masked
+    the turns. Each turn becomes one child observation typed by its role --
+    ``assistant`` turns are generations (that is what Langfuse costs and
+    renders as model output), ``tool`` turns are tool observations, ``user``
+    turns are spans carrying the input side. The SDK batches in a background
+    thread, so ``emit`` flushes before returning: a hook process exits
+    immediately after, and an unflushed batch would be dropped silently --
+    while the spine, seeing ``emit`` return, would advance the watermark past
+    turns that never left the machine.
+
+Pattern/Convention:
+    SDK v4 SURFACE, pinned by ``pyproject.toml`` (``langfuse>=4``): trace-level
+    attributes travel through ``propagate_attributes``; v3's
+    ``update_trace``/``start_as_current_span`` spellings do not exist in v4,
+    and the floor keeps an older resolve failing at import rather than
+    misbehaving.
+
+    The provisioned endpoint carries the ``/api/public/ingestion`` path the
+    #372 HMAC lane posts to; the SDK wants the bare host. Normalised here, at
+    the boundary that owns the SDK, so the shared env file keeps one spelling.
+
+    NO VALUE FROM SETTINGS IN ANY ERROR PATH. A transport failure's message
+    can carry the endpoint; the spine's caller logs failures as the exception
+    class alone, and nothing here adds a message of its own.
+
+See Also:
+    - ``openbrain.apps.capture.observe`` - the spine that calls this
+    - ``openbrain.config.ObservationSettings`` - where the coordinates live
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from openbrain.config import ObservationSettings
+    from openbrain.models.turn import RawTurn
+
+#: The path suffix the provisioned endpoint carries for the #372 ingestion
+#: lane. The SDK addresses the server root and appends its own paths.
+INGESTION_SUFFIX = "/api/public/ingestion"
+
+#: Tags on every trace this emitter writes, so capture-sink traffic is
+#: filterable next to anything else the server ingests.
+TRACE_TAGS = ("claude-code", "open-brain-capture")
+
+
+class ObservationSinkUnconfiguredError(ValueError):
+    """The emitter was asked to send without every coordinate the SDK needs.
+
+    Unreachable through the spine, which gates on ``observation_active`` first;
+    named so a future caller that skips the gate fails with the cause, not an
+    SDK stack trace. Carries no value from settings, per this module's rule.
+    """
+
+    def __init__(self) -> None:
+        """The message is fixed; there is nothing safe to interpolate."""
+        super().__init__("observation sink is not configured")
+
+
+def sink_host(endpoint: str) -> str:
+    """The server root the SDK addresses, from the provisioned endpoint.
+
+    Accepts either spelling -- the bare host, or the ingestion URL the #372
+    lane posts to -- and returns the root, without a trailing slash either
+    way, so both forms of the env value configure the same client.
+    """
+    return endpoint.removesuffix("/").removesuffix(INGESTION_SUFFIX)
+
+
+class LangfuseEmitter:
+    """An :class:`~openbrain.apps.capture.observe.ObservationEmitter` over the SDK.
+
+    Built from a validated :class:`~openbrain.config.ObservationSettings` whose
+    coordinates :func:`~openbrain.apps.capture.observe.observation_active` has
+    already confirmed present -- the constructor asserts nothing and a missing
+    key surfaces as the SDK's own authentication failure, which the spine's
+    caller logs content-free like any other emit failure.
+    """
+
+    def __init__(self, settings: ObservationSettings) -> None:
+        """Hold the coordinates; the client is built per emit.
+
+        Per emit rather than here because a hook is a short-lived process: one
+        Stop is one emit, and a client held across emits would buy nothing
+        while making the constructor a network boundary.
+        """
+        self._settings = settings
+
+    def emit(self, session_key: str, turns: Sequence[RawTurn]) -> None:
+        """Send one delivery as one trace; flush before returning.
+
+        Raises:
+            Whatever the SDK raises building the client or flushing. The spine
+            leaves its watermark unadvanced in that case, which is the retry.
+        """
+        # Imported at use, not module top: every hook entrypoint imports the
+        # session capability, which imports the capture package -- and the SDK
+        # starts OpenTelemetry machinery at import. Only the one process that
+        # actually emits should pay that, or crash if the dependency is absent.
+        from langfuse import Langfuse, propagate_attributes
+
+        settings = self._settings
+        if (
+            settings.endpoint is None
+            or settings.public_key is None
+            or settings.secret_key is None
+        ):  # pragma: no cover - the spine gates on observation_active first
+            raise ObservationSinkUnconfiguredError
+
+        client = Langfuse(
+            public_key=settings.public_key,
+            secret_key=settings.secret_key.get_secret_value(),
+            host=sink_host(settings.endpoint),
+        )
+        try:
+            repo = next((turn.repo for turn in turns if turn.repo), None)
+            with (
+                propagate_attributes(
+                    session_id=session_key,
+                    tags=list(TRACE_TAGS),
+                    metadata={"repo": repo} if repo else None,
+                    trace_name="claude-code-exchange",
+                ),
+                client.start_as_current_observation(
+                    name="claude-code-exchange", as_type="span"
+                ),
+            ):
+                for turn in turns:
+                    self._observe_turn(client, turn)
+        finally:
+            # flush() drains the batch; shutdown() also stops the SDK's
+            # background machinery so the hook process exits promptly. In the
+            # finally so a mapping failure still releases the threads --
+            # flushing a partial trace is harmless next to the alternative,
+            # a hook process that lingers.
+            client.shutdown()
+
+    @staticmethod
+    def _observe_turn(client: object, turn: RawTurn) -> None:
+        """One turn as one child observation, typed by who produced it."""
+        from openbrain.models.turn import TurnRole
+
+        if turn.role is TurnRole.ASSISTANT:
+            observation = client.start_observation(  # type: ignore[attr-defined]
+                name="assistant-turn", as_type="generation", output=turn.content
+            )
+        elif turn.role is TurnRole.TOOL:
+            observation = client.start_observation(  # type: ignore[attr-defined]
+                name="tool-turn", as_type="tool", output=turn.content
+            )
+        else:
+            observation = client.start_observation(  # type: ignore[attr-defined]
+                name="user-turn", as_type="span", input=turn.content
+            )
+        observation.end()

--- a/python/openbrain/src/openbrain/apps/capture/observe.py
+++ b/python/openbrain/src/openbrain/apps/capture/observe.py
@@ -1,0 +1,162 @@
+"""Ship captured turns to the observation sink, then advance its own watermark.
+
+Purpose:
+    The SECOND destination for captured turns (#523). The same transcript the
+    raw lane reads is also emitted to the fleet Langfuse server as content-ful
+    session traces, so a session can be replayed and debugged in an observation
+    UI. Open Brain remains the memory authority; this lane is the flight
+    recorder.
+
+Architecture:
+    The same spine shape as ``deliver``, run against the sink's OWN watermark
+    key: read forward from the recorded position, hand the turns to the
+    emitter, advance only after the emitter returns. The two lanes share the
+    reader and the store but NOT a position -- an observation failure must not
+    hold back memory, and a memory failure must not hold back observation, so
+    each lane retries from its own watermark independently
+    (``docs/decisions/capture-never-drops-a-turn.md`` applied per lane; the
+    subagent spine already set the precedent of a second key over the same
+    store, ``apps.hooks.session.SubagentStopHook.watermark_key``).
+
+    The emitter is a Protocol, like the raw lane's
+    (:class:`~openbrain.apps.capture.deliver.RawLane`): tests hand in a
+    recorder, the wiring hands in the real Langfuse client.
+
+Pattern/Convention:
+    REDACT BEFORE EMITTING. The raw lane sends turns untouched because the
+    Open Brain server owns redaction (``apps/capture/__init__.py``); Langfuse
+    is a third-party server that redacts nothing, so this module masks
+    secret-shaped values client-side with the existing
+    :func:`~openbrain.apps.capture.redaction.redact` before anything leaves
+    the process. The turn itself is never dropped -- masking, not rejection.
+
+    Nothing here samples or shortens. Every turn the reader returns is
+    emitted.
+
+See Also:
+    - ``openbrain.apps.capture.deliver`` - the raw-lane spine this mirrors
+    - ``openbrain.apps.capture.langfuse_emitter`` - the real emitter
+    - ``openbrain.config.ObservationSettings`` - the sink's coordinates
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Protocol
+
+from pydantic import BaseModel, ConfigDict
+
+from openbrain.apps.capture.redaction import redact
+from openbrain.apps.capture.transcript import read_since
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from openbrain.apps.capture.watermark import WatermarkStore
+    from openbrain.config import ObservationSettings
+    from openbrain.models.turn import RawTurn
+
+#: Prefix distinguishing the observation lane's watermark from the raw lane's,
+#: over the same store and the same transcript. A colon cannot appear in a
+#: Claude Code session id (a UUID), so the prefixed key can never collide with
+#: a raw-lane key.
+OBSERVE_KEY_PREFIX = "observe:"
+
+
+class ObservationEmitter(Protocol):
+    """The single call this module needs from an observation client.
+
+    Synchronous, like :class:`~openbrain.apps.capture.deliver.RawLane`, and run
+    in a worker thread by the spine for the same reason.
+    """
+
+    def emit(self, session_key: str, turns: Sequence[RawTurn]) -> None:
+        """Send one delivery's turns as a trace; raise on failure.
+
+        A raise is the contract: the spine advances the watermark only when
+        this returns, so an exception is what makes the next Stop retry.
+        """
+        ...
+
+
+class ObservationDelivery(BaseModel):
+    """What one observation delivery did.
+
+    Attributes:
+        emitted: Count of turns handed to the emitter. Zero is ordinary -- a
+            Stop with nothing new since the observation watermark.
+        next_offset: The byte position the observation watermark now holds.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    emitted: int
+    next_offset: int
+
+
+def observation_active(settings: ObservationSettings) -> bool:
+    """Whether the sink is enabled AND has every coordinate it needs.
+
+    Use-time enforcement, the same posture as capture and canon: the settings
+    section loads with everything optional, and the decision to decline lives
+    here, where the caller can skip the sink without logging an error --
+    an unconfigured observer is an ordinary state, not a failure.
+    """
+    return (
+        settings.enabled
+        and settings.endpoint is not None
+        and settings.public_key is not None
+        and settings.secret_key is not None
+    )
+
+
+async def observe_new_turns(
+    path: Path,
+    session_key: str,
+    store: WatermarkStore,
+    emitter: ObservationEmitter,
+) -> ObservationDelivery:
+    """Emit every turn written since the observation watermark, then advance it.
+
+    Args:
+        path: The session's transcript file -- the same file the raw lane
+            reads.
+        session_key: The session's key as the RAW lane knows it. The
+            observation position is stored under :data:`OBSERVE_KEY_PREFIX`
+            plus this key; the emitter receives the key unprefixed, so the
+            trace groups under the real session.
+        store: The same watermark store the raw lane uses.
+        emitter: The observation client, or a test recorder.
+
+    Returns:
+        An :class:`ObservationDelivery`.
+
+    Raises:
+        Whatever the emitter or the reader raises. The watermark is NOT
+        advanced in that case, so the same turns are re-emitted by the next
+        delivery -- the retry is the watermark, exactly as in the raw lane.
+    """
+    watermark_key = OBSERVE_KEY_PREFIX + session_key
+    position = await store.position_for(watermark_key)
+    read = await read_since(path, position.offset, position.identity)
+
+    if read.turns:
+        # Masked HERE, not in the emitter, so no emitter -- real or future --
+        # can forget it. The copy leaves the original turns untouched; the raw
+        # lane's delivery reads the transcript independently anyway.
+        masked = tuple(
+            turn.model_copy(update={"content": redact(turn.content)})
+            for turn in read.turns
+        )
+        # The emitter is synchronous; a thread keeps this coroutine's caller
+        # responsive, matching the raw lane's call shape.
+        await asyncio.to_thread(emitter.emit, session_key, masked)
+
+    # identity is None only when the file was unreadable; same rule as the raw
+    # lane -- overwriting a stored identity with None would disable
+    # replaced-file detection for the next read.
+    if read.identity is not None:
+        await store.advance(watermark_key, read.next_offset, read.identity)
+
+    return ObservationDelivery(emitted=len(read.turns), next_offset=read.next_offset)

--- a/python/openbrain/src/openbrain/apps/hooks/session.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session.py
@@ -56,16 +56,28 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
 from pydantic import BaseModel, ConfigDict, SkipValidation
 
 from openbrain.apps.capture.deliver import Delivery, RawLane, deliver_new_turns
+from openbrain.apps.capture.langfuse_emitter import LangfuseEmitter
+from openbrain.apps.capture.observe import (
+    ObservationEmitter,
+    observation_active,
+    observe_new_turns,
+)
 from openbrain.apps.capture.watermark import WatermarkStore
 from openbrain.apps.hooks.receipts import (
     note_capture,
     note_compaction,
     note_verified_recall_for_current_cycle,
 )
-from openbrain.config import CanonSettings, CaptureSettings, ConfigurationError
+from openbrain.config import (
+    CanonSettings,
+    CaptureSettings,
+    ConfigurationError,
+    ObservationSettings,
+)
 from openbrain.models.turn import RawTurn, TurnRole
 
 #: The ``SessionStart`` ``source`` value that means "a compaction just finished".
@@ -428,6 +440,9 @@ async def run_stop(
     settings: CaptureSettings,
     *,
     lane_factory: Callable[[CaptureSettings, str], StartedLane] | None = None,
+    observation: ObservationSettings | None = None,
+    emitter_factory: Callable[[ObservationSettings], ObservationEmitter]
+    | None = None,
 ) -> Delivery | None:
     """Deliver the turns written since the watermark for one ``Stop`` payload.
 
@@ -438,6 +453,11 @@ async def run_stop(
         lane_factory: Builds the :class:`StartedLane` for a session key. Injected
             so tests hand in a recorder; defaults to a real ``openbrain_memory``
             client with its session started.
+        observation: The observation sink's coordinates (#523), or ``None`` to
+            observe nothing. Passed by the entrypoint like ``settings`` is; an
+            inactive or absent sink is an ordinary state, not a failure.
+        emitter_factory: Builds the observation emitter. Injected so tests hand
+            in a recorder; defaults to the real Langfuse client.
 
     Returns:
         The :class:`~openbrain.apps.capture.deliver.Delivery`, or ``None`` when
@@ -448,6 +468,9 @@ async def run_stop(
         Whatever the lane or the reader raises. The ENTRYPOINT swallows these;
         this capability surfaces them so its tests can see a failure and so the
         watermark is left unadvanced (the spine's rule), which is the retry.
+        The OBSERVATION lane never raises out of here: its failure is logged
+        content-free and its own watermark stays unadvanced, so it retries on
+        the next Stop without ever holding the memory lane back.
     """
     if payload.transcript_path is None or payload.session_id is None:
         return None
@@ -473,7 +496,47 @@ async def run_stop(
     # a delivery of zero turns too -- the gate's question is "did this session
     # reach Open Brain", and a turn with nothing new to send did.
     note_capture(payload.session_id, payload.cwd)
+
+    # The second sink (#523), after the receipt because it must never affect
+    # it. Ordered after the memory delivery on purpose: when the memory lane
+    # raises, this is never reached, both watermarks stay put, and the next
+    # Stop retries both lanes -- neither ever advances past the other's
+    # failure into inconsistency.
+    await _observe_best_effort(
+        payload.transcript_path,
+        payload.session_id,
+        store,
+        observation,
+        emitter_factory,
+    )
     return delivery
+
+
+async def _observe_best_effort(
+    path: Path,
+    session_key: str,
+    store: WatermarkStore,
+    observation: ObservationSettings | None,
+    emitter_factory: Callable[[ObservationSettings], ObservationEmitter] | None,
+) -> None:
+    """Run the observation lane, declining quietly and failing silently.
+
+    Declining (no settings, disabled, missing coordinates) is not logged at
+    all -- most hosts will run with the sink off, and a warning per Stop would
+    be noise presented as a problem. A FAILURE of an active sink is logged as
+    the exception class alone, the entrypoints' content-free convention: a
+    transport error's message can carry the endpoint.
+    """
+    if observation is None or not observation_active(observation):
+        return
+    build = emitter_factory if emitter_factory is not None else LangfuseEmitter
+    try:
+        await observe_new_turns(path, session_key, store, build(observation))
+    except Exception as error:  # noqa: BLE001 -- observation never breaks capture
+        logger.warning(
+            "observation emit failed ({}); turns left for retry",
+            type(error).__name__,
+        )
 
 
 async def run_subagent_stop(
@@ -481,6 +544,9 @@ async def run_subagent_stop(
     settings: CaptureSettings,
     *,
     lane_factory: Callable[[CaptureSettings, str], StartedLane] | None = None,
+    observation: ObservationSettings | None = None,
+    emitter_factory: Callable[[ObservationSettings], ObservationEmitter]
+    | None = None,
 ) -> Delivery | None:
     """Deliver the subagent's unread turns, keyed to its own transcript.
 
@@ -489,6 +555,10 @@ async def run_subagent_stop(
         settings: The ``capture`` configuration section.
         lane_factory: Builds the :class:`StartedLane`; injected for tests,
             defaults to the real ``openbrain_memory`` client.
+        observation: The observation sink's coordinates, passed through to
+            :func:`run_stop` unchanged -- a subagent's turns are observed under
+            its own watermark key the same way they are captured under it.
+        emitter_factory: Builds the observation emitter; injected for tests.
 
     Returns:
         The :class:`~openbrain.apps.capture.deliver.Delivery`, or ``None`` when
@@ -510,6 +580,8 @@ async def run_subagent_stop(
         StopHook(transcript_path=payload.agent_transcript_path, session_id=key),
         settings,
         lane_factory=lane_factory,
+        observation=observation,
+        emitter_factory=emitter_factory,
     )
 
 

--- a/python/openbrain/src/openbrain/apps/hooks/stop.py
+++ b/python/openbrain/src/openbrain/apps/hooks/stop.py
@@ -45,12 +45,12 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from openbrain.apps.hooks.session import StopHook, run_stop
-from openbrain.config import load_capture_settings
+from openbrain.config import load_capture_settings, load_observation_settings
 
 if TYPE_CHECKING:
     from typing import TextIO
 
-    from openbrain.config import CaptureSettings
+    from openbrain.config import CaptureSettings, ObservationSettings
 
 
 def capture_stop(stream: TextIO) -> None:
@@ -85,7 +85,7 @@ def capture_stop_with(stream: TextIO, settings: CaptureSettings | None) -> None:
         raw = stream.read()
         payload = StopHook.model_validate_json(raw)
         capture = settings if settings is not None else _loaded_capture()
-        asyncio.run(run_stop(payload, capture))
+        asyncio.run(run_stop(payload, capture, observation=loaded_observation()))
     except Exception as error:  # noqa: BLE001 -- an observer must never break its subject
         # Content-free BY CONSTRUCTION, not by handler config. The exception can
         # hold transcript text or a token -- a pydantic ValidationError carries
@@ -108,6 +108,25 @@ def _loaded_capture() -> CaptureSettings:
     swallowed here, is a silent zero capture on every ``Stop``.
     """
     return load_capture_settings()
+
+
+def loaded_observation() -> ObservationSettings | None:
+    """The ``observation`` section (#523), or ``None`` when it cannot load.
+
+    Swallowed SEPARATELY from the outer catch, and that is the point: the
+    observation sink is best-effort, so a malformed observation variable must
+    degrade to "observe nothing" rather than ride the shared exception path
+    and take the memory capture down with it.
+    """
+    try:
+        return load_observation_settings()
+    except Exception as error:  # noqa: BLE001 -- observation never breaks capture
+        # Class name only, the entrypoint's content-free convention.
+        logger.warning(
+            "observation settings unreadable ({}); observing nothing",
+            type(error).__name__,
+        )
+        return None
 
 
 def main(stream: TextIO | None = None) -> int:

--- a/python/openbrain/src/openbrain/apps/hooks/subagent_stop.py
+++ b/python/openbrain/src/openbrain/apps/hooks/subagent_stop.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from openbrain.apps.hooks.session import SubagentStopHook, run_subagent_stop
+from openbrain.apps.hooks.stop import loaded_observation
 from openbrain.config import load_capture_settings
 
 if TYPE_CHECKING:
@@ -88,7 +89,11 @@ def capture_subagent_stop_with(
         raw = stream.read()
         payload = SubagentStopHook.model_validate_json(raw)
         capture = settings if settings is not None else load_capture_settings()
-        asyncio.run(run_subagent_stop(payload, capture))
+        asyncio.run(
+            run_subagent_stop(
+                payload, capture, observation=loaded_observation()
+            )
+        )
     except Exception as error:  # noqa: BLE001 -- an observer must never break its subject
         # Content-free BY CONSTRUCTION: only the exception class name is passed,
         # never the exception object, so no transcript text or token reaches the

--- a/python/openbrain/src/openbrain/config.py
+++ b/python/openbrain/src/openbrain/config.py
@@ -409,6 +409,68 @@ class CaptureSettings(_Base):
     )
 
 
+class ObservationSettings(_Base):
+    """Where the capture hooks ship observation traces, and the keys they use.
+
+    The observation sink (#523) is the SECOND destination for captured turns:
+    the same turns the raw lane receives are also emitted to the fleet Langfuse
+    server as content-ful session traces, for observation and debugging. Open
+    Brain remains the memory authority; this lane is the flight recorder. It is
+    deliberately DISTINCT from the content-free telemetry lane #372 specifies --
+    the operator decided 2026-08-03 that full transcript content (with
+    secret-shaped values masked client-side, ``apps.capture.redaction``) goes to
+    Langfuse.
+
+    Every coordinate is OPTIONAL for the same reason capture's are: a process
+    that never observes -- the server, a migration -- must load without this
+    being configured, and the requirement is enforced at use time
+    (``apps.capture.observe``), where an unconfigured or disabled sink declines
+    quietly. ``enabled`` defaults to ``False`` on top of that: observation is
+    opt-in per host, and an endpoint present in a shared env file must not by
+    itself start shipping transcripts.
+
+    ``hmac_secret`` is declared but UNUSED here. The provisioned env file
+    carries it for the #372 ingestion lane; an ``OPENBRAIN_``-prefixed variable
+    matching no declared field is rejected by :func:`unknown_prefixed_variables`
+    as a typo, and that rejection -- swallowed by the hook entrypoints -- is a
+    silent zero capture. Declaring it is what lets the variable exist.
+
+    Attributes:
+        enabled: Ship observation traces. Off by default; the sink declines
+            without logging when disabled.
+        endpoint: The Langfuse server, host or ingestion URL. The provisioned
+            value carries the ``/api/public/ingestion`` path the #372 lane
+            posts to; the SDK wants the bare host, so the sink normalises the
+            suffix away rather than requiring the env file to change shape.
+        public_key: The Langfuse public key (``pk-lf-...``).
+        secret_key: The Langfuse secret key, held as a ``SecretStr`` so it
+            never reaches a log line, repr, or traceback.
+        hmac_secret: Reserved for the #372 content-free lane. Declared so the
+            provisioned variable is recognised; nothing reads it yet.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("OPENBRAIN_OBSERVATION_ENABLED"),
+    )
+    endpoint: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENBRAIN_OBSERVATION_ENDPOINT"),
+    )
+    public_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENBRAIN_OBSERVATION_PUBLIC_KEY"),
+    )
+    secret_key: SecretStr | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENBRAIN_OBSERVATION_SECRET_KEY"),
+    )
+    hmac_secret: SecretStr | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENBRAIN_OBSERVATION_HMAC_SECRET"),
+    )
+
+
 class CanonSettings(_Base):
     """Where the ``SessionStart`` hook reads canon from, and the scope it reads under.
 
@@ -637,6 +699,7 @@ _SECTION_MODELS: tuple[tuple[str, type[BaseModel]], ...] = (
     ("database", DatabaseSettings),
     ("embedding", EmbeddingSettings),
     ("capture", CaptureSettings),
+    ("observation", ObservationSettings),
     ("canon", CanonSettings),
     ("logging", LogSettings),
     ("server", ServerSettings),
@@ -813,6 +876,10 @@ class Settings(BaseSettings):
     # reason the others are: it lets the submodel build from its own env aliases
     # when no source supplies a `capture` key.
     capture: CaptureSettings = Field(default_factory=CaptureSettings)
+    # No required fields -- observation is optional like capture, and off by
+    # default besides (see ObservationSettings): a process that never observes
+    # loads without it.
+    observation: ObservationSettings = Field(default_factory=ObservationSettings)
     # No required fields -- canon is optional like capture, so a non-hook process
     # loads without it. The SessionStart hook enforces base_url/token at use time
     # (see CanonSettings and apps.hooks.session).
@@ -1089,6 +1156,44 @@ def load_capture_settings(
     # ``populate_by_name``, so ``model_validate`` accepts the names. A splat would
     # not type-check the heterogeneous mapping against each field's type.
     return CaptureSettings.model_validate(values)
+
+
+def load_observation_settings(
+    environ: Mapping[str, str] | None = None,
+) -> ObservationSettings:
+    """Resolve ONLY the ``observation`` section, without the rest of the tree.
+
+    The capture hooks need the observation sink's coordinates alongside
+    capture's own, in the same environment-configured hook process the ``Stop``
+    entrypoint runs (``load_capture_settings`` explains why the full
+    ``load_settings`` cannot serve a hook). This mirrors that loader exactly:
+    validate the whole prefixed environment for typos first, then resolve this
+    section's aliases through the shared resolver.
+
+    Args:
+        environ: Environment to read. Defaults to the live process environment;
+            the argument exists so the resolver is testable without mutating it.
+
+    Returns:
+        The validated :class:`ObservationSettings`. Coordinates are ``None``
+        and ``enabled`` is ``False`` when unset -- the requirement is enforced
+        at use time in ``apps.capture.observe``, not here.
+
+    Raises:
+        UnknownEnvironmentVariableError: When a prefixed variable matches no
+            declared setting -- the same check every section loader runs, so a
+            typo like ``OPENBRAIN_OBSERVATION_ENDPONT`` is rejected rather than
+            loading clean as an unset endpoint and declining observation
+            silently.
+    """
+    source = os.environ if environ is None else environ
+
+    unknown = unknown_prefixed_variables(source)
+    if unknown:
+        raise UnknownEnvironmentVariableError(unknown)
+
+    values = _resolve_section_from_env(ObservationSettings, source)
+    return ObservationSettings.model_validate(values)
 
 
 def load_canon_settings(

--- a/python/openbrain/tests/test_observe_sink.py
+++ b/python/openbrain/tests/test_observe_sink.py
@@ -1,0 +1,354 @@
+"""Functional tests for the observation sink (#523).
+
+The contract under test is the one ``apps.capture.observe`` states: the
+observation lane reads the same transcript as the raw lane from its OWN
+watermark, masks secret-shaped values before anything leaves the process,
+advances only after the emitter returns, and never -- under any failure --
+affects the memory delivery or its watermark.
+
+The emitter here is always a recorder or a deliberate failure; the real
+Langfuse client is covered by the live canary
+(``/Volumes/ThunderBolt/_tmp/open-brain/_scratch/langfuse-canary``), not by
+unit tests that would dial a server.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conftest import RecordingLane, operator_line, write_lines
+from openbrain.apps.capture.langfuse_emitter import INGESTION_SUFFIX, sink_host
+from openbrain.apps.capture.observe import (
+    OBSERVE_KEY_PREFIX,
+    observation_active,
+    observe_new_turns,
+)
+from openbrain.apps.capture.watermark import WatermarkStore
+from openbrain.apps.hooks.session import (
+    StartedLane,
+    StopHook,
+    SubagentStopHook,
+    run_stop,
+    run_subagent_stop,
+)
+from openbrain.config import (
+    CaptureSettings,
+    ObservationSettings,
+    UnknownEnvironmentVariableError,
+    load_observation_settings,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from openbrain.models.turn import RawTurn
+
+
+class RecordingEmitter:
+    """An ObservationEmitter that remembers what it was asked to send."""
+
+    def __init__(self) -> None:
+        """Start with nothing recorded."""
+        self.calls: list[tuple[str, tuple[RawTurn, ...]]] = []
+
+    def emit(self, session_key: str, turns: Sequence[RawTurn]) -> None:
+        self.calls.append((session_key, tuple(turns)))
+
+
+class UnreachableEmitter:
+    """An ObservationEmitter whose endpoint is down; every emit raises."""
+
+    def __init__(self) -> None:
+        """Count attempts, so a test can prove the emit was actually tried."""
+        self.calls = 0
+
+    def emit(self, session_key: str, turns: Sequence[RawTurn]) -> None:
+        self.calls += 1
+        message = "observation endpoint unreachable"
+        raise RuntimeError(message)
+
+
+def observation_settings() -> ObservationSettings:
+    """An active sink config; the endpoint is inert under injected emitters."""
+    return ObservationSettings(
+        enabled=True,
+        endpoint="http://127.0.0.1:0" + INGESTION_SUFFIX,
+        public_key="pk-lf-test",
+        secret_key="sk-lf-test",  # noqa: S106 -- not a real secret
+    )
+
+
+def capture_settings(watermark_path: Path) -> CaptureSettings:
+    """A CaptureSettings pointed at a temp watermark; endpoints are inert."""
+    return CaptureSettings(
+        base_url="http://127.0.0.1:0",
+        token="unused-in-injected-lane-tests",  # noqa: S106 -- not a real secret
+        watermark_path=watermark_path,
+    )
+
+
+def started(lane: object) -> StartedLane:
+    """Wrap a recorder as the StartedLane a lane_factory returns."""
+    return StartedLane(lane=lane, close=lambda: None)  # type: ignore[arg-type]
+
+
+class TestObservationActive:
+    """The sink is opt-in AND needs every coordinate; anything less declines."""
+
+    def test_the_default_section_is_inactive(self) -> None:
+        assert observation_active(ObservationSettings()) is False
+
+    def test_enabled_without_coordinates_is_inactive(self) -> None:
+        assert observation_active(ObservationSettings(enabled=True)) is False
+
+    def test_coordinates_without_enabled_are_inactive(self) -> None:
+        settings = observation_settings().model_copy(update={"enabled": False})
+        assert observation_active(settings) is False
+
+    def test_enabled_with_every_coordinate_is_active(self) -> None:
+        assert observation_active(observation_settings()) is True
+
+
+class TestSinkHost:
+    """Both provisioned spellings of the endpoint reach the same server root."""
+
+    def test_the_ingestion_url_is_normalised_to_its_host(self) -> None:
+        assert (
+            sink_host("https://langfuse.example" + INGESTION_SUFFIX)
+            == "https://langfuse.example"
+        )
+
+    def test_a_bare_host_passes_through(self) -> None:
+        assert sink_host("https://langfuse.example") == "https://langfuse.example"
+
+    def test_a_trailing_slash_does_not_hide_the_suffix(self) -> None:
+        assert (
+            sink_host("https://langfuse.example" + INGESTION_SUFFIX + "/")
+            == "https://langfuse.example"
+        )
+
+
+class TestObserveDeliversUnderItsOwnWatermark:
+    """The observe spine mirrors the raw lane's rules against its own key."""
+
+    async def test_turns_are_emitted_and_the_watermark_advances_after(
+        self, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "observe me", session="sess")])
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+        emitter = RecordingEmitter()
+
+        result = await observe_new_turns(transcript, "sess", store, emitter)
+
+        assert result.emitted == 1
+        # The emitter sees the UNPREFIXED key, so traces group under the real
+        # session; the stored position lives under the prefixed one.
+        assert emitter.calls[0][0] == "sess"
+        assert emitter.calls[0][1][0].content == "observe me"
+        stored = await store.offset_for(OBSERVE_KEY_PREFIX + "sess")
+        assert stored == result.next_offset == transcript.stat().st_size
+
+    async def test_the_raw_lane_watermark_is_untouched(self, tmp_path: Path) -> None:
+        """Independent lanes: observing must not move the memory lane's position."""
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "observe me", session="sess")])
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+
+        await observe_new_turns(transcript, "sess", store, RecordingEmitter())
+
+        assert await store.offset_for("sess") == 0
+
+    async def test_already_observed_turns_are_not_re_emitted(
+        self, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "once only", session="sess")])
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+        emitter = RecordingEmitter()
+
+        await observe_new_turns(transcript, "sess", store, emitter)
+        second = await observe_new_turns(transcript, "sess", store, emitter)
+
+        assert second.emitted == 0
+        assert len(emitter.calls) == 1
+
+    async def test_secret_shaped_values_are_masked_before_the_emitter(
+        self, tmp_path: Path
+    ) -> None:
+        """Langfuse redacts nothing server-side, so the mask happens here."""
+        transcript = tmp_path / "t.jsonl"
+        write_lines(
+            transcript,
+            [
+                operator_line(
+                    "u1",
+                    "token is sk-abc123def456ghi789jkl",
+                    session="sess",
+                )
+            ],
+        )
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+        emitter = RecordingEmitter()
+
+        await observe_new_turns(transcript, "sess", store, emitter)
+
+        sent = emitter.calls[0][1][0].content
+        assert "sk-abc123def456ghi789jkl" not in sent
+        assert "[REDACTED]" in sent
+
+    async def test_a_failed_emit_leaves_the_watermark_where_it_was(
+        self, tmp_path: Path
+    ) -> None:
+        """The unadvanced watermark is the retry, exactly as in the raw lane."""
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "retry me", session="sess")])
+        store = WatermarkStore(tmp_path / "wm.sqlite")
+        broken = UnreachableEmitter()
+
+        with pytest.raises(RuntimeError):
+            await observe_new_turns(transcript, "sess", store, broken)
+
+        assert broken.calls == 1
+        assert await store.offset_for(OBSERVE_KEY_PREFIX + "sess") == 0
+
+        recovered = RecordingEmitter()
+        result = await observe_new_turns(transcript, "sess", store, recovered)
+        assert result.emitted == 1
+
+
+class TestRunStopObservationWiring:
+    """run_stop runs the sink best-effort, after and independent of memory."""
+
+    async def test_an_active_sink_receives_the_delivered_turns(
+        self, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "both lanes", session="sess")])
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        emitter = RecordingEmitter()
+        payload = StopHook(transcript_path=transcript, session_id="sess")
+
+        result = await run_stop(
+            payload,
+            settings,
+            lane_factory=lambda _s, _k: started(RecordingLane()),
+            observation=observation_settings(),
+            emitter_factory=lambda _o: emitter,
+        )
+
+        assert result is not None
+        assert result.delivered == 1
+        assert emitter.calls[0][1][0].content == "both lanes"
+
+    async def test_an_emit_failure_never_reaches_the_caller(
+        self, tmp_path: Path
+    ) -> None:
+        """Observation is best-effort: the memory delivery's result stands."""
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "kept", session="sess")])
+        watermark = tmp_path / "wm.sqlite"
+        settings = capture_settings(watermark)
+        broken = UnreachableEmitter()
+        payload = StopHook(transcript_path=transcript, session_id="sess")
+
+        result = await run_stop(
+            payload,
+            settings,
+            lane_factory=lambda _s, _k: started(RecordingLane()),
+            observation=observation_settings(),
+            emitter_factory=lambda _o: broken,
+        )
+
+        assert result is not None
+        assert result.delivered == 1
+        assert broken.calls == 1
+        # The observe watermark stayed put -- the failure's retry -- while the
+        # raw lane's advanced normally.
+        store = WatermarkStore(watermark)
+        assert await store.offset_for(OBSERVE_KEY_PREFIX + "sess") == 0
+        assert await store.offset_for("sess") == transcript.stat().st_size
+
+    async def test_an_inactive_sink_never_builds_an_emitter(
+        self, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "t.jsonl"
+        write_lines(transcript, [operator_line("u1", "memory only", session="sess")])
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        payload = StopHook(transcript_path=transcript, session_id="sess")
+
+        def never(_: ObservationSettings) -> RecordingEmitter:
+            message = "emitter built for an inactive sink"
+            raise AssertionError(message)
+
+        result = await run_stop(
+            payload,
+            settings,
+            lane_factory=lambda _s, _k: started(RecordingLane()),
+            observation=ObservationSettings(),
+            emitter_factory=never,
+        )
+
+        assert result is not None
+        assert result.delivered == 1
+
+    async def test_the_subagent_spine_observes_under_its_own_key(
+        self, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "sub.jsonl"
+        write_lines(transcript, [operator_line("u1", "subagent turn", session="sess")])
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        emitter = RecordingEmitter()
+        payload = SubagentStopHook(
+            agent_transcript_path=transcript,
+            session_id="sess",
+            agent_id="agent-1",
+        )
+
+        result = await run_subagent_stop(
+            payload,
+            settings,
+            lane_factory=lambda _s, _k: started(RecordingLane()),
+            observation=observation_settings(),
+            emitter_factory=lambda _o: emitter,
+        )
+
+        assert result is not None
+        assert result.delivered == 1
+        assert emitter.calls[0][0] == payload.watermark_key()
+
+
+class TestObservationSettingsResolution:
+    """The provisioned variable names resolve; a typo is rejected, not inert."""
+
+    def test_the_provisioned_variables_resolve(self) -> None:
+        settings = load_observation_settings(
+            {
+                "OPENBRAIN_OBSERVATION_ENABLED": "1",
+                "OPENBRAIN_OBSERVATION_ENDPOINT": "https://lf.example"
+                + INGESTION_SUFFIX,
+                "OPENBRAIN_OBSERVATION_PUBLIC_KEY": "pk-lf-x",
+                "OPENBRAIN_OBSERVATION_SECRET_KEY": "sk-lf-x",
+                "OPENBRAIN_OBSERVATION_HMAC_SECRET": "hmac-x",
+            }
+        )
+        assert settings.enabled is True
+        assert observation_active(settings) is True
+        assert settings.secret_key is not None
+        assert settings.secret_key.get_secret_value() == "sk-lf-x"
+
+    def test_an_empty_environment_loads_the_inactive_default(self) -> None:
+        settings = load_observation_settings({})
+        assert settings.enabled is False
+        assert observation_active(settings) is False
+
+    def test_a_typo_is_rejected_rather_than_loading_clean(self) -> None:
+        with pytest.raises(UnknownEnvironmentVariableError):
+            load_observation_settings({"OPENBRAIN_OBSERVATION_ENDPONT": "x"})
+
+    def test_a_secret_never_appears_in_the_repr(self) -> None:
+        settings = observation_settings()
+        assert "sk-lf-test" not in repr(settings)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -24,6 +24,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -65,6 +77,72 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -74,12 +152,89 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/7c/4cdf76a100f169a0855d4a7e69598a3bbe19bd2f048c5de3c298af1aa2c0/langfuse-4.14.2.tar.gz", hash = "sha256:76eb3f2c2106ddd63271154d1a33f8b3d4036f449a9f9b48403c36bd5e7c1bba", size = 389507, upload-time = "2026-07-30T11:54:48.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/b5/1499bcedb6872e8acc4e7043c522c9f3a4fe2eafd78a6f37e73308d18753/langfuse-4.14.2-py3-none-any.whl", hash = "sha256:27879cbaea570e94323c6ced60a0997feedf5294f18b51436009947c42f9f92e", size = 688132, upload-time = "2026-07-30T11:54:49.553Z" },
 ]
 
 [[package]]
@@ -205,6 +360,7 @@ name = "openbrain"
 version = "0.9.0"
 source = { editable = "openbrain" }
 dependencies = [
+    { name = "langfuse" },
     { name = "loguru" },
     { name = "openbrain-memory" },
     { name = "pydantic" },
@@ -222,6 +378,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "langfuse", specifier = ">=4" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "openbrain-memory", editable = "openbrain-memory" },
     { name = "pydantic", specifier = ">=2.9" },
@@ -300,6 +457,87 @@ version = "0.1.0"
 source = { virtual = "." }
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -324,6 +562,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -504,6 +757,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -559,10 +827,72 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "win32-setctime"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/6e/0f88a072483e76b881e3fdcd6b6ffb4a5791002514fe541e72b1b73c859a/wrapt-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d3fb71e65b001adfc42684522eeccd9c21d8ba679945abc993439567b66e59f", size = 81960, upload-time = "2026-07-28T06:04:49.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ff/b7e2776e7c294075eb712cc9ef573d1b818f393006d09787262b8fc871c4/wrapt-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51a7a4181c1295774812271fbcd7c909df372bc25579d4ed9eb875caaf0ae86f", size = 82435, upload-time = "2026-07-28T06:04:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/343bb5d0f1f9669bc252a6073f085b4abf862511bd5c9c9eaec754341f1d/wrapt-2.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9045917809c63fdf7abe3a2ceaed3d670b8ee4500ddd9291192d30aeb34467c5", size = 170350, upload-time = "2026-07-28T06:04:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f8/13b79a392930bd0dd6b86cbfbfe1c40944110456e1dc6d809e5c46ece904/wrapt-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54ca1d5573f69b5fe1d74f1f65799c68015e82f685efec9fd8cfa40a094c44d0", size = 170022, upload-time = "2026-07-28T06:04:53.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/4f1b6918f5290db959d6e0c07f77385d87cede29c39c9cf8f145e9c82954/wrapt-2.3.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:242b60c21e30866e6a2fa606c612b47c553fa60c0eaeeeb7797fb842ac0ce609", size = 161043, upload-time = "2026-07-28T06:04:54.936Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/45d3cf74414780bdff6d0380467e003f6eb0f028b6c9403db868dbc7209c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3f3d7ec0a51fbfe00d3aef047641ff2c58b25565b4717fc1f90e050be01cba8", size = 168576, upload-time = "2026-07-28T06:04:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/73/2fa58dd97f191c997755e2c6d569a68f0c433db4e4b36099bdd7227b6cac/wrapt-2.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:261f53870cd4fb2bf38f9f972c56c728fd224cb7c65721307de59d9e7e6741ae", size = 159140, upload-time = "2026-07-28T06:04:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a8/08a56e2000a8816d449dcbad8c8b081697acbbd490821ceca0f9d8e8d20c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8159ec0b0cb7608175eb150de94c19e34f4d47ac655f5ca9baf45df6b688ffd3", size = 169263, upload-time = "2026-07-28T06:04:59.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/354e1725e35a73b2af4fa70a3e024c7a5d1bf1802dfb862dcb668aae0253/wrapt-2.3.0-cp313-cp313-win32.whl", hash = "sha256:10461884b3014fbfc8eb7d09a93c5f246363e6711d9d881f95eb8c27fdef049f", size = 78241, upload-time = "2026-07-28T06:05:00.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/34c87fa2174848dfee820322aaa318bab08913998ccecc8d2f57b4ad4639/wrapt-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac870cc97b73bb00ac353329e9559a4bebc47c4c86792ed9b23b58c15b6ad838", size = 81113, upload-time = "2026-07-28T06:05:01.839Z" },
+    { url = "https://files.pythonhosted.org/packages/11/86/fcc9a530579e008c9478bb565a6cdfbfd33536660f069c8b91a6607c5050/wrapt-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:a65e8db2b4e90c2e7ade931086351c98ef420bf7a94ee08c95ac8a3cbbc43579", size = 80182, upload-time = "2026-07-28T06:05:03.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/50/3864848b95b28ef73e17551fc8dccbff2628a834f52cf26a57f9c419fb83/wrapt-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:fd1f2f557dd3491fe75905e578f4db967393d40d1a8f468edc4d40ac7f2d5944", size = 83921, upload-time = "2026-07-28T06:05:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/3d1921a60c3e8c71c540ff136e6a47a1fbccf7f671e818394889f7871d9c/wrapt-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9f5d2aec29dfc76c37e23897dee92766a3fd4f3bff3ae7fc9c6b4bf37d8c1360", size = 84412, upload-time = "2026-07-28T06:05:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1a/4a796ff7adb26ada6d4b758c94d47a38320b085e7099afc088efbbcdb006/wrapt-2.3.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:646d20d413ffcd1b0a2f700076e2d0252d872dcb7754860a73e45a59ea883614", size = 207168, upload-time = "2026-07-28T06:05:07.256Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3e/d7777776806c579b761bac2f91721dda9f04c7a1b380213c5935cc750ae6/wrapt-2.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379f670f45b7bb8993edd9f6fc36c6cc65edb81cffa0b504be34acb0303fff0a", size = 214351, upload-time = "2026-07-28T06:05:08.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/2d64d394df7bf181955b3bb562bf33c4492fb4be113f53071106d43ad8b5/wrapt-2.3.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6208f302f110295d64b22a7ac96500c791bf492dce4366e622e4912b077c9687", size = 199020, upload-time = "2026-07-28T06:05:10.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/fb31d3db7d9834d265fb1a27a2adf0ddf51557c67458c97b22439ad6ae3d/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ed635a9ca4f3a5a2b900c10c69e823373bc00ebc114b459383596d3487da3570", size = 209969, upload-time = "2026-07-28T06:05:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/8724b5da582e62070dc9bf4d8bf1972f317297eefd7ba1f2b5c6393ccf6c/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e3b9eaa742ae7a0aaaaad4ca4b69469d757af2d6e6663ef1dadc47adec0aeb41", size = 196324, upload-time = "2026-07-28T06:05:13.557Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/3d9ef411149543016ee6bcf3af707f787cebd946527452b94bf122e9b7b4/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d0f7284f88f4833705132d06d3b425a43095c2cbd07c58166aac3ab646ba12a4", size = 202610, upload-time = "2026-07-28T06:05:15.048Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9b/4fc042ceb757866dd4a5fc057b3b736f2b360d3703ce9f830d83dc9226e0/wrapt-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:7ebb274aba688b043429eb1500ff8a76ce0cb8ac0812ca3e301f06247b8722b3", size = 79178, upload-time = "2026-07-28T06:05:16.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/b94878f8eed809ca042685276bcea9f24e8c2ca7c9653bb80bbb920a68a5/wrapt-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c4bded758ad6f03b965830944a2f0bc5b2eb3767fe5a7310134315d1a6610e98", size = 82634, upload-time = "2026-07-28T06:05:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/663e1de5332a71685a729754312d327d4cada767c36e1c5a2db4c8de49e6/wrapt-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:d2cc64539da63e39ffb9c7ede849b6e8ddaaf7b3876b5cfb04efd85a5f3f4eb6", size = 81387, upload-time = "2026-07-28T06:05:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/58/10/b073beaea89bc0d3670a75ff51139430a54b6af7ba7796507730634536dd/wrapt-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea52a0d0f08c584943d5764be0e84efa912c8da23c23e1e285ff2f5641c18fcc", size = 81978, upload-time = "2026-07-28T06:05:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/31/0916d9cebf848ed3f1a0c1888faee421747df77331e4db2bc527a9a85988/wrapt-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd85b0aa88efdb189d6ae2f35f4526943a8f091c38599c9c31478241c819e6a1", size = 82518, upload-time = "2026-07-28T06:05:22.562Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/73/31c1bf0f3384062751c2094dadb314916d70aa9b6bfd26d994b4a7b393fa/wrapt-2.3.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:141ed6211286a9660d8d6702de598b43f0934b4f0eda16393f100a80f501d945", size = 170187, upload-time = "2026-07-28T06:05:23.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/25/fce087d54b79b8905f3c3c9dd5f454bbd8d8acb80b960c4a6aee5b4659b3/wrapt-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e49885a62ec4ee854d1b9e6371fda6afd219917225752abf729a3f36d4df9a5", size = 169288, upload-time = "2026-07-28T06:05:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/0d09e6dddc6b7a7230ac77f50254b5980ab4fcd22976f72f8cc8a0404458/wrapt-2.3.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d6159c9b2fefec02314e1332dbbbfaf960e369dfd26bcf7f8b258b5732065b3", size = 160932, upload-time = "2026-07-28T06:05:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/0913af0d2ec0c43865d32d615f518fea66c13c5c930e489e9b0de248e9a8/wrapt-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24da48596326ef8e448cfa837b454f638713d3531262375f00e5a9681682fc07", size = 169017, upload-time = "2026-07-28T06:05:28.501Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f2/3d1e47ea81b822210f5df1bf942fd90780a75c055243d569b664529dea88/wrapt-2.3.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cd3a2edf0427013736b8127955cec62608c56e53ea47e82812ea32059cda407f", size = 159065, upload-time = "2026-07-28T06:05:30.01Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a5/ef2066ced8e5fca204e2b361e9708e36555b40949c583d997ea3b590817d/wrapt-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fa0df3bff4e7ce45759f33fd39335fe2f60477bb9ecf7b8aa41e7d07ee36a23", size = 168821, upload-time = "2026-07-28T06:05:31.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e1/016104650d4e572fa91506eb396b3dd8efbccc9284fdc1c9479c3d21db28/wrapt-2.3.0-cp314-cp314-win32.whl", hash = "sha256:2935d5454b3f179a29b12cf390ee47246740ba2c3a7545b1b46ba31a5f2a4a0b", size = 78700, upload-time = "2026-07-28T06:05:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/6fdc20a9f2ca304748b3f0819cbf377d55260562777bf0b615431bc3c181/wrapt-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:cc2cea812e5cb179a796b766747e7d3b21088760d8deb95676d482b8c8e6fa7d", size = 81422, upload-time = "2026-07-28T06:05:34.774Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a4/9cbd53bf05746bea2c392af39cb052427a8ec95cbd494d930733d8f44681/wrapt-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:22cc5c0a717bd4da87018ae0bffd4c19c6fb679d3ff357216ba566ab26c76cab", size = 80639, upload-time = "2026-07-28T06:05:36.228Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/6c5e4a0f66ea0d2b2dd267e8dd05a0014eea56840b3c8595d40b0a5d1f91/wrapt-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a6b5984cd65dd639546f0eb4b8eacf1c31cb2fe9fb5c27bffe240987cdb2cf84", size = 84030, upload-time = "2026-07-28T06:05:37.714Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/eb/a1aedf03283bc9cbf8a1783995ddc54e3c5a86878f19002d2c428494f4c5/wrapt-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c88abcf53daef80e01a75c7530e727fa6e2c1888fe83e3dcdba4c96216a1f5c7", size = 84419, upload-time = "2026-07-28T06:05:39.131Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/50d511c0dc5105563849e86daa3e16ac7feef699f79fb05af45ea70107d5/wrapt-2.3.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:85de890ff968196e92dd1ae73a9fb8970495e7650a457b1c9ef0ac3dd550bce2", size = 207171, upload-time = "2026-07-28T06:05:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/59/9b538cf7795217e810699d16bc88b96a830d9b5c403eb2ec2db6b5f2ae81/wrapt-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50f416b74d092bb9f41b424e90dd457f365f7ba4b11de62a23679769a21bd85c", size = 214329, upload-time = "2026-07-28T06:05:42.287Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/28/9935d62b1499e5c8b3d191e99ba4eb31ca237a0b699142011a837e9dc7ea/wrapt-2.3.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39febbee6d77301d31da6996b152ce52452da7c7ef72aba10c2fa976dff9c295", size = 199079, upload-time = "2026-07-28T06:05:43.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/01/4446b80fa2ffa47a3449b250d004ba1c1937f07f64a179608fec735df866/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93513bec052c6cd987f9f580c3df068c8bc4ebae6543736be3ca7ec5959cafcd", size = 209992, upload-time = "2026-07-28T06:05:45.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/07/56f26c9f9979586a021e8148747004aba4498f49458c90b0502969b904e1/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:729126e667da34d251b8ebf8a45ef0c5ddadc21542b3d6e1abf4259ece6508df", size = 196334, upload-time = "2026-07-28T06:05:47.608Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/41/6d7bcc895b0f28b2250e10908f060687b9165429dcd7f22ddb3d4c031b74/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:626b69db2021aa01671ec7bbc9740e558522bd44c18cf2ce69bf3d666a014109", size = 202644, upload-time = "2026-07-28T06:05:49.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/25/7860927edba06b758b8852a6f02e832be715563c67a6795d94350bc81099/wrapt-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:629d73378082c00a8173031f9fb30a3ac6abbc894a5bfdfae71fabc60642d501", size = 79685, upload-time = "2026-07-28T06:05:50.976Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0f/270bafe92fde3b069a39bc01e39ee79340895b335640df861d43d2a51885/wrapt-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:42869085687f0aefd57c0f636c3f9354f8ffb321a8ba9cb52d19beb796e561c5", size = 83104, upload-time = "2026-07-28T06:05:52.405Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b3/af176d79a8515a8a720eccdad9a96f6e31a30abf2865430c8c42adf2fd13/wrapt-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1e5aa486e269b00ed35e64771c7d0ab8096cfd2643405ca8cd60ebedc099a51", size = 81774, upload-time = "2026-07-28T06:05:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]


### PR DESCRIPTION
## Summary

- Adds the observation sink (#523): the same turns the Stop/SubagentStop capture delivers to Open Brain also ship to the fleet Langfuse server (`langfuse.rodaddy.live`, v3.173.0) as content-ful session traces — Open Brain stays the memory authority, Langfuse is the flight recorder.
- New `ObservationSettings` config section + `load_observation_settings` (capture/canon pattern: optional coordinates, use-time enforcement, typo-guarded; `hmac_secret` declared-but-unused so the provisioned #372 variable is no longer an unknown-variable rejection).
- New `apps/capture/observe.py` spine: same reader and watermark store as the raw lane, own `observe:`-prefixed key, advance only after the emitter returns (`docs/decisions/capture-never-drops-a-turn.md` applied per lane). Secret-shaped values masked client-side with the existing `redact()` before anything leaves the process — Langfuse redacts nothing server-side.
- New `apps/capture/langfuse_emitter.py`: SDK v4 mapping, one trace per delivery grouped by session; `shutdown()` before return so the short-lived hook process never silently drops a batch.
- `run_stop`/`run_subagent_stop` wiring: observation runs after the memory delivery, best-effort — failure logged content-free (class name only), never reaches the caller or the memory watermark.
- `docs/CONFIG_REFERENCE.md`: the five variables + the deploy coupling.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`uv run mypy src/openbrain` clean (48 files), `uv run ruff check src tests` clean, `uv run pytest` 490 passed / 1 skipped. Red-proofs: the redaction test fails with the mask removed; the failure-isolation test fails with the catch narrowed (both run and restored in-session). Live: `run_stop` with the real emitter against the local brain + real Langfuse landed trace `104d933b276b2085803472025cfd69a2` — session-grouped, tagged, 2 observations, planted secret masked (`[REDACTED]` present, raw token absent), memory lane delivered 1 turn normally.

## Critical Self-Review

- Highest-risk behavior: shipping transcript CONTENT to a second server. Mitigated: opt-in (`enabled` defaults false), client-side `redact()` proven by a red test, operator decision 2026-08-03 explicitly chose a content-ful lane, langfuse LXC is inside the backup surface (operator statement).
- Assumptions that could be wrong: Langfuse SDK v4 surface stability (`propagate_attributes`); pinned `langfuse>=4` so an older resolve import-errors instead of misbehaving. Assumes a colon never appears in a raw-lane session key (Claude session ids are UUIDs; subagent watermark keys — verified they contain no colon-prefixed `observe:` collision path).
- Missing/weak tests: the real `LangfuseEmitter` mapping is covered by the live canary, not unit tests (a unit test would either mock the SDK into meaninglessness or dial a server). No test for a half-flushed SDK batch — `shutdown()` before return is the mitigation.
- Security/permission risk: keys held as `SecretStr`; no settings value appears in any error path (class-name-only logging convention). LAN-local Langfuse keys carry no rotation ceremony per standing pre-prod rule.
- Migration/deploy risk: **deploy coupling** — the deployed `openbrain-hook-env` wrapper must gain the `OPENBRAIN_OBSERVATION_*` pass-throughs only together with (or after) installing this package version; adding them to an older install trips `unknown_prefixed_variables` → silent zero capture. Documented in CONFIG_REFERENCE.md. No DB migration.
- Downstream client/runtime risk: none to MCP schema/tools — this is Python-hook-side only. Fleet copies of the wrapper tracked in `_plans/fleet-rollout-0.9.md`.
- Rollback/cleanup concern: unset `OPENBRAIN_OBSERVATION_ENABLED` (or drop the wrapper pass-throughs) and the sink declines silently; observe watermark rows are inert leftovers. Emitted traces stay in Langfuse.
- Fixes made before PR: ruff TRY003/nesting findings restructured (named error class, combined `with`); loguru import was missing from session.py — caught before commit by running the gates.
- Known residual risk: on the FIRST enabled Stop of a long-lived session the observe watermark starts at 0 and re-reads the whole transcript, emitting history the raw lane already delivered — a one-time backfill per session, by design (the watermark model's cold-start), not a loop.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no swarm findings yet; this PR introduces the lane, the swarm reviews it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because: live canary detailed under Verification (trace `104d933b276b2085803472025cfd69a2`).

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no MCP tool/schema change — Python hook process only; the server contract is untouched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing contract changes. The one rollout step is local/deployed-host config (wrapper pass-throughs + package install), sequenced in CONFIG_REFERENCE.md and `_plans/fleet-rollout-0.9.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
