### PR TITLE
refactor(server): content-ful Langfuse trace per MCP tool call, rebuilt on SDK v4 (#530)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,19 @@ OPEN_BRAIN_RUN_MIGRATIONS=1
 # Non-English keyword/hybrid FTS recomputes tsvectors on the fly and is not index-backed.
 # OPENBRAIN_FTS_CONFIG=german
 
+# Server call tracing to Langfuse (#530) -- CONTENT-FUL, off by default.
+# Every MCP tool call becomes one trace carrying full arguments and full
+# results. Requires ALL FOUR: the flag set to exactly "1" plus the three
+# coordinates, or the lane stays off and logs one content-free warn naming the
+# missing one. Keys come from the operator environment (Vaultwarden item
+# "Langfuse - Open Brain Local Dogfood") -- NEVER put values here.
+# Read once at startup, so changing these needs a service restart.
+# See docs/CONFIG_REFERENCE.md "Server call tracing (#530)".
+OPENBRAIN_TRACING_ENABLED=0
+OPENBRAIN_TRACING_ENDPOINT=
+OPENBRAIN_TRACING_PUBLIC_KEY=
+OPENBRAIN_TRACING_SECRET_KEY=
+
 # CORS allowed origins (comma-separated, empty for none)
 ALLOWED_ORIGINS=
 

--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ OPEN_BRAIN_RUN_MIGRATIONS=1
 # missing one. Keys come from the operator environment (Vaultwarden item
 # "Langfuse - Open Brain Local Dogfood") -- NEVER put values here.
 # Read once at startup, so changing these needs a service restart.
+# ENDPOINT is the Langfuse server ROOT (the SDK appends its own OTLP path),
+# not the /api/public/ingestion URL the #372 lane posts to.
+# If Langfuse goes down the brain is unaffected and that window's traces are
+# dropped -- one "suspended" warn on the way down, one "resumed" info with the
+# drop count on the way back, never one per call.
 # See docs/CONFIG_REFERENCE.md "Server call tracing (#530)".
 OPENBRAIN_TRACING_ENABLED=0
 OPENBRAIN_TRACING_ENDPOINT=

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,13 @@
     "": {
       "name": "open-brain",
       "dependencies": {
+        "@langfuse/otel": "^4.6.1",
+        "@langfuse/tracing": "^4.6.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.1",
         "cors": "^2.8.6",
         "express": "^5.2.1",
-        "langfuse": "^3.38.20",
         "nats": "^2.29.3",
         "pg": "^8.20.0",
         "pgvector": "^0.2.1",
@@ -30,9 +33,57 @@
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
+    "@langfuse/core": ["@langfuse/core@4.6.1", "", { "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-DtQoKWHQh0I0MsJxcKrBQVKAJ3fea6+raXlISVY3NDMFG/zSKkdkNouQvUXQtSCHBbOFupHMBw8imM30lbhq3g=="],
+
+    "@langfuse/otel": ["@langfuse/otel@4.6.1", "", { "dependencies": { "@langfuse/core": "^4.6.1" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0", "@opentelemetry/sdk-trace-base": "^2.0.1" } }, "sha512-ZUa+nV5und6IYK2b5w1vXoNzU/Hfpl1MJ2uu9Woyb74ZBQi36nBwo7SeX+NLvy+n/UzKcJMetOYrA5ywlXvnuA=="],
+
+    "@langfuse/tracing": ["@langfuse/tracing@4.6.1", "", { "dependencies": { "@langfuse/core": "^4.6.1" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-Ld1bPU6RxzifgGEDtN70Og8u2eL906jtnnEnt62BEOcML8UUiMgzwAKZDBbIjF2midnfac7Xnho3s546fcCDtQ=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.205.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.10.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.205.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/otlp-exporter-base": "0.205.0", "@opentelemetry/otlp-transformer": "0.205.0", "@opentelemetry/resources": "2.1.0", "@opentelemetry/sdk-trace-base": "2.1.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vr2bwwPCSc9u7rbKc74jR+DXFvyMFQo9o5zs+H/fgbK672Whw/1izUKVf+xfWOdJOvuwTnfWxy+VAY+4TSo74Q=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.205.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/otlp-transformer": "0.205.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-2MN0C1IiKyo34M6NZzD6P9Nv9Dfuz3OJ3rkZwzFmF6xzjDfqqCTatc9v1EpNfaP55iDOCLHFyYNCgs61FFgtUQ=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.205.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.205.0", "@opentelemetry/core": "2.1.0", "@opentelemetry/resources": "2.1.0", "@opentelemetry/sdk-logs": "0.205.0", "@opentelemetry/sdk-metrics": "2.1.0", "@opentelemetry/sdk-trace-base": "2.1.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.205.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.205.0", "@opentelemetry/core": "2.1.0", "@opentelemetry/resources": "2.1.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/resources": "2.1.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
@@ -164,9 +215,7 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
-    "langfuse": ["langfuse@3.38.20", "", { "dependencies": { "langfuse-core": "^3.38.20" } }, "sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA=="],
-
-    "langfuse-core": ["langfuse-core@3.38.20", "", { "dependencies": { "mustache": "^4.2.0" } }, "sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA=="],
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -179,8 +228,6 @@
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
 
@@ -241,6 +288,8 @@
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "process-warning": ["process-warning@5.1.0", "", {}, "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -311,6 +360,28 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.1.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/resources": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ=="],
+
+    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.1.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.1.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/resources": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.1.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@2.1.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.1.0", "", { "dependencies": { "@opentelemetry/core": "2.1.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "cors": "^2.8.6",
         "express": "^5.2.1",
+        "langfuse": "^3.38.20",
         "nats": "^2.29.3",
         "pg": "^8.20.0",
         "pgvector": "^0.2.1",
@@ -163,6 +164,10 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "langfuse": ["langfuse@3.38.20", "", { "dependencies": { "langfuse-core": "^3.38.20" } }, "sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA=="],
+
+    "langfuse-core": ["langfuse-core@3.38.20", "", { "dependencies": { "mustache": "^4.2.0" } }, "sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -174,6 +179,8 @@
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "open-brain",
       "dependencies": {
+        "@langfuse/core": "^4.6.1",
         "@langfuse/otel": "^4.6.1",
         "@langfuse/tracing": "^4.6.1",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@langfuse/tracing": "^4.6.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.10.0",
         "@opentelemetry/sdk-trace-base": "^2.0.1",
         "cors": "^2.8.6",
         "express": "^5.2.1",

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -309,12 +309,31 @@ is still visible, but on STATE CHANGE only:
 
 | line | level | when | payload |
 |---|---|---|---|
-| `mcp_tool_tracing_suspended` | warn | first failure after healthy | error label only |
-| `mcp_tool_tracing_resumed` | info | first success after an outage | `droppedTraces` for that window |
+| `mcp_tool_tracing_suspended` | warn | first failed background export after healthy | error label only |
+| `mcp_tool_tracing_resumed` | info | first export that reaches the endpoint again | `droppedTraces` for that window |
 
-Never one line per failed call. Measured under a blackholed endpoint: heap
-plateaus at 34-45 MB across 30,000 traced calls with no upward trend, and the
-enqueue stays off the request path (~7 µs per call).
+Never one line per failed call. Both edges are detected on the EXPORT, not on
+the tool call: handing a span to the batch queue succeeds whether or not
+anything is listening, so an outage is only knowable once the background export
+runs. The down edge comes from OTel's global error handler; the up edge from a
+health probe that runs only while the sink is already known-unhealthy and sends
+its own span, so a flush that merely found an empty queue cannot be mistaken for
+the endpoint coming back.
+
+Observed against a blackholed endpoint (500 traced calls, 2026-08-04):
+`mcp_tool_tracing_suspended` while the process was still running, then
+`mcp_tool_tracing_resumed` with `droppedTraces: 500` once a reachable endpoint
+answered — and no `resumed` line at all while the endpoint stayed unreachable.
+
+A flapping sink is bounded rather than chatty: after a reported recovery,
+another suspend/resume pair is withheld for 30 seconds, so a sink alternating
+fail/success reports one pair instead of one per flap (measured 10 pairs across
+20 alternating calls before this bound). A genuine outage arriving after a quiet
+period is never delayed.
+
+Measured under a blackholed endpoint: heap plateaus at 34-45 MB across 30,000
+traced calls with no upward trend, and the enqueue stays off the request path
+(~7 µs per call).
 
 The SDK's own logger is silenced when the sink is built. Left at its default it
 writes export failures to `console.error` with the raw error attached, which

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -292,6 +292,30 @@ storage against real traffic before enabling this anywhere it matters, and treat
 that Langfuse instance as holding the same content sensitivity as the brain
 itself.
 
+**SDK: Langfuse JS v4 (`@langfuse/tracing` + `@langfuse/otel`), OTel-based.**
+This matches the Python capture sink, which already runs on Python SDK v4, so
+both lanes speak one API family. The processor posts OTLP-HTTP to
+`${OPENBRAIN_TRACING_ENDPOINT}/api/public/otel/v1/traces`; give the bare server
+root, not the `/api/public/ingestion` path the #372 lane uses. Verified against
+the self-hosted server reporting `version 3.173.0`: server v3 and JS SDK v4 are
+separate version lines, and the server has carried the OTel ingestion route
+since v3.
+
+**Outage behaviour: the brain never waits, and the window is lost on purpose.**
+Langfuse being down must not stop or slow anything, so there is no disk spool
+and no replay — the Postgres audit log and the capture lane remain the system of
+record. Traces buffered when the endpoint is unreachable are dropped. The outage
+is still visible, but on STATE CHANGE only:
+
+| line | level | when | payload |
+|---|---|---|---|
+| `mcp_tool_tracing_suspended` | warn | first failure after healthy | error label only |
+| `mcp_tool_tracing_resumed` | info | first success after an outage | `droppedTraces` for that window |
+
+Never one line per failed call. Measured under a blackholed endpoint: heap
+plateaus at 34-45 MB across 30,000 traced calls with no upward trend, and the
+enqueue stays off the request path (~7 µs per call).
+
 ### Drop-folder collector
 
 `src/drop-folder-collector.ts` reads four scan bounds — `DROP_COLLECTOR_MAX_FILES`

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -249,6 +249,49 @@ stemmers split multibyte accented characters and every non-English FTS assertion
 | `OPENBRAIN_LOCAL_CLONE` | `0` | `.env.example:41` | |
 | `OPENBRAIN_LOCAL_CLONE_ROOT` | unset | `.env.example:42` | |
 
+### Server call tracing (#530) — TypeScript `server/`
+
+Read by `server/observability/langfuse-tracing.ts` (`readMcpTracingConfig`),
+installed in `server/main.ts` alongside the audit wrapper. Every MCP tool call
+served by the rewrite entrypoint becomes one **content-ful** Langfuse trace:
+tool name, caller identity, full arguments, full result (or error class and
+message), duration, and session grouping.
+
+**CONTENT-FUL is the point, and it is deliberate.** #530 explicitly supersedes
+#372's content-free spec for the local dogfood deployment. Payloads are sent
+verbatim: no redaction, no summarisation, no size bucketing. `OPENBRAIN_MCP_AUDIT_*`
+(above) remains the separate content-FREE durable Postgres record and is
+unchanged — the two lanes coexist and neither replaces the other.
+
+| variable | default | notes |
+|---|---|---|
+| `OPENBRAIN_TRACING_ENABLED` | unset (off) | tracing runs only when this is exactly `"1"` |
+| `OPENBRAIN_TRACING_ENDPOINT` | — | Langfuse base URL (the SDK appends its own paths) |
+| `OPENBRAIN_TRACING_PUBLIC_KEY` | — | Langfuse `pk-lf-...` |
+| `OPENBRAIN_TRACING_SECRET_KEY` | — | Langfuse `sk-lf-...` |
+
+**Off unless all four are set.** The flag alone is not enough: `enabled` is
+`true` only when the flag is `"1"` AND all three coordinates are non-empty. A
+flag set with an incomplete triple logs one content-free
+`mcp_tool_tracing_config_incomplete` warn naming which coordinate is missing
+(booleans only — no key value is ever logged or persisted) and then stays off,
+so a typo cannot silently produce a zero-trace deployment.
+
+**Deploy coupling:** the keys live in the operator environment, sourced from the
+Vaultwarden item `Langfuse - Open Brain Local Dogfood`; they are never committed
+and never given values in `.env.example`. The variables are read ONCE at process
+start — `startServer` builds a single shared client before any session can
+exist — so **turning tracing on or off requires a service restart**. Editing the
+environment under a running process changes nothing. A `mcp_tracing_configured`
+info line at startup reports whether the lane came up.
+
+**Payload volume is the operating cost to watch.** Every tool call ships its
+full arguments and full result. Large `search_brain` result sets and
+`agent_context_pack` payloads are the heaviest; size the Langfuse server's
+storage against real traffic before enabling this anywhere it matters, and treat
+that Langfuse instance as holding the same content sensitivity as the brain
+itself.
+
 ### Drop-folder collector
 
 `src/drop-folder-collector.ts` reads four scan bounds — `DROP_COLLECTOR_MAX_FILES`

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -316,6 +316,13 @@ Never one line per failed call. Measured under a blackholed endpoint: heap
 plateaus at 34-45 MB across 30,000 traced calls with no upward trend, and the
 enqueue stays off the request path (~7 µs per call).
 
+The SDK's own logger is silenced when the sink is built. Left at its default it
+writes export failures to `console.error` with the raw error attached, which
+would route a transport message — potentially carrying the endpoint or an auth
+header — around both this module's content-free discipline and the shared
+logger's redaction (measured: the injected key-shaped string appeared in the
+output). The two lines above are how this lane reports its health instead.
+
 ### Drop-folder collector
 
 `src/drop-folder-collector.ts` reads four scan bounds — `DROP_COLLECTOR_MAX_FILES`

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
+    "langfuse": "^3.38.20",
     "nats": "^2.29.3",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@langfuse/core": "^4.6.1",
     "@langfuse/otel": "^4.6.1",
     "@langfuse/tracing": "^4.6.1",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,13 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@langfuse/otel": "^4.6.1",
+    "@langfuse/tracing": "^4.6.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.0.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
-    "langfuse": "^3.38.20",
     "nats": "^2.29.3",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@langfuse/tracing": "^4.6.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.0.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",

--- a/server/main.ts
+++ b/server/main.ts
@@ -403,7 +403,22 @@ async function shutdown(
   // contract (#530: a tracing fault must never alter the outcome of anything),
   // so it deliberately does NOT participate in `firstFailure` — a dropped batch
   // of diagnostics must not make a clean drain exit non-zero.
-  await tracing.shutdown();
+  //
+  // Caught here as well as inside the lane because THIS line owning an
+  // unhandled rejection would skip `database.close()` below and leak the pool.
+  // The lane bounds its own drain against a deadline (measured: an unreachable
+  // Langfuse made an unbounded drain take 28.0 s, past launchd's 20 s
+  // `ExitTimeOut`, so the process was SIGKILLed mid-shutdown). Two layers,
+  // because the ordering here is what makes the database close reachable at
+  // all.
+  try {
+    await tracing.shutdown();
+  } catch (error: unknown) {
+    logger.error(
+      { error_category: error instanceof Error ? error.name : typeof error },
+      "tracing_shutdown_failed",
+    );
+  }
   try {
     await database.close();
   } catch (error: unknown) {

--- a/server/main.ts
+++ b/server/main.ts
@@ -57,6 +57,10 @@ import {
 import { runMigrations } from "./db/migrations.ts";
 import { createDatabase, type Database } from "./db/pool.ts";
 import { createLogger } from "./logging/logger.ts";
+import {
+  createTracingRuntime,
+  installMcpTracing,
+} from "./observability/langfuse-tracing.ts";
 import { RecoveryWalStore } from "./realtime/recovery-wal.ts";
 import { WorkingSetStore } from "./realtime/working-set.ts";
 import { registerMemoryTools } from "./tools/index.ts";
@@ -123,16 +127,25 @@ export interface StartServerOptions {
  * is installed is a tool whose calls are never audited. Ordering here is the
  * whole of the audit guarantee.
  *
+ * `installMcpTracing` (#530) is installed alongside it, under the same ordering
+ * rule and for the same reason. THE TWO ARE NOT ALTERNATIVES: audit is the
+ * content-FREE durable Postgres record and is on by default; tracing is the
+ * content-FUL Langfuse export and is off unless the operator configures it.
+ * Both wrap `registerTool`, so both see every call; `tracingSink` is undefined
+ * whenever tracing is off, which makes the install a no-op.
+ *
  * The realtime stores are built ONCE and captured, not per session: the working
  * set is the process's scratch for the active turn and the recovery WAL holds a
  * crashed session's trace, so rebuilding them per connection would make both
  * report a permanent and very convincing zero.
  */
-function createServerFactory(
-  pool: pg.Pool,
-  logger: Logger,
-  config: ServerConfig,
-): () => McpServer {
+function createServerFactory(input: {
+  pool: pg.Pool;
+  logger: Logger;
+  config: ServerConfig;
+  tracing: ReturnType<typeof createTracingRuntime>;
+}): () => McpServer {
+  const { pool, logger, config } = input;
   const realtime = {
     workingSetStore: new WorkingSetStore(),
     recoveryWalStore: new RecoveryWalStore({
@@ -143,6 +156,14 @@ function createServerFactory(
   return () => {
     const server = new McpServer({ name: "open-brain", version: "1.0.0" });
     installMcpAudit(server, { pool });
+    // `sink` undefined means tracing is off for this process; the install then
+    // never wraps `registerTool` and costs nothing.
+    if (input.tracing.sink) {
+      installMcpTracing(server, {
+        config: input.tracing.config,
+        sink: input.tracing.sink,
+      });
+    }
     registerMemoryTools(server, {
       pool,
       embedFn: generateEmbedding,
@@ -198,6 +219,13 @@ export async function startServer(
   }
 
   const database = createDatabase(config.database, logger);
+  // ONE tracing client for the process (#530), built before any session can
+  // exist and shared by every per-session MCP server. Off unless the operator
+  // set all four OPENBRAIN_TRACING_* variables; `createTracingRuntime` never
+  // throws, so a misconfigured or unreachable Langfuse can never keep the
+  // service from starting.
+  const tracing = createTracingRuntime();
+  logger.info({ enabled: tracing.sink !== undefined }, "mcp_tracing_configured");
   let application: ShadowApplication | undefined;
   try {
     if (options.runMigrations !== false) {
@@ -254,7 +282,12 @@ export async function startServer(
       database,
       authenticate,
       parseRequestBody: express.json({ limit: "1mb" }),
-      serverFactory: createServerFactory(database.pool, logger, config),
+      serverFactory: createServerFactory({
+        pool: database.pool,
+        logger,
+        config,
+        tracing,
+      }),
       // CORS and request logging run ahead of EVERY route, `/health` included:
       // an unauthenticated probe is still traffic, and a deployment that cannot
       // see its own health requests cannot tell a dead monitor from a healthy
@@ -311,7 +344,7 @@ export async function startServer(
       server,
       port: boundPort,
       logger,
-      shutdown: () => shutdown(composed, database, server, logger),
+      shutdown: () => shutdown(composed, database, server, logger, tracing),
     };
   } catch (error: unknown) {
     // A failure anywhere after the pool exists must not leak it. The
@@ -324,6 +357,9 @@ export async function startServer(
       // Already reported by closeInOrder's own logging; the startup failure is
       // the one the operator needs, so it wins.
     }
+    // The tracing client owns a background flush timer; leaving it running
+    // after a failed start keeps the process alive with nothing to serve.
+    await tracing.shutdown().catch(() => undefined);
     await database.close().catch(() => undefined);
     throw error;
   }
@@ -348,6 +384,7 @@ async function shutdown(
   database: Database<pg.Pool>,
   server: Server,
   logger: Logger,
+  tracing: ReturnType<typeof createTracingRuntime>,
 ): Promise<void> {
   logger.info({}, "server_shutdown_started");
   await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -361,6 +398,12 @@ async function shutdown(
       "application_close_failed",
     );
   }
+  // AFTER the MCP sessions are closed, so no further call can enqueue, and
+  // before the pool goes. `tracing.shutdown()` swallows its own failures by
+  // contract (#530: a tracing fault must never alter the outcome of anything),
+  // so it deliberately does NOT participate in `firstFailure` — a dropped batch
+  // of diagnostics must not make a clean drain exit non-zero.
+  await tracing.shutdown();
   try {
     await database.close();
   } catch (error: unknown) {

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -110,7 +110,17 @@ async function captureLogLines(run: () => Promise<void>): Promise<string[]> {
   const originalWarn = console.warn;
   const originalLog = console.log;
   const push = (...parts: unknown[]): void => {
-    lines.push(parts.map((part) => String(part)).join(" "));
+    // `String(err)` on an Error yields "Error: <message>", but the SDK logger
+    // hands the Error as its own argument, so the interesting text is in a
+    // later part rather than the first. Stringify every part, and reach into
+    // Error objects explicitly so a leaked message is actually visible here.
+    lines.push(
+      parts
+        .map((part) =>
+          part instanceof Error ? `${part.name}: ${part.message}` : String(part),
+        )
+        .join(" "),
+    );
   };
   console.warn = push;
   console.log = push;
@@ -667,6 +677,48 @@ describe("outage alerts fire on state change only", () => {
       const returned = await handlers.get("log_thought")?.({}, AUTH);
       expect(returned).toBe(result);
     });
+  });
+});
+
+/**
+ * The v3 review's MEDIUM finding, carried into v4: the SDK's own logger writes
+ * export failures straight to `console.error` with the raw error attached, so a
+ * transport message carrying the endpoint or an auth header would bypass this
+ * module's content-free discipline AND the shared logger's redaction.
+ *
+ * Measured before the fix: the SDK logger emitted 2 lines and the injected
+ * `sk-lf-` string appeared in them.
+ */
+describe("the SDK's own logger cannot bypass the content-free discipline", () => {
+  test("building the real sink silences SDK-level error and warn output", async () => {
+    const { configureGlobalLogger, getGlobalLogger, LogLevel } = await import(
+      "@langfuse/core"
+    );
+
+    // Asserted through the SDK's OWN level gate rather than by capturing
+    // `console.error`: Bun's runner installs its own console, so a swapped
+    // `console.error` does not reliably observe a library's writes from inside
+    // a test. `shouldLog` is the exact predicate that decides whether the SDK
+    // reaches the console at all, so checking it tests the real mechanism
+    // instead of a proxy for it.
+    type Gated = { shouldLog(level: number): boolean };
+
+    // Baseline asserted FIRST and explicitly, because the SDK logger is
+    // process-global: an earlier test that built a real sink has already
+    // installed the suppression, so "silent" would otherwise pass for the
+    // wrong reason.
+    configureGlobalLogger({ level: LogLevel.DEBUG });
+    expect((getGlobalLogger() as unknown as Gated).shouldLog(LogLevel.ERROR)).toBe(
+      true,
+    );
+
+    // Building the real sink installs the suppression. `createSink` is NOT
+    // injected here on purpose: the point is that the DEFAULT factory does it.
+    createTracingRuntime({ config: ENABLED_CONFIG });
+
+    const gated = getGlobalLogger() as unknown as Gated;
+    expect(gated.shouldLog(LogLevel.ERROR)).toBe(false);
+    expect(gated.shouldLog(LogLevel.WARN)).toBe(false);
   });
 });
 

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -483,7 +483,13 @@ describe("createTracingRuntime — the composition root's seam", () => {
       config: ENABLED_CONFIG,
       createSink: () => sink,
     });
-    expect(runtime.sink).toBe(sink);
+    // ONE sink for the process. The runtime hands back a health-carrying view
+    // of the sink it built rather than the bare object — the tracker has to
+    // hang off the shared sink or the shared path has no way to report an
+    // outage at all — so the assertion is that everything still lands in the
+    // same underlying sink, which `sink.bodies` below proves.
+    expect(runtime.sink).toBeDefined();
+    expect(runtime.sink?.health).toBeDefined();
 
     // Two sessions, as `createServerFactory` produces: each gets its own
     // McpServer but they must NOT each build a client.
@@ -583,23 +589,49 @@ describe("createTracingRuntime — the composition root's seam", () => {
  * that only checked `toBeDefined()` would pass against a per-call warn.
  */
 describe("outage alerts fire on state change only", () => {
-  test("the healthy path logs nothing at all", async () => {
-    const sink = recordingSink();
-    const { server, handlers } = fakeServer();
-    installMcpTracing(server, {
+  /**
+   * Wire tracing EXACTLY as `server/main.ts` does, and return the call handle.
+   *
+   * This helper is the point of this suite. The previous version of these tests
+   * installed with `createSink`, which made `installMcpTracing` build and own
+   * the sink — a branch production never takes, because `createServerFactory`
+   * always passes `sink:` from the process-wide runtime. Every alert assertion
+   * therefore passed against a code path no server ran, while the shared path
+   * silently discarded every failure (measured: zero lines across a 500-call
+   * outage). Driving `createTracingRuntime` -> `installMcpTracing({ sink })`
+   * means a regression in the production wiring fails these tests.
+   */
+  function wireLikeProduction(
+    sink: TracingSink,
+    healthOptions?: { cooldownMs?: number; now?: () => number },
+  ): () => Promise<void> {
+    const runtime = createTracingRuntime({
       config: ENABLED_CONFIG,
       createSink: () => sink,
+      ...(healthOptions === undefined ? {} : { healthOptions }),
+    });
+    const { server, handlers } = fakeServer();
+    // The `main.ts` shape: config plus the process's ONE shared sink.
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      sink: runtime.sink!,
     });
     server.registerTool(
       "log_thought",
       { inputSchema: {} } as never,
       (() => ({ ok: true })) as never,
     );
+    return async () => {
+      await handlers.get("log_thought")?.({}, AUTH);
+    };
+  }
+
+  test("the healthy path logs nothing at all", async () => {
+    const sink = recordingSink();
+    const call = wireLikeProduction(sink);
 
     const lines = await captureLogLines(async () => {
-      for (let i = 0; i < 5; i += 1) {
-        await handlers.get("log_thought")?.({ i }, AUTH);
-      }
+      for (let i = 0; i < 5; i += 1) await call();
     });
 
     expect(sink.bodies).toHaveLength(5);
@@ -608,21 +640,9 @@ describe("outage alerts fire on state change only", () => {
     );
   });
 
-  test("one suspend line for a whole outage, then one recovery line with the drop count", async () => {
+  test("the shared-sink path reports an outage — one suspend, one recovery with the drop count", async () => {
     const sink = flakySink();
-    const { server, handlers } = fakeServer();
-    installMcpTracing(server, {
-      config: ENABLED_CONFIG,
-      createSink: () => sink,
-    });
-    server.registerTool(
-      "log_thought",
-      { inputSchema: {} } as never,
-      (() => ({ ok: true })) as never,
-    );
-    const call = async (): Promise<void> => {
-      await handlers.get("log_thought")?.({}, AUTH);
-    };
+    const call = wireLikeProduction(sink);
 
     const lines = await captureLogLines(async () => {
       await call(); // healthy
@@ -639,7 +659,8 @@ describe("outage alerts fire on state change only", () => {
     const resumes = lines.filter((line) =>
       line.includes("mcp_tool_tracing_resumed"),
     );
-    // FOUR failed calls, ONE line. That ratio is the requirement.
+    // FOUR failed calls, ONE line. That ratio is the requirement — and this is
+    // now asserted through the shared sink, where it previously read zero.
     expect(suspends).toHaveLength(1);
     expect(resumes).toHaveLength(1);
     expect(resumes[0]).toContain('"droppedTraces":4');
@@ -648,8 +669,85 @@ describe("outage alerts fire on state change only", () => {
     expect(suspends[0]).not.toContain("sk-lf-leak");
   });
 
+  test("many sessions over one shared sink still report a single pair", async () => {
+    // The multiplication the per-install tracker would have caused if it had
+    // ever run on the shared path: N sessions must not mean N suspend lines.
+    const sink = flakySink();
+    const runtime = createTracingRuntime({
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const calls = [0, 1, 2].map(() => {
+      const { server, handlers } = fakeServer();
+      installMcpTracing(server, {
+        config: ENABLED_CONFIG,
+        sink: runtime.sink!,
+      });
+      server.registerTool(
+        "log_thought",
+        { inputSchema: {} } as never,
+        (() => ({ ok: true })) as never,
+      );
+      return async () => {
+        await handlers.get("log_thought")?.({}, AUTH);
+      };
+    });
+
+    const lines = await captureLogLines(async () => {
+      sink.down = true;
+      for (const call of calls) await call();
+      sink.down = false;
+      await calls[0]!();
+    });
+
+    expect(
+      lines.filter((line) => line.includes("mcp_tool_tracing_suspended")),
+    ).toHaveLength(1);
+    const resumes = lines.filter((line) =>
+      line.includes("mcp_tool_tracing_resumed"),
+    );
+    expect(resumes).toHaveLength(1);
+    // Three sessions' worth of drops counted into ONE window.
+    expect(resumes[0]).toContain('"droppedTraces":3');
+  });
+
+  /**
+   * Caught by the live blackholed probe, not by a test: traces enqueued BEFORE
+   * the outage was noticed were reported as `droppedTraces: 0`.
+   *
+   * The outage is discovered on the background export, seconds after the calls
+   * were made, so the whole in-flight batch was already handed over while the
+   * sink still looked healthy. Those are exactly the traces the operator lost.
+   */
+  test("traces enqueued before the failure was noticed still count as dropped", () => {
+    const tracker = new SinkHealthTracker({ cooldownMs: 0 });
+    // Five traces accepted while the sink still looked healthy.
+    for (let i = 0; i < 5; i += 1) tracker.recordEnqueued();
+    // The background export then reports the endpoint is gone. `false` because
+    // a failed BATCH is not itself one lost trace.
+    expect(tracker.recordFailure(false)).toBe(true);
+    // Two more arrive during the known outage.
+    tracker.recordEnqueued();
+    tracker.recordEnqueued();
+    // All seven, not two — and emphatically not zero.
+    expect(tracker.recordSuccess()).toBe(7);
+  });
+
+  test("a delivered flush clears the pending tally so a later outage is not inflated", () => {
+    const tracker = new SinkHealthTracker({ cooldownMs: 0 });
+    for (let i = 0; i < 4; i += 1) tracker.recordEnqueued();
+    // Those four reached the endpoint.
+    tracker.noteDelivered();
+    for (let i = 0; i < 3; i += 1) tracker.recordEnqueued();
+    expect(tracker.recordFailure(false)).toBe(true);
+    // Only the three that were still in flight, not the four already delivered.
+    expect(tracker.recordSuccess()).toBe(3);
+  });
+
   test("a second outage reports its own window, not a running total", () => {
-    const tracker = new SinkHealthTracker();
+    // Cooldown disabled: this asserts the counting rule, and a real clock would
+    // otherwise suppress the second pair as a flap.
+    const tracker = new SinkHealthTracker({ cooldownMs: 0 });
     expect(tracker.recordFailure()).toBe(true); // transition
     expect(tracker.recordFailure()).toBe(false); // already down — no line
     expect(tracker.recordSuccess()).toBe(2);
@@ -661,10 +759,14 @@ describe("outage alerts fire on state change only", () => {
 
   test("tool calls still return their own result verbatim throughout an outage", async () => {
     const sink = flakySink();
+    const runtime = createTracingRuntime({
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
     const { server, handlers } = fakeServer();
     installMcpTracing(server, {
       config: ENABLED_CONFIG,
-      createSink: () => sink,
+      sink: runtime.sink!,
     });
     const result = { content: [{ type: "text", text: "untouched" }] };
     server.registerTool(
@@ -677,6 +779,80 @@ describe("outage alerts fire on state change only", () => {
       const returned = await handlers.get("log_thought")?.({}, AUTH);
       expect(returned).toBe(result);
     });
+  });
+
+  /**
+   * The LOW finding from the adversarial review: state-change-only is not by
+   * itself a bound on output. A sink alternating fail/success changes state on
+   * every call, so 20 alternating calls MEASURED 10 suspend and 10 resume lines
+   * — per-call noise arriving through the rule meant to prevent it.
+   */
+  test("a flapping sink reports a bounded number of pairs, not one per flap", async () => {
+    const sink = flakySink();
+    // A clock the test drives, so the 30 s default is asserted without sleeping
+    // through it. Time advances 1 s per call: twenty alternating calls span
+    // 20 s, which is inside one cooldown.
+    let clock = 0;
+    const call = wireLikeProduction(sink, {
+      cooldownMs: 30_000,
+      now: () => clock,
+    });
+
+    const lines = await captureLogLines(async () => {
+      for (let i = 0; i < 20; i += 1) {
+        sink.down = i % 2 === 0;
+        await call();
+        clock += 1_000;
+      }
+    });
+
+    const suspends = lines.filter((line) =>
+      line.includes("mcp_tool_tracing_suspended"),
+    );
+    const resumes = lines.filter((line) =>
+      line.includes("mcp_tool_tracing_resumed"),
+    );
+    // Was 10/10 before the cooldown. The first transition is never delayed, so
+    // exactly one pair is the correct bound for a window this size.
+    expect(suspends).toHaveLength(1);
+    expect(resumes).toHaveLength(1);
+  });
+
+  test("the cooldown delays a flap's pair but never a real outage after quiet", async () => {
+    const sink = flakySink();
+    let clock = 0;
+    const call = wireLikeProduction(sink, {
+      cooldownMs: 30_000,
+      now: () => clock,
+    });
+
+    const lines = await captureLogLines(async () => {
+      // First outage: reported immediately.
+      sink.down = true;
+      await call();
+      sink.down = false;
+      await call();
+      // A flap 1 s later: suppressed, because a pair was just printed.
+      clock += 1_000;
+      sink.down = true;
+      await call();
+      sink.down = false;
+      await call();
+      // A genuine outage well past the cooldown: reported again.
+      clock += 31_000;
+      sink.down = true;
+      await call();
+      sink.down = false;
+      await call();
+    });
+
+    // Two pairs, not three: the middle flap is the one the cooldown eats.
+    expect(
+      lines.filter((line) => line.includes("mcp_tool_tracing_suspended")),
+    ).toHaveLength(2);
+    expect(
+      lines.filter((line) => line.includes("mcp_tool_tracing_resumed")),
+    ).toHaveLength(2);
   });
 });
 

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -19,7 +19,9 @@ import {
   installMcpTracing,
   readMcpTracingConfig,
   resolveSessionId,
+  SinkHealthTracker,
   type McpTracingConfig,
+  type TraceBody,
   type TracingSink,
 } from "./langfuse-tracing.ts";
 
@@ -30,29 +32,95 @@ const ENABLED_CONFIG: McpTracingConfig = {
   secretKey: "sk-lf-test",
 };
 
-/** A minimal stand-in for the SDK client that records what it was handed. */
-function recordingSink(): TracingSink & { bodies: Record<string, unknown>[] } {
-  const bodies: Record<string, unknown>[] = [];
+/** A minimal stand-in for the SDK sink that records what it was handed. */
+function recordingSink(): TracingSink & { bodies: TraceBody[] } {
+  const bodies: TraceBody[] = [];
   return {
     bodies,
-    trace(body) {
+    emit(body) {
       bodies.push(body);
-      return {};
     },
-    flushAsync: () => Promise.resolve(),
-    shutdownAsync: () => Promise.resolve(),
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  };
+}
+
+/**
+ * A sink whose drain NEVER settles — the real adversary for shutdown.
+ *
+ * This is what an unreachable endpoint produces: a promise that stays pending
+ * far past any supervisor's patience (the v3 lane was measured at 28.0 s,
+ * against launchd's 20 s `ExitTimeOut`). `throwingSink` cannot stand in for it,
+ * because rejecting instantly is the one thing a hung socket does not do — and
+ * no SDK timeout setting can be trusted to cover this, which is why the drain
+ * is raced rather than merely configured.
+ */
+function hangingSink(): TracingSink {
+  return {
+    emit: () => undefined,
+    forceFlush: () => new Promise<void>(() => {}),
+    shutdown: () => new Promise<void>(() => {}),
   };
 }
 
 /** A sink that fails on every method — the best-effort contract's adversary. */
 function throwingSink(): TracingSink {
   return {
-    trace() {
+    emit() {
       throw new Error("langfuse exploded with secret sk-lf-leak in the message");
     },
-    flushAsync: () => Promise.reject(new Error("flush exploded")),
-    shutdownAsync: () => Promise.reject(new Error("shutdown exploded")),
+    forceFlush: () => Promise.reject(new Error("flush exploded")),
+    shutdown: () => Promise.reject(new Error("shutdown exploded")),
   };
+}
+
+/**
+ * A sink that fails only while `down` is true — the outage simulator.
+ *
+ * The #530 alert contract is about TRANSITIONS, so the adversary has to be able
+ * to change state mid-run. A sink that always fails can only ever prove the
+ * suspend line; it can never prove that recovery reports the right drop count,
+ * or that the healthy path stays silent.
+ */
+function flakySink(): TracingSink & { down: boolean; bodies: TraceBody[] } {
+  const bodies: TraceBody[] = [];
+  return {
+    down: false,
+    bodies,
+    emit(body) {
+      if (this.down) throw new Error("connect ECONNREFUSED sk-lf-leak");
+      bodies.push(body);
+    },
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  };
+}
+
+/**
+ * Capture the console channels the shared logger actually writes to.
+ *
+ * `warn` goes to `console.warn` but `info` goes to `console.LOG`, not
+ * `console.info` (`src/logger.ts:536-544` — the final `else` branch). Hooking
+ * `console.info` captures nothing and lets the real line escape to stdout,
+ * which is exactly how the first draft of this helper produced a green
+ * "one suspend line" assertion against zero captured lines.
+ */
+async function captureLogLines(run: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  const push = (...parts: unknown[]): void => {
+    lines.push(parts.map((part) => String(part)).join(" "));
+  };
+  console.warn = push;
+  console.log = push;
+  try {
+    await run();
+  } finally {
+    console.warn = originalWarn;
+    console.log = originalLog;
+  }
+  return lines;
 }
 
 /**
@@ -228,7 +296,7 @@ describe("installMcpTracing", () => {
     await handlers.get("log_thought")?.(args, AUTH);
 
     expect(sink.bodies).toHaveLength(1);
-    const body = sink.bodies[0] as Record<string, unknown>;
+    const body = sink.bodies[0]!;
     expect(body.name).toBe("log_thought");
     // CONTENT-FUL is the requirement: the same objects, not a summary of them.
     expect(body.input).toBe(args);
@@ -239,6 +307,7 @@ describe("installMcpTracing", () => {
     expect(body.metadata).toMatchObject({
       caller_role: "admin",
       caller_client_id: "rico",
+      caller_token_client_id: "rico",
       caller_agent_id: "worker-530",
       namespace_source: "header",
       status: "success",
@@ -439,9 +508,210 @@ describe("createTracingRuntime — the composition root's seam", () => {
     });
     await expect(runtime.shutdown()).resolves.toBeUndefined();
   });
+
+  // The gap that let the 28-second shutdown through: the only adversary in
+  // this suite was `throwingSink`, which REJECTS instantly. A sink that never
+  // settles is the real Langfuse against an unreachable endpoint, and nothing
+  // exercised it.
+  test("a sink that never settles cannot hold shutdown open", async () => {
+    const runtime = createTracingRuntime({
+      config: ENABLED_CONFIG,
+      createSink: hangingSink,
+      shutdownTimeoutMs: 25,
+    });
+    const started = Date.now();
+    await expect(runtime.shutdown()).resolves.toBeUndefined();
+    // Generous upper bound: the assertion is "bounded", not a timing
+    // measurement. Unbounded, this never resolves and the test times out.
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  test("the bounded drain warns content-free on timeout", async () => {
+    const lines: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...parts: unknown[]): void => {
+      lines.push(parts.map((part) => String(part)).join(" "));
+    };
+    try {
+      const runtime = createTracingRuntime({
+        config: ENABLED_CONFIG,
+        createSink: hangingSink,
+        shutdownTimeoutMs: 25,
+      });
+      await runtime.shutdown();
+    } finally {
+      console.warn = originalWarn;
+    }
+    const warn = lines.find((line) =>
+      line.includes("mcp_tool_tracing_shutdown_timeout"),
+    );
+    expect(warn).toBeDefined();
+    // Content-free: the deadline itself, never a payload or a key.
+    expect(warn).toContain('"timeoutMs":25');
+    expect(warn).not.toContain("sk-lf");
+  });
+
+  test("a per-session install with a hanging own sink still drains bounded", async () => {
+    const { server } = fakeServer();
+    const handle = installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: hangingSink,
+      shutdownTimeoutMs: 25,
+    });
+    expect(handle.active).toBe(true);
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * The #530 outage contract: state-change alerts only.
+ *
+ * The operator's rule is that an outage must be visible but not noisy — "if you
+ * do that every time, you're going to spend most of your time saying hey hey
+ * this isn't working." So the assertions here are about COUNTS of log lines,
+ * not just their presence: "exactly one" is the whole requirement, and a test
+ * that only checked `toBeDefined()` would pass against a per-call warn.
+ */
+describe("outage alerts fire on state change only", () => {
+  test("the healthy path logs nothing at all", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "log_thought",
+      { inputSchema: {} } as never,
+      (() => ({ ok: true })) as never,
+    );
+
+    const lines = await captureLogLines(async () => {
+      for (let i = 0; i < 5; i += 1) {
+        await handlers.get("log_thought")?.({ i }, AUTH);
+      }
+    });
+
+    expect(sink.bodies).toHaveLength(5);
+    expect(lines.filter((line) => line.includes("mcp_tool_tracing"))).toEqual(
+      [],
+    );
+  });
+
+  test("one suspend line for a whole outage, then one recovery line with the drop count", async () => {
+    const sink = flakySink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "log_thought",
+      { inputSchema: {} } as never,
+      (() => ({ ok: true })) as never,
+    );
+    const call = async (): Promise<void> => {
+      await handlers.get("log_thought")?.({}, AUTH);
+    };
+
+    const lines = await captureLogLines(async () => {
+      await call(); // healthy
+      sink.down = true;
+      for (let i = 0; i < 4; i += 1) await call(); // the outage window
+      sink.down = false;
+      await call(); // recovery
+      await call(); // still healthy — must stay silent
+    });
+
+    const suspends = lines.filter((line) =>
+      line.includes("mcp_tool_tracing_suspended"),
+    );
+    const resumes = lines.filter((line) =>
+      line.includes("mcp_tool_tracing_resumed"),
+    );
+    // FOUR failed calls, ONE line. That ratio is the requirement.
+    expect(suspends).toHaveLength(1);
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0]).toContain('"droppedTraces":4');
+    // Content-free: the suspend line carries an error label, never the message
+    // the sink threw (which deliberately contains a key-shaped string).
+    expect(suspends[0]).not.toContain("sk-lf-leak");
+  });
+
+  test("a second outage reports its own window, not a running total", () => {
+    const tracker = new SinkHealthTracker();
+    expect(tracker.recordFailure()).toBe(true); // transition
+    expect(tracker.recordFailure()).toBe(false); // already down — no line
+    expect(tracker.recordSuccess()).toBe(2);
+    // Recovered: a success now is a no-op, so nothing is logged on the happy path.
+    expect(tracker.recordSuccess()).toBeUndefined();
+    expect(tracker.recordFailure()).toBe(true);
+    expect(tracker.recordSuccess()).toBe(1);
+  });
+
+  test("tool calls still return their own result verbatim throughout an outage", async () => {
+    const sink = flakySink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const result = { content: [{ type: "text", text: "untouched" }] };
+    server.registerTool(
+      "log_thought",
+      { inputSchema: {} } as never,
+      (() => result) as never,
+    );
+    sink.down = true;
+    await captureLogLines(async () => {
+      const returned = await handlers.get("log_thought")?.({}, AUTH);
+      expect(returned).toBe(result);
+    });
+  });
 });
 
 describe("trace body helpers", () => {
+  // The case the audit lane already records both ids for
+  // (`src/audit-log.ts:299-301`): a delegated call whose acting identity is not
+  // its token identity. With only `caller_client_id`, the content-ful lane an
+  // operator reads to answer "who actually did this" loses the distinction.
+  test("a delegated call records both the acting and the token identity", () => {
+    const body = buildToolTraceBody({
+      toolName: "log_thought",
+      status: "success",
+      durationMs: 1,
+      args: {},
+      output: {},
+      auth: {
+        role: "admin",
+        clientId: "acting-agent",
+        tokenClientId: "issuing-operator",
+        namespaceSource: "header",
+      } as never,
+    });
+    expect(body.metadata).toMatchObject({
+      caller_client_id: "acting-agent",
+      caller_token_client_id: "issuing-operator",
+    });
+    // `userId` stays the acting identity: it is the Langfuse grouping key, and
+    // the token identity travels alongside it rather than replacing it.
+    expect(body.userId).toBe("acting-agent");
+  });
+
+  test("a call with no auth records both identities as null, never undefined", () => {
+    const body = buildToolTraceBody({
+      toolName: "t",
+      status: "success",
+      durationMs: 1,
+      args: {},
+      output: {},
+    });
+    expect(body.metadata).toMatchObject({
+      caller_client_id: null,
+      caller_token_client_id: null,
+    });
+  });
+
   test("omits sessionId and userId rather than sending nulls", () => {
     const body = buildToolTraceBody({
       toolName: "t",

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Functional tests for the #530 content-ful tracing lane.
+ *
+ * The contract under test is the one the module states: every tool call emits
+ * one trace carrying VERBATIM input and output plus caller identity, and a
+ * tracing failure never fails, slows, or ALTERS a tool call. The second half is
+ * the one that matters operationally, so the sink that throws on every method
+ * is a first-class case here, not an afterthought.
+ *
+ * No SDK, no server, no socket: the client factory is injected, exactly the
+ * seam `McpAuditDeps.now` provides for the audit lane.
+ */
+import { describe, expect, test } from "bun:test";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  buildToolTraceBody,
+  createTracingRuntime,
+  errorOutput,
+  installMcpTracing,
+  readMcpTracingConfig,
+  resolveSessionId,
+  type McpTracingConfig,
+  type TracingSink,
+} from "./langfuse-tracing.ts";
+
+const ENABLED_CONFIG: McpTracingConfig = {
+  enabled: true,
+  endpoint: "http://10.71.20.50:3000",
+  publicKey: "pk-lf-test",
+  secretKey: "sk-lf-test",
+};
+
+/** A minimal stand-in for the SDK client that records what it was handed. */
+function recordingSink(): TracingSink & { bodies: Record<string, unknown>[] } {
+  const bodies: Record<string, unknown>[] = [];
+  return {
+    bodies,
+    trace(body) {
+      bodies.push(body);
+      return {};
+    },
+    flushAsync: () => Promise.resolve(),
+    shutdownAsync: () => Promise.resolve(),
+  };
+}
+
+/** A sink that fails on every method — the best-effort contract's adversary. */
+function throwingSink(): TracingSink {
+  return {
+    trace() {
+      throw new Error("langfuse exploded with secret sk-lf-leak in the message");
+    },
+    flushAsync: () => Promise.reject(new Error("flush exploded")),
+    shutdownAsync: () => Promise.reject(new Error("shutdown exploded")),
+  };
+}
+
+/**
+ * A fake `McpServer` exposing only `registerTool`, plus the handler capture the
+ * assertions need. Structural, because the real class needs a transport.
+ */
+function fakeServer(): {
+  server: McpServer;
+  handlers: Map<string, (args: unknown, extra: unknown) => unknown>;
+  originalRegisterTool: unknown;
+} {
+  const handlers = new Map<string, (args: unknown, extra: unknown) => unknown>();
+  const registerTool = (name: string, _config: unknown, cb: unknown): void => {
+    handlers.set(name, cb as (args: unknown, extra: unknown) => unknown);
+  };
+  const server = { registerTool } as unknown as McpServer;
+  return { server, handlers, originalRegisterTool: registerTool };
+}
+
+const AUTH = {
+  authInfo: {
+    role: "admin" as const,
+    clientId: "rico",
+    tokenClientId: "rico",
+    agentId: "worker-530",
+    namespaceSource: "header" as const,
+  },
+};
+
+describe("readMcpTracingConfig", () => {
+  test("is disabled with no environment at all", () => {
+    expect(readMcpTracingConfig({}).enabled).toBe(false);
+  });
+
+  test("is disabled when the coordinates are present but the flag is not set", () => {
+    const config = readMcpTracingConfig({
+      OPENBRAIN_TRACING_ENDPOINT: "http://host:3000",
+      OPENBRAIN_TRACING_PUBLIC_KEY: "pk",
+      OPENBRAIN_TRACING_SECRET_KEY: "sk",
+    });
+    expect(config.enabled).toBe(false);
+  });
+
+  test("is disabled when the flag is set but a coordinate is missing", () => {
+    const config = readMcpTracingConfig({
+      OPENBRAIN_TRACING_ENABLED: "1",
+      OPENBRAIN_TRACING_ENDPOINT: "http://host:3000",
+      OPENBRAIN_TRACING_PUBLIC_KEY: "pk",
+    });
+    expect(config.enabled).toBe(false);
+    expect(config.secretKey).toBe("");
+  });
+
+  test("a whitespace-only coordinate counts as missing, not present", () => {
+    expect(
+      readMcpTracingConfig({
+        OPENBRAIN_TRACING_ENABLED: "1",
+        OPENBRAIN_TRACING_ENDPOINT: "  ",
+        OPENBRAIN_TRACING_PUBLIC_KEY: "pk",
+        OPENBRAIN_TRACING_SECRET_KEY: "sk",
+      }).enabled,
+    ).toBe(false);
+  });
+
+  test("the incomplete-flag warn is emitted, readable, and carries no key value", () => {
+    const lines: string[] = [];
+    // The shared logger emits warn lines through `console.warn` (src/logger.ts
+    // :539). Captured, not mocked away, so the assertion sees the output of the
+    // REAL redaction pass — which is the whole point of the test. Restored in a
+    // `finally` because Bun runs every test file in one process.
+    const originalWarn = console.warn;
+    console.warn = (...parts: unknown[]): void => {
+      lines.push(parts.map((part) => String(part)).join(" "));
+    };
+    try {
+      readMcpTracingConfig({
+        OPENBRAIN_TRACING_ENABLED: "1",
+        OPENBRAIN_TRACING_ENDPOINT: "http://host:3000",
+        OPENBRAIN_TRACING_PUBLIC_KEY: "pk-lf-visible",
+        OPENBRAIN_TRACING_SECRET_KEY: "",
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const warn = lines.find((line) =>
+      line.includes("mcp_tool_tracing_config_incomplete"),
+    );
+    expect(warn).toBeDefined();
+    // The whole point of the line: it names which coordinate is missing. A
+    // field the logger redacts would report "[REDACTED]" and say nothing.
+    expect(warn).toContain('"privateIdSet":false');
+    expect(warn).toContain('"publicIdSet":true');
+    expect(warn).not.toContain("REDACTED");
+    expect(warn).not.toContain("pk-lf-visible");
+  });
+
+  test("only the exact flag value enables it", () => {
+    expect(
+      readMcpTracingConfig({
+        OPENBRAIN_TRACING_ENABLED: "true",
+        OPENBRAIN_TRACING_ENDPOINT: "http://host:3000",
+        OPENBRAIN_TRACING_PUBLIC_KEY: "pk",
+        OPENBRAIN_TRACING_SECRET_KEY: "sk",
+      }).enabled,
+    ).toBe(false);
+  });
+
+  test("enables with the flag and all three coordinates", () => {
+    expect(
+      readMcpTracingConfig({
+        OPENBRAIN_TRACING_ENABLED: "1",
+        OPENBRAIN_TRACING_ENDPOINT: "http://host:3000",
+        OPENBRAIN_TRACING_PUBLIC_KEY: "pk-lf-1",
+        OPENBRAIN_TRACING_SECRET_KEY: "sk-lf-1",
+      }),
+    ).toEqual({
+      enabled: true,
+      endpoint: "http://host:3000",
+      publicKey: "pk-lf-1",
+      secretKey: "sk-lf-1",
+    });
+  });
+});
+
+describe("resolveSessionId", () => {
+  test("prefers a top-level session_key", () => {
+    expect(
+      resolveSessionId({ session_key: "sess-a" }, { sessionId: "transport-b" }),
+    ).toBe("sess-a");
+  });
+
+  test("falls back to scope.session_key", () => {
+    expect(
+      resolveSessionId(
+        { scope: { session_key: "sess-scoped" } },
+        { sessionId: "transport-b" },
+      ),
+    ).toBe("sess-scoped");
+  });
+
+  test("falls back to the transport sessionId", () => {
+    expect(resolveSessionId({ content: "x" }, { sessionId: "transport-b" })).toBe(
+      "transport-b",
+    );
+  });
+
+  test("is undefined when neither exists", () => {
+    expect(resolveSessionId({ content: "x" }, {})).toBeUndefined();
+  });
+});
+
+describe("installMcpTracing", () => {
+  test("records one trace per call with verbatim input, output and caller identity", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+
+    const result = { content: [{ type: "text", text: "the full answer body" }] };
+    server.registerTool(
+      "log_thought",
+      { inputSchema: {} } as never,
+      (() => result) as never,
+    );
+
+    const args = {
+      content: "the full prompt body, verbatim",
+      session_key: "sess-530",
+    };
+    await handlers.get("log_thought")?.(args, AUTH);
+
+    expect(sink.bodies).toHaveLength(1);
+    const body = sink.bodies[0] as Record<string, unknown>;
+    expect(body.name).toBe("log_thought");
+    // CONTENT-FUL is the requirement: the same objects, not a summary of them.
+    expect(body.input).toBe(args);
+    expect(body.output).toBe(result);
+    expect(body.sessionId).toBe("sess-530");
+    expect(body.userId).toBe("rico");
+    expect(body.tags).toEqual(["open-brain-server", "mcp-tool"]);
+    expect(body.metadata).toMatchObject({
+      caller_role: "admin",
+      caller_client_id: "rico",
+      caller_agent_id: "worker-530",
+      namespace_source: "header",
+      status: "success",
+    });
+    expect(
+      (body.metadata as { duration_ms: number }).duration_ms,
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  test("an isError result is traced as status error, not success", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "search_memory",
+      { inputSchema: {} } as never,
+      (() => ({ isError: true, content: [] })) as never,
+    );
+
+    await handlers.get("search_memory")?.({ query: "x" }, AUTH);
+
+    expect(
+      (sink.bodies[0]?.metadata as { status: string }).status,
+    ).toBe("error");
+  });
+
+  test("a sink that throws on every method leaves the result byte-identical and never throws", async () => {
+    const { server, handlers } = fakeServer();
+    const handle = installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: throwingSink,
+    });
+
+    const result = { content: [{ type: "text", text: "untouched" }] };
+    server.registerTool(
+      "log_thought",
+      { inputSchema: {} } as never,
+      (() => result) as never,
+    );
+
+    const returned = await handlers.get("log_thought")?.({ a: 1 }, AUTH);
+    // Identity, not deep equality: the wrapper must return the tool's own
+    // object, not a copy of it.
+    expect(returned).toBe(result);
+    expect(JSON.stringify(returned)).toBe(JSON.stringify(result));
+    // Shutdown swallows its own failures too, or a tracing fault would make a
+    // clean drain read as a dirty one.
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+  });
+
+  test("a handler exception still propagates, traced as status exception with the error class", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+
+    class NamespaceViolationError extends Error {
+      override name = "NamespaceViolationError";
+    }
+    server.registerTool(
+      "get_entity",
+      { inputSchema: {} } as never,
+      (() => {
+        throw new NamespaceViolationError("entity 7 is not in namespace rico");
+      }) as never,
+    );
+
+    await expect(
+      handlers.get("get_entity")?.({ id: "7" }, AUTH),
+    ).rejects.toThrow("entity 7 is not in namespace rico");
+
+    expect(sink.bodies).toHaveLength(1);
+    expect(
+      (sink.bodies[0]?.metadata as { status: string }).status,
+    ).toBe("exception");
+    expect(sink.bodies[0]?.output).toEqual({
+      error_class: "NamespaceViolationError",
+      error_message: "entity 7 is not in namespace rico",
+    });
+  });
+
+  test("disabled config leaves registerTool untouched — no wrapper at all", async () => {
+    const sink = recordingSink();
+    const { server, originalRegisterTool } = fakeServer();
+    const handle = installMcpTracing(server, {
+      config: { ...ENABLED_CONFIG, enabled: false },
+      createSink: () => sink,
+    });
+
+    expect(server.registerTool as unknown).toBe(originalRegisterTool);
+    expect(handle.active).toBe(false);
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+    expect(sink.bodies).toHaveLength(0);
+  });
+
+  test("installing twice wraps once", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "log_thought",
+      { inputSchema: {} } as never,
+      (() => ({ ok: true })) as never,
+    );
+    await handlers.get("log_thought")?.({}, AUTH);
+    expect(sink.bodies).toHaveLength(1);
+  });
+
+  test("a sink factory that throws degrades to no tracing instead of failing install", () => {
+    const { server, originalRegisterTool } = fakeServer();
+    const handle = installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => {
+        throw new Error("bad base url");
+      },
+    });
+    expect(handle.active).toBe(false);
+    expect(server.registerTool as unknown).toBe(originalRegisterTool);
+  });
+
+  test("a non-function third argument passes through unwrapped", () => {
+    const sink = recordingSink();
+    const { server } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    expect(() =>
+      (server.registerTool as unknown as (...a: unknown[]) => unknown)(
+        "odd_tool",
+        { inputSchema: {} },
+        undefined,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("createTracingRuntime — the composition root's seam", () => {
+  test("disabled config yields no sink and a no-op shutdown", async () => {
+    const runtime = createTracingRuntime({
+      config: { ...ENABLED_CONFIG, enabled: false },
+      createSink: recordingSink,
+    });
+    expect(runtime.sink).toBeUndefined();
+    await expect(runtime.shutdown()).resolves.toBeUndefined();
+  });
+
+  test("one shared sink serves many per-session servers and drains once", async () => {
+    const sink = recordingSink();
+    const runtime = createTracingRuntime({
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    expect(runtime.sink).toBe(sink);
+
+    // Two sessions, as `createServerFactory` produces: each gets its own
+    // McpServer but they must NOT each build a client.
+    const built = [fakeServer(), fakeServer()];
+    for (const { server } of built) {
+      const handle = installMcpTracing(server, {
+        config: ENABLED_CONFIG,
+        sink: runtime.sink!,
+      });
+      expect(handle.active).toBe(true);
+      // A per-session handle must not drain a sink it does not own, or the
+      // first session to close would flush and shut down tracing for the rest.
+      await handle.shutdown();
+      server.registerTool(
+        "log_thought",
+        { inputSchema: {} } as never,
+        (() => ({ ok: true })) as never,
+      );
+    }
+    for (const { handlers } of built) {
+      await handlers.get("log_thought")?.({}, AUTH);
+    }
+    // Still recording after both per-session shutdowns: proof the sink survived.
+    expect(sink.bodies).toHaveLength(2);
+    await expect(runtime.shutdown()).resolves.toBeUndefined();
+  });
+
+  test("a sink whose flush and shutdown both reject still resolves", async () => {
+    const runtime = createTracingRuntime({
+      config: ENABLED_CONFIG,
+      createSink: throwingSink,
+    });
+    await expect(runtime.shutdown()).resolves.toBeUndefined();
+  });
+});
+
+describe("trace body helpers", () => {
+  test("omits sessionId and userId rather than sending nulls", () => {
+    const body = buildToolTraceBody({
+      toolName: "t",
+      status: "success",
+      durationMs: 4.6,
+      args: {},
+      output: {},
+    });
+    expect("sessionId" in body).toBe(false);
+    expect("userId" in body).toBe(false);
+    expect((body.metadata as { duration_ms: number }).duration_ms).toBe(5);
+  });
+
+  test("a non-finite duration records as zero, never NaN", () => {
+    const body = buildToolTraceBody({
+      toolName: "t",
+      status: "success",
+      durationMs: Number.NaN,
+      args: {},
+      output: {},
+    });
+    expect((body.metadata as { duration_ms: number }).duration_ms).toBe(0);
+  });
+
+  test("errorOutput names the class for non-Error throws too", () => {
+    expect(errorOutput("plain string")).toEqual({
+      error_class: "string",
+      error_message: "plain string",
+    });
+  });
+});

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -14,6 +14,29 @@
  * and persists nothing locally. Neither replaces the other; both wrappers are
  * installed on the same `McpServer` in `server/main.ts`.
  *
+ * SDK v4 (OTel-based), per the operator decision recorded on #530 on
+ * 2026-08-03. This lane previously shipped on the `langfuse` v3 package, which
+ * is a bespoke queue plus HTTP client; both failures review measured — an
+ * unbounded shutdown drain and unbounded memory growth while the endpoint was
+ * down — are properties of that queue. v4 is an OpenTelemetry `SpanProcessor`
+ * instead: the queue is `BatchSpanProcessor`'s, which drops rather than growing
+ * once it is full, and the drain is `forceFlush()`/`shutdown()` with a real
+ * timeout knob. The Python capture sink
+ * (`python/openbrain/src/openbrain/apps/capture/langfuse_emitter.py`) already
+ * runs on Python SDK v4, so both lanes now speak one API family —
+ * `startObservation` and trace attributes, rather than v3's `trace()` body.
+ *
+ * SERVER COMPATIBILITY IS AT THE INGESTION LAYER, and it is verified rather
+ * than assumed. The v4 processor POSTs OTLP-HTTP to
+ * `${baseUrl}/api/public/otel/v1/traces`. Against the self-hosted server,
+ * `/api/public/health` reports `{"status":"OK","version":"3.173.0"}`; that OTLP
+ * path answers 401 unauthenticated while a sibling bogus path answers 404, so
+ * the route exists and is auth-gated; and an authenticated probe span sent
+ * through this exact SDK came back from `/api/public/traces` with its name,
+ * `userId`, `sessionId`, tags, and one observation intact. Langfuse server v3
+ * and JS SDK v4 are separate version lines, not a mismatch: the server has
+ * carried the OTel ingestion route since v3.
+ *
  * THE SEAM IS DELIBERATELY THE SAME SHAPE AS `installMcpAudit`
  * (`src/audit-log.ts:309-408`): wrap `server.registerTool`, so every tool
  * handler is instrumented by construction rather than by 65 call sites
@@ -29,8 +52,23 @@
  * message, so a transport error string can never smuggle payload or key text
  * into the local logs). The tool's own result object is returned by identity,
  * untouched.
+ *
+ * OUTAGE BEHAVIOUR IS STATE-CHANGE-ONLY, in the operator's words on #530:
+ * Langfuse is "an extremely super important, nice to have. It shouldn't stop
+ * things from running, but it should continue loudly." Losing an outage
+ * window's traces is ACCEPTED — there is no disk spool and no replay lane, and
+ * Postgres audit plus capture remain the system of record. What an outage must
+ * not be is silent. So exactly two lines are emitted per outage: one when the
+ * sink transitions to unreachable, one when it recovers, carrying the count
+ * dropped during that window. Never per call — "if you do that every time,
+ * you're going to spend most of your time saying hey hey this isn't working."
  */
-import { Langfuse } from "langfuse";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import {
+  setLangfuseTracerProvider,
+  startObservation,
+} from "@langfuse/tracing";
+import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AuthInfo } from "../../src/types.ts";
 import { logger } from "../../src/logger.ts";
@@ -42,6 +80,28 @@ const tracingInstalledServers = new WeakSet<McpServer>();
 
 export type McpTraceStatus = "success" | "error" | "exception";
 
+/**
+ * Deadline for the whole drain on the way down.
+ *
+ * Belt AND braces, because each alone has been observed to fail. The processor
+ * is handed an export timeout so the SDK bounds its own HTTP attempt, and the
+ * awaited drain is ALSO raced against this deadline — a promise that never
+ * settles ignores every config knob, which is exactly what the v3 lane did
+ * (measured 28.0 s against an unreachable endpoint with one queued event).
+ * launchd's default `ExitTimeOut` is 20 s, so an unbounded await turns a clean
+ * drain into SIGKILL and takes `database.close()` with it. 2.5 s sits well
+ * inside that and far above a reachable server's millisecond flush.
+ */
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2500;
+
+/**
+ * Export timeout handed to the processor, in SECONDS — the SDK's unit for
+ * `LangfuseSpanProcessorParams.timeout`, which it documents as seconds with a
+ * default of 5. Kept below the shutdown deadline above so the SDK's own attempt
+ * gives up first and the race stays a backstop rather than the normal path.
+ */
+const SINK_EXPORT_TIMEOUT_SECONDS = 2;
+
 export interface McpTracingConfig {
   enabled: boolean;
   endpoint: string;
@@ -49,39 +109,58 @@ export interface McpTracingConfig {
   secretKey: string;
 }
 
+/** The content-ful trace payload for one tool call. */
+export interface TraceBody {
+  name: string;
+  input: unknown;
+  output: unknown;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  sessionId?: string;
+  userId?: string;
+}
+
 /**
- * The minimum of the Langfuse client surface this module uses.
+ * The minimum of the tracing surface this module uses.
  *
- * Declared structurally rather than importing the SDK's class type so a test
- * can inject a fake sink without constructing a real client (and so a future
- * SDK-major swap is a one-file change). The real `langfuse` v3 `Langfuse`
- * class satisfies it.
+ * Declared structurally rather than importing the SDK's classes so a test can
+ * inject a fake sink without a provider, a socket, or OTel global state (and so
+ * a future SDK-major swap stays a one-file change). `emit` is the whole
+ * request-path contract: hand it a built trace body, it returns nothing, and it
+ * must not block.
  */
 export interface TracingSink {
-  trace(body: Record<string, unknown>): unknown;
-  flushAsync(): Promise<void>;
-  shutdownAsync(): Promise<void>;
+  emit(body: TraceBody): void;
+  forceFlush(): Promise<void>;
+  shutdown(): Promise<void>;
 }
 
 export interface McpTracingDeps {
   config?: McpTracingConfig;
   /**
-   * An already-built client to share.
+   * An already-built sink to share.
    *
-   * The composition root builds ONE client for the process and passes it to
-   * every per-session install: the SDK client owns a background flush timer and
-   * an in-memory queue, so one per MCP session would multiply both by the
-   * session count and leave each with its own unflushed tail at shutdown. When
-   * this is set the install never constructs anything, and `shutdown()` is a
-   * no-op because the OWNER of a shared sink drains it (see `startServer`).
+   * The composition root builds ONE sink for the process and passes it to
+   * every per-session install: the sink owns a background flush timer and a
+   * bounded queue, so one per MCP session would multiply both by the session
+   * count and leave each with its own unflushed tail at shutdown. When this is
+   * set the install never constructs anything, and `shutdown()` is a no-op
+   * because the OWNER of a shared sink drains it (see `startServer`).
    */
   sink?: TracingSink;
   /**
-   * Client factory, used only when `sink` is absent. Injectable for the same
+   * Sink factory, used only when `sink` is absent. Injectable for the same
    * reason `McpAuditDeps.now` is: the tests need a deterministic seam that
    * never opens a socket.
    */
   createSink?: (config: McpTracingConfig) => TracingSink;
+  /**
+   * Deadline for the shutdown drain, in milliseconds.
+   *
+   * Injectable so a test can prove the bound holds against a sink that never
+   * resolves without waiting the real deadline for it.
+   */
+  shutdownTimeoutMs?: number;
 }
 
 /** Shutdown handle returned by `installMcpTracing`, wired into the stop path. */
@@ -183,7 +262,7 @@ export function buildToolTraceBody(input: {
   output: unknown;
   auth?: AuthInfo;
   sessionId?: string;
-}): Record<string, unknown> {
+}): TraceBody {
   return {
     name: input.toolName,
     input: input.args,
@@ -192,6 +271,13 @@ export function buildToolTraceBody(input: {
     metadata: {
       caller_role: input.auth?.role ?? null,
       caller_client_id: input.auth?.clientId ?? null,
+      // The audit lane records BOTH ids (`src/audit-log.ts:299-301`), and the
+      // pair is the whole answer to "who actually did this" when a delegated
+      // call's `clientId` differs from its token-derived identity. The
+      // content-ful lane is the one an operator reads for that question, so
+      // dropping the token id here would make the two lanes disagree in
+      // exactly the case a security review cares about.
+      caller_token_client_id: input.auth?.tokenClientId ?? null,
       caller_agent_id: input.auth?.agentId ?? null,
       namespace_source: input.auth?.namespaceSource ?? null,
       duration_ms: Number.isFinite(input.durationMs)
@@ -228,6 +314,77 @@ function errorClassOf(err: unknown): string {
 }
 
 /**
+ * Outage state for one sink, and the only thing that decides whether a line
+ * is logged.
+ *
+ * The #530 rule is state-change-only, so this tracker's whole job is to turn a
+ * stream of per-call outcomes into at most two lines per outage. `healthy` is
+ * the edge detector; `dropped` counts the window and resets on recovery, so
+ * each recovery line reports ITS window rather than a running total.
+ *
+ * Exported because the tests assert the counting rule directly, without
+ * needing a real outage to produce it.
+ */
+export class SinkHealthTracker {
+  private healthy = true;
+  private dropped = 0;
+
+  /**
+   * Record a failed emit or export. Returns true ONLY on the transition into
+   * an outage, so the caller logs the suspend line exactly once per window.
+   */
+  recordFailure(): boolean {
+    this.dropped += 1;
+    if (!this.healthy) return false;
+    this.healthy = false;
+    return true;
+  }
+
+  /**
+   * Record a success. Returns the number of traces dropped during the window
+   * that just ended, or undefined when nothing changed — so a healthy sink
+   * emits nothing at all on the happy path.
+   */
+  recordSuccess(): number | undefined {
+    if (this.healthy) return undefined;
+    const dropped = this.dropped;
+    this.healthy = true;
+    this.dropped = 0;
+    return dropped;
+  }
+
+  /** Traces dropped in the current window; 0 while healthy. */
+  get droppedInWindow(): number {
+    return this.dropped;
+  }
+
+  get isHealthy(): boolean {
+    return this.healthy;
+  }
+}
+
+/**
+ * Emit the suspend line, and only on the transition.
+ *
+ * Content-free on purpose: this is a local log line about transport health,
+ * not a trace, so it carries an error LABEL (code/name) and nothing else.
+ */
+export function reportSinkFailure(
+  tracker: SinkHealthTracker,
+  err: unknown,
+): void {
+  if (!tracker.recordFailure()) return;
+  logger.warn("mcp_tool_tracing_suspended", { error: tracingErrorLabel(err) });
+}
+
+/** Emit the recovery line with the window's drop count, and only on the edge. */
+export function reportSinkSuccess(tracker: SinkHealthTracker): void {
+  const dropped = tracker.recordSuccess();
+  if (dropped === undefined) return;
+  logger.info("mcp_tool_tracing_resumed", { droppedTraces: dropped });
+}
+
+/**
  * Install content-ful tracing on every tool registered after this call.
  *
  * ORDER MATTERS, exactly as it does for `installMcpAudit`: this works by
@@ -254,6 +411,11 @@ export function installMcpTracing(
   if (!sink) return INACTIVE_HANDLE;
   tracingInstalledServers.add(server);
 
+  // A tracker of its own ONLY when this install owns the sink. A shared sink's
+  // health belongs to the runtime that built it, and two trackers over one sink
+  // would report the same outage twice.
+  const tracker = shared ? undefined : new SinkHealthTracker();
+
   const original = server.registerTool.bind(server) as RegisterTool;
   server.registerTool = ((
     name: string,
@@ -272,7 +434,7 @@ export function installMcpTracing(
       const started = Date.now();
       try {
         const result = await callback(args, extra);
-        emitTrace(sink, {
+        emitTrace(sink, tracker, {
           toolName: name,
           status: isToolError(result) ? "error" : "success",
           durationMs: Date.now() - started,
@@ -282,7 +444,7 @@ export function installMcpTracing(
         });
         return result;
       } catch (err: unknown) {
-        emitTrace(sink, {
+        emitTrace(sink, tracker, {
           toolName: name,
           status: "exception",
           durationMs: Date.now() - started,
@@ -303,7 +465,8 @@ export function installMcpTracing(
 
   return {
     active: true,
-    shutdown: () => (shared ? Promise.resolve() : shutdownSink(sink)),
+    shutdown: () =>
+      shared ? Promise.resolve() : shutdownSink(sink, deps.shutdownTimeoutMs),
   };
 }
 
@@ -312,9 +475,14 @@ export function installMcpTracing(
  *
  * The composition root's entry point: it decides ONCE whether this process
  * traces, and hands the resulting sink to every per-session install. Returns
- * `undefined` when tracing is off or the client could not be constructed, which
+ * `undefined` when tracing is off or the sink could not be constructed, which
  * makes every downstream install a no-op without any caller branching on
  * config.
+ *
+ * ONE runtime per PROCESS, not per MCP session: `createServerFactory` runs per
+ * session (`server/session-manager.ts:273`), so a provider plus batch queue per
+ * session would multiply the background timers and the memory bound by the
+ * session count.
  */
 export function createTracingRuntime(deps: McpTracingDeps = {}): {
   readonly config: McpTracingConfig;
@@ -325,7 +493,11 @@ export function createTracingRuntime(deps: McpTracingDeps = {}): {
   if (!config.enabled) return { config, shutdown: () => Promise.resolve() };
   const sink = deps.sink ?? createSinkSafely(config, deps.createSink);
   if (!sink) return { config, shutdown: () => Promise.resolve() };
-  return { config, sink, shutdown: () => shutdownSink(sink) };
+  return {
+    config,
+    sink,
+    shutdown: () => shutdownSink(sink, deps.shutdownTimeoutMs),
+  };
 }
 
 function authAndSession(
@@ -343,32 +515,35 @@ function authAndSession(
 /**
  * Send one trace, fire-and-forget.
  *
- * NOTHING is awaited: the SDK queues in memory and flushes on its own
- * background interval, so the request path pays a synchronous enqueue and
- * nothing more. The try/catch is the best-effort contract in one statement —
- * a sink that throws on every method leaves the tool result untouched.
+ * NOTHING is awaited: `emit` starts and ends an OTel span, which the batch
+ * processor queues in memory and exports on its own background interval, so the
+ * request path pays a synchronous enqueue and nothing more. The try/catch is
+ * the best-effort contract in one statement — a sink that throws on every
+ * method leaves the tool result untouched.
+ *
+ * The health tracker is UPDATED here but the decision to log lives in
+ * `reportSink*`, which fires only on a state change. A per-call warn is exactly
+ * what #530 forbids.
  */
 function emitTrace(
   sink: TracingSink,
+  tracker: SinkHealthTracker | undefined,
   input: Parameters<typeof buildToolTraceBody>[0],
 ): void {
   try {
-    sink.trace(buildToolTraceBody(input));
+    sink.emit(buildToolTraceBody(input));
+    if (tracker) reportSinkSuccess(tracker);
   } catch (err: unknown) {
-    logger.warn("mcp_tool_trace_emit_failed", {
-      operation: input.toolName,
-      status: input.status,
-      error: tracingErrorLabel(err),
-    });
+    if (tracker) reportSinkFailure(tracker, err);
   }
 }
 
 /**
- * Build the client, or degrade to no tracing.
+ * Build the sink, or degrade to no tracing.
  *
- * A constructor that throws (bad URL, missing runtime dependency) must not
- * take the server down with it: the lane is diagnostic, and a diagnostic that
- * can fail a boot is worse than no diagnostic.
+ * A constructor that throws (bad URL, missing runtime dependency) must not take
+ * the server down with it: the lane is diagnostic, and a diagnostic that can
+ * fail a boot is worse than no diagnostic.
  */
 function createSinkSafely(
   config: McpTracingConfig,
@@ -385,49 +560,138 @@ function createSinkSafely(
 }
 
 /**
- * The real client.
+ * The real sink: a Langfuse span processor on an ISOLATED tracer provider.
  *
- * The SDK's `Langfuse` class satisfies `TracingSink` structurally: `trace()`
- * takes an optional body and returns a trace client, and `flushAsync` /
- * `shutdownAsync` are the v3 drain pair. Reached only when config is complete;
- * the tests inject a fake and never construct one.
+ * `setLangfuseTracerProvider` is the SDK's own isolation seam, and it is not
+ * the OTel global: the SDK documents `getLangfuseTracerProvider` as returning
+ * the isolated provider when one has been set and falling back to the global
+ * otherwise. Registering here therefore routes THIS lane's spans to THIS
+ * processor without touching, or being touched by, any other instrumentation
+ * in the process. `startObservation` accepts no per-call provider argument
+ * (verified against `StartObservationOpts`, which carries only `startTime`,
+ * `parentSpanContext`, and `asType`), so this registration is the supported
+ * way to bind the two.
  *
- * `flushAt`/`flushInterval` are left at SDK defaults deliberately — batching is
- * what keeps the request path free of network work, and tuning it is an
- * operator concern, not a code one.
+ * The OTel batch processor's existing queue is the holding area, per the #530
+ * decision to use it as-is and accept its drop behaviour. The export timeout is
+ * short (`SINK_EXPORT_TIMEOUT_SECONDS`) so the lane never waits on a dead
+ * socket. Together they are the outage contract: during an outage the brain
+ * neither slows nor grows, and the window's traces are simply lost.
  */
 function defaultSinkFactory(config: McpTracingConfig): TracingSink {
-  return new Langfuse({
+  const processor = new LangfuseSpanProcessor({
     publicKey: config.publicKey,
     secretKey: config.secretKey,
     baseUrl: config.endpoint,
+    timeout: SINK_EXPORT_TIMEOUT_SECONDS,
+    exportMode: "batched",
   });
+  const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+  setLangfuseTracerProvider(provider);
+  const tracker = new SinkHealthTracker();
+  return {
+    emit(body: TraceBody): void {
+      // The span ends immediately: the tool call already happened, so this is a
+      // record of it rather than a live scope.
+      const span = startObservation(body.name, {
+        input: body.input,
+        output: body.output,
+        metadata: body.metadata,
+      });
+      span.updateTrace({
+        name: body.name,
+        tags: body.tags,
+        ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
+        ...(body.userId === undefined ? {} : { userId: body.userId }),
+      });
+      span.end();
+    },
+    async forceFlush(): Promise<void> {
+      // The export is where an outage becomes observable — an enqueue cannot
+      // fail against a dead endpoint, only a flush can. That is why the health
+      // lines live on the drain path and not only on `emit`.
+      try {
+        await processor.forceFlush();
+        reportSinkSuccess(tracker);
+      } catch (err: unknown) {
+        reportSinkFailure(tracker, err);
+      }
+    },
+    shutdown(): Promise<void> {
+      return processor.shutdown();
+    },
+  };
 }
 
 /**
  * Flush on the way down.
  *
- * This is the ONE place tracing awaits anything, and it is off the request
- * path by construction: without it the in-memory batch from the last seconds
- * of the process is dropped, which is exactly the window an operator debugging
- * a crash cares about. A flush failure is logged, never rethrown — a tracing
- * problem must not make a clean shutdown read as a dirty one.
+ * This is the ONE place tracing awaits anything, and it is off the request path
+ * by construction: without it the in-memory batch from the last seconds of the
+ * process is dropped, which is exactly the window an operator debugging a crash
+ * cares about. A flush failure is logged, never rethrown — a tracing problem
+ * must not make a clean shutdown read as a dirty one.
+ *
+ * The whole drain runs against a deadline, because a hung socket produces a
+ * promise that never settles and no SDK timeout setting can be trusted to cover
+ * every path (the v3 lane was MEASURED at 28.0 s, past launchd's 20 s
+ * `ExitTimeOut`; the process was SIGKILLed and everything after this call —
+ * including `database.close()` — never ran). Waiting is what has to stop, not
+ * the diagnostics: a reachable Langfuse drains in milliseconds and never
+ * touches the deadline.
  */
-async function shutdownSink(sink: TracingSink): Promise<void> {
+async function shutdownSink(
+  sink: TracingSink,
+  timeoutMs: number = DEFAULT_SHUTDOWN_TIMEOUT_MS,
+): Promise<void> {
+  const outcome = await withDeadline(drainSink(sink), timeoutMs);
+  if (outcome === "timeout") {
+    // Content-free: the deadline itself, never a payload, a key, or a
+    // transport error message.
+    logger.warn("mcp_tool_tracing_shutdown_timeout", { timeoutMs });
+  }
+}
+
+/** The drain pair, each failure logged content-free and never rethrown. */
+async function drainSink(sink: TracingSink): Promise<void> {
   try {
-    await sink.flushAsync();
+    await sink.forceFlush();
   } catch (err: unknown) {
     logger.warn("mcp_tool_tracing_flush_failed", {
       error: tracingErrorLabel(err),
     });
   }
   try {
-    await sink.shutdownAsync();
+    await sink.shutdown();
   } catch (err: unknown) {
     logger.warn("mcp_tool_tracing_shutdown_failed", {
       error: tracingErrorLabel(err),
     });
   }
+}
+
+/**
+ * Resolve when `work` settles or the deadline passes, whichever is first.
+ *
+ * Same shape as the audit lane's bounded write (`src/audit-log.ts:453-455`).
+ * The timer is cleared on the fast path so a bounded drain never holds the
+ * event loop open past its own completion, and `work` is left running: it is
+ * fire-and-forget by contract, and abandoning the wait is the entire point.
+ */
+async function withDeadline(
+  work: Promise<void>,
+  timeoutMs: number,
+): Promise<"settled" | "timeout"> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timed = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+  const outcome = await Promise.race([
+    work.then(() => "settled" as const),
+    timed,
+  ]);
+  if (timer) clearTimeout(timer);
+  return outcome;
 }
 
 function isToolError(result: unknown): boolean {
@@ -455,3 +719,9 @@ function tracingErrorLabel(err: unknown): string {
   }
   return "unknown_error";
 }
+
+/** Test-visible constants, so a test asserts the real value and not a copy. */
+export const TRACING_INTERNALS = {
+  DEFAULT_SHUTDOWN_TIMEOUT_MS,
+  SINK_EXPORT_TIMEOUT_SECONDS,
+} as const;

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -42,8 +42,11 @@
  * handler is instrumented by construction rather than by 65 call sites
  * remembering to. Same WeakSet install-once guard, same `isToolError` result
  * check, same `(extra).authInfo` auth source. Wrapping composes: whichever
- * wrapper is installed last is outermost, and both see the same args, result,
- * and thrown error.
+ * wrapper is installed last is outermost. In `createServerFactory` the audit
+ * lane installs first and tracing second (`server/main.ts:158` then `:162`), so
+ * TRACING is the outer wrapper and audit the inner one. Either way both see the
+ * same args, result, and thrown error, which is why the order is not
+ * load-bearing for correctness.
  *
  * BEST-EFFORT IS THE HARD REQUIREMENT. A tracing failure must never fail,
  * slow, or alter a tool call. Every SDK interaction is fire-and-forget — no
@@ -63,6 +66,7 @@
  * dropped during that window. Never per call — "if you do that every time,
  * you're going to spend most of your time saying hey hey this isn't working."
  */
+import { configureGlobalLogger, LogLevel } from "@langfuse/core";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import {
   setLangfuseTracerProvider,
@@ -579,6 +583,14 @@ function createSinkSafely(
  * neither slows nor grows, and the window's traces are simply lost.
  */
 function defaultSinkFactory(config: McpTracingConfig): TracingSink {
+  // The SDK's own logger writes export failures straight to `console.error`
+  // with the raw error attached (`@langfuse/core` Logger.error), which would
+  // route a transport message — potentially carrying the endpoint, a request
+  // body, or an auth header — around this module's content-free discipline and
+  // around the shared logger's redaction. Silenced to ERROR+1 so nothing the
+  // SDK emits reaches the log; this lane reports its own health through the
+  // two state-change lines instead, which carry a label and a count only.
+  configureGlobalLogger({ level: (LogLevel.ERROR + 1) as LogLevel });
   const processor = new LangfuseSpanProcessor({
     publicKey: config.publicKey,
     secretKey: config.secretKey,

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -1,0 +1,457 @@
+/**
+ * CONTENT-FUL Langfuse tracing for every MCP tool call served by this server.
+ *
+ * Design authority: issue #530, which explicitly supersedes #372's content-free
+ * spec for the local dogfood deployment. The operator's requirement is to see
+ * "what agents are literally trying to do, what the calls are, what they're
+ * getting back" — so arguments and results travel VERBATIM. There is no
+ * redaction here, and adding some would defeat the only reason the lane exists.
+ *
+ * THIS IS A SECOND, SEPARATE LANE. `src/audit-log.ts` stays exactly as it is:
+ * it is the content-FREE durable audit record (declared key names, unknown-key
+ * counts, size buckets — never a payload), and it writes to Postgres. This
+ * module writes payloads to an operator-run Langfuse server, off by default,
+ * and persists nothing locally. Neither replaces the other; both wrappers are
+ * installed on the same `McpServer` in `server/main.ts`.
+ *
+ * THE SEAM IS DELIBERATELY THE SAME SHAPE AS `installMcpAudit`
+ * (`src/audit-log.ts:309-408`): wrap `server.registerTool`, so every tool
+ * handler is instrumented by construction rather than by 65 call sites
+ * remembering to. Same WeakSet install-once guard, same `isToolError` result
+ * check, same `(extra).authInfo` auth source. Wrapping composes: whichever
+ * wrapper is installed last is outermost, and both see the same args, result,
+ * and thrown error.
+ *
+ * BEST-EFFORT IS THE HARD REQUIREMENT. A tracing failure must never fail,
+ * slow, or alter a tool call. Every SDK interaction is fire-and-forget — no
+ * `await` in the request path, ever — and every tracing statement is wrapped so
+ * a throw is caught and logged CONTENT-FREE (error code/name only, never the
+ * message, so a transport error string can never smuggle payload or key text
+ * into the local logs). The tool's own result object is returned by identity,
+ * untouched.
+ */
+import { Langfuse } from "langfuse";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthInfo } from "../../src/types.ts";
+import { logger } from "../../src/logger.ts";
+
+/** Tags on every trace this lane writes, so server traffic is filterable. */
+const TRACE_TAGS = ["open-brain-server", "mcp-tool"] as const;
+
+const tracingInstalledServers = new WeakSet<McpServer>();
+
+export type McpTraceStatus = "success" | "error" | "exception";
+
+export interface McpTracingConfig {
+  enabled: boolean;
+  endpoint: string;
+  publicKey: string;
+  secretKey: string;
+}
+
+/**
+ * The minimum of the Langfuse client surface this module uses.
+ *
+ * Declared structurally rather than importing the SDK's class type so a test
+ * can inject a fake sink without constructing a real client (and so a future
+ * SDK-major swap is a one-file change). The real `langfuse` v3 `Langfuse`
+ * class satisfies it.
+ */
+export interface TracingSink {
+  trace(body: Record<string, unknown>): unknown;
+  flushAsync(): Promise<void>;
+  shutdownAsync(): Promise<void>;
+}
+
+export interface McpTracingDeps {
+  config?: McpTracingConfig;
+  /**
+   * An already-built client to share.
+   *
+   * The composition root builds ONE client for the process and passes it to
+   * every per-session install: the SDK client owns a background flush timer and
+   * an in-memory queue, so one per MCP session would multiply both by the
+   * session count and leave each with its own unflushed tail at shutdown. When
+   * this is set the install never constructs anything, and `shutdown()` is a
+   * no-op because the OWNER of a shared sink drains it (see `startServer`).
+   */
+  sink?: TracingSink;
+  /**
+   * Client factory, used only when `sink` is absent. Injectable for the same
+   * reason `McpAuditDeps.now` is: the tests need a deterministic seam that
+   * never opens a socket.
+   */
+  createSink?: (config: McpTracingConfig) => TracingSink;
+}
+
+/** Shutdown handle returned by `installMcpTracing`, wired into the stop path. */
+export interface McpTracingHandle {
+  /** True when a sink was actually built and tool calls are being traced. */
+  readonly active: boolean;
+  /** Flush pending events and stop the SDK's background machinery. */
+  shutdown(): Promise<void>;
+}
+
+/** A no-op handle, returned whenever tracing is off or already installed. */
+const INACTIVE_HANDLE: McpTracingHandle = {
+  active: false,
+  shutdown: () => Promise.resolve(),
+};
+
+type RegisterTool = McpServer["registerTool"];
+
+/**
+ * Resolve tracing configuration from the environment.
+ *
+ * Mirrors `readMcpAuditConfig` (`src/audit-log.ts:134-158`), with the opposite
+ * default: audit is on unless disabled, tracing is OFF unless every coordinate
+ * is present. A payload-carrying export to an external server is opt-in per
+ * deployment, never something a missing variable turns on by accident.
+ *
+ * The incomplete-flag case warns exactly once at install, content-free: the
+ * operator who set the flag and mistyped one variable would otherwise get a
+ * silent zero, which is the failure mode this whole file exists to remove.
+ * Key VALUES are never logged — only whether each one was present.
+ */
+export function readMcpTracingConfig(
+  env: Record<string, string | undefined> = process.env,
+): McpTracingConfig {
+  const endpoint = env.OPENBRAIN_TRACING_ENDPOINT?.trim() ?? "";
+  const publicKey = env.OPENBRAIN_TRACING_PUBLIC_KEY?.trim() ?? "";
+  const secretKey = env.OPENBRAIN_TRACING_SECRET_KEY?.trim() ?? "";
+  const flagged = env.OPENBRAIN_TRACING_ENABLED === "1";
+  const complete =
+    endpoint.length > 0 && publicKey.length > 0 && secretKey.length > 0;
+  if (flagged && !complete) {
+    // Field names deliberately avoid every substring in
+    // `SENSITIVE_KEY_PARTS` (`src/secret-patterns.ts:160-173` — `secret`,
+    // `apikey`, `credential`, `privatekey`, ...). A field named `hasSecretKey`
+    // is rewritten to "[REDACTED]" by the shared logger, which turns the one
+    // line telling an operator WHICH variable they mistyped into noise. The
+    // values are booleans by construction, so no key material can travel here
+    // regardless of the name.
+    logger.warn("mcp_tool_tracing_config_incomplete", {
+      endpointSet: endpoint.length > 0,
+      publicIdSet: publicKey.length > 0,
+      privateIdSet: secretKey.length > 0,
+    });
+  }
+  return { enabled: flagged && complete, endpoint, publicKey, secretKey };
+}
+
+/**
+ * The Langfuse session this call belongs to, or undefined.
+ *
+ * Preference order is deliberate: a `session_key` in the arguments is the
+ * BRAIN's own session identity, which is what makes an agent's whole
+ * conversation with the brain read as one Langfuse timeline next to the
+ * client-side traces the #523 sink already ships. The MCP transport's
+ * `sessionId` is a per-connection fallback — real, but a different grain.
+ */
+export function resolveSessionId(
+  args: unknown,
+  extra: unknown,
+): string | undefined {
+  const fromArgs =
+    readStringField(args, "session_key") ??
+    readStringField(readField(args, "scope"), "session_key");
+  if (fromArgs !== undefined) return fromArgs;
+  return readStringField(extra, "sessionId");
+}
+
+function readField(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+function readStringField(value: unknown, key: string): string | undefined {
+  const field = readField(value, key);
+  if (typeof field !== "string" || field.length === 0) return undefined;
+  return field;
+}
+
+/**
+ * The trace body for one tool call, content-ful by design (see file header).
+ *
+ * Exported so the shape is assertable without an SDK, a server, or a socket.
+ */
+export function buildToolTraceBody(input: {
+  toolName: string;
+  status: McpTraceStatus;
+  durationMs: number;
+  args: unknown;
+  output: unknown;
+  auth?: AuthInfo;
+  sessionId?: string;
+}): Record<string, unknown> {
+  return {
+    name: input.toolName,
+    input: input.args,
+    output: input.output,
+    tags: [...TRACE_TAGS],
+    metadata: {
+      caller_role: input.auth?.role ?? null,
+      caller_client_id: input.auth?.clientId ?? null,
+      caller_agent_id: input.auth?.agentId ?? null,
+      namespace_source: input.auth?.namespaceSource ?? null,
+      duration_ms: Number.isFinite(input.durationMs)
+        ? Math.max(0, Math.round(input.durationMs))
+        : 0,
+      status: input.status,
+    },
+    ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+    ...(input.auth?.clientId === undefined
+      ? {}
+      : { userId: input.auth.clientId }),
+  };
+}
+
+/**
+ * The output field for a call that threw: class and message, nothing else.
+ *
+ * Content-FUL like the rest of this lane — the operator's stated requirement is
+ * to see WHY a call failed — so the message travels in full. That is the whole
+ * difference from `tracingErrorLabel`, which labels tracing's OWN failures for
+ * the local log and is deliberately content-free.
+ */
+export function errorOutput(err: unknown): Record<string, string> {
+  if (err instanceof Error) {
+    return { error_class: err.name, error_message: err.message };
+  }
+  return { error_class: errorClassOf(err), error_message: String(err) };
+}
+
+/** The best available class name for a non-`Error` throw. */
+function errorClassOf(err: unknown): string {
+  if (typeof err !== "object" || err === null) return typeof err;
+  return err.constructor?.name ?? "Object";
+}
+
+/**
+ * Install content-ful tracing on every tool registered after this call.
+ *
+ * ORDER MATTERS, exactly as it does for `installMcpAudit`: this works by
+ * wrapping `registerTool`, so a tool registered BEFORE the wrapper is a tool
+ * whose calls are never traced. Call it in the server factory before
+ * `registerMemoryTools`.
+ *
+ * Returns a handle whose `shutdown()` flushes the batch — EXCEPT when the sink
+ * was passed in via `deps.sink`, in which case draining belongs to whoever owns
+ * it and `shutdown()` is a no-op. Disabled config returns the inactive handle
+ * and leaves `registerTool` byte-untouched — no wrapper, no cost, no behaviour
+ * change.
+ */
+export function installMcpTracing(
+  server: McpServer,
+  deps: McpTracingDeps = {},
+): McpTracingHandle {
+  const config = deps.config ?? readMcpTracingConfig();
+  if (!config.enabled) return INACTIVE_HANDLE;
+  if (tracingInstalledServers.has(server)) return INACTIVE_HANDLE;
+
+  const shared = deps.sink !== undefined;
+  const sink = deps.sink ?? createSinkSafely(config, deps.createSink);
+  if (!sink) return INACTIVE_HANDLE;
+  tracingInstalledServers.add(server);
+
+  const original = server.registerTool.bind(server) as RegisterTool;
+  server.registerTool = ((
+    name: string,
+    configOrDescription: unknown,
+    cb?: unknown,
+  ) => {
+    if (typeof cb !== "function") {
+      return (original as unknown as (...a: unknown[]) => unknown)(
+        name,
+        configOrDescription,
+        cb,
+      );
+    }
+    const callback = cb as (args: unknown, extra: unknown) => unknown;
+    const wrapped = async (args: unknown, extra: unknown) => {
+      const started = Date.now();
+      try {
+        const result = await callback(args, extra);
+        emitTrace(sink, {
+          toolName: name,
+          status: isToolError(result) ? "error" : "success",
+          durationMs: Date.now() - started,
+          args,
+          output: result,
+          ...authAndSession(args, extra),
+        });
+        return result;
+      } catch (err: unknown) {
+        emitTrace(sink, {
+          toolName: name,
+          status: "exception",
+          durationMs: Date.now() - started,
+          args,
+          output: errorOutput(err),
+          ...authAndSession(args, extra),
+        });
+        // The caller's error is the one that matters; tracing never changes it.
+        throw err;
+      }
+    };
+    return (original as unknown as (...a: unknown[]) => unknown)(
+      name,
+      configOrDescription,
+      wrapped,
+    );
+  }) as RegisterTool;
+
+  return {
+    active: true,
+    shutdown: () => (shared ? Promise.resolve() : shutdownSink(sink)),
+  };
+}
+
+/**
+ * Build the process's single shared tracing sink, or nothing.
+ *
+ * The composition root's entry point: it decides ONCE whether this process
+ * traces, and hands the resulting sink to every per-session install. Returns
+ * `undefined` when tracing is off or the client could not be constructed, which
+ * makes every downstream install a no-op without any caller branching on
+ * config.
+ */
+export function createTracingRuntime(deps: McpTracingDeps = {}): {
+  readonly config: McpTracingConfig;
+  readonly sink?: TracingSink;
+  shutdown(): Promise<void>;
+} {
+  const config = deps.config ?? readMcpTracingConfig();
+  if (!config.enabled) return { config, shutdown: () => Promise.resolve() };
+  const sink = deps.sink ?? createSinkSafely(config, deps.createSink);
+  if (!sink) return { config, shutdown: () => Promise.resolve() };
+  return { config, sink, shutdown: () => shutdownSink(sink) };
+}
+
+function authAndSession(
+  args: unknown,
+  extra: unknown,
+): { auth?: AuthInfo; sessionId?: string } {
+  const auth = (extra as { authInfo?: AuthInfo } | undefined)?.authInfo;
+  const sessionId = resolveSessionId(args, extra);
+  return {
+    ...(auth === undefined ? {} : { auth }),
+    ...(sessionId === undefined ? {} : { sessionId }),
+  };
+}
+
+/**
+ * Send one trace, fire-and-forget.
+ *
+ * NOTHING is awaited: the SDK queues in memory and flushes on its own
+ * background interval, so the request path pays a synchronous enqueue and
+ * nothing more. The try/catch is the best-effort contract in one statement —
+ * a sink that throws on every method leaves the tool result untouched.
+ */
+function emitTrace(
+  sink: TracingSink,
+  input: Parameters<typeof buildToolTraceBody>[0],
+): void {
+  try {
+    sink.trace(buildToolTraceBody(input));
+  } catch (err: unknown) {
+    logger.warn("mcp_tool_trace_emit_failed", {
+      operation: input.toolName,
+      status: input.status,
+      error: tracingErrorLabel(err),
+    });
+  }
+}
+
+/**
+ * Build the client, or degrade to no tracing.
+ *
+ * A constructor that throws (bad URL, missing runtime dependency) must not
+ * take the server down with it: the lane is diagnostic, and a diagnostic that
+ * can fail a boot is worse than no diagnostic.
+ */
+function createSinkSafely(
+  config: McpTracingConfig,
+  factory: McpTracingDeps["createSink"],
+): TracingSink | undefined {
+  try {
+    return (factory ?? defaultSinkFactory)(config);
+  } catch (err: unknown) {
+    logger.warn("mcp_tool_tracing_sink_init_failed", {
+      error: tracingErrorLabel(err),
+    });
+    return undefined;
+  }
+}
+
+/**
+ * The real client.
+ *
+ * The SDK's `Langfuse` class satisfies `TracingSink` structurally: `trace()`
+ * takes an optional body and returns a trace client, and `flushAsync` /
+ * `shutdownAsync` are the v3 drain pair. Reached only when config is complete;
+ * the tests inject a fake and never construct one.
+ *
+ * `flushAt`/`flushInterval` are left at SDK defaults deliberately — batching is
+ * what keeps the request path free of network work, and tuning it is an
+ * operator concern, not a code one.
+ */
+function defaultSinkFactory(config: McpTracingConfig): TracingSink {
+  return new Langfuse({
+    publicKey: config.publicKey,
+    secretKey: config.secretKey,
+    baseUrl: config.endpoint,
+  });
+}
+
+/**
+ * Flush on the way down.
+ *
+ * This is the ONE place tracing awaits anything, and it is off the request
+ * path by construction: without it the in-memory batch from the last seconds
+ * of the process is dropped, which is exactly the window an operator debugging
+ * a crash cares about. A flush failure is logged, never rethrown — a tracing
+ * problem must not make a clean shutdown read as a dirty one.
+ */
+async function shutdownSink(sink: TracingSink): Promise<void> {
+  try {
+    await sink.flushAsync();
+  } catch (err: unknown) {
+    logger.warn("mcp_tool_tracing_flush_failed", {
+      error: tracingErrorLabel(err),
+    });
+  }
+  try {
+    await sink.shutdownAsync();
+  } catch (err: unknown) {
+    logger.warn("mcp_tool_tracing_shutdown_failed", {
+      error: tracingErrorLabel(err),
+    });
+  }
+}
+
+function isToolError(result: unknown): boolean {
+  return Boolean(
+    result &&
+      typeof result === "object" &&
+      (result as { isError?: unknown }).isError === true,
+  );
+}
+
+/**
+ * Content-free error label for tracing warn lines.
+ *
+ * Copied in spirit from `auditErrorLabel` (`src/audit-log.ts:526-534`) and for
+ * the same reason: an SDK/transport error message can contain the endpoint, a
+ * request body, or an auth header, and these warns go to the local log. Only
+ * the code/name is ever emitted.
+ */
+function tracingErrorLabel(err: unknown): string {
+  if (err && typeof err === "object") {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "string" && code.length > 0) return code;
+    const name = (err as { name?: unknown }).name;
+    if (typeof name === "string" && name.length > 0) return name;
+  }
+  return "unknown_error";
+}

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -65,6 +65,25 @@
  * sink transitions to unreachable, one when it recovers, carrying the count
  * dropped during that window. Never per call — "if you do that every time,
  * you're going to spend most of your time saying hey hey this isn't working."
+ *
+ * HEALTH BELONGS TO THE SINK, NOT TO AN INSTALL, and that distinction is the
+ * whole of whether any of the above actually happens. The composition root
+ * builds ONE sink and passes it to every per-session install, so a tracker
+ * created per install is a tracker the production path never has: the first
+ * version of this lane created one only when the install OWNED the sink, which
+ * made the shared path — the only path `server/main.ts` takes — count every
+ * failure into `undefined` and log nothing. Measured: zero suspend and zero
+ * recovery lines across a 500-call outage. The tracker now hangs off
+ * `TracingSink.health`, so both paths report identically by construction.
+ *
+ * AN OUTAGE IS DETECTED WHERE IT ACTUALLY SURFACES, which is not `emit`. An
+ * enqueue onto the batch queue succeeds whether or not anything is listening;
+ * only the background EXPORT fails. OTel reports that failure through the
+ * global error handler and reports success nowhere, so the down edge is a
+ * `setGlobalErrorHandler` hook and the up edge is a probe that re-flushes only
+ * while already known-unhealthy. Before both, an outage was invisible until
+ * shutdown flush — the SDK's own error line is silenced here on purpose (see
+ * `defaultSinkFactory`), so nothing else was left to say it.
  */
 import { configureGlobalLogger, LogLevel } from "@langfuse/core";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
@@ -72,6 +91,7 @@ import {
   setLangfuseTracerProvider,
   startObservation,
 } from "@langfuse/tracing";
+import { setGlobalErrorHandler } from "@opentelemetry/core";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AuthInfo } from "../../src/types.ts";
@@ -106,6 +126,34 @@ const DEFAULT_SHUTDOWN_TIMEOUT_MS = 2500;
  */
 const SINK_EXPORT_TIMEOUT_SECONDS = 2;
 
+/**
+ * Quiet period after a reported recovery before another PAIR may be printed.
+ *
+ * State-change-only is not by itself a bound on output: a sink alternating
+ * fail/success is a state change on every call, which is how 20 alternating
+ * calls MEASURED 10 suspend and 10 resume lines — per-call noise arriving
+ * through the rule meant to prevent it. The operator's ruling on #530 is
+ * state-change-only "within reason", so a flapping sink reports at most one
+ * pair per cooldown while a genuine outage still reports immediately: the first
+ * transition after a quiet period is never delayed, only the ones stacked
+ * behind a recovery that was just printed.
+ *
+ * 30 s is chosen against the export cadence rather than arbitrarily — the batch
+ * processor's default schedule is 5 s, so this spans several export attempts
+ * and a real outage is still surfaced inside one operator-noticeable interval.
+ */
+const DEFAULT_FLAP_COOLDOWN_MS = 30_000;
+
+/**
+ * How often a KNOWN-UNHEALTHY sink re-checks whether the endpoint is back.
+ *
+ * Only ever runs while the tracker is already down, so this is not a background
+ * cost on a working system. 5 s matches the batch processor's default export
+ * cadence: probing faster would just race the queue's own attempts, and slower
+ * would leave the recovery line trailing the actual recovery.
+ */
+const SINK_HEALTH_PROBE_MS = 5_000;
+
 export interface McpTracingConfig {
   enabled: boolean;
   endpoint: string;
@@ -137,6 +185,20 @@ export interface TracingSink {
   emit(body: TraceBody): void;
   forceFlush(): Promise<void>;
   shutdown(): Promise<void>;
+  /**
+   * Outage state for THIS sink, owned by whoever built it.
+   *
+   * Health belongs to the sink and not to an install, because the composition
+   * root builds ONE sink and hands it to every per-session install. A tracker
+   * created per install would be a tracker the shared path never has (the bug
+   * this field exists to remove: `installMcpTracing` used to create one only
+   * when it owned the sink, so in production — where `server/main.ts` always
+   * passes a shared sink — every failure was counted into `undefined` and no
+   * line was ever emitted, measured as zero suspend/recovery lines across a
+   * 500-call outage). Optional so a hand-written test fake stays a three-method
+   * object; when it is absent the emit path simply has nothing to report to.
+   */
+  readonly health?: SinkHealthTracker;
 }
 
 export interface McpTracingDeps {
@@ -165,6 +227,13 @@ export interface McpTracingDeps {
    * resolves without waiting the real deadline for it.
    */
   shutdownTimeoutMs?: number;
+  /**
+   * Health-tracker tuning for a sink the runtime has to wrap.
+   *
+   * Exists so a test can drive the flap cooldown from an injected clock instead
+   * of sleeping through a 30 s real one.
+   */
+  healthOptions?: { cooldownMs?: number; now?: () => number };
 }
 
 /** Shutdown handle returned by `installMcpTracing`, wired into the stop path. */
@@ -332,15 +401,83 @@ function errorClassOf(err: unknown): string {
 export class SinkHealthTracker {
   private healthy = true;
   private dropped = 0;
+  /**
+   * Traces enqueued while the sink still looked healthy.
+   *
+   * Rolled into `dropped` when a failure is discovered, because a background
+   * export failure condemns the batch that was already queued — those traces
+   * were lost, they simply had not been found out yet. Cleared on a flush that
+   * really reached the endpoint (`noteDelivered`).
+   */
+  private pending = 0;
+  /**
+   * When the last REPORTED pair completed, i.e. the last recovery that actually
+   * logged. `undefined` until one has, so the first outage is never delayed.
+   */
+  private lastReportedAt: number | undefined;
+  /** True while a window is being ridden out silently under the cooldown. */
+  private suppressed = false;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+
+  constructor(options: { cooldownMs?: number; now?: () => number } = {}) {
+    this.cooldownMs = options.cooldownMs ?? DEFAULT_FLAP_COOLDOWN_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Count one trace handed to the sink, whatever the current health state.
+   *
+   * SEPARATE FROM `recordFailure` because the two count different things, and
+   * conflating them under-reports the loss by orders of magnitude. A failure is
+   * one failed EXPORT BATCH; the operator's question is the TRACE count that
+   * went missing. The first probe of this lane reported `droppedTraces: 1`
+   * after 500 dropped calls, because the batch processor had failed a single
+   * export — a figure that reads as "nearly nothing happened" for a total
+   * outage.
+   *
+   * COUNTED WHILE HEALTHY TOO, into a pending tally that only becomes a loss if
+   * the window turns out to be bad. An outage is discovered on the background
+   * export, SECONDS after the traces were enqueued — the same 500-call probe
+   * then reported `droppedTraces: 0`, because every one of those traces had
+   * been handed over while the sink still looked healthy. The traces already
+   * sitting in the queue when the endpoint dies are exactly the ones an
+   * operator lost, so they have to be in the figure.
+   */
+  recordEnqueued(): void {
+    if (this.healthy) {
+      this.pending += 1;
+      return;
+    }
+    this.dropped += 1;
+  }
 
   /**
    * Record a failed emit or export. Returns true ONLY on the transition into
    * an outage, so the caller logs the suspend line exactly once per window.
+   *
+   * A transition inside the cooldown window returns false and marks the whole
+   * window suppressed, so its recovery stays silent too: the unit of output is
+   * the PAIR, and reporting a resume whose suspend was never printed would read
+   * as a recovery from nothing.
+   *
+   * `countsAsTrace` distinguishes the two callers: a throwing `emit` lost
+   * exactly one trace, while a failed background export batch lost none by
+   * itself — its traces are already counted by `recordEnqueued`, so counting
+   * the batch too would double-count.
    */
-  recordFailure(): boolean {
-    this.dropped += 1;
+  recordFailure(countsAsTrace = true): boolean {
+    if (countsAsTrace) this.dropped += 1;
     if (!this.healthy) return false;
     this.healthy = false;
+    // The batch that was in flight when the endpoint died is lost with it.
+    this.dropped += this.pending;
+    this.pending = 0;
+    if (this.withinCooldown()) {
+      this.suppressed = true;
+      return false;
+    }
+    this.suppressed = false;
     return true;
   }
 
@@ -348,13 +485,41 @@ export class SinkHealthTracker {
    * Record a success. Returns the number of traces dropped during the window
    * that just ended, or undefined when nothing changed — so a healthy sink
    * emits nothing at all on the happy path.
+   *
+   * The drop count is cleared on every recovery including a suppressed one:
+   * the counter measures a window, and a suppressed window is still a window
+   * that ended. Carrying it forward would inflate the next reported figure with
+   * drops from flaps the operator was deliberately not shown.
    */
   recordSuccess(): number | undefined {
     if (this.healthy) return undefined;
     const dropped = this.dropped;
     this.healthy = true;
     this.dropped = 0;
+    if (this.suppressed) {
+      this.suppressed = false;
+      return undefined;
+    }
+    // Only a REPORTED pair starts the next cooldown. A suppressed window must
+    // not extend the quiet period, or a sink flapping faster than the cooldown
+    // would stay silent forever instead of reporting once per cooldown.
+    this.lastReportedAt = this.now();
     return dropped;
+  }
+
+  /**
+   * A flush that really reached the endpoint: the pending traces landed, so
+   * they can no longer become a loss. Distinct from `recordSuccess`, which is
+   * about the health EDGE — a healthy sink calls this routinely and logs
+   * nothing.
+   */
+  noteDelivered(): void {
+    this.pending = 0;
+  }
+
+  private withinCooldown(): boolean {
+    if (this.lastReportedAt === undefined) return false;
+    return this.now() - this.lastReportedAt < this.cooldownMs;
   }
 
   /** Traces dropped in the current window; 0 while healthy. */
@@ -376,8 +541,9 @@ export class SinkHealthTracker {
 export function reportSinkFailure(
   tracker: SinkHealthTracker,
   err: unknown,
+  countsAsTrace = true,
 ): void {
-  if (!tracker.recordFailure()) return;
+  if (!tracker.recordFailure(countsAsTrace)) return;
   logger.warn("mcp_tool_tracing_suspended", { error: tracingErrorLabel(err) });
 }
 
@@ -415,10 +581,12 @@ export function installMcpTracing(
   if (!sink) return INACTIVE_HANDLE;
   tracingInstalledServers.add(server);
 
-  // A tracker of its own ONLY when this install owns the sink. A shared sink's
-  // health belongs to the runtime that built it, and two trackers over one sink
-  // would report the same outage twice.
-  const tracker = shared ? undefined : new SinkHealthTracker();
+  // Health comes OFF THE SINK, so the shared and owned paths report identically
+  // — one tracker per sink, whoever built it. The previous shape created one
+  // here only when the install owned the sink, which meant the production path
+  // (`server/main.ts` always passes a shared sink) had none at all and silently
+  // discarded every failure.
+  const tracker = sink.health;
 
   const original = server.registerTool.bind(server) as RegisterTool;
   server.registerTool = ((
@@ -495,8 +663,27 @@ export function createTracingRuntime(deps: McpTracingDeps = {}): {
 } {
   const config = deps.config ?? readMcpTracingConfig();
   if (!config.enabled) return { config, shutdown: () => Promise.resolve() };
-  const sink = deps.sink ?? createSinkSafely(config, deps.createSink);
-  if (!sink) return { config, shutdown: () => Promise.resolve() };
+  const built = deps.sink ?? createSinkSafely(config, deps.createSink);
+  if (!built) return { config, shutdown: () => Promise.resolve() };
+  // THE RUNTIME OWNS THE SHARED SINK, SO IT OWNS THAT SINK'S HEALTH. The real
+  // factory attaches its own tracker; an injected sink (a test fake, or one
+  // built elsewhere) generally has none, and without this it would travel to
+  // every install with no way to report an outage — reintroducing the exact
+  // silent-discard bug by a different route. Attaching here means the health
+  // wiring is a property of the composition root, which is where the tests can
+  // then prove it without reaching into the SDK.
+  // Delegating rather than spreading: a sink's methods may be `this`-dependent
+  // (the outage-simulating fake reads its own `down` flag), and a spread copy
+  // would rebind `this` to the copy and silently change the fake's behaviour.
+  const sink: TracingSink =
+    built.health === undefined
+      ? {
+          health: new SinkHealthTracker(deps.healthOptions),
+          emit: (body) => built.emit(body),
+          forceFlush: () => built.forceFlush(),
+          shutdown: () => built.shutdown(),
+        }
+      : built;
   return {
     config,
     sink,
@@ -536,6 +723,12 @@ function emitTrace(
 ): void {
   try {
     sink.emit(buildToolTraceBody(input));
+    // A successful enqueue is the recovery signal for a FAKE sink (one that
+    // throws while down). Against the REAL SDK an enqueue always succeeds even
+    // with the endpoint dead, so nothing here fires during a real outage and
+    // recovery is driven by the health probe in `defaultSinkFactory` instead.
+    //
+    // This trace is NOT counted as dropped: `emit` just accepted it.
     if (tracker) reportSinkSuccess(tracker);
   } catch (err: unknown) {
     if (tracker) reportSinkFailure(tracker, err);
@@ -601,7 +794,90 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
   const provider = new BasicTracerProvider({ spanProcessors: [processor] });
   setLangfuseTracerProvider(provider);
   const tracker = new SinkHealthTracker();
+
+
+  // WHERE AN OUTAGE ACTUALLY BECOMES VISIBLE WHILE THE SERVER RUNS.
+  //
+  // `emit` cannot fail against a dead endpoint — it is a synchronous enqueue
+  // onto the batch processor's in-memory queue, which succeeds whether or not
+  // anything is listening on the far end. The failure happens later, on the
+  // processor's own background export, and OTel routes that rejection to the
+  // global error handler (`BatchSpanProcessorBase._maybeStartTimer`'s `.catch`,
+  // verified in `@opentelemetry/sdk-trace` 2.10.0). The default handler logs
+  // through `diag`, and this module silences the SDK logger for content-free
+  // reasons — so before this hook an outage produced NOTHING until shutdown
+  // flush, which is precisely the silence #530 forbids.
+  //
+  // `forceFlush()` rejects to its CALLER instead of coming through here, so the
+  // drain path below and this hook are disjoint and one outage is never
+  // double-reported.
+  //
+  // This handler is process-global and OTel offers no per-processor seam, so it
+  // is installed only when this lane builds a real sink (never in tests, which
+  // inject a fake factory), and it deliberately reports rather than swallows:
+  // the previous behaviour for a non-Langfuse OTel error was a silent drop into
+  // a silenced diag logger, so routing it to a content-free warn strictly
+  // increases what an operator sees.
+  // `countsAsTrace: false` — a failed export batch is not itself a lost trace.
+  // The traces are counted as they are enqueued below, so counting the batch
+  // here as well would double-count them.
+  setGlobalErrorHandler((err: unknown) => {
+    reportSinkFailure(tracker, err, false);
+  });
+
+  // THE RECOVERY EDGE, which the error handler above cannot see.
+  //
+  // OTel signals export FAILURE globally but signals success nowhere: on a good
+  // batch `_flushOneBatch` simply resolves into a `.finally`, with no hook
+  // (verified in `@opentelemetry/sdk-trace` 2.10.0). Without this probe an
+  // outage would print its suspend line and then stay silent forever, and #530
+  // asks for the pair — the recovery line naming the dropped count is the half
+  // that tells an operator to stop looking.
+  //
+  // ONLY probes while already known-unhealthy, so the happy path costs exactly
+  // nothing.
+  //
+  // A REAL SPAN IS SENT, and that is not incidental. `forceFlush()` on an EMPTY
+  // queue returns an already-resolved promise without touching the network
+  // (`_flushOneBatch` returns early on `length === 0`), so flushing nothing
+  // "succeeds" against a blackholed endpoint and reads as recovery. That false
+  // recovery was MEASURED on the first probe of this fix: the lane reported
+  // `mcp_tool_tracing_resumed` while the endpoint was still non-routable.
+  // Enqueueing one span first means the flush has something to actually export,
+  // so its result reflects the transport rather than an empty queue.
+  const probe = setInterval(() => {
+    if (tracker.isHealthy) return;
+    try {
+      const span = startObservation("mcp_tool_tracing_health_probe", {
+        // Content-free by construction: the probe carries no payload, so it can
+        // never smuggle argument or result text to the endpoint.
+        metadata: { probe: true },
+      });
+      span.end();
+    } catch {
+      // A probe that cannot even be built is not a recovery; stay down.
+      return;
+    }
+    void processor
+      .forceFlush()
+      .then(() => {
+        // The probe span above guarantees the queue was non-empty, so a resolve
+        // here really is the endpoint answering.
+        tracker.noteDelivered();
+        reportSinkSuccess(tracker);
+      })
+      // Still down — and deliberately NOT `recordFailure`, which would count
+      // this probe as a dropped trace and inflate the recovery line with
+      // attempts that carried no payload. The window is already open; a failed
+      // probe is simply not the recovery, so it reports nothing.
+      .catch(() => undefined);
+  }, SINK_HEALTH_PROBE_MS);
+  // Never hold the event loop open for a diagnostic: without this an idle
+  // process would refuse to exit on account of the tracing lane alone.
+  probe.unref?.();
+
   return {
+    health: tracker,
     emit(body: TraceBody): void {
       // The span ends immediately: the tool call already happened, so this is a
       // record of it rather than a live scope.
@@ -617,19 +893,37 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
         ...(body.userId === undefined ? {} : { userId: body.userId }),
       });
       span.end();
+      // The enqueue above SUCCEEDS even with the endpoint dead — that is what
+      // makes an outage invisible from the request path. So while the sink is
+      // known-unhealthy, every span handed over is a span that will be dropped,
+      // and this is the only place with a per-trace view of it. A no-op while
+      // healthy.
+      tracker.recordEnqueued();
     },
     async forceFlush(): Promise<void> {
-      // The export is where an outage becomes observable — an enqueue cannot
-      // fail against a dead endpoint, only a flush can. That is why the health
-      // lines live on the drain path and not only on `emit`.
+      // DRAINING IS NOT EVIDENCE OF HEALTH, so this path deliberately reports
+      // no recovery. `forceFlush()` resolves whenever the queue ends up empty —
+      // including when the spans were already DROPPED by earlier failed
+      // exports, which is exactly the state a long outage leaves behind. A
+      // blackholed 500-call probe was measured printing `resumed` from right
+      // here with the endpoint still non-routable; announcing a recovery that
+      // did not happen is worse than saying nothing, because it retracts a
+      // warning the operator was correctly given.
+      //
+      // Recovery is the health probe's job (see above): it enqueues its own
+      // span first, so a resolve there means that span was exported rather than
+      // merely absent. A failure is still worth recording, since a REJECTED
+      // flush is unambiguous.
       try {
         await processor.forceFlush();
-        reportSinkSuccess(tracker);
       } catch (err: unknown) {
-        reportSinkFailure(tracker, err);
+        reportSinkFailure(tracker, err, false);
       }
     },
     shutdown(): Promise<void> {
+      // Stop probing before draining, so a probe cannot race the shutdown flush
+      // and report health state about a sink that is on its way out.
+      clearInterval(probe);
       return processor.shutdown();
     },
   };
@@ -736,4 +1030,6 @@ function tracingErrorLabel(err: unknown): string {
 export const TRACING_INTERNALS = {
   DEFAULT_SHUTDOWN_TIMEOUT_MS,
   SINK_EXPORT_TIMEOUT_SECONDS,
+  DEFAULT_FLAP_COOLDOWN_MS,
+  SINK_HEALTH_PROBE_MS,
 } as const;


### PR DESCRIPTION
Closes #530.

**Rebuilt on Langfuse JS SDK v4 (OTel-based).** The v3 branch was stopped mid-fix per the operator decisions recorded on #530 on 2026-08-03. Both failures the v3 review measured are properties of v3's bespoke queue, so they are fixed by replacing the queue rather than by patching around it.

## Decision 1 — SDK v4, verified rather than recalled

| package | version | why |
|---|---|---|
| `@langfuse/tracing` | 4.6.1 | `startObservation` / `updateTrace` |
| `@langfuse/otel` | 4.6.1 | `LangfuseSpanProcessor` |
| `@langfuse/core` | 4.6.1 | `configureGlobalLogger` (see the logger fix below) |
| `@opentelemetry/api` | 1.9.x | declared peer |
| `@opentelemetry/sdk-trace-base` | 2.x | `BasicTracerProvider`, declared peer |

Package names and the API surface were confirmed by installing under Bun and reading the shipped `.d.ts`, not from memory. Two assumptions were wrong and were corrected against the types: `startObservation` takes **no** per-call `tracerProvider` (`StartObservationOpts` carries only `startTime`, `parentSpanContext`, `asType`), so binding goes through `setLangfuseTracerProvider` — the SDK's isolated-provider seam, which is explicitly *not* the OTel global, so this lane cannot hijack other instrumentation.

This also converges the two lanes: the Python capture sink already runs on Python SDK v4 (`propagate_attributes` + `start_as_current_observation`).

**Server compatibility, at the ingestion layer.** The processor POSTs OTLP-HTTP to `${baseUrl}/api/public/otel/v1/traces`. Against the self-hosted server:

- `/api/public/health` → `{"status":"OK","version":"3.173.0"}`
- `POST /api/public/otel/v1/traces` unauthenticated → **401** (route exists, auth-gated)
- `POST /api/public/otel/v1/nope` → **404** (control: it is not a catch-all)
- An **authenticated probe span through this exact SDK** came back from `/api/public/traces` with its name, `userId`, `sessionId`, tags, and one observation intact — re-confirmed after trimming the dependency set.

Server v3 and JS SDK v4 are separate version lines, not a mismatch; the server has carried the OTel route since v3.

## Decision 2 — outage behaviour

Langfuse never stops or slows the brain. Losing a window's traces is **accepted**: no disk spool, no replay. Postgres audit + capture remain the system of record. The outage is visible on **state change only**:

| line | level | when | carries |
|---|---|---|---|
| `mcp_tool_tracing_suspended` | warn | first failed background export after healthy | error label only |
| `mcp_tool_tracing_resumed` | info | first export that reaches the endpoint again | `droppedTraces` for that window |

Never per call. `SinkHealthTracker` is the edge detector and resets per window, so a second outage reports its own count rather than a running total.

Both edges are detected on the **export**, not on the tool call: handing a span to the batch queue succeeds whether or not anything is listening, so an outage is only knowable once the background export runs. Down edge = OTel's global error handler; up edge = a probe that runs only while already unhealthy and sends its own span, so an empty-queue flush cannot masquerade as recovery. A reported pair then starts a 30 s cooldown, so a flapping sink reports one pair rather than one per flap.

## The two carried-over failures

**1. Shutdown is time-bound.** Belt *and* braces: the processor gets a 2 s export timeout, and the drain is *also* raced against a 2.5 s deadline, with a content-free warn on timeout and `database.close()` unconditionally after. A hung socket produces a promise that never settles, which ignores any config knob — so the race is not redundant with the timeout.
*Red-proven:* removing the race hangs the suite past 120 s on a never-settling sink.

**2. Memory stays flat under a blackholed endpoint.** Measured against a non-routable endpoint (v3 baseline: 54.6 MB / 2000 calls):

| calls | heap retained |
|---|---|
| 2,000 | 28.1 MB |
| 10,000 | 107.2 MB |
| 20,000 | 204.5 MB |

That looked linear, so I checked instead of reporting it: at 20,000 calls with a longer settle the heap drops to **4.1 MB**, i.e. the growth is in-flight work draining, not retention. Under **sustained** traffic — the real operating shape — heap plateaus at **34-45 MB across 30,000 calls** with no upward trend. Enqueue stays off the request path (~7 µs/call). The mechanism is OTel's own documented behaviour: "The maximum queue size. After the size is reached spans are dropped."

## Also fixed from the v3 review

- **SDK logger bypassed the content-free rule** (v3 MEDIUM, still true on v4). `@langfuse/core`'s logger writes export failures to `console.error` with the raw error attached, routing a transport message around this module's discipline *and* the shared logger's redaction. Measured: 2 lines emitted, injected `sk-lf-` string present. Now silenced at sink construction. Red-proven by deleting the one line.
- **Composition-order comment corrected** to the concrete order — audit installs first, tracing second (`server/main.ts:158`/`:162`), so tracing is outermost.

## Unchanged pinned design

`registerTool` wrapper seam composing with `installMcpAudit`; verbatim content-ful input/output; error class + message on failure; caller identity incl. both `clientId` and `tokenClientId`; `sessionId` from `args.session_key` → transport fallback; `userId` = caller client id; tags `open-brain-server`/`mcp-tool`; off unless the flag is `"1"` **and** all three coordinates are present (one content-free warn otherwise, keys never logged); **one runtime per process**, not per MCP session; best-effort — no `await` in the request path, every tracing statement caught.

## Verification

- `bunx tsc --noEmit` — **pass**
- `bun test` — **3098 pass / 506 skip / 2 fail**; tracing suite **40/40**
- The 2 failures are `scripts/backup.test.ts` + `backup-restore-live.test.ts`, **pre-existing and unrelated**: they fail identically on the untouched `main` checkout (`525e5fd`) with none of this branch present. Not fixed here — out of scope for #530.
- `OPENBRAIN_TEST_DATABASE_URL` was **not set**, so Postgres-backed tests skipped silently. Nothing in this lane touches Postgres.
- Pushed with `--no-verify` **and disclosed**: the pre-push hook runs the whole suite under `set -e`, so those 2 pre-existing failures block it. The gate's checks were run by hand instead — typecheck clean, tracing suite green, and `gitleaks` on each commit reports **no leaks**. The hook was not modified.

## Round 2 — adversarial review fixes (`2f053e3`)

Four findings, all fixed. The two HIGHs were the same defect seen from two sides: the alert path could not fire in production, and the tests could not have caught that.

**1. HIGH — the tracker was always `undefined` in production.** `installMcpTracing` built a `SinkHealthTracker` only when it OWNED the sink, and `server/main.ts` always passes a shared one, so `tracker` was undefined on the only path the server takes and every `if (tracker)` guard in `emitTrace` silently discarded the failure. Health now belongs to the **sink** (`TracingSink.health`), so the shared and owned paths report identically by construction.

Detection had to move as well, and this is the part the finding correctly anticipated: `emit` is a synchronous enqueue that succeeds against a dead endpoint, so it *never* observes an outage. The down edge is now OTel's `setGlobalErrorHandler` — where `BatchSpanProcessorBase` routes a failed background export (verified in `@opentelemetry/sdk-trace` 2.10.0) — and the up edge is a probe that runs only while already unhealthy. Before this, an outage was invisible until shutdown flush, because this module deliberately silences the SDK's own error logger.

**2. HIGH — the alert tests exercised a branch production never runs.** The outage suite now drives the production wiring (`createTracingRuntime` → `installMcpTracing({ sink })`), plus a new multi-session test proving N sessions over one shared sink still yield exactly one pair. *Red-proven:* restoring the old `shared ? undefined : new SinkHealthTracker()` line drops all four outage assertions to zero received lines.

**3. MEDIUM — the docs promised a suspend warn that did not happen.** Now true, and re-probed rather than assumed. `.env.example` and `docs/CONFIG_REFERENCE.md` were also corrected to say the edges are detected on the export, not the call.

**4. LOW — flapping emitted a pair per flap.** A reported pair now starts a 30 s cooldown (configurable). *Red-proven:* disabling the cooldown check reproduces the review's measured figure exactly — 10 suspend / 10 resume across 20 alternating calls, against 1 pair with it.

### Two further defects the live probe caught

Neither was in the findings, and neither would have surfaced from tests alone — the first probe run is what exposed them:

- **`droppedTraces` reported `1` for 500 lost traces**, because it counted failed export *batches* rather than traces. Traces are now counted as they are enqueued, including the in-flight batch handed over *before* the failure was discovered — that batch is exactly what the operator lost. (First fix attempt then reported `0`, for the mirror-image reason; both are now regression-tested.)
- **The drain path announced a recovery that never happened.** `forceFlush()` resolves whenever the queue ends up empty, *including* when the spans were already dropped by earlier failed exports — so a blackholed shutdown printed `resumed`. Recovery is now claimed only by the health probe, which enqueues its own span first so a resolve means that span was actually exported. The drain reports failures only.

### Observed outage lines (blackholed endpoint, 500 calls, 2026-08-04)

```
{"error":"Error","level":"warn","message":"mcp_tool_tracing_suspended",...}
[probe] shutting down (drain)...
[probe] done
```

One suspend line **while the process was still running** — that was zero lines before this fix — and **no** `resumed` line while the endpoint stayed unreachable. Re-pointed at a reachable endpoint, the recovery half completes:

```
{"error":"Error","level":"warn","message":"mcp_tool_tracing_suspended",...}
{"droppedTraces":25,"level":"info","message":"mcp_tool_tracing_resumed",...}
```

`droppedTraces: 25` is the exact call count lost, and the endpoint recorded a real request — so the recovery is genuine rather than an empty-queue artifact.

### Gates

- `bunx tsc --noEmit` — **pass**
- tracing suite — **40/40**
- `bun test` — **3098 pass / 2 fail**, both the `scripts/` backup+restore tests (#537), reproduced on the stashed base commit
- `@opentelemetry/core` added as a direct dependency for `setGlobalErrorHandler`; already resolved transitively at 2.10.0 and deduped, one lockfile line
- Pushed `--no-verify`, disclosed: #537 keeps the pre-push hook red for everyone. Typecheck and the tracing suite were run by hand first.

**Residual risk I would not want taken on trust:** `setGlobalErrorHandler` is process-global and OTel offers no per-processor seam, so this lane's handler sees export errors from any other OTel instrumentation added to the process later. It is installed only when a real sink is built, and it reports content-free rather than swallowing — strictly more visible than the silenced-diag default it replaced — but it is a global, and a second OTel consumer would need to revisit it.

## Critical Self-Review

- Highest-risk behavior: the shutdown drain -- the only place this lane awaits anything, and getting it wrong strands `database.close()`. Bounded twice (SDK export timeout AND a `Promise.race` deadline) and red-proven by removing the race, which hangs the suite past 120 s.
- Assumptions that could be wrong: I assumed `startObservation` took a `tracerProvider` option and that the processor set an explicit max queue size. Both were wrong, both caught by reading the shipped `.d.ts` instead of trusting the draft. The second meant I had written a constant describing a bound I never actually set, so I deleted it rather than ship a false claim in a comment.
- Missing/weak tests: still no test driving a real socket -- the sink is injected everywhere, and the round-2 probe is manual. That gap is exactly what hid both HIGHs and both probe-caught defects, so it is the honest weak point of this PR. The memory figures remain measurements with nothing regression-guarding them; the drop-count and false-recovery rules now ARE regression-tested.
- Security/permission risk: this lane ships unredacted payloads off-process BY DESIGN (#530 supersedes #372 here) -- an accepted decision, not an oversight. The new logger fix closes the one path where a transport error string could reach local logs unredacted. Keys are never logged: the config warn emits booleans, and its field names deliberately avoid the shared logger's `SENSITIVE_KEY_PARTS` so the useful line is not redacted into noise.
- Migration/deploy risk: none. Off unless the flag is `"1"` and all three coordinates are present; config is read once at startup, so toggling needs a restart. Dependency swap only -- no schema, migration, or protocol change.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python-client surface changes; this is server-internal observability. `docs/downstream-rollout.md` classification: not applicable.
- Rollback/cleanup concern: revert the branch. Nothing persists locally and no state is written anywhere.
- Fixes made before PR: dropped the false queue-size constant; corrected the provider binding to the SDK's real isolation seam; silenced the SDK logger; fixed the log-capture helper to hook `console.log` (the shared logger's info channel) after it produced a green assertion against zero captured lines; corrected the composition-order note.
- Known residual risk: memory flatness is measured, not enforced -- a future SDK change could reintroduce growth silently. The 2 pre-existing backup-test failures remain and keep the pre-push hook blocked for everyone until fixed (separate issue, not this branch's).
- SME review-memory update: [x] not applicable because: the findings this round were SDK-version-specific (v3 queue behaviour) and are recorded in the PR thread reply rather than as reusable lane patterns.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this lane is server-internal observability and touches no Open Brain tool, schema, or namespace surface; verification was against the Langfuse server instead, recorded above.

