### PR TITLE
feat: add Langfuse trace forensics CLI

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -390,10 +390,13 @@ bun scripts/langfuse-trace.ts get 28a6758fe84d34490816d28bfcd4ac20
 # Last five traces for one brain/MCP session, printed in chronological order.
 bun scripts/langfuse-trace.ts session e07dcb17-0026-4dfb-8d2c-c8a5280833d2 -n 5
 
-# Stage-aligned retrieval evidence comparison; exit 1 means evidence differs.
+# Occurrence-aligned retrieval evidence comparison. Exit 1 means evidence
+# differs; exit 2 means the trace/API result is inconclusive or invalid.
 bun scripts/langfuse-trace.ts diff <trace-id-a> <trace-id-b>
 
 # Repeat one live search and report deterministic versus varying stage fields.
+# Traces are correlated to this run, ordered oldest-first, and exit 1 if any
+# retrieval evidence varies (exit 2 if the comparison is inconclusive).
 bun scripts/langfuse-trace.ts repeat search_brain --query "trace forensics" -n 3
 ```
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -375,6 +375,30 @@ header — around both this module's content-free discipline and the shared
 logger's redaction (measured: the injected key-shaped string appeared in the
 output). The two lines above are how this lane reports its health instead.
 
+#### Operator trace forensics (#569)
+
+Source `/Volumes/ThunderBolt/open-brain-local/local-clone.env` before using
+`scripts/langfuse-trace.ts`; it supplies the Langfuse coordinates without putting
+values in arguments or output. The consumer uses Langfuse's Basic-authenticated
+public API. `repeat` drives the local dogfood server through the existing Python
+`openbrain-memory` `OpenBrainClient.call_tool` path via `uv run`.
+
+```bash
+# Compact trace identity plus its start-time-ordered observation timeline.
+bun scripts/langfuse-trace.ts get 28a6758fe84d34490816d28bfcd4ac20
+
+# Last five traces for one brain/MCP session, printed in chronological order.
+bun scripts/langfuse-trace.ts session e07dcb17-0026-4dfb-8d2c-c8a5280833d2 -n 5
+
+# Stage-aligned retrieval evidence comparison; exit 1 means evidence differs.
+bun scripts/langfuse-trace.ts diff <trace-id-a> <trace-id-b>
+
+# Repeat one live search and report deterministic versus varying stage fields.
+bun scripts/langfuse-trace.ts repeat search_brain --query "trace forensics" -n 3
+```
+
+Add `--json` to `get`, `session`, `diff`, or `repeat` for machine-readable output.
+
 ### Drop-folder collector
 
 `src/drop-folder-collector.ts` reads four scan bounds — `DROP_COLLECTOR_MAX_FILES`

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1818,3 +1818,14 @@ This repo has TWO serving trees (`server/main.ts` for the local clone, `src/inde
 ### Pattern (same PR, finding M3)
 
 A span or timing wrapper around `run: () => alreadyComputedValue` measures nothing: `duration_ms` is structurally ~0 and the stage's exception path can never fire, while the identically-named span on the other tree measures real work. A silently-wrong diagnostic is worse than an absent one. Check that the computation is INSIDE the measured callback everywhere the span name is emitted.
+
+## [2026-08-06] Verification tooling must never render absence of evidence as equivalence
+
+**Severity:** HIGH
+**Source:** PR #601 review swarm (trace forensics tooling), findings H1/H2/H3
+**Scope key:** `review.comparison_tools_fail_toward_unknown`
+**Status:** active
+
+### Pattern
+
+A diff/comparison tool is an operator trust surface: what it prints is what the operator believes happened, so its worst failure is a false "identical". PR #601 shipped three ways to produce one: (1) same-named spans unioned into one bucket, so swapped per-occurrence results compared equal — align occurrences pairwise by index, never union; (2) two traces with zero observations compared equal — but batched exporters make "not flushed yet" and "identical" indistinguishable, so zero compared evidence is `unknown` with its own exit code, never `equivalent`; (3) stages whose evidence is counts-only (the degraded shape) compared equal because only row-id sets were consulted — when the primary evidence is absent, compare the fallback fields and NAME the basis in the output. Also: ranked selections compare as ordered sequences (order IS the ranking; a Set comparison hides a pure reordering regression). Review question for any comparison/verification tool: enumerate every path that can print "same" and prove each one actually compared something.

--- a/scripts/fixtures/langfuse-trace-a.json
+++ b/scripts/fixtures/langfuse-trace-a.json
@@ -1,0 +1,64 @@
+{
+  "id": "trace-a",
+  "name": "search_brain",
+  "timestamp": "2026-08-06T12:00:00.000Z",
+  "release": "abc1234",
+  "sessionId": "session-569",
+  "userId": "rico",
+  "latency": 0.12,
+  "observations": [
+    {
+      "id": "root-a",
+      "name": "search_brain",
+      "type": "SPAN",
+      "parentObservationId": null,
+      "startTime": "2026-08-06T12:00:00.000Z",
+      "endTime": "2026-08-06T12:00:00.120Z",
+      "metadata": {
+        "caller_client_id": "rico",
+        "caller_token_client_id": "rico",
+        "caller_agent_id": "trace-fixture",
+        "caller_role": "agent",
+        "resolved_namespace": ["rico", "shared-kb"],
+        "status": "success",
+        "duration_ms": 120
+      },
+      "output": {"content": [{"type": "text", "text": "fixture"}]}
+    },
+    {
+      "id": "rank-a",
+      "name": "retrieval.rank_rrf",
+      "type": "SPAN",
+      "parentObservationId": "root-a",
+      "startTime": "2026-08-06T12:00:00.080Z",
+      "endTime": "2026-08-06T12:00:00.100Z",
+      "metadata": {"stage": "scoring_ranking", "status": "success", "duration_ms": 20},
+      "output": {
+        "candidate_count": 2,
+        "selected_count": 1,
+        "selected_row_ids": ["row-1"],
+        "candidates": [
+          {"row_id": "row-1", "rrf_score": 0.03, "similarity": 0.91, "chosen": true, "filtered_by": null},
+          {"row_id": "row-2", "rrf_score": 0.02, "similarity": 0.82, "chosen": false, "filtered_by": "rrf_window"}
+        ]
+      }
+    },
+    {
+      "id": "vector-a",
+      "name": "retrieval.vector_query",
+      "type": "SPAN",
+      "parentObservationId": "root-a",
+      "startTime": "2026-08-06T12:00:00.020Z",
+      "endTime": "2026-08-06T12:00:00.070Z",
+      "metadata": {"stage": "candidate_generation", "status": "success", "duration_ms": 50},
+      "output": {
+        "count": 2,
+        "row_ids": ["row-1", "row-2"],
+        "candidates": [
+          {"row_id": "row-1", "distance": 0.09, "similarity": 0.91},
+          {"row_id": "row-2", "distance": 0.18, "similarity": 0.82}
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-b.json
+++ b/scripts/fixtures/langfuse-trace-b.json
@@ -1,0 +1,64 @@
+{
+  "id": "trace-b",
+  "name": "search_brain",
+  "timestamp": "2026-08-06T12:01:00.000Z",
+  "release": "def5678",
+  "sessionId": "session-569",
+  "userId": "rico",
+  "latency": 0.15,
+  "observations": [
+    {
+      "id": "vector-b",
+      "name": "retrieval.vector_query",
+      "type": "SPAN",
+      "parentObservationId": "root-b",
+      "startTime": "2026-08-06T12:01:00.020Z",
+      "endTime": "2026-08-06T12:01:00.080Z",
+      "metadata": {"stage": "candidate_generation", "status": "success", "duration_ms": 60},
+      "output": {
+        "count": 2,
+        "row_ids": ["row-1", "row-3"],
+        "candidates": [
+          {"row_id": "row-1", "distance": 0.1, "similarity": 0.9},
+          {"row_id": "row-3", "distance": 0.2, "similarity": 0.8}
+        ]
+      }
+    },
+    {
+      "id": "root-b",
+      "name": "search_brain",
+      "type": "SPAN",
+      "parentObservationId": null,
+      "startTime": "2026-08-06T12:01:00.000Z",
+      "endTime": "2026-08-06T12:01:00.150Z",
+      "metadata": {
+        "caller_client_id": "rico",
+        "caller_token_client_id": "rico",
+        "caller_agent_id": "trace-fixture",
+        "caller_role": "agent",
+        "resolved_namespace": ["rico"],
+        "status": "success",
+        "duration_ms": 150
+      },
+      "output": {"content": [{"type": "text", "text": "fixture changed"}]}
+    },
+    {
+      "id": "rank-b",
+      "name": "retrieval.rank_rrf",
+      "type": "SPAN",
+      "parentObservationId": "root-b",
+      "startTime": "2026-08-06T12:01:00.090Z",
+      "endTime": "2026-08-06T12:01:00.120Z",
+      "metadata": {"stage": "scoring_ranking", "status": "success", "duration_ms": 30},
+      "output": {
+        "candidate_count": 2,
+        "selected_count": 1,
+        "selected_row_ids": ["row-3"],
+        "candidates": [
+          {"row_id": "row-1", "rrf_score": 0.025, "similarity": 0.9, "chosen": false, "filtered_by": "rrf_window"},
+          {"row_id": "row-3", "rrf_score": 0.035, "similarity": 0.8, "chosen": true, "filtered_by": null}
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-degraded-a.json
+++ b/scripts/fixtures/langfuse-trace-degraded-a.json
@@ -1,0 +1,16 @@
+{
+  "id": "trace-degraded-a",
+  "name": "search_brain",
+  "observations": [
+    {
+      "id": "degraded-a",
+      "name": "retrieval.vector_query",
+      "metadata": {
+        "payload_degraded": true,
+        "payload_degradation_reason": "active_span_bytes_limit",
+        "payload_limit_bytes": 32768
+      },
+      "output": {"counts": {"values": 10, "arrays": 2, "objects": 3, "strings": 4, "string_bytes": 100}}
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-degraded-b.json
+++ b/scripts/fixtures/langfuse-trace-degraded-b.json
@@ -1,0 +1,16 @@
+{
+  "id": "trace-degraded-b",
+  "name": "search_brain",
+  "observations": [
+    {
+      "id": "degraded-b",
+      "name": "retrieval.vector_query",
+      "metadata": {
+        "payload_degraded": true,
+        "payload_degradation_reason": "serialization_error",
+        "payload_limit_bytes": 32768
+      },
+      "output": {"counts": {"values": 11, "arrays": 2, "objects": 3, "strings": 4, "string_bytes": 101}}
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-duplicates-a.json
+++ b/scripts/fixtures/langfuse-trace-duplicates-a.json
@@ -1,0 +1,16 @@
+{
+  "id": "trace-duplicates-a",
+  "name": "search_all",
+  "observations": [
+    {
+      "id": "duplicate-a-1",
+      "name": "retrieval.fallback_dedupe",
+      "output": {"selected_row_ids": ["row-1"]}
+    },
+    {
+      "id": "duplicate-a-2",
+      "name": "retrieval.fallback_dedupe",
+      "output": {"selected_row_ids": ["row-2"]}
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-duplicates-b.json
+++ b/scripts/fixtures/langfuse-trace-duplicates-b.json
@@ -1,0 +1,16 @@
+{
+  "id": "trace-duplicates-b",
+  "name": "search_all",
+  "observations": [
+    {
+      "id": "duplicate-b-1",
+      "name": "retrieval.fallback_dedupe",
+      "output": {"selected_row_ids": ["row-2"]}
+    },
+    {
+      "id": "duplicate-b-2",
+      "name": "retrieval.fallback_dedupe",
+      "output": {"selected_row_ids": ["row-1"]}
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-empty-a.json
+++ b/scripts/fixtures/langfuse-trace-empty-a.json
@@ -1,0 +1,6 @@
+{
+  "id": "trace-empty-a",
+  "name": "search_brain",
+  "timestamp": "2026-08-06T12:10:00.000Z",
+  "observations": []
+}

--- a/scripts/fixtures/langfuse-trace-empty-b.json
+++ b/scripts/fixtures/langfuse-trace-empty-b.json
@@ -1,0 +1,6 @@
+{
+  "id": "trace-empty-b",
+  "name": "search_brain",
+  "timestamp": "2026-08-06T12:10:01.000Z",
+  "observations": []
+}

--- a/scripts/fixtures/langfuse-trace-qmd-a.json
+++ b/scripts/fixtures/langfuse-trace-qmd-a.json
@@ -1,0 +1,17 @@
+{
+  "id": "trace-qmd-a",
+  "name": "search_all",
+  "observations": [
+    {
+      "id": "qmd-a",
+      "name": "retrieval.qmd_query",
+      "output": {
+        "candidate_count": 2,
+        "candidates": [
+          {"row_id": null, "path": "docs/a.md"},
+          {"row_id": null, "path": "docs/b.md"}
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-qmd-b.json
+++ b/scripts/fixtures/langfuse-trace-qmd-b.json
@@ -1,0 +1,17 @@
+{
+  "id": "trace-qmd-b",
+  "name": "search_all",
+  "observations": [
+    {
+      "id": "qmd-b",
+      "name": "retrieval.qmd_query",
+      "output": {
+        "candidate_count": 2,
+        "candidates": [
+          {"row_id": null, "path": "docs/c.md"},
+          {"row_id": null, "path": "docs/d.md"}
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/langfuse-trace-timeline-degenerate.json
+++ b/scripts/fixtures/langfuse-trace-timeline-degenerate.json
@@ -1,0 +1,28 @@
+{
+  "id": "trace-timeline-degenerate",
+  "name": "search_brain",
+  "observations": [
+    {
+      "id": "z-last-tie",
+      "name": "tied-later-end",
+      "startTime": "2026-08-06T12:00:00.020Z",
+      "endTime": "2026-08-06T12:00:00.070Z"
+    },
+    {
+      "id": "unknown-start",
+      "name": "missing-start"
+    },
+    {
+      "id": "b-second-id",
+      "name": "tied-same-end-b",
+      "startTime": "2026-08-06T12:00:00.020Z",
+      "endTime": "2026-08-06T12:00:00.060Z"
+    },
+    {
+      "id": "a-first-id",
+      "name": "tied-same-end-a",
+      "startTime": "2026-08-06T12:00:00.020Z",
+      "endTime": "2026-08-06T12:00:00.060Z"
+    }
+  ]
+}

--- a/scripts/langfuse-trace-lib.ts
+++ b/scripts/langfuse-trace-lib.ts
@@ -25,20 +25,27 @@ export interface LangfuseTrace {
   observations?: LangfuseObservation[];
 }
 
+export type ComparisonBasis = "row_ids" | "counts+degradation" | "mixed";
+
 export interface StageComparison {
   name: string;
   durationA?: number;
   durationB?: number;
+  basis: ComparisonBasis;
   candidateAdded: string[];
   candidateRemoved: string[];
   chosenAdded: string[];
   chosenRemoved: string[];
+  chosenReordered: boolean;
+  countDifferences: string[];
+  degradationDifferences: string[];
   filteredDifferences: string[];
   scoreDeltas: string[];
+  equivalent: boolean;
 }
 
 export interface TraceComparison {
-  equivalent: boolean;
+  equivalent: boolean | null;
   toolA: string;
   toolB: string;
   releaseA: string;
@@ -51,9 +58,11 @@ export interface TraceComparison {
 interface StageEvidence {
   durationMs: number;
   candidates: Set<string>;
-  chosen: Set<string>;
+  chosen: string[];
   filtered: Map<string, string>;
   scores: Map<string, Map<string, number>>;
+  counts: Map<string, number>;
+  degradation: Map<string, string>;
 }
 
 function objectValue(value: unknown): Record<string, unknown> | undefined {
@@ -66,10 +75,10 @@ function stableValue(value: unknown): string {
   if (value === undefined || value === null) return "—";
   if (Array.isArray(value)) return value.map(stableValue).sort().join(",");
   if (typeof value === "object") {
-    const entries = Object.entries(value as Record<string, unknown>)
+    return Object.entries(value as Record<string, unknown>)
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, child]) => `${key}:${stableValue(child)}`);
-    return entries.join(",");
+      .map(([key, child]) => `${key}:${stableValue(child)}`)
+      .join(",");
   }
   return String(value);
 }
@@ -127,6 +136,16 @@ function namespaceOf(trace: LangfuseTrace): string {
   return stableValue(input?.namespace ?? objectValue(input?.scope)?.namespace);
 }
 
+function escapeControl(value: string): string {
+  return [...value]
+    .map((character) => {
+      const code = character.charCodeAt(0);
+      const isControl = code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+      return isControl ? `\\u${code.toString(16).padStart(4, "0")}` : character;
+    })
+    .join("");
+}
+
 function collectDigestFields(value: unknown, prefix = "", found: string[] = []): string[] {
   const object = objectValue(value);
   if (!object) return found;
@@ -136,13 +155,10 @@ function collectDigestFields(value: unknown, prefix = "", found: string[] = []):
     const rowIdsField = key === "row_ids" || key.endsWith("_row_ids");
     if (countField && typeof child === "number") found.push(`${path}=${child}`);
     if (rowIdsField && Array.isArray(child)) {
-      found.push(`${path}=[${child.map(String).join(",")}]`);
+      found.push(`${path}=[${child.map((item) => escapeControl(String(item))).join(",")}]`);
     }
-    if (Array.isArray(child)) {
-      child.forEach((item, index) => collectDigestFields(item, `${path}[${index}]`, found));
-    } else {
-      collectDigestFields(child, path, found);
-    }
+    if (Array.isArray(child)) child.forEach((item, index) => collectDigestFields(item, `${path}[${index}]`, found));
+    else collectDigestFields(child, path, found);
   }
   return found;
 }
@@ -153,50 +169,57 @@ export function digestOutput(output: unknown): string {
   const candidateRowIds = [
     ...new Set(
       candidateObjects(output)
-        .map((candidate) => candidate.row_id)
-        .filter((rowId) => rowId !== undefined)
-        .map(String),
+        .map((candidate, index) => candidateKey(candidate, index))
+        .filter((key) => key !== undefined)
+        .map((key) => escapeControl(key)),
     ),
   ];
-  if (candidateRowIds.length > 0) {
-    fields.push(`candidate_row_ids=[${candidateRowIds.join(",")}]`);
-  }
+  if (candidateRowIds.length > 0) fields.push(`candidate_row_ids=[${candidateRowIds.join(",")}]`);
   return fields.length > 0 ? fields.join(" ") : "—";
 }
 
-/** Render one trace and all observations in chronological order. */
+function parsedTimestamp(value?: string): number {
+  if (!value) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+function compareObservations(a: LangfuseObservation, b: LangfuseObservation): number {
+  return parsedTimestamp(a.startTime) - parsedTimestamp(b.startTime)
+    || parsedTimestamp(a.endTime) - parsedTimestamp(b.endTime)
+    || String(a.id ?? "").localeCompare(String(b.id ?? ""));
+}
+
+/** Render one trace and all observations in deterministic chronological order. */
 export function renderTimeline(trace: LangfuseTrace): string {
-  const observations = [...(trace.observations ?? [])].sort((a, b) =>
-    String(a.startTime ?? "").localeCompare(String(b.startTime ?? "")),
-  );
+  const observations = [...(trace.observations ?? [])].sort(compareObservations);
   const lines = [
     `name=${trace.name ?? "—"}`,
     `release=${trace.release ?? "—"}`,
-    `sessionId=${trace.sessionId ?? "—"}`,
+    `sessionId=${escapeControl(trace.sessionId ?? "—")}`,
     `caller=${callerIdentity(trace)}`,
     `status=${traceStatus(trace)}`,
   ];
   for (const observation of observations) {
     const metadata = metadataOf(observation);
     const stage = typeof metadata.stage === "string" ? metadata.stage : observation.type?.toLowerCase() ?? "observation";
+    const start = observation.startTime ?? "[startTime=unknown]";
     lines.push(
-      `${observation.startTime ?? "—"} ${observation.name ?? "unnamed"} stage=${stage} duration_ms=${observationDuration(observation)} output=${digestOutput(observation.output)}`,
+      `${start} ${observation.name ?? "unnamed"} id=${escapeControl(observation.id ?? "—")} stage=${stage} duration_ms=${observationDuration(observation)} output=${digestOutput(observation.output)}`,
     );
   }
   return lines.join("\n");
 }
 
-function rowIdArrays(value: unknown, chosenOnly: boolean, found = new Set<string>()): Set<string> {
+function rowIdSequence(value: unknown, chosenOnly: boolean, found: string[] = []): string[] {
   const object = objectValue(value);
   if (!object) return found;
   for (const [key, child] of Object.entries(object)) {
     const isRowIds = key === "row_ids" || key.endsWith("_row_ids");
     const isChosen = /^(selected|returned|chosen)_row_ids$/.test(key);
-    if (isRowIds && Array.isArray(child) && (!chosenOnly || isChosen)) {
-      child.forEach((id) => found.add(String(id)));
-    }
-    if (Array.isArray(child)) child.forEach((item) => rowIdArrays(item, chosenOnly, found));
-    else rowIdArrays(child, chosenOnly, found);
+    if (isRowIds && Array.isArray(child) && (!chosenOnly || isChosen)) child.forEach((id) => found.push(String(id)));
+    if (Array.isArray(child)) child.forEach((item) => rowIdSequence(item, chosenOnly, found));
+    else rowIdSequence(child, chosenOnly, found);
   }
   return found;
 }
@@ -217,47 +240,68 @@ function candidateObjects(value: unknown, found: Record<string, unknown>[] = [])
   return found;
 }
 
-function candidateKey(candidate: Record<string, unknown>, index: number): string {
-  return String(candidate.row_id ?? candidate.id ?? candidate.path ?? `candidate_${index}`);
+function candidateKey(candidate: Record<string, unknown>, index: number): string | undefined {
+  if (candidate.row_id !== undefined && candidate.row_id !== null) return String(candidate.row_id);
+  if (candidate.id !== undefined && candidate.id !== null) return String(candidate.id);
+  if (candidate.path !== undefined && candidate.path !== null) return `${String(candidate.path)}#${index + 1}`;
+  return undefined;
+}
+
+function collectCounts(value: unknown, prefix = "", found = new Map<string, number>()): Map<string, number> {
+  const object = objectValue(value);
+  if (!object) return found;
+  for (const [key, child] of Object.entries(object)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if ((key === "count" || key.endsWith("_count") || prefix.endsWith("counts")) && typeof child === "number") {
+      found.set(path, child);
+    }
+    if (Array.isArray(child)) child.forEach((item, index) => collectCounts(item, `${path}[${index}]`, found));
+    else collectCounts(child, path, found);
+  }
+  return found;
 }
 
 function stageEvidence(observation: LangfuseObservation): StageEvidence {
-  const candidates = rowIdArrays(observation.output, false);
-  const chosen = rowIdArrays(observation.output, true);
+  const candidates = new Set(rowIdSequence(observation.output, false));
+  const chosen = rowIdSequence(observation.output, true);
   const filtered = new Map<string, string>();
   const scores = new Map<string, Map<string, number>>();
   candidateObjects(observation.output).forEach((candidate, index) => {
     const key = candidateKey(candidate, index);
-    if (candidate.row_id !== undefined) candidates.add(String(candidate.row_id));
-    if (candidate.chosen === true) chosen.add(key);
+    if (!key) return;
+    candidates.add(key);
+    if (candidate.chosen === true && !chosen.includes(key)) chosen.push(key);
     if (candidate.filtered_by !== undefined) filtered.set(key, stableValue(candidate.filtered_by));
     const numeric = new Map<string, number>();
     for (const [field, value] of Object.entries(candidate)) {
-      if (typeof value === "number" && /score|distance|similarity|usefulness/i.test(field)) {
-        numeric.set(field, value);
-      }
+      if (typeof value === "number" && /score|distance|similarity|usefulness/i.test(field)) numeric.set(field, value);
     }
     if (numeric.size > 0) scores.set(key, numeric);
   });
-  return { durationMs: observationDuration(observation), candidates, chosen, filtered, scores };
+  const metadata = metadataOf(observation);
+  const degradation = new Map<string, string>();
+  for (const key of ["payload_degraded", "payload_degradation_reason", "payload_limit_bytes", "additional_spans_omitted"]) {
+    if (metadata[key] !== undefined) degradation.set(key, stableValue(metadata[key]));
+  }
+  return {
+    durationMs: observationDuration(observation),
+    candidates,
+    chosen,
+    filtered,
+    scores,
+    counts: collectCounts(observation.output),
+    degradation,
+  };
 }
 
-function mergeEvidence(target: StageEvidence, source: StageEvidence): void {
-  target.durationMs += source.durationMs;
-  source.candidates.forEach((value) => target.candidates.add(value));
-  source.chosen.forEach((value) => target.chosen.add(value));
-  source.filtered.forEach((value, key) => target.filtered.set(key, value));
-  source.scores.forEach((value, key) => target.scores.set(key, value));
-}
-
-function stagesOf(trace: LangfuseTrace): Map<string, StageEvidence> {
-  const stages = new Map<string, StageEvidence>();
-  for (const observation of trace.observations ?? []) {
+function stagesOf(trace: LangfuseTrace): Map<string, StageEvidence[]> {
+  const stages = new Map<string, StageEvidence[]>();
+  const observations = [...(trace.observations ?? [])].sort(compareObservations);
+  for (const observation of observations) {
     const name = observation.name ?? "unnamed";
-    const evidence = stageEvidence(observation);
-    const current = stages.get(name);
-    if (current) mergeEvidence(current, evidence);
-    else stages.set(name, evidence);
+    const group = stages.get(name) ?? [];
+    group.push(stageEvidence(observation));
+    stages.set(name, group);
   }
   return stages;
 }
@@ -266,16 +310,24 @@ function setDifference(a: Set<string>, b: Set<string>): string[] {
   return [...a].filter((value) => !b.has(value)).sort();
 }
 
-function mapsEqual(a: Set<string>, b: Set<string>): boolean {
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
   return a.size === b.size && [...a].every((value) => b.has(value));
 }
 
-function compareFiltered(a?: StageEvidence, b?: StageEvidence): string[] {
-  const keys = new Set([...(a?.filtered.keys() ?? []), ...(b?.filtered.keys() ?? [])]);
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function compareMaps(a: Map<string, string | number>, b: Map<string, string | number>): string[] {
+  const keys = new Set([...a.keys(), ...b.keys()]);
   return [...keys]
     .sort()
-    .filter((key) => a?.filtered.get(key) !== b?.filtered.get(key))
-    .map((key) => `${key}: ${a?.filtered.get(key) ?? "—"} -> ${b?.filtered.get(key) ?? "—"}`);
+    .filter((key) => a.get(key) !== b.get(key))
+    .map((key) => `${key}: ${a.get(key) ?? "—"} -> ${b.get(key) ?? "—"}`);
+}
+
+function compareFiltered(a?: StageEvidence, b?: StageEvidence): string[] {
+  return compareMaps(a?.filtered ?? new Map(), b?.filtered ?? new Map());
 }
 
 function compareScores(a?: StageEvidence, b?: StageEvidence): string[] {
@@ -294,34 +346,75 @@ function compareScores(a?: StageEvidence, b?: StageEvidence): string[] {
   return deltas;
 }
 
-/** Compare stage evidence while keeping timing and metadata changes informational. */
+function hasEvidence(stage?: StageEvidence): boolean {
+  return Boolean(stage && (
+    stage.candidates.size > 0
+    || stage.chosen.length > 0
+    || stage.counts.size > 0
+    || stage.degradation.size > 0
+  ));
+}
+
+function comparisonBasis(a?: StageEvidence, b?: StageEvidence): ComparisonBasis {
+  const aHasRows = Boolean(a && (a.candidates.size > 0 || a.chosen.length > 0));
+  const bHasRows = Boolean(b && (b.candidates.size > 0 || b.chosen.length > 0));
+  if (aHasRows && bHasRows) return "row_ids";
+  if (!aHasRows && !bHasRows) return "counts+degradation";
+  return "mixed";
+}
+
+function compareStage(name: string, a?: StageEvidence, b?: StageEvidence): StageComparison {
+  const basis = comparisonBasis(a, b);
+  const candidateAdded = setDifference(b?.candidates ?? new Set(), a?.candidates ?? new Set());
+  const candidateRemoved = setDifference(a?.candidates ?? new Set(), b?.candidates ?? new Set());
+  const chosenA = a?.chosen ?? [];
+  const chosenB = b?.chosen ?? [];
+  const chosenAdded = setDifference(new Set(chosenB), new Set(chosenA));
+  const chosenRemoved = setDifference(new Set(chosenA), new Set(chosenB));
+  const chosenReordered = chosenAdded.length === 0 && chosenRemoved.length === 0 && !arraysEqual(chosenA, chosenB);
+  const countDifferences = compareMaps(a?.counts ?? new Map(), b?.counts ?? new Map());
+  const degradationDifferences = compareMaps(a?.degradation ?? new Map(), b?.degradation ?? new Map());
+  const rowEvidenceEqual = Boolean(a && b && setsEqual(a.candidates, b.candidates) && arraysEqual(chosenA, chosenB));
+  const fallbackEvidenceEqual = Boolean(a && b && countDifferences.length === 0 && degradationDifferences.length === 0);
+  const equivalent = basis === "row_ids" ? rowEvidenceEqual : basis === "counts+degradation" && fallbackEvidenceEqual;
+  return {
+    name,
+    durationA: a?.durationMs,
+    durationB: b?.durationMs,
+    basis,
+    candidateAdded,
+    candidateRemoved,
+    chosenAdded,
+    chosenRemoved,
+    chosenReordered,
+    countDifferences,
+    degradationDifferences,
+    filteredDifferences: compareFiltered(a, b),
+    scoreDeltas: compareScores(a, b),
+    equivalent,
+  };
+}
+
+/** Compare repeated stage occurrences pairwise while keeping timing and score changes informational. */
 export function diffTraces(traceA: LangfuseTrace, traceB: LangfuseTrace): TraceComparison {
   const stagesA = stagesOf(traceA);
   const stagesB = stagesOf(traceB);
   const names = [...new Set([...stagesA.keys(), ...stagesB.keys()])].sort();
-  let equivalent = (traceA.name ?? "") === (traceB.name ?? "");
-  const stages = names.map((name) => {
-    const a = stagesA.get(name);
-    const b = stagesB.get(name);
-    const candidateAdded = setDifference(b?.candidates ?? new Set(), a?.candidates ?? new Set());
-    const candidateRemoved = setDifference(a?.candidates ?? new Set(), b?.candidates ?? new Set());
-    const chosenAdded = setDifference(b?.chosen ?? new Set(), a?.chosen ?? new Set());
-    const chosenRemoved = setDifference(a?.chosen ?? new Set(), b?.chosen ?? new Set());
-    if (!a || !b || !mapsEqual(a.candidates, b.candidates) || !mapsEqual(a.chosen, b.chosen)) {
-      equivalent = false;
+  const stages: StageComparison[] = [];
+  let evidenceStageCount = 0;
+  for (const name of names) {
+    const groupA = stagesA.get(name) ?? [];
+    const groupB = stagesB.get(name) ?? [];
+    const occurrences = Math.max(groupA.length, groupB.length);
+    for (let index = 0; index < occurrences; index += 1) {
+      const label = occurrences > 1 ? `${name}[${index + 1}]` : name;
+      if (hasEvidence(groupA[index]) || hasEvidence(groupB[index])) evidenceStageCount += 1;
+      stages.push(compareStage(label, groupA[index], groupB[index]));
     }
-    return {
-      name,
-      durationA: a?.durationMs,
-      durationB: b?.durationMs,
-      candidateAdded,
-      candidateRemoved,
-      chosenAdded,
-      chosenRemoved,
-      filteredDifferences: compareFiltered(a, b),
-      scoreDeltas: compareScores(a, b),
-    };
-  });
+  }
+  const equivalent = evidenceStageCount === 0
+    ? null
+    : (traceA.name ?? "") === (traceB.name ?? "") && stages.every((stage) => stage.equivalent);
   return {
     equivalent,
     toolA: traceA.name ?? "—",
@@ -335,25 +428,36 @@ export function diffTraces(traceA: LangfuseTrace, traceB: LangfuseTrace): TraceC
 }
 
 function list(values: string[]): string {
-  return values.length > 0 ? values.join(",") : "—";
+  return values.length > 0 ? values.map(escapeControl).join(",") : "—";
 }
 
 export function traceDiffExitCode(comparison: TraceComparison): number {
+  if (comparison.equivalent === null) return 2;
   return comparison.equivalent ? 0 : 1;
+}
+
+export function repeatExitCode(comparisons: TraceComparison[]): number {
+  if (comparisons.some((comparison) => comparison.equivalent === null)) return 2;
+  return comparisons.some((comparison) => comparison.equivalent === false) ? 1 : 0;
 }
 
 /** Render a stage-aligned trace comparison. */
 export function renderTraceDiff(comparison: TraceComparison): string {
+  const equivalence = comparison.equivalent === null
+    ? "unknown (no retrieval evidence found)"
+    : String(comparison.equivalent);
   const lines = [
-    `equivalent=${comparison.equivalent}`,
+    `equivalent=${equivalence}`,
     `tool A=${comparison.toolA} B=${comparison.toolB}`,
     `release A=${comparison.releaseA} B=${comparison.releaseB}`,
     `namespace A=${comparison.namespaceA} B=${comparison.namespaceB}`,
   ];
   for (const stage of comparison.stages) {
-    lines.push(`stage=${stage.name} duration_ms A=${stage.durationA ?? "—"} B=${stage.durationB ?? "—"}`);
+    lines.push(`stage=${stage.name} basis=${stage.basis} duration_ms A=${stage.durationA ?? "—"} B=${stage.durationB ?? "—"}`);
     lines.push(`  candidate_row_ids added=${list(stage.candidateAdded)} removed=${list(stage.candidateRemoved)}`);
-    lines.push(`  chosen_row_ids added=${list(stage.chosenAdded)} removed=${list(stage.chosenRemoved)}`);
+    lines.push(`  chosen_row_ids added=${list(stage.chosenAdded)} removed=${list(stage.chosenRemoved)} reordered=${stage.chosenReordered}`);
+    lines.push(`  counts ${list(stage.countDifferences)}`);
+    lines.push(`  degradation ${list(stage.degradationDifferences)}`);
     lines.push(`  filtered ${list(stage.filteredDifferences)}`);
     lines.push(`  scores ${list(stage.scoreDeltas)}`);
   }
@@ -362,22 +466,23 @@ export function renderTraceDiff(comparison: TraceComparison): string {
 
 export function renderSessionTraces(traces: LangfuseTrace[]): string {
   return [...traces]
-    .sort((a, b) => String(a.timestamp ?? "").localeCompare(String(b.timestamp ?? "")))
+    .sort((a, b) => parsedTimestamp(a.timestamp) - parsedTimestamp(b.timestamp) || a.id.localeCompare(b.id))
     .map((trace) => {
       const durationMs = Math.max(0, (trace.latency ?? 0) * 1_000);
-      return `${trace.id} ${trace.name ?? "—"} ${trace.timestamp ?? "—"} release=${trace.release ?? "—"} status=${traceStatus(trace)} duration_ms=${durationMs}`;
+      const timestamp = trace.timestamp ?? "[timestamp=unknown]";
+      return `${escapeControl(trace.id)} ${trace.name ?? "—"} ${timestamp} release=${trace.release ?? "—"} status=${traceStatus(trace)} duration_ms=${durationMs}`;
     })
     .join("\n");
 }
 
 export function renderRepeatReport(sessionId: string, traces: LangfuseTrace[]): string {
   const baseline = traces[0];
-  if (!baseline) return `sessionId=${sessionId}\nno traces found`;
+  if (!baseline) return `sessionId=${escapeControl(sessionId)}\nno traces found`;
   const comparisons = traces.slice(1).map((trace) => diffTraces(baseline, trace));
   const stageNames = new Set(comparisons.flatMap((comparison) => comparison.stages.map((stage) => stage.name)));
   const lines = [
-    `sessionId=${sessionId}`,
-    `trace_ids=${traces.map((trace) => trace.id).join(",")}`,
+    `sessionId=${escapeControl(sessionId)}`,
+    `trace_ids=${traces.map((trace) => escapeControl(trace.id)).join(",")}`,
   ];
   for (const stageName of [...stageNames].sort()) {
     const changes = new Set<string>();
@@ -390,14 +495,15 @@ export function renderRepeatReport(sessionId: string, traces: LangfuseTrace[]): 
       if (stage.durationA !== stage.durationB) changes.add("duration_ms");
       if (stage.candidateAdded.length > 0 || stage.candidateRemoved.length > 0) changes.add("candidate_row_ids");
       if (stage.chosenAdded.length > 0 || stage.chosenRemoved.length > 0) changes.add("chosen_row_ids");
+      if (stage.chosenReordered) changes.add("chosen_order");
+      if (stage.countDifferences.length > 0) changes.add("counts");
+      if (stage.degradationDifferences.length > 0) changes.add("degradation");
       if (stage.filteredDifferences.length > 0) changes.add("filtered");
       if (stage.scoreDeltas.length > 0) changes.add("score_fields");
     }
-    lines.push(
-      changes.size === 0
-        ? `stage=${stageName} DETERMINISTIC`
-        : `stage=${stageName} VARIES fields=${[...changes].sort().join(",")}`,
-    );
+    lines.push(changes.size === 0
+      ? `stage=${stageName} DETERMINISTIC`
+      : `stage=${stageName} VARIES fields=${[...changes].sort().join(",")}`);
   }
   comparisons.forEach((comparison, index) => {
     lines.push(`\ncomparison=1:${index + 2}`);

--- a/scripts/langfuse-trace-lib.ts
+++ b/scripts/langfuse-trace-lib.ts
@@ -1,0 +1,407 @@
+export interface LangfuseObservation {
+  id?: string;
+  name?: string;
+  type?: string;
+  parentObservationId?: string | null;
+  startTime?: string;
+  endTime?: string;
+  latency?: number;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface LangfuseTrace {
+  id: string;
+  name?: string;
+  timestamp?: string;
+  release?: string | null;
+  sessionId?: string | null;
+  userId?: string | null;
+  latency?: number;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown> | null;
+  observations?: LangfuseObservation[];
+}
+
+export interface StageComparison {
+  name: string;
+  durationA?: number;
+  durationB?: number;
+  candidateAdded: string[];
+  candidateRemoved: string[];
+  chosenAdded: string[];
+  chosenRemoved: string[];
+  filteredDifferences: string[];
+  scoreDeltas: string[];
+}
+
+export interface TraceComparison {
+  equivalent: boolean;
+  toolA: string;
+  toolB: string;
+  releaseA: string;
+  releaseB: string;
+  namespaceA: string;
+  namespaceB: string;
+  stages: StageComparison[];
+}
+
+interface StageEvidence {
+  durationMs: number;
+  candidates: Set<string>;
+  chosen: Set<string>;
+  filtered: Map<string, string>;
+  scores: Map<string, Map<string, number>>;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stableValue(value: unknown): string {
+  if (value === undefined || value === null) return "—";
+  if (Array.isArray(value)) return value.map(stableValue).sort().join(",");
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${key}:${stableValue(child)}`);
+    return entries.join(",");
+  }
+  return String(value);
+}
+
+function metadataOf(value: { metadata?: Record<string, unknown> | null }): Record<string, unknown> {
+  return value.metadata ?? {};
+}
+
+function rootObservation(trace: LangfuseTrace): LangfuseObservation | undefined {
+  return trace.observations?.find((observation) => !observation.parentObservationId);
+}
+
+function observationDuration(observation: LangfuseObservation): number {
+  const metadataDuration = metadataOf(observation).duration_ms;
+  if (typeof metadataDuration === "number" && Number.isFinite(metadataDuration)) {
+    return Math.max(0, metadataDuration);
+  }
+  const start = Date.parse(observation.startTime ?? "");
+  const end = Date.parse(observation.endTime ?? "");
+  if (Number.isFinite(start) && Number.isFinite(end)) return Math.max(0, end - start);
+  return Math.max(0, (observation.latency ?? 0) * 1_000);
+}
+
+function traceStatus(trace: LangfuseTrace): string {
+  const root = rootObservation(trace);
+  const status = root ? metadataOf(root).status : undefined;
+  if (typeof status === "string") return status;
+  const failed = trace.observations?.some((observation) =>
+    ["ERROR", "WARNING"].includes(String((observation as { level?: unknown }).level ?? "").toUpperCase()),
+  );
+  return failed ? "error" : "unknown";
+}
+
+function callerIdentity(trace: LangfuseTrace): string {
+  const rootMetadata = metadataOf(rootObservation(trace) ?? {});
+  const fields = [
+    ["user", trace.userId],
+    ["client", rootMetadata.caller_client_id],
+    ["token_client", rootMetadata.caller_token_client_id],
+    ["agent", rootMetadata.caller_agent_id],
+    ["role", rootMetadata.caller_role],
+  ] as const;
+  return fields
+    .filter(([, value]) => value !== undefined && value !== null && value !== "")
+    .map(([name, value]) => `${name}=${String(value)}`)
+    .join(" ") || "—";
+}
+
+function namespaceOf(trace: LangfuseTrace): string {
+  const root = rootObservation(trace);
+  const metadata = root ? metadataOf(root) : metadataOf(trace);
+  const namespace = metadata.resolved_namespace ?? metadata.namespace;
+  if (namespace !== undefined) return stableValue(namespace);
+  const input = objectValue(trace.input);
+  return stableValue(input?.namespace ?? objectValue(input?.scope)?.namespace);
+}
+
+function collectDigestFields(value: unknown, prefix = "", found: string[] = []): string[] {
+  const object = objectValue(value);
+  if (!object) return found;
+  for (const [key, child] of Object.entries(object)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const countField = key === "count" || key.endsWith("_count");
+    const rowIdsField = key === "row_ids" || key.endsWith("_row_ids");
+    if (countField && typeof child === "number") found.push(`${path}=${child}`);
+    if (rowIdsField && Array.isArray(child)) {
+      found.push(`${path}=[${child.map(String).join(",")}]`);
+    }
+    if (Array.isArray(child)) {
+      child.forEach((item, index) => collectDigestFields(item, `${path}[${index}]`, found));
+    } else {
+      collectDigestFields(child, path, found);
+    }
+  }
+  return found;
+}
+
+/** Return a compact, content-free summary of count and row-id fields. */
+export function digestOutput(output: unknown): string {
+  const fields = collectDigestFields(output);
+  const candidateRowIds = [
+    ...new Set(
+      candidateObjects(output)
+        .map((candidate) => candidate.row_id)
+        .filter((rowId) => rowId !== undefined)
+        .map(String),
+    ),
+  ];
+  if (candidateRowIds.length > 0) {
+    fields.push(`candidate_row_ids=[${candidateRowIds.join(",")}]`);
+  }
+  return fields.length > 0 ? fields.join(" ") : "—";
+}
+
+/** Render one trace and all observations in chronological order. */
+export function renderTimeline(trace: LangfuseTrace): string {
+  const observations = [...(trace.observations ?? [])].sort((a, b) =>
+    String(a.startTime ?? "").localeCompare(String(b.startTime ?? "")),
+  );
+  const lines = [
+    `name=${trace.name ?? "—"}`,
+    `release=${trace.release ?? "—"}`,
+    `sessionId=${trace.sessionId ?? "—"}`,
+    `caller=${callerIdentity(trace)}`,
+    `status=${traceStatus(trace)}`,
+  ];
+  for (const observation of observations) {
+    const metadata = metadataOf(observation);
+    const stage = typeof metadata.stage === "string" ? metadata.stage : observation.type?.toLowerCase() ?? "observation";
+    lines.push(
+      `${observation.startTime ?? "—"} ${observation.name ?? "unnamed"} stage=${stage} duration_ms=${observationDuration(observation)} output=${digestOutput(observation.output)}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function rowIdArrays(value: unknown, chosenOnly: boolean, found = new Set<string>()): Set<string> {
+  const object = objectValue(value);
+  if (!object) return found;
+  for (const [key, child] of Object.entries(object)) {
+    const isRowIds = key === "row_ids" || key.endsWith("_row_ids");
+    const isChosen = /^(selected|returned|chosen)_row_ids$/.test(key);
+    if (isRowIds && Array.isArray(child) && (!chosenOnly || isChosen)) {
+      child.forEach((id) => found.add(String(id)));
+    }
+    if (Array.isArray(child)) child.forEach((item) => rowIdArrays(item, chosenOnly, found));
+    else rowIdArrays(child, chosenOnly, found);
+  }
+  return found;
+}
+
+function candidateObjects(value: unknown, found: Record<string, unknown>[] = []): Record<string, unknown>[] {
+  const object = objectValue(value);
+  if (!object) return found;
+  for (const [key, child] of Object.entries(object)) {
+    if (key === "candidates" && Array.isArray(child)) {
+      child.forEach((candidate) => {
+        const item = objectValue(candidate);
+        if (item) found.push(item);
+      });
+    }
+    if (Array.isArray(child)) child.forEach((item) => candidateObjects(item, found));
+    else candidateObjects(child, found);
+  }
+  return found;
+}
+
+function candidateKey(candidate: Record<string, unknown>, index: number): string {
+  return String(candidate.row_id ?? candidate.id ?? candidate.path ?? `candidate_${index}`);
+}
+
+function stageEvidence(observation: LangfuseObservation): StageEvidence {
+  const candidates = rowIdArrays(observation.output, false);
+  const chosen = rowIdArrays(observation.output, true);
+  const filtered = new Map<string, string>();
+  const scores = new Map<string, Map<string, number>>();
+  candidateObjects(observation.output).forEach((candidate, index) => {
+    const key = candidateKey(candidate, index);
+    if (candidate.row_id !== undefined) candidates.add(String(candidate.row_id));
+    if (candidate.chosen === true) chosen.add(key);
+    if (candidate.filtered_by !== undefined) filtered.set(key, stableValue(candidate.filtered_by));
+    const numeric = new Map<string, number>();
+    for (const [field, value] of Object.entries(candidate)) {
+      if (typeof value === "number" && /score|distance|similarity|usefulness/i.test(field)) {
+        numeric.set(field, value);
+      }
+    }
+    if (numeric.size > 0) scores.set(key, numeric);
+  });
+  return { durationMs: observationDuration(observation), candidates, chosen, filtered, scores };
+}
+
+function mergeEvidence(target: StageEvidence, source: StageEvidence): void {
+  target.durationMs += source.durationMs;
+  source.candidates.forEach((value) => target.candidates.add(value));
+  source.chosen.forEach((value) => target.chosen.add(value));
+  source.filtered.forEach((value, key) => target.filtered.set(key, value));
+  source.scores.forEach((value, key) => target.scores.set(key, value));
+}
+
+function stagesOf(trace: LangfuseTrace): Map<string, StageEvidence> {
+  const stages = new Map<string, StageEvidence>();
+  for (const observation of trace.observations ?? []) {
+    const name = observation.name ?? "unnamed";
+    const evidence = stageEvidence(observation);
+    const current = stages.get(name);
+    if (current) mergeEvidence(current, evidence);
+    else stages.set(name, evidence);
+  }
+  return stages;
+}
+
+function setDifference(a: Set<string>, b: Set<string>): string[] {
+  return [...a].filter((value) => !b.has(value)).sort();
+}
+
+function mapsEqual(a: Set<string>, b: Set<string>): boolean {
+  return a.size === b.size && [...a].every((value) => b.has(value));
+}
+
+function compareFiltered(a?: StageEvidence, b?: StageEvidence): string[] {
+  const keys = new Set([...(a?.filtered.keys() ?? []), ...(b?.filtered.keys() ?? [])]);
+  return [...keys]
+    .sort()
+    .filter((key) => a?.filtered.get(key) !== b?.filtered.get(key))
+    .map((key) => `${key}: ${a?.filtered.get(key) ?? "—"} -> ${b?.filtered.get(key) ?? "—"}`);
+}
+
+function compareScores(a?: StageEvidence, b?: StageEvidence): string[] {
+  const rows = new Set([...(a?.scores.keys() ?? []), ...(b?.scores.keys() ?? [])]);
+  const deltas: string[] = [];
+  for (const row of [...rows].sort()) {
+    const fields = new Set([...(a?.scores.get(row)?.keys() ?? []), ...(b?.scores.get(row)?.keys() ?? [])]);
+    for (const field of [...fields].sort()) {
+      const left = a?.scores.get(row)?.get(field);
+      const right = b?.scores.get(row)?.get(field);
+      if (left === right) continue;
+      const delta = left === undefined || right === undefined ? "—" : String(right - left);
+      deltas.push(`${row}.${field}: ${left ?? "—"} -> ${right ?? "—"} delta=${delta}`);
+    }
+  }
+  return deltas;
+}
+
+/** Compare stage evidence while keeping timing and metadata changes informational. */
+export function diffTraces(traceA: LangfuseTrace, traceB: LangfuseTrace): TraceComparison {
+  const stagesA = stagesOf(traceA);
+  const stagesB = stagesOf(traceB);
+  const names = [...new Set([...stagesA.keys(), ...stagesB.keys()])].sort();
+  let equivalent = (traceA.name ?? "") === (traceB.name ?? "");
+  const stages = names.map((name) => {
+    const a = stagesA.get(name);
+    const b = stagesB.get(name);
+    const candidateAdded = setDifference(b?.candidates ?? new Set(), a?.candidates ?? new Set());
+    const candidateRemoved = setDifference(a?.candidates ?? new Set(), b?.candidates ?? new Set());
+    const chosenAdded = setDifference(b?.chosen ?? new Set(), a?.chosen ?? new Set());
+    const chosenRemoved = setDifference(a?.chosen ?? new Set(), b?.chosen ?? new Set());
+    if (!a || !b || !mapsEqual(a.candidates, b.candidates) || !mapsEqual(a.chosen, b.chosen)) {
+      equivalent = false;
+    }
+    return {
+      name,
+      durationA: a?.durationMs,
+      durationB: b?.durationMs,
+      candidateAdded,
+      candidateRemoved,
+      chosenAdded,
+      chosenRemoved,
+      filteredDifferences: compareFiltered(a, b),
+      scoreDeltas: compareScores(a, b),
+    };
+  });
+  return {
+    equivalent,
+    toolA: traceA.name ?? "—",
+    toolB: traceB.name ?? "—",
+    releaseA: traceA.release ?? "—",
+    releaseB: traceB.release ?? "—",
+    namespaceA: namespaceOf(traceA),
+    namespaceB: namespaceOf(traceB),
+    stages,
+  };
+}
+
+function list(values: string[]): string {
+  return values.length > 0 ? values.join(",") : "—";
+}
+
+export function traceDiffExitCode(comparison: TraceComparison): number {
+  return comparison.equivalent ? 0 : 1;
+}
+
+/** Render a stage-aligned trace comparison. */
+export function renderTraceDiff(comparison: TraceComparison): string {
+  const lines = [
+    `equivalent=${comparison.equivalent}`,
+    `tool A=${comparison.toolA} B=${comparison.toolB}`,
+    `release A=${comparison.releaseA} B=${comparison.releaseB}`,
+    `namespace A=${comparison.namespaceA} B=${comparison.namespaceB}`,
+  ];
+  for (const stage of comparison.stages) {
+    lines.push(`stage=${stage.name} duration_ms A=${stage.durationA ?? "—"} B=${stage.durationB ?? "—"}`);
+    lines.push(`  candidate_row_ids added=${list(stage.candidateAdded)} removed=${list(stage.candidateRemoved)}`);
+    lines.push(`  chosen_row_ids added=${list(stage.chosenAdded)} removed=${list(stage.chosenRemoved)}`);
+    lines.push(`  filtered ${list(stage.filteredDifferences)}`);
+    lines.push(`  scores ${list(stage.scoreDeltas)}`);
+  }
+  return lines.join("\n");
+}
+
+export function renderSessionTraces(traces: LangfuseTrace[]): string {
+  return [...traces]
+    .sort((a, b) => String(a.timestamp ?? "").localeCompare(String(b.timestamp ?? "")))
+    .map((trace) => {
+      const durationMs = Math.max(0, (trace.latency ?? 0) * 1_000);
+      return `${trace.id} ${trace.name ?? "—"} ${trace.timestamp ?? "—"} release=${trace.release ?? "—"} status=${traceStatus(trace)} duration_ms=${durationMs}`;
+    })
+    .join("\n");
+}
+
+export function renderRepeatReport(sessionId: string, traces: LangfuseTrace[]): string {
+  const baseline = traces[0];
+  if (!baseline) return `sessionId=${sessionId}\nno traces found`;
+  const comparisons = traces.slice(1).map((trace) => diffTraces(baseline, trace));
+  const stageNames = new Set(comparisons.flatMap((comparison) => comparison.stages.map((stage) => stage.name)));
+  const lines = [
+    `sessionId=${sessionId}`,
+    `trace_ids=${traces.map((trace) => trace.id).join(",")}`,
+  ];
+  for (const stageName of [...stageNames].sort()) {
+    const changes = new Set<string>();
+    for (const comparison of comparisons) {
+      const stage = comparison.stages.find((item) => item.name === stageName);
+      if (!stage) {
+        changes.add("presence");
+        continue;
+      }
+      if (stage.durationA !== stage.durationB) changes.add("duration_ms");
+      if (stage.candidateAdded.length > 0 || stage.candidateRemoved.length > 0) changes.add("candidate_row_ids");
+      if (stage.chosenAdded.length > 0 || stage.chosenRemoved.length > 0) changes.add("chosen_row_ids");
+      if (stage.filteredDifferences.length > 0) changes.add("filtered");
+      if (stage.scoreDeltas.length > 0) changes.add("score_fields");
+    }
+    lines.push(
+      changes.size === 0
+        ? `stage=${stageName} DETERMINISTIC`
+        : `stage=${stageName} VARIES fields=${[...changes].sort().join(",")}`,
+    );
+  }
+  comparisons.forEach((comparison, index) => {
+    lines.push(`\ncomparison=1:${index + 2}`);
+    lines.push(renderTraceDiff(comparison));
+  });
+  return lines.join("\n");
+}

--- a/scripts/langfuse-trace.test.ts
+++ b/scripts/langfuse-trace.test.ts
@@ -6,12 +6,70 @@ import {
   renderSessionTraces,
   renderTimeline,
   renderTraceDiff,
+  repeatExitCode,
   traceDiffExitCode,
   type LangfuseTrace,
+  type TraceComparison,
 } from "./langfuse-trace-lib.ts";
+import {
+  parseRepeatChildOutput,
+  repeatChildFailureMessage,
+  selectRepeatedTraceSummaries,
+} from "./langfuse-trace.ts";
 
 async function fixture(name: string): Promise<LangfuseTrace> {
   return Bun.file(new URL(`./fixtures/${name}`, import.meta.url)).json();
+}
+
+function comparison(equivalent: boolean | null): TraceComparison {
+  return {
+    equivalent,
+    toolA: "search_brain",
+    toolB: "search_brain",
+    releaseA: "a",
+    releaseB: "b",
+    namespaceA: "rico",
+    namespaceB: "rico",
+    stages: [],
+  };
+}
+
+async function runCliDiff(
+  traceA: unknown,
+  traceB: unknown,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const id = new URL(request.url).pathname.split("/").at(-1);
+      return Response.json(id === "trace-a" ? traceA : traceB);
+    },
+  });
+  try {
+    const child = Bun.spawn(
+      ["bun", "scripts/langfuse-trace.ts", "diff", "trace-a", "trace-b"],
+      {
+        cwd: new URL("../", import.meta.url).pathname,
+        env: {
+          ...process.env,
+          OPENBRAIN_TRACING_ENDPOINT: server.url.origin,
+          OPENBRAIN_TRACING_PUBLIC_KEY: "fixture-public",
+          OPENBRAIN_TRACING_SECRET_KEY: "fixture-secret",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    server.stop(true);
+  }
 }
 
 describe("Langfuse trace forensics", () => {
@@ -46,6 +104,15 @@ describe("Langfuse trace forensics", () => {
     expect(output).toContain("row_ids=[row-1,row-2]");
   });
 
+  test("orders tied timestamps by end time then observation id and renders missing starts last", async () => {
+    const lines = renderTimeline(await fixture("langfuse-trace-timeline-degenerate.json")).split("\n").slice(5);
+
+    expect(lines[0]).toContain("tied-same-end-a");
+    expect(lines[1]).toContain("tied-same-end-b");
+    expect(lines[2]).toContain("tied-later-end");
+    expect(lines[3]).toContain("[startTime=unknown] missing-start");
+  });
+
   test("treats duration, score, release, and namespace changes as informational when evidence is equivalent", async () => {
     const left = await fixture("langfuse-trace-a.json");
     const right = structuredClone(left);
@@ -60,26 +127,26 @@ describe("Langfuse trace forensics", () => {
     const candidate = (rank?.output as { candidates?: Array<Record<string, unknown>> })?.candidates?.[0];
     if (candidate) candidate.rrf_score = 0.5;
 
-    const comparison = diffTraces(left, right);
+    const result = diffTraces(left, right);
 
-    expect(comparison.equivalent).toBeTrue();
-    expect(traceDiffExitCode(comparison)).toBe(0);
-    expect(comparison.releaseB).toBe("different-release");
-    expect(comparison.namespaceB).toBe("rico");
-    expect(comparison.stages.find((stage) => stage.name === "retrieval.rank_rrf")?.scoreDeltas).toContain(
+    expect(result.equivalent).toBeTrue();
+    expect(traceDiffExitCode(result)).toBe(0);
+    expect(result.releaseB).toBe("different-release");
+    expect(result.namespaceB).toBe("rico");
+    expect(result.stages.find((stage) => stage.name === "retrieval.rank_rrf")?.scoreDeltas).toContain(
       "row-1.rrf_score: 0.03 -> 0.5 delta=0.47",
     );
   });
 
   test("non-equivalent fixture pair reports evidence changes and the diff exit path", async () => {
-    const comparison = diffTraces(
+    const result = diffTraces(
       await fixture("langfuse-trace-a.json"),
       await fixture("langfuse-trace-b.json"),
     );
-    const output = renderTraceDiff(comparison);
+    const output = renderTraceDiff(result);
 
-    expect(comparison.equivalent).toBeFalse();
-    expect(traceDiffExitCode(comparison)).toBe(1);
+    expect(result.equivalent).toBeFalse();
+    expect(traceDiffExitCode(result)).toBe(1);
     expect(output).toContain("equivalent=false");
     expect(output).toContain("release A=abc1234 B=def5678");
     expect(output).toContain("namespace A=rico,shared-kb B=rico");
@@ -87,6 +154,109 @@ describe("Langfuse trace forensics", () => {
     expect(output).toContain("chosen_row_ids added=row-3 removed=row-1");
     expect(output).toContain("row-1: — -> rrf_window");
     expect(output).toContain("row-1.rrf_score: 0.03 -> 0.025");
+  });
+
+  test("aligns duplicate stage names pairwise instead of unioning their evidence", async () => {
+    const result = diffTraces(
+      await fixture("langfuse-trace-duplicates-a.json"),
+      await fixture("langfuse-trace-duplicates-b.json"),
+    );
+
+    expect(result.equivalent).toBeFalse();
+    expect(traceDiffExitCode(result)).toBe(1);
+    expect(result.stages.map((stage) => stage.name)).toEqual([
+      "retrieval.fallback_dedupe[1]",
+      "retrieval.fallback_dedupe[2]",
+    ]);
+  });
+
+  test("zero compared stages are inconclusive", async () => {
+    const result = diffTraces(
+      await fixture("langfuse-trace-empty-a.json"),
+      await fixture("langfuse-trace-empty-b.json"),
+    );
+
+    expect(result.equivalent).toBeNull();
+    expect(traceDiffExitCode(result)).toBe(2);
+    expect(renderTraceDiff(result)).toContain("equivalent=unknown (no retrieval evidence found)");
+
+    const rootOnly = structuredClone(await fixture("langfuse-trace-empty-a.json"));
+    rootOnly.observations = [{ id: "root", name: "search_brain", output: { content: "not evidence" } }];
+    expect(diffTraces(rootOnly, rootOnly).equivalent).toBeNull();
+  });
+
+  test("compares counts and degradation markers when row ids are absent", async () => {
+    const result = diffTraces(
+      await fixture("langfuse-trace-degraded-a.json"),
+      await fixture("langfuse-trace-degraded-b.json"),
+    );
+    const stage = result.stages[0]!;
+
+    expect(result.equivalent).toBeFalse();
+    expect(stage.basis).toBe("counts+degradation");
+    expect(stage.countDifferences).toContain("counts.values: 10 -> 11");
+    expect(stage.degradationDifferences).toContain(
+      "payload_degradation_reason: active_span_bytes_limit -> serialization_error",
+    );
+    expect(renderTraceDiff(result)).toContain("basis=counts+degradation");
+  });
+
+  test("treats chosen rows as an ordered ranking", () => {
+    const left: LangfuseTrace = {
+      id: "ordered-a",
+      name: "search_brain",
+      observations: [{ name: "retrieval.rank_rrf", output: { selected_row_ids: ["row-1", "row-2"] } }],
+    };
+    const right = structuredClone(left);
+    right.id = "ordered-b";
+    right.observations![0]!.output = { selected_row_ids: ["row-2", "row-1"] };
+
+    const result = diffTraces(left, right);
+    const stage = result.stages[0]!;
+
+    expect(result.equivalent).toBeFalse();
+    expect(stage.chosenAdded).toEqual([]);
+    expect(stage.chosenRemoved).toEqual([]);
+    expect(stage.chosenReordered).toBeTrue();
+    expect(renderTraceDiff(result)).toContain("reordered=true");
+  });
+
+  test("keys qmd candidates with null row ids by path and position", async () => {
+    const result = diffTraces(
+      await fixture("langfuse-trace-qmd-a.json"),
+      await fixture("langfuse-trace-qmd-b.json"),
+    );
+
+    expect(result.equivalent).toBeFalse();
+    expect(result.stages[0]?.candidateRemoved).toEqual(["docs/a.md#1", "docs/b.md#2"]);
+    expect(result.stages[0]?.candidateAdded).toEqual(["docs/c.md#1", "docs/d.md#2"]);
+  });
+
+  test("escapes control characters in rendered identifiers", () => {
+    const left: LangfuseTrace = {
+      id: "control-a",
+      name: "search_brain",
+      observations: [{ name: "retrieval.vector_query", output: { row_ids: ["row-safe"] } }],
+    };
+    const right: LangfuseTrace = {
+      id: "control-b",
+      name: "search_brain",
+      observations: [{ name: "retrieval.vector_query", output: { row_ids: ["row\nforged"] } }],
+    };
+
+    const output = renderTraceDiff(diffTraces(left, right));
+
+    expect(output).toContain("row\\u000a\\u001bforged");
+    expect(output).not.toContain("row\nforged");
+  });
+
+  test("maps comparison outcomes to isolated exit codes", () => {
+    // Mutation proof: changing any one expected mapping makes only this boundary test fail.
+    expect([
+      traceDiffExitCode(comparison(true)),
+      traceDiffExitCode(comparison(false)),
+      traceDiffExitCode(comparison(null)),
+    ]).toEqual([0, 1, 2]);
   });
 
   test("renders session summaries in chronological order with status and duration", async () => {
@@ -99,16 +269,62 @@ describe("Langfuse trace forensics", () => {
     expect(output.split("\n")[1]).toStartWith("trace-b search_brain 2026-08-06T12:01:00.000Z");
   });
 
-  test("repeat report names the fields that vary by stage", async () => {
-    const output = renderRepeatReport("session-569", [
+  test("repeat report names varying fields and repeat exits nonzero", async () => {
+    const traces = [
       await fixture("langfuse-trace-a.json"),
       await fixture("langfuse-trace-b.json"),
-    ]);
+    ];
+    const output = renderRepeatReport("session-569", traces);
+    const comparisons = [diffTraces(traces[0]!, traces[1]!)];
 
     expect(output).toContain("stage=retrieval.rank_rrf VARIES");
     expect(output).toContain("candidate_row_ids");
     expect(output).toContain("chosen_row_ids");
     expect(output).toContain("score_fields");
     expect(output).toContain("stage=search_brain VARIES fields=duration_ms");
+    expect(repeatExitCode(comparisons)).toBe(1);
+    expect(repeatExitCode([comparison(true)])).toBe(0);
+    expect(repeatExitCode([comparison(null)])).toBe(2);
+  });
+
+  test("selects the run's oldest fresh traces and rejects unexpected extras", () => {
+    const summaries: LangfuseTrace[] = [
+      { id: "newest", timestamp: "2026-08-06T12:00:03.000Z" },
+      { id: "old", timestamp: "2026-08-06T11:59:59.000Z" },
+      { id: "first", timestamp: "2026-08-06T12:00:01.000Z" },
+      { id: "second", timestamp: "2026-08-06T12:00:02.000Z" },
+    ];
+
+    expect(selectRepeatedTraceSummaries(summaries.slice(1), 2, "2026-08-06T12:00:00.000Z")?.map((trace) => trace.id))
+      .toEqual(["first", "second"]);
+    expect(() => selectRepeatedTraceSummaries(summaries, 2, "2026-08-06T12:00:00.000Z"))
+      .toThrow("3 fresh traces; expected exactly 2");
+  });
+
+  test("parses the last JSON line and preserves child stderr in failures", () => {
+    expect(parseRepeatChildOutput("uv notice\n{\"session_id\":\"session-own\"}\n")).toBe("session-own");
+    expect(() => parseRepeatChildOutput("uv notice only\n")).toThrow("invalid JSON");
+    expect(repeatChildFailureMessage(7, "python traceback\n")).toBe(
+      "OpenBrainClient repeat failed (exit 7): python traceback",
+    );
+  });
+
+  test("CLI wires a differing comparison to exit 1", async () => {
+    const result = await runCliDiff(
+      await fixture("langfuse-trace-a.json"),
+      await fixture("langfuse-trace-b.json"),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("equivalent=false");
+    expect(result.stderr).toBe("");
+  });
+
+  test("CLI rejects an unexpected HTTP 200 body with exit 2", async () => {
+    const result = await runCliDiff({ error: "unexpected" }, await fixture("langfuse-trace-b.json"));
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Langfuse returned an invalid trace for trace-a");
   });
 });

--- a/scripts/langfuse-trace.test.ts
+++ b/scripts/langfuse-trace.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  diffTraces,
+  digestOutput,
+  renderRepeatReport,
+  renderSessionTraces,
+  renderTimeline,
+  renderTraceDiff,
+  traceDiffExitCode,
+  type LangfuseTrace,
+} from "./langfuse-trace-lib.ts";
+
+async function fixture(name: string): Promise<LangfuseTrace> {
+  return Bun.file(new URL(`./fixtures/${name}`, import.meta.url)).json();
+}
+
+describe("Langfuse trace forensics", () => {
+  test("digests nested count and row-id evidence without returning content", () => {
+    const digest = digestOutput({
+      count: 2,
+      row_ids: ["row-1", "row-2"],
+      nested: { selected_count: 1, selected_row_ids: ["row-1"] },
+      candidates: [{ row_id: "row-1" }, { row_id: "row-2" }],
+      content: "must not appear",
+    });
+
+    expect(digest).toBe(
+      "count=2 row_ids=[row-1,row-2] nested.selected_count=1 nested.selected_row_ids=[row-1] candidate_row_ids=[row-1,row-2]",
+    );
+    expect(digest).not.toContain("must not appear");
+  });
+
+  test("renders trace identity and observations in start-time order", async () => {
+    const output = renderTimeline(await fixture("langfuse-trace-a.json"));
+    const vectorIndex = output.indexOf("retrieval.vector_query");
+    const rankIndex = output.indexOf("retrieval.rank_rrf");
+
+    expect(output).toContain("name=search_brain");
+    expect(output).toContain("release=abc1234");
+    expect(output).toContain("sessionId=session-569");
+    expect(output).toContain("caller=user=rico client=rico token_client=rico agent=trace-fixture role=agent");
+    expect(output).toContain("status=success");
+    expect(vectorIndex).toBeGreaterThan(0);
+    expect(rankIndex).toBeGreaterThan(vectorIndex);
+    expect(output).toContain("stage=candidate_generation duration_ms=50");
+    expect(output).toContain("row_ids=[row-1,row-2]");
+  });
+
+  test("treats duration, score, release, and namespace changes as informational when evidence is equivalent", async () => {
+    const left = await fixture("langfuse-trace-a.json");
+    const right = structuredClone(left);
+    right.id = "trace-equivalent";
+    right.release = "different-release";
+    const root = right.observations?.find((observation) => !observation.parentObservationId);
+    if (root?.metadata) {
+      root.metadata.duration_ms = 999;
+      root.metadata.resolved_namespace = ["rico"];
+    }
+    const rank = right.observations?.find((observation) => observation.name === "retrieval.rank_rrf");
+    const candidate = (rank?.output as { candidates?: Array<Record<string, unknown>> })?.candidates?.[0];
+    if (candidate) candidate.rrf_score = 0.5;
+
+    const comparison = diffTraces(left, right);
+
+    expect(comparison.equivalent).toBeTrue();
+    expect(traceDiffExitCode(comparison)).toBe(0);
+    expect(comparison.releaseB).toBe("different-release");
+    expect(comparison.namespaceB).toBe("rico");
+    expect(comparison.stages.find((stage) => stage.name === "retrieval.rank_rrf")?.scoreDeltas).toContain(
+      "row-1.rrf_score: 0.03 -> 0.5 delta=0.47",
+    );
+  });
+
+  test("non-equivalent fixture pair reports evidence changes and the diff exit path", async () => {
+    const comparison = diffTraces(
+      await fixture("langfuse-trace-a.json"),
+      await fixture("langfuse-trace-b.json"),
+    );
+    const output = renderTraceDiff(comparison);
+
+    expect(comparison.equivalent).toBeFalse();
+    expect(traceDiffExitCode(comparison)).toBe(1);
+    expect(output).toContain("equivalent=false");
+    expect(output).toContain("release A=abc1234 B=def5678");
+    expect(output).toContain("namespace A=rico,shared-kb B=rico");
+    expect(output).toContain("candidate_row_ids added=row-3 removed=row-2");
+    expect(output).toContain("chosen_row_ids added=row-3 removed=row-1");
+    expect(output).toContain("row-1: — -> rrf_window");
+    expect(output).toContain("row-1.rrf_score: 0.03 -> 0.025");
+  });
+
+  test("renders session summaries in chronological order with status and duration", async () => {
+    const first = await fixture("langfuse-trace-a.json");
+    const second = await fixture("langfuse-trace-b.json");
+    const output = renderSessionTraces([second, first]);
+
+    expect(output.split("\n")[0]).toStartWith("trace-a search_brain 2026-08-06T12:00:00.000Z");
+    expect(output).toContain("release=abc1234 status=success duration_ms=120");
+    expect(output.split("\n")[1]).toStartWith("trace-b search_brain 2026-08-06T12:01:00.000Z");
+  });
+
+  test("repeat report names the fields that vary by stage", async () => {
+    const output = renderRepeatReport("session-569", [
+      await fixture("langfuse-trace-a.json"),
+      await fixture("langfuse-trace-b.json"),
+    ]);
+
+    expect(output).toContain("stage=retrieval.rank_rrf VARIES");
+    expect(output).toContain("candidate_row_ids");
+    expect(output).toContain("chosen_row_ids");
+    expect(output).toContain("score_fields");
+    expect(output).toContain("stage=search_brain VARIES fields=duration_ms");
+  });
+});

--- a/scripts/langfuse-trace.ts
+++ b/scripts/langfuse-trace.ts
@@ -1,0 +1,279 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "node:util";
+import {
+  diffTraces,
+  renderRepeatReport,
+  renderSessionTraces,
+  renderTimeline,
+  renderTraceDiff,
+  traceDiffExitCode,
+  type LangfuseTrace,
+} from "./langfuse-trace-lib.ts";
+
+interface LangfuseConfig {
+  endpoint: string;
+  publicKey: string;
+  secretKey: string;
+}
+
+interface CliOptions {
+  command: "get" | "session" | "diff" | "repeat";
+  positionals: string[];
+  json: boolean;
+  query?: string;
+  count: number;
+}
+
+const HELP = `Open Brain Langfuse trace forensics
+
+Usage:
+  bun scripts/langfuse-trace.ts get <traceId> [--json]
+  bun scripts/langfuse-trace.ts session <sessionKey> [-n N] [--json]
+  bun scripts/langfuse-trace.ts diff <traceIdA> <traceIdB> [--json]
+  bun scripts/langfuse-trace.ts repeat <toolName> --query <q> [-n N] [--json]
+
+Environment:
+  OPENBRAIN_TRACING_ENDPOINT
+  OPENBRAIN_TRACING_PUBLIC_KEY
+  OPENBRAIN_TRACING_SECRET_KEY
+
+The local values live in /Volumes/ThunderBolt/open-brain-local/local-clone.env.
+Source that file before running these commands; values are never printed.
+The repeat command also uses OPENBRAIN_BASE_URL, OPENBRAIN_TOKEN, and
+OPENBRAIN_NAMESPACE from that environment and drives the existing Python
+openbrain-memory OpenBrainClient.call_tool path through uv run.
+`;
+
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint
+    .replace(/\/$/, "")
+    .replace(/\/api\/public\/ingestion$/, "");
+}
+
+function readConfig(env: Record<string, string | undefined> = process.env): LangfuseConfig {
+  const endpoint = env.OPENBRAIN_TRACING_ENDPOINT?.trim() ?? "";
+  const publicKey = env.OPENBRAIN_TRACING_PUBLIC_KEY?.trim() ?? "";
+  const secretKey = env.OPENBRAIN_TRACING_SECRET_KEY?.trim() ?? "";
+  if (!endpoint || !publicKey || !secretKey) {
+    throw new Error("OPENBRAIN_TRACING_ENDPOINT, OPENBRAIN_TRACING_PUBLIC_KEY, and OPENBRAIN_TRACING_SECRET_KEY are required");
+  }
+  return { endpoint: normalizeEndpoint(endpoint), publicKey, secretKey };
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseCli(args: string[]): CliOptions | "help" {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: true,
+    options: {
+      json: { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+      query: { type: "string" },
+      n: { type: "string", short: "n", default: "3" },
+    },
+  });
+  if (parsed.values.help || parsed.positionals.length === 0) return "help";
+  const [command, ...positionals] = parsed.positionals;
+  if (!command || !["get", "session", "diff", "repeat"].includes(command)) {
+    throw new Error(`unknown command: ${command ?? ""}`);
+  }
+  const expectedPositionals: Record<string, number> = { get: 1, session: 1, diff: 2, repeat: 1 };
+  if (positionals.length !== expectedPositionals[command]) {
+    throw new Error(`${command} received the wrong number of positional arguments`);
+  }
+  if (command === "repeat" && !parsed.values.query) throw new Error("repeat requires --query <q>");
+  const count = parsePositiveInteger(parsed.values.n ?? "3", "-n");
+  if (command === "repeat" && count < 2) throw new Error("repeat requires -n 2 or greater");
+  return {
+    command: command as CliOptions["command"],
+    positionals,
+    json: parsed.values.json ?? false,
+    query: parsed.values.query,
+    count,
+  };
+}
+
+function authorization(config: LangfuseConfig): string {
+  return `Basic ${Buffer.from(`${config.publicKey}:${config.secretKey}`).toString("base64")}`;
+}
+
+async function fetchJson(url: URL, config: LangfuseConfig): Promise<unknown> {
+  const response = await fetch(url, { headers: { authorization: authorization(config) } });
+  if (!response.ok) throw new Error(`Langfuse API request failed (${response.status})`);
+  return response.json();
+}
+
+function pageData(payload: unknown): LangfuseTrace[] {
+  if (Array.isArray(payload)) return payload as LangfuseTrace[];
+  const data = (payload as { data?: unknown } | null)?.data;
+  return Array.isArray(data) ? (data as LangfuseTrace[]) : [];
+}
+
+function totalPages(payload: unknown): number | undefined {
+  const meta = (payload as { meta?: Record<string, unknown> } | null)?.meta;
+  const value = meta?.totalPages ?? meta?.total_pages;
+  return typeof value === "number" ? value : undefined;
+}
+
+async function fetchTrace(id: string, config: LangfuseConfig): Promise<LangfuseTrace> {
+  const url = new URL(`/api/public/traces/${encodeURIComponent(id)}`, config.endpoint);
+  const payload = await fetchJson(url, config);
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error(`Langfuse returned an invalid trace for ${id}`);
+  }
+  return payload as LangfuseTrace;
+}
+
+async function listTraceSummaries(
+  filters: Record<string, string>,
+  requested: number,
+  config: LangfuseConfig,
+): Promise<LangfuseTrace[]> {
+  const traces: LangfuseTrace[] = [];
+  let page = 1;
+  while (traces.length < requested) {
+    const url = new URL("/api/public/traces", config.endpoint);
+    Object.entries(filters).forEach(([key, value]) => url.searchParams.set(key, value));
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("limit", "100");
+    const payload = await fetchJson(url, config);
+    const rows = pageData(payload);
+    traces.push(...rows);
+    const pages = totalPages(payload);
+    if (rows.length === 0 || (pages !== undefined && page >= pages)) break;
+    page += 1;
+  }
+  return traces.slice(0, requested);
+}
+
+async function listTraceDetails(
+  filters: Record<string, string>,
+  requested: number,
+  config: LangfuseConfig,
+): Promise<LangfuseTrace[]> {
+  const summaries = await listTraceSummaries(filters, requested, config);
+  return Promise.all(summaries.map((trace) => fetchTrace(trace.id, config)));
+}
+
+const PYTHON_REPEAT = String.raw`
+import json
+import os
+import sys
+from openbrain_memory import OpenBrainClient
+
+tool_name, query, count_text = sys.argv[1:]
+client = OpenBrainClient(
+    os.environ["OPENBRAIN_BASE_URL"],
+    os.environ["OPENBRAIN_TOKEN"],
+    os.environ.get("OPENBRAIN_NAMESPACE", "rico"),
+    agent_id=os.environ.get("OPENBRAIN_AGENT_ID"),
+    role=os.environ.get("OPENBRAIN_ROLE"),
+    allow_insecure_http=os.environ.get("OPENBRAIN_ALLOW_INSECURE_HTTP") == "1",
+)
+try:
+    for _ in range(int(count_text)):
+        client.call_tool(tool_name, {"query": query})
+    print(json.dumps({"session_id": client.session_id}))
+finally:
+    client.close()
+`;
+
+async function driveRepeat(toolName: string, query: string, count: number): Promise<string> {
+  for (const key of ["OPENBRAIN_BASE_URL", "OPENBRAIN_TOKEN"]) {
+    if (!process.env[key]) throw new Error(`${key} is required for repeat`);
+  }
+  const child = Bun.spawn(
+    ["uv", "run", "python", "-c", PYTHON_REPEAT, toolName, query, String(count)],
+    {
+      cwd: new URL("../python/openbrain-memory/", import.meta.url).pathname,
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [exitCode, stdout] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`OpenBrainClient repeat failed (exit ${exitCode})`);
+  const payload = JSON.parse(stdout) as { session_id?: unknown };
+  if (typeof payload.session_id !== "string" || payload.session_id.length === 0) {
+    throw new Error("OpenBrainClient repeat returned no MCP session id");
+  }
+  return payload.session_id;
+}
+
+async function waitForRepeatedTraces(
+  sessionId: string,
+  toolName: string,
+  count: number,
+  startedAt: string,
+  config: LangfuseConfig,
+): Promise<LangfuseTrace[]> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() <= deadline) {
+    const summaries = await listTraceSummaries({ sessionId, name: toolName }, count, config);
+    const fresh = summaries.filter((trace) => String(trace.timestamp ?? "") >= startedAt);
+    if (fresh.length >= count) {
+      const selected = fresh.slice(0, count).reverse();
+      return Promise.all(selected.map((trace) => fetchTrace(trace.id, config)));
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(`Langfuse did not return ${count} fresh ${toolName} traces for session ${sessionId}`);
+}
+
+async function run(options: CliOptions, config: LangfuseConfig): Promise<{ output: unknown; exitCode: number }> {
+  switch (options.command) {
+    case "get": {
+      const trace = await fetchTrace(options.positionals[0]!, config);
+      return { output: options.json ? trace : renderTimeline(trace), exitCode: 0 };
+    }
+    case "session": {
+      const traces = await listTraceDetails({ sessionId: options.positionals[0]! }, options.count, config);
+      return { output: options.json ? traces : renderSessionTraces(traces), exitCode: 0 };
+    }
+    case "diff": {
+      const [traceA, traceB] = await Promise.all([
+        fetchTrace(options.positionals[0]!, config),
+        fetchTrace(options.positionals[1]!, config),
+      ]);
+      const comparison = diffTraces(traceA, traceB);
+      return {
+        output: options.json ? comparison : renderTraceDiff(comparison),
+        exitCode: traceDiffExitCode(comparison),
+      };
+    }
+    case "repeat": {
+      const startedAt = new Date().toISOString();
+      const sessionId = await driveRepeat(options.positionals[0]!, options.query!, options.count);
+      const traces = await waitForRepeatedTraces(sessionId, options.positionals[0]!, options.count, startedAt, config);
+      const report = { sessionId, traces, comparisons: traces.slice(1).map((trace) => diffTraces(traces[0]!, trace)) };
+      return { output: options.json ? report : renderRepeatReport(sessionId, traces), exitCode: 0 };
+    }
+  }
+}
+
+if (import.meta.main) {
+  try {
+    const options = parseCli(Bun.argv.slice(2));
+    if (options === "help") {
+      console.log(HELP);
+    } else {
+      const outcome = await run(options, readConfig());
+      console.log(typeof outcome.output === "string" ? outcome.output : JSON.stringify(outcome.output, null, 2));
+      process.exitCode = outcome.exitCode;
+    }
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : "unknown trace forensics error");
+    process.exitCode = 2;
+  }
+}

--- a/scripts/langfuse-trace.ts
+++ b/scripts/langfuse-trace.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env bun
 
 import { parseArgs } from "node:util";
+import { z } from "zod";
 import {
   diffTraces,
   renderRepeatReport,
   renderSessionTraces,
   renderTimeline,
   renderTraceDiff,
+  repeatExitCode,
   traceDiffExitCode,
   type LangfuseTrace,
 } from "./langfuse-trace-lib.ts";
@@ -24,6 +26,41 @@ interface CliOptions {
   query?: string;
   count: number;
 }
+
+const observationSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  type: z.string().optional(),
+  parentObservationId: z.string().nullable().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  latency: z.number().optional(),
+  input: z.unknown().optional(),
+  output: z.unknown().optional(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+}).passthrough();
+
+const traceSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().optional(),
+  timestamp: z.string().optional(),
+  release: z.string().nullable().optional(),
+  sessionId: z.string().nullable().optional(),
+  userId: z.string().nullable().optional(),
+  latency: z.number().optional(),
+  input: z.unknown().optional(),
+  output: z.unknown().optional(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  observations: z.array(observationSchema).optional(),
+}).passthrough();
+
+const tracePageSchema = z.union([
+  z.array(traceSchema),
+  z.object({
+    data: z.array(traceSchema),
+    meta: z.record(z.string(), z.unknown()).optional(),
+  }).passthrough(),
+]);
 
 const HELP = `Open Brain Langfuse trace forensics
 
@@ -110,25 +147,22 @@ async function fetchJson(url: URL, config: LangfuseConfig): Promise<unknown> {
   return response.json();
 }
 
-function pageData(payload: unknown): LangfuseTrace[] {
-  if (Array.isArray(payload)) return payload as LangfuseTrace[];
-  const data = (payload as { data?: unknown } | null)?.data;
-  return Array.isArray(data) ? (data as LangfuseTrace[]) : [];
-}
-
-function totalPages(payload: unknown): number | undefined {
-  const meta = (payload as { meta?: Record<string, unknown> } | null)?.meta;
-  const value = meta?.totalPages ?? meta?.total_pages;
-  return typeof value === "number" ? value : undefined;
+function parseTracePage(payload: unknown): { traces: LangfuseTrace[]; totalPages?: number } {
+  const parsed = tracePageSchema.safeParse(payload);
+  if (!parsed.success) throw new Error("Langfuse returned an invalid trace-list response");
+  if (Array.isArray(parsed.data)) return { traces: parsed.data };
+  const value = parsed.data.meta?.totalPages ?? parsed.data.meta?.total_pages;
+  return {
+    traces: parsed.data.data,
+    totalPages: typeof value === "number" ? value : undefined,
+  };
 }
 
 async function fetchTrace(id: string, config: LangfuseConfig): Promise<LangfuseTrace> {
   const url = new URL(`/api/public/traces/${encodeURIComponent(id)}`, config.endpoint);
-  const payload = await fetchJson(url, config);
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    throw new Error(`Langfuse returned an invalid trace for ${id}`);
-  }
-  return payload as LangfuseTrace;
+  const parsed = traceSchema.safeParse(await fetchJson(url, config));
+  if (!parsed.success) throw new Error(`Langfuse returned an invalid trace for ${id}`);
+  return parsed.data;
 }
 
 async function listTraceSummaries(
@@ -143,11 +177,9 @@ async function listTraceSummaries(
     Object.entries(filters).forEach(([key, value]) => url.searchParams.set(key, value));
     url.searchParams.set("page", String(page));
     url.searchParams.set("limit", "100");
-    const payload = await fetchJson(url, config);
-    const rows = pageData(payload);
-    traces.push(...rows);
-    const pages = totalPages(payload);
-    if (rows.length === 0 || (pages !== undefined && page >= pages)) break;
+    const result = parseTracePage(await fetchJson(url, config));
+    traces.push(...result.traces);
+    if (result.traces.length === 0 || (result.totalPages !== undefined && page >= result.totalPages)) break;
     page += 1;
   }
   return traces.slice(0, requested);
@@ -185,6 +217,28 @@ finally:
     client.close()
 `;
 
+export function repeatChildFailureMessage(exitCode: number, stderr: string): string {
+  const detail = stderr.trim();
+  return `OpenBrainClient repeat failed (exit ${exitCode})${detail ? `: ${detail}` : ""}`;
+}
+
+export function parseRepeatChildOutput(stdout: string): string {
+  const lastLine = stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).at(-1);
+  if (!lastLine) throw new Error("OpenBrainClient repeat returned no JSON result");
+  let payload: unknown;
+  try {
+    payload = JSON.parse(lastLine);
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : "invalid JSON";
+    throw new Error(`OpenBrainClient repeat returned invalid JSON: ${detail}`);
+  }
+  const sessionId = (payload as { session_id?: unknown } | null)?.session_id;
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    throw new Error("OpenBrainClient repeat returned no MCP session id");
+  }
+  return sessionId;
+}
+
 async function driveRepeat(toolName: string, query: string, count: number): Promise<string> {
   for (const key of ["OPENBRAIN_BASE_URL", "OPENBRAIN_TOKEN"]) {
     if (!process.env[key]) throw new Error(`${key} is required for repeat`);
@@ -198,17 +252,28 @@ async function driveRepeat(toolName: string, query: string, count: number): Prom
       stderr: "pipe",
     },
   );
-  const [exitCode, stdout] = await Promise.all([
+  const [exitCode, stdout, stderr] = await Promise.all([
     child.exited,
     new Response(child.stdout).text(),
     new Response(child.stderr).text(),
   ]);
-  if (exitCode !== 0) throw new Error(`OpenBrainClient repeat failed (exit ${exitCode})`);
-  const payload = JSON.parse(stdout) as { session_id?: unknown };
-  if (typeof payload.session_id !== "string" || payload.session_id.length === 0) {
-    throw new Error("OpenBrainClient repeat returned no MCP session id");
+  if (exitCode !== 0) throw new Error(repeatChildFailureMessage(exitCode, stderr));
+  return parseRepeatChildOutput(stdout);
+}
+
+export function selectRepeatedTraceSummaries(
+  summaries: LangfuseTrace[],
+  count: number,
+  startedAt: string,
+): LangfuseTrace[] | undefined {
+  const startedAtMs = Date.parse(startedAt);
+  const fresh = summaries
+    .filter((trace) => Date.parse(trace.timestamp ?? "") >= startedAtMs)
+    .sort((a, b) => Date.parse(a.timestamp ?? "") - Date.parse(b.timestamp ?? "") || a.id.localeCompare(b.id));
+  if (fresh.length > count) {
+    throw new Error(`Langfuse returned ${fresh.length} fresh traces; expected exactly ${count}`);
   }
-  return payload.session_id;
+  return fresh.length === count ? fresh : undefined;
 }
 
 async function waitForRepeatedTraces(
@@ -220,12 +285,9 @@ async function waitForRepeatedTraces(
 ): Promise<LangfuseTrace[]> {
   const deadline = Date.now() + 30_000;
   while (Date.now() <= deadline) {
-    const summaries = await listTraceSummaries({ sessionId, name: toolName }, count, config);
-    const fresh = summaries.filter((trace) => String(trace.timestamp ?? "") >= startedAt);
-    if (fresh.length >= count) {
-      const selected = fresh.slice(0, count).reverse();
-      return Promise.all(selected.map((trace) => fetchTrace(trace.id, config)));
-    }
+    const summaries = await listTraceSummaries({ sessionId, name: toolName }, count + 1, config);
+    const selected = selectRepeatedTraceSummaries(summaries, count, startedAt);
+    if (selected) return Promise.all(selected.map((trace) => fetchTrace(trace.id, config)));
     await Bun.sleep(500);
   }
   throw new Error(`Langfuse did not return ${count} fresh ${toolName} traces for session ${sessionId}`);
@@ -256,8 +318,12 @@ async function run(options: CliOptions, config: LangfuseConfig): Promise<{ outpu
       const startedAt = new Date().toISOString();
       const sessionId = await driveRepeat(options.positionals[0]!, options.query!, options.count);
       const traces = await waitForRepeatedTraces(sessionId, options.positionals[0]!, options.count, startedAt, config);
-      const report = { sessionId, traces, comparisons: traces.slice(1).map((trace) => diffTraces(traces[0]!, trace)) };
-      return { output: options.json ? report : renderRepeatReport(sessionId, traces), exitCode: 0 };
+      const comparisons = traces.slice(1).map((trace) => diffTraces(traces[0]!, trace));
+      const report = { sessionId, traces, comparisons };
+      return {
+        output: options.json ? report : renderRepeatReport(sessionId, traces),
+        exitCode: repeatExitCode(comparisons),
+      };
     }
   }
 }


### PR DESCRIPTION
## Summary

- add `scripts/langfuse-trace.ts` with `get`, `session`, `diff`, and `repeat` trace-forensics commands
- align repeated stage occurrences pairwise, preserve chosen-row ranking order, and compare row-id evidence or count/degradation evidence explicitly
- return inconclusive exit 2 when retrieval evidence is absent or Langfuse returns an invalid response; return exit 1 from `diff` and `repeat` when evidence differs
- render deterministic timelines with parsed timestamp ordering, stable tie-breakers, explicit unknown timestamps, and escaped identifiers
- correlate repeat results to the oldest fresh traces from the current run and reject unexpected extras
- add fixture-backed library and CLI regressions plus operator examples in `docs/CONFIG_REFERENCE.md`

Part of #569

Tracked under epic #571.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — Python package source is unchanged; `repeat` uses the existing installed client boundary
- [x] Live Open Brain smoke passed or is not applicable — the original author lane exercised `get`, `session`, equivalent `diff`, and two-run `repeat search_brain` against local dogfood; this fix lane added fixture and CLI-boundary regressions without another mutating repeat

## Critical Self-Review

- Highest-risk behavior: False equivalence would hide retrieval drift. Comparisons now pair duplicate stage occurrences by chronological index, compare candidates as identities and chosen rows as an ordered sequence, fall back to count/degradation markers when row IDs are absent, and return inconclusive rather than equivalent when no retrieval evidence exists.
- Assumptions that could be wrong: Langfuse continues to expose trace IDs, timestamps, observations, and list `data` in the v3.173-compatible public API shape. Both detail and list responses are now schema-validated, and unexpected HTTP 200 bodies exit 2.
- Missing/weak tests: HTTP pagination and eventual trace arrival still use the prior live smoke rather than a timed network integration test. The fix suite covers response validation, CLI exit wiring, duplicate occurrences, zero evidence, degraded payloads, qmd null IDs, chosen ordering, tied/missing timestamps, repeat ordering/extras, and child-output parsing.
- Security/permission risk: Langfuse Basic-auth values are read only from environment variables and never printed; rendered row/trace/observation IDs escape control characters; `--json` intentionally returns content-ful trace data to the invoking operator.
- Migration/deploy risk: No migration or service deployment is required; this is an operator script and documentation change.
- Downstream client/runtime risk: No MCP tool, schema, transport, Python package, generated skill, or Hermes contract changes; downstream rollout is not applicable.
- Rollback/cleanup concern: Rollback is the three PR commits; no live data was mutated by the fix lane.
- Fixes made before PR: Closed all findings from pull/601#issuecomment-5204027299, including truthful tri-state exits, occurrence alignment, degraded evidence, deterministic timelines, repeat correlation/error handling, response validation, ordered chosen rows, qmd candidate identities, control escaping, and fixture/CLI regressions.
- Known residual risk: `repeat` fails if Langfuse has not exposed exactly the expected number of fresh traces within 30 seconds; unexpected extras now fail explicitly rather than silently changing the baseline.
- SME review-memory update: [x] docs/sme/ updated (correctness — commit 895728a on this branch; provenance pull/601#issuecomment-5204027299)

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in docs/sme/ (commit 895728a)
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this operator-only consumer does not change MCP names, schemas, result shapes, or runtime contracts

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable; no registry or public contract change
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable; no tool or schema change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable; no runtime/plugin change
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable; no agent-facing contract change

Notes/evidence:

- `bunx tsc --noEmit` — passed
- `bun test scripts/langfuse-trace.test.ts` — 18 passed, 0 failed
- `bun test` — 3312 passed, 509 skipped, 0 failed across 240 files
- Pre-push reran typecheck and the full Bun suite with the same green result
- Exit mapping mutation proof: changed the inconclusive mapping from 2 to 0 and ran only `maps comparison outcomes to isolated exit codes`; it failed with expected `[0,1,2]` / received `[0,1,0]`, then passed after byte-for-byte behavior restoration
- CLI boundary tests prove differing traces exit 1 and an invalid HTTP 200 Langfuse body exits 2
- Original live repeat session `4d994277-5bf6-4471-a0bb-c246e892b3fa` produced traces `082b2c754bfa47669a83b4c280ed18ad` and `0d0ec2fae0068798538fec238149ecd5`

