### PR TITLE
fix(nats): answer an undeliverable reply with an error envelope, not silence (#549)

### DIFF
--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -344,28 +344,39 @@ curl -fsS http://127.0.0.1:3100/health    # must stay healthy across a worker re
 launchctl kickstart -k "gui/$(id -u)/com.rico.open-brain-local-nats-worker"
 ```
 
-### OPEN DEFECT — large context packs get no reply at all (2026-08-04)
+### The silence is fixed; large context packs still do not fit (#549, 2026-08-04)
 
 A live request/reply on `dev.ob.memory.context_pack` returns `status: ok` in
 ~1.2s for `repo_facts` / `working_set` / `pointers`. Asking for
 `durable_memory` in the `rico` namespace currently builds a **58.5 MB** reply
 (the `durable_memory` section alone is 39.9 MB), which exceeds the broker's
-8 MB `max_payload`. The publish is rejected, `message.respond()` returns false,
-`startNatsContextPackBridge` throws "NATS request did not include a reply
-inbox", and the caller sees **no reply at all** — it waits until its own
-timeout.
+8 MB `max_payload`. The publish is rejected and `message.respond()` returns
+false.
 
-This is a real defect and not specific to this broker: `src/nats-bridge.ts`
-guards the REQUEST at `MAX_NATS_REQUEST_BYTES` (64 KB) but has **no response
-size guard**, and NATS's own protocol default `max_payload` is 1 MB — so a
-default broker or the fleet bus would fail sooner and the same silent way. The
-handler completes its work successfully first, so this burns a full context-pack
-build before dropping it.
+**What used to happen:** `startNatsContextPackBridge` threw "NATS request did
+not include a reply inbox" — a misattribution, since the reply inbox was
+present — and published nothing, so the caller saw **no reply at all** and
+waited out its own timeout with no client-visible reason.
 
-The 8 MB figure is the NATS server's own `max_payload` ceiling, not an Open
-Brain choice — this is reported here as a measurement, and how to resolve it is
-the operator's call, not something this runbook prescribes. The one thing that
-is unambiguously wrong regardless of size is the SILENCE: the bridge should
-answer with a redacted `payload_too_large` error envelope instead of leaving the
-caller to time out with no reply and no client-visible reason.
+**What happens now (#549):** the bridge answers with a redacted
+`payload_too_large` error envelope carrying the same `correlation_id` as a
+normal reply, so the caller is released immediately instead of timing out. The
+envelope is content-free — it names the measured reply bytes, the broker's own
+advertised `max_payload`, and which sections were requested, and carries no pack
+data. Before publishing, the bridge compares the encoded reply against the
+figure the broker advertises on the connection (`connection.info.max_payload`),
+never a value of Open Brain's own, so a broker advertising the NATS protocol
+default of 1 MB and this one advertising 8 MB are both handled correctly. If the
+publish is refused anyway, the error envelope is sent regardless. Only when that
+small envelope is ALSO refused does the bridge log a missing reply inbox — which
+is now the accurate reading of that case.
+
+The handler still builds the full pack first, and nothing about what it builds
+changed; this changed only how an undeliverable reply is answered.
+
+**Still open:** the 58.5 MB reply does not fit an 8 MB broker, so a
+`durable_memory` request on this namespace gets a clear error rather than a
+pack. The 8 MB figure is the NATS server's own `max_payload`, not an Open Brain
+choice — it is reported here as a measurement, and how to resolve it is the
+operator's call, not something this runbook prescribes.
 

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -350,13 +350,21 @@ A live request/reply on `dev.ob.memory.context_pack` returns `status: ok` in
 ~1.2s for `repo_facts` / `working_set` / `pointers`. Asking for
 `durable_memory` in the `rico` namespace currently builds a **58.5 MB** reply
 (the `durable_memory` section alone is 39.9 MB), which exceeds the broker's
-8 MB `max_payload`. The publish is rejected and `message.respond()` returns
-false.
+8 MB `max_payload`, so the client rejects the publish.
 
-**What used to happen:** `startNatsContextPackBridge` threw "NATS request did
-not include a reply inbox" — a misattribution, since the reply inbox was
-present — and published nothing, so the caller saw **no reply at all** and
-waited out its own timeout with no client-visible reason.
+**How the rejection actually surfaces:** the nats.js client THROWS on it. Its
+`Msg.respond()` publishes through `protocol.publish()`, which raises
+`NatsError(MAX_PAYLOAD_EXCEEDED)` once the encoded length passes
+`info.max_payload` (`nats-base-client/msg.js` -> `protocol.js`). It does NOT
+return false — `respond()` returns false in exactly one case, a request that
+carried no reply inbox at all, which is unrelated to size.
+
+**What used to happen:** that throw escaped to
+`processNatsSubscriptionMessage`, whose catch logged the generic **"NATS
+context-pack bridge request failed"** and published nothing, so the caller saw
+**no reply at all** and waited out its own timeout with no client-visible
+reason. The "NATS request did not include a reply inbox" message was never the
+one this path produced; it was reserved for its own, correct condition.
 
 **What happens now (#549):** the bridge answers with a redacted
 `payload_too_large` error envelope carrying the same `correlation_id` as a
@@ -366,10 +374,15 @@ advertised `max_payload`, and which sections were requested, and carries no pack
 data. Before publishing, the bridge compares the encoded reply against the
 figure the broker advertises on the connection (`connection.info.max_payload`),
 never a value of Open Brain's own, so a broker advertising the NATS protocol
-default of 1 MB and this one advertising 8 MB are both handled correctly. If the
-publish is refused anyway, the error envelope is sent regardless. Only when that
-small envelope is ALSO refused does the bridge log a missing reply inbox — which
-is now the accurate reading of that case.
+default of 1 MB and this one advertising 8 MB are both handled correctly. When
+the figure is unreadable the reply cannot be pre-judged, so the publish is
+attempted — and that call is wrapped, so a thrown `MAX_PAYLOAD_EXCEEDED` routes
+to the same error envelope instead of escaping to the handler-error catch. The
+throw is matched by its machine **code**, never by message text, so a reworded
+client string cannot silently reopen this. Any other throw is not the bridge's
+to reinterpret and is rethrown unchanged. Only when `respond()` returns false —
+the genuine no-reply-inbox condition — does the bridge log a missing reply
+inbox, which is the accurate reading of that case.
 
 The handler still builds the full pack first, and nothing about what it builds
 changed; this changed only how an undeliverable reply is answered.

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -489,17 +489,31 @@ describe("startNatsContextPackBridge", () => {
     expect(runtime).toBeNull();
   });
 
-  it("surfaces reply failures from request messages", async () => {
+  // #549 regression lane. Before this fix the bridge threw "NATS request did
+  // not include a reply inbox" and published NOTHING, so a caller whose reply
+  // the broker refused waited out its own timeout with no reason. Each test
+  // below fails on that old behavior: the throw escapes, and no reply exists to
+  // assert against.
+  it("answers with an error envelope when the broker refuses the reply publish", async () => {
+    const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
     const driver: NatsBridgeDriver = {
       subscribe: async (subject, handler) => {
-        await expect(
-          handler({
-            subject,
-            data: data(envelope({ from: "rico" })),
-            headers: {},
-            respond: () => false,
-          } satisfies NatsRequestMessage),
-        ).rejects.toThrow("NATS request did not include a reply inbox");
+        let firstPublish = true;
+        await handler({
+          subject,
+          data: data(envelope({ id: "req-refused", from: "rico" })),
+          headers: {},
+          respond: (payload: Uint8Array) => {
+            // The broker refuses the real reply, then carries the small error
+            // envelope — exactly the live shape from the runbook.
+            if (firstPublish) {
+              firstPublish = false;
+              return false;
+            }
+            published.push(envelopeFromBytes(payload));
+            return true;
+          },
+        } satisfies NatsRequestMessage);
         return { close: () => undefined };
       },
       close: () => undefined,
@@ -512,7 +526,140 @@ describe("startNatsContextPackBridge", () => {
       driver,
     });
 
+    expect(published).toHaveLength(1);
+    const reply = published[0]!;
+    expect(reply.kind).toBe(RESPONSE_KIND);
+    expect(reply.from).toBe(RESPONSE_FROM);
+    // The correlation id is what lets the waiting caller match this reply to
+    // its request instead of timing out.
+    expect(reply.correlation_id).toBe("req-refused");
+    const payload = reply.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.operation).toBe("agent_context_pack");
+    expect(payload.error.code).toBe("payload_too_large");
+    expect(payload.error.message).toContain("broker refused");
+    expect(payload.error.message).toContain("working_set");
+
     await runtime?.close();
+  });
+
+  it("answers with an error envelope without attempting a publish the broker's advertised figure rules out", async () => {
+    const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
+    const attempts: number[] = [];
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        await handler({
+          subject,
+          data: data(envelope({ id: "req-oversized", from: "rico" })),
+          headers: {},
+          // A figure small enough that the real reply cannot fit, while the
+          // content-free error envelope still can.
+          maxPayloadBytes: 400,
+          respond: (payload: Uint8Array) => {
+            attempts.push(payload.byteLength);
+            published.push(envelopeFromBytes(payload));
+            return true;
+          },
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+      driver,
+    });
+
+    // Only the error envelope was ever put on the wire: the doomed publish was
+    // never spent, because the reply already exceeded what the broker advertises.
+    expect(attempts).toHaveLength(1);
+    const payload = published[0]!.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.error.code).toBe("payload_too_large");
+    // The envelope names the measured reply size and the broker's own figure.
+    expect(payload.error.message).toContain("400 bytes");
+    expect(payload.error.message).toMatch(/Reply was \d+ bytes/);
+    expect(published[0]!.correlation_id).toBe("req-oversized");
+
+    await runtime?.close();
+  });
+
+  it("carries the reply normally when it fits the broker's advertised figure", async () => {
+    const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        await handler({
+          subject,
+          data: data(envelope({ id: "req-ok", from: "rico" })),
+          headers: {},
+          maxPayloadBytes: 8 * 1024 * 1024,
+          respond: (payload: Uint8Array) => {
+            published.push(envelopeFromBytes(payload));
+            return true;
+          },
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+      driver,
+    });
+
+    expect(published).toHaveLength(1);
+    expect((published[0]!.payload as Record<string, any>).status).toBe("ok");
+
+    await runtime?.close();
+  });
+
+  it("logs an accurate reason when even the error envelope cannot be published", async () => {
+    const loggedErrors: string[] = [];
+    const originalError = logger.error;
+    logger.error = (message, extra) => {
+      loggedErrors.push(`${message}:${JSON.stringify(extra ?? {})}`);
+    };
+
+    try {
+      const driver: NatsBridgeDriver = {
+        subscribe: async (subject, handler) => {
+          await handler({
+            subject,
+            data: data(envelope({ id: "req-no-inbox", from: "rico" })),
+            headers: {},
+            // Every publish is refused, including the small error envelope —
+            // the only case where a missing reply inbox is the accurate reading.
+            respond: () => false,
+          } satisfies NatsRequestMessage);
+          return { close: () => undefined };
+        },
+        close: () => undefined,
+      };
+
+      const runtime = await startNatsContextPackBridge({
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
+        driver,
+      });
+
+      const joined = loggedErrors.join("\n");
+      expect(joined).toContain(
+        "NATS reply could not be published to a reply inbox",
+      );
+      // The old misattribution claimed this about EVERY refused publish.
+      expect(joined).not.toContain("NATS request did not include a reply inbox");
+
+      await runtime?.close();
+    } finally {
+      logger.error = originalError;
+    }
   });
 
   it("attempts driver close when subscription close fails", async () => {
@@ -629,7 +776,15 @@ describe("startNatsContextPackBridge", () => {
           }),
         ]),
       );
+      // The `req-no-reply` message refuses EVERY publish, including the error
+      // envelope, so the bridge logs the one accurate reading of that case and
+      // moves on. It no longer throws (#549): the old throw was misattributed,
+      // and turning a refused publish into a handler error is what let the
+      // caller receive nothing at all.
       expect(loggedErrors).toContain(
+        "NATS reply could not be published to a reply inbox:",
+      );
+      expect(loggedErrors).not.toContain(
         "NATS context-pack bridge request failed:Error",
       );
       expect(loggedErrors).toContain(

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -587,6 +587,125 @@ describe("startNatsContextPackBridge", () => {
     await runtime?.close();
   });
 
+  it("answers with an error envelope when the client THROWS MaxPayloadExceeded on the reply publish", async () => {
+    // This mirrors the REAL nats.js client, which is what makes this the
+    // regression test for #549 rather than a restatement of the false-return
+    // case. `Msg.respond()` publishes through `protocol.publish()`, and that
+    // raises NatsError(MAX_PAYLOAD_EXCEEDED) — it does not return false. The
+    // false return is reserved for a genuinely absent reply inbox.
+    //
+    // The message text is deliberately NOT what the bridge matches on, so this
+    // fixture carries the machine code and prose the client is free to reword.
+    const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        let firstPublish = true;
+        await handler({
+          subject,
+          data: data(envelope({ id: "req-thrown", from: "rico" })),
+          headers: {},
+          // The figure is UNREADABLE, so the bridge cannot pre-judge the reply
+          // and must attempt the publish — the exact path that had no guard.
+          maxPayloadBytes: undefined,
+          respond: (payload: Uint8Array) => {
+            if (firstPublish) {
+              firstPublish = false;
+              const err = new Error("Maximum payload exceeded") as Error & {
+                code: string;
+                name: string;
+              };
+              err.name = "NatsError";
+              err.code = "MAX_PAYLOAD_EXCEEDED";
+              throw err;
+            }
+            published.push(envelopeFromBytes(payload));
+            return true;
+          },
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+      driver,
+    });
+
+    // The caller is answered. Before the guard the throw escaped to the
+    // handler-error catch and NOTHING was published, so this array was empty.
+    expect(published).toHaveLength(1);
+    const reply = published[0]!;
+    expect(reply.kind).toBe(RESPONSE_KIND);
+    expect(reply.from).toBe(RESPONSE_FROM);
+    // The correlation id is what releases the waiting caller.
+    expect(reply.correlation_id).toBe("req-thrown");
+    const payload = reply.payload as Record<string, any>;
+    expect(payload.status).toBe("error");
+    expect(payload.operation).toBe("agent_context_pack");
+    expect(payload.error.code).toBe("payload_too_large");
+    expect(payload.error.message).toContain("working_set");
+
+    await runtime?.close();
+  });
+
+  it("rethrows a respond failure that is not the client's payload refusal", async () => {
+    // A connection-closed throw is not ours to reinterpret as an undeliverable
+    // reply. It must reach the handler-error path, not be answered with a
+    // payload_too_large envelope that would misdescribe what happened.
+    const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
+    const loggedErrors: string[] = [];
+    const originalError = logger.error;
+    logger.error = (message, extra) => {
+      loggedErrors.push(`${message}:${JSON.stringify(extra ?? {})}`);
+    };
+
+    try {
+      let handlerRejection: unknown = null;
+      const driver: NatsBridgeDriver = {
+        subscribe: async (subject, handler) => {
+          await handler({
+            subject,
+            data: data(envelope({ id: "req-closed", from: "rico" })),
+            headers: {},
+            respond: (payload: Uint8Array) => {
+              published.push(envelopeFromBytes(payload));
+              const err = new Error("connection closed") as Error & {
+                code: string;
+              };
+              err.code = "CONNECTION_CLOSED";
+              throw err;
+            },
+          } satisfies NatsRequestMessage).catch((err) => {
+            handlerRejection = err;
+          });
+          return { close: () => undefined };
+        },
+        close: () => undefined,
+      };
+
+      const runtime = await startNatsContextPackBridge({
+        boundary: localBoundary(),
+        tokenMap: new Map(),
+        deps: depsWithWorkingSet("rico"),
+        driver,
+      });
+
+      expect((handlerRejection as { code?: string } | null)?.code).toBe(
+        "CONNECTION_CLOSED",
+      );
+      // Exactly one publish was attempted; no error envelope followed it.
+      expect(published).toHaveLength(1);
+      expect((published[0]!.payload as Record<string, any>).status).toBe("ok");
+
+      await runtime?.close();
+    } finally {
+      logger.error = originalError;
+    }
+  });
+
   it("carries the reply normally when it fits the broker's advertised figure", async () => {
     const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
     const driver: NatsBridgeDriver = {

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -6,6 +6,7 @@ import { logger } from "./logger.ts";
 import {
   buildAgentContextPackPayload,
   parseAgentContextPackArgs,
+  SECTION_NAMES,
 } from "./tools/agent-context-pack.ts";
 import type {
   FleetEnvelope,
@@ -29,6 +30,18 @@ export interface NatsRequestMessage {
   subject: string;
   data: Uint8Array;
   headers?: Record<string, string | undefined>;
+  /**
+   * The broker's OWN advertised payload figure for this connection, in bytes,
+   * as reported by the server in its INFO (`connection.info.max_payload`).
+   *
+   * REPO LAW for this seam: never substitute a constant of our own here. The
+   * figure differs per broker (this fleet's local broker advertises 8 MiB; the
+   * NATS protocol default is 1 MiB), so a hardcoded number would either refuse
+   * replies the broker would have carried or keep letting undeliverable ones
+   * through. `undefined` means the driver could not read it — in that case the
+   * bridge does not pre-judge the reply and simply publishes.
+   */
+  maxPayloadBytes?: number;
   respond(data: Uint8Array): boolean | void | Promise<boolean | void>;
 }
 
@@ -131,10 +144,7 @@ export async function startNatsContextPackBridge(
       deps: options.deps,
       health,
     });
-    const responded = await message.respond(envelopeToBytes(response));
-    if (responded === false) {
-      throw new Error("NATS request did not include a reply inbox");
-    }
+    await respondWithinBrokerFigure(message, response);
   });
 
   return {
@@ -160,6 +170,154 @@ export async function startNatsContextPackBridge(
       }
     },
   };
+}
+
+/**
+ * Publish a reply, answering an undeliverable one with an error envelope.
+ *
+ * THE DEFECT THIS CLOSES (#549): the handler finishes its work, builds a large
+ * pack, and `respond()` returns false because the broker refuses to carry the
+ * publish. The old code threw "NATS request did not include a reply inbox" —
+ * which was BOTH a misattribution (the reply inbox was present; the broker's
+ * refusal was the problem) and, worse, SILENCE: nothing was ever published, so
+ * the caller waited out its own timeout with no client-visible reason. A
+ * measured live case built a 58.5 MB reply against a broker advertising 8 MiB.
+ *
+ * The answer is an error envelope, never silence. Two paths reach it:
+ *   (a) the encoded reply exceeds the broker's OWN advertised figure, which we
+ *       compare against BEFORE publishing so we never spend a doomed publish;
+ *   (b) the publish is refused anyway (`respond()` returned false) — the
+ *       advertised figure was unreadable, or the broker refused for its own
+ *       reason. We answer with the same envelope rather than assume why.
+ *
+ * The error envelope is CONTENT-FREE: it names what happened, the measured
+ * reply bytes, the broker's advertised figure, and which sections were asked
+ * for. No pack data crosses into it, so an undeliverable reply cannot leak
+ * through the error path.
+ *
+ * This changes only how an undeliverable reply is ANSWERED. What the handler
+ * builds is untouched — the pack is still built in full, and nothing here
+ * reshapes, shortens, or withholds any part of it.
+ *
+ * If the error envelope ITSELF cannot be published there is nothing further the
+ * bridge can do on the wire, so it logs accurately and gives up — that case is
+ * a genuinely missing reply inbox, which is what the old message claimed about
+ * every case.
+ */
+async function respondWithinBrokerFigure(
+  message: NatsRequestMessage,
+  response: FleetEnvelope,
+): Promise<void> {
+  const encoded = envelopeToBytes(response);
+  const advertised = message.maxPayloadBytes;
+  const exceedsAdvertised =
+    typeof advertised === "number" &&
+    Number.isFinite(advertised) &&
+    advertised > 0 &&
+    encoded.byteLength > advertised;
+
+  if (!exceedsAdvertised) {
+    const responded = await message.respond(encoded);
+    if (responded !== false) return;
+  }
+
+  const undeliverable = undeliverableReplyEnvelope(
+    message,
+    response,
+    encoded.byteLength,
+    advertised,
+  );
+  const respondedWithError = await message.respond(
+    envelopeToBytes(undeliverable),
+  );
+  if (respondedWithError === false) {
+    // Only now is "no reply inbox" the accurate reading: a small, known-good
+    // error envelope was refused too, so the refusal is not about the figure.
+    logger.error("NATS reply could not be published to a reply inbox", {
+      subject: message.subject,
+      reply_bytes: encoded.byteLength,
+    });
+    return;
+  }
+
+  logger.warn("NATS reply exceeded the broker's advertised payload figure", {
+    subject: message.subject,
+    reply_bytes: encoded.byteLength,
+    broker_advertised_bytes: advertised ?? null,
+    correlation_id: response.correlation_id,
+  });
+}
+
+/**
+ * Build the content-free error envelope for a reply the broker will not carry.
+ *
+ * Reuses the EXISTING wire error shape (`status`/`operation`/`namespace_source`
+ * /`error{code,message}`) and the existing `payload_too_large` code, so nothing
+ * about the cross-language contract changes — no fixture and no Python mirror
+ * edit. It echoes the same `correlation_id` a normal reply would, which is what
+ * lets the waiting caller match this to its request instead of timing out.
+ *
+ * The message states measurements only — what the reply weighed, what the
+ * broker advertises, what was asked for. It prescribes nothing about how the
+ * caller should react; that is the operator's call, not this envelope's.
+ */
+function undeliverableReplyEnvelope(
+  message: NatsRequestMessage,
+  response: FleetEnvelope,
+  replyBytes: number,
+  advertisedBytes: number | undefined,
+): FleetEnvelope {
+  const sections = requestedSectionsFromRequest(message.data);
+  const advertisedText =
+    typeof advertisedBytes === "number"
+      ? `${advertisedBytes} bytes`
+      : "not advertised by the broker";
+  const sectionsText = sections.length > 0 ? sections.join(", ") : "default";
+  return buildResponseEnvelope(response.correlation_id ?? response.id, {
+    status: "error",
+    operation: "agent_context_pack",
+    namespace_source: namespaceSourceFromResponse(response),
+    error: {
+      code: "payload_too_large",
+      message:
+        "The broker refused to carry this context pack reply. " +
+        `Reply was ${replyBytes} bytes; the broker advertises ${advertisedText}. ` +
+        `Requested sections: ${sectionsText}.`,
+    },
+  });
+}
+
+/**
+ * Read the requested section names back off the INBOUND request bytes.
+ *
+ * Best-effort and deliberately defensive: this runs on the failure path, where
+ * the one thing that must not happen is a second failure. Anything unparseable
+ * or unexpected yields an empty list, and the error envelope says "default".
+ * Only known section names are echoed, so arbitrary caller text cannot be
+ * reflected back into the error message.
+ */
+function requestedSectionsFromRequest(data: Uint8Array): string[] {
+  try {
+    const envelope = envelopeFromBytes(data);
+    const payload = envelope.payload as { body?: unknown } | undefined;
+    const body = payload?.body as { requested_sections?: unknown } | undefined;
+    const requested = body?.requested_sections;
+    if (!Array.isArray(requested)) return [];
+    const known = new Set<string>(SECTION_NAMES);
+    return requested.filter(
+      (name): name is string => typeof name === "string" && known.has(name),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function namespaceSourceFromResponse(
+  response: FleetEnvelope,
+): NamespaceSource | null {
+  const source = (response.payload as { namespace_source?: unknown })
+    .namespace_source;
+  return typeof source === "string" ? (source as NamespaceSource) : null;
 }
 
 interface LaneBinding {
@@ -457,7 +615,15 @@ async function createNatsJsDriver(
               consecutiveEmptySubscriptions = 0;
               markNatsBridgeAvailable(health);
               resubscribeDelayMs = NATS_RESUBSCRIBE_INITIAL_DELAY_MS;
-              await processNatsSubscriptionMessage(message, handler);
+              await processNatsSubscriptionMessage(
+                message,
+                handler,
+                // Read the figure PER MESSAGE, not once at connect: nats.js
+                // refreshes `connection.info` on reconnect, so a failover to a
+                // broker advertising a different figure is picked up here
+                // instead of being judged against a stale one.
+                advertisedMaxPayloadBytes(connection),
+              );
             }
             if (!closed && !processedMessage) {
               consecutiveEmptySubscriptions += 1;
@@ -551,6 +717,7 @@ function delay(ms: number): Promise<void> {
 async function processNatsSubscriptionMessage(
   message: NatsSubscriptionMessage,
   handler: (message: NatsRequestMessage) => Promise<void>,
+  maxPayloadBytes?: number,
   onError: (err: unknown, subject: string) => void = logNatsHandlerError,
 ): Promise<void> {
   try {
@@ -558,6 +725,7 @@ async function processNatsSubscriptionMessage(
       subject: message.subject,
       data: message.data,
       headers: headersToRecord(message.headers),
+      maxPayloadBytes,
       respond: (data) => {
         return message.respond(data);
       },
@@ -565,6 +733,24 @@ async function processNatsSubscriptionMessage(
   } catch (err) {
     onError(err, message.subject);
   }
+}
+
+/**
+ * The broker's own advertised payload figure for this connection, in bytes.
+ *
+ * Sourced ONLY from the server's INFO (`connection.info.max_payload`) — the
+ * bridge never supplies a figure of its own, because the correct value is
+ * whatever THIS broker says it is and that differs between deployments. A
+ * connection that has not yet reported INFO returns undefined, and the reply is
+ * published without being pre-judged.
+ */
+function advertisedMaxPayloadBytes(connection: {
+  info?: { max_payload?: number };
+}): number | undefined {
+  const advertised = connection.info?.max_payload;
+  return typeof advertised === "number" && Number.isFinite(advertised) && advertised > 0
+    ? advertised
+    : undefined;
 }
 
 function logNatsHandlerError(err: unknown, subject: string): void {

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -176,19 +176,30 @@ export async function startNatsContextPackBridge(
  * Publish a reply, answering an undeliverable one with an error envelope.
  *
  * THE DEFECT THIS CLOSES (#549): the handler finishes its work, builds a large
- * pack, and `respond()` returns false because the broker refuses to carry the
- * publish. The old code threw "NATS request did not include a reply inbox" —
- * which was BOTH a misattribution (the reply inbox was present; the broker's
- * refusal was the problem) and, worse, SILENCE: nothing was ever published, so
- * the caller waited out its own timeout with no client-visible reason. A
- * measured live case built a 58.5 MB reply against a broker advertising 8 MiB.
+ * pack, and the reply publish cannot be carried. In the real nats.js client
+ * that surfaces as a THROW, not a false return: `Msg.respond()` publishes
+ * through `protocol.publish()`, which raises `NatsError(MaxPayloadExceeded)`
+ * once the encoded length passes `info.max_payload`
+ * (`nats-base-client/msg.js` -> `protocol.js`). The old code let that throw
+ * escape to `processNatsSubscriptionMessage`, whose catch logged the generic
+ * "NATS context-pack bridge request failed" and published NOTHING — so the
+ * caller waited out its own timeout with no client-visible reason. A measured
+ * live case built a 58.5 MB reply against a broker advertising 8 MiB.
  *
- * The answer is an error envelope, never silence. Two paths reach it:
+ * `respond()` returns false in exactly ONE case: the request carried no reply
+ * inbox at all. That condition is real but unrelated to size, which is why the
+ * "no reply inbox" reading is kept for it and only for it, below.
+ *
+ * The answer is an error envelope, never silence. Three paths reach it:
  *   (a) the encoded reply exceeds the broker's OWN advertised figure, which we
  *       compare against BEFORE publishing so we never spend a doomed publish;
- *   (b) the publish is refused anyway (`respond()` returned false) — the
- *       advertised figure was unreadable, or the broker refused for its own
- *       reason. We answer with the same envelope rather than assume why.
+ *   (b) the publish THROWS `MaxPayloadExceeded` anyway — the advertised figure
+ *       was unreadable, so the reply was never pre-judged and the broker's own
+ *       client rejected it. Matched by error CODE, never by message text, so a
+ *       reworded client string cannot silently reopen the defect. Any other
+ *       throw is not ours to interpret and is rethrown unchanged;
+ *   (c) `respond()` returns false — no reply inbox. We answer with the same
+ *       envelope, and if that is refused too the reading below is accurate.
  *
  * The error envelope is CONTENT-FREE: it names what happened, the measured
  * reply bytes, the broker's advertised figure, and which sections were asked
@@ -201,8 +212,7 @@ export async function startNatsContextPackBridge(
  *
  * If the error envelope ITSELF cannot be published there is nothing further the
  * bridge can do on the wire, so it logs accurately and gives up — that case is
- * a genuinely missing reply inbox, which is what the old message claimed about
- * every case.
+ * a genuinely missing reply inbox.
  */
 async function respondWithinBrokerFigure(
   message: NatsRequestMessage,
@@ -217,8 +227,17 @@ async function respondWithinBrokerFigure(
     encoded.byteLength > advertised;
 
   if (!exceedsAdvertised) {
-    const responded = await message.respond(encoded);
-    if (responded !== false) return;
+    // The advertised figure was unreadable or the reply fits it, so the publish
+    // is worth attempting. It can still be rejected by the client itself, and
+    // the real nats.js client rejects by THROWING rather than returning false —
+    // an unguarded call here would let that escape to the handler-error catch
+    // and hand the caller silence, which is the whole #549 defect.
+    try {
+      const responded = await message.respond(encoded);
+      if (responded !== false) return;
+    } catch (err) {
+      if (!isMaxPayloadExceededError(err)) throw err;
+    }
   }
 
   const undeliverable = undeliverableReplyEnvelope(
@@ -227,12 +246,25 @@ async function respondWithinBrokerFigure(
     encoded.byteLength,
     advertised,
   );
-  const respondedWithError = await message.respond(
-    envelopeToBytes(undeliverable),
-  );
+  let respondedWithError: boolean | void;
+  try {
+    respondedWithError = await message.respond(envelopeToBytes(undeliverable));
+  } catch (err) {
+    if (!isMaxPayloadExceededError(err)) throw err;
+    // Even the content-free envelope was rejected against the advertised
+    // figure. The bridge has nothing further it can put on the wire, so it
+    // records what happened and stops.
+    logger.error("NATS error envelope exceeded the broker's advertised figure", {
+      subject: message.subject,
+      reply_bytes: encoded.byteLength,
+      broker_advertised_bytes: advertised ?? null,
+    });
+    return;
+  }
+
   if (respondedWithError === false) {
-    // Only now is "no reply inbox" the accurate reading: a small, known-good
-    // error envelope was refused too, so the refusal is not about the figure.
+    // Only now is "no reply inbox" the accurate reading: the client returns
+    // false for exactly one condition, and it is not about the figure.
     logger.error("NATS reply could not be published to a reply inbox", {
       subject: message.subject,
       reply_bytes: encoded.byteLength,
@@ -246,6 +278,32 @@ async function respondWithinBrokerFigure(
     broker_advertised_bytes: advertised ?? null,
     correlation_id: response.correlation_id,
   });
+}
+
+/**
+ * The nats.js client's own code for a publish it will not carry.
+ *
+ * `ErrorCode.MaxPayloadExceeded` in `nats-base-client/core.js`. Reproduced as a
+ * literal rather than imported so this seam stays testable without a live
+ * client and so the bridge's own driver interface (which is what the tests
+ * drive) does not gain a hard dependency on the client's module shape.
+ */
+const NATS_MAX_PAYLOAD_EXCEEDED_CODE = "MAX_PAYLOAD_EXCEEDED";
+
+/**
+ * Is this the client's refusal to carry a publish of this length?
+ *
+ * Matched on the error's `code`, NEVER on its message text. `NatsError` carries
+ * a stable machine code while its message is prose the client is free to
+ * reword; matching prose would reopen #549 silently on a client upgrade.
+ */
+function isMaxPayloadExceededError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === NATS_MAX_PAYLOAD_EXCEEDED_CODE
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #549.

## What was wrong

The NATS bridge finished its work and then vanished. A `durable_memory` context
pack for namespace `rico` built a **58.5 MB** reply against a broker advertising
8 MiB (measured live 2026-08-04); the caller got nothing and waited out its own
timeout with no client-visible reason.

**The mechanism, read from the installed client's source.** `Msg.respond()`
publishes through `protocol.publish()`, which **throws**
`NatsError(MAX_PAYLOAD_EXCEEDED)` once the encoded length passes
`info.max_payload` (`nats-base-client/msg.js:72-78` → `protocol.js:786-788`).
That throw escaped to `processNatsSubscriptionMessage`, whose catch logged the
generic **`NATS context-pack bridge request failed`** and published nothing.

`respond()` returns **false** in exactly one case: the request carried no reply
inbox at all. So `NATS request did not include a reply inbox` was never the
message this oversize path produced — it was reserved for its own, correct
condition, and it still is. (An earlier revision of this PR body described the
oversize failure as surfacing through that message; that account was wrong and
is corrected here.)

The request side was already guarded at `src/nats-bridge.ts`; the reply side had
nothing.

## What changed

At the respond seam only:

- Before publishing, the encoded reply is compared against the figure the
  **broker itself advertises** on the connection (`connection.info.max_payload`),
  read per message so a reconnect to a broker advertising something different is
  picked up rather than judged against a stale value. Open Brain never supplies
  a figure of its own — this fleet's local broker advertises 8 MiB, the NATS
  protocol default is 1 MiB, and a hardcoded number would be wrong for one of
  them.
- When the reply exceeds what the broker will carry, the doomed publish is not
  spent.
- **Both respond calls are wrapped.** When the advertised figure is unreadable
  the reply cannot be pre-judged, so the publish is attempted — and a thrown
  `MAX_PAYLOAD_EXCEEDED` now routes into the **same** undeliverable-reply
  envelope instead of escaping to the handler-error catch and handing the caller
  silence. Matched by the error's machine **code**, never by message text:
  `NatsError` carries a stable code while its prose is the client's to reword,
  and matching prose would reopen this silently on a client upgrade. Any other
  throw is not the bridge's to reinterpret and is **rethrown unchanged**, so a
  connection-closed failure still reaches the handler-error path.
- The answer is a redacted error envelope with the same `correlation_id` a
  normal reply carries, which releases the waiting caller. It is content-free:
  it names what happened, the measured reply bytes, the broker's advertised
  figure, and the requested sections. No pack data crosses into it, and only
  known section names are echoed back.
- `no reply inbox` is logged only for the condition that actually produces it —
  `respond()` returning false.

Nothing about what the handler builds changed. This changes only how an
undeliverable reply is answered.

**Single-source confirmed:** one bridge serves both trees. `src/nats-worker.ts`
and `server/application/nats.ts:107` both call `startNatsContextPackBridge` from
`src/nats-bridge.ts`, so this lands once and covers both.

## Red proof

Round two (`45e9de3`), against the unhardened source with the new tests kept:

- `answers with an error envelope when the client THROWS MaxPayloadExceeded on
  the reply publish` — **fails**, the thrown `MAX_PAYLOAD_EXCEEDED` escapes
  through `respondWithinBrokerFigure` and **nothing is published**. This mock
  throws, mirroring the real client, rather than returning false.
- `rethrows a respond failure that is not the client's payload refusal` — proves
  a `CONNECTION_CLOSED` throw is not swallowed into a `payload_too_large`
  envelope that would misdescribe it.

Round one (`8549d04`), with `src/nats-bridge.ts` reverted, all four fail — the
old code publishes nothing, so there is no reply to assert against:

- answers with an error envelope when the broker refuses the reply publish
- answers with an error envelope without attempting a publish the broker's advertised figure rules out
- carries the reply normally when it fits the broker's advertised figure
- logs an accurate reason when even the error envelope cannot be published

One pre-existing test (`resubscribes the real NATS subscription loop after
handler and iterator failures`) asserted the old throw reached the handler-error
path; it now asserts the accurate reply-inbox log instead.

## Gates

- `bunx tsc --noEmit` — clean
- `bun test` — 3175 pass, 0 fail, 506 skip (Postgres-gated)
- `bun test src/nats-bridge.test.ts` — 29 pass, 0 fail
- `bun install --frozen-lockfile` — clean

## Critical Self-Review

- Highest-risk behavior: the respond seam now swallows a `MAX_PAYLOAD_EXCEEDED` throw and a false return instead of letting them escape. Scoped by code match, so only that one client condition is absorbed; every other throw is rethrown and still reaches the handler-error path. If the error envelope publish also fails the bridge logs and returns, so a message can complete with no reply on the wire — strictly better than the old path, which published nothing on every refusal.
- Assumptions that could be wrong: that `NatsError.code` stays `MAX_PAYLOAD_EXCEEDED`. Verified against the installed client (`nats-base-client/core.js`); the literal is reproduced in `src/nats-bridge.ts` rather than imported so the seam stays testable through its own driver interface. If a future client renames the code the guard stops matching and the failure reverts to the old visible-log-plus-silence shape — a regression to the prior behavior, not a new failure mode, and the test would not catch it. Also assumed: `connection.info.max_payload` is populated after reconnect; if absent the reply is not pre-judged and the throw guard covers it, which is why the round-two test pins `maxPayloadBytes: undefined`.
- Missing/weak tests: no live broker round-trip in this lane — the tests drive the seam through the driver interface with a simulated throw, not a real NATS server rejecting a real 58.5 MB publish. Left as a post-merge operator step.
- Security/permission risk: the error envelope is content-free by construction — byte counts and section names only, filtered against the known `SECTION_NAMES` set so arbitrary caller text cannot be reflected back. No pack data, no namespace data, no broker URL. The new catch does not log the error object, so no client-supplied prose reaches the log line.
- Migration/deploy risk: none — no schema, no config, no new env var. `maxPayloadBytes` is optional on `NatsRequestMessage`, so an existing driver that does not supply it keeps working.
- Downstream client/runtime risk: none to the wire contract. The existing error payload shape and the existing `payload_too_large` code are reused unchanged, so no fixture and no Python mirror edit were needed. Clients that already handle `status: "error"` handle this.
- Rollback/cleanup concern: two commits on one source file, one test file, one doc. The worktree is removed after merge.
- Fixes made before PR: the round-two commit exists because the round-one lane inferred the client's behavior from the false return instead of reading `msg.js`/`protocol.js`. Reading the source found both the unguarded path and the wrong narrative.
- Known residual risk: a 58.5 MB reply still does not fit an 8 MB broker, so `durable_memory` on this namespace returns a clear error rather than a pack. That is the reported-and-open half of #549 and is the operator's call; this PR closes the silence only. The runbook separates the two.
- SME review-memory update: [x] not applicable because: no new cross-cutting review pattern surfaced — this is a single-seam fix reusing an existing wire error shape, and the existing SME lanes already cover redaction on error paths.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: the live NATS round-trip needs a local broker restart, which is operator-visible, so it is recorded as a post-merge step rather than run in this lane.

## Contract Parity

- Contract parity: [x] runtime-specific because: no wire shape changed — the existing envelope error payload and the existing `payload_too_large` code are reused unchanged, so `nats-context-pack-wire.json` and the Python `nats_wire` mirror needed no edit and byte parity is untouched.

## Post-merge

- [ ] Live NATS round-trip against the local broker: request `durable_memory` for namespace `rico` on `dev.ob.memory.context_pack` and confirm the caller receives a `payload_too_large` error envelope with a matching `correlation_id` instead of timing out.
