### PR TITLE
fix(eval): carry child stderr into eval receipts and stop the vacuous secret_scan green (#583)

### DIFF
--- a/eval/open-brain/live/__tests__/scenario-gate.test.ts
+++ b/eval/open-brain/live/__tests__/scenario-gate.test.ts
@@ -24,6 +24,12 @@ const FIXTURE = parseScenarioFixture(
 interface FakeOptions {
   zeroWrite?: boolean;
   emptyProviderOutput?: boolean;
+  /** Raw stderr a failing capture child writes before dying (issue #583). */
+  captureStderr?: string;
+  /** Exit code for that failing capture child. */
+  captureExitCode?: number;
+  /** Stdout for that failing capture child; defaults to empty. */
+  captureStdout?: string;
   lostCapture?: boolean;
   ignoredKeys?: string[];
   packCharLimit?: number;
@@ -76,6 +82,15 @@ function fakeTransport(opts: FakeOptions = {}): ScenarioTransport {
       lanes.set(scope.session_key, lane);
       if (operation === "capture" && opts.emptyProviderOutput) {
         return parseProviderOutput("", 0);
+      }
+      if (operation === "capture" && opts.captureStderr !== undefined) {
+        // Exercised through the real parser, so the test proves the production
+        // stderr path rather than a hand-built execution object.
+        return parseProviderOutput(
+          opts.captureStdout ?? "",
+          opts.captureExitCode ?? 1,
+          opts.captureStderr,
+        );
       }
       if (operation === "capture") {
         if (!opts.zeroWrite && !opts.lostCapture) {
@@ -211,6 +226,39 @@ describe("runScenarioGate", () => {
     expect(capture.checks.provider_exit_zero).toBe(true);
     expect(capture.checks.receipt_saved).toBe(true);
     expect(capture.checks.read_back_exact).toBe(false);
+  });
+
+  it("carries a failing child's stderr first line into the scenario receipt", async () => {
+    // Issue #583: a dead provider used to present as a bare exit code, so the
+    // real root cause had to be recovered by replaying the command by hand.
+    const outcome = await run(
+      fakeTransport({
+        captureStderr: [
+          "Traceback (most recent call last):",
+          '  File "provider.py", line 12, in main',
+          "PermissionError: scope key 'project' was rejected",
+        ].join("\n"),
+      }),
+    );
+    expect(outcome.passed).toBe(false);
+    const capture = outcome.receipt.scenarios[0]!;
+    expect(capture.error_class).toBe("PermissionError");
+    expect(capture.stderr_first_line).toBe(
+      "PermissionError: scope key 'project' was rejected",
+    );
+    expect(outcome.receipt.failures.join(" ")).toContain(
+      "capture-round-trip:scenario_transport_error",
+    );
+    expectContentFree(outcome.receipt);
+  });
+
+  it("leaves stderr diagnostics off a passing scenario", async () => {
+    const outcome = await run(fakeTransport());
+    expect(outcome.passed).toBe(true);
+    for (const scenario of outcome.receipt.scenarios) {
+      expect(scenario.error_class).toBeUndefined();
+      expect(scenario.stderr_first_line).toBeUndefined();
+    }
   });
 
   it("names an exit-0 empty provider result as an absent capture receipt", async () => {

--- a/eval/open-brain/live/scenario-gate.ts
+++ b/eval/open-brain/live/scenario-gate.ts
@@ -10,7 +10,7 @@ import type {
   ScenarioVerdict,
   TeardownTally,
 } from "./scenario-types.ts";
-import type { ContextPackScope } from "./transport.ts";
+import { LiveTransportError, type ContextPackScope } from "./transport.ts";
 
 export interface RunScenarioGateOptions {
   fixture: ScenarioFixture;
@@ -74,6 +74,24 @@ function ignoredRequestFailures(
   return ignored
     .filter((key) => Object.hasOwn(request, key))
     .map((key) => `provider_ignored_request_key:${key}`);
+}
+
+/**
+ * Content-free child diagnostics for a verdict. A provider can exit nonzero and
+ * still emit a parseable receipt, so this covers the path that never throws;
+ * only attached when the scenario actually failed and the child said something.
+ */
+function executionDiagnostics(
+  execution: ProviderExecution,
+  passed: boolean,
+): { error_class?: string; stderr_first_line?: string } {
+  if (passed) return {};
+  return {
+    ...(execution.error_class ? { error_class: execution.error_class } : {}),
+    ...(execution.stderr_first_line
+      ? { stderr_first_line: execution.stderr_first_line }
+      : {}),
+  };
 }
 
 function providerFailures(
@@ -176,6 +194,7 @@ async function runCaptureScenario(
       durable: execution.receipt?.durable ?? false,
       read_back_exact: roundTrip.found,
     },
+    ...executionDiagnostics(execution, failures.length === 0),
   };
 }
 
@@ -308,6 +327,12 @@ async function runCheckpointScenario(
       lane_events_surface: roundTrip.found,
       checkpoint_summary_surface: summarySurfaced,
     },
+    // Two children run here; the checkpoint call is the later one, so its
+    // stderr is the more proximate explanation when both spoke.
+    ...executionDiagnostics(
+      checkpointExecution.stderr_first_line ? checkpointExecution : eventExecution,
+      failures.length === 0,
+    ),
   };
 }
 
@@ -341,13 +366,28 @@ export async function runScenarioGate(
         verdicts.push(
           await runScenario(scenario, opts.namespace, opts.transport, records),
         );
-      } catch {
+      } catch (error: unknown) {
+        // A transport throw is the case that used to be a bare label with no
+        // way to tell WHY the provider died (issue #583). Carry the child's
+        // content-free diagnostics into the verdict.
+        const transportError =
+          error instanceof LiveTransportError ? error : undefined;
         verdicts.push({
           scenario_id: scenario.id,
           kind: scenario.kind,
           passed: false,
-          failures: ["scenario_transport_error"],
+          failures: [
+            transportError
+              ? `scenario_transport_error:${transportError.label}`
+              : "scenario_transport_error",
+          ],
           checks: {},
+          ...(transportError?.errorClass
+            ? { error_class: transportError.errorClass }
+            : {}),
+          ...(transportError?.stderrFirstLine
+            ? { stderr_first_line: transportError.stderrFirstLine }
+            : {}),
         });
       }
     }

--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { Pool } from "pg";
+import { summarizeChildStderr } from "../../../src/child-stderr.ts";
 import type { LiveEvalConfig } from "./config.ts";
 import { teardownRecords } from "./gate.ts";
 import type {
@@ -26,23 +27,33 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 export function parseProviderOutput(
   text: string,
   exitCode: number,
+  stderr = "",
 ): ProviderExecution {
+  // Summarized once and attached to every exit from this function, so a
+  // provider failure never presents as a bare exit code (issue #583).
+  const diagnostics = summarizeChildStderr(stderr);
+  const fail = (label: string): LiveTransportError =>
+    new LiveTransportError(label, false, {
+      errorClass: diagnostics.error_class,
+      stderrFirstLine: diagnostics.stderr_first_line,
+    });
+
   if (exitCode === 0 && text.trim() === "") {
-    return { exitCode, result: {} };
+    return { exitCode, result: {}, ...diagnostics };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch {
-    throw new LiveTransportError("openbrain-memory:malformed-output", false);
+    throw fail("openbrain-memory:malformed-output");
   }
   const output = asRecord(parsed);
   const receipt = asRecord(output?.receipt);
   if (!receipt && exitCode === 0) {
-    return { exitCode, result: asRecord(output?.result) ?? {} };
+    return { exitCode, result: asRecord(output?.result) ?? {}, ...diagnostics };
   }
   if (!receipt) {
-    throw new LiveTransportError("openbrain-memory:missing-receipt", false);
+    throw fail("openbrain-memory:missing-receipt");
   }
   const required = {
     operation: receipt.operation,
@@ -58,7 +69,7 @@ export function parseProviderOutput(
     typeof required.direct_attempted !== "boolean" ||
     typeof required.fallback_attempted !== "boolean"
   ) {
-    throw new LiveTransportError("openbrain-memory:invalid-receipt", false);
+    throw fail("openbrain-memory:invalid-receipt");
   }
   const ignored = receipt.ignored_optional_request_keys;
   const providerReceipt: ProviderReceipt = {
@@ -109,8 +120,8 @@ export class LiveScenarioTransport implements ScenarioTransport {
     proc.stdin.write(JSON.stringify(request));
     proc.stdin.end();
     const stdout = await new Response(proc.stdout).text();
-    await new Response(proc.stderr).text();
-    return parseProviderOutput(stdout, await proc.exited);
+    const stderr = await new Response(proc.stderr).text();
+    return parseProviderOutput(stdout, await proc.exited, stderr);
   }
 
   async logMemory(opts: {

--- a/eval/open-brain/live/scenario-types.ts
+++ b/eval/open-brain/live/scenario-types.ts
@@ -87,6 +87,10 @@ export interface ProviderExecution {
   exitCode: number;
   receipt?: ProviderReceipt;
   result: Record<string, unknown>;
+  /** Error class recognized in the provider's stderr, when it failed. */
+  error_class?: string;
+  /** First meaningful stderr line, redacted. */
+  stderr_first_line?: string;
 }
 
 export type ScenarioRecord =
@@ -139,6 +143,13 @@ export interface ScenarioVerdict {
   passed: boolean;
   failures: string[];
   checks: Record<string, boolean | number | string>;
+  /**
+   * Content-free child diagnostics for a failing scenario: error class plus one
+   * redacted stderr line. Present only when the provider actually said
+   * something on stderr (issue #583).
+   */
+  error_class?: string;
+  stderr_first_line?: string;
 }
 
 export interface ScenarioGateReceipt {

--- a/eval/open-brain/live/transport.ts
+++ b/eval/open-brain/live/transport.ts
@@ -162,11 +162,25 @@ export interface ReflexPointersPayload {
 export class LiveTransportError extends Error {
   readonly label: string;
   readonly denied: boolean;
-  constructor(label: string, denied: boolean) {
+  /**
+   * Content-free diagnostics carried from a failing child process: the error
+   * class and one redacted stderr line. Without these a provider failure
+   * presents as a bare exit code and has to be recovered by replaying the
+   * command by hand (issue #583).
+   */
+  readonly errorClass?: string;
+  readonly stderrFirstLine?: string;
+  constructor(
+    label: string,
+    denied: boolean,
+    diagnostics: { errorClass?: string; stderrFirstLine?: string } = {},
+  ) {
     super(label);
     this.name = "LiveTransportError";
     this.label = label;
     this.denied = denied;
+    this.errorClass = diagnostics.errorClass;
+    this.stderrFirstLine = diagnostics.stderrFirstLine;
   }
 }
 

--- a/scripts/eval-langfuse-egress.test.ts
+++ b/scripts/eval-langfuse-egress.test.ts
@@ -220,8 +220,35 @@ describe("Langfuse egress verification", () => {
     expect(check(receipt, "secret_scan")).toMatchObject({
       status: "skipped-no-data",
       observed: 0,
+      passed: false,
     });
     expect(check(receipt, "arrival_count")).toMatchObject({
+      passed: false,
+      fatal: true,
+    });
+    expect(receipt.passed).toBeFalse();
+  });
+
+  test("skipped-no-data fails the run even when the caller expects zero traces", async () => {
+    // Review finding on #584: with expectedTraces: 0 the arrival_count check
+    // passes (0 === 0), so if secret_scan's passed were decoupled from the
+    // data, a run would be certified secret-free while the scanner examined
+    // nothing. The skip itself must be a fatal failure.
+    const emptyTransport: HttpTransport = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/public/traces") {
+        return Response.json({ data: [], meta: { totalPages: 1 } });
+      }
+      throw new Error(`unexpected request ${url.pathname}`);
+    };
+    const receipt = await verify([], {
+      transport: emptyTransport,
+      expectedTraces: 0,
+      expected: 0,
+    });
+
+    expect(check(receipt, "secret_scan")).toMatchObject({
+      status: "skipped-no-data",
       passed: false,
       fatal: true,
     });

--- a/scripts/eval-langfuse-egress.test.ts
+++ b/scripts/eval-langfuse-egress.test.ts
@@ -204,6 +204,37 @@ describe("Langfuse egress verification", () => {
     });
   });
 
+  test("secret scan over an empty trace set is skipped-no-data, not a pass", async () => {
+    // Issue #583: at observed=0 traces the scan examined nothing, so calling it
+    // a pass was a vacuous green. It must report skipped-no-data, and the
+    // fatal arrival_count check must still fail the run.
+    const emptyTransport: HttpTransport = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/public/traces") {
+        return Response.json({ data: [], meta: { totalPages: 1 } });
+      }
+      throw new Error(`unexpected request ${url.pathname}`);
+    };
+    const receipt = await verify([], { transport: emptyTransport });
+
+    expect(check(receipt, "secret_scan")).toMatchObject({
+      status: "skipped-no-data",
+      observed: 0,
+    });
+    expect(check(receipt, "arrival_count")).toMatchObject({
+      passed: false,
+      fatal: true,
+    });
+    expect(receipt.passed).toBeFalse();
+  });
+
+  test("secret scan over a real trace set reports an explicit pass status", async () => {
+    const receipt = await verify([generation()]);
+
+    expect(check(receipt, "secret_scan")).toMatchObject({ status: "pass" });
+    expect(receipt.passed).toBeTrue();
+  });
+
   test("settle polling records a late successful arrival", async () => {
     let listCalls = 0;
     let now = 0;
@@ -339,6 +370,61 @@ describe("Langfuse egress verification", () => {
       observed: 42,
       emit_failure_detected: false,
     });
+  });
+
+  test("failing drive child surfaces its stderr first line in the receipt", () => {
+    // Issue #583: the drive path captured stdout/stderr and never surfaced
+    // them, so a dead child presented as a bare exit code.
+    const receipt = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 1,
+      exitCode: 1,
+      stdout: "",
+      stderr: [
+        "Traceback (most recent call last):",
+        '  File "capture_stop.py", line 40, in main',
+        "RuntimeError: langfuse client refused the scope key",
+      ].join("\n"),
+      observeOffset: 0,
+    });
+
+    expect(receipt.passed).toBeFalse();
+    expect(receipt.error_class).toBe("RuntimeError");
+    expect(receipt.stderr_first_line).toBe(
+      "RuntimeError: langfuse client refused the scope key",
+    );
+    expect(serializeCliOutcome({ exitCode: 1, receipt }, false)).toContain(
+      "error_class=RuntimeError",
+    );
+  });
+
+  test("passing drive child carries no stderr diagnostics", () => {
+    const receipt = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 1,
+      exitCode: 0,
+      stdout: "",
+      stderr: "warming embedding cache",
+      observeOffset: 5,
+    });
+
+    expect(receipt.passed).toBeTrue();
+    expect(receipt.error_class).toBeUndefined();
+    expect(receipt.stderr_first_line).toBeUndefined();
+  });
+
+  test("drive receipt redacts labeled secret material from stderr", () => {
+    const receipt = evaluateDriveOutcome({
+      tag: "run-tag",
+      count: 1,
+      exitCode: 1,
+      stdout: "",
+      stderr: "ValueError: rejected token=abcd1234efgh5678ijkl",
+      observeOffset: 0,
+    });
+
+    expect(receipt.stderr_first_line).not.toContain("abcd1234efgh5678ijkl");
+    expect(receipt.stderr_first_line).toContain("[REDACTED]");
   });
 
   test("drive outcome fails without watermark proof or on explicit emit failure", () => {

--- a/scripts/eval-langfuse-egress.ts
+++ b/scripts/eval-langfuse-egress.ts
@@ -430,10 +430,12 @@ export async function verifyLangfuseEgress(
     {
       label: "secret_scan",
       // An empty scanned set proves nothing about egress safety, so it reports
-      // skipped-no-data rather than pass. It stays non-blocking on its own —
-      // the arrival_count check above is fatal and already fails at zero
-      // traces, so a skip can never be the reason a run is green (issue #583).
-      passed: secretHitCount === 0,
+      // skipped-no-data AND fails: passed is coupled to the data, not to the
+      // absence of hits, so a caller passing expectedTraces: 0 cannot get a
+      // run certified secret-free while the scanner examined nothing (#583
+      // review finding — the arrival_count default was the only thing holding
+      // the old comment's claim, and it is caller-overridable).
+      passed: traces.length > 0 && secretHitCount === 0,
       fatal: true,
       observed: secretHitCount,
       detector_counts: scan.counts,

--- a/scripts/eval-langfuse-egress.ts
+++ b/scripts/eval-langfuse-egress.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { Database } from "bun:sqlite";
+import { summarizeChildStderr } from "../src/child-stderr.ts";
 import { SECRET_DETECTORS } from "../src/secret-patterns.ts";
 
 const OPT_IN_ENV = "OPEN_BRAIN_LANGFUSE_EGRESS";
@@ -53,6 +54,12 @@ export interface EgressCheck {
   detector_counts?: Record<string, number>;
   content_fields_present?: boolean;
   emit_failure_detected?: boolean;
+  /**
+   * `skipped-no-data` marks a check that had nothing to examine, which is NOT
+   * the same claim as `pass`. A scan over zero traces found zero secrets
+   * trivially; reporting that as a pass is a vacuous green (issue #583).
+   */
+  status?: "pass" | "fail" | "skipped-no-data";
 }
 
 export interface EgressReceipt {
@@ -64,6 +71,13 @@ export interface EgressReceipt {
   observed: { traces: number; observations: number; generations: number };
   checks: EgressCheck[];
   settle?: { waited_ms: number; timed_out: boolean; polls: number };
+  /**
+   * Content-free diagnostics from the drive child: error class plus one
+   * redacted stderr line. Without these a drive failure presents as a bare
+   * exit code and has to be recovered by replaying the command (issue #583).
+   */
+  error_class?: string;
+  stderr_first_line?: string;
 }
 
 export interface CliOutcome {
@@ -415,11 +429,21 @@ export async function verifyLangfuseEgress(
     },
     {
       label: "secret_scan",
+      // An empty scanned set proves nothing about egress safety, so it reports
+      // skipped-no-data rather than pass. It stays non-blocking on its own —
+      // the arrival_count check above is fatal and already fails at zero
+      // traces, so a skip can never be the reason a run is green (issue #583).
       passed: secretHitCount === 0,
       fatal: true,
       observed: secretHitCount,
       detector_counts: scan.counts,
       content_fields_present: scan.contentFieldsPresent,
+      status:
+        traces.length === 0
+          ? "skipped-no-data"
+          : secretHitCount === 0
+            ? "pass"
+            : "fail",
     },
   ];
   const passed = checks.every((check) => check.passed || !check.fatal);
@@ -539,14 +563,19 @@ export function evaluateDriveOutcome(outcome: DriveOutcome): EgressReceipt {
       emit_failure_detected: emitFailureDetected,
     },
   ];
+  const passed = checks.every((check) => check.passed || !check.fatal);
+  // Only surfaced on failure: a healthy run's stderr is noise, and the receipt
+  // stays content-free either way (issue #583).
+  const diagnostics = passed ? {} : summarizeChildStderr(outcome.stderr);
   return {
     gate: "langfuse_egress",
     mode: "drive",
     tag: outcome.tag,
-    passed: checks.every((check) => check.passed || !check.fatal),
+    passed,
     expected: { traces: 1, observations: outcome.count + 1 },
     observed: { traces: 0, observations: 0, generations: 0 },
     checks,
+    ...diagnostics,
   };
 }
 
@@ -658,12 +687,17 @@ export function serializeCliOutcome(
       check.emit_failure_detected === undefined
         ? ""
         : ` emit_failure_detected=${check.emit_failure_detected}`;
+    const status = check.status ?? (check.passed ? "pass" : "fail");
     lines.push(
-      `check=${check.label} status=${check.passed ? "PASS" : "FAIL"} fatal=${check.fatal} observed=${check.observed}${check.expected === undefined ? "" : ` expected=${check.expected}`}${contentFields}${emitFailure}`,
+      `check=${check.label} status=${status.toUpperCase()} fatal=${check.fatal} observed=${check.observed}${check.expected === undefined ? "" : ` expected=${check.expected}`}${contentFields}${emitFailure}`,
     );
     for (const [kind, count] of Object.entries(check.detector_counts ?? {})) {
       lines.push(`detector=${kind} count=${count}`);
     }
+  }
+  if (receipt.error_class) lines.push(`error_class=${receipt.error_class}`);
+  if (receipt.stderr_first_line) {
+    lines.push(`stderr_first_line=${receipt.stderr_first_line}`);
   }
   return lines.join("\n");
 }

--- a/src/__tests__/child-stderr.test.ts
+++ b/src/__tests__/child-stderr.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeChildStderr } from "../child-stderr.ts";
+
+describe("summarizeChildStderr", () => {
+  test("returns nothing for empty or whitespace-only stderr", () => {
+    expect(summarizeChildStderr("")).toEqual({});
+    expect(summarizeChildStderr("  \n\n \t ")).toEqual({});
+  });
+
+  test("names the error class from a Python traceback tail", () => {
+    const stderr = [
+      "Traceback (most recent call last):",
+      '  File "provider.py", line 12, in main',
+      "    raise PermissionError(msg)",
+      "PermissionError: scope key 'project' was rejected",
+    ].join("\n");
+    expect(summarizeChildStderr(stderr)).toEqual({
+      error_class: "PermissionError",
+      stderr_first_line: "PermissionError: scope key 'project' was rejected",
+    });
+  });
+
+  test("falls back to the first line when no class is recognizable", () => {
+    const summary = summarizeChildStderr("uv: command not found\nsecond line");
+    expect(summary.error_class).toBeUndefined();
+    expect(summary.stderr_first_line).toBe("uv: command not found");
+  });
+
+  test("redacts labeled secret material out of the surfaced line", () => {
+    // Detection is label-gated by design (src/secret-patterns.ts): a bare
+    // high-entropy string is intentionally left alone, so the credential here
+    // carries the label the detectors key on.
+    const summary = summarizeChildStderr(
+      "ValueError: rejected token=abcd1234efgh5678ijkl",
+    );
+    expect(summary.error_class).toBe("ValueError");
+    expect(summary.stderr_first_line).not.toContain("abcd1234efgh5678ijkl");
+    expect(summary.stderr_first_line).toContain("[REDACTED]");
+  });
+});

--- a/src/child-stderr.ts
+++ b/src/child-stderr.ts
@@ -1,0 +1,66 @@
+/**
+ * Content-free summarization of a child process's stderr.
+ *
+ * A gate that is trusted as the acceptance instrument has to carry the child's
+ * error text, or every real failure presents as a bare exit code and has to be
+ * recovered by hand-replaying the command (issue #583). The discipline that
+ * makes that safe is the same one the receipts already use elsewhere: keep the
+ * error CLASS and ONE line, never bodies and never secrets.
+ *
+ * Built on the import-free `secret-patterns.ts` leaf rather than
+ * `sharing.redactText` so the eval transport does not pull the server logger
+ * into a child-process code path.
+ */
+
+import { SECRET_PATTERNS } from "./secret-patterns.ts";
+
+/**
+ * Python tracebacks put the useful class on the LAST line, not the first, and
+ * that line is what names the actual failure ("PermissionError: ..."). Anything
+ * shaped `Name: detail` or a bare `Name` at line start is treated as a class.
+ */
+const ERROR_CLASS_SHAPE = /^([A-Za-z_][\w.]*(?:Error|Exception|Warning))\b/;
+
+export interface ChildStderrSummary {
+  /** Exception/error class name when one is recognizable. */
+  error_class?: string;
+  /** First meaningful stderr line, redacted. */
+  stderr_first_line?: string;
+}
+
+function redact(text: string): string {
+  let redacted = text;
+  for (const pattern of SECRET_PATTERNS) {
+    const flags = pattern.flags.includes("g")
+      ? pattern.flags
+      : `${pattern.flags}g`;
+    redacted = redacted.replace(new RegExp(pattern.source, flags), "[REDACTED]");
+  }
+  return redacted;
+}
+
+/**
+ * Reduce raw stderr to at most an error class plus one redacted line. Returns
+ * an empty object for empty or whitespace-only stderr, so a receipt field is
+ * absent rather than present-and-empty when the child said nothing.
+ */
+export function summarizeChildStderr(stderr: string): ChildStderrSummary {
+  const lines = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return {};
+
+  // Prefer the last class-shaped line (Python traceback tail); fall back to the
+  // first line so non-Python children still surface something useful.
+  const classLine = [...lines]
+    .reverse()
+    .find((line) => ERROR_CLASS_SHAPE.test(line));
+  const chosen = classLine ?? lines[0];
+  const errorClass = classLine?.match(ERROR_CLASS_SHAPE)?.[1];
+
+  return {
+    ...(errorClass ? { error_class: errorClass } : {}),
+    stderr_first_line: redact(chosen as string),
+  };
+}


### PR DESCRIPTION
Fixes #583.

Both #578 eval tools read their child process's stderr and discarded it, so
every actionable failure in the first live run presented as a bare exit code
and had to be recovered by hand-replaying the command. A gate trusted as the
acceptance instrument has to carry the child's error text.

## What changed

- **`src/child-stderr.ts` (new)** reduces raw stderr to an error class plus one
  redacted line. Built on the import-free `secret-patterns.ts` leaf rather than
  `sharing.redactText`, so the eval transport does not pull the server logger
  into a child-process code path. The class is read from the *last* class-shaped
  line, because that is where a Python traceback puts the useful one.
- **`eval/open-brain/live/scenario-transport.ts:109`** now passes the stderr it
  was already capturing into `parseProviderOutput`. `LiveTransportError` and
  `ScenarioVerdict` carry `error_class` / `stderr_first_line` through to the
  scenario receipt, on both the throwing path and the nonzero-exit-with-receipt
  path. The transport catch also names which label threw instead of a flat
  `scenario_transport_error`.
- **`scripts/eval-langfuse-egress.ts:581-585`** surfaces the same two fields in
  the drive receipt, only on failure, and the serializer prints them.
- **`secret_scan`** reports `status: skipped-no-data` when it scanned zero
  traces. That is a different claim than `pass`, and it cannot be the reason a
  run is green either way: `arrival_count` is fatal and already fails at zero
  traces. Non-empty scans report an explicit `pass`/`fail` status.

Receipts stay content-free: only an error class and one redacted line, never
bodies or secrets. Detection reuses `SECRET_PATTERNS` unchanged, which is
label-gated by design (`src/secret-patterns.ts:60-65`).

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test scripts/ eval/ src/__tests__/child-stderr.test.ts` — 535 pass, 29
  skip, 0 fail.
- **Each new test was proven to fail before the fix.** Source files were
  reverted while the tests stayed, and all six new cases failed for the right
  reasons (missing `status`, `error_class` undefined, module absent).

## Critical Self-Review

- Highest-risk behavior: writing child-process stderr into a receipt that is
  contractually content-free — a redaction miss here would leak a secret into
  an artifact that gets pasted into issues.
- Assumptions that could be wrong: that the last class-shaped stderr line is
  the most useful one. True for Python tracebacks, which is what both children
  are; a non-Python child falls back to the first line.
- Missing/weak tests: no test drives a real `uv run` child, so the wiring from
  an actual spawned process is covered only through `parseProviderOutput`. The
  redaction assertions use one labeled-secret shape rather than the full
  detector matrix, which `src/secret-patterns.ts` tests already cover.
- Security/permission risk: reduced. Stderr previously reached nothing; it now
  reaches a receipt, so redaction is the load-bearing control and is applied
  before the line is stored. Only one line survives, never the body.
- Migration/deploy risk: none. No schema, no migration, no runtime service
  path — eval tooling only, and all added receipt fields are optional.
- Downstream client/runtime risk: none identified. The changed files are eval
  scripts and their types; no MCP tool, transport schema, or Python client
  surface is touched, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: revert is a clean single commit; the new module is
  additive and imported by exactly two call sites.
- Fixes made before PR: moved `child-stderr.ts` out of `eval/` into `src/` once
  the egress script needed it, so the two consumers share one implementation
  instead of forking a second redactor.
- Known residual risk: the fallback path surfaces the first stderr line from a
  non-Python child unclassified. It is redacted the same way, but a child that
  prints an unlabeled credential on its first line would be carried — the same
  exposure the existing label-gated detector design already accepts.
- SME review-memory update: [x] not applicable because: this is a first
  instance of the swallowed-child-stderr pattern rather than a repeat of a
  finding already in `docs/sme/`; if review flags it as recurring it belongs in
  `gotcha-agent.md`.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: the changes are eval
  tooling with no server, schema, or tool-surface impact, and both gates are
  opt-in scripts that were exercised through their own unit tests rather than a
  live run.
