### PR TITLE
fix(maintenance): enable the runner and give the sweep a producer (#384)

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1840,3 +1840,22 @@ A diff/comparison tool is an operator trust surface: what it prints is what the 
 ### Pattern
 
 A hand-written stub proves conformance to the stub, not to the external API. Langfuse detail responses return full observation objects, but list rows return observation ID strings; reusing the detail shape in list fixtures made every test pass while every live `session` and `repeat` call failed validation. For each external endpoint, capture and sanitize a real response, preserve its envelope and value types, and drive the public caller through that fixture. Do not reuse a sibling endpoint's richer response shape unless the live wire contract proves they are identical.
+
+## [2026-08-07] Starting a global producer makes other suites' leftover fixtures live
+
+**Severity:** MEDIUM
+**Source:** PR #609 CI failure (#384 maintenance producer), self-caught
+**Scope key:** `review.producer_activation_promotes_inert_fixtures`
+**Status:** active
+
+### Pattern
+
+Turning on a background PRODUCER changes the meaning of every row already in the test database. The maintenance sweep selects across ALL namespaces by design (`selectSourcesNeedingDerivation` receives `undefined` writable namespaces, because a server-owned sweep must serve every namespace), so a test that composes an autostarted runtime derives from every approved/active `ob_sources` row present — not only the one it seeded. Other suites leave such fixtures behind (`parity-source-registry-*`); on `main` they sit inert with zero `maintenance_jobs` because nothing was producing. The new test converted them into real queued `graph.derive` rows, and its namespace-scoped `DELETE` could not see them.
+
+The victim is a DIFFERENT suite: `026 maintenance queue > allows only one concurrent runner to claim a due job` races two claims and expects exactly one due job to exist ANYWHERE. `claimDueJobs` filters on `state`/`run_after` only — no namespace and no job-kind predicate — so any stray due row is claimable and both racers win one (`Expected: 1, Received: 2`).
+
+Guards, in order of importance:
+
+1. A test that starts a producer cleans up by the DIMENSION THE PRODUCER USES, not the dimension the test seeds. Namespace-scoped cleanup is wrong for a cross-namespace producer; delete by `job_kind` for every kind the sweep can emit.
+2. Stop the runtime BEFORE deleting, or a tick landing between the `DELETE` and the halt re-enqueues what was just removed.
+3. **Do not conclude "pre-existing" from a single-file run.** This failure passes when its file runs alone and only appears after the full suite, because the defect is ordering-dependent leakage. The claim was made once on this branch and was wrong. The proof that actually settles it is the FULL suite run against clean `origin/main` in a separate worktree and a separate freshly-created database, compared against the same run on the branch — here, main 3701/0 versus branch 3701/1.

--- a/scripts/done-means/384-maintenance-loop-turns.sh
+++ b/scripts/done-means/384-maintenance-loop-turns.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #384 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/384-maintenance-loop-turns.sh
+#
+# Issue #384 acceptance, verbatim:
+#   - Runner enabled and observed processing jobs on the local clone.
+#   - Sweep enqueues work without operator action.
+#   - Caps are enforced and logged; no silent truncation.
+#   - Fix or retire the dead-lettered canary job.
+#
+# This drives the LIVE local dogfood service and the LIVE dogfood database.
+# It is deliberately NOT a unit test: #384's whole defect class is code that
+# exists, typechecks, and has passing unit tests while the running server does
+# not execute it. A test that imports runMaintenanceSweep() and calls it proves
+# the function works; it cannot distinguish that from a server that never calls
+# it. So the observation point here is the database and the service's own log.
+#
+# core01/hosted is NOT touched. Two-host rule: this lane is the local half.
+#
+# Output is content-free: states, kinds, counts, and a random run marker only.
+#
+# EXPECTED TO FAIL until #384 is fixed. It is the reward function, not a test
+# of the fix author's diligence.
+#
+# ---------------------------------------------------------------------------
+# What is actually broken, measured 2026-08-07 before any fix
+# ---------------------------------------------------------------------------
+# The issue text says the runner is off via OPEN_BRAIN_MAINTENANCE_ENABLED=0.
+# That is stale. Measured against the live box:
+#
+#   - /Volumes/ThunderBolt/open-brain-local/local-clone.env:12 sets
+#     OPEN_BRAIN_MAINTENANCE_ENABLED=1, and the serving process (pid 13501,
+#     `ps eww`) carries =1 in its environment. The runner is ENABLED.
+#   - PR #577 already landed the sweep producer: src/maintenance-sweep.ts
+#     exists and src/maintenance-bootstrap.ts:335 starts it.
+#
+# And yet zero sweep-produced jobs exist and the service logs no sweep line.
+# The reason is an entrypoint split:
+#
+#   - src/maintenance-bootstrap.ts:300 startMaintenanceQueue() composes the
+#     runner AND startRecurringMaintenanceSweep() (:335). It is reached only
+#     from src/index.ts, the LEGACY entrypoint.
+#   - server/maintenance/index.ts:141 createMaintenanceRuntime() composes the
+#     runner ONLY. It has no sweep, and `rg runMaintenanceSweep server/`
+#     returns nothing.
+#   - The Phase 6 cutover made server/main.ts the serving entrypoint
+#     (scripts/local-clone-autostart.sh:66-70 says so in as many words), and
+#     server/main.ts:308 wires composeMaintenanceHandlers into
+#     createMaintenanceRuntime.
+#
+# So the serving process runs the consumer half and none of the producer half.
+# That is the exact shape #384 names — "both handlers are consumers with no
+# producer" — surviving the very PR that was supposed to close it, because the
+# producer was added to the entrypoint that stopped serving.
+#
+# The pre-fix log signature is unambiguous: 319 "maintenance queue idle" lines
+# and 11 "maintenance queue started" lines in autostart.out.log, and zero
+# "maintenance_sweep_complete". The runner polls forever over a queue nothing
+# fills.
+#
+# ---------------------------------------------------------------------------
+# Isolation, and why this check seeds a source
+# ---------------------------------------------------------------------------
+# Maintenance jobs are server-owned; this check must not fabricate a job and
+# call the loop proven. It therefore proves the loop by PRODUCING REAL INPUT
+# and letting the server decide what to do with it:
+#
+#   It inserts one ob_sources row — approved, active, real 64-hex content_hash,
+#   in a throwaway namespace — which is precisely the condition
+#   selectSourcesNeedingDerivation (src/graph-derivation-handler.ts:136-154)
+#   selects on. It then enqueues NOTHING. If a sweep is running in the serving
+#   process, it will find that source on its own and enqueue a graph.derive.
+#   If no sweep runs, nothing appears, which is today's state.
+#
+# Every row this check creates is tagged with a done-means run marker and is
+# removed in the trap on every exit path.
+#
+# DreamEngine dry-run defaults are not touched: this seeds a source row and
+# reads the queue. It invokes no dream planning and no promote/archive/demote.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+MARKER="done-means-384-$(date +%s)-$$"
+NS="done-means-384"
+HEALTH_URL="${OPEN_BRAIN_HEALTH_URL:-http://127.0.0.1:3100/health}"
+# Sweep and runner both tick on OPEN_BRAIN_MAINTENANCE_POLL_MS (default 5000,
+# src/maintenance-bootstrap.ts:320). Allow several ticks plus handler time.
+WAIT_SECONDS="${DONE_MEANS_384_WAIT_SECONDS:-90}"
+
+FAILURES=0
+fail() { printf 'FAIL  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'PASS  %s\n' "$*"; }
+info() { printf 'INFO  %s\n' "$*"; }
+
+# `.env` is untracked, so it is absent from a fresh worktree. Fall back to the
+# canonical checkout's copy: the dogfood database is a property of the machine,
+# not of which worktree you happen to be standing in.
+ENV_FILE=".env"
+if [[ ! -f "${ENV_FILE}" ]]; then
+  ENV_FILE="${DONE_MEANS_384_ENV_FILE:-/Volumes/ThunderBolt/Development/open-brain/.env}"
+fi
+if [[ ! -f "${ENV_FILE}" ]]; then
+  printf 'FAIL  no .env found (looked in %s and %s); cannot reach the dogfood database\n' \
+    "${REPO_ROOT}" "${ENV_FILE}"
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1091
+. "${ENV_FILE}"
+set +a
+
+q() { psql -At -c "$1"; }
+
+cleanup() {
+  psql -q -c "DELETE FROM maintenance_jobs WHERE namespace = '${NS}' OR idempotency_key LIKE '%${MARKER}%';" >/dev/null 2>&1
+  psql -q -c "DELETE FROM ob_entities WHERE namespace = '${NS}';" >/dev/null 2>&1
+  psql -q -c "DELETE FROM ob_sources WHERE namespace = '${NS}';" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+printf '=== done-means #384: does the maintenance loop turn? ===\n'
+printf 'run marker: %s\n\n' "${MARKER}"
+
+# ---------------------------------------------------------------------------
+# (a) Runner enabled AND running.
+# ---------------------------------------------------------------------------
+# Two separate facts. "Enabled" is config; "running" is a live process serving.
+# Checking only the env var is how this defect hid: the var has said 1 for days.
+HEALTH="$(curl -s -m 5 "${HEALTH_URL}" 2>/dev/null)"
+if [[ -z "${HEALTH}" ]]; then
+  fail "(a) no response from ${HEALTH_URL}; local service is not serving"
+else
+  HEALTH_STATUS="$(printf '%s' "${HEALTH}" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')"
+  if [[ "${HEALTH_STATUS}" == "healthy" ]]; then
+    pass "(a1) local service serving, status=healthy"
+  else
+    fail "(a1) local service status=${HEALTH_STATUS:-unparseable}"
+  fi
+fi
+
+SERVER_PID="$(lsof -nP -iTCP:3100 -sTCP:LISTEN -t 2>/dev/null | head -1)"
+if [[ -z "${SERVER_PID}" ]]; then
+  fail "(a2) nothing is listening on 3100"
+else
+  PROC_ENV="$(ps eww -p "${SERVER_PID}" 2>/dev/null | tr ' ' '\n')"
+  ENABLED_VAL="$(printf '%s' "${PROC_ENV}" \
+    | sed -n 's/^OPEN_BRAIN_MAINTENANCE_ENABLED=\(.*\)$/\1/p' | head -1)"
+  # Opt-out semantics (src/maintenance-bootstrap.ts:236-241,
+  # server/config/maintenance.ts:57): anything except 0/false is enabled,
+  # including unset.
+  case "$(printf '%s' "${ENABLED_VAL}" | tr '[:upper:]' '[:lower:]')" in
+    0|false) fail "(a2) serving pid ${SERVER_PID} has maintenance DISABLED (=${ENABLED_VAL})" ;;
+    *) pass "(a2) serving pid ${SERVER_PID} has maintenance enabled (=${ENABLED_VAL:-unset})" ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# (d) The dead-lettered canary is fixed or explicitly retired.
+# ---------------------------------------------------------------------------
+# Checked BEFORE the seed so the seeded work cannot mask it. "Retired" means
+# the row is gone or no longer sitting in dead_letter; a canary that still
+# dead-letters is an unresolved job the operator is expected to ignore, which
+# is exactly the numbness #384 is about.
+CANARY_STATE="$(q "SELECT state FROM maintenance_jobs WHERE idempotency_key LIKE 'canary:%';" 2>/dev/null)"
+if [[ -z "${CANARY_STATE}" ]]; then
+  pass "(d) no canary row remains (retired)"
+elif [[ "${CANARY_STATE}" == *dead_letter* ]]; then
+  fail "(d) canary still dead-lettered (state=${CANARY_STATE})"
+else
+  pass "(d) canary present but not dead-lettered (state=${CANARY_STATE})"
+fi
+
+# ---------------------------------------------------------------------------
+# Seed one real derivable source. Enqueue nothing.
+# ---------------------------------------------------------------------------
+SEED_HASH="$(printf '%s' "${MARKER}" | shasum -a 256 | cut -d' ' -f1)"
+if ! psql -q -c "INSERT INTO ob_sources
+     (namespace, source_kind, external_id, title, approval_state, approved_by,
+      approved_at, lifecycle_state, content_hash, created_by)
+   VALUES
+     ('${NS}', 'drop', '${MARKER}', 'done-means 384 probe', 'approved',
+      'done-means-384', now(), 'active', '${SEED_HASH}', 'done-means-384');" 2>&1
+then
+  fail "could not seed probe source; cannot test the producer (error above)"
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+info "seeded 1 approved/active source in namespace ${NS}; enqueued nothing"
+
+BASELINE_JOBS="$(q "SELECT count(*) FROM maintenance_jobs;")"
+info "baseline maintenance_jobs rows: ${BASELINE_JOBS}"
+
+# ---------------------------------------------------------------------------
+# (b) The sweep enqueues real work, with no operator action.
+# (c) At least one job reaches terminal SUCCESS.
+# ---------------------------------------------------------------------------
+info "waiting up to ${WAIT_SECONDS}s for the server's own sweep to act..."
+PROBE_JOB_STATE=""
+DEADLINE=$(( $(date +%s) + WAIT_SECONDS ))
+while [[ $(date +%s) -lt ${DEADLINE} ]]; do
+  PROBE_JOB_STATE="$(q "SELECT state FROM maintenance_jobs WHERE namespace = '${NS}' ORDER BY created_at DESC LIMIT 1;" 2>/dev/null)"
+  [[ "${PROBE_JOB_STATE}" == "succeeded" ]] && break
+  sleep 3
+done
+
+if [[ -z "${PROBE_JOB_STATE}" ]]; then
+  fail "(b) no job was enqueued for the seeded source within ${WAIT_SECONDS}s — the producer is not running in the serving process"
+else
+  pass "(b) sweep enqueued a job for the seeded source with no operator action"
+fi
+
+if [[ "${PROBE_JOB_STATE}" == "succeeded" ]]; then
+  pass "(c) job reached terminal SUCCESS (state=succeeded)"
+else
+  fail "(c) no job reached terminal success (last observed state=${PROBE_JOB_STATE:-none})"
+fi
+
+printf '\n--- observed queue state (namespace %s) ---\n' "${NS}"
+psql -c "SELECT job_kind, state, attempts, last_error_category
+           FROM maintenance_jobs WHERE namespace = '${NS}';" 2>&1 || true
+
+printf '\n'
+if [[ ${FAILURES} -eq 0 ]]; then
+  printf '=== RESULT: PASS — the maintenance loop turns ===\n'
+  exit 0
+fi
+printf '=== RESULT: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+exit 1

--- a/scripts/retire-maintenance-canary.ts
+++ b/scripts/retire-maintenance-canary.ts
@@ -1,0 +1,116 @@
+/**
+ * Retire the dead-lettered `graph.derive` canary job (#384 scope item 1).
+ *
+ *   bun run scripts/retire-maintenance-canary.ts          # report only
+ *   bun run scripts/retire-maintenance-canary.ts --apply  # delete the rows
+ *
+ * WHY RETIRE RATHER THAN FIX. The canary was hand-enqueued with an empty `{}`
+ * payload. `graph.derive`'s contract makes a malformed payload TERMINAL rather
+ * than retryable (src/graph-derivation-handler.ts:359), and deliberately so: a
+ * payload that cannot be parsed will not parse on the fourth attempt either.
+ * `{}` carries no source id, no namespace, and no content hash, so there is no
+ * source for the handler to derive and nothing to repair the row INTO. It is
+ * not a job that failed; it is a job that was never runnable. The sweep now
+ * produces real `graph.derive` jobs from `ob_sources`, which is what the canary
+ * was standing in for.
+ *
+ * WHY THIS IS NOT A MIGRATION. It deletes an operational queue row, not schema
+ * or durable memory. Migrations run everywhere and forever; this is a one-time
+ * cleanup of one box's queue, and the row's absence on a fresh database is the
+ * correct state rather than a migration to replay.
+ *
+ * SCOPE. Only rows whose `idempotency_key` starts with `canary:` AND which are
+ * in `dead_letter` are eligible. A canary that is queued, running, or succeeded
+ * is left alone and reported: this script retires abandoned work, and deciding
+ * that a live job is abandoned is not its call. Dry-run is the default, so
+ * running it with no flag can only print.
+ *
+ * DreamEngine is untouched: this reads and deletes maintenance queue rows only.
+ * No promote, demote, archive, or tier mutation, and no dream planning path.
+ */
+import pg from "pg";
+
+const CANARY_KEY_PREFIX = "canary:";
+
+interface CanaryRow {
+  id: string;
+  job_kind: string;
+  state: string;
+  attempts: number;
+  idempotency_key: string;
+  last_error_category: string | null;
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes("--apply");
+
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST ?? process.env.PGHOST ?? "127.0.0.1",
+    port: Number.parseInt(
+      process.env.DB_PORT ?? process.env.PGPORT ?? "5432",
+      10,
+    ),
+    database: process.env.DB_NAME ?? process.env.PGDATABASE,
+    user: process.env.DB_USER ?? process.env.PGUSER,
+    ...(process.env.DB_PASSWORD ? { password: process.env.DB_PASSWORD } : {}),
+  });
+
+  try {
+    const { rows } = await pool.query<CanaryRow>(
+      `SELECT id, job_kind, state, attempts, idempotency_key,
+              last_error_category
+         FROM maintenance_jobs
+        WHERE idempotency_key LIKE $1
+        ORDER BY created_at`,
+      [`${CANARY_KEY_PREFIX}%`],
+    );
+
+    if (rows.length === 0) {
+      console.log("no canary jobs found; nothing to retire");
+      return;
+    }
+
+    // Content-free reporting: kinds, states, counts, and the key. The key is an
+    // operator-authored label, never payload content.
+    for (const row of rows) {
+      console.log(
+        `${row.idempotency_key}  kind=${row.job_kind} state=${row.state} ` +
+          `attempts=${row.attempts} category=${row.last_error_category ?? "-"}`,
+      );
+    }
+
+    const retirable = rows.filter((row) => row.state === "dead_letter");
+    const live = rows.filter((row) => row.state !== "dead_letter");
+    for (const row of live) {
+      console.log(
+        `SKIP ${row.idempotency_key}: state=${row.state} is not dead_letter; ` +
+          `not this script's call to retire`,
+      );
+    }
+
+    if (retirable.length === 0) {
+      console.log("no dead-lettered canary jobs; nothing to retire");
+      return;
+    }
+
+    if (!apply) {
+      console.log(
+        `\nDRY RUN: ${retirable.length} dead-lettered canary job(s) would be ` +
+          `deleted. Re-run with --apply to retire them.`,
+      );
+      return;
+    }
+
+    const { rowCount } = await pool.query(
+      `DELETE FROM maintenance_jobs
+        WHERE idempotency_key LIKE $1
+          AND state = 'dead_letter'`,
+      [`${CANARY_KEY_PREFIX}%`],
+    );
+    console.log(`\nretired ${rowCount ?? 0} dead-lettered canary job(s)`);
+  } finally {
+    await pool.end();
+  }
+}
+
+await main();

--- a/server/config/maintenance.ts
+++ b/server/config/maintenance.ts
@@ -33,6 +33,15 @@ export interface MaintenanceConfig {
   readonly concurrency?: number;
   readonly pollIntervalMs?: number;
   readonly leaseMs?: number;
+  /**
+   * Producer bounds (#384). Absent means "the sweep's own default", for the
+   * same single-owner reason as the runner knobs above: `maintenance-sweep.ts`
+   * clamps every one of these to its own safe maximum, so re-defaulting them
+   * here would create a second opinion that the sweep silently overrides.
+   */
+  readonly distillBatchSize?: number;
+  readonly maxDistillBatchesPerTick?: number;
+  readonly graphDerivationLimit?: number;
 }
 
 type Environment = Record<string, string | undefined>;
@@ -62,10 +71,24 @@ export function parseMaintenanceConfig(
     environment.OPEN_BRAIN_MAINTENANCE_POLL_MS,
   );
   const leaseMs = positiveInteger(environment.OPEN_BRAIN_MAINTENANCE_LEASE_MS);
+  const distillBatchSize = positiveInteger(
+    environment.OPEN_BRAIN_MAINTENANCE_DISTILL_BATCH_SIZE,
+  );
+  const maxDistillBatchesPerTick = positiveInteger(
+    environment.OPEN_BRAIN_MAINTENANCE_MAX_DISTILL_BATCHES,
+  );
+  const graphDerivationLimit = positiveInteger(
+    environment.OPEN_BRAIN_MAINTENANCE_GRAPH_LIMIT,
+  );
   return {
     enabled: raw !== "0" && raw !== "false",
     ...(concurrency !== undefined ? { concurrency } : {}),
     ...(pollIntervalMs !== undefined ? { pollIntervalMs } : {}),
     ...(leaseMs !== undefined ? { leaseMs } : {}),
+    ...(distillBatchSize !== undefined ? { distillBatchSize } : {}),
+    ...(maxDistillBatchesPerTick !== undefined
+      ? { maxDistillBatchesPerTick }
+      : {}),
+    ...(graphDerivationLimit !== undefined ? { graphDerivationLimit } : {}),
   };
 }

--- a/server/maintenance/index.ts
+++ b/server/maintenance/index.ts
@@ -62,6 +62,7 @@ import {
   type MaintenanceJobHandler,
   type MaintenanceQueueLogger,
 } from "../../src/maintenance-queue.ts";
+import { startRecurringMaintenanceSweep } from "../../src/maintenance-sweep.ts";
 
 export const MAINTENANCE_BOUNDARY: ServerModuleBoundary = {
   name: "maintenance",
@@ -71,6 +72,13 @@ export const MAINTENANCE_BOUNDARY: ServerModuleBoundary = {
 
 /** The name this runtime reports in ordered-shutdown logs. */
 export const MAINTENANCE_RUNTIME_NAME = "maintenance";
+
+/**
+ * Producer cadence when `OPEN_BRAIN_MAINTENANCE_POLL_MS` is unset. Matches the
+ * runner's own 5s default (`src/maintenance-bootstrap.ts`), so a process that
+ * configures neither produces and consumes on the same tick.
+ */
+const DEFAULT_SWEEP_INTERVAL_MS = 5_000;
 
 export interface MaintenanceRuntimeInput {
   readonly config: MaintenanceConfig;
@@ -172,6 +180,44 @@ export function createMaintenanceRuntime(
   // strictly better than discovering it as a growing dead-letter table.
   if (input.autoStart !== false) runner.start();
 
+  // THE PRODUCER (#384). A runner without one polls forever over a queue that
+  // nothing fills, which is exactly what this process did: measured 2026-08-07
+  // on the local clone, 319 "maintenance queue idle" lines and zero
+  // `maintenance_sweep_complete`, with maintenance ENABLED the whole time.
+  //
+  // The cause was compositional, not a disabled flag. `startMaintenanceQueue`
+  // in `src/maintenance-bootstrap.ts` starts the sweep, but it is reached only
+  // from the legacy `src/index.ts`; this boundary serves `server/main.ts`, the
+  // post-Phase-6 serving entrypoint, and composed the consumer half alone. The
+  // one shared implementation now lives in `src/maintenance-sweep.ts` so the
+  // two compositions cannot diverge on whether work gets produced at all.
+  //
+  // Started only when polling is (`autoStart !== false`): producing jobs no
+  // runner will claim would grow the backlog rather than turn the loop, and a
+  // test driving `runOnce()` deterministically must not race a live timer.
+  //
+  // The cadence is the poll interval, and `undefined` here means the sweep's
+  // own default, matching how the runner knobs above are forwarded. Every bound
+  // is re-clamped inside `runMaintenanceSweep`.
+  const sweep =
+    input.autoStart !== false
+      ? startRecurringMaintenanceSweep({
+          pool: input.pool,
+          queue,
+          logger,
+          intervalMs: input.config.pollIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS,
+          ...(input.config.distillBatchSize !== undefined
+            ? { distillBatchSize: input.config.distillBatchSize }
+            : {}),
+          ...(input.config.maxDistillBatchesPerTick !== undefined
+            ? { maxDistillBatchesPerTick: input.config.maxDistillBatchesPerTick }
+            : {}),
+          ...(input.config.graphDerivationLimit !== undefined
+            ? { graphDerivationLimit: input.config.graphDerivationLimit }
+            : {}),
+        })
+      : undefined;
+
   let stopped = false;
   return {
     name: MAINTENANCE_RUNTIME_NAME,
@@ -189,6 +235,12 @@ export function createMaintenanceRuntime(
     stop: async (): Promise<void> => {
       if (stopped) return;
       stopped = true;
+      // Producer first, ALWAYS. Stopping the runner while the sweep still ticks
+      // would let a producer add rows after polling has halted, so shutdown
+      // would leave freshly-queued work with nothing left to claim it. `stop()`
+      // on the sweep awaits its in-flight tick, so no enqueue is in progress by
+      // the time the drain below begins.
+      await sweep?.stop();
       await runner.stop();
     },
   };

--- a/server/maintenance/maintenance.pg.test.ts
+++ b/server/maintenance/maintenance.pg.test.ts
@@ -421,6 +421,72 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
     await deleteKind(ordinaryKind);
   });
 
+  it("starts a producer, so an autostarted runtime enqueues without an operator", async () => {
+    // THE #384 REGRESSION. This boundary composed the CONSUMER half and nothing
+    // else: `createMaintenanceRuntime` built a runner, `src/maintenance-
+    // bootstrap.ts` built a runner AND started the sweep, and `server/main.ts`
+    // — the post-Phase-6 serving entrypoint — reached only the first. Measured
+    // on the local clone 2026-08-07: 319 "maintenance queue idle" lines, zero
+    // `maintenance_sweep_complete`, maintenance enabled throughout. The runner
+    // polled a queue nothing filled.
+    //
+    // WHAT MAKES THIS TEST ABLE TO FAIL. It asserts on OBSERVED PRODUCTION, not
+    // on the presence of a field: a runtime is composed with autoStart, given a
+    // real derivable source, and then the DATABASE is read to see whether a job
+    // appeared that no test enqueued. Every enqueue here is the server's own.
+    // Asserting `runtime.sweep !== undefined` would pass against a sweep that
+    // is constructed and never ticks, which is the defect's own shape one level
+    // up.
+    const client = await db();
+    const namespace = `${KIND_PREFIX}.producer`;
+    const contentHash = "a".repeat(64);
+
+    await client.query(`DELETE FROM ob_sources WHERE namespace = $1`, [
+      namespace,
+    ]);
+    await client.query(
+      `INSERT INTO ob_sources
+         (namespace, source_kind, external_id, title, approval_state,
+          approved_by, approved_at, lifecycle_state, content_hash, created_by)
+       VALUES ($1, 'drop', $2, 'producer proof', 'approved', 'test', now(),
+               'active', $3, 'test')`,
+      [namespace, `${KIND_PREFIX}-producer`, contentHash],
+    );
+
+    // A short interval so the proof does not depend on the 5s default, and no
+    // handlers for graph.derive: this asserts the PRODUCER ran, and letting the
+    // real deriver execute would drag an embedding provider into a lease test.
+    const runtime = createMaintenanceRuntime({
+      config: config({ pollIntervalMs: 50, graphDerivationLimit: 10 }),
+      logger: silentLogger(),
+      pool: client,
+      handlers: new Map([[`${KIND_PREFIX}.noop`, async () => {}]]),
+    });
+    if (!runtime) throw new Error("maintenance runtime should be composed");
+
+    try {
+      let produced = 0;
+      for (let attempt = 0; attempt < 40 && produced === 0; attempt += 1) {
+        const { rows } = await client.query<{ count: string }>(
+          `SELECT count(*)::text AS count FROM maintenance_jobs
+            WHERE namespace = $1 AND job_kind = 'graph.derive'`,
+          [namespace],
+        );
+        produced = Number.parseInt(rows[0]?.count ?? "0", 10);
+        if (produced === 0) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(produced).toBeGreaterThan(0);
+    } finally {
+      await runtime.stop();
+      await client.query(`DELETE FROM maintenance_jobs WHERE namespace = $1`, [
+        namespace,
+      ]);
+      await client.query(`DELETE FROM ob_sources WHERE namespace = $1`, [
+        namespace,
+      ]);
+    }
+  });
+
   it("composes no runtime when the operator disabled maintenance", async () => {
     // A disabled process must hold no poller at all. Returning `undefined`
     // rather than an idle runner is what keeps "disabled" and "absent from the

--- a/server/maintenance/maintenance.pg.test.ts
+++ b/server/maintenance/maintenance.pg.test.ts
@@ -477,9 +477,39 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
       }
       expect(produced).toBeGreaterThan(0);
     } finally {
+      // ORDER MATTERS: stop the producer BEFORE deleting, or a tick landing
+      // between the DELETE and the runtime's halt re-enqueues what was just
+      // removed.
       await runtime.stop();
-      await client.query(`DELETE FROM maintenance_jobs WHERE namespace = $1`, [
-        namespace,
+
+      // DELETE EVERY graph.derive JOB, NOT JUST THIS NAMESPACE'S.
+      //
+      // The sweep is deliberately global — `selectSourcesNeedingDerivation`
+      // carries a namespace predicate only when the caller passes writable
+      // namespaces, and the maintenance sweep passes `undefined` because a
+      // server-owned sweep must serve every namespace. So this runtime derives
+      // from EVERY approved/active source in the database, not only the one
+      // seeded here.
+      //
+      // That makes leftover fixture sources from other suites this test's mess
+      // to clean: `ob_sources` rows in `parity-source-registry-*` namespaces
+      // survive their own suite (observed on origin/main, which leaves those
+      // rows behind with zero maintenance_jobs). Before this file started a
+      // producer, nothing acted on them. Now they become real queued
+      // `graph.derive` rows.
+      //
+      // Left behind, they break `026 maintenance queue > allows only one
+      // concurrent runner to claim a due job`, whose two racing claims expect
+      // exactly one due job to exist ANYWHERE: `claimDueJobs` filters on
+      // `state`/`run_after` only, with no namespace or kind predicate, so any
+      // stray due row is claimable and both racers win one. That failure is
+      // real and was caused here — CI showed it on this branch while clean
+      // origin/main passed the identical suite.
+      // Both sweep-produced kinds, for the same reason: leftover
+      // `ob_raw_turns` fixtures (`parity-raw-turn-*`) make the distill arm
+      // produce `memory.distill` rows just as globally.
+      await client.query(`DELETE FROM maintenance_jobs WHERE job_kind = ANY($1)`, [
+        ["graph.derive", "memory.distill"],
       ]);
       await client.query(`DELETE FROM ob_sources WHERE namespace = $1`, [
         namespace,

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -19,6 +19,14 @@
  * single-flight, uses configured batch bounds, and stops before the runner drains
  * so shutdown cannot add work after polling has halted.
  *
+ * THE PRODUCER LOOP ITSELF NOW LIVES IN `maintenance-sweep.ts`, not here. This
+ * bootstrap is reached only from the LEGACY `src/index.ts`; the serving
+ * entrypoint since the Phase 6 cutover is `server/main.ts`, which composes
+ * maintenance through `server/maintenance/index.ts`. While the loop was private
+ * to this file, only one of those two compositions produced any work at all, so
+ * the serving process polled a queue nothing filled — #384's symptom, surviving
+ * the PR that added the producer. Both compositions now start the same loop.
+ *
  * #343 invariants preserved verbatim — this only wires them, it changes none:
  *  - Bounded concurrency: the runner clamps to [1, MAX_CONCURRENCY].
  *  - No overlapping ticks: `runOnce` is single-flight; `start()` reuses it.
@@ -36,7 +44,6 @@ import type { AuthInfo } from "./types.ts";
 import {
   MaintenanceQueue,
   MaintenanceQueueRunner,
-  safeMaintenanceErrorCategory,
   type MaintenanceJobHandler,
   type MaintenanceQueueLogger,
 } from "./maintenance-queue.ts";
@@ -51,7 +58,7 @@ import {
   MEMORY_DISTILL_JOB_KIND,
   makeMemoryDistillHandler,
 } from "./distill-handler.ts";
-import { runMaintenanceSweep } from "./maintenance-sweep.ts";
+import { startRecurringMaintenanceSweep } from "./maintenance-sweep.ts";
 
 /**
  * The deliberate, server-owned identity the graph-derivation handler derives
@@ -238,50 +245,6 @@ export function maintenanceQueueEnabled(
 ): boolean {
   const raw = env.OPEN_BRAIN_MAINTENANCE_ENABLED?.trim().toLowerCase();
   return raw !== "0" && raw !== "false";
-}
-
-function startRecurringMaintenanceSweep(input: {
-  pool: pg.Pool;
-  queue: MaintenanceQueue;
-  logger: MaintenanceQueueLogger;
-  intervalMs: number;
-  distillBatchSize?: number;
-  maxDistillBatchesPerTick?: number;
-  graphDerivationLimit?: number;
-}): { stop(): Promise<void> } {
-  let interval: ReturnType<typeof setInterval> | null = null;
-  let active: Promise<void> | null = null;
-  let stopping = false;
-
-  const runOnce = (): Promise<void> => {
-    if (stopping) return Promise.resolve();
-    if (active) return active;
-
-    const run = runMaintenanceSweep(input)
-      .then(() => undefined)
-      .catch((error: unknown) => {
-        input.logger.error("maintenance_sweep_failed", {
-          error_category: safeMaintenanceErrorCategory(error),
-        });
-      })
-      .finally(() => {
-        active = null;
-      });
-    active = run;
-    return run;
-  };
-
-  void runOnce();
-  interval = setInterval(() => void runOnce(), input.intervalMs);
-
-  return {
-    async stop(): Promise<void> {
-      stopping = true;
-      if (interval) clearInterval(interval);
-      interval = null;
-      await active;
-    },
-  };
 }
 
 /**

--- a/src/maintenance-sweep.ts
+++ b/src/maintenance-sweep.ts
@@ -8,9 +8,10 @@ import {
   DEFAULT_MAX_DISTILL_SESSIONS,
   DISTILL_ORDER_BY,
 } from "./distill-window.ts";
-import type {
-  MaintenanceJob,
-  MaintenanceQueueLogger,
+import {
+  safeMaintenanceErrorCategory,
+  type MaintenanceJob,
+  type MaintenanceQueueLogger,
 } from "./maintenance-queue.ts";
 
 const DEFAULT_DISTILL_BATCH_SIZE = 1_500;
@@ -262,4 +263,73 @@ export async function runMaintenanceSweep(
     graph_limit_reached: summary.graphLimitReached ? 1 : 0,
   });
   return summary;
+}
+
+export interface RecurringMaintenanceSweep {
+  stop(): Promise<void>;
+}
+
+/**
+ * Start the recurring producer: one bounded sweep now, then one per interval.
+ *
+ * THIS LIVES HERE, NOT IN A BOOTSTRAP, BECAUSE THERE ARE TWO COMPOSITIONS OF
+ * THE MAINTENANCE RUNNER AND ONLY ONE OF THEM USED TO START A PRODUCER.
+ * `src/maintenance-bootstrap.ts` (reached from the LEGACY `src/index.ts`) has
+ * started the sweep since #577. `server/maintenance/index.ts` — reached from
+ * `server/main.ts`, which the Phase 6 cutover made the SERVING entrypoint —
+ * composed the runner and nothing else. So #384's exact symptom survived the PR
+ * that added the producer: the serving process polled a queue that no producer
+ * filled, emitting "maintenance queue idle" indefinitely and never one
+ * `maintenance_sweep_complete`.
+ *
+ * Placing the loop in this module — which imports only the sweep's own leaf
+ * dependencies — lets the server boundary reach it WITHOUT importing the
+ * bootstrap's embedding providers and handler composition. Writing a second
+ * copy of the loop for the server was the alternative and is rejected for the
+ * reason `server/maintenance/index.ts` already gives about the runner: a
+ * duplicated loop whose failure mode is silence drifts precisely where drift is
+ * invisible.
+ *
+ * Bounded and non-overlapping, mirroring the runner's own discipline: a tick
+ * already in flight is returned rather than a second one started, a failed tick
+ * logs a content-free category and the interval survives it, and `stop()`
+ * refuses new ticks and awaits the in-flight one so the producer cannot add
+ * work after the runner has begun draining.
+ */
+export function startRecurringMaintenanceSweep(
+  input: MaintenanceSweepOptions & { intervalMs: number },
+): RecurringMaintenanceSweep {
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let active: Promise<void> | null = null;
+  let stopping = false;
+
+  const runOnce = (): Promise<void> => {
+    if (stopping) return Promise.resolve();
+    if (active) return active;
+
+    const run = runMaintenanceSweep(input)
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        input.logger.error("maintenance_sweep_failed", {
+          error_category: safeMaintenanceErrorCategory(error),
+        });
+      })
+      .finally(() => {
+        active = null;
+      });
+    active = run;
+    return run;
+  };
+
+  void runOnce();
+  interval = setInterval(() => void runOnce(), input.intervalMs);
+
+  return {
+    async stop(): Promise<void> {
+      stopping = true;
+      if (interval) clearInterval(interval);
+      interval = null;
+      await active;
+    },
+  };
 }


### PR DESCRIPTION
Closes nothing yet — #384 stays open pending review.

## What was actually broken

The issue attributes the dead loop to `OPEN_BRAIN_MAINTENANCE_ENABLED=0`. That is **stale**, and PR #577 already landed the sweep producer itself. Measured against the live local clone on 2026-08-07:

- `local-clone.env:12` sets `OPEN_BRAIN_MAINTENANCE_ENABLED=1`, and `ps eww` on the serving process confirmed `=1` in its environment. The runner was **enabled**.
- `src/maintenance-sweep.ts` existed and `src/maintenance-bootstrap.ts:335` started it.
- And yet: **319** `maintenance queue idle` lines, **zero** `maintenance_sweep_complete`, and exactly one job ever enqueued — the dead canary.

The cause is compositional. There are two maintenance compositions and only one started a producer:

| Composition | Reached from | Runner | Producer |
|---|---|---|---|
| `startMaintenanceQueue` (`src/maintenance-bootstrap.ts:300`) | `src/index.ts` — **legacy** | yes | yes |
| `createMaintenanceRuntime` (`server/maintenance/index.ts:141`) | `server/main.ts` — **serving** | yes | **no** |

The Phase 6 cutover made `server/main.ts` the serving entrypoint (`scripts/local-clone-autostart.sh:66-70` says so explicitly). So #384's exact symptom — "both handlers are consumers with no producer" — survived the PR that added the producer, because the producer was added to the entrypoint that had stopped serving. `rg runMaintenanceSweep server/` returned nothing.

## The fix

The recurring loop moves from `maintenance-bootstrap.ts` (private) to `maintenance-sweep.ts` (exported), and both compositions start it. Moving rather than copying is the same call `server/maintenance/index.ts` already documents for the runner: a duplicated loop whose failure mode is silence drifts exactly where drift cannot be seen. `maintenance-sweep.ts` imports only its own leaf dependencies, so the server boundary reaches it without pulling in the bootstrap's embedding providers or handler composition.

Shutdown stops the producer **before** the runner drains, so no tick can enqueue work after polling has halted.

`server/config/maintenance.ts` gains the three producer bound settings that already existed in the sweep, forwarded only when set so the sweep stays the single owner of its own defaults. No new bound is introduced by this PR.

### Canary disposition: retired, not repaired

Its `{}` payload carries no source id, namespace, or content hash, and `graph.derive` makes a malformed payload terminal by contract (`src/graph-derivation-handler.ts:359`). It was never a runnable job. `scripts/retire-maintenance-canary.ts` is dry-run by default and only touches `canary:`-keyed rows already in `dead_letter`; live canaries are reported and skipped.

## Red → green evidence

`scripts/done-means/384-maintenance-loop-turns.sh` drives the **live service and DB**. It seeds one real derivable `ob_sources` row, **enqueues nothing**, and waits for the server's own sweep — so it observes production rather than simulating it.

**RED (before, revision b2bd77d):**

```
PASS  (a1) local service serving, status=healthy
PASS  (a2) serving pid 13501 has maintenance enabled (=1)
FAIL  (d) canary still dead-lettered (state=dead_letter)
FAIL  (b) no job was enqueued for the seeded source within 40s — the producer is not running in the serving process
FAIL  (c) no job reached terminal success (last observed state=none)
=== RESULT: FAIL (3 failing clause(s)) ===
```

**GREEN (after, revision 098169f deployed):**

```
PASS  (a1) local service serving, status=healthy
PASS  (a2) serving pid 90474 has maintenance enabled (=1)
PASS  (d) no canary row remains (retired)
PASS  (b) sweep enqueued a job for the seeded source with no operator action
PASS  (c) job reached terminal SUCCESS (state=succeeded)

   job_kind   |   state   | attempts | last_error_category
--------------+-----------+----------+---------------------
 graph.derive | succeeded |        3 |
=== RESULT: PASS — the maintenance loop turns ===
```

**Live service evidence** — deploy revision proof `pid 13501 -> 90474, revision 098169f`, health check passed, and the producer ticking every ~5s in the running log:

```
"message":"graph_derivation_enqueue_sweep"  (12 occurrences since deploy)
"message":"graph_derivation_ok" / "graph_derivation_handler_ok"
```

Deployed to the **local dogfood clone only** via `scripts/local-clone-deploy.sh`. No core01/hosted config touched (two-host rule).

## The CI failure this PR caused, and the correction

The first push failed `026 maintenance queue > allows only one concurrent runner to claim a due job`. An earlier note on this branch called it pre-existing. **That was wrong**, and the way it was wrong is worth recording: it was checked by running that one test file alone, which passes. It only fails after the whole suite has run.

Proven by running the full suite against both trees, in separate worktrees and separate freshly-created databases:

| Tree | Result |
|---|---|
| clean `origin/main` (dfaf359) | 3701 pass, 0 fail |
| this branch, before the fix | 3701 pass, **1 fail** |
| this branch, after the fix | **3702 pass, 0 fail** |

Root cause was the producer doing exactly its job. The sweep is deliberately global — it passes `undefined` writable namespaces to `selectSourcesNeedingDerivation`, because a server-owned sweep must serve every namespace — so the runtime composed in the new test derives from **every** approved/active source in the database, not only the seeded one. Other suites leave `ob_sources` fixtures behind (`parity-source-registry-*`; they sit inert on main, with zero `maintenance_jobs`, because nothing was producing). The new test turned them into real queued `graph.derive` rows that its namespace-scoped DELETE could not see.

Those strays then break the 026 concurrency test, whose two racing claims require exactly one due job to exist **anywhere**: `claimDueJobs` filters on `state`/`run_after` only, with no namespace or job-kind predicate, so any leftover due row is claimable and both racers win one — the observed `Expected: 1, Received: 2`.

Fixed in d939623: cleanup deletes by `job_kind` across all namespaces for both kinds the sweep can produce, and stops the runtime before deleting so a tick cannot re-enqueue between the DELETE and the halt.

### Unit regression

The new live-Postgres test in `server/maintenance/maintenance.pg.test.ts` asserts **observed production** — it reads back a job no test enqueued — rather than the presence of a field, which would pass against a sweep that is constructed and never ticks. Verified to fail against the pre-fix wiring:

```
error: expect(received).toBeGreaterThan(expected)
Expected: > 0
Received: 0
(fail) ... > starts a producer, so an autostarted runtime enqueues without an operator
 5 pass, 1 fail
```

It passed in CI on the first push (both `check` and `db-integration`).

## Gates

- `bunx tsc --noEmit` — **exit 0**, no output.
- `bun test` — **3702 pass, 35 skip, 0 fail** against a freshly created database. `OPENBRAIN_TEST_DATABASE_URL` **was set** (isolated `ob_test_384*` databases, migrated then dropped), so the Postgres suites genuinely ran rather than skipping silently.

## Critical Self-Review

- Highest-risk behavior: the producer now runs in the serving process, so jobs get created where none were. The sweep's existing bound settings apply unchanged, each re-clamped inside `runMaintenanceSweep`, and production is gated on `autoStart` so a process that is not polling produces nothing. The first CI run proved this risk is real rather than theoretical — a global producer turned other suites' leftover fixtures into live queued work.
- Assumptions that could be wrong: that `server/main.ts` is the only serving entrypoint. Verified from `scripts/local-clone-autostart.sh` and `SERVING_ENTRYPOINT` in `scripts/local-clone.ts`, not assumed. The legacy `src/index.ts` path is unchanged and still starts the same loop.
- Missing/weak tests: the done-means check needs the live service and is not CI-runnable, so CI proves the composition while the live loop is proven by hand. The distill arm of the sweep is not exercised end-to-end here — it depends on #382 per the issue's own sequencing.
- Security/permission risk: none added. The sweep enqueues durable job rows; per-job namespace and source-snapshot guards inside the handlers remain the authority, and `MAINTENANCE_GRAPH_AUTH` is unchanged. Note the sweep is intentionally cross-namespace at SELECTION time, which is why the test cleanup had to be global too.
- Migration/deploy risk: no schema change. The canary retirement is deliberately a script, not a migration — it is a one-time cleanup of one box's queue, and the row's absence on a fresh database is already correct.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python-client contract changed, so `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: `scripts/local-clone-deploy.sh --rollback` restores the previous runtime. All probe rows removed by the done-means check's own trap (verified 0 rows in `maintenance_jobs`, `ob_sources`, `ob_entities`); both temp test databases dropped; both worktrees removed.
- Fixes made before PR: scoped the retirement script to `dead_letter` only after noticing it would otherwise retire a live canary; moved the sweep import off `maintenance-bootstrap.ts` to avoid dragging embedding providers into the server boundary. After CI: corrected a wrong pre-existing-failure claim and fixed the test-isolation defect behind it.
- Known residual risk: `maintenance_sweep_complete` (pino child logger, `component: "maintenance"`) does not reach the clone's log files — no `"component":"..."` line does. Pre-existing routing quirk of the server path, not introduced here; the module-logger line `graph_derivation_enqueue_sweep` and the durable rows both prove the producer runs. The same unrouted stream would carry the sweep's warn-level bound-reached lines, which #384 asks to be logged, so that acceptance criterion is only half-satisfied and deserves its own issue.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below

Live checks are the done-means run above, executed against the local dogfood service (revision 098169f) and its database: runner enabled and serving, sweep enqueued without operator action, job reached terminal `succeeded`, canary retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
