### PR TITLE
fix(observability): carry model and token usage to Langfuse so cost prices (#560)

### DIFF
--- a/python/openbrain/src/openbrain/apps/capture/langfuse_emitter.py
+++ b/python/openbrain/src/openbrain/apps/capture/langfuse_emitter.py
@@ -39,13 +39,15 @@ See Also:
 
 from __future__ import annotations
 
+import subprocess
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from openbrain.config import ObservationSettings
-    from openbrain.models.turn import RawTurn
+    from openbrain.models.turn import RawTurn, TurnUsage
 
 #: The path suffix the provisioned endpoint carries for the #372 ingestion
 #: lane. The SDK addresses the server root and appends its own paths.
@@ -54,6 +56,67 @@ INGESTION_SUFFIX = "/api/public/ingestion"
 #: Tags on every trace this emitter writes, so capture-sink traffic is
 #: filterable next to anything else the server ingests.
 TRACE_TAGS = ("claude-code", "open-brain-capture")
+
+#: How long ``git rev-parse`` may take before the release is treated as unknown.
+#:
+#: Short by intent: this runs on a hook's delivery path, and a hung git call
+#: must never be what delays a capture. Resolving the SHA is an enrichment, so
+#: the timeout expiring costs a metadata field and nothing else.
+REV_PARSE_TIMEOUT_S = 2.0
+
+
+def _usage_details(usage: TurnUsage) -> dict[str, int]:
+    """One turn's token counts under the key names LANGFUSE prices against.
+
+    THE KEY NAMES ARE THE CONTRACT, not a formatting choice. Langfuse matches
+    ``usage_details`` keys against a model price's own unit names; a key it does
+    not recognise contributes NOTHING to the total, and the generation lands at
+    NULL cost exactly as if no usage had been sent. Sending the transcript's own
+    ``input_tokens``/``output_tokens`` spelling would look correct in the UI's
+    raw JSON and still price at zero, which is the failure mode #560 exists to
+    remove -- so the rename happens here, once, at the boundary that owns the
+    SDK, and a test asserts the literal strings.
+    """
+    return {
+        "input": usage.input_tokens,
+        "output": usage.output_tokens,
+        "cache_read_input_tokens": usage.cache_read_input_tokens,
+        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+    }
+
+
+@lru_cache(maxsize=1)
+def repo_release() -> str | None:
+    """The short git SHA of the checkout this process runs from, or ``None``.
+
+    Langfuse's ``release`` is what turns "cost went up" into "cost went up at
+    THIS commit"; #560 measured it empty on 100% of traces.
+
+    Cached for the process, because the SHA cannot change under a running
+    process and a hook is short-lived -- resolving it per emit would put a
+    subprocess on the delivery path, which is a defect rather than a cost.
+
+    Returns ``None`` when the SHA cannot be resolved -- a deployed tarball, no
+    git binary, a timeout. Deliberately NOT a placeholder like ``"unknown"``:
+    an omitted release is correctly read as absent, while a placeholder becomes
+    a release value that groups every unversioned trace together as if they
+    shared a commit.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell, no input
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=REV_PARSE_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # No git, or it could not be executed. Not knowing the release is not
+        # a reason to lose the trace.
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
 
 
 class ObservationSinkUnconfiguredError(ValueError):
@@ -119,10 +182,20 @@ class LangfuseEmitter:
         ):  # pragma: no cover - the spine gates on observation_active first
             raise ObservationSinkUnconfiguredError
 
+        # `release` is a CLIENT-level attribute in SDK v4, not a
+        # `propagate_attributes` one -- that function's signature accepts
+        # user_id/session_id/metadata/version/tags/trace_name/environment/prompt
+        # and nothing else, so passing release there is a TypeError that would
+        # take the whole capture down (verified against the installed SDK).
+        # Passed straight through as None when unresolvable (#560): the
+        # parameter is declared `Optional[str]` and defaults to None, so an
+        # explicit None is exactly equivalent to omitting it -- and unlike a
+        # `**dict` splat it stays checkable, which is what mypy caught here.
         client = Langfuse(
             public_key=settings.public_key,
             secret_key=settings.secret_key.get_secret_value(),
             host=sink_host(settings.endpoint),
+            release=repo_release(),
         )
         try:
             repo = next((turn.repo for turn in turns if turn.repo), None)
@@ -153,8 +226,25 @@ class LangfuseEmitter:
         from openbrain.models.turn import TurnRole
 
         if turn.role is TurnRole.ASSISTANT:
+            # #560: model and usage_details are what make a generation COST
+            # something. Without them Langfuse has a model-less observation with
+            # no quantity to price, and total_cost lands NULL -- measured on
+            # 23,439 of 23,440 live generations.
+            #
+            # Built as kwargs and splatted so an absent field is OMITTED rather
+            # than sent as None or {}. A zeroed usage_details reads as a turn
+            # that was measured at zero cost, which is a false measurement; an
+            # absent one correctly reads as unknown.
+            cost: dict[str, object] = {}
+            if turn.model is not None:
+                cost["model"] = turn.model
+            if turn.usage is not None:
+                cost["usage_details"] = _usage_details(turn.usage)
             observation = client.start_observation(  # type: ignore[attr-defined]
-                name="assistant-turn", as_type="generation", output=turn.content
+                name="assistant-turn",
+                as_type="generation",
+                output=turn.content,
+                **cost,
             )
         elif turn.role is TurnRole.TOOL:
             observation = client.start_observation(  # type: ignore[attr-defined]

--- a/python/openbrain/src/openbrain/apps/capture/records.py
+++ b/python/openbrain/src/openbrain/apps/capture/records.py
@@ -133,7 +133,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from openbrain.models.turn import RawTurn, TurnRole
+from openbrain.models.turn import RawTurn, TurnRole, TurnUsage
 
 #: The record type carrying a message, whoever authored it.
 #:
@@ -198,6 +198,15 @@ class TranscriptMessage(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     content: Any = None
+    #: The model that produced this record, present on assistant records only.
+    model: str | None = None
+    #: The token counts for this record, present on assistant records only.
+    #:
+    #: Held as a raw mapping and converted at the boundary below rather than
+    #: declared as :class:`~openbrain.models.turn.TurnUsage` here, so a blob
+    #: whose shape drifts is still PARSED -- the conversion can then decline it
+    #: without the whole transcript line failing validation.
+    usage: dict[str, Any] | None = None
 
 
 class TranscriptRecord(BaseModel):
@@ -349,6 +358,12 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
     # BOTH SIDES, and the branch order is not arbitrary: the operator test is
     # the narrower one (a type AND a promptSource), so it is asked first and the
     # assistant test never sees a record the operator test already claimed.
+    # Cost attribution data, and it is set on the ASSISTANT BRANCH ONLY (#560).
+    # A person typing has no model and burns no tokens; carrying either onto
+    # their turn would attribute their words, and their spend, to an agent.
+    model: str | None = None
+    usage: TurnUsage | None = None
+
     if record.is_operator_turn:
         content = record.operator_text
         role = TurnRole.USER
@@ -361,6 +376,8 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
         content = record.assistant_text
         role = TurnRole.ASSISTANT
         is_human_prompt = False
+        model = record.message.model if record.message else None
+        usage = _turn_usage(record.message.usage if record.message else None)
     else:
         return None
 
@@ -382,4 +399,35 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
         parent_turn_uuid=record.parent_uuid or None,
         session_ref=record.session_id or None,
         repo=record.cwd or None,
+        # #560: without these the observation lane writes a generation with no
+        # model and no quantity, and Langfuse prices it at NULL.
+        model=model,
+        usage=usage,
     )
+
+
+def _turn_usage(blob: dict[str, Any] | None) -> TurnUsage | None:
+    """The four priced token counts from a transcript's ``usage`` object.
+
+    Args:
+        blob: The record's ``message.usage``, straight off the transcript and
+            therefore untrusted in shape.
+
+    Returns:
+        A :class:`~openbrain.models.turn.TurnUsage`, or ``None`` when the
+        record carried no usage at all or carried something unreadable.
+
+    ``None`` and a zeroed model are DIFFERENT ANSWERS and the distinction is the
+    point: an omitted ``usage_details`` says "this turn's cost is unknown",
+    while zeros say "this turn was measured and cost nothing". The second is a
+    false measurement, so an unusable blob returns ``None`` rather than a
+    defaulted object.
+    """
+    if not blob:
+        return None
+    try:
+        return TurnUsage.model_validate(blob)
+    except ValidationError:
+        # A shape change upstream must not cost the TURN. The text is what the
+        # raw lane exists to keep; the counts are an enrichment on top of it.
+        return None

--- a/python/openbrain/src/openbrain/apps/capture/records.py
+++ b/python/openbrain/src/openbrain/apps/capture/records.py
@@ -198,15 +198,13 @@ class TranscriptMessage(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     content: Any = None
-    #: The model that produced this record, present on assistant records only.
-    model: str | None = None
-    #: The token counts for this record, present on assistant records only.
+    #: Cost fields are untrusted enrichments, not part of the turn's identity.
     #:
-    #: Held as a raw mapping and converted at the boundary below rather than
-    #: declared as :class:`~openbrain.models.turn.TurnUsage` here, so a blob
-    #: whose shape drifts is still PARSED -- the conversion can then decline it
-    #: without the whole transcript line failing validation.
-    usage: dict[str, Any] | None = None
+    #: Keep both raw here so a malformed value cannot reject the whole message
+    #: and permanently drop its text. The boundary below validates each value
+    #: independently and omits only the unusable enrichment.
+    model: Any = None
+    usage: Any = None
 
 
 class TranscriptRecord(BaseModel):
@@ -376,7 +374,7 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
         content = record.assistant_text
         role = TurnRole.ASSISTANT
         is_human_prompt = False
-        model = record.message.model if record.message else None
+        model = _turn_model(record.message.model if record.message else None)
         usage = _turn_usage(record.message.usage if record.message else None)
     else:
         return None
@@ -406,7 +404,12 @@ def raw_turn_from_line(line: str) -> RawTurn | None:
     )
 
 
-def _turn_usage(blob: dict[str, Any] | None) -> TurnUsage | None:
+def _turn_model(value: Any) -> str | None:
+    """Return a usable model identifier without risking the turn's text."""
+    return value if isinstance(value, str) else None
+
+
+def _turn_usage(blob: Any) -> TurnUsage | None:
     """The four priced token counts from a transcript's ``usage`` object.
 
     Args:
@@ -423,7 +426,7 @@ def _turn_usage(blob: dict[str, Any] | None) -> TurnUsage | None:
     false measurement, so an unusable blob returns ``None`` rather than a
     defaulted object.
     """
-    if not blob:
+    if not isinstance(blob, dict) or not blob:
         return None
     try:
         return TurnUsage.model_validate(blob)

--- a/python/openbrain/src/openbrain/models/turn.py
+++ b/python/openbrain/src/openbrain/models/turn.py
@@ -23,6 +23,7 @@ Key Components:
     - EventType: the nine accepted event types
     - TurnRole: who produced a turn -- user, assistant, or tool
     - TurnSignal: an event type plus the content it was derived from
+    - TurnUsage: what one assistant turn cost, in tokens
     - RawTurn: a transcript record bound for the raw lane
 
 Pattern/Convention:
@@ -182,6 +183,47 @@ class TurnSignal(BaseModel):
         return value
 
 
+class TurnUsage(BaseModel):
+    """What one assistant turn cost, in tokens, as the transcript reported it.
+
+    The four counts Langfuse prices against, and nothing else. They are carried
+    so the observation lane can set ``usage_details`` on a generation: without
+    them Langfuse has no quantity to multiply a model price by, and every
+    generation lands with ``total_cost = NULL`` (#560 measured 23,439 of 23,440
+    such rows).
+
+    ``extra="ignore"`` is LOAD-BEARING and differs deliberately from
+    :class:`RawTurn`'s ``extra="forbid"``. The live ``usage`` blob carries
+    ``server_tool_use``, ``service_tier``, ``iterations``, ``speed``,
+    ``inference_geo`` and more (measured on a real transcript 2026-08-05), and
+    the set grows without notice. Forbidding extras here would turn an upstream
+    addition into a parse failure on the CAPTURE path, which
+    ``docs/decisions/capture-never-drops-a-turn.md`` forbids -- a turn would be
+    lost over a field nobody reads.
+
+    Every count defaults to 0 rather than being optional: a token count is a
+    quantity, and an assistant turn that reports no cache read genuinely read
+    zero cached tokens. Absence of the WHOLE blob is expressed by
+    ``RawTurn.usage`` being ``None``, not by a field-by-field null.
+
+    Attributes:
+        input_tokens: Fresh input tokens billed at the full input rate.
+        output_tokens: Tokens the model generated.
+        cache_read_input_tokens: Tokens served from cache, billed at a
+            reduced rate -- the field that makes a cached agent look cheap
+            instead of impossible.
+        cache_creation_input_tokens: Tokens written into the cache, billed at
+            a premium.
+    """
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
+
 class RawTurn(BaseModel):
     """One transcript record, bound for the raw lane.
 
@@ -207,6 +249,12 @@ class RawTurn(BaseModel):
         parent_turn_uuid: The preceding record, when the transcript names one.
         session_ref: The session this belongs to.
         repo: The repository the turn happened in, when derivable.
+        model: The model that produced this turn, verbatim from the transcript
+            (``claude-fable-5``, ``claude-opus-5``). ASSISTANT TURNS ONLY --
+            a person typing has no model, and defaulting one onto their turn
+            would attribute their words to an agent.
+        usage: What the turn cost in tokens, when the transcript reported it.
+            Assistant turns only, for the same reason.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -219,3 +267,5 @@ class RawTurn(BaseModel):
     parent_turn_uuid: str | None = None
     session_ref: str | None = None
     repo: str | None = None
+    model: str | None = None
+    usage: TurnUsage | None = None

--- a/python/openbrain/src/openbrain/models/turn.py
+++ b/python/openbrain/src/openbrain/models/turn.py
@@ -54,6 +54,7 @@ See Also:
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -201,10 +202,9 @@ class TurnUsage(BaseModel):
     ``docs/decisions/capture-never-drops-a-turn.md`` forbids -- a turn would be
     lost over a field nobody reads.
 
-    Every count defaults to 0 rather than being optional: a token count is a
-    quantity, and an assistant turn that reports no cache read genuinely read
-    zero cached tokens. Absence of the WHOLE blob is expressed by
-    ``RawTurn.usage`` being ``None``, not by a field-by-field null.
+    All four counts are required, strict, and non-negative. A partial or
+    mistyped blob is not a measurement: capture omits the whole enrichment as
+    ``RawTurn.usage = None`` rather than fabricating zeros or coercing values.
 
     Attributes:
         input_tokens: Fresh input tokens billed at the full input rate.
@@ -218,10 +218,10 @@ class TurnUsage(BaseModel):
 
     model_config = ConfigDict(extra="ignore", frozen=True)
 
-    input_tokens: int = 0
-    output_tokens: int = 0
-    cache_read_input_tokens: int = 0
-    cache_creation_input_tokens: int = 0
+    input_tokens: Annotated[int, Field(strict=True, ge=0)]
+    output_tokens: Annotated[int, Field(strict=True, ge=0)]
+    cache_read_input_tokens: Annotated[int, Field(strict=True, ge=0)]
+    cache_creation_input_tokens: Annotated[int, Field(strict=True, ge=0)]
 
 
 class RawTurn(BaseModel):

--- a/python/openbrain/tests/test_capture_transcript.py
+++ b/python/openbrain/tests/test_capture_transcript.py
@@ -90,6 +90,56 @@ def assistant_line(uuid: str) -> str:
     return json.dumps({"type": "assistant", "uuid": uuid, "message": {"content": []}})
 
 
+def assistant_reply_line(
+    uuid: str,
+    text: str = "the index was empty",
+    *,
+    model: str | None = "claude-fable-5",
+    usage: dict[str, object] | None = None,
+) -> str:
+    """An assistant record that SAID something, with its model and usage.
+
+    The usage default is the live shape measured on a real transcript
+    2026-08-05, extra keys and all -- ``service_tier``, ``iterations``,
+    ``server_tool_use`` -- because those extras are precisely what
+    ``TurnUsage(extra="ignore")`` exists to survive.
+    """
+    message: dict[str, object] = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+    }
+    if model is not None:
+        message["model"] = model
+    if usage is not None:
+        message["usage"] = usage
+    return json.dumps(
+        {
+            "type": "assistant",
+            "uuid": uuid,
+            "sessionId": "s1",
+            "cwd": "/repo",
+            "message": message,
+        }
+    )
+
+
+#: The ``usage`` object as Claude Code actually writes it, verbatim.
+LIVE_USAGE = {
+    "input_tokens": 2,
+    "cache_creation_input_tokens": 41238,
+    "cache_read_input_tokens": 15510,
+    "output_tokens": 456,
+    "server_tool_use": {"web_search_requests": 0, "web_fetch_requests": 0},
+    "service_tier": "standard",
+    "cache_creation": {
+        "ephemeral_1h_input_tokens": 41238,
+        "ephemeral_5m_input_tokens": 0,
+    },
+    "inference_geo": "not_available",
+    "speed": "standard",
+}
+
+
 def write_lines(path: Path, lines: list[str]) -> None:
     path.write_text("".join(f"{line}\n" for line in lines), encoding="utf-8")
 
@@ -319,6 +369,62 @@ class TestFieldsCarriedThrough:
 
         assert turn is not None
         assert turn.parent_turn_uuid is None
+
+
+class TestCostAttributionSurvivesTheParse:
+    """Model and token counts reach the RawTurn, or cost is NULL forever (#560).
+
+    This is the boundary the data used to die at: the transcript carried
+    ``message.model`` and ``message.usage`` on every assistant record and
+    ``TranscriptMessage`` declared neither, so the observation lane had nothing
+    to price. 23,439 of 23,440 live generations landed with ``total_cost =
+    NULL``.
+    """
+
+    async def test_an_assistant_turn_carries_its_model(self) -> None:
+        turn = raw_turn_from_line(assistant_reply_line("a1", usage=LIVE_USAGE))
+
+        assert turn is not None
+        assert turn.model == "claude-fable-5"
+
+    async def test_an_assistant_turn_carries_the_four_priced_counts(self) -> None:
+        """The live blob's extra keys are ignored, not fatal."""
+        turn = raw_turn_from_line(assistant_reply_line("a1", usage=LIVE_USAGE))
+
+        assert turn is not None
+        assert turn.usage is not None
+        assert turn.usage.input_tokens == 2
+        assert turn.usage.output_tokens == 456
+        assert turn.usage.cache_read_input_tokens == 15510
+        assert turn.usage.cache_creation_input_tokens == 41238
+
+    async def test_an_operator_turn_claims_no_model_and_no_usage(self) -> None:
+        """A person typing burns no tokens; inventing some misattributes spend."""
+        turn = raw_turn_from_line(operator_line("u1", "hello"))
+
+        assert turn is not None
+        assert turn.model is None
+        assert turn.usage is None
+
+    async def test_an_assistant_turn_without_usage_reports_none(self) -> None:
+        """Unknown cost is ``None``, never a zeroed blob that reads as measured."""
+        turn = raw_turn_from_line(assistant_reply_line("a1", model=None))
+
+        assert turn is not None
+        assert turn.model is None
+        assert turn.usage is None
+
+    async def test_an_unreadable_usage_blob_costs_the_counts_not_the_turn(
+        self,
+    ) -> None:
+        """A shape change upstream must never drop a turn's TEXT."""
+        turn = raw_turn_from_line(
+            assistant_reply_line("a1", usage={"input_tokens": "lots"})
+        )
+
+        assert turn is not None
+        assert turn.content == "the index was empty"
+        assert turn.usage is None
 
 
 class TestWatermarkStore:

--- a/python/openbrain/tests/test_capture_transcript.py
+++ b/python/openbrain/tests/test_capture_transcript.py
@@ -414,13 +414,38 @@ class TestCostAttributionSurvivesTheParse:
         assert turn.model is None
         assert turn.usage is None
 
-    async def test_an_unreadable_usage_blob_costs_the_counts_not_the_turn(
-        self,
+    @pytest.mark.parametrize(
+        ("field", "malformed"),
+        [("model", {"unexpected": "shape"}), ("usage", ["not", "a", "mapping"])],
+    )
+    async def test_malformed_cost_enrichment_costs_only_the_enrichment(
+        self, field: str, malformed: object
     ) -> None:
         """A shape change upstream must never drop a turn's TEXT."""
-        turn = raw_turn_from_line(
-            assistant_reply_line("a1", usage={"input_tokens": "lots"})
-        )
+        line = json.loads(assistant_reply_line("a1", usage=LIVE_USAGE))
+        line["message"][field] = malformed
+
+        turn = raw_turn_from_line(json.dumps(line))
+
+        assert turn is not None
+        assert turn.content == "the index was empty"
+        assert getattr(turn, field) is None
+
+    @pytest.mark.parametrize(
+        "usage",
+        [
+            pytest.param({"input_tokens": 2}, id="partial"),
+            pytest.param({**LIVE_USAGE, "input_tokens": "2"}, id="string"),
+            pytest.param({**LIVE_USAGE, "input_tokens": True}, id="bool"),
+            pytest.param({**LIVE_USAGE, "input_tokens": -1}, id="negative"),
+        ],
+    )
+    async def test_invalid_usage_is_unknown_not_fabricated(self, usage: object) -> None:
+        """Incomplete, coerced, or negative counts are not measurements."""
+        line = json.loads(assistant_reply_line("a1", usage=LIVE_USAGE))
+        line["message"]["usage"] = usage
+
+        turn = raw_turn_from_line(json.dumps(line))
 
         assert turn is not None
         assert turn.content == "the index was empty"

--- a/python/openbrain/tests/test_observe_sink.py
+++ b/python/openbrain/tests/test_observe_sink.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conftest import RecordingLane, operator_line, write_lines
-from openbrain.apps.capture.langfuse_emitter import INGESTION_SUFFIX, sink_host
+from openbrain.apps.capture.langfuse_emitter import (
+    INGESTION_SUFFIX,
+    LangfuseEmitter,
+    sink_host,
+)
 from openbrain.apps.capture.observe import (
     OBSERVE_KEY_PREFIX,
     observation_active,
@@ -41,12 +45,11 @@ from openbrain.config import (
     UnknownEnvironmentVariableError,
     load_observation_settings,
 )
+from openbrain.models.turn import RawTurn, TurnRole, TurnUsage
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
-
-    from openbrain.models.turn import RawTurn
 
 
 class RecordingEmitter:
@@ -354,6 +357,106 @@ class TestObservationSettingsResolution:
     def test_a_secret_never_appears_in_the_repr(self) -> None:
         settings = observation_settings()
         assert "sk-lf-test" not in repr(settings)
+
+
+class FakeObservation:
+    """The two methods ``_observe_turn`` uses on what it starts."""
+
+    def __init__(self) -> None:
+        """Start un-ended, so a test can prove the observation was closed."""
+        self.ended = False
+
+    def end(self) -> None:
+        self.ended = True
+
+
+class FakeClient:
+    """Records the kwargs each observation was started with.
+
+    Deliberately NOT a real ``Langfuse``: the assertion here is about the
+    arguments this module composes, and a real client would dial the fleet
+    server (the failure #544 pinned).
+    """
+
+    def __init__(self) -> None:
+        """Start with nothing recorded."""
+        self.started: list[dict[str, object]] = []
+
+    def start_observation(self, **kwargs: object) -> FakeObservation:
+        self.started.append(kwargs)
+        return FakeObservation()
+
+
+def observed(turn: RawTurn) -> dict[str, object]:
+    """The kwargs ``_observe_turn`` passes for one turn."""
+    client = FakeClient()
+    LangfuseEmitter._observe_turn(client, turn)  # noqa: SLF001
+    return client.started[0]
+
+
+class TestAGenerationCarriesWhatLangfusePrices:
+    """Model and usage reach the generation, under the names that PRICE (#560).
+
+    ``usage_details`` keys are matched against a model price's own unit names.
+    A key Langfuse does not recognise contributes nothing, so a generation with
+    the transcript's own ``input_tokens`` spelling looks populated in the UI and
+    still costs NULL -- which is why these tests assert the literal strings
+    rather than only the values.
+    """
+
+    async def test_the_generation_names_its_model(self) -> None:
+        turn = RawTurn(
+            turn_uuid="a1",
+            content="hi",
+            role=TurnRole.ASSISTANT,
+            model="claude-opus-5",
+        )
+
+        assert observed(turn)["model"] == "claude-opus-5"
+
+    async def test_usage_details_uses_the_keys_langfuse_prices_against(
+        self,
+    ) -> None:
+        turn = RawTurn(
+            turn_uuid="a1",
+            content="hi",
+            role=TurnRole.ASSISTANT,
+            model="claude-opus-5",
+            usage=TurnUsage(
+                input_tokens=2,
+                output_tokens=456,
+                cache_read_input_tokens=15510,
+                cache_creation_input_tokens=41238,
+            ),
+        )
+
+        assert observed(turn)["usage_details"] == {
+            "input": 2,
+            "output": 456,
+            "cache_read_input_tokens": 15510,
+            "cache_creation_input_tokens": 41238,
+        }
+
+    async def test_a_turn_without_usage_omits_the_field_entirely(self) -> None:
+        """Absent, not empty: ``{}`` would read as a turn measured at zero."""
+        turn = RawTurn(
+            turn_uuid="a1", content="hi", role=TurnRole.ASSISTANT, model="claude-opus-5"
+        )
+
+        assert "usage_details" not in observed(turn)
+
+    async def test_a_turn_without_a_model_omits_the_field_entirely(self) -> None:
+        turn = RawTurn(turn_uuid="a1", content="hi", role=TurnRole.ASSISTANT)
+
+        assert "model" not in observed(turn)
+
+    async def test_a_user_turn_is_a_span_and_is_never_priced(self) -> None:
+        """Only the assistant produces a generation; a span has no cost."""
+        kwargs = observed(RawTurn(turn_uuid="u1", content="hi", role=TurnRole.USER))
+
+        assert kwargs["as_type"] == "span"
+        assert "model" not in kwargs
+        assert "usage_details" not in kwargs
 
 
 class TestTheSuiteNeverInheritsAnOperatorsSink:

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -18,6 +18,7 @@ import {
   errorOutput,
   installMcpTracing,
   readMcpTracingConfig,
+  repoRelease,
   resolveSessionId,
   SinkHealthTracker,
   type McpTracingConfig,
@@ -969,5 +970,34 @@ describe("trace body helpers", () => {
       error_class: "string",
       error_message: "plain string",
     });
+  });
+});
+
+/**
+ * #560: `release` is what lets an operator ask "which COMMIT got expensive".
+ *
+ * It was empty on 100% of traces because nothing ever resolved it. The resolver
+ * is asserted rather than the processor option, because constructing a real
+ * `LangfuseSpanProcessor` would build an exporter and this suite dials nothing.
+ */
+describe("the release stamped on every trace", () => {
+  test("resolves to the short SHA of the checkout under test", () => {
+    const release = repoRelease();
+
+    // This suite runs from a git checkout, so a SHA is expected here — but the
+    // shape is what is asserted, since the value changes with every commit.
+    expect(release).toMatch(/^[0-9a-f]{7,40}$/);
+  });
+
+  test("is never a placeholder standing in for an unknown commit", () => {
+    // A placeholder would group every unversioned trace as one release, which
+    // is worse than an absent field: it reads as a real, shared commit.
+    expect(repoRelease()).not.toBe("unknown");
+  });
+
+  test("is resolved once and cached, never forked per trace", () => {
+    // A subprocess per emit would put a fork on the request path, which is the
+    // one thing this lane is built not to do.
+    expect(repoRelease()).toBe(repoRelease());
   });
 });

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -154,6 +154,52 @@ const DEFAULT_FLAP_COOLDOWN_MS = 30_000;
  */
 const SINK_HEALTH_PROBE_MS = 5_000;
 
+/**
+ * How long `git rev-parse` may take before the release is treated as unknown.
+ *
+ * Short by intent: resolving the SHA is an enrichment, so a hung git call must
+ * never be what delays server startup. The timeout expiring costs one metadata
+ * field and nothing else.
+ */
+const REV_PARSE_TIMEOUT_MS = 2_000;
+
+/**
+ * The short git SHA of the checkout this process runs from, or `undefined`.
+ *
+ * Langfuse's `release` is what turns "cost went up" into "cost went up at THIS
+ * commit"; #560 measured it empty on 100% of traces.
+ *
+ * Resolved ONCE, lazily, and cached for the process: the SHA cannot change
+ * under a running process, and a subprocess per emit would put a fork on the
+ * request path — which is the one thing this whole lane is built not to do.
+ *
+ * `undefined` when the SHA cannot be resolved — a deployed tarball, no git
+ * binary, a timeout. Deliberately NOT a placeholder like `"unknown"`: an
+ * omitted release reads as absent, while a placeholder becomes a release value
+ * that groups every unversioned trace together as though they shared a commit.
+ */
+let cachedRelease: string | undefined | null = null;
+
+export function repoRelease(): string | undefined {
+  if (cachedRelease !== null) return cachedRelease;
+  cachedRelease = undefined;
+  try {
+    const result = Bun.spawnSync({
+      cmd: ["git", "rev-parse", "--short", "HEAD"],
+      stdout: "pipe",
+      stderr: "ignore",
+      timeout: REV_PARSE_TIMEOUT_MS,
+    });
+    if (result.success) {
+      const sha = result.stdout.toString().trim();
+      if (sha) cachedRelease = sha;
+    }
+  } catch {
+    // Not knowing the release is never a reason to lose tracing.
+  }
+  return cachedRelease;
+}
+
 export interface McpTracingConfig {
   enabled: boolean;
   endpoint: string;
@@ -784,12 +830,22 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
   // SDK emits reaches the log; this lane reports its own health through the
   // two state-change lines instead, which carry a label and a count only.
   configureGlobalLogger({ level: (LogLevel.ERROR + 1) as LogLevel });
+  // `release` belongs to the PROCESSOR, not to `updateTrace` (#560). The SDK
+  // stamps it onto every span it sees at start, and `LangfuseTraceAttributes`
+  // — what `updateTrace` accepts — has no release field at all, so setting it
+  // there would be silently dropped rather than rejected. Verified against the
+  // installed `@langfuse/otel` 4.6.x type surface.
+  //
+  // Spread so an unresolvable SHA omits the option entirely instead of passing
+  // `undefined`, keeping "unknown release" distinct from a placeholder value.
+  const release = repoRelease();
   const processor = new LangfuseSpanProcessor({
     publicKey: config.publicKey,
     secretKey: config.secretKey,
     baseUrl: config.endpoint,
     timeout: SINK_EXPORT_TIMEOUT_SECONDS,
     exportMode: "batched",
+    ...(release === undefined ? {} : { release }),
   });
   const provider = new BasicTracerProvider({ spanProcessors: [processor] });
   setLangfuseTracerProvider(provider);


### PR DESCRIPTION
Closes #560.

## The problem

23,439 of the dogfood project's 23,440 GENERATION observations had
`provided_model_name = NULL`, zero `usage_details`, and `total_cost = NULL`.
Every cost dashboard computed over NULL, so the instance could not answer
"which agent burned $40 yesterday" — the primary reason to run it.

## Where it actually broke

The data was never missing from the transcript. Every assistant record carries
`message.model` and `message.usage`:

```json
{"model":"claude-fable-5",
 "usage":{"input_tokens":2,"cache_creation_input_tokens":41238,
          "cache_read_input_tokens":15510,"output_tokens":456, ...}}
```

`TranscriptMessage` declared neither, so it died at the **parse boundary** long
before the emitter could price it. Fixed there rather than by re-reading the
transcript inside the emitter.

## Changes

- **`records.py` / `turn.py`** — `TranscriptMessage` declares `model`/`usage`;
  `RawTurn` carries them, populated on the **assistant branch only**. A person
  typing has no model and burns no tokens; defaulting either onto their turn
  would attribute their words, and their spend, to an agent.
- **`TurnUsage`** holds the four priced counts with `extra="ignore"` — the live
  blob carries `service_tier`, `iterations`, `server_tool_use` and more, and the
  set grows without notice. `extra="forbid"` here would turn an upstream field
  addition into lost capture, which `capture-never-drops-a-turn.md` forbids.
- **`langfuse_emitter.py`** — `_observe_turn` sets `model` and `usage_details`
  on the generation, under the key names Langfuse **prices against**
  (`input`/`output`/`cache_read_input_tokens`/`cache_creation_input_tokens`).
  The transcript's own `input_tokens` spelling would look populated in the UI
  and still price at zero, so a test asserts the literal strings.
- **`release`** is stamped from the short git SHA, resolved once and cached
  (never a fork per emit).

## Two SDK facts worth flagging, both verified against the installed packages

`release` is **not** where it looks like it goes in either SDK, and both wrong
spellings fail quietly or fatally rather than obviously:

- Python: `propagate_attributes()` accepts
  `user_id/session_id/metadata/version/tags/trace_name/environment/prompt` and
  **no `release`** — passing one is a `TypeError` that would take **all capture
  down**. It is a `Langfuse(...)` **client** option.
- TypeScript: `LangfuseTraceAttributes` (what `updateTrace` takes) has **no
  release field**, so setting it there is **silently dropped**. It is a
  `LangfuseSpanProcessor` constructor option.

## Scope note — the TS lane gets `release` only

`server/observability/langfuse-tracing.ts` traces **MCP tool calls**:
`buildToolTraceBody` receives `toolName/args/output/auth/durationMs`. There is
no LLM call and no token usage anywhere in that path, and those observations are
spans, not generations. Adding `usage_details` there would be **fabricated
data**. The NULL-cost generations are entirely the Python capture lane.

## Absent vs zero

Omitted throughout, never zeroed or placeholder'd. An omitted `usage_details`
reads as *unknown cost*; zeros read as *a turn measured at zero*, which is a
false measurement. Likewise `release` is omitted rather than `"unknown"`, which
would group every unversioned trace as one shared commit.

## Evidence

```
$ uv run pytest tests/test_observe_sink.py tests/test_turn_models.py \
      tests/test_capture_transcript.py -q
133 passed in 2.00s

$ uv run mypy src
Success: no issues found in 49 source files

$ uv run ruff check .
All checks passed!

$ bun test server/observability/langfuse-tracing.test.ts
 43 pass / 0 fail / 95 expect() calls

$ bunx tsc --noEmit
(clean, 0 errors)
```

**Falsifiability check** — commenting out the `model`/`usage_details` kwargs in
`_observe_turn` fails 2 tests, then restored:

```
FAILED tests/test_observe_sink.py::TestAGenerationCarriesWhatLangfusePrices::test_the_generation_names_its_model
FAILED tests/test_observe_sink.py::TestAGenerationCarriesWhatLangfusePrices::test_usage_details_uses_the_keys_langfuse_prices_against
E       KeyError: 'usage_details'
```

`ruff format --check` reports 2 pre-existing unformatted test files; both fail
identically on unmodified `origin/main` (verified by stashing) and are untouched
here.

## Still needed before cost is non-zero — operator step, not code

Custom model prices must be seeded on the instance for a rate to exist. Three
custom prices already exist there, so the mechanism is proven. Needed for
`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, priced per-token against
the four unit names above (`input`, `output`, `cache_read_input_tokens`,
`cache_creation_input_tokens`).

**CT273 was not touched by this work** — no network writes, no live mutation.

## Status (LAW 0)

**WRITTEN + MERGED-pending.** Tests pass locally; nothing here is verified
against the live Langfuse instance. Whether real generations land with non-NULL
cost is RUNNING-state evidence that does not exist yet and requires the model
prices above.

## Runtime attribution

Spec authored by the Claude Opus 5 owner node; a Codex Sol worker was launched
twice to write the code and produced **zero files** both times (first run died on
`stream error: stream disconnected before completion`, relaunch exited 144).
**All code and tests in this PR were written natively by the Opus 5 owner node.**
The owner's own SDK verification caught what would have been a capture-killing
`TypeError` from the `propagate_attributes(release=...)` shape in its own spec.

## Critical Self-Review

- Highest-risk behavior: `_observe_turn` now passes `model` and `usage_details` into the Langfuse generation on every assistant turn; a wrong kwarg shape here raises inside the emitter and takes down all capture, which is why the `propagate_attributes(release=...)` `TypeError` was caught and removed before this PR.
- Assumptions that could be wrong: that Langfuse prices against the literal unit names `input`, `output`, `cache_read_input_tokens`, `cache_creation_input_tokens`. If the instance's price units differ, the fields populate in the UI and still price at zero.
- Missing/weak tests: no test drives a real Langfuse client end to end; the emitter tests assert against a fake sink, so SDK-signature drift would pass locally and only fail at runtime.
- Security/permission risk: none identified. No auth, namespace, token, or SQL path is touched; the added fields are model name and integer token counts, and no transcript text is newly exported.
- Migration/deploy risk: no schema migration. Deploy risk is confined to the Python capture lane restarting with the new emitter; an SDK version whose `usage_details` kwarg differs would raise on first emit rather than degrade.
- Downstream client/runtime risk: `docs/downstream-rollout.md` classified as not applicable — no MCP tool, schema, transport, or client-facing contract changes, and `contract-parity` is green with `CONTRACT_PARITY_REQUIRED: false` on this PR. `TurnUsage` uses `extra="ignore"` so upstream usage-blob additions cannot drop a turn.
- Rollback/cleanup concern: revertible as a single commit; nothing is persisted or backfilled, so a revert simply returns generations to omitted model/usage. No cleanup of already-emitted data is required.
- Fixes made before PR: removed `propagate_attributes(release=...)` from the original spec after verifying the installed SDK rejects it; moved `release` to the client/span-processor option in each lane; cached the git SHA rather than forking per emit; scoped model/usage population to the assistant branch so a human turn is not attributed agent spend.
- Known residual risk: cost stays NULL until custom model prices for `claude-opus-5`, `claude-sonnet-5`, and `claude-fable-5` are seeded on the instance. That is an operator step, unverified here, and this PR is WRITTEN-state only against live Langfuse.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no review lane produced a MEDIUM+ finding on this PR; the two SDK gotchas it did surface are recorded in the PR body itself and no `docs/sme/` file is changed by this diff.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this change touches only the Langfuse capture/emitter path; no Open Brain MCP tool, schema, or live service behavior is exercised by it, and CT273 was not touched.
