### PR TITLE
feat(eval): add Langfuse egress verifier (#578)

### DIFF
--- a/scripts/eval-langfuse-egress.test.ts
+++ b/scripts/eval-langfuse-egress.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import {
+  langfuseHost,
+  runEgressCli,
+  serializeCliOutcome,
+  verifyLangfuseEgress,
+  type HttpTransport,
+  type LangfuseReadConfig,
+} from "./eval-langfuse-egress.ts";
+
+const CONFIG: LangfuseReadConfig = {
+  endpoint: "https://langfuse.example",
+  publicKey: "public-id",
+  secretKey: "private-id",
+};
+
+const OPTED_IN_ENV = {
+  OPEN_BRAIN_LANGFUSE_EGRESS: "1",
+  OPENBRAIN_TRACING_ENABLED: "1",
+  OPENBRAIN_TRACING_ENDPOINT: "https://langfuse.example/api/public/ingestion",
+  OPENBRAIN_TRACING_PUBLIC_KEY: "public-id",
+  OPENBRAIN_TRACING_SECRET_KEY: "private-id",
+};
+
+interface FakeObservationOptions {
+  usage?: boolean;
+  cost?: number | null;
+}
+
+function generation(
+  options: FakeObservationOptions = {},
+): Record<string, unknown> {
+  return {
+    id: "observation-1",
+    type: "GENERATION",
+    providedModelName: "claude-fable-5",
+    usageDetails: options.usage === false ? undefined : { input: 2, output: 3 },
+    totalCost: options.cost === undefined ? 0.001 : options.cost,
+    output: "SAFE_BODY_MARKER",
+  };
+}
+
+function fakeTransport(
+  observations: unknown[],
+  bodyExtras: Record<string, unknown> = {},
+): HttpTransport {
+  return async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/api/public/traces") {
+      return Response.json({
+        data: [{ id: "trace-1" }],
+        meta: { totalPages: 1 },
+      });
+    }
+    if (url.pathname === "/api/public/traces/trace-1") {
+      return Response.json({
+        id: "trace-1",
+        sessionId: "run-tag",
+        observations,
+        ...bodyExtras,
+      });
+    }
+    return new Response(null, { status: 404 });
+  };
+}
+
+async function verify(
+  observations: unknown[],
+  options: {
+    expected?: number;
+    requireCost?: boolean;
+    body?: Record<string, unknown>;
+  } = {},
+) {
+  return verifyLangfuseEgress({
+    tag: "run-tag",
+    expectedObservations: options.expected ?? 1,
+    requireCost: options.requireCost,
+    config: CONFIG,
+    transport: fakeTransport(observations, options.body),
+  });
+}
+
+function check(receipt: Awaited<ReturnType<typeof verify>>, label: string) {
+  const found = receipt.checks.find((item) => item.label === label);
+  if (!found) throw new Error(`missing check ${label}`);
+  return found;
+}
+
+describe("Langfuse egress verification", () => {
+  test("normalizes bare hosts and ingestion URLs identically", () => {
+    expect(langfuseHost("https://langfuse.example")).toBe(
+      "https://langfuse.example",
+    );
+    expect(langfuseHost("https://langfuse.example/api/public/ingestion/")).toBe(
+      "https://langfuse.example",
+    );
+  });
+
+  test("arrival-count miss is fatal", async () => {
+    const receipt = await verify([generation()], { expected: 2 });
+
+    expect(receipt.passed).toBeFalse();
+    expect(check(receipt, "arrival_count")).toMatchObject({
+      passed: false,
+      fatal: true,
+      observed: 1,
+      expected: 2,
+    });
+  });
+
+  test("missing usage_details is fatal", async () => {
+    const receipt = await verify([generation({ usage: false })]);
+
+    expect(receipt.passed).toBeFalse();
+    expect(check(receipt, "generation_metadata")).toMatchObject({
+      passed: false,
+      fatal: true,
+      observed: 0,
+      expected: 1,
+    });
+  });
+
+  test("NULL cost is labelled but non-fatal by default", async () => {
+    const receipt = await verify([generation({ cost: null })]);
+
+    expect(receipt.passed).toBeTrue();
+    expect(check(receipt, "total_cost")).toMatchObject({
+      passed: false,
+      fatal: false,
+      observed: 0,
+      expected: 1,
+    });
+  });
+
+  test("NULL cost is fatal when required", async () => {
+    const receipt = await verify([generation({ cost: null })], {
+      requireCost: true,
+    });
+
+    expect(receipt.passed).toBeFalse();
+    expect(check(receipt, "total_cost")).toMatchObject({
+      passed: false,
+      fatal: true,
+    });
+  });
+
+  test("secret-shaped trace content is fatal and reports labels only", async () => {
+    const receipt = await verify([generation()], {
+      body: { metadata: "password=do-not-emit-this-value" },
+    });
+    const output = JSON.stringify(receipt);
+
+    expect(receipt.passed).toBeFalse();
+    expect(check(receipt, "secret_scan")).toMatchObject({
+      passed: false,
+      fatal: true,
+    });
+    expect(output).toContain("labeled_secret");
+    expect(output).not.toContain("do-not-emit-this-value");
+  });
+
+  test("missing explicit opt-in refuses to run", async () => {
+    const outcome = await runEgressCli(
+      ["--verify", "--tag", "run-tag", "--count", "1"],
+      { ...OPTED_IN_ENV, OPEN_BRAIN_LANGFUSE_EGRESS: undefined },
+      fakeTransport([generation()]),
+    );
+
+    expect(outcome).toEqual({
+      exitCode: 2,
+      error: "OPEN_BRAIN_LANGFUSE_EGRESS must equal 1",
+    });
+  });
+
+  test("passing serialized output never contains a returned trace body", async () => {
+    const outcome = await runEgressCli(
+      ["--verify", "--tag", "run-tag", "--count", "1", "--json"],
+      OPTED_IN_ENV,
+      fakeTransport([{ id: "root-span", type: "SPAN" }, generation()]),
+    );
+    const output = serializeCliOutcome(outcome, true);
+
+    expect(outcome.exitCode).toBe(0);
+    expect(output).not.toContain("SAFE_BODY_MARKER");
+    expect(output).not.toContain("public-id");
+    expect(output).not.toContain("private-id");
+  });
+});

--- a/scripts/eval-langfuse-egress.test.ts
+++ b/scripts/eval-langfuse-egress.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+  evaluateDriveOutcome,
   langfuseHost,
+  parseEgressArgs,
   runEgressCli,
   serializeCliOutcome,
   verifyLangfuseEgress,
@@ -25,6 +27,7 @@ const OPTED_IN_ENV = {
 interface FakeObservationOptions {
   usage?: boolean;
   cost?: number | null;
+  output?: unknown;
 }
 
 function generation(
@@ -36,7 +39,7 @@ function generation(
     providedModelName: "claude-fable-5",
     usageDetails: options.usage === false ? undefined : { input: 2, output: 3 },
     totalCost: options.cost === undefined ? 0.001 : options.cost,
-    output: "SAFE_BODY_MARKER",
+    output: options.output ?? "SAFE_BODY_MARKER",
   };
 }
 
@@ -68,16 +71,27 @@ async function verify(
   observations: unknown[],
   options: {
     expected?: number;
+    expectedTraces?: number;
     requireCost?: boolean;
     body?: Record<string, unknown>;
+    settleTimeoutSeconds?: number;
+    pollIntervalMs?: number;
+    now?: () => number;
+    sleep?: (milliseconds: number) => Promise<void>;
+    transport?: HttpTransport;
   } = {},
 ) {
   return verifyLangfuseEgress({
     tag: "run-tag",
     expectedObservations: options.expected ?? 1,
+    expectedTraces: options.expectedTraces,
     requireCost: options.requireCost,
+    settleTimeoutSeconds: options.settleTimeoutSeconds ?? 0,
+    pollIntervalMs: options.pollIntervalMs,
+    now: options.now,
+    sleep: options.sleep,
     config: CONFIG,
-    transport: fakeTransport(observations, options.body),
+    transport: options.transport ?? fakeTransport(observations, options.body),
   });
 }
 
@@ -158,6 +172,253 @@ describe("Langfuse egress verification", () => {
     });
     expect(output).toContain("labeled_secret");
     expect(output).not.toContain("do-not-emit-this-value");
+  });
+
+  test("secret in observation output is fatal and content visibility is explicit", async () => {
+    const receipt = await verify([
+      generation({ output: "password=observation-only-secret" }),
+    ]);
+    const output = JSON.stringify(receipt);
+
+    expect(receipt.passed).toBeFalse();
+    expect(check(receipt, "secret_scan")).toMatchObject({
+      passed: false,
+      fatal: true,
+      content_fields_present: true,
+      detector_counts: { labeled_secret: 1 },
+    });
+    expect(output).not.toContain("observation-only-secret");
+  });
+
+  test("secret scan discloses when observation content fields are absent", async () => {
+    const receipt = await verify([
+      {
+        id: "span-1",
+        type: "SPAN",
+      },
+    ], { expected: 1 });
+
+    expect(check(receipt, "secret_scan")).toMatchObject({
+      passed: true,
+      content_fields_present: false,
+    });
+  });
+
+  test("settle polling records a late successful arrival", async () => {
+    let listCalls = 0;
+    let now = 0;
+    const transport: HttpTransport = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/public/traces") {
+        listCalls += 1;
+        return Response.json({
+          data: listCalls === 1 ? [] : [{ id: "trace-1" }],
+        });
+      }
+      if (url.pathname === "/api/public/traces/trace-1") {
+        return Response.json({ id: "trace-1", observations: [generation()] });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const receipt = await verify([], {
+      settleTimeoutSeconds: 5,
+      pollIntervalMs: 2_000,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds;
+      },
+      transport,
+    });
+
+    expect(receipt.passed).toBeTrue();
+    expect(receipt.settle).toEqual({
+      waited_ms: 2_000,
+      timed_out: false,
+      polls: 2,
+    });
+  });
+
+  test("settle timeout reports the final observed counts", async () => {
+    let listCalls = 0;
+    let now = 0;
+    const transport: HttpTransport = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/public/traces") {
+        listCalls += 1;
+        return Response.json({
+          data: listCalls === 1 ? [] : [{ id: "trace-1" }],
+        });
+      }
+      if (url.pathname === "/api/public/traces/trace-1") {
+        return Response.json({ id: "trace-1", observations: [generation()] });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const receipt = await verify([], {
+      expected: 2,
+      settleTimeoutSeconds: 2,
+      pollIntervalMs: 2_000,
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds;
+      },
+      transport,
+    });
+
+    expect(receipt.passed).toBeFalse();
+    expect(receipt.observed.observations).toBe(1);
+    expect(receipt.settle).toEqual({
+      waited_ms: 2_000,
+      timed_out: true,
+      polls: 2,
+    });
+  });
+
+  test("pagination falls back to full pages when totalPages is absent", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `trace-${index + 1}`,
+    }));
+    const transport: HttpTransport = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/public/traces") {
+        return Response.json({
+          data: url.searchParams.get("page") === "1"
+            ? firstPage
+            : [{ id: "trace-101" }],
+        });
+      }
+      const id = url.pathname.split("/").at(-1) ?? "missing";
+      return Response.json({
+        id,
+        observations: [generation()],
+      });
+    };
+
+    const receipt = await verify([], {
+      expected: 101,
+      expectedTraces: 101,
+      settleTimeoutSeconds: 0,
+      transport,
+    });
+
+    expect(receipt.passed).toBeTrue();
+    expect(receipt.observed).toEqual({
+      traces: 101,
+      observations: 101,
+      generations: 101,
+    });
+  });
+
+  test("drive outcome requires a successful exit and advanced observe watermark", () => {
+    const receipt = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 3,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      observeOffset: 42,
+    });
+
+    expect(receipt.passed).toBeTrue();
+    expect(receipt.observed).toEqual({
+      traces: 0,
+      observations: 0,
+      generations: 0,
+    });
+    expect(check(receipt, "capture_exit")).toMatchObject({
+      passed: true,
+      fatal: true,
+      observed: 0,
+      expected: 0,
+    });
+    expect(check(receipt, "emit_proven")).toMatchObject({
+      passed: true,
+      fatal: true,
+      observed: 42,
+      emit_failure_detected: false,
+    });
+  });
+
+  test("drive outcome fails without watermark proof or on explicit emit failure", () => {
+    const missingWatermark = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 1,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      observeOffset: 0,
+    });
+    const explicitFailure = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 1,
+      exitCode: 0,
+      stdout: "",
+      stderr: "observation emit failed (network); turns left for retry",
+      observeOffset: 9,
+    });
+    const captureFailure = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 1,
+      exitCode: 7,
+      stdout: "",
+      stderr: "",
+      observeOffset: 9,
+    });
+
+    expect(missingWatermark.passed).toBeFalse();
+    expect(check(missingWatermark, "emit_proven")).toMatchObject({
+      passed: false,
+      observed: 0,
+      emit_failure_detected: false,
+    });
+    expect(explicitFailure.passed).toBeFalse();
+    expect(check(explicitFailure, "emit_proven")).toMatchObject({
+      passed: false,
+      observed: 9,
+      emit_failure_detected: true,
+    });
+    expect(captureFailure.passed).toBeFalse();
+    expect(check(captureFailure, "capture_exit")).toMatchObject({
+      passed: false,
+      observed: 7,
+      expected: 0,
+    });
+  });
+
+  test("settle timeout CLI flag accepts non-negative seconds and rejects invalid values", () => {
+    expect(
+      parseEgressArgs(["--verify", "--tag", "run-tag"])
+        .settleTimeoutSeconds,
+    ).toBe(60);
+    expect(
+      parseEgressArgs([
+        "--verify",
+        "--tag",
+        "run-tag",
+        "--settle-timeout",
+        "2.5",
+      ]).settleTimeoutSeconds,
+    ).toBe(2.5);
+    expect(() =>
+      parseEgressArgs([
+        "--verify",
+        "--tag",
+        "run-tag",
+        "--settle-timeout",
+        "-1",
+      ]),
+    ).toThrow("--settle-timeout must be a non-negative number");
+    expect(() =>
+      parseEgressArgs([
+        "--verify",
+        "--tag",
+        "run-tag",
+        "--settle-timeout",
+        "later",
+      ]),
+    ).toThrow("--settle-timeout must be a non-negative number");
   });
 
   test("missing explicit opt-in refuses to run", async () => {

--- a/scripts/eval-langfuse-egress.ts
+++ b/scripts/eval-langfuse-egress.ts
@@ -1,0 +1,505 @@
+#!/usr/bin/env bun
+
+/**
+ * Live Langfuse egress verifier for Open Brain (issue #578, phase 1).
+ *
+ *   OPEN_BRAIN_LANGFUSE_EGRESS=1 bun scripts/eval-langfuse-egress.ts --drive
+ *   OPEN_BRAIN_LANGFUSE_EGRESS=1 bun scripts/eval-langfuse-egress.ts --verify --tag <tag>
+ *
+ * The explicit OPEN_BRAIN_LANGFUSE_EGRESS=1 opt-in is mandatory. Langfuse
+ * coordinates come from the existing OPENBRAIN_TRACING_* variables. Output is
+ * content-free: counts, ids, statuses, and detector labels only. Trace bodies,
+ * credentials, matching values, and match offsets are never emitted.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { SECRET_DETECTORS } from "../src/secret-patterns.ts";
+
+const OPT_IN_ENV = "OPEN_BRAIN_LANGFUSE_EGRESS";
+const INGESTION_SUFFIX = "/api/public/ingestion";
+const DEFAULT_EVENT_COUNT = 3;
+const DEFAULT_PAGE_LIMIT = 100;
+
+export interface LangfuseReadConfig {
+  endpoint: string;
+  publicKey: string;
+  secretKey: string;
+}
+
+export type HttpTransport = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface EgressCheck {
+  label: "arrival_count" | "generation_metadata" | "total_cost" | "secret_scan";
+  passed: boolean;
+  fatal: boolean;
+  observed: number;
+  expected?: number;
+  detector_counts?: Record<string, number>;
+}
+
+export interface EgressReceipt {
+  gate: "langfuse_egress";
+  mode: "drive" | "verify";
+  tag: string;
+  passed: boolean;
+  expected: { traces: number; observations: number };
+  observed: { traces: number; observations: number; generations: number };
+  checks: EgressCheck[];
+}
+
+export interface CliOutcome {
+  exitCode: number;
+  receipt?: EgressReceipt;
+  error?: string;
+}
+
+interface CliOptions {
+  mode: "drive" | "verify";
+  tag: string;
+  count: number;
+  requireCost: boolean;
+}
+
+interface LangfuseTrace {
+  id: string;
+  observations: unknown[];
+  body: unknown;
+}
+
+interface VerificationOptions {
+  tag: string;
+  expectedObservations: number;
+  expectedGenerations?: number;
+  expectedTraces?: number;
+  requireCost?: boolean;
+  config: LangfuseReadConfig;
+  transport?: HttpTransport;
+}
+
+interface DriveOptions {
+  tag: string;
+  count: number;
+  env: Record<string, string | undefined>;
+  cwd?: string;
+}
+
+/** Normalize either a bare Langfuse host or its public ingestion URL. */
+export function langfuseHost(endpoint: string): string {
+  return endpoint
+    .replace(/\/$/, "")
+    .replace(new RegExp(`${INGESTION_SUFFIX}$`), "");
+}
+
+/** Resolve read-side coordinates from the existing tracing environment. */
+export function readLangfuseEgressConfig(
+  env: Record<string, string | undefined> = process.env,
+): LangfuseReadConfig {
+  const enabled = env.OPENBRAIN_TRACING_ENABLED === "1";
+  const endpoint = env.OPENBRAIN_TRACING_ENDPOINT?.trim() ?? "";
+  const publicKey = env.OPENBRAIN_TRACING_PUBLIC_KEY?.trim() ?? "";
+  const secretKey = env.OPENBRAIN_TRACING_SECRET_KEY?.trim() ?? "";
+  if (!enabled) throw new Error("OPENBRAIN_TRACING_ENABLED must equal 1");
+  if (!endpoint || !publicKey || !secretKey) {
+    throw new Error("OPENBRAIN_TRACING_* coordinates are incomplete");
+  }
+  return { endpoint: langfuseHost(endpoint), publicKey, secretKey };
+}
+
+function assertSafeTag(tag: string): void {
+  const validShape = /^[A-Za-z0-9._:-]{1,128}$/.test(tag);
+  const secretShaped = SECRET_DETECTORS.some((detector) =>
+    detector.pattern.test(tag),
+  );
+  if (!validShape || secretShaped)
+    throw new Error("--tag must be a safe identifier");
+}
+
+function argumentValue(args: string[], name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inline = args.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = args.indexOf(`--${name}`);
+  const next = index >= 0 ? args[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+/** Parse the CLI without touching the environment or network. */
+export function parseEgressArgs(args: string[]): CliOptions {
+  const drive = args.includes("--drive");
+  const verify = args.includes("--verify");
+  if (drive === verify)
+    throw new Error("select exactly one of --drive or --verify");
+  const countText = argumentValue(args, "count") ?? String(DEFAULT_EVENT_COUNT);
+  const count = Number.parseInt(countText, 10);
+  if (!Number.isSafeInteger(count) || count < 1) {
+    throw new Error("--count must be a positive integer");
+  }
+  const tag = argumentValue(args, "tag") ?? randomUUID();
+  assertSafeTag(tag);
+  return {
+    mode: drive ? "drive" : "verify",
+    tag,
+    count,
+    requireCost: args.includes("--require-cost"),
+  };
+}
+
+function basicAuthorization(config: LangfuseReadConfig): string {
+  return `Basic ${Buffer.from(`${config.publicKey}:${config.secretKey}`).toString("base64")}`;
+}
+
+async function fetchJson(
+  url: URL,
+  config: LangfuseReadConfig,
+  transport: HttpTransport,
+): Promise<unknown> {
+  const response = await transport(url, {
+    headers: { authorization: basicAuthorization(config) },
+  });
+  if (!response.ok)
+    throw new Error(`Langfuse API request failed (${response.status})`);
+  return response.json();
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function arrayField(value: unknown, name: string): unknown[] {
+  const object = objectValue(value);
+  return Array.isArray(object?.[name]) ? object[name] : [];
+}
+
+function stringField(value: unknown, ...names: string[]): string | undefined {
+  const object = objectValue(value);
+  const found = names
+    .map((name) => object?.[name])
+    .find((item) => typeof item === "string");
+  return typeof found === "string" ? found : undefined;
+}
+
+function fieldPresent(value: unknown, ...names: string[]): boolean {
+  const object = objectValue(value);
+  return names.some(
+    (name) => object?.[name] !== null && object?.[name] !== undefined,
+  );
+}
+
+function isGeneration(value: unknown): boolean {
+  return stringField(value, "type")?.toUpperCase() === "GENERATION";
+}
+
+function traceFrom(value: unknown): LangfuseTrace | undefined {
+  const id = stringField(value, "id");
+  if (!id) return undefined;
+  return { id, observations: arrayField(value, "observations"), body: value };
+}
+
+function pageData(value: unknown): unknown[] {
+  const direct = arrayField(value, "data");
+  if (direct.length > 0) return direct;
+  return Array.isArray(value) ? value : [];
+}
+
+function hasNextPage(value: unknown, page: number): boolean {
+  const meta = objectValue(objectValue(value)?.meta);
+  const totalPages = meta?.totalPages ?? meta?.total_pages;
+  return typeof totalPages === "number" && page < totalPages;
+}
+
+async function queryTaggedTraces(
+  tag: string,
+  config: LangfuseReadConfig,
+  transport: HttpTransport,
+): Promise<LangfuseTrace[]> {
+  const traces: LangfuseTrace[] = [];
+  let page = 1;
+  let more = true;
+  while (more) {
+    const url = new URL("/api/public/traces", config.endpoint);
+    url.searchParams.set("sessionId", tag);
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("limit", String(DEFAULT_PAGE_LIMIT));
+    const payload = await fetchJson(url, config, transport);
+    const summaries = pageData(payload);
+    for (const summary of summaries) {
+      const summaryTrace = traceFrom(summary);
+      if (!summaryTrace) continue;
+      const detailUrl = new URL(
+        `/api/public/traces/${encodeURIComponent(summaryTrace.id)}`,
+        config.endpoint,
+      );
+      const detail = await fetchJson(detailUrl, config, transport);
+      traces.push(traceFrom(detail) ?? summaryTrace);
+    }
+    more = hasNextPage(payload, page);
+    page += 1;
+  }
+  return traces;
+}
+
+function secretCounts(traces: LangfuseTrace[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const trace of traces) {
+    const serialized = JSON.stringify(trace.body);
+    for (const detector of SECRET_DETECTORS) {
+      if (!detector.pattern.test(serialized)) continue;
+      counts[detector.kind] = (counts[detector.kind] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+/** Query Langfuse and evaluate the issue #578 egress assertions. */
+export async function verifyLangfuseEgress(
+  options: VerificationOptions,
+): Promise<EgressReceipt> {
+  const transport = options.transport ?? fetch;
+  const traces = await queryTaggedTraces(
+    options.tag,
+    options.config,
+    transport,
+  );
+  const observations = traces.flatMap((trace) => trace.observations);
+  const generations = observations.filter(isGeneration);
+  const metadataCount = generations.filter(
+    (row) =>
+      fieldPresent(row, "providedModelName", "provided_model_name") &&
+      fieldPresent(row, "usageDetails", "usage_details"),
+  ).length;
+  const costCount = generations.filter((row) =>
+    fieldPresent(row, "totalCost", "total_cost"),
+  ).length;
+  const detectorCounts = secretCounts(traces);
+  const secretHitCount = Object.values(detectorCounts).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+  const expectedTraces = options.expectedTraces ?? 1;
+  const expectedGenerations =
+    options.expectedGenerations ?? options.expectedObservations;
+  const checks: EgressCheck[] = [
+    {
+      label: "arrival_count",
+      passed:
+        traces.length === expectedTraces &&
+        observations.length === options.expectedObservations,
+      fatal: true,
+      observed: observations.length,
+      expected: options.expectedObservations,
+    },
+    {
+      label: "generation_metadata",
+      passed:
+        generations.length === expectedGenerations &&
+        metadataCount === expectedGenerations,
+      fatal: true,
+      observed: metadataCount,
+      expected: expectedGenerations,
+    },
+    {
+      label: "total_cost",
+      passed: costCount === expectedGenerations,
+      fatal: options.requireCost === true,
+      observed: costCount,
+      expected: expectedGenerations,
+    },
+    {
+      label: "secret_scan",
+      passed: secretHitCount === 0,
+      fatal: true,
+      observed: secretHitCount,
+      detector_counts: detectorCounts,
+    },
+  ];
+  const passed = checks.every((check) => check.passed || !check.fatal);
+  return {
+    gate: "langfuse_egress",
+    mode: "verify",
+    tag: options.tag,
+    passed,
+    expected: {
+      traces: expectedTraces,
+      observations: options.expectedObservations,
+    },
+    observed: {
+      traces: traces.length,
+      observations: observations.length,
+      generations: generations.length,
+    },
+    checks,
+  };
+}
+
+function scratchRoot(cwd: string): string {
+  const marker = `${path.sep}_worktrees${path.sep}`;
+  const markerIndex = cwd.indexOf(marker);
+  const projectRoot = markerIndex >= 0 ? cwd.slice(0, markerIndex) : cwd;
+  return path.join(projectRoot, "_scratch", "langfuse-egress");
+}
+
+function transcriptLine(tag: string, index: number): string {
+  return JSON.stringify({
+    type: "assistant",
+    uuid: randomUUID(),
+    sessionId: tag,
+    cwd: `langfuse-egress:${tag}`,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "assistant",
+      model: "claude-fable-5",
+      usage: {
+        input_tokens: 2,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 3,
+      },
+      content: [
+        {
+          type: "text",
+          text: `egress verifier event ${index + 1}; run ${tag}`,
+        },
+      ],
+    },
+  });
+}
+
+function captureEnvironment(
+  env: Record<string, string | undefined>,
+  config: LangfuseReadConfig,
+  watermarkPath: string,
+): Record<string, string> {
+  const child: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined || key.startsWith("OPENBRAIN_TRACING_")) continue;
+    child[key] = value;
+  }
+  child.OPENBRAIN_OBSERVATION_ENABLED = "1";
+  child.OPENBRAIN_OBSERVATION_ENDPOINT = config.endpoint;
+  child.OPENBRAIN_OBSERVATION_PUBLIC_KEY = config.publicKey;
+  child.OPENBRAIN_OBSERVATION_SECRET_KEY = config.secretKey;
+  child.OPENBRAIN_CAPTURE_WATERMARK_PATH = watermarkPath;
+  return child;
+}
+
+/** Drive the real Python Stop-hook capture path with known generation turns. */
+export async function driveLangfuseEgress(
+  options: DriveOptions,
+): Promise<EgressReceipt> {
+  const config = readLangfuseEgressConfig(options.env);
+  const cwd = options.cwd ?? process.cwd();
+  const runDir = path.join(scratchRoot(cwd), `${options.tag}-${randomUUID()}`);
+  await mkdir(runDir, { recursive: true });
+  const transcriptPath = path.join(runDir, "transcript.jsonl");
+  const watermarkPath = path.join(runDir, "watermarks.sqlite");
+  const transcript = Array.from({ length: options.count }, (_, index) =>
+    transcriptLine(options.tag, index),
+  );
+  await Bun.write(transcriptPath, `${transcript.join("\n")}\n`);
+  const payload = JSON.stringify({
+    session_id: options.tag,
+    transcript_path: transcriptPath,
+    cwd,
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+  });
+  const processHandle = Bun.spawn(["uv", "run", "openbrain-capture-stop"], {
+    cwd: path.join(cwd, "python", "openbrain"),
+    env: captureEnvironment(options.env, config, watermarkPath),
+    stdin: new Blob([payload]),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await processHandle.exited;
+  if (exitCode !== 0) throw new Error(`capture path exited ${exitCode}`);
+  return {
+    gate: "langfuse_egress",
+    mode: "drive",
+    tag: options.tag,
+    passed: true,
+    expected: { traces: 1, observations: options.count + 1 },
+    observed: {
+      traces: 0,
+      observations: options.count,
+      generations: options.count,
+    },
+    checks: [],
+  };
+}
+
+/** Execute the CLI lifecycle with injectable environment and HTTP transport. */
+export async function runEgressCli(
+  args: string[],
+  env: Record<string, string | undefined> = process.env,
+  transport: HttpTransport = fetch,
+): Promise<CliOutcome> {
+  if (env[OPT_IN_ENV] !== "1") {
+    return { exitCode: 2, error: `${OPT_IN_ENV} must equal 1` };
+  }
+  try {
+    const options = parseEgressArgs(args);
+    const config = readLangfuseEgressConfig(env);
+    const receipt =
+      options.mode === "drive"
+        ? await driveLangfuseEgress({
+            tag: options.tag,
+            count: options.count,
+            env,
+          })
+        : await verifyLangfuseEgress({
+            tag: options.tag,
+            expectedObservations: options.count + 1,
+            expectedGenerations: options.count,
+            requireCost: options.requireCost,
+            config,
+            transport,
+          });
+    return { exitCode: receipt.passed ? 0 : 1, receipt };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    return { exitCode: 2, error: message };
+  }
+}
+
+/** Serialize only the content-free receipt or stable error message. */
+export function serializeCliOutcome(
+  outcome: CliOutcome,
+  json: boolean,
+): string {
+  if (outcome.error) return `Langfuse egress gate error: ${outcome.error}`;
+  const receipt = outcome.receipt;
+  if (!receipt) return "Langfuse egress gate error: no receipt";
+  if (json) return JSON.stringify(receipt, null, 2);
+  const lines = [
+    `Langfuse egress gate: ${receipt.passed ? "PASS" : "FAIL"}`,
+    `mode=${receipt.mode} tag=${receipt.tag}`,
+    `expected traces=${receipt.expected.traces} observations=${receipt.expected.observations}`,
+    `observed traces=${receipt.observed.traces} observations=${receipt.observed.observations} generations=${receipt.observed.generations}`,
+  ];
+  for (const check of receipt.checks) {
+    lines.push(
+      `check=${check.label} status=${check.passed ? "PASS" : "FAIL"} fatal=${check.fatal} observed=${check.observed}${check.expected === undefined ? "" : ` expected=${check.expected}`}`,
+    );
+    for (const [kind, count] of Object.entries(check.detector_counts ?? {})) {
+      lines.push(`detector=${kind} count=${count}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+if (import.meta.main) {
+  const args = Bun.argv.slice(2);
+  runEgressCli(args).then((outcome) => {
+    const output = serializeCliOutcome(outcome, args.includes("--json"));
+    const writer = outcome.exitCode === 0 ? console.log : console.error;
+    writer(output);
+    process.exitCode = outcome.exitCode;
+  });
+}

--- a/scripts/eval-langfuse-egress.ts
+++ b/scripts/eval-langfuse-egress.ts
@@ -15,12 +15,17 @@
 import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { Database } from "bun:sqlite";
 import { SECRET_DETECTORS } from "../src/secret-patterns.ts";
 
 const OPT_IN_ENV = "OPEN_BRAIN_LANGFUSE_EGRESS";
 const INGESTION_SUFFIX = "/api/public/ingestion";
 const DEFAULT_EVENT_COUNT = 3;
 const DEFAULT_PAGE_LIMIT = 100;
+const DEFAULT_SETTLE_TIMEOUT_SECONDS = 60;
+const DEFAULT_SETTLE_POLL_INTERVAL_MS = 2_000;
+const MAX_TRACE_PAGES = 100;
+const EMIT_FAILURE_MARKER = "observation emit failed";
 
 export interface LangfuseReadConfig {
   endpoint: string;
@@ -34,12 +39,20 @@ export type HttpTransport = (
 ) => Promise<Response>;
 
 export interface EgressCheck {
-  label: "arrival_count" | "generation_metadata" | "total_cost" | "secret_scan";
+  label:
+    | "arrival_count"
+    | "generation_metadata"
+    | "total_cost"
+    | "secret_scan"
+    | "capture_exit"
+    | "emit_proven";
   passed: boolean;
   fatal: boolean;
   observed: number;
   expected?: number;
   detector_counts?: Record<string, number>;
+  content_fields_present?: boolean;
+  emit_failure_detected?: boolean;
 }
 
 export interface EgressReceipt {
@@ -50,6 +63,7 @@ export interface EgressReceipt {
   expected: { traces: number; observations: number };
   observed: { traces: number; observations: number; generations: number };
   checks: EgressCheck[];
+  settle?: { waited_ms: number; timed_out: boolean; polls: number };
 }
 
 export interface CliOutcome {
@@ -63,6 +77,7 @@ interface CliOptions {
   tag: string;
   count: number;
   requireCost: boolean;
+  settleTimeoutSeconds: number;
 }
 
 interface LangfuseTrace {
@@ -77,8 +92,21 @@ interface VerificationOptions {
   expectedGenerations?: number;
   expectedTraces?: number;
   requireCost?: boolean;
+  settleTimeoutSeconds?: number;
+  pollIntervalMs?: number;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
   config: LangfuseReadConfig;
   transport?: HttpTransport;
+}
+
+export interface DriveOutcome {
+  tag: string;
+  count: number;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  observeOffset: number;
 }
 
 interface DriveOptions {
@@ -139,6 +167,13 @@ export function parseEgressArgs(args: string[]): CliOptions {
   if (!Number.isSafeInteger(count) || count < 1) {
     throw new Error("--count must be a positive integer");
   }
+  const settleTimeoutText =
+    argumentValue(args, "settle-timeout") ??
+    String(DEFAULT_SETTLE_TIMEOUT_SECONDS);
+  const settleTimeoutSeconds = Number(settleTimeoutText);
+  if (!Number.isFinite(settleTimeoutSeconds) || settleTimeoutSeconds < 0) {
+    throw new Error("--settle-timeout must be a non-negative number");
+  }
   const tag = argumentValue(args, "tag") ?? randomUUID();
   assertSafeTag(tag);
   return {
@@ -146,6 +181,7 @@ export function parseEgressArgs(args: string[]): CliOptions {
     tag,
     count,
     requireCost: args.includes("--require-cost"),
+    settleTimeoutSeconds,
   };
 }
 
@@ -199,7 +235,9 @@ function isGeneration(value: unknown): boolean {
 function traceFrom(value: unknown): LangfuseTrace | undefined {
   const id = stringField(value, "id");
   if (!id) return undefined;
-  return { id, observations: arrayField(value, "observations"), body: value };
+  const object = objectValue(value) ?? {};
+  const { observations: _observations, ...body } = object;
+  return { id, observations: arrayField(value, "observations"), body };
 }
 
 function pageData(value: unknown): unknown[] {
@@ -208,10 +246,16 @@ function pageData(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
 }
 
-function hasNextPage(value: unknown, page: number): boolean {
+function hasNextPage(
+  value: unknown,
+  page: number,
+  rowCount: number,
+  pageSize: number,
+): boolean {
   const meta = objectValue(objectValue(value)?.meta);
   const totalPages = meta?.totalPages ?? meta?.total_pages;
-  return typeof totalPages === "number" && page < totalPages;
+  if (typeof totalPages === "number") return page < totalPages;
+  return rowCount === pageSize;
 }
 
 async function queryTaggedTraces(
@@ -222,7 +266,7 @@ async function queryTaggedTraces(
   const traces: LangfuseTrace[] = [];
   let page = 1;
   let more = true;
-  while (more) {
+  while (more && page <= MAX_TRACE_PAGES) {
     const url = new URL("/api/public/traces", config.endpoint);
     url.searchParams.set("sessionId", tag);
     url.searchParams.set("page", String(page));
@@ -239,22 +283,83 @@ async function queryTaggedTraces(
       const detail = await fetchJson(detailUrl, config, transport);
       traces.push(traceFrom(detail) ?? summaryTrace);
     }
-    more = hasNextPage(payload, page);
+    more = hasNextPage(
+      payload,
+      page,
+      summaries.length,
+      DEFAULT_PAGE_LIMIT,
+    );
     page += 1;
   }
   return traces;
 }
 
-function secretCounts(traces: LangfuseTrace[]): Record<string, number> {
+function observationContentPresent(observation: unknown): boolean {
+  const body = objectValue(observation);
+  if (!body) return false;
+  return Object.hasOwn(body, "input") || Object.hasOwn(body, "output");
+}
+
+function secretScan(traces: LangfuseTrace[]): {
+  counts: Record<string, number>;
+  contentFieldsPresent: boolean;
+} {
   const counts: Record<string, number> = {};
+  let contentFieldsPresent = false;
   for (const trace of traces) {
-    const serialized = JSON.stringify(trace.body);
+    const observationBodies = trace.observations.map((observation) => {
+      if (observationContentPresent(observation)) contentFieldsPresent = true;
+      return observation;
+    });
+    const serialized = JSON.stringify({
+      trace: trace.body,
+      observations: observationBodies,
+    });
     for (const detector of SECRET_DETECTORS) {
       if (!detector.pattern.test(serialized)) continue;
       counts[detector.kind] = (counts[detector.kind] ?? 0) + 1;
     }
   }
-  return counts;
+  return { counts, contentFieldsPresent };
+}
+
+interface SettledTraces {
+  traces: LangfuseTrace[];
+  waitedMs: number;
+  timedOut: boolean;
+  polls: number;
+}
+
+async function queryUntilSettled(
+  options: VerificationOptions,
+  transport: HttpTransport,
+  expectedTraces: number,
+): Promise<SettledTraces> {
+  const timeoutMs =
+    (options.settleTimeoutSeconds ?? DEFAULT_SETTLE_TIMEOUT_SECONDS) * 1_000;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? DEFAULT_SETTLE_POLL_INTERVAL_MS;
+  const now = options.now ?? Date.now;
+  const sleep =
+    options.sleep ??
+    ((milliseconds: number) => Bun.sleep(milliseconds));
+  const startedAt = now();
+  let polls = 0;
+  let traces: LangfuseTrace[] = [];
+  while (true) {
+    traces = await queryTaggedTraces(options.tag, options.config, transport);
+    polls += 1;
+    const observations = traces.flatMap((trace) => trace.observations);
+    const arrived =
+      traces.length >= expectedTraces &&
+      observations.length >= options.expectedObservations;
+    const waitedMs = Math.max(0, now() - startedAt);
+    if (arrived) return { traces, waitedMs, timedOut: false, polls };
+    if (waitedMs >= timeoutMs) {
+      return { traces, waitedMs, timedOut: true, polls };
+    }
+    await sleep(Math.min(pollIntervalMs, timeoutMs - waitedMs));
+  }
 }
 
 /** Query Langfuse and evaluate the issue #578 egress assertions. */
@@ -262,11 +367,9 @@ export async function verifyLangfuseEgress(
   options: VerificationOptions,
 ): Promise<EgressReceipt> {
   const transport = options.transport ?? fetch;
-  const traces = await queryTaggedTraces(
-    options.tag,
-    options.config,
-    transport,
-  );
+  const expectedTraces = options.expectedTraces ?? 1;
+  const settled = await queryUntilSettled(options, transport, expectedTraces);
+  const traces = settled.traces;
   const observations = traces.flatMap((trace) => trace.observations);
   const generations = observations.filter(isGeneration);
   const metadataCount = generations.filter(
@@ -277,12 +380,11 @@ export async function verifyLangfuseEgress(
   const costCount = generations.filter((row) =>
     fieldPresent(row, "totalCost", "total_cost"),
   ).length;
-  const detectorCounts = secretCounts(traces);
-  const secretHitCount = Object.values(detectorCounts).reduce(
+  const scan = secretScan(traces);
+  const secretHitCount = Object.values(scan.counts).reduce(
     (sum, count) => sum + count,
     0,
   );
-  const expectedTraces = options.expectedTraces ?? 1;
   const expectedGenerations =
     options.expectedGenerations ?? options.expectedObservations;
   const checks: EgressCheck[] = [
@@ -316,7 +418,8 @@ export async function verifyLangfuseEgress(
       passed: secretHitCount === 0,
       fatal: true,
       observed: secretHitCount,
-      detector_counts: detectorCounts,
+      detector_counts: scan.counts,
+      content_fields_present: scan.contentFieldsPresent,
     },
   ];
   const passed = checks.every((check) => check.passed || !check.fatal);
@@ -335,6 +438,11 @@ export async function verifyLangfuseEgress(
       generations: generations.length,
     },
     checks,
+    settle: {
+      waited_ms: settled.waitedMs,
+      timed_out: settled.timedOut,
+      polls: settled.polls,
+    },
   };
 }
 
@@ -389,6 +497,59 @@ function captureEnvironment(
   return child;
 }
 
+async function observationOffset(
+  watermarkPath: string,
+  tag: string,
+): Promise<number> {
+  if (!(await Bun.file(watermarkPath).exists())) return 0;
+  const database = new Database(watermarkPath, {
+    readonly: true,
+    create: false,
+  });
+  try {
+    const row = database
+      .query("SELECT offset FROM watermark WHERE session_key = ?")
+      .get(`observe:${tag}`);
+    const offset = objectValue(row)?.offset;
+    return typeof offset === "number" && offset > 0 ? offset : 0;
+  } finally {
+    database.close();
+  }
+}
+
+/** Evaluate content-free evidence produced by the drive child process. */
+export function evaluateDriveOutcome(outcome: DriveOutcome): EgressReceipt {
+  const emitFailureDetected = `${outcome.stdout}\n${outcome.stderr}`.includes(
+    EMIT_FAILURE_MARKER,
+  );
+  const checks: EgressCheck[] = [
+    {
+      label: "capture_exit",
+      passed: outcome.exitCode === 0,
+      fatal: true,
+      observed: outcome.exitCode,
+      expected: 0,
+    },
+    {
+      label: "emit_proven",
+      passed: outcome.observeOffset > 0 && !emitFailureDetected,
+      fatal: true,
+      observed: outcome.observeOffset,
+      expected: 1,
+      emit_failure_detected: emitFailureDetected,
+    },
+  ];
+  return {
+    gate: "langfuse_egress",
+    mode: "drive",
+    tag: outcome.tag,
+    passed: checks.every((check) => check.passed || !check.fatal),
+    expected: { traces: 1, observations: outcome.count + 1 },
+    observed: { traces: 0, observations: 0, generations: 0 },
+    checks,
+  };
+}
+
 /** Drive the real Python Stop-hook capture path with known generation turns. */
 export async function driveLangfuseEgress(
   options: DriveOptions,
@@ -417,21 +578,20 @@ export async function driveLangfuseEgress(
     stdout: "pipe",
     stderr: "pipe",
   });
-  const exitCode = await processHandle.exited;
-  if (exitCode !== 0) throw new Error(`capture path exited ${exitCode}`);
-  return {
-    gate: "langfuse_egress",
-    mode: "drive",
+  const [exitCode, stdout, stderr] = await Promise.all([
+    processHandle.exited,
+    new Response(processHandle.stdout).text(),
+    new Response(processHandle.stderr).text(),
+  ]);
+  const observeOffset = await observationOffset(watermarkPath, options.tag);
+  return evaluateDriveOutcome({
     tag: options.tag,
-    passed: true,
-    expected: { traces: 1, observations: options.count + 1 },
-    observed: {
-      traces: 0,
-      observations: options.count,
-      generations: options.count,
-    },
-    checks: [],
-  };
+    count: options.count,
+    exitCode,
+    stdout,
+    stderr,
+    observeOffset,
+  });
 }
 
 /** Execute the CLI lifecycle with injectable environment and HTTP transport. */
@@ -458,6 +618,7 @@ export async function runEgressCli(
             expectedObservations: options.count + 1,
             expectedGenerations: options.count,
             requireCost: options.requireCost,
+            settleTimeoutSeconds: options.settleTimeoutSeconds,
             config,
             transport,
           });
@@ -483,9 +644,22 @@ export function serializeCliOutcome(
     `expected traces=${receipt.expected.traces} observations=${receipt.expected.observations}`,
     `observed traces=${receipt.observed.traces} observations=${receipt.observed.observations} generations=${receipt.observed.generations}`,
   ];
-  for (const check of receipt.checks) {
+  if (receipt.settle) {
     lines.push(
-      `check=${check.label} status=${check.passed ? "PASS" : "FAIL"} fatal=${check.fatal} observed=${check.observed}${check.expected === undefined ? "" : ` expected=${check.expected}`}`,
+      `settle waited_ms=${receipt.settle.waited_ms} timed_out=${receipt.settle.timed_out} polls=${receipt.settle.polls}`,
+    );
+  }
+  for (const check of receipt.checks) {
+    const contentFields =
+      check.content_fields_present === undefined
+        ? ""
+        : ` content_fields_present=${check.content_fields_present}`;
+    const emitFailure =
+      check.emit_failure_detected === undefined
+        ? ""
+        : ` emit_failure_detected=${check.emit_failure_detected}`;
+    lines.push(
+      `check=${check.label} status=${check.passed ? "PASS" : "FAIL"} fatal=${check.fatal} observed=${check.observed}${check.expected === undefined ? "" : ` expected=${check.expected}`}${contentFields}${emitFailure}`,
     );
     for (const [kind, count] of Object.entries(check.detector_counts ?? {})) {
       lines.push(`detector=${kind} count=${count}`);


### PR DESCRIPTION
Adds `scripts/eval-langfuse-egress.ts`, the net-new Langfuse egress verifier from the #578 phase-1 delta (item 2). This is the leg that turns "merged, unverified live" into a command that produces a live receipt: after traffic is driven with a unique run tag, it queries Langfuse and asserts what actually arrived.

Scope is item 2 only. Scenario-fixture breadth (delta item 1) is a separate lane and is not touched here.

## What it does

- `--drive` emits N known generation turns through the REAL capture path, stamped with the run tag.
- `--verify` queries the Langfuse public trace API for that tag (as trace `sessionId`) and asserts arrival.
- `--tag <s>` (fresh UUID default, secret-shaped tags rejected), `--count <n>`, `--json`.

Assertions, as four labelled checks:

| check | fatal |
|---|---|
| `arrival_count` — exact trace/observation count for the tag (the silent-drop class) | yes |
| `generation_metadata` — GENERATION rows carry `provided_model_name` + `usage_details` | yes |
| `total_cost` — non-NULL cost | **no by default**, fatal with `--require-cost` |
| `secret_scan` — secret-shaped content in returned trace bodies | yes |

`total_cost` is deliberately reported-not-fatal: cost legitimately stays NULL until model prices are seeded. `--require-cost` promotes it, which is #560's live receipt on demand.

## Reuse, not reinvention

- Secret scanning imports `SECRET_DETECTORS` from `src/secret-patterns.ts` — the regex set already in the repo — rather than re-embedding the #561 audit patterns. Only detector `kind` and a count can reach output; matched values, offsets, and bodies never can.
- Env coordinates are the existing `OPENBRAIN_TRACING_ENDPOINT` / `_PUBLIC_KEY` / `_SECRET_KEY` / `_ENABLED`, matching `readMcpTracingConfig` in `server/observability/langfuse-tracing.ts`. For `--drive` these are translated to the capture sink's existing `OPENBRAIN_OBSERVATION_*` variables (`python/openbrain/src/openbrain/config.py`), because the emitter reads that older spelling.
- Endpoint normalisation accepts a bare host or the `/api/public/ingestion` URL, mirroring `sink_host()` in `langfuse_emitter.py`.
- Opt-in guard (`OPEN_BRAIN_LANGFUSE_EGRESS=1`), content-free output, and nonzero-exit discipline follow `scripts/eval-open-brain-live.ts`.

## Verification

Re-run by the supervising node in the worktree, not merely reported by the implementer:

- `bunx tsc --noEmit` — exit 0, no output.
- `bun test scripts/eval-langfuse-egress.test.ts` — 8 pass, 0 fail, 19 expect() calls.

Red-test proof: the arrival assertion was deliberately weakened from `===` to `<=`, and `arrival-count miss is fatal` then failed (`expect(received).toBeFalse()`, Received: true), 6 pass / 1 fail. The mutation was reverted before commit. Tests cover: arrival-count miss fatal, missing `usage_details` fatal, cost-NULL non-fatal by default, cost-NULL fatal under `--require-cost`, secret-pattern hit fatal, missing-opt-in refusal, and an output test asserting no trace-body marker or credential appears in the serialized receipt.

Not verified: a live `--drive`/`--verify` run against the real Langfuse service on CT 273. No live opt-in invocation was authorized in this lane, so authentication, live public-API response shape, cost seeding, and true end-to-end arrival remain **unverified**. This is written and tested, not live-proven.

## Critical Self-Review

- Highest-risk behavior: the live Langfuse public-API response shape is assumed from the documented API and has never been exercised against the real instance, so field-name drift would surface only on the first live run.
- Assumptions that could be wrong: that the run tag propagates as the trace `sessionId`, that `--drive`'s `OPENBRAIN_TRACING_*`-to-`OPENBRAIN_OBSERVATION_*` mapping is the correct bridge, and that camelCase/snake_case field acceptance covers what the API actually returns.
- Missing/weak tests: no live integration test, and pagination beyond a single page is implemented but only exercised through the fake transport.
- Security/permission risk: the tool reads trace bodies that may contain secrets, so the containment control is that only detector `kind` labels and counts reach stdout; a future edit that logs a body or a match offset would break that boundary and no test outside the output-marker test guards every path.
- Migration/deploy risk: none, additive script with no schema, migration, or runtime wiring.
- Downstream client/runtime risk: none, no MCP tool, transport, contract, or Python client surface changes, so no downstream rollout applies.
- Rollback/cleanup concern: revert the single commit; the script is opt-in and inert without `OPEN_BRAIN_LANGFUSE_EGRESS=1`.
- Fixes made before PR: corrected the env names from the assumed `LANGFUSE_*` to the repo's real `OPENBRAIN_TRACING_*`, and replaced hand-embedded secret regexes with an import of the existing `SECRET_DETECTORS`.
- Known residual risk: the verifier is merged-and-tested but not live-proven, so its first real run against CT 273 should be treated as the actual acceptance event for #560.

- SME review-memory update: [x] not applicable because: no new MEDIUM+ finding surfaced; the reused `SECRET_DETECTORS` and live-gate discipline are already recorded in `docs/sme/security.md` and `docs/sme/correctness.md`.

SME lanes reviewed: [x] correctness [x] adversarial [x] quality [x] security [x] domain-backend [x] gotcha-agent

## Review Gate

- Tier: Standard — net-new operator-facing script, no contract or client surface change.
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this lane adds an opt-in script and was not authorized to run live traffic against CT 273; the first live run is flagged as the acceptance event for #560.
- `bunx tsc --noEmit` and `bun test scripts/eval-langfuse-egress.test.ts` re-run independently by the supervising node; both green.
- Red-test proof performed and reverted, so the suite is known capable of failing.
- Contract parity: not applicable, no tool payload or schema touched.
- Live Langfuse run is explicitly out of scope and flagged unverified above.

Refs #578. Feeds #571; provides the automated receipt path for #560 and a permanent regression check for #561.
