### PR TITLE
fix(config): declare the LAN plain-http opt-in so remote hooks can reach the brain (#525)

### DIFF
--- a/_plans/fleet-rollout-0.9.md
+++ b/_plans/fleet-rollout-0.9.md
@@ -177,9 +177,18 @@ the wrong brain. Before #74, a session with no `OPENBRAIN_*` silently hydrated
 from core01 — two sessions chased a phantom core01 outage over exactly that.
 
 `OPENBRAIN_ALLOW_INSECURE_HTTP` is present because the local/LAN endpoint is
-plain `http`. **UNVERIFIED for cc-\* boxes:** whether cross-box plain-HTTP bearer
-tokens over the LAN are acceptable to Rico, or whether the boxes must go through
-`https://open-brain.rodaddy.live`. §6.
+plain `http`, and as of #525 it is a **declared** setting on both
+`CaptureSettings` and `CanonSettings` that the wrapper passes through — see §1.3.
+Before that fix it was declared nowhere and stripped by the wrapper, which is why
+a LAN box could not reach the brain at all: the client refuses non-loopback plain
+`http` without the flag, and exporting the flag made the strict config reject the
+whole environment. A LAN box now needs this variable set; on `127.0.0.1` it is
+inert (loopback http is auto-permitted).
+
+**UNVERIFIED for cc-\* boxes:** whether cross-box plain-HTTP bearer tokens over
+the LAN are acceptable to Rico, or whether the boxes must go through
+`https://open-brain.rodaddy.live`. §6. The declared opt-in makes plain-HTTP LAN
+possible; it does not decide that it is the chosen posture for those boxes.
 
 ### 1.3 The hook-env wrapper — EXISTS, and it is not optional
 
@@ -193,15 +202,29 @@ exec env -i \
   PATH="$PATH" HOME="$HOME" \
   OPENBRAIN_BASE_URL="${OPENBRAIN_BASE_URL:-}" \
   OPENBRAIN_TOKEN="${OPENBRAIN_TOKEN:-}" \
+  OPENBRAIN_OBSERVATION_*="..." \
+  OPENBRAIN_ALLOW_INSECURE_HTTP="${OPENBRAIN_ALLOW_INSECURE_HTTP:-}" \
   "$@"
 ```
 
-**Why it must be copied and not skipped** (`docs/420-cutover-rollback.md:46-56`):
+**Why it must be copied and not skipped** (`docs/420-cutover-rollback.md`):
 the Python config **rejects** any `OPENBRAIN_*` variable it does not declare
 (`config.unknown_prefixed_variables`), *and the hooks swallow that rejection*.
 So sourcing the whole env file into a hook would **silently zero every
 capture** — a green-looking box writing nothing. The wrapper's `env -i` passes
-exactly the two accepted variables.
+exactly the accepted variables and nothing else.
+
+**The pass-through list grows only AFTER the installed package declares the
+field** — declare in `openbrain.config`, `uv tool install --reinstall`, verify
+the installed interpreter accepts it, then edit the wrapper. Getting that order
+backwards is itself the silent-zero-capture failure. `OPENBRAIN_OBSERVATION_*`
+(#523) and `OPENBRAIN_ALLOW_INSECURE_HTTP` (#525) were both added this way.
+
+**A LAN box needs `OPENBRAIN_ALLOW_INSECURE_HTTP` in its env file** (the Air,
+`10.71.1.26`, pointing at `http://10.71.1.20:3100`). Without it the client
+refuses the non-loopback plain-`http` base URL and canon *and* capture decline
+silently — the #525 symptom. This is the family-A delta a LAN box has that the
+dev Mac does not, because loopback needs no flag.
 
 This is the single highest-risk thing to get wrong on a new box, because the
 failure is silent. The Step-5 gate below is written specifically to catch it by

--- a/docs/420-cutover-rollback.md
+++ b/docs/420-cutover-rollback.md
@@ -50,12 +50,22 @@ handled independently. No `sha256-` path is involved; a `uv tool install
 The Python config REJECTS any `OPENBRAIN_*` variable it does not declare
 (`config.unknown_prefixed_variables`), and the hooks swallow that rejection —
 so sourcing the whole `claudex-observation.env` (which carries
-`OPENBRAIN_OBSERVATION_*`, `OPENBRAIN_ALLOW_INSECURE_HTTP`, `OPENBRAIN_NAMESPACE`)
-would silently zero every capture. The wrapper
+`OPENBRAIN_NAMESPACE`) would silently zero every capture. The wrapper
 `~/.local/share/openbrain-memory/env/openbrain-hook-env` sources that file and
-passes the child ONLY the two accepted variables (`OPENBRAIN_BASE_URL`,
-`OPENBRAIN_TOKEN`) via `env -i`. The token stays in the env file; it is never
-written into `settings.json`.
+passes the child ONLY the accepted variables via `env -i`: `OPENBRAIN_BASE_URL`,
+`OPENBRAIN_TOKEN`, `OPENBRAIN_OBSERVATION_*` (#523), and
+`OPENBRAIN_ALLOW_INSECURE_HTTP` (#525). The token stays in the env file; it is
+never written into `settings.json`.
+
+**The pass-through list only ever grows AFTER the installed package declares the
+field.** A variable added here against an older install makes
+`unknown_prefixed_variables` reject the whole environment, and the hooks swallow
+that into a silent zero capture — so the order is: declare in
+`openbrain.config`, `uv tool install --reinstall`, verify the installed
+interpreter accepts it, then edit the wrapper. Verified in that order for #525 on
+2026-08-04 (old install raised `UnknownEnvironmentVariableError`; reinstalled
+one resolved `allow_insecure_http=True`). See `docs/CONFIG_REFERENCE.md`
+("LAN plain-HTTP opt-in").
 
 ## Verify the NEW path is ACTIVE
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -398,6 +398,50 @@ pass-throughs only at or after the moment the installed package includes
 `unknown_prefixed_variables` reject the whole environment, which the hooks
 swallow into a silent zero capture.
 
+### LAN plain-HTTP opt-in (#525) — Python `openbrain` hooks
+
+Declared on `CaptureSettings` and `CanonSettings`
+(`python/openbrain/src/openbrain/config.py`, `ALLOW_INSECURE_HTTP_ALIASES`), and
+flowed to `OpenBrainClient(allow_insecure_http=...)` at every site the hook
+stack builds a client.
+
+| variable | default | notes |
+|---|---|---|
+| `OPENBRAIN_ALLOW_INSECURE_HTTP` | `false` | permit a plain-`http` endpoint whose host is **not** loopback. One name, bound by both sections, and the same name `openbrain_memory.runtime` already reads |
+
+**What it is scoped to: a LAN-internal, pre-production posture.** The brain
+listens on a private address the operator controls, and putting TLS in front of
+3100 is a separate and larger piece of work (#525 names both routes; this is the
+declared opt-in route). It does **not** weaken the default — unset, the client's
+loopback-only rule stands exactly as before, so a public endpoint still has to be
+`https`. Turning it on is an explicit, per-host, documented choice.
+
+**Why it had to be declared rather than just exported.** The client refuses a
+non-loopback plain-`http` base URL unless the caller passes
+`allow_insecure_http=True` (`openbrain_memory.client._validate_base_url`) — and
+an `OPENBRAIN_`-prefixed variable matching no declared field is rejected by
+`unknown_prefixed_variables` as a typo, which the hook entrypoints swallow into a
+silent zero capture. So a LAN host had no legal way to say it: exporting the
+variable killed the whole environment, and not exporting it left the client
+refusing the URL. Measured 2026-08-02 (#525): a hook process pointing at
+`http://10.71.1.20:3100` declined canon **and** capture with no error anywhere —
+a Claude-family agent on a LAN box woke with the policy hook firing and zero
+hydration.
+
+**Deploy coupling — the wrapper must pass it through.** The deployed
+`openbrain-hook-env` wrapper (see `docs/420-cutover-rollback.md`) hands hooks only
+the variables it lists explicitly, and it stripped this one deliberately, because
+before this change the installed package rejected it. The wrapper adds the
+pass-through only at or after the moment the installed package declares the
+field. This is the same ordering rule the `OPENBRAIN_OBSERVATION_*` and
+`OPENBRAIN_SPOOL_PATH` notes carry: **the package declares first, the wrapper
+passes second.** Reversing it makes `unknown_prefixed_variables` reject the whole
+environment, which the hooks swallow into a silent zero capture.
+
+Both halves are required. Declaring the field without the wrapper pass-through
+leaves the hook process never seeing the variable; passing it through without the
+declaration is the rejection above.
+
 ### Sibling-package variables that must still be declared
 
 | variable | default | notes |

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -442,6 +442,34 @@ Both halves are required. Declaring the field without the wrapper pass-through
 leaves the hook process never seeing the variable; passing it through without the
 declaration is the rejection above.
 
+**An EMPTY value means unset, and both halves enforce that (PR #544).** The
+wrapper's pass-through style is `VAR="${VAR:-}"`, which cannot express "absent" —
+it turns an unset variable into an **empty string** in the child. For a string
+setting that is harmless; for this `bool` it was not. Measured 2026-08-04 against
+the installed binary: with the variable omitted from `claudex-observation.env`,
+the child received `OPENBRAIN_ALLOW_INSECURE_HTTP=""`, pydantic's bool parser
+rejected it (`Input should be a valid boolean … input_value=''`), **both**
+`load_capture_settings` and `load_canon_settings` raised, the entrypoints
+swallowed the raise, and the hook exited 0 having captured and injected nothing —
+the #525 defect class, re-armed by the fix for #525 on every host that never
+opted in. Only the loaders reproduce it; a bare `CaptureSettings()` reads no
+environment and looked healthy throughout.
+
+Fixed at the owning boundary — a `mode="before"` validator on the field in both
+declaring sections maps a blank string to the default `False`. This is the same
+empty-means-unset reading `OPENBRAIN_SPOOL_PATH`
+(`apps.capture.outage.default_spool_path`) and `XDG_STATE_HOME`
+(`receipts.state.default_receipt_state_path`) already use. It is narrow on
+purpose: `1`/`true` still enable, `false` still disables, a garbage **value**
+like `maybe` still raises, and a misspelled **name** is still caught by
+`unknown_prefixed_variables`.
+
+The wrapper carries the second layer: it passes the variable only when non-empty,
+prepending `NAME=VALUE` to the positional list rather than listing it in `env -i`.
+That is what protects an **older installed package** that predates the validator.
+Any future non-string pass-through belongs in that conditional block, not the
+`env -i` list, for the same reason.
+
 ### Sibling-package variables that must still be declared
 
 | variable | default | notes |

--- a/python/openbrain/src/openbrain/apps/bulk/run.py
+++ b/python/openbrain/src/openbrain/apps/bulk/run.py
@@ -134,6 +134,8 @@ def _lane(settings: CaptureSettings, session_key: str) -> BulkLane:
         token=settings.token.get_secret_value(),
         namespace=settings.agent_id,
         agent_id=settings.agent_id,
+        # The LAN opt-in (#525), same environment the hook lanes read.
+        allow_insecure_http=settings.allow_insecure_http,
     )
     memory = AgentMemory(client, agent=settings.agent_id)
     memory.start_session(session_key)

--- a/python/openbrain/src/openbrain/apps/canon/run.py
+++ b/python/openbrain/src/openbrain/apps/canon/run.py
@@ -250,6 +250,10 @@ def _apply(planned: Sequence[PlannedWrite], settings: CanonSettings) -> None:
         base_url=settings.base_url,
         token=settings.token.get_secret_value(),
         namespace=settings.agent,
+        # The LAN opt-in (#525). The operator path reads the same environment the
+        # hooks do, so an operator on a LAN host reconciles canon rather than
+        # hitting the client's loopback-only refusal.
+        allow_insecure_http=settings.allow_insecure_http,
     )
     try:
         for call in planned:

--- a/python/openbrain/src/openbrain/apps/hooks/session.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session.py
@@ -812,6 +812,10 @@ def _record_skill_usage(
         agent_id=settings.agent_id,
         timeout=CAPTURE_REQUEST_TIMEOUT_SECONDS,
         retry_policy=RetryPolicy(attempts=1),
+        # The LAN opt-in (#525). Unset it is False, so the client's loopback-only
+        # http rule stands; a LAN host that declared it reaches the dev brain
+        # over plain http instead of this metric declining silently.
+        allow_insecure_http=settings.allow_insecure_http,
     )
     try:
         client.call_tool("record_skill_usage", arguments)
@@ -875,6 +879,9 @@ def _started_memory(settings: CaptureSettings, session_key: str) -> StartedLane:
         # CAPTURE_REQUEST_TIMEOUT_SECONDS.
         timeout=CAPTURE_REQUEST_TIMEOUT_SECONDS,
         retry_policy=single_attempt,
+        # The LAN opt-in (#525). This is the capture spine: without it a LAN host
+        # loses every turn, which is the silent zero capture the issue measured.
+        allow_insecure_http=settings.allow_insecure_http,
     )
     # Annotated to RawLane, the Protocol the spine needs, which AgentMemory
     # structurally satisfies. start_session is not part of that Protocol -- it is
@@ -1063,6 +1070,10 @@ def _canon_context(settings: CanonSettings) -> CanonContext:
         agent_id=settings.agent,
         timeout=CANON_REQUEST_TIMEOUT_SECONDS,
         retry_policy=RetryPolicy(attempts=1),
+        # The LAN opt-in (#525). This is the CANON PACK read -- the lane whose
+        # absence the issue opens on ("the hook told me the rules and then handed
+        # me an empty skull").
+        allow_insecure_http=settings.allow_insecure_http,
     )
     # repo is OMITTED when None, never sent as null. The client method is a
     # pure **arguments pass-through, so a None here reaches the wire as

--- a/python/openbrain/src/openbrain/apps/hooks/session_start.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session_start.py
@@ -396,6 +396,9 @@ def _lane_resume_text(payload: SessionStartHook, canon: CanonSettings) -> str | 
         agent_id=canon.agent,
         timeout=CANON_REQUEST_TIMEOUT_SECONDS,
         retry_policy=RetryPolicy(attempts=1),
+        # The LAN opt-in (#525), on the same client configuration the canon read
+        # uses -- emission two must not be the one lane that still refuses.
+        allow_insecure_http=canon.allow_insecure_http,
     )
     try:
         context = client.session_context(

--- a/python/openbrain/src/openbrain/config.py
+++ b/python/openbrain/src/openbrain/config.py
@@ -114,6 +114,36 @@ PositiveInt = Annotated[int, Field(gt=0)]
 #: A positive number of milliseconds.
 PositiveMs = Annotated[int, Field(gt=0)]
 
+#: The environment spelling of the plain-HTTP opt-in, shared by every section
+#: that builds an ``openbrain_memory`` client.
+#:
+#: WHY THIS IS ONE NAME AND NOT A PER-SECTION ONE. The sibling client refuses a
+#: plain-``http`` base URL unless the host is loopback or the caller passes
+#: ``allow_insecure_http=True`` (``openbrain_memory.client._validate_base_url``),
+#: and ``openbrain_memory.runtime`` already reads exactly this variable for its
+#: own direct-client path (``runtime.py``: ``RuntimeConfig.from_sources``). A
+#: second, section-scoped spelling would mean a LAN host had to set two
+#: variables that mean the same thing, and the sibling would keep ignoring the
+#: new one. So capture and canon BOTH bind this single name.
+#:
+#: WHY IT MUST BE DECLARED AT ALL (#525). An ``OPENBRAIN_``-prefixed variable
+#: matching no declared field is rejected by :func:`unknown_prefixed_variables`
+#: as a typo, and the hook entrypoints swallow that rejection into a SILENT ZERO
+#: CAPTURE / ZERO INJECTION with a clean exit 0. Measured 2026-08-02 and recorded
+#: in the issue: a hook process on a LAN box pointing at ``http://10.71.1.20:3100``
+#: declined canon AND capture with no error anywhere, because the deployed
+#: ``openbrain-hook-env`` wrapper strips this variable precisely to avoid that
+#: rejection. This is the same trap ``CaptureSettings.spool_path`` and
+#: ``ObservationSettings.hmac_secret`` document, hit a third time.
+#:
+#: WHAT IT IS SCOPED TO. A LAN-internal pre-production posture: the brain listens
+#: on a private address the operator controls, and the alternative -- TLS in front
+#: of 3100 -- is a separate, larger piece of work (#525 names both routes; this is
+#: the declared opt-in route). It does NOT weaken the default. Unset, the client's
+#: loopback-only rule stands exactly as before, so a public endpoint still has to
+#: be ``https``. Turning it on is an explicit, per-host, documented choice.
+ALLOW_INSECURE_HTTP_ALIASES = AliasChoices("OPENBRAIN_ALLOW_INSECURE_HTTP")
+
 
 class ConfigurationError(ValueError):
     """A setting is missing, malformed, or inert, and the process cannot start.
@@ -397,6 +427,11 @@ class CaptureSettings(_Base):
             reads this to report spool depth
             (``apps.capture.outage.default_spool_path``); declaring it is what
             makes setting it legal.
+        allow_insecure_http: Permit a plain-``http`` endpoint whose host is not
+            loopback, for a LAN client reaching the dev brain. See
+            :data:`ALLOW_INSECURE_HTTP_ALIASES` for the posture this is scoped
+            to; the value flows to ``OpenBrainClient(allow_insecure_http=...)``
+            at every capture-lane construction site.
     """
 
     base_url: str | None = Field(
@@ -424,6 +459,10 @@ class CaptureSettings(_Base):
     spool_path: Path | None = Field(
         default=None,
         validation_alias=AliasChoices("OPENBRAIN_SPOOL_PATH"),
+    )
+    allow_insecure_http: bool = Field(
+        default=False,
+        validation_alias=ALLOW_INSECURE_HTTP_ALIASES,
     )
 
 
@@ -535,6 +574,12 @@ class CanonSettings(_Base):
         repo: The repository slug ``repo_facts`` binds to exactly.
         sections: The sections to request. The canon-only default is the three
             structured-guidance sections; an operator may override it.
+        allow_insecure_http: Permit a plain-``http`` endpoint whose host is not
+            loopback, for a LAN client reaching the dev brain. Binds the SAME
+            variable capture does (:data:`ALLOW_INSECURE_HTTP_ALIASES`), because
+            both lanes reach the one service the environment points at -- a host
+            that can capture over LAN http can read canon over it too, and #525
+            proved that a lane left off the flow declines silently.
     """
 
     base_url: str | None = Field(
@@ -585,6 +630,10 @@ class CanonSettings(_Base):
     sections: tuple[str, ...] = Field(
         default=("profile_guidance", "process_guidance", "repo_facts"),
         validation_alias=AliasChoices("OPENBRAIN_CANON_SECTIONS"),
+    )
+    allow_insecure_http: bool = Field(
+        default=False,
+        validation_alias=ALLOW_INSECURE_HTTP_ALIASES,
     )
 
     @field_validator("sections", mode="before")

--- a/python/openbrain/src/openbrain/config.py
+++ b/python/openbrain/src/openbrain/config.py
@@ -145,6 +145,43 @@ PositiveMs = Annotated[int, Field(gt=0)]
 ALLOW_INSECURE_HTTP_ALIASES = AliasChoices("OPENBRAIN_ALLOW_INSECURE_HTTP")
 
 
+def _empty_opt_in_means_unset(value: object) -> object:
+    """Treat an empty ``OPENBRAIN_ALLOW_INSECURE_HTTP`` as absent, not malformed.
+
+    Args:
+        value: Whatever the environment layer resolved for the field. Only a
+            string can be empty; a real ``bool`` passed in code goes through
+            untouched.
+
+    Returns:
+        ``False`` for an empty or whitespace-only string, the input unchanged
+        otherwise -- so ``"1"``/``"true"`` still enable, ``"false"`` still
+        disables, and genuine garbage like ``"maybe"`` still raises.
+
+    WHY THIS EXISTS (measured 2026-08-04, against the installed wrapper). The
+    deployed ``openbrain-hook-env`` passes the child
+    ``OPENBRAIN_ALLOW_INSECURE_HTTP="${OPENBRAIN_ALLOW_INSECURE_HTTP:-}"``, so a
+    machine whose env file does not set the variable hands the hook an EMPTY
+    STRING rather than nothing at all. Pydantic's bool parser rejects ``""``
+    with a ``ValidationError``, the hook entrypoints swallow it (fail-open
+    observer contract), and the result is a SILENT ZERO CAPTURE / ZERO
+    INJECTION with a clean exit 0 -- #525's exact defect class, re-armed on
+    every host that never opted in. ``load_capture_settings`` and
+    ``load_canon_settings`` both raised; only the direct constructor, which
+    reads no environment, appeared healthy.
+
+    Empty-means-unset is this repo's established reading of an environment
+    variable, not a new leniency: ``apps.capture.outage.default_spool_path``
+    and ``receipts.state.default_receipt_state_path`` both fall back on an
+    empty value rather than resolving it. The typo check
+    (:func:`unknown_prefixed_variables`) is untouched, so a MISSPELLED opt-in
+    still raises -- silence is only ever granted to the name we declared.
+    """
+    if isinstance(value, str) and not value.strip():
+        return False
+    return value
+
+
 class ConfigurationError(ValueError):
     """A setting is missing, malformed, or inert, and the process cannot start.
 
@@ -465,6 +502,10 @@ class CaptureSettings(_Base):
         validation_alias=ALLOW_INSECURE_HTTP_ALIASES,
     )
 
+    _empty_opt_in = field_validator("allow_insecure_http", mode="before")(
+        _empty_opt_in_means_unset
+    )
+
 
 class ObservationSettings(_Base):
     """Where the capture hooks ship observation traces, and the keys they use.
@@ -634,6 +675,10 @@ class CanonSettings(_Base):
     allow_insecure_http: bool = Field(
         default=False,
         validation_alias=ALLOW_INSECURE_HTTP_ALIASES,
+    )
+
+    _empty_opt_in = field_validator("allow_insecure_http", mode="before")(
+        _empty_opt_in_means_unset
     )
 
     @field_validator("sections", mode="before")

--- a/python/openbrain/tests/conftest.py
+++ b/python/openbrain/tests/conftest.py
@@ -18,11 +18,74 @@ shape; only the ``-m live`` tests prove a write survives Postgres.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+#: Environment prefixes the settings models read, cleared for every test.
+#:
+#: ``OPENBRAIN_TEST_`` is deliberately NOT among them: the ``-m live`` tests
+#: address the playground service through that prefix, and clearing it would
+#: skip the live gate having run nothing.
+_LEAKING_PREFIXES = ("OPENBRAIN_", "OPEN_BRAIN_", "DB_", "EMBEDDING_", "LOG_")
+
+#: Unprefixed names the settings models read.
+_LEAKING_NAMES = frozenset({"PORT", "SERVICE_NAME", "ALLOWED_ORIGINS"})
+
+
+@pytest.fixture(autouse=True)
+def _clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove every variable the settings models read, for every test.
+
+    WHY THIS IS SUITE-WIDE AND NOT PER-FILE (#544). ``test_settings`` has
+    carried a file-scoped copy of this since it was written, for the reason its
+    docstring gives -- "a developer's real shell leaks into the assertions and a
+    test that should fail passes on their machine only". The leak is not
+    confined to settings tests. Every hook entrypoint reads the environment
+    itself for the sections its CALLER did not inject: ``capture_stop_with``
+    takes ``settings`` but still calls ``loaded_observation()``, which resolves
+    ``ObservationSettings`` from the live process environment. So a test that
+    injects a fake capture lane still runs the observation lane against
+    whatever the developer's shell happens to hold.
+
+    MEASURED, ON THIS BRANCH. An operator shell with the four observation
+    coordinates set (``OPENBRAIN_OBSERVATION_ENABLED`` /``_ENDPOINT``
+    /``_PUBLIC_KEY``/``_SECRET_KEY``, as
+    ``~/.local/share/openbrain-memory/env/claudex-observation.env`` provides)
+    made ``test_capture_outage_notice`` HANG INDEFINITELY at test 8 of 45. The
+    faulthandler stack named it exactly: ``capture_stop_with`` ->
+    ``LangfuseEmitter.emit`` -> ``client.shutdown()``, blocked draining an
+    OpenTelemetry batch worker against the real fleet Langfuse server. The test
+    suite was posting the fixture's transcripts to production and waiting on
+    the network to answer.
+
+    WHY IT LOOKED LIKE THIS BRANCH INTRODUCED IT. It did not; it UNMASKED it.
+    ``unknown_prefixed_variables`` rejects any ``OPENBRAIN_``-prefixed variable
+    matching no declared field, and before this branch
+    ``OPENBRAIN_ALLOW_INSECURE_HTTP`` was undeclared -- so on a host that set it
+    the settings load raised, ``loaded_observation()`` swallowed the raise, and
+    the sink silently stayed off. Declaring the variable (the whole point of
+    #525) let the load SUCCEED, and the observation lane it had been shadowing
+    all along started dialing. The typo check was acting as an accidental
+    network guard, which is why CI never saw this: CI sets no observation
+    coordinates, so ``observation_active`` is False there either way.
+
+    Prefix-based rather than a fixed list, because the failure mode is a
+    variable nobody thought to enumerate -- the one that hung the suite was
+    added to the environment file after the tests were written.
+    """
+    for name in list(os.environ):
+        upper = name.upper()
+        if upper.startswith("OPENBRAIN_TEST_"):
+            continue
+        if upper.startswith(_LEAKING_PREFIXES) or upper in _LEAKING_NAMES:
+            monkeypatch.delenv(name, raising=False)
+
 
 #: The timestamp every helper line carries. Real transcripts always set one, and
 #: the server orders a session by it; a fixed value keeps assertions stable.

--- a/python/openbrain/tests/test_lan_http_optin.py
+++ b/python/openbrain/tests/test_lan_http_optin.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from openbrain_memory.client import OpenBrainClient
+from pydantic import ValidationError
 
 from openbrain.config import (
     CanonSettings,
@@ -139,6 +140,62 @@ def test_the_opt_in_is_off_when_the_variable_is_absent() -> None:
     without = {k: v for k, v in LAN_ENV.items() if "INSECURE" not in k}
     assert load_capture_settings(without).allow_insecure_http is False
     assert load_canon_settings(without).allow_insecure_http is False
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [load_capture_settings, load_canon_settings],
+    ids=["capture", "canon"],
+)
+@pytest.mark.parametrize("blank", ["", "   "], ids=["empty", "whitespace"])
+def test_an_empty_opt_in_loads_with_the_opt_in_off(loader: Any, blank: str) -> None:
+    """An EMPTY opt-in is unset, not malformed -- the shape the wrapper sends.
+
+    This is the assertion that fails on the pre-fix branch head, with
+    ``ValidationError ... bool_parsing, input_value=''``. It is not a
+    hypothetical: the deployed ``openbrain-hook-env`` passes
+    ``OPENBRAIN_ALLOW_INSECURE_HTTP="${OPENBRAIN_ALLOW_INSECURE_HTTP:-}"``, so
+    every host whose env file omits the variable hands the hook an empty
+    string. The entrypoints swallow the raise, so the visible symptom is a
+    clean exit 0 with no rows -- #525's own defect class, re-armed by the fix
+    for it.
+
+    Loading must SUCCEED with the opt-in OFF. A raise is the bug; silently
+    reading it as ON would be worse, so the value is asserted too.
+
+    Only the loaders reproduce this. A bare ``CaptureSettings()`` reads no
+    environment, so it looked healthy while both hook paths raised.
+    """
+    settings = loader({**LAN_ENV, "OPENBRAIN_ALLOW_INSECURE_HTTP": blank})
+
+    assert settings.allow_insecure_http is False
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [load_capture_settings, load_canon_settings],
+    ids=["capture", "canon"],
+)
+@pytest.mark.parametrize("enabling", ["1", "true"], ids=["one", "true"])
+def test_a_real_opt_in_value_still_enables(loader: Any, enabling: str) -> None:
+    """Empty-means-unset does not blunt the values that mean yes.
+
+    The narrow reading is the point: only a blank string becomes the default.
+    """
+    enabled = loader({**LAN_ENV, "OPENBRAIN_ALLOW_INSECURE_HTTP": enabling})
+
+    assert enabled.allow_insecure_http is True
+
+
+def test_a_garbage_opt_in_value_is_still_rejected() -> None:
+    """Blank is unset; nonsense is still an error.
+
+    Treating ``""`` as absent must not slide into "treat anything unparseable
+    as off", which would let a typo'd VALUE (as opposed to a typo'd NAME) load
+    clean as an unset opt-in and decline the LAN endpoint silently.
+    """
+    with pytest.raises(ValidationError):
+        load_capture_settings({**LAN_ENV, "OPENBRAIN_ALLOW_INSECURE_HTTP": "maybe"})
 
 
 def test_a_misspelled_opt_in_is_still_rejected() -> None:

--- a/python/openbrain/tests/test_lan_http_optin.py
+++ b/python/openbrain/tests/test_lan_http_optin.py
@@ -1,0 +1,378 @@
+"""The LAN plain-HTTP opt-in (#525): declared, and flowed to every client.
+
+Two failures stacked to make a remote Claude-family host wake with an empty
+skull, and this file pins both ends of the fix.
+
+The FIRST is configuration: ``OPENBRAIN_ALLOW_INSECURE_HTTP`` matched no
+declared setting, so :func:`unknown_prefixed_variables` rejected the whole
+environment as a typo. The hook entrypoints swallow that rejection (fail-open
+observer contract), which makes it a SILENT ZERO CAPTURE / ZERO INJECTION with
+a clean exit 0 -- the worst shape a config error can take. The deployed
+``openbrain-hook-env`` wrapper stripped the variable for exactly that reason.
+
+The SECOND is plumbing: declaring the field changes nothing unless it reaches
+``OpenBrainClient(allow_insecure_http=...)`` at EVERY site the hook stack
+constructs one. A site left off the flow is a lane that silently declines on a
+LAN box, which is #525 again in miniature -- so the construction sites are
+enumerated here as a test, not as a comment.
+
+The listener test is the one that cannot be faked by a stub: it binds a real
+socket on this machine's real LAN address and drives a real client through it,
+proving a non-loopback ``http`` endpoint is genuinely reachable under the opt-in
+rather than merely passing a string check.
+
+See Also:
+    - ``openbrain.config.ALLOW_INSECURE_HTTP_ALIASES`` -- the posture and scope
+    - ``openbrain_memory.client._validate_base_url`` -- the rule being opted out of
+    - ``docs/CONFIG_REFERENCE.md`` -- the field and its wrapper coupling
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from openbrain_memory.client import OpenBrainClient
+
+from openbrain.config import (
+    CanonSettings,
+    CaptureSettings,
+    UnknownEnvironmentVariableError,
+    load_canon_settings,
+    load_capture_settings,
+    load_observation_settings,
+    unknown_prefixed_variables,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+#: A LAN-shaped endpoint: plain http, and a host that is NOT loopback. The
+#: literal is a TEST FIXTURE, not configuration -- nothing here reads it as a
+#: real endpoint, and the repo's never-hardcode-a-host rule is about the code
+#: that connects, which takes its address from the environment.
+LAN_BASE_URL = "http://10.71.1.20:3100"
+
+#: A throwaway bearer value. Named rather than inlined so the linter's
+#: hardcoded-credential check is satisfied by construction: there is one obvious
+#: place a real token would have to be pasted, and it is a test fixture.
+FAKE_TOKEN = "test-token"  # noqa: S105 - fixture value, never a real credential
+
+#: The environment a LAN hook process actually carries, in the shape the
+#: wrapper hands it: endpoint, token, and the opt-in.
+LAN_ENV = {
+    "OPENBRAIN_BASE_URL": LAN_BASE_URL,
+    "OPENBRAIN_TOKEN": FAKE_TOKEN,
+    "OPENBRAIN_ALLOW_INSECURE_HTTP": "true",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop every prefixed variable so a developer's shell cannot mask a failure.
+
+    The loaders validate the WHOLE prefixed environment, not just the section
+    being read, so an unrelated ``OPENBRAIN_*`` left in a real shell would raise
+    from the typo check and make these assertions pass or fail for the wrong
+    reason.
+    """
+    for name in list(os.environ):
+        if name.upper().startswith(("OPENBRAIN_", "OPEN_BRAIN_")):
+            monkeypatch.delenv(name, raising=False)
+
+
+# --------------------------------------------------------------------------
+# The config half: the variable is declared, so the environment is not rejected
+# --------------------------------------------------------------------------
+
+
+def test_the_variable_is_recognised_rather_than_flagged_as_a_typo() -> None:
+    """The opt-in is a DECLARED name, not an unknown one.
+
+    This is the assertion that fails on the pre-fix code, and it is deliberately
+    the narrowest one: :func:`unknown_prefixed_variables` is the exact function
+    whose verdict the loaders turn into a raise.
+    """
+    assert unknown_prefixed_variables(LAN_ENV) == ()
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [load_capture_settings, load_canon_settings, load_observation_settings],
+    ids=["capture", "canon", "observation"],
+)
+def test_every_section_loader_accepts_the_lan_environment(
+    loader: Any,
+) -> None:
+    """No hook-section loader rejects a LAN environment.
+
+    ``observation`` is included even though it builds no Open Brain client: each
+    loader validates the ENTIRE prefixed environment, so an undeclared variable
+    takes down whichever loader runs first regardless of which section owns it.
+    That is precisely how one missing declaration killed all three lanes.
+    """
+    loader(LAN_ENV)
+
+
+def test_capture_and_canon_both_read_the_opt_in_from_one_variable() -> None:
+    """One environment name reaches both lanes.
+
+    A per-section spelling would make a LAN host set two variables meaning the
+    same thing, and would still leave the sibling package's own reader
+    (``openbrain_memory.runtime``) looking at a third.
+    """
+    assert load_capture_settings(LAN_ENV).allow_insecure_http is True
+    assert load_canon_settings(LAN_ENV).allow_insecure_http is True
+
+
+def test_the_opt_in_is_off_when_the_variable_is_absent() -> None:
+    """The default is unchanged: no opt-in unless a host asks for one.
+
+    The fix must not weaken the client's loopback-only rule for anybody who did
+    not explicitly turn it on.
+    """
+    without = {k: v for k, v in LAN_ENV.items() if "INSECURE" not in k}
+    assert load_capture_settings(without).allow_insecure_http is False
+    assert load_canon_settings(without).allow_insecure_http is False
+
+
+def test_a_misspelled_opt_in_is_still_rejected() -> None:
+    """Declaring one name does not stop the typo check doing its job.
+
+    ``OPENBRAIN_ALLOW_INSECURE_HTTPS`` is the plausible slip, and it must raise
+    rather than load clean as an unset opt-in -- otherwise the operator believes
+    the LAN endpoint is permitted and the lane declines silently anyway.
+    """
+    typo = dict(LAN_ENV)
+    del typo["OPENBRAIN_ALLOW_INSECURE_HTTP"]
+    typo["OPENBRAIN_ALLOW_INSECURE_HTTPS"] = "true"
+
+    with pytest.raises(UnknownEnvironmentVariableError) as raised:
+        load_capture_settings(typo)
+
+    assert "OPENBRAIN_ALLOW_INSECURE_HTTPS" in str(raised.value)
+
+
+# --------------------------------------------------------------------------
+# The plumbing half: every construction site passes the flag through
+# --------------------------------------------------------------------------
+
+
+class _ClientSpy:
+    """Stand in for ``OpenBrainClient`` and remember its keyword arguments.
+
+    Only the constructor contract matters here, so every call the lanes make is
+    absorbed by ``__getattr__``. The point of the test is what was PASSED, not
+    what came back.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    def __getattr__(self, name: str) -> Any:
+        def _anything(*_args: Any, **_kwargs: Any) -> Any:
+            return {}
+
+        return _anything
+
+
+@pytest.fixture
+def spy_client(monkeypatch: pytest.MonkeyPatch) -> list[_ClientSpy]:
+    """Capture every client the code under test constructs.
+
+    Patched on ``openbrain_memory.client``, which is where all five sites import
+    the name from at call time, so one patch covers them all.
+    """
+    built: list[_ClientSpy] = []
+
+    def _factory(**kwargs: Any) -> _ClientSpy:
+        spy = _ClientSpy(**kwargs)
+        built.append(spy)
+        return spy
+
+    monkeypatch.setattr("openbrain_memory.client.OpenBrainClient", _factory)
+    return built
+
+
+def test_capture_spine_passes_the_opt_in(spy_client: list[_ClientSpy]) -> None:
+    """``_started_memory`` -- the lane every captured turn goes through."""
+    from openbrain.apps.hooks.session import _started_memory
+
+    _started_memory(load_capture_settings(LAN_ENV), "session-key")
+
+    assert spy_client[0].kwargs["allow_insecure_http"] is True
+
+
+def test_skill_usage_recorder_passes_the_opt_in(
+    spy_client: list[_ClientSpy],
+) -> None:
+    """``_record_skill_usage`` -- the ``PostToolUse`` metric lane."""
+    from openbrain.apps.hooks.session import _record_skill_usage
+
+    _record_skill_usage(load_capture_settings(LAN_ENV), "session-key", {})
+
+    assert spy_client[0].kwargs["allow_insecure_http"] is True
+
+
+def test_canon_read_passes_the_opt_in(spy_client: list[_ClientSpy]) -> None:
+    """``_canon_context`` -- the CANON PACK read #525 opens on."""
+    from openbrain.apps.hooks.session import _canon_context
+
+    _canon_context(load_canon_settings(LAN_ENV))
+
+    assert spy_client[0].kwargs["allow_insecure_http"] is True
+
+
+def test_lane_resume_passes_the_opt_in(spy_client: list[_ClientSpy]) -> None:
+    """``_lane_resume_text`` -- emission two (#519), on the same coordinates."""
+    from openbrain.apps.hooks import session_start
+
+    canon = load_canon_settings(LAN_ENV)
+    monkey_payload = object()
+
+    original = session_start._resolve_lane_key
+    session_start._resolve_lane_key = lambda *_a, **_k: "lane-key"  # type: ignore[assignment]
+    try:
+        session_start._lane_resume_text(monkey_payload, canon)  # type: ignore[arg-type]
+    finally:
+        session_start._resolve_lane_key = original  # type: ignore[assignment]
+
+    assert spy_client[0].kwargs["allow_insecure_http"] is True
+
+
+def test_canon_reconcile_passes_the_opt_in(spy_client: list[_ClientSpy]) -> None:
+    """``apps.canon.run._apply`` -- the operator reconcile path."""
+    from openbrain.apps.canon.run import _apply
+
+    _apply([], load_canon_settings(LAN_ENV))
+
+    assert spy_client[0].kwargs["allow_insecure_http"] is True
+
+
+def test_bulk_ingest_passes_the_opt_in(spy_client: list[_ClientSpy]) -> None:
+    """``apps.bulk.run._lane`` -- the operator bulk-ingest path."""
+    from openbrain.apps.bulk.run import _lane
+
+    _lane(load_capture_settings(LAN_ENV), "session-key")
+
+    assert spy_client[0].kwargs["allow_insecure_http"] is True
+
+
+# --------------------------------------------------------------------------
+# The real-socket proof: non-loopback plain http actually connects
+# --------------------------------------------------------------------------
+
+
+def _lan_address() -> str:
+    """This machine's own LAN address, or skip.
+
+    Opening a UDP socket toward a routable address makes the kernel choose the
+    outbound interface without sending anything, which is how the real
+    non-loopback address is learned without hardcoding one. A host with no LAN
+    address (an isolated CI container) skips rather than fails: the test needs a
+    genuinely non-loopback bind to mean anything.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect(("10.255.255.255", 1))
+        address: str = probe.getsockname()[0]
+    except OSError:  # pragma: no cover - depends on the host's network
+        pytest.skip("no non-loopback address available on this host")
+    finally:
+        probe.close()
+
+    if address.startswith("127."):  # pragma: no cover - depends on the host
+        pytest.skip("resolved address is loopback; nothing to prove")
+    return address
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    """Answer ``/health`` and say nothing to the test log."""
+
+    def do_GET(self) -> None:  # noqa: N802 - name fixed by BaseHTTPRequestHandler
+        body = json.dumps({"status": "ok"}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: Any) -> None:
+        """Silence the default stderr access log."""
+
+
+@pytest.fixture
+def lan_server() -> Iterator[str]:
+    """A real HTTP server bound to this machine's real LAN address.
+
+    Port 0 lets the kernel pick a free port, so the test never collides with the
+    7100-7199 development range or with anything else already listening.
+    """
+    address = _lan_address()
+    server = HTTPServer((address, 0), _HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{address}:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_a_real_non_loopback_http_endpoint_is_refused_without_the_opt_in(
+    lan_server: str,
+) -> None:
+    """The default still refuses, against a genuinely reachable endpoint.
+
+    Reachability is not the question the rule asks -- the server here is up and
+    answering, and the client must still decline, which is what makes the opt-in
+    a deliberate choice rather than a fallback.
+    """
+    with pytest.raises(ValueError, match="allow_insecure_http"):
+        OpenBrainClient(base_url=lan_server, token=FAKE_TOKEN, namespace="n")
+
+
+def test_a_real_non_loopback_http_endpoint_answers_under_the_opt_in(
+    lan_server: str,
+) -> None:
+    """A LAN client built from the declared setting completes a real request.
+
+    End to end in one assertion: the environment a LAN host carries, through the
+    strict config that used to reject it, into a client that used to refuse the
+    URL, over a real socket on a real non-loopback address, to a 200.
+    """
+    settings = load_capture_settings({**LAN_ENV, "OPENBRAIN_BASE_URL": lan_server})
+    assert settings.base_url is not None
+    assert settings.token is not None
+
+    client = OpenBrainClient(
+        base_url=settings.base_url,
+        token=settings.token.get_secret_value(),
+        namespace=settings.agent_id,
+        agent_id=settings.agent_id,
+        allow_insecure_http=settings.allow_insecure_http,
+    )
+    try:
+        assert client.health() == {"status": "ok"}
+    finally:
+        client.close()
+
+
+def test_the_settings_sections_agree_on_the_flag_type() -> None:
+    """Both sections coerce the environment's string to a real bool.
+
+    An env layer hands ``"true"`` in as a string; a field that silently kept it
+    as a truthy string would also make ``"false"`` mean True -- the failure mode
+    where turning the opt-in OFF turns it on.
+    """
+    off = {**LAN_ENV, "OPENBRAIN_ALLOW_INSECURE_HTTP": "false"}
+    assert load_capture_settings(off).allow_insecure_http is False
+    assert load_canon_settings(off).allow_insecure_http is False
+    assert CaptureSettings().allow_insecure_http is False
+    assert CanonSettings().allow_insecure_http is False

--- a/python/openbrain/tests/test_observe_sink.py
+++ b/python/openbrain/tests/test_observe_sink.py
@@ -14,6 +14,7 @@ unit tests that would dial a server.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -33,6 +34,7 @@ from openbrain.apps.hooks.session import (
     run_stop,
     run_subagent_stop,
 )
+from openbrain.apps.hooks.stop import loaded_observation
 from openbrain.config import (
     CaptureSettings,
     ObservationSettings,
@@ -352,3 +354,53 @@ class TestObservationSettingsResolution:
     def test_a_secret_never_appears_in_the_repr(self) -> None:
         settings = observation_settings()
         assert "sk-lf-test" not in repr(settings)
+
+
+class TestTheSuiteNeverInheritsAnOperatorsSink:
+    """A developer's real observation coordinates must not reach a test (#544).
+
+    THE FAILURE THIS PINS. ``capture_stop_with`` accepts an injected
+    ``CaptureSettings`` but resolves the OBSERVATION section itself, from the
+    live process environment, on every call. On a machine whose shell carries
+    the four provisioned coordinates -- which the operator env file
+    ``claudex-observation.env`` supplies, so any hook-configured host has them
+    -- the unit suite built a real ``LangfuseEmitter`` and posted its fixture
+    transcripts to the fleet server. ``emit`` ends in ``client.shutdown()``,
+    which BLOCKS draining the OpenTelemetry batch worker, so
+    ``test_capture_outage_notice`` hung indefinitely at test 8 of 45 rather
+    than failing. A hang is the worst shape for this: it reports nothing, and
+    it looked like the branch that merely UNMASKED it (declaring
+    ``OPENBRAIN_ALLOW_INSECURE_HTTP`` stopped the typo check from rejecting the
+    load, which had been shadowing the sink) was the branch that caused it.
+
+    Asserted at ``loaded_observation`` and at the environment itself, rather
+    than by running the hook: the hook's symptom is a HANG, and a test that
+    hangs to prove a hang reports nothing and blocks the suite behind it. These
+    two are the boundary that reads the environment and the environment it
+    reads; the autouse ``_clean_environment`` fixture in ``conftest`` is what
+    keeps both inert. Both fail without it -- verified by flipping the fixture
+    to ``autouse=False`` in an operator shell, 2026-08-04.
+    """
+
+    def test_ambient_coordinates_do_not_activate_the_sink(self) -> None:
+        """The section the hook resolves for itself is inert under the fixture."""
+        resolved = loaded_observation()
+        assert resolved is not None
+        assert observation_active(resolved) is False
+
+    def test_the_environment_the_hook_reads_carries_no_openbrain_variables(
+        self,
+    ) -> None:
+        """No ``OPENBRAIN_*`` survives into a test, whatever the shell holds.
+
+        The one exception is the ``OPENBRAIN_TEST_*`` prefix the ``-m live``
+        gate addresses its playground service through; clearing that would make
+        the live gate pass having run nothing.
+        """
+        leaked = [
+            name
+            for name in os.environ
+            if name.upper().startswith("OPENBRAIN_")
+            and not name.upper().startswith("OPENBRAIN_TEST_")
+        ]
+        assert leaked == []


### PR DESCRIPTION
Closes #525 (the config/plumbing half; the parked namespace decision is Rico's and is untouched).

## Summary

- A Claude-family agent on a LAN box woke with the policy hook firing and **zero** Open Brain hydration — no CANON PACK, no capture — and nothing anywhere said why. Two walls, stacked, each silent.
- `openbrain_memory.client._validate_base_url` refuses a non-loopback plain-`http` base URL unless the caller passes `allow_insecure_http=True`. The strict `openbrain` config declared no such field, so exporting `OPENBRAIN_ALLOW_INSECURE_HTTP` made `unknown_prefixed_variables` reject the **whole** environment as a typo — which the hook entrypoints swallow into a clean exit 0.
- So a LAN host had no legal way to say it: setting the variable killed every lane, not setting it left the client refusing the URL. The deployed `openbrain-hook-env` wrapper stripped the variable precisely to avoid the first failure, which locked in the second.
- **Fix:** declare `allow_insecure_http` on `CaptureSettings` and `CanonSettings`, binding **one** environment name — the same name `openbrain_memory.runtime` already reads — and flow it to all five client construction sites. This is the declared-opt-in route the issue names, **not** the Caddy/TLS route.
- This is the **third** time a variable the hook environment can carry had to be declared even though this package barely reads it (after `OPENBRAIN_OBSERVATION_*` and `OPENBRAIN_SPOOL_PATH`), so the rationale lives on `ALLOW_INSECURE_HTTP_ALIASES` rather than in a commit message nobody will find.
- **The default is untouched.** Unset, loopback-only stands exactly as before, so a public endpoint still has to be `https`. Turning it on is an explicit, per-host, documented choice scoped to the LAN-internal pre-production posture.

Construction sites covered (all five; a site left off the flow is a lane that declines silently on a LAN box, which is this bug again in miniature):

| site | lane |
|---|---|
| `apps/hooks/session.py::_started_memory` | capture spine — every turn |
| `apps/hooks/session.py::_record_skill_usage` | `PostToolUse` skill metric |
| `apps/hooks/session.py::_canon_context` | the CANON PACK read |
| `apps/hooks/session_start.py::_lane_resume_text` | emission two (#519) |
| `apps/canon/run.py::_apply` | operator canon reconcile |
| `apps/bulk/run.py::_lane` | operator bulk ingest |

`ObservationSettings` needs no flag — that sink ships to Langfuse via its own SDK, not `OpenBrainClient`. `openbrain-provider` builds no clients (pure policy gates).

## Red-proof

**Pre-fix refusal, both walls, reproduced first:**

```
load_capture_settings     RAISED: unrecognised Open Brain environment variable(s): OPENBRAIN_ALLOW_INSECURE_HTTP
load_canon_settings       RAISED: unrecognised Open Brain environment variable(s): OPENBRAIN_ALLOW_INSECURE_HTTP
load_observation_settings RAISED: unrecognised Open Brain environment variable(s): OPENBRAIN_ALLOW_INSECURE_HTTP
client REFUSED: OpenBrainClient base_url must use https, localhost http, or allow_insecure_http=True
```

**New tests against the pre-fix source** (`git stash` of `python/openbrain/src`): **14 failed, 2 passed**. The 2 that pass are the ones asserting the *unchanged default* (`test_a_real_non_loopback_http_endpoint_is_refused_without_the_opt_in`, `test_a_misspelled_opt_in_is_still_rejected`) — they must pass both ways, which is the point of including them. Restored: **16 passed**.

**The construction-site assertions are not vacuous.** Deleting a single `allow_insecure_http=` line from `apps/canon/run.py` fails exactly its own test — `KeyError: 'allow_insecure_http'`, 1 failed / 15 deselected — and nothing else.

**Non-loopback http is proven over a real socket, not a string check.** `test_a_real_non_loopback_http_endpoint_answers_under_the_opt_in` binds an `HTTPServer` on this machine's real LAN address — resolved to `10.71.1.20`, the exact endpoint shape from the issue — and drives a real `OpenBrainClient` built from the declared setting to a `200`. The paired test proves the same live endpoint is still **refused** without the opt-in, so reachability is not what the rule is answering.

## Follow-up fix in this PR: the suite hung on an operator's machine

Reported after the first push: `uv run pytest -q` **hung indefinitely** at test 8 of 45 of
`test_capture_outage_notice.py`, reproducibly, while the same file passed on merge-base `main`.
The test file is byte-identical between the two commits, so the branch was the suspect.

**Root cause — this branch unmasked a pre-existing leak; it did not introduce one.**
`capture_stop_with` accepts an injected `CaptureSettings` but resolves the *observation* section
itself, from the live process environment, on every call. On a machine whose shell carries the four
provisioned coordinates — which `~/.local/share/openbrain-memory/env/claudex-observation.env`
supplies, so any hook-configured host has them — the unit suite built a **real `LangfuseEmitter`
and posted its fixture transcripts to the production fleet Langfuse server**. `emit` ends in
`client.shutdown()`, which blocks draining the OpenTelemetry batch worker, so the suite waited on
the network forever rather than failing.

`unknown_prefixed_variables` had been acting as an accidental network guard: with
`OPENBRAIN_ALLOW_INSECURE_HTTP` undeclared, the settings load *raised*, `loaded_observation()`
swallowed the raise, and the sink stayed silently off. Declaring the variable — the entire point of
this PR — let the load succeed, and the observation lane it had been shadowing started dialing.
CI never saw it because CI sets no observation coordinates, so `observation_active` is False there
either way.

**Faulthandler stack at the stall (abridged):**

```
capture_stop_with (stop.py:145)
  -> asyncio.run -> run_stop -> _observe_best_effort
  -> LangfuseEmitter.emit -> client.shutdown()
Thread: opentelemetry/sdk/_shared_internal/__init__.py:156 in worker
Thread: langfuse/_utils/prompt_cache.py:50 in run
```

**Fix, at the owning boundary:** the autouse `_clean_environment` fixture that `test_settings` has
carried file-scoped since it was written is promoted to the shared `tests/conftest.py`, so it
applies to the whole suite. `OPENBRAIN_TEST_*` is deliberately preserved — the `-m live` gate
addresses its playground service through that prefix, and clearing it would make the live gate pass
having run nothing.

**Red-proof:** with the fixture at `autouse=False` in an operator shell, the two new
`TestTheSuiteNeverInheritsAnOperatorsSink` tests fail (`assert True is False`; `assert
['OPENBRAIN_ALLOW_INSECURE_HTTP', ...] == []`). With it restored they pass, the previously hanging
file passes **3/3**, and the full suite reaches a real summary line — **565 passed, 19 deselected in
13.6s** — in the exact environment that hung.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `uv run pytest -q` in `python/openbrain`: **565 passed, 19 deselected**; pre-push full suite passed with **no bypass**
- [x] Python package checks passed or are not applicable — `uv run mypy src/openbrain` clean (49 files); `uv run ruff check src tests` clean. Sibling `openbrain-memory` also re-checked (mypy clean, 17 files; ruff clean) though untouched
- [x] `bunx tsc --noEmit` — not applicable: no TypeScript touched (`git diff --name-only -- 'src/*.ts'` empty)
- [x] Live Open Brain smoke passed — a real `SessionStart` driven through the **deployed wrapper** emitted a real CANON PACK with non-zero section counts (`profile_guidance=10, process_guidance=22`, `namespace=rico`), exit 0

## Critical Self-Review

- Highest-risk behavior: relaxing a transport security check. Scoped hard — the field defaults `False`, the client's loopback-only rule is untouched, and the opt-in only takes effect when a host explicitly sets one documented variable. A public endpoint still requires `https`. I did not weaken `_validate_base_url` itself, which is where a careless fix would have gone.
- Assumptions that could be wrong: that the LAN-internal pre-prod posture is the intended route rather than TLS. The issue offers both and the operator direction for this run named the opt-in explicitly; if that posture changes, this field becomes the thing to remove, not a thing to widen. Also assumed `ObservationSettings` needs no flag — verified it emits through the Langfuse SDK, not `OpenBrainClient`.
- Missing/weak tests: the socket test proves a `/health` round trip, not a full MCP session against a real brain over LAN — the genuine end-to-end receipt is a LAN box (the Air, `10.71.1.26`) hydrating, which is deployment, not a test. The five construction-site tests assert the constructor argument, not that each lane's subsequent traffic succeeds. Added after the reported hang: the two `TestTheSuiteNeverInheritsAnOperatorsSink` tests assert the environment the hook resolves is inert, red-proven by flipping the fixture to `autouse=False`. They cannot assert the hang itself — a test that hangs to prove a hang reports nothing and blocks the suite behind it — so they pin the precondition (`observation_active` False, no `OPENBRAIN_*` leaked) instead of the symptom.
- Security/permission risk: this permits plain-text bearer tokens over the LAN when enabled. That is the accepted pre-prod posture for `10.71.x` and is stated as such in the doc rather than left implicit; it is off by default and per-host. No namespace, auth, or server-side check is touched.
- Migration/deploy risk: the real risk here was **ordering**, and it is the one that bites silently. Passing the variable through the wrapper against an install that does not declare it rejects the whole environment and zeroes every lane. Verified empirically in the safe order — old install raised `UnknownEnvironmentVariableError`, then reinstall, then the installed interpreter resolved `allow_insecure_http=True`, then the wrapper edit, then a live CANON PACK. The rule is now written into `CONFIG_REFERENCE.md`, `420-cutover-rollback.md`, and the rollout plan so the next person does not have to rediscover it.
- Downstream client/runtime risk: none — no MCP tool, schema, transport, or wire surface changes. `openbrain-memory` is unmodified; it already read this variable.
- Rollback/cleanup concern: reverting the commit restores the old strict config, at which point the **deployed wrapper must also drop the pass-through** or every hook on a box with the variable set goes to silent zero capture. That coupling is the reason it is called out in three docs. The wrapper lives outside this repo (`~/.local/share/openbrain-memory/env/openbrain-hook-env`) and cannot be versioned here.
- Fixes made before PR: reinstalled the `openbrain` uv tool from this branch *before* touching the wrapper, after proving the old install rejected the variable — doing it the other way round would have broken live capture on this machine. Replaced a ruff-flagged inline token literal with a named fixture constant rather than blanket-suppressing the rule. After the hang report: promoted the env-isolation fixture to the shared conftest rather than adding a narrow guard to the one file that happened to hang, because the leak is in every hook entrypoint that resolves a section its caller did not inject.
- Known residual risk: the fleet rollout plan's family-A/LAN notes are updated, but the Buzz/`claude-agent-acp` launch-path steps (the issue's second bullet) are **not** added — I have not observed that host and will not write rollout steps I cannot verify. Filed as follow-up below. Also: the wrapper change is live on this machine only; every other family-A box needs the same two-part change in the same order. Also: the env-isolation fixture fixes the TEST suite, not the underlying design — `capture_stop_with` still resolves the observation section from the ambient process environment at runtime, which is correct for a hook but means any future in-process caller inherits the same coupling.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review-lane pattern arose — this is the third instance of an already-documented gotcha (undeclared sibling-owned env var → silent zero capture), and the rationale is recorded at the rule site in code plus `CONFIG_REFERENCE.md`, which is where the previous two instances put it

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — none arose
- Live Open Brain checks: [x] linked below or [ ] not applicable because: real `SessionStart` through the deployed wrapper returned a CANON PACK with non-zero section counts; no server, transport, MCP tool, or schema surface is touched

## Contract Parity

- Contract parity: [x] runtime-specific because: `CaptureSettings` / `CanonSettings` are Python-side hook configuration with no contract fixture, wire representation, or client binding. The client keyword `allow_insecure_http` it feeds is pre-existing `openbrain_memory` API, unchanged by this PR.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- No MCP tool, schema, transport, or client-facing surface is modified. Changes are the Python `openbrain` hook config plus three docs.
- **Deploy coupling, outside this repo:** `~/.local/share/openbrain-memory/env/openbrain-hook-env` was updated in place to pass `OPENBRAIN_ALLOW_INSECURE_HTTP` through, and its comments now explain why it used to strip it. Every other family-A box needs the same change, in the same order (declare → reinstall → verify → wrapper).

**Follow-up (not in this PR):** the Buzz / `claude-agent-acp` launch path still needs adding to the Claude-family rollout steps in `_plans/fleet-rollout-0.9.md` — the issue's second bullet. Deliberately deferred: writing rollout steps for a host I have not observed would be a guess in the grammar of a procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

