### PR TITLE
fix(maintenance): add the missing recurring sweep producer (#384)

### DIFF
--- a/src/distill-handler.ts
+++ b/src/distill-handler.ts
@@ -101,8 +101,10 @@ export interface DistillSweepDeps {
   model?: NamedDistillModel;
   /** Injectable embed fn; defaults to the configured provider. */
   embedFn?: DistillEmbedFn;
-  /** Restrict the sweep to one namespace. Omit to sweep every namespace. */
+  /** Bind the sweep to one namespace. Omit to sweep every namespace. */
   namespace?: string;
+  /** Bind a queued batch to one owning lane. */
+  laneId?: string | null;
   maxSessions?: number;
   maxTurns?: number;
   contextWindow?: number;
@@ -259,6 +261,7 @@ export async function runDistillSweep(
 
   const batch = await claimDistillBatch(deps.pool, {
     ...(deps.namespace !== undefined ? { namespace: deps.namespace } : {}),
+    ...(deps.laneId !== undefined ? { laneId: deps.laneId } : {}),
     ...(deps.maxSessions !== undefined
       ? { maxSessions: deps.maxSessions }
       : {}),
@@ -361,6 +364,10 @@ export function makeMemoryDistillHandler(
     // default for a recurring maintenance job. Values are read defensively
     // because a job row is durable and may predate a code change.
     const payload = job.payload ?? {};
+    const laneId =
+      payload.lane_id === null || typeof payload.lane_id === "string"
+        ? payload.lane_id
+        : undefined;
     const maxSessions =
       typeof payload.max_sessions === "number"
         ? payload.max_sessions
@@ -377,6 +384,7 @@ export function makeMemoryDistillHandler(
       // one was scoped. A null namespace is a deliberate global sweep, which is
       // what a maintenance identity is for -- not an error.
       ...(job.namespace !== null ? { namespace: job.namespace } : {}),
+      ...(laneId !== undefined ? { laneId } : {}),
       ...(maxSessions !== undefined ? { maxSessions } : {}),
       ...(maxTurns !== undefined ? { maxTurns } : {}),
       distillJobId: job.id,
@@ -398,10 +406,12 @@ export function makeMemoryDistillHandler(
 export function buildMemoryDistillEnqueue(input: {
   sweepLabel: string;
   namespace?: string;
+  laneId?: string | null;
   maxSessions?: number;
   maxTurns?: number;
 }) {
   const payload: Record<string, unknown> = {};
+  if (input.laneId !== undefined) payload.lane_id = input.laneId;
   if (input.maxSessions !== undefined) payload.max_sessions = input.maxSessions;
   if (input.maxTurns !== undefined) payload.max_turns = input.maxTurns;
 

--- a/src/distill-window.test.ts
+++ b/src/distill-window.test.ts
@@ -269,6 +269,25 @@ describe("claimDistillBatch — ordering key and stamping", () => {
     expect(db.seen[0]!.values[0]).toBe("rico");
   });
 
+  it("binds both due selection and context reads to the producer's lane", async () => {
+    const db = fakeDb([]);
+    const laneId = "77777777-7777-4777-8777-777777777777";
+    await claimDistillBatch(db, { namespace: "rico", laneId });
+    const sql = db.seen[0]!.text;
+    expect(sql).toContain("AND lane_id = $2::uuid");
+    expect(sql).toContain("AND t.lane_id = $2::uuid");
+    expect(db.seen[0]!.values.slice(0, 2)).toEqual(["rico", laneId]);
+  });
+
+  it("keeps lane-less turns in their own producer batch", async () => {
+    const db = fakeDb([]);
+    await claimDistillBatch(db, { namespace: "rico", laneId: null });
+    const sql = db.seen[0]!.text;
+    expect(sql).toContain("AND lane_id IS NULL");
+    expect(sql).toContain("AND t.lane_id IS NULL");
+    expect(db.seen[0]!.values[0]).toBe("rico");
+  });
+
   it("bounds both the session and turn limits so one sweep cannot read the table", async () => {
     const db = fakeDb([]);
     await claimDistillBatch(db, { maxSessions: 10_000, maxTurns: 10_000_000 });

--- a/src/distill-window.ts
+++ b/src/distill-window.ts
@@ -76,6 +76,8 @@ export interface DistillUnit {
  * justify a different number yet -- so it is adopted, not invented.
  */
 export const DEFAULT_CONTEXT_WINDOW = 3;
+/** Default whole-session bound shared by direct and scheduled distill sweeps. */
+export const DEFAULT_MAX_DISTILL_SESSIONS = 4;
 
 /**
  * Is this turn SPEECH -- something a person or an agent actually said, and
@@ -211,7 +213,10 @@ export async function claimDistillBatch(
     contextWindow?: number;
   } = {},
 ): Promise<DistillBatch> {
-  const maxSessions = Math.min(Math.max(options.maxSessions ?? 4, 1), 64);
+  const maxSessions = Math.min(
+    Math.max(options.maxSessions ?? DEFAULT_MAX_DISTILL_SESSIONS, 1),
+    64,
+  );
   const maxTurns = Math.min(Math.max(options.maxTurns ?? 1500, 1), 20_000);
 
   const params: unknown[] = [];

--- a/src/distill-window.ts
+++ b/src/distill-window.ts
@@ -202,6 +202,8 @@ export async function claimDistillBatch(
   db: Pick<pg.Pool, "query">,
   options: {
     namespace?: string;
+    /** Bind one queued batch to the lane selected by the sweep producer. */
+    laneId?: string | null;
     /** Max sessions per batch. Bounded: one sweep must not read the whole table. */
     maxSessions?: number;
     /** Max turns per batch, a second bound for pathologically large sessions. */
@@ -217,6 +219,17 @@ export async function claimDistillBatch(
   if (options.namespace !== undefined) {
     params.push(options.namespace);
     nsPredicate = ` AND namespace = $${params.length}`;
+  }
+  let lanePredicate = "";
+  let outerLanePredicate = "";
+  if (options.laneId === null) {
+    lanePredicate = " AND lane_id IS NULL";
+    outerLanePredicate = " AND t.lane_id IS NULL";
+  }
+  if (typeof options.laneId === "string") {
+    params.push(options.laneId);
+    lanePredicate = ` AND lane_id = $${params.length}::uuid`;
+    outerLanePredicate = ` AND t.lane_id = $${params.length}::uuid`;
   }
   params.push(maxSessions);
   const sessionLimit = `$${params.length}`;
@@ -235,7 +248,7 @@ export async function claimDistillBatch(
        SELECT session_ref, min(occurred_at) AS first_due
          FROM ob_raw_turns
         WHERE distilled_at IS NULL
-          AND retention_tier = 'live'${nsPredicate}
+          AND retention_tier = 'live'${nsPredicate}${lanePredicate}
         GROUP BY session_ref
         ORDER BY first_due ASC NULLS LAST
         LIMIT ${sessionLimit}
@@ -246,7 +259,7 @@ export async function claimDistillBatch(
        FROM ob_raw_turns t
        JOIN due_sessions d
          ON t.session_ref IS NOT DISTINCT FROM d.session_ref
-      WHERE t.retention_tier = 'live'${nsPredicate}
+      WHERE t.retention_tier = 'live'${nsPredicate}${outerLanePredicate}
       ORDER BY ${DISTILL_ORDER_BY}
       LIMIT ${turnLimit}`,
     params,

--- a/src/graph-derivation-handler.test.ts
+++ b/src/graph-derivation-handler.test.ts
@@ -509,12 +509,13 @@ describe("selectSourcesNeedingDerivation", () => {
     expect(call.params).toContainEqual(["other-team"]);
   });
 
-  it("bounds the limit to the hard cap", async () => {
+  it("bounds selection to the enqueue maximum plus one sentinel", async () => {
     const pool = new FakeSourcePool();
     await selectSourcesNeedingDerivation(pool, undefined, 10_000);
     const call = pool.calls.at(-1)!;
-    // Limit is a bound param (last param); never interpolated as a literal.
-    expect(call.params.at(-1)).toBe(256);
+    // The final row is observation-only: enqueueGraphDerivationJobs still emits
+    // at most 256 jobs and uses row 257 solely to prove real deferral.
+    expect(call.params.at(-1)).toBe(257);
   });
 });
 
@@ -584,13 +585,14 @@ describe("enqueueGraphDerivationJobs", () => {
       },
     };
     let resolveCalls = 0;
-    const jobs = await enqueueGraphDerivationJobs(pool, queue, ["team-kb"], {
+    const batch = await enqueueGraphDerivationJobs(pool, queue, ["team-kb"], {
       resolveMetadata: (s) => {
         resolveCalls += 1;
         return { topics: [`topic-${s.id.slice(0, 8)}`], people: [] };
       },
     });
-    expect(jobs.length).toBe(2);
+    expect(batch.jobs.length).toBe(2);
+    expect(batch.limitReached).toBe(false);
     expect(enqueued.length).toBe(2);
     expect(resolveCalls).toBe(2);
     expect(enqueued[0]!.kind).toBe(GRAPH_DERIVATION_JOB_KIND);

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -339,10 +339,10 @@ interface GraphDerivationHandlerDeps {
  * MaintenanceJobHandler the runner invokes per claimed job. It is registered by
  * composeMaintenanceHandlers (maintenance-bootstrap.ts) and dispatched by the
  * runner started in startMaintenanceQueue — the queue/index wiring is present.
- * graph.derive jobs are produced only by the explicit, bounded
- * enqueueGraphDerivationJobs producer (an operator or the future #347
- * scheduler); the bootstrap enqueues nothing and defines no recurring sweep, so
- * there is no automatic continuous derivation.
+ * graph.derive jobs are produced by the explicit, bounded
+ * enqueueGraphDerivationJobs producer. The maintenance bootstrap now calls that
+ * shared producer from its recurring #384 sweep, so scheduled and direct callers
+ * retain one selection/idempotency path.
  *
  * On each run it:
  *  0. Rejects any job.version other than GRAPH_DERIVATION_JOB_VERSION BEFORE

--- a/src/graph-derivation-handler.ts
+++ b/src/graph-derivation-handler.ts
@@ -63,10 +63,10 @@ export const GRAPH_DERIVATION_JOB_VERSION = 1 as const;
 /** The anchor entity_type every derived source graph hangs from. */
 export const SOURCE_ANCHOR_ENTITY_TYPE = "source" as const;
 
-// Upper bound on how many sources one selection/enqueue sweep considers. The
-// scheduler sweeps repeatedly; a single sweep must not scan or enqueue the whole
-// table unbounded.
-const MAX_SELECT_LIMIT = 256;
+// One enqueue sweep emits at most 256 jobs. Selection may read one additional
+// sentinel row so the caller reports deferral only when work actually remains.
+const MAX_ENQUEUE_LIMIT = 256;
+const MAX_SELECT_LIMIT = MAX_ENQUEUE_LIMIT + 1;
 const DEFAULT_SELECT_LIMIT = 100;
 
 // The stored content_hash / derivation payload hashes are lowercase sha256 hex.
@@ -258,7 +258,8 @@ export interface GraphDerivationEnqueuePort {
  * supplies already-extracted topics/people per source (the collector seam);
  * when omitted, the job carries no metadata and the handler falls back to the
  * deterministic extractor. Both selection and metadata resolution happen here,
- * OUTSIDE any queue lock. Returns the enqueued jobs. Content-free logging only.
+ * OUTSIDE any queue lock. Returns the enqueued jobs plus a true deferral signal
+ * derived from one sentinel selection row. Content-free logging only.
  */
 export async function enqueueGraphDerivationJobs(
   pool: Pick<pg.Pool, "query">,
@@ -271,14 +272,19 @@ export async function enqueueGraphDerivationJobs(
     ) =>
       Promise<DerivationMetadata | undefined> | DerivationMetadata | undefined;
   } = {},
-): Promise<MaintenanceJob[]> {
+): Promise<{ jobs: MaintenanceJob[]; limitReached: boolean }> {
+  const enqueueLimit = Math.min(
+    Math.max(Math.trunc(options.limit ?? DEFAULT_SELECT_LIMIT), 1),
+    MAX_ENQUEUE_LIMIT,
+  );
   const sources = await selectSourcesNeedingDerivation(
     pool,
     writableNamespaces,
-    options.limit,
+    enqueueLimit + 1,
   );
+  const selected = sources.slice(0, enqueueLimit);
   const enqueued: MaintenanceJob[] = [];
-  for (const source of sources) {
+  for (const source of selected) {
     const metadata = options.resolveMetadata
       ? await options.resolveMetadata(source)
       : undefined;
@@ -287,11 +293,13 @@ export async function enqueueGraphDerivationJobs(
     );
     enqueued.push(job);
   }
+  const limitReached = sources.length > enqueueLimit;
   logger.info("graph_derivation_enqueue_sweep", {
-    selected: sources.length,
+    selected: selected.length,
     enqueued: enqueued.length,
+    limit_reached: limitReached ? 1 : 0,
   });
-  return enqueued;
+  return { jobs: enqueued, limitReached };
 }
 
 /**

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -13,22 +13,20 @@
  * which the server's shutdown path awaits before `pool.end()` so in-flight jobs
  * drain (their leases are honored) instead of being stranded mid-run.
  *
- * The bootstrap enqueues nothing and defines no recurring sweep: the maintenance
- * queue has no recurrence primitive. graph.derive jobs are produced only by the
- * explicit, bounded `enqueueGraphDerivationJobs` producer, which an operator or
- * a future scheduler (#347) must call. This bootstrap only DISPATCHES claimed
- * graph.derive jobs; it never invents or schedules them, and there is no
- * automatic continuous derivation.
+ * The bootstrap also starts the missing recurring producer from #384. Each
+ * producer tick selects lane-owned undistilled work for memory.distill and reuses
+ * enqueueGraphDerivationJobs for changed source hashes. The producer is
+ * single-flight, uses configured batch bounds, and stops before the runner drains
+ * so shutdown cannot add work after polling has halted.
  *
  * #343 invariants preserved verbatim — this only wires them, it changes none:
  *  - Bounded concurrency: the runner clamps to [1, MAX_CONCURRENCY].
  *  - No overlapping ticks: `runOnce` is single-flight; `start()` reuses it.
  *  - Persisted retries/backoff: owned by `MaintenanceQueue.fail`, durable-row-derived.
- *  - Content-free logs: the handler and runner log counts/table/kind only.
- *  - No Dream/MCP mutation path: this bootstrap touches only `maintenance_jobs`
- *    and the embedding columns via the repair primitive; it never enqueues jobs.
- *    Enqueue stays an explicit, auth-scoped operator/caller boundary (a job
- *    payload MUST carry an explicit namespace scope — the bootstrap invents none).
+ *  - Content-free logs: handlers, runner, and producer log counts/kinds only.
+ *  - No Dream/MCP mutation path: the producer writes only durable maintenance
+ *    jobs. Distill jobs bind the selected lane and namespace; graph jobs retain
+ *    the source snapshot and namespace checks owned by their existing producer.
  */
 import type pg from "pg";
 import { generateEmbeddingWithMetadata } from "./embedding.ts";
@@ -37,6 +35,7 @@ import type { AuthInfo } from "./types.ts";
 import {
   MaintenanceQueue,
   MaintenanceQueueRunner,
+  safeMaintenanceErrorCategory,
   type MaintenanceJobHandler,
   type MaintenanceQueueLogger,
 } from "./maintenance-queue.ts";
@@ -51,6 +50,7 @@ import {
   MEMORY_DISTILL_JOB_KIND,
   makeMemoryDistillHandler,
 } from "./distill-handler.ts";
+import { runMaintenanceSweep } from "./maintenance-sweep.ts";
 
 /**
  * The deliberate, server-owned identity the graph-derivation handler derives
@@ -106,7 +106,13 @@ export interface StartMaintenanceQueueOptions {
   concurrency?: number;
   /** Lease duration override; else env, else the runner default. */
   leaseMs?: number;
-  /** Start automatic polling immediately (default true). Set false to wire without polling. */
+  /** Maximum turns assigned to one memory.distill job. */
+  distillBatchSize?: number;
+  /** Maximum memory.distill jobs produced by one recurring sweep. */
+  maxDistillBatchesPerTick?: number;
+  /** Maximum graph.derive jobs produced by one recurring sweep. */
+  graphDerivationLimit?: number;
+  /** Start automatic polling and recurring production immediately (default true). */
   autoStart?: boolean;
   /**
    * The server-owned identity the graph-derivation handler derives under.
@@ -169,9 +175,8 @@ export function composeMaintenanceHandlers(input: {
   // through the manual entrypoint scripts/dream-light-run.ts.
   //
   // NONE OF THESE ENQUEUE ANYTHING. Registration is dispatch only. The
-  // maintenance queue has no recurrence primitive (see the module note above),
-  // so a DREAM cycle still starts from an explicit producer -- an operator
-  // running scripts/dream-cycle.ts, or a future scheduler (#347).
+  // recurring producer starts below after this map and the durable queue exist;
+  // manual DREAM cycles remain available through scripts/dream-cycle.ts.
   handlers.set(
     MEMORY_DISTILL_JOB_KIND,
     makeMemoryDistillHandler({
@@ -227,15 +232,62 @@ export function maintenanceQueueEnabled(
   return raw !== "0" && raw !== "false";
 }
 
+function startRecurringMaintenanceSweep(input: {
+  pool: pg.Pool;
+  queue: MaintenanceQueue;
+  logger: MaintenanceQueueLogger;
+  intervalMs: number;
+  distillBatchSize?: number;
+  maxDistillBatchesPerTick?: number;
+  graphDerivationLimit?: number;
+}): { stop(): Promise<void> } {
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let active: Promise<void> | null = null;
+  let stopping = false;
+
+  const runOnce = (): Promise<void> => {
+    if (stopping) return Promise.resolve();
+    if (active) return active;
+
+    const run = runMaintenanceSweep(input)
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        input.logger.error("maintenance_sweep_failed", {
+          error_category: safeMaintenanceErrorCategory(error),
+        });
+      })
+      .finally(() => {
+        active = null;
+      });
+    active = run;
+    return run;
+  };
+
+  void runOnce();
+  interval = setInterval(() => void runOnce(), input.intervalMs);
+
+  return {
+    async stop(): Promise<void> {
+      stopping = true;
+      if (interval) clearInterval(interval);
+      interval = null;
+      await active;
+    },
+  };
+}
+
 /**
  * Construct the durable queue + runner, register the embedding-repair handler,
  * and (by default) start bounded automatic polling. Caller owns `stop()` in its
  * shutdown lifecycle.
  *
  * Env-configurable safe defaults (each clamped again by the runner):
- *  - OPEN_BRAIN_MAINTENANCE_POLL_MS         poll cadence (runner default 5000)
- *  - OPEN_BRAIN_MAINTENANCE_CONCURRENCY     max concurrent jobs (runner default 2)
- *  - OPEN_BRAIN_MAINTENANCE_LEASE_MS        job lease window (runner default 30000)
+ *  - OPEN_BRAIN_MAINTENANCE_POLL_MS              runner + producer cadence (5000)
+ *  - OPEN_BRAIN_MAINTENANCE_CONCURRENCY          concurrent jobs (runner default 2)
+ *  - OPEN_BRAIN_MAINTENANCE_LEASE_MS             job lease window (default 30000)
+ *  - OPEN_BRAIN_MAINTENANCE_DISTILL_BATCH_SIZE   turns assigned per distill job
+ *  - OPEN_BRAIN_MAINTENANCE_MAX_DISTILL_BATCHES  distill jobs produced per tick
+ *  - OPEN_BRAIN_MAINTENANCE_GRAPH_LIMIT          graph jobs produced per tick
  */
 export function startMaintenanceQueue(
   options: StartMaintenanceQueueOptions,
@@ -253,6 +305,10 @@ export function startMaintenanceQueue(
     graphAuth: options.graphAuth ?? MAINTENANCE_GRAPH_AUTH,
   });
 
+  const pollIntervalMs =
+    options.pollIntervalMs ??
+    envPositiveInt("OPEN_BRAIN_MAINTENANCE_POLL_MS") ??
+    5_000;
   const runner = new MaintenanceQueueRunner({
     queue,
     handlers,
@@ -260,14 +316,30 @@ export function startMaintenanceQueue(
     concurrency:
       options.concurrency ??
       envPositiveInt("OPEN_BRAIN_MAINTENANCE_CONCURRENCY"),
-    pollIntervalMs:
-      options.pollIntervalMs ??
-      envPositiveInt("OPEN_BRAIN_MAINTENANCE_POLL_MS"),
+    pollIntervalMs,
     leaseMs:
       options.leaseMs ?? envPositiveInt("OPEN_BRAIN_MAINTENANCE_LEASE_MS"),
   });
 
-  if (options.autoStart !== false) runner.start();
+  const autoStart = options.autoStart !== false;
+  if (autoStart) runner.start();
+  const sweep = autoStart
+    ? startRecurringMaintenanceSweep({
+        pool: options.pool,
+        queue,
+        logger: options.logger,
+        intervalMs: pollIntervalMs,
+        distillBatchSize:
+          options.distillBatchSize ??
+          envPositiveInt("OPEN_BRAIN_MAINTENANCE_DISTILL_BATCH_SIZE"),
+        maxDistillBatchesPerTick:
+          options.maxDistillBatchesPerTick ??
+          envPositiveInt("OPEN_BRAIN_MAINTENANCE_MAX_DISTILL_BATCHES"),
+        graphDerivationLimit:
+          options.graphDerivationLimit ??
+          envPositiveInt("OPEN_BRAIN_MAINTENANCE_GRAPH_LIMIT"),
+      })
+    : null;
 
   let stopped = false;
   return {
@@ -278,6 +350,7 @@ export function startMaintenanceQueue(
       // null tick, empty active set). Guard only against a double shutdown call.
       if (stopped) return;
       stopped = true;
+      await sweep?.stop();
       await runner.stop();
     },
   };

--- a/src/maintenance-sweep.live.test.ts
+++ b/src/maintenance-sweep.live.test.ts
@@ -1,0 +1,177 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import type { Pool } from "pg";
+import {
+  MEMORY_DISTILL_JOB_KIND,
+  runDistillSweep,
+} from "./distill-handler.ts";
+import { MaintenanceQueue, type MaintenanceQueueLogger } from "./maintenance-queue.ts";
+import { runMaintenanceSweep } from "./maintenance-sweep.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+const namespace = "test-maintenance-sweep-live";
+
+const logger: MaintenanceQueueLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+dbDescribe("maintenance sweep idempotency (live Postgres)", () => {
+  let pool: Pool;
+  let laneId: string;
+
+  async function cleanup(): Promise<void> {
+    await pool.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+      namespace,
+    ]);
+    await pool.query("DELETE FROM ob_raw_turns WHERE namespace = $1", [
+      namespace,
+    ]);
+    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [
+      namespace,
+    ]);
+  }
+
+  async function insertLane(): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO ob_session_lanes
+         (session_key, namespace, agent, created_by)
+       VALUES ($1, $2, 'test', 'test')
+       RETURNING id`,
+      ["maintenance-sweep-live", namespace],
+    );
+    return rows[0]!.id;
+  }
+
+  async function insertTurn(input: {
+    sessionRef: string;
+    occurredAt: string;
+    createdAt: string;
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO ob_raw_turns
+         (namespace, turn_uuid, lane_id, session_ref, role, content,
+          content_hash, turn_index, occurred_at, created_at, created_by)
+       VALUES ($1, $2, $3, $4, 'tool', 'test tool context',
+               $2, 0, $5, $6, 'test')`,
+      [
+        namespace,
+        crypto.randomUUID(),
+        laneId,
+        input.sessionRef,
+        input.occurredAt,
+        input.createdAt,
+      ],
+    );
+  }
+
+  async function jobRows(): Promise<
+    Array<{ id: string; idempotency_key: string }>
+  > {
+    const { rows } = await pool.query<{
+      id: string;
+      idempotency_key: string;
+    }>(
+      `SELECT id, idempotency_key
+         FROM maintenance_jobs
+        WHERE namespace = $1 AND job_kind = $2
+        ORDER BY created_at, id`,
+      [namespace, MEMORY_DISTILL_JOB_KIND],
+    );
+    return rows;
+  }
+
+  function sweepPool(): Pick<Pool, "query"> {
+    const query = (async (sql: string, params?: unknown[]) => {
+      if (sql.includes("LEFT JOIN ob_entities anchor")) {
+        return { rows: [], rowCount: 0 };
+      }
+      return pool.query(sql, params);
+    }) as Pool["query"];
+    return { query };
+  }
+
+  async function sweep(): Promise<void> {
+    await runMaintenanceSweep({
+      pool: sweepPool(),
+      queue: new MaintenanceQueue(pool),
+      logger,
+      distillBatchSize: 100,
+      maxDistillBatchesPerTick: 1,
+      graphDerivationLimit: 1,
+    });
+  }
+
+  beforeAll(async () => {
+    const pg = await import("pg");
+    pool = new pg.Pool({ connectionString: DB_URL });
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    laneId = await insertLane();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("dedupes an unchanged window and enqueues again after the consumed window advances", async () => {
+    // created_at deliberately disagrees with occurred_at: the old producer chose
+    // session-5 as its key anchor, while the real handler consumes sessions 1-4.
+    await insertTurn({
+      sessionRef: "session-5",
+      occurredAt: "2026-01-05T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    for (let session = 1; session <= 4; session++) {
+      await insertTurn({
+        sessionRef: `session-${session}`,
+        occurredAt: `2026-01-0${session}T00:00:00.000Z`,
+        createdAt: `2026-01-0${session + 1}T00:00:00.000Z`,
+      });
+    }
+
+    await sweep();
+    const firstTick = await jobRows();
+    expect(firstTick).toHaveLength(1);
+
+    // The actual UNIQUE(job_kind, idempotency_key) conflict path must return the
+    // existing job, not insert an overlapping duplicate for an unchanged window.
+    await sweep();
+    expect(await jobRows()).toEqual(firstTick);
+
+    const consumed = await runDistillSweep({
+      pool,
+      logger,
+      namespace,
+      laneId,
+      maxSessions: 4,
+      maxTurns: 100,
+      skipEmbeddings: true,
+    });
+    expect(consumed.turns_stamped).toBe(4);
+
+    await insertTurn({
+      sessionRef: "session-6",
+      occurredAt: "2026-01-06T00:00:00.000Z",
+      createdAt: "2026-01-06T00:00:00.000Z",
+    });
+    await sweep();
+
+    const advanced = await jobRows();
+    expect(advanced).toHaveLength(2);
+    expect(advanced[1]!.idempotency_key).not.toBe(
+      advanced[0]!.idempotency_key,
+    );
+  });
+});

--- a/src/maintenance-sweep.test.ts
+++ b/src/maintenance-sweep.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, mock } from "bun:test";
+import { MEMORY_DISTILL_JOB_KIND } from "./distill-handler.ts";
+import { GRAPH_DERIVATION_JOB_KIND } from "./graph-derivation-handler.ts";
+import { startMaintenanceQueue } from "./maintenance-bootstrap.ts";
+import {
+  runMaintenanceSweep,
+  type MaintenanceSweepSummary,
+} from "./maintenance-sweep.ts";
+import type {
+  EnqueueMaintenanceJob,
+  MaintenanceJob,
+  MaintenanceQueueLogger,
+} from "./maintenance-queue.ts";
+
+const HASH = "a".repeat(64);
+const NOW = new Date("2026-08-05T12:00:00.000Z");
+
+function maintenanceJob(
+  input: EnqueueMaintenanceJob,
+  sequence: number,
+): MaintenanceJob {
+  return {
+    id: `00000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`,
+    kind: input.kind,
+    version: input.version,
+    payload: input.payload,
+    idempotencyKey: input.idempotencyKey,
+    state: "queued",
+    runAfter: input.runAfter ?? NOW,
+    leaseToken: null,
+    leaseUntil: null,
+    attempts: 0,
+    maxAttempts: input.retry?.maxAttempts ?? 3,
+    backoffBaseMs: input.retry?.backoffBaseMs ?? 1_000,
+    backoffMaxMs: input.retry?.backoffMaxMs ?? 300_000,
+    lastErrorCategory: null,
+    terminalAt: null,
+    deadLetteredAt: null,
+    namespace: input.scope?.namespace ?? null,
+    provenance: input.scope?.provenance ?? null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function recordingLogger() {
+  const info: Array<{ message: string; fields: Record<string, string | number> }> =
+    [];
+  const warn: Array<{ message: string; fields: Record<string, string | number> }> =
+    [];
+  const error: Array<{
+    message: string;
+    fields: Record<string, string | number>;
+  }> = [];
+  const logger: MaintenanceQueueLogger = {
+    info: (message, fields) => info.push({ message, fields }),
+    warn: (message, fields) => warn.push({ message, fields }),
+    error: (message, fields) => error.push({ message, fields }),
+  };
+  return { logger, info, warn, error };
+}
+
+function producerPool() {
+  const query = mock(async (sql: string) => {
+    if (sql.includes("WITH due_lanes")) {
+      return {
+        rows: [
+          {
+            lane_id: "11111111-1111-4111-8111-111111111111",
+            namespace: "lane-a",
+            batch_anchor: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            pending_turns: 9,
+            total_batches: 3,
+          },
+          {
+            lane_id: null,
+            namespace: "unassigned-ns",
+            batch_anchor: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            pending_turns: 2,
+            total_batches: 3,
+          },
+        ],
+        rowCount: 2,
+      };
+    }
+    if (sql.includes("LEFT JOIN ob_entities anchor")) {
+      return {
+        rows: [
+          {
+            id: "33333333-3333-4333-8333-333333333333",
+            namespace: "source-ns",
+            source_kind: "git",
+            external_id: "https://example.invalid/repo.git",
+            content_hash: HASH,
+            revision: 2,
+            derived_content_hash: null,
+          },
+        ],
+        rowCount: 1,
+      };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return { query };
+}
+
+describe("runMaintenanceSweep", () => {
+  it("produces bounded distill batches and drifted graph jobs in one tick", async () => {
+    const pool = producerPool();
+    const enqueued: EnqueueMaintenanceJob[] = [];
+    const queue = {
+      enqueue: async (input: EnqueueMaintenanceJob) => {
+        enqueued.push(input);
+        return maintenanceJob(input, enqueued.length);
+      },
+    };
+    const logs = recordingLogger();
+
+    const summary: MaintenanceSweepSummary = await runMaintenanceSweep({
+      pool: pool as any,
+      queue,
+      logger: logs.logger,
+      distillBatchSize: 5,
+      maxDistillBatchesPerTick: 2,
+      graphDerivationLimit: 1,
+    });
+
+    expect(enqueued.map((job) => job.kind)).toEqual([
+      MEMORY_DISTILL_JOB_KIND,
+      MEMORY_DISTILL_JOB_KIND,
+      GRAPH_DERIVATION_JOB_KIND,
+    ]);
+    expect(enqueued[0]?.payload).toMatchObject({
+      lane_id: "11111111-1111-4111-8111-111111111111",
+      max_turns: 5,
+    });
+    expect(enqueued[1]?.scope?.namespace).toBe("unassigned-ns");
+    expect(enqueued[1]?.payload).toMatchObject({ lane_id: null, max_turns: 5 });
+    expect(summary).toEqual({
+      distillBatchesSelected: 2,
+      distillJobsEnqueued: 2,
+      distillBatchesDeferred: 1,
+      distillTurnsDeferredByBatchCap: 4,
+      graphJobsEnqueued: 1,
+      graphLimitReached: true,
+    });
+    expect(logs.warn.map((entry) => entry.message)).toEqual([
+      "maintenance_sweep_distill_cap_hit",
+      "maintenance_sweep_graph_cap_reached",
+    ]);
+    expect(logs.info.at(-1)?.message).toBe("maintenance_sweep_complete");
+  });
+});
+
+function bootstrapPool(insertedKinds: string[]) {
+  let sequence = 0;
+  const query = mock(async (sql: string, params: unknown[] = []) => {
+    if (sql.includes("WITH due_lanes")) {
+      return {
+        rows: [
+          {
+            lane_id: "44444444-4444-4444-8444-444444444444",
+            namespace: "bootstrap-ns",
+            batch_anchor: "55555555-5555-4555-8555-555555555555",
+            pending_turns: 1,
+            total_batches: 1,
+          },
+        ],
+        rowCount: 1,
+      };
+    }
+    if (sql.includes("LEFT JOIN ob_entities anchor")) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (sql.includes("INSERT INTO maintenance_jobs")) {
+      const input: EnqueueMaintenanceJob = {
+        kind: params[0] as string,
+        version: params[1] as number,
+        payload: JSON.parse(params[2] as string) as Record<string, unknown>,
+        idempotencyKey: params[3] as string,
+        runAfter: params[4] as Date,
+        retry: {
+          maxAttempts: params[5] as number,
+          backoffBaseMs: params[6] as number,
+          backoffMaxMs: params[7] as number,
+        },
+        ...(params[8] === null
+          ? {}
+          : { scope: { namespace: params[8] as string } }),
+      };
+      insertedKinds.push(input.kind);
+      sequence++;
+      const job = maintenanceJob(input, sequence);
+      return {
+        rows: [
+          {
+            id: job.id,
+            job_kind: job.kind,
+            job_version: job.version,
+            payload: job.payload,
+            idempotency_key: job.idempotencyKey,
+            state: job.state,
+            run_after: job.runAfter,
+            lease_token: null,
+            lease_until: null,
+            attempts: job.attempts,
+            max_attempts: job.maxAttempts,
+            backoff_base_ms: job.backoffBaseMs,
+            backoff_max_ms: job.backoffMaxMs,
+            last_error_category: null,
+            terminal_at: null,
+            dead_lettered_at: null,
+            namespace: job.namespace,
+            provenance: job.provenance,
+            created_at: job.createdAt,
+            updated_at: job.updatedAt,
+          },
+        ],
+        rowCount: 1,
+      };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  const client = { query, release: mock(() => undefined) };
+  return {
+    query,
+    connect: mock(async () => client),
+    end: mock(async () => undefined),
+  };
+}
+
+async function waitForEnqueue(insertedKinds: string[]): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (insertedKinds.length > 0) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("maintenance bootstrap produced no jobs");
+}
+
+describe("startMaintenanceQueue recurring producer", () => {
+  it("enqueues sweep work automatically without an operator call", async () => {
+    const insertedKinds: string[] = [];
+    const pool = bootstrapPool(insertedKinds);
+    const logs = recordingLogger();
+    const runtime = startMaintenanceQueue({
+      pool: pool as any,
+      logger: logs.logger,
+      embedFn: async () => ({ embedding: Array(768).fill(0.01) }),
+      pollIntervalMs: 60_000,
+    });
+
+    await waitForEnqueue(insertedKinds);
+    await runtime.stop();
+
+    expect(insertedKinds).toEqual([MEMORY_DISTILL_JOB_KIND]);
+    expect(logs.error).toEqual([]);
+  });
+});

--- a/src/maintenance-sweep.test.ts
+++ b/src/maintenance-sweep.test.ts
@@ -60,23 +60,25 @@ function recordingLogger() {
   return { logger, info, warn, error };
 }
 
-function producerPool() {
+function producerPool(graphRows = 1) {
   const query = mock(async (sql: string) => {
-    if (sql.includes("WITH due_lanes")) {
+    if (sql.includes("WITH due_turns")) {
       return {
         rows: [
           {
             lane_id: "11111111-1111-4111-8111-111111111111",
             namespace: "lane-a",
-            batch_anchor: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            batch_hash: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
             pending_turns: 9,
+            processable_turns: 4,
             total_batches: 3,
           },
           {
             lane_id: null,
             namespace: "unassigned-ns",
-            batch_anchor: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            batch_hash: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
             pending_turns: 2,
+            processable_turns: 2,
             total_batches: 3,
           },
         ],
@@ -84,20 +86,16 @@ function producerPool() {
       };
     }
     if (sql.includes("LEFT JOIN ob_entities anchor")) {
-      return {
-        rows: [
-          {
-            id: "33333333-3333-4333-8333-333333333333",
-            namespace: "source-ns",
-            source_kind: "git",
-            external_id: "https://example.invalid/repo.git",
-            content_hash: HASH,
-            revision: 2,
-            derived_content_hash: null,
-          },
-        ],
-        rowCount: 1,
-      };
+      const rows = Array.from({ length: graphRows }, (_, index) => ({
+        id: `33333333-3333-4333-8333-${String(index + 1).padStart(12, "3")}`,
+        namespace: "source-ns",
+        source_kind: "git",
+        external_id: `https://example.invalid/repo-${index}.git`,
+        content_hash: HASH,
+        revision: 2,
+        derived_content_hash: null,
+      }));
+      return { rows, rowCount: rows.length };
     }
     return { rows: [], rowCount: 0 };
   });
@@ -132,6 +130,7 @@ describe("runMaintenanceSweep", () => {
     ]);
     expect(enqueued[0]?.payload).toMatchObject({
       lane_id: "11111111-1111-4111-8111-111111111111",
+      max_sessions: 4,
       max_turns: 5,
     });
     expect(enqueued[1]?.scope?.namespace).toBe("unassigned-ns");
@@ -140,29 +139,53 @@ describe("runMaintenanceSweep", () => {
       distillBatchesSelected: 2,
       distillJobsEnqueued: 2,
       distillBatchesDeferred: 1,
-      distillTurnsDeferredByBatchCap: 4,
+      distillTurnsDeferred: 5,
       graphJobsEnqueued: 1,
-      graphLimitReached: true,
+      graphLimitReached: false,
     });
     expect(logs.warn.map((entry) => entry.message)).toEqual([
       "maintenance_sweep_distill_cap_hit",
-      "maintenance_sweep_graph_cap_reached",
     ]);
     expect(logs.info.at(-1)?.message).toBe("maintenance_sweep_complete");
+  });
+
+  it("reports graph deferral only when a sentinel source exists", async () => {
+    const pool = producerPool(2);
+    const enqueued: EnqueueMaintenanceJob[] = [];
+    const queue = {
+      enqueue: async (input: EnqueueMaintenanceJob) => {
+        enqueued.push(input);
+        return maintenanceJob(input, enqueued.length);
+      },
+    };
+    const logs = recordingLogger();
+
+    const summary = await runMaintenanceSweep({
+      pool: pool as any,
+      queue,
+      logger: logs.logger,
+      graphDerivationLimit: 1,
+    });
+
+    expect(
+      enqueued.filter((job) => job.kind === GRAPH_DERIVATION_JOB_KIND),
+    ).toHaveLength(1);
+    expect(summary.graphLimitReached).toBe(true);
   });
 });
 
 function bootstrapPool(insertedKinds: string[]) {
   let sequence = 0;
   const query = mock(async (sql: string, params: unknown[] = []) => {
-    if (sql.includes("WITH due_lanes")) {
+    if (sql.includes("WITH due_turns")) {
       return {
         rows: [
           {
             lane_id: "44444444-4444-4444-8444-444444444444",
             namespace: "bootstrap-ns",
-            batch_anchor: "55555555-5555-4555-8555-555555555555",
+            batch_hash: "55555555-5555-4555-8555-555555555555",
             pending_turns: 1,
+            processable_turns: 1,
             total_batches: 1,
           },
         ],

--- a/src/maintenance-sweep.ts
+++ b/src/maintenance-sweep.ts
@@ -4,6 +4,10 @@ import {
   type GraphDerivationEnqueuePort,
 } from "./graph-derivation-handler.ts";
 import { buildMemoryDistillEnqueue } from "./distill-handler.ts";
+import {
+  DEFAULT_MAX_DISTILL_SESSIONS,
+  DISTILL_ORDER_BY,
+} from "./distill-window.ts";
 import type {
   MaintenanceJob,
   MaintenanceQueueLogger,
@@ -19,8 +23,9 @@ const MAX_GRAPH_DERIVATION_LIMIT = 256;
 interface DistillLaneBatch {
   laneId: string | null;
   namespace: string;
-  batchAnchor: string;
+  batchHash: string;
   pendingTurns: number;
+  processableTurns: number;
   totalBatches: number;
 }
 
@@ -37,7 +42,7 @@ export interface MaintenanceSweepSummary {
   distillBatchesSelected: number;
   distillJobsEnqueued: number;
   distillBatchesDeferred: number;
-  distillTurnsDeferredByBatchCap: number;
+  distillTurnsDeferred: number;
   graphJobsEnqueued: number;
   graphLimitReached: boolean;
 }
@@ -52,32 +57,89 @@ function boundedInteger(
 
 async function selectDistillLaneBatches(
   pool: Pick<pg.Pool, "query">,
+  maxSessions: number,
+  maxTurns: number,
   maxBatches: number,
 ): Promise<DistillLaneBatch[]> {
   const { rows } = await pool.query(
-    `WITH due_lanes AS (
-       SELECT lane_id, namespace,
-              count(*)::int AS pending_turns,
-              (array_agg(id ORDER BY created_at, id))[1]::text AS batch_anchor,
-              min(created_at) AS first_due
+    `WITH due_turns AS (
+       SELECT id, lane_id, namespace, session_ref, occurred_at, created_at
          FROM ob_raw_turns
         WHERE distilled_at IS NULL
           AND retention_tier = 'live'
+     ),
+     due_sessions AS (
+       SELECT lane_id, namespace, session_ref, min(occurred_at) AS first_due
+         FROM due_turns
+        GROUP BY lane_id, namespace, session_ref
+     ),
+     ranked_sessions AS (
+       SELECT *, row_number() OVER (
+                PARTITION BY lane_id, namespace
+                ORDER BY first_due ASC NULLS LAST,
+                         session_ref ASC NULLS LAST
+              ) AS session_rank
+         FROM due_sessions
+     ),
+     window_turns AS (
+       SELECT t.id, t.lane_id, t.namespace, t.session_ref, t.occurred_at,
+              t.content_hash, (t.distilled_at IS NULL) AS is_due
+         FROM ob_raw_turns t
+         JOIN ranked_sessions s
+           ON s.lane_id IS NOT DISTINCT FROM t.lane_id
+          AND s.namespace = t.namespace
+          AND s.session_ref IS NOT DISTINCT FROM t.session_ref
+          AND s.session_rank <= $1
+        WHERE t.retention_tier = 'live'
+     ),
+     ranked_window_turns AS (
+       SELECT *, row_number() OVER (
+                PARTITION BY lane_id, namespace
+                ORDER BY ${DISTILL_ORDER_BY}
+              ) AS turn_rank
+         FROM window_turns
+     ),
+     lane_totals AS (
+       SELECT lane_id, namespace, count(*)::int AS pending_turns,
+              min(created_at) AS first_due
+         FROM due_turns
         GROUP BY lane_id, namespace
+     ),
+     due_lanes AS (
+       SELECT totals.lane_id, totals.namespace, totals.pending_turns,
+              count(*) FILTER (
+                WHERE w.is_due AND w.turn_rank <= $2
+              )::int AS processable_turns,
+              md5(string_agg(w.id::text || ':' || w.content_hash, ','
+                             ORDER BY w.turn_rank)
+                  FILTER (
+                    WHERE w.is_due AND w.turn_rank <= $2
+                  )) AS batch_hash,
+              totals.first_due
+         FROM lane_totals totals
+         JOIN ranked_window_turns w
+           ON w.lane_id IS NOT DISTINCT FROM totals.lane_id
+          AND w.namespace = totals.namespace
+        GROUP BY totals.lane_id, totals.namespace, totals.pending_turns,
+                 totals.first_due
+       HAVING count(*) FILTER (
+                WHERE w.is_due AND w.turn_rank <= $2
+              ) > 0
      )
-     SELECT lane_id, namespace, pending_turns, batch_anchor,
+     SELECT lane_id, namespace, pending_turns, processable_turns, batch_hash,
             count(*) OVER()::int AS total_batches
        FROM due_lanes
       ORDER BY first_due, lane_id
-      LIMIT $1`,
-    [maxBatches],
+      LIMIT $3`,
+    [maxSessions, maxTurns, maxBatches],
   );
 
   return rows.map((row) => ({
     laneId: (row.lane_id as string | null) ?? null,
     namespace: row.namespace as string,
-    batchAnchor: row.batch_anchor as string,
+    batchHash: row.batch_hash as string,
     pendingTurns: row.pending_turns as number,
+    processableTurns: row.processable_turns as number,
     totalBatches: row.total_batches as number,
   }));
 }
@@ -85,19 +147,27 @@ async function selectDistillLaneBatches(
 async function enqueueDistillBatches(
   options: MaintenanceSweepOptions,
   batches: readonly DistillLaneBatch[],
-  batchSize: number,
+  maxSessions: number,
+  maxTurns: number,
 ): Promise<{ jobs: MaintenanceJob[]; deferredTurns: number }> {
   const jobs: MaintenanceJob[] = [];
   let deferredTurns = 0;
   for (const batch of batches) {
-    deferredTurns += Math.max(batch.pendingTurns - batchSize, 0);
+    deferredTurns += Math.max(
+      batch.pendingTurns - batch.processableTurns,
+      0,
+    );
     jobs.push(
       await options.queue.enqueue(
         buildMemoryDistillEnqueue({
-          sweepLabel: `${batch.laneId ?? "unassigned"}:${batch.batchAnchor}`,
+          // The key binds the exact bounded due-turn window the handler can
+          // consume. Unchanged ticks dedupe; consuming any due turn changes the
+          // watermark, so a succeeded job cannot block the lane's next window.
+          sweepLabel: `${batch.batchHash}:s${maxSessions}:t${maxTurns}`,
           namespace: batch.namespace,
           laneId: batch.laneId,
-          maxTurns: batchSize,
+          maxSessions,
+          maxTurns,
         }),
       ),
     );
@@ -109,20 +179,19 @@ async function enqueueGraphBatches(
   options: MaintenanceSweepOptions,
   graphLimit: number,
 ): Promise<{ jobs: MaintenanceJob[]; limitReached: boolean }> {
-  const jobs = await enqueueGraphDerivationJobs(
+  const batch = await enqueueGraphDerivationJobs(
     options.pool,
     options.queue,
     undefined,
     { limit: graphLimit },
   );
-  const limitReached = jobs.length === graphLimit;
-  if (limitReached) {
+  if (batch.limitReached) {
     options.logger.warn("maintenance_sweep_graph_cap_reached", {
       graph_limit: graphLimit,
-      enqueued: jobs.length,
+      enqueued: batch.jobs.length,
     });
   }
-  return { jobs, limitReached };
+  return batch;
 }
 
 /**
@@ -149,20 +218,25 @@ export async function runMaintenanceSweep(
     MAX_GRAPH_DERIVATION_LIMIT,
   );
 
+  const distillMaxSessions = DEFAULT_MAX_DISTILL_SESSIONS;
   const batches = await selectDistillLaneBatches(
     options.pool,
+    distillMaxSessions,
+    distillBatchSize,
     maxDistillBatches,
   );
   const totalBatches = batches[0]?.totalBatches ?? 0;
   const distill = await enqueueDistillBatches(
     options,
     batches,
+    distillMaxSessions,
     distillBatchSize,
   );
   const deferredBatches = Math.max(totalBatches - batches.length, 0);
   if (deferredBatches > 0 || distill.deferredTurns > 0) {
     options.logger.warn("maintenance_sweep_distill_cap_hit", {
       batch_size: distillBatchSize,
+      max_sessions: distillMaxSessions,
       max_batches: maxDistillBatches,
       selected_batches: batches.length,
       deferred_batches: deferredBatches,
@@ -175,7 +249,7 @@ export async function runMaintenanceSweep(
     distillBatchesSelected: batches.length,
     distillJobsEnqueued: distill.jobs.length,
     distillBatchesDeferred: deferredBatches,
-    distillTurnsDeferredByBatchCap: distill.deferredTurns,
+    distillTurnsDeferred: distill.deferredTurns,
     graphJobsEnqueued: graph.jobs.length,
     graphLimitReached: graph.limitReached,
   };
@@ -183,8 +257,7 @@ export async function runMaintenanceSweep(
     distill_batches_selected: summary.distillBatchesSelected,
     distill_jobs_enqueued: summary.distillJobsEnqueued,
     distill_batches_deferred: summary.distillBatchesDeferred,
-    distill_turns_deferred_by_batch_cap:
-      summary.distillTurnsDeferredByBatchCap,
+    distill_turns_deferred: summary.distillTurnsDeferred,
     graph_jobs_enqueued: summary.graphJobsEnqueued,
     graph_limit_reached: summary.graphLimitReached ? 1 : 0,
   });

--- a/src/maintenance-sweep.ts
+++ b/src/maintenance-sweep.ts
@@ -1,0 +1,192 @@
+import type pg from "pg";
+import {
+  enqueueGraphDerivationJobs,
+  type GraphDerivationEnqueuePort,
+} from "./graph-derivation-handler.ts";
+import { buildMemoryDistillEnqueue } from "./distill-handler.ts";
+import type {
+  MaintenanceJob,
+  MaintenanceQueueLogger,
+} from "./maintenance-queue.ts";
+
+const DEFAULT_DISTILL_BATCH_SIZE = 1_500;
+const MAX_DISTILL_BATCH_SIZE = 20_000;
+const DEFAULT_MAX_DISTILL_BATCHES = 4;
+const MAX_DISTILL_BATCHES = 64;
+const DEFAULT_GRAPH_DERIVATION_LIMIT = 100;
+const MAX_GRAPH_DERIVATION_LIMIT = 256;
+
+interface DistillLaneBatch {
+  laneId: string | null;
+  namespace: string;
+  batchAnchor: string;
+  pendingTurns: number;
+  totalBatches: number;
+}
+
+export interface MaintenanceSweepOptions {
+  pool: Pick<pg.Pool, "query">;
+  queue: GraphDerivationEnqueuePort;
+  logger: MaintenanceQueueLogger;
+  distillBatchSize?: number;
+  maxDistillBatchesPerTick?: number;
+  graphDerivationLimit?: number;
+}
+
+export interface MaintenanceSweepSummary {
+  distillBatchesSelected: number;
+  distillJobsEnqueued: number;
+  distillBatchesDeferred: number;
+  distillTurnsDeferredByBatchCap: number;
+  graphJobsEnqueued: number;
+  graphLimitReached: boolean;
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  return Math.min(Math.max(Math.trunc(value ?? fallback), 1), max);
+}
+
+async function selectDistillLaneBatches(
+  pool: Pick<pg.Pool, "query">,
+  maxBatches: number,
+): Promise<DistillLaneBatch[]> {
+  const { rows } = await pool.query(
+    `WITH due_lanes AS (
+       SELECT lane_id, namespace,
+              count(*)::int AS pending_turns,
+              (array_agg(id ORDER BY created_at, id))[1]::text AS batch_anchor,
+              min(created_at) AS first_due
+         FROM ob_raw_turns
+        WHERE distilled_at IS NULL
+          AND retention_tier = 'live'
+        GROUP BY lane_id, namespace
+     )
+     SELECT lane_id, namespace, pending_turns, batch_anchor,
+            count(*) OVER()::int AS total_batches
+       FROM due_lanes
+      ORDER BY first_due, lane_id
+      LIMIT $1`,
+    [maxBatches],
+  );
+
+  return rows.map((row) => ({
+    laneId: (row.lane_id as string | null) ?? null,
+    namespace: row.namespace as string,
+    batchAnchor: row.batch_anchor as string,
+    pendingTurns: row.pending_turns as number,
+    totalBatches: row.total_batches as number,
+  }));
+}
+
+async function enqueueDistillBatches(
+  options: MaintenanceSweepOptions,
+  batches: readonly DistillLaneBatch[],
+  batchSize: number,
+): Promise<{ jobs: MaintenanceJob[]; deferredTurns: number }> {
+  const jobs: MaintenanceJob[] = [];
+  let deferredTurns = 0;
+  for (const batch of batches) {
+    deferredTurns += Math.max(batch.pendingTurns - batchSize, 0);
+    jobs.push(
+      await options.queue.enqueue(
+        buildMemoryDistillEnqueue({
+          sweepLabel: `${batch.laneId ?? "unassigned"}:${batch.batchAnchor}`,
+          namespace: batch.namespace,
+          laneId: batch.laneId,
+          maxTurns: batchSize,
+        }),
+      ),
+    );
+  }
+  return { jobs, deferredTurns };
+}
+
+async function enqueueGraphBatches(
+  options: MaintenanceSweepOptions,
+  graphLimit: number,
+): Promise<{ jobs: MaintenanceJob[]; limitReached: boolean }> {
+  const jobs = await enqueueGraphDerivationJobs(
+    options.pool,
+    options.queue,
+    undefined,
+    { limit: graphLimit },
+  );
+  const limitReached = jobs.length === graphLimit;
+  if (limitReached) {
+    options.logger.warn("maintenance_sweep_graph_cap_reached", {
+      graph_limit: graphLimit,
+      enqueued: jobs.length,
+    });
+  }
+  return { jobs, limitReached };
+}
+
+/**
+ * Produce one bounded maintenance sweep. Selection is read-only and happens
+ * outside queue claims; the durable queue's idempotency keys make repeated
+ * ticks over unchanged backlog converge without duplicate work.
+ */
+export async function runMaintenanceSweep(
+  options: MaintenanceSweepOptions,
+): Promise<MaintenanceSweepSummary> {
+  const distillBatchSize = boundedInteger(
+    options.distillBatchSize,
+    DEFAULT_DISTILL_BATCH_SIZE,
+    MAX_DISTILL_BATCH_SIZE,
+  );
+  const maxDistillBatches = boundedInteger(
+    options.maxDistillBatchesPerTick,
+    DEFAULT_MAX_DISTILL_BATCHES,
+    MAX_DISTILL_BATCHES,
+  );
+  const graphDerivationLimit = boundedInteger(
+    options.graphDerivationLimit,
+    DEFAULT_GRAPH_DERIVATION_LIMIT,
+    MAX_GRAPH_DERIVATION_LIMIT,
+  );
+
+  const batches = await selectDistillLaneBatches(
+    options.pool,
+    maxDistillBatches,
+  );
+  const totalBatches = batches[0]?.totalBatches ?? 0;
+  const distill = await enqueueDistillBatches(
+    options,
+    batches,
+    distillBatchSize,
+  );
+  const deferredBatches = Math.max(totalBatches - batches.length, 0);
+  if (deferredBatches > 0 || distill.deferredTurns > 0) {
+    options.logger.warn("maintenance_sweep_distill_cap_hit", {
+      batch_size: distillBatchSize,
+      max_batches: maxDistillBatches,
+      selected_batches: batches.length,
+      deferred_batches: deferredBatches,
+      deferred_turns_in_selected_lanes: distill.deferredTurns,
+    });
+  }
+
+  const graph = await enqueueGraphBatches(options, graphDerivationLimit);
+  const summary: MaintenanceSweepSummary = {
+    distillBatchesSelected: batches.length,
+    distillJobsEnqueued: distill.jobs.length,
+    distillBatchesDeferred: deferredBatches,
+    distillTurnsDeferredByBatchCap: distill.deferredTurns,
+    graphJobsEnqueued: graph.jobs.length,
+    graphLimitReached: graph.limitReached,
+  };
+  options.logger.info("maintenance_sweep_complete", {
+    distill_batches_selected: summary.distillBatchesSelected,
+    distill_jobs_enqueued: summary.distillJobsEnqueued,
+    distill_batches_deferred: summary.distillBatchesDeferred,
+    distill_turns_deferred_by_batch_cap:
+      summary.distillTurnsDeferredByBatchCap,
+    graph_jobs_enqueued: summary.graphJobsEnqueued,
+    graph_limit_reached: summary.graphLimitReached ? 1 : 0,
+  });
+  return summary;
+}


### PR DESCRIPTION
Closes #384 (MAINT-6).

## Summary

The maintenance queue had handlers and no producer. `maintenance-bootstrap.ts`
registered `graph.derive`, `memory.distill`, `dream.light`, and `dream.rem`, but
its own module docstring stated the defect outright: "the bootstrap enqueues
nothing and defines no recurring sweep, so there is no automatic continuous
derivation." Exactly one job had ever been enqueued on either box — a canary
`graph.derive` that dead-lettered. A queue that exists is not a server that
works.

This adds the missing recurring sweep producer (`src/maintenance-sweep.ts`) and
wires it into the bootstrap alongside the runner, so the loop turns without an
operator call.

Per tick the sweep:

- selects undistilled turns grouped by lane (including lane-less turns) and
  enqueues one `memory.distill` job per selected batch;
- reuses the existing `enqueueGraphDerivationJobs` producer for sources whose
  observed `content_hash` drifted.

Deferred work is **logged, never silently dropped** — the issue's explicit
acceptance criterion. `maintenance_sweep_distill_cap_hit` and
`maintenance_sweep_graph_cap_reached` name the deferred batch and turn counts;
`maintenance_sweep_complete` reports the per-tick totals. All bounding
parameters are env-configurable in the same `envPositiveInt` style already used
in the bootstrap. Producer ticks are non-overlapping, and production stops
before the runner drains on shutdown.

`distill-handler.ts` / `distill-window.ts` carry the producer-selected lane
through the durable job payload so distillation binds to the selected lane or
the lane-less group.

No new maintenance framework; `MaintenanceQueue` is untouched.

## Verification

Run by the reviewing wrapper, not merely reported by the implementer:

- `bunx tsc --noEmit` — exit 0.
- `bun test src/maintenance-sweep.test.ts src/maintenance-bootstrap.test.ts src/distill-handler.test.ts src/distill-window.test.ts` — 66 pass, 0 fail, 182 assertions.
- Pre-push hook full suite — 3696 tests across 232 files, 0 fail.

**Red-test proof, independently reproduced.** The point of this change is to
kill a silent-no-op, so the test has to fail when the producer is absent. I
reverted the sweep startup to the old behavior (`const sweep = false`) and ran
the test:

```
error: maintenance bootstrap produced no jobs
(fail) startMaintenanceQueue recurring producer > enqueues sweep work automatically without an operator call
1 pass, 1 fail
```

Restored, re-ran: 2 pass, 0 fail. The test genuinely detects the defect it
claims to cover.

## Critical Self-Review

- Highest-risk behavior: the sweep now runs automatically on every boot where maintenance is enabled, so a large undistilled backlog becomes real enqueued work immediately instead of staying dormant — the first time this loop has ever turned on its own.
- Assumptions that could be wrong: that `distilled_at IS NULL AND retention_tier = 'live'` is the right definition of undistilled work, that grouping by `(lane_id, namespace)` matches the intended distillation partitioning, and that the durable queue's idempotency keys make repeated ticks over an unchanged backlog converge instead of duplicating.
- Missing/weak tests: the sweep tests drive a fake pool/queue port, so the SQL in `selectDistillLaneBatches` never executes against live Postgres here, and the end-to-end "sweep enqueues, runner claims, handler distills against a real database" path is unproven.
- Security/permission risk: low but non-zero — the sweep enqueues under the existing `MAINTENANCE_GRAPH_AUTH` identity and invents no namespace; each payload carries the namespace read from the source row, and handlers still re-check `canWriteNamespace` and re-validate against the live source before deriving.
- Migration/deploy risk: no schema migration; the risk is operational, since enabling this on core01 turns a dormant queue into an active one, and this PR deliberately does not flip core01.
- Downstream client/runtime risk: none identified — no MCP tool, schema, transport, or Python-client surface changed, so `docs/downstream-rollout.md` is not-applicable; the distill payload's new lane field is internal to the server-owned queue.
- Rollback/cleanup concern: `OPEN_BRAIN_MAINTENANCE_ENABLED=0` disables the whole loop including this producer, so rollback is an env flip plus restart with no data migration to undo, though already-enqueued jobs and the pre-existing dead-lettered canary (scope item 1, not addressed here) need operator disposition.
- Fixes made before PR: reproduced the red-test mutation myself rather than trusting the implementer's report, and confirmed the worktree was clean with the mutation fully reverted before pushing.
- Known residual risk: the live-Postgres path for the new sweep SQL is unproven and acceptance criteria 1 and 4 (observed processing locally, core01 enablement) remain operator-verified steps — this is merged-not-running work.
- SME review-memory update: [ ] `docs/sme/` updated [x] not applicable because: this change added a missing producer and surfaced no new review-miss pattern; promote one here if review finds a MEDIUM+ finding.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below [x] not applicable because: acceptance criteria 1 and 4 are operator observations against the local clone and core01, and this PR enables neither — no live Open Brain surface was exercised.

- Scope is the named gap only: a producer plus its wiring. No new maintenance
  framework, no `MaintenanceQueue` refactor.
- Reviewers should focus on the sweep SQL in `selectDistillLaneBatches`
  (grouping and the undistilled predicate), the lane threading through
  `distill-window.ts`, and whether deferred-work logging is sufficient to rule
  out silent truncation.
- Do not merge on the strength of green CI alone: acceptance criteria 1 and 4
  are operator observations against the local clone and core01, and neither is
  claimed complete here.
