### PR TITLE
fix(launcher): pass OPENBRAIN_TRACING_* through to the server child (#530)

### DIFF
--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -216,6 +216,8 @@ describe("local clone launcher", () => {
       SSH_AUTH_SOCK: "/should/not/be/inherited",
       CORE01_HOST: "10.71.1.21",
       AUTH_TOKEN_USER_LOCAL: "rico:local-user-token",
+      OPENBRAIN_TRACING_ENABLED: "1",
+      OPENBRAIN_TRACING_ENDPOINT: "http://langfuse.local:3000",
     };
     const deps = fakeDependencies({
       child: {
@@ -239,6 +241,12 @@ describe("local clone launcher", () => {
     expect(spawnedEnv).toEqual(buildChildEnvironment(env));
     expect(spawnedEnv?.DB_PASSWORD).toBe("local-secret");
     expect(spawnedEnv?.AUTH_TOKEN_USER_LOCAL).toBe("rico:local-user-token");
+    // #530: the tracing coordinates must reach the server child, or
+    // createTracingRuntime silently stays off while the env file says on.
+    expect(spawnedEnv?.OPENBRAIN_TRACING_ENABLED).toBe("1");
+    expect(spawnedEnv?.OPENBRAIN_TRACING_ENDPOINT).toBe(
+      "http://langfuse.local:3000",
+    );
     expect(spawnedEnv).not.toHaveProperty("PATH");
     expect(spawnedEnv).not.toHaveProperty("SSH_AUTH_SOCK");
     expect(spawnedEnv).not.toHaveProperty("CORE01_HOST");

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -151,6 +151,12 @@ export function buildChildEnvironment(
     if (key.startsWith("AUTH_TOKEN_USER_") && configured !== undefined) {
       childEnv[key] = configured;
     }
+    // #530 server-side tracing: the four OPENBRAIN_TRACING_* variables must
+    // reach the server child or createTracingRuntime silently stays off — the
+    // same deploy coupling the hook wrapper documents for OPENBRAIN_OBSERVATION_*.
+    if (key.startsWith("OPENBRAIN_TRACING_") && configured !== undefined) {
+      childEnv[key] = configured;
+    }
   }
   return childEnv;
 }


### PR DESCRIPTION
Final wiring for #530 (does not close it — the live Langfuse receipt does).

## Summary

- PR #534 shipped and deployed the Langfuse tracing runtime, and `local-clone.env` enables it — but no traces appeared. The running server child had **no** `OPENBRAIN_TRACING_*` variables in its environment (verified with `ps -wwE` against the live pid).
- Root cause: `scripts/local-clone.ts` filters the child environment through the `CHILD_ENV_KEYS` allowlist in `buildChildEnvironment()`, and the tracing prefix was not on it. The feature shipped without its env pass-through — the same deploy-coupling class the hook wrapper documents for `OPENBRAIN_OBSERVATION_*`.
- Fix: a prefix rule mirroring the existing `AUTH_TOKEN_USER_` pattern, passing the four `OPENBRAIN_TRACING_*` variables through to the server child.

## Red-proof

With the fix stashed (allowlist reverted, test kept), `bun test scripts/local-clone.test.ts`: **1 fail** — `expect(spawnedEnv?.OPENBRAIN_TRACING_ENABLED).toBe("1")` receives `undefined`. Restored: **9 pass, 0 fail**.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bun test scripts/local-clone.test.ts` 9 pass / 0 fail; `bunx tsc --noEmit` clean; pre-push full suite passed with **no bypass** (first branch to prove the #540-repaired gate live)
- [x] Python package checks passed or are not applicable — not applicable: no `python/` paths touched
- [x] Live Open Brain smoke passed or is not applicable — the live proof (redeploy, process env check, traced calls in Langfuse) is the follow-up receipt on #530, deliberately after merge since the launcher only takes effect on service restart

## Critical Self-Review

- Highest-risk behavior: widening the child env allowlist. Scoped to one documented four-variable prefix, mirroring an existing reviewed pattern; the allowlist stays opt-in per prefix.
- Assumptions that could be wrong: that no other unshipped feature needs the same pass-through — by design each new env-coupled feature must add its own prefix, which is exactly the coupling this PR documents in a comment at the rule site.
- Missing/weak tests: the test proves pass-through at the spawn seam, not that the server child actually starts tracing; that end-to-end proof is the live receipt on #530.
- Security/permission risk: the tracing keys go only to the server child, which is exactly the process that must dial Langfuse. Nothing else gains access.
- Migration/deploy risk: none — env-only behavior; the next `local-clone-deploy.sh` run picks it up.
- Downstream client/runtime risk: none — launcher-local, no MCP tool, schema, or transport surface.
- Rollback/cleanup concern: revert restores the old allowlist; tracing goes silently off again (the original defect), with no other side effect.
- Fixes made before PR: none beyond the change itself; branch rebased onto main to include #540 so the pre-push gate ran honestly.
- Known residual risk: the running service has written no log lines since Aug 2 (0-byte worker log) — separate defect, being filed — so `mcp_tracing_configured` may not be observable in logs until that is fixed; the Langfuse trace query is the primary receipt instead.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review-lane pattern arose; the deploy-coupling gotcha is documented at the rule site in code

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — none arose
- Live Open Brain checks: [x] not applicable because: no service, transport, MCP tool, or schema surface is touched — launcher-only; the live tracing receipt lands on #530 after redeploy

## Contract Parity

- Contract parity: [x] runtime-specific because: `buildChildEnvironment` is a private launcher helper with no contract fixture, client binding, or wire representation

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- Changed files are `scripts/local-clone.ts` and `scripts/local-clone.test.ts` only. No MCP tool, schema, transport, or client-facing surface is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
