### PR TITLE
fix(context-budget-gate): derive advisory thresholds from the active profile's real compaction point

### DIFF
--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -92,8 +92,30 @@ __all__ = ["main"]
 
 #: Advisory notice thresholds. These are notice points, not blocks: crossing
 #: them prints a line and nothing else (``nag_banner`` says so in its own text).
-_DEFAULT_NAG_TOKENS: Final[int] = 200_000
-_DEFAULT_ADVISORY_TOKENS: Final[int] = 250_000
+#:
+#: THESE ARE THE LAST RESORT, NOT THE OPERATING VALUES. They apply only when the
+#: compaction window cannot be resolved from settings at all (see
+#: ``resolve_thresholds``). Read as absolute token counts they are meaningless;
+#: they are the fractions below applied to a 200k window, which is the smallest
+#: context any supported model ships with.
+_FALLBACK_COMPACT_WINDOW: Final[int] = 200_000
+
+#: Claude Code reserves output tokens before measuring the compaction trigger,
+#: then fires at ``percent`` of what is left. Mirrors the live formula in
+#: ``~/.claudex/doctor.ts`` (``computedCompactAt``: ``floor((window -
+#: OUTPUT_RESERVE) * percent / 100)``) and its ``OUTPUT_RESERVE = 16_384``.
+#: Verified against that source 2026-08-05 (issue #77).
+_OUTPUT_RESERVE: Final[int] = 16_384
+_DEFAULT_COMPACT_PCT: Final[int] = 92
+
+#: Where the advisory sits relative to the REAL compaction point, not a fixed
+#: token count. An advisory that fires with 40%+ of the window still free is
+#: noise, and noise trains the reader to skip the channel -- so the nag opens at
+#: 88% of the way to compaction (~35k of runway on a 450k window: enough to wrap
+#: a thought, short enough to mean something) and the second tier at 96%
+#: (~14k out, compaction is imminent).
+_NAG_FRACTION_OF_COMPACT: Final[float] = 0.88
+_ADVISORY_FRACTION_OF_COMPACT: Final[float] = 0.96
 
 #: context-budget-gate.ts:75 -- how much the count must climb before the same
 #: advisory is repeated, so one long session does not print it every turn.
@@ -129,6 +151,98 @@ _EVENTS: Final[tuple[str, ...]] = (
 )
 
 
+def compaction_trigger(window: int, percent: int) -> int:
+    """Return the token count at which automatic compaction actually fires.
+
+    Mirrors ``computedCompactAt`` in ``~/.claudex/doctor.ts``: the output reserve
+    comes off the window first, and the trigger is ``percent`` of the remainder.
+    """
+    return (window - _OUTPUT_RESERVE) * percent // 100
+
+
+def _settings_env(settings_path: Path) -> dict[str, str]:
+    """Return the ``env`` block of a Claude settings file, or ``{}``.
+
+    Fail-open by contract: an unreadable, absent, or malformed settings file
+    leaves the caller on its fallbacks rather than raising inside a hook.
+    """
+    try:
+        if not settings_path.is_file():
+            return {}
+        if settings_path.stat().st_size > _MAX_STATE_SCAN_BYTES:
+            return {}
+        parsed = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    env = parsed.get("env")
+    return {k: str(v) for k, v in env.items()} if isinstance(env, dict) else {}
+
+
+def _positive_int(raw: str | None) -> int | None:
+    """Parse a positive integer, or return ``None`` for anything else."""
+    try:
+        value = int(str(raw))
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def resolve_thresholds(env: dict[str, str], settings_path: Path) -> tuple[int, int]:
+    """Return ``(nag, advisory)`` token counts for the ACTIVE profile.
+
+    Resolution order, most authoritative first:
+
+    1. ``CONTEXT_BUDGET_NAG`` / ``CONTEXT_BUDGET_HARD`` in the environment --
+       an explicit operator override, honoured verbatim.
+    2. The compaction window for the profile that is actually running, read out
+       of the settings file, with the thresholds placed as fractions of the real
+       trigger point.
+    3. ``_FALLBACK_COMPACT_WINDOW``, when no window can be resolved at all.
+
+    Why it reads the FILE and not just the environment (issue #77): the live
+    hook wrapper ``openbrain-hook-env`` starts the gate with ``exec env -i`` and
+    an explicit allowlist that carries no ``CONTEXT_BUDGET_*`` and no
+    ``CLAUDE_CODE_AUTO_COMPACT_WINDOW``. Every one of those variables is
+    stripped before the gate is reached, so a value set in ``settings.json`` had
+    no effect and the gate silently ran on the old hardcoded 200k -- firing at
+    roughly half the real compaction point, on every turn, until the reader
+    learned to ignore it. Reading the same file the settings live in needs no
+    passthrough and cannot be defeated by the wrapper.
+
+    Profiles differ and must not be hardcoded: the global profile runs a 450000
+    window and the Claudex native/Sol profiles run 397000, which is a ~49k
+    difference in where compaction lands.
+    """
+    window = _positive_int(env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW"))
+    percent = _positive_int(env.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"))
+    nag_override = _positive_int(env.get("CONTEXT_BUDGET_NAG"))
+    advisory_override = _positive_int(env.get("CONTEXT_BUDGET_HARD"))
+
+    if None in (window, percent, nag_override, advisory_override):
+        settings_env = _settings_env(settings_path)
+        window = window or _positive_int(
+            settings_env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+        )
+        percent = percent or _positive_int(
+            settings_env.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")
+        )
+        nag_override = nag_override or _positive_int(
+            settings_env.get("CONTEXT_BUDGET_NAG")
+        )
+        advisory_override = advisory_override or _positive_int(
+            settings_env.get("CONTEXT_BUDGET_HARD")
+        )
+
+    trigger = compaction_trigger(
+        window or _FALLBACK_COMPACT_WINDOW, percent or _DEFAULT_COMPACT_PCT
+    )
+    nag = nag_override or int(trigger * _NAG_FRACTION_OF_COMPACT)
+    advisory = advisory_override or int(trigger * _ADVISORY_FRACTION_OF_COMPACT)
+    return nag, advisory
+
+
 def _iso_now() -> str:
     """Return the current instant the way the TypeScript writer spells it."""
     utc = datetime.now(UTC)
@@ -158,16 +272,11 @@ def _build_parser(env: dict[str, str]) -> argparse.ArgumentParser:
     parser.add_argument("--event", default="status", choices=_EVENTS)
     parser.add_argument("--session-id", default="")
     parser.add_argument("--project", default="")
-    parser.add_argument(
-        "--nag-tokens",
-        type=int,
-        default=int(env.get("CONTEXT_BUDGET_NAG") or _DEFAULT_NAG_TOKENS),
-    )
-    parser.add_argument(
-        "--hard-tokens",
-        type=int,
-        default=int(env.get("CONTEXT_BUDGET_HARD") or _DEFAULT_ADVISORY_TOKENS),
-    )
+    # Defaulted to None and filled in by ``resolve_thresholds`` AFTER parsing:
+    # resolution reads ``--settings-path``, which is parsed in this same pass, so
+    # it cannot be computed while the parser is still being built.
+    parser.add_argument("--nag-tokens", type=int, default=None)
+    parser.add_argument("--hard-tokens", type=int, default=None)
     parser.add_argument(
         "--state-path",
         type=Path,
@@ -785,6 +894,15 @@ def main(
     """
     environment = dict(os.environ) if env is None else env
     args = _build_parser(environment).parse_args(sys.argv[1:] if argv is None else argv)
+    # Resolved here, not in the parser: it depends on ``--settings-path``, which
+    # the same parse produces. An explicit --nag-tokens/--hard-tokens still wins.
+    resolved_nag, resolved_advisory = resolve_thresholds(
+        environment, args.settings_path
+    )
+    if args.nag_tokens is None:
+        args.nag_tokens = resolved_nag
+    if args.hard_tokens is None:
+        args.hard_tokens = resolved_advisory
     event = read_hook_event(stdin)
     _warn_missing_development_root(event, stderr)
     gate = _Gate(args, event, stdout)

--- a/python/openbrain-provider/tests/test_gate_thresholds.py
+++ b/python/openbrain-provider/tests/test_gate_thresholds.py
@@ -1,0 +1,277 @@
+"""Where the advisory speaks, and why it is not a hardcoded token count.
+
+The nag is the gate's only routine voice. If it fires with most of the window
+still free it is noise, and noise is not harmless -- a channel that cries wolf
+trains the reader to skip it, so a REAL budget warning arrives pre-discredited.
+That is the failure issue #77 recorded: the gate ran on a 200k default against a
+~399k compaction point and nagged every turn until it was ignored.
+
+The cause was not the number. ``openbrain-hook-env`` starts the gate with
+``exec env -i`` and an allowlist carrying no ``CONTEXT_BUDGET_*`` and no
+``CLAUDE_CODE_AUTO_COMPACT_WINDOW``, so the operator's configured 300000 was
+stripped before the gate could read it and the stale default silently won.
+These tests pin both halves: the thresholds track the ACTIVE profile's real
+compaction point, and they are resolved from the settings FILE so no wrapper
+allowlist can strip them.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+from gate_harness import PROJECT, SESSION, GatePaths, gate_paths
+
+from openbrain_provider import context_budget_gate
+from openbrain_provider.context_budget_gate import (
+    compaction_trigger,
+    resolve_thresholds,
+)
+
+#: The two windows actually in service on the operator's machine, read from
+#: `~/.claude/settings.json` (global) and `~/.claudex/profiles/native` and
+#: `.../sol` on 2026-08-05. They differ by 53000 tokens of window and ~49000 of
+#: real trigger, which is precisely why one hardcoded number cannot serve both.
+_GLOBAL_WINDOW = 450_000
+_CLAUDEX_WINDOW = 397_000
+_PCT = 92
+
+
+def _write_settings(path: Path, env: dict[str, str]) -> None:
+    """Write a Claude settings file carrying ``env``."""
+    path.write_text(json.dumps({"env": env}), encoding="utf8")
+
+
+def _usage_transcript(root: Path, tokens: int) -> str:
+    """Write a transcript whose latest assistant turn reports ``tokens`` used."""
+    path = root / f"usage-{tokens}.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": {"content": "go"}}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [],
+                            "usage": {
+                                "input_tokens": tokens,
+                                "cache_read_input_tokens": 0,
+                                "cache_creation_input_tokens": 0,
+                            },
+                        },
+                    }
+                ),
+            ]
+        ),
+        encoding="utf8",
+    )
+    return str(path)
+
+
+def _run_unpinned(
+    paths: GatePaths, tokens: int, *, env: dict[str, str] | None = None
+) -> dict[str, Any]:
+    """Drive one ``user-prompt-submit`` WITHOUT pinning the thresholds.
+
+    ``gate_harness.run_gate`` passes explicit ``--nag-tokens/--hard-tokens`` so
+    the other suites stay independent of configuration. This file is the one
+    that must exercise resolution itself, so it builds its own argv and leaves
+    both flags off.
+    """
+    argv = [
+        "--event",
+        "user-prompt-submit",
+        "--state-path",
+        str(paths.state),
+        "--receipt-state-path",
+        str(paths.receipts),
+        "--settings-path",
+        str(paths.settings),
+        "--policy-state-path",
+        str(paths.policy_state),
+        "--spool-path",
+        str(paths.spool),
+        "--session-id",
+        SESSION,
+        "--project",
+        PROJECT,
+    ]
+    payload = {
+        "session_id": SESSION,
+        "cwd": "/Volumes/ThunderBolt/Development",
+        "transcript_path": _usage_transcript(paths.root, tokens),
+    }
+    stdout = io.StringIO()
+    context_budget_gate.main(
+        argv,
+        stdin=io.StringIO(json.dumps(payload)),
+        stdout=stdout,
+        stderr=io.StringIO(),
+        env=dict(env or {}, HOME=str(paths.root)),
+    )
+    return {"stdout": stdout.getvalue()}
+
+
+def _nag_fired(result: dict[str, Any]) -> bool:
+    """Return whether the advisory banner was injected into the turn."""
+    for line in result["stdout"].splitlines():
+        try:
+            payload = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(payload, dict) and "hookSpecificOutput" in payload:
+            return True
+    return False
+
+
+class TestCompactionTrigger:
+    """The formula the thresholds are measured against."""
+
+    def test_mirrors_the_live_claudex_formula(self) -> None:
+        """Reserve comes off the window first, then the percentage.
+
+        Pinned against ``~/.claudex/doctor.ts::computedCompactAt``, read
+        2026-08-05. A drift here means the gate is aiming at a point that no
+        longer exists, which is silent -- nothing else in the system would fail.
+        """
+        assert compaction_trigger(_GLOBAL_WINDOW, _PCT) == 398_926
+        assert compaction_trigger(_CLAUDEX_WINDOW, _PCT) == 350_166
+
+
+class TestThresholdResolution:
+    """Where the numbers come from when nobody passes a flag."""
+
+    def test_reads_the_window_from_the_settings_file(self, tmp_path: Path) -> None:
+        """A stripped environment still resolves, because the FILE is read.
+
+        This is the #77 regression in one assertion: the environment is empty,
+        exactly as ``env -i`` leaves it, and the thresholds must still land on
+        the real window rather than falling back to a hardcoded 200000.
+        """
+        settings = tmp_path / "settings.json"
+        _write_settings(
+            settings,
+            {
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": str(_GLOBAL_WINDOW),
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": str(_PCT),
+            },
+        )
+        nag, advisory = resolve_thresholds({}, settings)
+        trigger = compaction_trigger(_GLOBAL_WINDOW, _PCT)
+        assert nag > 200_000
+        assert nag < advisory < trigger
+
+    def test_each_profile_gets_its_own_thresholds(self, tmp_path: Path) -> None:
+        """The 450k and 397k profiles must not resolve to the same numbers."""
+        wide = tmp_path / "wide.json"
+        narrow = tmp_path / "narrow.json"
+        _write_settings(
+            wide,
+            {
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": str(_GLOBAL_WINDOW),
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": str(_PCT),
+            },
+        )
+        _write_settings(
+            narrow,
+            {
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": str(_CLAUDEX_WINDOW),
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": str(_PCT),
+            },
+        )
+        assert resolve_thresholds({}, wide)[0] > resolve_thresholds({}, narrow)[0]
+
+    def test_advisory_leaves_actionable_runway(self, tmp_path: Path) -> None:
+        """The nag must be close enough to compaction to mean something.
+
+        The bug was a nag at ~50% of the trigger. Anything under 80% is the same
+        class of noise, so that is the floor this pins; the ceiling keeps it from
+        arriving too late to act on.
+        """
+        settings = tmp_path / "settings.json"
+        _write_settings(
+            settings,
+            {
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": str(_GLOBAL_WINDOW),
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": str(_PCT),
+            },
+        )
+        nag, _ = resolve_thresholds({}, settings)
+        trigger = compaction_trigger(_GLOBAL_WINDOW, _PCT)
+        assert 0.80 <= nag / trigger <= 0.95
+
+    def test_explicit_operator_values_win(self, tmp_path: Path) -> None:
+        """A configured budget is honoured verbatim, not recomputed."""
+        settings = tmp_path / "settings.json"
+        _write_settings(
+            settings,
+            {
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": str(_GLOBAL_WINDOW),
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": str(_PCT),
+                "CONTEXT_BUDGET_NAG": "300000",
+                "CONTEXT_BUDGET_HARD": "390000",
+            },
+        )
+        assert resolve_thresholds({}, settings) == (300_000, 390_000)
+
+    def test_environment_outranks_the_file(self, tmp_path: Path) -> None:
+        """When a variable DOES survive, it is still the more specific source."""
+        settings = tmp_path / "settings.json"
+        _write_settings(settings, {"CONTEXT_BUDGET_NAG": "300000"})
+        nag, _ = resolve_thresholds({"CONTEXT_BUDGET_NAG": "310000"}, settings)
+        assert nag == 310_000
+
+    def test_unreadable_settings_do_not_raise(self, tmp_path: Path) -> None:
+        """A hook fails open: a missing or corrupt file yields usable numbers."""
+        corrupt = tmp_path / "corrupt.json"
+        corrupt.write_text("{not json", encoding="utf8")
+        for path in (corrupt, tmp_path / "absent.json"):
+            nag, advisory = resolve_thresholds({}, path)
+            assert 0 < nag < advisory
+
+
+class TestNagFiringBehaviour:
+    """End to end: the banner appears on the right side of the line."""
+
+    def _configured(self, tmp_path: Path) -> GatePaths:
+        paths = gate_paths(tmp_path / "gate")
+        _write_settings(
+            paths.settings,
+            {
+                "CLAUDE_CODE_AUTO_COMPACT_WINDOW": str(_GLOBAL_WINDOW),
+                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": str(_PCT),
+            },
+        )
+        return paths
+
+    def test_silent_below_the_threshold(self, tmp_path: Path) -> None:
+        """210000 tokens fired the old gate. It must now say nothing.
+
+        Measured on the live 0.9.0 gate through the real hook wrapper on
+        2026-08-05: a 210000-token turn injected the advisory banner, against a
+        compaction point of 398926 -- 47% of the way there.
+        """
+        paths = self._configured(tmp_path)
+        assert _nag_fired(_run_unpinned(paths, 210_000)) is False
+
+    def test_silent_just_under_the_line(self, tmp_path: Path) -> None:
+        """One token below the resolved nag point is still silence."""
+        paths = self._configured(tmp_path)
+        nag, _ = resolve_thresholds({}, paths.settings)
+        assert _nag_fired(_run_unpinned(paths, nag - 1)) is False
+
+    def test_fires_at_the_threshold(self, tmp_path: Path) -> None:
+        """At the resolved nag point the advisory appears."""
+        paths = self._configured(tmp_path)
+        nag, _ = resolve_thresholds({}, paths.settings)
+        assert _nag_fired(_run_unpinned(paths, nag)) is True
+
+    def test_fires_when_compaction_is_imminent(self, tmp_path: Path) -> None:
+        """Just short of compaction the advisory is certainly owed."""
+        paths = self._configured(tmp_path)
+        trigger = compaction_trigger(_GLOBAL_WINDOW, _PCT)
+        assert _nag_fired(_run_unpinned(paths, trigger - 5_000)) is True


### PR DESCRIPTION
Fixes the noise half of **rodaddy/development#77**. The fix lands here, not in
`development`: the live gate is this repo's Python package
(`openbrain-context-budget-gate`, installed 0.9.0), and the
`_ob/scripts/context-budget-gate.ts` named in that issue is not registered in any
live hook — every `context-budget-gate` entry in `~/.claude/settings.json` invokes
the Python console script.

## The actual defect is not the number

The reported symptom was a nag at 200k against a ~399k compaction point, firing
every turn until it was ignored. The stale default was the symptom; the cause is
that **the configured value never reached the gate at all**.

`~/.local/share/openbrain-memory/env/openbrain-hook-env` starts the gate with
`exec env -i` and an explicit allowlist. That allowlist carries no
`CONTEXT_BUDGET_*` and no `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, so
`CONTEXT_BUDGET_NAG=300000` — set in `~/.claude/settings.json` since before the
issue was filed — was stripped before the gate could read it, and the hardcoded
200k silently won. Demonstrated directly:

```
$ CONTEXT_BUDGET_NAG=300000 sh .../openbrain-hook-env printenv CONTEXT_BUDGET_NAG
(no output, exit 1)
```

Same gate, same 210k transcript, only difference being whether the variable
survives: through the wrapper the banner fires; with the variable actually
present it is silent. That is why issue #77's own correcting comment ("already
set to 300000, so the thresholds are fine") read the config correctly and still
described behaviour that was not happening.

## Change

`resolve_thresholds()` reads the same settings **file** the values live in, so no
env passthrough is required and the wrapper allowlist cannot defeat it.
Resolution order: explicit `--nag-tokens`/`--hard-tokens` → environment →
settings file → derived.

When no budget is configured, thresholds are derived from the **real** compaction
trigger rather than a fixed count:

```
compaction_trigger = floor((window - 16384) * pct / 100)
```

mirroring `computedCompactAt` in `~/.claudex/doctor.ts` (`OUTPUT_RESERVE = 16_384`),
read from that source rather than from memory. This has to be per-profile: the
global profile runs a **450000** window (trigger **398926**) and the Claudex
native/Sol profiles run **397000** (trigger **350166**) — ~49k apart, so one
hardcoded number cannot serve both.

Nag at **88%** of the trigger (~48k of runway: enough to wrap a thought, short
enough to mean something), second tier at **96%** (~14k out, compaction imminent).
The old nag sat at ~50% of the trigger, which is the noise this removes.

## Measured before/after

Driven through the real hook wrapper against synthetic transcripts:

| tokens | before (installed 0.9.0) | after |
|--------|--------------------------|-------|
| 210000 | NAG FIRED | silent |
| 250000 | NAG FIRED | silent |
| 299999 | NAG FIRED | silent |
| 300000 | NAG FIRED | NAG FIRED |
| 310000 | NAG FIRED | NAG FIRED |
| 398000 | NAG FIRED | NAG FIRED |

The boundary lands exactly on the operator's configured 300000, which is now
actually reaching the gate.

## What is deliberately untouched

The `readbackRequired`/`checkpointRequired` blocking half — the durability
guarantee issue #77 says to leave alone. `tests/test_gate_receipts.py` and
`tests/test_gate_repair.py` pass unchanged (58 tests in those files plus parity).

## Verification

- `uv run pytest tests/` — **607 passed, 1 skipped**
- `uv run mypy src/openbrain_provider` — clean, 19 files
- `uv run ruff check src tests` — clean
- 11 new tests in `tests/test_gate_thresholds.py`, covering silent-below /
  fires-at-and-above, per-profile divergence, the stripped-environment
  regression, operator override precedence, and fail-open on corrupt settings.

## Related, NOT fixed here (one ticket per lane)

- **rodaddy/development#81** (post-compact allowlist deadlock) is the *same
  wrapper file* and the same `env -i` allowlist mechanism. This PR sidesteps the
  allowlist by reading the settings file instead of widening it; #81 is about the
  invocation form, and is untouched.
- **rodaddy/development#79** (receipts written with `at:null`) shares
  `receipt_state.py` but not this code path.

Neither is addressed here.

Critical self-review:
- Highest-risk behavior: thresholds resolving too HIGH would silence the advisory
  entirely, which is a silent failure. Pinned from both sides — tests assert the
  nag is silent below and fires at/above, and `test_advisory_leaves_actionable_runway`
  bounds the fraction to 0.80-0.95 so a future edit cannot drift it to either extreme.
- Assumptions that could be wrong: that `doctor.ts::computedCompactAt` is the
  formula Claude Code actually uses. It is the operator's own mirror of it, not
  Anthropic's source; if upstream changes, the derived tier drifts silently. Bounded
  by the fact that the derived path only runs when no budget is configured, and both
  live profiles DO configure one — so the operator's explicit values are what serve
  today, and `test_mirrors_the_live_claudex_formula` pins the constants.
- Missing/weak tests: no test drives the real `openbrain-hook-env` wrapper; the
  stripped environment is simulated by passing `{}`. A change to the wrapper's
  allowlist would not fail this suite. Measured by hand instead, shown above.
- Security/permission risk: none. Reads one already-referenced settings path,
  adds no network, no writes, no new dependency.
- Migration/deploy risk: needs a package reinstall to take effect on this machine —
  the installed 0.9.0 keeps the old behaviour until then, and a merged fix is not a
  live fix (the same trap recorded in #77's first comment, where a merged repair did
  not save a session running the pre-rebase tree).
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or
  client-facing surface is touched; this is hook-local.
- Rollback/cleanup concern: single-commit revert, no state migration. Existing
  state files are unaffected — no schema field added or removed.
- Fixes made before PR: parser defaults moved to `None` and resolved after parsing,
  because resolution depends on `--settings-path` which the same parse produces;
  computing it in the parser would have ignored the flag and silently read the
  operator's live settings during tests.
- Known residual risk: the `env -i` allowlist remains narrow for everything else it
  strips. This PR routes around it for thresholds only; #81 owns the general case.

Refs rodaddy/development#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
