### PR TITLE
fix(health): report the real server IP and hostname instead of "unknown"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ secrets/*
 !secrets/README.md
 !secrets/*.example
 !secrets/*.example.json
+
+# Deploy stamp written into a DEPLOYED tree by scripts/local-clone-deploy.sh
+# and read back by `/health` as `revision`. It describes one deployment, not
+# the source, so it must never be committed — a checked-in stamp would make
+# every tree claim to be whichever one happened to be deployed when it landed.
+.deployed-revision

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -145,8 +145,34 @@ watchdog restart script, not by the server itself: `MLX_EMBED_DAEMON`,
 | variable | default | read at |
 |---|---|---|
 | `PORT` | `3100` | `src/index.ts:349` |
-| `OPEN_BRAIN_BIND_HOST` | unset | `src/index.ts:353` |
-| `OPEN_BRAIN_SERVER_IP` | unset | `src/index.ts:44` |
+| `OPEN_BRAIN_BIND_HOST` | unset | `src/index.ts`, `server/main.ts`; also an identity input (below) |
+| `OPEN_BRAIN_SERVER_IP` | unset | `server/transport/server-identity.ts`; the advertised address |
+
+### Host identity in `/health`
+
+`/health` answers "which brain am I pointed at?", so it reports `hostname`,
+`server_ip`, `server_ips`, and — on a deployed tree — `revision`. Identity is
+resolved ONCE per process by `server/transport/server-identity.ts`, in this
+order:
+
+1. **`OPEN_BRAIN_SERVER_IP`** — an explicit advertised address. Always wins.
+   Set this when the address a client should use is not one the host can see
+   (behind NAT, a reverse proxy, or a floating VIP).
+2. **`OPEN_BRAIN_BIND_HOST`**, when it names a concrete address. A wildcard or
+   loopback bind (`0.0.0.0`, `::`, `127.0.0.1`, `::1`, `localhost`) is skipped:
+   it identifies no particular machine, which is the whole question being asked.
+3. **Detected private LAN interfaces**, physical adapters first, each interface
+   name sorted numerically so the answer is stable across reboots.
+4. **`"unknown"`** — only when the host genuinely has no private address.
+
+Detection is deliberately bounded to private ranges (RFC1918, RFC3927,
+RFC6598). `/health` is unauthenticated, so a public address is never volunteered
+automatically; an operator who wants one advertised sets
+`OPEN_BRAIN_SERVER_IP` and owns that decision.
+
+`revision` is the `short_sha` from the `.deployed-revision` stamp that
+`scripts/local-clone-deploy.sh` writes into a deployed tree. It is absent on a
+dev tree that was never deployed through the script, which is normal.
 | `ALLOWED_ORIGINS` | `[]` (none) | `src/index.ts:78`, comma-separated |
 | `OPEN_BRAIN_RUN_MIGRATIONS` | `1` | `src/index.ts:272`; `"0"` disables |
 | `OPEN_BRAIN_MAINTENANCE_ENABLED` | unset | `src/index.ts:383` |

--- a/scripts/run-two-worker.ts
+++ b/scripts/run-two-worker.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { buildHttpWorkerEnv } from "./worker-env.ts";
+import { resolveServerIdentity } from "../server/transport/server-identity.ts";
 
 type WorkerConfig = {
   name: string;
@@ -16,12 +17,15 @@ const workerPorts = (process.env.OPEN_BRAIN_WORKER_PORTS ?? "3101,3102")
 const workerCount = parseInt(process.env.OPEN_BRAIN_WORKERS ?? "2", 10);
 const poolMax = process.env.OPEN_BRAIN_WORKER_DB_POOL_MAX ?? "5";
 
-function serverIps(): string[] {
-  const configured = process.env.OPEN_BRAIN_SERVER_IP?.trim();
-  if (configured) return [configured];
-
-  return ["unknown"];
-}
+/**
+ * Host identity for the aggregate front, resolved once. Shares the single
+ * resolver with both serving trees so the front and the workers behind it can
+ * never disagree about which machine they are.
+ */
+const SERVER_IDENTITY = resolveServerIdentity({
+  configuredServerIp: process.env.OPEN_BRAIN_SERVER_IP,
+  bindHost: process.env.OPEN_BRAIN_BIND_HOST,
+});
 
 if (workerCount < 1) {
   throw new Error("OPEN_BRAIN_WORKERS must be at least 1");
@@ -134,12 +138,12 @@ const proxy = Bun.serve({
     if (url.pathname === "/health") {
       const results = await Promise.all(workers.map(workerHealth));
       const healthy = results.every((result) => result.ok);
-      const ips = serverIps();
       return Response.json(
         {
           status: healthy ? "healthy" : "degraded",
-          server_ip: ips[0] ?? "unknown",
-          server_ips: ips,
+          hostname: SERVER_IDENTITY.hostname,
+          server_ip: SERVER_IDENTITY.serverIp,
+          server_ips: SERVER_IDENTITY.serverIps,
           workers: results,
           timestamp: new Date().toISOString(),
         },

--- a/server/application/index.ts
+++ b/server/application/index.ts
@@ -123,7 +123,12 @@ export function createShadowApplication(
   });
   const health = {
     databaseHealth: input.database.health,
+    hostname: input.config.transport.hostname,
     serverIp: input.config.transport.serverIp,
+    serverIps: input.config.transport.serverIps,
+    ...(input.config.transport.deployedRevision
+      ? { revision: input.config.transport.deployedRevision }
+      : {}),
     probeTimeoutMs: input.config.transport.healthProbeTimeoutMs,
     logger: transportLogger,
     ...(input.config.transport.embeddingBaseUrl

--- a/server/application/sdk-protocol.pg.test.ts
+++ b/server/application/sdk-protocol.pg.test.ts
@@ -653,7 +653,9 @@ dbDescribe("rewrite candidate over the real MCP SDK and real HTTP transport (liv
     ];
     const front = createWorkerProxyHandler({
       workers,
+      hostname: "test-host",
       serverIp: "127.0.0.1",
+      serverIps: ["127.0.0.1"],
       healthProbeTimeoutMs: 2_000,
       logger: silentLogger(),
     });
@@ -700,7 +702,9 @@ dbDescribe("rewrite candidate over the real MCP SDK and real HTTP transport (liv
           baseUrl: `http://127.0.0.1:${workerTwo.port}`,
         },
       ],
+      hostname: "test-host",
       serverIp: "127.0.0.1",
+      serverIps: ["127.0.0.1"],
       healthProbeTimeoutMs: 2_000,
       logger: silentLogger(),
     });

--- a/server/config.ts
+++ b/server/config.ts
@@ -6,12 +6,17 @@
  * public shared namespace is `shared-kb`). Environment input is validated once
  * here and passed inward as typed data.
  */
+import { readFileSync } from "node:fs";
 import { z } from "zod";
 import {
   parseMaintenanceConfig,
   type MaintenanceConfig,
 } from "./config/maintenance.ts";
 import { parseNatsConfig, type NatsConfig } from "./config/nats.ts";
+import {
+  readDeployedRevision,
+  resolveServerIdentity,
+} from "./transport/server-identity.ts";
 
 export type { MaintenanceConfig } from "./config/maintenance.ts";
 export { parseMaintenanceConfig } from "./config/maintenance.ts";
@@ -106,6 +111,7 @@ const environmentSchema = z
     SERVICE_NAME: nonEmpty.default("open-brain-server"),
     OPEN_BRAIN_WORKER_NAME: nonEmpty.default("worker"),
     OPEN_BRAIN_SERVER_IP: nonEmpty.optional(),
+    OPEN_BRAIN_BIND_HOST: nonEmpty.optional(),
     OPEN_BRAIN_SESSION_TTL_SECONDS: positiveInteger.default(30),
     OPEN_BRAIN_MAX_SESSIONS: positiveInteger.default(100),
     OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS: positiveInteger.default(2),
@@ -150,7 +156,22 @@ export interface ServerConfig {
   };
   readonly authTokens: readonly AuthTokenConfig[];
   readonly transport: {
+    /**
+     * Host identity for `/health`, resolved from configuration rather than
+     * guessed at request time. See `transport/server-identity.ts`: a client
+     * asking `/health` is asking WHICH brain it reached, so a wildcard or
+     * loopback bind is never the answer.
+     */
+    readonly hostname: string;
     readonly serverIp: string;
+    readonly serverIps: readonly string[];
+    /**
+     * Short sha of the deployed tree, from the `.deployed-revision` stamp that
+     * `scripts/local-clone-deploy.sh` writes. Read once at startup — a running
+     * process does not change its own code — and absent on a dev tree that was
+     * never deployed through the script.
+     */
+    readonly deployedRevision?: string;
     readonly sessionTtlMs: number;
     readonly maxSessions: number;
     readonly retryAfterSeconds: number;
@@ -209,7 +230,15 @@ function parseUserTokens(environment: Environment): ConfigResult | AuthTokenConf
   return issues.length > 0 ? { ok: false, issues } : configured;
 }
 
-function buildConfig(parsed: ParsedEnvironment, userTokens: AuthTokenConfig[]): ServerConfig {
+function buildConfig(
+  parsed: ParsedEnvironment,
+  userTokens: AuthTokenConfig[],
+  deployedRevision?: string,
+): ServerConfig {
+  const identity = resolveServerIdentity({
+    configuredServerIp: parsed.OPEN_BRAIN_SERVER_IP,
+    bindHost: parsed.OPEN_BRAIN_BIND_HOST,
+  });
   return {
     database: {
       host: parsed.DB_HOST,
@@ -230,7 +259,10 @@ function buildConfig(parsed: ParsedEnvironment, userTokens: AuthTokenConfig[]): 
     },
     authTokens: [...roleTokenConfig(parsed), ...userTokens],
     transport: {
-      serverIp: parsed.OPEN_BRAIN_SERVER_IP ?? "unknown",
+      hostname: identity.hostname,
+      serverIp: identity.serverIp,
+      serverIps: identity.serverIps,
+      ...(deployedRevision ? { deployedRevision } : {}),
       sessionTtlMs: parsed.OPEN_BRAIN_SESSION_TTL_SECONDS * 1_000,
       maxSessions: parsed.OPEN_BRAIN_MAX_SESSIONS,
       retryAfterSeconds: parsed.OPEN_BRAIN_SESSION_RETRY_AFTER_SECONDS,
@@ -257,8 +289,17 @@ function buildConfig(parsed: ParsedEnvironment, userTokens: AuthTokenConfig[]): 
   };
 }
 
-/** Validate an explicit environment-shaped input without reading global state. */
-export function parseServerConfig(environment: Environment): ConfigResult {
+/**
+ * Validate an explicit environment-shaped input without reading global state.
+ *
+ * `deployedRevision` is passed IN rather than read here: this function is the
+ * pure half of the boundary, and touching the filesystem would break that. The
+ * composition root below supplies it.
+ */
+export function parseServerConfig(
+  environment: Environment,
+  deployedRevision?: string,
+): ConfigResult {
   const parsed = environmentSchema.safeParse(environment);
   if (!parsed.success) {
     return {
@@ -271,12 +312,27 @@ export function parseServerConfig(environment: Environment): ConfigResult {
   }
   const userTokens = parseUserTokens(environment);
   if (!Array.isArray(userTokens)) return userTokens;
-  return { ok: true, config: buildConfig(parsed.data, userTokens) };
+  return {
+    ok: true,
+    config: buildConfig(parsed.data, userTokens, deployedRevision),
+  };
+}
+
+/**
+ * The deploy stamp lives beside the running tree, so it is read relative to
+ * this module rather than the process cwd — a service started from anywhere
+ * still identifies its own code correctly.
+ */
+function readDeployStamp(): string | undefined {
+  return readDeployedRevision(() => {
+    const stamp = new URL("../.deployed-revision", import.meta.url);
+    return readFileSync(stamp, "utf8");
+  });
 }
 
 /** Composition-root environment read. No other `server/` module reads it. */
 export function loadServerConfig(): ServerConfig {
-  const result = parseServerConfig(process.env);
+  const result = parseServerConfig(process.env, readDeployStamp());
   if (result.ok) return result.config;
   const summary = result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ");
   throw new Error(`server_configuration_invalid: ${summary}`);

--- a/server/main.pg.test.ts
+++ b/server/main.pg.test.ts
@@ -68,7 +68,10 @@ function testConfig(): ServerConfig {
     DB_USER: decodeURIComponent(url.username) || "postgres",
     ...(url.password ? { DB_PASSWORD: decodeURIComponent(url.password) } : {}),
     LOG_FILE: "logs/open-brain-entrypoint-test.log",
-    OPEN_BRAIN_SERVER_IP: "127.0.0.1",
+    // A concrete LAN address, NOT loopback: `/health` exists to tell a client
+    // WHICH machine it reached, so `127.0.0.1` is not a valid answer and
+    // identity resolution deliberately falls through it to real detection.
+    OPEN_BRAIN_SERVER_IP: "10.71.1.99",
     OPENBRAIN_MIGRATIONS_DIR: "src/db/migrations",
     // One configured token, in the role the tool assertions need. The entrypoint
     // refuses to start with none, which is a separate test below.
@@ -116,8 +119,9 @@ dbDescribe("rewrite entrypoint start-equivalence (live Postgres)", () => {
     // `undefined` that an assertion happens to notice.
     const body = (await response.json()) as SingleWorkerHealth;
     expect(["healthy", "degraded"]).toContain(body.status);
-    expect(body.server_ip).toBe("127.0.0.1");
-    expect(body.server_ips).toEqual(["127.0.0.1"]);
+    expect(body.server_ip).toBe("10.71.1.99");
+    expect(body.server_ips).toEqual(["10.71.1.99"]);
+    expect(body.hostname.length).toBeGreaterThan(0);
     expect(body.database).toMatchObject({ connected: true });
     expect(body.embedding).toHaveProperty("configured");
     expect(body.embedding).toHaveProperty("connected");
@@ -259,7 +263,10 @@ dbDescribe("rewrite entrypoint startup and shutdown ordering (live Postgres)", (
       DB_NAME: url.pathname.replace(/^\//, ""),
       DB_USER: decodeURIComponent(url.username) || "postgres",
       LOG_FILE: "logs/open-brain-entrypoint-empty-secret-test.log",
-      OPEN_BRAIN_SERVER_IP: "127.0.0.1",
+      // A concrete LAN address, NOT loopback: `/health` exists to tell a client
+    // WHICH machine it reached, so `127.0.0.1` is not a valid answer and
+    // identity resolution deliberately falls through it to real detection.
+    OPEN_BRAIN_SERVER_IP: "10.71.1.99",
       OPENBRAIN_MIGRATIONS_DIR: "src/db/migrations",
       AUTH_TOKEN_AGENT: TOKEN,
       // Exactly the local clone env's shape: the MLX embedding server needs no

--- a/server/transport/health.test.ts
+++ b/server/transport/health.test.ts
@@ -27,7 +27,9 @@ const DISCONNECTED: DatabaseHealth = {
 function input(overrides?: Partial<SingleWorkerHealthInput>): SingleWorkerHealthInput {
   return {
     databaseHealth: async () => CONNECTED,
+    hostname: "core01",
     serverIp: "10.71.1.21",
+    serverIps: ["10.71.1.21"],
     probeTimeoutMs: 3_000,
     logger: silentLogger(),
     ...overrides,

--- a/server/transport/health.ts
+++ b/server/transport/health.ts
@@ -12,8 +12,12 @@ export interface TransportNatsHealth {
 
 export interface SingleWorkerHealth {
   readonly status: "healthy" | "degraded";
+  /** Machine hostname — the human half of "which brain did I reach?". */
+  readonly hostname: string;
   readonly server_ip: string;
   readonly server_ips: readonly string[];
+  /** Deploy stamp short sha; absent on a tree that was never deployed. */
+  readonly revision?: string;
   readonly database: DatabaseHealth;
   readonly embedding: {
     readonly configured: boolean;
@@ -27,7 +31,10 @@ export interface SingleWorkerHealthInput {
   readonly databaseHealth: () => Promise<DatabaseHealth>;
   readonly embeddingBaseUrl?: string;
   readonly embeddingApiKey?: string;
+  readonly hostname: string;
   readonly serverIp: string;
+  readonly serverIps: readonly string[];
+  readonly revision?: string | undefined;
   readonly probeTimeoutMs: number;
   readonly logger: Logger;
   readonly fetch?: typeof fetch;
@@ -92,8 +99,10 @@ export async function getSingleWorkerHealth(
   );
   return {
     status,
+    hostname: input.hostname,
     server_ip: input.serverIp,
-    server_ips: [input.serverIp],
+    server_ips: input.serverIps,
+    ...(input.revision ? { revision: input.revision } : {}),
     database,
     embedding: {
       configured: Boolean(input.embeddingBaseUrl),

--- a/server/transport/server-identity.test.ts
+++ b/server/transport/server-identity.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from "bun:test";
+import type os from "node:os";
+import {
+  readDeployedRevision,
+  resolveServerIdentity,
+} from "./server-identity.ts";
+
+type Interfaces = NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+
+function ipv4(
+  address: string,
+  internal = false,
+): os.NetworkInterfaceInfo {
+  return {
+    address,
+    netmask: "255.255.255.0",
+    family: "IPv4",
+    mac: "00:00:00:00:00:00",
+    internal,
+    cidr: `${address}/24`,
+  };
+}
+
+/**
+ * The interface table of the Mac that exposed this defect, verified live on
+ * 2026-08-04: a loopback, the true LAN address on `en0`, a second physical
+ * address on `en1`, and a VM bridge on `en10`.
+ */
+function macMiniInterfaces(): Interfaces {
+  return {
+    lo0: [ipv4("127.0.0.1", true)],
+    en0: [ipv4("10.71.1.20")],
+    en1: [ipv4("10.71.1.131")],
+    en10: [ipv4("192.168.127.11")],
+  };
+}
+
+const hostname = () => "Mini-M4-Pro.local";
+
+describe("server identity resolution", () => {
+  // -- The defect ------------------------------------------------------------
+  it("reports the real LAN address when the bind host is the 0.0.0.0 wildcard", () => {
+    // RED PROOF. This is the measured local-clone configuration: no
+    // OPEN_BRAIN_SERVER_IP, OPEN_BRAIN_BIND_HOST=0.0.0.0. The shipped code
+    // answered "unknown" here, which is what a client saw on 127.0.0.1:3100.
+    const identity = resolveServerIdentity({
+      bindHost: "0.0.0.0",
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+    expect(identity.serverIp).not.toBe("unknown");
+    expect(identity.serverIps).toContain("10.71.1.20");
+  });
+
+  it("reports the real LAN address when nothing at all is configured", () => {
+    const identity = resolveServerIdentity({
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+    expect(identity.serverIps).not.toEqual(["unknown"]);
+  });
+
+  // -- Precedence ------------------------------------------------------------
+  it("prefers the explicitly advertised address over detection", () => {
+    const identity = resolveServerIdentity({
+      configuredServerIp: "10.71.1.21",
+      bindHost: "0.0.0.0",
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.21");
+    expect(identity.serverIps).toEqual(["10.71.1.21"]);
+  });
+
+  it("uses a concrete bind host in preference to detection", () => {
+    const identity = resolveServerIdentity({
+      bindHost: "10.71.1.131",
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.131");
+    expect(identity.serverIps).toEqual(["10.71.1.131"]);
+  });
+
+  it.each([
+    ["0.0.0.0"],
+    ["::"],
+    ["[::]"],
+    ["127.0.0.1"],
+    ["::1"],
+    ["[::1]"],
+    ["localhost"],
+    ["unknown"],
+  ])("never answers with the non-identifying bind value %s", (bindHost) => {
+    const identity = resolveServerIdentity({
+      bindHost,
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+  });
+
+  it("ignores an explicit server IP that is itself loopback or wildcard", () => {
+    const identity = resolveServerIdentity({
+      configuredServerIp: "127.0.0.1",
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+  });
+
+  it("treats a blank or whitespace-only configuration value as unset", () => {
+    const identity = resolveServerIdentity({
+      configuredServerIp: "   ",
+      bindHost: "",
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+  });
+
+  // -- Ordering and disclosure bounds ----------------------------------------
+  it("orders physical interfaces ahead of virtual bridges", () => {
+    const identity = resolveServerIdentity({
+      interfaces: () => ({
+        bridge100: [ipv4("192.168.64.1")],
+        en0: [ipv4("10.71.1.20")],
+      }),
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+    expect(identity.serverIps).toEqual(["10.71.1.20", "192.168.64.1"]);
+  });
+
+  it("orders interfaces deterministically regardless of enumeration order", () => {
+    // Interface enumeration order is not stable across reboots, and a /health
+    // answer that reshuffles between restarts is not an identity.
+    const shuffled = resolveServerIdentity({
+      interfaces: () => ({
+        en10: [ipv4("192.168.127.11")],
+        en1: [ipv4("10.71.1.131")],
+        en0: [ipv4("10.71.1.20")],
+      }),
+      hostname,
+    });
+
+    expect(shuffled.serverIps).toEqual(
+      resolveServerIdentity({ interfaces: macMiniInterfaces, hostname })
+        .serverIps,
+    );
+  });
+
+  it("sorts interface names numerically so en2 precedes en10", () => {
+    const identity = resolveServerIdentity({
+      interfaces: () => ({
+        en10: [ipv4("192.168.127.11")],
+        en2: [ipv4("10.71.1.55")],
+      }),
+      hostname,
+    });
+
+    expect(identity.serverIps).toEqual(["10.71.1.55", "192.168.127.11"]);
+  });
+
+  it("keeps every detected private address visible, not just the winner", () => {
+    const identity = resolveServerIdentity({
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    // en0, en1, en10 — numerically sorted, so the VM bridge on en10 stays
+    // visible but never displaces a real adapter.
+    expect(identity.serverIps).toEqual([
+      "10.71.1.20",
+      "10.71.1.131",
+      "192.168.127.11",
+    ]);
+  });
+
+  it("never volunteers a public address through detection", () => {
+    // `/health` is unauthenticated, so detection is bounded to private ranges.
+    const identity = resolveServerIdentity({
+      interfaces: () => ({ en0: [ipv4("203.0.113.7")] }),
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("unknown");
+    expect(identity.serverIps).toEqual(["unknown"]);
+  });
+
+  it("still advertises a public address when an operator configures one explicitly", () => {
+    const identity = resolveServerIdentity({
+      configuredServerIp: "203.0.113.7",
+      interfaces: () => ({ en0: [ipv4("203.0.113.7")] }),
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("203.0.113.7");
+  });
+
+  it("skips internal loopback interfaces during detection", () => {
+    const identity = resolveServerIdentity({
+      interfaces: () => ({ lo0: [ipv4("127.0.0.1", true)] }),
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("unknown");
+  });
+
+  it("accepts the numeric IPv4 family that older Node runtimes report", () => {
+    const identity = resolveServerIdentity({
+      interfaces: () =>
+        ({
+          en0: [{ ...ipv4("10.71.1.20"), family: 4 as unknown as "IPv4" }],
+        }) as Interfaces,
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("10.71.1.20");
+  });
+
+  it("deduplicates an address that appears on more than one interface", () => {
+    const identity = resolveServerIdentity({
+      interfaces: () => ({
+        en0: [ipv4("10.71.1.20")],
+        en5: [ipv4("10.71.1.20")],
+      }),
+      hostname,
+    });
+
+    expect(identity.serverIps).toEqual(["10.71.1.20"]);
+  });
+
+  // -- Hostname --------------------------------------------------------------
+  it("reports the machine hostname alongside the address", () => {
+    const identity = resolveServerIdentity({
+      interfaces: macMiniInterfaces,
+      hostname,
+    });
+
+    expect(identity.hostname).toBe("Mini-M4-Pro.local");
+  });
+
+  it("degrades the hostname rather than failing when it cannot be read", () => {
+    const identity = resolveServerIdentity({
+      interfaces: macMiniInterfaces,
+      hostname: () => {
+        throw new Error("no hostname");
+      },
+    });
+
+    expect(identity.hostname).toBe("unknown");
+    expect(identity.serverIp).toBe("10.71.1.20");
+  });
+
+  it("degrades identity rather than failing when interfaces cannot be read", () => {
+    const identity = resolveServerIdentity({
+      interfaces: () => {
+        throw new Error("no interfaces");
+      },
+      hostname,
+    });
+
+    expect(identity.serverIp).toBe("unknown");
+    expect(identity.hostname).toBe("Mini-M4-Pro.local");
+  });
+});
+
+describe("deployed revision stamp", () => {
+  const stamp = [
+    "sha=f705fc9011baf60c28ef3acd4132d00ff8afc004",
+    "short_sha=f705fc9",
+    "ref=HEAD",
+    "deployed_at=2026-08-04T14:34:50Z",
+    "repo=/Volumes/ThunderBolt/Development/open-brain",
+    "subject=feat(capture): say it out loud when a turn cannot be written",
+  ].join("\n");
+
+  it("reads the short sha from a real deploy stamp", () => {
+    expect(readDeployedRevision(() => stamp)).toBe("f705fc9");
+  });
+
+  it("does not expose the commit subject", () => {
+    // The subject is arbitrary operator text; only the sha identifies code.
+    expect(readDeployedRevision(() => stamp)).not.toContain("feat");
+  });
+
+  it("tolerates a subject containing its own equals signs", () => {
+    expect(
+      readDeployedRevision(() => "short_sha=abc1234\nsubject=fix: a=b resolved"),
+    ).toBe("abc1234");
+  });
+
+  it("returns undefined for an undeployed tree with no stamp", () => {
+    expect(readDeployedRevision(() => undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when the stamp is unreadable", () => {
+    expect(
+      readDeployedRevision(() => {
+        throw new Error("ENOENT");
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the stamp carries no short_sha line", () => {
+    expect(readDeployedRevision(() => "sha=abc\nref=HEAD")).toBeUndefined();
+  });
+
+  it("returns undefined when short_sha is present but empty", () => {
+    expect(readDeployedRevision(() => "short_sha=")).toBeUndefined();
+  });
+});

--- a/server/transport/server-identity.ts
+++ b/server/transport/server-identity.ts
@@ -1,0 +1,239 @@
+import os from "node:os";
+
+/**
+ * Who and where this brain is, for `/health`.
+ *
+ * `/health` is the only surface a client can hit to answer "am I pointed at the
+ * right brain?", and until now it could not: `server_ip` came from
+ * `OPEN_BRAIN_SERVER_IP` alone (#197, `db2e05b`), so a host that never set the
+ * variable — every local clone — reported the literal string `unknown`. core01
+ * looked correct only because its env happens to carry the value. The field
+ * existed; the resolution did not.
+ *
+ * The rule this module implements: the answer comes from CONFIGURATION first,
+ * and falls back to the host's real LAN interfaces only when configuration
+ * names no concrete address. A loopback or wildcard bind is NOT an answer —
+ * `0.0.0.0` tells a client nothing about which machine it reached, which is the
+ * entire question `/health` is being asked.
+ *
+ * This deliberately supersedes the `does not auto-disclose host interface IPs`
+ * stance that shipped alongside #197. That was an implementation choice, never
+ * a recorded requirement, and it is what produced the `unknown` defect. The
+ * disclosure it guarded against is instead bounded below: detection only ever
+ * volunteers private addresses.
+ */
+
+/** A bind value that identifies no particular machine, so it can never be the answer. */
+const UNSPECIFIED_HOSTS = new Set([
+  "0.0.0.0",
+  "::",
+  "[::]",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+  "localhost",
+  "unknown",
+]);
+
+export const UNKNOWN_SERVER_IP = "unknown";
+
+/**
+ * `/health` is unauthenticated (`server/transport/http-app.ts`), so automatic
+ * interface disclosure is bounded to addresses that are only meaningful inside
+ * the LAN already. A routable public address is never volunteered by detection:
+ * an operator who genuinely wants to advertise one sets `OPEN_BRAIN_SERVER_IP`
+ * and owns that decision explicitly.
+ *
+ * RFC1918 plus RFC3927 link-local and RFC6598 carrier-grade NAT, which are the
+ * ranges this fleet actually appears on.
+ */
+function isPrivateIpv4(address: string): boolean {
+  const octets = address.split(".").map((part) => Number(part));
+  if (
+    octets.length !== 4 ||
+    octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
+    return false;
+  }
+  const [a, b] = octets as [number, number, number, number];
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+/**
+ * Interfaces that exist on developer machines but are not how anything reaches
+ * this service: container/VM bridges and virtual adapters. They are real,
+ * non-internal, and private, so nothing else here excludes them — and on the
+ * Mac that exposed this defect one of them (`en10`, 192.168.127.11) would
+ * otherwise compete with the true LAN address. They stay in `server_ips`; they
+ * just never take first place.
+ */
+const VIRTUAL_INTERFACE_PREFIXES = [
+  "bridge",
+  "utun",
+  "vmnet",
+  "docker",
+  "veth",
+  "tap",
+  "tun",
+  "awdl",
+  "llw",
+];
+
+function isVirtualInterface(name: string): boolean {
+  const lower = name.toLowerCase();
+  return VIRTUAL_INTERFACE_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+export interface ServerIdentityInput {
+  /** `OPEN_BRAIN_SERVER_IP` — an explicit advertised address; always wins. */
+  readonly configuredServerIp?: string | undefined;
+  /** `OPEN_BRAIN_BIND_HOST` — used when it names a concrete (non-wildcard) address. */
+  readonly bindHost?: string | undefined;
+  /** Injected for tests; defaults to the host's real interfaces. */
+  readonly interfaces?: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  /** Injected for tests; defaults to the machine hostname. */
+  readonly hostname?: () => string;
+}
+
+export interface ServerIdentity {
+  readonly hostname: string;
+  readonly serverIp: string;
+  readonly serverIps: readonly string[];
+}
+
+function normalize(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isConcreteHost(value: string): boolean {
+  return !UNSPECIFIED_HOSTS.has(value.toLowerCase());
+}
+
+/**
+ * Every private IPv4 the host actually carries, best candidate first.
+ *
+ * Ordering is what makes a single `server_ip` meaningful on a multi-homed
+ * machine: physical interfaces precede virtual bridges, so the address a client
+ * would really use to reach this brain is the one reported, and the rest stay
+ * visible in `server_ips` rather than being silently dropped.
+ */
+function detectLanIpv4(
+  interfaces: () => NodeJS.Dict<os.NetworkInterfaceInfo[]>,
+): string[] {
+  let entries: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+  try {
+    entries = interfaces();
+  } catch {
+    // Fail open: an unreadable interface table degrades identity, never health.
+    return [];
+  }
+
+  const physical: Array<{ name: string; address: string }> = [];
+  const virtual: string[] = [];
+  for (const [name, addresses] of Object.entries(entries)) {
+    for (const address of addresses ?? []) {
+      // Node <18.4 reports `family` as the number 4; newer as the string "IPv4".
+      const isV4 =
+        address.family === "IPv4" || (address.family as unknown) === 4;
+      if (!isV4 || address.internal) continue;
+      if (!isPrivateIpv4(address.address)) continue;
+      if (isVirtualInterface(name)) {
+        virtual.push(address.address);
+      } else {
+        physical.push({ name, address: address.address });
+      }
+    }
+  }
+
+  // Interface enumeration order is not guaranteed stable across reboots, and a
+  // `/health` answer that reshuffles between restarts is not an identity. Sort
+  // physical interfaces by name — naturally, so `en2` precedes `en10` rather
+  // than sorting as text — which puts the primary adapter (`en0`) first on
+  // every machine in this fleet and makes the rest deterministic.
+  physical.sort((a, b) =>
+    a.name.localeCompare(b.name, "en", { numeric: true, sensitivity: "base" }),
+  );
+
+  return [...new Set([...physical.map((i) => i.address), ...virtual])];
+}
+
+/**
+ * Resolve the identity `/health` reports.
+ *
+ * Precedence, highest first:
+ *   1. `OPEN_BRAIN_SERVER_IP` — the explicit advertised address.
+ *   2. `OPEN_BRAIN_BIND_HOST`, when it names a concrete address rather than a
+ *      wildcard or loopback.
+ *   3. Detected private LAN interfaces.
+ *   4. `"unknown"` — only when the host genuinely has no private address.
+ */
+export function resolveServerIdentity(
+  input: ServerIdentityInput = {},
+): ServerIdentity {
+  const hostnameFn = input.hostname ?? (() => os.hostname());
+  let hostname: string;
+  try {
+    hostname = hostnameFn().trim() || UNKNOWN_SERVER_IP;
+  } catch {
+    hostname = UNKNOWN_SERVER_IP;
+  }
+
+  const configured = normalize(input.configuredServerIp);
+  if (configured && isConcreteHost(configured)) {
+    return { hostname, serverIp: configured, serverIps: [configured] };
+  }
+
+  const bindHost = normalize(input.bindHost);
+  if (bindHost && isConcreteHost(bindHost)) {
+    return { hostname, serverIp: bindHost, serverIps: [bindHost] };
+  }
+
+  const detected = detectLanIpv4(
+    input.interfaces ?? (() => os.networkInterfaces()),
+  );
+  const [first] = detected;
+  if (first !== undefined) {
+    return { hostname, serverIp: first, serverIps: detected };
+  }
+
+  return {
+    hostname,
+    serverIp: UNKNOWN_SERVER_IP,
+    serverIps: [UNKNOWN_SERVER_IP],
+  };
+}
+
+/**
+ * The deploy stamp's short sha, or `undefined` when the tree carries none.
+ *
+ * `scripts/local-clone-deploy.sh` writes `.deployed-revision` as plain
+ * `key=value` lines (deliberately not JSON — the commit subject is arbitrary
+ * text). Only `short_sha` is read here: it is the which-code discriminator, and
+ * the subject line is free-form text that does not belong on a public endpoint.
+ * A dev tree that was never deployed has no stamp, which is normal, not a fault.
+ */
+export function readDeployedRevision(
+  readStamp: () => string | undefined,
+): string | undefined {
+  let raw: string | undefined;
+  try {
+    raw = readStamp();
+  } catch {
+    return undefined;
+  }
+  if (!raw) return undefined;
+  for (const line of raw.split("\n")) {
+    const [key, ...rest] = line.split("=");
+    if (key?.trim() === "short_sha") {
+      const value = rest.join("=").trim();
+      if (value) return value;
+    }
+  }
+  return undefined;
+}

--- a/server/transport/worker-proxy.test.ts
+++ b/server/transport/worker-proxy.test.ts
@@ -33,7 +33,9 @@ function handlerWith(options: {
 }) {
   const input: WorkerProxyInput = {
     workers: options.workers ?? WORKERS,
+    hostname: "core01",
     serverIp: "10.71.1.21",
+    serverIps: ["10.71.1.21"],
     healthProbeTimeoutMs: 3_000,
     logger: silentLogger(),
     fetch: (async (url: string | URL | Request, init?: RequestInit) => {
@@ -194,7 +196,9 @@ describe("aggregate worker front boundary", () => {
     expect(() =>
       createWorkerProxyHandler({
         workers: [],
+        hostname: "core01",
         serverIp: "10.71.1.21",
+        serverIps: ["10.71.1.21"],
         healthProbeTimeoutMs: 3_000,
         logger: silentLogger(),
       }),

--- a/server/transport/worker-proxy.ts
+++ b/server/transport/worker-proxy.ts
@@ -17,15 +17,20 @@ export interface WorkerHealthResult {
 
 export interface AggregateHealth {
   readonly status: "healthy" | "degraded";
+  readonly hostname: string;
   readonly server_ip: string;
   readonly server_ips: readonly string[];
+  readonly revision?: string;
   readonly workers: readonly WorkerHealthResult[];
   readonly timestamp: string;
 }
 
 export interface WorkerProxyInput {
   readonly workers: readonly WorkerTarget[];
+  readonly hostname: string;
   readonly serverIp: string;
+  readonly serverIps: readonly string[];
+  readonly revision?: string | undefined;
   readonly healthProbeTimeoutMs: number;
   readonly logger: Logger;
   readonly fetch?: typeof fetch;
@@ -101,8 +106,10 @@ export function createWorkerProxyHandler(input: WorkerProxyInput): WorkerProxyHa
       const healthy = workers.every((worker) => worker.ok);
       const health: AggregateHealth = {
         status: healthy ? "healthy" : "degraded",
+        hostname: input.hostname,
         server_ip: input.serverIp,
-        server_ips: [input.serverIp],
+        server_ips: input.serverIps,
+        ...(input.revision ? { revision: input.revision } : {}),
         workers,
         timestamp: new Date().toISOString(),
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import express from "express";
 import cors from "cors";
+import { readFileSync } from "node:fs";
+import {
+  readDeployedRevision,
+  resolveServerIdentity,
+} from "../server/transport/server-identity.ts";
 import type { Request, Response, NextFunction } from "express";
 import type pg from "pg";
 import { createPool, checkPoolHealth } from "./db/pool.ts";
@@ -40,12 +45,25 @@ import { validateLocalCloneMode } from "./local-clone-mode.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
 
-function serverIps(): string[] {
-  const configured = process.env.OPEN_BRAIN_SERVER_IP?.trim();
-  if (configured) return [configured];
+/**
+ * Host identity for `/health`, resolved once per process.
+ *
+ * This used to read `OPEN_BRAIN_SERVER_IP` and return the literal `"unknown"`
+ * when it was unset (#197), which is exactly what every local clone reported.
+ * Resolution now lives in `server/transport/server-identity.ts` so both serving
+ * trees answer identically — this file still serves core01
+ * (`deploy/open-brain.service`), while the local clone runs `server/main.ts`.
+ *
+ * Read once: a process does not change hosts or change its own code.
+ */
+const SERVER_IDENTITY = resolveServerIdentity({
+  configuredServerIp: process.env.OPEN_BRAIN_SERVER_IP,
+  bindHost: process.env.OPEN_BRAIN_BIND_HOST,
+});
 
-  return ["unknown"];
-}
+const DEPLOYED_REVISION = readDeployedRevision(() =>
+  readFileSync(new URL("../.deployed-revision", import.meta.url), "utf8"),
+);
 
 /**
  * `/health`'s probe timeout, preserved from the private copy this file used to
@@ -102,7 +120,6 @@ export function createApp(
         : Promise.resolve(false),
     ]);
 
-    const ips = serverIps();
     const natsAvailability =
       toolDeps.natsBridgeHealth?.availability ??
       natsRuntimeBoundary.nats.availability;
@@ -112,8 +129,10 @@ export function createApp(
     );
     const status: HealthStatus = {
       status: dbHealth.connected && !natsDegraded ? "healthy" : "degraded",
-      server_ip: ips[0] ?? "unknown",
-      server_ips: ips,
+      hostname: SERVER_IDENTITY.hostname,
+      server_ip: SERVER_IDENTITY.serverIp,
+      server_ips: [...SERVER_IDENTITY.serverIps],
+      ...(DEPLOYED_REVISION ? { revision: DEPLOYED_REVISION } : {}),
       database: dbHealth,
       embedding: {
         configured: Boolean(EMBEDDING_BASE_URL),

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -99,40 +99,42 @@ function mockFetchOk() {
 
 // -- Tests --------------------------------------------------------------------
 describe("GET /health", () => {
-  it("includes server IP identity", async () => {
-    const originalServerIp = process.env.OPEN_BRAIN_SERVER_IP;
-    process.env.OPEN_BRAIN_SERVER_IP = "10.71.1.21";
+  it("includes a concrete server IP identity", async () => {
+    // Identity is resolved ONCE at module load, not per request: a process does
+    // not change hosts, and re-reading the environment on every probe would let
+    // a mutated variable silently change what the endpoint claims to be. The
+    // precedence rules themselves are covered directly, against injected
+    // interfaces, in `server/transport/server-identity.test.ts`.
+    const res = await fetch(`${baseUrl}/health`);
+    const body = (await res.json()) as HealthStatus;
 
-    try {
-      const res = await fetch(`${baseUrl}/health`);
-      const body = (await res.json()) as HealthStatus;
-
-      expect(body.server_ip).toBe("10.71.1.21");
-      expect(body.server_ips).toEqual(["10.71.1.21"]);
-    } finally {
-      if (originalServerIp === undefined) {
-        delete process.env.OPEN_BRAIN_SERVER_IP;
-      } else {
-        process.env.OPEN_BRAIN_SERVER_IP = originalServerIp;
-      }
-    }
+    expect(body.server_ip).not.toBe("unknown");
+    expect(body.server_ips.length).toBeGreaterThan(0);
+    expect(body.server_ips).toContain(body.server_ip);
   });
 
-  it("does not auto-disclose host interface IPs when identity is not configured", async () => {
-    const originalServerIp = process.env.OPEN_BRAIN_SERVER_IP;
-    delete process.env.OPEN_BRAIN_SERVER_IP;
+  it("reports the machine hostname alongside the address", async () => {
+    // The operator's question is "which brain am I pointed at?", and an address
+    // alone does not answer it on a multi-homed or NAT'd host.
+    const res = await fetch(`${baseUrl}/health`);
+    const body = (await res.json()) as HealthStatus;
 
-    try {
-      const res = await fetch(`${baseUrl}/health`);
-      const body = (await res.json()) as HealthStatus;
+    expect(typeof body.hostname).toBe("string");
+    expect(body.hostname.length).toBeGreaterThan(0);
+  });
 
-      expect(body.server_ip).toBe("unknown");
-      expect(body.server_ips).toEqual(["unknown"]);
-    } finally {
-      if (originalServerIp !== undefined) {
-        process.env.OPEN_BRAIN_SERVER_IP = originalServerIp;
-      }
-    }
+  it("never answers with a loopback or wildcard address", async () => {
+    // Supersedes the original `does not auto-disclose host interface IPs`
+    // assertion from #197. That stance is what made every local clone report
+    // `unknown`; identity resolution now lives in
+    // `server/transport/server-identity.ts`, which bounds automatic disclosure
+    // to private LAN ranges instead of withholding the answer entirely.
+    const res = await fetch(`${baseUrl}/health`);
+    const body = (await res.json()) as HealthStatus;
+
+    expect(["0.0.0.0", "127.0.0.1", "localhost", "::1"]).not.toContain(
+      body.server_ip,
+    );
   });
 
   it("does not degrade when the embedding provider is unreachable", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,8 +47,12 @@ export interface PoolHealth {
 
 export interface HealthStatus {
   status: "healthy" | "degraded";
+  /** Machine hostname — the human half of "which brain did I reach?". */
+  hostname: string;
   server_ip: string;
   server_ips: string[];
+  /** Deploy stamp short sha; absent on a tree that was never deployed. */
+  revision?: string;
   database: PoolHealth;
   embedding: { configured: boolean; connected: boolean };
   nats: {


### PR DESCRIPTION
`/health` on the local dev brain reported `"server_ip": "unknown"`, so a client had no way to tell which brain it was talking to.

## Summary

- Measured tonight: `GET http://127.0.0.1:3100/health` returned `"server_ip":"unknown","server_ips":["unknown"]`, while core01 returned `10.71.1.21`.
- Root cause: **the field was never detected.** `serverIps()` (`src/index.ts`, #197 / `db2e05b`) read `OPEN_BRAIN_SERVER_IP` and returned the literal string `"unknown"` when it was unset. There was no `os.networkInterfaces()` call anywhere in the repo. core01 looked correct only because its env happens to carry the variable — which is exactly why this stayed invisible: the host that would have exposed it is the one nobody checked.
- Fix: identity resolves from **configuration**, in one new module (`server/transport/server-identity.ts`), consumed by all three copies of the defect.

Precedence, highest first:

1. `OPEN_BRAIN_SERVER_IP` — the explicit advertised address. Always wins.
2. `OPEN_BRAIN_BIND_HOST`, when it names a concrete address. A wildcard or loopback bind is **skipped**: `0.0.0.0` identifies no particular machine, which is the entire question `/health` is being asked.
3. Detected private LAN interfaces — physical adapters first, interface names sorted numerically so the answer is stable across reboots rather than dependent on enumeration order.
4. `"unknown"` only when the host genuinely has no private address.

`/health` also now reports `hostname` and, on a deployed tree, `revision` — the `short_sha` from the `.deployed-revision` stamp `local-clone-deploy.sh` already writes. That gives an exact which-brain-and-which-code discriminator instead of inferring it from the `workers` array.

**Three copies, one resolver.** `src/index.ts` (serves core01 via `deploy/open-brain.service`), `server/` (serves the local clone via `SERVING_ENTRYPOINT`), and the `run-two-worker.ts` aggregate front each carried the same `["unknown"]` function. All three now call the same resolver, so a front and the workers behind it cannot disagree about which machine they are.

## A deliberate reversal, called out for review

This supersedes the `does not auto-disclose host interface IPs when identity is not configured` test that shipped alongside #197. That was an implementation choice, never an issue-recorded requirement — and withholding the answer is precisely what produced the defect.

The disclosure concern is real (`/health` is unauthenticated, `server/transport/http-app.ts`), so it is bounded properly instead of by refusing to answer: **detection only ever volunteers private addresses** (RFC1918, RFC3927 link-local, RFC6598 CGNAT). A public address is reported only when an operator sets `OPEN_BRAIN_SERVER_IP` explicitly and owns that decision. Both behaviors are covered by tests.

## Red-proof

Against the shipped `serverIps()` logic, with the measured local-clone config (`OPEN_BRAIN_BIND_HOST=0.0.0.0`, no `OPEN_BRAIN_SERVER_IP`):

```
Expected: "10.71.1.20"
Received: "unknown"          ← 1 fail
```

The same scenario in `server/transport/server-identity.test.ts` (`reports the real LAN address when the bind host is the 0.0.0.0 wildcard`) passes with the fix: **33 pass, 0 fail**.

Independently red-proven end to end: `server/main.pg.test.ts` failed on the live-Postgres health shape with `Expected: "127.0.0.1" / Received: "10.71.1.20"` — the fix changing real server output, not just a unit assertion.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — pre-push full suite **3155 pass / 0 fail** across 3661 tests, **no bypass**; `bunx tsc --noEmit` clean; `server/transport/server-identity.test.ts` 33 pass; `server/main.pg.test.ts` 8 pass against the live dogfood DB (these SKIP silently without `OPENBRAIN_TEST_DATABASE_URL`, so they were run with it set)
- [x] Python package checks passed or are not applicable — not applicable: no `python/` paths touched
- [x] Live Open Brain smoke passed or is not applicable — **passed, RUNNING**: a server bound to `0.0.0.0` answers `{"hostname":"Mini-M4-Pro.local","server_ip":"10.71.1.20","server_ips":["10.71.1.20","10.71.1.131","192.168.127.11"]}` on **both** `127.0.0.1:7145` and `10.71.1.20:7145`, and reports `"revision":"f705fc9"` when a deploy stamp is present

**No new test failures.** The `server/` suite fails exactly the 7 tests it already failed before this change (`list_stale` ×4, `reporting tools` ×3, all pre-existing on `main` and in files this PR does not touch). Verified by diffing the sorted failing-test-name lists: byte-identical.

## Critical Self-Review

- Highest-risk behavior: reversing the #197 non-disclosure stance on an unauthenticated endpoint. Mitigated by bounding automatic detection to private ranges only, with a test asserting a public address is never volunteered; explicit operator configuration remains the only way to advertise one.
- Assumptions that could be wrong: that `en0`-style physical naming reliably identifies the primary adapter. On this Mac `en10` is a real registered network service (S3), not a bridge, so the name heuristic cannot fully separate them — this is why `server_ips` keeps every address rather than reporting only the winner, and why ordering is sorted rather than incidental. `server_ip` is correct here; a host whose primary adapter is not the lowest-numbered one would need `OPEN_BRAIN_SERVER_IP`.
- Missing/weak tests: no test asserts against a live multi-homed host's real interface table (that is environment-dependent); coverage uses injected tables plus the live smoke above. IPv6 is not reported — deliberate, out of scope, and it would need its own scope/disclosure decision.
- Security/permission risk: this endpoint is unauthenticated by design. The change discloses private LAN addresses and the hostname that were not previously disclosed. Judged acceptable because both are already visible to anyone who can reach the port, and the operator explicitly asked for them; public addresses stay opt-in. The commit subject line is deliberately **not** exposed — only `short_sha` is parsed out of the stamp.
- Migration/deploy risk: none — no schema or migration. `/health` gains fields; it removes none, so existing consumers are unaffected.
- Downstream client/runtime risk: `/health` is a client-facing response shape. Fields are **added** (`hostname`, optional `revision`) and `server_ips` may now contain more than one entry — a consumer that assumed exactly one element would see a longer array. No consumer in this repo does.
- Rollback/cleanup concern: revert restores `"unknown"` — the original defect — with no other side effect. `.deployed-revision` was added to `.gitignore` so a stamp can never be committed and make every tree claim someone else's sha.
- Fixes made before PR: initial interface ordering put a VM bridge (`192.168.127.11`) ahead of a real adapter in `server_ips`; caught in live verification and fixed with deterministic numeric sorting plus two ordering tests.
- Known residual risk: identity is resolved **once at process start**, not per request. That is deliberate (a process does not change hosts, and re-reading env per probe would let a mutated variable silently change what the endpoint claims), but it means a host that changes IP requires a restart before `/health` tells the truth.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review-lane pattern arose; the "field exists, detection never did" gotcha is documented at the code site and in `docs/CONFIG_REFERENCE.md`

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — none arose
- Live Open Brain checks: [x] linked below

Live check evidence (RUNNING, this session, server bound to `0.0.0.0`):

```
$ curl -s http://127.0.0.1:7145/health
$ curl -s http://10.71.1.20:7145/health     # identical answer from the LAN
{"status":"healthy","hostname":"Mini-M4-Pro.local","server_ip":"10.71.1.20",
 "server_ips":["10.71.1.20","10.71.1.131","192.168.127.11"],
 "database":{"connected":true,...},"embedding":{"configured":true,"connected":true}}

# with a .deployed-revision stamp present:
{"status":"healthy","hostname":"Mini-M4-Pro.local","server_ip":"10.71.1.20",...,"revision":"f705fc9",...}
```

Before this change, the same endpoint on this machine answered `"server_ip":"unknown","server_ips":["unknown"]`.

## Contract Parity

- Contract parity: [x] runtime-specific because: `/health` is an operational endpoint with no contract fixture, client binding, or wire representation in `contracts/`. The response type is declared in `src/types.ts` and `server/transport/health.ts`, both updated together; `server/main.pg.test.ts` asserts the shape against a live server so a dropped field is a compile error, not a silent `undefined`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable: no MCP tool or schema surface touched
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable: no tool definitions changed
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable: no `python/` paths touched
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable: additive fields on an operational endpoint no Hermes path parses

Notes/evidence:

- `/health` is client-facing, so it was classified rather than waved through: the change is **additive** (`hostname`, optional `revision`) and removes nothing, so no downstream consumer breaks. The one behavioral change a consumer could notice is `server_ips` returning multiple entries where it previously returned a single-element array — no in-repo consumer indexes it that way.
- core01 is unaffected in practice: it sets `OPEN_BRAIN_SERVER_IP`, which is still the highest-precedence source, so it keeps reporting `10.71.1.21` exactly as before. This PR changes what happens when that variable is **absent**.
- `/health` gains fields only; deploying this does not require a coordinated client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
