### PR TITLE
fix(capture): honor the lifecycle keys the provider CLI was dropping (#464)

### DIFF
--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -969,3 +969,50 @@ its sibling silently did not is a defect signal, not a style difference.
 - **For a capture/ingest path specifically: does an end-to-end test assert a
   COUNT, not just per-record shape?** Every per-record assertion in #447 passed.
   Only "a two-speaker transcript delivers 2" fails on the defect.
+
+---
+
+## An allowlist that drops unrecognized keys is accept-and-ignore, not tolerance
+
+**Provenance:** #464, found 2026-08-03 during the canon seeding run. Same
+family as #447 and #515 — a request key the reader does not recognize is
+discarded while the caller is told the write succeeded.
+**Severity:** HIGH — false receipt on the advertised durable-write path.
+**Status:** active.
+
+### Pattern
+
+The provider JSON-stdin CLI projects each request through a per-operation key
+allowlist and drops everything else. That behavior was deliberate and
+documented — "N-1 tolerant reader," so a newer caller does not break an older
+reader — and it was the right idea applied without a boundary.
+
+`capture` allowed `content`/`distilled`/`event_type`. The #445 promotion
+vocabulary (`candidate_type`, `memory_lifecycle_action`, `candidate_scope`) was
+not in that set, so a scripted promotion returned `status:saved`, wrote a row
+with none of the metadata that makes it promotable, and seeded nothing. The
+only trace was `compatibility_note: ignored_optional_request_keys` with a
+COUNT and no names, which nothing fails on and nobody can act on.
+
+Forward tolerance is for keys a future caller adds that this reader has no
+opinion about. It is NOT a place to put keys the system already defines: those
+have a meaning, and dropping one silently is the defect the tolerance was never
+meant to cover.
+
+### Review Questions
+
+- **Does the drop path name what it dropped?** A count tells a caller that
+  something was ignored without saying what, which is unactionable at the exact
+  moment it matters. Names cost one list and make the receipt diagnosable.
+- **Is any dropped key part of a vocabulary this codebase already defines?** Grep
+  the dropped name against the project's own constant sets. A key that appears in
+  `CANDIDATE_TYPES`, an enum, or a schema is not an unknown future field — it is
+  a supported concept the reader forgot, and dropping it is a bug in both
+  directions (honor it or reject it by name).
+- **Does a sibling path accept what this one drops?** The client library
+  (`AgentMemory.promote_candidate`) had carried the full vocabulary all along.
+  One surface of the same product accepting what its sibling silently discards is
+  the same asymmetry signal as #447.
+- **Does a test assert the ABSENCE of a compatibility note on the happy path?**
+  Asserting `status == "saved"` passes on both the honored and the dropped case.
+  Only `"compatibility_note" not in receipt` distinguishes them.

--- a/python/openbrain-memory/README.md
+++ b/python/openbrain-memory/README.md
@@ -262,10 +262,18 @@ capped at 64 KiB, output at 1 MB, and distilled lifecycle content at 16 KiB.
 The `recall` and `reflex` operations read; capture, checkpoint, and wrap
 requests must include `"distilled": true`.
 
+`capture` additionally accepts the optional memory-lifecycle vocabulary —
+`candidate_type`, `memory_lifecycle_action`, and `candidate_scope` — and
+forwards them to the written event's metadata, so a promotion can be scripted
+through the console rather than only through `AgentMemory.promote_candidate`.
+A value outside `CANDIDATE_TYPES` or `MEMORY_LIFECYCLE_ACTIONS` fails the write
+by name; it is never dropped.
+
 The console is an N-1 tolerant reader for unknown optional top-level operation
 fields. It projects only recognized common and operation fields into dispatch,
-never forwards unknown fields, and adds a content-free compatibility note and
-bounded ignored-key count to the receipt. Unknown operations, missing or
+never forwards unknown fields, and adds a content-free compatibility note, a
+bounded ignored-key count, and the ignored key NAMES
+(`ignored_optional_request_keys`) to the receipt. Unknown operations, missing or
 mistyped known fields, nested `scope`/`config` authority fields, and reflex
 `prior_context` references remain fail-closed.
 

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -609,11 +609,33 @@ class AgentMemory:
         channel_id: str,
         thread_id: str | None = None,
         event_type: str = "fact",
+        **metadata: Any,
     ) -> JSON:
-        """Append an event with server-validated exact-scope coordinates."""
+        """Append an event with server-validated exact-scope coordinates.
+
+        Args:
+            role: Source role recorded on the event.
+            content: Already-distilled event content.
+            platform: Exact-scope platform coordinate.
+            server_id: Exact-scope server coordinate.
+            channel_id: Exact-scope channel coordinate.
+            thread_id: Optional exact-scope thread coordinate.
+            event_type: Event vocabulary value; must be in ``EVENT_TYPES``.
+            **metadata: Extra event metadata merged into the written row,
+                screened by the same ``_reject_reserved_metadata`` pass that
+                ``append_event`` already applies.
+
+        Returns:
+            The server's ``append_session_event`` result.
+
+        Raises:
+            ValueError: If ``event_type`` is outside ``EVENT_TYPES`` or
+                ``_reject_reserved_metadata`` refuses the metadata.
+        """
         self._require_session("append_scoped_event")
         if event_type not in EVENT_TYPES:
             raise ValueError(unsupported_event_type(event_type))
+        self._reject_reserved_metadata(metadata)
         key = idempotency_key()
         payload: dict[str, Any] = {
             "session_key": self.conversation_key,
@@ -624,7 +646,7 @@ class AgentMemory:
             "event_type": event_type,
             "content": content,
             "source": role,
-            "metadata": {"idempotency_key": key},
+            "metadata": {**dict(metadata), "idempotency_key": key},
         }
         if thread_id is not None:
             payload["thread_id"] = _required_str(thread_id, "thread_id")

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, cast
 
 from .agent import MemorySpool
@@ -21,8 +21,6 @@ from .runtime import (
 
 _LOGGER = logging.getLogger(__name__)
 
-MAX_IGNORED_OPTIONAL_KEY_COUNT = 65_535
-IGNORED_OPTIONAL_REQUEST_KEYS_NOTE = "ignored_optional_request_keys"
 # One admission size for EVERY operation.
 #
 # Until 2026-07-30 the distilled verbs -- capture, checkpoint, wrap -- were held
@@ -58,9 +56,20 @@ _OPERATION_SPECS = {
         "Load body-free reflex pointers for a query.",
         {"max_latency_ms", "max_tokens", "prior_context", "query"},
     ),
+    # The three lifecycle keys are the #445 promotion vocabulary. They were
+    # absent here until 2026-08-03, which meant a scripted promotion through
+    # this lane returned status:saved and wrote a row with none of the
+    # metadata that makes it promotable -- a false receipt (#464).
     "capture": (
         "Persist one distilled memory event.",
-        {"content", "distilled", "event_type"},
+        {
+            "candidate_scope",
+            "candidate_type",
+            "content",
+            "distilled",
+            "event_type",
+            "memory_lifecycle_action",
+        },
     ),
     # The raw lane carries no "distilled" key by design: it is the one verb
     # that ships the transcript rather than a summary of it.
@@ -114,10 +123,10 @@ def execute_json(
 ) -> dict[str, Any]:
     """Execute one bounded JSON lifecycle request and return JSON-ready output."""
     runtime: FirstClassMemoryRuntime | None = None
-    ignored_optional_key_count = 0
+    ignored_optional_keys: list[str] = []
     try:
         operation = _operation_text(payload)
-        projected, ignored_optional_key_count = _project_request(payload, operation)
+        projected, ignored_optional_keys = _project_request(payload, operation)
         if operation == "help":
             output = usage_output()
         else:
@@ -139,13 +148,13 @@ def execute_json(
             output = _dispatch(runtime, operation, projected).as_dict()
     except Exception as error:
         output = failure_output(_safe_operation(payload.get("operation")), error)
-    _attach_compatibility_receipt(output, ignored_optional_key_count)
+    _attach_compatibility_receipt(output, ignored_optional_keys)
     if runtime is not None:
         try:
             runtime.close()
         except Exception as error:
             output = failure_output("close", error)
-            _attach_compatibility_receipt(output, ignored_optional_key_count)
+            _attach_compatibility_receipt(output, ignored_optional_keys)
             return output
     return output
 
@@ -264,6 +273,12 @@ def _dispatch(
         return runtime.capture_distilled(
             _mapping_text(payload, "content"),
             event_type=_mapping_default_text(payload, "event_type", "fact"),
+            candidate_type=_mapping_optional_text(payload, "candidate_type"),
+            memory_lifecycle_action=_mapping_optional_text(
+                payload,
+                "memory_lifecycle_action",
+            ),
+            candidate_scope=_mapping_optional_object(payload, "candidate_scope"),
         )
     if operation == "ingest":
         # Deliberately NOT _require_distilled: this is the raw lane. Every
@@ -304,7 +319,7 @@ def _dispatch(
 def _project_request(
     payload: Mapping[str, Any],
     operation: str,
-) -> tuple[dict[str, Any], int]:
+) -> tuple[dict[str, Any], list[str]]:
     allowed = _OPERATION_KEYS.get(operation)
     if allowed is None:
         raise ValueError(
@@ -313,24 +328,31 @@ def _project_request(
         )
     known_keys = _COMMON_KEYS | allowed
     projected = {key: value for key, value in payload.items() if key in known_keys}
-    ignored_count = min(
-        sum(1 for key in payload if key not in known_keys),
-        MAX_IGNORED_OPTIONAL_KEY_COUNT,
-    )
-    return projected, ignored_count
+    ignored_keys = sorted(
+        _safe_text(str(key)) for key in payload if key not in known_keys
+    )[:MAX_IGNORED_OPTIONAL_KEY_COUNT]
+    return projected, ignored_keys
 
 
 def _attach_compatibility_receipt(
     output: dict[str, Any],
-    ignored_optional_key_count: int,
+    ignored_optional_keys: Sequence[str],
 ) -> None:
-    if ignored_optional_key_count <= 0:
+    """Record WHICH request keys were dropped, not just how many.
+
+    A bare count told a caller that something was ignored without saying what,
+    so a promotion whose lifecycle keys were dropped read as a successful write
+    with an unexplained note attached (#464). The names make the same receipt
+    diagnosable at the point of the write.
+    """
+    if not ignored_optional_keys:
         return
     receipt = output.get("receipt")
     if not isinstance(receipt, dict):
         return
     receipt["compatibility_note"] = IGNORED_OPTIONAL_REQUEST_KEYS_NOTE
-    receipt["ignored_optional_key_count"] = ignored_optional_key_count
+    receipt["ignored_optional_key_count"] = len(ignored_optional_keys)
+    receipt["ignored_optional_request_keys"] = list(ignored_optional_keys)
 
 
 def _require_distilled(payload: Mapping[str, Any], operation: str) -> None:
@@ -363,6 +385,24 @@ def _mapping_default_text(
     if name not in value:
         return default
     return _mapping_text(value, name)
+
+
+def _mapping_optional_text(value: Mapping[str, Any], name: str) -> str | None:
+    if value.get(name) is None:
+        return None
+    return _mapping_text(value, name)
+
+
+def _mapping_optional_object(
+    value: Mapping[str, Any],
+    name: str,
+) -> Mapping[str, Any] | None:
+    item = value.get(name)
+    if item is None:
+        return None
+    if not isinstance(item, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    return item
 
 
 def _mapping_optional_int(value: Mapping[str, Any], name: str) -> int | None:

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -73,7 +73,9 @@ from ._runtime_validation import (
     wrap_metadata as _validate_wrap_metadata,
 )
 from .agent import (
+    CANDIDATE_TYPES,
     EVENT_TYPES,
+    MEMORY_LIFECYCLE_ACTIONS,
     AgentMemory,
     MemoryClient,
     MemorySpool,
@@ -775,13 +777,41 @@ class FirstClassMemoryRuntime:
         content: str,
         *,
         event_type: str = "fact",
+        candidate_type: str | None = None,
+        memory_lifecycle_action: str | None = None,
+        candidate_scope: Mapping[str, Any] | None = None,
     ) -> RuntimeOutput:
-        """Capture one already-distilled event; raw transcript APIs are absent."""
+        """Capture one already-distilled event; raw transcript APIs are absent.
+
+        The three lifecycle arguments are the #445 promotion vocabulary. They
+        are OPTIONAL but never ignored: a value outside the shared vocabulary
+        fails the write by name rather than being dropped, because a capture
+        that reports ``saved`` while silently discarding the metadata canon
+        promotion keys off is the exact accept-and-ignore defect this lane
+        exists to prevent (#464).
+
+        Args:
+            content: Already-distilled event content.
+            event_type: Event vocabulary value; must be in ``EVENT_TYPES``.
+            candidate_type: Optional value from ``CANDIDATE_TYPES``.
+            memory_lifecycle_action: Optional value from
+                ``MEMORY_LIFECYCLE_ACTIONS``.
+            candidate_scope: Optional JSON object narrowing the candidate.
+
+        Returns:
+            The write receipt, with the lifecycle keys on the written event's
+            metadata when supplied.
+        """
         try:
             safe_content = _distilled_content(content, "content")
             safe_event_type = _require_text(event_type, "event_type")
             if safe_event_type not in EVENT_TYPES:
                 raise ValueError(unsupported_event_type(safe_event_type))
+            lifecycle = _lifecycle_metadata(
+                candidate_type=candidate_type,
+                memory_lifecycle_action=memory_lifecycle_action,
+                candidate_scope=candidate_scope,
+            )
         except ValueError as error:
             return _failed_write("capture", error)
         return self._write(
@@ -794,6 +824,7 @@ class FirstClassMemoryRuntime:
                 channel_id=self.scope.channel_id,
                 thread_id=self.scope.thread_id,
                 event_type=safe_event_type,
+                **lifecycle,
             ),
         )
 
@@ -1304,3 +1335,53 @@ def _wrap_metadata(
         receipt_refs,
         _reject_secret_payload,
     )
+
+
+def _lifecycle_metadata(
+    *,
+    candidate_type: str | None,
+    memory_lifecycle_action: str | None,
+    candidate_scope: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Validate the optional #445 promotion vocabulary for a capture.
+
+    The vocabularies are the SAME sets ``AgentMemory`` enforces on the client
+    library promotion path, imported rather than re-listed: two copies drift,
+    and a value this side accepts but the server's CHECK constraint refuses is
+    a silent no-row write.
+
+    Args:
+        candidate_type: Optional value from ``CANDIDATE_TYPES``.
+        memory_lifecycle_action: Optional value from
+            ``MEMORY_LIFECYCLE_ACTIONS``.
+        candidate_scope: Optional JSON object narrowing the candidate.
+
+    Returns:
+        The metadata keys to merge into the written event, empty when the
+        caller supplied none.
+
+    Raises:
+        ValueError: If any supplied value is outside its vocabulary, is not a
+            JSON object, or carries a secret value.
+    """
+    metadata: dict[str, Any] = {}
+    if candidate_type is not None:
+        safe_candidate_type = _require_text(candidate_type, "candidate_type")
+        if safe_candidate_type not in CANDIDATE_TYPES:
+            raise ValueError(f"Unsupported candidate_type: {safe_candidate_type}")
+        metadata["candidate_type"] = safe_candidate_type
+    if memory_lifecycle_action is not None:
+        safe_action = _require_text(
+            memory_lifecycle_action,
+            "memory_lifecycle_action",
+        )
+        if safe_action not in MEMORY_LIFECYCLE_ACTIONS:
+            raise ValueError(f"Unsupported memory_lifecycle_action: {safe_action}")
+        metadata["memory_lifecycle_action"] = safe_action
+    if candidate_scope is not None:
+        if not isinstance(candidate_scope, Mapping):
+            raise ValueError("candidate_scope must be a JSON object")
+        scope = dict(candidate_scope)
+        _reject_secret_payload(scope, "candidate_scope")
+        metadata["candidate_scope"] = scope
+    return metadata

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -404,6 +404,80 @@ def test_json_adapter_required_field_typo_still_fails_closed() -> None:
     assert tool_calls(transport) == []
 
 
+def test_json_capture_forwards_lifecycle_keys_to_event_metadata() -> None:
+    """The #445 promotion vocabulary must reach the written event (#464).
+
+    Before this landed, `candidate_type`, `memory_lifecycle_action`, and
+    `candidate_scope` were outside the capture key allowlist, so the projector
+    dropped them: the write returned `status:saved` and the row landed with no
+    promotable metadata. A scripted promotion through this lane got a receipt
+    that said it worked and seeded nothing.
+    """
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        request_payload(
+            "capture",
+            distilled=True,
+            content="Rico prefers the smallest correct change.",
+            candidate_type="user_preference",
+            memory_lifecycle_action="promote",
+            candidate_scope={"repo": "rodaddy/open-brain"},
+        ),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "saved"
+    # Accept-and-ignore leaves this note behind; honoring the keys must not.
+    assert "compatibility_note" not in output["receipt"]
+    event = tool_calls(transport)[-1]["params"]["arguments"]
+    assert event["metadata"]["candidate_type"] == "user_preference"
+    assert event["metadata"]["memory_lifecycle_action"] == "promote"
+    assert event["metadata"]["candidate_scope"] == {"repo": "rodaddy/open-brain"}
+
+
+def test_json_capture_rejects_lifecycle_value_outside_the_vocabulary() -> None:
+    """A bad lifecycle value fails by name rather than being dropped (#464)."""
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        request_payload(
+            "capture",
+            distilled=True,
+            content="Distilled candidate.",
+            candidate_type="not_a_candidate_type",
+        ),
+        transport=transport,
+    )
+
+    assert output["receipt"]["status"] == "failed"
+    assert output["receipt"]["error"] == (
+        "Unsupported candidate_type: not_a_candidate_type"
+    )
+    assert "append_session_event" not in json.dumps(tool_calls(transport))
+
+
+def test_json_receipt_names_the_ignored_request_keys() -> None:
+    """A dropped key is named in the receipt, not just counted (#464)."""
+    transport = LaneAwareTransport()
+
+    output = execute_json(
+        request_payload(
+            "capture",
+            distilled=True,
+            content="Distilled event.",
+            future_optional_field="must-never-be-forwarded",
+        ),
+        transport=transport,
+    )
+
+    assert output["receipt"]["compatibility_note"] == "ignored_optional_request_keys"
+    assert output["receipt"]["ignored_optional_request_keys"] == [
+        "future_optional_field"
+    ]
+    assert output["receipt"]["ignored_optional_key_count"] == 1
+
+
 def test_first_capture_establishes_lane_before_append() -> None:
     transport = LaneAwareTransport()
     runtime = FirstClassMemoryRuntime(


### PR DESCRIPTION
## Summary

- Closes #464. The provider JSON-stdin `capture` operation allowed only
  `content`/`distilled`/`event_type` (+`config`/`scope`). The #445 promotion
  vocabulary — `candidate_type`, `memory_lifecycle_action`, `candidate_scope` —
  fell outside that allowlist, so `_project_request` dropped it: the write
  returned `status:saved` and the row landed with none of the metadata that
  makes it promotable. A promotion scripted through the advertised durable-write
  path got a receipt saying it worked and seeded nothing.
- **Honored, not rejected**, per the issue's stated preference and because canon
  seeding through this lane is imminent. The chain had three gaps, each fixed at
  its owning boundary:
  - `cli.py` — the three keys are in the `capture` allowlist and are forwarded.
  - `runtime.capture_distilled` — validates them against the SAME
    `CANDIDATE_TYPES` and `MEMORY_LIFECYCLE_ACTIONS` sets `AgentMemory` uses,
    imported rather than re-listed (two copies drift; a value this side accepts
    but the server's CHECK constraint refuses is a silent no-row write). A value
    outside the vocabulary now fails BY NAME:
    `Unsupported candidate_type: not_a_candidate_type`.
  - `agent.append_scoped_event` — merged caller metadata into the written event
    instead of hardcoding `{"idempotency_key": key}`. This was the actual drop
    point: `append_event` (the client-library path the canon seeder used as its
    workaround) already merged metadata; its scoped sibling did not. Same
    `_reject_reserved_metadata` screening as `append_event`.
- **Receipt now names the keys.** `ignored_optional_request_keys` is added
  alongside the existing `compatibility_note` and `ignored_optional_key_count`.
  A bare count told a caller that something was ignored without saying what,
  which is unactionable at exactly the moment it matters. Forward tolerance for
  genuinely unknown future keys is unchanged.
- Drive-by: `cli.py` declared `MAX_IGNORED_OPTIONAL_KEY_COUNT` and
  `IGNORED_OPTIONAL_REQUEST_KEYS_NOTE` twice, identically (lines 24-25 and
  42-43). Removed the first pair.
- `docs/sme/gotcha-agent.md` gains the defect family entry (same family as #447
  / #515): an allowlist that drops unrecognized keys is accept-and-ignore, not
  tolerance.

### Red-proof (fix reverted via `git stash`, tests kept)

```
FAILED tests/test_runtime.py::test_json_capture_forwards_lifecycle_keys_to_event_metadata
FAILED tests/test_runtime.py::test_json_capture_rejects_lifecycle_value_outside_the_vocabulary
FAILED tests/test_runtime.py::test_json_receipt_names_the_ignored_request_keys
3 failed, 81 deselected in 0.09s
```

The first failure reproduces the reported defect exactly — a `saved` receipt
with the keys silently discarded:

```
>       assert "compatibility_note" not in output["receipt"]
E       AssertionError: assert 'compatibility_note' not in {'schema': 'openbrain.runtime_receipt.v1',
        'operation': 'capture', 'status': 'saved', 'durable': True, ...}
```

Fix restored (`git stash pop`) → `3 passed`.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

**Which suites actually ran:**

- `bunx tsc --noEmit` — clean, no output.
- `bun test` — 3060 pass, 0 fail, 506 skip, 3566 tests across 227 files.
  `OPENBRAIN_TEST_DATABASE_URL` was **unset**, so the Postgres-backed suites
  SKIPPED SILENTLY and did not run. Stating that plainly per the repo warning.
  This change is Python-only and touches no SQL, migration, or server code, so
  that gap does not cover this fix — but it is a gap, not a pass.
- `uv run mypy src/openbrain_memory` — `Success: no issues found in 17 source files`.
- `uv run ruff check src tests` — `All checks passed!`.
- `uv run pytest -q` — `553 passed, 9 skipped`. The 9 skips are pre-existing and
  env-gated: 4 × `OPENBRAIN_RUN_0_1_17_CLI_COMPAT` wheel-compat proof, 5 ×
  `OPENBRAIN_LIVE_CANARY` live canaries. None relate to this change.
- No live Open Brain smoke was run: the task scope forbids touching the running
  service or any deployed artifact.

## Critical Self-Review

- Highest-risk behavior: `append_scoped_event` now merges arbitrary caller metadata into the written event where it previously wrote a fixed dict, widening what can reach the durable row from this path. Mitigated by routing it through the identical `_reject_reserved_metadata` screening `append_event` already applies (protected keys, nested authority keys, JSON-serializability), and by the runtime layer admitting only three named, vocabulary-checked keys — the CLI cannot pass anything else through, because `_project_request` still drops unrecognized keys before dispatch.
- Assumptions that could be wrong: (1) That the server accepts these three metadata keys on `append_session_event` — verified from the client-library path, which already sends exactly this shape via `append_event`, and from `_plans/issues/445-*.md` / #443 which specify the row as `metadata.candidate_type` + `memory_lifecycle_action='promote'`. NOT verified against a live server in this change. (2) That honoring is preferred over rejecting — stated in the issue and in the task, but it is a contract widening and reviewers should confirm it is wanted now rather than after #445 lands.
- Missing/weak tests: No live/Postgres test proves the row actually persists with this metadata; the transport is the in-repo `LaneAwareTransport` fake, so what is proven is the outbound call shape, not the stored row. Given #464's own history — a write that reported success and stored nothing — that is the meaningful residual gap, and it is exactly what a live canary or an `OPENBRAIN_TEST_DATABASE_URL` run would close. `candidate_scope` nesting depth and secret-in-scope rejection ride on the existing `_reject_secret_payload` recursion and are not separately asserted here.
- Security/permission risk: Low but non-zero, and it is the reason the screening was reused rather than skipped. `candidate_scope` is a caller-supplied nested object that now reaches durable metadata; it is passed through `_reject_secret_payload` (which recurses mappings and sequences) and `_reject_reserved_metadata` (which refuses `PROTECTED_KEYS` including `namespace`, `token`, `authorization`, `role`). No namespace or authority field can be smuggled in through it. No SQL is constructed anywhere in this change.
- Migration/deploy risk: None. No schema, migration, or server change. The values written are drawn from vocabularies the existing `ob_session_events` CHECK constraint and the client library already use.
- Downstream client/runtime risk: Additive change to the `openbrain-memory` console contract — previously-valid requests behave identically and the new keys are optional. The one observable change for an existing caller is the extra `ignored_optional_request_keys` field on receipts that already carried `compatibility_note`; a consumer asserting on the exact receipt key set would see it. `ignored_optional_key_count` and `compatibility_note` are unchanged in name, type, and value.
- Rollback/cleanup concern: Single commit, no state to unwind, revert is clean. Nothing was written to a deployed artifact, the running service, or `local-clone.env`.
- Fixes made before PR: Reworded two docstrings that described reusing the existing metadata screening in cap/limit language; removed the duplicated constant pair rather than leaving a second copy to drift.
- Known residual risk: The end-to-end claim rests on a fake transport. Status is MERGED-pending, not RUNNING — nobody has driven a promotion through the installed console against a real database on this branch. The canon seeder should be re-pointed at the CLI path and its row read back before this is treated as the working promotion route.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the task
  scope explicitly forbids touching the running service or any deployed artifact;
  this change is client-package-only with no server or schema component.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is confined to the
  Python provider's JSON-stdin request projection and its own call into
  `append_session_event`. No MCP tool schema, server contract, or wire shape
  changes — the outbound `append_session_event` arguments use metadata keys the
  client library already sends today via `AgentMemory.append_event`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across all four: no MCP tool, schema, protocol, or server-facing
  contract changed. The `openbrain-memory` console gains three OPTIONAL request
  keys and one additional receipt field; every existing request and every
  existing receipt field keeps its current shape and meaning, so no downstream
  consumer must change to keep working.
- A downstream consumer that WANTS to script promotions through the console does
  need the newly-published package version — that is a capability rollout, not a
  compatibility break, and it belongs with whatever ships #445.
