### PR TITLE
feat(tracing): instrument background worker jobs

### DIFF
--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1217,3 +1217,14 @@ therefore emitted no release on every deployed trace.
   checkout?
 - When development fallback behavior remains, is it exercised separately from
   the deployed-artifact path?
+
+## [2026-08-06] A fix lane's trunk merge silently reverted the sibling feature — both suites green
+
+**Severity:** HIGH (caught pre-merge by delta verification)
+**Source:** PR #600 fix lane, merge commit 55d701d; detected in the 3cfbd75..06430ef delta verify
+**Scope key:** `review.trunk_merge_verified_against_sibling_features`
+**Status:** active
+
+### Pattern
+
+When a fix lane merges trunk into its branch and both branches touched the same module, the merge resolution is new, unreviewed code — and the failure mode is silent feature reversion: PR #600's merge rewrote the real sink's `emit` for its background lane and dropped the only call that renders `body.spans`, so PR #599's retrieval-evidence children would have been built, masked, and discarded in production. Every test stayed green on both sides because both features asserted against fake sinks; no test drove the REAL sink with the sibling's payload. Review checks: (1) diff the merge commit itself, not just the fix commits; (2) any shared-module merge needs a behavioral check that BOTH features still function through the real seam; (3) uncovered rendering/dispatch seams (a helper whose only callers are its export and a test) are where reverts hide. The catch here came from a delta verifier running the same mocked-SDK script against both refs — cheap, decisive, worth repeating.

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -1101,3 +1101,25 @@ binary views expose credential bytes as numeric arrays.
 ### Pattern
 
 In any record that mixes server-derived authority fields (caller_role, caller_client_id, namespace_source, status) with handler- or caller-supplied maps, the spread/merge ORDER is a security control: `{...authFields, ...suppliedMap}` lets the supplied map silently displace the identity and outcome evidence — making a failed call read as success or a trace disagree with the audit log exactly where a review needs them to agree. Safe shape is supplied-first, authority-last, plus a regression that stamps a forged `caller_role`/`status` from inside a handler that then throws and asserts the emitted record keeps the token-derived values. "No current call site collides" is not a defense; the exported API is the surface.
+
+## [2026-08-06] Trace session identity must come from the server-resolved binding, never the unauthenticated wire
+
+**Severity:** HIGH
+**Source:** PR #600 review swarm, finding H2
+**Scope key:** `review.trace_session_identity_binds_after_auth`
+**Status:** active
+
+### Pattern
+
+Any observability record that carries a session/user identity must derive it AFTER the request passes auth and binding — never from a caller-declared field read off the wire before any control has run. PR #600 built the NATS trace recorder from `envelope.payload.identity.session_key` at the top of the subscription callback, before the size/kind/auth/namespace checks, and emitted the trace even for REJECTED requests — so any publisher could stamp another tenant's session key onto traces, and the field bypassed masking entirely (sessionId/userId spread through untouched). Fix shape: identity flows from the resolved binding via a post-auth callback; a wire-declared value may appear only as masked metadata under an explicitly untrusted name. Regression shape: forged key + no valid bearer → emitted body has no sessionId.
+
+## [2026-08-06] Global background sweeps must not join to any one session's trace
+
+**Severity:** HIGH
+**Source:** PR #600 review swarm, finding H3
+**Scope key:** `review.global_sweeps_never_session_joined`
+**Status:** active
+
+### Pattern
+
+A maintenance/dream/distill job that sweeps with `namespace IS NULL` touches every tenant; joining its trace to a job-supplied `session_key` renders all tenants' row identities and content inside one session's timeline — a namespace-isolation breach in the observability lane even though the data path is unchanged. Honour a job's session key only when the job is namespace-scoped; a global sweep emits no sessionId, and each observation stamps its own resolved namespace so cross-namespace evidence is visibly attributed. "No current enqueuer sets it" is not a defense — the job-row field is durable and the sweep is global by design.

--- a/scripts/run-nats-worker.test.ts
+++ b/scripts/run-nats-worker.test.ts
@@ -1,9 +1,81 @@
 import { describe, expect, it } from "bun:test";
 import { createNatsBridgeHealth } from "../src/nats-bridge.ts";
-import { readNatsWorkerBoundary, type NatsWorkerRuntime } from "../src/nats-worker.ts";
+import {
+  readNatsWorkerBoundary,
+  type NatsWorkerRuntime,
+  type StartNatsWorkerOptions,
+} from "../src/nats-worker.ts";
+import type { BackgroundTraceBody } from "../src/background-tracing.ts";
+import {
+  createTracingRuntime,
+  type McpTracingConfig,
+  type TraceBody,
+  type TracingSink,
+} from "../server/observability/langfuse-tracing.ts";
 import { safeWorkerError, startNatsWorkerProcess } from "./run-nats-worker.ts";
 
+const ENABLED_CONFIG: McpTracingConfig = {
+  enabled: true,
+  maskingEnabled: true,
+  endpoint: "http://127.0.0.1:3000",
+  publicKey: "pk-test",
+  secretKey: "sk-test",
+};
+
+function recordingSink(): TracingSink & { bodies: TraceBody[]; shutdowns: number } {
+  const bodies: TraceBody[] = [];
+  return {
+    bodies,
+    shutdowns: 0,
+    emit: (body) => bodies.push(body),
+    forceFlush: () => Promise.resolve(),
+    async shutdown() {
+      this.shutdowns += 1;
+    },
+  };
+}
+
 describe("startNatsWorkerProcess", () => {
+  it("routes background traces into the process-owned sink and drains it on shutdown", async () => {
+    const env = {
+      OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+      OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "0",
+    };
+    const sink = recordingSink();
+    const body: BackgroundTraceBody = {
+      name: "nats.message",
+      tags: ["background-job", "nats"],
+      metadata: { status: "success" },
+      observations: [],
+      startedAt: 1,
+      endedAt: 2,
+    };
+    const runtime: NatsWorkerRuntime = {
+      boundary: readNatsWorkerBoundary(env),
+      health: createNatsBridgeHealth("available"),
+      subject: "dev.ob.memory.context_pack",
+      close: async () => undefined,
+    };
+
+    const processRuntime = await startNatsWorkerProcess({
+      env,
+      log: { info: () => undefined, error: () => undefined },
+      buildTokens: () =>
+        new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+      createDbPool: () => ({ end: async () => undefined }) as any,
+      createTracing: () => createTracingRuntime({ config: ENABLED_CONFIG, sink }),
+      startWorker: async (options: StartNatsWorkerOptions) => {
+        options.tracing?.emitBackground(body);
+        return runtime;
+      },
+    });
+
+    expect(sink.bodies).toHaveLength(1);
+    expect(sink.bodies[0]).toMatchObject({ name: "nats.message" });
+    await processRuntime.shutdown();
+    expect(sink.shutdowns).toBe(1);
+  });
+
   it("closes the bridge and pool when health server bind fails after subscription startup", async () => {
     const env = {
       OPENBRAIN_NATS_URL: "nats://user:pass@127.0.0.1:4222",

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -11,10 +11,12 @@ import {
   type NatsWorkerRuntime,
 } from "../src/nats-worker.ts";
 import type { AuthInfo } from "../src/types.ts";
+import { createTracingRuntime } from "../server/observability/langfuse-tracing.ts";
 
 type LoggerLike = Pick<typeof logger, "error" | "info">;
 type HealthServer = { stop(force?: boolean): void };
 type ServeFn = typeof Bun.serve;
+type TracingRuntime = ReturnType<typeof createTracingRuntime>;
 
 export interface NatsWorkerProcess {
   runtime: NatsWorkerRuntime;
@@ -29,6 +31,7 @@ export interface StartNatsWorkerProcessOptions {
   buildTokens?: typeof buildTokenMap;
   createDbPool?: typeof createPool;
   startWorker?: typeof startNatsWorker;
+  createTracing?: typeof createTracingRuntime;
   serve?: ServeFn;
 }
 
@@ -144,6 +147,18 @@ function closeHealthServer(
   }
 }
 
+async function closeTracing(
+  tracing: TracingRuntime | undefined,
+  log: LoggerLike,
+): Promise<void> {
+  if (!tracing) return;
+  try {
+    await tracing.shutdown();
+  } catch (err) {
+    log.error("Open Brain NATS worker tracing shutdown failed", safeWorkerError(err));
+  }
+}
+
 async function closePool(
   pool: pg.Pool | undefined,
   log: LoggerLike,
@@ -163,10 +178,12 @@ export async function startNatsWorkerProcess(
   const buildTokens = options.buildTokens ?? buildTokenMap;
   const createDbPool = options.createDbPool ?? createPool;
   const startWorker = options.startWorker ?? startNatsWorker;
+  const createTracing = options.createTracing ?? createTracingRuntime;
   const serve = options.serve ?? Bun.serve;
   const env = options.env;
 
   let pool: pg.Pool | undefined;
+  let tracing: TracingRuntime | undefined;
   let runtime: NatsWorkerRuntime | undefined;
   let healthServer: HealthServer | null = null;
   const shutdownTimeoutMs = shutdownTimeoutMsFromEnv(env);
@@ -178,10 +195,12 @@ export async function startNatsWorkerProcess(
     }
 
     pool = createDbPool();
+    tracing = createTracing();
     runtime = await startWorker({
       env,
       pool,
       tokenMap: tokenMap as Map<string, AuthInfo>,
+      ...(tracing.background ? { tracing: tracing.background } : {}),
     });
     healthServer = startHealthServer({ env, runtime, serve });
     log.info("Open Brain NATS worker started", {
@@ -197,6 +216,7 @@ export async function startNatsWorkerProcess(
         log.info("Shutting down Open Brain NATS worker");
         closeHealthServer(healthServer, log);
         await closeRuntime(runtime, log, shutdownTimeoutMs);
+        await closeTracing(tracing, log);
         await closePool(pool, log);
       },
     };
@@ -207,6 +227,7 @@ export async function startNatsWorkerProcess(
     });
     closeHealthServer(healthServer, log);
     await closeRuntime(runtime, log, shutdownTimeoutMs);
+    await closeTracing(tracing, log);
     await closePool(pool, log);
     throw err;
   }

--- a/server/application/nats.ts
+++ b/server/application/nats.ts
@@ -31,6 +31,7 @@ import {
 import type { NatsRuntimeBoundary } from "../../src/nats-runtime.ts";
 import type { ToolDeps } from "../../src/tools/index.ts";
 import type { AuthInfo } from "../../src/types.ts";
+import type { BackgroundTraceEmitter } from "../../src/background-tracing.ts";
 import type { BackgroundRuntime } from "./index.ts";
 
 /** Project the parsed config onto the bridge's runtime-boundary shape. */
@@ -57,6 +58,7 @@ export interface NatsBridgeInput {
   readonly tokenMap: Map<string, AuthInfo>;
   readonly deps: ToolDeps;
   readonly health: NatsBridgeHealth;
+  readonly tracing?: BackgroundTraceEmitter;
   readonly start?: typeof startNatsContextPackBridge;
 }
 
@@ -112,6 +114,7 @@ export async function startNatsBridgeRuntime(
       tokenMap: input.tokenMap,
       deps: input.deps,
       health,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
     });
   } catch (error: unknown) {
     health.availability = "not_runtime_available";

--- a/server/main.ts
+++ b/server/main.ts
@@ -264,6 +264,7 @@ export async function startServer(
       tokenMap,
       deps: toolDeps,
       health: natsHealth,
+      ...(tracing.background ? { tracing: tracing.background } : {}),
     });
 
     const authenticate = createAuthMiddleware(config.authTokens);
@@ -309,6 +310,7 @@ export async function startServer(
         logger: handlerLogger(logger.child({ component: "maintenance" })),
         embedFn: generateEmbeddingWithMetadata,
         graphAuth: MAINTENANCE_GRAPH_AUTH,
+        ...(tracing.background ? { tracing: tracing.background } : {}),
       }),
       // A LIVE bridge knows its own failure counters; config cannot. Health
       // therefore reads the running health object, falling back to the parsed

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -1512,6 +1512,106 @@ describe("the SDK's own logger cannot bypass the content-free discipline", () =>
   });
 });
 
+const REAL_SINK_PROBE_SCRIPT = String.raw`
+      import { mock } from "bun:test";
+
+      const names = [];
+      let parentEnded = 0;
+      const child = { end: () => undefined };
+      const parent = {
+        otelSpan: {
+          spanContext: () => ({
+            traceId: "00000000000000000000000000000001",
+            spanId: "0000000000000001",
+            traceFlags: 1,
+          }),
+        },
+        updateTrace: () => undefined,
+        startObservation: (name) => {
+          names.push(name);
+          return child;
+        },
+        end: () => {
+          parentEnded += 1;
+        },
+      };
+
+      mock.module("@langfuse/tracing", () => ({
+        setLangfuseTracerProvider: () => undefined,
+        startObservation: (name) => {
+          names.push(name);
+          return name === "search_brain" ? parent : child;
+        },
+      }));
+
+      const { createTracingRuntime } = await import(
+        "./server/observability/langfuse-tracing.ts"
+      );
+      const runtime = createTracingRuntime({
+        config: {
+          enabled: true,
+          maskingEnabled: true,
+          endpoint: "http://127.0.0.1:1",
+          publicKey: "pk-lf-test",
+          secretKey: "sk-lf-test",
+        },
+      });
+      runtime.sink.emit({
+        name: "search_brain",
+        input: {},
+        output: {},
+        tags: ["open-brain-server"],
+        metadata: {},
+        spans: [
+          {
+            name: "retrieval.evidence",
+            input: {},
+            output: {},
+            metadata: {},
+          },
+        ],
+        observations: [
+          {
+            name: "background.observation",
+            type: "span",
+            input: {},
+            output: {},
+            metadata: {},
+            startedAt: 10,
+            endedAt: 20,
+          },
+        ],
+        startedAt: 1,
+        endedAt: 30,
+      });
+      await runtime.shutdown();
+      console.log(JSON.stringify({ names, parentEnded }));
+`;
+
+describe("the real default sink", () => {
+  test("emits retrieval spans and background observations before ending the parent", () => {
+    const result = Bun.spawnSync({
+      cmd: ["bun", "-e", REAL_SINK_PROBE_SCRIPT],
+      cwd: join(import.meta.dir, "../.."),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.stderr.toString()).toBe("");
+    expect(result.success).toBe(true);
+    const emitted = JSON.parse(result.stdout.toString()) as {
+      names: string[];
+      parentEnded: number;
+    };
+    expect(emitted.names).toEqual([
+      "search_brain",
+      "retrieval.evidence",
+      "background.observation",
+    ]);
+    expect(emitted.parentEnded).toBe(1);
+  });
+});
+
 describe("trace body helpers", () => {
   const fakeLabeledSecret = [
     "pass",

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -882,6 +882,60 @@ describe("outage alerts fire on state change only", () => {
   });
 });
 
+describe("background job tracing", () => {
+  test("uses the shared masking boundary for root and child observations", () => {
+    const sink = recordingSink();
+    const runtime = createTracingRuntime({ config: ENABLED_CONFIG, sink });
+    runtime.background!.emitBackground({
+      name: "memory.distill",
+      input: { prompt: "password=fake-background-secret" },
+      output: { status: "ok", api_key: "fake-opaque-value" },
+      tags: ["background-job", "dream"],
+      metadata: { status: "success" },
+      observations: [
+        {
+          name: "distill.extract",
+          type: "generation",
+          model: "fixture-model",
+          input: { text: "token=fake-child-secret" },
+          output: { answer: "kept around password=fake-output-secret" },
+          metadata: { authorization: "fake-bearer" },
+          usageDetails: { input: 12, output: 4 },
+          startedAt: 10,
+          endedAt: 20,
+        },
+      ],
+      startedAt: 1,
+      endedAt: 30,
+      sessionId: "session-569",
+    });
+
+    expect(sink.bodies[0]).toMatchObject({
+      input: { prompt: "password=[MASKED:labeled_secret]" },
+      output: { status: "ok", api_key: "[MASKED:sensitive_key]" },
+      sessionId: "session-569",
+      observations: [
+        {
+          type: "generation",
+          model: "fixture-model",
+          input: { text: "token=[MASKED:labeled_secret]" },
+          output: { answer: "kept around password=[MASKED:labeled_secret]" },
+          metadata: { authorization: "[MASKED:sensitive_key]" },
+          usageDetails: { input: 12, output: 4 },
+        },
+      ],
+    });
+  });
+
+  test("does not expose a background emitter when tracing is disabled", () => {
+    const runtime = createTracingRuntime({
+      config: { ...ENABLED_CONFIG, enabled: false },
+    });
+    expect(runtime.background).toBeUndefined();
+    expect(runtime.sink).toBeUndefined();
+  });
+});
+
 /**
  * The v3 review's MEDIUM finding, carried into v4: the SDK's own logger writes
  * export failures straight to `console.error` with the raw error attached, so a

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -1253,16 +1253,27 @@ interface TraceObservation {
   updateTrace(input: {
     name: string;
     tags: string[];
+    input?: unknown;
+    output?: unknown;
+    metadata?: Record<string, unknown>;
     sessionId?: string;
     userId?: string;
   }): void;
-  end(): void;
+  end(endTime?: Date): void;
+}
+
+interface TraceEmissionOptions<T extends TraceObservation> {
+  emitObservation?: (
+    parent: T,
+    observation: BackgroundObservation,
+  ) => void;
 }
 
 /** Materialize one completed trace body through the SDK observation surface. */
-export function emitTraceBodyWithObservations(
+export function emitTraceBodyWithObservations<T extends TraceObservation>(
   body: TraceBody,
-  start: (name: string, body: Record<string, unknown>) => TraceObservation,
+  start: (name: string, body: Record<string, unknown>) => T,
+  options: TraceEmissionOptions<T> = {},
 ): void {
   const span = start(body.name, {
     input: body.input,
@@ -1273,6 +1284,9 @@ export function emitTraceBodyWithObservations(
     span.updateTrace({
       name: body.name,
       tags: body.tags,
+      input: body.input,
+      output: body.output,
+      metadata: body.metadata,
       ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
       ...(body.userId === undefined ? {} : { userId: body.userId }),
     });
@@ -1284,8 +1298,11 @@ export function emitTraceBodyWithObservations(
       });
       child.end();
     }
+    for (const observation of body.observations ?? []) {
+      options.emitObservation?.(span, observation);
+    }
   } finally {
-    span.end();
+    span.end(body.endedAt === undefined ? undefined : new Date(body.endedAt));
   }
 }
 
@@ -1466,30 +1483,18 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
       // These records are emitted after the work completes. Supplying the real
       // timestamps preserves worker/provider duration instead of measuring the
       // few microseconds spent enqueueing the completed trace.
-      const span = startObservation(
-        body.name,
-        {
-          input: body.input,
-          output: body.output,
-          metadata: body.metadata,
-        },
-        body.startedAt === undefined
-          ? undefined
-          : { startTime: new Date(body.startedAt) },
+      emitTraceBodyWithObservations(
+        body,
+        (name, attributes) =>
+          startObservation(
+            name,
+            attributes,
+            body.startedAt === undefined
+              ? undefined
+              : { startTime: new Date(body.startedAt) },
+          ),
+        { emitObservation: emitChildObservation },
       );
-      span.updateTrace({
-        name: body.name,
-        tags: body.tags,
-        input: body.input,
-        output: body.output,
-        metadata: body.metadata,
-        ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
-        ...(body.userId === undefined ? {} : { userId: body.userId }),
-      });
-      for (const observation of body.observations ?? []) {
-        emitChildObservation(span, observation);
-      }
-      span.end(body.endedAt === undefined ? undefined : new Date(body.endedAt));
       tracker.recordEnqueued();
     },
     async forceFlush(): Promise<void> {

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -90,6 +90,7 @@ import { LangfuseSpanProcessor } from "@langfuse/otel";
 import {
   setLangfuseTracerProvider,
   startObservation,
+  type LangfuseSpan,
 } from "@langfuse/tracing";
 import { setGlobalErrorHandler } from "@opentelemetry/core";
 import { BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
@@ -100,6 +101,11 @@ import {
   isSensitiveKey,
   SECRET_DETECTORS,
 } from "../../src/secret-patterns.ts";
+import type {
+  BackgroundObservation,
+  BackgroundTraceBody,
+  BackgroundTraceEmitter,
+} from "../../src/background-tracing.ts";
 import type { AuthInfo } from "../../src/types.ts";
 import { readDeployedRevision } from "../transport/server-identity.ts";
 
@@ -248,6 +254,9 @@ export interface TraceBody {
   metadata: Record<string, unknown>;
   sessionId?: string;
   userId?: string;
+  observations?: BackgroundObservation[];
+  startedAt?: number;
+  endedAt?: number;
 }
 
 /**
@@ -819,6 +828,7 @@ export function installMcpTracing(
 export function createTracingRuntime(deps: McpTracingDeps = {}): {
   readonly config: McpTracingConfig;
   readonly sink?: TracingSink;
+  readonly background?: BackgroundTraceEmitter;
   shutdown(): Promise<void>;
 } {
   const config = deps.config ?? readMcpTracingConfig();
@@ -847,7 +857,53 @@ export function createTracingRuntime(deps: McpTracingDeps = {}): {
   return {
     config,
     sink,
+    background: createBackgroundTraceEmitter(
+      sink,
+      sink.health,
+      config.maskingEnabled,
+    ),
     shutdown: () => shutdownSink(sink, deps.shutdownTimeoutMs),
+  };
+}
+
+function createBackgroundTraceEmitter(
+  sink: TracingSink,
+  tracker: SinkHealthTracker | undefined,
+  maskingEnabled: boolean,
+): BackgroundTraceEmitter {
+  return {
+    emitBackground(body: BackgroundTraceBody): void {
+      const traceBody: TraceBody = {
+        name: body.name,
+        input: maskingEnabled ? maskTraceValue(body.input) : body.input,
+        output: maskingEnabled ? maskTraceValue(body.output) : body.output,
+        tags: body.tags,
+        metadata: (maskingEnabled
+          ? maskTraceValue(body.metadata)
+          : body.metadata) as Record<string, unknown>,
+        observations: body.observations.map((observation) =>
+          maskBackgroundObservation(observation, maskingEnabled),
+        ),
+        startedAt: body.startedAt,
+        endedAt: body.endedAt,
+        ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
+        ...(body.userId === undefined ? {} : { userId: body.userId }),
+      };
+      emitBuiltTrace(sink, tracker, traceBody);
+    },
+  };
+}
+
+function maskBackgroundObservation(
+  observation: BackgroundObservation,
+  maskingEnabled: boolean,
+): BackgroundObservation {
+  if (!maskingEnabled) return observation;
+  return {
+    ...observation,
+    input: maskTraceValue(observation.input),
+    output: maskTraceValue(observation.output),
+    metadata: maskTraceValue(observation.metadata) as Record<string, unknown>,
   };
 }
 
@@ -881,14 +937,20 @@ function emitTrace(
   tracker: SinkHealthTracker | undefined,
   input: Parameters<typeof buildToolTraceBody>[0],
 ): void {
+  emitBuiltTrace(sink, tracker, buildToolTraceBody(input));
+}
+
+function emitBuiltTrace(
+  sink: TracingSink,
+  tracker: SinkHealthTracker | undefined,
+  body: TraceBody,
+): void {
   try {
-    sink.emit(buildToolTraceBody(input));
+    sink.emit(body);
     // A successful enqueue is the recovery signal for a FAKE sink (one that
     // throws while down). Against the REAL SDK an enqueue always succeeds even
     // with the endpoint dead, so nothing here fires during a real outage and
     // recovery is driven by the health probe in `defaultSinkFactory` instead.
-    //
-    // This trace is NOT counted as dropped: `emit` just accepted it.
     if (tracker) reportSinkSuccess(tracker);
   } catch (err: unknown) {
     if (tracker) reportSinkFailure(tracker, err);
@@ -935,6 +997,48 @@ function createSinkSafely(
  * socket. Together they are the outage contract: during an outage the brain
  * neither slows nor grows, and the window's traces are simply lost.
  */
+function emitChildObservation(
+  parent: LangfuseSpan,
+  observation: BackgroundObservation,
+): void {
+  const attributes = {
+    input: observation.input,
+    output: observation.output,
+    metadata: {
+      ...observation.metadata,
+      duration_ms: Math.max(0, observation.endedAt - observation.startedAt),
+    },
+    ...(observation.model === undefined ? {} : { model: observation.model }),
+    ...(observation.usageDetails === undefined
+      ? {}
+      : { usageDetails: observation.usageDetails }),
+    ...(observation.level === undefined ? {} : { level: observation.level }),
+    ...(observation.statusMessage === undefined
+      ? {}
+      : { statusMessage: observation.statusMessage }),
+  };
+  const options = {
+    startTime: new Date(observation.startedAt),
+    parentSpanContext: parent.otelSpan.spanContext(),
+  };
+  const child =
+    observation.type === "generation"
+      ? startObservation(observation.name, attributes, {
+          ...options,
+          asType: "generation",
+        })
+      : observation.type === "embedding"
+        ? startObservation(observation.name, attributes, {
+            ...options,
+            asType: "embedding",
+          })
+        : startObservation(observation.name, attributes, {
+            ...options,
+            asType: "span",
+          });
+  child.end(new Date(observation.endedAt));
+}
+
 function defaultSinkFactory(config: McpTracingConfig): TracingSink {
   // The SDK's own logger writes export failures straight to `console.error`
   // with the raw error attached (`@langfuse/core` Logger.error), which would
@@ -1049,25 +1153,33 @@ function defaultSinkFactory(config: McpTracingConfig): TracingSink {
   return {
     health: tracker,
     emit(body: TraceBody): void {
-      // The span ends immediately: the tool call already happened, so this is a
-      // record of it rather than a live scope.
-      const span = startObservation(body.name, {
-        input: body.input,
-        output: body.output,
-        metadata: body.metadata,
-      });
+      // These records are emitted after the work completes. Supplying the real
+      // timestamps preserves worker/provider duration instead of measuring the
+      // few microseconds spent enqueueing the completed trace.
+      const span = startObservation(
+        body.name,
+        {
+          input: body.input,
+          output: body.output,
+          metadata: body.metadata,
+        },
+        body.startedAt === undefined
+          ? undefined
+          : { startTime: new Date(body.startedAt) },
+      );
       span.updateTrace({
         name: body.name,
         tags: body.tags,
+        input: body.input,
+        output: body.output,
+        metadata: body.metadata,
         ...(body.sessionId === undefined ? {} : { sessionId: body.sessionId }),
         ...(body.userId === undefined ? {} : { userId: body.userId }),
       });
-      span.end();
-      // The enqueue above SUCCEEDS even with the endpoint dead — that is what
-      // makes an outage invisible from the request path. So while the sink is
-      // known-unhealthy, every span handed over is a span that will be dropped,
-      // and this is the only place with a per-trace view of it. A no-op while
-      // healthy.
+      for (const observation of body.observations ?? []) {
+        emitChildObservation(span, observation);
+      }
+      span.end(body.endedAt === undefined ? undefined : new Date(body.endedAt));
       tracker.recordEnqueued();
     },
     async forceFlush(): Promise<void> {

--- a/src/background-tracing.test.ts
+++ b/src/background-tracing.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BackgroundTraceRecorder,
+  backgroundSessionId,
+  type BackgroundTraceBody,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
+
+function recordingEmitter(): BackgroundTraceEmitter & {
+  bodies: BackgroundTraceBody[];
+} {
+  const bodies: BackgroundTraceBody[] = [];
+  return {
+    bodies,
+    emitBackground(body) {
+      bodies.push(body);
+    },
+  };
+}
+
+describe("BackgroundTraceRecorder", () => {
+  test("disabled tracing is a no-op around the original work", async () => {
+    let calls = 0;
+    const trace = new BackgroundTraceRecorder(undefined, {
+      name: "disabled",
+      tags: ["background-job"],
+    });
+
+    const result = await trace.span("work", async () => {
+      calls++;
+      return { value: 42 };
+    });
+    trace.finish(result);
+
+    expect(result).toEqual({ value: 42 });
+    expect(calls).toBe(1);
+    expect(trace.active).toBe(false);
+  });
+
+  test("emits one job trace with stage and generation usage", async () => {
+    const emitter = recordingEmitter();
+    let now = 100;
+    const trace = new BackgroundTraceRecorder(
+      emitter,
+      {
+        name: "memory.distill",
+        input: { job_id: "job-1" },
+        tags: ["background-job", "dream"],
+        sessionId: "session-569",
+      },
+      () => ++now,
+    );
+
+    await trace.span("distill.claim", async () => ["turn-1", "turn-2"], {
+      output: (rowIds) => ({ row_ids: rowIds }),
+    });
+    await trace.generation(
+      "distill.extract",
+      async () => ({ candidates: ["candidate-1"], usage: { input: 8, output: 3 } }),
+      {
+        model: "test-llm",
+        input: { row_ids: ["turn-1"] },
+        output: (result) => ({ candidate_ids: result.candidates }),
+        usageDetails: (result) => result.usage,
+      },
+    );
+    trace.finish({ outcome: "succeeded" });
+
+    expect(emitter.bodies).toHaveLength(1);
+    expect(emitter.bodies[0]).toMatchObject({
+      name: "memory.distill",
+      sessionId: "session-569",
+      output: { outcome: "succeeded" },
+      metadata: { status: "success" },
+      observations: [
+        {
+          name: "distill.claim",
+          type: "span",
+          output: { row_ids: ["turn-1", "turn-2"] },
+        },
+        {
+          name: "distill.extract",
+          type: "generation",
+          model: "test-llm",
+          usageDetails: { input: 8, output: 3 },
+        },
+      ],
+    });
+  });
+
+  test("a broken trace summarizer cannot change a successful job result", async () => {
+    const emitter = recordingEmitter();
+    const trace = new BackgroundTraceRecorder(emitter, {
+      name: "best-effort",
+      tags: ["background-job"],
+    });
+
+    const result = await trace.span("work", async () => "job-result", {
+      output: () => {
+        throw new Error("summarizer failed");
+      },
+    });
+    trace.finish(result);
+
+    expect(result).toBe("job-result");
+    expect(emitter.bodies).toHaveLength(1);
+    expect(emitter.bodies[0]!.observations).toEqual([]);
+  });
+
+  test("records a failed stage and rethrows the original error", async () => {
+    const emitter = recordingEmitter();
+    const trace = new BackgroundTraceRecorder(emitter, {
+      name: "nats.message",
+      tags: ["background-job", "nats"],
+    });
+    const failure = new TypeError("provider failed");
+
+    await expect(
+      trace.span("nats.reply", async () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+    trace.fail(failure);
+
+    expect(emitter.bodies[0]).toMatchObject({
+      metadata: { status: "exception" },
+      output: { error_class: "TypeError", error_message: "provider failed" },
+      observations: [
+        {
+          name: "nats.reply",
+          level: "ERROR",
+          statusMessage: "TypeError",
+        },
+      ],
+    });
+  });
+});
+
+describe("backgroundSessionId", () => {
+  test("prefers a payload session key and falls back to provenance", () => {
+    expect(
+      backgroundSessionId({
+        payload: { session_key: "payload-session" },
+        provenance: { session_key: "provenance-session" },
+      }),
+    ).toBe("payload-session");
+    expect(
+      backgroundSessionId({ provenance: { session_key: "provenance-session" } }),
+    ).toBe("provenance-session");
+  });
+});

--- a/src/background-tracing.test.ts
+++ b/src/background-tracing.test.ts
@@ -6,6 +6,14 @@ import {
   type BackgroundTraceEmitter,
 } from "./background-tracing.ts";
 
+function throwingEmitter(): BackgroundTraceEmitter {
+  return {
+    emitBackground() {
+      throw new Error("emitter failed");
+    },
+  };
+}
+
 function recordingEmitter(): BackgroundTraceEmitter & {
   bodies: BackgroundTraceBody[];
 } {
@@ -105,6 +113,33 @@ describe("BackgroundTraceRecorder", () => {
     expect(result).toBe("job-result");
     expect(emitter.bodies).toHaveLength(1);
     expect(emitter.bodies[0]!.observations).toEqual([]);
+  });
+
+  test("a throwing emitter cannot fail finish()", () => {
+    const trace = new BackgroundTraceRecorder(throwingEmitter(), {
+      name: "best-effort-success",
+      tags: ["background-job"],
+    });
+
+    expect(() => trace.finish({ outcome: "succeeded" })).not.toThrow();
+  });
+
+  test("a throwing emitter cannot mask the original job error in fail()", async () => {
+    const original = new TypeError("original job failure");
+    const run = async () => {
+      const trace = new BackgroundTraceRecorder(throwingEmitter(), {
+        name: "best-effort-failure",
+        tags: ["background-job"],
+      });
+      try {
+        throw original;
+      } catch (error: unknown) {
+        trace.fail(error);
+        throw error;
+      }
+    };
+
+    await expect(run()).rejects.toBe(original);
   });
 
   test("records a failed stage and rethrows the original error", async () => {

--- a/src/background-tracing.ts
+++ b/src/background-tracing.ts
@@ -1,0 +1,208 @@
+import { logger } from "./logger.ts";
+
+export type BackgroundObservationType = "span" | "generation" | "embedding";
+
+export interface BackgroundObservation {
+  name: string;
+  type: BackgroundObservationType;
+  input?: unknown;
+  output?: unknown;
+  metadata: Record<string, unknown>;
+  startedAt: number;
+  endedAt: number;
+  model?: string;
+  usageDetails?: Record<string, number>;
+  level?: "DEFAULT" | "ERROR" | "WARNING";
+  statusMessage?: string;
+}
+
+export interface BackgroundTraceBody {
+  name: string;
+  input?: unknown;
+  output?: unknown;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  observations: BackgroundObservation[];
+  startedAt: number;
+  endedAt: number;
+  sessionId?: string;
+  userId?: string;
+}
+
+export interface BackgroundTraceEmitter {
+  emitBackground(body: BackgroundTraceBody): void;
+}
+
+export interface BackgroundTraceStart {
+  name: string;
+  input?: unknown;
+  tags: string[];
+  metadata?: Record<string, unknown>;
+  sessionId?: string;
+  userId?: string;
+}
+
+export interface ObservationOptions<T> {
+  input?: unknown;
+  output?: (result: T) => unknown;
+  metadata?: Record<string, unknown>;
+  model?: string;
+  usageDetails?: (result: T) => Record<string, number> | undefined;
+}
+
+function errorOutput(error: unknown): Record<string, string> {
+  if (error instanceof Error) {
+    return { error_class: error.name, error_message: error.message };
+  }
+  return { error_class: typeof error, error_message: String(error) };
+}
+
+/**
+ * In-memory job trace recorder. It changes no job control flow: with no emitter,
+ * every observation method calls the work directly and allocates no records.
+ */
+export class BackgroundTraceRecorder {
+  private readonly observations: BackgroundObservation[] = [];
+  private readonly startedAt: number;
+
+  constructor(
+    private readonly emitter: BackgroundTraceEmitter | undefined,
+    private readonly trace: BackgroundTraceStart,
+    private readonly now: () => number = Date.now,
+  ) {
+    this.startedAt = now();
+  }
+
+  get active(): boolean {
+    return this.emitter !== undefined;
+  }
+
+  span<T>(
+    name: string,
+    work: () => Promise<T>,
+    options: ObservationOptions<T> = {},
+  ): Promise<T> {
+    return this.observe("span", name, work, options);
+  }
+
+  generation<T>(
+    name: string,
+    work: () => Promise<T>,
+    options: ObservationOptions<T> & { model: string },
+  ): Promise<T> {
+    return this.observe("generation", name, work, options);
+  }
+
+  embedding<T>(
+    name: string,
+    work: () => Promise<T>,
+    options: ObservationOptions<T> & { model: string },
+  ): Promise<T> {
+    return this.observe("embedding", name, work, options);
+  }
+
+  finish(output: unknown): void {
+    this.emit(output, "success");
+  }
+
+  fail(error: unknown): void {
+    this.emit(errorOutput(error), "exception");
+  }
+
+  private async observe<T>(
+    type: BackgroundObservationType,
+    name: string,
+    work: () => Promise<T>,
+    options: ObservationOptions<T>,
+  ): Promise<T> {
+    if (!this.emitter) return work();
+    const startedAt = this.now();
+    let result: T;
+    try {
+      result = await work();
+    } catch (error: unknown) {
+      this.recordSafely({
+        name,
+        type,
+        input: options.input,
+        output: errorOutput(error),
+        metadata: options.metadata ?? {},
+        startedAt,
+        endedAt: this.now(),
+        ...(options.model === undefined ? {} : { model: options.model }),
+        level: "ERROR",
+        statusMessage: error instanceof Error ? error.name : typeof error,
+      });
+      throw error;
+    }
+
+    try {
+      const usageDetails = options.usageDetails?.(result);
+      this.observations.push({
+        name,
+        type,
+        input: options.input,
+        output: options.output?.(result),
+        metadata: options.metadata ?? {},
+        startedAt,
+        endedAt: this.now(),
+        ...(options.model === undefined ? {} : { model: options.model }),
+        ...(usageDetails === undefined ? {} : { usageDetails }),
+        level: "DEFAULT",
+      });
+    } catch (error: unknown) {
+      logger.warn("background_tracing_observation_failed", {
+        error_category: error instanceof Error ? error.name : typeof error,
+      });
+    }
+    return result;
+  }
+
+  private recordSafely(observation: BackgroundObservation): void {
+    try {
+      this.observations.push(observation);
+    } catch (error: unknown) {
+      logger.warn("background_tracing_observation_failed", {
+        error_category: error instanceof Error ? error.name : typeof error,
+      });
+    }
+  }
+
+  private emit(output: unknown, status: "success" | "exception"): void {
+    if (!this.emitter) return;
+    try {
+      this.emitter.emitBackground({
+        name: this.trace.name,
+        input: this.trace.input,
+        output,
+        tags: this.trace.tags,
+        metadata: { ...this.trace.metadata, status },
+        observations: this.observations,
+        startedAt: this.startedAt,
+        endedAt: this.now(),
+        ...(this.trace.sessionId === undefined
+          ? {}
+          : { sessionId: this.trace.sessionId }),
+        ...(this.trace.userId === undefined ? {} : { userId: this.trace.userId }),
+      });
+    } catch (error: unknown) {
+      // Tracing is diagnostic-only. Keep this content-free because a custom
+      // emitter error may carry an endpoint, payload, or credential.
+      logger.warn("background_tracing_emit_failed", {
+        error_category: error instanceof Error ? error.name : typeof error,
+      });
+    }
+  }
+}
+
+/** Resolve a session key carried by a durable job payload or provenance. */
+export function backgroundSessionId(input: {
+  payload?: Record<string, unknown> | null;
+  provenance?: Record<string, unknown> | null;
+}): string | undefined {
+  for (const source of [input.payload, input.provenance]) {
+    const value = source?.session_key;
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}

--- a/src/distill-handler.test.ts
+++ b/src/distill-handler.test.ts
@@ -42,12 +42,28 @@ import {
   type MaintenanceQueueLogger,
 } from "./maintenance-queue.ts";
 import { ruleBasedDistiller } from "./distiller.ts";
+import type {
+  BackgroundTraceBody,
+  BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 
 const silentLogger: MaintenanceQueueLogger = {
   info: () => {},
   warn: () => {},
   error: () => {},
 };
+
+function recordingTracing(): BackgroundTraceEmitter & {
+  bodies: BackgroundTraceBody[];
+} {
+  const bodies: BackgroundTraceBody[] = [];
+  return {
+    bodies,
+    emitBackground(body) {
+      bodies.push(body);
+    },
+  };
+}
 
 function collectingLogger() {
   const records: Array<{ level: string; msg: string; fields: unknown }> = [];
@@ -562,6 +578,51 @@ describe("makeMemoryDistillHandler", () => {
     });
     await handler(job());
     expect(corpus.candidates[0]!.distill_job_id).toBe("job-distill-1");
+  });
+
+  it("emits a trace with stage spans and row ids read and written", async () => {
+    const source = rawTurn({ content: "we are going with traced distillation" });
+    const corpus = fakeCorpus([source]);
+    const tracing = recordingTracing();
+    const handler = makeMemoryDistillHandler({
+      pool: corpus.pool,
+      logger: silentLogger,
+      tracing,
+      embedFn: async () => ({
+        embedding: Array(768).fill(0.1),
+        usageDetails: { promptTokens: 6, totalTokens: 6 },
+      }),
+    });
+
+    await handler(
+      job({ payload: { session_key: "session-distill" } }),
+    );
+
+    expect(tracing.bodies[0]).toMatchObject({
+      name: "memory.distill",
+      sessionId: "session-distill",
+      metadata: { status: "success" },
+      observations: [
+        {
+          name: "distill.claim",
+          output: { row_ids: [source.id], units: 1 },
+        },
+        { name: "distill.extract", type: "span" },
+        {
+          name: "embedding.provider",
+          type: "embedding",
+          usageDetails: { promptTokens: 6, totalTokens: 6 },
+        },
+        { name: "distill.embedding_batch", type: "span" },
+        {
+          name: "distill.persist",
+          output: {
+            written_candidate_ids: ["cand-1"],
+            stamped_turn_ids: [source.id],
+          },
+        },
+      ],
+    });
   });
 
   it("a global (null-namespace) job sweeps every namespace", async () => {

--- a/src/distill-handler.test.ts
+++ b/src/distill-handler.test.ts
@@ -595,7 +595,10 @@ describe("makeMemoryDistillHandler", () => {
     });
 
     await handler(
-      job({ payload: { session_key: "session-distill" } }),
+      job({
+        namespace: "rico",
+        payload: { session_key: "session-distill" },
+      }),
     );
 
     expect(tracing.bodies[0]).toMatchObject({

--- a/src/distill-handler.ts
+++ b/src/distill-handler.ts
@@ -35,6 +35,12 @@
 import type pg from "pg";
 import { toSql } from "pgvector/pg";
 import {
+  BackgroundTraceRecorder,
+  backgroundSessionId,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
+import {
+  EMBEDDING_MODEL,
   generateEmbeddingWithMetadata,
   type EmbeddingResult,
 } from "./embedding.ts";
@@ -112,6 +118,8 @@ export interface DistillSweepDeps {
   distillJobId?: string | null;
   /** Skip the embedding call entirely. For runs where the provider is known down. */
   skipEmbeddings?: boolean;
+  /** Recorder for the containing maintenance job trace. */
+  trace?: BackgroundTraceRecorder;
 }
 
 function emptySummary(): DistillSweepSummary {
@@ -143,6 +151,7 @@ async function resolveEmbeddings(
   candidates: readonly PreparedCandidate[],
   embedFn: DistillEmbedFn,
   logger: MaintenanceQueueLogger,
+  trace?: BackgroundTraceRecorder,
 ): Promise<Map<string, number[] | null>> {
   const byHash = new Map<string, number[] | null>();
   let failures = 0;
@@ -150,7 +159,18 @@ async function resolveEmbeddings(
 
   for (const candidate of candidates) {
     if (byHash.has(candidate.content_hash)) continue;
-    const result = await embedFn(candidate.content);
+    const call = () => embedFn(candidate.content);
+    const result = trace
+      ? await trace.embedding("embedding.provider", call, {
+          model: EMBEDDING_MODEL,
+          input: { text: candidate.content },
+          output: (value) => ({
+            embedded: value.embedding !== null,
+            error: value.error ?? null,
+          }),
+          usageDetails: (value) => value.usageDetails,
+        })
+      : await call();
     if (result.embedding) {
       byHash.set(candidate.content_hash, result.embedding);
       continue;
@@ -189,7 +209,8 @@ async function persist(
   consumedTurnIds: readonly string[],
   distillJobId: string | null,
   summary: DistillSweepSummary,
-): Promise<void> {
+): Promise<string[]> {
+  const writtenRowIds: string[] = [];
   for (const candidate of candidates) {
     const vector = embeddings.get(candidate.content_hash) ?? null;
     if (vector === null) summary.embeddings_missing++;
@@ -224,6 +245,8 @@ async function persist(
 
     if (inserted.rowCount && inserted.rowCount > 0) {
       summary.candidates_written++;
+      const insertedId = (inserted.rows[0] as { id?: unknown } | undefined)?.id;
+      if (typeof insertedId === "string") writtenRowIds.push(insertedId);
       if (candidate.uncertain) summary.candidates_uncertain++;
     } else {
       // The dedupe fired. Not an error: the distiller is re-runnable by design
@@ -243,6 +266,7 @@ async function persist(
     );
     summary.turns_stamped = stamped.rowCount ?? 0;
   }
+  return writtenRowIds;
 }
 
 /**
@@ -259,15 +283,26 @@ export async function runDistillSweep(
   const embedFn = deps.embedFn ?? generateEmbeddingWithMetadata;
   const summary = emptySummary();
 
-  const batch = await claimDistillBatch(deps.pool, {
-    ...(deps.namespace !== undefined ? { namespace: deps.namespace } : {}),
-    ...(deps.laneId !== undefined ? { laneId: deps.laneId } : {}),
-    ...(deps.maxSessions !== undefined
-      ? { maxSessions: deps.maxSessions }
-      : {}),
-    ...(deps.maxTurns !== undefined ? { maxTurns: deps.maxTurns } : {}),
-    contextWindow: deps.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-  });
+  const claim = () =>
+    claimDistillBatch(deps.pool, {
+      ...(deps.namespace !== undefined ? { namespace: deps.namespace } : {}),
+      ...(deps.laneId !== undefined ? { laneId: deps.laneId } : {}),
+      ...(deps.maxSessions !== undefined
+        ? { maxSessions: deps.maxSessions }
+        : {}),
+      ...(deps.maxTurns !== undefined ? { maxTurns: deps.maxTurns } : {}),
+      contextWindow: deps.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    });
+  const batch = deps.trace
+    ? await deps.trace.span("distill.claim", claim, {
+        input: { namespace: deps.namespace ?? null, lane_id: deps.laneId ?? null },
+        output: (result) => ({
+          row_ids: result.consumedTurnIds,
+          units: result.units.length,
+          missing_session_seq: result.missingSessionSeq,
+        }),
+      })
+    : await claim();
 
   summary.units = batch.units.length;
   summary.missing_session_seq = batch.missingSessionSeq;
@@ -276,39 +311,72 @@ export async function runDistillSweep(
 
   const candidates: PreparedCandidate[] = [];
   for (const unit of batch.units) {
-    candidates.push(...(await runDistillUnit(model, unit)));
+    candidates.push(...(await runDistillUnit(model, unit, deps.trace)));
   }
   summary.candidates_extracted = candidates.length;
 
   // Outside the transaction -- see the module note on why.
-  const embeddings = deps.skipEmbeddings
-    ? new Map<string, number[] | null>()
-    : await resolveEmbeddings(candidates, embedFn, deps.logger);
+  const resolve = () =>
+    deps.skipEmbeddings
+      ? Promise.resolve(new Map<string, number[] | null>())
+      : resolveEmbeddings(candidates, embedFn, deps.logger, deps.trace);
+  const embeddings = deps.trace
+    ? await deps.trace.span("distill.embedding_batch", resolve, {
+        input: {
+          model: EMBEDDING_MODEL,
+          item_count: candidates.length,
+          row_ids: candidates.flatMap((candidate) => candidate.source_turn_ids),
+          skipped: deps.skipEmbeddings === true,
+        },
+        output: (result) => ({
+          model: EMBEDDING_MODEL,
+          item_count: result.size,
+          provider_errors: [...result.entries()]
+            .filter(([, vector]) => vector === null)
+            .map(([contentHash]) => contentHash),
+        }),
+      })
+    : await resolve();
 
-  const client = await deps.pool.connect();
-  try {
-    await client.query("BEGIN");
-    await persist(
-      client,
-      candidates,
-      embeddings,
-      batch.consumedTurnIds,
-      deps.distillJobId ?? null,
-      summary,
-    );
-    await client.query("COMMIT");
-  } catch (err) {
-    await client.query("ROLLBACK").catch(() => undefined);
-    // Logged before it propagates, so a failed sweep is never silent even if
-    // the queue's own failure record is later pruned.
-    deps.logger.error("distill_sweep_failed", {
-      units: summary.units,
-      candidates_extracted: summary.candidates_extracted,
-      reason: err instanceof Error ? err.name : "non_error",
+  const persistWork = async (): Promise<string[]> => {
+    const client = await deps.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const written = await persist(
+        client,
+        candidates,
+        embeddings,
+        batch.consumedTurnIds,
+        deps.distillJobId ?? null,
+        summary,
+      );
+      await client.query("COMMIT");
+      return written;
+    } catch (err: unknown) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      deps.logger.error("distill_sweep_failed", {
+        units: summary.units,
+        candidates_extracted: summary.candidates_extracted,
+        reason: err instanceof Error ? err.name : "non_error",
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+  };
+  if (deps.trace) {
+    await deps.trace.span("distill.persist", persistWork, {
+      input: {
+        source_turn_ids: batch.consumedTurnIds,
+        candidate_hashes: candidates.map((candidate) => candidate.content_hash),
+      },
+      output: (writtenRowIds) => ({
+        written_candidate_ids: writtenRowIds,
+        stamped_turn_ids: batch.consumedTurnIds,
+      }),
     });
-    throw err;
-  } finally {
-    client.release();
+  } else {
+    await persistWork();
   }
 
   // Content-free telemetry: counts and a model name, never content or hashes.
@@ -335,6 +403,7 @@ export interface MemoryDistillHandlerDeps {
   /** Present for signature parity with the other registered handlers. */
   auth?: unknown;
   model?: NamedDistillModel;
+  tracing?: BackgroundTraceEmitter;
 }
 
 /**
@@ -353,42 +422,49 @@ export function makeMemoryDistillHandler(
   deps: MemoryDistillHandlerDeps,
 ): MaintenanceJobHandler {
   return async (job: MaintenanceJob): Promise<void> => {
-    if (job.version !== MEMORY_DISTILL_JOB_VERSION) {
-      throw new MaintenanceTerminalError(
-        "memory distill job version is not supported by this handler",
-      );
-    }
-
-    // The payload is optional scoping, not a contract the sweep depends on:
-    // an empty payload means "sweep the oldest due work", which is the useful
-    // default for a recurring maintenance job. Values are read defensively
-    // because a job row is durable and may predate a code change.
-    const payload = job.payload ?? {};
-    const laneId =
-      payload.lane_id === null || typeof payload.lane_id === "string"
-        ? payload.lane_id
-        : undefined;
-    const maxSessions =
-      typeof payload.max_sessions === "number"
-        ? payload.max_sessions
-        : undefined;
-    const maxTurns =
-      typeof payload.max_turns === "number" ? payload.max_turns : undefined;
-
-    await runDistillSweep({
-      pool: deps.pool,
-      logger: deps.logger,
-      embedFn: deps.embedFn,
-      ...(deps.model ? { model: deps.model } : {}),
-      // The job's own namespace is the only namespace this run may touch when
-      // one was scoped. A null namespace is a deliberate global sweep, which is
-      // what a maintenance identity is for -- not an error.
-      ...(job.namespace !== null ? { namespace: job.namespace } : {}),
-      ...(laneId !== undefined ? { laneId } : {}),
-      ...(maxSessions !== undefined ? { maxSessions } : {}),
-      ...(maxTurns !== undefined ? { maxTurns } : {}),
-      distillJobId: job.id,
+    const trace = new BackgroundTraceRecorder(deps.tracing, {
+      name: "memory.distill",
+      input: { job_id: job.id, namespace: job.namespace },
+      tags: ["open-brain-server", "background-job", "dream", "distill"],
+      metadata: { job_kind: job.kind, attempt: job.attempts },
+      sessionId: backgroundSessionId(job),
     });
+    try {
+      if (job.version !== MEMORY_DISTILL_JOB_VERSION) {
+        throw new MaintenanceTerminalError(
+          "memory distill job version is not supported by this handler",
+        );
+      }
+
+      const payload = job.payload ?? {};
+      const laneId =
+        payload.lane_id === null || typeof payload.lane_id === "string"
+          ? payload.lane_id
+          : undefined;
+      const maxSessions =
+        typeof payload.max_sessions === "number"
+          ? payload.max_sessions
+          : undefined;
+      const maxTurns =
+        typeof payload.max_turns === "number" ? payload.max_turns : undefined;
+
+      const summary = await runDistillSweep({
+        pool: deps.pool,
+        logger: deps.logger,
+        embedFn: deps.embedFn,
+        trace,
+        ...(deps.model ? { model: deps.model } : {}),
+        ...(job.namespace !== null ? { namespace: job.namespace } : {}),
+        ...(laneId !== undefined ? { laneId } : {}),
+        ...(maxSessions !== undefined ? { maxSessions } : {}),
+        ...(maxTurns !== undefined ? { maxTurns } : {}),
+        distillJobId: job.id,
+      });
+      trace.finish(summary);
+    } catch (error: unknown) {
+      trace.fail(error);
+      throw error;
+    }
   };
 }
 

--- a/src/distill-handler.ts
+++ b/src/distill-handler.ts
@@ -163,7 +163,11 @@ async function resolveEmbeddings(
     const result = trace
       ? await trace.embedding("embedding.provider", call, {
           model: EMBEDDING_MODEL,
-          input: { text: candidate.content },
+          input: {
+            row_id: candidate.source_turn_ids[0] ?? null,
+            char_count: candidate.content.length,
+            content_hash: candidate.content_hash,
+          },
           metadata: { namespace: candidate.namespace },
           output: (value) => ({
             embedded: value.embedding !== null,
@@ -329,7 +333,9 @@ export async function runDistillSweep(
         input: {
           model: EMBEDDING_MODEL,
           item_count: candidates.length,
-          row_ids: candidates.flatMap((candidate) => candidate.source_turn_ids),
+          row_ids: [
+            ...new Set(candidates.flatMap((candidate) => candidate.source_turn_ids)),
+          ],
           skipped: deps.skipEmbeddings === true,
         },
         output: (result) => ({

--- a/src/distill-handler.ts
+++ b/src/distill-handler.ts
@@ -164,6 +164,7 @@ async function resolveEmbeddings(
       ? await trace.embedding("embedding.provider", call, {
           model: EMBEDDING_MODEL,
           input: { text: candidate.content },
+          metadata: { namespace: candidate.namespace },
           output: (value) => ({
             embedded: value.embedding !== null,
             error: value.error ?? null,
@@ -322,6 +323,9 @@ export async function runDistillSweep(
       : resolveEmbeddings(candidates, embedFn, deps.logger, deps.trace);
   const embeddings = deps.trace
     ? await deps.trace.span("distill.embedding_batch", resolve, {
+        metadata: {
+          namespaces: [...new Set(candidates.map((candidate) => candidate.namespace))],
+        },
         input: {
           model: EMBEDDING_MODEL,
           item_count: candidates.length,
@@ -366,6 +370,9 @@ export async function runDistillSweep(
   };
   if (deps.trace) {
     await deps.trace.span("distill.persist", persistWork, {
+      metadata: {
+        namespaces: [...new Set(candidates.map((candidate) => candidate.namespace))],
+      },
       input: {
         source_turn_ids: batch.consumedTurnIds,
         candidate_hashes: candidates.map((candidate) => candidate.content_hash),
@@ -427,7 +434,7 @@ export function makeMemoryDistillHandler(
       input: { job_id: job.id, namespace: job.namespace },
       tags: ["open-brain-server", "background-job", "dream", "distill"],
       metadata: { job_kind: job.kind, attempt: job.attempts },
-      sessionId: backgroundSessionId(job),
+      sessionId: job.namespace === null ? undefined : backgroundSessionId(job),
     });
     try {
       if (job.version !== MEMORY_DISTILL_JOB_VERSION) {

--- a/src/distiller.test.ts
+++ b/src/distiller.test.ts
@@ -463,7 +463,8 @@ describe("runDistillUnit — provenance and write guards", () => {
       }),
     };
 
-    const prepared = await runDistillUnit(model, unit(), trace);
+    const sourceUnit = unit();
+    const prepared = await runDistillUnit(model, sourceUnit, trace);
     trace.finish({ candidates: prepared.length });
 
     expect(emitter.bodies[0]).toMatchObject({
@@ -472,6 +473,11 @@ describe("runDistillUnit — provenance and write guards", () => {
           name: "distill.extract",
           type: "generation",
           model: "fixture-distiller",
+          output: {
+            candidate_ids: [`${sourceUnit.current.id}:0`],
+            candidate_hashes: [contentHash("provider-backed candidate")],
+            candidate_count: 1,
+          },
           usageDetails: { input: 11, output: 4 },
         },
       ],

--- a/src/distiller.test.ts
+++ b/src/distiller.test.ts
@@ -30,9 +30,27 @@ import {
   type NamedDistillModel,
 } from "./distiller.ts";
 import { contentHash } from "./embedding.ts";
+import {
+  BackgroundTraceRecorder,
+  type BackgroundTraceBody,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import type { DistillTurn, DistillUnit } from "./distill-window.ts";
 
 let n = 0;
+
+function recordingTracing(): BackgroundTraceEmitter & {
+  bodies: BackgroundTraceBody[];
+} {
+  const bodies: BackgroundTraceBody[] = [];
+  return {
+    bodies,
+    emitBackground(body) {
+      bodies.push(body);
+    },
+  };
+}
+
 function turn(over: Partial<DistillTurn> = {}): DistillTurn {
   n++;
   return {
@@ -421,5 +439,42 @@ describe("runDistillUnit — provenance and write guards", () => {
     expect(keys).not.toContain("reviewed_at");
     expect(keys).not.toContain("graded_by");
     expect(keys).not.toContain("machine_grade");
+  });
+
+  it("emits an LLM extractor as a generation with model usage", async () => {
+    const emitter = recordingTracing();
+    const trace = new BackgroundTraceRecorder(emitter, {
+      name: "memory.distill",
+      tags: ["background-job", "dream"],
+    });
+    const model: NamedDistillModel = {
+      name: "fixture-distiller",
+      observationType: "generation",
+      extract: async (request) => ({
+        candidates: [
+          {
+            candidate_type: "fact",
+            content: "provider-backed candidate",
+            source_turn_ids: [request.current.id],
+            uncertain: false,
+          },
+        ],
+        usageDetails: { input: 11, output: 4 },
+      }),
+    };
+
+    const prepared = await runDistillUnit(model, unit(), trace);
+    trace.finish({ candidates: prepared.length });
+
+    expect(emitter.bodies[0]).toMatchObject({
+      observations: [
+        {
+          name: "distill.extract",
+          type: "generation",
+          model: "fixture-distiller",
+          usageDetails: { input: 11, output: 4 },
+        },
+      ],
+    });
   });
 });

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -462,6 +462,7 @@ export async function runDistillUnit(
     output: (response: DistillResponse) => ({
       candidates: response.candidates,
     }),
+    metadata: { namespace: unit.current.namespace },
   };
   const response =
     trace && model.observationType === "generation"

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -460,7 +460,13 @@ export async function runDistillUnit(
       context_turn_ids: unit.context.map((turn) => turn.id),
     },
     output: (response: DistillResponse) => ({
-      candidates: response.candidates,
+      candidate_ids: response.candidates.map(
+        (_candidate, index) => `${unit.current.id}:${index}`,
+      ),
+      candidate_hashes: response.candidates.map((candidate) =>
+        contentHash(normalizeWhitespace(candidate.content ?? "")),
+      ),
+      candidate_count: response.candidates.length,
     }),
     metadata: { namespace: unit.current.namespace },
   };

--- a/src/distiller.ts
+++ b/src/distiller.ts
@@ -40,6 +40,7 @@
  * grade on day one.
  */
 
+import type { BackgroundTraceRecorder } from "./background-tracing.ts";
 import { contentHash } from "./embedding.ts";
 import { isHarnessNoise } from "./tools/ingest-raw-turn.ts";
 import type { DistillTurn, DistillUnit } from "./distill-window.ts";
@@ -89,6 +90,8 @@ export interface DistillRequest {
 
 export interface DistillResponse {
   candidates: DistillCandidate[];
+  /** Provider-reported usage for an LLM-backed extractor. */
+  usageDetails?: Record<string, number>;
 }
 
 /**
@@ -107,6 +110,8 @@ export type DistillModel = (req: DistillRequest) => Promise<DistillResponse>;
 /** Names the producer in `candidate_memory.model`. Required for ethereal-run comparison. */
 export interface NamedDistillModel {
   name: string;
+  /** Set only for a server-side LLM implementation; deterministic rules stay spans. */
+  observationType?: "generation";
   extract: DistillModel;
 }
 
@@ -442,11 +447,32 @@ export interface PreparedCandidate extends DistillCandidate {
 export async function runDistillUnit(
   model: NamedDistillModel,
   unit: DistillUnit,
+  trace?: BackgroundTraceRecorder,
 ): Promise<PreparedCandidate[]> {
-  const response = await model.extract({
+  const request = {
     current: unit.current,
     context: unit.context,
-  });
+  };
+  const observe = () => model.extract(request);
+  const options = {
+    input: {
+      current_turn_id: unit.current.id,
+      context_turn_ids: unit.context.map((turn) => turn.id),
+    },
+    output: (response: DistillResponse) => ({
+      candidates: response.candidates,
+    }),
+  };
+  const response =
+    trace && model.observationType === "generation"
+      ? await trace.generation("distill.extract", observe, {
+          ...options,
+          model: model.name,
+          usageDetails: (result) => result.usageDetails,
+        })
+      : trace
+        ? await trace.span("distill.extract", observe, options)
+        : await observe();
 
   const out: PreparedCandidate[] = [];
   for (const candidate of response.candidates) {

--- a/src/dream-light.test.ts
+++ b/src/dream-light.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { isCountable } from "./dream-light.ts";
+import {
+  DREAM_LIGHT_JOB_KIND,
+  DREAM_LIGHT_JOB_VERSION,
+  isCountable,
+  makeDreamLightHandler,
+} from "./dream-light.ts";
+import {
+  MaintenanceTerminalError,
+  type MaintenanceJob,
+} from "./maintenance-queue.ts";
 
 /**
  * Functional tests for Light's countability boundary (Issue #390).
@@ -76,6 +85,47 @@ describe("isCountable — only speech corroborates", () => {
 
   it("treats a missing role as speech", () => {
     expect(isCountable("a genuine utterance with no role given")).toBe(true);
+  });
+});
+
+describe("makeDreamLightHandler", () => {
+  it("rejects an unsupported job version before running the sweep", async () => {
+    let queried = false;
+    const handler = makeDreamLightHandler({
+      pool: {
+        query: async () => {
+          queried = true;
+          return { rows: [], rowCount: 0 };
+        },
+      } as any,
+      logger: { info: () => undefined, warn: () => undefined },
+    });
+    const now = new Date("2026-08-06T00:00:00.000Z");
+    const job: MaintenanceJob = {
+      id: "job-light-version",
+      kind: DREAM_LIGHT_JOB_KIND,
+      version: DREAM_LIGHT_JOB_VERSION + 1,
+      payload: {},
+      idempotencyKey: "light-version",
+      state: "running",
+      runAfter: now,
+      leaseToken: "00000000-0000-4000-8000-000000000001",
+      leaseUntil: new Date("2026-08-06T00:00:30.000Z"),
+      attempts: 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_000,
+      backoffMaxMs: 4_000,
+      lastErrorCategory: null,
+      terminalAt: null,
+      deadLetteredAt: null,
+      namespace: "rico",
+      provenance: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await expect(handler(job)).rejects.toBeInstanceOf(MaintenanceTerminalError);
+    expect(queried).toBe(false);
   });
 });
 

--- a/src/dream-light.ts
+++ b/src/dream-light.ts
@@ -52,6 +52,12 @@
  */
 
 import type { Pool } from "pg";
+import {
+  BackgroundTraceRecorder,
+  backgroundSessionId,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
+import type { MaintenanceJob } from "./maintenance-queue.ts";
 import { isHarnessNoise } from "./tools/ingest-raw-turn.ts";
 
 /** Job kind this stage registers under in the maintenance queue. */
@@ -228,6 +234,7 @@ export interface DreamLightDeps {
     warn: (msg: string, meta: Record<string, string | number>) => void;
   };
   batchSize?: number;
+  tracing?: BackgroundTraceEmitter;
 }
 
 interface SweepRow {
@@ -390,8 +397,28 @@ export async function runLightSweep(
  * retry policy re-deliver.
  */
 export function makeDreamLightHandler(deps: DreamLightDeps) {
-  return async function dreamLightHandler(): Promise<void> {
-    await runLightSweep(deps);
+  return async function dreamLightHandler(job: MaintenanceJob): Promise<void> {
+    const trace = new BackgroundTraceRecorder(deps.tracing, {
+      name: "dream.light",
+      input: { job_id: job.id, namespace: job.namespace },
+      tags: ["open-brain-server", "background-job", "dream", "light"],
+      metadata: { job_kind: job.kind, attempt: job.attempts },
+      sessionId: backgroundSessionId(job),
+    });
+    try {
+      const summary = await trace.span(
+        "dream.light.sweep",
+        () => runLightSweep(deps),
+        {
+          input: { namespace: job.namespace },
+          output: (result) => result,
+        },
+      );
+      trace.finish(summary);
+    } catch (error: unknown) {
+      trace.fail(error);
+      throw error;
+    }
   };
 }
 

--- a/src/dream-light.ts
+++ b/src/dream-light.ts
@@ -57,11 +57,15 @@ import {
   backgroundSessionId,
   type BackgroundTraceEmitter,
 } from "./background-tracing.ts";
-import type { MaintenanceJob } from "./maintenance-queue.ts";
+import {
+  MaintenanceTerminalError,
+  type MaintenanceJob,
+} from "./maintenance-queue.ts";
 import { isHarnessNoise } from "./tools/ingest-raw-turn.ts";
 
 /** Job kind this stage registers under in the maintenance queue. */
 export const DREAM_LIGHT_JOB_KIND = "dream.light";
+export const DREAM_LIGHT_JOB_VERSION = 1;
 
 /**
  * Turns processed per sweep. Bounded because an unbounded sweep over a growing
@@ -398,14 +402,20 @@ export async function runLightSweep(
  */
 export function makeDreamLightHandler(deps: DreamLightDeps) {
   return async function dreamLightHandler(job: MaintenanceJob): Promise<void> {
-    const trace = new BackgroundTraceRecorder(deps.tracing, {
-      name: "dream.light",
-      input: { job_id: job.id, namespace: job.namespace },
-      tags: ["open-brain-server", "background-job", "dream", "light"],
-      metadata: { job_kind: job.kind, attempt: job.attempts },
-      sessionId: backgroundSessionId(job),
-    });
+    let trace: BackgroundTraceRecorder | undefined;
     try {
+      trace = new BackgroundTraceRecorder(deps.tracing, {
+        name: "dream.light",
+        input: { job_id: job.id, namespace: job.namespace },
+        tags: ["open-brain-server", "background-job", "dream", "light"],
+        metadata: { job_kind: job.kind, attempt: job.attempts },
+        sessionId: backgroundSessionId(job),
+      });
+      if (job.version !== DREAM_LIGHT_JOB_VERSION) {
+        throw new MaintenanceTerminalError(
+          "dream light job version is not supported by this handler",
+        );
+      }
       const summary = await trace.span(
         "dream.light.sweep",
         () => runLightSweep(deps),
@@ -416,7 +426,7 @@ export function makeDreamLightHandler(deps: DreamLightDeps) {
       );
       trace.finish(summary);
     } catch (error: unknown) {
-      trace.fail(error);
+      trace?.fail(error);
       throw error;
     }
   };

--- a/src/dream-rem.test.ts
+++ b/src/dream-rem.test.ts
@@ -20,9 +20,10 @@
 
 import { describe, expect, it } from "bun:test";
 import type pg from "pg";
-import type {
-  BackgroundTraceBody,
-  BackgroundTraceEmitter,
+import {
+  BackgroundTraceRecorder,
+  type BackgroundTraceBody,
+  type BackgroundTraceEmitter,
 } from "./background-tracing.ts";
 import {
   buildDreamRemEnqueue,
@@ -313,6 +314,37 @@ describe("runRemGrading — the operator queue is untouchable", () => {
     const summary = await runRemGrading({ pool, logger: silentLogger });
     expect(summary.corroborated).toBe(1);
     expect(summary.by_grade.promoted).toBe(1);
+  });
+
+  it("records generation grading by candidate id without candidate content", async () => {
+    const candidate = candidateRow({
+      id: "candidate-trace-id",
+      content: "tenant candidate content must not be traced",
+    });
+    const { pool } = fakePool((sql) =>
+      sql.includes("FROM candidate_memory c") ? { rows: [candidate] } : undefined,
+    );
+    const emitter = recordingTracing();
+    const trace = new BackgroundTraceRecorder(emitter, {
+      name: "dream.rem",
+      tags: ["background-job", "dream"],
+    });
+    const grader: NamedRemGrader = {
+      name: "fixture-grader",
+      observationType: "generation",
+      grade: () => ({
+        grade: "promoted",
+        reason: "tenant candidate content must not be traced",
+      }),
+    };
+
+    await runRemGrading({ pool, logger: silentLogger, grader, trace });
+    trace.finish({ outcome: "succeeded" });
+
+    const observation = emitter.bodies[0]!.observations[0]!;
+    expect(observation.input).toEqual({ candidate_id: "candidate-trace-id" });
+    expect(observation.output).toEqual({ grade: "promoted", has_reason: true });
+    expect(JSON.stringify(observation)).not.toContain(candidate.content);
   });
 
   it("skips one bad grader verdict instead of stalling the whole pass", async () => {

--- a/src/dream-rem.test.ts
+++ b/src/dream-rem.test.ts
@@ -20,6 +20,10 @@
 
 import { describe, expect, it } from "bun:test";
 import type pg from "pg";
+import type {
+  BackgroundTraceBody,
+  BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import {
   buildDreamRemEnqueue,
   DREAM_REM_JOB_KIND,
@@ -49,6 +53,18 @@ const silentLogger: MaintenanceQueueLogger = {
   warn: () => {},
   error: () => {},
 };
+
+function recordingTracing(): BackgroundTraceEmitter & {
+  bodies: BackgroundTraceBody[];
+} {
+  const bodies: BackgroundTraceBody[] = [];
+  return {
+    bodies,
+    emitBackground(body) {
+      bodies.push(body);
+    },
+  };
+}
 
 function collectingLogger() {
   const records: Array<{ msg: string; fields: Record<string, unknown> }> = [];
@@ -579,6 +595,37 @@ describe("makeDreamRemHandler", () => {
       s.text.includes("FROM candidate_memory c"),
     )!;
     expect(select.values[0]).toBeNull();
+  });
+
+  it("emits one REM run trace with stage spans and session binding", async () => {
+    const { pool } = fakePool(() => undefined);
+    const tracing = recordingTracing();
+    const handler = makeDreamRemHandler({
+      pool,
+      logger: silentLogger,
+      tracing,
+    });
+
+    await handler(
+      job({
+        payload: {
+          skip_dedupe: true,
+          skip_rewarm: true,
+          session_key: "session-rem",
+        },
+      }),
+    );
+
+    expect(tracing.bodies[0]).toMatchObject({
+      name: "dream.rem",
+      sessionId: "session-rem",
+      metadata: { status: "success" },
+      observations: [
+        { name: "dream.rem.dedupe", type: "span" },
+        { name: "dream.rem.grading", type: "span" },
+        { name: "dream.rem.rewarm", type: "span" },
+      ],
+    });
   });
 });
 

--- a/src/dream-rem.test.ts
+++ b/src/dream-rem.test.ts
@@ -597,6 +597,42 @@ describe("makeDreamRemHandler", () => {
     expect(select.values[0]).toBeNull();
   });
 
+  it("keeps a global REM sweep off tenant sessions and attributes candidate namespaces", async () => {
+    const { pool } = fakePool((sql) =>
+      sql.includes("FROM candidate_memory c")
+        ? {
+            rows: [
+              candidateRow({ id: "candidate-rico", namespace: "rico" }),
+              candidateRow({ id: "candidate-other", namespace: "other" }),
+            ],
+          }
+        : undefined,
+    );
+    const tracing = recordingTracing();
+    const handler = makeDreamRemHandler({ pool, logger: silentLogger, tracing });
+
+    await handler(
+      job({
+        namespace: null,
+        payload: {
+          skip_dedupe: true,
+          skip_rewarm: true,
+          session_key: "tenant-session-must-not-bind",
+        },
+      }),
+    );
+
+    expect(tracing.bodies).toHaveLength(1);
+    expect(tracing.bodies[0]?.sessionId).toBeUndefined();
+    const grades = tracing.bodies[0]!.observations.filter(
+      (observation) => observation.name === "dream.rem.grade",
+    );
+    expect(grades.map((observation) => observation.metadata.namespace)).toEqual([
+      "rico",
+      "other",
+    ]);
+  });
+
   it("emits one REM run trace with stage spans and session binding", async () => {
     const { pool } = fakePool(() => undefined);
     const tracing = recordingTracing();
@@ -608,6 +644,7 @@ describe("makeDreamRemHandler", () => {
 
     await handler(
       job({
+        namespace: "rico",
         payload: {
           skip_dedupe: true,
           skip_rewarm: true,

--- a/src/dream-rem.ts
+++ b/src/dream-rem.ts
@@ -326,15 +326,21 @@ export async function runRemGrading(deps: RemDeps): Promise<RemGradeSummary> {
       deps.trace && grader.observationType === "generation"
         ? await deps.trace.generation("dream.rem.grade", grade, {
             model: grader.name,
-            input: candidate,
-            output: (result) => result,
+            input: { candidate_id: candidate.id },
+            output: (result) => ({
+              grade: result.grade,
+              has_reason: Boolean(result.reason),
+            }),
             metadata: { namespace: candidate.namespace },
             usageDetails: (result) => result.usageDetails,
           })
         : deps.trace
           ? await deps.trace.span("dream.rem.grade", grade, {
               input: { candidate_id: candidate.id },
-              output: (result) => result,
+              output: (result) => ({
+              grade: result.grade,
+              has_reason: Boolean(result.reason),
+            }),
               metadata: { namespace: candidate.namespace },
             })
           : await grade();

--- a/src/dream-rem.ts
+++ b/src/dream-rem.ts
@@ -328,12 +328,14 @@ export async function runRemGrading(deps: RemDeps): Promise<RemGradeSummary> {
             model: grader.name,
             input: candidate,
             output: (result) => result,
+            metadata: { namespace: candidate.namespace },
             usageDetails: (result) => result.usageDetails,
           })
         : deps.trace
           ? await deps.trace.span("dream.rem.grade", grade, {
               input: { candidate_id: candidate.id },
               output: (result) => result,
+              metadata: { namespace: candidate.namespace },
             })
           : await grade();
 
@@ -637,7 +639,7 @@ export function makeDreamRemHandler(
       input: { job_id: job.id, namespace: job.namespace },
       tags: ["open-brain-server", "background-job", "dream", "rem"],
       metadata: { job_kind: job.kind, attempt: job.attempts },
-      sessionId: backgroundSessionId(job),
+      sessionId: job.namespace === null ? undefined : backgroundSessionId(job),
     });
     try {
       if (job.version !== DREAM_REM_JOB_VERSION) {

--- a/src/dream-rem.ts
+++ b/src/dream-rem.ts
@@ -46,6 +46,11 @@
  */
 
 import type pg from "pg";
+import {
+  BackgroundTraceRecorder,
+  backgroundSessionId,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import type { MaintenanceQueueLogger } from "./maintenance-queue.ts";
 import {
   MaintenanceTerminalError,
@@ -101,6 +106,8 @@ export interface RemGrade {
   grade: GradeValue;
   /** Free text; stored on the candidate as uncertainty_reason when doubtful. */
   reason?: string;
+  /** Provider-reported usage for an LLM-backed grader. */
+  usageDetails?: Record<string, number>;
 }
 
 /**
@@ -109,6 +116,8 @@ export interface RemGrade {
  */
 export interface NamedRemGrader {
   readonly name: string;
+  /** Set only when grade() itself calls an LLM provider. */
+  readonly observationType?: "generation";
   grade(candidate: RemCandidate): Promise<RemGrade> | RemGrade;
 }
 
@@ -212,6 +221,8 @@ export interface RemDeps {
   skipRewarm?: boolean;
   /** Re-engagement lookback. Defaults to {@link REWARM_WINDOW_DAYS}. */
   rewarmWindowDays?: number;
+  /** Recorder for the containing REM maintenance job. */
+  trace?: BackgroundTraceRecorder;
 }
 
 function emptyGradeSummary(): RemGradeSummary {
@@ -310,7 +321,21 @@ export async function runRemGrading(deps: RemDeps): Promise<RemGradeSummary> {
       reinforcement_count: Number(row.reinforcement_count),
     };
 
-    const verdict = await grader.grade(candidate);
+    const grade = () => Promise.resolve(grader.grade(candidate));
+    const verdict =
+      deps.trace && grader.observationType === "generation"
+        ? await deps.trace.generation("dream.rem.grade", grade, {
+            model: grader.name,
+            input: candidate,
+            output: (result) => result,
+            usageDetails: (result) => result.usageDetails,
+          })
+        : deps.trace
+          ? await deps.trace.span("dream.rem.grade", grade, {
+              input: { candidate_id: candidate.id },
+              output: (result) => result,
+            })
+          : await grade();
 
     // A grader returning an out-of-vocabulary value is a bug in the grader, and
     // the check-constraint would reject the row anyway -- catching it here
@@ -545,19 +570,43 @@ export async function runRemRewarm(deps: RemDeps): Promise<RemRewarmSummary> {
  * machine_grade IS NULL.
  */
 export async function runRemPass(deps: RemDeps): Promise<RemSummary> {
-  const dedupe = deps.skipDedupe
-    ? { examined: 0, merged: 0, reinforced: 0, skipped_no_embedding: 0 }
-    : await runCandidateDedupe({
-        pool: deps.pool,
-        logger: deps.logger,
-        ...(deps.namespace !== undefined ? { namespace: deps.namespace } : {}),
-      });
+  const dedupeWork = () =>
+    deps.skipDedupe
+      ? Promise.resolve({
+          examined: 0,
+          merged: 0,
+          reinforced: 0,
+          skipped_no_embedding: 0,
+        })
+      : runCandidateDedupe({
+          pool: deps.pool,
+          logger: deps.logger,
+          ...(deps.namespace !== undefined ? { namespace: deps.namespace } : {}),
+        });
+  const dedupe = deps.trace
+    ? await deps.trace.span("dream.rem.dedupe", dedupeWork, {
+        input: { namespace: deps.namespace ?? null, skipped: deps.skipDedupe === true },
+        output: (result) => result,
+      })
+    : await dedupeWork();
 
-  const grading = await runRemGrading(deps);
+  const grading = deps.trace
+    ? await deps.trace.span("dream.rem.grading", () => runRemGrading(deps), {
+        input: { namespace: deps.namespace ?? null },
+        output: (result) => result,
+      })
+    : await runRemGrading(deps);
 
-  const rewarm = deps.skipRewarm
-    ? { projects_seen: 0, warmed: 0, noticed_only: 0 }
-    : await runRemRewarm(deps);
+  const rewarmWork = () =>
+    deps.skipRewarm
+      ? Promise.resolve({ projects_seen: 0, warmed: 0, noticed_only: 0 })
+      : runRemRewarm(deps);
+  const rewarm = deps.trace
+    ? await deps.trace.span("dream.rem.rewarm", rewarmWork, {
+        input: { namespace: deps.namespace ?? null, skipped: deps.skipRewarm === true },
+        output: (result) => result,
+      })
+    : await rewarmWork();
 
   return { grading, dedupe, rewarm };
 }
@@ -567,6 +616,7 @@ export interface DreamRemHandlerDeps {
   pool: pg.Pool;
   logger: MaintenanceQueueLogger;
   grader?: NamedRemGrader;
+  tracing?: BackgroundTraceEmitter;
 }
 
 /**
@@ -582,27 +632,39 @@ export function makeDreamRemHandler(
   deps: DreamRemHandlerDeps,
 ): MaintenanceJobHandler {
   return async (job: MaintenanceJob): Promise<void> => {
-    if (job.version !== DREAM_REM_JOB_VERSION) {
-      throw new MaintenanceTerminalError(
-        "dream rem job version is not supported by this handler",
-      );
-    }
-
-    const payload = job.payload ?? {};
-    const batchSize =
-      typeof payload.batch_size === "number" ? payload.batch_size : undefined;
-
-    await runRemPass({
-      pool: deps.pool,
-      logger: deps.logger,
-      ...(deps.grader ? { grader: deps.grader } : {}),
-      // A null job namespace is a deliberate global pass, which is what a
-      // maintenance identity is for -- not an error.
-      ...(job.namespace !== null ? { namespace: job.namespace } : {}),
-      ...(batchSize !== undefined ? { batchSize } : {}),
-      ...(payload.skip_dedupe === true ? { skipDedupe: true } : {}),
-      ...(payload.skip_rewarm === true ? { skipRewarm: true } : {}),
+    const trace = new BackgroundTraceRecorder(deps.tracing, {
+      name: "dream.rem",
+      input: { job_id: job.id, namespace: job.namespace },
+      tags: ["open-brain-server", "background-job", "dream", "rem"],
+      metadata: { job_kind: job.kind, attempt: job.attempts },
+      sessionId: backgroundSessionId(job),
     });
+    try {
+      if (job.version !== DREAM_REM_JOB_VERSION) {
+        throw new MaintenanceTerminalError(
+          "dream rem job version is not supported by this handler",
+        );
+      }
+
+      const payload = job.payload ?? {};
+      const batchSize =
+        typeof payload.batch_size === "number" ? payload.batch_size : undefined;
+
+      const summary = await runRemPass({
+        pool: deps.pool,
+        logger: deps.logger,
+        trace,
+        ...(deps.grader ? { grader: deps.grader } : {}),
+        ...(job.namespace !== null ? { namespace: job.namespace } : {}),
+        ...(batchSize !== undefined ? { batchSize } : {}),
+        ...(payload.skip_dedupe === true ? { skipDedupe: true } : {}),
+        ...(payload.skip_rewarm === true ? { skipRewarm: true } : {}),
+      });
+      trace.finish(summary);
+    } catch (error: unknown) {
+      trace.fail(error);
+      throw error;
+    }
   };
 }
 

--- a/src/embedding-repair-handler.test.ts
+++ b/src/embedding-repair-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock } from "bun:test";
-import type { EmbeddingError } from "./embedding.ts";
+import { contentHash, type EmbeddingError } from "./embedding.ts";
 import type {
   BackgroundTraceBody,
   BackgroundTraceEmitter,
@@ -261,6 +261,14 @@ describe("createEmbeddingRepairHandler", () => {
         },
       ],
     });
+    expect(
+      tracing.bodies[0]!.observations
+        .filter((observation) => observation.name === "embedding.provider")
+        .map((observation) => observation.input),
+    ).toEqual([
+      { row_id: "t1", char_count: 2, content_hash: contentHash("hi") },
+      { row_id: "t2", char_count: 2, content_hash: contentHash("hi") },
+    ]);
   });
 
   it("is a no-op on replay after a full repair (idempotent, selected:0)", async () => {
@@ -389,9 +397,11 @@ describe("createEmbeddingRepairHandler", () => {
       updateRowCount: 1,
     });
     const { logger, lines } = recordingLogger();
+    const tracing = recordingTracing();
     const handler = createEmbeddingRepairHandler({
       db,
       logger,
+      tracing,
       embedFn: okEmbed,
     });
     await handler(
@@ -400,8 +410,20 @@ describe("createEmbeddingRepairHandler", () => {
       }),
     );
     const payload = JSON.stringify(lines);
+    const tracePayload = JSON.stringify(tracing.bodies);
     expect(payload).not.toContain("SECRET SOURCE TEXT");
     expect(payload).not.toContain("ns-secret");
+    expect(tracePayload).not.toContain("SECRET SOURCE TEXT");
+    expect(tracePayload).not.toContain("ns-secret");
+    expect(
+      tracing.bodies[0]!.observations.find(
+        (observation) => observation.name === "embedding.provider",
+      )?.input,
+    ).toEqual({
+      row_id: "t1",
+      char_count: "SECRET SOURCE TEXT".length,
+      content_hash: contentHash("SECRET SOURCE TEXT"),
+    });
   });
 });
 

--- a/src/embedding-repair-handler.test.ts
+++ b/src/embedding-repair-handler.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, mock } from "bun:test";
 import type { EmbeddingError } from "./embedding.ts";
+import type {
+  BackgroundTraceBody,
+  BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import {
   MaintenanceQueueRunner,
   type MaintenanceJob,
@@ -38,6 +42,18 @@ function recordingLogger(): {
   return {
     lines,
     logger: { info: push("info"), warn: push("warn"), error: push("error") },
+  };
+}
+
+function recordingTracing(): BackgroundTraceEmitter & {
+  bodies: BackgroundTraceBody[];
+} {
+  const bodies: BackgroundTraceBody[] = [];
+  return {
+    bodies,
+    emitBackground(body) {
+      bodies.push(body);
+    },
   };
 }
 
@@ -188,6 +204,63 @@ describe("createEmbeddingRepairHandler", () => {
     const done = lines.find((l) => l.message === "embedding_repair_job_done");
     expect(done?.fields.repaired).toBe(2);
     expect(done?.fields.table).toBe("thoughts");
+  });
+
+  it("emits a batch span with row ids and provider embedding usage", async () => {
+    const { db } = mockDb({
+      selectRowsByCall: [[missingThought("t1"), missingThought("t2")]],
+      updateRowCount: 1,
+    });
+    const { logger } = recordingLogger();
+    const tracing = recordingTracing();
+    const handler = createEmbeddingRepairHandler({
+      db,
+      logger,
+      tracing,
+      embedFn: async () => ({
+        embedding: Array(768).fill(0.1),
+        usageDetails: { promptTokens: 5, totalTokens: 5 },
+      }),
+    });
+
+    await handler(
+      job({
+        payload: {
+          table: "thoughts",
+          scope: { global: true },
+          session_key: "session-embedding",
+        },
+      }),
+    );
+
+    expect(tracing.bodies).toHaveLength(1);
+    expect(tracing.bodies[0]).toMatchObject({
+      name: "embedding.repair",
+      sessionId: "session-embedding",
+      observations: [
+        {
+          name: "embedding.provider",
+          type: "embedding",
+          usageDetails: { promptTokens: 5, totalTokens: 5 },
+        },
+        {
+          name: "embedding.provider",
+          type: "embedding",
+          usageDetails: { promptTokens: 5, totalTokens: 5 },
+        },
+        {
+          name: "embedding.batch",
+          type: "span",
+          output: {
+            model: expect.any(String),
+            item_count: 2,
+            row_ids: ["t1", "t2"],
+            repaired: 2,
+            provider_errors: [],
+          },
+        },
+      ],
+    });
   });
 
   it("is a no-op on replay after a full repair (idempotent, selected:0)", async () => {

--- a/src/embedding-repair-handler.ts
+++ b/src/embedding-repair-handler.ts
@@ -191,39 +191,34 @@ export function createEmbeddingRepairHandler(
     try {
       assertSupportedVersion(job);
       const payload = parsePayload(job);
-      const tracedEmbedFn: EmbedWithMetaFn = (text, embeddingUrl, options) =>
-        trace.embedding(
-          "embedding.provider",
-          () => embedFn(text, embeddingUrl, options),
-          {
-            model: currentModel,
-            input: { text },
-            output: (result) => ({
-              embedded: result.embedding !== null,
-              error: result.error ?? null,
-            }),
-            usageDetails: (result) => result.usageDetails,
-          },
-        );
-
       let summary: RepairBatchSummary;
       try {
         summary = await trace.span(
           "embedding.batch",
           () =>
-            repairStaleBatch(deps.db, payload.table, tracedEmbedFn, {
+            repairStaleBatch(deps.db, payload.table, embedFn, {
               scope: payload.scope,
               reasons: payload.reasons,
               limit: payload.limit ?? DEFAULT_BATCH,
               currentModel,
               embeddingUrl: deps.embeddingUrl,
+              observeEmbedding: (identity, work) =>
+                trace.embedding("embedding.provider", work, {
+                  model: currentModel,
+                  input: identity,
+                  output: (result) => ({
+                    embedded: result.embedding !== null,
+                    error: result.error ?? null,
+                  }),
+                  usageDetails: (result) => result.usageDetails,
+                }),
             }),
           {
             input: { model: currentModel, table: payload.table },
             output: (result) => ({
               model: currentModel,
               item_count: result.selected,
-              row_ids: result.results.map((item) => item.id),
+              row_ids: [...new Set(result.results.map((item) => item.id))],
               repaired: result.repaired,
               skipped: result.skipped,
               provider_errors: result.results

--- a/src/embedding-repair-handler.ts
+++ b/src/embedding-repair-handler.ts
@@ -43,6 +43,11 @@
  */
 import { z } from "zod";
 import type pg from "pg";
+import {
+  BackgroundTraceRecorder,
+  backgroundSessionId,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import { generateEmbeddingWithMetadata, EMBEDDING_MODEL } from "./embedding.ts";
 import {
   repairStaleBatch,
@@ -114,6 +119,8 @@ export interface EmbeddingRepairHandlerDeps {
   currentModel?: string;
   /** Provider URL override (defaults to the configured endpoint). */
   embeddingUrl?: string;
+  /** Optional shared Langfuse background-job emitter. */
+  tracing?: BackgroundTraceEmitter;
 }
 
 /**
@@ -173,51 +180,89 @@ export function createEmbeddingRepairHandler(
   return async function embeddingRepairHandler(
     job: MaintenanceJob,
   ): Promise<void> {
-    assertSupportedVersion(job);
-    const payload = parsePayload(job);
-
-    let summary: RepairBatchSummary;
-    try {
-      summary = await repairStaleBatch(deps.db, payload.table, embedFn, {
-        scope: payload.scope,
-        reasons: payload.reasons,
-        limit: payload.limit ?? DEFAULT_BATCH,
-        currentModel,
-        embeddingUrl: deps.embeddingUrl,
-      });
-    } catch (error) {
-      // A thrown scope/registry error here is a permanent input problem (an
-      // unscoped or unknown-target payload that slipped a shape check). Surface
-      // it content-free; the runner dead-letters after the retry bound.
-      deps.logger.error("embedding_repair_job_input_error", {
-        job_kind: job.kind,
-        table: payload.table,
-      });
-      throw error;
-    }
-
-    // Content-free: counts and the target table name only.
-    deps.logger.info("embedding_repair_job_done", {
-      job_kind: job.kind,
-      table: summary.table,
-      selected: summary.selected,
-      repaired: summary.repaired,
-      skipped: summary.skipped,
-      retryable_failures: summary.retryableFailures,
-      permanent_failures: summary.permanentFailures,
+    const trace = new BackgroundTraceRecorder(deps.tracing, {
+      name: "embedding.repair",
+      input: { job_id: job.id, table: job.payload.table ?? null },
+      tags: ["open-brain-server", "background-job", "embedding"],
+      metadata: { job_kind: job.kind, attempt: job.attempts },
+      sessionId: backgroundSessionId(job),
     });
 
-    // Retryable provider failures mean some units could not be repaired due to a
-    // transient outage. Throw so the queue re-delivers with backoff; the replay
-    // re-selects only the still-stale units (repaired ones no-op) until the
-    // provider recovers or the job hits its retry bound and dead-letters.
-    if (summary.retryableFailures > 0) {
-      throw new Error(
-        `embedding repair deferred: ${summary.retryableFailures} unit(s) hit a retryable provider failure`,
-      );
+    try {
+      assertSupportedVersion(job);
+      const payload = parsePayload(job);
+      const tracedEmbedFn: EmbedWithMetaFn = (text, embeddingUrl, options) =>
+        trace.embedding(
+          "embedding.provider",
+          () => embedFn(text, embeddingUrl, options),
+          {
+            model: currentModel,
+            input: { text },
+            output: (result) => ({
+              embedded: result.embedding !== null,
+              error: result.error ?? null,
+            }),
+            usageDetails: (result) => result.usageDetails,
+          },
+        );
+
+      let summary: RepairBatchSummary;
+      try {
+        summary = await trace.span(
+          "embedding.batch",
+          () =>
+            repairStaleBatch(deps.db, payload.table, tracedEmbedFn, {
+              scope: payload.scope,
+              reasons: payload.reasons,
+              limit: payload.limit ?? DEFAULT_BATCH,
+              currentModel,
+              embeddingUrl: deps.embeddingUrl,
+            }),
+          {
+            input: { model: currentModel, table: payload.table },
+            output: (result) => ({
+              model: currentModel,
+              item_count: result.selected,
+              row_ids: result.results.map((item) => item.id),
+              repaired: result.repaired,
+              skipped: result.skipped,
+              provider_errors: result.results
+                .filter((item) => "errorCode" in item)
+                .map((item) => ({ id: item.id, code: item.errorCode })),
+            }),
+          },
+        );
+      } catch (error: unknown) {
+        deps.logger.error("embedding_repair_job_input_error", {
+          job_kind: job.kind,
+          table: payload.table,
+        });
+        throw error;
+      }
+
+      deps.logger.info("embedding_repair_job_done", {
+        job_kind: job.kind,
+        table: summary.table,
+        selected: summary.selected,
+        repaired: summary.repaired,
+        skipped: summary.skipped,
+        retryable_failures: summary.retryableFailures,
+        permanent_failures: summary.permanentFailures,
+      });
+
+      if (summary.retryableFailures > 0) {
+        throw new Error(
+          `embedding repair deferred: ${summary.retryableFailures} unit(s) hit a retryable provider failure`,
+        );
+      }
+      trace.finish({
+        outcome: "succeeded",
+        row_ids: summary.results.map((item) => item.id),
+      });
+    } catch (error: unknown) {
+      trace.fail(error);
+      throw error;
     }
-    // Resolving here marks the job succeeded. Permanent per-unit failures were
-    // already recorded content-free by the primitive and do not re-queue.
   };
 }
 

--- a/src/embedding-repair.ts
+++ b/src/embedding-repair.ts
@@ -419,6 +419,10 @@ export interface RepairOptions {
   currentModel?: string;
   embeddingUrl?: string;
   signal?: AbortSignal;
+  observeEmbedding?: (
+    identity: { row_id: string; char_count: number; content_hash: string },
+    work: () => Promise<EmbeddingResult>,
+  ) => Promise<EmbeddingResult>;
   /**
    * REQUIRED namespace scope for the guarded UPDATE. A non-empty auth-derived
    * `{ namespaces: [...] }` binds namespace (directly or via the target FK) IN
@@ -485,9 +489,16 @@ export async function repairOne(
   }
 
   // --- Provider round trip: OUTSIDE any transaction/lock. ---
-  const result = await embedFn(embedText, options.embeddingUrl, {
-    signal: options.signal,
-  });
+  const embed = () =>
+    embedFn(embedText, options.embeddingUrl, {
+      signal: options.signal,
+    });
+  const result = options.observeEmbedding
+    ? await options.observeEmbedding(
+        { row_id: id, char_count: embedText.length, content_hash: freshHash },
+        embed,
+      )
+    : await embed();
 
   if (!result.embedding) {
     const code = result.error?.code;

--- a/src/embedding-repair.ts
+++ b/src/embedding-repair.ts
@@ -54,6 +54,7 @@ import {
   generateEmbeddingWithMetadata,
   type EmbeddingError,
   type EmbeddingOptions,
+  type EmbeddingResult,
 } from "./embedding.ts";
 import {
   getEmbeddingTarget,
@@ -71,7 +72,7 @@ export type EmbedWithMetaFn = (
   text: string,
   embeddingUrl?: string,
   options?: EmbeddingOptions,
-) => Promise<{ embedding: number[] | null; error?: EmbeddingError }>;
+) => Promise<EmbeddingResult>;
 
 export type StalenessReason = "missing" | "model_drift" | "source_drift";
 

--- a/src/embedding.test.ts
+++ b/src/embedding.test.ts
@@ -485,6 +485,26 @@ describe("generateEmbeddingWithMetadata", () => {
     expect(result.error).toBeUndefined();
   });
 
+  it("preserves provider-reported token usage for Langfuse cost attribution", async () => {
+    mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ embedding: make768() }],
+            usage: { prompt_tokens: 9, total_tokens: 9 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await generateEmbeddingWithMetadata(
+      "usage fixture",
+      "http://fake:4000",
+    );
+
+    expect(result.usageDetails).toEqual({ promptTokens: 9, totalTokens: 9 });
+  });
+
   it("returns structured error with code on server failure", async () => {
     mockFetch(
       async () => new Response("Internal Server Error", { status: 500 }),

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -52,6 +52,7 @@ export interface EmbeddingError {
 export interface EmbeddingResult {
   embedding: number[] | null;
   error?: EmbeddingError;
+  usageDetails?: Record<string, number>;
 }
 
 export interface EmbeddingOptions {
@@ -360,6 +361,7 @@ export async function generateEmbeddingWithMetadata(
       segments: segments.length,
     });
     const embedded: { embedding: number[]; weight: number }[] = [];
+    const usageDetails: Record<string, number> = {};
     for (const segment of segments) {
       const result = await embedOnce(segment.text, embeddingUrl, options);
       // One failed segment fails the whole embedding. Combining the survivors
@@ -379,8 +381,14 @@ export async function generateEmbeddingWithMetadata(
         embedding: result.embedding,
         weight: segment.text.length,
       });
+      for (const [key, value] of Object.entries(result.usageDetails ?? {})) {
+        usageDetails[key] = (usageDetails[key] ?? 0) + value;
+      }
     }
-    return { embedding: combineEmbeddings(embedded) };
+    return {
+      embedding: combineEmbeddings(embedded),
+      ...(Object.keys(usageDetails).length === 0 ? {} : { usageDetails }),
+    };
   }
 
   return embedOnce(text, embeddingUrl, options);
@@ -500,6 +508,10 @@ async function embedOnce(
 
       const json = (await response.json()) as {
         data?: Array<{ embedding?: unknown }>;
+        usage?: {
+          prompt_tokens?: unknown;
+          total_tokens?: unknown;
+        };
       };
 
       const embedding = json.data?.[0]?.embedding;
@@ -527,7 +539,17 @@ async function embedOnce(
       logger.info("Embedding generated", { latencyMs: latency, attempt });
 
       resetWatchdogFailures();
-      return { embedding: embedding as number[] };
+      const usageDetails: Record<string, number> = {};
+      if (typeof json.usage?.prompt_tokens === "number") {
+        usageDetails.promptTokens = json.usage.prompt_tokens;
+      }
+      if (typeof json.usage?.total_tokens === "number") {
+        usageDetails.totalTokens = json.usage.total_tokens;
+      }
+      return {
+        embedding: embedding as number[],
+        ...(Object.keys(usageDetails).length === 0 ? {} : { usageDetails }),
+      };
     } catch (err) {
       lastError = err;
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  createTracingRuntime,
+  type McpTracingConfig,
+  type TraceBody,
+  type TracingSink,
+} from "../server/observability/langfuse-tracing.ts";
+import { EMBEDDING_REPAIR_JOB_VERSION } from "./embedding-repair-handler.ts";
+import { startServerMaintenanceQueue } from "./index.ts";
+
+const ENABLED_CONFIG: McpTracingConfig = {
+  enabled: true,
+  maskingEnabled: true,
+  endpoint: "http://127.0.0.1:3000",
+  publicKey: "pk-test",
+  secretKey: "sk-test",
+};
+
+function recordingSink(): TracingSink & { bodies: TraceBody[] } {
+  const bodies: TraceBody[] = [];
+  return {
+    bodies,
+    emit: (body) => bodies.push(body),
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  };
+}
+
+function maintenancePool() {
+  let claimed = false;
+  const now = new Date("2026-08-06T00:00:00.000Z");
+  const job = {
+    id: "job-index-composition",
+    job_kind: "embedding.repair",
+    job_version: EMBEDDING_REPAIR_JOB_VERSION,
+    payload: { table: "thoughts", scope: { global: true } },
+    idempotency_key: "index-composition",
+    state: "running",
+    run_after: now,
+    lease_token: "00000000-0000-4000-8000-000000000001",
+    lease_until: new Date("2026-08-06T00:00:30.000Z"),
+    attempts: 1,
+    max_attempts: 3,
+    backoff_base_ms: 1_000,
+    backoff_max_ms: 4_000,
+    last_error_category: null,
+    terminal_at: null,
+    dead_lettered_at: null,
+    namespace: null,
+    provenance: null,
+    created_at: now,
+    updated_at: now,
+  };
+  const query = mock(async (sql: string) => {
+    if (/SET\s+state\s*=\s*'running'/i.test(sql)) {
+      if (claimed) return { rows: [], rowCount: 0 };
+      claimed = true;
+      return { rows: [job], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  const client = { query, release: () => undefined };
+  return { query, connect: async () => client } as any;
+}
+
+describe("server background tracing composition", () => {
+  it("routes a maintenance handler trace into the process-owned sink", async () => {
+    const sink = recordingSink();
+    const tracing = createTracingRuntime({ config: ENABLED_CONFIG, sink });
+    const runtime = startServerMaintenanceQueue(
+      {
+        pool: maintenancePool(),
+        logger: { info: () => undefined, warn: () => undefined, error: () => undefined },
+        autoStart: false,
+      },
+      tracing,
+    );
+
+    await runtime.runner.runOnce();
+    await runtime.stop();
+    await tracing.shutdown();
+
+    expect(sink.bodies).toHaveLength(1);
+    expect(sink.bodies[0]).toMatchObject({
+      name: "embedding.repair",
+      metadata: { status: "success" },
+    });
+    expect(sink.bodies[0]?.tags).toEqual(
+      expect.arrayContaining(["background-job", "embedding"]),
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   startMaintenanceQueue,
   maintenanceQueueEnabled,
   type MaintenanceRuntime,
+  type StartMaintenanceQueueOptions,
 } from "./maintenance-bootstrap.ts";
 import { safeMaintenanceErrorCategory } from "./maintenance-queue.ts";
 import { validateLocalCloneMode } from "./local-clone-mode.ts";
@@ -77,11 +78,27 @@ const DEPLOYED_REVISION = readDeployedRevision(() =>
  */
 const HEALTH_PROBE_TIMEOUT_MS = 3000;
 
+type TracingRuntime = ReturnType<typeof createTracingRuntime>;
+
+/**
+ * Server composition seam for the maintenance worker tree. The process owns one
+ * tracing runtime and passes only its background emitter into job handlers.
+ */
+export function startServerMaintenanceQueue(
+  options: StartMaintenanceQueueOptions,
+  tracing: TracingRuntime,
+): MaintenanceRuntime {
+  return startMaintenanceQueue({
+    ...options,
+    ...(tracing.background ? { tracing: tracing.background } : {}),
+  });
+}
+
 export function createApp(
   pool: pg.Pool,
   tokenMap: Map<string, AuthInfo>,
   deps?: ToolDeps,
-  tracing?: ReturnType<typeof createTracingRuntime>,
+  tracing?: TracingRuntime,
 ): express.Express {
   const app = express();
   const natsRuntimeBoundary =
@@ -341,6 +358,7 @@ if (import.meta.main) {
         tokenMap,
         deps: toolDeps,
         health: natsBridgeHealth,
+        ...(tracing.background ? { tracing: tracing.background } : {}),
       });
       logger.info("NATS context-pack bridge started", {
         subject: natsBridge?.subject,
@@ -403,7 +421,7 @@ if (import.meta.main) {
   // per-worker with OPEN_BRAIN_MAINTENANCE_ENABLED=0.
   let maintenance: MaintenanceRuntime | null = null;
   if (maintenanceQueueEnabled()) {
-    maintenance = startMaintenanceQueue({ pool, logger });
+    maintenance = startServerMaintenanceQueue({ pool, logger }, tracing);
     logger.info("maintenance queue started", {
       handlers:
         "embedding.repair,graph.derive,memory.distill,dream.light,dream.rem",

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -101,6 +101,8 @@ export interface StartMaintenanceQueueOptions {
   logger: MaintenanceQueueLogger;
   /** Injectable embed fn for tests; defaults to the configured provider. */
   embedFn?: EmbedWithMetaFn;
+  /** Process-owned background tracing emitter; omitted when tracing is disabled. */
+  tracing?: BackgroundTraceEmitter;
   /** Poll cadence override; else env, else the runner default. */
   pollIntervalMs?: number;
   /** Concurrency override; else env, else the runner default. */
@@ -309,6 +311,7 @@ export function startMaintenanceQueue(
     logger: options.logger,
     embedFn: options.embedFn ?? generateEmbeddingWithMetadata,
     graphAuth: options.graphAuth ?? MAINTENANCE_GRAPH_AUTH,
+    ...(options.tracing ? { tracing: options.tracing } : {}),
   });
 
   const pollIntervalMs =

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -29,6 +29,7 @@
  *    the source snapshot and namespace checks owned by their existing producer.
  */
 import type pg from "pg";
+import type { BackgroundTraceEmitter } from "./background-tracing.ts";
 import { generateEmbeddingWithMetadata } from "./embedding.ts";
 import type { EmbedWithMetaFn } from "./embedding-repair.ts";
 import type { AuthInfo } from "./types.ts";
@@ -141,6 +142,7 @@ export function composeMaintenanceHandlers(input: {
   logger: MaintenanceQueueLogger;
   embedFn: EmbedWithMetaFn;
   graphAuth: AuthInfo;
+  tracing?: BackgroundTraceEmitter;
 }): ReadonlyMap<string, MaintenanceJobHandler> {
   if (!input.graphAuth.role || !input.graphAuth.clientId) {
     throw new Error(
@@ -153,6 +155,7 @@ export function composeMaintenanceHandlers(input: {
       db: input.pool,
       logger: input.logger,
       embedFn: input.embedFn,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
     }),
   );
   handlers.set(
@@ -184,6 +187,7 @@ export function composeMaintenanceHandlers(input: {
       logger: input.logger,
       embedFn: input.embedFn,
       auth: input.graphAuth,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
     }),
   );
   handlers.set(
@@ -191,6 +195,7 @@ export function composeMaintenanceHandlers(input: {
     makeDreamLightHandler({
       pool: input.pool,
       logger: input.logger,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
     }),
   );
   handlers.set(
@@ -198,6 +203,7 @@ export function composeMaintenanceHandlers(input: {
     makeDreamRemHandler({
       pool: input.pool,
       logger: input.logger,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
     }),
   );
 

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -559,6 +559,52 @@ describe("startNatsContextPackBridge", () => {
     await runtime?.close();
   });
 
+  it("does not trust a forged wire session key when auth rejects the request", async () => {
+    const tracing = recordingTracing();
+    const forgedSessionKey = "victim/session";
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        await handler({
+          subject,
+          data: data(
+            envelope({
+              payload: {
+                ...requestPayload,
+                identity: {
+                  ...requestPayload.identity,
+                  session_key: forgedSessionKey,
+                },
+              },
+            }),
+          ),
+          headers: {},
+          respond: () => true,
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: localBoundary({ OPENBRAIN_NATS_REQUIRE_AUTH: "true" }),
+      tokenMap: new Map([
+        ["valid-token", { role: "agent", clientId: "rico" }],
+      ]),
+      deps: depsWithWorkingSet("rico"),
+      driver,
+      tracing,
+    });
+
+    expect(tracing.bodies).toHaveLength(1);
+    expect(tracing.bodies[0]?.sessionId).toBeUndefined();
+    expect(tracing.bodies[0]?.metadata).toMatchObject({
+      declared_session_key_unverified: "[MASKED:unverified]",
+      status: "success",
+    });
+    expect(JSON.stringify(tracing.bodies)).not.toContain(forgedSessionKey);
+    await runtime?.close();
+  });
+
   it("traces an undeliverable reply as a handled error-envelope outcome", async () => {
     const tracing = recordingTracing();
     const driver: NatsBridgeDriver = {

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -769,59 +769,56 @@ describe("startNatsContextPackBridge", () => {
     await runtime?.close();
   });
 
-  it("rethrows a respond failure that is not the client's payload refusal", async () => {
+  it("rethrows a generic respond failure and emits one exception trace", async () => {
     // A connection-closed throw is not ours to reinterpret as an undeliverable
-    // reply. It must reach the handler-error path, not be answered with a
-    // payload_too_large envelope that would misdescribe what happened.
+    // reply. It must reject the subscription callback unchanged, not be answered
+    // with a payload_too_large envelope that would misdescribe what happened.
     const published: Array<ReturnType<typeof envelopeFromBytes>> = [];
-    const loggedErrors: string[] = [];
-    const originalError = logger.error;
-    logger.error = (message, extra) => {
-      loggedErrors.push(`${message}:${JSON.stringify(extra ?? {})}`);
+    const tracing = recordingTracing();
+    const failure = new Error("connection closed") as Error & { code: string };
+    failure.code = "CONNECTION_CLOSED";
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        await handler({
+          subject,
+          data: data(envelope({ id: "req-closed", from: "rico" })),
+          headers: {},
+          respond: (payload: Uint8Array) => {
+            published.push(envelopeFromBytes(payload));
+            throw failure;
+          },
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
     };
 
-    try {
-      let handlerRejection: unknown = null;
-      const driver: NatsBridgeDriver = {
-        subscribe: async (subject, handler) => {
-          await handler({
-            subject,
-            data: data(envelope({ id: "req-closed", from: "rico" })),
-            headers: {},
-            respond: (payload: Uint8Array) => {
-              published.push(envelopeFromBytes(payload));
-              const err = new Error("connection closed") as Error & {
-                code: string;
-              };
-              err.code = "CONNECTION_CLOSED";
-              throw err;
-            },
-          } satisfies NatsRequestMessage).catch((err) => {
-            handlerRejection = err;
-          });
-          return { close: () => undefined };
-        },
-        close: () => undefined,
-      };
-
-      const runtime = await startNatsContextPackBridge({
+    await expect(
+      startNatsContextPackBridge({
         boundary: localBoundary(),
         tokenMap: new Map(),
         deps: depsWithWorkingSet("rico"),
         driver,
-      });
+        tracing,
+      }),
+    ).rejects.toBe(failure);
 
-      expect((handlerRejection as { code?: string } | null)?.code).toBe(
-        "CONNECTION_CLOSED",
-      );
-      // Exactly one publish was attempted; no error envelope followed it.
-      expect(published).toHaveLength(1);
-      expect((published[0]!.payload as Record<string, any>).status).toBe("ok");
-
-      await runtime?.close();
-    } finally {
-      logger.error = originalError;
-    }
+    // Exactly one publish was attempted; no error envelope followed it.
+    expect(published).toHaveLength(1);
+    expect((published[0]!.payload as Record<string, any>).status).toBe("ok");
+    expect(tracing.bodies).toHaveLength(1);
+    expect(tracing.bodies[0]).toMatchObject({
+      name: "nats.message",
+      metadata: { status: "exception" },
+      observations: [
+        { name: "nats.handle", level: "DEFAULT" },
+        {
+          name: "nats.reply",
+          level: "ERROR",
+          statusMessage: "Error",
+        },
+      ],
+    });
   });
 
   it("carries the reply normally when it fits the broker's advertised figure", async () => {

--- a/src/nats-bridge.test.ts
+++ b/src/nats-bridge.test.ts
@@ -7,6 +7,10 @@ import {
   type NatsRequestMessage,
 } from "./nats-bridge.ts";
 import { logger } from "./logger.ts";
+import type {
+  BackgroundTraceBody,
+  BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import {
   envelopeFromBytes,
   readNatsRuntimeBoundary,
@@ -87,6 +91,18 @@ function depsWithWorkingSet(namespace = scope.namespace): ToolDeps {
 
 function data(payload: unknown): Uint8Array {
   return encoder.encode(JSON.stringify(payload));
+}
+
+function recordingTracing(): BackgroundTraceEmitter & {
+  bodies: BackgroundTraceBody[];
+} {
+  const bodies: BackgroundTraceBody[] = [];
+  return {
+    bodies,
+    emitBackground(body) {
+      bodies.push(body);
+    },
+  };
 }
 
 function localBoundary(extra: Record<string, string> = {}) {
@@ -539,6 +555,62 @@ describe("startNatsContextPackBridge", () => {
     expect(payload.error.code).toBe("payload_too_large");
     expect(payload.error.message).toContain("broker refused");
     expect(payload.error.message).toContain("working_set");
+
+    await runtime?.close();
+  });
+
+  it("traces an undeliverable reply as a handled error-envelope outcome", async () => {
+    const tracing = recordingTracing();
+    const driver: NatsBridgeDriver = {
+      subscribe: async (subject, handler) => {
+        let firstPublish = true;
+        await handler({
+          subject,
+          data: data(envelope({ id: "req-traced", from: "rico" })),
+          headers: {},
+          respond: () => {
+            if (firstPublish) {
+              firstPublish = false;
+              return false;
+            }
+            return true;
+          },
+        } satisfies NatsRequestMessage);
+        return { close: () => undefined };
+      },
+      close: () => undefined,
+    };
+
+    const runtime = await startNatsContextPackBridge({
+      boundary: localBoundary(),
+      tokenMap: new Map(),
+      deps: depsWithWorkingSet("rico"),
+      driver,
+      tracing,
+    });
+
+    expect(tracing.bodies).toHaveLength(1);
+    expect(tracing.bodies[0]).toMatchObject({
+      name: "nats.message",
+      sessionId: scope.session_key,
+      output: {
+        subject: SUBJECT,
+        outcome: "ok",
+        reply_outcome: "undeliverable_error_published",
+        error: { code: "payload_too_large" },
+      },
+      observations: [
+        { name: "nats.handle", type: "span" },
+        {
+          name: "nats.reply",
+          type: "span",
+          output: {
+            outcome: "undeliverable_error_published",
+            error: { code: "payload_too_large" },
+          },
+        },
+      ],
+    });
 
     await runtime?.close();
   });

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -142,13 +142,19 @@ export async function startNatsContextPackBridge(
   markNatsBridgeAvailable(health);
   const subject = options.boundary.nats.context_pack_subject;
   const subscription = await driver.subscribe(subject, async (message) => {
-    const trace = new BackgroundTraceRecorder(options.tracing, {
+    const traceStart = {
       name: "nats.message",
       input: { subject: message.subject, bytes: message.data.byteLength },
       tags: ["open-brain-server", "background-job", "nats"],
-      metadata: { subject: message.subject },
-      sessionId: natsSessionId(message.data),
-    });
+      metadata: {
+        subject: message.subject,
+        ...(hasDeclaredSessionKey(message.data)
+          ? { declared_session_key_unverified: "[MASKED:unverified]" }
+          : {}),
+      },
+      sessionId: undefined as string | undefined,
+    };
+    const trace = new BackgroundTraceRecorder(options.tracing, traceStart);
     try {
       const response = await trace.span(
         "nats.handle",
@@ -159,6 +165,9 @@ export async function startNatsContextPackBridge(
             tokenMap: options.tokenMap,
             deps: options.deps,
             health,
+            onResolvedBinding: (binding) => {
+              traceStart.sessionId = binding.sessionId;
+            },
           }),
         {
           input: { subject: message.subject },
@@ -213,20 +222,17 @@ export async function startNatsContextPackBridge(
   };
 }
 
-function natsSessionId(data: Uint8Array): string | undefined {
+function hasDeclaredSessionKey(data: Uint8Array): boolean {
   try {
     const envelope = envelopeFromBytes(data);
     const payload = envelope.payload as { identity?: unknown } | undefined;
     const identity = payload?.identity as { session_key?: unknown } | undefined;
-    const sessionKey = identity?.session_key;
-    return typeof sessionKey === "string" && sessionKey.length > 0
-      ? sessionKey
-      : undefined;
+    return typeof identity?.session_key === "string" && identity.session_key.length > 0;
   } catch (error: unknown) {
-    logger.debug("NATS trace session key unavailable", {
+    logger.debug("NATS trace declared session key unavailable", {
       error_type: safeErrorType(error),
     });
-    return undefined;
+    return false;
   }
 }
 
@@ -474,6 +480,7 @@ function namespaceSourceFromResponse(
 interface LaneBinding {
   auth: AuthInfo;
   namespaceSource: NamespaceSource;
+  sessionId: string;
 }
 
 /**
@@ -506,7 +513,11 @@ function resolveLaneBinding(
     // Auth ON: the bearer-derived identity is authoritative. Override is already
     // force-disabled at the boundary; we defensively ignore payload.namespace.
     if (!auth) return { rejected: true };
-    return { auth, namespaceSource: "token" };
+    return {
+      auth,
+      namespaceSource: "token",
+      sessionId: payload.identity.session_key,
+    };
   }
 
   // Auth OFF (trusted local bus). Bind a synthetic non-privileged identity to
@@ -515,12 +526,20 @@ function resolveLaneBinding(
   if (payload.namespace && boundary.nats.allow_namespace_override) {
     const ns = normalizeNamespaceToken(payload.namespace);
     if (!ns) return { rejected: true };
-    return { auth: localBusAuth(ns), namespaceSource: "override" };
+    return {
+      auth: localBusAuth(ns),
+      namespaceSource: "override",
+      sessionId: payload.identity.session_key,
+    };
   }
 
   const declared = declaredNamespace(payload, envelope);
   if (declared) {
-    return { auth: localBusAuth(declared), namespaceSource: "declared" };
+    return {
+      auth: localBusAuth(declared),
+      namespaceSource: "declared",
+      sessionId: payload.identity.session_key,
+    };
   }
 
   return { rejected: true };
@@ -556,6 +575,7 @@ export async function handleNatsContextPackMessage(input: {
   tokenMap: Map<string, AuthInfo>;
   deps: ToolDeps;
   health?: NatsBridgeHealth;
+  onResolvedBinding?: (binding: LaneBinding) => void;
 }): Promise<FleetEnvelope> {
   let requestId: string | null = null;
   let namespaceSource: NamespaceSource | null = null;
@@ -613,6 +633,13 @@ export async function handleNatsContextPackMessage(input: {
       );
     }
     namespaceSource = binding.namespaceSource;
+    try {
+      input.onResolvedBinding?.(binding);
+    } catch (error: unknown) {
+      logger.warn("NATS resolved-binding observer failed", {
+        error_type: safeErrorType(error),
+      });
+    }
 
     const result = await buildAgentContextPackPayload(
       // On the override/declared local-bus path the synthetic auth.clientId IS

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -54,6 +54,13 @@ export interface NatsSubscriptionHandle {
 }
 
 export interface NatsBridgeDriver {
+  /**
+   * Deliver messages under the driver's native acknowledgement contract.
+   * A resolved handler means processing completed. A rejected handler must
+   * propagate unchanged: the driver must not synthesize an acknowledgement or
+   * swallow the rejection, so broker-native error/redelivery behavior remains
+   * authoritative.
+   */
   subscribe(
     subject: string,
     handler: (message: NatsRequestMessage) => Promise<void>,

--- a/src/nats-bridge.ts
+++ b/src/nats-bridge.ts
@@ -1,5 +1,9 @@
 import type { AuthInfo } from "./types.ts";
 import type { ToolDeps } from "./tools/index.ts";
+import {
+  BackgroundTraceRecorder,
+  type BackgroundTraceEmitter,
+} from "./background-tracing.ts";
 import { z } from "zod";
 import { findAuthInfoForToken } from "./auth.ts";
 import { logger } from "./logger.ts";
@@ -88,6 +92,7 @@ export interface StartNatsContextPackBridgeOptions {
   deps: ToolDeps;
   driver?: NatsBridgeDriver;
   health?: NatsBridgeHealth;
+  tracing?: BackgroundTraceEmitter;
 }
 
 const MAX_NATS_REQUEST_BYTES = 64 * 1024;
@@ -137,14 +142,50 @@ export async function startNatsContextPackBridge(
   markNatsBridgeAvailable(health);
   const subject = options.boundary.nats.context_pack_subject;
   const subscription = await driver.subscribe(subject, async (message) => {
-    const response = await handleNatsContextPackMessage({
-      message,
-      boundary: options.boundary,
-      tokenMap: options.tokenMap,
-      deps: options.deps,
-      health,
+    const trace = new BackgroundTraceRecorder(options.tracing, {
+      name: "nats.message",
+      input: { subject: message.subject, bytes: message.data.byteLength },
+      tags: ["open-brain-server", "background-job", "nats"],
+      metadata: { subject: message.subject },
+      sessionId: natsSessionId(message.data),
     });
-    await respondWithinBrokerFigure(message, response);
+    try {
+      const response = await trace.span(
+        "nats.handle",
+        () =>
+          handleNatsContextPackMessage({
+            message,
+            boundary: options.boundary,
+            tokenMap: options.tokenMap,
+            deps: options.deps,
+            health,
+          }),
+        {
+          input: { subject: message.subject },
+          output: (value) => ({
+            outcome: responseOutcome(value),
+            correlation_id: value.correlation_id ?? null,
+          }),
+        },
+      );
+      const reply = await trace.span(
+        "nats.reply",
+        () => respondWithinBrokerFigure(message, response),
+        {
+          input: { subject: message.subject },
+          output: (value) => value,
+        },
+      );
+      trace.finish({
+        subject: message.subject,
+        outcome: responseOutcome(response),
+        reply_outcome: reply.outcome,
+        ...(reply.error === undefined ? {} : { error: reply.error }),
+      });
+    } catch (error: unknown) {
+      trace.fail(error);
+      throw error;
+    }
   });
 
   return {
@@ -170,6 +211,40 @@ export async function startNatsContextPackBridge(
       }
     },
   };
+}
+
+function natsSessionId(data: Uint8Array): string | undefined {
+  try {
+    const envelope = envelopeFromBytes(data);
+    const payload = envelope.payload as { identity?: unknown } | undefined;
+    const identity = payload?.identity as { session_key?: unknown } | undefined;
+    const sessionKey = identity?.session_key;
+    return typeof sessionKey === "string" && sessionKey.length > 0
+      ? sessionKey
+      : undefined;
+  } catch (error: unknown) {
+    logger.debug("NATS trace session key unavailable", {
+      error_type: safeErrorType(error),
+    });
+    return undefined;
+  }
+}
+
+function responseOutcome(response: FleetEnvelope): string {
+  const payload = response.payload as { status?: unknown; error?: unknown };
+  const status = typeof payload.status === "string" ? payload.status : "unknown";
+  if (status !== "error") return status;
+  const error = payload.error as { code?: unknown } | undefined;
+  return typeof error?.code === "string" ? `error:${error.code}` : "error";
+}
+
+interface NatsReplyResult {
+  outcome:
+    | "published"
+    | "undeliverable_error_published"
+    | "error_envelope_exceeded"
+    | "no_reply_inbox";
+  error?: Record<string, unknown>;
 }
 
 /**
@@ -217,7 +292,7 @@ export async function startNatsContextPackBridge(
 async function respondWithinBrokerFigure(
   message: NatsRequestMessage,
   response: FleetEnvelope,
-): Promise<void> {
+): Promise<NatsReplyResult> {
   const encoded = envelopeToBytes(response);
   const advertised = message.maxPayloadBytes;
   const exceedsAdvertised =
@@ -234,7 +309,7 @@ async function respondWithinBrokerFigure(
     // and hand the caller silence, which is the whole #549 defect.
     try {
       const responded = await message.respond(encoded);
-      if (responded !== false) return;
+      if (responded !== false) return { outcome: "published" };
     } catch (err) {
       if (!isMaxPayloadExceededError(err)) throw err;
     }
@@ -259,7 +334,14 @@ async function respondWithinBrokerFigure(
       reply_bytes: encoded.byteLength,
       broker_advertised_bytes: advertised ?? null,
     });
-    return;
+    return {
+      outcome: "error_envelope_exceeded",
+      error: {
+        code: "payload_too_large",
+        reply_bytes: encoded.byteLength,
+        broker_advertised_bytes: advertised ?? null,
+      },
+    };
   }
 
   if (respondedWithError === false) {
@@ -269,7 +351,10 @@ async function respondWithinBrokerFigure(
       subject: message.subject,
       reply_bytes: encoded.byteLength,
     });
-    return;
+    return {
+      outcome: "no_reply_inbox",
+      error: { code: "reply_inbox_missing", reply_bytes: encoded.byteLength },
+    };
   }
 
   logger.warn("NATS reply exceeded the broker's advertised payload figure", {
@@ -278,6 +363,14 @@ async function respondWithinBrokerFigure(
     broker_advertised_bytes: advertised ?? null,
     correlation_id: response.correlation_id,
   });
+  return {
+    outcome: "undeliverable_error_published",
+    error: {
+      code: "payload_too_large",
+      reply_bytes: encoded.byteLength,
+      broker_advertised_bytes: advertised ?? null,
+    },
+  };
 }
 
 /**

--- a/src/nats-worker.ts
+++ b/src/nats-worker.ts
@@ -1,4 +1,5 @@
 import type pg from "pg";
+import type { BackgroundTraceEmitter } from "./background-tracing.ts";
 import { generateEmbedding } from "./embedding.ts";
 import { createNatsBridgeHealth, startNatsContextPackBridge, type NatsBridgeDriver, type NatsBridgeHealth } from "./nats-bridge.ts";
 import { readNatsRuntimeBoundary, summarizeNatsUrlForLog, type NatsRuntimeBoundary } from "./nats-runtime.ts";
@@ -11,6 +12,7 @@ export interface StartNatsWorkerOptions {
   tokenMap: Map<string, AuthInfo>;
   driver?: NatsBridgeDriver;
   deps?: Partial<ToolDeps>;
+  tracing?: BackgroundTraceEmitter;
 }
 
 export interface NatsWorkerRuntime {
@@ -52,6 +54,7 @@ export async function startNatsWorker(
     deps,
     driver: options.driver,
     health,
+    ...(options.tracing ? { tracing: options.tracing } : {}),
   });
   if (!bridge) {
     throw new Error("Dedicated NATS worker did not start a bridge runtime");


### PR DESCRIPTION
## Summary

- extend the existing masked, env-gated, release-stamped Langfuse runtime with background-job traces and child observations
- trace embedding repair batches and provider calls, preserving provider-reported token usage for cost attribution
- trace DISTILL and DREAM Light/REM runs with stage spans, row identifiers, and LLM-backed model calls as Langfuse generations
- trace each handled NATS message through handling and reply publication, including undeliverable error-envelope outcomes
- keep instrumentation best-effort and preserve existing dry-run, retry, mutation, and wire behavior

Part of #569

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — Python package unchanged
- [ ] Live Open Brain smoke passed or is not applicable — no live Langfuse credentials/canary were used in this coding lane

Evidence:

- `bunx tsc --noEmit` — passed with `/Users/rico/.config/open-brain/env.release-test` sourced
- `bun test` — 3,677 passed, 35 skipped, 0 failed across 239 files
- Postgres-gated tests **did run**: `OPENBRAIN_TEST_DATABASE_URL` was set by the release-test environment
- mutation proof: suppressing `BackgroundTraceRecorder.emit` made 8 emission tests fail across 6 files; restoring it returned the suite to green. This proves background emission, not masking.
- masking is covered separately by the shared masking-boundary regressions; it is not part of the emission mutation proof
- payload-size portions of review findings H4/M1 are intentionally held for an operator decision and are not addressed by this fix lane

## Critical Self-Review

- Highest-risk behavior: tracing summarizers or emitter failures could accidentally alter a background job; the recorder separates worker callback failures from instrumentation failures, logs instrumentation faults content-free, and preserves the original result or error.
- Assumptions that could be wrong: OpenAI-compatible embedding providers report usage as `prompt_tokens`/`total_tokens`; usage degrades to omitted metadata. NATS session identity is attached only after server-side schema/auth/lane binding succeeds.
- Missing/weak tests: no live OTLP export to the operator Langfuse instance occurred; fake-exporter tests cover emitted trace shape, masking, disabled no-op behavior, generations, usage details, identifiers/hashes, composition-root wiring, and failure outcomes. The Postgres-backed suite ran under the release-test environment.
- Security/permission risk: background evidence observations use identifiers, hashes, lengths, and counts instead of source/candidate text. NATS wire-declared session keys remain untrusted until server binding and are otherwise represented only by a fixed masked marker. Auth and namespace enforcement remain server-side.
- Migration/deploy risk: no database migration or configuration key was added; activation uses the existing `OPENBRAIN_TRACING_*` gate and existing release stamp, so rollback is a code revert with no stored-state cleanup.
- Downstream client/runtime risk: no MCP schema, Python client, error-envelope contract, or agent-facing call shape changed; NATS wire responses remain byte-contract compatible.
- Rollback/cleanup concern: reverting the PR removes the instrumentation; traces already exported to Langfuse are observational records and are not replayed into Open Brain.
- Fixes made before PR: wired both production composition roots, bound NATS session identity after auth, isolated global DREAM sweeps, removed raw evidence content, added emitter-failure tests, added Light version parity, and pinned NATS reply-failure propagation.
- Known residual risk: Langfuse cost computation still depends on providers reporting usage and on the configured model name matching Langfuse pricing; live exporter timing and cost display remain unverified. Payload-size policy remains an explicit operator decision.
- SME review-memory update: [x] docs/sme/ updated (security x2, gotcha-agent — commit 7e36d5b on this branch; provenance pull/600#issuecomment-5202749565)

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in docs/sme/ (commit 7e36d5b)
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this lane had no live Langfuse credentials/canary; fake exporters and the full repository suite were used.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is internal observability instrumentation and changes no MCP, NATS, Python, or agent-facing contract.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable; no registry or public contract changed
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable; tool schemas and guidance are unchanged
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable; no client call shape changed
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable; this is server-internal tracing

Notes/evidence:

- The MEDIUM+ review-findings box is intentionally left unchecked for the controller to complete after the required review follow-up.
- Latent bugs found outside this instrumentation scope: none.

