### PR TITLE
fix(search): restore full retrieval evidence and remediate transcript dumps

### DIFF
--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -1017,11 +1017,11 @@ Verbatim, from the source:
 **Severity:** HIGH
 **Source:** PR #599 review swarm, finding H2 (measured: 47.6 MB / 528 ms on one traced search)
 **Scope key:** `review.evidence_payload_bounded_and_deduplicated`
-**Status:** active
+**Status:** superseded by issue #604 operator ruling (2026-08-06)
 
 ### Pattern
 
-`content_preview` in this repo is defined as the FULL `t.content` (src/tools/table-constants.ts) — the name promises a bound the projection does not have. Evidence/observability payloads that embed row content must (1) apply a real character bound at the projection, (2) not re-serialize the same rows into multiple spans of one call (query output + rank input + rank output + execute output was 4-5 copies), and (3) bound total payload with an explicit degradation recorded in the emitted record. Also check WHERE masking runs: synchronous masking on the tool's own path multiplies per-string regex cost by payload size, and per-string `new RegExp` compilation belongs at module scope. Measure worst-case with the live corpus (max content size × caller-controlled limit × fetch multiplier), not the happy path.
+`content_preview` in this repo is defined as the FULL `t.content` (src/tools/table-constants.ts). PR #599 initially responded to the measured transcript-dump payload by slicing every evidence row to 300 characters. Issue #604 reversed that remedy at the owning boundary: healthy retrieval evidence flows in full after masking; rank input stays ids/counts-only so rows are not serialized redundantly; the whole-call byte guard remains only as an emergency circuit breaker for pathological corpus rows; and the four raw-JSONL transcript dumps were decomposed and archived through the normal lifecycle. Do not reintroduce routine per-row shortening. Review the corpus shape first, preserve full evidence, deduplicate repeated span payloads, and keep detector compilation at module scope.
 
 ## [2026-08-06] Chosen-vs-filtered evidence keyed on a collapsing identity reports dropped rows as chosen
 

--- a/scripts/decompose-oversize-thoughts.test.ts
+++ b/scripts/decompose-oversize-thoughts.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildTargetPlan,
+  isRawTranscriptDump,
+  REMEDIATION_VERSION,
+} from "./decompose-oversize-thoughts.ts";
+
+function transcript(records: number, messageChars = 20): string {
+  return Array.from({ length: records }, (_, index) =>
+    JSON.stringify({
+      type: index % 2 === 0 ? "user" : "assistant",
+      uuid: `turn-${index}`,
+      sessionId: "session-604",
+      message: { role: "user", content: "x".repeat(messageChars) },
+    }),
+  ).join("\n");
+}
+
+describe("decompose-oversize-thoughts", () => {
+  test("recognizes the raw Claude transcript JSONL class", () => {
+    expect(isRawTranscriptDump(transcript(120))).toEqual({
+      matched: true,
+      recordCount: 120,
+    });
+  });
+
+  test("rejects prose, short JSONL, and malformed transcript rows", () => {
+    expect(isRawTranscriptDump("ordinary thought prose").matched).toBe(false);
+    expect(isRawTranscriptDump(transcript(10)).matched).toBe(false);
+    expect(
+      isRawTranscriptDump(`${transcript(120)}\nnot-json`).matched,
+    ).toBe(false);
+  });
+
+  test("plans linked pieces through the existing decomposition chunker", () => {
+    const content = transcript(120, 100);
+    const plan = buildTargetPlan({
+      id: "00000000-0000-4000-8000-000000000604",
+      content,
+      tags: ["planning"],
+      source: "planning-skippy-agentspace",
+      created_by: "skippy",
+      namespace: "rico",
+      tier: "warm",
+      created_at: "2026-03-17T00:00:00Z",
+      archived_at: null,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.decomposition.would_write).toBeGreaterThan(1);
+    expect(plan?.decomposition.source_ref.id).toBe(
+      "00000000-0000-4000-8000-000000000604",
+    );
+    expect(
+      plan?.decomposition.proposed_replacements.every(
+        (proposal) =>
+          proposal.provenance.source === "dreamengine-decomposition" &&
+          proposal.source_ref.id === plan.decomposition.source_ref.id,
+      ),
+    ).toBe(true);
+    expect(REMEDIATION_VERSION).toBe("issue-604-v1");
+  });
+});

--- a/scripts/decompose-oversize-thoughts.ts
+++ b/scripts/decompose-oversize-thoughts.ts
@@ -1,0 +1,385 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from "node:util";
+import { Pool, type PoolClient } from "pg";
+import { contentHash } from "../src/embedding.ts";
+import {
+  planEntryDecomposition,
+  type DecompositionPlan,
+  type ReplacementProposal,
+} from "../src/decomposition.ts";
+
+export const REMEDIATION_VERSION = "issue-604-v1";
+const TARGET_SOURCE = "planning-skippy-agentspace";
+const PIECE_SOURCE = "issue-604-transcript-decomposition";
+const REMEDIATION_ACTOR = "issue-604-remediation";
+const MIN_TRANSCRIPT_RECORDS = 100;
+const REQUIRED_RECORD_FIELDS = ["type", "uuid", "sessionId"] as const;
+
+type ThoughtRow = {
+  id: string;
+  content: string;
+  tags: string[] | null;
+  source: string | null;
+  created_by: string | null;
+  namespace: string;
+  tier: string | null;
+  created_at: Date | string;
+  archived_at: Date | string | null;
+};
+
+type TargetPlan = {
+  row: ThoughtRow;
+  recordCount: number;
+  decomposition: DecompositionPlan;
+};
+
+type AppliedTarget = {
+  original_id: string;
+  namespace: string;
+  original_bytes: number;
+  record_count: number;
+  planned_pieces: number;
+  written_ids: string[];
+  reused_ids: string[];
+  piece_ids: string[];
+  archived: boolean;
+  discard_recorded: boolean;
+  embedding_status: "pending";
+};
+
+type SourceReference = {
+  source_type: "document";
+  document_id: string;
+  title: string;
+  section: string;
+  source_hash: string;
+};
+
+export function isRawTranscriptDump(content: string): {
+  matched: boolean;
+  recordCount: number;
+} {
+  const lines = content.split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length < MIN_TRANSCRIPT_RECORDS) {
+    return { matched: false, recordCount: lines.length };
+  }
+
+  let signatureMatches = 0;
+  for (const line of lines) {
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      return { matched: false, recordCount: lines.length };
+    }
+    if (!isObjectRecord(record)) return { matched: false, recordCount: lines.length };
+    const hasSignature = REQUIRED_RECORD_FIELDS.every(
+      (field) => typeof record[field] === "string",
+    );
+    if (hasSignature) signatureMatches++;
+  }
+
+  return {
+    matched: signatureMatches >= Math.ceil(lines.length * 0.8),
+    recordCount: lines.length,
+  };
+}
+
+export function buildTargetPlan(row: ThoughtRow): TargetPlan | null {
+  if (row.source !== TARGET_SOURCE || row.archived_at !== null) return null;
+  const classification = isRawTranscriptDump(row.content);
+  if (!classification.matched) return null;
+  const decomposition = planEntryDecomposition({
+    table: "thoughts",
+    id: row.id,
+    namespace: row.namespace,
+    content: row.content,
+  });
+  if (!decomposition.oversized) return null;
+  return { row, recordCount: classification.recordCount, decomposition };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readTargets(pool: Pool): Promise<TargetPlan[]> {
+  const { rows } = await pool.query<ThoughtRow>(
+    `SELECT id, content, tags, source, created_by, namespace, tier, created_at, archived_at
+       FROM thoughts
+      WHERE source = $1
+        AND archived_at IS NULL
+        AND parent_id IS NULL
+      ORDER BY created_at, id`,
+    [TARGET_SOURCE],
+  );
+  return rows.flatMap((row) => {
+    const plan = buildTargetPlan(row);
+    return plan ? [plan] : [];
+  });
+}
+
+function sourceReference(
+  target: TargetPlan,
+  proposal: ReplacementProposal,
+): SourceReference {
+  return {
+    source_type: "document",
+    document_id: target.row.id,
+    title: `Archived Claude Code transcript dump ${target.row.id}`,
+    section: `chunk:${proposal.chunk_index}`,
+    source_hash: contentHash(target.row.content),
+  };
+}
+
+function promotedFrom(
+  target: TargetPlan,
+  proposal: ReplacementProposal,
+): Record<string, unknown> {
+  return {
+    source: PIECE_SOURCE,
+    remediation_version: REMEDIATION_VERSION,
+    source_table: "thoughts",
+    source_id: target.row.id,
+    source_namespace: target.row.namespace,
+    chunk_index: proposal.chunk_index,
+  };
+}
+
+function pieceTags(target: TargetPlan): string[] {
+  return Array.from(
+    new Set([
+      ...(target.row.tags ?? []),
+      "issue-604-decomposition",
+      "claude-code-transcript",
+    ]),
+  );
+}
+
+async function appendSourceReference(
+  client: PoolClient,
+  id: string,
+  reference: SourceReference,
+  provenance: Record<string, unknown>,
+): Promise<void> {
+  await client.query(
+    `UPDATE thoughts
+        SET source_refs = CASE
+              WHEN EXISTS (
+                SELECT 1
+                  FROM jsonb_array_elements(COALESCE(source_refs, '[]'::jsonb)) AS ref(value)
+                 WHERE ref.value->>'document_id' = $3
+                   AND ref.value->>'section' = $4
+              ) THEN COALESCE(source_refs, '[]'::jsonb)
+              ELSE COALESCE(source_refs, '[]'::jsonb) || $2::jsonb
+            END,
+            promoted_from = COALESCE(promoted_from, $5::jsonb)
+      WHERE id = $1`,
+    [
+      id,
+      JSON.stringify([reference]),
+      reference.document_id,
+      reference.section,
+      JSON.stringify(provenance),
+    ],
+  );
+}
+
+async function writeProposal(
+  client: PoolClient,
+  target: TargetPlan,
+  proposal: ReplacementProposal,
+): Promise<{ id: string; written: boolean }> {
+  const hash = contentHash(proposal.content);
+  const reference = sourceReference(target, proposal);
+  const provenance = promotedFrom(target, proposal);
+  const { rows } = await client.query<{ id: string }>(
+    `INSERT INTO thoughts
+       (content, tags, source, created_by, namespace, embedding, content_hash,
+        embedded_at, embedding_model, promoted_from, source_refs, parent_id,
+        chunk_index, tier)
+     VALUES ($1, $2, $3, $4, $5, NULL, $6, NULL, NULL, $7::jsonb, $8::jsonb,
+             $9, $10, $11)
+     ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
+     DO NOTHING
+     RETURNING id`,
+    [
+      proposal.content,
+      pieceTags(target),
+      PIECE_SOURCE,
+      REMEDIATION_ACTOR,
+      target.row.namespace,
+      hash,
+      JSON.stringify(provenance),
+      JSON.stringify([reference]),
+      target.row.id,
+      proposal.chunk_index,
+      target.row.tier ?? "warm",
+    ],
+  );
+  const insertedId = rows[0]?.id;
+  if (insertedId) return { id: insertedId, written: true };
+
+  const existing = await client.query<{ id: string }>(
+    `SELECT id
+       FROM thoughts
+      WHERE content_hash = $1
+        AND namespace = $2
+        AND archived_at IS NULL`,
+    [hash, target.row.namespace],
+  );
+  const existingId = existing.rows[0]?.id;
+  if (!existingId) throw new Error("piece conflict resolved without a live row");
+  await appendSourceReference(client, existingId, reference, provenance);
+  return { id: existingId, written: false };
+}
+
+async function writePieces(
+  client: PoolClient,
+  target: TargetPlan,
+): Promise<{ writtenIds: string[]; reusedIds: string[]; pieceIds: string[] }> {
+  const writtenIds: string[] = [];
+  const reusedIds: string[] = [];
+  const pieceIds: string[] = [];
+  for (const proposal of target.decomposition.proposed_replacements) {
+    const result = await writeProposal(client, target, proposal);
+    pieceIds.push(result.id);
+    if (result.written) writtenIds.push(result.id);
+    else reusedIds.push(result.id);
+  }
+  return { writtenIds, reusedIds, pieceIds };
+}
+
+async function archiveOriginal(
+  client: PoolClient,
+  target: TargetPlan,
+  replacementId: string,
+): Promise<{ archived: boolean; discardRecorded: boolean }> {
+  const discard = await client.query(
+    `INSERT INTO discarded_entries
+       (original_id, source_table, original_content, tags, namespace,
+        tier_at_discard, access_summary, reason, expires_at, consolidated_into)
+     VALUES ($1, 'thoughts', $2, $3, $4, $5, $6::jsonb, 'manual', NULL, $7)`,
+    [
+      target.row.id,
+      target.row.content,
+      target.row.tags ?? [],
+      target.row.namespace,
+      target.row.tier,
+      JSON.stringify({
+        remediation_version: REMEDIATION_VERSION,
+        replacement_count: target.decomposition.would_write,
+      }),
+      replacementId,
+    ],
+  );
+  const archived = await client.query(
+    `UPDATE thoughts
+        SET archived_at = NOW()
+      WHERE id = $1
+        AND archived_at IS NULL`,
+    [target.row.id],
+  );
+  return {
+    archived: archived.rowCount === 1,
+    discardRecorded: discard.rowCount === 1,
+  };
+}
+
+async function applyTargets(pool: Pool, targets: TargetPlan[]): Promise<AppliedTarget[]> {
+  const client = await pool.connect();
+  const applied: AppliedTarget[] = [];
+  try {
+    await client.query("BEGIN");
+    for (const target of targets) {
+      const pieces = await writePieces(client, target);
+      const replacementId = pieces.pieceIds[0];
+      if (!replacementId) throw new Error("oversized transcript produced no pieces");
+      const lifecycle = await archiveOriginal(client, target, replacementId);
+      if (!lifecycle.archived || !lifecycle.discardRecorded) {
+        throw new Error("original lifecycle transition did not complete");
+      }
+      applied.push({
+        original_id: target.row.id,
+        namespace: target.row.namespace,
+        original_bytes: Buffer.byteLength(target.row.content, "utf8"),
+        record_count: target.recordCount,
+        planned_pieces: target.decomposition.would_write,
+        written_ids: pieces.writtenIds,
+        reused_ids: pieces.reusedIds,
+        piece_ids: pieces.pieceIds,
+        archived: lifecycle.archived,
+        discard_recorded: lifecycle.discardRecorded,
+        embedding_status: "pending",
+      });
+    }
+    await client.query("COMMIT");
+    return applied;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function dryRunReceipt(targets: TargetPlan[]): Record<string, unknown> {
+  return {
+    remediation_version: REMEDIATION_VERSION,
+    mode: "dry-run",
+    matched_originals: targets.length,
+    total_original_bytes: targets.reduce(
+      (sum, target) => sum + Buffer.byteLength(target.row.content, "utf8"),
+      0,
+    ),
+    total_planned_pieces: targets.reduce(
+      (sum, target) => sum + target.decomposition.would_write,
+      0,
+    ),
+    originals: targets.map((target) => ({
+      id: target.row.id,
+      namespace: target.row.namespace,
+      bytes: Buffer.byteLength(target.row.content, "utf8"),
+      records: target.recordCount,
+      planned_pieces: target.decomposition.would_write,
+      largest_piece_chars: Math.max(
+        ...target.decomposition.proposed_replacements.map(
+          (proposal) => proposal.content_length,
+        ),
+      ),
+      lifecycle: "copy to discarded_entries, then set thoughts.archived_at",
+      embeddings: "new rows are written pending embedding repair",
+    })),
+  };
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: { apply: { type: "boolean", default: false } },
+    strict: true,
+  });
+  const pool = new Pool();
+  try {
+    const targets = await readTargets(pool);
+    const receipt = values.apply
+      ? {
+          remediation_version: REMEDIATION_VERSION,
+          mode: "apply",
+          matched_originals: targets.length,
+          originals: await applyTargets(pool, targets),
+        }
+      : dryRunReceipt(targets);
+    process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+  } finally {
+    await pool.end();
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    const name = error instanceof Error ? error.name : "unknown";
+    process.stderr.write(`decompose-oversize-thoughts failed: ${name}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -42,7 +42,10 @@ import {
   type SearchRow,
 } from "../../src/tools/search-brain.ts";
 import { registerSearchAll } from "../../src/tools/search-all.ts";
-import { mergeFallbackRows } from "../tools/search-engine.ts";
+import {
+  executeSearch as executeServerSearch,
+  mergeFallbackRows,
+} from "../tools/search-engine.ts";
 
 const ENABLED_CONFIG: McpTracingConfig = {
   enabled: true,
@@ -470,14 +473,16 @@ describe("installMcpTracing", () => {
     expect(serialized).toContain("[MASKED:");
   });
 
-  test("a real registered src search emits its full retrieval stage list", async () => {
+  test("a real registered src search emits full masked retrieval evidence", async () => {
     const sink = recordingSink();
     const { server, handlers } = fakeServer();
     installMcpTracing(server, {
       config: ENABLED_CONFIG,
       createSink: () => sink,
     });
-    const longContent = "x".repeat(1_000);
+    const tail = "FULL_CONTENT_TAIL";
+    const secret = "sk-live-evidence-secret";
+    const longContent = `${"x".repeat(1_000)} api_key=${secret} ${tail}`;
     const pool = {
       query: async (sql: string) => {
         if (sql.includes("FROM ob_links")) return { rows: [] };
@@ -507,17 +512,73 @@ describe("installMcpTracing", () => {
       "retrieval.keyword_query",
       "retrieval.execute",
     ]);
-    const serialized = JSON.stringify(body.spans);
-    expect(serialized).not.toContain(longContent);
-    expect(
-      (
-        (
-          body.spans?.[0]?.output as {
-            candidates: Array<{ content_preview: string }>;
-          }
-        ).candidates[0]?.content_preview ?? ""
-      ).length,
-    ).toBe(300);
+    const evidence = (
+      body.spans?.[0]?.output as {
+        candidates: Array<{ content_preview: string }>;
+      }
+    ).candidates[0]?.content_preview;
+    expect(evidence).toContain(tail);
+    expect(evidence).toContain("[MASKED:");
+    expect(evidence).not.toContain(secret);
+  });
+
+  test("the server search tree emits full masked retrieval evidence", async () => {
+    const sink = recordingSink();
+    const { server, handlers } = fakeServer();
+    installMcpTracing(server, {
+      config: ENABLED_CONFIG,
+      createSink: () => sink,
+    });
+    const tail = "SERVER_FULL_CONTENT_TAIL";
+    const secret = "sk-live-server-evidence-secret";
+    const longContent = `${"y".repeat(1_000)} api_key=${secret} ${tail}`;
+    const pool = {
+      query: async () => ({
+        rows: [searchRow("server-search-row", longContent)],
+      }),
+    };
+    server.registerTool(
+      "server_search_evidence",
+      { inputSchema: {} } as never,
+      (async () => {
+        await executeServerSearch(
+          {
+            pool: pool as never,
+            embedFn: async () => Array(768).fill(0.1),
+            logger: {
+              warn() {},
+              error() {},
+              info() {},
+              debug() {},
+            } as never,
+          },
+          ["thoughts"],
+          "real retrieval",
+          1,
+          "keyword",
+          undefined,
+          0,
+          "rico",
+        );
+        return { content: [{ type: "text", text: "ok" }] };
+      }) as never,
+    );
+
+    await handlers.get("server_search_evidence")?.({}, AUTH);
+
+    const body = sink.bodies[0]!;
+    expect(body.spans?.map((span) => span.name)).toEqual([
+      "retrieval.keyword_query",
+      "retrieval.execute",
+    ]);
+    const evidence = (
+      body.spans?.[0]?.output as {
+        candidates: Array<{ content_preview: string }>;
+      }
+    ).candidates[0]?.content_preview;
+    expect(evidence).toContain(tail);
+    expect(evidence).toContain("[MASKED:");
+    expect(evidence).not.toContain(secret);
   });
 
   test("handler metadata cannot overwrite auth identity or exception status", async () => {

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -167,7 +167,11 @@ const DEFAULT_FLAP_COOLDOWN_MS = 30_000;
  */
 const SINK_HEALTH_PROBE_MS = 5_000;
 
-/** Maximum serialized child-span payload retained for one tool call. */
+/**
+ * Emergency circuit breaker for pathological payloads such as the issue #604
+ * transcript-dump class. Per the operator ruling, a healthy corpus must never
+ * reach this branch; ordinary retrieval evidence flows in full.
+ */
 export const MAX_ACTIVE_SPAN_BYTES = 256 * 1024;
 
 const COMPILED_SECRET_DETECTORS = SECRET_DETECTORS.map((detector) => ({

--- a/server/tools/search-engine.ts
+++ b/server/tools/search-engine.ts
@@ -120,7 +120,7 @@ function rowEvidence(row: SearchRow): Record<string, unknown> {
     row_id: row.id,
     source_type: row.source_type,
     namespace: row.namespace ?? null,
-    content_preview: row.content_preview?.slice(0, 300) ?? null,
+    content_preview: row.content_preview ?? null,
     distance: row.distance ?? null,
     similarity: row.distance === undefined ? null : 1 - row.distance,
     bm25_score: row.fts_rank ?? null,

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -282,7 +282,7 @@ function rowEvidence(row: SearchRow): Record<string, unknown> {
     row_id: row.id,
     source_type: row.source_type,
     namespace: row.namespace ?? null,
-    content_preview: row.content_preview?.slice(0, 300) ?? null,
+    content_preview: row.content_preview ?? null,
     distance: row.distance ?? null,
     similarity: row.distance === undefined ? null : 1 - row.distance,
     bm25_score: row.fts_rank ?? null,


### PR DESCRIPTION
Fixes #604

## Summary

- restore full masked retrieval evidence in both serving trees by removing the 300-character projection slice
- retain ids/counts-only rank input and keep `MAX_ACTIVE_SPAN_BYTES` as an emergency circuit breaker for pathological corpus rows
- add dry-run-first `scripts/decompose-oversize-thoughts.ts` and functional detector/planning coverage
- record the issue #604 operator ruling in the adversarial SME entry
- remediate the four live raw-JSONL transcript dumps and file #605 for the broader chunk-write caller gap

## Verification

- `bunx tsc --noEmit` — passed
- focused tests — 71 passed, 0 failed
- full `bun test` with `/Users/rico/.config/open-brain/env.release-test` sourced — 3,701 passed, 35 skipped, 0 failed across 241 files
- `OPENBRAIN_TEST_DATABASE_URL` was populated and the registered live-Postgres suites executed; the anti-skip audit found one separate skip: `local clone real PostgreSQL boundary (live Postgres)` because `OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL` is not present in the requested release-test environment
- mutation proof: restoring both old 300-character slices made both new full-evidence tests fail on the missing tail; restoring this patch made them pass
- live dogfood remediation and `search_brain` receipts: https://github.com/rodaddy/open-brain/issues/604#issuecomment-5208118786
- chunk-write investigation: https://github.com/rodaddy/open-brain/issues/604#issuecomment-5208132517

## Data Remediation

- dry-run plan posted before mutation: https://github.com/rodaddy/open-brain/issues/604#issuecomment-5208089983
- 4 active transcript-dump rows / 3,437,076 bytes became 0 active monster rows
- 1,218 active replacement rows now carry `parent_id`, `promoted_from`, and `source_refs`; all are keyword-searchable
- all 4 originals have `archived_at` set and complete reversible copies in `discarded_entries`
- replacement embeddings are pending repair; this PR does not claim vector readiness for those rows

## Downstream Rollout

Not applicable: no MCP tool name, schema, response shape, auth/namespace behavior, transport behavior, migration, Python client, generated skill, or Hermes-facing contract changes. The changed evidence projection is internal observability data.

## Critical Self-Review

- Highest-risk behavior: The remediation script performs a multi-row lifecycle transition against live data; it is dry-run by default and applies all four originals in one transaction before archiving them.
- Assumptions that could be wrong: The detector assumes the pathological class is valid JSONL with at least 100 records and transcript identity fields on at least 80% of records; live measurement showed all 1,073 records on each target carry those fields.
- Missing/weak tests: The script has functional detector/planning tests and a successful live apply receipt, but no isolated fault-injection test that throws midway through the 2,360 proposal loop and observes rollback.
- Security/permission risk: The script uses the operator-supplied database identity directly and emits IDs/counts only; no transcript bodies, tokens, or connection values were posted or committed.
- Migration/deploy risk: No schema migration is required; deploying the code does not rerun the already-completed remediation because the script is operator-invoked and dry-run-first.
- Downstream client/runtime risk: Public MCP results are unchanged; only masked tracing evidence regains full row content, while rank input remains ids/counts-only.
- Rollback/cleanup concern: Originals remain present with `archived_at` and are copied in full to `discarded_entries`; rollback would restore originals and archive the issue-604 pieces through normal lifecycle rather than hard-delete.
- Fixes made before PR: Corrected the live transcript detector after measuring message-field distribution, proved the new evidence tests fail against the old slice, updated stale SME guidance, and filed #605 instead of broadening this PR across unrelated writers.
- Known residual risk: The 1,218 replacement rows have pending embeddings, and server/REST/lane thought writers still bypass the shared chunk writer until #605 is resolved.
- SME review-memory update: [x] `docs/sme/` updated [ ] not applicable because: the issue #604 operator ruling supersedes PR #599 H2's routine per-row shortening recommendation.

## Review Gate

- [x] Critical self-review fields above are filled
- [ ] MEDIUM+ review findings were captured — controller owns this checkbox after fresh-context review
- Live Open Brain checks: [x] linked below [ ] not applicable because: dry-run, apply, database, provenance, and live `search_brain` receipts are linked in Verification and Data Remediation.
