### PR TITLE
docs(client): land the client-install story as a bundle, a runbook, and four gotchas

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -969,3 +969,132 @@ Two sessions diagnosed a missing token as a core01 outage, and core01 was probed
 healthy mid-incident — the healthy probe was read as noise instead of as the
 answer. A healthy `/health` next to a failing gate is positive evidence the
 problem is credentials or environment, not the network.
+
+---
+
+## 2026-08-04 client-install traps
+
+These four all bit while putting the direct client stack on a second machine.
+Full procedure: `docs/client-install-runbook.md`.
+
+### A stale MCP registration answers instead of the direct stack — and `/mcp` in an error is the tell
+
+**Symptom.** Recall or a hook fails, and the error names a URL ending in `/mcp`.
+The direct client stack is installed, the env file is right, `/health` answers,
+and it still does not work.
+
+**Cause.** A retired MCP-lane registration is still configured on the box —
+`claude mcp list` shows an open-brain entry — and it is being reached instead of
+the direct client.
+
+**The tell is exact: the direct stack NEVER uses a `/mcp` URL.** Its base URL is
+a bare `scheme://host:port`. So a `/mcp` path appearing anywhere in an error
+message is not a routing detail to investigate; it is positive proof that the
+retired lane is configured and answering. There is no configuration in which the
+direct stack legitimately produces that URL.
+
+**Check and fix.**
+
+```bash
+claude mcp list
+claude mcp remove <name>   # any open-brain entry
+```
+
+`setup-client.sh` prints this reminder and the current registrations at the end
+of every install, because a fresh install onto a box that used to run the MCP
+lane is exactly when this happens.
+
+### The hook wrapper and the installed package are a MATCHED PAIR, and the mismatch is silent
+
+**Symptom.** Every hook exits 0. Receipts look fine. No rows are written and no
+canon is injected. The box looks completely healthy and is doing nothing.
+
+**Cause.** Three facts that compound:
+
+1. `config.unknown_prefixed_variables` **rejects** any `OPENBRAIN_*` variable
+   that matches no declared setting — and rejects the **whole environment**, not
+   the one variable.
+2. The hook entrypoints **swallow every exception** (fail-open observer
+   contract).
+3. So a wrapper passing a variable the installed package does not declare turns
+   **every hook on the box** into a clean exit 0 with zero capture and zero
+   injection.
+
+This has happened three times with three variables: `OPENBRAIN_OBSERVATION_*`,
+`OPENBRAIN_SPOOL_PATH`, and `OPENBRAIN_ALLOW_INSECURE_HTTP`.
+
+**The ordering rule (PR #544).** Install the package that declares the variable
+**first**, then edit the wrapper to pass it. PR #544 verified this empirically in
+that order — the old install raised `UnknownEnvironmentVariableError` with the
+variable present; the reinstalled package accepted it and resolved
+`allow_insecure_http=True` on both sections. Reversed, the box goes dark between
+the two steps.
+
+**The empty-string half, which re-armed the same defect.** The wrapper's
+`env -i VAR="${VAR:-}"` style **cannot express "absent"** — an unset variable
+reaches the child as an **empty string**. For the bool `allow_insecure_http`,
+pydantic rejected `""` with `Input should be a valid boolean`, both
+`load_capture_settings` and `load_canon_settings` raised, the entrypoints
+swallowed it, and every hook on a host that **never opted in** went silently
+dead. The fix for #525 re-created the #525 defect class.
+
+Two layers guard it now: a validator in `config.py` mapping `""` to the default
+`False`, and a conditional in the wrapper that prepends the assignment only when
+non-empty — the conditional is what protects an **older** installed package that
+predates the validator, which is exactly the state of a client mid-upgrade.
+
+**Rule:** a non-string pass-through goes in the wrapper's conditional block,
+never in the `env -i` list. A string tolerates the empty spelling; a bool, an
+int, or an enum does not.
+
+**The check that catches it.** Not exit code, and not `/health` — both pass on a
+dead box. Start a fresh session and read the CANON PACK section counts. Zero
+counts, or no pack, is this bug.
+
+### Clients cannot install from GitHub — wheels from the Mini are the paved road
+
+**Symptom.** `uv tool install git+ssh://git@github.com/rodaddy/open-brain...`
+fails on a client box, and reaching for a package index does not help either.
+
+**Cause.** The repo is private and the client boxes have no deploy key. There is
+also no published index: `python/openbrain-memory/pyproject.toml` records that
+its `fleet-nats` dependency is **not** on PyPI and lives in a private monorepo.
+Docs showing `uv pip install openbrain-memory==<version>` imply an index that
+does not exist for these packages.
+
+**The paved road.** Build wheels on the Mini and stage them —
+`scripts/client-bundle.sh` does this, into
+`/Volumes/ThunderBolt/open-brain-local/air-bundle/`, and the bundle's
+`setup-client.sh` installs from `--find-links` against the bundle's own
+`wheels/`. That reuses the wheelhouse convention the Mini already runs on
+(`OPENBRAIN_MEMORY_FIND_LINKS`, default
+`~/.local/share/openbrain-memory/wheels`) rather than inventing a second one.
+
+Do not burn time looking for an install route from the client. There isn't one;
+the artifact has to be carried.
+
+### `OPENBRAIN_BASE_URL` is a BARE `scheme://host:port` — no path, ever
+
+**Symptom.** Requests 404, or fail in a way that mentions a path segment nobody
+configured on purpose.
+
+**Cause.** A path was appended to the base URL — `/mcp`, `/api`, a trailing
+route. The client appends its own paths (`/health` and the rest) to whatever it
+is given, so a base URL with a path produces `…/mcp/health`.
+
+**The correct spellings**, and only these two shapes:
+
+```
+https://ob.rodaddy.live        # preferred — TLS, no opt-in needed
+http://10.71.1.20:3100         # LAN plain http — needs OPENBRAIN_ALLOW_INSECURE_HTTP=1
+```
+
+`openbrain_memory.client._validate_base_url` permits plain `http` only for
+loopback, so the LAN spelling is refused outright without the opt-in declared by
+#525 / PR #544. Prefer `https://ob.rodaddy.live`: no opt-in, no plain-text
+bearer token on the wire, and one fewer silent-failure mode.
+
+`127.0.0.1` is correct **on the Mini only** and needs no opt-in there. The bundle
+copies the Mini's env file verbatim, so a client staged from a loopback-pointed
+env file must have its `OPENBRAIN_BASE_URL` edited — that is a required step, not
+a nicety.

--- a/docs/client-install-runbook.md
+++ b/docs/client-install-runbook.md
@@ -1,0 +1,244 @@
+# Client install runbook — putting the Open Brain direct stack on a new box
+
+**Status: WRITTEN, and the bundle mechanism has been RUN once** (2026-08-04, the
+first bundle staged at `/Volumes/ThunderBolt/open-brain-local/air-bundle/`). The
+client-side half — a full `setup-client.sh` run on the Air — is **not yet
+proven**; see [Proof ladder](#proof-ladder) for what "done" actually requires.
+
+This is the procedure for installing the Open Brain **direct** client stack on a
+machine that is not the Mini. It exists because this has been re-derived from
+scratch more than once, each time from the same handful of files, and each time
+the same four things went wrong.
+
+---
+
+## 1. What actually has to land — four artifacts
+
+An Open Brain client is not one package. It is four things, and **three of the
+four are outside any git repo**, which is precisely why this keeps getting
+rebuilt from memory.
+
+| # | Artifact | Where it lives on the client | Versioned in the repo? |
+|---|---|---|---|
+| 1 | Three wheels: `openbrain`, `openbrain-memory`, `openbrain-provider` | `uv` tool environments, console scripts in `~/.local/bin/` | source is, built wheels are not |
+| 2 | The env file `claudex-observation.env` | `~/.local/share/openbrain-memory/env/` | **no** — it holds a live token |
+| 3 | The wrapper `openbrain-hook-env` | `~/.local/share/openbrain-memory/env/` | **no** |
+| 4 | Hook wiring in `~/.claude/settings.json` | the harness settings file | **no** |
+
+`docs/420-cutover-rollback.md` says this plainly for artifact 4: `settings.json`
+is outside this repo, so it is not versioned here. The same is true of 2 and 3.
+The bundle in this runbook is the mechanism that carries the unversioned three
+without hand-copying.
+
+### Why three packages and not one
+
+The hook commands in `settings.json` are spread across all three:
+
+- `openbrain` — `openbrain-session-start`, `openbrain-session-start-remaining`,
+  `openbrain-capture-stop`, `openbrain-capture-subagent-stop`,
+  `openbrain-session-end`, `openbrain-post-compact`
+- `openbrain-provider` — `openbrain-policy-refresh-gate`,
+  `openbrain-context-budget-gate`, `ob-guard`
+- `openbrain-memory` — `openbrain-memory` (recall, and the durable-write path)
+
+Install two of three and the harness looks fine while a whole class of hook
+quietly fails to exec.
+
+---
+
+## 2. Distribution — the wheels come FROM THE MINI
+
+**Clients cannot install from GitHub.** The repo is private, the client boxes
+have no deploy key, and there is no published index — `python/openbrain-memory`
+records that its `fleet-nats` dependency is not on PyPI and lives in a private
+monorepo. `_plans/fleet-rollout-0.9.md` §1.1 lists three candidate delivery
+mechanisms and names staged wheels as the lowest-friction one. This runbook is
+that option, chosen and built.
+
+The Mini already uses a local wheelhouse convention for its own installs —
+`OPENBRAIN_MEMORY_FIND_LINKS`, defaulting to
+`~/.local/share/openbrain-memory/wheels`
+(`_ob/scripts/ob-memory-provider/package-runtime.ts`). The client side reuses
+that idea rather than inventing a second one: `setup-client.sh` passes
+`--find-links` at the bundle's own `wheels/` directory. Same shape, resolved
+from a local directory, never from an index.
+
+### Build the bundle (on the Mini)
+
+```bash
+cd /Volumes/ThunderBolt/Development/open-brain
+scripts/client-bundle.sh
+```
+
+It stages into a fresh timestamped directory under
+`/Volumes/ThunderBolt/open-brain-local/air-bundle/` and flips a `current`
+symlink at it.
+
+**The bundle home is deliberate.** It is a sibling of the running `app/` on the
+ThunderBolt volume — a durable location an operator can find without knowing
+anything about this session. It is **not** in the temp workspace, because temp
+has no persistence guarantee and nobody should be picking artifacts out of a
+worktree. It is **not** in the repo, because artifact 2 contains a live bearer
+token.
+
+**Nothing is ever deleted.** Each run stages fresh and flips the symlink; stale
+bundles stay on disk until an operator removes them by hand. A superseded bundle
+costs disk. A wrong recursive delete costs the volume.
+
+### Install it (on the client)
+
+Copy the bundle across — `scp`, a mounted share, a USB stick, whatever the box
+can do — then:
+
+```bash
+./setup-client.sh
+```
+
+Then **restart the agent harness**, because `SessionStart` hooks are read at
+session start.
+
+---
+
+## 3. The two URL flavors
+
+`OPENBRAIN_BASE_URL` in the env file is the single switch that says which brain a
+client talks to. There are two legitimate spellings and they have different
+requirements.
+
+| URL | Opt-in needed | Notes |
+|---|---|---|
+| `https://ob.rodaddy.live` | **none** | **Preferred.** TLS, so the client's transport check passes with no extra variable. |
+| `http://10.71.1.20:3100` | `OPENBRAIN_ALLOW_INSECURE_HTTP=1` | LAN plain-http. Requires the opt-in declared by #525 / PR #544. |
+
+`openbrain_memory.client._validate_base_url` permits plain `http` only for
+loopback. A LAN address over plain `http` is refused outright unless the client
+was built with `allow_insecure_http=True`, which is what
+`OPENBRAIN_ALLOW_INSECURE_HTTP` now sets (PR #544 declared it on
+`CaptureSettings` and `CanonSettings` and flowed it to all five client
+construction sites).
+
+Prefer the `https://` flavor. It needs no opt-in, it does not put a bearer token
+on the wire in plain text, and it removes an entire category of "why is this box
+silent" from the install.
+
+**The URL is a BARE `scheme://host:port` with no path.** Not `/mcp`, not `/api`,
+no trailing path segment of any kind. See the gotchas.
+
+**Loopback is for the Mini only.** `127.0.0.1` in the env file means "the brain
+on this machine". On a client that is wrong and will fail, and on the Mini it is
+correct and needs no opt-in. The bundle copies the Mini's env file verbatim, so
+**editing `OPENBRAIN_BASE_URL` on the client is a required step** when the
+staged value is loopback.
+
+---
+
+## 4. The MATCHED-PAIR rule — the one that fails silently
+
+**The wrapper and the installed package must move together, package first.**
+
+The mechanism, in three facts that compound:
+
+1. The Python config (`config.unknown_prefixed_variables`) **rejects** any
+   `OPENBRAIN_*` environment variable that matches no declared setting.
+2. The hook entrypoints **swallow every exception** — that is the fail-open
+   observer contract.
+3. Therefore a rejected environment is a **clean exit 0 with zero capture and
+   zero injection**. Receipts, no rows. The box looks perfectly healthy.
+
+So if the wrapper passes a variable the installed package does not declare,
+**every hook on that box silently stops working**. Not some. Every one, because
+the rejection is of the whole environment, not of the one variable.
+
+This has now happened three times with three different variables —
+`OPENBRAIN_OBSERVATION_*`, `OPENBRAIN_SPOOL_PATH`, and
+`OPENBRAIN_ALLOW_INSECURE_HTTP` — which is why the rationale lives in the
+wrapper's own header comment and in `docs/CONFIG_REFERENCE.md` rather than in a
+commit message.
+
+**The ordering rule, from PR #544:** install the package that declares the
+variable, *then* edit the wrapper to pass it. PR #544 verified this empirically
+in exactly that order — the old install raised `UnknownEnvironmentVariableError`
+with the variable present; the reinstalled package accepted it and resolved
+`allow_insecure_http=True`. Reversed, the box goes dark between the two steps.
+
+`setup-client.sh` installs wheels before placing the wrapper for this reason.
+
+### The empty-string gotcha, on top of it
+
+The wrapper's `env -i VAR="${VAR:-}"` pass-through style **cannot express
+"absent"** — an unset variable arrives in the child as an **empty string**.
+
+For a string field that is harmless. For `allow_insecure_http`, a bool, it is
+not: pydantic rejected `""` with `Input should be a valid boolean`, both
+`load_capture_settings` and `load_canon_settings` raised, the entrypoints
+swallowed it, and every hook on a host that **never opted in** became a silent
+zero capture. The #525 defect class, re-armed by the fix for #525.
+
+Two layers now guard it: a validator in `config.py` mapping `""` to the default
+`False`, and a conditional in the wrapper that prepends the assignment only when
+the value is non-empty. The conditional is what protects an **older** installed
+package that predates the validator — which is exactly the situation a client
+being upgraded is in.
+
+**Rule for anyone adding a pass-through:** a non-string variable goes in the
+conditional block, never in the `env -i` list.
+
+---
+
+## 5. Proof ladder
+
+An install is not done because the commands exist and the script exited 0. It is
+done when each rung holds, in order. Each one can pass while the next fails, so
+stopping early is how a green-looking dead box happens.
+
+| # | Rung | How | What a failure means |
+|---|---|---|---|
+| 1 | **Health** | `curl -sS $OPENBRAIN_BASE_URL/health` → `200` | Service down, wrong URL, or the plain-http opt-in is missing. |
+| 2 | **Recall is `direct`** | `sh …/openbrain-hook-env openbrain-memory recall --query … --limit 1` → `"status": "direct"` | Anything other than `direct` means the direct stack is not the lane answering — suspect a stale MCP registration. |
+| 3 | **CANON PACK, non-zero counts** | Start a **fresh** session; the `SessionStart` emissions carry section counts | Counts of zero, or no pack at all, is the matched-pair failure. The hooks ran and swallowed a rejection. |
+| 4 | **The turn is visible in Langfuse** | Find the session's turn in the Langfuse observation sink | The capture spine reached the brain but the observation lane did not. |
+
+Rung 3 is the one that catches the silent failure, because rungs 1 and 2 both
+pass on a box whose hooks are dead — they exercise the client library directly
+and never go through the hook entrypoints' exception swallowing.
+
+**Agent-side note:** the terminal `OB ✓ gate passed` receipt is a
+`systemMessage` for the operator's eyes and never appears in an agent's own
+context. An agent proving its own hydration reads the CANON PACK section counts,
+not that line.
+
+---
+
+## 6. Diagnosing a client that came up silent
+
+In order, because each check makes the next one meaningful:
+
+1. **Are `OPENBRAIN_BASE_URL` and `OPENBRAIN_TOKEN` both present?** A present
+   URL with a missing token produces the *same* message as an unreachable host.
+   Two sessions once diagnosed a missing token as a core01 outage. Name the
+   variable in your report, never the value.
+2. **Does the wrapper's `ENV_FILE` path exist on this box?** It is an absolute
+   path baked in at build time. `setup-client.sh` rewrites it, but a hand-copied
+   wrapper will still point at the build machine's `$HOME`.
+3. **Is the wrapper executable?** A copy that lost its mode bit makes every hook
+   a no-op.
+4. **Does the installed package declare every variable the wrapper passes?**
+   This is the matched pair. Run one entrypoint by hand and read the error
+   instead of trusting exit 0.
+5. **Is there a stale MCP registration?** `claude mcp list`. A URL ending `/mcp`
+   in any error is the retired lane.
+6. **Only then** probe host availability. A healthy `/health` next to a failing
+   gate is positive evidence that the problem is credentials or environment, not
+   the network.
+
+---
+
+## 7. Related documents
+
+- `docs/420-cutover-rollback.md` — the settings.json cutover, the wrapper's
+  design, and the rollback procedure.
+- `docs/CONFIG_REFERENCE.md` — every `OPENBRAIN_*` variable and which section
+  declares it.
+- `docs/GOTCHAS.md` — the four client-install traps, stated as failures.
+- `_plans/fleet-rollout-0.9.md` §1 — the artifact inventory and the delivery
+  options this runbook chose from.

--- a/scripts/client-bundle.sh
+++ b/scripts/client-bundle.sh
@@ -1,0 +1,256 @@
+#!/opt/homebrew/bin/bash
+# client-bundle.sh — build the offline install bundle that puts the Open Brain
+# direct client stack onto a machine that CANNOT reach GitHub.
+#
+# RUN THIS ON THE MINI (10.71.1.20). It reads this machine's live, working
+# installation and freezes it into a directory the client can copy from.
+#
+# Why this exists: the clients (the Air, and every other family-A box) have no
+# route to the private GitHub repo, so `uv tool install git+ssh://...` is not
+# available to them. There is no published index either — python/openbrain-memory
+# records that its `fleet-nats` dependency is not on PyPI. Wheels built here and
+# staged on the ThunderBolt volume are the paved road, and this script is what
+# makes that road reproducible instead of a thing somebody re-derives at 2am.
+#
+# WHAT IT STAGES — the four artifacts, plus the installer that applies them:
+#
+#   1. wheels/          three wheels: openbrain, openbrain-memory,
+#                       openbrain-provider, built with `uv build` from the
+#                       CURRENT WORKING TREE of this checkout.
+#   2. env/             a copy of ~/.local/share/openbrain-memory/env/, which is
+#                       the env file AND the openbrain-hook-env wrapper.
+#   3. settings-hooks.json  the openbrain-* hook entries lifted out of
+#                       ~/.claude/settings.json, hook events only, so the client
+#                       installer can MERGE them instead of clobbering a
+#                       settings file that has unrelated content in it.
+#   4. setup-client.sh  the installer that runs on the client.
+#      README.md        what this bundle is and the commit it came from.
+#
+# THE ENV DIR CARRIES A LIVE TOKEN. That is why the bundle home is on the
+# ThunderBolt volume next to the running app and NOT in this repo, and why
+# nothing here ever writes into the repo. Do not commit a bundle. Do not copy
+# one anywhere a token should not go.
+#
+# NO RECURSIVE DELETES. Each run stages into a FRESH timestamped directory and
+# then flips the `current` symlink. Stale bundles stay on disk until an operator
+# removes them by hand — a superseded bundle costs disk, a wrong `rm -rf` costs
+# the volume.
+#
+# Usage:
+#   scripts/client-bundle.sh                 # stage into the default home
+#   BUNDLE_HOME=/some/path scripts/client-bundle.sh
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLE_HOME="${BUNDLE_HOME:-/Volumes/ThunderBolt/open-brain-local/air-bundle}"
+SOURCE_ENV_DIR="${SOURCE_ENV_DIR:-$HOME/.local/share/openbrain-memory/env}"
+SOURCE_SETTINGS="${SOURCE_SETTINGS:-$HOME/.claude/settings.json}"
+
+PACKAGES=(openbrain openbrain-memory openbrain-provider)
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'client-bundle: %s\n' "$*" >&2; exit 1; }
+
+# --- preflight -------------------------------------------------------------
+# Fail before staging anything, so a half-built bundle never becomes `current`.
+
+command -v uv >/dev/null 2>&1 || die "uv not on PATH"
+command -v python3 >/dev/null 2>&1 || die "python3 not on PATH"
+
+[ -d "$SOURCE_ENV_DIR" ] || die "env dir not found: $SOURCE_ENV_DIR"
+[ -f "$SOURCE_ENV_DIR/claudex-observation.env" ] || \
+  die "env file missing: $SOURCE_ENV_DIR/claudex-observation.env"
+[ -f "$SOURCE_ENV_DIR/openbrain-hook-env" ] || \
+  die "hook wrapper missing: $SOURCE_ENV_DIR/openbrain-hook-env"
+[ -f "$SOURCE_SETTINGS" ] || die "settings.json not found: $SOURCE_SETTINGS"
+
+for pkg in "${PACKAGES[@]}"; do
+  [ -f "$REPO_DIR/python/$pkg/pyproject.toml" ] || \
+    die "missing package source: python/$pkg/pyproject.toml"
+done
+
+BUILT_FROM_COMMIT="$(git -C "$REPO_DIR" rev-parse HEAD)"
+BUILT_FROM_REF="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [ "$BUILT_FROM_REF" = "HEAD" ]; then
+  # Detached (building from a PR head is normal here) — name the branches that
+  # contain the commit, so the README says something more useful than "HEAD".
+  BUILT_FROM_REF="detached; contained in: $(
+    git -C "$REPO_DIR" branch -r --contains HEAD --format='%(refname:short)' 2>/dev/null |
+      paste -sd', ' - || echo 'unknown'
+  )"
+fi
+if [ -n "$(git -C "$REPO_DIR" status --porcelain -- python/)" ]; then
+  BUILT_FROM_DIRTY="yes — python/ had uncommitted edits at build time"
+else
+  BUILT_FROM_DIRTY="no"
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+STAGE="$BUNDLE_HOME/$STAMP"
+
+log "==> staging into $STAGE"
+mkdir -p "$STAGE/wheels" "$STAGE/env"
+
+# --- 1. wheels -------------------------------------------------------------
+# `uv build --wheel` writes into the package's own dist/, so each build is
+# directed at the bundle instead to keep the checkout clean.
+
+for pkg in "${PACKAGES[@]}"; do
+  log "==> building wheel: $pkg"
+  uv build --wheel \
+    --project "$REPO_DIR/python/$pkg" \
+    --out-dir "$STAGE/wheels" >&2
+done
+
+for pkg in "${PACKAGES[@]}"; do
+  # Wheel filenames normalise '-' to '_'. ('openbrain' has no hyphen, so its
+  # glob stays 'openbrain-*' and does not match the two underscored siblings.)
+  normalised="${pkg//-/_}"
+  compgen -G "$STAGE/wheels/${normalised}-*.whl" >/dev/null || \
+    die "no wheel produced for $pkg (expected ${normalised}-*.whl)"
+done
+
+# `uv build` drops a '*' .gitignore into its out-dir to keep dist/ out of git.
+# The bundle is not a git tree, so the file means nothing here except confusion
+# for whoever opens the directory next.
+# (`if`, not `[ ] && mv` — under `set -e` a false test as the last command of a
+# list is itself a nonzero exit.)
+if [ -f "$STAGE/wheels/.gitignore" ]; then
+  mv "$STAGE/wheels/.gitignore" "$STAGE/wheels/.gitignore.uv-artifact"
+fi
+
+# --- 2. env dir ------------------------------------------------------------
+# Mode is preserved deliberately: the env file is 0600 because it holds the
+# token, and the wrapper is 0755 because settings.json execs it.
+
+log "==> copying env dir"
+cp -p "$SOURCE_ENV_DIR/claudex-observation.env" "$STAGE/env/"
+cp -p "$SOURCE_ENV_DIR/openbrain-hook-env" "$STAGE/env/"
+chmod 600 "$STAGE/env/claudex-observation.env"
+chmod 755 "$STAGE/env/openbrain-hook-env"
+
+# --- 3. hook entries -------------------------------------------------------
+# Extract ONLY hook entries whose command mentions openbrain. Everything else in
+# settings.json is this machine's business and must not travel.
+
+log "==> extracting openbrain hook entries"
+python3 - "$SOURCE_SETTINGS" "$STAGE/settings-hooks.json" <<'PY'
+import json
+import sys
+
+source, dest = sys.argv[1], sys.argv[2]
+with open(source, encoding="utf-8") as handle:
+    settings = json.load(handle)
+
+extracted = {}
+for event, matchers in (settings.get("hooks") or {}).items():
+    kept_matchers = []
+    for matcher in matchers:
+        kept = [
+            hook
+            for hook in matcher.get("hooks", [])
+            if "openbrain" in str(hook.get("command", ""))
+        ]
+        if kept:
+            entry = {k: v for k, v in matcher.items() if k != "hooks"}
+            entry["hooks"] = kept
+            kept_matchers.append(entry)
+    if kept_matchers:
+        extracted[event] = kept_matchers
+
+if not extracted:
+    sys.exit("client-bundle: no openbrain hook entries found in " + source)
+
+with open(dest, "w", encoding="utf-8") as handle:
+    json.dump({"hooks": extracted}, handle, indent=2)
+    handle.write("\n")
+
+total = sum(len(h["hooks"]) for ms in extracted.values() for h in ms)
+print(f"    {total} hook entries across {len(extracted)} events", file=sys.stderr)
+PY
+
+# --- 4. installer + README -------------------------------------------------
+
+log "==> writing setup-client.sh"
+cp -p "$REPO_DIR/scripts/setup-client.sh" "$STAGE/setup-client.sh"
+chmod 755 "$STAGE/setup-client.sh"
+
+BASE_URL="$(python3 - "$STAGE/env/claudex-observation.env" <<'PY'
+import sys
+for line in open(sys.argv[1], encoding="utf-8"):
+    line = line.strip()
+    if line.startswith("OPENBRAIN_BASE_URL="):
+        print(line.split("=", 1)[1].strip())
+        break
+PY
+)"
+
+log "==> writing README.md"
+cat > "$STAGE/README.md" <<EOF
+# Open Brain client bundle — $STAMP
+
+Everything a client machine needs to run the Open Brain **direct** stack
+(hooks + recall) without reaching GitHub or a package index.
+
+## Provenance
+
+| | |
+|---|---|
+| Built on | \`$(hostname -s)\` at $(date '+%Y-%m-%d %H:%M:%S %Z') |
+| Built from commit | \`$BUILT_FROM_COMMIT\` |
+| Branch/ref at build | \`$BUILT_FROM_REF\` |
+| \`python/\` dirty at build | $BUILT_FROM_DIRTY |
+| Base URL in the staged env | \`$BASE_URL\` |
+
+The wheels are built from that commit's \`python/\` tree. The env dir and the
+hook wrapper are a copy of the **live, working** installation on the build
+machine, so this bundle reproduces a configuration that was actually running
+rather than one assembled from documentation.
+
+## Contents
+
+| Path | What it is |
+|---|---|
+| \`wheels/\` | \`openbrain\`, \`openbrain-memory\`, \`openbrain-provider\` wheels |
+| \`env/claudex-observation.env\` | base URL, token, namespace, observation keys |
+| \`env/openbrain-hook-env\` | the wrapper every hook command runs through |
+| \`settings-hooks.json\` | the \`openbrain-*\` hook entries, for merging |
+| \`setup-client.sh\` | the installer — run this on the CLIENT |
+
+## Install
+
+Copy this directory to the client, then:
+
+\`\`\`bash
+./setup-client.sh
+\`\`\`
+
+It installs the three wheels, places the env dir, merges the hook entries into
+\`~/.claude/settings.json\` without clobbering it, and then proves the install
+(health, then a real recall). Restart the agent harness afterwards so the new
+\`SessionStart\` hooks load.
+
+## SECURITY
+
+\`env/claudex-observation.env\` contains a **live bearer token**. This bundle is
+not in git and must never be committed, attached to an issue or PR, or copied
+anywhere a token should not go.
+
+## Full procedure and rationale
+
+\`docs/client-install-runbook.md\` in the open-brain repo.
+EOF
+
+# --- publish ---------------------------------------------------------------
+# Symlink flip, not a delete. `ln -sfn` replaces the link atomically enough for
+# this purpose and never touches the directory the old link pointed at.
+
+ln -sfn "$STAMP" "$BUNDLE_HOME/current"
+
+log ""
+log "==> bundle staged: $STAGE"
+log "==> current -> $(readlink "$BUNDLE_HOME/current")"
+log "==> built from commit: $BUILT_FROM_COMMIT ($BUILT_FROM_REF)"
+log ""
+log "Older bundles are left in place on purpose. Remove them by hand if disk"
+log "matters; this script never deletes."

--- a/scripts/setup-client.sh
+++ b/scripts/setup-client.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# setup-client.sh — install the Open Brain direct client stack from a bundle.
+#
+# RUN THIS ON THE CLIENT (the Air, or any other box that cannot reach GitHub),
+# from inside a bundle directory produced by scripts/client-bundle.sh.
+#
+# This file lives in the repo so it is versioned and reviewable; client-bundle.sh
+# copies it into each bundle so the client gets it without a checkout.
+#
+# It is /usr/bin/env bash, not the Homebrew absolute path the Mini's scripts use,
+# because the client may not have Homebrew at that path — the bundle has to run
+# on a machine we have not standardised.
+#
+# WHAT IT DOES, and why each step is not optional:
+#
+#   1. Installs three wheels with `uv tool install --force`. All three: the hook
+#      commands in settings.json come from all of `openbrain` (capture/session),
+#      `openbrain-provider` (the gates), and `openbrain-memory` (recall).
+#   2. Copies the env dir to ~/.local/share/openbrain-memory/. The wrapper reads
+#      an ABSOLUTE path, so the location is load-bearing, not a preference.
+#   3. chmod +x on the wrapper — settings.json execs it, and a copy that lost its
+#      mode bit turns every hook into a silent no-op.
+#   4. MERGES hook entries into ~/.claude/settings.json. Merge, never clobber:
+#      that file holds permissions, model choice, and other hooks that are not
+#      ours to overwrite.
+#   5. Proves it: /health, then a real recall through the installed client.
+#
+# ORDER MATTERS — the wrapper and the installed package are a MATCHED PAIR. The
+# wrapper passes OPENBRAIN_* variables through; the Python config REJECTS any
+# OPENBRAIN_* it does not declare, and the hook entrypoints SWALLOW that
+# rejection into a clean exit 0. A wrapper newer than its package is therefore a
+# silent, green-looking, zero-capture install. This script installs the wheels
+# BEFORE placing the wrapper for exactly that reason.
+set -euo pipefail
+
+BUNDLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SHARE="${TARGET_SHARE:-$HOME/.local/share/openbrain-memory}"
+TARGET_ENV_DIR="$TARGET_SHARE/env"
+SETTINGS="${SETTINGS:-$HOME/.claude/settings.json}"
+
+log() { printf '%s\n' "$*"; }
+die() { printf 'setup-client: %s\n' "$*" >&2; exit 1; }
+
+command -v uv >/dev/null 2>&1 || die "uv not on PATH — install uv first (https://astral.sh/uv)"
+command -v python3 >/dev/null 2>&1 || die "python3 not on PATH"
+
+[ -d "$BUNDLE_DIR/wheels" ] || die "bundle incomplete: no wheels/ next to this script"
+[ -f "$BUNDLE_DIR/env/claudex-observation.env" ] || die "bundle incomplete: env/claudex-observation.env missing"
+[ -f "$BUNDLE_DIR/env/openbrain-hook-env" ] || die "bundle incomplete: env/openbrain-hook-env missing"
+[ -f "$BUNDLE_DIR/settings-hooks.json" ] || die "bundle incomplete: settings-hooks.json missing"
+
+# --- 1. wheels -------------------------------------------------------------
+# --find-links points at the bundle's own wheels/, mirroring the
+# OPENBRAIN_MEMORY_FIND_LINKS convention the Mini already uses
+# (~/.local/share/openbrain-memory/wheels). Same idea, client side: resolve from
+# a local wheelhouse, never from an index.
+
+log "==> installing wheels from $BUNDLE_DIR/wheels"
+for pkg in openbrain openbrain-memory openbrain-provider; do
+  normalised="${pkg//-/_}"
+  wheel="$(ls -1 "$BUNDLE_DIR"/wheels/${normalised}-*.whl 2>/dev/null | head -1 || true)"
+  [ -n "$wheel" ] || die "no wheel for $pkg in $BUNDLE_DIR/wheels"
+  log "    $pkg <- $(basename "$wheel")"
+  uv tool install --force --find-links "$BUNDLE_DIR/wheels" "$wheel"
+done
+
+# --- 2/3. env dir + wrapper ------------------------------------------------
+
+log "==> placing env dir at $TARGET_ENV_DIR"
+mkdir -p "$TARGET_ENV_DIR"
+if [ -f "$TARGET_ENV_DIR/claudex-observation.env" ]; then
+  backup="$TARGET_ENV_DIR/claudex-observation.env.bak-$(date +%Y%m%d-%H%M%S)"
+  cp -p "$TARGET_ENV_DIR/claudex-observation.env" "$backup"
+  log "    existing env file backed up to $(basename "$backup")"
+fi
+cp "$BUNDLE_DIR/env/claudex-observation.env" "$TARGET_ENV_DIR/"
+cp "$BUNDLE_DIR/env/openbrain-hook-env" "$TARGET_ENV_DIR/"
+chmod 600 "$TARGET_ENV_DIR/claudex-observation.env"
+chmod +x "$TARGET_ENV_DIR/openbrain-hook-env"
+
+# The wrapper hardcodes ENV_FILE as an absolute path from the BUILD machine. If
+# this client's $HOME differs, that path is wrong and every hook silently fails
+# to find its env — so rewrite it to this machine's actual location.
+BUILD_ENV_PATH="$(python3 - "$TARGET_ENV_DIR/openbrain-hook-env" <<'PY'
+import re
+import sys
+text = open(sys.argv[1], encoding="utf-8").read()
+match = re.search(r'^ENV_FILE="([^"]+)"', text, re.M)
+print(match.group(1) if match else "")
+PY
+)"
+WANT_ENV_PATH="$TARGET_ENV_DIR/claudex-observation.env"
+if [ -n "$BUILD_ENV_PATH" ] && [ "$BUILD_ENV_PATH" != "$WANT_ENV_PATH" ]; then
+  log "    rewriting wrapper ENV_FILE: $BUILD_ENV_PATH -> $WANT_ENV_PATH"
+  python3 - "$TARGET_ENV_DIR/openbrain-hook-env" "$WANT_ENV_PATH" <<'PY'
+import re
+import sys
+path, want = sys.argv[1], sys.argv[2]
+text = open(path, encoding="utf-8").read()
+text = re.sub(r'^ENV_FILE="[^"]+"', f'ENV_FILE="{want}"', text, count=1, flags=re.M)
+open(path, "w", encoding="utf-8").write(text)
+PY
+fi
+
+# The hook COMMANDS in settings-hooks.json also carry the build machine's
+# absolute wrapper path; retarget them the same way during the merge below.
+
+# --- 4. merge hook entries -------------------------------------------------
+
+log "==> merging openbrain hook entries into $SETTINGS"
+mkdir -p "$(dirname "$SETTINGS")"
+[ -f "$SETTINGS" ] || printf '{}\n' > "$SETTINGS"
+cp -p "$SETTINGS" "$SETTINGS.bak-openbrain-$(date +%Y%m%d-%H%M%S)"
+
+python3 - "$SETTINGS" "$BUNDLE_DIR/settings-hooks.json" "$TARGET_ENV_DIR/openbrain-hook-env" <<'PY'
+import json
+import re
+import sys
+
+settings_path, hooks_path, wrapper_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(settings_path, encoding="utf-8") as handle:
+    settings = json.load(handle)
+with open(hooks_path, encoding="utf-8") as handle:
+    incoming = json.load(handle)["hooks"]
+
+
+def retarget(command: str) -> str:
+    """Point the command at THIS machine's wrapper, keeping the arguments."""
+    return re.sub(r"\S*openbrain-hook-env", wrapper_path, command)
+
+
+hooks = settings.setdefault("hooks", {})
+added = replaced = 0
+
+for event, matchers in incoming.items():
+    existing = hooks.setdefault(event, [])
+    # Drop any openbrain entries already present, so re-running is idempotent
+    # and an upgrade replaces rather than duplicates. Non-openbrain hooks in the
+    # same matcher are preserved untouched.
+    for matcher in existing:
+        kept = [h for h in matcher.get("hooks", []) if "openbrain" not in str(h.get("command", ""))]
+        replaced += len(matcher.get("hooks", [])) - len(kept)
+        matcher["hooks"] = kept
+    existing[:] = [m for m in existing if m.get("hooks")]
+
+    for matcher in matchers:
+        entry = dict(matcher)
+        entry["hooks"] = [
+            {**h, "command": retarget(str(h.get("command", "")))} for h in matcher["hooks"]
+        ]
+        added += len(entry["hooks"])
+        # Fold into an existing matcher with the same selector when there is one,
+        # so we do not fragment the file into near-duplicate matcher blocks.
+        same = next(
+            (m for m in existing if m.get("matcher") == entry.get("matcher")),
+            None,
+        )
+        if same is None:
+            existing.append(entry)
+        else:
+            same["hooks"].extend(entry["hooks"])
+
+with open(settings_path, "w", encoding="utf-8") as handle:
+    json.dump(settings, handle, indent=2)
+    handle.write("\n")
+
+print(f"    {added} openbrain hook entries written ({replaced} stale ones replaced)")
+PY
+
+# --- 5. proof --------------------------------------------------------------
+# An install is not done because commands exist. It is done when the brain
+# answers and a recall comes back through the DIRECT stack.
+
+log ""
+log "==> proving the install"
+
+BASE_URL="$(python3 - "$TARGET_ENV_DIR/claudex-observation.env" <<'PY'
+import sys
+for line in open(sys.argv[1], encoding="utf-8"):
+    line = line.strip()
+    if line.startswith("OPENBRAIN_BASE_URL="):
+        print(line.split("=", 1)[1].strip())
+        break
+PY
+)"
+[ -n "$BASE_URL" ] || die "OPENBRAIN_BASE_URL not found in the env file"
+log "    base URL: $BASE_URL"
+
+case "$BASE_URL" in
+  */mcp|*/mcp/)
+    die "OPENBRAIN_BASE_URL ends in /mcp — the direct stack needs a BARE
+    scheme://host:port with no path. A /mcp URL is the retired MCP lane." ;;
+esac
+
+health_code="$(curl -sS -m 10 -o /dev/null -w '%{http_code}' "$BASE_URL/health" || echo 000)"
+if [ "$health_code" = "200" ]; then
+  log "    [ok] /health -> 200"
+else
+  log "    [FAIL] /health -> $health_code"
+  log "           The brain is unreachable from this box. Check: is the service"
+  log "           up on the Mini, is the URL right, and if it is plain http on a"
+  log "           LAN address, is OPENBRAIN_ALLOW_INSECURE_HTTP=1 set?"
+fi
+
+log "    recall through the installed openbrain-memory:"
+recall_out="$(sh "$TARGET_ENV_DIR/openbrain-hook-env" openbrain-memory recall \
+  --query "open brain client install" --limit 1 2>&1 || true)"
+if printf '%s' "$recall_out" | rg -q '"status"\s*:\s*"direct"' 2>/dev/null; then
+  log "    [ok] recall returned status=direct"
+else
+  log "    [FAIL] recall did not return status=direct"
+  log "           First 400 chars of the response:"
+  printf '%s\n' "$recall_out" | head -c 400 | sed 's/^/           /'
+fi
+
+# --- 6. stale MCP registration reminder ------------------------------------
+
+log ""
+log "==> CHECK FOR A STALE MCP REGISTRATION"
+log "    The direct stack NEVER uses a /mcp URL. If any error you see later"
+log "    mentions a URL ending in /mcp, a retired MCP-lane registration is still"
+log "    configured on this box and is answering instead of the direct client."
+log ""
+log "      claude mcp list"
+log "      claude mcp remove <name>     # for any open-brain entry it shows"
+log ""
+if command -v claude >/dev/null 2>&1; then
+  log "    Current registrations:"
+  claude mcp list 2>&1 | sed 's/^/      /' || true
+else
+  log "    (claude CLI not on PATH — check by hand)"
+fi
+
+log ""
+log "==> done. RESTART the agent harness so the new SessionStart hooks load."
+log "    Then confirm a fresh session emits CANON PACK with non-zero counts."


### PR DESCRIPTION
Lands the client-install story so it stops being re-derived. No issue closed — this is the procedure and the tooling behind the #525/#544 work, not a fix.

## Summary

- Installing the direct stack on a box that is not the Mini has been rebuilt from scratch more than once, from the same handful of files, and the **same four things went wrong each time**. The cause is structural: the install is **four artifacts and three of them live outside any git repo** — the env file, the hook wrapper, and the `settings.json` wiring. Only the package source is versioned, so the rest travelled by memory.
- `scripts/client-bundle.sh` (runs on the **Mini**) freezes the live, working installation into a bundle: three wheels via `uv build` at the current commit, a copy of `~/.local/share/openbrain-memory/env/`, the `openbrain-*` hook entries lifted out of `~/.claude/settings.json`, plus the installer and a README recording the build commit.
- `scripts/setup-client.sh` (runs on the **client**) installs the wheels, places the env dir, `chmod +x` the wrapper, **merges** hook entries into `settings.json` via `python3`, and then **proves** the install rather than asserting it.
- `docs/client-install-runbook.md` is the procedure and its **why**. `docs/GOTCHAS.md` gains the four traps, symptom first.

**Distribution is from the Mini because clients cannot reach GitHub** — the repo is private with no client deploy key, and `python/openbrain-memory/pyproject.toml` records that `fleet-nats` is not on PyPI. `_plans/fleet-rollout-0.9.md` §1.1 listed three candidate mechanisms; this is the staged-wheels one, chosen and built. The client resolves with `--find-links` against the bundle's own `wheels/`, **reusing the `OPENBRAIN_MEMORY_FIND_LINKS` wheelhouse convention the Mini already runs on** (`_ob/scripts/ob-memory-provider/package-runtime.ts`) rather than inventing a second one.

**Bundle home is `/Volumes/ThunderBolt/open-brain-local/air-bundle/`** — a sibling of the running `app/`. Durable and findable, explicitly *not* the temp workspace (no persistence guarantee, and nobody should be picking deliverables out of a worktree) and explicitly *not* the repo, because the env dir carries a **live bearer token**. Nothing in this PR contains a secret; the script reads `~/.local` paths at runtime.

**No deletes anywhere.** Each run stages into a fresh timestamped directory and flips a `current` symlink. Superseded bundles stay on disk for an operator. A stale bundle costs disk; a wrong recursive delete costs the volume.

### The ordering the installer encodes

`setup-client.sh` installs wheels **before** placing the wrapper, because they are a **matched pair**: `config.unknown_prefixed_variables` rejects any undeclared `OPENBRAIN_*` — and rejects the **whole environment**, not the one variable — while the hook entrypoints swallow the exception into a clean **exit 0**. A wrapper ahead of its package is a silent, green-looking, zero-capture box. This is the PR #544 ordering note, encoded in the script instead of left in prose.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — pre-push full suite passed with **no bypass**: **3121 pass, 506 skip, 0 fail** across 228 files. The gate itself reported `Python package unchanged`, `openbrain package unchanged`, `Client/contract paths unchanged` — correct, this PR touches only `docs/` and `scripts/`
- [x] Python package checks passed or are not applicable — **not applicable**: no `python/` paths touched (`git diff --name-only` is 4 files, all `docs/` and `scripts/`)
- [x] `bunx tsc --noEmit` — not applicable: no TypeScript touched
- [x] Live Open Brain smoke passed or is not applicable — **the bundle build is the live receipt, and it was RUN**: `scripts/client-bundle.sh` executed against a checkout of `4b8db88` (the PR #544 head this machine's deployed wrapper matches), producing `/Volumes/ThunderBolt/open-brain-local/air-bundle/20260804-112335/` with three wheels (`openbrain-0.9.0`, `openbrain_memory-0.9.0`, `openbrain_provider-0.9.0`), the complete env dir (`0600` env file, `0755` wrapper), and **17 hook entries across 8 events** extracted. `current` points at it.

### What is NOT proven

**A full `setup-client.sh` run on a client has not happened.** The client half is WRITTEN, not RUN. Rungs 1 and 2 of the proof ladder could not be exercised from here either: `com.rico.open-brain-local-clone` shows PID `-` in `launchctl list` and `/health` refuses on `127.0.0.1:3100`, `10.71.1.20:3100`, and `https://ob.rodaddy.live` (502). That is the documented "service dies and no one notices" gotcha, out of scope for this PR, and it is stated in the runbook's status line rather than papered over.

## Critical self-review

- **Highest-risk behavior:** `setup-client.sh` mutates `~/.claude/settings.json`, the file that controls the harness. Mitigated by merging rather than writing: it timestamps a backup first, removes only entries whose command contains `openbrain` (so re-running upgrades instead of duplicating), preserves non-openbrain hooks inside the same matcher, and folds into an existing matcher with the same selector instead of fragmenting the file. It is still the thing to review hardest.
- **Assumptions that could be wrong:** that a client's `uv`, `python3`, and `~/.claude/settings.json` layout match the Mini's closely enough. The script fails closed on missing `uv`/`python3` and on an incomplete bundle, and it rewrites the wrapper's hardcoded `ENV_FILE` for a differing `$HOME` — but I have not observed the Air, so those paths are reasoned, not measured. Also assumed the three-package set is complete; verified against the actual hook commands in `settings.json` (all three are represented).
- **Missing/weak tests:** there are none, and that is a real gap — these are shell scripts with no test harness in this repo. What I did instead is empirical: the bundle script was **run twice** end to end, and I verified the wheel-resolution globs by executing them against the real staged directory (`openbrain` has no hyphen, so its glob stays `openbrain-*` and does not collide with the two underscored siblings — checked, not assumed). The merge logic in `setup-client.sh` is **not** exercised, because running it would rewrite this machine's live settings.
- **Security/permission risk:** the bundle contains a live token by design. The repo does not: no secret is in any committed file (`rg` for token/bearer patterns is clean), the script reads `~/.local` at runtime, and the bundle lives outside the repo entirely. The bundle README carries an explicit SECURITY section. Modes are set deliberately (`0600` env, `0755` wrapper), and the installer backs up before overwriting an existing env file.
- **Migration/deploy risk:** none to the service — nothing here deploys or touches the running brain. The client-side risk is the matched-pair ordering, which is exactly what the script encodes and the gotcha documents.
- **Downstream client/runtime risk:** none — no MCP tool, schema, transport, or wire surface. This is operator tooling and documentation.
- **Rollback/cleanup concern:** reverting the commit removes the scripts and docs; staged bundles are outside git and survive, which is correct — an existing client keeps working. On the client, `setup-client.sh` leaves a timestamped `settings.json` backup for a manual restore.
- **Fixes made before PR:** two, both found by running the script rather than reading it. (1) `[ -f ... ] && mv` as the last command of a list exits nonzero under `set -e` — converted to `if`, with the reason in a comment. (2) The README recorded `Branch/ref: HEAD` when building from a detached PR head, which is useless provenance; it now names the containing remote branch. Also moved the `.gitignore` `uv build` drops into its out-dir aside, so the bundle directory has nothing confusing in it.
- **Known residual risk:** the client half is unproven, stated above and in the runbook's status line. The staged env file points at `http://127.0.0.1:3100`, which is correct on the Mini and **wrong on a client** — the runbook and the fourth gotcha both call editing it a required step, but a hurried operator could miss it. The bundle copies the Mini's env verbatim by design (it reproduces a working config); rewriting the URL automatically would mean guessing the client's intended brain.
- **SME review-memory update:** [ ] `docs/sme/` updated or [x] not applicable because: no new review-lane pattern arose. The one reusable trap class here (undeclared/empty-valued env var → silent zero capture) is already documented at the rule site in `config.py`, in the wrapper header, and in `CONFIG_REFERENCE.md`; this PR adds the operator-facing statement of it to `GOTCHAS.md`, which is that file's job.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — none arose
- Live Open Brain checks: [x] not applicable because: no service, transport, MCP tool, or schema surface is touched. The live receipt that *does* apply — the bundle build — was run and is recorded under Verification

## Contract Parity

- Contract parity: [x] runtime-specific because: these are operator shell scripts and documentation, with no contract fixture, client binding, or wire representation

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence: no MCP tool, schema, transport, or client-facing surface changes. The install path this documents is for the direct stack, which is the lane that *replaced* the MCP registration — the first gotcha exists to help operators remove the retired one.
