### PR TITLE
fix(client): make the install prover run, and the errors say where to look

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -1098,3 +1098,44 @@ bearer token on the wire, and one fewer silent-failure mode.
 copies the Mini's env file verbatim, so a client staged from a loopback-pointed
 env file must have its `OPENBRAIN_BASE_URL` edited — that is a required step, not
 a nicety.
+
+**Written down is not enforced.** The paragraph above predates the first real
+client install and did not prevent it: the Air was installed from an unedited
+loopback env file anyway. `setup-client.sh` now REFUSES a loopback base URL
+rather than warning, with `OPENBRAIN_ALLOW_LOOPBACK_CLIENT=1` to run the script
+on the Mini itself. A rule that only exists in a doc is a rule the install can
+skip.
+
+### The provider CLI takes JSON on stdin — the namespace comes from the ENVIRONMENT
+
+**Symptom.** A request that looks exactly like the documented example fails with
+`namespace must be a non-empty string`, and nothing in the error mentions an
+environment variable. Adding `"namespace"` to the request body does not fix it —
+it produces a receipt that lists `namespace` under
+`ignored_optional_request_keys` **and** fails on `namespace` in the same JSON
+object.
+
+**Cause.** Two separate things, both fixed now, both worth knowing:
+
+- The CLI has **no argv interface**. `openbrain-memory recall --query …` returns
+  `arguments are not supported` and never reaches the brain. It reads ONE
+  bounded JSON object on stdin with `operation` inside it. The shipped prover in
+  `setup-client.sh` used the argv form, so it reported `[FAIL]` on every install
+  regardless of whether the install worked — a check whose failure carried no
+  information.
+- Identity is environmental, not a request field. `OPENBRAIN_BASE_URL`,
+  `OPENBRAIN_TOKEN`, and `OPENBRAIN_NAMESPACE` are read from the environment;
+  the one documented in-request override is `{"config": {"namespace": "…"}}`
+  (`docs/memory-contract.md`). A top-level `namespace` is now rejected with an
+  error that says where it actually lives.
+
+**The example is a request body, and a body carries no identity.** That is why
+following it on a clean shell fails. `openbrain-memory --help` now carries an
+`environment` block naming the three variables next to the example they qualify.
+
+**Also fixed: scope errors arrive all at once.** Validation used to surface one
+missing field per attempt, so assembling a scope by hand cost a round trip per
+field — the Air hit `namespace`, satisfied it, then hit `server_id`, then the
+next. Every error was true and every error was a fraction of the answer. All
+five (`agent`, `platform`, `server_id`, `channel_id`, `session_key`) are now
+reported in a single receipt.

--- a/docs/client-install-runbook.md
+++ b/docs/client-install-runbook.md
@@ -193,10 +193,26 @@ stopping early is how a green-looking dead box happens.
 
 | # | Rung | How | What a failure means |
 |---|---|---|---|
+| 0 | **The env file was edited** | `OPENBRAIN_BASE_URL` is the Mini's LAN address, and `OPENBRAIN_NAMESPACE` is present | The bundle ships the build machine's env verbatim, so an unedited `OPENBRAIN_BASE_URL` is loopback and points the client at itself. A missing `OPENBRAIN_NAMESPACE` fails later as a message about a *request key*, which points at the JSON instead of at this file. `setup-client.sh` now refuses on both. |
 | 1 | **Health** | `curl -sS $OPENBRAIN_BASE_URL/health` → `200` | Service down, wrong URL, or the plain-http opt-in is missing. |
-| 2 | **Recall is `direct`** | `sh …/openbrain-hook-env openbrain-memory recall --query … --limit 1` → `"status": "direct"` | Anything other than `direct` means the direct stack is not the lane answering — suspect a stale MCP registration. |
+| 2 | **Recall is `direct`** | source the env file, then pipe one JSON object (below) to `openbrain-memory` → `"status": "direct"` | Anything other than `direct` means the direct stack is not the lane answering — suspect a stale MCP registration. |
 | 3 | **CANON PACK, non-zero counts** | Start a **fresh** session; the `SessionStart` emissions carry section counts | Counts of zero, or no pack at all, is the matched-pair failure. The hooks ran and swallowed a rejection. |
 | 4 | **The turn is visible in Langfuse** | Find the session's turn in the Langfuse observation sink | The capture spine reached the brain but the observation lane did not. |
+
+Rung 2 in full. **The CLI takes one bounded JSON object on stdin** — with
+`operation` inside it — and it takes no argv flags at all; an argv invocation
+returns `arguments are not supported` without ever reaching the brain. The
+namespace comes from `OPENBRAIN_NAMESPACE` in the environment, which is why the
+env file is sourced first and why it is not a key in the JSON:
+
+```sh
+set -a; . ~/.local/share/openbrain-memory/env/claudex-observation.env; set +a
+printf '%s' '{"operation":"recall","query":"client install proof","scope":{"agent":"setup-client","platform":"claude-code","server_id":"client-install","channel_id":"client-install","session_key":"client-install-proof"}}' \
+  | openbrain-memory
+```
+
+All five scope fields are required. They are reported together in one receipt,
+so a scope that is missing several does not cost one attempt per field.
 
 Rung 3 is the one that catches the silent failure, because rungs 1 and 2 both
 pass on a box whose hooks are dead — they exercise the client library directly

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -110,6 +110,79 @@ _HELP_EXAMPLE = {
     },
 }
 
+# The example above is a REQUEST BODY, and a request body carries no identity.
+# base_url, token, and namespace come from the environment (or an explicit
+# `config` object), so the example alone does not run on a clean shell -- it
+# fails with "namespace must be a non-empty string" and says nothing about
+# where namespace was supposed to come from. The first client install
+# (2026-08-04) burned four round trips on exactly that. Name the requirement in
+# the help output itself, next to the example it qualifies.
+#
+# The variable names are VALUES in a list rather than keys of an object on
+# purpose. As `{"OPENBRAIN_TOKEN": "bearer token"}` the redactor matched the
+# key -- its rule is `"token": "..."` -- and replaced the DESCRIPTION with
+# [REDACTED], so the help hid its own explanation. The rule is right (a live
+# token in that shape must never print); the help just has to stop looking like
+# a credential it is not.
+_HELP_ENVIRONMENT = {
+    "required": [
+        "OPENBRAIN_BASE_URL -- bare scheme://host:port, no path",
+        "OPENBRAIN_NAMESPACE -- namespace for every request; NOT a request key",
+        "OPENBRAIN_TOKEN -- the bearer value sent as the Authorization header",
+    ],
+    "note": (
+        "The example is a request body and carries no identity. base_url, "
+        "token, and namespace are read from these variables, or from an "
+        "explicit top-level \"config\" object. Putting \"namespace\" at the top "
+        "level of the request does nothing."
+    ),
+}
+
+# Keys that are NOT request fields but that callers reach for anyway, mapped to
+# the sentence that says where each one actually lives. Silently folding these
+# into `ignored_optional_request_keys` produced a self-contradicting receipt:
+# `namespace` listed as ignored AND `namespace must be a non-empty string` as
+# the error, in the same JSON object. Ignoring a key is right when the key is
+# merely unrecognised; it is wrong when the key names a real setting the caller
+# is trying to set, because the request then fails for the exact thing the
+# receipt says was optional.
+#
+# Rejecting rather than aliasing is deliberate. `docs/memory-contract.md` and
+# `_CONFIG_KEYS` in runtime.py already give `config.namespace` as the explicit
+# override; accepting a second top-level spelling would add an undocumented
+# field with the same meaning. The error names the environment variable and the
+# config path instead.
+_MISPLACED_CONFIG_KEYS = {
+    "namespace": (
+        "namespace comes from OPENBRAIN_NAMESPACE in the environment, not the "
+        "request body; to override it in-request use "
+        '{"config": {"namespace": "..."}}'
+    ),
+    "base_url": (
+        "base_url comes from OPENBRAIN_BASE_URL in the environment, not the "
+        "request body; to override it in-request use "
+        '{"config": {"base_url": "..."}}'
+    ),
+    "token": (
+        "token comes from OPENBRAIN_TOKEN in the environment, not the request "
+        'body; to override it in-request use {"config": {"token": "..."}}'
+    ),
+}
+
+
+def _reject_misplaced_config_keys(
+    payload: Mapping[str, Any],
+    allowed: set[str],
+) -> None:
+    """Fail a request that puts a config setting at the top level.
+
+    Only for keys this operation does not itself define -- `ingest` owns a real
+    top-level ``namespace``, so it keeps it.
+    """
+    for key in sorted(_MISPLACED_CONFIG_KEYS):
+        if key in payload and key not in allowed:
+            raise ValueError(_MISPLACED_CONFIG_KEYS[key])
+
 
 def execute_json(
     payload: Mapping[str, Any],
@@ -192,6 +265,7 @@ def usage_output() -> dict[str, Any]:
                 for name, (description, _) in _OPERATION_SPECS.items()
             ],
             "example": _HELP_EXAMPLE,
+            "environment": _HELP_ENVIRONMENT,
         },
     ).as_dict()
 
@@ -326,6 +400,7 @@ def _project_request(
             f"unsupported operation: {_safe_text(operation)}; "
             f"valid operations: {_OPERATION_VOCABULARY}"
         )
+    _reject_misplaced_config_keys(payload, allowed)
     known_keys = _COMMON_KEYS | allowed
     projected = {key: value for key, value in payload.items() if key in known_keys}
     ignored_keys = sorted(

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -114,6 +114,15 @@ _SCOPE_KEYS = {
     "session_key",
     "thread_id",
 }
+# Ordered, so a multi-field scope error reads the same way twice and a test can
+# assert on it. `thread_id` is absent because it is the one optional field.
+_REQUIRED_SCOPE_FIELDS = (
+    "agent",
+    "platform",
+    "server_id",
+    "channel_id",
+    "session_key",
+)
 _CONTEXT_PACK_SECTIONS = {
     "candidate_memory",
     "durable_lane_context",
@@ -200,16 +209,34 @@ class RuntimeScope:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, Any]) -> RuntimeScope:
-        """Build a validated scope from untrusted JSON-like input."""
+        """Build a validated scope from untrusted JSON-like input.
+
+        Every required field is checked before ANY of them raises. Validating
+        field-by-field surfaced exactly one missing key per attempt, so a caller
+        assembling a scope by hand paid one round trip per field: the first
+        client install (2026-08-04) hit `namespace`, satisfied it, then hit
+        `server_id`, and each error was true and each was a third of the answer.
+        The full set is known up front, so reporting one at a time is a choice,
+        not a limit.
+        """
         _reject_unknown_keys(value, _SCOPE_KEYS, "scope")
-        return cls(
-            agent=_mapping_text(value, "agent"),
-            platform=_mapping_text(value, "platform"),
-            server_id=_mapping_text(value, "server_id"),
-            channel_id=_mapping_text(value, "channel_id"),
-            session_key=_mapping_text(value, "session_key"),
-            thread_id=_mapping_optional_text(value, "thread_id"),
-        )
+        fields: dict[str, str] = {}
+        errors: list[str] = []
+        for name in _REQUIRED_SCOPE_FIELDS:
+            try:
+                fields[name] = _mapping_text(value, name)
+            except ValueError as error:
+                errors.append(str(error))
+        try:
+            thread_id = _mapping_optional_text(value, "thread_id")
+        except ValueError as error:
+            thread_id = None
+            errors.append(str(error))
+        if errors:
+            raise ValueError(
+                f"scope is invalid ({len(errors)} problems): " + "; ".join(errors)
+            )
+        return cls(**fields, thread_id=thread_id)
 
     def context_pack_arguments(self, query: str) -> dict[str, Any]:
         """Return the server contract's exact-scope context-pack fields."""

--- a/python/openbrain-memory/tests/test_cli_request_diagnostics.py
+++ b/python/openbrain-memory/tests/test_cli_request_diagnostics.py
@@ -1,0 +1,148 @@
+"""Regressions for the errors a hand-assembled request actually gets back.
+
+Every case here was hit by a human during the FIRST real client install
+(2026-08-04). None of them was a wrong result -- the runtime refused requests it
+was right to refuse. They are all failures of the RECEIPT: it named a third of
+the problem, or named a key as ignorable and then failed on that same key, so
+the caller paid one round trip per field to learn a set the runtime knew in
+full on the first call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openbrain_memory.cli import execute_json, usage_output
+
+from ._runtime_fakes import LaneAwareTransport
+
+_FULL_SCOPE = {
+    "agent": "agent-name",
+    "platform": "claude-code",
+    "server_id": "server-id",
+    "channel_id": "channel-id",
+    "session_key": "session-key",
+}
+
+
+def _error(request: dict[str, object]) -> str:
+    output = execute_json(request, transport=LaneAwareTransport())
+    receipt = output["receipt"]
+    assert receipt["status"] == "failed"
+    return str(receipt["error"])
+
+
+def test_missing_scope_fields_are_all_named_in_one_receipt() -> None:
+    """The Air satisfied `namespace`, then hit `server_id`, then the next one.
+
+    Field-at-a-time validation made each error true and each error a fraction
+    of the answer. Two missing fields must produce ONE receipt naming BOTH.
+    """
+    error = _error(
+        {
+            "operation": "recall",
+            "query": "client install proof",
+            "scope": {"agent": "agent-name", "platform": "claude-code"},
+        }
+    )
+
+    assert "server_id" in error
+    assert "channel_id" in error
+    assert "session_key" in error
+    assert "3 problems" in error
+
+
+def test_scope_error_does_not_name_fields_that_were_supplied() -> None:
+    error = _error(
+        {
+            "operation": "recall",
+            "query": "client install proof",
+            "scope": {**_FULL_SCOPE, "session_key": ""},
+        }
+    )
+
+    assert "session_key" in error
+    assert "agent" not in error
+    assert "server_id" not in error
+
+
+def test_top_level_namespace_is_rejected_by_where_it_belongs() -> None:
+    """The contradictory receipt: ignored AND fatal, in the same JSON object.
+
+    `namespace` was folded into `ignored_optional_request_keys` and the request
+    then failed `namespace must be a non-empty string` -- the receipt called the
+    key optional and died on it at once. Rejecting is deliberate:
+    `docs/memory-contract.md` gives `config.namespace` as the ONE in-request
+    override, so accepting a second top-level spelling would add an undocumented
+    field with the same meaning.
+    """
+    output = execute_json(
+        {
+            "operation": "recall",
+            "query": "client install proof",
+            "namespace": "rico",
+            "scope": _FULL_SCOPE,
+        },
+        transport=LaneAwareTransport(),
+    )
+    receipt = output["receipt"]
+    error = str(receipt["error"])
+
+    assert receipt["status"] == "failed"
+    assert "OPENBRAIN_NAMESPACE" in error
+    assert "environment" in error
+    assert "config" in error
+    # The key that killed the request is never also advertised as ignorable.
+    assert "namespace" not in receipt.get("ignored_optional_request_keys", [])
+
+
+@pytest.mark.parametrize("key", ["base_url", "token"])
+def test_other_misplaced_config_keys_say_where_they_live(key: str) -> None:
+    error = _error(
+        {
+            "operation": "recall",
+            "query": "client install proof",
+            key: "value",
+            "scope": _FULL_SCOPE,
+        }
+    )
+
+    assert f"OPENBRAIN_{key.upper()}" in error
+    assert "config" in error
+
+
+def test_ingest_keeps_its_own_top_level_namespace() -> None:
+    """`ingest` DEFINES a top-level `namespace`; the guard must not eat it."""
+    output = execute_json(
+        {
+            "operation": "ingest",
+            "namespace": "rico",
+            "turns": [],
+            "scope": _FULL_SCOPE,
+        },
+        transport=LaneAwareTransport(),
+    )
+
+    assert "OPENBRAIN_NAMESPACE" not in str(output["receipt"].get("error") or "")
+
+
+def test_help_names_the_environment_the_example_depends_on() -> None:
+    """The example is a request body, and a body carries no identity.
+
+    Following the example on a clean shell failed with "namespace must be a
+    non-empty string" and said nothing about where namespace comes from.
+    """
+    environment = usage_output()["result"]["environment"]
+    required = " ".join(environment["required"])
+
+    assert "OPENBRAIN_NAMESPACE" in required
+    assert "OPENBRAIN_BASE_URL" in required
+    assert "OPENBRAIN_TOKEN" in required
+    # The help must not redact its own explanation.
+    assert "REDACTED" not in required
+
+
+def test_help_example_carries_the_full_required_scope() -> None:
+    example = usage_output()["result"]["example"]
+
+    assert set(example["scope"]) == set(_FULL_SCOPE)

--- a/python/openbrain-memory/tests/test_cli_request_diagnostics.py
+++ b/python/openbrain-memory/tests/test_cli_request_diagnostics.py
@@ -23,10 +23,26 @@ _FULL_SCOPE = {
     "channel_id": "channel-id",
     "session_key": "session-key",
 }
+# Config is supplied EXPLICITLY, never inherited from the environment.
+#
+# Without it these tests read OPENBRAIN_BASE_URL from the developer's shell, so
+# they passed on a machine that had the env set and failed in CI with
+# `base_url must be a non-empty string` -- config is built before the scope is
+# validated, so the assertion never reached the error it was written for. A
+# test that only passes where the environment is already right is the same
+# defect this file exists to document.
+_CONFIG = {
+    "base_url": "https://brain.example",
+    "namespace": "bilby",
+    "token": "fixture-token",
+}
 
 
 def _error(request: dict[str, object]) -> str:
-    output = execute_json(request, transport=LaneAwareTransport())
+    output = execute_json(
+        {"config": _CONFIG, **request},
+        transport=LaneAwareTransport(),
+    )
     receipt = output["receipt"]
     assert receipt["status"] == "failed"
     return str(receipt["error"])
@@ -78,6 +94,7 @@ def test_top_level_namespace_is_rejected_by_where_it_belongs() -> None:
     """
     output = execute_json(
         {
+            "config": _CONFIG,
             "operation": "recall",
             "query": "client install proof",
             "namespace": "rico",
@@ -115,6 +132,7 @@ def test_ingest_keeps_its_own_top_level_namespace() -> None:
     """`ingest` DEFINES a top-level `namespace`; the guard must not eat it."""
     output = execute_json(
         {
+            "config": _CONFIG,
             "operation": "ingest",
             "namespace": "rico",
             "turns": [],

--- a/scripts/setup-client.sh
+++ b/scripts/setup-client.sh
@@ -193,6 +193,39 @@ case "$BASE_URL" in
     scheme://host:port with no path. A /mcp URL is the retired MCP lane." ;;
 esac
 
+# The bundle ships the BUILD MACHINE's env file verbatim, and on the Mini that
+# file says 127.0.0.1. Copied to a client, a loopback URL points the client at
+# ITSELF -- where nothing is listening -- so every later failure reads as "the
+# brain is down" instead of "this line was never edited." That is not a
+# hypothetical: it is the unedited default of every bundle produced so far.
+#
+# Refuse rather than warn. A warning here is printed above a wall of install
+# output and scrolls away, and the install then "succeeds" into a stack that
+# cannot work.
+case "$BASE_URL" in
+  http://127.0.0.1*|http://localhost*|https://127.0.0.1*|https://localhost*|*'[::1]'*)
+    if [ "${OPENBRAIN_ALLOW_LOOPBACK_CLIENT:-}" = "1" ]; then
+      log "    [warn] loopback base URL allowed by OPENBRAIN_ALLOW_LOOPBACK_CLIENT=1"
+    else
+      die "OPENBRAIN_BASE_URL is $BASE_URL — a LOOPBACK address.
+
+    On a client box that is always the unedited build-machine value: the
+    bundle ships the Mini's env file as-is, and loopback points this box at
+    itself, where no brain is listening.
+
+    Edit the line to the Mini's LAN address, then re-run:
+
+      $TARGET_ENV_DIR/claudex-observation.env
+      OPENBRAIN_BASE_URL=http://10.71.1.21:3100
+
+    Plain http on the LAN also needs OPENBRAIN_ALLOW_INSECURE_HTTP=1 in that
+    same file.
+
+    Running this script ON the Mini itself, where loopback is correct? Set
+    OPENBRAIN_ALLOW_LOOPBACK_CLIENT=1 to skip this check."
+    fi ;;
+esac
+
 health_code="$(curl -sS -m 10 -o /dev/null -w '%{http_code}' "$BASE_URL/health" || echo 000)"
 if [ "$health_code" = "200" ]; then
   log "    [ok] /health -> 200"
@@ -203,10 +236,44 @@ else
   log "           LAN address, is OPENBRAIN_ALLOW_INSECURE_HTTP=1 set?"
 fi
 
+# The CLI reads the namespace from OPENBRAIN_NAMESPACE in the ENVIRONMENT; it
+# is not a request field. Assert the export exists BEFORE recalling, because
+# without it the recall fails deep inside scope validation with a message about
+# a request key -- pointing at the JSON rather than at the missing line in the
+# env file. The first client install spent four round trips on that gap.
+if rg -q '^[[:space:]]*(export[[:space:]]+)?OPENBRAIN_NAMESPACE=' \
+    "$TARGET_ENV_DIR/claudex-observation.env" 2>/dev/null; then
+  log "    [ok] OPENBRAIN_NAMESPACE present in the env file"
+else
+  die "OPENBRAIN_NAMESPACE is missing from
+    $TARGET_ENV_DIR/claudex-observation.env
+
+    The provider CLI takes the namespace from the ENVIRONMENT, never from the
+    request body, so without this line every recall fails with a message about
+    a request key and says nothing about the env file. Add:
+
+      OPENBRAIN_NAMESPACE=rico"
+fi
+
+# The prover is the ONLY end-to-end check that the direct stack works, so it
+# has to call the CLI the way the CLI is actually called: ONE bounded JSON
+# object on stdin, with `operation` inside it and the full five-field scope.
+#
+# It previously ran `openbrain-memory recall --query ... --limit 1`, an argv
+# interface that has never existed. That invocation cannot reach the brain at
+# all -- it returns "arguments are not supported" -- so the prover reported
+# [FAIL] on every install regardless of whether the install was good, which
+# makes it worse than no prover: it is a check whose failure carries no
+# information.
 log "    recall through the installed openbrain-memory:"
-recall_out="$(sh "$TARGET_ENV_DIR/openbrain-hook-env" openbrain-memory recall \
-  --query "open brain client install" --limit 1 2>&1 || true)"
-if printf '%s' "$recall_out" | rg -q '"status"\s*:\s*"direct"' 2>/dev/null; then
+recall_out="$(
+  set -a
+  . "$TARGET_ENV_DIR/claudex-observation.env"
+  set +a
+  printf '%s' '{"operation":"recall","query":"client install proof","scope":{"agent":"setup-client","platform":"claude-code","server_id":"client-install","channel_id":"client-install","session_key":"client-install-proof"}}' \
+    | openbrain-memory 2>&1 || true
+)"
+if printf '%s' "$recall_out" | rg -q '"status"[[:space:]]*:[[:space:]]*"direct"' 2>/dev/null; then
   log "    [ok] recall returned status=direct"
 else
   log "    [FAIL] recall did not return status=direct"


### PR DESCRIPTION
Five defects found during the FIRST real client install (the Air, 2026-08-04), all reproduced locally before fixing.

## Summary

None of these was a wrong result — every refusal the runtime made was correct. They were failures of the **receipt**: it named a fraction of the problem, or called a key optional and then died on that same key, so a human paid one round trip per field for a set the runtime knew in full on the first call.

- **The prover never worked.** `scripts/setup-client.sh` called `openbrain-memory recall --query ... ` — an argv interface that has never existed. It returns `arguments are not supported` without reaching the brain, so the prover reported `[FAIL]` on every install regardless of whether the install was good. That is worse than no prover: a check whose failure carries no information. It now sources the env file and pipes one bounded JSON object with the full five-field scope, asserting `OPENBRAIN_NAMESPACE` is present **first** so a missing export is reported against the env file rather than surfacing deep in scope validation as a message about a request key.
- **Loopback base URL is now refused on a client.** The bundle ships the Mini's env verbatim, so an unedited `OPENBRAIN_BASE_URL` is always loopback and points the client at itself. This was already written in `docs/GOTCHAS.md` and the doc did not stop it — the Air was installed from an unedited file anyway — so it is enforcement now, with `OPENBRAIN_ALLOW_LOOPBACK_CLIENT=1` to run the script on the Mini.
- **The contradictory receipt is gone.** A top-level `namespace` was listed in `ignored_optional_request_keys` **and** failed `namespace must be a non-empty string` in the same JSON object. It is now rejected with an error naming `OPENBRAIN_NAMESPACE` and the documented `{"config": {"namespace": "..."}}` override. Rejecting rather than aliasing is deliberate: `docs/memory-contract.md` already gives `config.namespace` as the one in-request spelling, so a second top-level spelling would be an undocumented duplicate field. Same treatment for misplaced `base_url`/`token`; `ingest` keeps the top-level `namespace` it genuinely defines.
- **`--help` names the environment.** The example is a request body, and a body carries no identity, so following it on a clean shell failed and said nothing about where namespace comes from.
- **Scope errors arrive all at once.** `RuntimeScope.from_mapping` validated field-by-field, surfacing one missing key per attempt — the Air hit `namespace`, satisfied it, then hit `server_id`, then the next. All five required fields are now checked before any of them raises.

## Red-proof

- **Old prover invocation, stock CLI:** `{"error":"arguments are not supported; use --help or provide bounded JSON on stdin; ..."}` — confirms it could never have reached the brain.
- **New prover, live against `http://127.0.0.1:3100`** with the override flag, running the block exactly as the script does: `[ok] recall returned status=direct`.
- **Contradictory receipt, before:** `"ignored_optional_request_keys":["namespace"]` alongside `"error":"namespace must be a non-empty string"` in one receipt. After: an error naming `OPENBRAIN_NAMESPACE` and the `config` path.
- **One-at-a-time scope, before:** a scope missing three fields reported only `server_id must be a non-empty string`. After: `scope is invalid (3 problems): server_id ...; channel_id ...; session_key ...`.
- **New tests fail without the fix.** Reverting only the two source files and keeping `tests/test_cli_request_diagnostics.py`: **5 failed, 3 passed**, each failure the exact field-report symptom (`KeyError: 'environment'`, `assert 'channel_id' in 'server_id must be a non-empty string'`). Restored: **8 passed**.
- **Loopback guard**, all three branches executed: unedited `http://127.0.0.1:3100` refuses; same URL with the override proceeds; `http://10.71.1.21:3100` proceeds.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bun install --frozen-lockfile` clean; `sh -n` and `shellcheck` on the script
- [x] Python package checks passed or are not applicable — `uv run mypy src/openbrain_memory` clean (17 files), `uv run ruff check src tests` clean, `uv run pytest -q` **562 passed / 9 skipped** (554 before; +8 new)
- [x] Live Open Brain smoke passed or is not applicable — the new prover was run live against the running brain and returned `status=direct`

## Critical Self-Review

- Highest-risk behavior: rejecting a top-level `namespace` that was previously ignored. A caller who sent it and relied on the environment value silently winning now gets a hard failure instead of a working call. That is intended — the same request already failed on the contradictory path, so the previously-"working" case is only one where `namespace` was sent redundantly — but it is the one behavior change with a blast radius beyond error text.
- Assumptions that could be wrong: that no in-tree caller sends a top-level `namespace` to a non-`ingest` operation. Checked the full pytest suite (562 pass) and `ingest` is explicitly exempted via the per-operation allowed-key set; an out-of-tree caller doing this is possible and would now fail loudly rather than silently.
- Missing/weak tests: the loopback guard and the namespace-line assertion are shell and are proven by executing the extracted blocks, not by a committed test — `setup-client.sh` has no test harness in this repo. The live `status=direct` proof is a manual run, not CI-enforced.
- Security/permission risk: none added. The help `environment` block names variables but prints no values; the variable names are list values rather than object keys specifically so the redactor does not mistake the help for a credential (as an object key, `OPENBRAIN_TOKEN`'s description was replaced with `[REDACTED]`, hiding the explanation). The redaction rule itself is untouched.
- Migration/deploy risk: none — no schema, no migration. The script change takes effect on the next bundle install.
- Downstream client/runtime risk: the error text and `--help` result shape change, so anything asserting on the old single-field message or on `result` lacking `environment` would need updating. No MCP tool, transport, or wire schema is touched; the receipt schema (`openbrain.runtime_receipt.v1`) is unchanged.
- Rollback/cleanup concern: revert restores the old behavior wholesale; the prover would go back to reporting `[FAIL]` on every install.
- Fixes made before PR: `shellcheck` caught a real bug in my own new code — `[::1]*` in a `case` pattern is a character **range** matching single chars, not the literal IPv6 loopback, so the guard would have missed `http://[::1]:3100`. Corrected to `*'[::1]'*` and verified against all four loopback spellings.
- Known residual risk: the guard matches loopback by URL spelling, so a hostname that resolves to loopback (a `/etc/hosts` alias) still passes. Left alone deliberately rather than adding resolution to an install script; the failure mode it targets is the literal unedited `127.0.0.1` the bundle ships.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review-lane pattern arose — the findings are install-surface defects, captured in `docs/GOTCHAS.md` and the runbook where installers will read them

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` — none arose
- Live Open Brain checks: [x] linked below — the new prover was run live against the running service and returned `status=direct` (evidence in the Red-proof section above)

## Contract Parity

- Contract parity: [x] runtime-specific because: the changes are error text, `--help` output, and an install script. The receipt schema, MCP tools, and wire representation are unchanged; `config.namespace` remains the one documented in-request override.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- No MCP tool, schema, or transport surface is modified. The client-facing change is error text and `--help` output from the provider CLI; a downstream consumer asserting on the old single-field scope error would need updating, which is the intended improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
