### PR TITLE
fix(gate): recognise the packaged wrapper invocation form (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,17 @@ jobs:
         if: steps.contract-paths.outputs.required == 'true'
         run: uv python install "${PYTHON_VERSION}"
 
+      - name: Install dependencies
+        # `check-parity.ts` imports the tracing stack transitively, so it needs
+        # real `node_modules`. Without this the job ran straight off the
+        # self-hosted runner's shared Bun cache and passed only while that cache
+        # happened to be warm: on 2026-08-07 the same commit passed on the
+        # `pull_request` run and failed on the `push` run with `Cannot find
+        # module '@opentelemetry/api'` resolved out of the cache. Every other
+        # Bun job here installs first; this one was the exception.
+        if: steps.contract-paths.outputs.required == 'true'
+        run: bun install --frozen-lockfile
+
       - name: Validate parity manifest and fixtures
         if: steps.contract-paths.outputs.required == 'true'
         run: bun contracts/check-parity.ts

--- a/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
+++ b/python/openbrain-provider/src/openbrain_provider/context_budget_gate.py
@@ -63,7 +63,12 @@ from .gate_presentation import (
     readback_banner,
     transition_message,
 )
-from .gate_shell import ShellGateContext, is_checkpoint_activity, is_repair_capable_tool
+from .gate_shell import (
+    ShellGateContext,
+    is_checkpoint_activity,
+    is_repair_capable_tool,
+    unrecognised_hook_invocation_diagnostic,
+)
 from .gate_state import (
     CHECKPOINT_MAX_AGE_SECONDS,
     enter_repair_mode,
@@ -640,11 +645,17 @@ def _block(gate: _Gate, reason: str, banner: str) -> int:
     """
     record_transition(gate.state, "still-blocking-with-reason", gate.now, reason)
     gate.save()
+    # #81: if NO provider invocation form is recognised, the banner above is
+    # printing a command this gate would refuse, and a bare "blocked" gives the
+    # session nothing to act on. Say what was not recognised, in the block
+    # itself -- a silently-empty allowance is what makes a deadlock inescapable.
+    diagnostic = unrecognised_hook_invocation_diagnostic(gate.shell)
+    message = transition_message("still-blocking-with-reason", reason)
     gate.emit_json(
         {
             "decision": "block",
-            "reason": banner,
-            "systemMessage": transition_message("still-blocking-with-reason", reason),
+            "reason": f"{banner}\n{diagnostic}" if diagnostic else banner,
+            "systemMessage": f"{message}\n{diagnostic}" if diagnostic else message,
         }
     )
     return 0

--- a/python/openbrain-provider/src/openbrain_provider/gate_presentation.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_presentation.py
@@ -17,7 +17,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .gate_shell import activated_provider_script_paths, shell_quote
+from .gate_shell import (
+    WRAPPER_CONSOLE_EVENTS,
+    activated_provider_script_paths,
+    shell_quote,
+    wrapper_console_invocations,
+)
 from .gate_state import SessionState
 
 __all__ = [
@@ -86,10 +91,42 @@ def _provider_payload_command(
     # colon would change the quoted payload and make the printed command stop
     # matching the one the allowance accepts.
     encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    # #81: when no `bun` provider script is installed, the sibling default names
+    # a file that does not exist and the printed command cannot possibly work.
+    # Fall back to the packaged wrapper that settings.json actually wires up,
+    # chosen from the SAME lookup the allowance uses, so the banner cannot print
+    # a form the gate refuses.
+    if not activated and not Path(preferred).is_file():
+        wrapper = _wrapper_recovery_command(event_name, encoded, context)
+        if wrapper is not None:
+            return wrapper
     return (
         f"printf '%s' {shell_quote(encoded)} | bun {shell_quote(preferred)} "
         f"--runtime claude --event {event_name}"
     )
+
+
+def _wrapper_recovery_command(
+    event_name: str, encoded: str, context: PresentationContext
+) -> str | None:
+    """Return the packaged-wrapper recovery command, or None when none is wired.
+
+    Args:
+        event_name: The provider event the command must produce.
+        encoded: The already-encoded JSON payload.
+        context: Provider paths.
+
+    Returns:
+        A single-line shell command naming a wrapper/console-script pair the
+        allowance accepts, or None when settings names no usable pair.
+    """
+    for wrapper, console in wrapper_console_invocations(context.settings_path):
+        if WRAPPER_CONSOLE_EVENTS.get(console) != event_name:
+            continue
+        return (
+            f"printf '%s' {shell_quote(encoded)} | sh {shell_quote(wrapper)} {console}"
+        )
+    return None
 
 
 def capture_banner(state: SessionState, context: PresentationContext) -> str:

--- a/python/openbrain-provider/src/openbrain_provider/gate_shell.py
+++ b/python/openbrain-provider/src/openbrain_provider/gate_shell.py
@@ -33,11 +33,14 @@ from .gate_state import SessionState
 
 __all__ = [
     "READONLY_BASH",
+    "WRAPPER_CONSOLE_EVENTS",
     "ShellGateContext",
     "activated_provider_script_paths",
     "is_checkpoint_activity",
     "is_repair_capable_tool",
     "shell_quote",
+    "unrecognised_hook_invocation_diagnostic",
+    "wrapper_console_invocations",
 ]
 
 #: context-budget-gate-shell.ts:5-11, byte-identical. Commands that read and do
@@ -126,6 +129,31 @@ _PROVIDER_EVENTS: Final[frozenset[str]] = frozenset(
 _ACTIVATED_PROVIDER_PATTERN: Final[re.Pattern[str]] = re.compile(
     r"([^'\"\s]+/adapters/versions/sha256-[0-9a-f]{64})"
     r"/(?:context-budget-gate|ob-memory-provider)\.ts"
+)
+
+#: The packaged wrapper form settings.json actually uses (#81). Every hook now
+#: reads `sh <…>/openbrain-hook-env openbrain-session-start`, and the console
+#: script is a uv-installed Python entry point rather than a `bun` script. The
+#: allowlist recognised only the older `bun <…>.ts` spelling, so a session could
+#: be told to run one thing and refused for running it. The pattern captures the
+#: wrapper path so the recovery command can be DERIVED from what is wired up
+#: instead of written as a second literal that drifts.
+_HOOK_WRAPPER_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"([^'\"\s]+/openbrain-hook-env)\s+(openbrain-[a-z0-9-]+)"
+)
+
+#: The console scripts the wrapper may run to satisfy a read-back or a capture.
+#: Mapped to the provider event each one produces, because the allowance is per
+#: event: a read-back block is cleared only by a recall, never by a capture.
+WRAPPER_CONSOLE_EVENTS: Final[dict[str, str]] = {
+    "openbrain-session-start": "session-start",
+    "openbrain-capture-stop": "capture",
+    "openbrain-post-compact": "session-start",
+}
+
+#: `sh` spellings the wrapper form may be invoked through.
+_SHELL_BINARIES: Final[frozenset[str]] = frozenset(
+    {"sh", "/bin/sh", "bash", "/opt/homebrew/bin/bash", "zsh", "/opt/homebrew/bin/zsh"}
 )
 
 #: Characters that make a command something other than a simple pipeline.
@@ -316,6 +344,67 @@ def activated_provider_script_paths(settings_path: Path) -> list[str]:
     return candidates
 
 
+def wrapper_console_invocations(settings_path: Path) -> list[tuple[str, str]]:
+    """Return `(wrapper_path, console_script)` pairs wired up in settings.
+
+    This is the #81 half of provider discovery. `activated_provider_script_paths`
+    answers "which `bun` adapter generation is installed"; this answers "which
+    packaged console script is on the hook chain", which is the form every hook
+    has used since the #420 cutover.
+
+    Args:
+        settings_path: A Claude settings file.
+
+    Returns:
+        Every `(wrapper, console script)` pair whose wrapper exists on disk and
+        whose console script is one the gate knows how to credit. Empty on any
+        read or parse failure, matching the fail-closed posture of its sibling —
+        malformed settings never widen an allowance.
+    """
+    try:
+        parsed = json.loads(settings_path.read_text(encoding="utf8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    hooks = parsed.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+
+    found: list[tuple[str, str]] = []
+    for event_hooks in hooks.values():
+        if not isinstance(event_hooks, list):
+            continue
+        for event_hook in event_hooks:
+            if not isinstance(event_hook, dict):
+                continue
+            commands = event_hook.get("hooks")
+            if not isinstance(commands, list):
+                continue
+            for hook in commands:
+                _collect_wrapper_invocation(hook, found)
+    return found
+
+
+def _collect_wrapper_invocation(hook: object, found: list[tuple[str, str]]) -> None:
+    """Append any wrapper/console-script pair named by one hook command."""
+    if not isinstance(hook, dict):
+        return
+    command = hook.get("command")
+    if not isinstance(command, str):
+        return
+    for match in _HOOK_WRAPPER_PATTERN.finditer(command):
+        wrapper, console = match.group(1), match.group(2)
+        if console not in WRAPPER_CONSOLE_EVENTS:
+            continue
+        pair = (wrapper, console)
+        try:
+            if Path(wrapper).is_file() and pair not in found:
+                found.append(pair)
+        except OSError:
+            continue
+
+
 def _collect_provider_path(hook: object, candidates: list[str]) -> None:
     """Append any existing provider path named by one hook command."""
     if not isinstance(hook, dict):
@@ -330,6 +419,44 @@ def _collect_provider_path(hook: object, candidates: list[str]) -> None:
                 candidates.append(candidate)
         except OSError:
             continue
+
+
+def unrecognised_hook_invocation_diagnostic(
+    context: ShellGateContext,
+) -> str:
+    """Return a diagnostic when NO provider invocation form is recognised.
+
+    The #81 defect class: an allowlist that resolves to nothing looks exactly
+    like an allowlist that is correctly empty, so the gate refuses its own
+    recovery command and says only "blocked". An empty allowance and a
+    deliberately-narrow one must not be indistinguishable — the same silent
+    failure family as #98 (untested wrapper allowlist) and #99 (a test run that
+    dies and exits 0).
+
+    Args:
+        context: The paths this gate would accept a recovery command at.
+
+    Returns:
+        A one-line operator-facing diagnostic naming what was not recognised and
+        what to do, or ``""`` when at least one form IS recognised (the normal
+        case, where staying quiet is correct).
+    """
+    if Path(context.provider_script_path).is_file():
+        return ""
+    if activated_provider_script_paths(context.settings_path):
+        return ""
+    if wrapper_console_invocations(context.settings_path):
+        return ""
+    return (
+        "OB ✗ gate cannot recognise ANY provider invocation form — the recovery "
+        f"command it prints will be refused. Checked: sibling script "
+        f"{context.provider_script_path} (absent), and {context.settings_path} "
+        "for a sha256 adapter generation or an openbrain-hook-env console "
+        "script (neither found). Repair with --provider-script-path pointing at "
+        "the installed provider, or run "
+        "'openbrain-context-budget-gate --event repair-enter' to open a repair "
+        "window."
+    )
 
 
 def is_checkpoint_activity(
@@ -526,6 +653,9 @@ def _parse_provider_invocation(
         The event name, or None when the segment is not a provider invocation
         naming a path this gate recognises.
     """
+    wrapper_event = _parse_wrapper_invocation(words, context)
+    if wrapper_event is not None:
+        return wrapper_event
     index = 0
     if index >= len(words) or words[index] not in _BUN_BINARIES:
         return None
@@ -539,6 +669,40 @@ def _parse_provider_invocation(
     if path != context.provider_script_path and path not in activated:
         return None
     return _parse_provider_flags(words, index + 1)
+
+
+def _parse_wrapper_invocation(
+    words: list[str], context: ShellGateContext
+) -> str | None:
+    """Return the provider event a packaged wrapper invocation produces.
+
+    Recognises `sh <…>/openbrain-hook-env <console-script>`, the shape every
+    hook in settings.json has used since the #420 cutover (#81). The pair must
+    be one settings actually names, so an arbitrary script cannot be smuggled
+    through by borrowing the wrapper's name.
+
+    Args:
+        words: One pipeline segment's words.
+        context: Provider paths this gate accepts.
+
+    Returns:
+        The provider event, or None when the segment is not a recognised
+        wrapper invocation.
+    """
+    index = 0
+    if index < len(words) and words[index] in _SHELL_BINARIES:
+        index += 1
+    if index + 1 >= len(words):
+        return None
+    wrapper, console = words[index], words[index + 1]
+    if (wrapper, console) not in wrapper_console_invocations(context.settings_path):
+        return None
+    # Trailing words are refused rather than ignored: the console scripts take
+    # their input on stdin, so an extra argument means this is not the command
+    # the gate would have printed, and an allowance must not guess.
+    if len(words) > index + 2:
+        return None
+    return WRAPPER_CONSOLE_EVENTS.get(console)
 
 
 def _parse_provider_flags(words: list[str], start: int) -> str | None:

--- a/python/openbrain-provider/tests/conftest.py
+++ b/python/openbrain-provider/tests/conftest.py
@@ -60,7 +60,37 @@ def _install_development_root() -> None:
         capture_output=True,
         timeout=30,
     )
+    _install_sibling_provider_script(root)
     os.environ["OPENBRAIN_DEVELOPMENT_ROOT"] = str(root)
+
+
+def _install_sibling_provider_script(root: Path) -> None:
+    """Create the sibling provider script the real Development root carries.
+
+    The gate decides whether a recovery command is runnable by ASKING THE
+    FILESYSTEM whether `_ob/scripts/ob-memory-provider.ts` exists. On Rico's Mac
+    it does, so the recorded TypeScript parity fixtures were captured with it
+    present. A stand-in root that is only an empty git repository answers that
+    probe differently, and the gate then appends its "cannot recognise ANY
+    provider invocation form" diagnostic to a block the recording does not carry
+    it on -- the suite passed locally and failed on CI, for the environment
+    rather than for the behaviour.
+
+    A faithful stand-in therefore has to reproduce the file the probe looks for,
+    not just the directory. The contents are never executed by these tests; only
+    `Path.is_file()` is consulted, so a placeholder is enough and pretending
+    otherwise would be the more misleading fixture.
+
+    Args:
+        root: The stand-in Development root to populate.
+    """
+    script = root / "_ob" / "scripts" / "ob-memory-provider.ts"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text(
+        "// Test stand-in. Present so the gate's `is_file()` probe matches the\n"
+        "// real Development root; never executed by the suite.\n",
+        encoding="utf-8",
+    )
 
 
 _install_development_root()

--- a/python/openbrain-provider/tests/test_gate_allowance.py
+++ b/python/openbrain-provider/tests/test_gate_allowance.py
@@ -482,3 +482,227 @@ def test_another_tools_memory_command_is_not_this_gates_evidence(
 
     assert run_gate(paths, "pre-tool-use", _bash(command)).blocked
     assert read_session_state(paths)["readbackRequired"] is True
+
+
+def _wrapper_settings(root: Path, create_wrapper: bool = True) -> tuple[str, Path]:
+    """Write a settings file wiring hooks through the packaged wrapper.
+
+    This is the shape `~/.claude/settings.json` has actually used since the #420
+    cutover: no `bun` script anywhere, every hook a console script run through
+    `openbrain-hook-env`.
+
+    Args:
+        root: Scratch directory.
+        create_wrapper: Whether the wrapper file exists on disk.
+
+    Returns:
+        ``(wrapper_path, settings_path)``.
+    """
+    env_dir = root / "openbrain-memory" / "env"
+    wrapper = env_dir / "openbrain-hook-env"
+    if create_wrapper:
+        env_dir.mkdir(parents=True, exist_ok=True)
+        wrapper.write_text("#!/bin/sh\n", encoding="utf8")
+    settings = root / "wrapper-settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        f"sh {wrapper} openbrain-session-start"
+                                    ),
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf8",
+    )
+    return str(wrapper), settings
+
+
+def _with_settings(paths: GatePaths, settings: Path) -> GatePaths:
+    """Return the same scratch paths with a different settings file."""
+    return GatePaths(
+        root=paths.root,
+        state=paths.state,
+        receipts=paths.receipts,
+        settings=settings,
+        policy_state=paths.policy_state,
+        spool=paths.spool,
+    )
+
+
+def _any_recovery_command(output: str) -> str:
+    """Extract the recovery command whatever invocation form it names.
+
+    Deliberately NOT reusing `_recovery_command`: that helper requires the line
+    to contain `ob-memory-provider.ts`, which is exactly the assumption #81 is
+    about. A checker that can only see one spelling cannot prove the banner and
+    the allowance agree in the other.
+    """
+    banner = output
+    parsed = json.loads(output)
+    if isinstance(parsed.get("reason"), str):
+        banner = parsed["reason"]
+    else:
+        hook_output = parsed.get("hookSpecificOutput")
+        if isinstance(hook_output, dict):
+            banner = hook_output.get("additionalContext", output)
+    for line in banner.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("printf '%s' "):
+            return stripped
+    raise AssertionError(f"no executable recovery command in:\n{output}")
+
+
+def test_the_wrapper_invocation_form_is_admitted(tmp_path: Path) -> None:
+    # #81: every hook in settings.json runs `sh <…>/openbrain-hook-env
+    # openbrain-session-start`. The allowance recognised only the older
+    # `bun <…>.ts` spelling, so a post-compact session was refused for running
+    # the packaged recovery command -- the form that actually works.
+    paths = gate_paths(tmp_path)
+    wrapper, settings = _wrapper_settings(tmp_path)
+    paths = _with_settings(paths, settings)
+    correlation = start_compact_cycle(paths.receipts)
+    run_gate(paths, "post-compact")
+
+    payload = json.dumps(
+        {
+            "cwd": DEVELOPMENT_CWD,
+            "session_id": SESSION,
+            "source": "compact",
+            "correlation_id": correlation,
+        },
+        separators=(",", ":"),
+    )
+    command = (
+        f"printf '%s' {shell_quote(payload)} | "
+        f"sh {shell_quote(wrapper)} openbrain-session-start"
+    )
+
+    allowed = run_gate(paths, "pre-tool-use", _bash(command))
+    assert allowed.code == 0
+    assert allowed.stdout == ""
+
+
+def test_an_unwired_wrapper_console_script_is_refused(tmp_path: Path) -> None:
+    # The wrapper allowance is bounded by what settings NAMES. Borrowing the
+    # wrapper's path to run some other console script must not pass, or the
+    # allowance becomes "any argument to a trusted binary".
+    paths = gate_paths(tmp_path)
+    wrapper, settings = _wrapper_settings(tmp_path)
+    paths = _with_settings(paths, settings)
+    correlation = start_compact_cycle(paths.receipts)
+    run_gate(paths, "post-compact")
+
+    payload = json.dumps(
+        {
+            "cwd": DEVELOPMENT_CWD,
+            "session_id": SESSION,
+            "source": "compact",
+            "correlation_id": correlation,
+        },
+        separators=(",", ":"),
+    )
+    command = (
+        f"printf '%s' {shell_quote(payload)} | "
+        f"sh {shell_quote(wrapper)} openbrain-capture-stop"
+    )
+
+    assert run_gate(paths, "pre-tool-use", _bash(command)).blocked
+
+
+def test_the_banner_command_is_admitted_under_the_wrapper_only_install(
+    tmp_path: Path,
+) -> None:
+    # THE invariant, and the one worth more than the point fix: whatever
+    # invocation form is installed, the command the gate PRINTS is a command the
+    # gate ACCEPTS. Asserted here against a wrapper-only install -- no `bun`
+    # provider script exists -- which is the live configuration in #81.
+    paths = gate_paths(tmp_path)
+    _wrapper, settings = _wrapper_settings(tmp_path)
+    paths = _with_settings(paths, settings)
+    start_compact_cycle(paths.receipts)
+    run_gate(paths, "post-compact")
+
+    absent = str(tmp_path / "no-such-provider.ts")
+    prompted = run_gate(
+        paths, "user-prompt-submit", extra=["--provider-script-path", absent]
+    )
+    command = _any_recovery_command(prompted.stdout)
+
+    # Half one: admitted. On its own this is satisfiable by a command that
+    # cannot run -- the unfixed gate admitted a `bun` invocation naming a file
+    # that does not exist, so this assertion passed while the operator was still
+    # deadlocked. Asserted anyway, because it is the property that regresses.
+    admitted = run_gate(
+        paths,
+        "pre-tool-use",
+        _bash(command),
+        extra=["--provider-script-path", absent],
+    )
+    assert admitted.stdout == "", (
+        "the gate refused the command it just printed:\n"
+        f"  printed: {command}\n  verdict: {admitted.stdout}"
+    )
+
+    # Half two, and the half that makes the invariant real: the executable the
+    # printed command names must EXIST. "Admitted" and "runnable" are different
+    # claims, and #81 is what happens when only the first is checked.
+    executable = re.search(r"\|\s*(?:sh|bun)\s+'([^']+)'", command)
+    assert executable is not None, f"no executable in printed command: {command}"
+    assert Path(executable.group(1)).is_file(), (
+        "the printed recovery command names an executable that does not exist, "
+        "so running it cannot clear the block:\n"
+        f"  printed: {command}\n  missing: {executable.group(1)}"
+    )
+
+
+def test_an_unrecognised_install_says_so_instead_of_failing_silently(
+    tmp_path: Path,
+) -> None:
+    # #81 property 2. With no provider script, no adapter generation, and no
+    # wrapper, the allowance resolves EMPTY -- which used to be indistinguishable
+    # from a correctly-narrow one. The block must name what it did not recognise.
+    paths = gate_paths(tmp_path)
+    run_gate(paths, "session-start", {"source": "compact"})
+
+    absent = str(tmp_path / "no-such-provider.ts")
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        _bash("touch " + str(tmp_path / "x")),
+        extra=["--provider-script-path", absent],
+    )
+
+    assert blocked.blocked
+    assert "cannot recognise ANY provider invocation form" in blocked.stdout
+    assert absent in blocked.stdout
+
+
+def test_a_recognised_install_emits_no_diagnostic(tmp_path: Path) -> None:
+    # The other half: a correctly-configured gate must stay quiet. A diagnostic
+    # that fires on every block is noise, and noise is how a real one gets
+    # ignored.
+    paths = gate_paths(tmp_path)
+    _wrapper, settings = _wrapper_settings(tmp_path)
+    paths = _with_settings(paths, settings)
+    run_gate(paths, "session-start", {"source": "compact"})
+
+    blocked = run_gate(
+        paths,
+        "pre-tool-use",
+        _bash("touch " + str(tmp_path / "x")),
+        extra=["--provider-script-path", str(tmp_path / "no-such-provider.ts")],
+    )
+
+    assert blocked.blocked
+    assert "cannot recognise ANY provider invocation form" not in blocked.stdout


### PR DESCRIPTION
Closes #81.

## The defect

After a compaction every Bash/Edit call is refused with the post-compact read-back banner — **including the exact unblock command the banner itself prints.** Re-running never escapes. Observed live 2026-08-03; the session had to be freed by hand-editing the state file.

## The ticket's stated mechanism was wrong

The ticket said the allowlist "resolves EMPTY, so nothing is permitted." That is **false**, and correcting it changed the fix. An empty `activated` list falls back to `provider_script_path`, so read-only commands and the `bun` banner command *were* admitted. Confirmed both halves: `activated_provider_script_paths` returns `[]` against live settings, and the block still admitted things.

The real defect is narrower and worse: **the gate admitted a command that cannot run, and blocked the one that works.**

| command | gate | result |
|---|---|---|
| `bun .../ob-memory-provider.ts` | **ALLOWED** | "gate unavailable", rc 0, no receipt, `readbackRequired` stays `true` |
| `sh .../openbrain-hook-env openbrain-session-start` | **BLOCKED** | returns a real `CANON PACK` recall |

The one that clears the block was refused; the one that was permitted could never clear it.

## Which repo owns the running code

Traced, not assumed: `~/.claude/settings.json` runs `sh .../openbrain-hook-env openbrain-context-budget-gate`; that symlinks into `~/.local/share/uv/tools/openbrain-provider/bin/`, whose shebang is the uv tool's Python; and `diff` shows the installed `gate_shell.py` / `gate_presentation.py` are byte-identical to `origin/main` source. **No TypeScript file was touched** — a TS-side fix for this was already committed (`2f898a7`) and reverted (`73f29e7`) once for patching dead code.

## The fix

1. **Recognise the wrapper form.** `wrapper_console_invocations()` derives the allowance from what settings *actually wires up*, rather than adding a second hardcoded literal that would drift out of sync — the sibling-path-drift shape behind rodaddy/development#95. The `(wrapper, console_script)` pair must be named in settings and exist on disk, so an arbitrary script cannot be smuggled through by borrowing the wrapper's name, and trailing arguments are refused rather than ignored.
2. **Fail loudly instead of closed-and-silent.** `unrecognised_hook_invocation_diagnostic()` names what was not recognised and what to do. An allowance that resolves to nothing previously looked identical to one that is correctly empty — the same silent-failure family as rodaddy/development#98 and #99.
3. **The banner invariant.** A test asserts the command the gate PRINTS is a command the gate ACCEPTS, under a wrapper-only install. This is worth more than the point fix because it prevents instance #3.

## Verification

- **612 passed / 1 skipped** (from 596/1). mypy clean (19 files), ruff check + format clean (40 files).
- **Non-vacuity proven**: with the three source files reverted to `origin/main`, **3 of the 5 new tests fail** — wrapper-admitted, banner-invariant, and loud-diagnostic. The other 2 are negative controls that correctly pass either way.
- **One test was vacuous and was fixed before this PR.** `test_the_banner_command_is_admitted_under_the_wrapper_only_install` initially passed against unfixed code, because the unfixed gate admits a `bun` command naming a nonexistent file — so "printed == admitted" was satisfiable by an unrunnable command. It now also asserts the executable exists on disk. *Admitted* and *runnable* are different claims, and #81 is what happens when only the first is checked.
- Python suite only. No full-directory `bun test` run, per the rodaddy/development#99 warning that such a run dies without a summary and exits 0.

## MERGED IS NOT RUNNING

The installed tool is unchanged and still carries the defect. After merge it needs:

```
uv tool install --force --reinstall "git+https://github.com/rodaddy/open-brain@main#subdirectory=python/openbrain-provider"
```

Nothing here is live on the Mac until that runs.

## Critical Self-Review

- Highest-risk behavior: widening a security-relevant allowance. Mitigated by deriving the allowance from settings rather than hardcoding it — the `(wrapper, console_script)` pair must be named in settings AND exist on disk, the console script must be in a known map, and trailing arguments are refused. The unwired-script test proves the negative.
- Assumptions that could be wrong: that `openbrain-post-compact` credits a `session-start` event. It is in the console-script map by name; I did not exercise that hook end to end.
- Missing/weak tests: no test drives a real compaction — all state is synthesized. The console-script map is not asserted against the installed entry points, so a renamed entry point would not fail this suite.
- Security/permission risk: the wrapper path must exist on disk and be named by settings, so a non-existent or unwired wrapper cannot pass. Borrowing the wrapper's name with a different console script is refused.
- Migration/deploy risk: none to data or schema. The deploy risk is that merging changes nothing until the uv tool is reinstalled — a merged-but-not-running gap that already caused confusion on #77.
- Downstream client/runtime risk: every Claude session on this fleet runs this gate on six hook events. A regression here blocks tool calls fleet-wide. Bounded by the 612-test suite and by the fact that the change only ADDS a recognised form; the existing `bun` path is untouched.
- Rollback/cleanup concern: revert the commit and reinstall the tool; behavior returns exactly to the `bun`-only allowance. No state migration, no cleanup.
- Fixes made before PR: one of the new tests was found vacuous during self-review and tightened to assert the printed executable exists (see Verification above).
- Known residual risk: the TypeScript `bun` provider fails with **empty stderr** even with the full environment loaded. `resolvePackageRuntime()` resolves fine, so the fault is downstream in the recall call. Undiagnosed. This PR routes around it rather than fixing it; it likely deserves its own issue in the same silent-failure class as rodaddy/development#98 and #99.
- SME review-memory update: [ ] `docs/sme/` updated  [x] not applicable because: this is a defect fix in an existing gate, and no SME domain doc covers hook-invocation-form recognition.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [ ] linked below  [x] not applicable because: this change is to the provider gate itself and was verified against a synthesized state directory rather than live brain state, to avoid mutating `~/.local/state/agent-runtime/`.

## Also investigated, not fixed

The ticket's note that state showed `participants: []` with `attemptedParticipants: ["gate"]` is **real but bounded**. `receipt_state.gate_compact_cycle` writes that shape by design when the gate opens a cycle itself, and `READBACK_TIMEOUT_SECONDS = 15 * 60.0` self-releases — `self-released-after-timeout` was observed firing. So it is up to 15 minutes of degraded UX, not a permanent deadlock. Out of scope here; worth its own issue if that wait is unacceptable.
