### PR TITLE
fix(config): declare OPENBRAIN_DEVELOPMENT_ROOT so a #557-installed box keeps canon (#565)

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -468,6 +468,37 @@ Both halves are required. Declaring the field without the wrapper pass-through
 leaves the hook process never seeing the variable; passing it through without the
 declaration is the rejection above.
 
+### Development lane root (#555 / #565) — Python `openbrain` hooks
+
+Declared on `ServerSettings`
+(`python/openbrain/src/openbrain/config.py`, `development_root`) and **resolved
+elsewhere**: `openbrain.receipts.scope.development_root` and the gate's
+`openbrain_provider.development_scope.development_root` both read the variable
+from `os.environ` per call, spelled identically, so a writer and a reader can
+never land in different scopes.
+
+| variable | default | notes |
+|---|---|---|
+| `OPENBRAIN_DEVELOPMENT_ROOT` | `/Volumes/ThunderBolt/Development` | this machine's Development lane root; written by `setup-client.sh` at install time, because the shipped default is the BUILD machine's volume. Empty reads as unset |
+
+**Why it had to be declared even though nothing in `config.py` reads it.** The
+`openbrain` package had consumed this variable since #556 — but through
+`os.environ` directly, which never registers the NAME with the config. So
+`unknown_prefixed_variables` still classed it a typo and rejected the whole
+environment: the package refusing a variable its own code depended on. #557
+added the wrapper pass-through without the declaration, and every box installed
+from bundle `air-bundle/20260804-203726` opened sessions with **no canon and
+exit 0**, field-proved on two machines 2026-08-04 (#565). Declaring a name the
+config itself does not read is precedented here — `OPENBRAIN_OBSERVATION_HMAC_SECRET`
+exists for exactly that reason.
+
+**Ordering, as always: the package declares first, the wrapper passes second.**
+`setup-client.sh` writes the variable into `claudex-observation.env` and the
+`exec env -i` list in `openbrain-hook-env`; both are safe only against an
+install that carries this field. Single-quote the value in the env file — the
+wrapper sources it with POSIX `.`, so an unquoted path containing a space
+sources to empty.
+
 **An EMPTY value means unset, and both halves enforce that (PR #544).** The
 wrapper's pass-through style is `VAR="${VAR:-}"`, which cannot express "absent" —
 it turns an unset variable into an **empty string** in the child. For a string

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -1047,9 +1047,48 @@ predates the validator, which is exactly the state of a client mid-upgrade.
 never in the `env -i` list. A string tolerates the empty spelling; a bool, an
 int, or an enum does not.
 
+**The third clause: EVERY package, not just the consuming one (#557 → #565).**
+A variable the wrapper passes must be declared in **every** package whose config
+applies strict prefix rejection — not merely in the package that reads it.
+
+`OPENBRAIN_DEVELOPMENT_ROOT` is the case study, and it is the sharpest form of
+this bug so far: the `openbrain` package had **read** the variable since #556
+(`receipts/scope.py`, via `os.environ` per call, because the value is answered
+against the filesystem and a module constant freezes during pytest collection).
+Reading it that way never registered the NAME with `config.py`, so
+`unknown_prefixed_variables` still classed it a typo. The package rejected a
+variable its own code depended on. #557 then shipped the wrapper line without
+the declaration, and every box built from bundle `air-bundle/20260804-203726`
+opened sessions with no canon and exit 0 — field-proved on two machines
+2026-08-04.
+
+The trap is that the variable **works** in `openbrain-provider`, which reads
+`os.environ` directly and rejects nothing. Testing it there proves nothing about
+the box. Only `openbrain` applies the check today; that is a property to
+re-verify, not assume.
+
+**Consuming a variable is not declaring it.** `os.environ.get(...)` anywhere in
+a package does not register the name. The declaration is what
+`_accepted_variable_names()` reads, and it derives from `_SECTION_MODELS` — so
+declaring the field on any registered section fixes all three section loaders at
+once. Declaring a variable the package does not otherwise read is normal and
+already precedented: `OPENBRAIN_OBSERVATION_HMAC_SECRET` is declared purely so
+the provisioned variable is not rejected as a typo.
+
 **The check that catches it.** Not exit code, and not `/health` — both pass on a
 dead box. Start a fresh session and read the CANON PACK section counts. Zero
-counts, or no pack, is this bug.
+counts, or no pack, is this bug. Since #565 the rejection also names the
+offending variable on **stderr**, so the fastest confirmation is to pipe a
+`SessionStart` payload through the installed wrapper and read the
+`[openbrain]` line:
+
+```
+printf '{"hook_event_name":"SessionStart","session_id":"probe","cwd":"'"$PWD"'"}' \
+  | ~/.local/share/openbrain-memory/env/openbrain-hook-env openbrain-session-start
+```
+
+A CANON PACK on stdout is healthy; an `[openbrain] unrecognised ...` line names
+the exact variable to declare or drop.
 
 ### Clients cannot install from GitHub — wheels from the Mini are the paved road
 

--- a/python/openbrain/src/openbrain/apps/hooks/session_start.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session_start.py
@@ -91,7 +91,7 @@ from openbrain.apps.hooks.session import (
     _derive_repo_slug,
     run_session_start,
 )
-from openbrain.config import load_canon_settings
+from openbrain.config import UnknownEnvironmentVariableError, load_canon_settings
 
 if TYPE_CHECKING:
     from typing import TextIO
@@ -196,6 +196,26 @@ def _inject_canon_with(
                 trailer=trailer,
             )
         )
+    except UnknownEnvironmentVariableError as error:
+        # THE ONE FAILURE AN OPERATOR CAN ACT ON, so it is the one that speaks.
+        #
+        # A rejected environment is not a degraded server or an unconfigured
+        # lane -- it is a misconfiguration of this box, and the fix is a
+        # specific variable name. Logged like every other failure AND named on
+        # stderr, following #558: loud diagnosis, non-blocking, stderr only,
+        # never touching the emitted JSON. Silence here cost two machines a
+        # session's canon on 2026-08-04 (open-brain#565); the warning alone did
+        # not say WHICH variable, so it read as noise.
+        #
+        # Safe to print: the error carries variable NAMES, never their values,
+        # so a token's spelling cannot reach the stream (see
+        # ``UnknownEnvironmentVariableError``).
+        logger.warning(
+            "SessionStart canon injection failed ({}); session opens uninjected",
+            type(error).__name__,
+        )
+        sys.stderr.write(f"[openbrain] {error}\n")
+        sys.stderr.flush()
     except Exception as error:  # noqa: BLE001 -- an observer must never break its subject
         # Content-free BY CONSTRUCTION: only the exception class name is passed,
         # never the exception object, so no payload text or token reaches the

--- a/python/openbrain/src/openbrain/config.py
+++ b/python/openbrain/src/openbrain/config.py
@@ -182,6 +182,36 @@ def _empty_opt_in_means_unset(value: object) -> object:
     return value
 
 
+def _empty_string_means_unset(value: object) -> object:
+    """Treat an empty optional string setting as absent, not as a real value.
+
+    The string counterpart of :func:`_empty_opt_in_means_unset`, and it exists
+    for the same measured reason. The deployed ``openbrain-hook-env`` builds the
+    child environment as ``env -i VAR="${VAR:-}"``, a style that CANNOT express
+    "absent": a machine whose env file omits the variable hands the hook an
+    EMPTY STRING. Without this, an empty ``OPENBRAIN_DEVELOPMENT_ROOT`` would
+    resolve to ``Path("")`` -- a path that exists as the current directory on
+    some platforms and not others -- instead of falling back to the shipped
+    default the operator expects.
+
+    Empty-means-unset is this repo's established reading of an environment
+    variable rather than a new leniency: ``receipts.scope.development_root``
+    already applies exactly this rule to the same variable
+    (``os.environ.get(...).strip()`` then fall back), and
+    ``apps.capture.outage.default_spool_path`` does the same for its own.
+
+    Args:
+        value: Whatever the environment layer resolved for the field.
+
+    Returns:
+        ``None`` for an empty or whitespace-only string, the input unchanged
+        otherwise.
+    """
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
 class ConfigurationError(ValueError):
     """A setting is missing, malformed, or inert, and the process cannot start.
 
@@ -767,13 +797,20 @@ class LogSettings(_Base):
 
 
 class ServerSettings(_Base):
-    """HTTP server binding.
+    """Process-level settings: the HTTP binding, and this machine's lane root.
+
+    ``development_root`` sits here rather than on a hook section because it
+    describes the BOX, not a lane -- the same value serves the receipts writer
+    and the provider gate, neither of which is capture, canon, or observation.
 
     Attributes:
         port: Listen port.
         bind_host: Interface to bind, or ``None`` for the runtime default.
         allowed_origins: CORS origins. Empty means none are permitted.
         run_migrations: Apply pending migrations at start.
+        development_root: This machine's Development lane root, or ``None`` to
+            use the shipped default. DECLARED HERE, RESOLVED ELSEWHERE -- see
+            the field comment.
     """
 
     port: PositiveInt = Field(
@@ -793,6 +830,34 @@ class ServerSettings(_Base):
         validation_alias=AliasChoices(
             "OPENBRAIN_RUN_MIGRATIONS", "OPEN_BRAIN_RUN_MIGRATIONS"
         ),
+    )
+    #: DECLARED HERE, RESOLVED IN ``receipts.scope`` -- and that split is the
+    #: point, not an oversight.
+    #:
+    #: This package has READ ``OPENBRAIN_DEVELOPMENT_ROOT`` since #556
+    #: (``receipts.scope.development_root``), through ``os.environ`` per call,
+    #: because the value is answered against the FILESYSTEM and a module
+    #: constant is frozen during pytest collection before a conftest can set it.
+    #: Reading it that way never registered the NAME, so
+    #: :func:`unknown_prefixed_variables` still classed it a typo and rejected
+    #: the whole environment -- the package refusing a variable its own code
+    #: depends on. #557 then shipped a wrapper that passes it, and every box
+    #: built from that bundle opened sessions with no canon and exit 0
+    #: (open-brain#565).
+    #:
+    #: The declaration exists to make the name RECOGNISED and readable. It is
+    #: deliberately not the resolver: ``receipts.scope`` and the gate's
+    #: ``openbrain_provider.development_scope`` read the same variable, spelled
+    #: identically, so a writer and a reader can never land in different
+    #: scopes. A settings field resolved independently would reintroduce exactly
+    #: that split.
+    development_root: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPENBRAIN_DEVELOPMENT_ROOT"),
+    )
+
+    _empty_root = field_validator("development_root", mode="before")(
+        _empty_string_means_unset
     )
 
 

--- a/python/openbrain/tests/test_development_root_declared.py
+++ b/python/openbrain/tests/test_development_root_declared.py
@@ -1,0 +1,168 @@
+"""``OPENBRAIN_DEVELOPMENT_ROOT`` is declared, so a #557-installed box keeps canon.
+
+The fourth instance of one defect class, and the first where the package
+REJECTED a variable its own code already READ.
+
+``receipts.scope`` has consumed ``OPENBRAIN_DEVELOPMENT_ROOT`` since #556 --
+via ``os.environ`` directly, per call, because the value is answered against
+the filesystem and a module constant would be frozen during pytest collection.
+Reading it that way never registered the name with the config, so
+:func:`unknown_prefixed_variables` still classed it a typo and rejected the
+WHOLE environment. PR #557 then taught the installer and ``openbrain-hook-env``
+to pass it, and every box built from that bundle lost canon injection: the
+``SessionStart`` entrypoint swallows the rejection (fail-open observer
+contract) and exits 0, so the session opens with an empty skull and no error
+the operator ever sees. Field-proved on two machines 2026-08-04 (open-brain#565).
+
+What the declaration is, and is not. It makes the config ACCEPT the name; it
+does not move the read. ``receipts.scope.development_root`` and the gate's
+``openbrain_provider.development_scope.development_root`` stay the single
+source of the resolved path, deliberately spelled identically so the writer and
+the reader can never land in different scopes. A settings field that some other
+module resolved independently would reintroduce exactly that split, so the test
+below pins the value as EXPOSED-BUT-NOT-AUTHORITATIVE: readable from settings,
+with the scope modules still answering the question.
+
+See Also:
+    - ``docs/GOTCHAS.md`` -- the matched-pair rule and its third clause
+    - ``openbrain.receipts.scope`` -- the reader this name has always served
+    - ``python/openbrain/tests/test_lan_http_optin.py`` -- the #544 precedent
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from openbrain.apps.hooks.session_start import inject_canon
+from openbrain.config import (
+    ServerSettings,
+    UnknownEnvironmentVariableError,
+    load_canon_settings,
+    load_capture_settings,
+    load_observation_settings,
+    unknown_prefixed_variables,
+)
+from openbrain.receipts.scope import DEVELOPMENT_ROOT_ENV_VAR, development_root
+
+#: A root that is not the shipped default, so a test asserting the override
+#: took effect cannot pass by accidentally matching the built-in value.
+OTHER_ROOT = "/Volumes/Elsewhere/Development"
+
+#: The environment a #557-installed hook process actually carries: the endpoint
+#: and token the wrapper always passed, plus the lane root it now adds.
+INSTALLED_ENV = {
+    "OPENBRAIN_BASE_URL": "http://127.0.0.1:3100",
+    "OPENBRAIN_TOKEN": "test-token",  # noqa: S106 - fixture value, never real
+    DEVELOPMENT_ROOT_ENV_VAR: OTHER_ROOT,
+}
+
+
+def test_development_root_is_a_recognised_variable() -> None:
+    """The name no longer reads as a typo.
+
+    This is the assertion that was RED before the declaration: the variable was
+    reported unknown, and every caller of the check raised on it.
+    """
+    assert unknown_prefixed_variables(INSTALLED_ENV) == ()
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [load_canon_settings, load_capture_settings, load_observation_settings],
+)
+def test_every_section_loader_accepts_the_installed_environment(loader) -> None:  # noqa: ANN001
+    """No hook lane rejects the environment #557 ships.
+
+    All three section loaders run the same whole-environment typo check, so one
+    undeclared variable took down capture, observation, and canon together.
+    Canon is the lane that was field-proved dead; the others are pinned because
+    they failed for the identical reason and would regress the same way.
+    """
+    loader(INSTALLED_ENV)
+
+
+def test_the_declared_field_exposes_the_configured_root() -> None:
+    """The value is readable from settings, not merely tolerated.
+
+    Declaring the name only to discard it would silence the crash while leaving
+    an operator unable to see what the process believes -- so the resolved
+    value is asserted, not just the absence of an exception.
+    """
+    settings = ServerSettings.model_validate(
+        {"development_root": INSTALLED_ENV[DEVELOPMENT_ROOT_ENV_VAR]}
+    )
+
+    assert settings.development_root == OTHER_ROOT
+
+
+def test_an_empty_value_reads_as_unset() -> None:
+    """``env -i VAR="${VAR:-}"`` hands the child ``""``, which must not raise.
+
+    The wrapper's assignment style cannot express "absent"; an unset variable
+    arrives as an empty string. #544 re-armed this exact defect by declaring a
+    field that rejected ``""``, killing every hook on a host that never opted
+    in. The convention this repo settled on is empty-means-unset.
+    """
+    settings = ServerSettings.model_validate({"development_root": ""})
+
+    assert settings.development_root is None
+
+
+def test_the_scope_module_remains_the_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The declaration did not move where the root is resolved.
+
+    ``receipts.scope`` and the provider gate read the SAME variable so a write
+    and a read cannot land in different scopes. If the config ever became the
+    resolver, that guarantee would depend on the two agreeing.
+    """
+    monkeypatch.setenv(DEVELOPMENT_ROOT_ENV_VAR, OTHER_ROOT)
+
+    assert str(development_root()) == OTHER_ROOT
+
+
+def test_a_rejected_environment_names_the_variable_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The one actionable failure says which variable, and does not block.
+
+    #558's posture: loud diagnosis, non-blocking, stderr, and stdout left
+    untouched so the harness still reads a clean "inject nothing". The bare
+    warning that shipped before named only the exception class, which is why
+    two machines read a dead canon as a healthy session.
+    """
+    monkeypatch.setenv("OPENBRAIN_DEVELOPMENT_ROOOT", OTHER_ROOT)
+    stream = io.StringIO(
+        json.dumps(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": "p",
+                "cwd": OTHER_ROOT,
+            }
+        )
+    )
+    out = io.StringIO()
+
+    inject_canon(stream, out)
+
+    captured = capsys.readouterr()
+    assert "OPENBRAIN_DEVELOPMENT_ROOOT" in captured.err
+    assert "ACTION REQUIRED" in captured.err
+    # stdout stays EMPTY: Claude Code's "proceed normally, inject nothing".
+    assert out.getvalue() == ""
+
+
+def test_a_misspelling_is_still_rejected() -> None:
+    """Silence is granted to the name we declared, never to a typo near it.
+
+    The declaration must not widen into prefix leniency: the typo check is the
+    only thing standing between a fat-fingered variable and a process running
+    on defaults nobody chose.
+    """
+    with pytest.raises(UnknownEnvironmentVariableError):
+        load_canon_settings({"OPENBRAIN_DEVELOPMENT_ROOOT": OTHER_ROOT})


### PR DESCRIPTION
Closes #565.

## What broke

PR #557 taught `setup-client.sh` and `openbrain-hook-env` to pass
`OPENBRAIN_DEVELOPMENT_ROOT`, but never declared it in the `openbrain` package.
`config.unknown_prefixed_variables` rejects any `OPENBRAIN_*` variable matching
no declared field — and rejects the **whole environment**, not the one variable.
The `SessionStart` entrypoint swallows that rejection (fail-open observer
contract) and exits 0, so every box built from bundle
`air-bundle/20260804-203726` opened sessions with **no canon and no error the
operator could see**.

Field-proved on two machines 2026-08-04: the Air hand-reverted its env pair, the
mini was restored from backups.

This is the matched-pair ordering rule (declare in package → reinstall → wrapper
passes) violated by #557 itself, and the fourth instance of the defect class
after `OPENBRAIN_OBSERVATION_*`, `OPENBRAIN_SPOOL_PATH`, and
`OPENBRAIN_ALLOW_INSECURE_HTTP` (#544). It is also the sharpest form yet: the
package had **read** the variable since #556 (`receipts/scope.py`, via
`os.environ` per call), so it was rejecting a variable its own code depended on.
Consuming a name never registers it.

## The fix, at the owning boundary

- **`config.py`** — declare `development_root` on `ServerSettings`, the
  process/machine-level section, because the value describes the **box**, not a
  lane. Declared to be RECOGNISED, not authoritative: `receipts.scope` and
  `openbrain_provider.development_scope` keep resolving the path from
  `os.environ`, spelled identically, so a writer and a reader can never land in
  different scopes. Declaring a name the config does not itself read is
  precedented — `OPENBRAIN_OBSERVATION_HMAC_SECRET` exists for that reason.
- **`config.py`** — add `_empty_string_means_unset`, the string counterpart of
  #544's `_empty_opt_in_means_unset`. The wrapper's `env -i VAR="${VAR:-}"`
  style cannot express "absent", so an unset variable arrives as `""`; without
  this it resolves to `Path("")` instead of the shipped default.
- **`session_start.py`** — visibility, minimal and at the same boundary. The
  config-rejection failure now names the offending variable(s) and the
  remediation on stderr, per the #558 precedent: loud diagnosis, non-blocking,
  stderr only, stdout left empty so the harness still reads "proceed normally,
  inject nothing". The prior warning named only the exception class, which is
  exactly why a dead canon read as a healthy session. Safe to print — the error
  carries variable NAMES, never values.

**Packages declared:** `openbrain` only. Verified rather than assumed:
`openbrain-provider` reads `os.environ` directly and rejects nothing, and
`openbrain-memory` carries no such check, so only `openbrain` applies strict
prefix rejection today.

## Red proof

Red first, both halves:

- Before the declaration, 6 of 8 new tests failed with
  `UnknownEnvironmentVariableError`; the 2 that passed were invariants that were
  already correctly true.
- The stderr test was separately proven red by stashing only the hook change —
  `assert 'OPENBRAIN_DEVELOPMENT_ROOOT' in ''`.

Live end-to-end, against the running service:

- Broken wrapper pair → `SessionStart canon injection failed
  (UnknownEnvironmentVariableError)`, zero canon, exit 0.
- Fixed package, wrapper-shaped clean environment, `OPENBRAIN_DEVELOPMENT_ROOT`
  set → the identical invocation emits the **CANON PACK**.

## Gates

- `openbrain`: 579 passed · mypy clean · ruff clean
- `openbrain-provider`: 596 passed, 1 skipped · mypy clean · ruff clean
- `openbrain-memory`: 569 passed, 9 skipped · mypy clean · ruff clean
- `bun install --frozen-lockfile`: ok

## Docs

`docs/GOTCHAS.md` gains the matched-pair rule's **third clause**: a variable the
wrapper passes must be declared in EVERY package whose config applies strict
prefix rejection, with #557 as the case study, plus the new stderr line as the
fastest confirmation. `docs/CONFIG_REFERENCE.md` documents the field.

## Deployment warning

Bundle `air-bundle/20260804-203726` ships the broken combination and **must not
be installed on new boxes** until superseded by a bundle carrying this package.

## Note found while fixing

The repro also surfaced `OPENBRAIN_NAMESPACE`, present in the live
`claudex-observation.env` today and equally undeclared. It does not break hooks
only because `openbrain-hook-env` runs the child under `env -i` with a strict
allowlist that strips it. Recorded in #565; out of scope here.

## Critical Self-Review

- Highest-risk behavior: the new stderr write in the `SessionStart` hook. It is
  additive and non-blocking, and the test asserts stdout stays empty so the
  injection contract is untouched; the failure path it sits on already existed.
- Assumptions that could be wrong: that only `openbrain` applies strict prefix
  rejection. Checked both sibling packages for `unknown_prefixed_variables` and
  `UnknownEnvironmentVariableError` and found neither, rather than assuming.
- Missing/weak tests: no test drives the real installed wrapper end-to-end — the
  wrapper lives outside the repo, so that leg was verified manually and is
  recorded above rather than automated.
- Security/permission risk: the stderr line prints an exception carrying only
  variable NAMES and fixed remediation text, never values, so no token can reach
  the stream. `SecretStr` fields are unaffected.
- Migration/deploy risk: none in-repo. The deploy-side risk is the ordering rule
  itself — this package must be installed before a wrapper passes the variable,
  which is what the GOTCHAS clause now states.
- Downstream client/runtime risk: no MCP tool, schema, transport, or
  client-facing contract changed; this is Python-package config plus a hook
  diagnostic, so `docs/downstream-rollout.md` classification is not applicable.
- Rollback/cleanup concern: revert is a single commit; the declared field is
  additive with a `None` default, so an older env without the variable behaves
  exactly as before.
- Fixes made before PR: switched the stderr emission from `print` to
  `sys.stderr.write`/`flush` to match the established `stop.py` convention after
  ruff flagged it; removed a `/tmp` literal from a test fixture payload.
- Known residual risk: `OPENBRAIN_NAMESPACE` remains undeclared and is protected
  only by the wrapper's allowlist — noted in #565, deliberately not fixed here
  to keep this change scoped to the reported defect.
- SME review-memory update: [x] not applicable because: the mandatory gotcha-agent lane was read (`docs/sme/gotcha-agent.md`) and none of its checks — live writes/redaction, namespace authority, spool durability/locking, transport bounds — are touched by an environment-variable declaration; the durable lesson here is the matched-pair rule, recorded in `docs/GOTCHAS.md` where that doctrine already lives.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Live checks are the before/after `openbrain-session-start` runs against the
local dogfood service documented under "Red proof" — the broken pair reproducing
a silent uninjected session, and the fixed package emitting the CANON PACK.

## Contract Parity

- Contract parity: [x] runtime-specific because: the change is confined to the Python `openbrain` package's environment-variable declaration plus one hook's stderr diagnostic; no MCP tool, schema, wire contract, or shared fixture is touched, and the TypeScript server neither reads `OPENBRAIN_DEVELOPMENT_ROOT` nor applies prefix rejection, so there is no parity fixture to update.
