### PR TITLE
fix(find-duplicates): scope the global-role self-join to a namespace (#485)

### DIFF
--- a/src/tools/__tests__/find-duplicates.test.ts
+++ b/src/tools/__tests__/find-duplicates.test.ts
@@ -122,17 +122,138 @@ describe("find_duplicates", () => {
       });
 
       expect(result.isError).toBeFalsy();
+      // Both sides bind the SAME list ($3): a pair spanning two namespaces is
+      // not a duplicate, and binding one side only leaves the join unbounded.
       expect(calls[0]!.sql).toContain("a.namespace = ANY($3::text[])");
-      expect(calls[0]!.sql).toContain("b.namespace = ANY($4::text[])");
-      expect(calls[0]!.params).toEqual([
-        0.08,
-        20,
-        ["bilby", "shared-kb"],
-        ["bilby", "shared-kb"],
-      ]);
+      expect(calls[0]!.sql).toContain("b.namespace = ANY($3::text[])");
+      expect(calls[0]!.params).toEqual([0.08, 20, ["bilby", "shared-kb"]]);
     } finally {
       await cleanup();
     }
+  });
+
+  // #485: for a global role `readableNamespaces()` returns undefined, so the
+  // old `appendReadNamespacePredicate()` call site contributed an empty string
+  // on BOTH sides and the self-join ran over every pair in the table. Measured
+  // on a 24,845-row corpus: 256.7ms scoped versus cancelled at 60,074ms by
+  // statement_timeout, with pooled connections that never came back.
+  describe("#485: a global role never emits an unscoped self-join", () => {
+    for (const role of ["admin", "ob-admin", "promoter"] as const) {
+      it(`binds ${role} to a concrete namespace on BOTH sides of the join`, async () => {
+        const calls: Array<{ sql: string; params?: any[] }> = [];
+        const mockPool = {
+          query: async (sql: string, params?: any[]) => {
+            calls.push({ sql, params });
+            return { rows: [] };
+          },
+        };
+        const auth: AuthInfo = { role, clientId: "operator" };
+
+        const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+        try {
+          const result = await client.callTool({
+            name: "find_duplicates",
+            arguments: { table: "thoughts", threshold: 0.08 },
+          });
+
+          expect(result.isError).toBeFalsy();
+          const join = calls[0]!;
+          // The whole defect: these two predicates were absent entirely.
+          expect(join.sql).toContain("a.namespace = ANY($3::text[])");
+          expect(join.sql).toContain("b.namespace = ANY($3::text[])");
+          expect(join.params).toEqual([0.08, 20, ["operator"]]);
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+
+    it("scans a named namespace the global caller may read", async () => {
+      const calls: Array<{ sql: string; params?: any[] }> = [];
+      const mockPool = {
+        query: async (sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "operator" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "find_duplicates",
+          arguments: { table: "thoughts", namespace: "bilby" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(calls[0]!.params).toEqual([0.08, 20, ["bilby"]]);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    // `canReadNamespace` treats the literal "all" as permitted for a global
+    // role, which is the one input that could smuggle the unbounded scan back
+    // in. It must resolve to a concrete single-element list -- a bounded
+    // (empty) namespace -- and never to "no predicate".
+    it("keeps the 'all' sentinel bounded rather than reopening the cross-product", async () => {
+      const calls: Array<{ sql: string; params?: any[] }> = [];
+      const mockPool = {
+        query: async (sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "admin", clientId: "operator" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "find_duplicates",
+          arguments: { table: "thoughts", namespace: "all" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(calls[0]!.sql).toContain("a.namespace = ANY($3::text[])");
+        expect(calls[0]!.sql).toContain("b.namespace = ANY($3::text[])");
+        const bound = calls[0]!.params![2] as string[];
+        expect(Array.isArray(bound)).toBe(true);
+        expect(bound.length).toBe(1);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("refuses a namespace the caller cannot read, before touching the pool", async () => {
+      const calls: Array<{ sql: string }> = [];
+      const mockPool = {
+        query: async (sql: string) => {
+          calls.push({ sql });
+          return { rows: [] };
+        },
+      };
+      const auth: AuthInfo = { role: "agent", clientId: "bilby" };
+
+      const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+      try {
+        const result = await client.callTool({
+          name: "find_duplicates",
+          arguments: { namespace: "someone-else" },
+        });
+
+        expect(result.isError).toBe(true);
+        expect((result.content as any)[0].text).toContain(
+          "Permission denied: cannot read namespace 'someone-else'",
+        );
+        expect(calls).toHaveLength(0);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   it("denies discord role (no read access)", async () => {

--- a/src/tools/find-duplicates.ts
+++ b/src/tools/find-duplicates.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../permissions.ts";
-import { appendReadNamespacePredicate } from "../read-policy.ts";
+import { canReadNamespace, readableNamespaces } from "../read-policy.ts";
+import { physicalNamespace } from "../shared-namespace.ts";
 import type { AuthInfo, Table } from "../types.ts";
 import { logger } from "../logger.ts";
 import type { ToolDeps } from "./index.ts";
@@ -23,12 +24,49 @@ function contentPreviewForAlias(table: Table, alias: string): string {
   }
 }
 
+/**
+ * Resolve the namespace set BOTH sides of the self-join are bound to (#485).
+ *
+ * This is a total function by design: it returns a non-empty list for every
+ * identity, so no input produces an unscoped join. `readableNamespaces()`
+ * returns `undefined` for a global role (`admin`, `ob-admin`, `promoter`),
+ * which the previous `appendReadNamespacePredicate()` call site turned into an
+ * empty clause on BOTH sides -- a full cross-product. Measured on a 24,845-row
+ * corpus: 256.7 ms scoped, versus cancelled at 60,074 ms unscoped, with pooled
+ * connections that never came back.
+ *
+ * A global ROLE may read every namespace, but the comparison SPACE is still
+ * per-namespace: a pair drawn from two different namespaces is not a duplicate.
+ * So a global role is bound to a concrete namespace -- its own by default, or
+ * any one it may read when named explicitly -- rather than to no predicate.
+ *
+ * @param auth Authenticated caller.
+ * @param requested Caller-supplied namespace, if any.
+ * @returns Namespaces to scan, or `undefined` when the caller may not read the
+ *   namespace it named.
+ */
+export function duplicateScanNamespaces(
+  auth: AuthInfo,
+  requested: string | undefined,
+): string[] | undefined {
+  if (requested !== undefined) {
+    return canReadNamespace(auth, requested)
+      ? [physicalNamespace(requested)]
+      : undefined;
+  }
+  // A scoped role's own readable set is already a bounded list, and keeping it
+  // preserves the pre-#485 behavior of pairing within own + shared.
+  return readableNamespaces(auth) ?? [auth.clientId];
+}
+
 export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void {
   server.registerTool(
     "find_duplicates",
     {
       description:
-        "Discover potential duplicate entries using vector similarity. Read-only -- does NOT archive anything.",
+        "Discover potential duplicate entries using vector similarity. Read-only -- does NOT archive anything. " +
+        "The pairwise scan is always bounded to a namespace set: it defaults to the caller's readable namespaces " +
+        "and can be pointed at any single namespace the caller may read.",
       inputSchema: {
         table: z
           .enum([
@@ -40,6 +78,14 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
           ])
           .optional()
           .describe("Optional: limit to a specific table (default: all)"),
+        namespace: z
+          .string()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe(
+            "Namespace to scan for duplicate pairs (defaults to the caller's readable namespaces)",
+          ),
         threshold: z
           .number()
           .min(0)
@@ -69,6 +115,19 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
             {
               type: "text" as const,
               text: "Permission denied: not authenticated",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const namespaces = duplicateScanNamespaces(auth, args.namespace);
+      if (namespaces === undefined) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Permission denied: cannot read namespace '${String(args.namespace)}'`,
             },
           ],
           isError: true,
@@ -107,18 +166,12 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
         const remaining = limit - duplicates.length;
         const previewA = contentPreviewForAlias(table, "a");
         const previewB = contentPreviewForAlias(table, "b");
-        const params: unknown[] = [threshold, remaining];
-        const namespacePredicateA = appendReadNamespacePredicate(
-          auth,
-          params,
-          "a.namespace",
-        );
-        const namespacePredicateB = appendReadNamespacePredicate(
-          auth,
-          params,
-          "b.namespace",
-        );
-
+        // BOTH sides of the join bind the SAME resolved namespace list ($3),
+        // so the predicate is never empty and the comparison space stays
+        // per-namespace-set. Binding one side only still admits a
+        // cross-namespace pair and still leaves the unbounded shape #485
+        // measured. The `b.namespace` predicate sits on the JOIN condition so
+        // the planner can cut the pair space before computing distances.
         // Table name is validated by Zod enum -- safe for interpolation
         const { rows } = await deps.pool.query(
           `SELECT
@@ -131,14 +184,14 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
           JOIN ${table} b ON a.id < b.id
             AND b.archived_at IS NULL
             AND b.embedding IS NOT NULL
+            AND b.namespace = ANY($3::text[])
           WHERE a.archived_at IS NULL
             AND a.embedding IS NOT NULL
+            AND a.namespace = ANY($3::text[])
             AND a.embedding <=> b.embedding < $1
-            ${namespacePredicateA}
-            ${namespacePredicateB}
           ORDER BY distance ASC
           LIMIT $2`,
-          params,
+          [threshold, remaining, namespaces],
         );
 
         for (const row of rows) {
@@ -153,6 +206,7 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
 
       logger.info("find_duplicates_success", {
         tables_scanned: accessibleTables.length,
+        namespaces_scanned: namespaces.length,
         duplicates_found: duplicates.length,
       });
 
@@ -162,6 +216,7 @@ export function registerFindDuplicates(server: McpServer, deps: ToolDeps): void 
             type: "text" as const,
             text: JSON.stringify({
               threshold,
+              namespaces,
               duplicates_found: duplicates.length,
               duplicates,
             }),


### PR DESCRIPTION
## Summary

- `src/tools/find-duplicates.ts` built its pairwise self-join by appending a read predicate to each side via `appendReadNamespacePredicate()`. For a global role `readableNamespaces()` returns `undefined`, so **both** predicates collapsed to the empty string and the emitted SQL carried no namespace filter at all — a full cross-product over the table. `ORDER BY distance ASC` means `LIMIT` bounds only the output, never the work.
- The fix replaces the two-sided predicate append with `duplicateScanNamespaces()`, a **total** function: it returns a non-empty list for every identity, so no input produces an unscoped join. Both sides of the join bind the **same** list (`$3`) — a pair drawn from two different namespaces is not a duplicate, and binding one side only would still admit a cross-namespace pair while leaving the unbounded shape intact.
- `find_duplicates` gains an optional `namespace` argument. `docs/sme/adversarial.md` names the absence of one as part of the defect: "a privileged path with no way to scope it is not an escape hatch." A global role defaults to its own namespace and may point the scan at any namespace it can read.
- The defect covers `promoter` as well as `admin`/`ob-admin` — all three return `undefined` from `readableNamespaces()`. The issue named the first two; the regression test covers all three.
- `server/tools/find-duplicates.ts` already carried this fix from the #463 rewrite (verified this session, including its `ported-tools-scope.test.ts` coverage). **No change was needed there**; this brings current-`src` to the same shape.

Refs #485.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

**Which suites actually ran** (`bun test` Postgres suites skip silently without `OPENBRAIN_TEST_DATABASE_URL`, so this is stated explicitly):

- `bunx tsc --noEmit` — clean.
- `bun test` **with** `OPENBRAIN_TEST_DATABASE_URL` pointed at the existing throwaway `open_brain_parity_463` database: **3449 pass, 0 fail, 35 skip** across 227 files. The DB-gated suites genuinely ran — the same command without the env var reports **506 skip** instead of 35.
- The Postgres-backed contract parity suite ran, so `contracts/server/server-duplicate-discovery.fixture.json` was actually exercised: 88 pass, 0 fail. `expectObserved` in `contracts/server-tool-parity.test.ts` iterates only the *expected* keys, so the added `namespaces` response key is compatible by design rather than by luck (read at `contracts/server-tool-parity.test.ts:102-127`).
- Python package checks not applicable: `client.py:1324` forwards `**arguments` and `dream.py:269` forwards `**filters`, so a new *optional* input argument needs no client change. No Python file is touched by this PR.
- Live hosted smoke **not run** — I did not touch the running service or any deployed artifact, per the task constraints. See Downstream Rollout below.

### Red-proof (the test fails on the old behavior)

Stashed only `src/tools/find-duplicates.ts`, keeping the new assertions, and reran: **3 pass, 6 fail**. The received SQL is the defect verbatim — both predicates rendered as empty strings:

```
error: expect(received).toContain(expected)
Expected to contain: "a.namespace = ANY($3::text[])"
Received: "... FROM thoughts a\n          JOIN thoughts b ON a.id < b.id\n
   AND b.archived_at IS NULL\n            AND b.embedding IS NOT NULL\n
 WHERE a.archived_at IS NULL\n            AND a.embedding IS NOT NULL\n
 AND a.embedding <=> b.embedding < $1\n            \n            \n
ORDER BY distance ASC\n          LIMIT $2"
```

Those two bare `\n            \n            \n` lines are where the namespace predicates should have been. Restored via `git stash pop`; the file suite is now 10 pass / 0 fail.

## Critical Self-Review

- Highest-risk behavior: cross-namespace duplicate pairs are no longer reported to a global caller. This is a real behavior change, not a side effect, and it is the deliberate trade — reporting such pairs is exactly what requires the unbounded join. It matches the decision already shipped on the `server/` rewrite path, so the two runtimes agree rather than diverge.
- Assumptions that could be wrong: that a duplicate is meaningful only *within* a namespace. If Rico wants cross-namespace duplicate detection for admins, that is a separate feature needing a bounded algorithm (per-namespace iterate-and-merge, or an ANN pre-filter), not a restored cross-product. Also assumed: `physicalNamespace()` is the right normalization for a caller-named namespace — it is what `namespaceFilterFor()` already uses for the same purpose.
- Missing/weak tests: the regression tests assert **SQL text and bound parameters** against a mock pool, not a seeded two-namespace corpus proving non-pairing at the data level. SQL-text assertions are brittle to reformatting. I chose them because they pin the exact defect (an *absent* predicate) precisely, and because the DB-backed alternative reintroduces the slow-join hazard into the suite. I did **not** add a performance/timing test — timing tests are flaky and the issue's measurements are already recorded in the SME KB.
- Security/permission risk: this *narrows* a read path, so it cannot widen access. `canReadNamespace()` is reused rather than reimplemented, keeping the authorization decision at its existing owning boundary. The refusal happens **before** any pool access (asserted by a test). The one input that could smuggle the unbounded scan back in is the literal `"all"` sentinel, which `canReadNamespace` permits for a global role — a dedicated test proves it resolves to a bounded single-element list, never to "no predicate". SQL stays fully parameterized; the only interpolation is the Zod-enum-validated table name, unchanged.
- Migration/deploy risk: none. No schema change, no migration, no config.
- Downstream client/runtime risk: additive only — a new *optional* input and a new *additive* output key. An existing caller sending no `namespace` keeps working; an existing consumer reading `duplicates`/`duplicates_found` is unaffected. The behavioral delta for an admin caller is narrower results, not an error.
- Rollback/cleanup concern: single commit, two files, revertible in isolation. No worktree or temp artifact left behind; no deployed artifact touched.
- Fixes made before PR: widened the fix and its tests from `admin`/`ob-admin` to include `promoter` after reading `read-policy.ts` and finding it takes the same `undefined` branch — the issue text names only the first two. Added the `"all"`-sentinel test after tracing `canReadNamespace` rather than assuming the sentinel was safe.
- Known residual risk: the `statement_timeout` safety net that the issue recommends as complementary (option 2) and that `server/tools/find-duplicates.ts` already implements is **not** ported to `src/` here. Scoping is the fix; the timeout is defense-in-depth for a pathologically large *single* namespace. I left it out to keep this change minimal at the owning boundary — `src/` has no transaction wrapper on this path, so adding one is a larger structural change than the bug requires. Worth a follow-up issue; it is not required to close #485.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: `docs/sme/adversarial.md` already carries this exact pattern ("a namespace predicate that vanishes for privileged roles", provenance #485, severity HIGH) with the measurements and review questions. Its status line says "fixed on the rewrite path" and is now also true of current-`src`; no new MEDIUM+ finding surfaced in this PR.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this PR is not deployed and the task explicitly scoped out touching the running service or any deployed artifact. A hosted `find_duplicates` call should be recorded at deploy time per the Downstream Rollout section.

## Contract Parity

- Contract parity: [x] fixtures updated
- Contract parity: [ ] runtime-specific because:

`contracts/server/server-duplicate-discovery.fixture.json` needed no edit and passes as-is against real Postgres. Its `json` expectation is matched subset-wise, and it runs under the scoped `agent` role, which was never the defective path. Its `description` field still narrates the old defect as current behavior ("under the admin role read-policy contributes no namespace predicate and the tool self-joins the whole table"); that prose is now stale for both runtimes. I left it untouched rather than silently rewriting a frozen parity artifact — flagging it for the reviewer to direct.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- The gate **applies**: this changes an MCP tool input schema and namespace semantics, which `docs/downstream-rollout.md` lists explicitly under "When This Applies". I am recording it as **owed, not done** rather than checking boxes I did not verify.
- **rtech-mcps / mcp2cli cache refresh / Hermes canaries: outstanding.** These require the candidate to be on `origin/main` and deployed to core01 (`workflow_dispatch` with `deploy_core01=true`, or a `v*` tag), which this PR deliberately does not do. Left unchecked.
- **rtech-hermes Python runtime/plugin: not applicable.** No Python source changes; `openbrain_memory` forwards tool arguments generically (`client.py:1324`, `dream.py:269`), so an added optional argument requires no runtime or plugin update.
- Because the change is additive (optional input, additive output key), a stale downstream cache degrades to *previous* behavior — callers omitting `namespace` — rather than erroring. That lowers rollout urgency but does not remove the step.
