### PR TITLE
feat(eval): scripted scenario fixtures for capture, durable_memory shape, and checkpoint round-trips (#578)

### DIFF
--- a/eval/open-brain/README.md
+++ b/eval/open-brain/README.md
@@ -307,6 +307,36 @@ URL + token). The receipt (`schema: openbrain.reflex_ab_gate.v1`) is
 content-free: only ids, namespaces, labels, counts, and booleans — no memory
 bodies, tokens, or secrets.
 
+## Scripted Scenario Gate (#578 phase 1)
+
+The scenario gate extends the existing live harness with scripted
+input-to-asserted-output fixtures. It uses the same opt-in environment,
+per-invocation throwaway namespace derivation, real MCP client/fake caller seam,
+content-free receipt discipline, and EVAL-3 teardown tally.
+
+```bash
+bun run eval:scenarios
+bun run eval:scenarios -- --json
+bun run eval:scenarios -- --fixture eval/open-brain/fixtures/scenarios-v1.json
+```
+
+`fixtures/scenarios-v1.json` contains the first three scenarios:
+
+- provider capture followed by exact `session_context` read-back (the write
+  receipt alone never proves persistence), including named failures for
+  lost/non-durable receipts and expected request keys reported as ignored;
+- a real-query `durable_memory` pack request carrying an explicit token budget,
+  with section/item shape and serialized whole-pack accounting assertions;
+- capture + checkpoint + resume-read, asserting the lane event and checkpoint
+  summary both surface.
+
+Plain `bun test` runs these against a fake `ScenarioTransport`; no service or
+PostgreSQL connection is touched. Live mode uses the installed
+`openbrain-memory` provider for capture/checkpoint, the existing MCP transport
+for reads and pack assembly, and exact-id cleanup for the records created by the
+run. Output contains only fixture/scenario ids, namespace labels, counts,
+statuses, booleans, and named failure classes.
+
 ## Next Expansion Points
 
 - Add a live Open Brain adapter that loads fixtures into an isolated namespace

--- a/eval/open-brain/fixtures/scenarios-v1.json
+++ b/eval/open-brain/fixtures/scenarios-v1.json
@@ -19,10 +19,6 @@
           "session_key": "eval:scenario:{{run_id}}:capture",
           "project": "open-brain"
         },
-        "expected_honored_request_keys": [
-          "candidate_type",
-          "memory_lifecycle_action"
-        ],
         "optional_request_fields": {
           "candidate_type": "durable_decision",
           "memory_lifecycle_action": "candidate"
@@ -69,8 +65,7 @@
           "channel_id": "checkpoint-round-trip",
           "session_key": "eval:scenario:{{run_id}}:checkpoint",
           "project": "open-brain"
-        },
-        "expected_honored_request_keys": []
+        }
       },
       "checkpoint": {
         "operation": "checkpoint",

--- a/eval/open-brain/fixtures/scenarios-v1.json
+++ b/eval/open-brain/fixtures/scenarios-v1.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 1,
+  "fixture_id": "open-brain-scenarios-v1",
+  "description": "Scripted live and fake-transport scenarios for capture, durable memory, and checkpoint resume behavior.",
+  "scenarios": [
+    {
+      "id": "capture-round-trip",
+      "kind": "capture_round_trip",
+      "request": {
+        "operation": "capture",
+        "distilled": true,
+        "content": "Scenario {{run_id}} capture round-trip marker.",
+        "event_type": "decision",
+        "scope": {
+          "agent": "scenario-eval",
+          "platform": "eval",
+          "server_id": "open-brain-scenarios",
+          "channel_id": "capture-round-trip",
+          "session_key": "eval:scenario:{{run_id}}:capture",
+          "project": "open-brain"
+        },
+        "expected_honored_request_keys": [
+          "candidate_type",
+          "memory_lifecycle_action"
+        ],
+        "optional_request_fields": {
+          "candidate_type": "durable_decision",
+          "memory_lifecycle_action": "candidate"
+        }
+      }
+    },
+    {
+      "id": "durable-memory-pack-shape",
+      "kind": "durable_memory_shape",
+      "seed": {
+        "table": "thoughts",
+        "content": "Scenario {{run_id}} marlin telemetry cache marker.",
+        "tags": ["eval", "scenario-578"]
+      },
+      "request": {
+        "query": "Scenario {{run_id}} marlin telemetry cache marker",
+        "budget_max_tokens": 1200,
+        "scope": {
+          "agent": "scenario-eval",
+          "platform": "eval",
+          "server_id": "open-brain-scenarios",
+          "channel_id": "durable-memory",
+          "session_key": "eval:scenario:{{run_id}}:durable-memory",
+          "project": "open-brain"
+        }
+      },
+      "expected": {
+        "section": "durable_memory",
+        "min_items": 1
+      }
+    },
+    {
+      "id": "checkpoint-wrap-round-trip",
+      "kind": "checkpoint_round_trip",
+      "event": {
+        "operation": "capture",
+        "distilled": true,
+        "content": "Scenario {{run_id}} lane event survives checkpoint resume.",
+        "event_type": "decision",
+        "scope": {
+          "agent": "scenario-eval",
+          "platform": "eval",
+          "server_id": "open-brain-scenarios",
+          "channel_id": "checkpoint-round-trip",
+          "session_key": "eval:scenario:{{run_id}}:checkpoint",
+          "project": "open-brain"
+        },
+        "expected_honored_request_keys": []
+      },
+      "checkpoint": {
+        "operation": "checkpoint",
+        "distilled": true,
+        "summary": "Scenario {{run_id}} checkpoint summary.",
+        "key_decisions": ["Keep the scripted lane event visible after resume."],
+        "next_steps": ["Verify the resumed lane context."],
+        "scope": {
+          "agent": "scenario-eval",
+          "platform": "eval",
+          "server_id": "open-brain-scenarios",
+          "channel_id": "checkpoint-round-trip",
+          "session_key": "eval:scenario:{{run_id}}:checkpoint",
+          "project": "open-brain"
+        }
+      }
+    }
+  ]
+}

--- a/eval/open-brain/live/__tests__/scenario-gate.test.ts
+++ b/eval/open-brain/live/__tests__/scenario-gate.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseScenarioFixture } from "../scenario-fixtures.ts";
 import { runScenarioGate } from "../scenario-gate.ts";
+import { parseProviderOutput } from "../scenario-transport.ts";
 import type {
   ProviderExecution,
   ScenarioFixture,
@@ -22,9 +23,12 @@ const FIXTURE = parseScenarioFixture(
 
 interface FakeOptions {
   zeroWrite?: boolean;
+  emptyProviderOutput?: boolean;
   lostCapture?: boolean;
   ignoredKeys?: string[];
   packCharLimit?: number;
+  packItems?: Array<Record<string, unknown>>;
+  packItemCount?: number;
   packThrows?: boolean;
   cleanupFails?: number;
 }
@@ -46,7 +50,7 @@ function fakeTransport(opts: FakeOptions = {}): ScenarioTransport {
   ): ProviderExecution {
     const lost = operation === "capture" && opts.lostCapture;
     return {
-      exitCode: lost ? 1 : 0,
+      exitCode: 0,
       receipt: {
         operation,
         status: lost ? "lost" : "saved",
@@ -70,6 +74,9 @@ function fakeTransport(opts: FakeOptions = {}): ScenarioTransport {
           events: [],
         };
       lanes.set(scope.session_key, lane);
+      if (operation === "capture" && opts.emptyProviderOutput) {
+        return parseProviderOutput("", 0);
+      }
       if (operation === "capture") {
         if (!opts.zeroWrite && !opts.lostCapture) {
           lane.events.push({
@@ -93,12 +100,15 @@ function fakeTransport(opts: FakeOptions = {}): ScenarioTransport {
     },
     async contextPack() {
       if (opts.packThrows) throw new Error("synthetic pack failure");
+      const items = opts.packItems ?? [
+        { id: "memory-1", citation_id: "citation-1" },
+      ];
       const sections = {
         durable_memory: {
           label: "durable_memory",
           namespace_scoped: true,
-          items: [{ id: "memory-1", citation_id: "citation-1" }],
-          item_count: 1,
+          items,
+          item_count: opts.packItemCount ?? items.length,
           truncated: false,
         },
       };
@@ -203,7 +213,22 @@ describe("runScenarioGate", () => {
     expect(capture.checks.read_back_exact).toBe(false);
   });
 
-  it("surfaces scope-proof loss as a named lost/durable failure", async () => {
+  it("names an exit-0 empty provider result as an absent capture receipt", async () => {
+    const outcome = await run(fakeTransport({ emptyProviderOutput: true }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "capture-round-trip:capture_receipt_absent",
+    );
+    expect(outcome.receipt.failures).not.toContain(
+      "capture-round-trip:scenario_transport_error",
+    );
+    const capture = outcome.receipt.scenarios[0]!;
+    expect(capture.checks.provider_exit_zero).toBe(true);
+    expect(capture.checks.receipt_saved).toBe(false);
+    expect(capture.checks.read_back_exact).toBe(false);
+  });
+
+  it("surfaces scope-proof loss independently of the provider exit code", async () => {
     const outcome = await run(fakeTransport({ lostCapture: true }));
     expect(outcome.passed).toBe(false);
     expect(outcome.receipt.failures).toContain(
@@ -212,20 +237,38 @@ describe("runScenarioGate", () => {
     expect(outcome.receipt.failures).toContain(
       "capture-round-trip:capture_not_durable",
     );
+    expect(outcome.receipt.failures).not.toContain(
+      "capture-round-trip:provider_exit_nonzero",
+    );
+    expect(outcome.receipt.scenarios[0]!.checks.provider_exit_zero).toBe(true);
     expectContentFree(outcome.receipt);
   });
 
-  it("fails when a key declared as honored is reported ignored", async () => {
+  it("fails when the provider ignores any key the request sent", async () => {
+    const outcome = await run(fakeTransport({ ignoredKeys: ["summary", "kind"] }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "checkpoint-wrap-round-trip:provider_ignored_request_key:summary",
+    );
+    expect(outcome.receipt.failures).not.toContain(
+      "checkpoint-wrap-round-trip:provider_ignored_request_key:kind",
+    );
+  });
+
+  it("fails when durable_memory item_count disagrees with the actual items", async () => {
     const outcome = await run(
-      fakeTransport({ ignoredKeys: ["candidate_type", "kind"] }),
+      fakeTransport({ packItems: [], packItemCount: 5 }),
     );
     expect(outcome.passed).toBe(false);
     expect(outcome.receipt.failures).toContain(
-      "capture-round-trip:capture_ignored_expected_key:candidate_type",
+      "durable-memory-pack-shape:durable_memory_item_count_mismatch",
     );
-    expect(outcome.receipt.failures).not.toContain(
-      "capture-round-trip:capture_ignored_expected_key:kind",
+    expect(outcome.receipt.failures).toContain(
+      "durable-memory-pack-shape:durable_memory_items_missing",
     );
+    const durable = outcome.receipt.scenarios[1]!;
+    expect(durable.checks.item_count).toBe(0);
+    expect(durable.checks.reported_item_count).toBe(5);
   });
 
   it("fails the durable_memory scenario when serialized sections exceed the reported budget", async () => {

--- a/eval/open-brain/live/__tests__/scenario-gate.test.ts
+++ b/eval/open-brain/live/__tests__/scenario-gate.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseScenarioFixture } from "../scenario-fixtures.ts";
+import { runScenarioGate } from "../scenario-gate.ts";
+import type {
+  ProviderExecution,
+  ScenarioFixture,
+  ScenarioRecord,
+  ScenarioTransport,
+  TeardownTally,
+} from "../scenario-types.ts";
+
+const FIXTURE = parseScenarioFixture(
+  JSON.parse(
+    readFileSync(
+      join(import.meta.dir, "../../fixtures/scenarios-v1.json"),
+      "utf8",
+    ),
+  ),
+);
+
+interface FakeOptions {
+  zeroWrite?: boolean;
+  lostCapture?: boolean;
+  ignoredKeys?: string[];
+  packCharLimit?: number;
+  packThrows?: boolean;
+  cleanupFails?: number;
+}
+
+interface LaneState {
+  id: string;
+  current_context_md: string | null;
+  events: Array<{ id: string; content: string }>;
+}
+
+function fakeTransport(opts: FakeOptions = {}): ScenarioTransport {
+  const lanes = new Map<string, LaneState>();
+  let sequence = 0;
+  const nextId = (prefix: string) => `${prefix}-${++sequence}`;
+
+  function execution(
+    operation: string,
+    result: Record<string, unknown>,
+  ): ProviderExecution {
+    const lost = operation === "capture" && opts.lostCapture;
+    return {
+      exitCode: lost ? 1 : 0,
+      receipt: {
+        operation,
+        status: lost ? "lost" : "saved",
+        durable: !lost,
+        direct_attempted: true,
+        fallback_attempted: false,
+        ignored_optional_request_keys: opts.ignoredKeys,
+      },
+      result,
+    };
+  }
+
+  return {
+    async executeProvider(request) {
+      const operation = String(request.operation);
+      const scope = request.scope as { session_key: string };
+      const lane =
+        lanes.get(scope.session_key) ?? {
+          id: nextId("lane"),
+          current_context_md: null,
+          events: [],
+        };
+      lanes.set(scope.session_key, lane);
+      if (operation === "capture") {
+        if (!opts.zeroWrite && !opts.lostCapture) {
+          lane.events.push({
+            id: nextId("event"),
+            content: String(request.content),
+          });
+        }
+        return execution(operation, {
+          event_id: lane.events.at(-1)?.id,
+          lane_id: lane.id,
+        });
+      }
+      lane.current_context_md = String(request.summary);
+      return execution(operation, {
+        session_id: nextId("session"),
+        lane_id: lane.id,
+      });
+    },
+    async logMemory() {
+      return { id: nextId("memory") };
+    },
+    async contextPack() {
+      if (opts.packThrows) throw new Error("synthetic pack failure");
+      const sections = {
+        durable_memory: {
+          label: "durable_memory",
+          namespace_scoped: true,
+          items: [{ id: "memory-1", citation_id: "citation-1" }],
+          item_count: 1,
+          truncated: false,
+        },
+      };
+      const serialized = JSON.stringify(sections).length;
+      return {
+        status: "ok",
+        sections,
+        budget: {
+          whole_pack: {
+            content_char_limit: opts.packCharLimit ?? serialized,
+          },
+        },
+      };
+    },
+    async sessionContext({ sessionKey }) {
+      const lane = lanes.get(sessionKey);
+      return lane
+        ? { lane, events: lane.events, event_count: lane.events.length }
+        : { lane: null, events: [], event_count: 0 };
+    },
+    async cleanup(records: ScenarioRecord[]): Promise<TeardownTally> {
+      const failed = Math.min(opts.cleanupFails ?? 0, records.length);
+      return {
+        attempted: records.length,
+        archived: records.length - failed,
+        already_absent: 0,
+        failed,
+      };
+    },
+    async close() {},
+  };
+}
+
+function run(
+  transport: ScenarioTransport,
+  fixture: ScenarioFixture = FIXTURE,
+) {
+  return runScenarioGate({
+    fixture,
+    namespace: "eval-live-recall-scenario-test",
+    transport,
+    commit: "testcommit",
+    generatedAt: "2026-08-05T00:00:00.000Z",
+    runId: "scenario-test-run",
+  });
+}
+
+function expectContentFree(receipt: unknown): void {
+  const json = JSON.stringify(receipt);
+  expect(json).not.toContain("capture round-trip marker");
+  expect(json).not.toContain("marlin telemetry cache marker");
+  expect(json).not.toContain("checkpoint summary");
+}
+
+describe("scenario fixture validation", () => {
+  it("loads the shipped three-scenario fixture", () => {
+    expect(FIXTURE.fixture_id).toBe("open-brain-scenarios-v1");
+    expect(FIXTURE.scenarios.map((scenario) => scenario.kind)).toEqual([
+      "capture_round_trip",
+      "durable_memory_shape",
+      "checkpoint_round_trip",
+    ]);
+  });
+
+  it("rejects duplicate scenario ids", () => {
+    expect(() =>
+      parseScenarioFixture({
+        ...FIXTURE,
+        scenarios: [FIXTURE.scenarios[0], FIXTURE.scenarios[0]],
+      }),
+    ).toThrow(/duplicate scenario id/);
+  });
+});
+
+describe("runScenarioGate", () => {
+  it("runs all scenarios through the fake transport and tears down exact records", async () => {
+    const outcome = await run(fakeTransport());
+    expect(outcome.receipt.failures).toEqual([]);
+    expect(outcome.passed).toBe(true);
+    expect(outcome.receipt.scenarios).toHaveLength(3);
+    expect(outcome.receipt.scenarios.every((scenario) => scenario.passed)).toBe(
+      true,
+    );
+    expect(outcome.receipt.teardown).toEqual({
+      attempted: 6,
+      archived: 6,
+      already_absent: 0,
+      failed: 0,
+    });
+    expectContentFree(outcome.receipt);
+  });
+
+  it("fails the exit-0 zero-write capture by reading it back", async () => {
+    const outcome = await run(fakeTransport({ zeroWrite: true }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "capture-round-trip:capture_round_trip_missing",
+    );
+    const capture = outcome.receipt.scenarios[0]!;
+    expect(capture.checks.provider_exit_zero).toBe(true);
+    expect(capture.checks.receipt_saved).toBe(true);
+    expect(capture.checks.read_back_exact).toBe(false);
+  });
+
+  it("surfaces scope-proof loss as a named lost/durable failure", async () => {
+    const outcome = await run(fakeTransport({ lostCapture: true }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "capture-round-trip:capture_receipt_lost",
+    );
+    expect(outcome.receipt.failures).toContain(
+      "capture-round-trip:capture_not_durable",
+    );
+    expectContentFree(outcome.receipt);
+  });
+
+  it("fails when a key declared as honored is reported ignored", async () => {
+    const outcome = await run(
+      fakeTransport({ ignoredKeys: ["candidate_type", "kind"] }),
+    );
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "capture-round-trip:capture_ignored_expected_key:candidate_type",
+    );
+    expect(outcome.receipt.failures).not.toContain(
+      "capture-round-trip:capture_ignored_expected_key:kind",
+    );
+  });
+
+  it("fails the durable_memory scenario when serialized sections exceed the reported budget", async () => {
+    const outcome = await run(fakeTransport({ packCharLimit: 1 }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "durable-memory-pack-shape:durable_memory_budget_exceeded",
+    );
+  });
+
+  it("registers a write for finally teardown before a later pack read throws", async () => {
+    const outcome = await run(fakeTransport({ packThrows: true }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "durable-memory-pack-shape:scenario_transport_error",
+    );
+    expect(outcome.receipt.teardown.attempted).toBe(6);
+    expect(outcome.receipt.teardown.failed).toBe(0);
+  });
+
+  it("fails an otherwise-green batch when teardown strands a record", async () => {
+    const outcome = await run(fakeTransport({ cleanupFails: 1 }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.teardown.failed).toBe(1);
+    expect(outcome.receipt.failures).toContain("teardown_failed:1");
+  });
+});

--- a/eval/open-brain/live/__tests__/scenario-gate.test.ts
+++ b/eval/open-brain/live/__tests__/scenario-gate.test.ts
@@ -255,6 +255,16 @@ describe("runScenarioGate", () => {
     );
   });
 
+  it("fails when the capture request's own sent key is ignored", async () => {
+    const outcome = await run(
+      fakeTransport({ ignoredKeys: ["candidate_type"] }),
+    );
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures).toContain(
+      "capture-round-trip:provider_ignored_request_key:candidate_type",
+    );
+  });
+
   it("fails when durable_memory item_count disagrees with the actual items", async () => {
     const outcome = await run(
       fakeTransport({ packItems: [], packItemCount: 5 }),

--- a/eval/open-brain/live/gate.ts
+++ b/eval/open-brain/live/gate.ts
@@ -60,11 +60,40 @@ export interface GateOutcome {
   passed: boolean;
 }
 
-interface TeardownTally {
+export interface TeardownTally {
   attempted: number;
   archived: number;
   already_absent: number;
   failed: number;
+}
+
+/**
+ * Shared EVAL-3 teardown accounting. Callers provide the exact records this run
+ * created and one record-specific cleanup operation; every record is attempted,
+ * individual failures never prevent later cleanup, and the receipt carries only
+ * counts.
+ */
+export async function teardownRecords<T>(
+  records: readonly T[],
+  cleanup: (record: T) => Promise<"archived" | "already_absent">,
+): Promise<TeardownTally> {
+  const tally: TeardownTally = {
+    attempted: 0,
+    archived: 0,
+    already_absent: 0,
+    failed: 0,
+  };
+  for (const record of records) {
+    tally.attempted += 1;
+    try {
+      const outcome = await cleanup(record);
+      if (outcome === "archived") tally.archived += 1;
+      else tally.already_absent += 1;
+    } catch {
+      tally.failed += 1;
+    }
+  }
+  return tally;
 }
 
 /**
@@ -108,30 +137,11 @@ async function teardown(
   seeded: SeededRecord[],
   clients: GateClients,
 ): Promise<TeardownTally> {
-  const tally: TeardownTally = {
-    attempted: 0,
-    archived: 0,
-    already_absent: 0,
-    failed: 0,
-  };
-  for (const record of seeded) {
+  return teardownRecords(seeded, async (record) => {
     const client =
       record.namespace_role === "negative" ? clients.negative : clients.primary;
-    tally.attempted += 1;
-    try {
-      const outcome = await client.archive({
-        table: record.table,
-        id: record.server_id,
-      });
-      if (outcome === "archived") tally.archived += 1;
-      else tally.already_absent += 1;
-    } catch {
-      // Content-free: never surface the record body or an error string that
-      // could carry one. The count is the only signal the receipt needs.
-      tally.failed += 1;
-    }
-  }
-  return tally;
+    return client.archive({ table: record.table, id: record.server_id });
+  });
 }
 
 /**

--- a/eval/open-brain/live/scenario-fixtures.ts
+++ b/eval/open-brain/live/scenario-fixtures.ts
@@ -17,7 +17,6 @@ const captureRequestSchema = z.object({
   content: z.string().min(1),
   event_type: z.string().min(1),
   scope: scopeSchema,
-  expected_honored_request_keys: z.array(z.string().min(1)),
   optional_request_fields: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/eval/open-brain/live/scenario-fixtures.ts
+++ b/eval/open-brain/live/scenario-fixtures.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import type { ScenarioFixture } from "./scenario-types.ts";
+
+const scopeSchema = z.object({
+  agent: z.string().min(1),
+  platform: z.string().min(1),
+  server_id: z.string().min(1),
+  channel_id: z.string().min(1),
+  thread_id: z.string().min(1).nullable().optional(),
+  session_key: z.string().min(1),
+  project: z.string().min(1),
+});
+
+const captureRequestSchema = z.object({
+  operation: z.literal("capture"),
+  distilled: z.literal(true),
+  content: z.string().min(1),
+  event_type: z.string().min(1),
+  scope: scopeSchema,
+  expected_honored_request_keys: z.array(z.string().min(1)),
+  optional_request_fields: z.record(z.string(), z.unknown()).optional(),
+});
+
+const checkpointRequestSchema = z.object({
+  operation: z.literal("checkpoint"),
+  distilled: z.literal(true),
+  summary: z.string().min(1),
+  key_decisions: z.array(z.string()),
+  next_steps: z.array(z.string()),
+  scope: scopeSchema,
+});
+
+const scenarioSchema = z.discriminatedUnion("kind", [
+  z.object({
+    id: z.string().min(1),
+    kind: z.literal("capture_round_trip"),
+    request: captureRequestSchema,
+  }),
+  z.object({
+    id: z.string().min(1),
+    kind: z.literal("durable_memory_shape"),
+    seed: z.object({
+      table: z.enum(["thoughts", "decisions"]),
+      content: z.string().min(1),
+      tags: z.array(z.string()),
+    }),
+    request: z.object({
+      query: z.string().min(1),
+      budget_max_tokens: z.number().int().min(100),
+      scope: scopeSchema,
+    }),
+    expected: z.object({
+      section: z.literal("durable_memory"),
+      min_items: z.number().int().min(1),
+    }),
+  }),
+  z.object({
+    id: z.string().min(1),
+    kind: z.literal("checkpoint_round_trip"),
+    event: captureRequestSchema,
+    checkpoint: checkpointRequestSchema,
+  }),
+]);
+
+export const scenarioFixtureSchema: z.ZodType<ScenarioFixture> = z.object({
+  schema_version: z.literal(1),
+  fixture_id: z.string().min(1),
+  description: z.string(),
+  scenarios: z.array(scenarioSchema).min(1),
+});
+
+export function parseScenarioFixture(raw: unknown): ScenarioFixture {
+  const fixture = scenarioFixtureSchema.parse(raw);
+  const ids = new Set<string>();
+  for (const scenario of fixture.scenarios) {
+    if (ids.has(scenario.id)) throw new Error(`duplicate scenario id: ${scenario.id}`);
+    ids.add(scenario.id);
+  }
+  return fixture;
+}
+
+export async function loadScenarioFixture(path: string): Promise<ScenarioFixture> {
+  let raw: unknown;
+  try {
+    raw = await Bun.file(path).json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read scenario fixture ${path}: ${message}`);
+  }
+  try {
+    return parseScenarioFixture(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid scenario fixture ${path}: ${message}`);
+  }
+}

--- a/eval/open-brain/live/scenario-gate.ts
+++ b/eval/open-brain/live/scenario-gate.ts
@@ -66,22 +66,34 @@ function recordArray(value: unknown): Array<Record<string, unknown>> {
   });
 }
 
+function ignoredRequestFailures(
+  execution: ProviderExecution,
+  request: Record<string, unknown>,
+): string[] {
+  const ignored = execution.receipt?.ignored_optional_request_keys ?? [];
+  return ignored
+    .filter((key) => Object.hasOwn(request, key))
+    .map((key) => `provider_ignored_request_key:${key}`);
+}
+
 function providerFailures(
   execution: ProviderExecution,
-  expectedHonoredKeys: string[],
+  request: Record<string, unknown>,
 ): string[] {
   const failures: string[] = [];
   if (execution.exitCode !== 0) failures.push("provider_exit_nonzero");
-  if (execution.receipt.status === "lost" && !execution.receipt.durable) {
+  const receipt = execution.receipt;
+  if (!receipt) {
+    failures.push("capture_receipt_absent");
+    return failures;
+  }
+  if (receipt.status === "lost" && !receipt.durable) {
     failures.push("capture_receipt_lost");
-  } else if (execution.receipt.status !== "saved") {
+  } else if (receipt.status !== "saved") {
     failures.push("capture_receipt_not_saved");
   }
-  if (!execution.receipt.durable) failures.push("capture_not_durable");
-  const ignored = new Set(execution.receipt.ignored_optional_request_keys ?? []);
-  for (const key of expectedHonoredKeys) {
-    if (ignored.has(key)) failures.push(`capture_ignored_expected_key:${key}`);
-  }
+  if (!receipt.durable) failures.push("capture_not_durable");
+  failures.push(...ignoredRequestFailures(execution, request));
   return failures;
 }
 
@@ -138,14 +150,10 @@ async function runCaptureScenario(
   transport: ScenarioTransport,
   records: ScenarioRecord[],
 ): Promise<ScenarioVerdict> {
-  const execution = await transport.executeProvider(
-    providerPayload(scenario.request, namespace),
-  );
+  const request = providerPayload(scenario.request, namespace);
+  const execution = await transport.executeProvider(request);
   collectProviderRecords(execution, scenario.request.scope.session_key, records);
-  const failures = providerFailures(
-    execution,
-    scenario.request.expected_honored_request_keys,
-  );
+  const failures = providerFailures(execution, request);
   const context = await transport.sessionContext({
     sessionKey: scenario.request.scope.session_key,
     namespace,
@@ -164,8 +172,8 @@ async function runCaptureScenario(
     failures,
     checks: {
       provider_exit_zero: execution.exitCode === 0,
-      receipt_saved: execution.receipt.status === "saved",
-      durable: execution.receipt.durable,
+      receipt_saved: execution.receipt?.status === "saved",
+      durable: execution.receipt?.durable ?? false,
       read_back_exact: roundTrip.found,
     },
   };
@@ -179,10 +187,13 @@ function durableSectionChecks(
   const failures: string[] = [];
   const section = asRecord(sections.durable_memory);
   const items = recordArray(section?.items);
-  const itemCount =
-    typeof section?.item_count === "number" ? section.item_count : items.length;
+  const reportedItemCount =
+    typeof section?.item_count === "number" ? section.item_count : null;
   if (!section) failures.push("durable_memory_section_missing");
-  if (itemCount < minItems) failures.push("durable_memory_items_missing");
+  if (reportedItemCount !== null && reportedItemCount !== items.length) {
+    failures.push("durable_memory_item_count_mismatch");
+  }
+  if (items.length < minItems) failures.push("durable_memory_items_missing");
   const wholePack = asRecord(budget.whole_pack);
   const charLimit =
     typeof wholePack?.content_char_limit === "number"
@@ -197,7 +208,8 @@ function durableSectionChecks(
     failures,
     checks: {
       section_present: Boolean(section),
-      item_count: itemCount,
+      item_count: items.length,
+      reported_item_count: reportedItemCount ?? -1,
       serialized_chars: serializedChars,
       content_char_limit: charLimit ?? -1,
       within_budget: charLimit !== null && serializedChars <= charLimit,
@@ -243,15 +255,11 @@ async function runCheckpointScenario(
   transport: ScenarioTransport,
   records: ScenarioRecord[],
 ): Promise<ScenarioVerdict> {
-  const eventExecution = await transport.executeProvider(
-    providerPayload(scenario.event, namespace),
-  );
+  const eventRequest = providerPayload(scenario.event, namespace);
+  const eventExecution = await transport.executeProvider(eventRequest);
   collectProviderRecords(eventExecution, scenario.event.scope.session_key, records);
-  const failures = providerFailures(
-    eventExecution,
-    scenario.event.expected_honored_request_keys,
-  );
-  const checkpointExecution = await transport.executeProvider({
+  const failures = providerFailures(eventExecution, eventRequest);
+  const checkpointRequest = {
     operation: scenario.checkpoint.operation,
     distilled: scenario.checkpoint.distilled,
     summary: scenario.checkpoint.summary,
@@ -259,12 +267,14 @@ async function runCheckpointScenario(
     next_steps: scenario.checkpoint.next_steps,
     scope: scenario.checkpoint.scope,
     config: { namespace },
-  });
+  };
+  const checkpointExecution = await transport.executeProvider(checkpointRequest);
+  failures.push(...ignoredRequestFailures(checkpointExecution, checkpointRequest));
   if (checkpointExecution.exitCode !== 0) failures.push("checkpoint_exit_nonzero");
-  if (checkpointExecution.receipt.status !== "saved") {
+  if (checkpointExecution.receipt?.status !== "saved") {
     failures.push("checkpoint_receipt_not_saved");
   }
-  if (!checkpointExecution.receipt.durable) failures.push("checkpoint_not_durable");
+  if (!checkpointExecution.receipt?.durable) failures.push("checkpoint_not_durable");
   const checkpointSessionId = checkpointExecution.result.session_id;
   if (typeof checkpointSessionId === "string") {
     records.push({ kind: "memory", table: "sessions", id: checkpointSessionId });
@@ -293,8 +303,8 @@ async function runCheckpointScenario(
     passed: failures.length === 0,
     failures,
     checks: {
-      event_receipt_saved: eventExecution.receipt.status === "saved",
-      checkpoint_receipt_saved: checkpointExecution.receipt.status === "saved",
+      event_receipt_saved: eventExecution.receipt?.status === "saved",
+      checkpoint_receipt_saved: checkpointExecution.receipt?.status === "saved",
       lane_events_surface: roundTrip.found,
       checkpoint_summary_surface: summarySurfaced,
     },

--- a/eval/open-brain/live/scenario-gate.ts
+++ b/eval/open-brain/live/scenario-gate.ts
@@ -1,0 +1,372 @@
+import type {
+  CaptureRequest,
+  ProviderExecution,
+  ScenarioFixture,
+  ScenarioFixtureCase,
+  ScenarioGateReceipt,
+  ScenarioRecord,
+  ScenarioScope,
+  ScenarioTransport,
+  ScenarioVerdict,
+  TeardownTally,
+} from "./scenario-types.ts";
+import type { ContextPackScope } from "./transport.ts";
+
+export interface RunScenarioGateOptions {
+  fixture: ScenarioFixture;
+  namespace: string;
+  transport: ScenarioTransport;
+  commit: string;
+  generatedAt: string;
+  runId: string;
+}
+
+export interface ScenarioGateOutcome {
+  receipt: ScenarioGateReceipt;
+  passed: boolean;
+}
+
+const EMPTY_TEARDOWN: TeardownTally = {
+  attempted: 0,
+  archived: 0,
+  already_absent: 0,
+  failed: 0,
+};
+
+function materialize<T>(value: T, runId: string, namespace: string): T {
+  const text = JSON.stringify(value)
+    .replaceAll("{{run_id}}", runId)
+    .replaceAll("{{namespace}}", namespace);
+  return JSON.parse(text) as T;
+}
+
+function packScope(scope: ScenarioScope, namespace: string): ContextPackScope {
+  return {
+    namespace,
+    agent: scope.agent,
+    platform: scope.platform,
+    server_id: scope.server_id,
+    channel_id: scope.channel_id,
+    thread_id: scope.thread_id ?? null,
+    session_key: scope.session_key,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function recordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    const record = asRecord(item);
+    return record ? [record] : [];
+  });
+}
+
+function providerFailures(
+  execution: ProviderExecution,
+  expectedHonoredKeys: string[],
+): string[] {
+  const failures: string[] = [];
+  if (execution.exitCode !== 0) failures.push("provider_exit_nonzero");
+  if (execution.receipt.status === "lost" && !execution.receipt.durable) {
+    failures.push("capture_receipt_lost");
+  } else if (execution.receipt.status !== "saved") {
+    failures.push("capture_receipt_not_saved");
+  }
+  if (!execution.receipt.durable) failures.push("capture_not_durable");
+  const ignored = new Set(execution.receipt.ignored_optional_request_keys ?? []);
+  for (const key of expectedHonoredKeys) {
+    if (ignored.has(key)) failures.push(`capture_ignored_expected_key:${key}`);
+  }
+  return failures;
+}
+
+function providerPayload(
+  request: CaptureRequest,
+  namespace: string,
+): Record<string, unknown> {
+  return {
+    operation: request.operation,
+    distilled: request.distilled,
+    content: request.content,
+    event_type: request.event_type,
+    scope: request.scope,
+    config: { namespace },
+    ...(request.optional_request_fields ?? {}),
+  };
+}
+
+function collectProviderRecords(
+  execution: ProviderExecution,
+  sessionKey: string,
+  records: ScenarioRecord[],
+): void {
+  const eventId = execution.result.event_id;
+  const laneId = execution.result.lane_id;
+  if (typeof laneId === "string") {
+    records.push({ kind: "lane", id: laneId, session_key: sessionKey });
+  }
+  if (typeof eventId === "string" && typeof laneId === "string") {
+    records.push({ kind: "event", id: eventId, lane_id: laneId });
+  }
+}
+
+function collectContextRecords(
+  context: Record<string, unknown>,
+  content: string,
+  sessionKey: string,
+): { found: boolean; records: ScenarioRecord[] } {
+  const lane = asRecord(context.lane);
+  const events = recordArray(context.events);
+  const event = events.find((item) => item.content === content);
+  const records: ScenarioRecord[] = [];
+  const laneId = typeof lane?.id === "string" ? lane.id : undefined;
+  if (laneId) records.push({ kind: "lane", id: laneId, session_key: sessionKey });
+  if (event && typeof event.id === "string" && laneId) {
+    records.push({ kind: "event", id: event.id, lane_id: laneId });
+  }
+  return { found: Boolean(event), records };
+}
+
+async function runCaptureScenario(
+  scenario: Extract<ScenarioFixtureCase, { kind: "capture_round_trip" }>,
+  namespace: string,
+  transport: ScenarioTransport,
+  records: ScenarioRecord[],
+): Promise<ScenarioVerdict> {
+  const execution = await transport.executeProvider(
+    providerPayload(scenario.request, namespace),
+  );
+  collectProviderRecords(execution, scenario.request.scope.session_key, records);
+  const failures = providerFailures(
+    execution,
+    scenario.request.expected_honored_request_keys,
+  );
+  const context = await transport.sessionContext({
+    sessionKey: scenario.request.scope.session_key,
+    namespace,
+  });
+  const roundTrip = collectContextRecords(
+    context,
+    scenario.request.content,
+    scenario.request.scope.session_key,
+  );
+  if (!roundTrip.found) failures.push("capture_round_trip_missing");
+  records.push(...roundTrip.records);
+  return {
+    scenario_id: scenario.id,
+    kind: scenario.kind,
+    passed: failures.length === 0,
+    failures,
+    checks: {
+      provider_exit_zero: execution.exitCode === 0,
+      receipt_saved: execution.receipt.status === "saved",
+      durable: execution.receipt.durable,
+      read_back_exact: roundTrip.found,
+    },
+  };
+}
+
+function durableSectionChecks(
+  sections: Record<string, unknown>,
+  budget: Record<string, unknown>,
+  minItems: number,
+): { failures: string[]; checks: Record<string, boolean | number | string> } {
+  const failures: string[] = [];
+  const section = asRecord(sections.durable_memory);
+  const items = recordArray(section?.items);
+  const itemCount =
+    typeof section?.item_count === "number" ? section.item_count : items.length;
+  if (!section) failures.push("durable_memory_section_missing");
+  if (itemCount < minItems) failures.push("durable_memory_items_missing");
+  const wholePack = asRecord(budget.whole_pack);
+  const charLimit =
+    typeof wholePack?.content_char_limit === "number"
+      ? wholePack.content_char_limit
+      : null;
+  const serializedChars = JSON.stringify(sections).length;
+  if (charLimit === null) failures.push("durable_memory_budget_missing");
+  if (charLimit !== null && serializedChars > charLimit) {
+    failures.push("durable_memory_budget_exceeded");
+  }
+  return {
+    failures,
+    checks: {
+      section_present: Boolean(section),
+      item_count: itemCount,
+      serialized_chars: serializedChars,
+      content_char_limit: charLimit ?? -1,
+      within_budget: charLimit !== null && serializedChars <= charLimit,
+    },
+  };
+}
+
+async function runDurableMemoryScenario(
+  scenario: Extract<ScenarioFixtureCase, { kind: "durable_memory_shape" }>,
+  namespace: string,
+  transport: ScenarioTransport,
+  records: ScenarioRecord[],
+): Promise<ScenarioVerdict> {
+  const seed = await transport.logMemory({ ...scenario.seed, namespace });
+  records.push({ kind: "memory", table: scenario.seed.table, id: seed.id });
+  const payload = await transport.contextPack({
+    scope: packScope(scenario.request.scope, namespace),
+    query: scenario.request.query,
+    budgetMaxTokens: scenario.request.budget_max_tokens,
+  });
+  const checked = durableSectionChecks(
+    payload.sections,
+    payload.budget,
+    scenario.expected.min_items,
+  );
+  if (payload.status !== "ok") checked.failures.push("durable_memory_status_not_ok");
+  return {
+    scenario_id: scenario.id,
+    kind: scenario.kind,
+    passed: checked.failures.length === 0,
+    failures: checked.failures,
+    checks: {
+      ...checked.checks,
+      explicit_token_budget: scenario.request.budget_max_tokens,
+      query_present: scenario.request.query.trim().length > 0,
+    },
+  };
+}
+
+async function runCheckpointScenario(
+  scenario: Extract<ScenarioFixtureCase, { kind: "checkpoint_round_trip" }>,
+  namespace: string,
+  transport: ScenarioTransport,
+  records: ScenarioRecord[],
+): Promise<ScenarioVerdict> {
+  const eventExecution = await transport.executeProvider(
+    providerPayload(scenario.event, namespace),
+  );
+  collectProviderRecords(eventExecution, scenario.event.scope.session_key, records);
+  const failures = providerFailures(
+    eventExecution,
+    scenario.event.expected_honored_request_keys,
+  );
+  const checkpointExecution = await transport.executeProvider({
+    operation: scenario.checkpoint.operation,
+    distilled: scenario.checkpoint.distilled,
+    summary: scenario.checkpoint.summary,
+    key_decisions: scenario.checkpoint.key_decisions,
+    next_steps: scenario.checkpoint.next_steps,
+    scope: scenario.checkpoint.scope,
+    config: { namespace },
+  });
+  if (checkpointExecution.exitCode !== 0) failures.push("checkpoint_exit_nonzero");
+  if (checkpointExecution.receipt.status !== "saved") {
+    failures.push("checkpoint_receipt_not_saved");
+  }
+  if (!checkpointExecution.receipt.durable) failures.push("checkpoint_not_durable");
+  const checkpointSessionId = checkpointExecution.result.session_id;
+  if (typeof checkpointSessionId === "string") {
+    records.push({ kind: "memory", table: "sessions", id: checkpointSessionId });
+  } else {
+    failures.push("checkpoint_session_id_missing");
+  }
+
+  const context = await transport.sessionContext({
+    sessionKey: scenario.checkpoint.scope.session_key,
+    namespace,
+  });
+  const roundTrip = collectContextRecords(
+    context,
+    scenario.event.content,
+    scenario.checkpoint.scope.session_key,
+  );
+  if (!roundTrip.found) failures.push("checkpoint_event_missing_on_resume");
+  const lane = asRecord(context.lane);
+  const summarySurfaced = lane?.current_context_md === scenario.checkpoint.summary;
+  if (!summarySurfaced) failures.push("checkpoint_summary_missing_on_resume");
+
+  records.push(...roundTrip.records);
+  return {
+    scenario_id: scenario.id,
+    kind: scenario.kind,
+    passed: failures.length === 0,
+    failures,
+    checks: {
+      event_receipt_saved: eventExecution.receipt.status === "saved",
+      checkpoint_receipt_saved: checkpointExecution.receipt.status === "saved",
+      lane_events_surface: roundTrip.found,
+      checkpoint_summary_surface: summarySurfaced,
+    },
+  };
+}
+
+async function runScenario(
+  scenario: ScenarioFixtureCase,
+  namespace: string,
+  transport: ScenarioTransport,
+  records: ScenarioRecord[],
+): Promise<ScenarioVerdict> {
+  switch (scenario.kind) {
+    case "capture_round_trip":
+      return runCaptureScenario(scenario, namespace, transport, records);
+    case "durable_memory_shape":
+      return runDurableMemoryScenario(scenario, namespace, transport, records);
+    case "checkpoint_round_trip":
+      return runCheckpointScenario(scenario, namespace, transport, records);
+  }
+}
+
+export async function runScenarioGate(
+  opts: RunScenarioGateOptions,
+): Promise<ScenarioGateOutcome> {
+  const fixture = materialize(opts.fixture, opts.runId, opts.namespace);
+  const records: ScenarioRecord[] = [];
+  const verdicts: ScenarioVerdict[] = [];
+  let teardown = EMPTY_TEARDOWN;
+
+  try {
+    for (const scenario of fixture.scenarios) {
+      try {
+        verdicts.push(
+          await runScenario(scenario, opts.namespace, opts.transport, records),
+        );
+      } catch {
+        verdicts.push({
+          scenario_id: scenario.id,
+          kind: scenario.kind,
+          passed: false,
+          failures: ["scenario_transport_error"],
+          checks: {},
+        });
+      }
+    }
+  } finally {
+    const uniqueRecords = Array.from(
+      new Map(records.map((record) => [`${record.kind}:${record.id}`, record])).values(),
+    );
+    teardown = await opts.transport.cleanup(uniqueRecords, opts.namespace);
+  }
+
+  const failures = verdicts.flatMap((verdict) =>
+    verdict.failures.map((failure) => `${verdict.scenario_id}:${failure}`),
+  );
+  if (teardown.failed > 0) {
+    failures.push(`teardown_failed:${teardown.failed}`);
+  }
+  const passed = failures.length === 0;
+  return {
+    passed,
+    receipt: {
+      schema: "openbrain.scenario_gate.v1",
+      generated_at: opts.generatedAt,
+      commit: opts.commit,
+      fixture_id: fixture.fixture_id,
+      namespace: opts.namespace,
+      scenarios: verdicts,
+      passed,
+      failures,
+      teardown,
+    },
+  };
+}

--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -1,0 +1,199 @@
+import { resolve } from "node:path";
+import { Pool } from "pg";
+import type { LiveEvalConfig } from "./config.ts";
+import { teardownRecords } from "./gate.ts";
+import type {
+  ProviderExecution,
+  ProviderReceipt,
+  ScenarioRecord,
+  ScenarioTransport,
+  TeardownTally,
+} from "./scenario-types.ts";
+import {
+  LiveTransportError,
+  OpenBrainLiveClient,
+  type OpenBrainToolCaller,
+} from "./transport.ts";
+
+const PROVIDER_CWD = resolve(import.meta.dir, "../../../python/openbrain-memory");
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseProviderOutput(text: string, exitCode: number): ProviderExecution {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new LiveTransportError("openbrain-memory:malformed-output", false);
+  }
+  const output = asRecord(parsed);
+  const receipt = asRecord(output?.receipt);
+  if (!receipt) {
+    throw new LiveTransportError("openbrain-memory:missing-receipt", false);
+  }
+  const required = {
+    operation: receipt.operation,
+    status: receipt.status,
+    durable: receipt.durable,
+    direct_attempted: receipt.direct_attempted,
+    fallback_attempted: receipt.fallback_attempted,
+  };
+  if (
+    typeof required.operation !== "string" ||
+    typeof required.status !== "string" ||
+    typeof required.durable !== "boolean" ||
+    typeof required.direct_attempted !== "boolean" ||
+    typeof required.fallback_attempted !== "boolean"
+  ) {
+    throw new LiveTransportError("openbrain-memory:invalid-receipt", false);
+  }
+  const ignored = receipt.ignored_optional_request_keys;
+  const providerReceipt: ProviderReceipt = {
+    operation: required.operation,
+    status: required.status,
+    durable: required.durable,
+    direct_attempted: required.direct_attempted,
+    fallback_attempted: required.fallback_attempted,
+    ignored_optional_request_keys: Array.isArray(ignored)
+      ? ignored.filter((item): item is string => typeof item === "string")
+      : undefined,
+  };
+  return {
+    exitCode,
+    receipt: providerReceipt,
+    result: asRecord(output?.result) ?? {},
+  };
+}
+
+export class LiveScenarioTransport implements ScenarioTransport {
+  private readonly client: OpenBrainLiveClient;
+  private readonly pool: Pool;
+
+  constructor(
+    caller: OpenBrainToolCaller,
+    private readonly config: LiveEvalConfig,
+    pool: Pool = new Pool(),
+  ) {
+    this.client = new OpenBrainLiveClient(caller);
+    this.pool = pool;
+  }
+
+  async executeProvider(
+    request: Record<string, unknown>,
+  ): Promise<ProviderExecution> {
+    const proc = Bun.spawn(["uv", "run", "openbrain-memory"], {
+      cwd: PROVIDER_CWD,
+      env: {
+        ...process.env,
+        OPENBRAIN_BASE_URL: this.config.baseUrl,
+        OPENBRAIN_TOKEN: this.config.primaryToken,
+        OPENBRAIN_NAMESPACE: this.config.primaryNamespace,
+      },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write(JSON.stringify(request));
+    proc.stdin.end();
+    const stdout = await new Response(proc.stdout).text();
+    await new Response(proc.stderr).text();
+    return parseProviderOutput(stdout, await proc.exited);
+  }
+
+  async logMemory(opts: {
+    table: "thoughts" | "decisions";
+    content: string;
+    tags: string[];
+    namespace: string;
+  }): Promise<{ id: string }> {
+    return this.client.logMemory(opts);
+  }
+
+  async contextPack(opts: {
+    scope: Parameters<OpenBrainLiveClient["contextPack"]>[0]["scope"];
+    query: string;
+    budgetMaxTokens: number;
+  }): Promise<{
+    status: string;
+    sections: Record<string, unknown>;
+    budget: Record<string, unknown>;
+  }> {
+    return this.client.contextPack({
+      scope: opts.scope,
+      query: opts.query,
+      requestedSections: ["durable_memory"],
+      budgetMaxTokens: opts.budgetMaxTokens,
+    });
+  }
+
+  sessionContext(opts: {
+    sessionKey: string;
+    namespace: string;
+  }): Promise<Record<string, unknown>> {
+    return this.client.structuredTool("session_context", {
+      session_key: opts.sessionKey,
+      namespace: opts.namespace,
+      include_events: true,
+      event_limit: 50,
+    });
+  }
+
+  async cleanup(
+    records: ScenarioRecord[],
+    namespace: string,
+  ): Promise<TeardownTally> {
+    const unique = Array.from(
+      new Map(records.map((record) => [`${record.kind}:${record.id}`, record])).values(),
+    );
+    const order: Record<ScenarioRecord["kind"], number> = {
+      event: 0,
+      memory: 1,
+      lane: 2,
+    };
+    unique.sort((a, b) => order[a.kind] - order[b.kind]);
+    return teardownRecords(unique, (record) =>
+      this.cleanupRecord(record, namespace),
+    );
+  }
+
+  /**
+   * Clean one exact record. Durable memory/session rows use archive_entry. The
+   * public tool surface has no archive operation for session events or lanes, so
+   * those two lifecycle rows are deleted by exact id plus namespace (and lane or
+   * session-key identity), never by a broad namespace/query sweep.
+   */
+  private async cleanupRecord(
+    record: ScenarioRecord,
+    namespace: string,
+  ): Promise<"archived" | "already_absent"> {
+    if (record.kind === "memory") {
+      return this.client.archive({ table: record.table, id: record.id });
+    }
+    const result =
+      record.kind === "event"
+        ? await this.pool.query(
+            `DELETE FROM ob_session_events AS event
+             USING ob_session_lanes AS lane
+             WHERE event.id = $1 AND event.lane_id = $2
+               AND lane.id = event.lane_id AND lane.namespace = $3
+             RETURNING event.id`,
+            [record.id, record.lane_id, namespace],
+          )
+        : await this.pool.query(
+            `DELETE FROM ob_session_lanes
+             WHERE id = $1 AND namespace = $2 AND session_key = $3
+             RETURNING id`,
+            [record.id, namespace, record.session_key],
+          );
+    return (result.rowCount ?? 0) > 0 ? "archived" : "already_absent";
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+    await this.pool.end();
+  }
+}

--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -23,7 +23,13 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function parseProviderOutput(text: string, exitCode: number): ProviderExecution {
+export function parseProviderOutput(
+  text: string,
+  exitCode: number,
+): ProviderExecution {
+  if (exitCode === 0 && text.trim() === "") {
+    return { exitCode, result: {} };
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
@@ -32,6 +38,9 @@ function parseProviderOutput(text: string, exitCode: number): ProviderExecution 
   }
   const output = asRecord(parsed);
   const receipt = asRecord(output?.receipt);
+  if (!receipt && exitCode === 0) {
+    return { exitCode, result: asRecord(output?.result) ?? {} };
+  }
   if (!receipt) {
     throw new LiveTransportError("openbrain-memory:missing-receipt", false);
   }

--- a/eval/open-brain/live/scenario-types.ts
+++ b/eval/open-brain/live/scenario-types.ts
@@ -18,7 +18,6 @@ export interface CaptureRequest {
   content: string;
   event_type: string;
   scope: ScenarioScope;
-  expected_honored_request_keys: string[];
   optional_request_fields?: Record<string, unknown>;
 }
 
@@ -86,7 +85,7 @@ export interface ProviderReceipt {
 
 export interface ProviderExecution {
   exitCode: number;
-  receipt: ProviderReceipt;
+  receipt?: ProviderReceipt;
   result: Record<string, unknown>;
 }
 

--- a/eval/open-brain/live/scenario-types.ts
+++ b/eval/open-brain/live/scenario-types.ts
@@ -1,0 +1,155 @@
+import type { TeardownTally } from "./gate.ts";
+import type { ContextPackScope } from "./transport.ts";
+
+export type ScenarioKind =
+  | "capture_round_trip"
+  | "durable_memory_shape"
+  | "checkpoint_round_trip";
+
+export interface ScenarioScope
+  extends Omit<ContextPackScope, "namespace" | "thread_id"> {
+  thread_id?: string | null;
+  project: string;
+}
+
+export interface CaptureRequest {
+  operation: "capture";
+  distilled: true;
+  content: string;
+  event_type: string;
+  scope: ScenarioScope;
+  expected_honored_request_keys: string[];
+  optional_request_fields?: Record<string, unknown>;
+}
+
+export interface CheckpointRequest {
+  operation: "checkpoint";
+  distilled: true;
+  summary: string;
+  key_decisions: string[];
+  next_steps: string[];
+  scope: ScenarioScope;
+}
+
+export interface CaptureRoundTripScenario {
+  id: string;
+  kind: "capture_round_trip";
+  request: CaptureRequest;
+}
+
+export interface DurableMemoryShapeScenario {
+  id: string;
+  kind: "durable_memory_shape";
+  seed: {
+    table: "thoughts" | "decisions";
+    content: string;
+    tags: string[];
+  };
+  request: {
+    query: string;
+    budget_max_tokens: number;
+    scope: ScenarioScope;
+  };
+  expected: {
+    section: "durable_memory";
+    min_items: number;
+  };
+}
+
+export interface CheckpointRoundTripScenario {
+  id: string;
+  kind: "checkpoint_round_trip";
+  event: CaptureRequest;
+  checkpoint: CheckpointRequest;
+}
+
+export type ScenarioFixtureCase =
+  | CaptureRoundTripScenario
+  | DurableMemoryShapeScenario
+  | CheckpointRoundTripScenario;
+
+export interface ScenarioFixture {
+  schema_version: 1;
+  fixture_id: string;
+  description: string;
+  scenarios: ScenarioFixtureCase[];
+}
+
+export interface ProviderReceipt {
+  operation: string;
+  status: string;
+  durable: boolean;
+  direct_attempted: boolean;
+  fallback_attempted: boolean;
+  ignored_optional_request_keys?: string[];
+}
+
+export interface ProviderExecution {
+  exitCode: number;
+  receipt: ProviderReceipt;
+  result: Record<string, unknown>;
+}
+
+export type ScenarioRecord =
+  | {
+      kind: "memory";
+      table: "thoughts" | "decisions" | "sessions";
+      id: string;
+    }
+  | {
+      kind: "event";
+      id: string;
+      lane_id: string;
+    }
+  | {
+      kind: "lane";
+      id: string;
+      session_key: string;
+    };
+
+export interface ScenarioTransport {
+  executeProvider(request: Record<string, unknown>): Promise<ProviderExecution>;
+  logMemory(opts: {
+    table: "thoughts" | "decisions";
+    content: string;
+    tags: string[];
+    namespace: string;
+  }): Promise<{ id: string }>;
+  contextPack(opts: {
+    scope: ContextPackScope;
+    query: string;
+    budgetMaxTokens: number;
+  }): Promise<{
+    status: string;
+    sections: Record<string, unknown>;
+    budget: Record<string, unknown>;
+  }>;
+  sessionContext(opts: {
+    sessionKey: string;
+    namespace: string;
+  }): Promise<Record<string, unknown>>;
+  cleanup(records: ScenarioRecord[], namespace: string): Promise<TeardownTally>;
+  close(): Promise<void>;
+}
+
+export type { TeardownTally };
+
+export interface ScenarioVerdict {
+  scenario_id: string;
+  kind: ScenarioKind;
+  passed: boolean;
+  failures: string[];
+  checks: Record<string, boolean | number | string>;
+}
+
+export interface ScenarioGateReceipt {
+  schema: "openbrain.scenario_gate.v1";
+  generated_at: string;
+  commit: string;
+  fixture_id: string;
+  namespace: string;
+  scenarios: ScenarioVerdict[];
+  passed: boolean;
+  failures: string[];
+  teardown: TeardownTally;
+}

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -47,6 +47,8 @@ export interface ToolCallResult {
   errorLabel: string;
 }
 
+export type ArchiveTable = LiveMemoryTable | "sessions";
+
 export interface LogMemoryResult {
   id: string;
   /** The namespace the server reported the row was written to. */
@@ -175,6 +177,27 @@ export class LiveTransportError extends Error {
  */
 export class OpenBrainLiveClient {
   constructor(private readonly caller: OpenBrainToolCaller) {}
+
+  /**
+   * Call a tool whose success contract is one JSON object and return that parsed
+   * object without ever logging or surfacing the raw body. Scenario fixtures use
+   * this narrow seam for lifecycle reads while retaining the same real/fake
+   * OpenBrainToolCaller boundary as the ranking and context-pack gates.
+   */
+  async structuredTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const result = await this.caller.callTool(name, args);
+    if (result.isError) {
+      throw new LiveTransportError(result.errorLabel, result.denied);
+    }
+    const parsed = safeJson(result.data);
+    if (!parsed) {
+      throw new LiveTransportError(`${name}:malformed-payload`, false);
+    }
+    return parsed;
+  }
 
   /**
    * Seed one memory into a namespace, returning the server-assigned id.
@@ -432,7 +455,7 @@ export class OpenBrainLiveClient {
    * as clean cleanup, stranding a live record while the gate reports PASS.
    */
   async archive(opts: {
-    table: LiveMemoryTable;
+    table: ArchiveTable;
     id: string;
   }): Promise<"archived" | "already_absent"> {
     const result = await this.caller.callTool("archive_entry", {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "codex-memory-smoke": "bun run scripts/codex-memory-smoke.ts",
     "eval:memory": "bun run scripts/eval-open-brain-memory.ts",
     "eval:live": "bun run scripts/eval-open-brain-live.ts",
+    "eval:scenarios": "bun run scripts/eval-open-brain-scenarios.ts",
     "eval:reflex-ab": "bun run eval/open-brain/live/reflex-ab-cli.ts",
     "import-kb": "bun run scripts/import-legacy-kb.ts",
     "promote:legacy-shared": "bun run scripts/promote-legacy-shared.ts",

--- a/scripts/eval-open-brain-scenarios.ts
+++ b/scripts/eval-open-brain-scenarios.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+
+import { randomUUID } from "node:crypto";
+import { loadLiveConfig, makeRunId } from "../eval/open-brain/live/config.ts";
+import { loadScenarioFixture } from "../eval/open-brain/live/scenario-fixtures.ts";
+import { runScenarioGate } from "../eval/open-brain/live/scenario-gate.ts";
+import { LiveScenarioTransport } from "../eval/open-brain/live/scenario-transport.ts";
+import { createMcpCaller } from "../eval/open-brain/live/transport.ts";
+
+const DEFAULT_FIXTURE_PATH = "eval/open-brain/fixtures/scenarios-v1.json";
+
+function argValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of Bun.argv.slice(2)) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  const index = Bun.argv.indexOf(`--${name}`);
+  const next = index >= 0 ? Bun.argv[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+async function gitCommit(): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    return (await proc.exited) === 0 ? output.trim() : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function printReceipt(
+  receipt: Awaited<ReturnType<typeof runScenarioGate>>["receipt"],
+): void {
+  const lines = [
+    `Open Brain scenario gate: ${receipt.passed ? "PASS" : "FAIL"}`,
+    `fixture=${receipt.fixture_id} commit=${receipt.commit}`,
+    `namespace=${receipt.namespace}`,
+    `teardown attempted=${receipt.teardown.attempted} archived=${receipt.teardown.archived} already_absent=${receipt.teardown.already_absent} failed=${receipt.teardown.failed}`,
+  ];
+  for (const scenario of receipt.scenarios) {
+    lines.push(
+      `- ${scenario.scenario_id}: kind=${scenario.kind} status=${scenario.passed ? "pass" : "fail"}`,
+    );
+    if (scenario.failures.length > 0) {
+      lines.push(`  failures=${scenario.failures.join(",")}`);
+    }
+  }
+  if (receipt.failures.length > 0) {
+    lines.push(`failures: ${receipt.failures.join(";")}`);
+  }
+  console.log(lines.join("\n"));
+}
+
+async function main(): Promise<number> {
+  const commit = await gitCommit();
+  const runId = makeRunId({
+    prefix: `scenario-${commit.slice(0, 12)}`,
+    randomHex: randomUUID().replaceAll("-", "").slice(0, 12),
+  });
+  const config = loadLiveConfig(runId);
+  const fixture = await loadScenarioFixture(
+    argValue("fixture") ?? DEFAULT_FIXTURE_PATH,
+  );
+  const caller = await createMcpCaller({
+    baseUrl: config.baseUrl,
+    token: config.primaryToken,
+    namespace: config.primaryNamespace,
+    timeoutMs: config.timeoutMs,
+  });
+  const transport = new LiveScenarioTransport(caller, config);
+
+  try {
+    const outcome = await runScenarioGate({
+      fixture,
+      namespace: config.primaryNamespace,
+      transport,
+      commit,
+      generatedAt: new Date().toISOString(),
+      runId,
+    });
+    const reportPath = argValue("report");
+    if (reportPath) {
+      await Bun.write(reportPath, `${JSON.stringify(outcome.receipt, null, 2)}\n`);
+    }
+    if (Bun.argv.includes("--json")) {
+      console.log(JSON.stringify(outcome.receipt, null, 2));
+    } else {
+      printReceipt(outcome.receipt);
+      if (reportPath) console.log(`\nWrote receipt: ${reportPath}`);
+    }
+    return outcome.passed ? 0 : 1;
+  } finally {
+    await transport.close().catch(() => {});
+  }
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Scenario gate error: ${message}`);
+      process.exitCode = 2;
+    });
+}


### PR DESCRIPTION
Phase 1 of #578: scenario breadth on the **existing** eval harness (plan delta
item 1). No new parallel harness — this extends `eval/open-brain/live/` and
reuses the EVAL-3 discipline: per-run throwaway namespace derivation from
`live/config.ts`, teardown accounting, the `OPEN_BRAIN_LIVE_EVAL=1` gate, and
content-free receipts.

A scenario is a scripted input with an asserted output, alongside (not replacing)
the existing ranking-probe path. Three first scenarios:

- **capture round-trip** — drives a capture, then proves the write by an
  independent `session_context` read-back matched on content. The load-bearing
  case from #529 is the **exit-0 / zero-write** silent drop: the gate fails with
  `capture_round_trip_missing` even when the provider exits 0 and claims success,
  because the verdict comes from reading the record back, never from the
  receipt's own status field. Also fails on `status: lost` + `durable: false`,
  and on any request key the receipt relegates to
  `ignored_optional_request_keys` that the fixture declared it expects honored.
- **durable_memory pack shape** — requests with an **explicit token budget** and
  asserts section presence, item count, and that the serialized reply stays
  within the budget. This is the shape check #563 measured the absence of
  (~40–60 MB whole-corpus serialization on a budgetless broad request); it uses a
  real query since `durable_memory` is query-gated.
- **checkpoint/wrap round-trip** — writes a checkpoint, resume-reads it, asserts
  the lane events surface.

Every scenario runs in both a fake-transport unit mode under plain `bun test`
(no hosted service, no database) and an env-gated live mode. Teardown runs in a
`finally` over exactly this run's collected record ids and reports
attempted/archived/already_absent/failed, with `teardown_failed` as a gate
failure.

Delta item 2 (Langfuse egress verifier) is deliberately **out of scope** here.

## Verification

Re-run independently by the supervising node in the worktree, not just reported
by the implementer:

- `bunx tsc --noEmit` — exit 0, no output.
- `bun test eval/` — 203 pass, 0 fail, 833 expect() calls.
- `bun test` (full suite, regression check) — 3212 pass, 509 skip, 0 fail across
  234 files.
- **Gate proven to bite:** flipping the durable-memory fixture `min_items` from
  1 to 2 produced exit 1 with the named failure
  `durable-memory-pack-shape:durable_memory_items_missing`; the break was
  reverted and the suite returned to green. Separately,
  `eval/open-brain/live/__tests__/scenario-gate.test.ts:194` asserts the
  zero-write case fails while `provider_exit_zero` is true.
- **Live: unrun.** The repo `.env` carries no `OPEN_BRAIN_LIVE_EVAL_*` variables
  (verified), so no live scenario was executed. No live coverage is claimed.

## Critical Self-Review

- Highest-risk behavior: the capture round-trip verdict — if it ever trusted the receipt's status instead of the independent read-back, the whole #529 exit-0/zero-write class would silently pass; a dedicated test pins exit-0-with-no-write as a failure.
- Assumptions that could be wrong: the fake transport's modelling of provider receipt and session_context shapes is asserted only against fixtures, so a real provider whose payload shape has drifted would not be caught until the live gate is first run.
- Missing/weak tests: no live execution at all this round, so the live transport path (`scenario-transport.ts`) is exercised only through fakes; the durable_memory budget check is asserted on serialized length rather than real tokenizer tokens.
- Security/permission risk: scenarios write only to a per-run throwaway namespace derived by the existing `boundRunId`/config helpers, and receipts print ids, counts, and statuses only — no memory bodies, tokens, or raw remote bodies.
- Migration/deploy risk: none — additive test/eval tooling plus one new package.json script; no schema, server, or runtime path changes.
- Downstream client/runtime risk: none for clients; no MCP tool, transport contract, or Python client shape changed, so contract parity fixtures are untouched.
- Rollback/cleanup concern: teardown runs in a `finally` over exactly this run's record ids and reports failed counts as a gate failure, so an aborted live run does not strand rows; reverting the commit removes the harness entirely.
- Fixes made before PR: supervising node re-ran tsc, the eval suite, and the full suite independently, verified the zero-write assertion reads back rather than trusting the receipt, and confirmed the live-unrun claim against the actual `.env` contents.
- Known residual risk: the gate is WRITTEN and green offline but has never driven real traffic, so its first live run against a hosted Open Brain is the outstanding proof and may surface shape drift.
- SME review-memory update: [x] not applicable because: this adds eval scenarios and found no new reviewer-facing defect pattern; the #529/#563 failure modes it encodes are already recorded in their issues.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: no `OPEN_BRAIN_LIVE_EVAL_*` variables are present in the repo `.env`, so the env-gated live mode cannot run; scenarios pass in fake-transport mode and live execution is the named residual risk.

Refs #578. Encodes failure modes from #529 and #563.
