### PR TITLE
fix(installer): ship OPENBRAIN_DEVELOPMENT_ROOT so a non-mini install resolves its own lane (#555)

### DIFF
--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -974,7 +974,7 @@ problem is credentials or environment, not the network.
 
 ## 2026-08-04 client-install traps
 
-These four all bit while putting the direct client stack on a second machine.
+These all bit while putting the direct client stack on a second machine.
 Full procedure: `docs/client-install-runbook.md`.
 
 ### A stale MCP registration answers instead of the direct stack — and `/mcp` in an error is the tell
@@ -1139,6 +1139,65 @@ field — the Air hit `namespace`, satisfied it, then hit `server_id`, then the
 next. Every error was true and every error was a fraction of the answer. All
 five (`agent`, `platform`, `server_id`, `channel_id`, `session_key`) are now
 reported in a single receipt.
+
+### A fresh box blocks EVERY tool call, and the escape hatch names a path it does not have
+
+**Symptom.** On a newly installed client whose Development tree is not on
+`/Volumes/ThunderBolt`, every tool call is blocked by the context-budget gate,
+and the remediation the banner prints names a directory that does not exist on
+that machine. Pasting it fails, so the block never clears and the session cannot
+be recovered from inside itself. On the operator-invoked path the same
+misconfiguration reads differently: the provider exits clean with no receipt and
+no output, which is indistinguishable from having worked.
+
+**Cause.** `development_scope.py` ships the BUILD machine's volume as
+`DEFAULT_DEVELOPMENT_ROOT`, and it resolves the lane by asking the FILESYSTEM. A
+root that is not there fails the `is_dir()` test, so `resolve_development_scope()`
+returns `None` for every cwd. The gate then has no project, and
+`context_budget_gate._development_cwd()` composes its recovery path out of that
+same absent root — which is how the escape hatch ends up pointing at nothing.
+
+The override `OPENBRAIN_DEVELOPMENT_ROOT` has always existed and always worked.
+**Nothing shipped it** (#555): neither installer script mentioned it, and the
+wrapper's `exec env -i` allowlist did not pass it, so even hand-setting it in the
+env file was stripped before any hook child saw it. Both halves are required —
+the value AND the pass-through.
+
+**Reproducing this on the Mini takes care.** `/Users/rico/Development` here is a
+**symlink** to `/Volumes/ThunderBolt/Development`, and `_canonical_directory`
+calls `.resolve()`. Probe with that path and both the broken and fixed cases
+return a healthy scope, hiding the defect entirely. Use a root that is a real
+directory with no symlink back to the volume:
+
+```bash
+cd python/openbrain-provider
+uv run python -c "
+from openbrain_provider.development_scope import resolve_development_scope, development_root
+print('root :', development_root())
+print('scope:', resolve_development_scope('/some/real/Development/open-brain'))"
+```
+
+`scope: None` with a `root` that is not this machine's tree is the defect.
+Setting `OPENBRAIN_DEVELOPMENT_ROOT` to the real tree turns it into a
+`DevelopmentScope`.
+
+**Fix and check.** `setup-client.sh` now resolves the root per box (exported
+value, then `DEV_ROOT`, then probing the known layouts), writes it into the
+installed env file, and adds the wrapper pass-through. It refuses to install when
+it cannot resolve one — `OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT=1` is the deliberate
+override for a box with no Development tree. On any box already installed:
+
+```bash
+python3 - "$HOME/.local/share/openbrain-memory/env/openbrain-hook-env" <<'EOF'
+import sys
+print("pass-through present:",
+      "OPENBRAIN_DEVELOPMENT_ROOT" in open(sys.argv[1], encoding="utf-8").read())
+EOF
+```
+
+**The shape to recognise:** a value that is correct on exactly one machine, with
+a working override that nothing ever ships. The build box cannot detect it,
+because the default is right there.
 
 ---
 

--- a/docs/client-install-runbook.md
+++ b/docs/client-install-runbook.md
@@ -151,7 +151,7 @@ composes its recovery command from the same missing root.
 
 | Where | What |
 |---|---|
-| `claudex-observation.env` | `OPENBRAIN_DEVELOPMENT_ROOT=/this/box/Development` |
+| `claudex-observation.env` | `OPENBRAIN_DEVELOPMENT_ROOT='/this/box/Development'` — keep the single quotes; the wrapper sources this file with POSIX `. `, so an unquoted path containing a space sources to empty and redelivers the exact wedge this variable exists to prevent |
 | `openbrain-hook-env` | `OPENBRAIN_DEVELOPMENT_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-}" \` in the `exec env -i` list |
 
 The wrapper starts a **clean** child, so a variable absent from its allowlist

--- a/docs/client-install-runbook.md
+++ b/docs/client-install-runbook.md
@@ -132,6 +132,47 @@ staged value is loopback.
 
 ---
 
+## 3b. The Development root — the other value that is right on exactly one box
+
+`OPENBRAIN_BASE_URL` is not the only machine-specific value in that env file.
+`OPENBRAIN_DEVELOPMENT_ROOT` is the second one, and it fails harder: a wrong base
+URL makes the brain unreachable, while a wrong Development root **blocks every
+tool call** and points the operator's escape hatch at a directory that does not
+exist on the box.
+
+`openbrain-provider` resolves the Development lane by asking the filesystem, and
+the shipped `DEFAULT_DEVELOPMENT_ROOT` is `/Volumes/ThunderBolt/Development` —
+the Mini's volume. On a client whose tree is elsewhere (the Air:
+`/Users/rico/Development`), that path is absent, `resolve_development_scope()`
+returns `None` for every cwd, and `context_budget_gate._development_cwd()`
+composes its recovery command from the same missing root.
+
+**Two edits are required, and one without the other does nothing:**
+
+| Where | What |
+|---|---|
+| `claudex-observation.env` | `OPENBRAIN_DEVELOPMENT_ROOT=/this/box/Development` |
+| `openbrain-hook-env` | `OPENBRAIN_DEVELOPMENT_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-}" \` in the `exec env -i` list |
+
+The wrapper starts a **clean** child, so a variable absent from its allowlist
+never reaches the hook no matter what the env file says. This is a **string**
+variable, so it takes the plain list spelling — the conditional block above the
+list is for non-string values, where `""` and absent differ (see §4).
+
+`setup-client.sh` does both automatically: it resolves the root from
+`OPENBRAIN_DEVELOPMENT_ROOT`, then `DEV_ROOT`, then by probing
+`/Volumes/ThunderBolt/Development` and `$HOME/Development`, writes the resolved
+value into the installed env file, and adds the pass-through. It **refuses to
+install** when it cannot resolve one, for the same reason as the loopback guard:
+a warning scrolls away and the install then succeeds into a box that blocks
+everything on first use. Override with
+`OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT=1` only on a box that runs no gated agent
+work.
+
+Both edits are idempotent — re-running never produces a second spelling.
+
+---
+
 ## 4. The MATCHED-PAIR rule — the one that fails silently
 
 **The wrapper and the installed package must move together, package first.**
@@ -194,6 +235,7 @@ stopping early is how a green-looking dead box happens.
 | # | Rung | How | What a failure means |
 |---|---|---|---|
 | 0 | **The env file was edited** | `OPENBRAIN_BASE_URL` is the Mini's LAN address, and `OPENBRAIN_NAMESPACE` is present | The bundle ships the build machine's env verbatim, so an unedited `OPENBRAIN_BASE_URL` is loopback and points the client at itself. A missing `OPENBRAIN_NAMESPACE` fails later as a message about a *request key*, which points at the JSON instead of at this file. `setup-client.sh` now refuses on both. |
+| 0b | **The Development root is this machine's** | `OPENBRAIN_DEVELOPMENT_ROOT` is set in the env file AND passed by the wrapper's `env -i` list | The shipped default is the build machine's volume. On a box where it does not exist, every cwd resolves to no scope and the context-budget gate blocks every tool call while naming a path that box does not have (#555). Both halves are required: the value alone is stripped by the wrapper. `setup-client.sh` now writes both and refuses when it cannot resolve a root. |
 | 1 | **Health** | `curl -sS $OPENBRAIN_BASE_URL/health` → `200` | Service down, wrong URL, or the plain-http opt-in is missing. |
 | 2 | **Recall is `direct`** | source the env file, then pipe one JSON object (below) to `openbrain-memory` → `"status": "direct"` | Anything other than `direct` means the direct stack is not the lane answering — suspect a stale MCP registration. |
 | 3 | **CANON PACK, non-zero counts** | Start a **fresh** session; the `SessionStart` emissions carry section counts | Counts of zero, or no pack at all, is the matched-pair failure. The hooks ran and swallowed a rejection. |

--- a/scripts/client-bundle.sh
+++ b/scripts/client-bundle.sh
@@ -156,11 +156,19 @@ fi
 
 python3 - "$STAGE/env/claudex-observation.env" "$BUILD_DEV_ROOT" <<'PY'
 import re
+import shlex
 import sys
 
 path, build_root = sys.argv[1], sys.argv[2]
 with open(path, encoding="utf-8") as handle:
     text = handle.read()
+
+# Shell-quote it for the same reason setup-client.sh does: this file is read
+# with POSIX `set -a; . "$ENV_FILE"`, so an unquoted path containing a space
+# splits on IFS and the variable arrives empty. The staged line is commented,
+# but it is the line an operator uncomments when hand-installing -- staging it
+# unquoted hands them the #555 wedge with the fix's own example.
+quoted_build_root = shlex.quote(build_root)
 
 # Stage the BUILD machine's value COMMENTED. Live, it would look authoritative
 # on a client where it is wrong; commented with the note, it reads as the
@@ -172,7 +180,10 @@ block = (
     "## so on a box where this path does not exist EVERY cwd resolves to no\n"
     "## scope and EVERY tool call is blocked behind a recovery command naming a\n"
     "## directory that box does not have (#555).\n"
-    f"# OPENBRAIN_DEVELOPMENT_ROOT={build_root}\n"
+    "## The value is shell-quoted: this file is sourced, so a path containing a\n"
+    "## space would otherwise split and arrive empty. Keep the quoting if you\n"
+    "## edit it by hand.\n"
+    f"# OPENBRAIN_DEVELOPMENT_ROOT={quoted_build_root}\n"
 )
 
 pattern = re.compile(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", re.M)

--- a/scripts/client-bundle.sh
+++ b/scripts/client-bundle.sh
@@ -129,6 +129,96 @@ cp -p "$SOURCE_ENV_DIR/openbrain-hook-env" "$STAGE/env/"
 chmod 600 "$STAGE/env/claudex-observation.env"
 chmod 755 "$STAGE/env/openbrain-hook-env"
 
+# --- 2b. Development root, staged -------------------------------------------
+# The staged env dir is a copy of THIS machine's live installation, and this
+# machine is the one box where the provider's built-in default happens to be
+# right -- so a bundle built here carries no evidence that the value is
+# machine-specific at all. On any client it is wrong, every cwd resolves to no
+# scope, and the context-budget gate blocks every tool call (#555).
+#
+# setup-client.sh resolves and overwrites this per box. What is staged here is
+# the BUILD machine's value plus a loud note, so the file is self-describing if
+# anyone reads or hand-installs it, and the allowlist entry, without which the
+# value cannot reach the hook child at all.
+
+log "==> staging the Development root marker"
+# The build machine's own root, by the same order setup-client.sh uses.
+BUILD_DEV_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-${DEV_ROOT:-}}"
+if [ -z "$BUILD_DEV_ROOT" ]; then
+  for candidate in /Volumes/ThunderBolt/Development "$HOME/Development"; do
+    if [ -d "$candidate" ]; then
+      BUILD_DEV_ROOT="$candidate"
+      break
+    fi
+  done
+fi
+[ -n "$BUILD_DEV_ROOT" ] || BUILD_DEV_ROOT="/Volumes/ThunderBolt/Development"
+
+python3 - "$STAGE/env/claudex-observation.env" "$BUILD_DEV_ROOT" <<'PY'
+import re
+import sys
+
+path, build_root = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+
+# Stage the BUILD machine's value COMMENTED. Live, it would look authoritative
+# on a client where it is wrong; commented with the note, it reads as the
+# example it actually is. setup-client.sh writes the live line per box.
+block = (
+    "## EDIT ME ON THE CLIENT -- or just let setup-client.sh do it, which is the\n"
+    "## paved road. This is the BUILD machine's Development root, staged as an\n"
+    "## example only. The provider resolves the lane by asking the filesystem,\n"
+    "## so on a box where this path does not exist EVERY cwd resolves to no\n"
+    "## scope and EVERY tool call is blocked behind a recovery command naming a\n"
+    "## directory that box does not have (#555).\n"
+    f"# OPENBRAIN_DEVELOPMENT_ROOT={build_root}\n"
+)
+
+pattern = re.compile(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", re.M)
+if pattern.search(text):
+    text = pattern.sub("", text)
+text = text.rstrip("\n") + "\n" + block
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(text)
+print("    staged OPENBRAIN_DEVELOPMENT_ROOT marker (commented)", file=sys.stderr)
+PY
+
+# The wrapper starts a clean child with `exec env -i`, so a variable missing
+# from its list never reaches the hook regardless of the env file. Stage the
+# pass-through here too, so a bundle is correct even if the build machine's own
+# wrapper predates this fix. String variable -> plain list spelling; the
+# conditional block above it is for non-string values only.
+python3 - "$STAGE/env/openbrain-hook-env" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+
+if "OPENBRAIN_DEVELOPMENT_ROOT=" in text:
+    print("    [ok] staged wrapper already passes it", file=sys.stderr)
+    sys.exit(0)
+
+anchor = '  OPENBRAIN_TOKEN="${OPENBRAIN_TOKEN:-}" \\\n'
+if anchor not in text:
+    sys.exit(
+        "client-bundle: the staged wrapper has no OPENBRAIN_TOKEN line in its\n"
+        "    env -i list, so the OPENBRAIN_DEVELOPMENT_ROOT pass-through could\n"
+        "    not be added. Fix the source wrapper before bundling."
+    )
+
+text = text.replace(
+    anchor,
+    anchor + '  OPENBRAIN_DEVELOPMENT_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-}" \\\n',
+    1,
+)
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(text)
+print("    added OPENBRAIN_DEVELOPMENT_ROOT pass-through to the staged wrapper",
+      file=sys.stderr)
+PY
+
 # --- 3. hook entries -------------------------------------------------------
 # Extract ONLY hook entries whose command mentions openbrain. Everything else in
 # settings.json is this machine's business and must not travel.

--- a/scripts/setup-client.sh
+++ b/scripts/setup-client.sh
@@ -49,36 +49,7 @@ command -v python3 >/dev/null 2>&1 || die "python3 not on PATH"
 [ -f "$BUNDLE_DIR/env/openbrain-hook-env" ] || die "bundle incomplete: env/openbrain-hook-env missing"
 [ -f "$BUNDLE_DIR/settings-hooks.json" ] || die "bundle incomplete: settings-hooks.json missing"
 
-# --- 1. wheels -------------------------------------------------------------
-# --find-links points at the bundle's own wheels/, mirroring the
-# OPENBRAIN_MEMORY_FIND_LINKS convention the Mini already uses
-# (~/.local/share/openbrain-memory/wheels). Same idea, client side: resolve from
-# a local wheelhouse, never from an index.
-
-log "==> installing wheels from $BUNDLE_DIR/wheels"
-for pkg in openbrain openbrain-memory openbrain-provider; do
-  normalised="${pkg//-/_}"
-  wheel="$(ls -1 "$BUNDLE_DIR"/wheels/${normalised}-*.whl 2>/dev/null | head -1 || true)"
-  [ -n "$wheel" ] || die "no wheel for $pkg in $BUNDLE_DIR/wheels"
-  log "    $pkg <- $(basename "$wheel")"
-  uv tool install --force --find-links "$BUNDLE_DIR/wheels" "$wheel"
-done
-
-# --- 2/3. env dir + wrapper ------------------------------------------------
-
-log "==> placing env dir at $TARGET_ENV_DIR"
-mkdir -p "$TARGET_ENV_DIR"
-if [ -f "$TARGET_ENV_DIR/claudex-observation.env" ]; then
-  backup="$TARGET_ENV_DIR/claudex-observation.env.bak-$(date +%Y%m%d-%H%M%S)"
-  cp -p "$TARGET_ENV_DIR/claudex-observation.env" "$backup"
-  log "    existing env file backed up to $(basename "$backup")"
-fi
-cp "$BUNDLE_DIR/env/claudex-observation.env" "$TARGET_ENV_DIR/"
-cp "$BUNDLE_DIR/env/openbrain-hook-env" "$TARGET_ENV_DIR/"
-chmod 600 "$TARGET_ENV_DIR/claudex-observation.env"
-chmod +x "$TARGET_ENV_DIR/openbrain-hook-env"
-
-# --- 2b. this machine's Development root -----------------------------------
+# --- 0. this machine's Development root, RESOLVED ---------------------------
 # openbrain-provider resolves the Development lane by asking the FILESYSTEM, and
 # the shipped default is the BUILD machine's volume
 # (development_scope.py: DEFAULT_DEVELOPMENT_ROOT). On a box whose Development
@@ -91,6 +62,14 @@ chmod +x "$TARGET_ENV_DIR/openbrain-hook-env"
 # The package already reads OPENBRAIN_DEVELOPMENT_ROOT per call; nothing ever
 # SHIPPED it. Resolving it here, per box, is that missing half. The package is
 # unchanged.
+#
+# RESOLUTION RUNS FIRST, BEFORE ANYTHING IS INSTALLED. It reads the environment
+# and the filesystem and writes nothing, but it can `die` -- and a refusal that
+# fires after the wheels are installed and the env dir is copied leaves a
+# half-installed box behind an error the operator then has to reason about
+# twice. Refusing here means the failure mode is "nothing happened yet". The
+# WRITE of the resolved value stays in section 2b, after the env file it edits
+# actually exists.
 #
 # Resolution order: an exported value wins (the operator said so), then DEV_ROOT
 # (what the fleet scripts already call it), then the two known layouts. Probing
@@ -154,17 +133,63 @@ else
   log "    Development root: $DEV_ROOT_RESOLVED [$DEV_ROOT_SOURCE]"
 fi
 
+# --- 1. wheels -------------------------------------------------------------
+# --find-links points at the bundle's own wheels/, mirroring the
+# OPENBRAIN_MEMORY_FIND_LINKS convention the Mini already uses
+# (~/.local/share/openbrain-memory/wheels). Same idea, client side: resolve from
+# a local wheelhouse, never from an index.
+
+log "==> installing wheels from $BUNDLE_DIR/wheels"
+for pkg in openbrain openbrain-memory openbrain-provider; do
+  normalised="${pkg//-/_}"
+  wheel="$(ls -1 "$BUNDLE_DIR"/wheels/${normalised}-*.whl 2>/dev/null | head -1 || true)"
+  [ -n "$wheel" ] || die "no wheel for $pkg in $BUNDLE_DIR/wheels"
+  log "    $pkg <- $(basename "$wheel")"
+  uv tool install --force --find-links "$BUNDLE_DIR/wheels" "$wheel"
+done
+
+# --- 2/3. env dir + wrapper ------------------------------------------------
+
+log "==> placing env dir at $TARGET_ENV_DIR"
+mkdir -p "$TARGET_ENV_DIR"
+if [ -f "$TARGET_ENV_DIR/claudex-observation.env" ]; then
+  backup="$TARGET_ENV_DIR/claudex-observation.env.bak-$(date +%Y%m%d-%H%M%S)"
+  cp -p "$TARGET_ENV_DIR/claudex-observation.env" "$backup"
+  log "    existing env file backed up to $(basename "$backup")"
+fi
+cp "$BUNDLE_DIR/env/claudex-observation.env" "$TARGET_ENV_DIR/"
+cp "$BUNDLE_DIR/env/openbrain-hook-env" "$TARGET_ENV_DIR/"
+chmod 600 "$TARGET_ENV_DIR/claudex-observation.env"
+chmod +x "$TARGET_ENV_DIR/openbrain-hook-env"
+
+# --- 2b. this machine's Development root, WRITTEN ---------------------------
+# The value was resolved in section 0, before anything was installed, so a bad
+# or missing root has already refused by the time we get here. What is left is
+# the write, and it lives here because it edits the env file section 2 just
+# placed.
+#
 # Write it into the INSTALLED env file. The bundle ships the build machine's
 # value (or none), so this rewrite is what makes the file correct per box --
 # same reason the wrapper's ENV_FILE is rewritten just below.
 if [ -n "$DEV_ROOT_RESOLVED" ]; then
   python3 - "$TARGET_ENV_DIR/claudex-observation.env" "$DEV_ROOT_RESOLVED" <<'PY'
 import re
+import shlex
 import sys
 
 path, root = sys.argv[1], sys.argv[2]
 with open(path, encoding="utf-8") as handle:
     text = handle.read()
+
+# Shell-quote the value. The wrapper reads this file with POSIX
+# `set -a; . "$ENV_FILE"`, which SPLITS an unquoted right-hand side on IFS: a
+# root containing a space becomes a word plus a stray command, the shell says
+# "No such file or directory", and the variable lands EMPTY -- which is exactly
+# the #555 wedge this line exists to close, delivered silently through its own
+# fix while the installer still prints success. Quoting preserves the value
+# whole. The other lines in this file are unquoted, which is fine; POSIX `.`
+# reads a quoted value just as happily, so only the line we write changes.
+quoted_root = shlex.quote(root)
 
 block = (
     "## This machine's Development root. Written by setup-client.sh at install\n"
@@ -172,7 +197,9 @@ block = (
     "## and a root that does not exist resolves every cwd to no scope, which\n"
     "## blocks every tool call behind a recovery command pointing somewhere\n"
     "## this box does not have (#555). Re-run setup-client.sh to update it.\n"
-    f"OPENBRAIN_DEVELOPMENT_ROOT={root}\n"
+    "## Shell-quoted: this file is sourced, so a path containing a space would\n"
+    "## otherwise split and arrive empty.\n"
+    f"OPENBRAIN_DEVELOPMENT_ROOT={quoted_root}\n"
 )
 
 # Replace any existing assignment (commented or live) so re-running is
@@ -183,7 +210,7 @@ if pattern.search(text):
 text = text.rstrip("\n") + "\n" + block
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(text)
-print(f"    OPENBRAIN_DEVELOPMENT_ROOT={root} written to the installed env file")
+print(f"    OPENBRAIN_DEVELOPMENT_ROOT={quoted_root} written to the installed env file")
 PY
 fi
 

--- a/scripts/setup-client.sh
+++ b/scripts/setup-client.sh
@@ -78,6 +78,150 @@ cp "$BUNDLE_DIR/env/openbrain-hook-env" "$TARGET_ENV_DIR/"
 chmod 600 "$TARGET_ENV_DIR/claudex-observation.env"
 chmod +x "$TARGET_ENV_DIR/openbrain-hook-env"
 
+# --- 2b. this machine's Development root -----------------------------------
+# openbrain-provider resolves the Development lane by asking the FILESYSTEM, and
+# the shipped default is the BUILD machine's volume
+# (development_scope.py: DEFAULT_DEVELOPMENT_ROOT). On a box whose Development
+# tree is somewhere else, that path does not exist, resolve_development_scope()
+# answers None for every cwd, and the context-budget gate then composes its
+# recovery command from the same wrong root -- so the banner tells the operator
+# to cd somewhere that is not there, and the session cannot be unblocked from
+# inside itself. Field-proved on the Air, 2026-08-04 (#555).
+#
+# The package already reads OPENBRAIN_DEVELOPMENT_ROOT per call; nothing ever
+# SHIPPED it. Resolving it here, per box, is that missing half. The package is
+# unchanged.
+#
+# Resolution order: an exported value wins (the operator said so), then DEV_ROOT
+# (what the fleet scripts already call it), then the two known layouts. Probing
+# is last because a guess should never beat an instruction.
+log "==> resolving this machine's Development root"
+DEV_ROOT_RESOLVED=""
+DEV_ROOT_SOURCE=""
+if [ -n "${OPENBRAIN_DEVELOPMENT_ROOT:-}" ]; then
+  DEV_ROOT_RESOLVED="$OPENBRAIN_DEVELOPMENT_ROOT"
+  DEV_ROOT_SOURCE="OPENBRAIN_DEVELOPMENT_ROOT in the environment"
+elif [ -n "${DEV_ROOT:-}" ]; then
+  DEV_ROOT_RESOLVED="$DEV_ROOT"
+  DEV_ROOT_SOURCE="DEV_ROOT in the environment"
+else
+  for candidate in /Volumes/ThunderBolt/Development "$HOME/Development"; do
+    if [ -d "$candidate" ]; then
+      DEV_ROOT_RESOLVED="$candidate"
+      DEV_ROOT_SOURCE="probed (found on disk)"
+      break
+    fi
+  done
+fi
+
+# An explicitly-given root that does not exist is a typo, not a preference, and
+# it fails exactly like the defect this guard exists to close. Say so now.
+if [ -n "$DEV_ROOT_RESOLVED" ] && [ ! -d "$DEV_ROOT_RESOLVED" ]; then
+  die "OPENBRAIN_DEVELOPMENT_ROOT / DEV_ROOT names a path that does not exist:
+
+      $DEV_ROOT_RESOLVED
+
+    The provider resolves the lane by asking the filesystem, so a path that is
+    not there behaves exactly like no value at all: every gate wedges. Point it
+    at this machine's real Development tree and re-run."
+fi
+
+# Refuse rather than warn, matching the loopback guard below: a warning here
+# scrolls away under install output and the install then "succeeds" into a box
+# that blocks every tool call on first use.
+if [ -z "$DEV_ROOT_RESOLVED" ]; then
+  if [ "${OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT:-}" = "1" ]; then
+    log "    [warn] no Development root resolved; continuing because"
+    log "           OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT=1"
+  else
+    die "cannot determine this machine's Development root.
+
+    Neither /Volumes/ThunderBolt/Development nor \$HOME/Development exists here,
+    and neither OPENBRAIN_DEVELOPMENT_ROOT nor DEV_ROOT was set.
+
+    Without it the provider keeps the build machine's default, every cwd
+    resolves to no scope, and the context-budget gate blocks every tool call
+    while pointing its own recovery command at a path this box does not have.
+
+    Re-run naming the variable:
+
+      OPENBRAIN_DEVELOPMENT_ROOT=/path/to/Development ./setup-client.sh
+
+    This box genuinely has no Development tree and runs no gated agent work?
+    Set OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT=1 to skip this check."
+  fi
+else
+  log "    Development root: $DEV_ROOT_RESOLVED [$DEV_ROOT_SOURCE]"
+fi
+
+# Write it into the INSTALLED env file. The bundle ships the build machine's
+# value (or none), so this rewrite is what makes the file correct per box --
+# same reason the wrapper's ENV_FILE is rewritten just below.
+if [ -n "$DEV_ROOT_RESOLVED" ]; then
+  python3 - "$TARGET_ENV_DIR/claudex-observation.env" "$DEV_ROOT_RESOLVED" <<'PY'
+import re
+import sys
+
+path, root = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+
+block = (
+    "## This machine's Development root. Written by setup-client.sh at install\n"
+    "## time -- the provider's built-in default is the BUILD machine's volume,\n"
+    "## and a root that does not exist resolves every cwd to no scope, which\n"
+    "## blocks every tool call behind a recovery command pointing somewhere\n"
+    "## this box does not have (#555). Re-run setup-client.sh to update it.\n"
+    f"OPENBRAIN_DEVELOPMENT_ROOT={root}\n"
+)
+
+# Replace any existing assignment (commented or live) so re-running is
+# idempotent and an install never leaves two spellings disagreeing.
+pattern = re.compile(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", re.M)
+if pattern.search(text):
+    text = pattern.sub("", text)
+text = text.rstrip("\n") + "\n" + block
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(text)
+print(f"    OPENBRAIN_DEVELOPMENT_ROOT={root} written to the installed env file")
+PY
+fi
+
+# The wrapper starts a CLEAN child (`exec env -i`), so a variable that is not on
+# its allowlist never reaches the hook no matter what the env file says. Ensure
+# the pass-through is present. OPENBRAIN_DEVELOPMENT_ROOT is a STRING, so it
+# takes the plain list spelling; the wrapper's header reserves the conditional
+# block for non-string values, where "" and absent differ.
+python3 - "$TARGET_ENV_DIR/openbrain-hook-env" <<'PY'
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    text = handle.read()
+
+if "OPENBRAIN_DEVELOPMENT_ROOT=" in text:
+    print("    [ok] wrapper already passes OPENBRAIN_DEVELOPMENT_ROOT")
+    sys.exit(0)
+
+anchor = '  OPENBRAIN_TOKEN="${OPENBRAIN_TOKEN:-}" \\\n'
+if anchor not in text:
+    sys.exit(
+        "setup-client: could not find the OPENBRAIN_TOKEN line in the wrapper's\n"
+        "    env -i list, so OPENBRAIN_DEVELOPMENT_ROOT could not be added. The\n"
+        "    wrapper's shape changed; add the pass-through by hand:\n"
+        '      OPENBRAIN_DEVELOPMENT_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-}" \\'
+    )
+
+text = text.replace(
+    anchor,
+    anchor + '  OPENBRAIN_DEVELOPMENT_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-}" \\\n',
+    1,
+)
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(text)
+print("    OPENBRAIN_DEVELOPMENT_ROOT pass-through added to the wrapper")
+PY
+
 # The wrapper hardcodes ENV_FILE as an absolute path from the BUILD machine. If
 # this client's $HOME differs, that path is wrong and every hook silently fails
 # to find its env — so rewrite it to this machine's actual location.


### PR DESCRIPTION
Closes #555.

## What broke

`openbrain-provider` resolves the Development lane by asking the filesystem, and `DEFAULT_DEVELOPMENT_ROOT` (`development_scope.py:36`) is the build machine's volume. On a client whose tree lives elsewhere — the Air, at `/Users/rico/Development` — that path is absent, `resolve_development_scope()` answers `None` for every cwd, and the context-budget gate blocks every tool call while composing its own recovery command out of the same missing root (`context_budget_gate.py:286-306`). The escape hatch names a directory the box does not have, so the session cannot be recovered from inside itself.

The `OPENBRAIN_DEVELOPMENT_ROOT` seam already existed and already worked — `development_root()` reads it per call and its docstring explains why it is a function. **Nothing ever shipped it.** Neither installer script mentioned the variable, and the wrapper's `exec env -i` allowlist did not pass it, so even hand-setting it in the env file was stripped before any hook child saw it. Both halves are required; either alone changes nothing.

## What the existing design already says

This is a delta on a solved problem, not a new mechanism. `python/openbrain-provider/tests/conftest.py:_install_development_root` names it outright — *"Depending on a machine-specific absolute path is the defect"* — and fixes it by pointing `OPENBRAIN_DEVELOPMENT_ROOT` at a real directory before import, after 11 tests failed on a Linux CI runner where the volume does not exist while passing locally "by accident of where the work happens".

The test suite has therefore been provisioning this variable all along. The installer never did. This PR makes the install path do at install time what `conftest` does at test time, through the same sanctioned seam.

## What ships

- `scripts/setup-client.sh` — resolves the root per box (exported value wins, then `DEV_ROOT`, then probing `/Volumes/ThunderBolt/Development` and `$HOME/Development`), writes it into the installed env file with an explanatory comment, and adds the wrapper pass-through. Refuses to install when it can resolve none, matching the loopback guard from #553 in shape and override-flag style; `OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT=1` is the deliberate opt-out. An explicitly given root that does not exist is refused too — that is a typo, and it fails exactly like the defect this closes.
- `scripts/client-bundle.sh` — stages the allowlist entry so a bundle is correct even when the build machine's own wrapper predates this fix, and stages the build machine's value **commented** with an edit-me note. Live, it would look authoritative on a client where it is wrong; commented, it reads as the example it is. `setup-client.sh` overwrites it per box either way.
- `docs/client-install-runbook.md` — new §3b, plus proof-ladder rung 0b.
- `docs/GOTCHAS.md` — the gotcha with symptom, cause, and proof commands.

`OPENBRAIN_DEVELOPMENT_ROOT` is a **string**, so it takes the plain pass-through spelling; the wrapper header reserves the conditional block for non-string values where `""` and absent differ.

**The package is unchanged.** This is installer, bundle, and env work.

## Red proof

Isolated `HOME` under the scratch workspace, synthetic Development root, stubbed `uv`/`curl` so the run reaches the env logic under test.

Old script (`origin/main`), both files installed:

```
  installed env file: 0 occurrence(s) of OPENBRAIN_DEVELOPMENT_ROOT
  installed wrapper: 0 occurrence(s) of OPENBRAIN_DEVELOPMENT_ROOT
```

New script:

```
==> resolving this machine's Development root
    Development root: .../redprove/fakedev/Development [OPENBRAIN_DEVELOPMENT_ROOT in the environment]
    OPENBRAIN_DEVELOPMENT_ROOT=.../redprove/fakedev/Development written to the installed env file
    OPENBRAIN_DEVELOPMENT_ROOT pass-through added to the wrapper
```

Installed env file line 9, and the allowlist line inside `exec env -i`:

```
  9: OPENBRAIN_DEVELOPMENT_ROOT=/Volumes/.../redprove/fakedev/Development

105:   OPENBRAIN_TOKEN="${OPENBRAIN_TOKEN:-}" \
106:   OPENBRAIN_DEVELOPMENT_ROOT="${OPENBRAIN_DEVELOPMENT_ROOT:-}" \   <== ADDED
```

Idempotent across a re-run (exactly 1 env assignment, 1 pass-through). Refusal fires with a named remediation when no root resolves, and on an explicit root that does not exist. Underlying behavior, clean subprocess per case:

```
BEFORE  root: /Volumes/ThunderBolt/Development   scope: None
AFTER   root: .../devroot-probe/Development      scope: DevelopmentScope(..., project='open-brain')
```

**Reproducing on the Mini takes care:** `/Users/rico/Development` here is a symlink to the ThunderBolt volume and `_canonical_directory` calls `.resolve()`, so probing with that path returns a healthy scope in both the broken and fixed cases and hides the defect entirely.

## Gates

- `sh -n` and `bash -n` clean on both scripts; `shellcheck -S warning` clean on both.
- `bun install --frozen-lockfile`, `bunx tsc --noEmit` clean.

## Critical Self-Review

- Highest-risk behavior: `setup-client.sh` now refuses to install on a box where no Development root resolves, which is a new way for an install to stop; the probe order and the `OPENBRAIN_ALLOW_NO_DEVELOPMENT_ROOT=1` opt-out were both exercised in the isolated-HOME run.
- Assumptions that could be wrong: that the two probed layouts cover the fleet — a box with its tree at a third location and neither variable exported will be refused rather than silently misconfigured, which is the intended trade but is a behavior change for that box.
- Missing/weak tests: these are shell installers with no unit-test harness in this repo, so the evidence is the isolated-HOME run above rather than a committed test; the wrapper-anchor rewrite would fail loudly if the wrapper's `env -i` shape changed, and it exits with an explicit hand-edit instruction rather than silently skipping.
- Security/permission risk: no change to token handling or file modes; the env file stays 0600 and the wrapper 0755, and the added variable is a filesystem path, not a credential.
- Migration/deploy risk: existing installs keep working unchanged because the shipped default is still correct on the Mini; re-running the installer is idempotent and rewrites rather than duplicating either edit.
- Downstream client/runtime risk: the Python package is untouched and no MCP tool, schema, or client call shape changes, so `docs/downstream-rollout.md` classification is installer-only with no rtech-mcps, mcp2cli, or Hermes step implied.
- Rollback/cleanup concern: reverting the commit restores the previous scripts, and an already-installed box keeps its env line and pass-through, both of which are inert on a machine where the default root is correct.
- Fixes made before PR: caught a `{BUILD_ROOT}` reference inside a non-f-string heredoc in `client-bundle.sh` that would have crashed the staging step, and corrected it to an argv-passed value; also corrected the GOTCHAS section header that claimed "these four".
- Known residual risk: the refusal path was proven with a harness that redirects the probe list, because this machine legitimately has `/Volumes/ThunderBolt/Development` and cannot reach the no-candidate branch naturally; the branch itself is a plain `if [ -z ... ]` and its message was printed verbatim by that run. A round-2 verifier also suggested an automated fixture-HOME test covering the installer's branches (resolve, refuse, write, re-run) so this class of defect is caught by CI rather than by a reviewer running the harness by hand; deferred, and tracked as a checklist item on #555.
- SME review-memory update: [x] not applicable because: this is installer and env-plumbing work with no new reviewable code pattern; the operational trap is recorded in `docs/GOTCHAS.md`, which is where client-install traps already live.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: no server, schema, or MCP surface changes; the fix is entirely in client installer scripts and docs, and the behavior it restores was proven directly against `openbrain-provider`'s scope resolver.

## Contract Parity

- Contract parity: [x] runtime-specific because: no contract, schema, or tool surface changes — the change is shell installer and bundle staging plus docs, and the Python package is untouched, so there are no fixtures to update.



## Round 2 (verifier findings, fixed and re-verified)

- Whitespace defect (CONFIRMED by execution): a Development root containing a space was written unquoted; the wrapper's POSIX `set -a; . env-file` sourced it to empty and — because the wrapper runs `set -eu` — aborted the wrapper entirely, so the hook never ran. Both env writers now quote via `shlex.quote` (shell-safe paths stay byte-identical, upgrades over an older unquoted install rewrite to exactly one quoted assignment), red-proven with a space-containing fixture root end-to-end through `exec env -i` to the child.
- Ordering: the pure resolution guard hoisted to section 0 — a refusal now fires with zero side effects (0 wheel installs, no env dir), measured on both orderings.
- Round 3 (docs): the runbook's hand-edit table now teaches the quoted spelling with the why.
