### PR TITLE
fix(eval): drop non-contract `project` key from scenario fixture scopes (#581)

### DIFF
--- a/eval/open-brain/fixtures/scenarios-v1.json
+++ b/eval/open-brain/fixtures/scenarios-v1.json
@@ -16,8 +16,7 @@
           "platform": "eval",
           "server_id": "open-brain-scenarios",
           "channel_id": "capture-round-trip",
-          "session_key": "eval:scenario:{{run_id}}:capture",
-          "project": "open-brain"
+          "session_key": "eval:scenario:{{run_id}}:capture"
         },
         "optional_request_fields": {
           "candidate_type": "durable_decision",
@@ -41,8 +40,7 @@
           "platform": "eval",
           "server_id": "open-brain-scenarios",
           "channel_id": "durable-memory",
-          "session_key": "eval:scenario:{{run_id}}:durable-memory",
-          "project": "open-brain"
+          "session_key": "eval:scenario:{{run_id}}:durable-memory"
         }
       },
       "expected": {
@@ -63,8 +61,7 @@
           "platform": "eval",
           "server_id": "open-brain-scenarios",
           "channel_id": "checkpoint-round-trip",
-          "session_key": "eval:scenario:{{run_id}}:checkpoint",
-          "project": "open-brain"
+          "session_key": "eval:scenario:{{run_id}}:checkpoint"
         }
       },
       "checkpoint": {
@@ -78,8 +75,7 @@
           "platform": "eval",
           "server_id": "open-brain-scenarios",
           "channel_id": "checkpoint-round-trip",
-          "session_key": "eval:scenario:{{run_id}}:checkpoint",
-          "project": "open-brain"
+          "session_key": "eval:scenario:{{run_id}}:checkpoint"
         }
       }
     }

--- a/eval/open-brain/live/__tests__/config-fixture.test.ts
+++ b/eval/open-brain/live/__tests__/config-fixture.test.ts
@@ -246,6 +246,7 @@ describe("live config validation", () => {
     expect(config.negativeToken).toBe("primary-token");
     expect(config.negativeTokenIsDistinct).toBe(false);
     expect(config.primaryNamespace).toBe("eval-live-recall-run-7");
+    expect(config.project).toBe("open-brain");
   });
 });
 

--- a/eval/open-brain/live/__tests__/scenario-gate.test.ts
+++ b/eval/open-brain/live/__tests__/scenario-gate.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseScenarioFixture } from "../scenario-fixtures.ts";
+import {
+  loadScenarioFixture,
+  parseScenarioFixture,
+  ScenarioFixtureScopeKeyError,
+} from "../scenario-fixtures.ts";
 import { runScenarioGate } from "../scenario-gate.ts";
 import { parseProviderOutput } from "../scenario-transport.ts";
 import type {
@@ -180,6 +184,14 @@ describe("scenario fixture validation", () => {
         scenarios: [FIXTURE.scenarios[0], FIXTURE.scenarios[0]],
       }),
     ).toThrow(/duplicate scenario id/);
+  });
+
+  it("rejects a non-contract fixture scope key at load", async () => {
+    const path = join(import.meta.dir, "scenario-invalid-scope.fixture.json");
+    const error = await loadScenarioFixture(path).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(ScenarioFixtureScopeKeyError);
+    expect(error.message).toMatch(/non-contract scope key\(s\): bogus/);
   });
 });
 

--- a/eval/open-brain/live/__tests__/scenario-invalid-scope.fixture.json
+++ b/eval/open-brain/live/__tests__/scenario-invalid-scope.fixture.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "fixture_id": "invalid-scenario-scope-key",
+  "description": "Fixture proving non-contract scope keys fail during load.",
+  "scenarios": [
+    {
+      "id": "invalid-scope-key",
+      "kind": "capture_round_trip",
+      "request": {
+        "operation": "capture",
+        "distilled": true,
+        "content": "Invalid fixture scope marker.",
+        "event_type": "decision",
+        "scope": {
+          "agent": "scenario-eval",
+          "platform": "eval",
+          "server_id": "open-brain-scenarios",
+          "channel_id": "invalid-scope",
+          "session_key": "eval:scenario:invalid-scope",
+          "bogus": "not-a-scope-key"
+        }
+      }
+    }
+  ]
+}

--- a/eval/open-brain/live/config.ts
+++ b/eval/open-brain/live/config.ts
@@ -36,6 +36,8 @@ export interface LiveEvalConfig {
   primaryNamespace: string;
   /** Per-run unique negative (unreadable-from-primary) sibling namespace. */
   negativeNamespace: string;
+  /** Provider lane metadata, separate from the exact-scope predicate. */
+  project: string;
   /** Recall search mode; hybrid by default to exercise the full retriever. */
   searchMode: "hybrid" | "vector" | "keyword";
   /** Per-request timeout in milliseconds. */
@@ -232,6 +234,7 @@ export function loadLiveConfig(
     negativeTokenIsDistinct,
     primaryNamespace: primary,
     negativeNamespace: negative,
+    project: "open-brain",
     searchMode: searchModeRaw,
     timeoutMs,
   };

--- a/eval/open-brain/live/scenario-fixtures.ts
+++ b/eval/open-brain/live/scenario-fixtures.ts
@@ -1,6 +1,54 @@
 import { z } from "zod";
 import type { ScenarioFixture } from "./scenario-types.ts";
 
+// Contract-defined closed set: docs/agent-context-pack-contract.md:99-105.
+const CONTRACT_SCOPE_KEYS = new Set([
+  "namespace",
+  "agent",
+  "platform",
+  "server_id",
+  "channel_id",
+  "thread_id",
+  "session_key",
+]);
+
+export class ScenarioFixtureScopeKeyError extends Error {
+  constructor(
+    readonly invalidKeys: string[],
+    path?: string,
+  ) {
+    const prefix = path ? `Invalid scenario fixture ${path}: ` : "";
+    super(`${prefix}non-contract scope key(s): ${invalidKeys.join(", ")}`);
+    this.name = "ScenarioFixtureScopeKeyError";
+  }
+}
+
+function assertScopeKeys(scope: unknown): void {
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) return;
+  const invalidKeys = Object.keys(scope)
+    .filter((key) => !CONTRACT_SCOPE_KEYS.has(key))
+    .sort();
+  if (invalidKeys.length > 0) throw new ScenarioFixtureScopeKeyError(invalidKeys);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function assertFixtureScopeKeys(value: unknown): void {
+  const scenarios = asRecord(value)?.scenarios;
+  if (!Array.isArray(scenarios)) return;
+  for (const value of scenarios) {
+    const scenario = asRecord(value);
+    if (!scenario) continue;
+    for (const key of ["request", "event", "checkpoint"] as const) {
+      assertScopeKeys(asRecord(scenario[key])?.scope);
+    }
+  }
+}
+
 const scopeSchema = z.object({
   agent: z.string().min(1),
   platform: z.string().min(1),
@@ -8,7 +56,6 @@ const scopeSchema = z.object({
   channel_id: z.string().min(1),
   thread_id: z.string().min(1).nullable().optional(),
   session_key: z.string().min(1),
-  project: z.string().min(1),
 });
 
 const captureRequestSchema = z.object({
@@ -69,6 +116,7 @@ export const scenarioFixtureSchema: z.ZodType<ScenarioFixture> = z.object({
 });
 
 export function parseScenarioFixture(raw: unknown): ScenarioFixture {
+  assertFixtureScopeKeys(raw);
   const fixture = scenarioFixtureSchema.parse(raw);
   const ids = new Set<string>();
   for (const scenario of fixture.scenarios) {
@@ -89,6 +137,9 @@ export async function loadScenarioFixture(path: string): Promise<ScenarioFixture
   try {
     return parseScenarioFixture(raw);
   } catch (error) {
+    if (error instanceof ScenarioFixtureScopeKeyError) {
+      throw new ScenarioFixtureScopeKeyError(error.invalidKeys, path);
+    }
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Invalid scenario fixture ${path}: ${message}`);
   }

--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -101,6 +101,7 @@ export class LiveScenarioTransport implements ScenarioTransport {
         OPENBRAIN_BASE_URL: this.config.baseUrl,
         OPENBRAIN_TOKEN: this.config.primaryToken,
         OPENBRAIN_NAMESPACE: this.config.primaryNamespace,
+        OPENBRAIN_PROJECT: this.config.project,
       },
       stdin: "pipe",
       stdout: "pipe",

--- a/eval/open-brain/live/scenario-types.ts
+++ b/eval/open-brain/live/scenario-types.ts
@@ -9,7 +9,6 @@ export type ScenarioKind =
 export interface ScenarioScope
   extends Omit<ContextPackScope, "namespace" | "thread_id"> {
   thread_id?: string | null;
-  project: string;
 }
 
 export interface CaptureRequest {

--- a/scripts/__tests__/eval-open-brain-live.test.ts
+++ b/scripts/__tests__/eval-open-brain-live.test.ts
@@ -26,6 +26,7 @@ const CONFIG: LiveEvalConfig = {
   negativeTokenIsDistinct: false,
   primaryNamespace: "eval-live-recall-run-test",
   negativeNamespace: "eval-live-recall-run-test-negative",
+  project: "open-brain",
   searchMode: "hybrid",
   timeoutMs: 1000,
 };


### PR DESCRIPTION
Refs #581

Research brief: https://github.com/rodaddy/open-brain/issues/581#issuecomment-5195138467

## Summary
- Remove `project` from all four scope objects in `eval/open-brain/fixtures/scenarios-v1.json`.
- Reject non-contract fixture scope keys during fixture load with `ScenarioFixtureScopeKeyError`.
- Preserve `project` as provider lane metadata through the existing `LiveEvalConfig` object and `OPENBRAIN_PROJECT` environment variable.

## Contract source
The closed scope vocabulary comes from `docs/agent-context-pack-contract.md:99-105` and is restated at `docs/agent-context-pack-contract.md:671-674`.

## Step (2)
Applied. `LiveScenarioTransport` already receives the existing `LiveEvalConfig` surface, so the project value is carried there and exported to the Python provider as `OPENBRAIN_PROJECT`. No new configuration mechanism was introduced.

## Validation
- `bunx tsc --noEmit` — passed with no output.
- `bun test eval/` — 207 pass, 0 fail, 851 assertions across 10 files.
- Test sensitivity proven: temporarily removing the scope guard made the named load-error test fail because the invalid fixture loaded successfully; restoring the guard returned the test to green.

## Downstream rollout
Not applicable. This changes eval fixtures, their loader, and live-eval provider configuration only; it does not change MCP tools, public schemas, transport protocol, database migrations, Python package exports, generated skills, or agent-facing runtime behavior.

Critical self-review:
- Highest-risk behavior: The guard could inspect an unrelated nested object as scope; it checks only the fixture's `request`, `event`, and `checkpoint` scope positions.
- Assumptions that could be wrong: The scripted scenarios should retain `open-brain` as lane metadata even though it is not part of exact scope; the existing provider config contract supports that assumption.
- Missing/weak tests: The spawn environment is not intercepted directly; config output is asserted, TypeScript checks the transport plumbing, and the eval suite exercises fixture behavior.
- Security/permission risk: No auth or namespace predicate changes; the fix narrows fixture scope to the documented contract.
- Migration/deploy risk: None; there are no database, service, or deployment changes.
- Downstream client/runtime risk: None identified because no public or package contract changes.
- Rollback/cleanup concern: A revert restores the previous fixture/config behavior; the invalid test fixture has no runtime side effects.
- Fixes made before PR: Replaced a general recursive scan with checks at the three schema-owned scope containers, and proved the load test goes red without the guard.
- Known residual risk: The transport environment assignment is covered indirectly rather than by a spawn interception test; its source config value and type path are verified.


## Critical Self-Review

- Highest-risk behavior: the fail-fast fixture guard rejects any scope key outside the seven contract keys at load; a legitimate future contract expansion would make every fixture load fail until the guard's set is updated alongside the contract doc it cites (docs/agent-context-pack-contract.md:99-105).
- Assumptions that could be wrong: that `project` never belongs in a scope object anywhere downstream — grounded in the #581 research brief (five caller sites all send it flat; zero send it in scope), but the brief could not read the unmerged fixture history.
- Missing/weak tests: the spawn env is not asserted by an interception test — OPENBRAIN_PROJECT reaching the child is covered by the type path plus config-fixture.test.ts:249, not by capturing a real spawn's env.
- Security/permission risk: none identified; no auth, token, namespace, or SQL surface changes — the guard narrows accepted input.
- Migration/deploy risk: none; eval-lane only, no schema, no server behavior.
- Downstream client/runtime risk: none — _runtime_router.py and runtime.py verified untouched (git diff name-only against the base); the documented flat-param bridge is unchanged.
- Rollback/cleanup concern: single-commit revert restores the fixture's non-conformant scope; nothing persisted.
- Fixes made before PR: Sol's first launch produced zero output and no edits; relaunched once. Guard placed before zod parsing because zod strips unknown keys silently — without the pre-parse check the bogus key would be dropped, not rejected, which is the #581 defect class itself.
- Known residual risk: fresh-context review verified the guard by mutation (removing the call fails exactly one targeted test); the hardcoded project literal in loadLiveConfig is deliberate lane metadata with a single valid value, per the review's assessment.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the review returned approve with no MEDIUM+ findings; the zod-strips-unknown-keys gotcha is recorded in this PR body and the #581 thread.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: eval-fixture and load-guard change only; no MCP tool, schema, or live service surface is exercised by this merge — the gate's next live run (#578) is the live proof path.
