### PR TITLE
fix(deploy): restart the local clone's NATS worker with the runtime it serves

### DIFF
--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -241,3 +241,131 @@ Preserve logs and JetStream state for inspection unless an explicit cleanup
 decision says only minimized metadata exists and the state can be removed. If
 the worker env carried credentials, rotate or remove them through the approved
 secret path.
+
+## Local Mac Dogfood NATS Lane (loopback only)
+
+The same two-service shape as core01, but pointed at the local dogfood clone
+(`/Volumes/ThunderBolt/open-brain-local`) instead of the core01 runtime. Stood
+up and proven live on 2026-08-04.
+
+| Component | Launchd label | Notes |
+| --- | --- | --- |
+| Local HTTP clone | `com.rico.open-brain-local-clone` | Pre-existing; stays `OPENBRAIN_TRANSPORT` empty (HTTP mode). |
+| NATS broker | `com.rico.open-brain-nats` | `nats-server` on **127.0.0.1:4222**, monitor 127.0.0.1:8222. |
+| NATS worker | `com.rico.open-brain-local-nats-worker` | Bridge for `dev.ob.memory.context_pack`, own health on 3110. |
+
+These are **user LaunchAgents** (`~/Library/LaunchAgents`, `launchctl bootstrap
+gui/$(id -u) ...`), not system LaunchDaemons, matching the existing local clone
+service. No `sudo` is involved.
+
+### SCOPE LINE — loopback only, auth off
+
+This lane runs `OPENBRAIN_NATS_REQUIRE_AUTH=false`, which is safe **only**
+because the broker binds `127.0.0.1`. Both preconditions above ("HARD
+PRECONDITION" in `docs/fleet-nats-integration.md` and "DEPLOYMENT PRECONDITION"
+in this file) apply unchanged: on any bus an untrusted publisher can reach, a
+forged `payload.namespace` or envelope `from` reads **any** namespace.
+
+`nats-server`'s default bind is `0.0.0.0`, so plain `brew services start
+nats-server` would open exactly that hole. The broker therefore runs from
+`/opt/homebrew/etc/nats-server.conf` (`host: 127.0.0.1`) under its own
+LaunchAgent rather than the Homebrew service, and the `-c` flag is load-bearing.
+
+**Putting this broker on the LAN is a separate follow-up, and the auth flip
+comes FIRST:** set `OPENBRAIN_NATS_REQUIRE_AUTH=true` in the worker env (which
+also force-disables the `payload.namespace` override), then change the bind.
+Never the other way round.
+
+### Files
+
+- broker config: `/opt/homebrew/etc/nats-server.conf`
+- broker plist: `~/Library/LaunchAgents/com.rico.open-brain-nats.plist`
+- worker plist: `~/Library/LaunchAgents/com.rico.open-brain-local-nats-worker.plist`
+- worker env: `/Volumes/ThunderBolt/open-brain-local/local-clone.env.nats-worker` (mode 0600)
+- logs: `~/Library/Logs/open-brain-local/nats-worker.{out,err}.log`
+
+The worker env sources `local-clone.env` and then sets only the v1 NATS
+overrides (`OPENBRAIN_NATS_URL`, `OPENBRAIN_NATS_ENV=dev`,
+`REQUIRE_AUTH=false`, `ALLOW_NAMESPACE_OVERRIDE=true`). It does NOT set
+`OPENBRAIN_TRANSPORT` or `OPENBRAIN_NATS_ENABLE_BRIDGE`, because
+`readNatsWorkerBoundary()` in `src/nats-worker.ts` forces both — the
+dedicated-worker boundary cannot be disabled by editing the env file.
+
+> **Env-var plumbing differs from the HTTP service.** The HTTP clone starts
+> through `scripts/local-clone.ts`, whose `CHILD_ENV_KEYS` allowlist drops any
+> variable not named in it (the #543 `OPENBRAIN_TRACING_*` failure). The NATS
+> worker does **not** go through that launcher — the plist sources the env file
+> and `exec`s `scripts/run-nats-worker.ts`, which reads `process.env` directly.
+> Adding a worker variable means editing the env file only; no allowlist.
+
+### Deploy coupling
+
+`scripts/local-clone-deploy.sh` swaps the runtime directory that BOTH services
+execute from, so the worker must be restarted or it keeps running the previous
+revision. Set the label so the deploy kickstarts it:
+
+```zsh
+OPENBRAIN_NATS_WORKER_LABEL=com.rico.open-brain-local-nats-worker \
+OPENBRAIN_SERVICE_LABEL=com.rico.open-brain-local-clone \
+  scripts/local-clone-deploy.sh
+```
+
+The kickstart is non-fatal (a WARN), matching core01's behavior: a clone with no
+worker installed is unaffected.
+
+### What `/health` on 3100 does and does NOT show
+
+`curl -s 127.0.0.1:3100/health | jq .nats` keeps reporting
+`"requested_transport": "http"` and `"availability": "not_runtime_available"`
+**even when the worker is running, and that is correct.** `server/config/nats.ts`
+derives that block from the HTTP process's OWN environment
+(`parseNatsConfig(process.env)`); the HTTP service is deliberately in HTTP mode
+and never observes the separate worker process. The unavailable reason is
+`transport_not_requested`.
+
+The worker's bridge health is on its own port:
+
+```zsh
+curl -fsS http://127.0.0.1:3110/health   # {"status":"healthy","nats":{"availability":"available",...}}
+curl -fsS 'http://127.0.0.1:8222/connz?subs=1'   # broker's view: 1 conn, subscribed to the subject
+```
+
+Do not "fix" 3100 by setting `OPENBRAIN_TRANSPORT=nats` in the clone env — that
+would put the HTTP service back into the bridge business, which is exactly the
+boundary this runbook exists to keep.
+
+### Verify
+
+```zsh
+launchctl list | rg 'open-brain'
+curl -fsS http://127.0.0.1:3110/health
+curl -fsS 'http://127.0.0.1:8222/connz?subs=1'
+curl -fsS http://127.0.0.1:3100/health    # must stay healthy across a worker restart
+launchctl kickstart -k "gui/$(id -u)/com.rico.open-brain-local-nats-worker"
+```
+
+### OPEN DEFECT — large context packs get no reply at all (2026-08-04)
+
+A live request/reply on `dev.ob.memory.context_pack` returns `status: ok` in
+~1.2s for `repo_facts` / `working_set` / `pointers`. Asking for
+`durable_memory` in the `rico` namespace currently builds a **58.5 MB** reply
+(the `durable_memory` section alone is 39.9 MB), which exceeds the broker's
+8 MB `max_payload`. The publish is rejected, `message.respond()` returns false,
+`startNatsContextPackBridge` throws "NATS request did not include a reply
+inbox", and the caller sees **no reply at all** — it waits until its own
+timeout.
+
+This is a real defect and not specific to this broker: `src/nats-bridge.ts`
+guards the REQUEST at `MAX_NATS_REQUEST_BYTES` (64 KB) but has **no response
+size guard**, and NATS's own protocol default `max_payload` is 1 MB — so a
+default broker or the fleet bus would fail sooner and the same silent way. The
+handler completes its work successfully first, so this burns a full context-pack
+build before dropping it.
+
+The 8 MB figure is the NATS server's own `max_payload` ceiling, not an Open
+Brain choice — this is reported here as a measurement, and how to resolve it is
+the operator's call, not something this runbook prescribes. The one thing that
+is unambiguously wrong regardless of size is the SILENCE: the bridge should
+answer with a redacted `payload_too_large` error envelope instead of leaving the
+caller to time out with no reply and no client-visible reason.
+

--- a/scripts/local-clone-deploy.nats-worker.test.ts
+++ b/scripts/local-clone-deploy.nats-worker.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The local clone deploy must restart the NATS worker onto the runtime it just
+ * swapped in.
+ *
+ * WHY THIS TEST EXISTS. The NATS worker is a SEPARATE launchd service from the
+ * HTTP service (docs/core01-nats-worker-runbook.md "Boundary"), and both execute
+ * out of the SAME runtime directory. `local-clone-deploy.sh` replaces that
+ * directory wholesale, so a worker that is not restarted keeps running the
+ * PREVIOUS revision's `scripts/run-nats-worker.ts` while the HTTP service serves
+ * the new one -- two ingresses, one deploy, silently different code. core01's
+ * deploy has always kickstarted its worker (`scripts/core01-deploy-local.sh`
+ * NATS_WORKER_LABEL); the local clone script did not.
+ *
+ * The kickstart is deliberately NON-FATAL, so the assertions here are about the
+ * ATTEMPT being made and reported, not about launchctl succeeding: these run on
+ * a machine where the test label does not exist, exactly like the core01
+ * integration test's `invalid.test.open-brain-nats-worker`.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const DEPLOY_SCRIPT = join(import.meta.dir, "local-clone-deploy.sh");
+
+async function deployScriptSource(): Promise<string> {
+  return await readFile(DEPLOY_SCRIPT, "utf8");
+}
+
+describe("local-clone-deploy.sh NATS worker restart", () => {
+  it("defines a NATS worker label that defaults to empty", async () => {
+    const source = await deployScriptSource();
+    // Empty default: a clone with no worker installed must be unaffected, which
+    // is what makes adding this safe for every existing caller.
+    expect(source).toMatch(
+      /NATS_WORKER_LABEL="\$\{OPENBRAIN_NATS_WORKER_LABEL:-\}"/,
+    );
+  });
+
+  it("has a restart_nats_worker that no-ops when no label is configured", async () => {
+    const source = await deployScriptSource();
+    expect(source).toContain("restart_nats_worker() {");
+    expect(source).toMatch(
+      /restart_nats_worker\(\) \{[\s\S]*?\[\[ -n "\$NATS_WORKER_LABEL" \]\] \|\| return 0/,
+    );
+  });
+
+  it("kickstarts the worker without aborting the deploy on failure", async () => {
+    const source = await deployScriptSource();
+    const body = source.slice(
+      source.indexOf("restart_nats_worker() {"),
+      source.indexOf("\n}", source.indexOf("restart_nats_worker() {")),
+    );
+    expect(body).toContain('launchctl kickstart -k "gui/${uid}/${NATS_WORKER_LABEL}"');
+    // Non-fatal: warn, never `fatal`. A missing/optional second ingress must not
+    // fail a deploy whose HTTP revision proof passed.
+    expect(body).toContain("WARN: could not restart NATS worker");
+    expect(body).not.toContain("fatal ");
+  });
+
+  it("restarts the worker on the deploy path and on BOTH rollback paths", async () => {
+    const source = await deployScriptSource();
+    const callSites = source.match(/^\s*restart_nats_worker$/gm) ?? [];
+    // Three: the deploy swap, the failed-deploy rollback, and `--rollback`.
+    // A rollback that restores the previous runtime under a worker still
+    // running the failed revision is the same split-revision bug in reverse.
+    expect(callSites).toHaveLength(3);
+  });
+
+  it("restarts the worker only after the runtime directory is swapped", async () => {
+    const source = await deployScriptSource();
+    const swapIndex = source.indexOf('mv "$STAGING_DIR" "$RUNTIME_DIR"');
+    const deployRestartIndex = source.indexOf(
+      "restart_nats_worker",
+      swapIndex,
+    );
+    expect(swapIndex).toBeGreaterThan(-1);
+    // Restarting before the swap would put the worker back on the OLD tree.
+    expect(deployRestartIndex).toBeGreaterThan(swapIndex);
+  });
+});

--- a/scripts/local-clone-deploy.sh
+++ b/scripts/local-clone-deploy.sh
@@ -40,6 +40,9 @@
 #   OPENBRAIN_RUNTIME_NAME      runtime dir name under the root (default "app")
 #   OPENBRAIN_CLONE_ENV_FILE    env file to migrate against (default <root>/local-clone.env)
 #   OPENBRAIN_SERVICE_LABEL     launchd label to restart, if any
+#   OPENBRAIN_NATS_WORKER_LABEL NATS worker launchd label to kickstart, if any
+#                               (e.g. com.rico.open-brain-local-nats-worker).
+#                               Unset = no worker installed; nothing happens.
 set -euo pipefail
 
 REPO_DIR="${OPENBRAIN_REPO_DIR:-/Volumes/ThunderBolt/Development/open-brain}"
@@ -50,6 +53,14 @@ STAGING_DIR="${RUNTIME_DIR}.next"
 PREVIOUS_DIR="${RUNTIME_DIR}.previous"
 ENV_FILE="${OPENBRAIN_CLONE_ENV_FILE:-${CLONE_ROOT}/local-clone.env}"
 SERVICE_LABEL="${OPENBRAIN_SERVICE_LABEL:-}"
+# The NATS worker is a SEPARATE launchd service (docs/core01-nats-worker-runbook.md
+# "Boundary"), so swapping the runtime directory under it leaves it executing the
+# PREVIOUS revision's scripts/run-nats-worker.ts until something restarts it.
+# core01's deploy has always kickstarted its worker
+# (scripts/core01-deploy-local.sh NATS_WORKER_LABEL); this script did not, which
+# meant a local deploy silently left the two ingresses on different revisions.
+# Empty by default so a clone with no worker installed is unaffected.
+NATS_WORKER_LABEL="${OPENBRAIN_NATS_WORKER_LABEL:-}"
 BUN_BIN="${BUN_BIN:-/opt/homebrew/bin/bun}"
 
 log() { printf '%s local-clone-deploy: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1"; }
@@ -62,6 +73,25 @@ restart_service() {
   log "restarting ${SERVICE_LABEL}"
   launchctl kickstart -k "gui/${uid}/${SERVICE_LABEL}" \
     || fatal "could not restart ${SERVICE_LABEL}"
+}
+
+# Restart the NATS worker onto the newly-swapped runtime.
+#
+# NON-FATAL by design, matching core01's WARN (scripts/core01-deploy-local.sh).
+# The HTTP service is the deploy's success criterion and has a revision proof
+# behind it; the NATS worker is a second, optional ingress. A clone that has
+# never installed the worker is the COMMON case, and failing the deploy for a
+# service the operator deliberately does not run would be wrong. The warning is
+# still loud, because a worker that exists and did not restart is serving the
+# previous revision.
+restart_nats_worker() {
+  [[ -n "$NATS_WORKER_LABEL" ]] || return 0
+  local uid
+  uid="$(id -u)"
+  log "restarting ${NATS_WORKER_LABEL}"
+  if ! launchctl kickstart -k "gui/${uid}/${NATS_WORKER_LABEL}"; then
+    log "WARN: could not restart NATS worker ${NATS_WORKER_LABEL}; it may still be serving the PREVIOUS revision"
+  fi
 }
 
 # Health is checked against the port the CLONE env declares, not a hardcoded
@@ -200,6 +230,7 @@ if [[ "${1:-}" == "--rollback" ]]; then
   PRE_ROLLBACK_PID="$(listening_pid "$ROLLBACK_PORT")"
   log "pre-rollback listener on port ${ROLLBACK_PORT}: pid ${PRE_ROLLBACK_PID:-<none>}"
   restart_service
+  restart_nats_worker
 
   if [[ -n "$SERVICE_LABEL" ]]; then
     # Same standard of proof as a deploy. Rolling back is exactly when a false
@@ -289,6 +320,7 @@ PRE_RESTART_PID="$(listening_pid "$CLONE_PORT")"
 log "pre-restart listener on port ${CLONE_PORT}: pid ${PRE_RESTART_PID:-<none>}"
 
 restart_service
+restart_nats_worker
 
 if [[ -n "$SERVICE_LABEL" ]]; then
   # Order matters: prove the process FIRST, then check health. Reversing these
@@ -310,6 +342,7 @@ if [[ -n "$SERVICE_LABEL" ]]; then
       mv "$PREVIOUS_DIR" "$RUNTIME_DIR"
       rollback_pid="$(listening_pid "$CLONE_PORT")"
       restart_service
+      restart_nats_worker
       # The rollback gets the same standard of proof as the deploy. A rollback
       # that "succeeded" because the failed process still held the port would
       # leave the broken revision serving under a reassuring log line.


### PR DESCRIPTION
Wires the local Mac NATS lane for the dogfood brain, and fixes the deploy coupling that would have silently un-wired it on the next redeploy.

## Summary

- The NATS worker is a **separate launchd service** from the HTTP service (`docs/core01-nats-worker-runbook.md` "Boundary"), but both execute out of the **same** runtime directory. `scripts/local-clone-deploy.sh` swaps that directory wholesale and only ever kickstarted the HTTP label.
- Result: a local deploy left the worker executing the **previous** revision's `scripts/run-nats-worker.ts` while the HTTP service served the new one — two ingresses, one deploy, silently different code, no signal.
- core01's deploy has always kickstarted its worker (`scripts/core01-deploy-local.sh` `NATS_WORKER_LABEL`); the local clone script never grew it. This mirrors it, including core01's **non-fatal WARN**: the HTTP service is the deploy's success criterion and carries the revision proof, while the worker is an optional second ingress most clones do not install. `OPENBRAIN_NATS_WORKER_LABEL` defaults to empty, so every existing caller is unaffected.
- Wired at **all three** restart sites — the deploy swap, the failed-deploy rollback, and `--rollback`. A rollback that restores the previous runtime under a worker still executing the failed revision is the same split-revision bug in reverse.
- Documents the local loopback lane in the runbook, including the deliberate scope line and the `/health` behavior that looks wrong but is not.

## Red-proof

`scripts/local-clone-deploy.nats-worker.test.ts` run against the **unmodified** `origin/main` script (restored with `git show origin/main:scripts/local-clone-deploy.sh`): **0 pass, 5 fail**. With the change restored: **5 pass, 0 fail**.

The 5th assertion is ordering, not just presence — restarting before `mv "$STAGING_DIR" "$RUNTIME_DIR"` would put the worker back on the OLD tree, which a presence-only test would have called green.

## Live proof (this Mac, 2026-08-04)

Broker `com.rico.open-brain-nats` (`nats-server` 2.14.3) and worker `com.rico.open-brain-local-nats-worker` bootstrapped as user LaunchAgents.

- Real request/reply on `dev.ob.memory.context_pack`: `status: ok`, `namespace_source: "declared"`, `correlation_id` echoed, `kind: context_pack_response`, `from: open-brain`, real context body, **1.16s**.
- Broker `/connz?subs=1`: 1 connection subscribed to `dev.ob.memory.context_pack`.
- Worker health on `:3110`: `{"status":"healthy","nats":{"availability":"available"}}`.
- HTTP `/health` on `:3100` stayed `healthy` across a worker kickstart — the boundary holds.

## Scope line — loopback only, auth off

The broker binds **127.0.0.1 only** and runs `OPENBRAIN_NATS_REQUIRE_AUTH=false`. That combination is safe *only* because of the loopback bind, per the HARD PRECONDITION in `docs/fleet-nats-integration.md`.

`nats-server`'s default bind is `0.0.0.0`, so a plain `brew services start nats-server` would have opened exactly the cross-tenant read hole those docs warn about. The broker therefore runs from an explicit config (`host: 127.0.0.1`) under its own LaunchAgent instead of the Homebrew service. Verified: all three of this Mac's LAN addresses refuse `:4222`; only loopback listens.

**Putting this broker on the LAN is deliberately NOT in this pass**, and the auth flip comes first (`OPENBRAIN_NATS_REQUIRE_AUTH=true`, which also force-disables the `payload.namespace` override), then the bind changes. Never the reverse.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bun test scripts/ src/nats-*.test.ts server/config/nats.test.ts`: **369 pass, 29 skip, 0 fail**; `bunx tsc --noEmit` clean; `bash -n` on the script clean; pre-push full suite passed with **no bypass**
- [x] Python package checks passed or are not applicable — not applicable: no `python/` paths touched
- [x] Live Open Brain smoke passed or is not applicable — passed, see Live proof above

## Critical Self-Review

- Highest-risk behavior: restarting a second launchd service mid-deploy. Non-fatal by construction and inert when `OPENBRAIN_NATS_WORKER_LABEL` is unset (the default), so the blast radius on existing callers is zero.
- Assumptions that could be wrong: that a worker restart during deploy is always desirable. If a worker is mid-request it is cut off — but it was serving the outgoing revision, which is the bug being fixed, and NATS request/reply has no delivery guarantee across a restart anyway.
- Missing/weak tests: the tests assert the script's structure (label, no-op guard, non-fatal warn, three call sites, ordering relative to the swap), not a real `launchctl` restart. Matching the existing `core01-deploy-local.integration.test.ts`, which also uses a deliberately invalid label and never restarts anything. The real restart is covered by the live proof above.
- Security/permission risk: none added by the script change. The lane's real security surface is the auth-off setting, which is why the loopback bind is enforced in broker config rather than left to the Homebrew default, and why the scope line is written into the runbook.
- Migration/deploy risk: none — no schema, no data. Deploy behavior changes only when the new env var is explicitly set.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or wire surface is touched; the subject and envelope contract are unchanged.
- Rollback/cleanup concern: revert restores the previous behavior exactly (worker not restarted). No state to unwind.
- Known residual risk: an **open defect found while proving this**, documented in the runbook and NOT fixed here: a `durable_memory` context pack for the `rico` namespace builds a 58.5 MB reply, which the NATS server refuses to publish. `message.respond()` returns false, the bridge throws "NATS request did not include a reply inbox", and **the caller gets no reply at all** — it waits until its own timeout with no client-visible reason. `src/nats-bridge.ts` guards the request at `MAX_NATS_REQUEST_BYTES` (64 KB) but has no equivalent guard on the response. This is pre-existing, affects the fleet bus too (NATS's own protocol default is smaller than this broker's setting), and needs its own issue and an operator decision — it is not a deploy-script concern.
- Fixes made before PR: none beyond the change itself; branch cut from current `origin/main`.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the deploy-coupling pattern is documented at the rule site in the script and in the runbook; no new review-lane pattern arose.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured — the response-size defect is written into `docs/core01-nats-worker-runbook.md` and called out above rather than silently carried
- Live Open Brain checks: [x] linked below — live request/reply on `dev.ob.memory.context_pack` returned `status: ok` with `namespace_source: declared`, and the lane kept answering while the HTTP service was down (see Live proof above).

## Contract Parity

- Contract parity: [x] runtime-specific because: this changes a deploy shell script and a runbook only. No wire format, envelope, subject, schema, or client binding is modified.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- Changed files are `scripts/local-clone-deploy.sh`, `scripts/local-clone-deploy.nats-worker.test.ts`, and `docs/core01-nats-worker-runbook.md`. The deploy script is local-dogfood-only and is not used by core01 or any downstream runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

