### PR TITLE
fix(provider): tell the operator when the configured Development root is absent

### DIFF
--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -48,7 +48,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
-from .development_scope import development_root, resolve_development_scope
+from .development_scope import (
+    describe_development_root,
+    development_root,
+    development_root_missing,
+    render_scope_diagnosis,
+    resolve_development_scope,
+)
 from .gate_presentation import (
     PresentationContext,
     capture_banner,
@@ -297,8 +303,18 @@ class _Gate:
         `context-budget-gate.ts:352-355` has this defect. It is fixed here
         rather than there, per the port's rule that bugs are fixed by being
         written correctly in Python.
+
+        The same fallback fails a second way when the CONFIGURED ROOT does not
+        exist on this machine: every composition from it names a directory that
+        cannot be entered, and the operator reads it as their own cwd
+        (open-brain#556). So a measured cwd is preferred over any composed path
+        whenever the root is absent -- it is the one directory here known to be
+        real. The diagnosis itself is emitted separately, by
+        `_warn_missing_development_root`.
         """
         if self.event.cwd and resolve_development_scope(self.event.cwd) is not None:
+            return self.event.cwd
+        if development_root_missing() and self.event.cwd:
             return self.event.cwd
         project = self.state.project or ""
         root = development_root()
@@ -721,11 +737,35 @@ _HANDLERS: Final[dict[str, Any]] = {
 }
 
 
+def _warn_missing_development_root(event: HookEvent, stderr: TextIO | None) -> None:
+    """Say so on stderr when the configured Development root does not exist.
+
+    Diagnostic only, and deliberately NOT a verdict. The gate's contract is that
+    it must not deadlock on what it gates (#419), and the repair for an absent
+    root is an environment variable the operator exports in a shell -- so a gate
+    that blocked here would be gating its own escape. Loud, then out of the way.
+
+    stderr rather than stdout for the same reason: stdout is the hook's verdict
+    channel and a JSON reader is on the other end of it.
+
+    Args:
+        event: The hook event, read for its measured cwd.
+        stderr: Where the diagnosis goes. Defaults to ``sys.stderr``.
+    """
+    if not development_root_missing():
+        return
+    diagnosis = describe_development_root(event.cwd or None)
+    if diagnosis is None:
+        return
+    print(render_scope_diagnosis(diagnosis), file=stderr or sys.stderr)
+
+
 def main(
     argv: list[str] | None = None,
     *,
     stdin: TextIO | None = None,
     stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
     env: dict[str, str] | None = None,
 ) -> int:
     """Run one gate invocation.
@@ -734,16 +774,19 @@ def main(
         argv: Command-line arguments. Defaults to ``sys.argv[1:]``.
         stdin: The hook's stdin. Defaults to ``sys.stdin``.
         stdout: The return channel. Defaults to ``sys.stdout``.
+        stderr: The diagnostic channel. Defaults to ``sys.stderr``.
         env: Environment mapping for defaults. Defaults to ``os.environ``.
 
     Returns:
         The process exit code: ``0`` for every verdict including a block, and
         ``1`` only for a REFUSED operator command. A block is data on stdout;
-        a non-zero exit means the hook itself failed.
+        a non-zero exit means the hook itself failed. An absent Development root
+        changes none of this -- it is reported on stderr and nothing else.
     """
     environment = dict(os.environ) if env is None else env
     args = _build_parser(environment).parse_args(sys.argv[1:] if argv is None else argv)
     event = read_hook_event(stdin)
+    _warn_missing_development_root(event, stderr)
     gate = _Gate(args, event, stdout)
     handler = _HANDLERS[gate.event_name]
     result = handler(gate)

--- a/python/openbrain-provider/src/openbrain_provider/development_scope.py
+++ b/python/openbrain-provider/src/openbrain_provider/development_scope.py
@@ -9,8 +9,17 @@ Ported from `ob-memory-provider.ts:336-338` (`resolveDevelopmentScope`) and its
 helpers at `:1455-1534`, which is the only piece of that 2,046-line module the
 gates actually import.
 
+A `None` answer has two causes, and they are not the same event. The cwd may be
+somebody else's repository — expected, and silent on purpose. Or the CONFIGURED
+ROOT ITSELF may not exist on this machine, which is a misconfiguration of the
+operator's own box and has no business being silent. `development_root_missing`
+and `describe_development_root` separate them, so a caller can stay quiet for
+the first and speak up for the second (open-brain#556).
+
 What this module does NOT do: it does not read config, contact a server, or
-decide anything about memory. It answers one question about one path.
+decide anything about memory. It answers one question about one path. It also
+does not decide what a caller does with a diagnosis — it renders the text and
+leaves the verdict to the gate, whose fail posture is its own.
 """
 
 from __future__ import annotations
@@ -26,10 +35,18 @@ __all__ = [
     "APPROVED_TEMP_WORKTREE_ROOTS",
     "DEFAULT_DEVELOPMENT_ROOT",
     "development_root",
+    "development_root_missing",
     "DevelopmentScope",
+    "ScopeDiagnosis",
     "approved_temp_worktree_path",
+    "describe_development_root",
+    "render_scope_diagnosis",
     "resolve_development_scope",
 ]
+
+#: The environment variable that overrides the shipped root. Named once here so
+#: the diagnosis can quote the exact spelling an operator has to export.
+DEVELOPMENT_ROOT_ENV_VAR: Final[str] = "OPENBRAIN_DEVELOPMENT_ROOT"
 
 #: ob-memory-provider.ts:143. The one lane root, as shipped. Public because the
 #: parity fixtures were recorded against it and have to recognise it by name.
@@ -59,8 +76,92 @@ def development_root() -> Path:
         The override when set and non-empty, else the shipped default. The
         default is unchanged, so production behaviour is identical.
     """
-    override = os.environ.get("OPENBRAIN_DEVELOPMENT_ROOT", "").strip()
+    override = os.environ.get(DEVELOPMENT_ROOT_ENV_VAR, "").strip()
     return Path(override) if override else DEFAULT_DEVELOPMENT_ROOT
+
+
+def development_root_missing() -> bool:
+    """Report whether the configured Development root is absent on this machine.
+
+    This is the half of a `None` scope that is a MISCONFIGURATION rather than a
+    correct silence. Kept separate from :func:`resolve_development_scope` on
+    purpose: a caller in somebody else's repository asks about a cwd and should
+    hear nothing, while a caller on a machine whose root does not exist has a
+    problem no amount of cwd changing will fix.
+
+    Returns:
+        True when the configured root is not an existing directory.
+    """
+    return _canonical_directory(development_root()) is None
+
+
+@dataclass(frozen=True)
+class ScopeDiagnosis:
+    """Why scope could not resolve, in the terms an operator can act on.
+
+    Attributes:
+        configured_root: The root that was consulted and found absent.
+        source: Where that value came from -- the env var name, or ``default``.
+        cwd: The directory actually measured, never a composed substitute.
+    """
+
+    configured_root: Path
+    source: str
+    cwd: Path
+
+
+def describe_development_root(cwd: str | Path | None) -> ScopeDiagnosis | None:
+    """Describe an absent Development root, or None when nothing is wrong.
+
+    Args:
+        cwd: The directory the caller is actually in. Recorded as measured; a
+            caller that has no cwd to report gets the process's, because a
+            diagnosis quoting a composed path is the defect this closes.
+
+    Returns:
+        The diagnosis when the configured root does not exist, else None. An
+        existing root always answers None, even when the cwd is out of lane --
+        that case is not a misconfiguration and must stay silent.
+    """
+    if not development_root_missing():
+        return None
+    override = os.environ.get(DEVELOPMENT_ROOT_ENV_VAR, "").strip()
+    measured = Path(cwd) if cwd is not None else Path.cwd()
+    return ScopeDiagnosis(
+        configured_root=development_root(),
+        source=DEVELOPMENT_ROOT_ENV_VAR if override else "default",
+        cwd=measured,
+    )
+
+
+def render_scope_diagnosis(diagnosis: ScopeDiagnosis) -> str:
+    """Render a diagnosis as the operator-facing line.
+
+    Three facts, in the order a reader needs them: the root that was consulted
+    and where that value came from, the directory actually measured, and the one
+    command that resolves it. The cwd is labelled, so the configured root can
+    never be misread as the session's directory -- which is exactly what
+    happened on the Air (open-brain#556).
+
+    Args:
+        diagnosis: The absent-root diagnosis.
+
+    Returns:
+        A single multi-line string, safe for stderr or a receipt field.
+    """
+    origin = (
+        "shipped default"
+        if diagnosis.source == "default"
+        else f"set via {DEVELOPMENT_ROOT_ENV_VAR}"
+    )
+    return (
+        "Open Brain: the configured Development root does not exist on this "
+        "machine.\n"
+        f"  configured root: {diagnosis.configured_root} ({origin})\n"
+        f"  cwd: {diagnosis.cwd}\n"
+        f"  fix: export {DEVELOPMENT_ROOT_ENV_VAR}=<this machine's Development "
+        "directory>"
+    )
 
 
 #: ob-memory-provider.ts:144-147. A worktree under one of these still counts as
@@ -239,6 +340,11 @@ def resolve_development_scope(cwd: str | Path | None) -> DevelopmentScope | None
         The scope when the directory is inside Development, or inside an
         approved temp worktree of the SAME repository. None otherwise — and None
         is what makes the gate silent outside its lane.
+
+        None does NOT distinguish "not my repository" from "the configured root
+        is absent on this machine". A caller that reports anything to an
+        operator must ask :func:`describe_development_root` before falling
+        silent, or it reproduces open-brain#556.
     """
     if cwd is None:
         return None

--- a/python/openbrain-provider/tests/gate_harness.py
+++ b/python/openbrain-provider/tests/gate_harness.py
@@ -117,10 +117,20 @@ def gate_paths(root: Path) -> GatePaths:
 
 @dataclass(frozen=True)
 class GateResult:
-    """One gate invocation's answer."""
+    """One gate invocation's answer.
+
+    Attributes:
+        stdout: The verdict channel, which a JSON reader is on the other end of.
+        code: The process exit code.
+        stderr: The operator-facing diagnostic channel, captured separately.
+            Held apart from ``stdout`` because the gate's contract is that a
+            diagnosis never contaminates the verdict -- an assertion that could
+            not tell the two apart would not be able to prove that.
+    """
 
     stdout: str
     code: int
+    stderr: str = ""
 
     @property
     def json(self) -> dict[str, Any]:
@@ -161,7 +171,12 @@ def run_gate(
         session_id: Session the event belongs to.
 
     Returns:
-        The answer.
+        The answer, with the verdict and the diagnosis captured separately.
+
+    Both streams are passed in explicitly. ``main`` selects ``stderr or
+    sys.stderr``, so leaving it unset would send any diagnosis to the real
+    process stderr, where no assertion can reach it -- which is how the
+    operator-facing text stayed untested while the suite stayed green.
     """
     stdin_payload = payload if payload is not None else {}
     stdin_payload.setdefault("session_id", session_id)
@@ -190,13 +205,15 @@ def run_gate(
         argv += ["--project", project]
     argv += extra or []
     stdout = io.StringIO()
+    stderr = io.StringIO()
     code = context_budget_gate.main(
         argv,
         stdin=io.StringIO(json.dumps(stdin_payload)),
         stdout=stdout,
+        stderr=stderr,
         env={"HOME": str(paths.root)},
     )
-    return GateResult(stdout=stdout.getvalue(), code=code)
+    return GateResult(stdout=stdout.getvalue(), code=code, stderr=stderr.getvalue())
 
 
 def run_policy_gate(

--- a/python/openbrain-provider/tests/test_development_scope_diagnosis.py
+++ b/python/openbrain-provider/tests/test_development_scope_diagnosis.py
@@ -1,0 +1,139 @@
+"""A configured Development root that does not exist must be loud.
+
+`resolve_development_scope` answers None for two unrelated reasons: the cwd is
+somebody else's repository (correct, and silent by design), or the configured
+root does not exist on this machine (a misconfiguration of the operator's own
+box). Field-proved on the Air, 2026-08-04: those two were indistinguishable, so
+the memory provider exited clean with no output and the context-budget gate
+printed the shipped default path in the position where an operator reads a cwd.
+
+These tests pin the distinction, the diagnosis text, and — equally load-bearing
+— that the diagnosis does NOT introduce a new blocking posture. The gate's own
+docstring forbids deadlocking on what it gates (#419), so a root the operator
+cannot reach must never gate the command that repairs it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openbrain_provider.development_scope import (
+    DEFAULT_DEVELOPMENT_ROOT,
+    ScopeDiagnosis,
+    describe_development_root,
+    development_root_missing,
+    render_scope_diagnosis,
+    resolve_development_scope,
+)
+
+
+@pytest.fixture
+def absent_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the override at a path that does not exist."""
+    missing = tmp_path / "not-on-this-machine" / "Development"
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(missing))
+    return missing
+
+
+def test_absent_configured_root_is_reported_as_missing(absent_root: Path) -> None:
+    """The misconfiguration answers True, and scope still resolves to None."""
+    assert development_root_missing() is True
+    assert resolve_development_scope(Path.cwd()) is None
+
+
+def test_present_root_outside_lane_is_not_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Somebody else's repository stays silent: the root exists, so nothing is wrong.
+
+    This is the case the module docstring protects. If it ever started reporting
+    a diagnosis, every hook in an unrelated repository would start talking.
+    """
+    root = tmp_path / "Development"
+    root.mkdir(parents=True)
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(root))
+
+    elsewhere = tmp_path / "someone-elses-repo"
+    elsewhere.mkdir()
+
+    assert development_root_missing() is False
+    assert resolve_development_scope(elsewhere) is None
+
+
+def test_diagnosis_names_the_configured_root_and_its_source(absent_root: Path) -> None:
+    """The override case names the environment variable it came from."""
+    diagnosis = describe_development_root(cwd=Path("/private/var/somewhere"))
+
+    assert diagnosis is not None
+    assert diagnosis.configured_root == absent_root
+    assert diagnosis.source == "OPENBRAIN_DEVELOPMENT_ROOT"
+    assert diagnosis.cwd == Path("/private/var/somewhere")
+
+
+def test_diagnosis_names_the_shipped_default_when_no_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no override set, the diagnosis says the value is the shipped default.
+
+    Only meaningful when the default is genuinely absent, which is the machine
+    this bug was found on; where it exists there is nothing to diagnose.
+    """
+    monkeypatch.delenv("OPENBRAIN_DEVELOPMENT_ROOT", raising=False)
+    if DEFAULT_DEVELOPMENT_ROOT.is_dir():
+        pytest.skip("the shipped default exists here, so there is no misconfiguration")
+
+    diagnosis = describe_development_root(cwd=Path("/private/var/somewhere"))
+
+    assert diagnosis is not None
+    assert diagnosis.configured_root == DEFAULT_DEVELOPMENT_ROOT
+    assert diagnosis.source == "default"
+
+
+def test_no_diagnosis_when_the_root_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reachable root produces no diagnosis at all."""
+    root = tmp_path / "Development"
+    root.mkdir(parents=True)
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(root))
+
+    assert describe_development_root(cwd=tmp_path) is None
+
+
+def test_rendered_text_prints_the_measured_cwd_not_the_default() -> None:
+    """The operator-facing text must never substitute the default for the cwd.
+
+    This is the exact Air symptom: remediation text quoted the hardcoded default
+    in the position where the reader expects the directory they are standing in.
+    """
+    diagnosis = ScopeDiagnosis(
+        configured_root=Path("/Volumes/ThunderBolt/Development"),
+        source="default",
+        cwd=Path("/Users/rico/somewhere-real"),
+    )
+
+    text = render_scope_diagnosis(diagnosis)
+
+    assert "/Users/rico/somewhere-real" in text
+    assert "OPENBRAIN_DEVELOPMENT_ROOT" in text
+    assert "/Volumes/ThunderBolt/Development" in text
+    # The measured cwd is quoted after the word that introduces it, so the
+    # default cannot be read as the session's directory.
+    assert "cwd: /Users/rico/somewhere-real" in text
+
+
+def test_rendered_text_distinguishes_override_from_default() -> None:
+    """An operator who already set the variable is told the value they set."""
+    diagnosis = ScopeDiagnosis(
+        configured_root=Path("/opt/dev"),
+        source="OPENBRAIN_DEVELOPMENT_ROOT",
+        cwd=Path("/opt/work"),
+    )
+
+    text = render_scope_diagnosis(diagnosis)
+
+    assert "/opt/dev" in text
+    assert "OPENBRAIN_DEVELOPMENT_ROOT" in text
+    assert "cwd: /opt/work" in text

--- a/python/openbrain-provider/tests/test_gate_scope_diagnosis.py
+++ b/python/openbrain-provider/tests/test_gate_scope_diagnosis.py
@@ -1,0 +1,84 @@
+"""The gate's remediation text on a machine whose configured root is absent.
+
+Field-proved on the Air, 2026-08-04: the context-budget gate blocked tool calls
+and printed remediation text quoting the shipped default path as though it were
+the session's directory. The operator pasted a `cd` into a directory that does
+not exist on that machine, so the block could not be cleared from inside the
+session.
+
+`_development_cwd` is where that string is produced, so that is where this is
+pinned. The companion assertion is that the diagnosis does not make the gate
+newly blocking: `context_budget_gate`'s own docstring forbids deadlocking on
+what it gates (#419), and a root the operator cannot reach is precisely the
+state in which the repair command must still run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from gate_harness import gate_paths, run_gate
+
+from openbrain_provider import context_budget_gate
+from openbrain_provider.hook_io import HookEvent
+
+
+@pytest.fixture
+def absent_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Configure a Development root that does not exist on this machine."""
+    missing = tmp_path / "absent-volume" / "Development"
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(missing))
+    return missing
+
+
+def _gate(paths_root: Path, cwd: Path) -> context_budget_gate._Gate:
+    """Build a gate whose event reports a real cwd outside the lane."""
+    args = context_budget_gate._build_parser({"HOME": str(paths_root)}).parse_args(
+        [
+            "--event",
+            "status",
+            "--session-id",
+            "scope-diagnosis",
+            "--state-path",
+            str(paths_root / "gate.json"),
+            "--project",
+            "open-brain",
+        ]
+    )
+    event = HookEvent({"session_id": "scope-diagnosis", "cwd": str(cwd)})
+    return context_budget_gate._Gate(args, event, None)
+
+
+def test_recovery_cwd_is_the_measured_directory_not_the_absent_root(
+    tmp_path: Path, absent_root: Path
+) -> None:
+    """The recovery command carries where the operator actually is.
+
+    Old behaviour composed `<configured root>/<project>` — a path that cannot
+    exist when the configured root itself does not. The measured cwd is a real
+    directory, so the command it produces can actually run.
+    """
+    here = tmp_path / "real-working-directory"
+    here.mkdir(parents=True)
+
+    recovery = _gate(tmp_path, here)._development_cwd()
+
+    assert recovery == str(here)
+    assert str(absent_root) not in recovery
+
+
+def test_gate_still_answers_when_the_configured_root_is_absent(
+    tmp_path: Path, absent_root: Path
+) -> None:
+    """A misconfigured root must not become a new block.
+
+    #419: the gate must not deadlock on what it gates. The remediation for an
+    absent root is an environment variable the operator sets in a shell, so a
+    gate that blocked here would gate its own repair.
+    """
+    paths = gate_paths(tmp_path / "gate")
+    result = run_gate(paths, "status", payload={"cwd": str(tmp_path)}, project=None)
+
+    assert result.code == 0
+    assert not result.blocked

--- a/python/openbrain-provider/tests/test_gate_scope_diagnosis.py
+++ b/python/openbrain-provider/tests/test_gate_scope_diagnosis.py
@@ -82,3 +82,79 @@ def test_gate_still_answers_when_the_configured_root_is_absent(
 
     assert result.code == 0
     assert not result.blocked
+
+
+def test_absent_root_diagnoses_on_stderr_through_the_gate_entrypoint(
+    tmp_path: Path, absent_root: Path
+) -> None:
+    """A full `main()` run tells the operator what is wrong and how to fix it.
+
+    The two tests above pin the pieces -- the recovery path and the non-blocking
+    posture -- but neither runs the entrypoint that decides whether the operator
+    ever SEES a diagnosis. Deleting the `_warn_missing_development_root` call
+    from `main()` leaves both of them passing and restores the Air's silence
+    verbatim, which is the gap this closes.
+
+    Four facts are asserted because all four were wrong or missing in the field
+    report: the root consulted, where that value came from, the directory
+    actually measured, and the variable that repairs it.
+    """
+    here = tmp_path / "real-working-directory"
+    here.mkdir(parents=True)
+    paths = gate_paths(tmp_path / "gate")
+
+    result = run_gate(paths, "status", payload={"cwd": str(here)}, project=None)
+
+    assert str(absent_root) in result.stderr
+    assert "set via OPENBRAIN_DEVELOPMENT_ROOT" in result.stderr
+    assert str(here) in result.stderr
+    assert "export OPENBRAIN_DEVELOPMENT_ROOT" in result.stderr
+
+
+def test_present_root_with_out_of_lane_cwd_says_nothing_on_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Somebody else's repository stays silent.
+
+    The gate runs in every directory the agent visits. A diagnosis that fired on
+    an out-of-lane cwd -- rather than only on an absent root -- would put this
+    text in front of the operator constantly, and noise that appears everywhere
+    is read as normal and stops carrying information. Silence here is what makes
+    the loud case worth reading.
+    """
+    root = tmp_path / "Development"
+    root.mkdir(parents=True)
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(root))
+    elsewhere = tmp_path / "somebody-elses-repository"
+    elsewhere.mkdir(parents=True)
+    paths = gate_paths(tmp_path / "gate")
+
+    result = run_gate(paths, "status", payload={"cwd": str(elsewhere)}, project=None)
+
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize("root_exists", [False, True])
+def test_stdout_stays_the_untouched_verdict_channel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, root_exists: bool
+) -> None:
+    """The diagnosis never contaminates the JSON a hook reader parses.
+
+    stdout is consumed by a JSON parser on the other end of the hook. Prose
+    written there would not be a cosmetic problem -- it would make the verdict
+    unreadable and the gate's answer indeterminate. Parsed rather than
+    pattern-matched, because parsing is the assertion that actually matches what
+    the reader does.
+    """
+    root = tmp_path / "Development"
+    if root_exists:
+        root.mkdir(parents=True)
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(root))
+    here = tmp_path / "real-working-directory"
+    here.mkdir(parents=True)
+    paths = gate_paths(tmp_path / "gate")
+
+    result = run_gate(paths, "status", payload={"cwd": str(here)}, project=None)
+
+    assert result.code == 0
+    assert isinstance(result.json, dict)

--- a/python/openbrain/src/openbrain/apps/hooks/receipts.py
+++ b/python/openbrain/src/openbrain/apps/hooks/receipts.py
@@ -58,10 +58,46 @@ from openbrain.receipts import (
     resolve_development_scope,
     start_compact_cycle,
 )
+from openbrain.receipts.scope import (
+    DEVELOPMENT_ROOT_ENV_VAR,
+    development_root,
+    development_root_missing,
+    development_root_origin,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+
+
+def _warn_missing_development_root(event: str, cwd: str | Path | None) -> None:
+    """Log when no receipt was written because the configured root is absent.
+
+    An out-of-scope ``cwd`` is silent on purpose -- it is somebody else's
+    repository. A configured root that does not exist on this machine is not
+    that: it is a misconfiguration, it makes EVERY directory out of scope, and
+    left silent it is indistinguishable from working correctly. Field-proved on
+    the Air (open-brain#556), where the provider exited clean with no output and
+    no receipt.
+
+    Names the measured ``cwd``, never a path composed from the absent root.
+
+    Args:
+        event: The hook name, for the log line only.
+        cwd: The hook payload's working directory, as measured.
+    """
+    if not development_root_missing():
+        return
+    origin = development_root_origin()
+    logger.warning(
+        "{} receipt not recorded: the configured Development root {} ({}) does "
+        "not exist on this machine; cwd: {}; set {} for this machine",
+        event,
+        development_root(),
+        origin,
+        cwd if cwd is not None else "<none reported>",
+        DEVELOPMENT_ROOT_ENV_VAR,
+    )
 
 
 def note_compaction(
@@ -266,6 +302,7 @@ def _guarded(
     """
     scope = resolve_development_scope(cwd)
     if scope is None:
+        _warn_missing_development_root(event, cwd)
         return None
 
     try:

--- a/python/openbrain/src/openbrain/receipts/scope.py
+++ b/python/openbrain/src/openbrain/receipts/scope.py
@@ -45,10 +45,58 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
 
-#: The one directory tree Development work happens in. A literal, matching
-#: ``DEVELOPMENT_ROOT``; the gate has the same literal, and a configurable value
-#: on one side only would put the writer and the reader in different scopes.
+#: The one directory tree Development work happens in, as shipped.
+#:
+#: The gate side became overridable (``openbrain_provider.development_scope``)
+#: because a machine without this exact macOS volume resolves every scope to
+#: None. This side reads the SAME variable, deliberately: a configurable value
+#: on one side only would put the writer and the reader in different scopes,
+#: which is what the previous literal-only comment was protecting against.
 DEVELOPMENT_ROOT = Path("/Volumes/ThunderBolt/Development")
+
+#: The override both sides honour. Spelled identically to the gate's.
+DEVELOPMENT_ROOT_ENV_VAR = "OPENBRAIN_DEVELOPMENT_ROOT"
+
+
+def development_root() -> Path:
+    """Return the Development root, honouring the shared override.
+
+    Read per call rather than frozen at import, matching the gate: the value is
+    answered against the FILESYSTEM, and a module constant is evaluated during
+    pytest collection, before a conftest can set the variable.
+
+    Returns:
+        The override when set and non-empty, else the shipped default.
+    """
+    override = os.environ.get(DEVELOPMENT_ROOT_ENV_VAR, "").strip()
+    return Path(override) if override else DEVELOPMENT_ROOT
+
+
+def development_root_missing() -> bool:
+    """Report whether the configured Development root is absent here.
+
+    Separates the two causes of a ``None`` scope: somebody else's repository
+    (silent by design) versus a root that does not exist on this machine (a
+    misconfiguration -- open-brain#556).
+
+    Returns:
+        True when the configured root is not an existing directory.
+    """
+    return _canonical_directory(development_root()) is None
+
+
+def development_root_origin() -> str:
+    """Name where the configured root's value came from.
+
+    Returns:
+        The environment variable name when it is set and non-empty, else
+        ``shipped default``. Quoted in the diagnosis so an operator who already
+        exported the variable is told the value THEY set, not a default they did
+        not choose.
+    """
+    override = os.environ.get(DEVELOPMENT_ROOT_ENV_VAR, "").strip()
+    return DEVELOPMENT_ROOT_ENV_VAR if override else "shipped default"
+
 
 #: Temp roots a Development worktree may legitimately live under, matching
 #: ``APPROVED_TEMP_WORKTREE_ROOTS``. The first is Rico's Mac, the second the
@@ -143,7 +191,7 @@ def _scoped_cwd(cwd: Path) -> Path | None:
     shape. The git check is what stops an arbitrary directory that happens to sit
     in the temp workspace from claiming Development scope.
     """
-    root = _canonical_directory(DEVELOPMENT_ROOT)
+    root = _canonical_directory(development_root())
     candidate = _canonical_directory(cwd)
     if root is None or candidate is None:
         return None
@@ -166,7 +214,7 @@ def _project_slug(cwd: Path) -> str:
     its own git top level, falling back to the directory when git says nothing.
     """
     top = _git_path(cwd, "--show-toplevel")
-    root = _canonical_directory(DEVELOPMENT_ROOT)
+    root = _canonical_directory(development_root())
     if top is not None and root is not None and _same_git_repository(top, root):
         return root.name
 

--- a/python/openbrain/tests/test_receipts_scope_diagnosis.py
+++ b/python/openbrain/tests/test_receipts_scope_diagnosis.py
@@ -1,0 +1,132 @@
+"""A missing Development root must not be a silent no-op on the receipt side.
+
+Field-proved on the Air, 2026-08-04 (open-brain#556): on a machine where the
+configured root does not exist, the provider exited CLEAN with no receipt and no
+output, so an operator could not tell "worked" from "did nothing". The guarded
+writer returned None for an unresolved scope without logging anything -- unlike
+the failure path directly below it, which does log.
+
+The distinction these pin: out of scope stays silent (it is somebody else's
+repository), while an absent configured root speaks up (it is a misconfiguration
+that makes EVERY directory out of scope).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from loguru import logger
+
+from openbrain.apps.hooks import receipts as hook_receipts
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from openbrain.receipts.scope import (
+    development_root,
+    development_root_missing,
+    development_root_origin,
+)
+
+
+@pytest.fixture
+def warnings() -> Iterator[list[str]]:
+    """Collect loguru warnings as text.
+
+    loguru does not write through the stdlib logging tree, so `caplog` sees
+    nothing, and its default sink holds a stderr reference that `capsys` cannot
+    intercept. A sink of our own asserts the MESSAGE rather than the transport,
+    which is what these tests are actually about.
+    """
+    captured: list[str] = []
+    sink_id = logger.add(lambda message: captured.append(str(message)), level="WARNING")
+    try:
+        yield captured
+    finally:
+        logger.remove(sink_id)
+
+
+@pytest.fixture
+def absent_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Configure a Development root that does not exist on this machine."""
+    missing = tmp_path / "absent-volume" / "Development"
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(missing))
+    return missing
+
+
+def test_absent_root_is_detected_and_attributed(absent_root: Path) -> None:
+    """The root is reported missing and attributed to the variable that set it."""
+    assert development_root_missing() is True
+    assert development_root() == absent_root
+    assert development_root_origin() == "OPENBRAIN_DEVELOPMENT_ROOT"
+
+
+def test_present_root_reports_the_shipped_default_origin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no override, the origin is named as the shipped default."""
+    monkeypatch.delenv("OPENBRAIN_DEVELOPMENT_ROOT", raising=False)
+    assert development_root_origin() == "shipped default"
+
+
+def test_absent_root_logs_a_diagnosis_naming_the_measured_cwd(
+    absent_root: Path, warnings: list[str]
+) -> None:
+    """The warning names the root, its origin, the measured cwd, and the fix.
+
+    The cwd is the one the caller reported, never a path composed from the
+    absent root -- that substitution is the Air symptom.
+    """
+    measured = "/Users/rico/some-real-directory"
+
+    hook_receipts._warn_missing_development_root("stop", measured)
+
+    text = "".join(warnings)
+    assert str(absent_root) in text
+    assert "OPENBRAIN_DEVELOPMENT_ROOT" in text
+    assert measured in text
+
+
+def test_out_of_scope_cwd_stays_silent_when_the_root_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, warnings: list[str]
+) -> None:
+    """Somebody else's repository logs nothing at all.
+
+    This is the behaviour the scope module exists to provide. If a diagnosis
+    ever fired here, every hook in every unrelated repo would start warning.
+    """
+    root = tmp_path / "Development"
+    root.mkdir(parents=True)
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOT", str(root))
+
+    hook_receipts._warn_missing_development_root("stop", str(tmp_path / "other"))
+
+    assert warnings == []
+
+
+def test_guarded_write_is_skipped_but_diagnosed(
+    absent_root: Path, tmp_path: Path, warnings: list[str]
+) -> None:
+    """No receipt is written, and the reason is now visible.
+
+    The write still does not happen -- an absent root means there is no resolved
+    project to file under. What changes is that the skip is no longer silent.
+    """
+    calls: list[str] = []
+
+    def _write(project: str, path: Path) -> str:
+        calls.append(project)
+        return "written"
+
+    result = hook_receipts._guarded(
+        "stop",
+        _write,
+        str(tmp_path),
+        tmp_path / "receipts.json",
+    )
+
+    assert result is None
+    assert calls == []
+    assert "OPENBRAIN_DEVELOPMENT_ROOT" in "".join(warnings)


### PR DESCRIPTION
Closes #556.

## What was wrong

`resolve_development_scope` returned a bare `None` for two unrelated questions,
so every caller downstream read a misconfiguration as a correct silence:

- the cwd is somebody else's repository — expected, and quiet on purpose;
- the configured Development root does not exist on this machine — a
  misconfiguration of the operator's own box, which was equally quiet.

Field-proved on the Air, 2026-08-04:

1. `ob-memory-provider` exited CLEAN with no receipt and no output. Running the
   gate's own remediation command by hand also produced nothing, so "worked" and
   "did nothing" were indistinguishable from inside the session.
2. The context-budget gate blocked tool calls and printed remediation text
   containing the shipped default path, presented where an operator reads a
   cwd — pointing at a directory that does not exist on that machine.

## What the existing design already said

This is a delta against an explicit design, not a design gap.

- `development_scope.py:1-13` — a `None` scope keeps the hook "silent in
  somebody else's repository". Silence is scoped to that case; an absent root is
  never claimed to be it.
- `development_scope.py:39-61` — the override exists because a machine without
  the macOS volume resolves every scope to `None` and "the gate correctly falls
  silent". The failure mode was already known; nothing told the operator.
- `context_budget_gate.py:19-28` — "THE GATE MUST NOT DEADLOCK ON WHAT IT
  GATES" (#419), and "EVERY BRANCH RECORDS A NAMED TRANSITION. Silence is a
  signal (#419 acceptance)."
- `src/openbrain_provider/README.md` — "A receipt always states durability.
  Returning nothing, or returning success without persisting, is the specific
  failure this package exists to prevent."
- `cli_guard.py:16-21`, `guard.py:29-31` — enforcement "ALWAYS EXIT 0, ALWAYS
  FAIL OPEN … rather than taking out unrelated tool use."
- `gate_presentation.py:1-10` — banner text must stay the command the gate
  accepts, or the banner prints an instruction the gate then refuses.

Fail posture is therefore derived, not invented: loud and diagnostic, and
deliberately NOT newly blocking. The repair is an environment variable exported
in a shell, so a gate that blocked here would gate its own escape.

## The change

- `development_scope.py` — `development_root_missing`,
  `describe_development_root`, `render_scope_diagnosis`, and a named
  `DEVELOPMENT_ROOT_ENV_VAR`. The rendered text names the configured root, its
  origin (env var vs shipped default), the measured cwd on a labelled `cwd:`
  line, and the one-line fix.
- `context_budget_gate.py` — reports the diagnosis on stderr (stdout is the
  verdict channel), and `_development_cwd` prefers the measured cwd over any
  path composed from a root that is not there.
- `openbrain/apps/hooks/receipts.py` — the guarded writer logs why no receipt
  was written instead of returning `None` in silence.
- `openbrain/receipts/scope.py` — gains the same override the gate already had,
  so the writer and the reader cannot end up in different scopes. Its previous
  literal-only comment warned about exactly that split.

Out-of-scope cwds stay silent; that behavior is pinned by its own test.

## Red proof

Both halves were proven to fail before the fix and pass after.

Gate half, against real pre-fix code (`_development_cwd` composing from the
absent root):

```
E  AssertionError: assert '/Volumes/Thu...nt/open-brain' == '/Volumes/Thu...ing-directory'
E  - he_measu0/real-working-directory
E  + he_measu0/absent-volume/Development/open-brain
```

Receipt half, re-proven by reverting only the one-line call and restoring it:

```
E  AssertionError: assert 'OPENBRAIN_DEVELOPMENT_ROOT' in ''
1 failed, 4 passed
```

The non-blocking assertion passed both before and after, confirming no new
blocking posture was introduced.

Note on test mechanism: this package logs through loguru, which does not write
through the stdlib logging tree, so `caplog` sees nothing and its default sink
holds a stderr reference `capsys` cannot intercept. The tests add their own
loguru sink and assert the message rather than the transport.

## Validation

- `uv run mypy src/openbrain_provider` — clean (19 files)
- `uv run mypy src/openbrain` — clean (49 files)
- `uv run ruff check src tests` — clean, both packages
- `uv run pytest -q` (openbrain-provider) — 592 passed, 1 skipped
- `uv run pytest -q` (openbrain) — 570 passed, 19 deselected
- `bun install --frozen-lockfile` + `bunx tsc --noEmit` — clean
- Cross-language parity (`test_receipts_gate_crosslang`, `test_receipts_scope`)
  — 18 passed

The gotcha-agent SME lane (`docs/sme/gotcha-agent.md`) was read before writing
tests, per the mandatory lane for `python/` PRs. Its "contract tests over
wrapper name tests" rule is why the assertions are on rendered operator text and
on whether the write actually happened, not on function names.

## Critical Self-Review

- Highest-risk behavior: the new stderr write in the gate's `main()` runs on
  every invocation; if it were noisy on a healthy machine it would pollute every
  hook. It is guarded by `development_root_missing()`, which is False whenever
  the root exists, and a test asserts total silence in that case.
- Assumptions that could be wrong: that stderr is safe for the gate's
  diagnosis. stdout is the verdict channel a JSON reader consumes, and the
  existing code already logs to stderr via loguru, so this follows the
  established split rather than inventing one.
- Missing/weak tests: no end-to-end test runs the real installed
  `openbrain-memory` console script against a machine with an absent root; the
  receipt-side proof is at the `_guarded` boundary that returned the silent
  `None`. A live canary on a machine without the volume would close that gap.
- Security/permission risk: none identified. No namespace, token, auth, or SQL
  path is touched. The diagnosis prints only a configured path, a measured cwd,
  and an environment variable NAME — never its value or any credential.
- Migration/deploy risk: no schema, no migration, no data change. Behavior on a
  machine where the root exists is unchanged, which is every current host.
- Downstream client/runtime risk: `main()` gained a keyword-only `stderr`
  parameter with a default, so existing callers are unaffected; no MCP tool,
  schema, transport, or client-facing contract changes, so per
  `docs/downstream-rollout.md` downstream rollout does not apply.
- Rollback/cleanup concern: a single revert restores prior behavior; no state is
  written or persisted by this change, so nothing needs cleaning up after one.
- Fixes made before PR: switched the receipt tests off `caplog`/`capsys` to a
  loguru sink after finding they asserted the transport rather than the message;
  routed the env-origin decision into `scope.py` instead of adding an `os`
  import to `receipts.py` for one lookup.
- Known residual risk: the two scope implementations remain separate modules
  that now share an override variable by convention rather than by import. They
  are pinned together by the cross-language parity tests, but a future edit to
  one could still drift from the other.
- SME review-memory update: [x] not applicable because: this is a first
  occurrence of the absent-root silent-diagnosis pattern rather than a
  recurrence of a lane finding; no MEDIUM+ review finding was produced by this
  cycle to promote.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: the change is confined to
  local scope resolution and operator-facing diagnostics and performs no Open
  Brain read or write; the affected path is a machine whose configured root is
  absent, which no live service exercises.

## Contract Parity

- Contract parity: [x] runtime-specific because: no wire contract, fixture, or
  cross-runtime shape changes — the added diagnosis is operator-facing text on
  stderr and a log line, and the existing cross-language parity tests
  (`test_receipts_gate_crosslang`, 18 passed) confirm the recorded shapes are
  untouched.
