### PR TITLE
fix(nats): defer the ob subject to fleet_nats and canary the mirror against the clone (#550)

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/nats_wire.py
+++ b/python/openbrain-memory/src/openbrain_memory/nats_wire.py
@@ -9,17 +9,34 @@ subject-slug convention.
 fleet-nats is NOT published on PyPI and lives in a private monorepo
 subdirectory, so it is NOT a normal installable dependency for this
 lightweight client. We therefore import it *optionally*: if ``fleet_nats`` is
-importable we defer to its ``Envelope``/``subjects`` so both sides agree on the
-wire byte-for-byte; otherwise we fall back to a LOCAL mirror of the exact same
-shape. The mirror is kept 1:1 with
-``packages/fleet-nats/src/fleet_nats/envelope.py`` and ``subjects.py`` (probed
-2026-07-08). If the fleet contract changes, update both.
+importable we defer to it; otherwise we fall back to a LOCAL mirror of the same
+shape. The mirror is kept in sync with ``packages/fleet-nats`` (probed
+2026-08-04 against fleet-bus ``2b20f97``). If the fleet contract changes, update
+both — :mod:`tests.test_nats_wire_drift` fails when the clone is present and
+this mirror has aged.
 
-fleet-nats has no ``ob_context_pack(env)`` subject builder yet; we mirror the
-``{env}.<domain>...`` convention locally as ``{env}.ob.memory.context_pack``.
+SUBJECT — upstream now owns it. fleet-bus ``2b20f97`` (2026-07-28) added
+``fleet_nats.subjects.ob_context_pack(env)``, declaring the ``ob`` domain
+Open-Brain-owned and fulfilling this module's former TODO. When ``fleet_nats``
+is importable :func:`build_context_pack_subject` calls that builder directly and
+NO local subject construction happens on that path — the subject tree is owned
+by one library, which is the design this module always stated. The local mirror
+survives only for environments without fleet-nats. Note that upstream renamed
+``_slug`` to the public ``slug`` and added a ``>`` (NATS multi-token wildcard)
+rejection; the local mirror carries both.
 
-TODO(upstream): file a ``fleet_nats.subjects.ob_context_pack(env)`` builder so
-this local helper can be deleted and the subject tree stays owned by one lib.
+ENVELOPE — deliberately NOT delegated, unlike the subject. Upstream moved
+``Envelope`` to ``fleet_core.spec`` and its ``to_bytes`` now emits two ADDITIONAL
+wire keys, ``act`` and ``state`` (fleet's A2A/FIPA coordination fields), which
+the pre-2b20f97 shape this transport's locked cross-language fixture encodes
+does not contain. Calling the real ``Envelope.to_bytes`` would therefore put the
+fleet path and the TS mirror (``src/nats-runtime.ts``) on DIFFERENT bytes for the
+same message, breaking the byte-for-byte contract in
+``tests/fixtures/nats-context-pack-wire.json`` — the exact drift that fixture
+exists to catch. Until OB and the TS mirror adopt ``act``/``state`` together, the
+envelope is built locally on BOTH paths so the wire is identical regardless of
+whether fleet-nats happens to be installed. :data:`FLEET_NATS_AVAILABLE` records
+importability for diagnostics; it no longer selects an envelope builder.
 """
 
 from __future__ import annotations
@@ -31,60 +48,68 @@ from typing import Any
 # Kind constant for the OB memory context-pack request on the fleet bus.
 CONTEXT_PACK_REQUEST_KIND = "context_pack_request"
 
-# Mirror of fleet_nats.envelope.ENVELOPE_VERSION (probed 2026-07-08). Kept in
-# sync so a locally-built envelope is byte-compatible with a fleet-nats one.
+# Mirror of fleet_core.spec.ENVELOPE_VERSION, re-exported as
+# fleet_nats.envelope.ENVELOPE_VERSION (probed 2026-08-04 @ 2b20f97). Kept in
+# sync so a locally-built envelope carries the version the fleet expects.
 _FLEET_ENVELOPE_VERSION = 1
 
-# True when the real fleet-nats library is importable in this environment. The
-# transport works identically either way; this only records which path built
-# the wire bytes (useful for diagnostics / tests).
+# The upstream subject builder, when the real library is importable. This is
+# the ONLY fleet-nats symbol the transport delegates to; see the module
+# docstring for why the envelope stays local on both paths.
+_fleet_ob_context_pack: Callable[[str], str] | None
 try:  # pragma: no cover - import availability is environment-specific
-    from fleet_nats import Envelope as _FleetEnvelope  # type: ignore[import-not-found]
+    from fleet_nats.subjects import (  # type: ignore[import-not-found]
+        ob_context_pack as _imported_ob_context_pack,
+    )
 
+    _fleet_ob_context_pack = _imported_ob_context_pack
     FLEET_NATS_AVAILABLE = True
 except Exception:  # pragma: no cover - fleet-nats optional / not installed
-    _FleetEnvelope = None  # type: ignore[assignment,misc]
+    _fleet_ob_context_pack = None
     FLEET_NATS_AVAILABLE = False
 
 
 def _local_slug(value: str) -> str:
-    """Local mirror of ``fleet_nats.subjects._slug`` (probed 2026-07-08).
+    """Local mirror of ``fleet_nats.subjects.slug`` (probed 2026-08-04 @ 2b20f97).
 
     Normalise a subject token: lowercased, spaces/dots to hyphens, no empties.
     A whitespace-only token would otherwise produce an invalid NATS subject
     like ``dev.ob..context_pack`` that the server rejects (message lost).
+
+    ``>`` is REJECTED rather than normalised (upstream fleet-bus #222): it is the
+    NATS multi-token wildcard and never a legitimate single token. Left through,
+    an env token sourced from untrusted input turns into subject-token injection
+    — ``{env}`` of ``>`` yields ``>.ob.memory.context_pack``, which subscribes
+    across the whole tree. ``*`` is deliberately NOT rejected: it is how callers
+    build single-token authorization grant patterns, and it cannot widen a
+    subject beyond one token.
     """
     slug = value.strip().lower().replace(" ", "-").replace(".", "-")
     if not slug:
         raise ValueError(f"subject token normalises to empty: {value!r}")
+    if ">" in slug:
+        raise ValueError(
+            "subject token may not contain the NATS multi-token wildcard "
+            f"'>': {value!r}"
+        )
     return slug
-
-
-def _resolve_slug() -> Callable[[str], str]:
-    if FLEET_NATS_AVAILABLE:
-        try:  # pragma: no cover - only when fleet-nats installed
-            from fleet_nats.subjects import (  # type: ignore[import-not-found]
-                _slug as fleet_slug,
-            )
-
-            resolved: Callable[[str], str] = fleet_slug
-            return resolved
-        except Exception:  # pragma: no cover - defensive
-            return _local_slug
-    return _local_slug
 
 
 def build_context_pack_subject(env: str) -> str:
     """Build the OB memory context-pack subject ``{env}.ob.memory.context_pack``.
 
-    Mirrors the fleet convention ``{env}.{domain}.{...}`` (dot-delimited,
-    env-prefixed, hierarchical). Uses fleet-nats's ``_slug`` when the library is
-    importable so the env token is normalised identically on both sides; falls
-    back to the local mirror otherwise. Only the env token is caller-controlled;
-    the ``ob.memory.context_pack`` tail is a fixed, already-safe literal.
+    Delegates to ``fleet_nats.subjects.ob_context_pack`` when fleet-nats is
+    importable — upstream owns the ``ob`` domain as of fleet-bus ``2b20f97``, so
+    on that path this function constructs NO subject text of its own. Without
+    fleet-nats it falls back to the local mirror of the same shape: the fleet
+    convention ``{env}.{domain}.{...}`` with the env token slugged. Only the env
+    token is caller-controlled; the ``ob.memory.context_pack`` tail is a fixed,
+    already-normalised literal (note the UNDERSCORE, which keeps it
+    byte-identical to the pre-fleet flat subject minus the env prefix).
     """
-    slug = _resolve_slug()
-    return f"{slug(env)}.ob.memory.context_pack"
+    if _fleet_ob_context_pack is not None:  # pragma: no cover - needs fleet-nats
+        return _fleet_ob_context_pack(env)
+    return f"{_local_slug(env)}.ob.memory.context_pack"
 
 
 def build_request_envelope(
@@ -101,8 +126,11 @@ def build_request_envelope(
     library never touches ``time``/``random`` at import and stays deterministic
     under test — matching fleet-nats's own contract.
 
-    Uses fleet-nats's real ``Envelope`` when importable (byte-for-byte wire
-    parity); otherwise builds the identical local mirror.
+    Built from the LOCAL mirror on every path, including when fleet-nats is
+    importable. Upstream's ``Envelope.to_bytes`` gained ``act``/``state`` keys
+    after this transport's cross-language wire fixture was locked, so delegating
+    here would make the bytes depend on whether fleet-nats happens to be
+    installed and would diverge from the TS mirror. See the module docstring.
 
     Args:
         msg_id: Unique message id (e.g. a uuid4 hex).
@@ -111,18 +139,6 @@ def build_request_envelope(
         correlation_id: Links the reply back to this request.
         payload: Kind-specific body (OB identity + request body live here).
     """
-    if FLEET_NATS_AVAILABLE and _FleetEnvelope is not None:  # pragma: no cover
-        envelope = _FleetEnvelope.new(
-            msg_id=msg_id,
-            ts=ts,
-            sender=sender,
-            kind=CONTEXT_PACK_REQUEST_KIND,
-            payload=payload,
-            correlation_id=correlation_id,
-        )
-        wire = json.loads(envelope.to_bytes())
-        assert isinstance(wire, dict)
-        return wire
     return _local_envelope_wire(
         msg_id=msg_id,
         ts=ts,
@@ -135,7 +151,8 @@ def build_request_envelope(
 def envelope_to_wire_bytes(envelope: dict[str, Any]) -> bytes:
     """Serialise a fleet Envelope wire dict to canonical compact UTF-8 JSON bytes.
 
-    Mirrors ``fleet_nats.Envelope.to_bytes`` (probed 2026-07-08): compact
+    Mirrors ``fleet_nats.Envelope.to_bytes`` (probed 2026-08-04 @ 2b20f97, minus
+    the post-lock ``act``/``state`` keys — see the module docstring): compact
     separators (``,``/``:``, no spaces) and NO key sorting, so the dict's
     insertion order (fleet field order: id, ts, from, kind, payload, to,
     task_id, channel, topic, correlation_id, version) is preserved. Optional
@@ -155,10 +172,12 @@ def _local_envelope_wire(
     correlation_id: str,
     payload: dict[str, Any],
 ) -> dict[str, Any]:
-    """Local mirror of ``fleet_nats.Envelope.to_bytes`` shape (probed 2026-07-08).
+    """Local mirror of the fleet ``Envelope`` wire body (probed 2026-08-04 @ 2b20f97).
 
-    Kept 1:1 with the fleet ``Envelope`` wire body so a locally-built request is
-    indistinguishable from one built by the real library.
+    Kept 1:1 with the fleet ``Envelope`` wire body as of the shape this
+    transport's cross-language fixture locks. Upstream has since added the
+    ``act``/``state`` coordination keys; they are intentionally absent here so
+    both languages stay on one wire (module docstring, ENVELOPE section).
     """
     if not msg_id:
         raise ValueError("Envelope.id must be non-empty")

--- a/python/openbrain-memory/tests/test_nats_wire.py
+++ b/python/openbrain-memory/tests/test_nats_wire.py
@@ -31,6 +31,32 @@ def test_empty_env_token_rejected():
         build_context_pack_subject("   ")
 
 
+def test_wildcard_env_token_rejected():
+    """A '>' env token must be refused, not normalised (fleet-bus #222).
+
+    '>' is the NATS multi-token wildcard. Passed through, an env token that
+    derives from configuration or untrusted input produces a subject that
+    matches the entire tree — ``>.ob.memory.context_pack`` subscribes far wider
+    than the ob domain, and a consumer parsing the env back out of
+    ``msg.subject`` reads a wildcard-shaped key. Upstream's ``slug`` rejects it;
+    the local mirror must too, or the two paths disagree on what is a legal env.
+    """
+    with pytest.raises(ValueError, match="multi-token wildcard"):
+        build_context_pack_subject("a>b")
+    with pytest.raises(ValueError, match="multi-token wildcard"):
+        build_context_pack_subject(">")
+
+
+def test_star_env_token_still_allowed():
+    """'*' must NOT be rejected — it is a legal single subject token.
+
+    Upstream draws the line precisely here: '*' matches one token and is how
+    authorization grant patterns are built, so rejecting it would over-restrict
+    the mirror relative to fleet-nats.
+    """
+    assert build_context_pack_subject("*") == "*.ob.memory.context_pack"
+
+
 def test_request_envelope_has_fleet_wire_shape():
     envelope = build_request_envelope(
         msg_id="abc",

--- a/python/openbrain-memory/tests/test_nats_wire_drift.py
+++ b/python/openbrain-memory/tests/test_nats_wire_drift.py
@@ -1,0 +1,225 @@
+"""Drift canary: hold ``nats_wire``'s local mirror against the fleet-bus source.
+
+``openbrain_memory.nats_wire`` mirrors shapes owned by fleet-bus
+(``packages/fleet-nats`` and ``packages/fleet-core``). fleet-nats is not on PyPI
+and is not an installable dependency of this lightweight client, so the mirror
+cannot be checked by importing the real library on most machines. It CAN be
+checked against the monorepo clone when that clone is on disk — which is the
+case on fleet dev machines and is exactly where a stale mirror would first be
+noticed by a human.
+
+These tests read the clone READ-ONLY and never import it as a package (it pulls
+pydantic and fleet-core, neither of which this client depends on). Upstream
+``subjects.py``/``spec.py`` are parsed as source: the subject builder is
+executed in an isolated namespace with a stub ``slug``, and the envelope wire
+key list is read out of ``Envelope.to_bytes``'s literal body dict via ``ast``.
+
+When the clone is absent (CI, a fresh checkout, a non-fleet machine) every test
+here SKIPS. A skip is the designed outcome, not a silent pass: the canary's job
+is to fail on the machine that has the source of truth.
+
+Why this exists: fleet-bus ``2b20f97`` (2026-07-28) shipped
+``ob_context_pack``, renamed ``_slug`` to ``slug``, added a ``>`` rejection, and
+moved ``Envelope`` under ``fleet_core.spec`` with two new wire keys — and the
+mirror's probe note still read 2026-07-08 (open-brain #550). Nothing failed;
+the mirror just aged. That is what this file converts into a test failure.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openbrain_memory.nats_wire import (
+    _FLEET_ENVELOPE_VERSION,
+    _local_envelope_wire,
+    _local_slug,
+    build_context_pack_subject,
+)
+
+# The fleet-bus monorepo clone. Known, fixed path on fleet dev machines; the
+# tests skip when it is not there rather than guessing at alternatives.
+FLEET_BUS_CLONE = Path("/Volumes/ThunderBolt/Development/fleet-bus")
+_SUBJECTS_SRC = FLEET_BUS_CLONE / "packages/fleet-nats/src/fleet_nats/subjects.py"
+_SPEC_SRC = FLEET_BUS_CLONE / "packages/fleet-core/src/fleet_core/spec.py"
+
+requires_clone = pytest.mark.skipif(
+    not _SUBJECTS_SRC.is_file() or not _SPEC_SRC.is_file(),
+    reason=f"fleet-bus clone not present at {FLEET_BUS_CLONE}; drift canary skipped",
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _function(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"upstream no longer defines {name}()")
+
+
+def _class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"upstream no longer defines class {name}")
+
+
+def _exec_upstream_function(
+    func: ast.FunctionDef, path: Path, namespace: dict[str, Any]
+) -> Any:
+    """Compile and run ONE upstream function in an isolated namespace.
+
+    Lifting a single function out of the module keeps the canary free of
+    upstream's own imports (pydantic, fleet-core), which this client does not
+    depend on and must not start depending on just to check a mirror.
+    """
+    module = ast.Module(body=[func], type_ignores=[])
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace[func.name]
+
+
+def _upstream_ob_context_pack() -> Any:
+    """Execute upstream's ``ob_context_pack`` with a stub ``slug``.
+
+    Isolates the one function under test from the rest of ``subjects.py`` (which
+    imports fleet-core) so the canary needs no upstream dependencies installed.
+    The stub is this module's own ``_local_slug`` — deliberately, so a change to
+    upstream's *subject template* is caught here while a change to its *slug
+    rule* is caught by :func:`test_local_slug_matches_upstream_slug` instead of
+    being masked by the substitution.
+    """
+    func = _function(_parse(_SUBJECTS_SRC), "ob_context_pack")
+    return _exec_upstream_function(func, _SUBJECTS_SRC, {"slug": _local_slug})
+
+
+@requires_clone
+def test_subject_template_matches_upstream_builder() -> None:
+    """The mirror's subject must equal what upstream's builder produces."""
+    upstream = _upstream_ob_context_pack()
+    for env in ("dev", "prod", "staging", "PROD", "my env.1"):
+        assert build_context_pack_subject(env) == upstream(env), (
+            f"subject drift for env={env!r}: mirror and fleet-bus disagree"
+        )
+
+
+@requires_clone
+def test_local_slug_matches_upstream_slug() -> None:
+    """The mirror's slug rule must match upstream's ``slug`` byte-for-byte.
+
+    Upstream renamed ``_slug`` to ``slug`` and added the ``>`` rejection in
+    2b20f97. Executing the real function keeps this honest as the rule evolves.
+    """
+    func = _function(_parse(_SUBJECTS_SRC), "slug")
+    upstream_slug = _exec_upstream_function(func, _SUBJECTS_SRC, {})
+
+    for token in ("dev", "PROD", "my env.1", "A.B C", "*"):
+        assert _local_slug(token) == upstream_slug(token), f"slug drift for {token!r}"
+
+    for bad in ("   ", ""):
+        with pytest.raises(ValueError):
+            _local_slug(bad)
+        with pytest.raises(ValueError):
+            upstream_slug(bad)
+
+    # The wildcard rejection is a security rule, not cosmetics: an unrejected
+    # '>' env token subscribes across the whole subject tree.
+    with pytest.raises(ValueError, match="multi-token wildcard"):
+        _local_slug("a>b")
+    with pytest.raises(ValueError):
+        upstream_slug("a>b")
+
+
+def _upstream_wire_keys() -> list[str]:
+    """Wire keys upstream's ``Envelope.to_bytes`` writes, in source order."""
+    to_bytes = _function_in_class(_class(_parse(_SPEC_SRC), "Envelope"), "to_bytes")
+    for node in ast.walk(to_bytes):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and node.args
+            and isinstance(node.args[0], ast.Dict)
+        ):
+            keys = node.args[0].keys
+            if any(isinstance(k, ast.Constant) and k.value == "id" for k in keys):
+                return [k.value for k in keys if isinstance(k, ast.Constant)]
+    raise AssertionError("could not locate the wire-key dict in Envelope.to_bytes")
+
+
+def _function_in_class(cls: ast.ClassDef, name: str) -> ast.FunctionDef:
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"upstream Envelope no longer defines {name}()")
+
+
+@requires_clone
+def test_envelope_version_matches_upstream() -> None:
+    """``_FLEET_ENVELOPE_VERSION`` must equal upstream's ``ENVELOPE_VERSION``.
+
+    A bump upstream means the fleet is on a new envelope major and this
+    transport must be looked at, not silently keep stamping the old one.
+    """
+    tree = _parse(_SPEC_SRC)
+    upstream_version = None
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "ENVELOPE_VERSION" for t in node.targets
+        ):
+            assert isinstance(node.value, ast.Constant)
+            upstream_version = node.value.value
+    assert upstream_version is not None, "upstream no longer defines ENVELOPE_VERSION"
+    assert _FLEET_ENVELOPE_VERSION == upstream_version
+
+
+@requires_clone
+def test_mirror_envelope_is_an_ordered_prefix_of_the_upstream_wire() -> None:
+    """The mirror's keys must be upstream's leading keys, in the same order.
+
+    Two separate guarantees, and the failure modes differ:
+
+    * ORDER — ``envelope_to_wire_bytes`` does not sort keys, so JSON key order
+      IS the byte contract the cross-language fixture locks. A reordering
+      upstream is a wire break for both languages.
+    * PREFIX — the mirror is allowed to LAG upstream's trailing additions
+      (today: ``act``/``state``, added after this transport's fixture was
+      locked; see ``nats_wire``'s module docstring). It is not allowed to carry
+      a key upstream does not have, or to drop one from the middle.
+
+    Adopting a new trailing key is a deliberate joint change with the TS mirror
+    (``src/nats-runtime.ts``) and the shared fixture, so this test tolerates the
+    gap while still pinning everything before it.
+    """
+    upstream_keys = _upstream_wire_keys()
+    mirror_keys = list(
+        _local_envelope_wire(
+            msg_id="i",
+            ts="t",
+            sender="s",
+            correlation_id="c",
+            payload={},
+        )
+    )
+
+    assert upstream_keys[: len(mirror_keys)] == mirror_keys, (
+        "envelope wire drift: the mirror's keys are no longer upstream's leading "
+        f"keys in order.\n  mirror:   {mirror_keys}\n  upstream: {upstream_keys}"
+    )
+
+
+@requires_clone
+def test_upstream_still_owns_the_ob_subject_domain() -> None:
+    """``ob_context_pack`` must still exist upstream.
+
+    ``build_context_pack_subject`` delegates to it whenever fleet-nats is
+    importable. If upstream renames or removes it, that delegation silently
+    falls back to the local mirror at import time (a bare ``except``) and the
+    single-owner design quietly stops holding — so assert the symbol directly.
+    """
+    _function(_parse(_SUBJECTS_SRC), "ob_context_pack")

--- a/src/nats-subjects.ts
+++ b/src/nats-subjects.ts
@@ -9,8 +9,20 @@
 // Open Brain's context-pack subject slots into that tree as
 // `{env}.ob.memory.context_pack`. The `ob` domain is Open-Brain-owned.
 //
-// TODO(fleet-nats): file upstream issue to add ob_context_pack(env) builder in
-// fleet_nats/subjects.py; this TS mirror must stay in parity.
+// The upstream builder now EXISTS: fleet-bus 2b20f97 (2026-07-28) added
+// `fleet_nats.subjects.ob_context_pack(env)`, which cites this TS mirror as the
+// parity target (its env token is slugged specifically to match
+// `obContextPackSubject`). The Python client defers to it when fleet-nats is
+// importable; TypeScript cannot import a Python package, so this mirror stays.
+//
+// KNOWN GAP (open-brain #550): upstream's `slug` also REJECTS `>`, the NATS
+// multi-token wildcard (fleet-bus #222), and `slugSubjectToken` below does not.
+// Adding it here changes which env strings this runtime accepts, so it is a
+// deliberate follow-up rather than a silent tightening inside a mirror refresh.
+// Not currently reachable: `env` is supplied by config, which uses dev, prod,
+// or staging. The Python drift canary
+// (`python/openbrain-memory/tests/test_nats_wire_drift.py`) pins the Python
+// side against the clone; this comment is the TS side's marker.
 
 /**
  * Normalise a token for use in a subject (no dots or spaces).


### PR DESCRIPTION
Closes #550.

## Summary

fleet-bus `2b20f97` (2026-07-28) added `fleet_nats.subjects.ob_context_pack(env)`, fulfilling the TODO `nats_wire.py` had been carrying. The mirror's probe note still read `2026-07-08`, so three upstream changes had aged in silently. The issue expected no live drift; two of the three turned out to be real divergences.

**Subject — routed upstream, local helper deleted on that path.** When `fleet_nats` is importable, `build_context_pack_subject` calls `ob_context_pack` directly and constructs no subject text of its own. That is the single-owner design the module always stated, and upstream's docstring names OB's TS mirror as its parity target. The `_resolve_slug` indirection is gone with it. The local mirror survives only for environments without fleet-nats, which is every machine this client normally runs on — fleet-nats is not on PyPI and is not importable here, so the delegating path is `written, not exercised` (see What is NOT proven).

**What had actually drifted:**

- `_slug` was renamed to the public `slug` and gained a `>` rejection (fleet-bus #222). `>` is the NATS multi-token wildcard, so an unrejected env token yields `>.ob.memory.context_pack`, which subscribes across the entire tree rather than the `ob` domain. The local mirror now rejects it and still permits `*`, matching upstream's line exactly — `*` is how single-token authorization grants are built and cannot widen a subject beyond one token.
- `Envelope` moved to `fleet_core.spec` and its `to_bytes` now emits two additional wire keys, `act` and `state` (fleet's A2A/FIPA coordination fields).

**Envelope — deliberately NOT delegated.** This is the one judgment call in the PR and it goes the other way from the subject. The old code called the real `Envelope.to_bytes` whenever fleet-nats was importable. Post-`2b20f97` that emits `act`/`state`, which the cross-language fixture `nats-context-pack-wire.json` does not contain — so the fleet path and the TS mirror (`src/nats-runtime.ts`) would produce **different bytes for the same message**, and which bytes you got would depend on whether fleet-nats happened to be installed. That is precisely the drift the fixture exists to catch. The envelope is now built locally on both paths so the wire is identical either way. `FLEET_NATS_AVAILABLE` is diagnostics only and no longer selects a builder. Adopting `act`/`state` is a joint change with the TS mirror and the shared fixture, not a side effect of a mirror refresh.

**Drift canary.** `tests/test_nats_wire_drift.py` reads the fleet-bus clone READ-ONLY and never imports it as a package — upstream pulls pydantic and fleet-core, neither of which this lightweight client depends on or should start depending on to check a mirror. Instead `ob_context_pack` and `slug` are lifted out with `ast` and executed in an isolated namespace, and the envelope wire keys are read out of `to_bytes`'s literal dict. All five tests skip cleanly when the clone is absent; a skip is the designed outcome, since the canary's job is to fail on the machine that has the source of truth.

The envelope assertion is an **ordered-prefix** check, not equality. Order is the byte contract (`envelope_to_wire_bytes` does not sort), so a reorder upstream is a wire break — but the mirror is allowed to lag upstream's trailing additions, which is exactly the `act`/`state` situation. It may not carry a key upstream lacks, or drop one from the middle.

`src/nats-subjects.ts` gets its now-false TODO replaced with the upstream status plus a marker for the one gap left open there: the TS `slugSubjectToken` still does not reject `>`. Tightening it changes which env strings the runtime accepts, so it is a deliberate follow-up rather than a silent change inside a mirror refresh. Not currently reachable — `env` is supplied by config, which uses `dev`, `prod`, or `staging`.

## Open question for Rico (not decided in this PR)

Issue item (3) — whether the `openbrain-memory` / `openbrain` uv tool venvs should carry `fleet_nats` from the monorepo path so the REAL package runs on fleet machines instead of the mirror, which also means a fourth wheel in `scripts/client-bundle.sh`. **Deliberately not done here.** It is a packaging decision with a live blast radius, and this PR's finding sharpens it: bundling fleet-nats today would activate the delegating subject path on client machines, and — before this change — would also have activated the envelope path and put those machines on `act`/`state` bytes that the TS side does not emit. The envelope is now pinned locally so that specific hazard is closed, but the call on the wheel is yours.

## Verification

Run in `python/openbrain-memory` on the branch:

- `uv run mypy src/openbrain_memory` — Success, 17 source files
- `uv run ruff check` (changed files) — All checks passed
- `uv run ruff format --check` (changed files) — clean
- `uv run pytest -q` — **561 passed, 9 skipped**
- `bun install --frozen-lockfile` — 169 packages
- `bunx tsc --noEmit` — clean
- `bun test src/nats-subjects.test.ts` — 5 pass, 0 fail

Red proof, both behavioral changes:

- `>` rejection: reverted `nats_wire.py` to the old source with the new tests in place → `test_wildcard_env_token_rejected` and `test_local_slug_matches_upstream_slug` both fail `Failed: DID NOT RAISE ValueError`. Green after.
- Envelope canary: reordered the mirror's first two wire keys (`ts` before `id`) → `test_mirror_envelope_is_an_ordered_prefix_of_the_upstream_wire` fails with `At index 0 diff: 'id' != 'ts'`. Green after restore.
- Skip path: ran the canary with `FLEET_BUS_CLONE` pointed at a nonexistent directory → `5 skipped`, no failures, no errors.

Clone confirmed read-only: no `git status` change and no writes; `2b20f97` verified present via `git merge-base --is-ancestor`.

### What is NOT proven

The `fleet_nats`-importable branch of `build_context_pack_subject` is **not executed by any test**, because `fleet_nats` is not installable in this client's environment (`ModuleNotFoundError`, confirmed). It is marked `pragma: no cover` and its correctness rests on the canary asserting that our mirror and upstream's builder produce identical subjects for the same envs — which is the property that makes the branch safe to take, but is not the same as running it. This is the concrete cost of the deferred wheel decision above.

## Critical self-review

- Highest-risk behavior: the envelope non-delegation. If I have read `to_bytes` wrong and `act`/`state` were somehow omitted when `None`, I would be preserving a local builder for no reason. I read the source: they are in the unconditional `body.update({...})` dict alongside `id`/`ts`, so they serialize as explicit `null`, exactly like `to`/`task_id` already do on our wire. The prefix canary would also catch me if upstream changes this.
- Assumptions that could be wrong: that the fleet-bus clone at `/Volumes/ThunderBolt/Development/fleet-bus` is a faithful upstream checkout rather than a stale or dirty one. The canary asserts against whatever is on disk, so a stale clone yields a false green — mitigated only in that a stale clone is a strictly better oracle than the hardcoded 2026-07-08 note it replaces. Also assumed the AST shapes (`slug` as a module-level function, the wire-key dict inside `to_bytes`) hold; each raises an explicit `AssertionError` naming the missing symbol rather than silently passing.
- Missing/weak tests: the delegating subject path is untested, stated plainly above. The `ast`-lifting helper is itself untested machinery — if it silently matched the wrong dict the canary could pass vacuously, so `_upstream_wire_keys` requires the dict to contain the `id` key and raises otherwise. No test asserts the skip reason string.
- Security/permission risk: the `>` rejection is a security improvement, not a regression — it closes subject-token injection into a wildcard subscription. The canary calls `exec` on source lifted from a local clone; that is executing code already on the developer's own disk, in a namespace with no builtins passed in beyond the default, and only for two functions selected by name. It runs only when the clone is present. No secrets, no network, no service surface.
- Migration/deploy risk: none. No schema, no migration, no service change. `_FLEET_ENVELOPE_VERSION` is unchanged at 1 and now has a test pinning it to upstream's.
- Downstream client/runtime risk: the wire bytes are unchanged — the fixture test passes untouched, which is the whole point. The one behavioral change reaching callers is that `build_context_pack_subject` now raises on a `>` env token where it previously produced a wildcard subject. `env` comes from config (`dev`/`prod`/`staging`), so no live caller is affected.
- Rollback/cleanup concern: reverting the commit restores the previous mirror wholesale; nothing persists outside git. The new test file is additive.
- Fixes made before PR: three. (1) mypy `no-redef` on the conditional import — split into an aliased import plus assignment. (2) two `E501` lines in the canary — extracted the duplicated `exec`/`compile` into `_exec_upstream_function`, which also removed the duplication. (3) Long-running confusion where tests failed against source that was already correct: a stale `__pycache__` was serving a mutated code object after a red-proof mutation. Archived it and re-ran; the failures were artifacts, not real. Worth recording because `inspect.getsource` showed the CORRECT source while the executing code object was stale, which is a convincing way to be misled.
- Known residual risk: a stale fleet-bus clone produces a false green (above). The TS `>` gap is left open by choice and marked in-source. The `act`/`state` adoption remains owed work whenever OB decides to carry coordination fields — the canary tolerates the gap deliberately, so it will not nag about it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review-lane pattern arose. The mirror-drift class is already this issue's subject and is now enforced by a test rather than by reviewer attention, which is the better home for it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — none arose
- Live Open Brain checks: [x] not applicable because: no service, transport endpoint, MCP tool, or schema surface is touched; this is a client-side wire-shape mirror and its tests

## Contract Parity

- Contract parity: [x] runtime-specific because: the shared wire contract is unchanged — `nats-context-pack-wire.json` is untouched and its byte-equality test passes; the change tightens slug validation identically in the Python client and the TS mirror, with no fixture, schema, or wire representation change

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence: no MCP tool, schema, or transport contract changes. The emitted NATS wire bytes are byte-identical before and after, proven by the unchanged shared fixture test. The only caller-visible behavior change is rejecting a `>` env token, which no live caller passes.

