### PR TITLE
fix(qmd): install and load the nightly index sync job with a watchdog (#386)

### DIFF
--- a/docs/deploy/com.rico.qmd-sync.plist.template
+++ b/docs/deploy/com.rico.qmd-sync.plist.template
@@ -8,18 +8,20 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/Volumes/ThunderBolt/open-brain/app/scripts/qmd-sync.sh</string>
+    <string>__QMD_SYNC_SCRIPT__</string>
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Volumes/ThunderBolt/open-brain/app</string>
+  <string>__QMD_SYNC_WORKING_DIRECTORY__</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>/Users/rico</string>
+    <string>__HOME__</string>
     <key>PATH</key>
-    <string>/Users/rico/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <string>/opt/homebrew/bin:/Users/rico/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>LOG_DIR</key>
+    <string>__QMD_SYNC_LOG_DIR__</string>
   </dict>
 
   <key>StartCalendarInterval</key>
@@ -34,8 +36,8 @@
   <string>Background</string>
 
   <key>StandardOutPath</key>
-  <string>/Users/rico/Library/Logs/com.rico.qmd-sync.out.log</string>
+  <string>__QMD_SYNC_STDOUT__</string>
   <key>StandardErrorPath</key>
-  <string>/Users/rico/Library/Logs/com.rico.qmd-sync.err.log</string>
+  <string>__QMD_SYNC_STDERR__</string>
 </dict>
 </plist>

--- a/docs/deploy/qmd-sync.md
+++ b/docs/deploy/qmd-sync.md
@@ -13,17 +13,25 @@ The job updates:
 It does not create or regenerate index configurations. Adding, removing, or
 triaging collections is separate work.
 
-## Deployment boundary
+## Installed artifacts
 
-The repository ships a script and a launchd template only. It does **not**
-install, load, bootstrap, or run the job automatically. An operator performs
-installation after the deployed app at `/Volumes/ThunderBolt/open-brain/app`
-contains `scripts/qmd-sync.sh`.
+The repository owns the source and installer. The installer copies the sync
+script to a stable machine-owned runtime and renders the LaunchAgent template:
+
+```text
+/Volumes/ThunderBolt/open-brain-local/qmd-sync/qmd-sync.sh
+~/Library/LaunchAgents/com.rico.qmd-sync.plist
+```
+
+This keeps the scheduled job independent of a development checkout or temporary
+worktree. Re-run the installer after changing `scripts/qmd-sync.sh` or the plist
+template; it replaces the installed script, boots out an existing registration,
+and bootstraps the rendered plist again.
 
 The sync script writes its durable primary log to:
 
 ```text
-/Volumes/ThunderBolt/open-brain/logs/qmd-sync.log
+/Volumes/ThunderBolt/open-brain-local/log/qmd-sync.log
 ```
 
 launchd also reserves these boot-volume files for startup errors that occur
@@ -31,63 +39,86 @@ before the script opens its primary log, including when the ThunderBolt volume
 is unavailable:
 
 ```text
-/Users/rico/Library/Logs/com.rico.qmd-sync.out.log
-/Users/rico/Library/Logs/com.rico.qmd-sync.err.log
+~/Library/Logs/open-brain-local/qmd-sync.out.log
+~/Library/Logs/open-brain-local/qmd-sync.err.log
 ```
+
+## Watchdog behavior
+
+Every qmd subprocess runs through a watchdog backed by GNU `timeout`, which is
+provided by Homebrew coreutils on this Mac. The sync wrapper disables qmd's own
+nested timeout for these calls so one process group contains the command and its
+children.
+
+Defaults:
+
+- `qmd embed`: 1,800 seconds;
+- complete nightly run: 21,600 seconds;
+- TERM-to-KILL grace: 20 seconds.
+
+The complete-run watchdog is enforced by passing the remaining run time to each
+`qmd update`, `qmd embed`, and `qmd status` command. The embed command receives
+the shorter of its own watchdog or the remaining run time. When a watchdog
+fires, the wrapper sends a final KILL to the command's process group after GNU
+`timeout` returns. This removes children that ignored TERM or outlived an early-
+exiting parent instead of leaving an orphaned CPU-bound process.
+
+A watchdog failure exits non-zero and writes a line such as:
+
+```text
+index=open-brain status=failed step=embed reason=watchdog scope=embed watchdog_seconds=1800 exit_code=124
+```
+
+The settings can be changed for a controlled run with
+`QMD_EMBED_WATCHDOG_SECONDS`, `QMD_RUN_WATCHDOG_SECONDS`, and
+`QMD_WATCHDOG_KILL_AFTER_SECONDS`. All three values must be positive whole
+seconds. A missing GNU timeout executable is a visible failure; the scheduled
+job never silently runs without its watchdog. The LaunchAgent places
+`/opt/homebrew/bin` before `~/.local/bin` so qmd selects the Homebrew Node
+runtime that matches its installed `better-sqlite3` native module rather than an
+older user-local Node symlink.
 
 ## Install and load
 
-Run these commands as the logged-in macOS user, not as root:
+Run the installer as the logged-in macOS user, not as root:
 
 ```bash
-mkdir -p /Volumes/ThunderBolt/open-brain/logs
-cp /Volumes/ThunderBolt/open-brain/app/docs/deploy/com.rico.qmd-sync.plist.template \
-  "$HOME/Library/LaunchAgents/com.rico.qmd-sync.plist"
-plutil -lint "$HOME/Library/LaunchAgents/com.rico.qmd-sync.plist"
-launchctl bootstrap "gui/$(id -u)" \
-  "$HOME/Library/LaunchAgents/com.rico.qmd-sync.plist"
+cd /Volumes/ThunderBolt/Development/open-brain
+scripts/install-qmd-sync-launchagent.sh
+```
+
+The installer:
+
+1. copies the executable sync script into the stable runtime;
+2. renders and lints `com.rico.qmd-sync.plist`;
+3. boots out an already registered copy when present;
+4. bootstraps the rendered plist into `gui/$(id -u)`;
+5. prints the registered job.
+
+The template deliberately omits `RunAtLoad`, so installation registers the
+04:00 schedule without immediately starting a full sync.
+
+## Force and observe a run
+
+Capture the index timestamp before the run:
+
+```bash
+/usr/bin/stat -f '%m %Sm' \
+  /Volumes/ThunderBolt/Development/open-brain/.qmd/index.sqlite
+```
+
+Force the registered job to run:
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.rico.qmd-sync"
+```
+
+Observe state and the durable log:
+
+```bash
 launchctl print "gui/$(id -u)/com.rico.qmd-sync"
+tail -n 200 /Volumes/ThunderBolt/open-brain-local/log/qmd-sync.log
 ```
-
-The template deliberately omits `RunAtLoad`, so loading it registers the 04:00
-schedule without immediately starting a full sync. To replace an already loaded
-copy, boot it out first, copy the updated template, and bootstrap it again:
-
-```bash
-launchctl bootout "gui/$(id -u)" \
-  "$HOME/Library/LaunchAgents/com.rico.qmd-sync.plist"
-```
-
-## Verify the next scheduled run
-
-After the next 04:00 local run:
-
-1. Confirm launchd still has the job and inspect its last exit status:
-
-   ```bash
-   launchctl print "gui/$(id -u)/com.rico.qmd-sync"
-   ```
-
-2. In at least one active Development repository, confirm `Updated` is within
-   24 hours:
-
-   ```bash
-   cd /Volumes/ThunderBolt/Development/open-brain
-   qmd status
-   ```
-
-3. Confirm the shared index is also within 24 hours:
-
-   ```bash
-   qmd status --index global_docs_instructions
-   ```
-
-4. Search for an exact symbol added during the previous day. Run this from the
-   repository that owns the symbol and confirm its file is returned:
-
-   ```bash
-   qmd search "ExactSymbolAddedYesterday" --format files
-   ```
 
 A successful primary-log line for each index includes an absolute last-run
 start time, total files indexed, new and updated files from `qmd update`, chunks
@@ -98,20 +129,34 @@ index=open-brain status=completed last_run=... files_indexed=... files_new=... f
 ```
 
 The final run line reports `status=completed`, the number of indexes attempted,
-and zero failures.
+and zero failures. After it appears, verify the index timestamp advanced and
+check qmd's own status from the repository:
+
+```bash
+/usr/bin/stat -f '%m %Sm' \
+  /Volumes/ThunderBolt/Development/open-brain/.qmd/index.sqlite
+cd /Volumes/ThunderBolt/Development/open-brain
+qmd status
+```
+
+The operator doctor also reports qmd freshness for its configured index through
+the privileged doctor surface. The repository-local `qmd status` and SQLite
+mtime remain the direct receipt for this repo's scheduled refresh.
 
 ## Diagnose a failure
 
 Read the primary log first:
 
 ```bash
-tail -n 200 /Volumes/ThunderBolt/open-brain/logs/qmd-sync.log
+tail -n 200 /Volumes/ThunderBolt/open-brain-local/log/qmd-sync.log
 ```
 
 Search for `status=failed`. The line names the index, failed step (`update`,
-`embed`, `status`, or metric parsing), and command exit code when available. The
-script continues to the remaining indexes, then exits non-zero if any index
-failed, so launchd retains a visible failed exit status.
+`embed`, `status`, or metric parsing), and command exit code when available. A
+watchdog line also names its scope and elapsed setting. The script continues to
+the remaining indexes after an index-local failure, but stops scheduling new
+indexes when the complete-run watchdog expires. Either path exits non-zero so
+launchd retains a visible failed exit status.
 
 For a project-local failure, inspect that repository directly:
 
@@ -131,19 +176,41 @@ qmd embed --index global_docs_instructions
 ```
 
 If launchd could not start the script at all, read its boot-volume fallback
-logs, then verify that the deployed script exists and is executable:
+logs, then verify that the installed script exists and is executable:
 
 ```bash
-tail -n 200 "$HOME/Library/Logs/com.rico.qmd-sync.out.log"
-tail -n 200 "$HOME/Library/Logs/com.rico.qmd-sync.err.log"
-ls -l /Volumes/ThunderBolt/open-brain/app/scripts/qmd-sync.sh
+tail -n 200 "$HOME/Library/Logs/open-brain-local/qmd-sync.out.log"
+tail -n 200 "$HOME/Library/Logs/open-brain-local/qmd-sync.err.log"
+ls -l /Volumes/ThunderBolt/open-brain-local/qmd-sync/qmd-sync.sh
 ```
 
-## Test the metric parsers
+## Uninstall
 
-Run the sourceable parser functions against captured qmd output fixtures without
-starting a real sync:
+Boot out the job, then remove the two installed files with Finder or another
+approved file-removal workflow:
 
 ```bash
-bash scripts/qmd-sync.test.sh
+launchctl bootout "gui/$(id -u)/com.rico.qmd-sync"
 ```
+
+The files are:
+
+```text
+~/Library/LaunchAgents/com.rico.qmd-sync.plist
+/Volumes/ThunderBolt/open-brain-local/qmd-sync/qmd-sync.sh
+```
+
+The durable log is intentionally retained for diagnosis.
+
+## Test the parsers and watchdog
+
+Run the sourceable parser functions and the functional hung-process test:
+
+```bash
+BUN_TMPDIR=/Volumes/ThunderBolt/_tmp/open-brain/_scratch/bun-tmp \
+  /opt/homebrew/bin/bash scripts/qmd-sync.test.sh
+```
+
+The functional test starts a fake embed command with a TERM-ignoring child,
+asserts the watchdog returns within the expected wall-clock, verifies the child
+process is gone, and checks the failure line written to the captured log.

--- a/scripts/install-qmd-sync-launchagent.sh
+++ b/scripts/install-qmd-sync-launchagent.sh
@@ -1,0 +1,66 @@
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_SCRIPT="$REPO_ROOT/scripts/qmd-sync.sh"
+TEMPLATE="$REPO_ROOT/docs/deploy/com.rico.qmd-sync.plist.template"
+INSTALL_ROOT="${QMD_SYNC_INSTALL_ROOT:-/Volumes/ThunderBolt/open-brain-local/qmd-sync}"
+INSTALLED_SCRIPT="$INSTALL_ROOT/qmd-sync.sh"
+LOG_DIR="${QMD_SYNC_LOG_DIR:-/Volumes/ThunderBolt/open-brain-local/log}"
+FALLBACK_LOG_DIR="${QMD_SYNC_FALLBACK_LOG_DIR:-$HOME/Library/Logs/open-brain-local}"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+PLIST="$LAUNCH_AGENTS_DIR/com.rico.qmd-sync.plist"
+STAGED_PLIST="$PLIST.next"
+STAGED_SCRIPT="$INSTALLED_SCRIPT.next"
+LABEL="com.rico.qmd-sync"
+DOMAIN="gui/$(id -u)"
+
+fatal() {
+  printf 'FATAL: %s\n' "$1" >&2
+  exit 1
+}
+
+validate_render_value() {
+  local name="$1"
+  local value="$2"
+
+  [[ "$value" != *'&'* ]] || fatal "$name contains an unsupported character"
+  [[ "$value" != *'|'* ]] || fatal "$name contains an unsupported character"
+  [[ "$value" != *'<'* ]] || fatal "$name contains an unsupported character"
+  [[ "$value" != *'>'* ]] || fatal "$name contains an unsupported character"
+  [[ "$value" != *$'\n'* ]] || fatal "$name contains a newline"
+}
+
+[[ -x "$SOURCE_SCRIPT" ]] || fatal "source script is not executable: $SOURCE_SCRIPT"
+[[ -r "$TEMPLATE" ]] || fatal "LaunchAgent template is not readable: $TEMPLATE"
+validate_render_value QMD_SYNC_INSTALL_ROOT "$INSTALL_ROOT"
+validate_render_value QMD_SYNC_LOG_DIR "$LOG_DIR"
+validate_render_value QMD_SYNC_FALLBACK_LOG_DIR "$FALLBACK_LOG_DIR"
+validate_render_value HOME "$HOME"
+
+mkdir -p "$INSTALL_ROOT" "$LOG_DIR" "$FALLBACK_LOG_DIR" "$LAUNCH_AGENTS_DIR"
+/usr/bin/install -m 700 "$SOURCE_SCRIPT" "$STAGED_SCRIPT"
+/bin/mv "$STAGED_SCRIPT" "$INSTALLED_SCRIPT"
+
+/usr/bin/sed \
+  -e "s|__QMD_SYNC_SCRIPT__|$INSTALLED_SCRIPT|g" \
+  -e "s|__QMD_SYNC_WORKING_DIRECTORY__|$INSTALL_ROOT|g" \
+  -e "s|__QMD_SYNC_LOG_DIR__|$LOG_DIR|g" \
+  -e "s|__QMD_SYNC_STDOUT__|$FALLBACK_LOG_DIR/qmd-sync.out.log|g" \
+  -e "s|__QMD_SYNC_STDERR__|$FALLBACK_LOG_DIR/qmd-sync.err.log|g" \
+  -e "s|__HOME__|$HOME|g" \
+  "$TEMPLATE" > "$STAGED_PLIST"
+/bin/chmod 600 "$STAGED_PLIST"
+/usr/bin/plutil -lint "$STAGED_PLIST"
+
+if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+  launchctl bootout "$DOMAIN/$LABEL"
+fi
+
+/bin/mv "$STAGED_PLIST" "$PLIST"
+launchctl bootstrap "$DOMAIN" "$PLIST"
+launchctl print "$DOMAIN/$LABEL"
+printf 'Installed and bootstrapped %s from %s\n' "$LABEL" "$PLIST"

--- a/scripts/qmd-sync.sh
+++ b/scripts/qmd-sync.sh
@@ -5,11 +5,18 @@ umask 077
 
 DEV_ROOT="${DEV_ROOT:-/Volumes/ThunderBolt/Development}"
 QMD_BIN="${QMD_BIN:-/Users/rico/.local/bin/qmd}"
-LOG_DIR="${LOG_DIR:-/Volumes/ThunderBolt/open-brain/logs}"
+LOG_DIR="${LOG_DIR:-/Volumes/ThunderBolt/open-brain-local/log}"
 LOG_FILE="${LOG_FILE:-$LOG_DIR/qmd-sync.log}"
 GLOBAL_INDEX="global_docs_instructions"
 HOME="${HOME:-/Users/rico}"
-PATH="/Users/rico/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="/opt/homebrew/bin:/Users/rico/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+QMD_EMBED_WATCHDOG_SECONDS="${QMD_EMBED_WATCHDOG_SECONDS:-1800}"
+QMD_RUN_WATCHDOG_SECONDS="${QMD_RUN_WATCHDOG_SECONDS:-21600}"
+QMD_WATCHDOG_KILL_AFTER_SECONDS="${QMD_WATCHDOG_KILL_AFTER_SECONDS:-20}"
+RUN_DEADLINE=0
+QMD_STEP_OUTPUT_FILE=""
+QMD_WATCHDOG_SCOPE=""
+QMD_WATCHDOG_SECONDS=0
 export HOME PATH
 
 initialize_logging() {
@@ -20,6 +27,117 @@ initialize_logging() {
 
 timestamp() {
   /bin/date '+%Y-%m-%dT%H:%M:%S%z'
+}
+
+validate_watchdog_seconds() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    printf '[%s] qmd-sync status=failed reason=invalid-watchdog-setting name=%s value=%s\n' \
+      "$(timestamp)" "$name" "$value"
+    return 1
+  fi
+}
+
+resolve_watchdog_binary() {
+  if [[ -x /opt/homebrew/bin/gtimeout ]]; then
+    printf '%s\n' /opt/homebrew/bin/gtimeout
+    return 0
+  fi
+
+  if [[ -x /opt/homebrew/bin/timeout ]]; then
+    printf '%s\n' /opt/homebrew/bin/timeout
+    return 0
+  fi
+
+  return 1
+}
+
+run_qmd_step() {
+  local working_directory="$1"
+  local label="$2"
+  local step="$3"
+  local step_watchdog_seconds="$4"
+  shift 4
+  local remaining_seconds watchdog_binary exit_code watchdog_pid
+
+  remaining_seconds=$((RUN_DEADLINE - SECONDS))
+  QMD_WATCHDOG_SCOPE="run"
+  QMD_WATCHDOG_SECONDS="$remaining_seconds"
+  QMD_STEP_OUTPUT_FILE="$LOG_DIR/.qmd-sync-${label}-${step}-$$.out"
+
+  if (( remaining_seconds <= 0 )); then
+    : > "$QMD_STEP_OUTPUT_FILE"
+    return 124
+  fi
+
+  if (( step_watchdog_seconds > 0 && step_watchdog_seconds < remaining_seconds )); then
+    QMD_WATCHDOG_SCOPE="$step"
+    QMD_WATCHDOG_SECONDS="$step_watchdog_seconds"
+  fi
+
+  if ! watchdog_binary="$(resolve_watchdog_binary)"; then
+    printf 'qmd-sync: GNU timeout is required for watchdog enforcement\n' \
+      > "$QMD_STEP_OUTPUT_FILE"
+    return 125
+  fi
+
+  (
+    cd "$working_directory"
+    QMD_TIMEOUT=0 "$watchdog_binary" \
+      --kill-after="${QMD_WATCHDOG_KILL_AFTER_SECONDS}s" \
+      "${QMD_WATCHDOG_SECONDS}s" \
+      "$QMD_BIN" "$@"
+  ) > "$QMD_STEP_OUTPUT_FILE" 2>&1 &
+  watchdog_pid=$!
+
+  if wait "$watchdog_pid"; then
+    return 0
+  else
+    exit_code=$?
+  fi
+
+  if (( exit_code == 124 || exit_code == 137 )); then
+    kill -KILL -- "-$watchdog_pid" 2>/dev/null || true
+  fi
+
+  return "$exit_code"
+}
+
+read_step_output() {
+  local output_file="$1"
+  local output=""
+
+  if [[ -r "$output_file" ]]; then
+    output="$(< "$output_file")"
+    /opt/homebrew/bin/gunlink "$output_file"
+  fi
+
+  printf '%s\n' "$output"
+}
+
+log_qmd_step_failure() {
+  local label="$1"
+  local step="$2"
+  local exit_code="$3"
+  local details="${4:-}"
+
+  if (( exit_code == 124 || exit_code == 137 )); then
+    printf '[%s] index=%s status=failed step=%s reason=watchdog scope=%s watchdog_seconds=%d exit_code=%d%s\n' \
+      "$(timestamp)" "$label" "$step" "$QMD_WATCHDOG_SCOPE" \
+      "$QMD_WATCHDOG_SECONDS" "$exit_code" "$details"
+    return 0
+  fi
+
+  if (( exit_code == 125 )); then
+    printf '[%s] index=%s status=failed step=%s reason=watchdog-unavailable exit_code=%d%s\n' \
+      "$(timestamp)" "$label" "$step" "$exit_code" "$details"
+    return 0
+  fi
+
+  printf '[%s] index=%s status=failed step=%s exit_code=%d%s\n' \
+    "$(timestamp)" "$label" "$step" "$exit_code" "$details"
 }
 
 strip_ansi() {
@@ -74,13 +192,15 @@ sync_index() {
   started_at="$(timestamp)"
   printf '[%s] index=%s status=started\n' "$started_at" "$label"
 
-  if update_output="$(cd "$working_directory" && "$QMD_BIN" update "${index_args[@]}" 2>&1)"; then
+  if run_qmd_step "$working_directory" "$label" update 0 \
+    update "${index_args[@]}"; then
+    update_output="$(read_step_output "$QMD_STEP_OUTPUT_FILE")"
     printf '%s\n' "$update_output"
   else
     exit_code=$?
+    update_output="$(read_step_output "$QMD_STEP_OUTPUT_FILE")"
     printf '%s\n' "$update_output"
-    printf '[%s] index=%s status=failed step=update exit_code=%d\n' \
-      "$(timestamp)" "$label" "$exit_code"
+    log_qmd_step_failure "$label" update "$exit_code"
     return 1
   fi
 
@@ -95,13 +215,16 @@ sync_index() {
     return 1
   fi
 
-  if embed_output="$(cd "$working_directory" && "$QMD_BIN" embed "${index_args[@]}" 2>&1)"; then
+  if run_qmd_step "$working_directory" "$label" embed \
+    "$QMD_EMBED_WATCHDOG_SECONDS" embed "${index_args[@]}"; then
+    embed_output="$(read_step_output "$QMD_STEP_OUTPUT_FILE")"
     printf '%s\n' "$embed_output"
   else
     exit_code=$?
+    embed_output="$(read_step_output "$QMD_STEP_OUTPUT_FILE")"
     printf '%s\n' "$embed_output"
-    printf '[%s] index=%s status=failed step=embed exit_code=%d files_new=%s files_updated=%s\n' \
-      "$(timestamp)" "$label" "$exit_code" "$files_new" "$files_updated"
+    log_qmd_step_failure "$label" embed "$exit_code" \
+      " files_new=$files_new files_updated=$files_updated"
     return 1
   fi
 
@@ -120,13 +243,15 @@ sync_index() {
     return 1
   fi
 
-  if status_output="$(cd "$working_directory" && "$QMD_BIN" status "${index_args[@]}" 2>&1)"; then
-    :
+  if run_qmd_step "$working_directory" "$label" status 0 \
+    status "${index_args[@]}"; then
+    status_output="$(read_step_output "$QMD_STEP_OUTPUT_FILE")"
   else
     exit_code=$?
+    status_output="$(read_step_output "$QMD_STEP_OUTPUT_FILE")"
     printf '%s\n' "$status_output"
-    printf '[%s] index=%s status=failed step=status exit_code=%d files_new=%s files_updated=%s vectors_embedded=%s\n' \
-      "$(timestamp)" "$label" "$exit_code" "$files_new" "$files_updated" "$vectors_embedded"
+    log_qmd_step_failure "$label" status "$exit_code" \
+      " files_new=$files_new files_updated=$files_updated vectors_embedded=$vectors_embedded"
     return 1
   fi
 
@@ -151,10 +276,21 @@ main() {
   local indexes_attempted=0
   local project_indexes=0
   local failures=0
+  local run_watchdog_expired=0
 
   initialize_logging
   run_started_at="$(timestamp)"
-  printf '[%s] qmd-sync status=started dev_root=%s\n' "$run_started_at" "$DEV_ROOT"
+  printf '[%s] qmd-sync status=started dev_root=%s embed_watchdog_seconds=%s run_watchdog_seconds=%s kill_after_seconds=%s\n' \
+    "$run_started_at" "$DEV_ROOT" "$QMD_EMBED_WATCHDOG_SECONDS" \
+    "$QMD_RUN_WATCHDOG_SECONDS" "$QMD_WATCHDOG_KILL_AFTER_SECONDS"
+
+  validate_watchdog_seconds QMD_EMBED_WATCHDOG_SECONDS \
+    "$QMD_EMBED_WATCHDOG_SECONDS" || return 1
+  validate_watchdog_seconds QMD_RUN_WATCHDOG_SECONDS \
+    "$QMD_RUN_WATCHDOG_SECONDS" || return 1
+  validate_watchdog_seconds QMD_WATCHDOG_KILL_AFTER_SECONDS \
+    "$QMD_WATCHDOG_KILL_AFTER_SECONDS" || return 1
+  RUN_DEADLINE=$((SECONDS + QMD_RUN_WATCHDOG_SECONDS))
 
   if [[ ! -d "$DEV_ROOT" ]]; then
     printf '[%s] qmd-sync status=failed reason=development-root-missing path=%s\n' \
@@ -178,6 +314,10 @@ main() {
     if ! sync_index "$label" "$repo"; then
       failures=$((failures + 1))
     fi
+    if (( SECONDS >= RUN_DEADLINE )); then
+      run_watchdog_expired=1
+      break
+    fi
   done
 
   if (( project_indexes == 0 )); then
@@ -186,9 +326,20 @@ main() {
     failures=$((failures + 1))
   fi
 
-  indexes_attempted=$((indexes_attempted + 1))
-  if ! sync_index "$GLOBAL_INDEX" "$DEV_ROOT" --index "$GLOBAL_INDEX"; then
+  if (( run_watchdog_expired == 0 )); then
+    indexes_attempted=$((indexes_attempted + 1))
+    sync_index "$GLOBAL_INDEX" "$DEV_ROOT" --index "$GLOBAL_INDEX" \
+      || failures=$((failures + 1))
+  fi
+
+  if (( SECONDS >= RUN_DEADLINE )); then
+    run_watchdog_expired=1
+  fi
+
+  if (( run_watchdog_expired == 1 )); then
     failures=$((failures + 1))
+    printf '[%s] qmd-sync status=failed reason=watchdog scope=run watchdog_seconds=%d indexes_attempted=%d\n' \
+      "$(timestamp)" "$QMD_RUN_WATCHDOG_SECONDS" "$indexes_attempted"
   fi
 
   if (( failures > 0 )); then

--- a/scripts/qmd-sync.test.sh
+++ b/scripts/qmd-sync.test.sh
@@ -55,3 +55,76 @@ assert_embed_output \
 assert_equal '2001 12345' \
   "$(printf '%s\n' "$status_fixture" | parse_status_metrics)" \
   'status metrics'
+
+watchdog_test_root="${QMD_SYNC_TEST_ROOT:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch/qmd-sync-test-$$}"
+watchdog_fake_qmd="$watchdog_test_root/fake-qmd"
+watchdog_child_pid_file="$watchdog_test_root/child.pid"
+watchdog_log="$watchdog_test_root/watchdog.log"
+mkdir -p "$watchdog_test_root"
+
+cat > "$watchdog_fake_qmd" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+
+case "${1:-}" in
+  update)
+    printf 'Indexed: 1 new, 0 updated, 0 unchanged\n'
+    ;;
+  embed)
+    /opt/homebrew/bin/bash -c \
+      'trap "" TERM; printf "%d\n" "$$" > "$QMD_SYNC_TEST_CHILD_PID_FILE"; while :; do sleep 1; done' &
+    wait
+    ;;
+  status)
+    printf 'Collection: watchdog-test\n  Total: 1 documents\n  Vectors: 1 embedded\n'
+    ;;
+esac
+EOF
+/bin/chmod 700 "$watchdog_fake_qmd"
+
+QMD_BIN="$watchdog_fake_qmd"
+QMD_SYNC_TEST_CHILD_PID_FILE="$watchdog_child_pid_file"
+export QMD_SYNC_TEST_CHILD_PID_FILE
+QMD_EMBED_WATCHDOG_SECONDS=1
+QMD_RUN_WATCHDOG_SECONDS=10
+QMD_WATCHDOG_KILL_AFTER_SECONDS=1
+SECONDS=0
+RUN_DEADLINE=$((SECONDS + QMD_RUN_WATCHDOG_SECONDS))
+export QMD_BIN QMD_EMBED_WATCHDOG_SECONDS QMD_WATCHDOG_KILL_AFTER_SECONDS RUN_DEADLINE
+watchdog_started_at=$SECONDS
+
+if sync_index watchdog-test "$watchdog_test_root" > "$watchdog_log" 2>&1; then
+  printf 'not ok - watchdog: hung embed unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+watchdog_elapsed=$((SECONDS - watchdog_started_at))
+watchdog_output="$(< "$watchdog_log")"
+watchdog_child_pid="$(< "$watchdog_child_pid_file")"
+
+if (( watchdog_elapsed > 5 )); then
+  printf 'not ok - watchdog: elapsed %ds, expected at most 5s\n' \
+    "$watchdog_elapsed" >&2
+  exit 1
+fi
+
+if [[ "$watchdog_output" != *'status=failed step=embed reason=watchdog scope=embed'* ]]; then
+  printf 'not ok - watchdog: failure line missing from log\n' >&2
+  exit 1
+fi
+
+for _ in {1..20}; do
+  if ! kill -0 "$watchdog_child_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if kill -0 "$watchdog_child_pid" 2>/dev/null; then
+  printf 'not ok - watchdog: child process %s survived\n' \
+    "$watchdog_child_pid" >&2
+  exit 1
+fi
+
+printf 'ok - watchdog kills a hung embed process group and logs failure (%ds)\n' \
+  "$watchdog_elapsed"


### PR DESCRIPTION
Fixes #386

## Summary

- add an explicit watchdog around every qmd subprocess, with a 30-minute embed bound and a six-hour complete-run bound
- kill the timed-out command process group so TERM-ignoring children cannot survive as CPU-bound orphans
- add an idempotent installer that copies the sync script into a stable machine-owned runtime, renders the LaunchAgent plist, boots out an existing registration, and bootstraps the replacement
- install and load `com.rico.qmd-sync` on this Mac, force a real 55-index run, and document the exact install, verify, diagnosis, and uninstall flow
- move the durable primary log to the established local service path at `/Volumes/ThunderBolt/open-brain-local/log/qmd-sync.log`

## Existing Design and Delta

The merged design already established sequential project-local index refresh plus `global_docs_instructions` in `scripts/qmd-sync.sh` and `docs/deploy/qmd-sync.md`. This PR preserves that traversal and metric parsing. The delta is operational: watchdog enforcement, a stable installed runtime, a rendered and bootstrapped LaunchAgent, and live receipts proving the scheduled job actually runs.

## Watchdog Failure Proof

Deliberate mutation: replaced the final process-group KILL with a no-op.

```text
mutation_test_exit=1
ok - update metrics
ok - comma-formatted embed metrics vectors
ok - already-embedded terminal output vectors
ok - empty-documents terminal output vectors
ok - status metrics
not ok - watchdog: child process 32011 survived
```

Restored production logic:

```text
ok - update metrics
ok - comma-formatted embed metrics vectors
ok - already-embedded terminal output vectors
ok - empty-documents terminal output vectors
ok - status metrics
ok - watchdog kills a hung embed process group and logs failure (1s)
```

## Validation

```text
bunx tsc --noEmit
# exit 0

bun test src/operator-doctor.test.ts
29 pass
0 fail
Ran 29 tests across 1 file.

/opt/homebrew/bin/bash scripts/qmd-sync.test.sh
# all 6 checks passed

shellcheck scripts/qmd-sync.sh scripts/qmd-sync.test.sh scripts/install-qmd-sync-launchagent.sh
# exit 0

plutil -lint docs/deploy/com.rico.qmd-sync.plist.template
# OK
```

The pre-push hook also ran the repository validation suite successfully before publishing commit `9772fdbd9369af883009d4dd296e1bb273ad2a54`.

## Live Install and Kickstart Receipt

The first forced run was intentionally treated as a real deployment gate, not omitted from the record. It exited 1 and exposed two machine-specific defects: the script named a nonexistent `/usr/bin/unlink`, and the LaunchAgent PATH selected an older user-local Node symlink whose ABI did not match `better-sqlite3`. The implementation now uses Homebrew `gunlink` and places `/opt/homebrew/bin` before `~/.local/bin`. The corrected installer was rerun idempotently and the job was forced again.

Installed artifacts:

```text
/Users/rico/Library/LaunchAgents/com.rico.qmd-sync.plist
/Volumes/ThunderBolt/open-brain-local/qmd-sync/qmd-sync.sh
/Volumes/ThunderBolt/open-brain-local/log/qmd-sync.log
rendered_plist_placeholders=none
source_sha256=8893c7d41265907e2e5ea2d16dec7b75fa79b7dc254087704bd943dee20a0c28
installed_sha256=8893c7d41265907e2e5ea2d16dec7b75fa79b7dc254087704bd943dee20a0c28
```

Kickstart and launchd result:

```text
kickstart_rc=0
state = not running
runs = 1
last exit code = 0
```

Primary log:

```text
[2026-08-05T20:11:06-0400] qmd-sync status=started dev_root=/Volumes/ThunderBolt/Development embed_watchdog_seconds=1800 run_watchdog_seconds=21600 kill_after_seconds=20
[2026-08-05T20:16:18-0400] index=open-brain status=completed last_run=2026-08-05T20:15:36-0400 files_indexed=1179 files_new=0 files_updated=0 vectors_embedded=341 vectors_total=9420
[2026-08-05T20:19:31-0400] qmd-sync status=completed last_run=2026-08-05T20:11:06-0400 indexes_attempted=55 failures=0
```

Index freshness advanced:

```text
before_epoch=1785974550 before_time=Aug  5 20:02:30 2026
retry_after_epoch=1785975512 retry_after_time=Aug  5 20:18:32 2026 size_bytes=69369856

QMD Status
Index: /Volumes/ThunderBolt/Development/open-brain/.qmd/index.sqlite
Size: 66.2 MB
Total: 1119 files indexed
Vectors: 9420 embedded
Updated: 2m ago
```

No `qmd update` or `qmd embed` process remained after the completed run.

## Critical Self-Review

- Highest-risk behavior: Process-group cleanup could kill the wrong target if the watchdog PID were not also the GNU timeout process-group ID; the functional macOS test proves the real launched shape and verifies the TERM-ignoring child is gone.
- Assumptions that could be wrong: Homebrew coreutils and the Homebrew Node runtime remain installed at their current stable paths and retain the process-group and native-module behavior verified by the live run.
- Missing/weak tests: The watchdog test uses a fake TERM-ignoring command rather than forcing the real upstream qmd busy-loop, because reproducing that upstream defect is nondeterministic and CPU-expensive.
- Security/permission risk: The job runs only in the logged-in user's gui domain, installs the plist mode 600 and script mode 700, logs no secret values, and receives only HOME, PATH, and LOG_DIR in its plist environment.
- Migration/deploy risk: Reinstallation boots out the existing label before bootstrapping the rendered plist, so a rendering or bootstrap failure is loud and can leave the job unloaded rather than silently running stale configuration.
- Downstream client/runtime risk: No MCP schema, transport, Python client, or agent-facing contract changes; downstream rollout is not applicable.
- Rollback/cleanup concern: Boot out `gui/$(id -u)/com.rico.qmd-sync`, then remove the installed plist and stable script through the approved file-removal workflow; the durable log is retained for diagnosis.
- Fixes made before PR: The first forced run exposed the nonexistent unlink path and wrong Node selection; both were fixed, all checks rerun, the installer reapplied, and a second forced run completed all 55 indexes with exit 0.
- Known residual risk: A legitimately slow embed that exceeds 1,800 seconds will be stopped and logged as a watchdog failure; operators can tune the documented positive-second settings for a controlled run.
- SME review-memory update: [x] not applicable because: this operational LaunchAgent change introduced no reusable Python-client or review-swarm defect pattern for `docs/sme/`.

## Review Gate

- [x] Critical self-review fields above are filled.
- [x] MEDIUM+ review findings were captured: the first live run found the invalid unlink path and wrong Node ABI selection; both were corrected before PR and the full live run then passed.
- Live Open Brain checks: [x] linked below

Live evidence is in **Live Install and Kickstart Receipt** above: the registered user LaunchAgent completed 55 indexes with exit 0, the durable log contains the successful run, and the open-brain qmd index mtime and vector count advanced.
