### PR TITLE
fix(installer): rewrite the dev-root block whole and point the loopback guard at a URL that works

### DIFF
--- a/scripts/client-bundle.sh
+++ b/scripts/client-bundle.sh
@@ -170,25 +170,57 @@ with open(path, encoding="utf-8") as handle:
 # unquoted hands them the #555 wedge with the fix's own example.
 quoted_build_root = shlex.quote(build_root)
 
+BEGIN = "## >>> openbrain: development root (managed) >>>"
+END = "## <<< openbrain: development root (managed) <<<"
+
 # Stage the BUILD machine's value COMMENTED. Live, it would look authoritative
 # on a client where it is wrong; commented with the note, it reads as the
-# example it actually is. setup-client.sh writes the live line per box.
+# example it actually is. setup-client.sh writes the live line per box, which is
+# why this no longer says "EDIT ME": on the paved road nobody edits it, and the
+# instruction outlived its own fix -- it was still sitting above the resolved
+# value on a box the installer had already configured correctly.
 block = (
-    "## EDIT ME ON THE CLIENT -- or just let setup-client.sh do it, which is the\n"
-    "## paved road. This is the BUILD machine's Development root, staged as an\n"
-    "## example only. The provider resolves the lane by asking the filesystem,\n"
-    "## so on a box where this path does not exist EVERY cwd resolves to no\n"
-    "## scope and EVERY tool call is blocked behind a recovery command naming a\n"
-    "## directory that box does not have (#555).\n"
+    f"{BEGIN}\n"
+    "## The BUILD machine's Development root, staged as an EXAMPLE ONLY.\n"
+    "## setup-client.sh resolves and rewrites this per box at install time; you\n"
+    "## only touch it when hand-installing without that script.\n"
+    "## The provider resolves the lane by asking the filesystem, so on a box\n"
+    "## where this path does not exist EVERY cwd resolves to no scope and EVERY\n"
+    "## tool call is blocked behind a recovery command naming a directory that\n"
+    "## box does not have (#555).\n"
     "## The value is shell-quoted: this file is sourced, so a path containing a\n"
     "## space would otherwise split and arrive empty. Keep the quoting if you\n"
-    "## edit it by hand.\n"
+    "## do edit it by hand.\n"
     f"# OPENBRAIN_DEVELOPMENT_ROOT={quoted_build_root}\n"
+    f"{END}\n"
 )
 
-pattern = re.compile(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", re.M)
-if pattern.search(text):
-    text = pattern.sub("", text)
+# Rewrite the block WHOLE, between markers -- same reason as setup-client.sh.
+# A bundle is staged FROM this machine's live installed env file, so without
+# this the staged copy carries every block the installer ever wrote, ships them
+# to the client, and the next rebuild stacks another pair.
+marked = re.compile(
+    rf"^{re.escape(BEGIN)}\n.*?^{re.escape(END)}\n?", re.M | re.S
+)
+text = marked.sub("", text)
+
+# Sweep the legacy UNMARKED copies emitted before markers existed, anchored on
+# their own first comment lines so operator-written comments are untouched. The
+# trailing assignment is OPTIONAL: the old writer stripped it while appending
+# the next block, so in a file with N stacked blocks only the last one still
+# carries a value and the rest are bare comment runs.
+legacy = (
+    r"^## This machine's Development root\. Written by setup-client\.sh at install\n"
+    r"(?:^##.*\n)*"
+    r"(?:^OPENBRAIN_DEVELOPMENT_ROOT=.*\n?)?",
+    r"^## EDIT ME ON THE CLIENT.*\n"
+    r"(?:^##.*\n)*"
+    r"(?:^#\s*OPENBRAIN_DEVELOPMENT_ROOT=.*\n?)?",
+)
+for pat in legacy:
+    text = re.sub(pat, "", text, flags=re.M)
+
+text = re.sub(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", "", text, flags=re.M)
 text = text.rstrip("\n") + "\n" + block
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(text)

--- a/scripts/setup-client.sh
+++ b/scripts/setup-client.sh
@@ -191,22 +191,63 @@ with open(path, encoding="utf-8") as handle:
 # reads a quoted value just as happily, so only the line we write changes.
 quoted_root = shlex.quote(root)
 
+BEGIN = "## >>> openbrain: development root (managed) >>>"
+END = "## <<< openbrain: development root (managed) <<<"
+
 block = (
-    "## This machine's Development root. Written by setup-client.sh at install\n"
-    "## time -- the provider's built-in default is the BUILD machine's volume,\n"
-    "## and a root that does not exist resolves every cwd to no scope, which\n"
-    "## blocks every tool call behind a recovery command pointing somewhere\n"
-    "## this box does not have (#555). Re-run setup-client.sh to update it.\n"
+    f"{BEGIN}\n"
+    "## Written by setup-client.sh at install time -- the provider's built-in\n"
+    "## default is the BUILD machine's volume, and a root that does not exist\n"
+    "## resolves every cwd to no scope, which blocks every tool call behind a\n"
+    "## recovery command pointing somewhere this box does not have (#555).\n"
+    "## Re-run setup-client.sh to update it; this block is rewritten whole.\n"
     "## Shell-quoted: this file is sourced, so a path containing a space would\n"
     "## otherwise split and arrive empty.\n"
     f"OPENBRAIN_DEVELOPMENT_ROOT={quoted_root}\n"
+    f"{END}\n"
 )
 
-# Replace any existing assignment (commented or live) so re-running is
-# idempotent and an install never leaves two spellings disagreeing.
-pattern = re.compile(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", re.M)
-if pattern.search(text):
-    text = pattern.sub("", text)
+# Rewrite the block WHOLE, between markers. The previous version replaced only
+# the assignment LINE, which is idempotent on its own but left the comment lines
+# behind -- so every bundle+install cycle appended another seven-line preamble.
+# The Air's env file reached THREE stacked blocks that way, one still reading
+# "EDIT ME" above the value the installer had just resolved. Delete every marked
+# block first (there may be several from before this fix, and `*?` keeps each
+# match to its own block rather than swallowing the span between the first BEGIN
+# and the last END), then append exactly one.
+marked = re.compile(
+    rf"^{re.escape(BEGIN)}\n.*?^{re.escape(END)}\n?", re.M | re.S
+)
+text = marked.sub("", text)
+
+# Sweep the legacy UNMARKED copies this writer and client-bundle.sh emitted
+# before markers existed. Each is anchored on its OWN opening comment line and
+# eats the "##" run that follows, so it removes blocks this project wrote and
+# leaves operator comments alone.
+#
+# The trailing assignment is OPTIONAL, and that is the whole subtlety: the old
+# writer stripped the assignment line as it appended the next block, so in a
+# file with N stacked blocks only the LAST one still has a value under it and
+# the earlier N-1 are bare comment runs. Requiring the assignment cleaned up
+# exactly one block and left the rest -- measured on the Air-shaped fixture,
+# which still reported EDIT-ME=1 after a reinstall.
+legacy = (
+    # setup-client.sh's own historical block (live assignment).
+    r"^## This machine's Development root\. Written by setup-client\.sh at install\n"
+    r"(?:^##.*\n)*"
+    r"(?:^OPENBRAIN_DEVELOPMENT_ROOT=.*\n?)?",
+    # client-bundle.sh's staged block (commented assignment).
+    r"^## EDIT ME ON THE CLIENT.*\n"
+    r"(?:^##.*\n)*"
+    r"(?:^#\s*OPENBRAIN_DEVELOPMENT_ROOT=.*\n?)?",
+)
+for pat in legacy:
+    text = re.sub(pat, "", text, flags=re.M)
+
+# Any remaining stray assignment (hand-edited, or a spelling neither block
+# above owns) still has to go: two live assignments would disagree silently.
+text = re.sub(r"^[#\s]*OPENBRAIN_DEVELOPMENT_ROOT=.*$\n?", "", text, flags=re.M)
+
 text = text.rstrip("\n") + "\n" + block
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(text)
@@ -384,13 +425,20 @@ case "$BASE_URL" in
     bundle ships the Mini's env file as-is, and loopback points this box at
     itself, where no brain is listening.
 
-    Edit the line to the Mini's LAN address, then re-run:
+    Edit this line, then re-run:
 
       $TARGET_ENV_DIR/claudex-observation.env
-      OPENBRAIN_BASE_URL=http://10.71.1.21:3100
 
-    Plain http on the LAN also needs OPENBRAIN_ALLOW_INSECURE_HTTP=1 in that
-    same file.
+    Preferred -- TLS, so it needs no extra variable and works off the LAN:
+
+      OPENBRAIN_BASE_URL=https://ob.rodaddy.live
+
+    Fallback, only if DNS or Caddy is down AND this box is on the LAN. Plain
+    http to a non-loopback address is refused by the client unless you ALSO add
+    OPENBRAIN_ALLOW_INSECURE_HTTP=1 to that same file -- both lines or neither:
+
+      OPENBRAIN_BASE_URL=http://10.71.1.20:3100
+      OPENBRAIN_ALLOW_INSECURE_HTTP=1
 
     Running this script ON the Mini itself, where loopback is correct? Set
     OPENBRAIN_ALLOW_LOOPBACK_CLIENT=1 to skip this check."


### PR DESCRIPTION
Two small verified defects from the Air's 2026-08-04 reinstall (bundle
`20260804-231742`). **The install itself succeeded** — both of these are
recovery guidance and file hygiene, not a broken install path.

## Defect 1 — the loopback guard named the wrong box

`scripts/setup-client.sh` refuses a loopback `OPENBRAIN_BASE_URL` and tells the
operator how to fix it. The die text said *"Edit the line to the Mini's LAN
address"* and then printed `http://10.71.1.21:3100` — which is **core01**, not
the Mini (`10.71.1.20`, per `client-bundle.sh:5`). Prose and address disagreed,
so following either one literally was wrong.

The second trap: a plain-http LAN URL is refused by
`openbrain_memory.client._validate_base_url` unless
`OPENBRAIN_ALLOW_INSECURE_HTTP=1` is **also** set. The old text mentioned that
in a separate trailing paragraph — easy to skip, and skipping it means the
"fix" still does not work.

The suggestion now leads with `https://ob.rodaddy.live`: TLS, so it needs no
opt-in variable and no LAN presence, and it is what the Air actually runs. One
LAN address stays as the DNS/Caddy-down fallback, corrected to the Mini, with
the insecure-http coupling on the line beside it and stated as *both lines or
neither*. This is what `docs/client-install-runbook.md` §3 and `docs/GOTCHAS.md`
already teach; the guard text was the odd one out.

## Defect 2 — a stacked comment block per reinstall

The env writer's assignment-line regex was idempotent. The seven comment lines
above it were not, so each write appended a fresh preamble. The Air's file
carried **three** blocks, one still reading `EDIT ME ON THE CLIENT` directly
above the value the installer had just resolved — guidance that outlived its own
fix and now contradicts it.

**The cycle is bundle-side, which is why both scripts change.**
`client-bundle.sh` stages from the build machine's *live installed* env file, so
every block the installer wrote travels into the next bundle, and the client's
install appends one more. Each rebuild stacked a pair — that is the three.

Both writers now emit a single marker-delimited block
(`## >>> openbrain: development root (managed) >>>` … `<<<`) and rewrite it
whole, plus sweep the legacy unmarked copies once. `client-bundle.sh` drops the
`EDIT ME` wording: on the paved road `setup-client.sh` resolves the value, and
the staged line only matters when hand-installing without it.

The legacy sweep treats the trailing assignment as **optional**, which is the
subtlety a first pass got wrong: the old writer stripped the assignment line as
it appended the next block, so in a file with N stacked blocks only the **last**
carries a value and the earlier N-1 are bare comment runs. Requiring the
assignment collapsed exactly one block and left the rest — caught by the
Air-shaped fixture still reporting `EDIT-ME=1` after a reinstall, then fixed.

## Red proof

Real scripts end-to-end, three bundle+install cycles into one fixture `HOME`
under the scratch workspace (stubbed `uv`/`curl`,
`OPENBRAIN_ALLOW_LOOPBACK_CLIENT=1`, per the PR #557 harness recipe). The
staging step is extracted **verbatim** out of `client-bundle.sh` rather than
hand-copied, so the harness cannot drift from the shipped code.

```
OLD   cycle 1: EDIT-ME=1  written-blocks=1  marked=0  live-assignments=1
OLD   cycle 2: EDIT-ME=2  written-blocks=2  marked=0  live-assignments=1
OLD   cycle 3: EDIT-ME=3  written-blocks=3  marked=0  live-assignments=1

NEW   cycle 1: EDIT-ME=0  written-blocks=0  marked=1  live-assignments=1
NEW   cycle 2: EDIT-ME=0  written-blocks=0  marked=1  live-assignments=1
NEW   cycle 3: EDIT-ME=0  written-blocks=0  marked=1  live-assignments=1
```

`OLD cycle 3` reproduces the Air's file exactly, including the surviving
`EDIT ME` above the resolved value. One wrapper pass-through after all three
runs, both old and new.

Seeding the OLD run's own output — the field artifact, not a hand-typed
imitation — one reinstall collapses it:

```
seeded            EDIT-ME=3  legacy-blocks=3  marked=0  live-assignments=1
after reinstall   EDIT-ME=0  legacy-blocks=0  marked=1  live-assignments=1
```

Guard text, from the live refusal path:

```
    Edit this line, then re-run:

      .../env/claudex-observation.env

    Preferred -- TLS, so it needs no extra variable and works off the LAN:

      OPENBRAIN_BASE_URL=https://ob.rodaddy.live

    Fallback, only if DNS or Caddy is down AND this box is on the LAN. Plain
    http to a non-loopback address is refused by the client unless you ALSO add
    OPENBRAIN_ALLOW_INSECURE_HTTP=1 to that same file -- both lines or neither:

      OPENBRAIN_BASE_URL=http://10.71.1.20:3100
      OPENBRAIN_ALLOW_INSECURE_HTTP=1
```

## Kept as-is (what the Air's reinstall got right)

The field notes recorded these working, and none of them are touched here:

- The install **succeeded end to end** — wheels, env dir, wrapper, hook merge,
  and the `status=direct` recall proof all landed on the first run.
- `OPENBRAIN_DEVELOPMENT_ROOT` resolution from #557 worked: the Air's own root
  was detected and written, and the wrapper pass-through was added once.
- The loopback guard **fired correctly** and refused the unedited build-machine
  value. Only its remediation text was wrong — the refusal itself is what caught
  the misconfiguration, and it stays.
- The `EDIT ME` staging marker did its job of not looking authoritative; it is
  retired because the installer now resolves the value, not because it misfired.
- Re-running the installer stayed safe and non-destructive (env file backed up,
  hook merge idempotent).

## Gates

- `sh -n` and `bash -n` clean on both scripts; `shellcheck -S warning` clean.
- All embedded Python heredocs parse (`ast.parse` over every `<<'PY'` block).
- `bun install --frozen-lockfile` clean.

## Critical Self-Review

- Highest-risk behavior: the legacy sweep deletes comment lines from an existing
  installed env file, so an over-broad pattern could eat an operator's own
  notes; each pattern is anchored on the exact opening line this project emitted
  and consumes only the contiguous `##` run beneath it, proven against the
  Air-shaped fixture where surrounding lines (`OPENBRAIN_BASE_URL`, `TOKEN`,
  `NAMESPACE`) survived byte-identical.
- Assumptions that could be wrong: that the two legacy spellings are the only
  unmarked blocks in the field — a box carrying a hand-edited variant keeps its
  comment lines and gets one marked block appended, which is untidy but not
  broken, and the final stray-assignment sweep still guarantees exactly one live
  assignment.
- Missing/weak tests: these are shell installers with no unit-test harness in
  this repo, so the evidence is the fixture-HOME run rather than a committed
  test; the same automated-fixture gap flagged on #557 is still open and this
  change does not close it.
- Security/permission risk: no change to token handling or file modes — the env
  file stays 0600 and the wrapper 0755, and the guard text now steers operators
  toward TLS rather than plain-http, which removes a bearer token from the wire
  on the paved road.
- Migration/deploy risk: a box installed before this change gets its stacked
  blocks collapsed on the next reinstall rather than needing a hand-edit, and
  the value written is unchanged, so no already-working box changes behavior.
- Downstream client/runtime risk: the Python package, MCP tools, schemas, and
  call shapes are all untouched — `docs/downstream-rollout.md` classification is
  installer-and-bundle-only, so no rtech-mcps, mcp2cli, or Hermes step applies.
- Rollback/cleanup concern: reverting restores the previous scripts; an
  already-installed box keeps its single marked block, which the old writer's
  assignment regex still matches and rewrites correctly, so a revert does not
  strand the marker.
- Fixes made before PR: caught the optional-assignment defect in the legacy
  sweep when the Air-shaped fixture still reported `EDIT-ME=1` after a
  reinstall, and fixed it before opening; also removed a duplicated comment
  paragraph in `client-bundle.sh` left by the edit.
- Known residual risk: the marked-block regex uses a non-greedy span between
  markers, so a file where an operator deleted a closing marker by hand would
  have its block treated as unmarked and swept by the legacy patterns only if it
  matches those exact opening lines; otherwise it is left in place and one more
  block is appended, which is the pre-existing untidy behavior rather than a new
  failure.
- SME review-memory update: [x] not applicable because: this is installer text
  and env-file hygiene with no new reviewable code pattern; the operational trap
  lives in `docs/GOTCHAS.md`, which is where client-install traps already sit.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: no server, schema, or MCP
  surface changes — the change is shell installer and bundle staging text, and
  the behavior was proven directly against the scripts in an isolated HOME.

## Contract Parity

- Contract parity: [x] runtime-specific because: no contract, schema, or tool
  surface changes — this is shell installer and bundle staging plus guard text,
  and the Python package is untouched, so there are no fixtures to update.
