### PR TITLE
fix(eval): make egress drive failures actionable

### DIFF
--- a/scripts/eval-langfuse-egress.test.ts
+++ b/scripts/eval-langfuse-egress.test.ts
@@ -119,6 +119,23 @@ describe("Langfuse egress verification", () => {
     );
   });
 
+  test("empty-string capture vars still reach the shared aliases", () => {
+    // Deployed hook-env wrappers pass VAR="${VAR:-}": unset arrives as "", not
+    // absence (#525's shape). The alias fallback must engage on both.
+    const config = readCaptureDriveConfig({
+      ...OPTED_IN_ENV,
+      OPENBRAIN_CAPTURE_BASE_URL: "",
+      OPENBRAIN_CAPTURE_TOKEN: "",
+      OPENBRAIN_BASE_URL: "http://127.0.0.1:3100",
+      OPENBRAIN_TOKEN: "alias-token",
+    });
+
+    expect(config).toEqual({
+      baseUrl: "http://127.0.0.1:3100",
+      token: "alias-token",
+    });
+  });
+
   test("drive returns a non-zero configuration error before spawning an invalid child", async () => {
     const outcome = await runEgressCli(
       ["--drive", "--tag", "run-tag"],

--- a/scripts/eval-langfuse-egress.test.ts
+++ b/scripts/eval-langfuse-egress.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import {
+  captureEnvironment,
   evaluateDriveOutcome,
   langfuseHost,
+  observationOffset,
   parseEgressArgs,
+  readCaptureDriveConfig,
   runEgressCli,
   serializeCliOutcome,
   verifyLangfuseEgress,
@@ -24,6 +28,12 @@ const OPTED_IN_ENV = {
   OPENBRAIN_TRACING_SECRET_KEY: "private-id",
 };
 
+const CAPTURE_DRIVE_ENV = {
+  ...OPTED_IN_ENV,
+  OPENBRAIN_CAPTURE_BASE_URL: "http://127.0.0.1:3100",
+  OPENBRAIN_CAPTURE_TOKEN: "capture-token",
+};
+
 interface FakeObservationOptions {
   usage?: boolean;
   cost?: number | null;
@@ -36,9 +46,9 @@ function generation(
   return {
     id: "observation-1",
     type: "GENERATION",
-    providedModelName: "claude-fable-5",
+    model: "claude-fable-5",
     usageDetails: options.usage === false ? undefined : { input: 2, output: 3 },
-    totalCost: options.cost === undefined ? 0.001 : options.cost,
+    totalPrice: options.cost === undefined ? 0.001 : options.cost,
     output: options.output ?? "SAFE_BODY_MARKER",
   };
 }
@@ -59,6 +69,7 @@ function fakeTransport(
       return Response.json({
         id: "trace-1",
         sessionId: "run-tag",
+        tags: ["open-brain-capture"],
         observations,
         ...bodyExtras,
       });
@@ -102,6 +113,71 @@ function check(receipt: Awaited<ReturnType<typeof verify>>, label: string) {
 }
 
 describe("Langfuse egress verification", () => {
+  test("drive configuration requires raw capture coordinates", () => {
+    expect(() => readCaptureDriveConfig(OPTED_IN_ENV)).toThrow(
+      "OPENBRAIN_CAPTURE_BASE_URL and OPENBRAIN_CAPTURE_TOKEN",
+    );
+  });
+
+  test("drive returns a non-zero configuration error before spawning an invalid child", async () => {
+    const outcome = await runEgressCli(
+      ["--drive", "--tag", "run-tag"],
+      OPTED_IN_ENV,
+    );
+
+    expect(outcome).toEqual({
+      exitCode: 2,
+      error:
+        "OPENBRAIN_CAPTURE_BASE_URL and OPENBRAIN_CAPTURE_TOKEN are required for --drive",
+    });
+  });
+
+  test("drive child keeps declared hook settings and drops foreign Open Brain names", () => {
+    const child = captureEnvironment(
+      {
+        ...CAPTURE_DRIVE_ENV,
+        OPENBRAIN_LOCAL_CLONE: "1",
+        OPENBRAIN_TRANSPORT: "typescript-only",
+        OPENBRAIN_ALLOW_INSECURE_HTTP: "1",
+        PATH: "/test/bin",
+      },
+      CONFIG,
+      readCaptureDriveConfig(CAPTURE_DRIVE_ENV),
+      "/scratch/watermarks.sqlite",
+    );
+
+    expect(child).toMatchObject({
+      PATH: "/test/bin",
+      OPENBRAIN_CAPTURE_BASE_URL: "http://127.0.0.1:3100",
+      OPENBRAIN_CAPTURE_TOKEN: "capture-token",
+      OPENBRAIN_ALLOW_INSECURE_HTTP: "1",
+      OPENBRAIN_OBSERVATION_ENABLED: "1",
+      OPENBRAIN_CAPTURE_WATERMARK_PATH: "/scratch/watermarks.sqlite",
+    });
+    expect(child.OPENBRAIN_LOCAL_CLONE).toBeUndefined();
+    expect(child.OPENBRAIN_TRANSPORT).toBeUndefined();
+  });
+
+  test("observation watermark read falls back after a post-child database failure", async () => {
+    let fallbackCalls = 0;
+
+    const offset = await observationOffset("/watermarks.sqlite", "run-tag", {
+      fileExists: async () => true,
+      databaseFactory: () => {
+        throw new Error("unable to open database file");
+      },
+      fallbackOffset: async (path, sessionKey) => {
+        fallbackCalls += 1;
+        expect(path).toBe("/watermarks.sqlite");
+        expect(sessionKey).toBe("observe:run-tag");
+        return 42;
+      },
+    });
+
+    expect(offset).toBe(42);
+    expect(fallbackCalls).toBe(1);
+  });
+
   test("normalizes bare hosts and ingestion URLs identically", () => {
     expect(langfuseHost("https://langfuse.example")).toBe(
       "https://langfuse.example",
@@ -109,6 +185,55 @@ describe("Langfuse egress verification", () => {
     expect(langfuseHost("https://langfuse.example/api/public/ingestion/")).toBe(
       "https://langfuse.example",
     );
+  });
+
+  test("verification excludes server traces that share the capture session", async () => {
+    const transport: HttpTransport = async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/public/traces") {
+        return Response.json({
+          data: [{ id: "capture-trace" }, { id: "server-trace" }],
+          meta: { totalPages: 1 },
+        });
+      }
+      if (url.pathname === "/api/public/traces/capture-trace") {
+        return Response.json({
+          id: "capture-trace",
+          tags: ["claude-code", "open-brain-capture"],
+          observations: [
+            { id: "span-1", type: "SPAN" },
+            generation(),
+            generation(),
+            generation(),
+          ],
+        });
+      }
+      if (url.pathname === "/api/public/traces/server-trace") {
+        return Response.json({
+          id: "server-trace",
+          tags: ["mcp-tool", "open-brain-server"],
+          observations: [{ id: "span-2", type: "SPAN" }],
+        });
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const receipt = await verifyLangfuseEgress({
+      tag: "run-tag",
+      expectedObservations: 4,
+      expectedGenerations: 3,
+      expectedTraces: 1,
+      settleTimeoutSeconds: 0,
+      config: CONFIG,
+      transport,
+    });
+
+    expect(receipt.passed).toBeTrue();
+    expect(receipt.observed).toEqual({
+      traces: 1,
+      observations: 4,
+      generations: 3,
+    });
   });
 
   test("arrival-count miss is fatal", async () => {
@@ -216,7 +341,11 @@ describe("Langfuse egress verification", () => {
         });
       }
       if (url.pathname === "/api/public/traces/trace-1") {
-        return Response.json({ id: "trace-1", observations: [generation()] });
+        return Response.json({
+          id: "trace-1",
+          tags: ["open-brain-capture"],
+          observations: [generation()],
+        });
       }
       return new Response(null, { status: 404 });
     };
@@ -251,7 +380,11 @@ describe("Langfuse egress verification", () => {
         });
       }
       if (url.pathname === "/api/public/traces/trace-1") {
-        return Response.json({ id: "trace-1", observations: [generation()] });
+        return Response.json({
+          id: "trace-1",
+          tags: ["open-brain-capture"],
+          observations: [generation()],
+        });
       }
       return new Response(null, { status: 404 });
     };
@@ -292,6 +425,7 @@ describe("Langfuse egress verification", () => {
       const id = url.pathname.split("/").at(-1) ?? "missing";
       return Response.json({
         id,
+        tags: ["open-brain-capture"],
         observations: [generation()],
       });
     };

--- a/scripts/eval-langfuse-egress.ts
+++ b/scripts/eval-langfuse-egress.ts
@@ -10,6 +10,11 @@
  * coordinates come from the existing OPENBRAIN_TRACING_* variables. Output is
  * content-free: counts, ids, statuses, and detector labels only. Trace bodies,
  * credentials, matching values, and match offsets are never emitted.
+ *
+ * ``--drive`` invokes the real raw-capture Stop hook, so it also requires
+ * OPENBRAIN_CAPTURE_BASE_URL and OPENBRAIN_CAPTURE_TOKEN (or their shared
+ * aliases). The driver rejects a missing raw configuration before spawning a
+ * child; a hook's normal exit-zero contract cannot prove a capture happened.
  */
 
 import { randomUUID } from "node:crypto";
@@ -26,11 +31,23 @@ const DEFAULT_SETTLE_TIMEOUT_SECONDS = 60;
 const DEFAULT_SETTLE_POLL_INTERVAL_MS = 2_000;
 const MAX_TRACE_PAGES = 100;
 const EMIT_FAILURE_MARKER = "observation emit failed";
+const CAPTURE_TRACE_TAG = "open-brain-capture";
+const CAPTURE_OPTION_ENV_KEYS = [
+  "OPENBRAIN_CAPTURE_AGENT_ID",
+  "OPENBRAIN_CAPTURE_AGENT",
+  "OPENBRAIN_SPOOL_PATH",
+  "OPENBRAIN_ALLOW_INSECURE_HTTP",
+] as const;
 
 export interface LangfuseReadConfig {
   endpoint: string;
   publicKey: string;
   secretKey: string;
+}
+
+interface CaptureDriveConfig {
+  baseUrl: string;
+  token: string;
 }
 
 export type HttpTransport = (
@@ -116,6 +133,12 @@ interface DriveOptions {
   cwd?: string;
 }
 
+interface ObservationOffsetOptions {
+  fileExists?: (path: string) => Promise<boolean>;
+  databaseFactory?: (path: string) => Database;
+  fallbackOffset?: (path: string, sessionKey: string) => Promise<number>;
+}
+
 /** Normalize either a bare Langfuse host or its public ingestion URL. */
 export function langfuseHost(endpoint: string): string {
   return endpoint
@@ -136,6 +159,22 @@ export function readLangfuseEgressConfig(
     throw new Error("OPENBRAIN_TRACING_* coordinates are incomplete");
   }
   return { endpoint: langfuseHost(endpoint), publicKey, secretKey };
+}
+
+/** Resolve the raw capture coordinates the real Stop hook needs before observing. */
+export function readCaptureDriveConfig(
+  env: Record<string, string | undefined> = process.env,
+): CaptureDriveConfig {
+  const baseUrl =
+    env.OPENBRAIN_CAPTURE_BASE_URL?.trim() ?? env.OPENBRAIN_BASE_URL?.trim() ?? "";
+  const token =
+    env.OPENBRAIN_CAPTURE_TOKEN?.trim() ?? env.OPENBRAIN_TOKEN?.trim() ?? "";
+  if (!baseUrl || !token) {
+    throw new Error(
+      "OPENBRAIN_CAPTURE_BASE_URL and OPENBRAIN_CAPTURE_TOKEN are required for --drive",
+    );
+  }
+  return { baseUrl, token };
 }
 
 function assertSafeTag(tag: string): void {
@@ -240,6 +279,10 @@ function traceFrom(value: unknown): LangfuseTrace | undefined {
   return { id, observations: arrayField(value, "observations"), body };
 }
 
+function isCaptureTrace(trace: LangfuseTrace): boolean {
+  return arrayField(trace.body, "tags").includes(CAPTURE_TRACE_TAG);
+}
+
 function pageData(value: unknown): unknown[] {
   const direct = arrayField(value, "data");
   if (direct.length > 0) return direct;
@@ -281,7 +324,8 @@ async function queryTaggedTraces(
         config.endpoint,
       );
       const detail = await fetchJson(detailUrl, config, transport);
-      traces.push(traceFrom(detail) ?? summaryTrace);
+      const trace = traceFrom(detail) ?? summaryTrace;
+      if (isCaptureTrace(trace)) traces.push(trace);
     }
     more = hasNextPage(
       payload,
@@ -374,11 +418,11 @@ export async function verifyLangfuseEgress(
   const generations = observations.filter(isGeneration);
   const metadataCount = generations.filter(
     (row) =>
-      fieldPresent(row, "providedModelName", "provided_model_name") &&
+      fieldPresent(row, "model", "providedModelName", "provided_model_name") &&
       fieldPresent(row, "usageDetails", "usage_details"),
   ).length;
   const costCount = generations.filter((row) =>
-    fieldPresent(row, "totalCost", "total_cost"),
+    fieldPresent(row, "totalPrice", "totalCost", "total_cost"),
   ).length;
   const scan = secretScan(traces);
   const secretHitCount = Object.values(scan.counts).reduce(
@@ -479,15 +523,22 @@ function transcriptLine(tag: string, index: number): string {
   });
 }
 
-function captureEnvironment(
+export function captureEnvironment(
   env: Record<string, string | undefined>,
   config: LangfuseReadConfig,
+  capture: CaptureDriveConfig,
   watermarkPath: string,
 ): Record<string, string> {
   const child: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    if (value === undefined || key.startsWith("OPENBRAIN_TRACING_")) continue;
+    if (value === undefined || key.startsWith("OPENBRAIN_")) continue;
     child[key] = value;
+  }
+  child.OPENBRAIN_CAPTURE_BASE_URL = capture.baseUrl;
+  child.OPENBRAIN_CAPTURE_TOKEN = capture.token;
+  for (const key of CAPTURE_OPTION_ENV_KEYS) {
+    const value = env[key];
+    if (value !== undefined) child[key] = value;
   }
   child.OPENBRAIN_OBSERVATION_ENABLED = "1";
   child.OPENBRAIN_OBSERVATION_ENDPOINT = config.endpoint;
@@ -497,24 +548,55 @@ function captureEnvironment(
   return child;
 }
 
-async function observationOffset(
+export async function observationOffset(
   watermarkPath: string,
   tag: string,
+  options: ObservationOffsetOptions = {},
 ): Promise<number> {
-  if (!(await Bun.file(watermarkPath).exists())) return 0;
-  const database = new Database(watermarkPath, {
-    readonly: true,
-    create: false,
-  });
+  const fileExists =
+    options.fileExists ?? ((path) => Bun.file(path).exists());
+  if (!(await fileExists(watermarkPath))) return 0;
+  const databaseFactory =
+    options.databaseFactory ??
+    ((path) => new Database(path, { readonly: true, create: false }));
+  const sessionKey = `observe:${tag}`;
   try {
-    const row = database
-      .query("SELECT offset FROM watermark WHERE session_key = ?")
-      .get(`observe:${tag}`);
-    const offset = objectValue(row)?.offset;
-    return typeof offset === "number" && offset > 0 ? offset : 0;
-  } finally {
-    database.close();
+    const database = databaseFactory(watermarkPath);
+    try {
+      const row = database
+        .query("SELECT offset FROM watermark WHERE session_key = ?")
+        .get(sessionKey);
+      const offset = objectValue(row)?.offset;
+      return typeof offset === "number" && offset > 0 ? offset : 0;
+    } finally {
+      database.close();
+    }
+  } catch {
+    const fallbackOffset = options.fallbackOffset ?? sqlite3WatermarkOffset;
+    return fallbackOffset(watermarkPath, sessionKey);
   }
+}
+
+async function sqlite3WatermarkOffset(
+  watermarkPath: string,
+  sessionKey: string,
+): Promise<number> {
+  const quotedSessionKey = sessionKey.replaceAll("'", "''");
+  const statement =
+    "SELECT offset FROM watermark WHERE session_key = '" +
+    `${quotedSessionKey}';`;
+  const child = Bun.spawn(["sqlite3", "-ifexists", watermarkPath, statement], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error("watermark SQLite probe failed");
+  const offset = Number.parseInt(stdout.trim(), 10);
+  return Number.isSafeInteger(offset) && offset > 0 ? offset : 0;
 }
 
 /** Evaluate content-free evidence produced by the drive child process. */
@@ -555,6 +637,7 @@ export async function driveLangfuseEgress(
   options: DriveOptions,
 ): Promise<EgressReceipt> {
   const config = readLangfuseEgressConfig(options.env);
+  const capture = readCaptureDriveConfig(options.env);
   const cwd = options.cwd ?? process.cwd();
   const runDir = path.join(scratchRoot(cwd), `${options.tag}-${randomUUID()}`);
   await mkdir(runDir, { recursive: true });
@@ -573,7 +656,7 @@ export async function driveLangfuseEgress(
   });
   const processHandle = Bun.spawn(["uv", "run", "openbrain-capture-stop"], {
     cwd: path.join(cwd, "python", "openbrain"),
-    env: captureEnvironment(options.env, config, watermarkPath),
+    env: captureEnvironment(options.env, config, capture, watermarkPath),
     stdin: new Blob([payload]),
     stdout: "pipe",
     stderr: "pipe",

--- a/scripts/eval-langfuse-egress.ts
+++ b/scripts/eval-langfuse-egress.ts
@@ -165,10 +165,13 @@ export function readLangfuseEgressConfig(
 export function readCaptureDriveConfig(
   env: Record<string, string | undefined> = process.env,
 ): CaptureDriveConfig {
+  // `||`, not `??`: deployed hook-env wrappers pass VAR="${VAR:-}", so an unset
+  // CAPTURE var arrives as an empty string and must still reach the alias (#525
+  // documented this exact shape for the Python side; config.py:163-171).
   const baseUrl =
-    env.OPENBRAIN_CAPTURE_BASE_URL?.trim() ?? env.OPENBRAIN_BASE_URL?.trim() ?? "";
+    env.OPENBRAIN_CAPTURE_BASE_URL?.trim() || env.OPENBRAIN_BASE_URL?.trim() || "";
   const token =
-    env.OPENBRAIN_CAPTURE_TOKEN?.trim() ?? env.OPENBRAIN_TOKEN?.trim() ?? "";
+    env.OPENBRAIN_CAPTURE_TOKEN?.trim() || env.OPENBRAIN_TOKEN?.trim() || "";
   if (!baseUrl || !token) {
     throw new Error(
       "OPENBRAIN_CAPTURE_BASE_URL and OPENBRAIN_CAPTURE_TOKEN are required for --drive",


### PR DESCRIPTION
Fixes #582.

## Summary

- Require raw-capture coordinates before `eval-langfuse-egress.ts --drive` starts a real Stop-hook child.
- Build that child environment from declared capture and observation settings only, dropping unrelated `OPENBRAIN_*` values that Python rejects.
- Fall back to `sqlite3 -ifexists` when Bun cannot immediately reopen the child-written watermark database.
- Verify only capture-emitter traces and recognize the actual Langfuse public-API model and cost field names.
- Add regression coverage for the previous silent, successful child result, environment isolation, transient watermark-read failure, and shared-session server traces.

## Diagnosis

All four tracing variables were confirmed present without disclosing their values. The previous driver copied unrelated `OPENBRAIN_*` names from the parent process into the Python child. `load_capture_settings()` rejects those names, `stop.capture_stop_with()` swallows the resulting `UnknownEnvironmentVariableError`, and the child returns `0` before it reaches the observation path. Under a strict tracing-only environment, raw capture is instead missing its endpoint/token and follows the same silent hook-success path before observation can run.

The repair preserves the raw-first watermark contract. It reports either setup defect from the egress CLI as stderr plus exit `2`, rather than treating an unstarted observation lane as a Langfuse emission result. If Bun cannot reopen the just-written watermark database, the verifier uses `sqlite3 -ifexists`; a persistent failure remains non-zero.

The live read path also exposed a separate verifier defect: the raw lane's `session_start` gives Open Brain server tracing the same Langfuse session ID as the capture emitter. The verifier now retains only the emitter's stable `open-brain-capture` tag. Its public API returns `model` and `totalPrice`, not the legacy field spellings the verifier previously required.

## Validation

- `BUN_TMPDIR=/Volumes/ThunderBolt/_tmp/open-brain/_scratch/bun-tmp bun test scripts/eval-langfuse-egress.test.ts` (21 tests)
- `BUN_TMPDIR=/Volumes/ThunderBolt/_tmp/open-brain/_scratch/bun-tmp bunx tsc --noEmit`
- `UV_CACHE_DIR=/Volumes/ThunderBolt/_tmp/open-brain/_validation-runs/uv-cache uv run mypy src/openbrain`
- `UV_CACHE_DIR=/Volumes/ThunderBolt/_tmp/open-brain/_validation-runs/uv-cache uv run ruff check src tests`
- `UV_CACHE_DIR=/Volumes/ThunderBolt/_tmp/open-brain/_validation-runs/uv-cache uv run pytest -q` (593 passed, 1 skipped, 19 deselected)
- Tracing-only configuration returns the raw-capture setup error on stderr and exits `2`; no values were printed.
- A configured live drive wrote both raw and `observe:` watermark rows. Its Langfuse verification now passes with 1 capture trace, 4 observations, and 3 generations; no credential values were printed.

## Downstream Rollout

Not applicable: this changes a repository-local evaluation script and does not change an MCP, transport, database, generated-skill, or Python client contract.

## Critical Self-Review

- Highest-risk behavior: the child environment must retain the two raw-capture coordinates while rejecting foreign `OPENBRAIN_*` names.
- Assumptions that could be wrong: a future valid Stop-hook setting may need forwarding; the driver currently needs only raw endpoint/token plus its own observation settings.
- Missing/weak tests: the test suite uses a synthetic child environment; it does not assert Langfuse arrival over the network.
- Security/permission risk: the child receives a capture token, but the driver never serializes the environment or error values.
- Migration/deploy risk: no migration or deployment behavior changes.
- Downstream client/runtime risk: no externally consumed Open Brain contract changes.
- Rollback/cleanup concern: reverting this two-file change restores the earlier driver behavior; no persisted state is created.
- Fixes made before PR: added fail-fast raw configuration validation, filtered the Python child environment to declared settings, added a durable watermark read fallback, and filtered the verifier to capture-owned traces using the public API field names it actually receives.
- Known residual risk: a persistently unreadable watermark returns a non-zero verifier error rather than a false receipt; a future emitter tag change must update the verifier fixture.
- SME review-memory update: [x] not applicable because: no reusable source-path review pattern changed; this is a bounded evaluator configuration repair.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured: no MEDIUM+ finding remained after the source-path diagnosis and focused regression checks.
- Live Open Brain checks: [x] not applicable because: the local evaluation driver stops before any network call when required raw-capture configuration is absent.
