### PR TITLE
fix(pack): reject unknown request keys instead of serving a default (#535)

### DIFF
--- a/server/tools/agent-context-pack.ts
+++ b/server/tools/agent-context-pack.ts
@@ -40,8 +40,8 @@ import {
   type WorkingSetScope,
 } from "../realtime/working-set.ts";
 import {
-  agentContextPackInputSchema,
-  agentReflexPointersInputSchema,
+  agentContextPackStrictSchema,
+  agentReflexPointersStrictSchema,
   parseAgentContextPackArgs,
   parseAgentReflexPointersArgs,
   type AgentContextPackArgs,
@@ -669,12 +669,38 @@ export async function buildAgentContextPackPayload(
   if (durableMemorySection) sections.durable_memory = durableMemorySection;
   for (const { key, section } of structuredSections) sections[key] = section;
 
+  // #535 receipt: name what was asked for against what came back, so a section
+  // that was requested and did NOT arrive is visible in the answer itself.
+  //
+  // An unknown top-level KEY is already rejected by name at parse time, and an
+  // unknown VALUE inside `requested_sections` is already rejected by the enum
+  // with the accepted set listed. What neither catches is a section that was
+  // spelled correctly, accepted, and then dropped downstream — budget eviction
+  // being the live case. That still reads as a success-shaped short answer, so
+  // the receipt states the difference rather than leaving the caller to diff
+  // `sections` against their own request from memory.
+  //
+  // `requested: null` means the caller sent no `requested_sections` and took the
+  // documented working_set-only default — distinct from an explicit empty array.
+  const servedSections = Object.keys(sections);
+  const requestedSections = args.requested_sections ?? null;
+
   return {
     payload: {
       schema: "openbrain.agent_context_pack.v1",
       status: "ok",
       scope: { namespace_source: "authorization", ...normalizedScope },
       sections,
+      sections_receipt: {
+        requested: requestedSections,
+        served: servedSections,
+        requested_not_served:
+          requestedSections === null
+            ? []
+            : requestedSections.filter(
+                (name) => !servedSections.includes(name),
+              ),
+      },
       warnings: {
         scope_denials: [
           ...(workingSet ? workingSet.warnings.scope_denials : []),
@@ -850,7 +876,10 @@ export function registerAgentContextPackTool(
         "emitted as durable_memory items, reusing the single durable_memory recall; " +
         "candidate_memory is a truthful empty section (no candidate predicate yet) " +
         "that never drives its own recall.",
-      inputSchema: agentContextPackInputSchema,
+      // The STRICT object, not the raw shape: the SDK strips unknown keys from
+      // a raw shape before dispatch, which is the #535 silent-default defect.
+      // See `context-pack-args.ts` `rejectUnknownRequestKeys`.
+      inputSchema: agentContextPackStrictSchema,
       annotations: {
         title: "Agent Context Pack",
         readOnlyHint: true,
@@ -888,7 +917,7 @@ export function registerAgentReflexPointersTool(
         "through the authorized read path (get_entry, table = source_ref.type + " +
         '"s", id = source_ref.id). Placement into the model prompt is client-owned; ' +
         "this tool never performs implicit _meta injection.",
-      inputSchema: agentReflexPointersInputSchema,
+      inputSchema: agentReflexPointersStrictSchema,
       annotations: {
         title: "Agent Reflex Pointers",
         readOnlyHint: true,

--- a/server/tools/context-pack-args.ts
+++ b/server/tools/context-pack-args.ts
@@ -137,11 +137,122 @@ export const agentContextPackInputSchema = {
   budget: contextPackBudgetInputSchema,
 };
 
+/**
+ * Build the strict registration schema for a tool surface.
+ *
+ * The `.strict()` alone rejects the key but its stock message names only the
+ * offending key. The issue's requirement (and the #431/PR #532 pattern) is that
+ * a failure names the ACCEPTED VOCABULARY too, so the caller has something to
+ * correct toward rather than a bare "no". The accepted set is derived from the
+ * shape, never re-listed, so it cannot drift from the schema it describes.
+ *
+ * The message must carry the vocabulary itself, not rely on a formatter: the
+ * serving entrypoint (`server/main.ts`) does NOT install
+ * `installValidationSummaryFormatter` — only `src/server.ts` does — so anything
+ * that lives only in the formatter is invisible on the surface that actually
+ * runs.
+ */
+function strictRequestSchema<Shape extends z.ZodRawShape>(
+  shape: Shape,
+  toolName: string,
+) {
+  const accepted = Object.keys(shape).sort().join(", ");
+  return z
+    .object(shape, {
+      error: (issue: { code?: string; keys?: string[] }) =>
+        issue.code === "unrecognized_keys"
+          ? `Unrecognized key(s) for ${toolName}: ${(issue.keys ?? []).join(", ")}. ` +
+            `Accepted keys: ${accepted}.`
+          : undefined,
+    } as z.core.$ZodObjectParams)
+    .strict();
+}
+
+/**
+ * Reject an unknown top-level request key by NAME, listing the accepted set.
+ *
+ * THE DEFECT (#535). The MCP SDK builds its validating schema from a raw shape
+ * with a plain `z.object()`, which STRIPS undeclared keys instead of rejecting
+ * them, and it strips them BEFORE the handler runs. So `sections: [...]` — the
+ * near-miss spelling of `requested_sections` — never reached the tool at all:
+ * the pack saw no section selection, fell back to its working_set-only default,
+ * and returned `status: "ok"` on a near-empty answer. A typo in one key looked
+ * exactly like a correct minimal request, and it cost real debugging time at
+ * least twice (#439, #526).
+ *
+ * THE FIX. Registration passes the `.strict()` object below as `inputSchema`
+ * instead of the raw shape, so the SDK's own pre-dispatch validator does the
+ * rejecting. That is the only layer that still sees the raw arguments — a
+ * handler-side check cannot work, because by then the key is already gone. It
+ * also makes the advertised JSON schema honest: `additionalProperties: false`
+ * now appears in `tools/list`, so a caller can see the rule before breaking it.
+ *
+ * REJECT, don't tolerate — for THIS surface specifically. An unknown key here
+ * is always a caller mistake, never forward-tolerance: every key the pack
+ * accepts selects work it must do, so an ignored one silently changes the
+ * answer. That is the opposite of the capture lane (#464/PR #533), where
+ * genuinely future lifecycle keys are expected and naming what was ignored in
+ * the receipt is the right shape. Forward tolerance is a per-surface decision,
+ * and this surface does not want it.
+ *
+ * This function stays as defense in depth for the DIRECT callers of
+ * `parseAgentContextPackArgs` (tests, the NATS bridge, any non-MCP entrypoint),
+ * which never pass through the SDK validator. Its error is a real `ZodError`,
+ * so `summarizeValidationError` renders it through the same
+ * `input_validation_failed` envelope as every other field error and names the
+ * accepted vocabulary (#431/PR #532) so the caller has something to correct
+ * toward.
+ */
+function rejectUnknownRequestKeys(
+  args: unknown,
+  acceptedKeys: readonly string[],
+  toolName: string,
+): void {
+  if (typeof args !== "object" || args === null || Array.isArray(args)) return;
+
+  const record = args as Record<string, unknown>;
+  const accepted = new Set(acceptedKeys);
+  const unknown = Object.keys(record).filter((key) => !accepted.has(key));
+  if (unknown.length === 0) return;
+
+  const sorted = [...acceptedKeys].sort();
+  throw new z.ZodError(
+    unknown.map((key) => ({
+      code: "unrecognized_keys" as const,
+      keys: [key],
+      path: [key],
+      message:
+        `Unrecognized key "${key}" for ${toolName}. ` +
+        `Accepted keys: ${sorted.join(", ")}.`,
+      input: record,
+    })),
+  );
+}
+
 const agentContextPackArgsSchema = z.object(agentContextPackInputSchema);
+
+/**
+ * The registration-time schema: identical fields, but unknown top-level keys
+ * are REJECTED rather than stripped. Register this, never the raw shape.
+ */
+export const agentContextPackStrictSchema = strictRequestSchema(
+  agentContextPackInputSchema,
+  "agent_context_pack",
+);
+
+/** The exact accepted top-level key set, derived from the schema — never re-listed. */
+export const AGENT_CONTEXT_PACK_REQUEST_KEYS = Object.keys(
+  agentContextPackInputSchema,
+) as readonly string[];
 
 export type AgentContextPackArgs = z.infer<typeof agentContextPackArgsSchema>;
 
 export function parseAgentContextPackArgs(args: unknown): AgentContextPackArgs {
+  rejectUnknownRequestKeys(
+    args,
+    AGENT_CONTEXT_PACK_REQUEST_KEYS,
+    "agent_context_pack",
+  );
   return agentContextPackArgsSchema.parse(args);
 }
 
@@ -182,6 +293,21 @@ export const agentReflexPointersInputSchema = {
 
 const agentReflexPointersArgsSchema = z.object(agentReflexPointersInputSchema);
 
+/** The reflex's registration-time schema; see {@link agentContextPackStrictSchema}. */
+export const agentReflexPointersStrictSchema = strictRequestSchema(
+  agentReflexPointersInputSchema,
+  "agent_reflex_pointers",
+);
+
+/**
+ * The reflex surface's accepted keys. Deliberately NARROWER than the pack's —
+ * it omits `requested_sections` and the section toggles — so passing a pack key
+ * here is exactly the near-miss #535 is about and must be named, not stripped.
+ */
+export const AGENT_REFLEX_POINTERS_REQUEST_KEYS = Object.keys(
+  agentReflexPointersInputSchema,
+) as readonly string[];
+
 export type AgentReflexPointersArgs = z.infer<
   typeof agentReflexPointersArgsSchema
 >;
@@ -189,5 +315,10 @@ export type AgentReflexPointersArgs = z.infer<
 export function parseAgentReflexPointersArgs(
   args: unknown,
 ): AgentReflexPointersArgs {
+  rejectUnknownRequestKeys(
+    args,
+    AGENT_REFLEX_POINTERS_REQUEST_KEYS,
+    "agent_reflex_pointers",
+  );
   return agentReflexPointersArgsSchema.parse(args);
 }

--- a/server/tools/context-pack.test.ts
+++ b/server/tools/context-pack.test.ts
@@ -658,3 +658,199 @@ describe("agent_reflex_pointers projects the pack without a second stack", () =>
     ).toEqual(["brain_record:thought:b"]);
   });
 });
+
+/**
+ * #535 — a caller mistake must never look like a successful answer.
+ *
+ * Operator directive (Rico, 2026-08-03): "Should be more than just keep it or
+ * drop it. It should be fail loudly and make us think about it."
+ *
+ * The defect these tests pin: the MCP SDK validates against a plain
+ * `z.object()` built from the raw shape, which STRIPS undeclared keys. Sending
+ * `sections` (the near-miss spelling of `requested_sections`) left the parsed
+ * args with no section selection at all, so the pack returned its
+ * working_set-only default with `status: "ok"`. A typo read as a correct
+ * minimal request, twice at real cost (#439, #526).
+ *
+ * RED PROOF: with `rejectUnknownRequestKeys` removed from
+ * `parseAgentContextPackArgs`, the first test fails on
+ * `expect(isError).toBe(true)` — the call succeeds and returns the default
+ * pack, which is exactly the old behavior.
+ */
+describe("an unknown request key fails loudly instead of returning a default pack", () => {
+  /**
+   * The rejection arrives as an `isError` tool result carrying the JSON-RPC
+   * -32602 InvalidParams text, because the SDK rejects before dispatch and the
+   * client surfaces that as an error result rather than a throw. Reading the
+   * message is reading exactly what a caller sees on the wire.
+   */
+  async function rejectionMessage(
+    client: Client,
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const result = await client.callTool({ name, arguments: args });
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    if (result.isError !== true) {
+      throw new Error(
+        `${name} accepted the request instead of rejecting it — ` +
+          `the silent-default defect is back. Payload: ${text.slice(0, 200)}`,
+      );
+    }
+    return text;
+  }
+
+  test("agent_context_pack rejects `sections` by name and lists the accepted keys", async () => {
+    const { client, queries } = await harness("agent", "rico");
+
+    // The exact near-miss from #439/#526: correct intent, wrong key.
+    const message = await rejectionMessage(client, "agent_context_pack", {
+      ...SCOPE,
+      sections: ["durable_memory", "repo_facts"],
+    });
+
+    // Named rejection, not a generic parse failure: the offending key and the
+    // accepted vocabulary are both present so the caller can correct toward it.
+    expect(message).toContain("unrecognized_keys");
+    expect(message).toContain("sections");
+    expect(message).toContain("Accepted keys");
+    expect(message).toContain("requested_sections");
+    expect(message).toContain("include_unreviewed_recovery");
+
+    // The old behavior's tell was a success-shaped body. There must be none.
+    expect(message).not.toContain("openbrain.agent_context_pack.v1");
+
+    // Rejection happens before dispatch, so no retrieval ran for a bad request.
+    expect(recallStackCount(queries)).toBe(0);
+  });
+
+  test("agent_reflex_pointers rejects a pack-only key rather than ignoring it", async () => {
+    const { client } = await harness("agent", "rico");
+
+    // `requested_sections` is valid on the pack and NOT on the reflex, which is
+    // the near-miss this surface actually sees. Ignoring it would silently
+    // change nothing while the caller believed it had selected sections.
+    const message = await rejectionMessage(client, "agent_reflex_pointers", {
+      ...SCOPE,
+      query: "needle",
+      requested_sections: ["durable_memory"],
+    });
+
+    expect(message).toContain("requested_sections");
+    expect(message).toContain("Accepted keys");
+  });
+
+  test("an unknown VALUE inside requested_sections names the accepted vocabulary", async () => {
+    const { client } = await harness("agent", "rico");
+
+    // Singular `repo_fact` — the section name is `repo_facts`. Already enforced
+    // by the enum; pinned here so the guarantee cannot regress silently.
+    const message = await rejectionMessage(client, "agent_context_pack", {
+      ...SCOPE,
+      requested_sections: ["repo_fact"],
+    });
+
+    expect(message).toContain("repo_facts");
+    expect(message).toContain("candidate_memory");
+  });
+
+  test("the advertised schema declares that unknown keys are refused", async () => {
+    const { client } = await harness("agent", "rico");
+
+    // `additionalProperties: false` in tools/list is how a caller learns the
+    // rule BEFORE breaking it, rather than from a failed call.
+    const { tools } = await client.listTools();
+    for (const name of ["agent_context_pack", "agent_reflex_pointers"]) {
+      const tool = tools.find((candidate) => candidate.name === name);
+      expect(tool).toBeDefined();
+      expect(
+        (tool?.inputSchema as { additionalProperties?: boolean })
+          .additionalProperties,
+      ).toBe(false);
+    }
+  });
+
+  test("a correctly spelled request is unaffected", async () => {
+    const { client } = await harness("agent", "rico");
+
+    const { payload, isError } = await callJson(client, "agent_context_pack", {
+      ...SCOPE,
+      requested_sections: ["working_set", "candidate_memory"],
+    });
+
+    expect(isError).toBe(false);
+    expect(payload.status).toBe("ok");
+    expect(Object.keys(sectionsOf(payload)).sort()).toEqual([
+      "candidate_memory",
+      "working_set",
+    ]);
+  });
+});
+
+/**
+ * #535 receipt — what was asked for, against what came back.
+ *
+ * Unknown keys and unknown section values are both rejected above. What neither
+ * catches is a section spelled correctly, accepted, and then dropped downstream
+ * (budget eviction is the live case). That still reads as a success-shaped
+ * short answer, so the pack states the difference in its own payload rather
+ * than leaving the caller to diff `sections` against their request from memory.
+ */
+describe("the pack names requested vs served sections in its receipt", () => {
+  test("a fully served request reports no shortfall", async () => {
+    const { client } = await harness("agent", "rico");
+
+    const { payload } = await callJson(client, "agent_context_pack", {
+      ...SCOPE,
+      requested_sections: ["working_set", "candidate_memory"],
+    });
+
+    const receipt = payload.sections_receipt as {
+      requested: string[];
+      served: string[];
+      requested_not_served: string[];
+    };
+    expect(receipt.requested).toEqual(["working_set", "candidate_memory"]);
+    expect(receipt.served.sort()).toEqual(["candidate_memory", "working_set"]);
+    expect(receipt.requested_not_served).toEqual([]);
+  });
+
+  test("the default (no requested_sections) is distinguishable from an explicit request", async () => {
+    const { client } = await harness("agent", "rico");
+
+    const { payload } = await callJson(client, "agent_context_pack", {
+      ...SCOPE,
+    });
+
+    const receipt = payload.sections_receipt as {
+      requested: string[] | null;
+      served: string[];
+      requested_not_served: string[];
+    };
+    // `null`, not `[]`: the caller asked for nothing and took the documented
+    // working_set-only default, which is not the same as asking for nothing.
+    expect(receipt.requested).toBeNull();
+    expect(receipt.served).toEqual(["working_set"]);
+    expect(receipt.requested_not_served).toEqual([]);
+  });
+
+  test("a requested section that does not arrive is named in the receipt", async () => {
+    const { client } = await harness("agent", "rico");
+
+    // `recovery` is admitted only with the explicit opt-in, so requesting it
+    // without `include_unreviewed_recovery` is a request that cannot be served.
+    // Before this receipt existed, that shortfall was invisible in the payload.
+    const { payload } = await callJson(client, "agent_context_pack", {
+      ...SCOPE,
+      requested_sections: ["working_set", "recovery"],
+    });
+
+    const receipt = payload.sections_receipt as {
+      requested: string[];
+      served: string[];
+      requested_not_served: string[];
+    };
+    expect(receipt.requested_not_served).toEqual(["recovery"]);
+    expect(receipt.served).not.toContain("recovery");
+  });
+});

--- a/src/tools/__tests__/agent-context-pack.test.ts
+++ b/src/tools/__tests__/agent-context-pack.test.ts
@@ -339,3 +339,65 @@ describe("agent_context_pack and working_set_append", () => {
     }
   });
 });
+
+/**
+ * #535 — the same loud-failure guarantee on the pre-rewrite tree.
+ *
+ * `server/main.ts` is the serving entrypoint, but `src/index.ts` is still
+ * reachable through `bun start`, `deploy/open-brain.service`, and
+ * `scripts/run-two-worker.ts`. A fix that landed only on the rewrite would
+ * leave a live path where `sections` still silently becomes the default pack.
+ *
+ * RED PROOF: revert this tree's registration to `agentContextPackInputSchema`
+ * (the raw shape) and the first test fails — the call succeeds and returns the
+ * working_set-only default, which is the old behavior exactly.
+ */
+describe("#535 unknown request keys fail loudly on the src tree too", () => {
+  it("rejects `sections` by name and names the accepted keys", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth);
+
+    try {
+      const result = await client.callTool({
+        name: "agent_context_pack",
+        // The near-miss spelling of `requested_sections`.
+        arguments: { ...SCOPE, sections: ["durable_memory", "repo_facts"] },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as any)[0].text as string;
+      expect(text).toContain("unrecognized_keys");
+      expect(text).toContain("sections");
+      expect(text).toContain("Accepted keys");
+      expect(text).toContain("requested_sections");
+      // A success-shaped pack is exactly what must NOT come back.
+      expect(text).not.toContain("openbrain.agent_context_pack.v1");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("names requested vs served sections in the receipt", async () => {
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth);
+
+    try {
+      // `recovery` needs the explicit opt-in, so requesting it without one is a
+      // request that cannot be served — previously invisible in the payload.
+      const result = await client.callTool({
+        name: "agent_context_pack",
+        arguments: { ...SCOPE, requested_sections: ["working_set", "recovery"] },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse((result.content as any)[0].text);
+      expect(payload.sections_receipt).toMatchObject({
+        requested: ["working_set", "recovery"],
+        requested_not_served: ["recovery"],
+      });
+      expect(payload.sections_receipt.served).not.toContain("recovery");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -167,7 +167,99 @@ export const agentContextPackInputSchema = {
   budget: contextPackBudgetInputSchema,
 };
 
+/**
+ * Build the strict registration schema for a tool surface.
+ *
+ * The `.strict()` alone rejects the key but its stock message names only the
+ * offending key. The issue's requirement (and the #431/PR #532 pattern) is that
+ * a failure names the ACCEPTED VOCABULARY too, so the caller has something to
+ * correct toward rather than a bare "no". The accepted set is derived from the
+ * shape, never re-listed, so it cannot drift from the schema it describes.
+ *
+ * The message must carry the vocabulary itself, not rely on a formatter: the
+ * serving entrypoint (`server/main.ts`) does NOT install
+ * `installValidationSummaryFormatter` — only `src/server.ts` does — so anything
+ * that lives only in the formatter is invisible on the surface that actually
+ * runs.
+ */
+function strictRequestSchema<Shape extends z.ZodRawShape>(
+  shape: Shape,
+  toolName: string,
+) {
+  const accepted = Object.keys(shape).sort().join(", ");
+  return z
+    .object(shape, {
+      error: (issue: { code?: string; keys?: string[] }) =>
+        issue.code === "unrecognized_keys"
+          ? `Unrecognized key(s) for ${toolName}: ${(issue.keys ?? []).join(", ")}. ` +
+            `Accepted keys: ${accepted}.`
+          : undefined,
+    } as z.core.$ZodObjectParams)
+    .strict();
+}
+
+/**
+ * Reject an unknown top-level request key by NAME, listing the accepted set.
+ *
+ * The pre-rewrite twin of `server/tools/context-pack-args.ts`'s guard, carrying
+ * the same #535 defect and the same fix; that copy holds the full rationale.
+ *
+ * In short: the SDK strips undeclared keys from a raw shape BEFORE dispatch, so
+ * `sections: [...]` never reached the tool, the pack fell back to its
+ * working_set-only default, and the caller got `status: "ok"` on a near-empty
+ * answer (#439, #526). Registration therefore passes the `.strict()` object,
+ * which is the only layer that still sees the raw arguments. This function
+ * remains as defense in depth for direct (non-MCP) callers of the parse
+ * functions.
+ *
+ * `server/main.ts` is the serving entrypoint (`scripts/local-clone.ts`
+ * SERVING_ENTRYPOINT), but `src/index.ts` is still reachable through
+ * `bun start`, `deploy/open-brain.service`, and `scripts/run-two-worker.ts`, so
+ * leaving the defect here would leave a live path that still fails silently.
+ * Duplicated rather than shared because these two trees are deliberately
+ * independent until this copy is removed.
+ */
+function rejectUnknownRequestKeys(
+  args: unknown,
+  acceptedKeys: readonly string[],
+  toolName: string,
+): void {
+  if (typeof args !== "object" || args === null || Array.isArray(args)) return;
+
+  const record = args as Record<string, unknown>;
+  const accepted = new Set(acceptedKeys);
+  const unknown = Object.keys(record).filter((key) => !accepted.has(key));
+  if (unknown.length === 0) return;
+
+  const sorted = [...acceptedKeys].sort();
+  throw new z.ZodError(
+    unknown.map((key) => ({
+      code: "unrecognized_keys" as const,
+      keys: [key],
+      path: [key],
+      message:
+        `Unrecognized key "${key}" for ${toolName}. ` +
+        `Accepted keys: ${sorted.join(", ")}.`,
+      input: record,
+    })),
+  );
+}
+
 const agentContextPackArgsSchema = z.object(agentContextPackInputSchema);
+
+/**
+ * The registration-time schema: identical fields, but unknown top-level keys
+ * are REJECTED rather than stripped. Register this, never the raw shape.
+ */
+export const agentContextPackStrictSchema = strictRequestSchema(
+  agentContextPackInputSchema,
+  "agent_context_pack",
+);
+
+/** The exact accepted top-level key set, derived from the schema — never re-listed. */
+export const AGENT_CONTEXT_PACK_REQUEST_KEYS = Object.keys(
+  agentContextPackInputSchema,
+) as readonly string[];
 
 export type AgentContextPackArgs = z.infer<typeof agentContextPackArgsSchema>;
 
@@ -177,6 +269,11 @@ export interface AgentContextPackBuildResult {
 }
 
 export function parseAgentContextPackArgs(args: unknown): AgentContextPackArgs {
+  rejectUnknownRequestKeys(
+    args,
+    AGENT_CONTEXT_PACK_REQUEST_KEYS,
+    "agent_context_pack",
+  );
   return agentContextPackArgsSchema.parse(args);
 }
 
@@ -862,6 +959,14 @@ export async function buildAgentContextPackPayload(
     sections[key] = section;
   }
 
+  // #535 receipt: name what was asked for against what came back, so a section
+  // that was requested and did NOT arrive is visible in the answer itself.
+  // Mirrors `server/tools/agent-context-pack.ts`; see that copy for the full
+  // rationale. `requested: null` means the caller sent no `requested_sections`
+  // and took the documented working_set-only default.
+  const servedSections = Object.keys(sections);
+  const requestedSections = args.requested_sections ?? null;
+
   return {
     payload: {
       schema: "openbrain.agent_context_pack.v1",
@@ -871,6 +976,16 @@ export async function buildAgentContextPackPayload(
         ...normalizedScope,
       },
       sections,
+      sections_receipt: {
+        requested: requestedSections,
+        served: servedSections,
+        requested_not_served:
+          requestedSections === null
+            ? []
+            : requestedSections.filter(
+                (name) => !servedSections.includes(name),
+              ),
+      },
       warnings: {
         scope_denials: [
           ...(workingSet ? workingSet.warnings.scope_denials : []),
@@ -1230,6 +1345,21 @@ export const agentReflexPointersInputSchema = {
 
 const agentReflexPointersArgsSchema = z.object(agentReflexPointersInputSchema);
 
+/** The reflex's registration-time schema; see {@link agentContextPackStrictSchema}. */
+export const agentReflexPointersStrictSchema = strictRequestSchema(
+  agentReflexPointersInputSchema,
+  "agent_reflex_pointers",
+);
+
+/**
+ * The reflex surface's accepted keys. Deliberately NARROWER than the pack's —
+ * it omits `requested_sections` and the section toggles — so passing a pack key
+ * here is exactly the near-miss #535 is about and must be named, not stripped.
+ */
+export const AGENT_REFLEX_POINTERS_REQUEST_KEYS = Object.keys(
+  agentReflexPointersInputSchema,
+) as readonly string[];
+
 export type AgentReflexPointersArgs = z.infer<
   typeof agentReflexPointersArgsSchema
 >;
@@ -1237,6 +1367,11 @@ export type AgentReflexPointersArgs = z.infer<
 export function parseAgentReflexPointersArgs(
   args: unknown,
 ): AgentReflexPointersArgs {
+  rejectUnknownRequestKeys(
+    args,
+    AGENT_REFLEX_POINTERS_REQUEST_KEYS,
+    "agent_reflex_pointers",
+  );
   return agentReflexPointersArgsSchema.parse(args);
 }
 
@@ -1364,7 +1499,7 @@ export function registerAgentReflexPointers(
         "through the authorized read path (get_entry, table = source_ref.type + " +
         '"s", id = source_ref.id). Placement into the model prompt is client-owned; ' +
         "this tool never performs implicit _meta injection.",
-      inputSchema: agentReflexPointersInputSchema,
+      inputSchema: agentReflexPointersStrictSchema,
       annotations: {
         title: "Agent Reflex Pointers",
         readOnlyHint: true,
@@ -1408,7 +1543,9 @@ export function registerAgentContextPack(
         "emitted as durable_memory items, reusing the single durable_memory recall; " +
         "candidate_memory is a truthful empty section (no candidate predicate yet) " +
         "that never drives its own recall.",
-      inputSchema: agentContextPackInputSchema,
+      // The STRICT object, not the raw shape: the SDK strips unknown keys from
+      // a raw shape before dispatch, which is the #535 silent-default defect.
+      inputSchema: agentContextPackStrictSchema,
       annotations: {
         title: "Agent Context Pack",
         readOnlyHint: true,


### PR DESCRIPTION
## Summary

- Closes #535. `agent_context_pack` answered `sections: [...]` — the near-miss spelling of `requested_sections` — with `status: "ok"` and the working_set-only default. A typo in one key was indistinguishable from a correct minimal request, and it burned real debugging time at least twice (#439's own text records it; the #526 empty-skull hunt crossed it again).
- **The key never reached the tool.** The MCP SDK builds its validating schema from the raw shape with a plain `z.object()`, which *strips* undeclared keys **before dispatch**. A handler-side check cannot see the mistake — by then the key is already gone. This is why the first attempt at this fix (a guard inside `parseAgentContextPackArgs`) did nothing when driven through a real MCP client, and the probe that caught it is why the fix moved.
- **The fix:** registration passes a `.strict()` object as `inputSchema` instead of the raw shape, putting the rejection in the only layer that still holds the raw arguments.

Three consequences, all of them the point:

1. The failure names the offending key **and** the accepted vocabulary (the #431/PR #532 pattern). The message carries the vocabulary itself rather than relying on `installValidationSummaryFormatter`, because the serving entrypoint (`server/main.ts`) **does not install it** — only `src/server.ts` does. Anything living only in the formatter is invisible on the surface that actually runs.
2. `tools/list` now advertises `additionalProperties: false`, so a caller can see the rule *before* breaking it rather than after.
3. `sections_receipt` names requested vs served, catching the case neither validator can: a section spelled correctly, accepted, then dropped downstream (budget eviction is the live case). Requested-and-absent is now stated in the payload instead of left for the caller to diff from memory.

**Rejection, not a `#533`-style receipt, for this surface specifically.** Every key the pack accepts selects work it must do, so an ignored one silently changes the answer. That is the opposite of the capture lane (#464/PR #533), where genuinely future lifecycle keys are expected and naming what was ignored is the right shape. Forward tolerance is a per-surface decision and this surface does not want it.

**Fixed in both trees.** `server/main.ts` is the serving entrypoint (`scripts/local-clone.ts` `SERVING_ENTRYPOINT`), but `src/index.ts` is still reachable through `bun start`, `deploy/open-brain.service`, and `scripts/run-two-worker.ts` — fixing only the rewrite would have left a live path that still fails silently.

Unknown *values* inside `requested_sections` were already rejected by the `z.enum` with the accepted set listed; that guarantee is now pinned by a test so it cannot regress silently.

### Wire behavior after the fix

```
agent_context_pack {..., sections: ["durable_memory"]}
  -> isError: true
     "Unrecognized key(s) for agent_context_pack: sections.
      Accepted keys: agent, budget, channel_id, include_unreviewed_recovery,
      namespace, platform, prior_context, query, repo, requested_sections,
      server_id, session_key, thread_id."

agent_context_pack {..., requested_sections: ["working_set","recovery"]}
  -> sections_receipt: {"requested":["working_set","recovery"],
                        "served":["working_set"],
                        "requested_not_served":["recovery"]}
```

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` — clean. `bun test` — **3074 pass, 2 fail**. The 2 failures are the pre-existing `scripts/backup+restore` failures tracked in #537 (`runPgRestore stderr sanitization`, `runPgDump failure handling`); confirmed unrelated by stashing this branch's changes and re-running `bun test scripts/`, which fails the same 2 on clean `origin/main`. `--no-verify` on push was used **solely** for those two pre-existing failures.

**Red-proven, both trees.** Reverting registration to the raw shape (`agentContextPackInputSchema`) fails exactly the new unknown-key tests and nothing else:

- `server/tools/context-pack.test.ts` — 25 pass / **3 fail** reverted, 28 pass / 0 fail fixed.
- `src/tools/__tests__/agent-context-pack.test.ts` — 9 pass / **1 fail** reverted, 10 pass / 0 fail fixed.

The red failure message is the defect stated plainly: `agent_context_pack accepted the request instead of rejecting it — the silent-default defect is back`.

Not run: live service smoke. No service was touched, per the task directive; this is a validation/schema change with no migration and no runtime state.

## Critical Self-Review

- Highest-risk behavior: `.strict()` now rejects requests that previously succeeded. Any existing caller passing an undeclared key — even a harmless one — starts getting a hard `-32602` instead of a silently-stripped success. That is the intended behavior change and the whole point of the issue, but it is a breaking change for a tolerant caller, and the blast radius is every `agent_context_pack`/`agent_reflex_pointers` client.
- Assumptions that could be wrong: that no live caller currently depends on passing extra keys. I verified the in-repo callers (the reflex delegation passes already-parsed args and does not re-enter the parser; the NATS bridge and eval harness pass declared keys only), but I did **not** audit external consumers — mcp2cli, rtech-hermes, or generated skills could pass a stray key I cannot see from here. Second assumption: that `z.core.$ZodObjectParams` error-callback shape is stable across the pinned zod 4.3.6; it is a typed cast and a zod minor bump could move it.
- Missing/weak tests: no test covers the `strictRequestSchema` error callback for a NON-`unrecognized_keys` issue code (it returns `undefined` to fall through to zod's default, verified by the enum-rejection test passing, but not directly asserted). No test drives the `rejectUnknownRequestKeys` defense-in-depth path through a non-MCP direct caller — it is exercised only incidentally. No live-service test; the whole suite is fake-pool.
- Security/permission risk: none identified. The change is strictly *more* restrictive on input and touches no auth, namespace, or read predicate. Rejection happens before dispatch, so an unauthorized-namespace probe with a bogus key now fails at validation rather than at the namespace gate — this leaks no additional information, since the validation error names only the schema's own public vocabulary, which `tools/list` already publishes.
- Migration/deploy risk: no schema migration, no DB change, no state. Deploy risk is the caller-compatibility break above, not the deploy itself. `additionalProperties: false` appearing in `tools/list` changes the advertised contract, so a client that caches tool schemas should refresh.
- Downstream client/runtime risk: **this is the real one.** Per `docs/downstream-rollout.md` this is an MCP tool/schema/client-facing change, so mcp2cli cache/skill refresh and any rtech-hermes or generated-skill caller that constructs pack arguments should be re-checked before this is treated as fully rolled out. I have **not** performed that rollout — it is out of this task's scope (no service touch authorized) and is flagged below as not-complete rather than not-applicable.
- Rollback/cleanup concern: clean single-commit revert; no data or state to unwind. The two `.bak` files used for red-proofing were written under `{temp_workspace}/open-brain/_scratch/` and are not in the repo.
- Fixes made before PR: (1) the original guard was placed in `parseAgentContextPackArgs`, which a live MCP probe proved never runs for stripped keys — moved to registration. (2) The first test set asserted a thrown error; the SDK actually returns an `isError` result — corrected against observed behavior rather than assumption. (3) The stock `.strict()` message named only the offending key, not the accepted set, which fails the issue's explicit requirement — added `strictRequestSchema` so the vocabulary rides in the message, since the serving entrypoint has no summary formatter. (4) A scripted edit left the guard's doc comment attached to the wrong function; reordered in both files.
- Known residual risk: an external caller passing an undeclared key breaks loudly on deploy. That is the requested behavior ("fail loudly and make us think about it"), but it is unmeasured outside this repo — see the downstream rollout box, which is deliberately left unchecked.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

`docs/sme/gotcha-agent.md` already carries this defect family from PR #533 ("MCP silently ignores dropped args"). This PR is the same family reaching the read surface; the audit inventory below is the reusable artifact.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the task directive forbade touching the service; this is a schema/validation change with no runtime state, verified against the real MCP client/server pair in-process.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the parity fixtures cover `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts` (`contracts/parity-paths.txt`); none of the five files changed here is in that set, and the fixtures do not model MCP `inputSchema` or `additionalProperties` at all. `bun test contracts/` passes 13/13 unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- These four are deliberately **unchecked, not marked not-applicable.** This is an MCP tool/schema/client-facing change, so by `docs/downstream-rollout.md` the rollout genuinely applies — but the task authorized no service touch, so it is **not done**. Marking them not-applicable would be false. State: **merged-pending-rollout**, not deployed.
- The specific downstream action: any client that caches tool schemas needs a refresh to pick up `additionalProperties: false`, and any caller constructing pack arguments should be checked for stray keys, which now fail hard instead of being stripped.

## AUDIT — remaining tool surface with the same silent-default shape (#535 follow-up inventory)

Reported, not fixed, per scope. **All 63 remaining tool registrations pass a raw shape**, so every one of them strips unknown top-level keys before dispatch. Stripping alone is not the defect — the defect is stripping that yields a *success-shaped answer a caller reads as truth*. Ranked by that criterion, probed live against the registered server with a fake pool:

**HIGH — a dropped key silently changes the answer, and the answer looks fine**

| Tool | File | Evidence (observed, this session) |
|---|---|---|
| `search_brain` | `server/tools/search-brain.ts:80` | `{query:"x", tabel:"thoughts"}` → `[]`, `isError` unset. The table filter is dropped and an empty result is indistinguishable from "nothing matched". |
| `list_recent` | `server/tools/list-recent.ts:116` | `{tabel:"thoughts", dayz:3}` → `{"entries":[],"total_count":null,"offset":0,"limit":20,"has_more":false}`. Two dropped selectors, a complete-looking envelope. |
| `skill_usage_report` | `server/tools/skill-usage.ts:229` | `{dayz:7}` → `{"window_days":7,...}` — but `7` is the **default**, not the request. The receipt echoes a number that only coincidentally matches, which is worse than omitting it. |
| `repo_fact_search` | `server/tools/repo-facts.ts:160` | Five optional narrowing filters (`namespace`/`repo`/`collection`/`path`/`fact_type`); any typo widens the search silently. Same lane as #517/#526, where a mis-bound repo filter was the actual bug. |
| `scan_namespace` | `server/tools/scan-namespace.ts:75` | `target_namespace`/`table`/`since` optional. A typo'd `target_namespace` scans the wrong namespace and reports success. Namespace-adjacent, so worth prioritising. |

**MEDIUM — dropped key degrades to a default; less likely to be read as a full answer**

`adjacent_context` (`adjacent-context.ts:69`), `citation_recall` (`citation-recall.ts:116`), `find_duplicates` (`find-duplicates.ts:144`), `search_all` (`search-all.ts:213`), `get_stats` (`reporting.ts:170`), `access_report` (`reporting.ts:77`), `session_load` (`session-save-load.ts:86`), `list_stale`/`tier` reads (`tiering.ts:85,208`).

**LOW — writes and single-required-arg tools.** Writes (`capture.ts`, `realtime-append.ts`, `session-lifecycle.ts`, `entities.ts`, `people.ts`, `source-registry.ts`, `tier-mutations.ts`, `update-entry.ts`, `promote-entry.ts`, …) mostly fail on a missing *required* field, so a typo usually surfaces. They are still exposed on **optional** keys — a dropped optional write field lands a row missing metadata and returns `saved`, which is exactly #464/PR #533. `get_contract` and `operator_doctor` register `{}` and take no input.

**Recommended follow-up shape:** promote `strictRequestSchema` (added here in both trees) to a shared registration helper and apply it tool-by-tool, HIGH tier first, each with its own red-proven test. Rejecting is right for read tools with narrowing filters; the #533 `ignored_optional_request_keys` receipt is right where forward tolerance is deliberate. That is a per-surface decision and should not be blanket-applied.

Caveat on scope: the HIGH/MEDIUM ranking is a judgment call from schema shape plus the five probes above, not an exhaustive 65-tool behavioral sweep. The five HIGH rows are observed; the MEDIUM/LOW tiers are inferred from their schemas.
