### PR TITLE
fix(canon): omit repo from the pack call when underivable — null killed the whole pack (#526)

### DIFF
--- a/python/openbrain/src/openbrain/apps/hooks/session.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session.py
@@ -1064,16 +1064,24 @@ def _canon_context(settings: CanonSettings) -> CanonContext:
         timeout=CANON_REQUEST_TIMEOUT_SECONDS,
         retry_policy=RetryPolicy(attempts=1),
     )
+    # repo is OMITTED when None, never sent as null. The client method is a
+    # pure **arguments pass-through, so a None here reaches the wire as
+    # `repo: null` and the server rejects the whole call -- which killed the
+    # entire pack (profile/process included) for every non-repo cwd (#526),
+    # not the defined-empty repo_facts state #517 intended. Same shape as the
+    # receipts call's conditional repo above.
+    scope: dict[str, Any] = {
+        "agent": settings.agent,
+        "platform": settings.platform,
+        "server_id": settings.server_id,
+        "channel_id": settings.channel_id,
+        "session_key": settings.session_key,
+        "requested_sections": list(settings.sections),
+    }
+    if settings.repo is not None:
+        scope["repo"] = settings.repo
     try:
-        pack = client.agent_context_pack(
-            agent=settings.agent,
-            platform=settings.platform,
-            server_id=settings.server_id,
-            channel_id=settings.channel_id,
-            session_key=settings.session_key,
-            repo=settings.repo,
-            requested_sections=list(settings.sections),
-        )
+        pack = client.agent_context_pack(**scope)
     except BaseException:
         # agent_context_pack lazily opens the MCP session (``_ensure_session``);
         # if the call then raises after the slot was allocated, close it so the

--- a/python/openbrain/tests/test_capture_hooks.py
+++ b/python/openbrain/tests/test_capture_hooks.py
@@ -1381,6 +1381,77 @@ class TestSessionStartParsesTheCapturedPayload:
         assert payload.source == "startup"
 
 
+class RecordingCanonClient:
+    """Stands in for OpenBrainClient at the wire boundary of `_canon_context`.
+
+    CanonPackReader replaces the whole factory, so it can never see what the
+    REAL factory puts on the wire -- which is exactly where #526 lived: a
+    `repo: null` argument the server rejects. This fake records the tool-call
+    arguments themselves.
+    """
+
+    instances: list[RecordingCanonClient] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        """Record construction and start with no calls."""
+        self.calls: list[dict[str, object]] = []
+        RecordingCanonClient.instances.append(self)
+
+    def agent_context_pack(self, **arguments: object) -> dict[str, object]:
+        self.calls.append(arguments)
+        return {"sections": {}}
+
+    def close(self) -> None:
+        """Nothing to release; the shape is what run paths call."""
+
+
+class TestCanonReadOmitsAnUnderivableRepo:
+    """#526: a non-repo cwd must OMIT `repo` from the wire call, never send null.
+
+    The live server rejects `repo: null` outright, which killed the WHOLE pack
+    (profile/process included) for every session outside a git repo -- proven
+    2026-08-03 against the dogfood service with two probes differing only in
+    cwd. #517's design is that an underivable repo yields the server's defined
+    empty repo_facts state; that requires the key to be absent.
+    """
+
+    def test_a_none_repo_is_omitted_from_the_wire_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import openbrain_memory.client as client_module
+
+        from openbrain.apps.hooks.session import _canon_context
+
+        RecordingCanonClient.instances = []
+        monkeypatch.setattr(client_module, "OpenBrainClient", RecordingCanonClient)
+        settings = canon_settings().model_copy(update={"repo": None})
+
+        context = _canon_context(settings)
+
+        call = RecordingCanonClient.instances[0].calls[0]
+        assert "repo" not in call
+        # The rest of the scope still travels -- omitting repo narrows nothing
+        # else.
+        assert call["session_key"] == settings.session_key
+        assert call["requested_sections"] == list(settings.sections)
+        assert context.pack == {"sections": {}}
+
+    def test_a_derived_repo_still_binds_exactly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import openbrain_memory.client as client_module
+
+        from openbrain.apps.hooks.session import _canon_context
+
+        RecordingCanonClient.instances = []
+        monkeypatch.setattr(client_module, "OpenBrainClient", RecordingCanonClient)
+        settings = canon_settings().model_copy(update={"repo": "king-signals"})
+
+        _canon_context(settings)
+
+        assert RecordingCanonClient.instances[0].calls[0]["repo"] == "king-signals"
+
+
 class TestSessionStartRequestsCanonOnly:
     """run_session_start requests the always-known layer and NOTHING episodic."""
 


### PR DESCRIPTION
## Summary

- Fixes #526: `_canon_context` passed `repo=None` into `client.agent_context_pack(...)` (a pure `**arguments` pass-through), so the wire carried `repo: null` and the live server rejected the whole call — zero canon, profile/process included, for every session outside a git repo. This is what left Buzz-Skippy (cwd `~/.buzz`) with an empty skull on a box where the OB stack works.
- The `repo` key is now omitted when None (`#517`'s intended defined-empty `repo_facts` state requires the key to be absent), the same conditional shape the receipts call already uses at `session.py:763-765`.
- Regression tests drive `_canon_context` itself with a recording client at the wire boundary — `CanonPackReader` replaces the whole factory, so the existing harness could never see this argument.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`uv run mypy` clean (48 files), `ruff` clean, `pytest` 492 passed / 1 skipped. Red-proof: reverting the conditional fails `test_a_none_repo_is_omitted_from_the_wire_call` and only it. Live: the failing probe (`openbrain-session-start` with `cwd=/Users/rico/.buzz`) reproduced `OpenBrainToolError` on deployed code, and the fixed entrypoint against the same live dogfood server emits `CANON PACK 1/2` normally.

## Critical Self-Review

- Highest-risk behavior: changing the canon read's wire arguments. Bounded: the only delta is key omission when None; a derived repo still binds exactly (second regression test).
- Assumptions that could be wrong: that no caller depends on sending `repo: null` — none can, the live server rejects it.
- Missing/weak tests: no live-server test in CI for the null shape (CI has no dogfood service); covered by the recorded live probes and the wire-boundary fakes.
- Security/permission risk: none; read-only call, no namespace change.
- Migration/deploy risk: needs the uv tool reinstall on this Mac to reach the deployed hooks (same step as every hook change; I'll run it on merge).
- Downstream client/runtime risk: none to MCP schema; Python hook side only.
- Rollback/cleanup concern: revert the commit; behavior returns to rejecting non-repo sessions.
- Fixes made before PR: ruff quoted-annotation nit.
- Known residual risk: other `**arguments` pass-through call sites could carry the same None-to-null trap; worth a sweep as a follow-up (not this fix's scope).
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: single-fix PR; the None-to-null pass-through pattern is a good future SME candidate once the sweep confirms other sites.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because: live probes under Verification.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no MCP tool/schema change; Python hook wire-argument construction only.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable: no contract change. Local deploy step on merge: `uv tool install --reinstall` of the `openbrain` package (same as #524's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)