### PR TITLE
fix(canon): verify reconcile apply provenance and namespace

### DIFF
--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1144,3 +1144,37 @@ Claude Code's SessionStart additionalContext has an observed practical inline bo
 Verbatim, from the source:
 
 > `openbrain-session-start` dumped the raw `agent_context_pack` JSON envelope (~30 KB of nested items, ids, citations, confidences, warnings) into `additionalContext`, and Claude Code persisted a payload that large to a file it surfaced as only a ~2 KB preview -- the session saw 2-3 of 31 items
+
+## [2026-08-05] Apply receipts must prove both source identity and destination scope
+
+**Severity:** HIGH
+**Source:** issue #588, first live canon reconcile apply after PR #538
+**Scope key:** `canon.apply_receipt_proves_source_and_namespace`
+**Status:** active
+
+### Pattern
+
+Two false assumptions can make an apply path report success while producing no
+usable state. First, a human provenance field is not a machine source pointer:
+repo-fact `source` prose was copied into `metadata.path`, while the server
+requires that path to equal the GitHub URL's repo-relative path exactly. The
+owning entrypoint must carry the pack artifact path separately and preserve the
+human citation in a prose provenance field.
+
+Second, a client's requested identity is not evidence of the namespace the
+server authorized. An admin-token fan-out reported 27 applied writes for
+`skippy`, but the write receipts identified token authority and the rows landed
+under `admin`. An apply command must inspect the returned receipt for the actual
+namespace authority. If the receipt has no usable namespace signal, perform one
+scoped read-back and verify the expected keys and texts before printing success.
+
+### Review Questions
+
+- Does any field serve as both human citation prose and a machine-exact path,
+  identifier, or URL component? Split those meanings at the owning boundary.
+- Does a write receipt prove where the row landed, or only that the request
+  returned without an error?
+- When client configuration requests another identity, does the server honor it
+  under this token role, and does the receipt expose which authority won?
+- If a receipt cannot identify the destination, does the apply path read back
+  the exact expected keys and values before claiming success?

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1165,8 +1165,16 @@ Second, a client's requested identity is not evidence of the namespace the
 server authorized. An admin-token fan-out reported 27 applied writes for
 `skippy`, but the write receipts identified token authority and the rows landed
 under `admin`. An apply command must inspect the returned receipt for the actual
-namespace authority. If the receipt has no usable namespace signal, perform one
-scoped read-back and verify the expected keys and texts before printing success.
+namespace authority. PR #594's opposite-family review found that the server's
+`writer_identity` is that authority on both token and delegated-header paths;
+`delegated_agent_id` is an independent agent label and cannot prove destination.
+If the receipt has no usable namespace signal, perform one scoped read-back and
+verify the expected keys and texts before printing success. That read-back must
+request every planned lane and carry the exact repo binding for repo facts, or a
+configuration gap can be mislabeled as a namespace incident.
+
+A duplicate receipt is also not a new write. Count it as already present and
+report it separately, so a retry cannot turn prior state into an applied count.
 
 ### Review Questions
 
@@ -1176,5 +1184,10 @@ scoped read-back and verify the expected keys and texts before printing success.
   returned without an error?
 - When client configuration requests another identity, does the server honor it
   under this token role, and does the receipt expose which authority won?
+- Is namespace validation based on the server's persisted writer identity rather
+  than an independent agent label or the caller's requested identity?
+- Are duplicate receipts reported as already present instead of newly applied?
 - If a receipt cannot identify the destination, does the apply path read back
   the exact expected keys and values before claiming success?
+- Can that read-back observe every planned lane under the exact repo binding, or
+  will a configuration gap be reported as a namespace mismatch?

--- a/python/openbrain/src/openbrain/apps/canon/run.py
+++ b/python/openbrain/src/openbrain/apps/canon/run.py
@@ -53,24 +53,26 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from openbrain.apps.canon.pack import Pack
+from openbrain.apps.canon.pack import Lane, Pack
 from openbrain.apps.canon.reconcile import (
     DriftReport,
     diff_pack,
     format_report,
+    live_items,
+    live_key_of,
+    live_text_of,
 )
 from openbrain.apps.canon.writes import FactProvenance, PlannedWrite, plan_promote
 from openbrain.apps.hooks.session import SessionStartHook, run_session_start
 from openbrain.config import load_canon_settings
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from openbrain.config import CanonSettings
 
 #: The ``source`` on the synthesised SessionStart payload. ``startup`` is the
@@ -141,23 +143,44 @@ def read_live_pack(settings: CanonSettings) -> Any:
     return asyncio.run(run_session_start(payload, settings))
 
 
+def _repo_relative_pack_path(pack_path: Path) -> str | None:
+    """Return the pack's path below its nearest git root.
+
+    The pack file is the reviewed artifact the repo fact cites. A worktree's
+    ``.git`` marker is a file rather than a directory, so ``exists`` deliberately
+    accepts either shape. No marker means the path cannot be proven repo-relative
+    and repo-fact planning must stop before a write is sent.
+    """
+    resolved = pack_path.resolve()
+    for parent in resolved.parents:
+        if (parent / ".git").exists():
+            return resolved.relative_to(parent).as_posix()
+    return None
+
+
 def provenance_from(
     args: argparse.Namespace, settings: CanonSettings
 ) -> FactProvenance | None:
-    """Assemble the repo-fact provenance, or ``None`` when it was not supplied.
+    """Assemble the repo-fact provenance, or ``None`` when it is incomplete.
 
     Args:
-        args: The parsed command line, carrying the commit, URL, and instant.
+        args: The parsed command line, carrying the pack path, commit, URL, and
+            verification instant.
         settings: The canon configuration, carrying the repo the facts bind to.
 
     Returns:
         The provenance, or ``None`` when any part is absent. All-or-nothing:
         ``repoFactMetadata`` refuses a write whose ``source_url`` does not
-        contain both the commit and the path, so a half-filled provenance is
-        never closer to valid than none at all -- it just fails later, at the
-        server.
+        contain both the commit and the pack's exact repo-relative path, so a
+        half-filled provenance is never closer to valid than none at all.
     """
-    if not (args.repo_source_commit and args.repo_source_url and args.repo_verified_at):
+    source_path = _repo_relative_pack_path(args.pack)
+    if not (
+        source_path
+        and args.repo_source_commit
+        and args.repo_source_url
+        and args.repo_verified_at
+    ):
         return None
     if settings.repo is None:
         # Same all-or-nothing rule: a fact cannot bind without a repo, and the
@@ -165,6 +188,7 @@ def provenance_from(
         return None
     return FactProvenance(
         repo=settings.repo,
+        source_path=source_path,
         source_commit=args.repo_source_commit,
         source_url=args.repo_source_url,
         verified_at=args.repo_verified_at,
@@ -218,18 +242,101 @@ def _describe(planned: Sequence[PlannedWrite]) -> str:
     return "\n".join(lines)
 
 
+class NamespaceMismatchError(RuntimeError):
+    """A canon write or verification read resolved outside the intended agent."""
+
+
+def _receipt_namespace(receipt: Any) -> str | None:
+    """Resolve the namespace named directly or through writer provenance."""
+    if not isinstance(receipt, Mapping):
+        return None
+    namespace = receipt.get("namespace")
+    if isinstance(namespace, str) and namespace:
+        return namespace
+    namespace_source = receipt.get("namespace_source")
+    if not isinstance(namespace_source, str):
+        return None
+    identity_field = {
+        "token": "token_identity",
+        "header": "delegated_agent_id",
+    }.get(namespace_source)
+    if identity_field is None:
+        return None
+    identity = receipt.get(identity_field)
+    return identity if isinstance(identity, str) and identity else None
+
+
+def _pack_readback_scope(settings: CanonSettings) -> dict[str, Any]:
+    """Build the same scoped read arguments the SessionStart canon path uses."""
+    scope: dict[str, Any] = {
+        "agent": settings.agent,
+        "platform": settings.platform,
+        "server_id": settings.server_id,
+        "channel_id": settings.channel_id,
+        "session_key": settings.session_key,
+        "requested_sections": list(settings.sections),
+    }
+    if settings.repo is not None:
+        scope["repo"] = settings.repo
+    return scope
+
+
+def _verify_readback(
+    planned: Sequence[PlannedWrite], payload: Any, intended_namespace: str
+) -> None:
+    """Prove unknown-receipt writes are visible under the intended namespace."""
+    if not isinstance(payload, Mapping):
+        message = "canon write read-back returned no scoped pack"
+        raise NamespaceMismatchError(message)
+    scope = payload.get("scope")
+    actual_namespace = scope.get("namespace") if isinstance(scope, Mapping) else None
+    if isinstance(actual_namespace, str) and actual_namespace != intended_namespace:
+        message = (
+            f"canon writes intended for {intended_namespace} read back from "
+            f"{actual_namespace}"
+        )
+        raise NamespaceMismatchError(message)
+
+    missing: list[str] = []
+    for call in planned:
+        metadata = call.arguments.get("metadata", {})
+        expected_key = metadata.get("subject") if call.lane is Lane.REPO_FACTS else call.key
+        expected_text = (
+            metadata.get("fact")
+            if call.lane is Lane.REPO_FACTS
+            else call.arguments.get("content")
+        )
+        items = live_items(payload, call.lane)
+        if not any(
+            live_key_of(item) == expected_key and live_text_of(item) == expected_text
+            for item in items
+        ):
+            missing.append(call.key)
+    if missing:
+        message = f"canon writes not visible for {intended_namespace}: {', '.join(missing)}"
+        raise NamespaceMismatchError(message)
+
+
 def _apply(planned: Sequence[PlannedWrite], settings: CanonSettings) -> None:
-    """Send every planned write through one client.
+    """Send every planned write through one client and verify its namespace.
 
     The client is built here rather than in a capability for the same reason
     ``apps.bulk.run`` builds its own: this is the operator path, so it does NOT
     inherit the hook path's single-attempt, deadline-pinned policy -- an operator
     run may retry, which is the sibling client's default.
 
+    Every write receipt is checked against ``settings.agent``. The append-event
+    receipt identifies whether the token or delegated header supplied the writer;
+    repo-fact writes return ``namespace`` directly. If a future write surface
+    carries neither signal, one scoped pack read verifies the exact written keys
+    and texts instead of reporting success from an unverified call count.
+
     Raises:
         CanonNotConfiguredError: No endpoint or token. Raised before the import
             so an unconfigured run fails identically whether or not the sibling
             package is installed.
+        NamespaceMismatchError: A receipt or verification read resolves outside
+            the intended agent namespace.
     """
     from openbrain.apps.hooks.session import CanonNotConfiguredError
 
@@ -255,9 +362,23 @@ def _apply(planned: Sequence[PlannedWrite], settings: CanonSettings) -> None:
         # hitting the client's loopback-only refusal.
         allow_insecure_http=settings.allow_insecure_http,
     )
+    unknown_receipt = False
     try:
         for call in planned:
-            client.call_tool(call.tool, call.arguments)
+            receipt = client.call_tool(call.tool, call.arguments)
+            actual_namespace = _receipt_namespace(receipt)
+            if actual_namespace is None:
+                unknown_receipt = True
+                continue
+            if actual_namespace != settings.agent:
+                message = (
+                    f"canon write {call.key} intended for {settings.agent} "
+                    f"landed in {actual_namespace}"
+                )
+                raise NamespaceMismatchError(message)
+        if unknown_receipt:
+            readback = client.agent_context_pack(**_pack_readback_scope(settings))
+            _verify_readback(planned, readback, settings.agent)
     finally:
         client.close()
 

--- a/python/openbrain/src/openbrain/apps/canon/run.py
+++ b/python/openbrain/src/openbrain/apps/canon/run.py
@@ -246,24 +246,23 @@ class NamespaceMismatchError(RuntimeError):
     """A canon write or verification read resolved outside the intended agent."""
 
 
+class ReadbackConfigurationError(ValueError):
+    """A scoped read cannot observe every lane in the planned writes."""
+
+
 def _receipt_namespace(receipt: Any) -> str | None:
-    """Resolve the namespace named directly or through writer provenance."""
+    """Resolve the authoritative namespace from a write receipt."""
     if not isinstance(receipt, Mapping):
         return None
     namespace = receipt.get("namespace")
     if isinstance(namespace, str) and namespace:
         return namespace
-    namespace_source = receipt.get("namespace_source")
-    if not isinstance(namespace_source, str):
-        return None
-    identity_field = {
-        "token": "token_identity",
-        "header": "delegated_agent_id",
-    }.get(namespace_source)
-    if identity_field is None:
-        return None
-    identity = receipt.get(identity_field)
-    return identity if isinstance(identity, str) and identity else None
+    writer_identity = receipt.get("writer_identity")
+    return (
+        writer_identity
+        if isinstance(writer_identity, str) and writer_identity
+        else None
+    )
 
 
 def _pack_readback_scope(settings: CanonSettings) -> dict[str, Any]:
@@ -281,10 +280,26 @@ def _pack_readback_scope(settings: CanonSettings) -> dict[str, Any]:
     return scope
 
 
+def _validate_readback_settings(
+    planned: Sequence[PlannedWrite], settings: CanonSettings
+) -> None:
+    """Require a scoped pack read that can observe every planned lane."""
+    requested = set(settings.sections)
+    missing_lanes = sorted({call.lane.value for call in planned} - requested)
+    if missing_lanes:
+        message = f"canon read-back lane {', '.join(missing_lanes)} is not requested"
+        raise ReadbackConfigurationError(message)
+    if settings.repo is None and any(call.lane is Lane.REPO_FACTS for call in planned):
+        message = "canon read-back of repo_facts requires a repo"
+        raise ReadbackConfigurationError(message)
+
+
 def _verify_readback(
-    planned: Sequence[PlannedWrite], payload: Any, intended_namespace: str
+    planned: Sequence[PlannedWrite], payload: Any, settings: CanonSettings
 ) -> None:
     """Prove unknown-receipt writes are visible under the intended namespace."""
+    _validate_readback_settings(planned, settings)
+    intended_namespace = settings.agent
     if not isinstance(payload, Mapping):
         message = "canon write read-back returned no scoped pack"
         raise NamespaceMismatchError(message)
@@ -317,19 +332,25 @@ def _verify_readback(
         raise NamespaceMismatchError(message)
 
 
-def _apply(planned: Sequence[PlannedWrite], settings: CanonSettings) -> None:
-    """Send every planned write through one client and verify its namespace.
+def _apply(
+    planned: Sequence[PlannedWrite], settings: CanonSettings
+) -> tuple[int, int]:
+    """Send every planned write and return new and already-present counts.
 
     The client is built here rather than in a capability for the same reason
     ``apps.bulk.run`` builds its own: this is the operator path, so it does NOT
     inherit the hook path's single-attempt, deadline-pinned policy -- an operator
     run may retry, which is the sibling client's default.
 
-    Every write receipt is checked against ``settings.agent``. The append-event
-    receipt identifies whether the token or delegated header supplied the writer;
-    repo-fact writes return ``namespace`` directly. If a future write surface
-    carries neither signal, one scoped pack read verifies the exact written keys
-    and texts instead of reporting success from an unverified call count.
+    Every write receipt is checked against ``settings.agent``. Append-event
+    receipts expose the persisted namespace as ``writer_identity``; repo-fact
+    writes return ``namespace`` directly. Duplicate receipts count as already
+    present rather than newly applied. If a future write surface carries neither
+    namespace signal, one scoped pack read verifies the exact written keys and
+    texts instead of reporting success from an unverified call count.
+
+    Returns:
+        A pair of ``(applied, already_present)`` counts.
 
     Raises:
         CanonNotConfiguredError: No endpoint or token. Raised before the import
@@ -363,9 +384,13 @@ def _apply(planned: Sequence[PlannedWrite], settings: CanonSettings) -> None:
         allow_insecure_http=settings.allow_insecure_http,
     )
     unknown_receipt = False
+    already_present = 0
     try:
         for call in planned:
             receipt = client.call_tool(call.tool, call.arguments)
+            already_present += int(
+                isinstance(receipt, Mapping) and receipt.get("duplicate") is True
+            )
             actual_namespace = _receipt_namespace(receipt)
             if actual_namespace is None:
                 unknown_receipt = True
@@ -378,7 +403,8 @@ def _apply(planned: Sequence[PlannedWrite], settings: CanonSettings) -> None:
                 raise NamespaceMismatchError(message)
         if unknown_receipt:
             readback = client.agent_context_pack(**_pack_readback_scope(settings))
-            _verify_readback(planned, readback, settings.agent)
+            _verify_readback(planned, readback, settings)
+        return len(planned) - already_present, already_present
     finally:
         client.close()
 
@@ -430,11 +456,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.apply and planned:
         try:
-            _apply(planned, settings)
+            applied, already_present = _apply(planned, settings)
         except Exception as error:  # noqa: BLE001 -- reported to the operator, then exit
             logger.error("apply failed ({})", type(error).__name__)
             return 2
-        logger.info("applied {} write(s)", len(planned))
+        logger.info(
+            "applied {} write(s); already present {}", applied, already_present
+        )
 
     return 1 if report.has_drift else 0
 

--- a/python/openbrain/src/openbrain/apps/canon/writes.py
+++ b/python/openbrain/src/openbrain/apps/canon/writes.py
@@ -92,19 +92,21 @@ REPO_FACT_STALENESS_POLICY = "stable_fact_verify_source"
 
 
 class FactProvenance(BaseModel):
-    """The four values ``repoFactMetadata`` validates on every repo fact.
+    """The five values ``repoFactMetadata`` validates on every repo fact.
 
-    They travel as ONE object rather than four parallel arguments because they
-    are one fact about one verification: the repo, the commit, the URL naming
-    that commit and path, and when it was checked. ``repoFactMetadata`` refuses
-    the write when ``source_url`` does not contain both the commit and the path,
-    so splitting them across a call signature invites exactly the mismatched
-    triple the server rejects.
+    They travel as ONE object rather than parallel arguments because they are
+    one fact about one verification: the repo, the pack's repo-relative path,
+    the commit, the URL naming that commit and path, and when it was checked.
+    ``repoFactMetadata`` refuses the write unless ``source_url`` contains the
+    exact same commit and path, so splitting them across a call signature invites
+    exactly the mismatched tuple the server rejects.
 
     Attributes:
         repo: The repo the fact binds to, EXACTLY -- the ``repo_facts`` selector
             has no fallback, so a fact under the wrong repo is invisible rather
             than misfiled.
+        source_path: The canon pack's repo-relative path, exactly as encoded in
+            ``source_url``.
         source_commit: The commit the fact was verified at.
         source_url: The URL naming that commit and path.
         verified_at: When it was verified, as an ISO-8601 instant.
@@ -113,6 +115,7 @@ class FactProvenance(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     repo: str
+    source_path: str
     source_commit: str
     source_url: str
     verified_at: str
@@ -268,7 +271,7 @@ def _plan_repo_fact(
                 "source_system": REPO_FACT_SOURCE_SYSTEM,
                 "repo": provenance.repo,
                 "collection": "canon-pack",
-                "path": entry.source or entry.key,
+                "path": provenance.source_path,
                 "subject": entry.subject,
                 "fact_type": str(entry.fact_type),
                 "fact": entry.text,
@@ -276,6 +279,11 @@ def _plan_repo_fact(
                 "source_url": provenance.source_url,
                 "verified_at": provenance.verified_at,
                 "staleness_policy": REPO_FACT_STALENESS_POLICY,
+                **(
+                    {"refresh_hint": f"Declared canon provenance: {entry.source}"}
+                    if entry.source
+                    else {}
+                ),
             }
         },
     )

--- a/python/openbrain/tests/test_canon_reconcile.py
+++ b/python/openbrain/tests/test_canon_reconcile.py
@@ -357,21 +357,28 @@ class TestPlannedWrites:
         planned = plan_promote(entry, session_key="lane")
         assert planned.arguments["metadata"]["memory_lifecycle_action"] != "candidate"
 
-    def test_a_repo_fact_takes_the_entity_write_path_with_full_provenance(self) -> None:
+    def test_a_repo_fact_uses_the_pack_path_not_its_prose_source(self) -> None:
+        prose_source = "open-brain PR #84; approved 2026-08-03"
+        source_path = "docs/canon/repo-facts.toml"
+        source_commit = "abc123"
         entry = PackEntry(
             key="repo.hosts",
             lane=Lane.REPO_FACTS,
             subject="hosts",
             text="Two hosts.",
-            source="AGENTS.md",
+            source=prose_source,
         )
         planned = plan_promote(
             entry,
             session_key="lane",
             provenance=FactProvenance(
                 repo="open-brain",
-                source_commit="abc123",
-                source_url="https://example.invalid/open-brain/blob/abc123/AGENTS.md",
+                source_path=source_path,
+                source_commit=source_commit,
+                source_url=(
+                    "https://github.com/rodaddy/open-brain/blob/"
+                    f"{source_commit}/{source_path}"
+                ),
                 verified_at="2026-08-02T00:00:00Z",
             ),
         )
@@ -379,6 +386,12 @@ class TestPlannedWrites:
         metadata = planned.arguments["metadata"]
         assert metadata["source_system"] == "qmd"
         assert metadata["repo"] == "open-brain"
+        assert metadata["path"] == source_path
+        assert metadata["source_url"] == (
+            "https://github.com/rodaddy/open-brain/blob/"
+            f"{source_commit}/{metadata['path']}"
+        )
+        assert metadata["refresh_hint"] == f"Declared canon provenance: {prose_source}"
         assert metadata["subject"] == "hosts"
         assert metadata["fact_type"] == "gotcha"
         assert metadata["staleness_policy"] == "stable_fact_verify_source"

--- a/python/openbrain/tests/test_canon_run.py
+++ b/python/openbrain/tests/test_canon_run.py
@@ -13,15 +13,16 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from loguru import logger
+from openbrain_memory import client as memory_client
 
 from openbrain.apps.canon import run as canon_run
+from openbrain.apps.canon.pack import Lane
+from openbrain.apps.canon.writes import PlannedWrite
 from openbrain.config import CanonSettings
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
-
-    from openbrain.apps.canon.writes import PlannedWrite
 
 PACK_TOML = """
 kind = "canon"
@@ -46,13 +47,29 @@ def live(*items: dict[str, str]) -> dict[str, Any]:
     return {"sections": {"process_guidance": {"items": list(items)}}}
 
 
-def settings() -> CanonSettings:
+def planned_process_write() -> PlannedWrite:
+    """One guidance write for direct apply-boundary tests."""
+    return PlannedWrite(
+        tool="append_session_event",
+        key="process.no_tmp",
+        lane=Lane.PROCESS,
+        arguments={
+            "session_key": "dev:open-brain",
+            "event_type": "decision",
+            "content": "Never /tmp.",
+            "metadata": {"candidate_scope": {"key": "process.no_tmp"}},
+        },
+    )
+
+
+def settings(*, agent: str = "claude") -> CanonSettings:
     """Canon settings with an endpoint and token, so nothing fails as unconfigured."""
     return CanonSettings(
         OPENBRAIN_BASE_URL="https://openbrain.invalid",  # type: ignore[call-arg]
         # noqa: S106 -- not a real secret; the tests assert this literal is
         # NEVER logged, so it has to be a recognisable sentinel.
         OPENBRAIN_TOKEN="not-a-real-token",  # type: ignore[call-arg]  # noqa: S106
+        OPENBRAIN_CANON_AGENT=agent,  # type: ignore[call-arg]
     )
 
 
@@ -146,6 +163,65 @@ def test_apply_still_exits_one_because_the_rows_were_not_re_read(
     assert canon_run.main([str(pack_file), "--apply"]) == 1
 
 
+def test_apply_rejects_a_receipt_from_the_token_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An admin-token receipt must not be reported as a successful skippy write."""
+
+    class MisScopedClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def call_tool(self, _tool: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "writer_identity": "admin",
+                "token_identity": "admin",
+                "delegated_agent_id": None,
+                "namespace_source": "token",
+            }
+
+        def agent_context_pack(self, **_arguments: Any) -> dict[str, Any]:
+            raise AssertionError
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(memory_client, "OpenBrainClient", MisScopedClient)
+
+    with pytest.raises(canon_run.NamespaceMismatchError, match="landed in admin"):
+        canon_run._apply([planned_process_write()], settings(agent="skippy"))
+
+
+def test_apply_reads_back_when_the_receipt_has_no_namespace_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A future sparse receipt still fails when the scoped read resolves to admin."""
+    state = {"read_back": False}
+
+    class SparseReceiptClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def call_tool(self, _tool: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+            return {"event_id": "event-1"}
+
+        def agent_context_pack(self, **_arguments: Any) -> dict[str, Any]:
+            state["read_back"] = True
+            return {
+                "scope": {"namespace": "admin"},
+                "sections": {"process_guidance": {"items": []}},
+            }
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(memory_client, "OpenBrainClient", SparseReceiptClient)
+
+    with pytest.raises(canon_run.NamespaceMismatchError, match="read back from admin"):
+        canon_run._apply([planned_process_write()], settings(agent="skippy"))
+    assert state["read_back"] is True
+
+
 def test_an_undeclared_rule_is_reported_and_never_written(
     pack_file: Path,
     wired: None,
@@ -194,6 +270,32 @@ def test_a_failed_canon_read_exits_two_without_naming_the_endpoint(
     assert "canon read failed" in err
     assert "openbrain.invalid" not in err
     assert "not-a-real-token" not in err
+
+
+def test_repo_fact_provenance_derives_the_pack_repo_relative_path(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    pack = repo / "docs" / "canon" / "facts.toml"
+    pack.parent.mkdir(parents=True)
+    pack.write_text('kind = "canon"\nentries = []\n', encoding="utf-8")
+    args = canon_run._parse_args(
+        [
+            str(pack),
+            "--repo-source-commit",
+            "abc123",
+            "--repo-source-url",
+            "https://github.com/rodaddy/open-brain/blob/abc123/docs/canon/facts.toml",
+            "--repo-verified-at",
+            "2026-08-02T00:00:00Z",
+        ]
+    )
+
+    provenance = canon_run.provenance_from(args, settings())
+
+    assert provenance is not None
+    assert provenance.source_path == "docs/canon/facts.toml"
 
 
 def test_a_repo_fact_without_provenance_exits_two_before_any_write(

--- a/python/openbrain/tests/test_canon_run.py
+++ b/python/openbrain/tests/test_canon_run.py
@@ -62,7 +62,28 @@ def planned_process_write() -> PlannedWrite:
     )
 
 
-def settings(*, agent: str = "claude") -> CanonSettings:
+def planned_repo_fact_write() -> PlannedWrite:
+    """One repo-fact write for read-back configuration tests."""
+    return PlannedWrite(
+        tool="record_repo_fact",
+        key="repo.hosts",
+        lane=Lane.REPO_FACTS,
+        arguments={
+            "metadata": {"subject": "hosts", "fact": "Two hosts."},
+        },
+    )
+
+
+def settings(
+    *,
+    agent: str = "claude",
+    repo: str | None = "open-brain",
+    sections: tuple[str, ...] = (
+        "profile_guidance",
+        "process_guidance",
+        "repo_facts",
+    ),
+) -> CanonSettings:
     """Canon settings with an endpoint and token, so nothing fails as unconfigured."""
     return CanonSettings(
         OPENBRAIN_BASE_URL="https://openbrain.invalid",  # type: ignore[call-arg]
@@ -70,6 +91,8 @@ def settings(*, agent: str = "claude") -> CanonSettings:
         # NEVER logged, so it has to be a recognisable sentinel.
         OPENBRAIN_TOKEN="not-a-real-token",  # type: ignore[call-arg]  # noqa: S106
         OPENBRAIN_CANON_AGENT=agent,  # type: ignore[call-arg]
+        OPENBRAIN_CANON_REPO=repo,  # type: ignore[call-arg]
+        OPENBRAIN_CANON_SECTIONS=sections,  # type: ignore[call-arg]
     )
 
 
@@ -144,8 +167,13 @@ def test_apply_sends_exactly_the_planned_writes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sent: list[PlannedWrite] = []
+
+    def apply(planned: list[PlannedWrite], _settings: CanonSettings) -> tuple[int, int]:
+        sent.extend(planned)
+        return len(planned), 0
+
     monkeypatch.setattr(canon_run, "read_live_pack", lambda _s: live())
-    monkeypatch.setattr(canon_run, "_apply", lambda planned, _s: sent.extend(planned))
+    monkeypatch.setattr(canon_run, "_apply", apply)
 
     canon_run.main([str(pack_file), "--apply"])
 
@@ -159,7 +187,7 @@ def test_apply_still_exits_one_because_the_rows_were_not_re_read(
 ) -> None:
     """A write is not an observation. Nothing has seen the row standing yet."""
     monkeypatch.setattr(canon_run, "read_live_pack", lambda _s: live())
-    monkeypatch.setattr(canon_run, "_apply", lambda _p, _s: None)
+    monkeypatch.setattr(canon_run, "_apply", lambda _p, _s: (1, 0))
     assert canon_run.main([str(pack_file), "--apply"]) == 1
 
 
@@ -190,6 +218,130 @@ def test_apply_rejects_a_receipt_from_the_token_namespace(
 
     with pytest.raises(canon_run.NamespaceMismatchError, match="landed in admin"):
         canon_run._apply([planned_process_write()], settings(agent="skippy"))
+
+
+def test_apply_accepts_header_receipt_without_an_agent_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The writer identity is the namespace even when X-Agent-Id was omitted."""
+    state = {"read_back": False}
+
+    class DelegatedClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def call_tool(self, _tool: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "writer_identity": "skippy",
+                "token_identity": "admin",
+                "delegated_agent_id": None,
+                "namespace_source": "header",
+            }
+
+        def agent_context_pack(self, **_arguments: Any) -> dict[str, Any]:
+            state["read_back"] = True
+            raise AssertionError
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(memory_client, "OpenBrainClient", DelegatedClient)
+
+    assert canon_run._apply([planned_process_write()], settings(agent="skippy")) == (1, 0)
+    assert state["read_back"] is False
+
+
+def test_apply_rejects_header_receipt_using_writer_not_agent_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An X-Agent-Id label cannot disguise the namespace where the row landed."""
+
+    class MisScopedDelegatedClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def call_tool(self, _tool: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "writer_identity": "admin",
+                "token_identity": "admin",
+                "delegated_agent_id": "skippy",
+                "namespace_source": "header",
+            }
+
+        def agent_context_pack(self, **_arguments: Any) -> dict[str, Any]:
+            raise AssertionError
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(memory_client, "OpenBrainClient", MisScopedDelegatedClient)
+
+    with pytest.raises(canon_run.NamespaceMismatchError, match="landed in admin"):
+        canon_run._apply([planned_process_write()], settings(agent="skippy"))
+
+
+def test_apply_reports_duplicate_receipt_as_already_present(
+    pack_file: Path,
+    wired: None,
+    monkeypatch: pytest.MonkeyPatch,
+    logged: io.StringIO,
+) -> None:
+    """A duplicate receipt is an observed prior row, not a new apply outcome."""
+
+    class DuplicateClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def call_tool(self, _tool: str, _arguments: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "duplicate": True,
+                "writer_identity": "claude",
+                "token_identity": "claude",
+                "delegated_agent_id": None,
+                "namespace_source": "token",
+            }
+
+        def agent_context_pack(self, **_arguments: Any) -> dict[str, Any]:
+            raise AssertionError
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(memory_client, "OpenBrainClient", DuplicateClient)
+    monkeypatch.setattr(canon_run, "read_live_pack", lambda _s: live())
+
+    assert canon_run.main([str(pack_file), "--apply"]) == 1
+    assert "applied 0 write(s); already present 1" in logged.getvalue()
+
+
+def test_readback_refuses_a_lane_missing_from_requested_sections() -> None:
+    """A configuration gap is not reported as a namespace incident."""
+    configured = settings(sections=("profile_guidance", "process_guidance"))
+
+    with pytest.raises(
+        canon_run.ReadbackConfigurationError,
+        match="repo_facts is not requested",
+    ):
+        canon_run._verify_readback(
+            [planned_repo_fact_write()],
+            {"scope": {"namespace": "claude"}},
+            configured,
+        )
+
+
+def test_readback_requires_a_repo_for_repo_facts() -> None:
+    """Repo-fact visibility cannot be checked without its exact repo binding."""
+    configured = settings(repo=None)
+
+    with pytest.raises(
+        canon_run.ReadbackConfigurationError,
+        match="repo_facts requires a repo",
+    ):
+        canon_run._verify_readback(
+            [planned_repo_fact_write()],
+            {"scope": {"namespace": "claude"}},
+            configured,
+        )
 
 
 def test_apply_reads_back_when_the_receipt_has_no_namespace_signal(


### PR DESCRIPTION
Fixes #588

## Summary
- Carry the canon pack's repo-relative file path in `FactProvenance` and use it as repo-fact `metadata.path`, while preserving entry source prose in `refresh_hint`.
- Verify every apply receipt against `settings.agent`; token and delegated-header receipts resolve through trusted writer provenance, and repo-fact receipts use their returned namespace.
- Fall back to one scoped `agent_context_pack` read when a receipt has no namespace signal, checking the returned scope plus the expected keys and texts.
- Add the post-merge failure pattern to `docs/sme/gotcha-agent.md`.

## Validation
- `bunx tsc --noEmit` — PASS.
- `bun test src/tools/__tests__/repo-facts.test.ts` — PASS, 20 tests.
- `uv run mypy src/openbrain` — PASS, 49 source files.
- `uv run ruff check src tests` — PASS.
- `uv run pytest -q` — PASS, 597 passed and 19 deselected.
- `git diff --check` — PASS.

## New-Test Failure Proof
- Changed repo-fact planning back to `path = entry.source or entry.key`; `test_a_repo_fact_uses_the_pack_path_not_its_prose_source` failed because the prose source differed from `docs/canon/repo-facts.toml`. Restored the pack path; PASS.
- Changed pack-path derivation to return only the filename; `test_repo_fact_provenance_derives_the_pack_repo_relative_path` failed with `facts.toml` instead of `docs/canon/facts.toml`. Restored repo-relative derivation; PASS.
- Changed token receipt resolution to read `delegated_agent_id`; `test_apply_rejects_a_receipt_from_the_token_namespace` failed because the sparse result incorrectly reached read-back instead of rejecting namespace `admin`. Restored `token_identity`; PASS.
- Disabled sparse-receipt read-back; `test_apply_reads_back_when_the_receipt_has_no_namespace_signal` failed with `DID NOT RAISE NamespaceMismatchError`. Restored read-back; PASS.
- Final focused receipt: all four new tests passed.

## Critical Self-Review
- Highest-risk behavior: Receipt provenance must map `namespace_source=token` to `token_identity` and `namespace_source=header` to `delegated_agent_id`, or a false success could return.
- Assumptions that could be wrong: The trusted append receipt fields continue to reflect the same namespace authority used by the server, and repo-fact receipts continue returning their persisted namespace.
- Missing/weak tests: No live fan-out apply was run because it would mutate canon; coverage uses the real planned-write boundary with fake client receipts plus existing server receipt tests.
- Security/permission risk: The change grants no delegation and adds no write authority; it fails closed when the authorized destination differs from the intended agent.
- Migration/deploy risk: No database migration, server schema, transport, or deployment configuration changes.
- Downstream client/runtime risk: Not applicable because no MCP contract, `python/openbrain-memory` behavior, generated skill, or Hermes-facing surface changed.
- Rollback/cleanup concern: Reverting the commit restores the old false-success behavior; the 27 pre-existing stray `admin` events remain an operator cleanup item and are not touched here.
- Fixes made before PR: Split machine path from prose provenance, added receipt and read-back verification, simplified error construction after lint feedback, and captured the pattern in SME memory.
- Known residual risk: Fan-out still requires a token or delegated session that the server authorizes for the target agent; this PR detects missing authority but does not provision it.
- SME review-memory update: [x] docs/sme/ updated — added the #588 source-identity and destination-scope receipt pattern to `gotcha-agent.md`.

## Review Gate
- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured: the #588 false-receipt pattern was added to `docs/sme/gotcha-agent.md`; no additional material finding remained after self-review.
- Live Open Brain checks: [x] not applicable because: this PR changes the local Python operator reconciler, and a live apply would mutate canon while target-agent authorization remains an operator provisioning concern.

## Downstream Rollout
Not applicable: this change does not alter MCP tool names, schemas, output contracts, transport behavior, migrations, `python/openbrain-memory`, generated skills, or Hermes-facing behavior.
