### PR TITLE
fix(config): a blank optional secret is an absent one, whitespace included (#548)

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { OPTIONAL_SECRET_KEYS, parseServerConfig } from "./config.ts";
+import { loadServerConfig, OPTIONAL_SECRET_KEYS, parseServerConfig } from "./config.ts";
 
 const REQUIRED = {
   DB_HOST: "db.internal",
@@ -140,5 +140,136 @@ describe("optional secrets that are present but empty", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected invalid configuration");
     expect(result.issues.map((issue) => issue.path)).toEqual(["DB_HOST"]);
+  });
+});
+
+/**
+ * The three states `EMBEDDING_API_KEY` is actually observed in (#548).
+ *
+ * The issue reported a restart-path rejection of the empty form. The empty case
+ * was already fixed by #507 and is asserted above; what had NO coverage was the
+ * pair of neighbours that make the rule a rule rather than one special case —
+ * absent must behave identically to empty, and a REAL key must still arrive
+ * intact. Without the third assertion, "treat blank as absent" could be
+ * satisfied by a schema that dropped the field unconditionally, which would
+ * disable provider auth everywhere and pass every other test in this file.
+ */
+describe("EMBEDDING_API_KEY across every observed state", () => {
+  it("absent: no key reaches the transport", () => {
+    const result = parseServerConfig({ ...REQUIRED });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect("embeddingApiKey" in result.config.transport).toBe(false);
+  });
+
+  it("empty: parses, and is indistinguishable from absent", () => {
+    const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: "" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect("embeddingApiKey" in result.config.transport).toBe(false);
+  });
+
+  it("set: the configured key reaches the transport byte-for-byte", () => {
+    const key = `real-${randomUUID()}`;
+    const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: key });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect(result.config.transport.embeddingApiKey).toBe(key);
+  });
+
+  /**
+   * Whitespace-only is the form that survived #507 and still reached the wire.
+   *
+   * `min(1)` counts a space, so `" "` parsed as a real key and
+   * `server/transport/health.ts` took its `if (input.embeddingApiKey)` branch
+   * and sent `Authorization: Bearer  `. Meanwhile the launcher that starts this
+   * process (`scripts/local-clone.ts`) reads `EMBEDDING_API_KEY?.trim()` and
+   * sent no header at all — preflight and server disagreeing about one
+   * variable. This asserts the config boundary now matches the launcher.
+   */
+  it("whitespace-only: treated as absent, matching the launcher's own check", () => {
+    for (const blank of [" ", "   ", "\t", "\n", " \t\n "]) {
+      const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: blank });
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected valid configuration");
+      expect("embeddingApiKey" in result.config.transport).toBe(false);
+    }
+  });
+
+  it("preserves internal and surrounding characters of a key that has content", () => {
+    // Only the blank/non-blank DECISION is normalized. A key whose padding is
+    // genuine must not be silently altered into a different credential.
+    const padded = "  padded-key  ";
+    const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: padded });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect(result.config.transport.embeddingApiKey).toBe(padded);
+  });
+
+  it("applies the blank rule to every optional secret, not just the embedding key", () => {
+    // Same reasoning as the empty-string parameterization above: the defect is
+    // in the shared schema, so a whitespace value in ANY of them must be absent.
+    const blanks = Object.fromEntries(OPTIONAL_SECRET_KEYS.map((key) => [key, "   "]));
+    const result = parseServerConfig({ ...REQUIRED, ...blanks });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect(result.config.authTokens).toEqual([]);
+    expect("password" in result.config.database).toBe(false);
+    expect("embeddingApiKey" in result.config.transport).toBe(false);
+  });
+});
+
+/**
+ * The composition root, which is the function that actually threw on 2026-08-02.
+ *
+ * Everything above tests `parseServerConfig`, which takes an environment as an
+ * argument. The crash stack named `loadServerConfig` — the wrapper that reads
+ * the real `process.env` — and it had no test at all. That gap is why the empty
+ * form could be fixed in the schema while nothing proved the STARTUP path a
+ * launchd service takes was fixed with it.
+ */
+describe("loadServerConfig against a real process.env", () => {
+  const OWNED = [...OPTIONAL_SECRET_KEYS, ...Object.keys(REQUIRED)];
+
+  function withEnv<T>(overrides: Record<string, string | undefined>, run: () => T): T {
+    const saved = new Map(OWNED.map((key) => [key, process.env[key]]));
+    try {
+      for (const key of OWNED) delete process.env[key];
+      for (const [key, value] of Object.entries({ ...REQUIRED, ...overrides })) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      return run();
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  }
+
+  it("starts with EMBEDDING_API_KEY empty, which is the shape that crashed launchd", () => {
+    const config = withEnv({ EMBEDDING_API_KEY: "" }, () => loadServerConfig());
+    expect("embeddingApiKey" in config.transport).toBe(false);
+  });
+
+  it("starts with EMBEDDING_API_KEY absent", () => {
+    const config = withEnv({ EMBEDDING_API_KEY: undefined }, () => loadServerConfig());
+    expect("embeddingApiKey" in config.transport).toBe(false);
+  });
+
+  it("starts with EMBEDDING_API_KEY set, and carries the key through", () => {
+    const key = `real-${randomUUID()}`;
+    const config = withEnv({ EMBEDDING_API_KEY: key }, () => loadServerConfig());
+    expect(config.transport.embeddingApiKey).toBe(key);
+  });
+
+  it("still throws a named, field-identifying error on a genuinely invalid environment", () => {
+    // The empty-as-absent rule must not have turned the boundary into one that
+    // accepts anything: a missing REQUIRED field still has to stop startup, and
+    // the message still has to say which field.
+    expect(() => withEnv({ DB_HOST: "" }, () => loadServerConfig())).toThrow(
+      /server_configuration_invalid.*DB_HOST/,
+    );
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -56,8 +56,8 @@ export const OPTIONAL_SECRET_KEYS = [
 ] as const;
 
 /**
- * An optional secret: absent, or a non-empty value. **Present-and-empty counts
- * as absent.**
+ * An optional secret: absent, or a value with content. **Present-but-BLANK
+ * counts as absent**, where blank means empty OR whitespace-only.
  *
  * The `z.preprocess` is the whole point and is not decoration. Without it,
  * `z.string().min(1).optional()` accepts an unset variable but REJECTS
@@ -74,6 +74,20 @@ export const OPTIONAL_SECRET_KEYS = [
  * `server_configuration_invalid` at startup and launchd throttle-looped it,
  * while `src/index.ts` had always started fine on the identical environment.
  *
+ * WHY WHITESPACE IS ALSO ABSENT (#548). `EMBEDDING_API_KEY=" "` used to survive
+ * this schema and arrive downstream as a real value, because `min(1)` counts a
+ * space as a character. `server/transport/health.ts` then takes the truthy
+ * branch and sends `Authorization: Bearer  ` — a header whose value is one
+ * space — on every embedding probe. The launcher that starts this same process
+ * already disagreed: `scripts/local-clone.ts` reads
+ * `env.EMBEDDING_API_KEY?.trim()` before its own truthiness check, so preflight
+ * saw "no key" and sent no header while the server saw "key" and sent a blank
+ * one. Two components deciding the same question differently off one variable
+ * is the defect; this makes the config boundary agree with the launcher rather
+ * than adding a third opinion downstream. A key is normalized for the DECISION
+ * only — a value with content is passed through byte-for-byte, because altering
+ * a real secret would silently corrupt a credential whose padding is genuine.
+ *
  * Normalizing HERE, at the parse boundary, rather than at each of the eight
  * declaration sites, is what makes the rule hold for a field added later:
  * everything typed `optionalSecret` gets it. Required fields keep rejecting
@@ -81,7 +95,8 @@ export const OPTIONAL_SECRET_KEYS = [
  * rather than an omission.
  */
 const optionalSecret = z.preprocess(
-  (value) => (value === "" ? undefined : value),
+  (value) =>
+    typeof value === "string" && value.trim() === "" ? undefined : value,
   z.string().min(1).optional(),
 );
 const userTokenValue = z


### PR DESCRIPTION
Closes #548.

## What the issue reported, and what was actually true

#548 says `server/config.ts` "intermittently rejects empty `EMBEDDING_API_KEY=` on restart" and treats the empty form as the open defect. Both halves turned out to be wrong, so this PR does not fix what the title asks for — it fixes what is actually still broken and states the rest.

**There is no intermittency.** The only `EMBEDDING_API_KEY: Too small` crash on this box is in `~/Library/Logs/open-brain-local/autostart.err.log`, at **2026-08-02 ~20:08:31**. That file's mtime is `Aug 2 19:42` — it has not been written since. Commit `5f1595b` (#507), which added the empty-as-absent `z.preprocess`, landed at **2026-08-02 20:09:16** — 45 seconds after that stack trace. The crash is what *prompted* #507, not something that survived it.

**The 2026-08-04 14:34:52Z timestamp in the issue is a healthy line, not a failure.** In `autostart.out.log`:

```
2026-08-04T14:34:52Z local-clone-autostart: serving f705fc9 from /Volumes/ThunderBolt/open-brain-local/app
2026-08-04T14:34:52Z local-clone-autostart: running preflight
2026-08-04T14:34:54Z local-clone-autostart: preflight verified, starting launcher
```

`app/.deployed-revision` stamps `f705fc9` at `deployed_at=2026-08-04T14:34:50Z`, and `git merge-base --is-ancestor 5f1595b f705fc9` passes — the runtime restarting at 14:34:52 already contained the fix, and it started fine. The service log confirms it: migrations run clean at `14:34:51`. The appearance of a restart coin-flip came from reading a **deploy-restart line in one log** next to a **two-day-old stack trace in another**. No log anywhere contains a config rejection after 2026-08-02.

So the operator mitigation was defusing a tripwire that was already disarmed.

## What is still broken (the actual fix)

`z.string().min(1)` counts a space as a character, so `EMBEDDING_API_KEY="   "` survived the schema and arrived downstream as a **real key**. `server/transport/health.ts:57` then takes its `if (input.embeddingApiKey)` branch and sends an `Authorization` header whose value is whitespace, on every embedding probe.

The launcher that starts that very same process already disagreed — `scripts/local-clone.ts:368`:

```ts
const apiKey = env.EMBEDDING_API_KEY?.trim();
if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
```

Preflight sees "no key" and sends no header; the server sees "key" and sends a blank one. **One variable, two components in the same startup sequence, two different answers.** That disagreement is the defect this PR closes.

The fix extends the shared `optionalSecret` preprocess so blank means empty **or** whitespace-only. It normalizes for the blank-vs-content **decision only** — a value with content is passed through byte-for-byte, because altering a real secret whose padding is genuine would silently swap one credential for another. Fixing it in the shared schema rather than at the `EMBEDDING_API_KEY` declaration is the same reasoning #507 recorded: all eight `OPTIONAL_SECRET_KEYS` fields get the rule, including any added later.

## The red proof found something wider than the embedding key

Against unmodified `config.ts`, the new whitespace test over every optional secret failed by registering blank `AUTH_TOKEN_*` values as **live auth credentials**:

```
+  { "clientId": "ob-admin",  "role": "ob-admin",  "token": "   " },
+  { "clientId": "promoter",  "role": "promoter",  "token": "   " },
+  { "clientId": "readonly",  "role": "readonly",  "token": "   " },
```

`src/auth.ts` skips a role token with `if (!token)`, so a whitespace-only token was a registered credential the auth layer believed was real. That is a wider blast radius than the embedding key and is now covered.

## Verification

Red-proved by reverting `server/config.ts` to `origin/main` with the new tests in place:

- RED (origin/main config.ts): `2 fail / 25 pass` — the whitespace case and the every-optional-secret case
- GREEN (with fix): `27 pass / 0 fail`

Gates:

- `bunx tsc --noEmit` — clean, exit 0
- `bun test server/config.test.ts` — 27 pass, 0 fail
- `bun test server/ src/auth.test.ts src/embedding.test.ts` — **335 pass, 0 fail**, 456 assertions across 36 files
- `bun install --frozen-lockfile` — no changes

The three states #548 asks for are asserted explicitly (absent, empty, set), plus whitespace-only and byte-for-byte preservation of a padded key. These also now cover **`loadServerConfig`** — the composition root named in the original crash stack, which had **no test at all**. That gap is precisely why the schema could be fixed in #507 while nothing proved the startup path a launchd service actually takes was fixed with it.

## Operator follow-up after merge

The placeholder applied 2026-08-04 can be reverted. `local-clone.env` currently carries `EMBEDDING_API_KEY=local-mlx-no-key-required`; the backup with the original empty value is at `local-clone.env.bak-20260804-embedkey`. Restoring the empty form is safe both before and after this PR — it was already safe as of #507. Reverting is preferred so the env states the truth (the local MLX embedder needs no key) rather than carrying a fake credential that a future reader could mistake for a real one.

## Critical self-review

- Highest-risk behavior: treating a whitespace value as absent. If any deployment legitimately used a whitespace-only secret as a real credential, this silently stops sending it. I judged that not credible — a provider cannot distinguish `Bearer` + whitespace from a malformed header, and `scripts/local-clone.ts` has always treated it as absent, so no working configuration can depend on the old behavior.
- Assumptions that could be wrong: that the log files I read are complete. `autostart.err.log` has not rotated (mtime `Aug 2 19:42`, one file, no `.1`), and `open-brain.log` covers 2026-08-02T23:43 onward with `.1`/`.2`/`.3` present — so the 08-02 crash and the 08-04 window are both in retained data. If a rotation dropped a genuine 08-04 failure, my "no intermittency" finding weakens; I found no evidence of one and the healthy 14:34:52 lines argue against it.
- Missing/weak tests: no test drives the whitespace value all the way to `server/transport/health.ts` and asserts the header is not sent. I asserted at the config boundary (the owning boundary, where the fix lives) and read the consumer to confirm the branch it feeds. A transport-level test would need the embedding probe fixture and belongs with that surface.
- Security/permission risk: this **closes** one. Blank `AUTH_TOKEN_*` values registered as usable credentials with whitespace tokens before this change, shown in the red proof above. No secret value appears in any test assertion — real-key cases use `randomUUID()`.
- Migration/deploy risk: none. No migration, no schema change, no wire change. The only behavior difference is which values count as absent, and it strictly widens what starts successfully.
- Downstream client/runtime risk: none. `optionalSecret` is internal to `server/config.ts`; no MCP tool, transport, schema, or Python client surface changes.
- Rollback/cleanup concern: reverting the commit restores the prior schema. The operator env placeholder is independent of the merge and is safe in either state, noted above.
- Fixes made before PR: the original scope was "make the schema accept empty." Investigation showed that already shipped in #507 and that the issue's evidence was two logs misread together, so the scope moved to the whitespace disagreement between launcher and config boundary — the defect that is genuinely still present. Reporting the empty case as fixed without checking would have closed the issue with no code change and left the real one in place.
- Known residual risk: the whitespace path is proven at the config boundary but has not been observed end to end against a live embedding probe, and I did not restart the local clone to prove it. The claim here is MERGED-pending, not RUNNING.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern class (empty/blank env value passing a `min(1)` optional and reaching a consumer as real) is already documented at the rule site in `optionalSecret`'s own doc comment, which this PR extends with the whitespace case and its two-components-disagreeing rationale. No new review-lane heuristic arose.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — the blank-auth-token finding is recorded in the commit message and this body at the rule site
- Live Open Brain checks: [x] not applicable because: no service, transport, MCP tool, or schema surface is touched. The live evidence that does apply — the deploy stamp and the two launchd logs — is quoted under the root-cause section

## Contract Parity

- Contract parity: [x] runtime-specific because: `optionalSecret` is a server-internal env-validation schema with no contract fixture, client binding, or wire representation

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence: no MCP tool, schema, transport, or client-facing surface changes. The change is confined to how `server/config.ts` decides whether an optional secret is present.

