### PR TITLE
feat(tracing): add retrieval evidence child spans

### DIFF
--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -1011,3 +1011,25 @@ Reusable review check: a security-boundary test that captures output by monkey-p
 Verbatim, from the source:
 
 > When `failLine` is `undefined`, the redaction assertions never meaningfully run. A test that silently stops checking is worse than one that is simply absent, because the suite still reports it as covered.
+
+## [2026-08-06] A field named preview that carries the full body turns evidence spans into a request-path amplifier
+
+**Severity:** HIGH
+**Source:** PR #599 review swarm, finding H2 (measured: 47.6 MB / 528 ms on one traced search)
+**Scope key:** `review.evidence_payload_bounded_and_deduplicated`
+**Status:** active
+
+### Pattern
+
+`content_preview` in this repo is defined as the FULL `t.content` (src/tools/table-constants.ts) — the name promises a bound the projection does not have. Evidence/observability payloads that embed row content must (1) apply a real character bound at the projection, (2) not re-serialize the same rows into multiple spans of one call (query output + rank input + rank output + execute output was 4-5 copies), and (3) bound total payload with an explicit degradation recorded in the emitted record. Also check WHERE masking runs: synchronous masking on the tool's own path multiplies per-string regex cost by payload size, and per-string `new RegExp` compilation belongs at module scope. Measure worst-case with the live corpus (max content size × caller-controlled limit × fetch multiplier), not the happy path.
+
+## [2026-08-06] Chosen-vs-filtered evidence keyed on a collapsing identity reports dropped rows as chosen
+
+**Severity:** MEDIUM
+**Source:** PR #599 review swarm, finding M4
+**Scope key:** `review.selection_evidence_keys_are_unique_per_candidate`
+**Status:** active
+
+### Pattern
+
+Selection evidence built by re-matching candidates against results via a derived key (`row.id ?? "qmd:" + path`) lies whenever the key collapses: qmd rows carry no id, chunks share paths, and absent paths collapse to one literal key — so a dropped candidate is reported `chosen: true`, answering "why wasn't this returned" with an affirmative falsehood. Key selection by pre-sort array index (or have the selecting code RETURN its classification) rather than re-deriving identity, and distinguish drop REASONS the branch structure knows (pagination offset vs ranking window vs limit). Test shape: two candidates that collapse to one key where only one survives; assert exactly one chosen.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1803,3 +1803,18 @@ Accept-and-ignore on a write surface is a false receipt: the openbrain-memory JS
 Verbatim, from the source:
 
 > Passing `candidate_type`, `memory_lifecycle_action`, or `candidate_scope` — the exact fields the #445 promotion mechanism requires — gets them **silently dropped**: the write succeeds, returns `status:saved`, and the row lands without the metadata.
+
+## [2026-08-06] Instrumentation on a tree whose wrapper is never installed is dead code the tests cannot see
+
+**Severity:** HIGH
+**Source:** PR #599 review swarm (retrieval-evidence spans), finding H1
+**Scope key:** `review.instrumentation_reaches_production_tree`
+**Status:** active
+
+### Pattern
+
+This repo has TWO serving trees (`server/main.ts` for the local clone, `src/index.ts` for core01), and a cross-cutting install (tracing, audit, any registerTool wrapper) done on only one of them leaves the other tree's call sites permanently inert: `activeMcpTrace.getStore()` is always undefined, every helper takes its early-return branch, and nothing fails. PR #599 shipped ~half its added lines as exactly this — the PR body claimed "both serving trees" while the core01 tree had zero tracing references. Unit tests driving the helper directly cannot catch it; the guard is an end-to-end test that registers a REAL tool under the installed wrapper and asserts the expected span/effect, per tree. Review question for any wrapper-based feature: name the file:line where the wrapper is INSTALLED on each tree that serves production, and the test that would fail if it were not.
+
+### Pattern (same PR, finding M3)
+
+A span or timing wrapper around `run: () => alreadyComputedValue` measures nothing: `duration_ms` is structurally ~0 and the stage's exception path can never fire, while the identically-named span on the other tree measures real work. A silently-wrong diagnostic is worse than an absent one. Check that the computation is INSIDE the measured callback everywhere the span name is emitted.

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -1090,3 +1090,14 @@ binary views expose credential bytes as numeric arrays.
 - Does a regression seed obviously fake detector-shaped text in both tool
   arguments and tool results and assert the emitted body rather than a private
   helper?
+
+## [2026-08-06] Handler-supplied metadata spread after auth-derived fields can rewrite trace identity
+
+**Severity:** MEDIUM
+**Source:** PR #599 review swarm, finding M1 (found independently by the security AND adversarial lanes)
+**Scope key:** `review.auth_derived_fields_win_merge_order`
+**Status:** active
+
+### Pattern
+
+In any record that mixes server-derived authority fields (caller_role, caller_client_id, namespace_source, status) with handler- or caller-supplied maps, the spread/merge ORDER is a security control: `{...authFields, ...suppliedMap}` lets the supplied map silently displace the identity and outcome evidence — making a failed call read as success or a trace disagree with the audit log exactly where a review needs them to agree. Safe shape is supplied-first, authority-last, plus a regression that stamps a forged `caller_role`/`status` from inside a handler that then throws and asserts the emitted record keeps the token-derived values. "No current call site collides" is not a defense; the exported API is the surface.

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -13,12 +13,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-  existsSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   buildToolTraceBody,
@@ -30,7 +25,10 @@ import {
   repoRelease,
   resolveRepoRelease,
   resolveSessionId,
+  setActiveMcpTraceMetadata,
   SinkHealthTracker,
+  traceRetrievalSpan,
+  traceRetrievalSpanSync,
   type McpTracingConfig,
   type TraceBody,
   type TracingSink,
@@ -79,7 +77,9 @@ function hangingSink(): TracingSink {
 function throwingSink(): TracingSink {
   return {
     emit() {
-      throw new Error("langfuse exploded with secret sk-lf-leak in the message");
+      throw new Error(
+        "langfuse exploded with secret sk-lf-leak in the message",
+      );
     },
     forceFlush: () => Promise.reject(new Error("flush exploded")),
     shutdown: () => Promise.reject(new Error("shutdown exploded")),
@@ -129,7 +129,9 @@ async function captureLogLines(run: () => Promise<void>): Promise<string[]> {
     lines.push(
       parts
         .map((part) =>
-          part instanceof Error ? `${part.name}: ${part.message}` : String(part),
+          part instanceof Error
+            ? `${part.name}: ${part.message}`
+            : String(part),
         )
         .join(" "),
     );
@@ -154,7 +156,10 @@ function fakeServer(): {
   handlers: Map<string, (args: unknown, extra: unknown) => unknown>;
   originalRegisterTool: unknown;
 } {
-  const handlers = new Map<string, (args: unknown, extra: unknown) => unknown>();
+  const handlers = new Map<
+    string,
+    (args: unknown, extra: unknown) => unknown
+  >();
   const registerTool = (name: string, _config: unknown, cb: unknown): void => {
     handlers.set(name, cb as (args: unknown, extra: unknown) => unknown);
   };
@@ -299,9 +304,9 @@ describe("resolveSessionId", () => {
   });
 
   test("falls back to the transport sessionId", () => {
-    expect(resolveSessionId({ content: "x" }, { sessionId: "transport-b" })).toBe(
-      "transport-b",
-    );
+    expect(
+      resolveSessionId({ content: "x" }, { sessionId: "transport-b" }),
+    ).toBe("transport-b");
   });
 
   test("is undefined when neither exists", () => {
@@ -318,7 +323,9 @@ describe("installMcpTracing", () => {
       createSink: () => sink,
     });
 
-    const result = { content: [{ type: "text", text: "the full answer body" }] };
+    const result = {
+      content: [{ type: "text", text: "the full answer body" }],
+    };
     server.registerTool(
       "log_thought",
       { inputSchema: {} } as never,
@@ -353,6 +360,101 @@ describe("installMcpTracing", () => {
     ).toBeGreaterThanOrEqual(0);
   });
 
+  test("emits masked retrieval child spans with row ids, scores, filter reasons, and namespace value", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "search_brain",
+      { inputSchema: {} } as never,
+      (async () => {
+        setActiveMcpTraceMetadata({ resolved_namespace: "rico" });
+        const candidates = await traceRetrievalSpan({
+          name: "retrieval.vector_query",
+          input: { namespace: "rico" },
+          run: async () => [
+            {
+              row_id: "row-569",
+              content_preview: "api_key=sk-live-candidate",
+              similarity: 0.93,
+              bm25_score: null,
+            },
+          ],
+          output: (rows) => ({ count: rows.length, candidates: rows }),
+        });
+        return traceRetrievalSpanSync({
+          name: "retrieval.rank_rrf",
+          input: { candidates },
+          run: () => ({ content: [{ type: "text", text: "ok" }] }),
+          output: () => ({
+            selected_row_ids: ["row-569"],
+            candidates: [
+              {
+                row_id: "row-569",
+                rrf_score: 0.031,
+                chosen: true,
+                filtered_by: null,
+              },
+            ],
+          }),
+        });
+      }) as never,
+    );
+
+    await handlers.get("search_brain")?.({ query: "memory" }, AUTH);
+
+    const body = sink.bodies[0]!;
+    expect(body.metadata.resolved_namespace).toBe("rico");
+    expect(body.spans?.map((span) => span.name)).toEqual([
+      "retrieval.vector_query",
+      "retrieval.rank_rrf",
+    ]);
+    expect(body.spans?.[0]?.output).toMatchObject({
+      count: 1,
+      candidates: [{ row_id: "row-569", similarity: 0.93 }],
+    });
+    expect(body.spans?.[1]?.output).toMatchObject({
+      selected_row_ids: ["row-569"],
+      candidates: [{ row_id: "row-569", chosen: true, filtered_by: null }],
+    });
+    const serialized = JSON.stringify(body.spans);
+    expect(serialized).not.toContain("sk-live-candidate");
+    expect(serialized).toContain("[MASKED:");
+  });
+
+  test("retrieval span helpers are direct no-ops outside an active traced call", async () => {
+    const object = { row_id: "row-no-trace" };
+    let calls = 0;
+    let summaries = 0;
+    const summarize = (): unknown => {
+      summaries += 1;
+      return {};
+    };
+    const asyncResult = await traceRetrievalSpan({
+      name: "retrieval.vector_query",
+      run: async () => {
+        calls += 1;
+        return object;
+      },
+      output: summarize,
+    });
+    const syncResult = traceRetrievalSpanSync({
+      name: "retrieval.rank_rrf",
+      run: () => {
+        calls += 1;
+        return object;
+      },
+      output: summarize,
+    });
+    expect(calls).toBe(2);
+    expect(summaries).toBe(0);
+    expect(asyncResult).toBe(object);
+    expect(syncResult).toBe(object);
+  });
+
   test("an isError result is traced as status error, not success", async () => {
     const sink = recordingSink();
     const { server, handlers } = fakeServer();
@@ -368,9 +470,9 @@ describe("installMcpTracing", () => {
 
     await handlers.get("search_memory")?.({ query: "x" }, AUTH);
 
-    expect(
-      (sink.bodies[0]?.metadata as { status: string }).status,
-    ).toBe("error");
+    expect((sink.bodies[0]?.metadata as { status: string }).status).toBe(
+      "error",
+    );
   });
 
   test("a sink that throws on every method leaves the result byte-identical and never throws", async () => {
@@ -421,9 +523,9 @@ describe("installMcpTracing", () => {
     ).rejects.toThrow("entity 7 is not in namespace rico");
 
     expect(sink.bodies).toHaveLength(1);
-    expect(
-      (sink.bodies[0]?.metadata as { status: string }).status,
-    ).toBe("exception");
+    expect((sink.bodies[0]?.metadata as { status: string }).status).toBe(
+      "exception",
+    );
     expect(sink.bodies[0]?.output).toEqual({
       error_class: "NamespaceViolationError",
       error_message: "entity 7 is not in namespace rico",
@@ -910,9 +1012,9 @@ describe("the SDK's own logger cannot bypass the content-free discipline", () =>
     // installed the suppression, so "silent" would otherwise pass for the
     // wrong reason.
     configureGlobalLogger({ level: LogLevel.DEBUG });
-    expect((getGlobalLogger() as unknown as Gated).shouldLog(LogLevel.ERROR)).toBe(
-      true,
-    );
+    expect(
+      (getGlobalLogger() as unknown as Gated).shouldLog(LogLevel.ERROR),
+    ).toBe(true);
 
     // Building the real sink installs the suppression. `createSink` is NOT
     // injected here on purpose: the point is that the DEFAULT factory does it.
@@ -1007,7 +1109,11 @@ describe("trace body helpers", () => {
         // The value is deliberately an obvious placeholder: key-based masking
         // triggers on the KEY alone, and a realistic-looking value here is
         // itself a secret-scanner hit (GitGuardian flagged the previous one).
-        text: JSON.stringify({ a: 1, password: "fake-placeholder-not-a-secret", b: 2 }),
+        text: JSON.stringify({
+          a: 1,
+          password: "fake-placeholder-not-a-secret",
+          b: 2,
+        }),
       },
     });
     const text = (body.output as { text: string }).text;
@@ -1164,10 +1270,7 @@ describe("the release stamped on every trace", () => {
       : undefined;
 
     try {
-      writeFileSync(
-        stampPath,
-        "sha=0123456789abcdef\nshort_sha=0123456\n",
-      );
+      writeFileSync(stampPath, "sha=0123456789abcdef\nshort_sha=0123456\n");
       expect(readRuntimeDeployStamp()).toContain("short_sha=0123456");
       expect(
         resolveRepoRelease({

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -18,8 +18,10 @@ import { join } from "node:path";
 import {
   buildToolTraceBody,
   createTracingRuntime,
+  emitTraceBodyWithObservations,
   errorOutput,
   installMcpTracing,
+  MAX_ACTIVE_SPAN_BYTES,
   readMcpTracingConfig,
   readRuntimeDeployStamp,
   repoRelease,
@@ -33,6 +35,14 @@ import {
   type TraceBody,
   type TracingSink,
 } from "./langfuse-tracing.ts";
+import {
+  mergeFallbackSearchRows,
+  registerSearchBrain,
+  rrfMerge,
+  type SearchRow,
+} from "../../src/tools/search-brain.ts";
+import { registerSearchAll } from "../../src/tools/search-all.ts";
+import { mergeFallbackRows } from "../tools/search-engine.ts";
 
 const ENABLED_CONFIG: McpTracingConfig = {
   enabled: true,
@@ -176,6 +186,41 @@ const AUTH = {
     namespaceSource: "header" as const,
   },
 };
+
+function searchRow(id: string, content = `content ${id}`): SearchRow {
+  return {
+    source_type: "thought",
+    id,
+    namespace: "rico",
+    content_preview: content,
+    tags: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    usefulness: 0.5,
+    tier: "warm",
+    distance: 0.1,
+    fts_rank: 0.5,
+  };
+}
+
+function qmdSpawn(docs: unknown[]): typeof Bun.spawn {
+  return (() => {
+    const encoded = new TextEncoder().encode(JSON.stringify(docs));
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoded);
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      exited: Promise.resolve(0),
+    };
+  }) as unknown as typeof Bun.spawn;
+}
 
 describe("readMcpTracingConfig", () => {
   test("is disabled with no environment at all", () => {
@@ -425,6 +470,352 @@ describe("installMcpTracing", () => {
     expect(serialized).toContain("[MASKED:");
   });
 
+  test("a real registered src search emits its full retrieval stage list", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const longContent = "x".repeat(1_000);
+    const pool = {
+      query: async (sql: string) => {
+        if (sql.includes("FROM ob_links")) return { rows: [] };
+        if (sql.startsWith("UPDATE") || sql.startsWith("INSERT")) {
+          return { rows: [] };
+        }
+        return { rows: [searchRow("real-search-row", longContent)] };
+      },
+    };
+    registerSearchBrain(server, {
+      pool: pool as never,
+      embedFn: async () => Array(768).fill(0.1),
+    });
+
+    await handlers.get("search_brain")?.(
+      {
+        query: "real retrieval",
+        table: "thoughts",
+        search_mode: "keyword",
+        limit: 1,
+      },
+      AUTH,
+    );
+
+    const body = sink.bodies[0]!;
+    expect(body.spans?.map((span) => span.name)).toEqual([
+      "retrieval.keyword_query",
+      "retrieval.execute",
+    ]);
+    const serialized = JSON.stringify(body.spans);
+    expect(serialized).not.toContain(longContent);
+    expect(
+      (
+        (
+          body.spans?.[0]?.output as {
+            candidates: Array<{ content_preview: string }>;
+          }
+        ).candidates[0]?.content_preview ?? ""
+      ).length,
+    ).toBe(300);
+  });
+
+  test("handler metadata cannot overwrite auth identity or exception status", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "guarded_tool",
+      { inputSchema: {} } as never,
+      (() => {
+        setActiveMcpTraceMetadata({
+          caller_role: "readonly",
+          caller_client_id: "forged",
+          status: "success",
+        });
+        throw new Error("handler failed");
+      }) as never,
+    );
+
+    await expect(handlers.get("guarded_tool")?.({}, AUTH)).rejects.toThrow(
+      "handler failed",
+    );
+    expect(sink.bodies[0]?.metadata).toMatchObject({
+      caller_role: "admin",
+      caller_client_id: "rico",
+      status: "exception",
+    });
+  });
+
+  test("a throwing summarizer records instrumentation_error without changing the tool result", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const result = { content: [{ type: "text", text: "unchanged" }] };
+    server.registerTool(
+      "summarizer_guard",
+      { inputSchema: {} } as never,
+      (() =>
+        traceRetrievalSpanSync({
+          name: "retrieval.rank_rrf",
+          run: () => result,
+          output: () => {
+            throw new Error("summary exploded");
+          },
+        })) as never,
+    );
+
+    const returned = await handlers.get("summarizer_guard")?.({}, AUTH);
+    expect(returned).toBe(result);
+    expect(sink.bodies[0]?.spans?.[0]?.output).toEqual({
+      instrumentation_error: "Error",
+    });
+  });
+
+  test("active child spans degrade to counts-only after the total payload bound", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const large = "z".repeat(MAX_ACTIVE_SPAN_BYTES);
+    server.registerTool(
+      "bounded_spans",
+      { inputSchema: {} } as never,
+      (() => {
+        traceRetrievalSpanSync({
+          name: "retrieval.vector_query",
+          input: { large },
+          run: () => ({ large }),
+        });
+        return traceRetrievalSpanSync({
+          name: "retrieval.rank_rrf",
+          input: { large },
+          run: () => ({ ok: true }),
+        });
+      }) as never,
+    );
+
+    await handlers.get("bounded_spans")?.({}, AUTH);
+
+    const spans = sink.bodies[0]?.spans ?? [];
+    expect(spans).toHaveLength(2);
+    expect(
+      spans.every((span) => span.metadata.payload_degraded === true),
+    ).toBe(true);
+    expect(JSON.stringify(spans)).not.toContain(large);
+    expect(Buffer.byteLength(JSON.stringify(spans), "utf8")).toBeLessThan(
+      MAX_ACTIVE_SPAN_BYTES,
+    );
+  });
+
+  test("concurrent calls keep child spans attributed to their own trace", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const releases = new Map<string, () => void>();
+    server.registerTool(
+      "concurrent_search",
+      { inputSchema: {} } as never,
+      (async (args: { call: string }) => {
+        await traceRetrievalSpan({
+          name: `retrieval.${args.call}`,
+          run: () =>
+            new Promise<void>((resolve) => {
+              releases.set(args.call, resolve);
+            }),
+        });
+        return { call: args.call };
+      }) as never,
+    );
+
+    const callA = handlers.get("concurrent_search")?.({ call: "a" }, AUTH);
+    const callB = handlers.get("concurrent_search")?.({ call: "b" }, AUTH);
+    await Bun.sleep(0);
+    releases.get("b")?.();
+    await Bun.sleep(0);
+    releases.get("a")?.();
+    await Promise.all([callA, callB]);
+
+    const byCall = new Map(
+      sink.bodies.map((body) => [
+        (body.input as { call: string }).call,
+        body.spans?.map((span) => span.name),
+      ]),
+    );
+    expect(byCall.get("a")).toEqual(["retrieval.a"]);
+    expect(byCall.get("b")).toEqual(["retrieval.b"]);
+  });
+
+  test("rrf and fallback transforms are deep-equal with tracing active or absent", async () => {
+    const equalRows = [searchRow("a"), searchRow("b"), searchRow("c")];
+    const cases = [
+      { vector: [] as SearchRow[], keyword: [] as SearchRow[], limit: 3 },
+      { vector: equalRows, keyword: [], limit: 2 },
+    ];
+    const baseline = {
+      rrf: cases.map((item) =>
+        rrfMerge(item.vector, item.keyword, item.limit),
+      ),
+      srcFallback: [
+        mergeFallbackSearchRows([], [], 3),
+        mergeFallbackSearchRows(equalRows.slice(0, 2), [equalRows[2]!], 2),
+      ],
+      serverFallback: [
+        mergeFallbackRows([], [], 3),
+        mergeFallbackRows(equalRows.slice(0, 2), [equalRows[2]!], 2),
+      ],
+    };
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "equivalence",
+      { inputSchema: {} } as never,
+      (() => ({
+        rrf: cases.map((item) =>
+          rrfMerge(item.vector, item.keyword, item.limit),
+        ),
+        srcFallback: [
+          mergeFallbackSearchRows([], [], 3),
+          mergeFallbackSearchRows(equalRows.slice(0, 2), [equalRows[2]!], 2),
+        ],
+        serverFallback: [
+          mergeFallbackRows([], [], 3),
+          mergeFallbackRows(equalRows.slice(0, 2), [equalRows[2]!], 2),
+        ],
+      })) as never,
+    );
+
+    const traced = await handlers.get("equivalence")?.({}, AUTH);
+    expect(traced).toEqual(baseline);
+  });
+
+  test("ranking inputs carry ids and counts instead of candidate content", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const content = "candidate content must not be copied into rank input";
+    server.registerTool(
+      "rank_input",
+      { inputSchema: {} } as never,
+      (() => rrfMerge([searchRow("ranked", content)], [], 1)) as never,
+    );
+
+    await handlers.get("rank_input")?.({}, AUTH);
+
+    const span = sink.bodies[0]?.spans?.[0];
+    expect(span?.input).toMatchObject({
+      vector: { count: 1, row_ids: ["ranked"] },
+      keyword: { count: 0, row_ids: [] },
+    });
+    expect(JSON.stringify(span?.input)).not.toContain(content);
+  });
+
+  test("fallback evidence uses the run's dedupe key and exact classifications", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    server.registerTool(
+      "fallback_classification",
+      { inputSchema: {} } as never,
+      (() =>
+        mergeFallbackRows(
+          [searchRow("primary", "same content")],
+          [
+            searchRow("legacy-duplicate", "same   content"),
+            searchRow("legacy-chosen", "unique content"),
+          ],
+          2,
+        )) as never,
+    );
+
+    await handlers.get("fallback_classification")?.({}, AUTH);
+
+    const output = sink.bodies[0]?.spans?.[0]?.output as {
+      candidates: Array<{ row_id: string; chosen: boolean; filtered_by: string | null }>;
+    };
+    expect(output.candidates).toMatchObject([
+      { row_id: "primary", chosen: true, filtered_by: null },
+      {
+        row_id: "legacy-duplicate",
+        chosen: false,
+        filtered_by: "fallback_duplicate",
+      },
+      { row_id: "legacy-chosen", chosen: true, filtered_by: null },
+    ]);
+  });
+
+  test("federated ranking distinguishes duplicate qmd paths by pre-sort index", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    registerSearchAll(server, {
+      pool: { query: async () => ({ rows: [] }) } as never,
+      embedFn: async () => Array(768).fill(0.1),
+    });
+    const originalSpawn = Bun.spawn;
+    Bun.spawn = qmdSpawn([
+      { path: "/same.md", content: "first", score: 1 },
+      { path: "/same.md", content: "second", score: 1 },
+      { path: "/same.md", content: "third", score: 1 },
+    ]);
+    try {
+      await handlers.get("search_all")?.(
+        {
+          query: "duplicate path",
+          sources: "qmd",
+          offset: 1,
+          limit: 1,
+        },
+        AUTH,
+      );
+    } finally {
+      Bun.spawn = originalSpawn;
+    }
+
+    const span = sink.bodies[0]?.spans?.find(
+      (candidate) => candidate.name === "retrieval.federated_rank",
+    );
+    const candidates = (
+      span?.output as {
+        candidates: Array<{ chosen: boolean; filtered_by: string | null }>;
+      }
+    ).candidates;
+    expect(candidates.map((candidate) => candidate.chosen)).toEqual([
+      false,
+      true,
+      false,
+    ]);
+    expect(candidates.map((candidate) => candidate.filtered_by)).toEqual([
+      "pagination_offset",
+      null,
+      "federated_rank_window",
+    ]);
+  });
+
   test("retrieval span helpers are direct no-ops outside an active traced call", async () => {
     const object = { row_id: "row-no-trace" };
     let calls = 0;
@@ -592,6 +983,47 @@ describe("installMcpTracing", () => {
         undefined,
       ),
     ).not.toThrow();
+  });
+});
+
+describe("child observation export", () => {
+  test("the parent observation ends when a child start throws", () => {
+    let parentEnded = 0;
+    let childStarts = 0;
+    const parent = {
+      updateTrace: () => undefined,
+      end: () => {
+        parentEnded += 1;
+      },
+      startObservation: () => {
+        childStarts += 1;
+        if (childStarts === 2) throw new Error("child start failed");
+        return {
+          updateTrace: () => undefined,
+          startObservation: () => {
+            throw new Error("unused");
+          },
+          end: () => undefined,
+        };
+      },
+    };
+    expect(() =>
+      emitTraceBodyWithObservations(
+        {
+          name: "tool",
+          input: {},
+          output: {},
+          metadata: {},
+          tags: [],
+          spans: [
+            { name: "one", input: {}, output: {}, metadata: {} },
+            { name: "two", input: {}, output: {}, metadata: {} },
+          ],
+        },
+        () => parent,
+      ),
+    ).toThrow("child start failed");
+    expect(parentEnded).toBe(1);
   });
 });
 

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -87,19 +87,14 @@
  */
 import { configureGlobalLogger, LogLevel } from "@langfuse/core";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
-import {
-  setLangfuseTracerProvider,
-  startObservation,
-} from "@langfuse/tracing";
+import { setLangfuseTracerProvider, startObservation } from "@langfuse/tracing";
 import { setGlobalErrorHandler } from "@opentelemetry/core";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { readFileSync } from "node:fs";
 import { logger } from "../../src/logger.ts";
-import {
-  isSensitiveKey,
-  SECRET_DETECTORS,
-} from "../../src/secret-patterns.ts";
+import { isSensitiveKey, SECRET_DETECTORS } from "../../src/secret-patterns.ts";
 import type { AuthInfo } from "../../src/types.ts";
 import { readDeployedRevision } from "../transport/server-identity.ts";
 
@@ -239,6 +234,14 @@ export interface McpTracingConfig {
   secretKey: string;
 }
 
+/** One child observation collected while a traced MCP tool call is active. */
+export interface TraceSpanBody {
+  name: string;
+  input: unknown;
+  output: unknown;
+  metadata: Record<string, unknown>;
+}
+
 /** The content-ful trace payload for one tool call. */
 export interface TraceBody {
   name: string;
@@ -246,6 +249,7 @@ export interface TraceBody {
   output: unknown;
   tags: string[];
   metadata: Record<string, unknown>;
+  spans?: TraceSpanBody[];
   sessionId?: string;
   userId?: string;
 }
@@ -327,6 +331,114 @@ const INACTIVE_HANDLE: McpTracingHandle = {
   active: false,
   shutdown: () => Promise.resolve(),
 };
+
+interface ActiveMcpTrace {
+  readonly spans: TraceSpanBody[];
+  readonly metadata: Record<string, unknown>;
+}
+
+const activeMcpTrace = new AsyncLocalStorage<ActiveMcpTrace>();
+
+/** Add trace-level metadata from inside the currently executing tool handler. */
+export function setActiveMcpTraceMetadata(
+  metadata: Record<string, unknown>,
+): void {
+  const active = activeMcpTrace.getStore();
+  if (!active) return;
+  Object.assign(active.metadata, metadata);
+}
+
+function recordTraceSpan(
+  name: string,
+  input: unknown,
+  output: unknown,
+  metadata: Record<string, unknown>,
+): void {
+  activeMcpTrace.getStore()?.spans.push({ name, input, output, metadata });
+}
+
+function traceSpanOutput<T>(
+  summarize: ((result: T) => unknown) | undefined,
+  result: T,
+): unknown {
+  if (!summarize) return result;
+  try {
+    return summarize(result);
+  } catch (err: unknown) {
+    return { instrumentation_error: tracingErrorLabel(err) };
+  }
+}
+
+/**
+ * Run an asynchronous retrieval stage as a child of the active MCP tool trace.
+ *
+ * With tracing disabled there is no async-local trace context, so this calls the
+ * operation directly and performs no masking, collection, or exporter work.
+ */
+export async function traceRetrievalSpan<T>(input: {
+  name: string;
+  input?: unknown;
+  metadata?: Record<string, unknown>;
+  run: () => Promise<T>;
+  output?: (result: T) => unknown;
+}): Promise<T> {
+  if (!activeMcpTrace.getStore()) return input.run();
+  const started = Date.now();
+  try {
+    const result = await input.run();
+    recordTraceSpan(
+      input.name,
+      input.input ?? null,
+      traceSpanOutput(input.output, result),
+      {
+        ...(input.metadata ?? {}),
+        status: "success",
+        duration_ms: Math.max(0, Date.now() - started),
+      },
+    );
+    return result;
+  } catch (err: unknown) {
+    recordTraceSpan(input.name, input.input ?? null, errorOutput(err), {
+      ...(input.metadata ?? {}),
+      status: "exception",
+      duration_ms: Math.max(0, Date.now() - started),
+    });
+    throw err;
+  }
+}
+
+/** Synchronous counterpart for ranking, filtering, and deterministic transforms. */
+export function traceRetrievalSpanSync<T>(input: {
+  name: string;
+  input?: unknown;
+  metadata?: Record<string, unknown>;
+  run: () => T;
+  output?: (result: T) => unknown;
+}): T {
+  if (!activeMcpTrace.getStore()) return input.run();
+  const started = Date.now();
+  try {
+    const result = input.run();
+    recordTraceSpan(
+      input.name,
+      input.input ?? null,
+      traceSpanOutput(input.output, result),
+      {
+        ...(input.metadata ?? {}),
+        status: "success",
+        duration_ms: Math.max(0, Date.now() - started),
+      },
+    );
+    return result;
+  } catch (err: unknown) {
+    recordTraceSpan(input.name, input.input ?? null, errorOutput(err), {
+      ...(input.metadata ?? {}),
+      status: "exception",
+      duration_ms: Math.max(0, Date.now() - started),
+    });
+    throw err;
+  }
+}
 
 type RegisterTool = McpServer["registerTool"];
 
@@ -448,7 +560,9 @@ function maskTraceValue(value: unknown): unknown {
   if (typeof value === "string") return maskTraceString(value);
   if (Array.isArray(value)) {
     const masked = value.map(maskTraceValue);
-    return masked.some((child, index) => child !== value[index]) ? masked : value;
+    return masked.some((child, index) => child !== value[index])
+      ? masked
+      : value;
   }
   if (!value || typeof value !== "object") return value;
   if (ArrayBuffer.isView(value)) return binaryViewMarker(value);
@@ -491,36 +605,50 @@ export function buildToolTraceBody(input: {
   auth?: AuthInfo;
   sessionId?: string;
   maskingEnabled?: boolean;
+  metadata?: Record<string, unknown>;
+  spans?: TraceSpanBody[];
 }): TraceBody {
   const maskingEnabled = input.maskingEnabled !== false;
-  const body: TraceBody = {
+  const traceMetadata = (
+    maskingEnabled
+      ? maskTraceValue(input.metadata ?? {})
+      : (input.metadata ?? {})
+  ) as Record<string, unknown>;
+  const metadata = {
+    caller_role: input.auth?.role ?? null,
+    caller_client_id: input.auth?.clientId ?? null,
+    // The audit lane records BOTH ids (`src/audit-log.ts:299-301`), and the
+    // pair is the whole answer to "who actually did this" when a delegated
+    // call's `clientId` differs from its token-derived identity.
+    caller_token_client_id: input.auth?.tokenClientId ?? null,
+    caller_agent_id: input.auth?.agentId ?? null,
+    namespace_source: input.auth?.namespaceSource ?? null,
+    duration_ms: Number.isFinite(input.durationMs)
+      ? Math.max(0, Math.round(input.durationMs))
+      : 0,
+    status: input.status,
+    ...traceMetadata,
+  };
+  const spans = input.spans?.map((span) => ({
+    name: span.name,
+    input: maskingEnabled ? maskTraceValue(span.input) : span.input,
+    output: maskingEnabled ? maskTraceValue(span.output) : span.output,
+    metadata: (maskingEnabled
+      ? maskTraceValue(span.metadata)
+      : span.metadata) as Record<string, unknown>,
+  }));
+  return {
     name: input.toolName,
     input: maskingEnabled ? maskTraceValue(input.args) : input.args,
     output: maskingEnabled ? maskTraceValue(input.output) : input.output,
     tags: [...TRACE_TAGS],
-    metadata: {
-      caller_role: input.auth?.role ?? null,
-      caller_client_id: input.auth?.clientId ?? null,
-      // The audit lane records BOTH ids (`src/audit-log.ts:299-301`), and the
-      // pair is the whole answer to "who actually did this" when a delegated
-      // call's `clientId` differs from its token-derived identity. The
-      // content-ful lane is the one an operator reads for that question, so
-      // dropping the token id here would make the two lanes disagree in
-      // exactly the case a security review cares about.
-      caller_token_client_id: input.auth?.tokenClientId ?? null,
-      caller_agent_id: input.auth?.agentId ?? null,
-      namespace_source: input.auth?.namespaceSource ?? null,
-      duration_ms: Number.isFinite(input.durationMs)
-        ? Math.max(0, Math.round(input.durationMs))
-        : 0,
-      status: input.status,
-    },
+    metadata,
+    ...(spans === undefined ? {} : { spans }),
     ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
     ...(input.auth?.clientId === undefined
       ? {}
       : { userId: input.auth.clientId }),
   };
-  return body;
 }
 
 /**
@@ -762,31 +890,38 @@ export function installMcpTracing(
     const callback = cb as (args: unknown, extra: unknown) => unknown;
     const wrapped = async (args: unknown, extra: unknown) => {
       const started = Date.now();
-      try {
-        const result = await callback(args, extra);
-        emitTrace(sink, tracker, {
-          toolName: name,
-          status: isToolError(result) ? "error" : "success",
-          durationMs: Date.now() - started,
-          maskingEnabled: config.maskingEnabled,
-          args,
-          output: result,
-          ...authAndSession(args, extra),
-        });
-        return result;
-      } catch (err: unknown) {
-        emitTrace(sink, tracker, {
-          toolName: name,
-          status: "exception",
-          durationMs: Date.now() - started,
-          maskingEnabled: config.maskingEnabled,
-          args,
-          output: errorOutput(err),
-          ...authAndSession(args, extra),
-        });
-        // The caller's error is the one that matters; tracing never changes it.
-        throw err;
-      }
+      const active: ActiveMcpTrace = { spans: [], metadata: {} };
+      return activeMcpTrace.run(active, async () => {
+        try {
+          const result = await callback(args, extra);
+          emitTrace(sink, tracker, {
+            toolName: name,
+            status: isToolError(result) ? "error" : "success",
+            durationMs: Date.now() - started,
+            maskingEnabled: config.maskingEnabled,
+            args,
+            output: result,
+            metadata: active.metadata,
+            spans: active.spans,
+            ...authAndSession(args, extra),
+          });
+          return result;
+        } catch (err: unknown) {
+          emitTrace(sink, tracker, {
+            toolName: name,
+            status: "exception",
+            durationMs: Date.now() - started,
+            maskingEnabled: config.maskingEnabled,
+            args,
+            output: errorOutput(err),
+            metadata: active.metadata,
+            spans: active.spans,
+            ...authAndSession(args, extra),
+          });
+          // The caller's error is the one that matters; tracing never changes it.
+          throw err;
+        }
+      });
     };
     return (original as unknown as (...a: unknown[]) => unknown)(
       name,
@@ -965,7 +1100,6 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
   setLangfuseTracerProvider(provider);
   const tracker = new SinkHealthTracker();
 
-
   // WHERE AN OUTAGE ACTUALLY BECOMES VISIBLE WHILE THE SERVER RUNS.
   //
   // `emit` cannot fail against a dead endpoint — it is a synchronous enqueue
@@ -1062,6 +1196,14 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
         ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
         ...(body.userId === undefined ? {} : { userId: body.userId }),
       });
+      for (const childBody of body.spans ?? []) {
+        const child = span.startObservation(childBody.name, {
+          input: childBody.input,
+          output: childBody.output,
+          metadata: childBody.metadata,
+        });
+        child.end();
+      }
       span.end();
       // The enqueue above SUCCEEDS even with the endpoint dead — that is what
       // makes an outage invisible from the request path. So while the sink is

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -155,6 +155,19 @@ const DEFAULT_FLAP_COOLDOWN_MS = 30_000;
  */
 const SINK_HEALTH_PROBE_MS = 5_000;
 
+/** Maximum serialized child-span payload retained for one tool call. */
+export const MAX_ACTIVE_SPAN_BYTES = 256 * 1024;
+
+const COMPILED_SECRET_DETECTORS = SECRET_DETECTORS.map((detector) => ({
+  kind: detector.kind,
+  pattern: new RegExp(
+    detector.pattern.source,
+    detector.pattern.flags.includes("g")
+      ? detector.pattern.flags
+      : `${detector.pattern.flags}g`,
+  ),
+}));
+
 /**
  * How long `git rev-parse` may take before the release is treated as unknown.
  *
@@ -335,6 +348,8 @@ const INACTIVE_HANDLE: McpTracingHandle = {
 interface ActiveMcpTrace {
   readonly spans: TraceSpanBody[];
   readonly metadata: Record<string, unknown>;
+  spanBytes: number;
+  payloadDegraded: boolean;
 }
 
 const activeMcpTrace = new AsyncLocalStorage<ActiveMcpTrace>();
@@ -348,13 +363,119 @@ export function setActiveMcpTraceMetadata(
   Object.assign(active.metadata, metadata);
 }
 
+function traceValueCounts(value: unknown): Record<string, number> {
+  const counts = {
+    values: 0,
+    arrays: 0,
+    objects: 0,
+    strings: 0,
+    string_bytes: 0,
+  };
+  const pending: unknown[] = [value];
+  const seen = new WeakSet<object>();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    counts.values += 1;
+    if (typeof current === "string") {
+      counts.strings += 1;
+      counts.string_bytes += Buffer.byteLength(current, "utf8");
+      continue;
+    }
+    if (!current || typeof current !== "object") continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    if (Array.isArray(current)) counts.arrays += 1;
+    else counts.objects += 1;
+    pending.push(...Object.values(current));
+  }
+  return counts;
+}
+
+function degradedTraceSpan(
+  span: TraceSpanBody,
+  reason: "active_span_bytes_limit" | "serialization_error",
+): TraceSpanBody {
+  return {
+    name: span.name,
+    input: { counts: traceValueCounts(span.input) },
+    output: { counts: traceValueCounts(span.output) },
+    metadata: {
+      ...span.metadata,
+      payload_degraded: true,
+      payload_degradation_reason: reason,
+      payload_limit_bytes: MAX_ACTIVE_SPAN_BYTES,
+    },
+  };
+}
+
+function appendDegradedSpan(
+  active: ActiveMcpTrace,
+  span: TraceSpanBody,
+  reason: "active_span_bytes_limit" | "serialization_error",
+): void {
+  const degraded = degradedTraceSpan(span, reason);
+  const bytes = Buffer.byteLength(JSON.stringify(degraded), "utf8");
+  if (active.spanBytes + bytes <= MAX_ACTIVE_SPAN_BYTES) {
+    active.spans.push(degraded);
+    active.spanBytes += bytes;
+    return;
+  }
+  const last = active.spans.at(-1);
+  if (!last) return;
+  const omitted = Number(last.metadata.additional_spans_omitted ?? 0);
+  last.metadata.additional_spans_omitted = omitted + 1;
+}
+
+function recordTraceSpanUnsafe(
+  name: string,
+  input: unknown,
+  output: unknown,
+  metadata: Record<string, unknown>,
+): void {
+  const active = activeMcpTrace.getStore();
+  if (!active) return;
+  const span = { name, input, output, metadata };
+  if (active.payloadDegraded) {
+    appendDegradedSpan(active, span, "active_span_bytes_limit");
+    return;
+  }
+  try {
+    const spanBytes = Buffer.byteLength(JSON.stringify(span), "utf8");
+    if (active.spanBytes + spanBytes <= MAX_ACTIVE_SPAN_BYTES) {
+      active.spans.push(span);
+      active.spanBytes += spanBytes;
+      return;
+    }
+    const degraded = active.spans.map((recorded) =>
+      degradedTraceSpan(recorded, "active_span_bytes_limit"),
+    );
+    degraded.push(degradedTraceSpan(span, "active_span_bytes_limit"));
+    active.spans.splice(0, active.spans.length, ...degraded);
+    active.spanBytes = Buffer.byteLength(JSON.stringify(degraded), "utf8");
+    active.payloadDegraded = true;
+  } catch (err: unknown) {
+    logger.warn("mcp_tool_trace_span_payload_degraded", {
+      error: tracingErrorLabel(err),
+      reason: "serialization_error",
+    });
+    appendDegradedSpan(active, span, "serialization_error");
+    active.payloadDegraded = true;
+  }
+}
+
 function recordTraceSpan(
   name: string,
   input: unknown,
   output: unknown,
   metadata: Record<string, unknown>,
 ): void {
-  activeMcpTrace.getStore()?.spans.push({ name, input, output, metadata });
+  try {
+    recordTraceSpanUnsafe(name, input, output, metadata);
+  } catch (err: unknown) {
+    logger.warn("mcp_tool_trace_span_collection_failed", {
+      error: tracingErrorLabel(err),
+    });
+  }
 }
 
 function traceSpanOutput<T>(
@@ -533,13 +654,9 @@ function maskDetectorMatch(kind: string, match: string): string {
 /** Replace every detector match while retaining the rest of the string. */
 function maskTraceString(value: string): string {
   let masked = value;
-  for (const detector of SECRET_DETECTORS) {
-    const flags = detector.pattern.flags.includes("g")
-      ? detector.pattern.flags
-      : `${detector.pattern.flags}g`;
-    masked = masked.replace(
-      new RegExp(detector.pattern.source, flags),
-      (match) => maskDetectorMatch(detector.kind, match),
+  for (const detector of COMPILED_SECRET_DETECTORS) {
+    masked = masked.replace(detector.pattern, (match) =>
+      maskDetectorMatch(detector.kind, match),
     );
   }
   return masked;
@@ -615,6 +732,7 @@ export function buildToolTraceBody(input: {
       : (input.metadata ?? {})
   ) as Record<string, unknown>;
   const metadata = {
+    ...traceMetadata,
     caller_role: input.auth?.role ?? null,
     caller_client_id: input.auth?.clientId ?? null,
     // The audit lane records BOTH ids (`src/audit-log.ts:299-301`), and the
@@ -627,7 +745,6 @@ export function buildToolTraceBody(input: {
       ? Math.max(0, Math.round(input.durationMs))
       : 0,
     status: input.status,
-    ...traceMetadata,
   };
   const spans = input.spans?.map((span) => ({
     name: span.name,
@@ -890,7 +1007,12 @@ export function installMcpTracing(
     const callback = cb as (args: unknown, extra: unknown) => unknown;
     const wrapped = async (args: unknown, extra: unknown) => {
       const started = Date.now();
-      const active: ActiveMcpTrace = { spans: [], metadata: {} };
+      const active: ActiveMcpTrace = {
+        spans: [],
+        metadata: {},
+        spanBytes: 0,
+        payloadDegraded: false,
+      };
       return activeMcpTrace.run(active, async () => {
         try {
           const result = await callback(args, extra);
@@ -1051,6 +1173,54 @@ function createSinkSafely(
   }
 }
 
+interface TraceObservation {
+  startObservation(
+    name: string,
+    body: {
+      input?: unknown;
+      output?: unknown;
+      metadata?: Record<string, unknown>;
+    },
+  ): TraceObservation;
+  updateTrace(input: {
+    name: string;
+    tags: string[];
+    sessionId?: string;
+    userId?: string;
+  }): void;
+  end(): void;
+}
+
+/** Materialize one completed trace body through the SDK observation surface. */
+export function emitTraceBodyWithObservations(
+  body: TraceBody,
+  start: (name: string, body: Record<string, unknown>) => TraceObservation,
+): void {
+  const span = start(body.name, {
+    input: body.input,
+    output: body.output,
+    metadata: body.metadata,
+  });
+  try {
+    span.updateTrace({
+      name: body.name,
+      tags: body.tags,
+      ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
+      ...(body.userId === undefined ? {} : { userId: body.userId }),
+    });
+    for (const childBody of body.spans ?? []) {
+      const child = span.startObservation(childBody.name, {
+        input: childBody.input,
+        output: childBody.output,
+        metadata: childBody.metadata,
+      });
+      child.end();
+    }
+  } finally {
+    span.end();
+  }
+}
+
 /**
  * The real sink: a Langfuse span processor on an ISOLATED tracer provider.
  *
@@ -1185,26 +1355,13 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
     emit(body: TraceBody): void {
       // The span ends immediately: the tool call already happened, so this is a
       // record of it rather than a live scope.
-      const span = startObservation(body.name, {
-        input: body.input,
-        output: body.output,
-        metadata: body.metadata,
-      });
-      span.updateTrace({
-        name: body.name,
-        tags: body.tags,
-        ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
-        ...(body.userId === undefined ? {} : { userId: body.userId }),
-      });
-      for (const childBody of body.spans ?? []) {
-        const child = span.startObservation(childBody.name, {
-          input: childBody.input,
-          output: childBody.output,
-          metadata: childBody.metadata,
-        });
-        child.end();
-      }
-      span.end();
+      emitTraceBodyWithObservations(
+        body,
+        startObservation as unknown as (
+          name: string,
+          body: Record<string, unknown>,
+        ) => TraceObservation,
+      );
       // The enqueue above SUCCEEDS even with the endpoint dead — that is what
       // makes an outage invisible from the request path. So while the sink is
       // known-unhealthy, every span handed over is a span that will be dropped,

--- a/server/tools/brain-answer.ts
+++ b/server/tools/brain-answer.ts
@@ -21,10 +21,19 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
 import { ALL_TABLES, type Tier } from "./search-constants.ts";
+import {
+  setActiveMcpTraceMetadata,
+  traceRetrievalSpanSync,
+} from "../observability/langfuse-tracing.ts";
 import {
   executeSearchWithSharedFallback,
   type SearchMode,
@@ -215,11 +224,16 @@ export function registerBrainAnswerTool(
       if (!identity) return errorResult(NOT_AUTHENTICATED);
 
       const requestedNamespace = args.namespace;
-      if (requestedNamespace && !canReadNamespace(identity, requestedNamespace)) {
+      if (
+        requestedNamespace &&
+        !canReadNamespace(identity, requestedNamespace)
+      ) {
         return errorResult(NAMESPACE_DENIED);
       }
 
-      const tables = ALL_TABLES.filter((table) => canRead(identity.role, table));
+      const tables = ALL_TABLES.filter((table) =>
+        canRead(identity.role, table),
+      );
       if (tables.length === 0) return errorResult(NO_READABLE_TABLES);
 
       const query = args.query;
@@ -228,6 +242,7 @@ export function registerBrainAnswerTool(
       const tier = args.tier as Tier | undefined;
       const maxAgeDays = args.max_age_days ?? DEFAULT_MAX_AGE_DAYS;
       const namespace = namespaceFilterFor(identity, requestedNamespace);
+      setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
 
       let rows: SearchRow[];
       try {
@@ -241,7 +256,8 @@ export function registerBrainAnswerTool(
           0,
           namespace,
           {},
-          requestedNamespace !== undefined && isSharedNamespace(requestedNamespace),
+          requestedNamespace !== undefined &&
+            isSharedNamespace(requestedNamespace),
         );
       } catch (error) {
         // Retrieval failed. An empty citation list here would read as "the brain
@@ -251,7 +267,8 @@ export function registerBrainAnswerTool(
             namespace,
             mode,
             tier,
-            error_message: error instanceof Error ? error.message : String(error),
+            error_message:
+              error instanceof Error ? error.message : String(error),
           },
           "brain_answer_retrieval_failed",
         );
@@ -271,24 +288,59 @@ export function registerBrainAnswerTool(
         });
       }
 
-      const evidence: Evidence[] = [];
-      const knownGaps: string[] = [];
+      const filtered = traceRetrievalSpanSync({
+        name: "retrieval.citation_filter",
+        input: {
+          candidate_count: rows.length,
+          candidates: rows.map((row) => ({
+            row_id: row.id,
+            source_type: row.source_type,
+            namespace: row.namespace ?? null,
+            content_preview: row.content_preview,
+            distance: row.distance ?? null,
+            similarity: row.distance === undefined ? null : 1 - row.distance,
+            bm25_score: row.fts_rank ?? null,
+          })),
+        },
+        metadata: {
+          stage: "filtering",
+          filter_names: ["missing_source_ref", "empty_excerpt"],
+        },
+        run: () => {
+          const evidence: Evidence[] = [];
+          const knownGaps: string[] = [];
+          for (const row of rows) {
+            const excerpt = excerptFor(row);
+            if (!row.source_ref || !excerpt) {
+              knownGaps.push(
+                `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
+              );
+              continue;
+            }
+            evidence.push({ row, excerpt, source_ref: row.source_ref });
+          }
+          return { evidence, knownGaps };
+        },
+        output: ({ evidence }) => {
+          const selected = new Set(evidence.map((item) => item.row.id));
+          return {
+            selected_count: evidence.length,
+            selected_row_ids: evidence.map((item) => item.row.id),
+            candidates: rows.map((row) => {
+              const chosen = selected.has(row.id);
+              let filteredBy: string | null = null;
+              if (!chosen) {
+                filteredBy = row.source_ref
+                  ? "empty_excerpt"
+                  : "missing_source_ref";
+              }
+              return { row_id: row.id, chosen, filtered_by: filteredBy };
+            }),
+          };
+        },
+      });
+      const { evidence, knownGaps } = filtered;
       const uncertainty: string[] = [];
-
-      for (const row of rows) {
-        const excerpt = excerptFor(row);
-        // A row with no source_ref cannot be cited, and a row with no excerpt has
-        // nothing to quote. Either way it is named in known_gaps rather than
-        // dropped silently, so the caller sees that something was retrieved and
-        // deliberately not used.
-        if (!row.source_ref || !excerpt) {
-          knownGaps.push(
-            `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
-          );
-          continue;
-        }
-        evidence.push({ row, excerpt, source_ref: row.source_ref });
-      }
 
       if (evidence.length === 0) {
         return textResult({
@@ -300,7 +352,9 @@ export function registerBrainAnswerTool(
             ...knownGaps,
             "No retrieved evidence had both citation metadata and usable preview text.",
           ],
-          uncertainty: ["Readable rows were retrieved, but none were safe to cite."],
+          uncertainty: [
+            "Readable rows were retrieved, but none were safe to cite.",
+          ],
           raw_results: args.include_raw ? rows : undefined,
         });
       }
@@ -341,7 +395,9 @@ export function registerBrainAnswerTool(
       const answer = [
         "Cited Open Brain evidence:",
         "",
-        ...citations.map((citation) => `- ${citation.excerpt} [${citation.index}]`),
+        ...citations.map(
+          (citation) => `- ${citation.excerpt} [${citation.index}]`,
+        ),
       ].join("\n");
 
       return textResult({

--- a/server/tools/search-all.ts
+++ b/server/tools/search-all.ts
@@ -80,6 +80,16 @@ interface UnifiedResult {
   tier?: string;
 }
 
+function federatedFilteredBy(
+  chosen: boolean,
+  rankIndex: number,
+  offset: number,
+): "pagination_offset" | "federated_rank_window" | null {
+  if (chosen) return null;
+  if (rankIndex < offset) return "pagination_offset";
+  return "federated_rank_window";
+}
+
 /** One qmd hit; every field is optional because the shape varies by version. */
 interface QmdDocument {
   path?: string;
@@ -412,11 +422,12 @@ export function registerSearchAllTool(
         fused.push({ ...result, rrf: 1 / (RRF_K + index + 1) });
       });
 
-      const merged = fused
-        .sort((a, b) => b.rrf - a.rrf)
-        .slice(offset, offset + limit)
-        .map(({ rrf, ...rest }) => ({ ...rest, score: rrf }));
-      const tracedMerged = traceRetrievalSpanSync({
+      type RankedCandidate = UnifiedResult & {
+        rrf: number;
+        trace_index: number;
+      };
+      let rankedCandidates: RankedCandidate[] = [];
+      const selectedCandidates = traceRetrievalSpanSync({
         name: "retrieval.federated_rank",
         input: {
           brain_count: brainResults.length,
@@ -424,22 +435,26 @@ export function registerSearchAllTool(
         },
         metadata: {
           stage: "scoring_ranking",
-          filter_names: ["federated_rank_window"],
+          filter_names: ["pagination_offset", "federated_rank_window"],
         },
-        run: () => merged,
+        run: () => {
+          rankedCandidates = fused
+            .map((row, trace_index) => ({ ...row, trace_index }))
+            .sort((a, b) => b.rrf - a.rrf);
+          return rankedCandidates.slice(offset, offset + limit);
+        },
         output: (selected) => {
-          const selectedKeys = new Set(
-            selected.map((row) => row.id ?? `qmd:${row.path ?? ""}`),
+          const selectedIndexes = new Set(
+            selected.map((row) => row.trace_index),
           );
           return {
-            candidate_count: fused.length,
+            candidate_count: rankedCandidates.length,
             selected_count: selected.length,
             returned_row_ids: selected
               .filter((row) => row.source === "brain")
               .map((row) => row.id),
-            candidates: fused.map((row) => {
-              const key = row.id ?? `qmd:${row.path ?? ""}`;
-              const chosen = selectedKeys.has(key);
+            candidates: rankedCandidates.map((row, rankIndex) => {
+              const chosen = selectedIndexes.has(row.trace_index);
               return {
                 source: row.source,
                 row_id: row.id ?? null,
@@ -448,15 +463,21 @@ export function registerSearchAllTool(
                 raw_score: row.score,
                 rrf_score: row.rrf,
                 chosen,
-                filtered_by: chosen ? null : "federated_rank_window",
+                filtered_by: federatedFilteredBy(chosen, rankIndex, offset),
               };
             }),
           };
         },
       });
+      const tracedMerged = selectedCandidates.map(
+        ({ rrf, trace_index: _traceIndex, ...rest }) => ({
+          ...rest,
+          score: rrf,
+        }),
+      );
 
       return textResult({
-        total: merged.length,
+        total: tracedMerged.length,
         brain_hits: brainResults.length,
         qmd_hits: qmdResults.length,
         results: tracedMerged,

--- a/server/tools/search-all.ts
+++ b/server/tools/search-all.ts
@@ -26,10 +26,25 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
-import { ALL_TABLES, RRF_K, TIER_BOOST, type Tier } from "./search-constants.ts";
+import {
+  ALL_TABLES,
+  RRF_K,
+  TIER_BOOST,
+  type Tier,
+} from "./search-constants.ts";
+import {
+  setActiveMcpTraceMetadata,
+  traceRetrievalSpan,
+  traceRetrievalSpanSync,
+} from "../observability/langfuse-tracing.ts";
 import {
   executeSearchWithSharedFallback,
   type SearchMode,
@@ -108,7 +123,7 @@ export function resolveQmdPath(
  *
  * @param qmdPath Resolved qmd entry point; never empty (see resolveQmdPath).
  */
-async function searchQmd(
+async function searchQmdInternal(
   dependencies: MemoryToolDependencies,
   qmdPath: string,
   query: string,
@@ -116,7 +131,15 @@ async function searchQmd(
   collection: string | undefined,
 ): Promise<UnifiedResult[]> {
   try {
-    const command = ["bun", qmdPath, "search", query, "--json", "-n", String(limit)];
+    const command = [
+      "bun",
+      qmdPath,
+      "search",
+      query,
+      "--json",
+      "-n",
+      String(limit),
+    ];
     if (collection) command.push("-c", collection);
 
     const proc = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
@@ -138,11 +161,17 @@ async function searchQmd(
     ]);
 
     if (outcome.timedOut) {
-      dependencies.logger.warn({ timeout_ms: QMD_TIMEOUT_MS }, "qmd_search_timeout");
+      dependencies.logger.warn(
+        { timeout_ms: QMD_TIMEOUT_MS },
+        "qmd_search_timeout",
+      );
       return [];
     }
     if (outcome.exitCode !== 0) {
-      dependencies.logger.warn({ exit_code: outcome.exitCode }, "qmd_search_failed");
+      dependencies.logger.warn(
+        { exit_code: outcome.exitCode },
+        "qmd_search_failed",
+      );
       return [];
     }
 
@@ -154,10 +183,13 @@ async function searchQmd(
       return {
         source: "qmd" as const,
         type: "file",
-        content: (doc.content ?? doc.text ?? doc.preview ?? doc.snippet ?? "").slice(
-          0,
-          MAX_CONTENT_CHARS,
-        ),
+        content: (
+          doc.content ??
+          doc.text ??
+          doc.preview ??
+          doc.snippet ??
+          ""
+        ).slice(0, MAX_CONTENT_CHARS),
         score: doc.score ?? doc.similarity ?? 0.5,
         path,
         collection: doc.collection,
@@ -176,6 +208,31 @@ async function searchQmd(
     );
     return [];
   }
+}
+
+function searchQmd(
+  dependencies: MemoryToolDependencies,
+  qmdPath: string,
+  query: string,
+  limit: number,
+  collection: string | undefined,
+): Promise<UnifiedResult[]> {
+  return traceRetrievalSpan({
+    name: "retrieval.qmd_query",
+    input: { query, limit, collection },
+    metadata: { stage: "candidate_generation", source: "qmd" },
+    run: () =>
+      searchQmdInternal(dependencies, qmdPath, query, limit, collection),
+    output: (rows) => ({
+      count: rows.length,
+      candidates: rows.map((row) => ({
+        path: row.path ?? null,
+        collection: row.collection ?? null,
+        content: row.content,
+        score: row.score,
+      })),
+    }),
+  });
 }
 
 /** Project a brain search row into the federated result shape. */
@@ -249,7 +306,9 @@ export function registerSearchAllTool(
         tier: z
           .enum(["hot", "warm", "cold"])
           .optional()
-          .describe("Optional: filter brain results to a specific cognitive tier"),
+          .describe(
+            "Optional: filter brain results to a specific cognitive tier",
+          ),
       },
       annotations: {
         title: "Search All",
@@ -269,14 +328,19 @@ export function registerSearchAllTool(
       const tier = args.tier as Tier | undefined;
       const requestedNamespace = args.namespace;
 
-      if (requestedNamespace && !canReadNamespace(identity, requestedNamespace)) {
+      if (
+        requestedNamespace &&
+        !canReadNamespace(identity, requestedNamespace)
+      ) {
         return errorResult(NAMESPACE_DENIED);
       }
 
       const namespace = namespaceFilterFor(identity, requestedNamespace);
+      setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
       const wantBrain = sources === "all" || sources === "brain";
       const qmdPath = dependencies.qmdPath ?? resolveQmdPath();
-      const wantQmd = (sources === "all" || sources === "qmd") && qmdPath !== undefined;
+      const wantQmd =
+        (sources === "all" || sources === "qmd") && qmdPath !== undefined;
       if ((sources === "all" || sources === "qmd") && qmdPath === undefined) {
         // Say it once, at the boundary. Without this the qmd arm's absence is
         // indistinguishable from a search that found no files.
@@ -286,7 +350,9 @@ export function registerSearchAllTool(
       const totalNeeded = offset + limit;
 
       const brainSearch = async (): Promise<UnifiedResult[]> => {
-        const tables = ALL_TABLES.filter((table) => canRead(identity.role, table));
+        const tables = ALL_TABLES.filter((table) =>
+          canRead(identity.role, table),
+        );
         if (tables.length === 0) return [];
         try {
           const rows = await executeSearchWithSharedFallback(
@@ -299,7 +365,8 @@ export function registerSearchAllTool(
             0,
             namespace,
             {},
-            requestedNamespace !== undefined && isSharedNamespace(requestedNamespace),
+            requestedNamespace !== undefined &&
+              isSharedNamespace(requestedNamespace),
           );
           return rows.map(toUnifiedResult);
         } catch (error) {
@@ -317,7 +384,13 @@ export function registerSearchAllTool(
       const [brainResults, qmdResults] = await Promise.all([
         wantBrain ? brainSearch() : Promise.resolve<UnifiedResult[]>([]),
         wantQmd && qmdPath
-          ? searchQmd(dependencies, qmdPath, args.query, totalNeeded, args.collection)
+          ? searchQmd(
+              dependencies,
+              qmdPath,
+              args.query,
+              totalNeeded,
+              args.collection,
+            )
           : Promise.resolve<UnifiedResult[]>([]),
       ]);
 
@@ -330,7 +403,8 @@ export function registerSearchAllTool(
           ...result,
           rrf: Math.max(
             0,
-            1 / (RRF_K + index + 1) + TIER_BOOST[(result.tier ?? "warm") as Tier],
+            1 / (RRF_K + index + 1) +
+              TIER_BOOST[(result.tier ?? "warm") as Tier],
           ),
         });
       });
@@ -342,12 +416,50 @@ export function registerSearchAllTool(
         .sort((a, b) => b.rrf - a.rrf)
         .slice(offset, offset + limit)
         .map(({ rrf, ...rest }) => ({ ...rest, score: rrf }));
+      const tracedMerged = traceRetrievalSpanSync({
+        name: "retrieval.federated_rank",
+        input: {
+          brain_count: brainResults.length,
+          qmd_count: qmdResults.length,
+        },
+        metadata: {
+          stage: "scoring_ranking",
+          filter_names: ["federated_rank_window"],
+        },
+        run: () => merged,
+        output: (selected) => {
+          const selectedKeys = new Set(
+            selected.map((row) => row.id ?? `qmd:${row.path ?? ""}`),
+          );
+          return {
+            candidate_count: fused.length,
+            selected_count: selected.length,
+            returned_row_ids: selected
+              .filter((row) => row.source === "brain")
+              .map((row) => row.id),
+            candidates: fused.map((row) => {
+              const key = row.id ?? `qmd:${row.path ?? ""}`;
+              const chosen = selectedKeys.has(key);
+              return {
+                source: row.source,
+                row_id: row.id ?? null,
+                path: row.path ?? null,
+                content: row.content,
+                raw_score: row.score,
+                rrf_score: row.rrf,
+                chosen,
+                filtered_by: chosen ? null : "federated_rank_window",
+              };
+            }),
+          };
+        },
+      });
 
       return textResult({
         total: merged.length,
         brain_hits: brainResults.length,
         qmd_hits: qmdResults.length,
-        results: merged,
+        results: tracedMerged,
       });
     },
   );

--- a/server/tools/search-brain.ts
+++ b/server/tools/search-brain.ts
@@ -27,7 +27,12 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ResourceTable } from "../auth/types.ts";
 import { canRead } from "../auth/permissions.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
 import { ALL_TABLES, type Tier } from "./search-constants.ts";
@@ -35,6 +40,7 @@ import {
   executeSearchWithSharedFallback,
   type SearchMode,
 } from "./search-engine.ts";
+import { setActiveMcpTraceMetadata } from "../observability/langfuse-tracing.ts";
 import {
   DEFAULT_FTS_CONFIG,
   requestFtsConfig,
@@ -182,10 +188,14 @@ export function registerSearchBrainTool(
         ftsConfig = DEFAULT_FTS_CONFIG;
       }
 
-      if (requestedNamespace && !canReadNamespace(identity, requestedNamespace)) {
+      if (
+        requestedNamespace &&
+        !canReadNamespace(identity, requestedNamespace)
+      ) {
         return errorResult(NAMESPACE_DENIED);
       }
       const namespace = namespaceFilterFor(identity, requestedNamespace);
+      setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
 
       try {
         const rows = await executeSearchWithSharedFallback(
@@ -198,7 +208,8 @@ export function registerSearchBrainTool(
           offset,
           namespace,
           { ftsConfig },
-          requestedNamespace !== undefined && isSharedNamespace(requestedNamespace),
+          requestedNamespace !== undefined &&
+            isSharedNamespace(requestedNamespace),
         );
         return textResult(rows);
       } catch (error) {
@@ -210,7 +221,8 @@ export function registerSearchBrainTool(
             namespace,
             mode,
             tier,
-            error_message: error instanceof Error ? error.message : String(error),
+            error_message:
+              error instanceof Error ? error.message : String(error),
           },
           "search_brain_failed",
         );

--- a/server/tools/search-engine.ts
+++ b/server/tools/search-engine.ts
@@ -52,8 +52,15 @@ import {
   ftsConfigLiteral,
   type FtsConfig,
 } from "./fts-config.ts";
-import { canonicalNamespace, sharedNamespaceConfig } from "./shared-namespace.ts";
+import {
+  canonicalNamespace,
+  sharedNamespaceConfig,
+} from "./shared-namespace.ts";
 import type { NamespaceFilter } from "./read-scope.ts";
+import {
+  traceRetrievalSpan,
+  traceRetrievalSpanSync,
+} from "../observability/langfuse-tracing.ts";
 
 export type SearchMode = "hybrid" | "vector" | "keyword";
 
@@ -108,6 +115,28 @@ export interface ExecuteSearchOptions {
   readonly ftsConfig?: FtsConfig;
 }
 
+function rowEvidence(row: SearchRow): Record<string, unknown> {
+  return {
+    row_id: row.id,
+    source_type: row.source_type,
+    namespace: row.namespace ?? null,
+    content_preview: row.content_preview,
+    distance: row.distance ?? null,
+    similarity: row.distance === undefined ? null : 1 - row.distance,
+    bm25_score: row.fts_rank ?? null,
+    usefulness: row.usefulness,
+    tier: row.tier ?? null,
+  };
+}
+
+function rowsEvidence(rows: readonly SearchRow[]): Record<string, unknown> {
+  return {
+    count: rows.length,
+    row_ids: rows.map((row) => row.id),
+    candidates: rows.map(rowEvidence),
+  };
+}
+
 /** Resolve the embedding timeout, ignoring an unusable environment value. */
 function searchEmbeddingTimeoutMs(): number {
   const raw =
@@ -134,22 +163,33 @@ async function generateSearchEmbedding(
 ): Promise<number[] | null> {
   const timeoutMs = searchEmbeddingTimeoutMs();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      dependencies.embedFn(query),
-      new Promise<null>((resolve) => {
-        timeoutId = setTimeout(() => {
-          dependencies.logger.warn(
-            { timeout_ms: timeoutMs, query_chars: query.length },
-            "search_embedding_timeout",
-          );
-          resolve(null);
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId);
-  }
+  return traceRetrievalSpan({
+    name: "retrieval.embedding",
+    input: { query, timeout_ms: timeoutMs },
+    metadata: { stage: "candidate_generation" },
+    run: async () => {
+      try {
+        return await Promise.race([
+          dependencies.embedFn(query),
+          new Promise<null>((resolve) => {
+            timeoutId = setTimeout(() => {
+              dependencies.logger.warn(
+                { timeout_ms: timeoutMs, query_chars: query.length },
+                "search_embedding_timeout",
+              );
+              resolve(null);
+            }, timeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
+    },
+    output: (embedding) => ({
+      generated: embedding !== null,
+      dimensions: embedding?.length ?? 0,
+    }),
+  });
 }
 
 /**
@@ -239,7 +279,11 @@ function buildVectorCTE(
   assertTier(tier);
   const alias = TABLE_ALIAS[table];
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
-  const nsFilter = namespaceFilterSql(alias, namespaceParamIndex, namespaceIsArray);
+  const nsFilter = namespaceFilterSql(
+    alias,
+    namespaceParamIndex,
+    namespaceIsArray,
+  );
   const distance = `${alias}.embedding <=> (SELECT emb FROM query_embedding)`;
   return `${table}_results AS (
   SELECT ${selectColumns(table, `${distance} AS distance`)}
@@ -292,7 +336,11 @@ function buildFtsCTE(
   assertTier(tier);
   const alias = TABLE_ALIAS[table];
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
-  const nsFilter = namespaceFilterSql(alias, namespaceParamIndex, namespaceIsArray);
+  const nsFilter = namespaceFilterSql(
+    alias,
+    namespaceParamIndex,
+    namespaceIsArray,
+  );
   const { vectorSql, querySql } = ftsMatchExpressions(table, ftsConfig);
   return `${table}_fts AS (
   SELECT ${selectColumns(table, `ts_rank_cd(${vectorSql}, ${querySql}) AS fts_rank`)}
@@ -340,7 +388,9 @@ function withSourceRefs(rows: SearchRow[]): SearchRow[] {
 function withCanonicalNamespaces(rows: SearchRow[]): SearchRow[] {
   return rows.map((row) => ({
     ...row,
-    namespace: row.namespace ? canonicalNamespace(row.namespace) : row.namespace,
+    namespace: row.namespace
+      ? canonicalNamespace(row.namespace)
+      : row.namespace,
     source_ref: row.source_ref
       ? {
           ...row.source_ref,
@@ -366,7 +416,13 @@ async function vectorSearch(
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
   const namespaceIsArray = Array.isArray(namespace);
   const ctes = tables.map((table) =>
-    buildVectorCTE(table, fetchLimit, tier, namespaceParamIndex, namespaceIsArray),
+    buildVectorCTE(
+      table,
+      fetchLimit,
+      tier,
+      namespaceParamIndex,
+      namespaceIsArray,
+    ),
   );
   const unionAll = tables
     .map((table) => `SELECT * FROM ${table}_results`)
@@ -384,8 +440,19 @@ ORDER BY (distance * ${VECTOR_WEIGHT}
   + EXTRACT(EPOCH FROM (NOW() - created_at)) / 86400.0 * ${AGE_WEIGHT}) ASC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await dependencies.pool.query(sql, params);
-  return withSourceRefs(rows as SearchRow[]);
+  return traceRetrievalSpan({
+    name: "retrieval.vector_query",
+    input: { tables, fetch_limit: fetchLimit, offset, tier, namespace },
+    metadata: {
+      stage: "candidate_generation",
+      filter_names: ["namespace", "tier", "archived_at"],
+    },
+    run: async () => {
+      const { rows } = await dependencies.pool.query(sql, params);
+      return withSourceRefs(rows as SearchRow[]);
+    },
+    output: rowsEvidence,
+  });
 }
 
 /** Run the lexical arm across every accessible table. */
@@ -426,8 +493,27 @@ ${unionAll}
 ORDER BY fts_rank DESC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await dependencies.pool.query(sql, params);
-  return withSourceRefs(rows as SearchRow[]);
+  return traceRetrievalSpan({
+    name: "retrieval.keyword_query",
+    input: {
+      query,
+      tables,
+      fetch_limit: fetchLimit,
+      offset,
+      tier,
+      namespace,
+      fts_config: ftsConfig,
+    },
+    metadata: {
+      stage: "candidate_generation",
+      filter_names: ["namespace", "tier", "archived_at"],
+    },
+    run: async () => {
+      const { rows } = await dependencies.pool.query(sql, params);
+      return withSourceRefs(rows as SearchRow[]);
+    },
+    output: rowsEvidence,
+  });
 }
 
 /**
@@ -449,34 +535,59 @@ function rrfMerge(
   ftsRows: readonly SearchRow[],
   limit: number,
 ): SearchRow[] {
-  const scored = new Map<string, { row: SearchRow; rrf: number }>();
-
-  const accumulate = (rows: readonly SearchRow[]): void => {
-    rows.forEach((row, index) => {
-      const key = `${row.source_type}:${row.id}`;
-      const contribution = 1 / (RRF_K + index + 1);
-      const existing = scored.get(key);
-      if (existing) existing.rrf += contribution;
-      else scored.set(key, { row, rrf: contribution });
-    });
-  };
-
-  accumulate(vectorRows);
-  accumulate(ftsRows);
-
-  return Array.from(scored.values())
-    .map(({ row, rrf }) => ({
-      row,
-      rrf: Math.max(
-        0,
-        (rrf + TIER_BOOST[(row.tier ?? "warm") as Tier]) *
-          (TABLE_WEIGHT[row.source_type] ?? 1) *
-          recencyFactor(row.created_at),
-      ),
-    }))
-    .sort((a, b) => b.rrf - a.rrf)
-    .slice(0, limit)
-    .map(({ row }) => row);
+  let ranked: Array<{ row: SearchRow; rrf: number }> = [];
+  return traceRetrievalSpanSync({
+    name: "retrieval.rank_rrf",
+    input: {
+      limit,
+      vector: rowsEvidence(vectorRows),
+      keyword: rowsEvidence(ftsRows),
+    },
+    metadata: { stage: "scoring_ranking", filter_names: ["rrf_limit"] },
+    run: () => {
+      const scored = new Map<string, { row: SearchRow; rrf: number }>();
+      const accumulate = (rows: readonly SearchRow[]): void => {
+        rows.forEach((row, index) => {
+          const key = `${row.source_type}:${row.id}`;
+          const contribution = 1 / (RRF_K + index + 1);
+          const existing = scored.get(key);
+          if (existing) existing.rrf += contribution;
+          else scored.set(key, { row, rrf: contribution });
+        });
+      };
+      accumulate(vectorRows);
+      accumulate(ftsRows);
+      ranked = Array.from(scored.values())
+        .map(({ row, rrf }) => ({
+          row,
+          rrf: Math.max(
+            0,
+            (rrf + TIER_BOOST[(row.tier ?? "warm") as Tier]) *
+              (TABLE_WEIGHT[row.source_type] ?? 1) *
+              recencyFactor(row.created_at),
+          ),
+        }))
+        .sort((a, b) => b.rrf - a.rrf);
+      return ranked.slice(0, limit).map(({ row }) => row);
+    },
+    output: (selected) => {
+      const selectedKeys = new Set(
+        selected.map((row) => `${row.source_type}:${row.id}`),
+      );
+      return {
+        candidate_count: ranked.length,
+        selected_count: selected.length,
+        candidates: ranked.map(({ row, rrf }) => ({
+          ...rowEvidence(row),
+          rrf_score: rrf,
+          chosen: selectedKeys.has(`${row.source_type}:${row.id}`),
+          filtered_by: selectedKeys.has(`${row.source_type}:${row.id}`)
+            ? null
+            : "rrf_limit",
+        })),
+      };
+    },
+  });
 }
 
 /**
@@ -496,7 +607,7 @@ function rrfMerge(
  * @param options Lexical-arm configuration.
  * @throws When `mode` is `vector` and the embedding could not be generated.
  */
-export async function executeSearch(
+async function executeSearchInternal(
   dependencies: SearchDependencies,
   tables: readonly ResourceTable[],
   query: string,
@@ -565,7 +676,15 @@ export async function executeSearch(
   const totalNeeded = offset + limit;
   const fetchLimit = totalNeeded * HYBRID_FETCH_MULTIPLIER;
   const [vectorRows, ftsRows] = await Promise.all([
-    vectorSearch(dependencies, tables, embedding, fetchLimit, tier, 0, namespace),
+    vectorSearch(
+      dependencies,
+      tables,
+      embedding,
+      fetchLimit,
+      tier,
+      0,
+      namespace,
+    ),
     ftsSearch(
       dependencies,
       tables,
@@ -578,6 +697,47 @@ export async function executeSearch(
     ),
   ]);
   return rrfMerge(vectorRows, ftsRows, totalNeeded).slice(offset);
+}
+
+export function executeSearch(
+  dependencies: SearchDependencies,
+  tables: readonly ResourceTable[],
+  query: string,
+  limit: number,
+  mode: SearchMode = "hybrid",
+  tier?: Tier,
+  offset = 0,
+  namespace?: NamespaceFilter,
+  options: ExecuteSearchOptions = {},
+): Promise<SearchRow[]> {
+  return traceRetrievalSpan({
+    name: "retrieval.execute",
+    input: { query, tables, limit, mode, tier, offset, namespace, options },
+    metadata: {
+      stage: "retrieval_pipeline",
+      resolved_namespace: namespace ?? null,
+      filter_names: [
+        "permissions",
+        "namespace",
+        "tier",
+        "archived_at",
+        "pagination",
+      ],
+    },
+    run: () =>
+      executeSearchInternal(
+        dependencies,
+        tables,
+        query,
+        limit,
+        mode,
+        tier,
+        offset,
+        namespace,
+        options,
+      ),
+    output: rowsEvidence,
+  });
 }
 
 /** Dedupe key used when topping up from the legacy namespace. */
@@ -616,18 +776,56 @@ function mergeFallbackRows(
   legacyRows: readonly SearchRow[],
   limit: number,
 ): SearchRow[] {
-  const primary = dedupeFallbackRows(primaryRows);
-  const primaryKeys = new Set(primary.map(fallbackDedupeKey));
-  const legacy = dedupeFallbackRows(
-    legacyRows.filter((row) => !primaryKeys.has(fallbackDedupeKey(row))),
-  );
-  if (legacy.length === 0) return primary.slice(0, limit);
-  if (primary.length >= limit) {
-    const first = legacy[0];
-    if (!first) return primary.slice(0, limit);
-    return [...primary.slice(0, Math.max(0, limit - 1)), first];
-  }
-  return [...primary, ...legacy.slice(0, limit - primary.length)];
+  return traceRetrievalSpanSync({
+    name: "retrieval.fallback_dedupe",
+    input: {
+      limit,
+      primary: rowsEvidence(primaryRows),
+      legacy: rowsEvidence(legacyRows),
+    },
+    metadata: {
+      stage: "filtering",
+      filter_names: ["fallback_duplicate", "fallback_limit"],
+    },
+    run: () => {
+      const primary = dedupeFallbackRows(primaryRows);
+      const primaryKeys = new Set(primary.map(fallbackDedupeKey));
+      const legacy = dedupeFallbackRows(
+        legacyRows.filter((row) => !primaryKeys.has(fallbackDedupeKey(row))),
+      );
+      if (legacy.length === 0) return primary.slice(0, limit);
+      if (primary.length >= limit) {
+        const first = legacy[0];
+        if (!first) return primary.slice(0, limit);
+        return [...primary.slice(0, Math.max(0, limit - 1)), first];
+      }
+      return [...primary, ...legacy.slice(0, limit - primary.length)];
+    },
+    output: (selected) => {
+      const selectedIds = new Set(selected.map((row) => row.id));
+      const primaryKeys = new Set(primaryRows.map(fallbackDedupeKey));
+      const seen = new Set<string>();
+      const candidates = [...primaryRows, ...legacyRows].map((row, index) => {
+        const key = fallbackDedupeKey(row);
+        const duplicate =
+          seen.has(key) ||
+          (index >= primaryRows.length && primaryKeys.has(key));
+        seen.add(key);
+        const chosen = selectedIds.has(row.id);
+        let filteredBy: string | null = null;
+        if (!chosen) {
+          filteredBy = duplicate ? "fallback_duplicate" : "fallback_limit";
+        }
+        return { ...rowEvidence(row), chosen, filtered_by: filteredBy };
+      });
+      return {
+        candidate_count: candidates.length,
+        selected_count: selected.length,
+        selected_row_ids: selected.map((row) => row.id),
+        candidates,
+      };
+    },
+  });
 }
 
 /**

--- a/server/tools/search-engine.ts
+++ b/server/tools/search-engine.ts
@@ -120,7 +120,7 @@ function rowEvidence(row: SearchRow): Record<string, unknown> {
     row_id: row.id,
     source_type: row.source_type,
     namespace: row.namespace ?? null,
-    content_preview: row.content_preview,
+    content_preview: row.content_preview?.slice(0, 300) ?? null,
     distance: row.distance ?? null,
     similarity: row.distance === undefined ? null : 1 - row.distance,
     bm25_score: row.fts_rank ?? null,
@@ -135,6 +135,10 @@ function rowsEvidence(rows: readonly SearchRow[]): Record<string, unknown> {
     row_ids: rows.map((row) => row.id),
     candidates: rows.map(rowEvidence),
   };
+}
+
+function rowIdsEvidence(rows: readonly SearchRow[]): Record<string, unknown> {
+  return { count: rows.length, row_ids: rows.map((row) => row.id) };
 }
 
 /** Resolve the embedding timeout, ignoring an unusable environment value. */
@@ -540,8 +544,8 @@ function rrfMerge(
     name: "retrieval.rank_rrf",
     input: {
       limit,
-      vector: rowsEvidence(vectorRows),
-      keyword: rowsEvidence(ftsRows),
+      vector: rowIdsEvidence(vectorRows),
+      keyword: rowIdsEvidence(ftsRows),
     },
     metadata: { stage: "scoring_ranking", filter_names: ["rrf_limit"] },
     run: () => {
@@ -771,12 +775,69 @@ function dedupeFallbackRows(rows: readonly SearchRow[]): SearchRow[] {
  * displaced so the caller can SEE that unmigrated content exists — a silent
  * omission is what makes a stalled migration invisible.
  */
-function mergeFallbackRows(
+type FallbackClassification = {
+  row: SearchRow;
+  chosen: boolean;
+  filtered_by: "fallback_duplicate" | "fallback_limit" | null;
+};
+
+function selectedFallbackRows(
+  primary: SearchRow[],
+  legacy: SearchRow[],
+  limit: number,
+): SearchRow[] {
+  if (legacy.length === 0) return primary.slice(0, limit);
+  const firstLegacy = legacy[0];
+  if (!firstLegacy) return primary.slice(0, limit);
+  if (primary.length >= limit) {
+    return [...primary.slice(0, Math.max(0, limit - 1)), firstLegacy];
+  }
+  return [...primary, ...legacy.slice(0, limit - primary.length)];
+}
+
+function fallbackFilteredBy(
+  chosen: boolean,
+  duplicate: boolean,
+): FallbackClassification["filtered_by"] {
+  if (chosen) return null;
+  return duplicate ? "fallback_duplicate" : "fallback_limit";
+}
+
+function computeFallbackRows(
+  primaryRows: readonly SearchRow[],
+  legacyRows: readonly SearchRow[],
+  limit: number,
+): { rows: SearchRow[]; classifications: FallbackClassification[] } {
+  const primary = dedupeFallbackRows(primaryRows);
+  const primaryKeys = new Set(primary.map(fallbackDedupeKey));
+  const legacy = dedupeFallbackRows(
+    legacyRows.filter((row) => !primaryKeys.has(fallbackDedupeKey(row))),
+  );
+  const rows = selectedFallbackRows(primary, legacy, limit);
+  const selectedKeys = new Set(rows.map(fallbackDedupeKey));
+  const seen = new Set<string>();
+  const classifications = [...primaryRows, ...legacyRows].map((row, index) => {
+    const key = fallbackDedupeKey(row);
+    const duplicate =
+      seen.has(key) ||
+      (index >= primaryRows.length && primaryKeys.has(key));
+    seen.add(key);
+    const chosen = !duplicate && selectedKeys.has(key);
+    return {
+      row,
+      chosen,
+      filtered_by: fallbackFilteredBy(chosen, duplicate),
+    } satisfies FallbackClassification;
+  });
+  return { rows, classifications };
+}
+
+export function mergeFallbackRows(
   primaryRows: readonly SearchRow[],
   legacyRows: readonly SearchRow[],
   limit: number,
 ): SearchRow[] {
-  return traceRetrievalSpanSync({
+  const result = traceRetrievalSpanSync({
     name: "retrieval.fallback_dedupe",
     input: {
       limit,
@@ -787,45 +848,19 @@ function mergeFallbackRows(
       stage: "filtering",
       filter_names: ["fallback_duplicate", "fallback_limit"],
     },
-    run: () => {
-      const primary = dedupeFallbackRows(primaryRows);
-      const primaryKeys = new Set(primary.map(fallbackDedupeKey));
-      const legacy = dedupeFallbackRows(
-        legacyRows.filter((row) => !primaryKeys.has(fallbackDedupeKey(row))),
-      );
-      if (legacy.length === 0) return primary.slice(0, limit);
-      if (primary.length >= limit) {
-        const first = legacy[0];
-        if (!first) return primary.slice(0, limit);
-        return [...primary.slice(0, Math.max(0, limit - 1)), first];
-      }
-      return [...primary, ...legacy.slice(0, limit - primary.length)];
-    },
-    output: (selected) => {
-      const selectedIds = new Set(selected.map((row) => row.id));
-      const primaryKeys = new Set(primaryRows.map(fallbackDedupeKey));
-      const seen = new Set<string>();
-      const candidates = [...primaryRows, ...legacyRows].map((row, index) => {
-        const key = fallbackDedupeKey(row);
-        const duplicate =
-          seen.has(key) ||
-          (index >= primaryRows.length && primaryKeys.has(key));
-        seen.add(key);
-        const chosen = selectedIds.has(row.id);
-        let filteredBy: string | null = null;
-        if (!chosen) {
-          filteredBy = duplicate ? "fallback_duplicate" : "fallback_limit";
-        }
-        return { ...rowEvidence(row), chosen, filtered_by: filteredBy };
-      });
-      return {
-        candidate_count: candidates.length,
-        selected_count: selected.length,
-        selected_row_ids: selected.map((row) => row.id),
-        candidates,
-      };
-    },
+    run: () => computeFallbackRows(primaryRows, legacyRows, limit),
+    output: ({ rows, classifications }) => ({
+      candidate_count: classifications.length,
+      selected_count: rows.length,
+      selected_row_ids: rows.map((row) => row.id),
+      candidates: classifications.map(({ row, chosen, filtered_by }) => ({
+        ...rowEvidence(row),
+        chosen,
+        filtered_by,
+      })),
+    }),
   });
+  return result.rows;
 }
 
 /**

--- a/src/candidate-dedupe.ts
+++ b/src/candidate-dedupe.ts
@@ -51,7 +51,6 @@
 
 import type pg from "pg";
 import type { MaintenanceQueueLogger } from "./maintenance-queue.ts";
-import { traceRetrievalSpanSync } from "../server/observability/langfuse-tracing.ts";
 
 /**
  * Cosine DISTANCE at or below which two candidates are the same claim.
@@ -242,35 +241,6 @@ export async function runCandidateDedupe(
         WHERE t.terminal <> n.dup_id`,
       [deps.namespace ?? null, batchSize, distance],
     );
-
-    traceRetrievalSpanSync({
-      name: "retrieval.candidate_dedupe",
-      input: {
-        namespace: deps.namespace ?? null,
-        distance_threshold: distance,
-        skipped_no_embedding: summary.skipped_no_embedding,
-      },
-      metadata: {
-        stage: "filtering",
-        filter_names: ["no_embedding", "distance_threshold", "oldest_survivor"],
-      },
-      run: () => pairs.rows,
-      output: (rows) => ({
-        candidate_count: rows.length,
-        chosen_count: rows.length,
-        candidates: rows.map((row) => ({
-          row_id: row.dup_id,
-          survivor_row_id: row.survivor_id,
-          namespace: row.namespace,
-          distance: row.distance,
-          similarity: 1 - row.distance,
-          chosen: true,
-          filtered_by: null,
-        })),
-        filtered: summary.skipped_no_embedding,
-        filtered_by: "no_embedding",
-      }),
-    });
 
     summary.examined = pairs.rows.length;
 

--- a/src/candidate-dedupe.ts
+++ b/src/candidate-dedupe.ts
@@ -51,6 +51,7 @@
 
 import type pg from "pg";
 import type { MaintenanceQueueLogger } from "./maintenance-queue.ts";
+import { traceRetrievalSpanSync } from "../server/observability/langfuse-tracing.ts";
 
 /**
  * Cosine DISTANCE at or below which two candidates are the same claim.
@@ -241,6 +242,35 @@ export async function runCandidateDedupe(
         WHERE t.terminal <> n.dup_id`,
       [deps.namespace ?? null, batchSize, distance],
     );
+
+    traceRetrievalSpanSync({
+      name: "retrieval.candidate_dedupe",
+      input: {
+        namespace: deps.namespace ?? null,
+        distance_threshold: distance,
+        skipped_no_embedding: summary.skipped_no_embedding,
+      },
+      metadata: {
+        stage: "filtering",
+        filter_names: ["no_embedding", "distance_threshold", "oldest_survivor"],
+      },
+      run: () => pairs.rows,
+      output: (rows) => ({
+        candidate_count: rows.length,
+        chosen_count: rows.length,
+        candidates: rows.map((row) => ({
+          row_id: row.dup_id,
+          survivor_row_id: row.survivor_id,
+          namespace: row.namespace,
+          distance: row.distance,
+          similarity: 1 - row.distance,
+          chosen: true,
+          filtered_by: null,
+        })),
+        filtered: summary.skipped_no_embedding,
+        filtered_by: "no_embedding",
+      }),
+    });
 
     summary.examined = pairs.rows.length;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ import {
 } from "./maintenance-bootstrap.ts";
 import { safeMaintenanceErrorCategory } from "./maintenance-queue.ts";
 import { validateLocalCloneMode } from "./local-clone-mode.ts";
+import {
+  createTracingRuntime,
+  installMcpTracing,
+} from "../server/observability/langfuse-tracing.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
 
@@ -77,6 +81,7 @@ export function createApp(
   pool: pg.Pool,
   tokenMap: Map<string, AuthInfo>,
   deps?: ToolDeps,
+  tracing?: ReturnType<typeof createTracingRuntime>,
 ): express.Express {
   const app = express();
   const natsRuntimeBoundary =
@@ -234,6 +239,12 @@ export function createApp(
   // "Already connected to a transport" errors with concurrent clients
   const serverFactory = () => {
     const s = createBrainServer();
+    if (tracing?.sink) {
+      installMcpTracing(s, {
+        config: tracing.config,
+        sink: tracing.sink,
+      });
+    }
     registerAllTools(s, toolDeps);
     return s;
   };
@@ -287,6 +298,7 @@ if (import.meta.main) {
   }
 
   const pool = createPool();
+  const tracing = createTracingRuntime();
 
   if (process.env.OPEN_BRAIN_RUN_MIGRATIONS !== "0") {
     try {
@@ -364,7 +376,7 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const app = createApp(pool, tokenMap, toolDeps);
+  const app = createApp(pool, tokenMap, toolDeps, tracing);
   const port = parseInt(process.env.PORT || "3100", 10);
 
   const bindHost = localClone.enabled
@@ -441,6 +453,7 @@ if (import.meta.main) {
         );
       }
     }
+    await tracing.shutdown();
     try {
       await pool.end();
     } catch (err) {

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -17,6 +17,10 @@ import {
 import { isSharedNamespace } from "../shared-namespace.ts";
 import { describeError, logger } from "../observability/index.ts";
 import {
+  setActiveMcpTraceMetadata,
+  traceRetrievalSpanSync,
+} from "../../server/observability/langfuse-tracing.ts";
+import {
   sourceScopeAuthorizationError,
   sourceScopeSchema,
 } from "../source-refs.ts";
@@ -235,6 +239,7 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         auth,
         requestedNamespace,
       ) as NamespaceFilter;
+      setActiveMcpTraceMetadata({ resolved_namespace: namespace });
 
       let rows: SearchRow[];
       try {
@@ -305,20 +310,59 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      const evidence: Evidence[] = [];
-      const knownGaps: string[] = [];
+      const filtered = traceRetrievalSpanSync({
+        name: "retrieval.citation_filter",
+        input: {
+          candidate_count: rows.length,
+          candidates: rows.map((row) => ({
+            row_id: row.id,
+            source_type: row.source_type,
+            namespace: row.namespace ?? null,
+            content_preview: row.content_preview,
+            distance: row.distance ?? null,
+            similarity: row.distance === undefined ? null : 1 - row.distance,
+            bm25_score: row.fts_rank ?? null,
+          })),
+        },
+        metadata: {
+          stage: "filtering",
+          filter_names: ["missing_source_ref", "empty_excerpt"],
+        },
+        run: () => {
+          const evidence: Evidence[] = [];
+          const knownGaps: string[] = [];
+          for (const row of rows) {
+            const excerpt = excerptFor(row);
+            if (!row.source_ref || !excerpt) {
+              knownGaps.push(
+                `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
+              );
+              continue;
+            }
+            evidence.push({ row, excerpt, source_ref: row.source_ref });
+          }
+          return { evidence, knownGaps };
+        },
+        output: ({ evidence }) => {
+          const selected = new Set(evidence.map((item) => item.row.id));
+          return {
+            selected_count: evidence.length,
+            selected_row_ids: evidence.map((item) => item.row.id),
+            candidates: rows.map((row) => {
+              const chosen = selected.has(row.id);
+              let filteredBy: string | null = null;
+              if (!chosen) {
+                filteredBy = row.source_ref
+                  ? "empty_excerpt"
+                  : "missing_source_ref";
+              }
+              return { row_id: row.id, chosen, filtered_by: filteredBy };
+            }),
+          };
+        },
+      });
+      const { evidence, knownGaps } = filtered;
       const uncertainty: string[] = [];
-
-      for (const row of rows) {
-        const excerpt = excerptFor(row);
-        if (!row.source_ref || !excerpt) {
-          knownGaps.push(
-            `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
-          );
-          continue;
-        }
-        evidence.push({ row, excerpt, source_ref: row.source_ref });
-      }
 
       if (evidence.length === 0) {
         return {

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -20,6 +20,11 @@ import {
 import { isSharedNamespace } from "../shared-namespace.ts";
 import { resolveQmdPath } from "../qmd-path.ts";
 import {
+  setActiveMcpTraceMetadata,
+  traceRetrievalSpan,
+  traceRetrievalSpanSync,
+} from "../../server/observability/langfuse-tracing.ts";
+import {
   sourceScopeAuthorizationError,
   sourceScopeSchema,
 } from "../source-refs.ts";
@@ -62,7 +67,7 @@ interface QmdDocument {
 
 const QMD_TIMEOUT_MS = 10_000;
 
-async function searchQmd(
+async function searchQmdInternal(
   query: string,
   limit: number,
   collection?: string,
@@ -81,10 +86,7 @@ async function searchQmd(
     ];
     if (collection) qmdArgs.push("-c", collection);
 
-    const proc = Bun.spawn(
-      qmdArgs,
-      { stdout: "pipe", stderr: "pipe" },
-    );
+    const proc = Bun.spawn(qmdArgs, { stdout: "pipe", stderr: "pipe" });
 
     const result = await Promise.race([
       (async () => {
@@ -140,6 +142,28 @@ async function searchQmd(
     });
     return [];
   }
+}
+
+function searchQmd(
+  query: string,
+  limit: number,
+  collection?: string,
+): Promise<UnifiedResult[]> {
+  return traceRetrievalSpan({
+    name: "retrieval.qmd_query",
+    input: { query, limit, collection },
+    metadata: { stage: "candidate_generation", source: "qmd" },
+    run: () => searchQmdInternal(query, limit, collection),
+    output: (rows) => ({
+      count: rows.length,
+      candidates: rows.map((row) => ({
+        path: row.path ?? null,
+        collection: row.collection ?? null,
+        content: row.content,
+        score: row.score,
+      })),
+    }),
+  });
 }
 
 export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
@@ -255,6 +279,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
         };
       }
       const namespace = namespaceFilterFor(auth, requestedNamespace);
+      setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
       const searchBrain = sources === "all" || sources === "brain";
       const searchQmdSource =
         !sourceScope && (sources === "all" || sources === "qmd");
@@ -302,6 +327,44 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
         .sort((a, b) => b.rrf - a.rrf)
         .slice(offset, offset + limit)
         .map(({ rrf, ...rest }) => ({ ...rest, score: rrf }));
+      const tracedMerged = traceRetrievalSpanSync({
+        name: "retrieval.federated_rank",
+        input: {
+          brain_count: brainResults.length,
+          qmd_count: qmdResults.length,
+        },
+        metadata: {
+          stage: "scoring_ranking",
+          filter_names: ["federated_rank_window"],
+        },
+        run: () => merged,
+        output: (selected) => {
+          const selectedKeys = new Set(
+            selected.map((row) => row.id ?? `qmd:${row.path ?? ""}`),
+          );
+          return {
+            candidate_count: withRrf.length,
+            selected_count: selected.length,
+            returned_row_ids: selected
+              .filter((row) => row.source === "brain")
+              .map((row) => row.id),
+            candidates: withRrf.map((row) => {
+              const key = row.id ?? `qmd:${row.path ?? ""}`;
+              const chosen = selectedKeys.has(key);
+              return {
+                source: row.source,
+                row_id: row.id ?? null,
+                path: row.path ?? null,
+                content: row.content,
+                raw_score: row.score,
+                rrf_score: row.rrf,
+                chosen,
+                filtered_by: chosen ? null : "federated_rank_window",
+              };
+            }),
+          };
+        },
+      });
 
       return {
         content: [
@@ -311,7 +374,7 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
               total: merged.length,
               brain_hits: brainResults.length,
               qmd_hits: qmdResults.length,
-              results: merged,
+              results: tracedMerged,
             }),
           },
         ],

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -52,6 +52,16 @@ interface QmdSourceRef {
   collection?: string;
 }
 
+function federatedFilteredBy(
+  chosen: boolean,
+  rankIndex: number,
+  offset: number,
+): "pagination_offset" | "federated_rank_window" | null {
+  if (chosen) return null;
+  if (rankIndex < offset) return "pagination_offset";
+  return "federated_rank_window";
+}
+
 interface QmdDocument {
   id?: string;
   path?: string;
@@ -323,11 +333,12 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
       for (let i = 0; i < qmdResults.length; i++) {
         withRrf.push({ ...qmdResults[i]!, rrf: 1 / (RRF_K + i + 1) });
       }
-      const merged = withRrf
-        .sort((a, b) => b.rrf - a.rrf)
-        .slice(offset, offset + limit)
-        .map(({ rrf, ...rest }) => ({ ...rest, score: rrf }));
-      const tracedMerged = traceRetrievalSpanSync({
+      type RankedCandidate = UnifiedResult & {
+        rrf: number;
+        trace_index: number;
+      };
+      let rankedCandidates: RankedCandidate[] = [];
+      const selectedCandidates = traceRetrievalSpanSync({
         name: "retrieval.federated_rank",
         input: {
           brain_count: brainResults.length,
@@ -335,22 +346,26 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
         },
         metadata: {
           stage: "scoring_ranking",
-          filter_names: ["federated_rank_window"],
+          filter_names: ["pagination_offset", "federated_rank_window"],
         },
-        run: () => merged,
+        run: () => {
+          rankedCandidates = withRrf
+            .map((row, trace_index) => ({ ...row, trace_index }))
+            .sort((a, b) => b.rrf - a.rrf);
+          return rankedCandidates.slice(offset, offset + limit);
+        },
         output: (selected) => {
-          const selectedKeys = new Set(
-            selected.map((row) => row.id ?? `qmd:${row.path ?? ""}`),
+          const selectedIndexes = new Set(
+            selected.map((row) => row.trace_index),
           );
           return {
-            candidate_count: withRrf.length,
+            candidate_count: rankedCandidates.length,
             selected_count: selected.length,
             returned_row_ids: selected
               .filter((row) => row.source === "brain")
               .map((row) => row.id),
-            candidates: withRrf.map((row) => {
-              const key = row.id ?? `qmd:${row.path ?? ""}`;
-              const chosen = selectedKeys.has(key);
+            candidates: rankedCandidates.map((row, rankIndex) => {
+              const chosen = selectedIndexes.has(row.trace_index);
               return {
                 source: row.source,
                 row_id: row.id ?? null,
@@ -359,19 +374,25 @@ export function registerSearchAll(server: McpServer, deps: ToolDeps): void {
                 raw_score: row.score,
                 rrf_score: row.rrf,
                 chosen,
-                filtered_by: chosen ? null : "federated_rank_window",
+                filtered_by: federatedFilteredBy(chosen, rankIndex, offset),
               };
             }),
           };
         },
       });
+      const tracedMerged = selectedCandidates.map(
+        ({ rrf, trace_index: _traceIndex, ...rest }) => ({
+          ...rest,
+          score: rrf,
+        }),
+      );
 
       return {
         content: [
           {
             type: "text" as const,
             text: JSON.stringify({
-              total: merged.length,
+              total: tracedMerged.length,
               brain_hits: brainResults.length,
               qmd_hits: qmdResults.length,
               results: tracedMerged,

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -29,6 +29,11 @@ import {
   VALID_TIERS,
 } from "./table-constants.ts";
 import {
+  setActiveMcpTraceMetadata,
+  traceRetrievalSpan,
+  traceRetrievalSpanSync,
+} from "../../server/observability/langfuse-tracing.ts";
+import {
   DEFAULT_FTS_CONFIG,
   ftsConfigLiteral,
   ftsStatementTimeoutMs,
@@ -179,23 +184,34 @@ async function generateSearchEmbedding(
   const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-  try {
-    return await Promise.race([
-      deps.embedFn(query, undefined, { signal: controller.signal }),
-      new Promise<null>((resolve) => {
-        timeoutId = setTimeout(() => {
-          controller.abort();
-          logger.warn("search_embedding_timeout", {
-            timeoutMs,
-            queryLength: query.length,
-          });
-          resolve(null);
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId);
-  }
+  return traceRetrievalSpan({
+    name: "retrieval.embedding",
+    input: { query, timeout_ms: timeoutMs },
+    metadata: { stage: "candidate_generation" },
+    run: async () => {
+      try {
+        return await Promise.race([
+          deps.embedFn(query, undefined, { signal: controller.signal }),
+          new Promise<null>((resolve) => {
+            timeoutId = setTimeout(() => {
+              controller.abort();
+              logger.warn("search_embedding_timeout", {
+                timeoutMs,
+                queryLength: query.length,
+              });
+              resolve(null);
+            }, timeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
+    },
+    output: (embedding) => ({
+      generated: embedding !== null,
+      dimensions: embedding?.length ?? 0,
+    }),
+  });
 }
 
 /** Gentle recency factor: today=1.0, 30d=0.97, 90d=0.92, 365d=0.73 */
@@ -258,6 +274,28 @@ export interface SearchRow {
     content_hash?: string;
     hash_version?: string;
     byte_length?: number;
+  };
+}
+
+function rowEvidence(row: SearchRow): Record<string, unknown> {
+  return {
+    row_id: row.id,
+    source_type: row.source_type,
+    namespace: row.namespace ?? null,
+    content_preview: row.content_preview,
+    distance: row.distance ?? null,
+    similarity: row.distance === undefined ? null : 1 - row.distance,
+    bm25_score: row.fts_rank ?? null,
+    usefulness: row.usefulness,
+    tier: row.tier ?? null,
+  };
+}
+
+function rowsEvidence(rows: readonly SearchRow[]): Record<string, unknown> {
+  return {
+    count: rows.length,
+    row_ids: rows.map((row) => row.id),
+    candidates: rows.map(rowEvidence),
   };
 }
 
@@ -776,8 +814,23 @@ async function relationalGraphSearch(
     .join("\nUNION ALL\n");
 
   try {
-    const { rows } = await deps.pool.query<SearchRow>(
-      `WITH relational_graph_seed AS (
+    const rows = await traceRetrievalSpan({
+      name: "retrieval.graph_query",
+      input: {
+        relation: parsed.relation,
+        direction: parsed.direction,
+        seed: parsed.seed,
+        fetch_limit: fetchLimit,
+        tier,
+        namespace,
+      },
+      metadata: {
+        stage: "candidate_generation",
+        filter_names: ["namespace", "relation", "archived_at"],
+      },
+      run: async () => {
+        const result = await deps.pool.query<SearchRow>(
+          `WITH relational_graph_seed AS (
          SELECT e.id, e.namespace
          FROM ob_entities e
          WHERE (
@@ -794,8 +847,12 @@ ${hydrationSql}
        ) relational_graph_rows
        ORDER BY fts_rank DESC, created_at DESC
        LIMIT $3`,
-      params,
-    );
+          params,
+        );
+        return withSourceRefs(result.rows);
+      },
+      output: rowsEvidence,
+    });
     logger.info("search_relational_graph", {
       relation: parsed.relation,
       direction: parsed.direction,
@@ -803,7 +860,7 @@ ${hydrationSql}
       target_tables: targetTables,
       candidate_count: rows.length,
     });
-    return withSourceRefs(rows);
+    return rows;
   } catch (err) {
     logger.warn("search_relational_graph_failed", {
       relation: parsed.relation,
@@ -855,8 +912,26 @@ ${unionAll}
 ORDER BY (distance * ${VECTOR_WEIGHT} + (1.0 - COALESCE(usefulness, 0.5)) * ${USEFULNESS_WEIGHT} + EXTRACT(EPOCH FROM (NOW() - created_at)) / 86400.0 * ${AGE_WEIGHT}) ASC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await deps.pool.query(sql, params);
-  return withSourceRefs(rows as SearchRow[]);
+  return traceRetrievalSpan({
+    name: "retrieval.vector_query",
+    input: {
+      accessible_tables: accessibleTables,
+      fetch_limit: fetchLimit,
+      offset,
+      tier,
+      namespace,
+      source_scope: sourceScope,
+    },
+    metadata: {
+      stage: "candidate_generation",
+      filter_names: ["namespace", "tier", "source_scope", "archived_at"],
+    },
+    run: async () => {
+      const { rows } = await deps.pool.query(sql, params);
+      return withSourceRefs(rows as SearchRow[]);
+    },
+    output: rowsEvidence,
+  });
 }
 
 /**
@@ -953,8 +1028,28 @@ ${unionAll}
 ORDER BY fts_rank DESC
 LIMIT $2 OFFSET $3`;
 
-  const { rows } = await runBoundedFtsQuery(deps, sql, params, ftsConfig);
-  return withSourceRefs(rows as SearchRow[]);
+  return traceRetrievalSpan({
+    name: "retrieval.keyword_query",
+    input: {
+      query,
+      accessible_tables: accessibleTables,
+      fetch_limit: fetchLimit,
+      offset,
+      tier,
+      namespace,
+      source_scope: sourceScope,
+      fts_config: ftsConfig,
+    },
+    metadata: {
+      stage: "candidate_generation",
+      filter_names: ["namespace", "tier", "source_scope", "archived_at"],
+    },
+    run: async () => {
+      const { rows } = await runBoundedFtsQuery(deps, sql, params, ftsConfig);
+      return withSourceRefs(rows as SearchRow[]);
+    },
+    output: rowsEvidence,
+  });
 }
 
 /**
@@ -1001,7 +1096,7 @@ function rrfMerge(
     }
   }
 
-  return Array.from(scoreMap.values())
+  const selected = Array.from(scoreMap.values())
     .map(({ row, rrf }) => {
       const tier = TIER_BOOST[(row.tier ?? "warm") as Tier];
       const weight = TABLE_WEIGHT[row.source_type] ?? 1.0;
@@ -1011,6 +1106,43 @@ function rrfMerge(
     .sort((a, b) => b.rrf - a.rrf)
     .slice(0, limit)
     .map(({ row }) => row);
+  return traceRetrievalSpanSync({
+    name: "retrieval.rank_rrf",
+    input: {
+      vector: rowsEvidence(vectorRows),
+      keyword: rowsEvidence(ftsRows),
+      graph: rowsEvidence(graphRows),
+    },
+    metadata: { stage: "scoring_ranking", filter_names: ["rrf_window"] },
+    run: () => selected,
+    output: (rows) => {
+      const selectedKeys = new Set(
+        rows.map((row) => `${row.source_type}:${row.id}`),
+      );
+      return {
+        candidate_count: scoreMap.size,
+        selected_count: rows.length,
+        selected_row_ids: rows.map((row) => row.id),
+        candidates: Array.from(scoreMap.values()).map(({ row, rrf }) => {
+          const chosen = selectedKeys.has(`${row.source_type}:${row.id}`);
+          const tier = TIER_BOOST[(row.tier ?? "warm") as Tier];
+          const rankScore = Math.max(
+            0,
+            (rrf + tier) *
+              (TABLE_WEIGHT[row.source_type] ?? 1.0) *
+              recencyFactor(row.created_at),
+          );
+          return {
+            ...rowEvidence(row),
+            rrf_contribution: rrf,
+            rank_score: rankScore,
+            chosen,
+            filtered_by: chosen ? null : "rrf_window",
+          };
+        }),
+      };
+    },
+  });
 }
 
 /** Circuit breaker: stop tracking after consecutive failures to avoid log floods */
@@ -1072,7 +1204,8 @@ export function trackUsage(
         });
       } else {
         const firstError = results.find((r) => r.status === "rejected") as
-          PromiseRejectedResult | undefined;
+          | PromiseRejectedResult
+          | undefined;
         logger.warn("search_tracking_error", {
           error:
             firstError?.reason instanceof Error
@@ -1623,6 +1756,7 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         };
       }
       const namespace = namespaceFilterFor(auth, requestedNamespace);
+      setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
       const shouldUseSharedFallback =
         requestedNamespace !== undefined &&
         isSharedNamespace(requestedNamespace);

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -282,7 +282,7 @@ function rowEvidence(row: SearchRow): Record<string, unknown> {
     row_id: row.id,
     source_type: row.source_type,
     namespace: row.namespace ?? null,
-    content_preview: row.content_preview,
+    content_preview: row.content_preview?.slice(0, 300) ?? null,
     distance: row.distance ?? null,
     similarity: row.distance === undefined ? null : 1 - row.distance,
     bm25_score: row.fts_rank ?? null,
@@ -297,6 +297,10 @@ function rowsEvidence(rows: readonly SearchRow[]): Record<string, unknown> {
     row_ids: rows.map((row) => row.id),
     candidates: rows.map(rowEvidence),
   };
+}
+
+function rowIdsEvidence(rows: readonly SearchRow[]): Record<string, unknown> {
+  return { count: rows.length, row_ids: rows.map((row) => row.id) };
 }
 
 const HAS_EXTRACTED_METADATA: Set<Table> = new Set(["thoughts", "decisions"]);
@@ -398,23 +402,92 @@ function dedupeFallbackSearchRows(rows: SearchRow[]): SearchRow[] {
   return deduped;
 }
 
-function mergeFallbackSearchRows(
+type FallbackClassification = {
+  row: SearchRow;
+  chosen: boolean;
+  filtered_by: "fallback_duplicate" | "fallback_limit" | null;
+};
+
+function selectedFallbackRows(
+  primary: SearchRow[],
+  legacy: SearchRow[],
+  limit: number,
+): SearchRow[] {
+  if (legacy.length === 0) return primary.slice(0, limit);
+  const firstLegacy = legacy[0];
+  if (!firstLegacy) return primary.slice(0, limit);
+  if (primary.length >= limit) {
+    return [...primary.slice(0, Math.max(0, limit - 1)), firstLegacy];
+  }
+  return [...primary, ...legacy.slice(0, limit - primary.length)];
+}
+
+function fallbackFilteredBy(
+  chosen: boolean,
+  duplicate: boolean,
+): FallbackClassification["filtered_by"] {
+  if (chosen) return null;
+  return duplicate ? "fallback_duplicate" : "fallback_limit";
+}
+
+function computeFallbackSearchRows(
   primaryRows: SearchRow[],
   legacyRows: SearchRow[],
   limit: number,
-): SearchRow[] {
+): { rows: SearchRow[]; classifications: FallbackClassification[] } {
   const primary = dedupeFallbackSearchRows(primaryRows);
   const primaryKeys = new Set(primary.map(fallbackDedupeKey));
   const legacy = dedupeFallbackSearchRows(
     legacyRows.filter((row) => !primaryKeys.has(fallbackDedupeKey(row))),
   );
-  if (legacy.length === 0) return primary.slice(0, limit);
-  if (primary.length >= limit) {
-    const fallbackRow = legacy[0];
-    if (!fallbackRow) return primary.slice(0, limit);
-    return [...primary.slice(0, Math.max(0, limit - 1)), fallbackRow];
-  }
-  return [...primary, ...legacy.slice(0, limit - primary.length)];
+  const rows = selectedFallbackRows(primary, legacy, limit);
+  const selectedKeys = new Set(rows.map(fallbackDedupeKey));
+  const seen = new Set<string>();
+  const classifications = [...primaryRows, ...legacyRows].map((row, index) => {
+    const key = fallbackDedupeKey(row);
+    const duplicate =
+      seen.has(key) ||
+      (index >= primaryRows.length && primaryKeys.has(key));
+    seen.add(key);
+    const chosen = !duplicate && selectedKeys.has(key);
+    return {
+      row,
+      chosen,
+      filtered_by: fallbackFilteredBy(chosen, duplicate),
+    } satisfies FallbackClassification;
+  });
+  return { rows, classifications };
+}
+
+export function mergeFallbackSearchRows(
+  primaryRows: SearchRow[],
+  legacyRows: SearchRow[],
+  limit: number,
+): SearchRow[] {
+  const result = traceRetrievalSpanSync({
+    name: "retrieval.fallback_dedupe",
+    input: {
+      limit,
+      primary: rowsEvidence(primaryRows),
+      legacy: rowsEvidence(legacyRows),
+    },
+    metadata: {
+      stage: "filtering",
+      filter_names: ["fallback_duplicate", "fallback_limit"],
+    },
+    run: () => computeFallbackSearchRows(primaryRows, legacyRows, limit),
+    output: ({ rows, classifications }) => ({
+      candidate_count: classifications.length,
+      selected_count: rows.length,
+      selected_row_ids: rows.map((row) => row.id),
+      candidates: classifications.map(({ row, chosen, filtered_by }) => ({
+        ...rowEvidence(row),
+        chosen,
+        filtered_by,
+      })),
+    }),
+  });
+  return result.rows;
 }
 
 function appendNamespaceParam(
@@ -1058,84 +1131,68 @@ LIMIT $2 OFFSET $3`;
  * Items in only one list get a single RRF score.
  * Hot entries get +0.3 boost, cold entries get -0.2, warm is unchanged.
  */
-function rrfMerge(
+export function rrfMerge(
   vectorRows: SearchRow[],
   ftsRows: SearchRow[],
   limit: number,
   graphRows: SearchRow[] = [],
 ): SearchRow[] {
-  const scoreMap = new Map<string, { row: SearchRow; rrf: number }>();
-
-  for (let i = 0; i < vectorRows.length; i++) {
-    const row = vectorRows[i]!;
-    const key = `${row.source_type}:${row.id}`;
-    scoreMap.set(key, { row, rrf: 1 / (RRF_K + i + 1) });
-  }
-
-  for (let i = 0; i < ftsRows.length; i++) {
-    const row = ftsRows[i]!;
-    const key = `${row.source_type}:${row.id}`;
-    const existing = scoreMap.get(key);
-    if (existing) {
-      existing.rrf += 1 / (RRF_K + i + 1);
-    } else {
-      scoreMap.set(key, { row, rrf: 1 / (RRF_K + i + 1) });
-    }
-  }
-
-  for (let i = 0; i < graphRows.length; i++) {
-    const row = graphRows[i]!;
-    const key = `${row.source_type}:${row.id}`;
-    const existing = scoreMap.get(key);
-    const graphRrf = 3 / (RRF_K + i + 1);
-    if (existing) {
-      existing.rrf += graphRrf;
-      existing.row = { ...existing.row, explicit_links: row.explicit_links };
-    } else {
-      scoreMap.set(key, { row, rrf: graphRrf });
-    }
-  }
-
-  const selected = Array.from(scoreMap.values())
-    .map(({ row, rrf }) => {
-      const tier = TIER_BOOST[(row.tier ?? "warm") as Tier];
-      const weight = TABLE_WEIGHT[row.source_type] ?? 1.0;
-      const recency = recencyFactor(row.created_at);
-      return { row, rrf: Math.max(0, (rrf + tier) * weight * recency) };
-    })
-    .sort((a, b) => b.rrf - a.rrf)
-    .slice(0, limit)
-    .map(({ row }) => row);
+  let ranked: Array<{ row: SearchRow; rrf: number }> = [];
   return traceRetrievalSpanSync({
     name: "retrieval.rank_rrf",
     input: {
-      vector: rowsEvidence(vectorRows),
-      keyword: rowsEvidence(ftsRows),
-      graph: rowsEvidence(graphRows),
+      limit,
+      vector: rowIdsEvidence(vectorRows),
+      keyword: rowIdsEvidence(ftsRows),
+      graph: rowIdsEvidence(graphRows),
     },
     metadata: { stage: "scoring_ranking", filter_names: ["rrf_window"] },
-    run: () => selected,
+    run: () => {
+      const scoreMap = new Map<string, { row: SearchRow; rrf: number }>();
+      const accumulate = (rows: SearchRow[], multiplier = 1): void => {
+        rows.forEach((row, index) => {
+          const key = `${row.source_type}:${row.id}`;
+          const contribution = multiplier / (RRF_K + index + 1);
+          const existing = scoreMap.get(key);
+          if (existing) {
+            existing.rrf += contribution;
+            if (multiplier === 3) {
+              existing.row = { ...existing.row, explicit_links: row.explicit_links };
+            }
+          } else {
+            scoreMap.set(key, { row, rrf: contribution });
+          }
+        });
+      };
+      accumulate(vectorRows);
+      accumulate(ftsRows);
+      accumulate(graphRows, 3);
+      ranked = Array.from(scoreMap.values())
+        .map(({ row, rrf }) => ({
+          row,
+          rrf: Math.max(
+            0,
+            (rrf + TIER_BOOST[(row.tier ?? "warm") as Tier]) *
+              (TABLE_WEIGHT[row.source_type] ?? 1.0) *
+              recencyFactor(row.created_at),
+          ),
+        }))
+        .sort((a, b) => b.rrf - a.rrf);
+      return ranked.slice(0, limit).map(({ row }) => row);
+    },
     output: (rows) => {
       const selectedKeys = new Set(
         rows.map((row) => `${row.source_type}:${row.id}`),
       );
       return {
-        candidate_count: scoreMap.size,
+        candidate_count: ranked.length,
         selected_count: rows.length,
         selected_row_ids: rows.map((row) => row.id),
-        candidates: Array.from(scoreMap.values()).map(({ row, rrf }) => {
+        candidates: ranked.map(({ row, rrf }) => {
           const chosen = selectedKeys.has(`${row.source_type}:${row.id}`);
-          const tier = TIER_BOOST[(row.tier ?? "warm") as Tier];
-          const rankScore = Math.max(
-            0,
-            (rrf + tier) *
-              (TABLE_WEIGHT[row.source_type] ?? 1.0) *
-              recencyFactor(row.created_at),
-          );
           return {
             ...rowEvidence(row),
-            rrf_contribution: rrf,
-            rank_score: rankScore,
+            rank_score: rrf,
             chosen,
             filtered_by: chosen ? null : "rrf_window",
           };
@@ -1219,7 +1276,7 @@ export function trackUsage(
   });
 }
 
-export async function executeSearch(
+async function executeSearchInternal(
   deps: ToolDeps,
   accessibleTables: SearchTable[],
   query: string,
@@ -1375,6 +1432,63 @@ export async function executeSearch(
     rows = await attachExplicitLinks(deps, rows, namespace);
   }
   return rows;
+}
+
+export function executeSearch(
+  deps: ToolDeps,
+  accessibleTables: SearchTable[],
+  query: string,
+  limit: number,
+  mode: SearchMode = "hybrid",
+  tier?: Tier,
+  offset = 0,
+  namespace?: NamespaceFilter,
+  includeLinks?: boolean,
+  sourceScope?: SourceScope,
+  options: ExecuteSearchOptions = {},
+): Promise<SearchRow[]> {
+  return traceRetrievalSpan({
+    name: "retrieval.execute",
+    input: {
+      query,
+      tables: accessibleTables,
+      limit,
+      mode,
+      tier,
+      offset,
+      namespace,
+      include_links: includeLinks,
+      source_scope: sourceScope,
+      options,
+    },
+    metadata: {
+      stage: "retrieval_pipeline",
+      resolved_namespace: namespace ?? null,
+      filter_names: [
+        "permissions",
+        "namespace",
+        "tier",
+        "source_scope",
+        "archived_at",
+        "pagination",
+      ],
+    },
+    run: () =>
+      executeSearchInternal(
+        deps,
+        accessibleTables,
+        query,
+        limit,
+        mode,
+        tier,
+        offset,
+        namespace,
+        includeLinks,
+        sourceScope,
+        options,
+      ),
+    output: rowsEvidence,
+  });
 }
 
 export async function executeSearchWithSharedFallback(


### PR DESCRIPTION
Part of #569

## Summary

- adds an async-local child-span API to the existing `installMcpTracing` wrapper; retrieval handlers can emit nested observations only while a traced MCP call is active
- keeps tracing disabled as a direct no-op and applies the existing shared masking pass to every child input, output, and metadata field before the sink receives it
- instruments both serving trees (`server/tools` for the local rewrite runtime and `src/tools` for the core01 runtime) across full retrieval execution, embedding generation, vector/keyword/graph/qmd candidate queries, fallback dedupe, RRF/federated ranking, and citation filtering
- records resolved namespace values, database row IDs, bounded 300-character candidate previews, cosine distance/similarity, lexical and ranking scores, selected/filtered status, filter names, and stage counts without changing retrieval return values
- bounds one tool call's collected child-span payload at 256 KiB; crossing the bound converts all child evidence to counts-only summaries and records the degradation reason in each retained span

## Verification

- `bunx tsc --noEmit --project /Volumes/ThunderBolt/_tmp/open-brain/_worktrees/issue-569-retrieval-evidence/tsconfig.json`
- full `bun test` with `/Users/rico/.config/open-brain/env.release-test`: **3656 pass, 35 skip, 0 fail** across 237 files
- database-backed tests actually ran, including graph derivation, source sync, maintenance queue, embedding repair, chunk write, and rewrite source-registry/decompose/promotion PostgreSQL suites
- pre-push hook: TypeScript passed; Bun completed **3272 pass, 509 skip, 0 fail** without the release-test DB environment; branch pushed successfully
- focused tracing suite: **64 pass, 0 fail, 143 assertions**, including a real registered `src/tools/search-brain` call, two concurrent calls, throwing summarizer, payload degradation, transform equivalence, duplicate-qmd-path classification, and child-observation cleanup
- regression-test proof: temporarily suppressed the parent `span.end()` in the child-observation exporter; the new test failed with `Expected: 1 / Received: 0`, then the implementation was restored and the focused tracing suite passed

## Retrieval behavior

Instrumentation only. Existing retrieval tests and the full suite pass unchanged. No retrieval bug was found while instrumenting the pipeline.

## Downstream rollout

Not applicable: this does not change MCP tool names, schemas, response shapes, auth/namespace semantics, transport behavior, migrations, Python client behavior, or agent-facing guidance. It adds operator-only Langfuse observations.

## Critical Self-Review

- Highest-risk behavior: Moving ranking and fallback computation inside tracing wrappers could accidentally alter ordering or selected rows; before/after equivalence tests cover `rrfMerge` and both fallback-merge implementations with empty and all-equal-score inputs, and the full suite passed.
- Assumptions that could be wrong: Langfuse SDK v4 child observations created with `parent.startObservation` will render as nested observations under the post-call tool trace; the fake sink proves emitted shape and cleanup, but this PR does not perform a live hosted Langfuse canary.
- Missing/weak tests: No live Langfuse OTLP egress assertion for parent/child rendering; functional coverage otherwise drives a real registered src search tool, concurrency, sink child failures, and the retrieval transform boundaries.
- Security/permission risk: Candidate previews and namespace values widen observability payloads; previews are capped at 300 characters, rank inputs carry only IDs/counts, total child evidence degrades to counts-only past 256 KiB, and every retained dynamic field still passes through shared detector/key masking. Permission and namespace predicates are unchanged.
- Migration/deploy risk: No migration. Deployment only activates the new observations where the existing `OPENBRAIN_TRACING_*` gate is enabled.
- Downstream client/runtime risk: None identified; public MCP contracts and retrieval results are unchanged.
- Rollback/cleanup concern: Reverting this commit removes the child observations without database cleanup because no local state is persisted.
- Fixes made before PR: Installed tracing in the core01 `src/index.ts` server factory; bounded evidence payloads and precompiled masking regexes; made auth/status metadata authoritative; removed the unreachable candidate-dedupe span; moved ranking work inside spans; corrected duplicate-qmd and pagination classifications; mirrored execute/fallback spans into src; returned fallback classifications from the computation; and guaranteed parent observation cleanup.
- Known residual risk: Child observations are materialized when the completed tool trace is emitted, so native observation timing is post-call; measured per-stage duration remains in metadata. The payload-size guard and cleanup paths are unit-tested, but live Langfuse parent/child rendering remains the rollout canary.
- SME review-memory update: [x] docs/sme/ updated (correctness, security, adversarial — commit 5c08455 on this branch, provenance pull/599#issuecomment-5202342752)

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: no MCP contract, namespace, or client change; live Langfuse rendering is the rollout canary and is verified by the controller before #569 closes

<!-- Controller note: the MEDIUM+ box stays unchecked until the controller re-verifies this fix delta and captures the posted findings. -->



