### PR TITLE
fix(observability): mask Langfuse trace payloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,8 @@ OPENBRAIN_RAW_TURN_TTL_SECONDS=604800
 
 # Server call tracing to Langfuse (#530) -- CONTENT-FUL, off by default.
 # Every MCP tool call becomes one trace carrying full arguments and full
-# results. Requires ALL FOUR: the flag set to exactly "1" plus the three
+# results, with detector matches replaced before egress. Requires ALL FOUR:
+# the flag set to exactly "1" plus the three
 # coordinates, or the lane stays off and logs one content-free warn naming the
 # missing one. Keys come from the operator environment (Vaultwarden item
 # "Langfuse - Open Brain Local Dogfood") -- NEVER put values here.
@@ -68,6 +69,8 @@ OPENBRAIN_RAW_TURN_TTL_SECONDS=604800
 # drop count on the way back, never one per call.
 # See docs/CONFIG_REFERENCE.md "Server call tracing (#530)".
 OPENBRAIN_TRACING_ENABLED=0
+# Default is on. Set exactly "0" only for an explicit operator-approved bypass.
+OPENBRAIN_TRACING_MASKING_ENABLED=1
 OPENBRAIN_TRACING_ENDPOINT=
 OPENBRAIN_TRACING_PUBLIC_KEY=
 OPENBRAIN_TRACING_SECRET_KEY=

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -286,14 +286,18 @@ tool name, caller identity, full arguments, full result (or error class and
 message), duration, and session grouping.
 
 **CONTENT-FUL is the point, and it is deliberate.** #530 explicitly supersedes
-#372's content-free spec for the local dogfood deployment. Payloads are sent
-verbatim: no redaction, no summarisation, no size bucketing. `OPENBRAIN_MCP_AUDIT_*`
-(above) remains the separate content-FREE durable Postgres record and is
-unchanged — the two lanes coexist and neither replaces the other.
+#372's content-free spec for the local dogfood deployment. #561 adds the required
+emitter-boundary protection before coverage widens: every string value passes
+`src/secret-patterns.ts` detectors, and each matched span becomes
+`[MASKED:<detector>]`. Surrounding content, object fields, and array items remain
+present. `OPENBRAIN_MCP_AUDIT_*` (above) remains the separate content-FREE durable
+Postgres record and is unchanged — the two lanes coexist and neither replaces
+the other.
 
 | variable | default | notes |
 |---|---|---|
 | `OPENBRAIN_TRACING_ENABLED` | unset (off) | tracing runs only when this is exactly `"1"` |
+| `OPENBRAIN_TRACING_MASKING_ENABLED` | unset (on) | detector-based masking is disabled only when this is exactly `"0"`; explicit operator bypass only |
 | `OPENBRAIN_TRACING_ENDPOINT` | — | Langfuse base URL (the SDK appends its own paths) |
 | `OPENBRAIN_TRACING_PUBLIC_KEY` | — | Langfuse `pk-lf-...` |
 | `OPENBRAIN_TRACING_SECRET_KEY` | — | Langfuse `sk-lf-...` |

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -1042,3 +1042,51 @@ When a strict scope/tenant proof gates dispatch, any replay or drain loop must d
 Verbatim, from the source:
 
 > A unit parked under project A ... therefore fails dispatch with `session_start result did not prove exact Open Brain scope` when the drain is triggered by a healthy operation in project B ... Units can sit undelivered indefinitely if the client rarely operates in that project again. Every drain attempt re-dispatches mismatched units, issuing a wasted live `session_start` per unit per healthy operation, plus a swallowed warning.
+
+## [2026-08-05] Content-ful observability needs masking at the final emitter boundary
+
+**Severity:** HIGH
+**Source:** issue #561, operator ruling after the Langfuse egress census
+**Scope key:** `sme.security.contentful_observability_masks_at_emitter`
+**Status:** active
+
+### Pattern
+
+A content-ful observability lane can preserve complete arguments, results, and
+surrounding context while still preventing credential-shaped spans from leaving
+the process. Apply the shared labeled detectors at the final emitter boundary,
+not at individual callers and not after transport. Replace each matched span
+with a stable classifier marker such as `[MASKED:github_token]`; retain every
+field, array item, and unmatched substring. Keep masking on by default, with any
+bypass requiring an explicit operator configuration value.
+
+Issue #561 measured the failure mode directly: PR #534 intentionally attached
+full tool inputs and outputs to Langfuse, while the live corpus had not exercised
+the highest-risk credential-return path. The fix belongs in
+`buildToolTraceBody()` so future tracing surfaces inherit the same protection
+without maintaining caller-specific detector forks.
+
+PR #593's opposite-family review proved three additional bypass shapes at this
+same boundary. Value-shaped detectors do not see opaque values carried under a
+sensitive object key. Replacing an entire labeled JSON pair removes the label
+and can make serialized JSON invalid. Non-plain carriers need normalization:
+Map and Set content otherwise disappears, nested Error messages disappear, and
+binary views expose credential bytes as numeric arrays.
+
+### Review Questions
+
+- Does every string value in tool arguments and results pass the shared
+  `src/secret-patterns.ts` detectors before the sink receives it?
+- Does the recursive walk also apply `isSensitiveKey()` while the field name is
+  available, including nested argument and result objects?
+- Do pair-shaped detector replacements retain the label and leave serialized
+  JSON parseable?
+- Are Map, Set, Error, Buffer, and typed-array carriers converted to observable,
+  maskable shapes without exposing binary bytes?
+- Are only matched spans replaced, with surrounding content and structure still
+  present?
+- Is masking on when its environment variable is absent, and can it be bypassed
+  only through the documented explicit value?
+- Does a regression seed obviously fake detector-shaped text in both tool
+  arguments and tool results and assert the emitted body rather than a private
+  helper?

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -2,8 +2,9 @@
  * Functional tests for the #530 content-ful tracing lane.
  *
  * The contract under test is the one the module states: every tool call emits
- * one trace carrying VERBATIM input and output plus caller identity, and a
- * tracing failure never fails, slows, or ALTERS a tool call. The second half is
+ * one trace retaining complete input and output around masked detector matches,
+ * plus caller identity; a tracing failure never fails, slows, or ALTERS a tool
+ * call. The second half is
  * the one that matters operationally, so the sink that throws on every method
  * is a first-class case here, not an afterthought.
  *
@@ -28,6 +29,7 @@ import {
 
 const ENABLED_CONFIG: McpTracingConfig = {
   enabled: true,
+  maskingEnabled: true,
   endpoint: "http://10.71.20.50:3000",
   publicKey: "pk-lf-test",
   secretKey: "sk-lf-test",
@@ -163,7 +165,20 @@ const AUTH = {
 
 describe("readMcpTracingConfig", () => {
   test("is disabled with no environment at all", () => {
-    expect(readMcpTracingConfig({}).enabled).toBe(false);
+    const config = readMcpTracingConfig({});
+    expect(config.enabled).toBe(false);
+    expect(config.maskingEnabled).toBe(true);
+  });
+
+  test("masking is disabled only by the explicit zero value", () => {
+    expect(
+      readMcpTracingConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "0" })
+        .maskingEnabled,
+    ).toBe(false);
+    expect(
+      readMcpTracingConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "false" })
+        .maskingEnabled,
+    ).toBe(true);
   });
 
   test("is disabled when the coordinates are present but the flag is not set", () => {
@@ -250,6 +265,7 @@ describe("readMcpTracingConfig", () => {
       }),
     ).toEqual({
       enabled: true,
+      maskingEnabled: true,
       endpoint: "http://host:3000",
       publicKey: "pk-lf-1",
       secretKey: "sk-lf-1",
@@ -285,7 +301,7 @@ describe("resolveSessionId", () => {
 });
 
 describe("installMcpTracing", () => {
-  test("records one trace per call with verbatim input, output and caller identity", async () => {
+  test("records one trace per call with complete benign input, output and caller identity", async () => {
     const sink = recordingSink();
     const { server, handlers } = fakeServer();
     installMcpTracing(server, {
@@ -900,6 +916,157 @@ describe("the SDK's own logger cannot bypass the content-free discipline", () =>
 });
 
 describe("trace body helpers", () => {
+  const fakeLabeledSecret = [
+    "pass",
+    "word=obviously-fake-561-fixture-value",
+  ].join("");
+
+  test("masks detector matches in tool arguments and results while retaining every field", () => {
+    const body = buildToolTraceBody({
+      toolName: "fixture_tool",
+      status: "success",
+      durationMs: 7,
+      args: {
+        query: `args-before ${fakeLabeledSecret} args-after`,
+        untouched: "plain argument",
+      },
+      output: {
+        content: [
+          {
+            type: "text",
+            text: `result-before ${fakeLabeledSecret} result-after`,
+          },
+        ],
+        isError: false,
+      },
+    });
+
+    expect(body.input).toEqual({
+      query: "args-before password=[MASKED:labeled_secret] args-after",
+      untouched: "plain argument",
+    });
+    expect(body.output).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "result-before password=[MASKED:labeled_secret] result-after",
+        },
+      ],
+      isError: false,
+    });
+  });
+
+  test("masks opaque values carried by sensitive argument and result keys", () => {
+    const opaqueValue = [
+      "obviously-fake-561-fixture-value-",
+      "aaaaaaaaaaaa",
+    ].join("");
+    const body = buildToolTraceBody({
+      toolName: "fixture_tool",
+      status: "success",
+      durationMs: 1,
+      args: {
+        password: opaqueValue,
+        nested: { api_key: opaqueValue },
+      },
+      output: {
+        password: opaqueValue,
+        nested: { api_key: opaqueValue, totp_secret: opaqueValue },
+      },
+    });
+
+    expect(body.input).toEqual({
+      password: "[MASKED:sensitive_key]",
+      nested: { api_key: "[MASKED:sensitive_key]" },
+    });
+    expect(body.output).toEqual({
+      password: "[MASKED:sensitive_key]",
+      nested: {
+        api_key: "[MASKED:sensitive_key]",
+        totp_secret: "[MASKED:sensitive_key]",
+      },
+    });
+  });
+
+  test("keeps serialized JSON parseable and retains a masked field label", () => {
+    const body = buildToolTraceBody({
+      toolName: "fixture_tool",
+      status: "success",
+      durationMs: 1,
+      args: {},
+      output: {
+        // The value is deliberately an obvious placeholder: key-based masking
+        // triggers on the KEY alone, and a realistic-looking value here is
+        // itself a secret-scanner hit (GitGuardian flagged the previous one).
+        text: JSON.stringify({ a: 1, password: "fake-placeholder-not-a-secret", b: 2 }),
+      },
+    });
+    const text = (body.output as { text: string }).text;
+
+    expect(JSON.parse(text)).toEqual({
+      a: 1,
+      password: "[MASKED:json_labeled_secret]",
+      b: 2,
+    });
+  });
+
+  test("normalizes non-plain carriers before masking their observable content", () => {
+    const opaqueValue = [
+      "obviously-fake-561-fixture-value-",
+      "bbbbbbbbbbbb",
+    ].join("");
+    const bytes = Buffer.from(`password=${opaqueValue}`);
+    const typedBytes = new Uint8Array(bytes);
+    const body = buildToolTraceBody({
+      toolName: "fixture_tool",
+      status: "success",
+      durationMs: 1,
+      args: {
+        map: new Map([
+          ["password", opaqueValue],
+          ["visible", "plain map value"],
+        ]),
+        set: new Set([`password=${opaqueValue}`, "plain set value"]),
+      },
+      output: {
+        error: new Error(`password=${opaqueValue}`),
+        buffer: bytes,
+        typedBytes,
+      },
+    });
+
+    expect(body.input).toEqual({
+      map: {
+        password: "[MASKED:sensitive_key]",
+        visible: "plain map value",
+      },
+      set: ["password=[MASKED:labeled_secret]", "plain set value"],
+    });
+    expect(body.output).toEqual({
+      error: {
+        name: "Error",
+        message: "password=[MASKED:labeled_secret]",
+      },
+      buffer: { type: "Buffer", byteLength: bytes.byteLength },
+      typedBytes: { type: "Uint8Array", byteLength: typedBytes.byteLength },
+    });
+    expect(JSON.stringify(body)).not.toContain(opaqueValue);
+  });
+
+  test("the explicit masking opt-out retains the original trace body", () => {
+    const body = buildToolTraceBody({
+      toolName: "fixture_tool",
+      status: "success",
+      durationMs: 7,
+      args: { query: fakeLabeledSecret },
+      output: { result: fakeLabeledSecret },
+      maskingEnabled: false,
+    });
+
+    expect(body.input).toEqual({ query: fakeLabeledSecret });
+    expect(body.output).toEqual({ result: fakeLabeledSecret });
+  });
+
   // The case the audit lane already records both ids for
   // (`src/audit-log.ts:299-301`): a delegated call whose acting identity is not
   // its token identity. With only `caller_client_id`, the content-ful lane an

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -2,10 +2,10 @@
  * CONTENT-FUL Langfuse tracing for every MCP tool call served by this server.
  *
  * Design authority: issue #530, which explicitly supersedes #372's content-free
- * spec for the local dogfood deployment. The operator's requirement is to see
- * "what agents are literally trying to do, what the calls are, what they're
- * getting back" — so arguments and results travel VERBATIM. There is no
- * redaction here, and adding some would defeat the only reason the lane exists.
+ * spec for the local dogfood deployment, plus #561's masking-before-widening
+ * ruling. The operator still receives every field and its surrounding content,
+ * but credential-shaped spans are replaced at this final emitter boundary before
+ * any payload reaches Langfuse. Masking is replacement, never field removal.
  *
  * THIS IS A SECOND, SEPARATE LANE. `src/audit-log.ts` stays exactly as it is:
  * it is the content-FREE durable audit record (declared key names, unknown-key
@@ -94,8 +94,12 @@ import {
 import { setGlobalErrorHandler } from "@opentelemetry/core";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { AuthInfo } from "../../src/types.ts";
 import { logger } from "../../src/logger.ts";
+import {
+  isSensitiveKey,
+  SECRET_DETECTORS,
+} from "../../src/secret-patterns.ts";
+import type { AuthInfo } from "../../src/types.ts";
 
 /** Tags on every trace this lane writes, so server traffic is filterable. */
 const TRACE_TAGS = ["open-brain-server", "mcp-tool"] as const;
@@ -202,6 +206,7 @@ export function repoRelease(): string | undefined {
 
 export interface McpTracingConfig {
   enabled: boolean;
+  maskingEnabled: boolean;
   endpoint: string;
   publicKey: string;
   secretKey: string;
@@ -318,6 +323,7 @@ export function readMcpTracingConfig(
   const publicKey = env.OPENBRAIN_TRACING_PUBLIC_KEY?.trim() ?? "";
   const secretKey = env.OPENBRAIN_TRACING_SECRET_KEY?.trim() ?? "";
   const flagged = env.OPENBRAIN_TRACING_ENABLED === "1";
+  const maskingEnabled = env.OPENBRAIN_TRACING_MASKING_ENABLED !== "0";
   const complete =
     endpoint.length > 0 && publicKey.length > 0 && secretKey.length > 0;
   if (flagged && !complete) {
@@ -334,7 +340,13 @@ export function readMcpTracingConfig(
       privateIdSet: secretKey.length > 0,
     });
   }
-  return { enabled: flagged && complete, endpoint, publicKey, secretKey };
+  return {
+    enabled: flagged && complete,
+    maskingEnabled,
+    endpoint,
+    publicKey,
+    secretKey,
+  };
 }
 
 /**
@@ -368,8 +380,78 @@ function readStringField(value: unknown, key: string): string | undefined {
   return field;
 }
 
+function maskDetectorMatch(kind: string, match: string): string {
+  const replacement = `[MASKED:${kind}]`;
+  if (kind === "json_labeled_secret") {
+    return match.replace(/"[^"]+"$/, `"${replacement}"`);
+  }
+  if (kind === "labeled_secret") {
+    return match.replace(/([:=]\s*)[^\s,;]+$/, `$1${replacement}`);
+  }
+  return replacement;
+}
+
+/** Replace every detector match while retaining the rest of the string. */
+function maskTraceString(value: string): string {
+  let masked = value;
+  for (const detector of SECRET_DETECTORS) {
+    const flags = detector.pattern.flags.includes("g")
+      ? detector.pattern.flags
+      : `${detector.pattern.flags}g`;
+    masked = masked.replace(
+      new RegExp(detector.pattern.source, flags),
+      (match) => maskDetectorMatch(detector.kind, match),
+    );
+  }
+  return masked;
+}
+
+function binaryViewMarker(value: ArrayBufferView): {
+  type: string;
+  byteLength: number;
+} {
+  return {
+    type: value.constructor.name || "ArrayBufferView",
+    byteLength: value.byteLength,
+  };
+}
+
+/** Recursively normalize and mask values without removing fields or array items. */
+function maskTraceValue(value: unknown): unknown {
+  if (typeof value === "string") return maskTraceString(value);
+  if (Array.isArray(value)) {
+    const masked = value.map(maskTraceValue);
+    return masked.some((child, index) => child !== value[index]) ? masked : value;
+  }
+  if (!value || typeof value !== "object") return value;
+  if (ArrayBuffer.isView(value)) return binaryViewMarker(value);
+  if (value instanceof Map) {
+    return maskTraceValue(
+      Object.fromEntries(
+        Array.from(value, ([key, child]) => [String(key), child]),
+      ),
+    );
+  }
+  if (value instanceof Set) return maskTraceValue(Array.from(value));
+  if (value instanceof Error) {
+    return maskTraceValue({ name: value.name, message: value.message });
+  }
+
+  let masked: Record<string, unknown> | undefined;
+  for (const [key, child] of Object.entries(value)) {
+    const maskedChild =
+      isSensitiveKey(key) && child !== null && child !== undefined
+        ? "[MASKED:sensitive_key]"
+        : maskTraceValue(child);
+    if (maskedChild === child) continue;
+    masked ??= { ...(value as Record<string, unknown>) };
+    masked[key] = maskedChild;
+  }
+  return masked ?? value;
+}
+
 /**
- * The trace body for one tool call, content-ful by design (see file header).
+ * The trace body for one tool call, content-ful and masked by default.
  *
  * Exported so the shape is assertable without an SDK, a server, or a socket.
  */
@@ -381,11 +463,13 @@ export function buildToolTraceBody(input: {
   output: unknown;
   auth?: AuthInfo;
   sessionId?: string;
+  maskingEnabled?: boolean;
 }): TraceBody {
-  return {
+  const maskingEnabled = input.maskingEnabled !== false;
+  const body: TraceBody = {
     name: input.toolName,
-    input: input.args,
-    output: input.output,
+    input: maskingEnabled ? maskTraceValue(input.args) : input.args,
+    output: maskingEnabled ? maskTraceValue(input.output) : input.output,
     tags: [...TRACE_TAGS],
     metadata: {
       caller_role: input.auth?.role ?? null,
@@ -409,6 +493,7 @@ export function buildToolTraceBody(input: {
       ? {}
       : { userId: input.auth.clientId }),
   };
+  return body;
 }
 
 /**
@@ -656,6 +741,7 @@ export function installMcpTracing(
           toolName: name,
           status: isToolError(result) ? "error" : "success",
           durationMs: Date.now() - started,
+          maskingEnabled: config.maskingEnabled,
           args,
           output: result,
           ...authAndSession(args, extra),
@@ -666,6 +752,7 @@ export function installMcpTracing(
           toolName: name,
           status: "exception",
           durationMs: Date.now() - started,
+          maskingEnabled: config.maskingEnabled,
           args,
           output: errorOutput(err),
           ...authAndSession(args, extra),


### PR DESCRIPTION
## Summary

- Apply masking at the Langfuse emitter boundary in `server/observability/langfuse-tracing.ts:419`, using the shared labeled detectors from `src/secret-patterns.ts:80`.
- Replace only matched string spans with `[MASKED:<detector>]`; retain surrounding text, object fields, array items, and complete tool input/output structure.
- Add default-on `OPENBRAIN_TRACING_MASKING_ENABLED`; only the explicit value `"0"` bypasses masking.
- Document the configuration and capture the reusable security pattern in `docs/sme/security.md`.

Fixes #561

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bun test server/observability/langfuse-tracing.test.ts` (46 pass, 0 fail) and `bunx tsc --noEmit` (exit 0); no migration changed.
- [x] Python package checks passed or are not applicable — not applicable; no Python package files or behavior changed.
- [x] Live Open Brain smoke passed or is not applicable — not applicable before merge/deploy; the changed boundary is directly exercised through the exported trace-body builder and injected sink tests.
- Deliberate-break proof: changed masking default logic so non-zero text disabled it; `readMcpTracingConfig > masking is disabled only by the explicit zero value` failed (`Expected: true`, `Received: false`). Restored and green.
- Deliberate-break proof: bypassed `maskTraceValue`; `trace body helpers > masks detector matches in tool arguments and results while retaining every field` failed because the seeded labeled fixture reached the builder output. Restored and green.
- Deliberate-break proof: inverted the explicit bypass branch; `trace body helpers > the explicit masking opt-out retains the original trace body` failed because the fixture was masked. Restored and green.

## Critical Self-Review

- Highest-risk behavior: A recursive transform at the egress boundary could accidentally remove structure or alter benign payload identity; the implementation uses replacement-only traversal and returns unchanged branches by identity when no detector fires.
- Assumptions that could be wrong: MCP tool arguments and results reaching this builder are JSON-compatible arrays, objects, primitives, and strings with outbound content represented by enumerable string-keyed fields.
- Missing/weak tests: No live Langfuse deployment smoke is included on this unmerged branch; focused tests prove builder output, explicit configuration behavior, and unchanged tool-call behavior through the injected sink seam.
- Security/permission risk: The explicit `OPENBRAIN_TRACING_MASKING_ENABLED=0` operator bypass permits detector matches to leave unmasked; default and every other value keep masking enabled.
- Migration/deploy risk: No database migration exists; the environment is read at process start, so changing the masking setting requires the same service restart as the existing tracing variables.
- Downstream client/runtime risk: Not applicable to MCP schemas, transport, Python exports, generated skills, mcp2cli, or Hermes call shapes; this changes only the server-owned observability copy.
- Rollback/cleanup concern: Revert the commit to restore prior behavior; no persisted local artifact, schema change, or cleanup job is introduced.
- Fixes made before PR: Preserved benign input/output identity after self-review found that an eager deep copy would break the existing same-object trace assertion even when no detector matched.
- Known residual risk: Pattern-based detectors cannot identify an arbitrary unlabelled secret with no recognizable shape; the emitter now consistently applies the repo's shared detector set rather than creating a separate heuristic.
- SME review-memory update: [x] docs/sme/ updated — security.md masking pattern

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this branch changes the pre-enqueue builder and is not deployed; local boundary tests are the applicable pre-PR evidence.
- Review tier: Full — secret-handling behavior at an outbound observability boundary.
- Independent review status: pending at the PR boundary; this run was explicitly required to use one process with no nested workers.

## Contract Parity

- Contract parity: [x] runtime-specific because: no MCP tool schema, contract manifest, fixture contract, or client call shape changes.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`.
- [x] rtech-mcps handoff is not applicable — no registry, schema, or service definition changes.
- [x] mcp2cli cache/skill refresh is not applicable — no consumer-visible tool contract changes.
- [x] rtech-hermes Python runtime/plugin changes are not applicable — no client or plugin behavior changes.
- [x] Hermes live rollout/canaries are not applicable — the server observability copy is not agent-facing behavior.

Notes/evidence:

- Existing design: #530 keeps complete tool-call content; #561 and the 2026-08-05 #569 ruling require masking before tracing coverage widens.
- Owning boundary: `buildToolTraceBody()` immediately before `sink.emit()` (`server/observability/langfuse-tracing.ts:419`, `server/observability/langfuse-tracing.ts:820`).
