### PR TITLE
fix(recall): brain_answer sees session events (#433, defect 1)

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1840,3 +1840,56 @@ A diff/comparison tool is an operator trust surface: what it prints is what the 
 ### Pattern
 
 A hand-written stub proves conformance to the stub, not to the external API. Langfuse detail responses return full observation objects, but list rows return observation ID strings; reusing the detail shape in list fixtures made every test pass while every live `session` and `repeat` call failed validation. For each external endpoint, capture and sanitize a real response, preserve its envelope and value types, and drive the public caller through that fixture. Do not reuse a sibling endpoint's richer response shape unless the live wire contract proves they are identical.
+
+## [2026-08-07] One selection rule, duplicated per caller, diverges silently
+
+**Severity:** HIGH
+**Source:** issue #433 defect 1, PR #610 (brain_answer could not see session events)
+**Scope key:** `sme.duplicated_selection_lists_diverge`
+**Status:** active
+
+### Pattern
+
+Reusable review check: when two or more call sites independently re-derive the
+same "what may I read/write/see" list, treat that as the defect, not the
+symptom. Fixing only the caller named in the bug leaves the other copies wrong.
+
+In #433 the selection was open-coded at each recall surface. `search_brain`
+computed `ALL_TABLES.filter(canRead)` and then appended `entities`;
+`brain_answer` computed `ALL_TABLES.filter(canRead)` and appended nothing.
+Neither appended `ob_session_events`. The two lists had already silently
+diverged from each other, and a corpus of 11,136 rows was unreachable from the
+tool agents actually ask. Each new recall surface was one more place to forget,
+and nothing in the type system or the tests noticed the disagreement, because
+each copy was internally consistent.
+
+Three things to check on any PR that adds a readable source:
+
+1. Grep for every site that filters the canonical list. If there is more than
+   one, the fix is to extract one selection function that all callers use, so
+   a new source appears everywhere at once instead of one place at a time.
+2. Check every SERVING TREE, not just the one you are editing. This repo has
+   two live entrypoints (`src/index.ts` serves core01 via
+   `deploy/open-brain.service` and `scripts/run-two-worker.ts`;
+   `server/main.ts` is the local-clone serving entrypoint), each with its own
+   `brain_answer`. Fixing one leaves a live path still blind.
+3. Beware the acceptance check re-deriving the list a fourth time. A gate that
+   hand-rolls its own copy of the selection can pass while the product stays
+   broken -- it must call the real exported selection function.
+
+Corollary on WIDENING: adding a physical table to the permissions/type union is
+usually the wrong shape for a read-only corpus. `ob_session_events` has no
+write contract and no PERMISSIONS row, so it was added as a read-only retrieval
+source with its own CTE branch (the existing `entities` precedent) rather than
+by widening `Table`/`ResourceTable`, which would have demanded a write contract
+it does not have. Also confirm the extraction did not quietly widen a caller:
+folding the two lists into one initially added `entities` to `brain_answer`,
+a behavior change the issue never asked for, so it was made opt-in.
+
+Corollary on INDIRECT NAMESPACING: a corpus without its own `namespace` column
+is a namespace-isolation risk the moment it becomes searchable.
+`ob_session_events` reaches namespace only through
+`ob_session_lanes` on `lane_id`, so every new CTE must carry the auth-derived
+predicate across that JOIN. Prove it by deleting the predicate and watching a
+cross-namespace test fail; an isolation test that has never been seen to fail
+is decoration.

--- a/scripts/done-means/433-recall-sees-session-events.sh
+++ b/scripts/done-means/433-recall-sees-session-events.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #433, DEFECT 1 ONLY — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/433-recall-sees-session-events.sh
+#
+# Defect 1, verbatim from the issue thread: `brain_answer` structurally cannot
+# see `ob_session_events`. Its table list (`ALL_TABLES`, src/tools/
+# table-constants.ts) names only thoughts/decisions/relationships/projects/
+# sessions, so asking "what happened in the last day" answers from months-old
+# thoughts while the session-event corpus — 11,136 rows on the dogfood DB as of
+# 2026-08-07, 80 of them from the last 24h — is invisible to recall.
+#
+# SCOPE. This gate covers recall VISIBILITY only. Defect 2 of the same issue
+# ("nothing promotes events into durable tables" — no producer calls
+# classifyLaneEvent -> tierLaneEvent -> graduateLaneEvent) is explicitly NOT
+# gated here and is not closed by this check passing. Visibility and promotion
+# are independent: this asks whether the retrieval path CAN reach the corpus,
+# not whether anything copies it elsewhere.
+#
+# EXPECTED TO FAIL until #433 defect 1 is fixed. It is the reward function, not
+# a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Why this drives executeSearch in-process rather than the running service
+# ---------------------------------------------------------------------------
+# A live service is listening on OPENBRAIN_BASE_URL, but it serves the DEPLOYED
+# revision, not this working tree. Probing it would measure whatever is already
+# installed, so the check could never go red-then-green on an uncommitted fix —
+# it would report the same answer before and after. This script therefore
+# imports `executeSearch` from THIS checkout via `bun`, with a real `pg` Pool
+# against the dogfood database. That is the same entry point `brain_answer`
+# calls (src/tools/brain-answer.ts imports executeSearch from ./search-brain.ts),
+# so the retrieval path under test is the real one.
+#
+# The source list comes from `readableSearchTables(role)` — the one exported
+# function brain_answer and search_brain both call — rather than being
+# re-derived here. That matters: #433 defect 1 IS a divergence between two
+# hand-maintained copies of that list, so a gate holding a third copy could
+# pass while the product stayed broken. The probe asks for the `admin` role,
+# the most permissive there is; if the marker is invisible to admin it is
+# invisible to everyone, and the failure cannot be dismissed as a permissions
+# artifact.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+# Clause 1 — VISIBILITY. A session event seeded seconds ago, carrying a unique
+#   marker token, surfaces from the real search path when queried by that
+#   marker. FAIL if the retrieval path returns no row bearing the marker.
+#
+# Clause 2 — NAMESPACE ISOLATION. The same query, run under a DIFFERENT
+#   namespace filter, must NOT return the marker. `ob_session_events` has no
+#   namespace column (verified against information_schema on the dogfood DB
+#   2026-08-07 — see the seeding SQL below); namespace is reachable only by
+#   joining ob_session_lanes on lane_id. A recall path that adds the corpus
+#   without carrying the auth-derived namespace predicate through that join
+#   leaks every agent's session history into every other namespace. Clause 2 is
+#   a security gate: it fails CLOSED, so if clause 1 cannot be satisfied at all
+#   the leak question is reported as untested rather than silently passed.
+#
+# Both clauses run against ONE seeded row so they cannot disagree about what
+# "the marker" means.
+#
+# Output is content-free apart from the random run marker: statuses and counts
+# only. No tokens, no memory bodies.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH (runs the retrieval probe)"
+
+# --- database access (seed + proof + teardown) ------------------------------
+# .env carries the libpq vars, so bare psql needs no connection arguments.
+# See AGENTS.md "Querying the dogfood database".
+[ -r "$REPO_ROOT/.env" ] || fail_hard "no .env at $REPO_ROOT/.env; cannot reach the dogfood database"
+set -a
+# shellcheck disable=SC1091
+. "$REPO_ROOT/.env"
+set +a
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+psql -At -c 'select 1' >/dev/null 2>&1 || fail_hard "cannot reach the dogfood database; seeding, row proof, and teardown are all impossible, so a PASS could not be trusted"
+
+# The probe needs a connection string; the app reads DB_* and psql reads PG*,
+# but `pg.Pool` reads neither implicitly in the shape we want. Build it from the
+# libpq vars already exported above rather than inventing a second source.
+PROBE_DB_URL="postgres://${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+MARKER="rlvr433${RUN_ID}"
+
+# ISOLATION IS BY THROWAWAY LANE. Two namespaces unique to this run give
+# clause 2 a real cross-namespace pair to test with. Neither can collide with
+# real data, and teardown cannot touch anything else.
+OWNER_NS="done-means-433-own-${RUN_ID}"
+OTHER_NS="done-means-433-other-${RUN_ID}"
+SESSION_KEY="done-means-433-${RUN_ID}"
+
+teardown() {
+  psql -At -c "delete from ob_session_events where lane_id in (select id from ob_session_lanes where session_key like 'done-means-433-${RUN_ID}%');" >/dev/null 2>&1
+  psql -At -c "delete from ob_session_lanes where session_key like 'done-means-433-${RUN_ID}%';" >/dev/null 2>&1
+}
+trap teardown EXIT
+
+# --- seed -------------------------------------------------------------------
+# The event is seeded directly rather than through the capture CLI on purpose:
+# this gate is about whether RECALL can see the corpus, so the write path must
+# not be able to fail the check for its own reasons (#598 covers that path).
+#
+# `embedding` is left NULL deliberately. The probe runs in keyword mode, so the
+# lexical arm is what must find the row; a seeded embedding would let a vector
+# hit mask a lexical arm that was never wired up.
+SEED_SQL=$(cat <<SQL
+insert into ob_session_lanes (session_key, namespace, created_by)
+values ('${SESSION_KEY}-owner', '${OWNER_NS}', 'done-means-433');
+insert into ob_session_events (lane_id, event_type, content, importance, created_by)
+select id, 'fact', '${MARKER} session event seeded by the done-means gate for issue 433', 'hot', 'done-means-433'
+from ob_session_lanes where session_key = '${SESSION_KEY}-owner';
+SQL
+)
+psql -At -v ON_ERROR_STOP=1 -c "$SEED_SQL" >/dev/null 2>&1 || fail_hard "could not seed the throwaway lane/event"
+
+SEEDED="$(psql -At -c "select count(*) from ob_session_events e join ob_session_lanes l on l.id = e.lane_id where l.namespace = '${OWNER_NS}' and e.content like '%${MARKER}%';" 2>/dev/null | tr -d '[:space:]')"
+[ "${SEEDED:-0}" = "1" ] || fail_hard "seed did not land exactly one event (got '${SEEDED:-0}'); the gate cannot distinguish a retrieval miss from a missing row"
+
+# --- probe ------------------------------------------------------------------
+# Runs the REAL executeSearch from this checkout, with the REAL table list
+# brain_answer would compute, once per namespace. Prints two integers: the count
+# of returned rows carrying the marker under the owning namespace, and the count
+# carrying it under the unrelated one.
+#
+# The probe is written into the repo-scoped scratch bucket rather than the
+# checkout, so it never dirties `git status` and needs no delete to clean up
+# (agents do not run forced/recursive deletes — Development AGENTS.md). It is
+# imported by absolute path, so bun still resolves this checkout's modules.
+PROBE_DIR="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-433"
+mkdir -p "$PROBE_DIR" || fail_hard "cannot create scratch dir $PROBE_DIR"
+PROBE="$PROBE_DIR/probe.$RUN_ID.ts"
+
+cat > "$PROBE" <<PROBE_TS
+import { Pool } from "pg";
+import {
+  executeSearch,
+  readableSearchTables,
+} from "${REPO_ROOT}/src/tools/search-brain.ts";
+import {
+  executeSearch as executeSearchServer,
+  readableSearchSources,
+} from "${REPO_ROOT}/server/tools/search-engine.ts";
+PROBE_TS
+cat >> "$PROBE" <<'PROBE_TS'
+
+const [dbUrl, marker, ownerNs, otherNs] = process.argv.slice(2);
+const pool = new Pool({ connectionString: dbUrl });
+
+// THE REAL SELECTION, not a copy of it. `readableSearchTables` is the single
+// function brain_answer and search_brain both call to decide what recall can
+// read. Re-implementing that choice here would let the gate pass while the
+// product stayed broken -- which is precisely the class of defect #433 is:
+// two hand-maintained copies of one list that silently disagreed.
+//
+// `admin` is the most permissive role there is. If the marker is invisible to
+// admin, it is invisible to everyone, and the failure cannot be waved off as a
+// permissions artifact.
+const accessibleTables = readableSearchTables("admin");
+const accessibleSources = readableSearchSources("admin");
+
+// Keyword mode: the lexical arm must find the marker on its own. The mock embed
+// returns null so no vector arm can mask a missing lexical path.
+const embedFn = async () => null;
+const deps = { pool, embedFn } as any;
+
+function countMarker(rows: any[]): number {
+  return rows.filter((r: any) =>
+    String(r.content_preview ?? "").includes(marker),
+  ).length;
+}
+
+// BOTH SERVING TREES ARE PROBED, because both are live. `server/main.ts` is the
+// local-clone serving entrypoint and `src/index.ts` still serves core01 via
+// deploy/open-brain.service and scripts/run-two-worker.ts -- the repo states
+// this itself at src/index.ts:52-60 and src/tools/agent-context-pack.ts:215.
+// Fixing one tree and reporting the defect closed would leave a live path
+// still blind to the corpus, so a PASS requires the marker to surface from
+// EACH tree and to leak from NEITHER.
+async function hitsSrc(namespace: string): Promise<number> {
+  return countMarker(
+    await executeSearch(
+      deps,
+      accessibleTables as any,
+      marker,
+      25,
+      "keyword",
+      undefined,
+      0,
+      namespace,
+    ),
+  );
+}
+
+async function hitsServer(namespace: string): Promise<number> {
+  return countMarker(
+    await executeSearchServer(
+      deps,
+      accessibleSources as any,
+      marker,
+      25,
+      "keyword",
+      undefined,
+      0,
+      namespace,
+    ),
+  );
+}
+
+try {
+  const ownSrc = await hitsSrc(ownerNs);
+  const otherSrc = await hitsSrc(otherNs);
+  const ownServer = await hitsServer(ownerNs);
+  const otherServer = await hitsServer(otherNs);
+  // Each side reports the WEAKEST result across the two trees: visibility is
+  // the minimum (a tree that cannot see it fails the clause) and leakage is the
+  // maximum (a leak in either tree is a leak).
+  console.log(
+    `${Math.min(ownSrc, ownServer)} ${Math.max(otherSrc, otherServer)} src=${ownSrc}/${otherSrc} server=${ownServer}/${otherServer}`,
+  );
+} catch (err) {
+  console.log(`ERR ${err instanceof Error ? err.message : String(err)}`);
+} finally {
+  await pool.end();
+}
+PROBE_TS
+
+PROBE_OUT="$(cd "$REPO_ROOT" && bun "$PROBE" "$PROBE_DB_URL" "$MARKER" "$OWNER_NS" "$OTHER_NS" 2>&1 | tail -1)"
+
+OWN_HITS="$(printf '%s' "$PROBE_OUT" | awk '{print $1}')"
+OTHER_HITS="$(printf '%s' "$PROBE_OUT" | awk '{print $2}')"
+# Per-tree detail (src=own/other server=own/other) so a failure names WHICH
+# serving tree is blind or leaking, rather than only that one of them is.
+PER_TREE="$(printf '%s' "$PROBE_OUT" | awk '{print $3, $4}')"
+
+SEARCHED_TABLES="$(cd "$REPO_ROOT" && bun -e 'import{readableSearchTables}from"./src/tools/search-brain.ts";console.log(readableSearchTables("admin").join(","))' 2>/dev/null)"
+
+CLAUSE1=FAIL
+CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL
+CLAUSE2_EVIDENCE=""
+
+if [ "$OWN_HITS" = "ERR" ]; then
+  CLAUSE1_EVIDENCE="retrieval path raised before returning rows: ${PROBE_OUT#ERR }"
+  CLAUSE2_EVIDENCE="not assessed: clause 1 never produced a result, so a non-leak cannot be distinguished from a path that returns nothing at all"
+elif ! printf '%s' "$OWN_HITS" | grep -Eq '^[0-9]+$'; then
+  fail_hard "probe emitted no parseable result: '$PROBE_OUT'"
+else
+  # Clause 1 — visibility.
+  if [ "$OWN_HITS" -ge 1 ]; then
+    CLAUSE1=PASS
+    CLAUSE1_EVIDENCE="seeded session event surfaced from the real executeSearch path: ${OWN_HITS} marker-bearing row(s) under namespace ${OWNER_NS}; searched tables [${SEARCHED_TABLES}]"
+  else
+    CLAUSE1_EVIDENCE="INVISIBLE: the row exists (seeded=1, confirmed in ob_session_events) but the real recall path returned 0 rows carrying the marker. Searched tables were [${SEARCHED_TABLES}] — the session-event corpus is not among them."
+  fi
+
+  # Clause 2 — namespace isolation. Fails closed when clause 1 failed.
+  if [ "$CLAUSE1" != "PASS" ]; then
+    CLAUSE2_EVIDENCE="not assessed: with the corpus invisible to recall, a zero cross-namespace count proves only that nothing is searched — not that the namespace predicate works. Re-run once clause 1 passes."
+  elif [ "$OTHER_HITS" = "0" ]; then
+    CLAUSE2=PASS
+    CLAUSE2_EVIDENCE="no leak: the same marker query under unrelated namespace ${OTHER_NS} returned 0 marker-bearing rows while the owning namespace returned ${OWN_HITS}"
+  else
+    CLAUSE2_EVIDENCE="NAMESPACE LEAK: ${OTHER_HITS} marker-bearing row(s) visible from namespace ${OTHER_NS}, which owns none of them. The lane join is not carrying the auth-derived namespace predicate."
+  fi
+fi
+
+printf '\n=== DONE-MEANS #433 (defect 1: recall visibility) ===\n'
+printf 'run marker      : %s\n' "$MARKER"
+printf 'seeded events   : %s (namespace %s)\n' "$SEEDED" "$OWNER_NS"
+printf 'probe result    : own=%s other=%s (worst across trees)\n' "${OWN_HITS:-?}" "${OTHER_HITS:-?}"
+printf 'per serving tree: %s\n' "${PER_TREE:-n/a}"
+printf '\nCLAUSE 1 visibility         : %s\n  %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '\nCLAUSE 2 namespace isolation: %s\n  %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+
+if [ "$CLAUSE1" = "PASS" ] && [ "$CLAUSE2" = "PASS" ]; then
+  printf '\nRESULT: PASS — defect 1 (recall visibility) satisfied. Defect 2 (promotion) is NOT covered by this gate and #433 does not close on this alone.\n'
+  exit 0
+fi
+
+printf '\nRESULT: FAIL\n'
+exit 1

--- a/server/tools/brain-answer.ts
+++ b/server/tools/brain-answer.ts
@@ -29,13 +29,14 @@ import {
 } from "./types.ts";
 import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
-import { ALL_TABLES, type Tier } from "./search-constants.ts";
+import type { Tier } from "./search-constants.ts";
 import {
   setActiveMcpTraceMetadata,
   traceRetrievalSpanSync,
 } from "../observability/langfuse-tracing.ts";
 import {
   executeSearchWithSharedFallback,
+  readableSearchSources,
   type SearchMode,
   type SearchRow,
   type SourceRef,
@@ -231,9 +232,15 @@ export function registerBrainAnswerTool(
         return errorResult(NAMESPACE_DENIED);
       }
 
-      const tables = ALL_TABLES.filter((table) =>
-        canRead(identity.role, table),
-      );
+      // #433 defect 1: brain_answer could not see `ob_session_events` at all.
+      // It filtered ALL_TABLES -- the PHYSICAL-table list, which drives
+      // PERMISSIONS and the write paths -- so the session-event corpus was
+      // structurally absent from every question this tool answered. "What
+      // happened in the last day" answered from months-old thoughts while the
+      // day's events sat unread. The selection now lives in ONE exported
+      // function so a new recall source cannot reach one caller and miss
+      // another, which is the shape of this defect.
+      const tables = readableSearchSources(identity.role);
       if (tables.length === 0) return errorResult(NO_READABLE_TABLES);
 
       const query = args.query;

--- a/server/tools/search-engine.ts
+++ b/server/tools/search-engine.ts
@@ -34,6 +34,7 @@ import { toSql } from "pgvector/pg";
 import type { Logger } from "pino";
 import type { Pool } from "pg";
 import type { ResourceTable } from "../auth/types.ts";
+import { canRead } from "../auth/permissions.ts";
 import {
   ALL_TABLES,
   CONTENT_PREVIEW,
@@ -272,6 +273,133 @@ function selectColumns(table: ResourceTable, rankExpression: string): string {
     ${metadata}`;
 }
 
+/**
+ * A source the search arms can read.
+ *
+ * `ResourceTable` is the PHYSICAL-table union: it drives `PERMISSIONS`, the
+ * REST enum, and every write path, so widening it would demand a permission
+ * row and a write contract for a corpus that has neither. `session_events` is
+ * a read-only retrieval source instead -- searchable here, never written
+ * through this surface -- and carries its own CTE builders below because its
+ * columns do not match the shared shape.
+ */
+export type SearchSource = ResourceTable | "session_events";
+
+/**
+ * The recall sources a role may read, in one place.
+ *
+ * This exists because the selection was OPEN-CODED at each call site, and that
+ * is exactly how #433 defect 1 happened: every caller filtered `ALL_TABLES`
+ * independently and nothing added the session-event corpus anywhere, so
+ * 11,136 rows were unreachable from the tool agents actually ask. One copy per
+ * caller is one chance per caller to forget. Callers needing the default set
+ * MUST use this function, so a new source is added once and appears on every
+ * recall surface at once.
+ *
+ * `session_events` has no PERMISSIONS row: it is a read-only retrieval source,
+ * never written through this surface, and it rides the `sessions` read
+ * permission because a session event is session-scoped content.
+ */
+export function readableSearchSources(
+  role: Parameters<typeof canRead>[0],
+): SearchSource[] {
+  const sources: SearchSource[] = ALL_TABLES.filter((table) =>
+    canRead(role, table),
+  );
+  if (canRead(role, "sessions")) sources.push("session_events");
+  return sources;
+}
+
+/**
+ * Session events are namespaced INDIRECTLY.
+ *
+ * `ob_session_events` has no `namespace` column at all (verified against
+ * information_schema on the dogfood DB, 2026-08-07); scope lives on
+ * `ob_session_lanes` and is reachable only through
+ * `ob_session_events.lane_id`. Both builders below therefore JOIN the lane
+ * table and apply the auth-derived namespace predicate to `sl.namespace`.
+ * Omitting that join would not merely widen results -- it would expose every
+ * agent's session history to every other namespace.
+ *
+ * The corpus also lacks `archived_at`, `tier`, `tags`, `usefulness_score`,
+ * `access_count`, and `search_vector`. Those slots are filled with typed
+ * literals so the UNION arms stay type-compatible, and two consequences are
+ * deliberate:
+ *   - no stored `search_vector` -> the lexical arm matches `content` with
+ *     ILIKE, so it is substring matching, not stemming. That is the honest
+ *     capability of a column that does not exist, and it is why `ftsConfig`
+ *     has nothing to configure for this source.
+ *   - no `tier` -> `importance` carries the same hot/warm/cold vocabulary
+ *     under the same CHECK constraint, so it fills the tier slot.
+ */
+const SESSION_EVENTS_LABEL = "session_event";
+
+/** Shared SELECT list for the session-event arms; `rank` differs per arm. */
+function sessionEventColumns(rankExpression: string): string {
+  return `'${SESSION_EVENTS_LABEL}' AS source_type,
+    se.id,
+    sl.namespace,
+    se.content AS content_preview,
+    NULL::text[] AS tags,
+    se.created_by,
+    se.created_at,
+    se.created_at AS updated_at,
+    se.importance AS tier,
+    ${rankExpression},
+    0.5 AS usefulness,
+    0 AS access_count,
+    se.metadata AS extracted_metadata`;
+}
+
+/** Build the session-event vector-similarity CTE. */
+function buildSessionEventsVectorCTE(
+  perTableLimit: number,
+  tier: Tier | undefined,
+  namespaceParamIndex: number | undefined,
+  namespaceIsArray: boolean,
+): string {
+  assertTier(tier);
+  const tierFilter = tier ? ` AND se.importance = '${tier}'` : "";
+  const nsFilter = namespaceFilterSql(
+    "sl",
+    namespaceParamIndex,
+    namespaceIsArray,
+  );
+  const distance = `se.embedding <=> (SELECT emb FROM query_embedding)`;
+  return `session_events_results AS (
+  SELECT ${sessionEventColumns(`${distance} AS distance`)}
+  FROM ob_session_events se
+  JOIN ob_session_lanes sl ON sl.id = se.lane_id
+  WHERE se.embedding IS NOT NULL${tierFilter}${nsFilter}
+  ORDER BY ${distance} ASC
+  LIMIT ${perTableLimit}
+)`;
+}
+
+/** Build the session-event lexical CTE. */
+function buildSessionEventsFtsCTE(
+  perTableLimit: number,
+  tier: Tier | undefined,
+  namespaceParamIndex: number | undefined,
+  namespaceIsArray: boolean,
+): string {
+  assertTier(tier);
+  const tierFilter = tier ? ` AND se.importance = '${tier}'` : "";
+  const nsFilter = namespaceFilterSql(
+    "sl",
+    namespaceParamIndex,
+    namespaceIsArray,
+  );
+  return `session_events_fts AS (
+  SELECT ${sessionEventColumns("1.0 AS fts_rank")}
+  FROM ob_session_events se
+  JOIN ob_session_lanes sl ON sl.id = se.lane_id
+  WHERE se.content ILIKE '%' || (SELECT q FROM fts_query) || '%'${tierFilter}${nsFilter}
+  ORDER BY se.created_at DESC
+  LIMIT ${perTableLimit}
+)`;
+}
+
 /** Build one table's vector-similarity CTE. */
 function buildVectorCTE(
   table: ResourceTable,
@@ -409,7 +537,7 @@ function withCanonicalNamespaces(rows: SearchRow[]): SearchRow[] {
 /** Run the vector arm across every accessible table. */
 async function vectorSearch(
   dependencies: SearchDependencies,
-  tables: readonly ResourceTable[],
+  tables: readonly SearchSource[],
   embedding: number[],
   fetchLimit: number,
   tier: Tier | undefined,
@@ -420,13 +548,20 @@ async function vectorSearch(
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
   const namespaceIsArray = Array.isArray(namespace);
   const ctes = tables.map((table) =>
-    buildVectorCTE(
-      table,
-      fetchLimit,
-      tier,
-      namespaceParamIndex,
-      namespaceIsArray,
-    ),
+    table === "session_events"
+      ? buildSessionEventsVectorCTE(
+          fetchLimit,
+          tier,
+          namespaceParamIndex,
+          namespaceIsArray,
+        )
+      : buildVectorCTE(
+          table,
+          fetchLimit,
+          tier,
+          namespaceParamIndex,
+          namespaceIsArray,
+        ),
   );
   const unionAll = tables
     .map((table) => `SELECT * FROM ${table}_results`)
@@ -462,7 +597,7 @@ LIMIT $2 OFFSET $3`;
 /** Run the lexical arm across every accessible table. */
 async function ftsSearch(
   dependencies: SearchDependencies,
-  tables: readonly ResourceTable[],
+  tables: readonly SearchSource[],
   query: string,
   fetchLimit: number,
   tier: Tier | undefined,
@@ -474,14 +609,21 @@ async function ftsSearch(
   const namespaceParamIndex = appendNamespaceParam(params, namespace);
   const namespaceIsArray = Array.isArray(namespace);
   const ctes = tables.map((table) =>
-    buildFtsCTE(
-      table,
-      fetchLimit,
-      ftsConfig,
-      tier,
-      namespaceParamIndex,
-      namespaceIsArray,
-    ),
+    table === "session_events"
+      ? buildSessionEventsFtsCTE(
+          fetchLimit,
+          tier,
+          namespaceParamIndex,
+          namespaceIsArray,
+        )
+      : buildFtsCTE(
+          table,
+          fetchLimit,
+          ftsConfig,
+          tier,
+          namespaceParamIndex,
+          namespaceIsArray,
+        ),
   );
   const unionAll = tables
     .map((table) => `SELECT * FROM ${table}_fts`)
@@ -613,7 +755,7 @@ function rrfMerge(
  */
 async function executeSearchInternal(
   dependencies: SearchDependencies,
-  tables: readonly ResourceTable[],
+  tables: readonly SearchSource[],
   query: string,
   limit: number,
   mode: SearchMode = "hybrid",
@@ -705,7 +847,7 @@ async function executeSearchInternal(
 
 export function executeSearch(
   dependencies: SearchDependencies,
-  tables: readonly ResourceTable[],
+  tables: readonly SearchSource[],
   query: string,
   limit: number,
   mode: SearchMode = "hybrid",
@@ -880,7 +1022,7 @@ export function mergeFallbackRows(
  */
 export async function executeSearchWithSharedFallback(
   dependencies: SearchDependencies,
-  tables: readonly ResourceTable[],
+  tables: readonly SearchSource[],
   query: string,
   limit: number,
   mode: SearchMode,

--- a/src/tools/__tests__/session-events-recall.pg.test.ts
+++ b/src/tools/__tests__/session-events-recall.pg.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Live-Postgres coverage for session-event recall visibility (#433, defect 1).
+ *
+ * The defect: `brain_answer` filtered `ALL_TABLES` -- the PHYSICAL-table list
+ * that drives `PERMISSIONS` and the write paths -- so `ob_session_events` was
+ * structurally absent from every question it answered. Asking "what happened
+ * in the last day" returned months-old thoughts while the day's events sat
+ * unread. The corpus held 11,136 rows on the dogfood database when this was
+ * found.
+ *
+ * SCOPE. Defect 2 of the same issue ("nothing promotes events into durable
+ * tables") is NOT covered here and is not closed by these tests. Visibility and
+ * promotion are independent concerns.
+ *
+ * These need a live Postgres because the thing under test is a JOIN predicate.
+ * `ob_session_events` has NO `namespace` column; scope lives on
+ * `ob_session_lanes` and is reachable only through `lane_id`. A fake pool can
+ * assert that some predicate string was emitted, but only the database can
+ * prove that the predicate actually excludes a foreign row -- and that is the
+ * whole security question, because a recall path that reads this corpus without
+ * carrying the auth-derived namespace through the lane join exposes every
+ * agent's session history to every other namespace.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention). Note that
+ * without it these SKIP SILENTLY -- a green `bun test` run with the variable
+ * unset has proven nothing here.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "../../db/migrate.ts";
+import { executeSearch, readableSearchTables } from "../search-brain.ts";
+import {
+  executeSearch as executeSearchServer,
+  readableSearchSources,
+} from "../../../server/tools/search-engine.ts";
+import { createMockEmbed } from "./test-helpers.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+const CREATED_BY = "session-events-recall-pg-test";
+const OWNER_NS = "test-433-owner";
+const OTHER_NS = "test-433-other";
+
+// Keyword mode with a null-returning embed: the lexical arm must find the row
+// on its own, so a vector hit cannot mask a lexical path that was never wired.
+const embed = createMockEmbed(null);
+
+dbDescribe("session-event recall visibility (#433 defect 1)", () => {
+  const pool = new Pool({ connectionString: DB_URL });
+  const deps = { pool: pool as any, embedFn: embed };
+
+  beforeAll(async () => {
+    await runMigrations(pool as any);
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  async function cleanup(): Promise<void> {
+    await pool.query(
+      `DELETE FROM ob_session_events
+        WHERE lane_id IN (SELECT id FROM ob_session_lanes WHERE created_by = $1)`,
+      [CREATED_BY],
+    );
+    await pool.query("DELETE FROM ob_session_lanes WHERE created_by = $1", [
+      CREATED_BY,
+    ]);
+  }
+
+  /** Seed one lane in `namespace` holding one event whose content is `content`. */
+  async function seedEvent(
+    namespace: string,
+    content: string,
+  ): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO ob_session_lanes (session_key, namespace, created_by)
+       VALUES ($1, $2, $3) RETURNING id`,
+      [`${CREATED_BY}-${namespace}-${content.slice(0, 12)}`, namespace, CREATED_BY],
+    );
+    const laneId = rows[0]!.id;
+    await pool.query(
+      `INSERT INTO ob_session_events (lane_id, event_type, content, importance, created_by)
+       VALUES ($1, 'fact', $2, 'hot', $3)`,
+      [laneId, content, CREATED_BY],
+    );
+    return laneId;
+  }
+
+  function markerRows(rows: readonly any[], marker: string): any[] {
+    return rows.filter((row) =>
+      String(row.content_preview ?? "").includes(marker),
+    );
+  }
+
+  it("brain_answer's source list reaches the session-event corpus", () => {
+    // The regression that started #433 was a table list, so pin the list. Both
+    // serving trees are asserted because both are live: server/main.ts is the
+    // local-clone entrypoint and src/index.ts still serves core01.
+    expect(readableSearchTables("admin")).toContain("session_events");
+    expect(readableSearchSources("admin")).toContain("session_events");
+  });
+
+  it("keeps entities opt-in so brain_answer's citations are unchanged", () => {
+    // The fix must not quietly widen brain_answer beyond #433. `entities` rows
+    // preview as name labels rather than statements, so they belong to
+    // search_brain (which opts in) and not to the citation path.
+    expect(readableSearchTables("admin")).not.toContain("entities");
+    expect(
+      readableSearchTables("admin", { includeEntities: true }),
+    ).toContain("entities");
+  });
+
+  it("a role without sessions read access gets no session-event source", () => {
+    // `discord` holds write-only on thoughts and nothing else, so it must not
+    // reach a corpus it cannot read. This is what stops the fix from becoming a
+    // blanket widening.
+    expect(readableSearchTables("discord")).not.toContain("session_events");
+    expect(readableSearchSources("discord")).not.toContain("session_events");
+  });
+
+  it("surfaces a session event from the src serving tree", async () => {
+    const marker = "marker433src";
+    await seedEvent(OWNER_NS, `${marker} a thing that happened this session`);
+
+    const rows = await executeSearch(
+      deps,
+      readableSearchTables("admin") as any,
+      marker,
+      25,
+      "keyword",
+      undefined,
+      0,
+      OWNER_NS,
+    );
+
+    const hits = markerRows(rows, marker);
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.source_type).toBe("session_event");
+    // brain_answer refuses to cite a row without citation metadata, so an
+    // invisible-to-citation row would be as useless as an unsearchable one.
+    expect(hits[0]!.source_ref).toBeTruthy();
+    expect(hits[0]!.namespace).toBe(OWNER_NS);
+  });
+
+  it("surfaces a session event from the server serving tree", async () => {
+    const marker = "marker433srv";
+    await seedEvent(OWNER_NS, `${marker} a thing that happened this session`);
+
+    const rows = await executeSearchServer(
+      deps as any,
+      readableSearchSources("admin") as any,
+      marker,
+      25,
+      "keyword",
+      undefined,
+      0,
+      OWNER_NS,
+    );
+
+    const hits = markerRows(rows, marker);
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.source_type).toBe("session_event");
+    expect(hits[0]!.namespace).toBe(OWNER_NS);
+  });
+
+  it("does not leak another namespace's session events (src tree)", async () => {
+    // THE SECURITY ASSERTION. The event belongs to OWNER_NS; the search runs as
+    // OTHER_NS. Because ob_session_events has no namespace column, this passes
+    // only if the lane JOIN carries the predicate. Deleting the namespace
+    // filter from the session-event CTE makes exactly this fail.
+    const marker = "marker433leaksrc";
+    await seedEvent(OWNER_NS, `${marker} private to the owning namespace`);
+
+    const rows = await executeSearch(
+      deps,
+      readableSearchTables("admin") as any,
+      marker,
+      25,
+      "keyword",
+      undefined,
+      0,
+      OTHER_NS,
+    );
+
+    expect(markerRows(rows, marker)).toEqual([]);
+  });
+
+  it("does not leak another namespace's session events (server tree)", async () => {
+    const marker = "marker433leaksrv";
+    await seedEvent(OWNER_NS, `${marker} private to the owning namespace`);
+
+    const rows = await executeSearchServer(
+      deps as any,
+      readableSearchSources("admin") as any,
+      marker,
+      25,
+      "keyword",
+      undefined,
+      0,
+      OTHER_NS,
+    );
+
+    expect(markerRows(rows, marker)).toEqual([]);
+  });
+
+  it("returns the owning namespace's event and not a foreign one for the same query", async () => {
+    // Both namespaces hold a row matching the SAME query token, so a passing
+    // result cannot be explained by the query simply matching nothing. This is
+    // the case that distinguishes "the predicate works" from "the search is
+    // broken", which a single-row leak test cannot separate on its own.
+    const shared = "marker433shared";
+    await seedEvent(OWNER_NS, `${shared} owned by the caller`);
+    await seedEvent(OTHER_NS, `${shared} owned by somebody else`);
+
+    const rows = await executeSearch(
+      deps,
+      readableSearchTables("admin") as any,
+      shared,
+      25,
+      "keyword",
+      undefined,
+      0,
+      OWNER_NS,
+    );
+
+    const hits = markerRows(rows, shared);
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.namespace).toBe(OWNER_NS);
+    expect(String(hits[0]!.content_preview)).toContain("owned by the caller");
+  });
+});

--- a/src/tools/brain-answer.ts
+++ b/src/tools/brain-answer.ts
@@ -1,16 +1,16 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { canRead } from "../permissions.ts";
 import { canReadNamespace, namespaceFilterFor } from "../read-policy.ts";
 import type { AuthInfo, Tier } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import {
-  ALL_TABLES,
   executeSearch,
   executeSearchWithScopedSharedFallback,
   executeSearchWithSharedFallback,
   type SearchMode,
   type SearchRow,
+  type SearchTable,
+  readableSearchTables,
   type SourceScope,
   type SourceRef,
 } from "./search-brain.ts";
@@ -207,9 +207,16 @@ export function registerBrainAnswer(server: McpServer, deps: ToolDeps): void {
         };
       }
 
-      const accessibleTables = ALL_TABLES.filter((table) =>
-        canRead(auth.role, table),
-      );
+      // #433 defect 1: brain_answer could not see `ob_session_events` at all.
+      // It filtered ALL_TABLES -- the PHYSICAL-table list, which drives
+      // PERMISSIONS and the write paths -- so the session-event corpus was
+      // structurally absent from every question this tool answered. "What
+      // happened in the last day" answered from months-old thoughts while the
+      // day's events sat unread. search_brain had already grown a second,
+      // divergent copy of this list (it added `entities`; this one did not),
+      // which is why the selection now lives in ONE exported function that
+      // both call. Adding a source there adds it to every recall surface.
+      const accessibleTables: SearchTable[] = readableSearchTables(auth.role);
       if (accessibleTables.length === 0) {
         return {
           content: [

--- a/src/tools/search-brain.ts
+++ b/src/tools/search-brain.ts
@@ -15,7 +15,7 @@ import {
   sourceScopeSchema,
   type SourceScope,
 } from "../source-refs.ts";
-import type { AuthInfo, LinkRelation, Table, Tier } from "../types.ts";
+import type { AuthInfo, LinkRelation, Role, Table, Tier } from "../types.ts";
 import type { ToolDeps } from "./index.ts";
 import { logger } from "../logger.ts";
 import { describeError } from "../observability/index.ts";
@@ -54,7 +54,77 @@ const LABEL_TO_TABLE: Record<string, Table> = Object.fromEntries(
 
 export type SearchMode = "hybrid" | "vector" | "keyword";
 type NamespaceFilter = string | string[];
-type SearchTable = Table | "entities";
+/**
+ * Tables the retrieval arms can read.
+ *
+ * `Table` is the PHYSICAL-table type: it drives `PERMISSIONS`, the REST table
+ * enum, and every write path, so widening it would demand a permission row and
+ * a write contract for corpora that have neither. `entities` and
+ * `session_events` are read-only retrieval sources instead — searchable, never
+ * writable through this surface — and each carries its own CTE branch below
+ * because its columns do not match the shared shape.
+ */
+export type SearchTable = Table | "entities" | "session_events";
+
+/**
+ * Session events are namespaced INDIRECTLY. `ob_session_events` has no
+ * `namespace` column at all (verified against information_schema on the
+ * dogfood DB, 2026-08-07); scope lives on `ob_session_lanes` and is reached
+ * only through `ob_session_events.lane_id`. Every CTE below therefore joins
+ * the lane table and applies the auth-derived namespace predicate to
+ * `lane.namespace` — omitting that join does not merely widen results, it
+ * exposes every agent's session history to every other namespace.
+ *
+ * The corpus also lacks `archived_at`, `tier`, `tags`, `usefulness_score`,
+ * `access_count`, `search_vector`, and `source_refs`. Those slots are filled
+ * with typed literals so the UNION arms stay type-compatible, and the
+ * consequences are deliberate:
+ *   - no stored `search_vector` -> the lexical arm matches with ILIKE on
+ *     `content` rather than `to_tsvector`, so it is substring-based, not
+ *     stemmed. That is the honest capability of a column that does not exist.
+ *   - no `tier` -> `importance` carries the same hot/warm/cold vocabulary and
+ *     the same CHECK constraint, so it is used as the tier for filtering and
+ *     for TIER_BOOST.
+ *   - no `source_refs` -> a source-scope filter cannot be satisfied, so the
+ *     corpus is excluded when one is requested rather than silently ignoring
+ *     the scope (which would leak out-of-scope rows into a scoped query).
+ */
+const SESSION_EVENTS_SOURCE_LABEL = "session_event";
+
+/**
+ * The recall sources a role may read, in one place.
+ *
+ * This exists because the selection was previously OPEN-CODED at each call
+ * site, and that is exactly how #433 defect 1 happened: `search_brain` added
+ * `entities` to its list, `brain_answer` did not, and nothing added
+ * `session_events` anywhere -- so a corpus of 11,136 rows was unreachable from
+ * the tool agents actually ask. Three copies of a list is three chances to
+ * forget one. Callers that need the default set MUST use this function so a
+ * new source is added once and appears everywhere at once.
+ *
+ * `entities` and `session_events` have no PERMISSIONS row: they are read-only
+ * retrieval sources, never written through this surface, and both ride the
+ * `sessions` read permission.
+ */
+export function readableSearchTables(
+  role: Role,
+  options: { includeEntities?: boolean } = {},
+): SearchTable[] {
+  const tables: SearchTable[] = ALL_TABLES.filter((table) =>
+    canRead(role, table),
+  );
+  if (canRead(role, "sessions")) {
+    // `entities` is opt-in because the two recall surfaces legitimately differ:
+    // search_brain returns rows for a caller to read, while brain_answer cites
+    // extractive evidence, and an entity row's preview is a name label rather
+    // than a statement. Silently adding it to brain_answer would be a behavior
+    // change #433 never asked for. `session_events` is unconditional: it is
+    // real recorded content and its absence IS the defect.
+    if (options.includeEntities) tables.push("entities");
+    tables.push("session_events");
+  }
+  return tables;
+}
 export type { SourceScope };
 
 type ExecuteSearchOptions = {
@@ -652,6 +722,39 @@ function buildTableCTE(
   LIMIT ${perTableLimit}
 )`;
   }
+  if (table === "session_events") {
+    // A source scope cannot be evaluated against a corpus with no source_refs;
+    // the caller drops this table from the list in that case (see
+    // executeSearchInternal), rather than ignoring the scope and leaking
+    // out-of-scope rows into a scoped query.
+    const tierFilter = tier ? ` AND se.importance = '${tier}'` : "";
+    const nsFilter = namespaceParamIndex
+      ? namespaceIsArray
+        ? ` AND sl.namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
+        : ` AND sl.namespace = ${paramRef(namespaceParamIndex)}`
+      : "";
+    return `session_events_results AS (
+  SELECT
+    '${SESSION_EVENTS_SOURCE_LABEL}' AS source_type,
+    se.id,
+    sl.namespace,
+    se.content AS content_preview,
+    NULL::text[] AS tags,
+    se.created_by,
+    se.created_at,
+    se.created_at AS updated_at,
+    se.importance AS tier,
+    se.embedding <=> (SELECT emb FROM query_embedding) AS distance,
+    0.5 AS usefulness,
+    0 AS access_count,
+    se.metadata AS extracted_metadata
+  FROM ob_session_events se
+  JOIN ob_session_lanes sl ON sl.id = se.lane_id
+  WHERE se.embedding IS NOT NULL${tierFilter}${nsFilter}
+  ORDER BY se.embedding <=> (SELECT emb FROM query_embedding) ASC
+  LIMIT ${perTableLimit}
+)`;
+  }
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -763,6 +866,43 @@ function buildFtsCTE(
   LIMIT ${perTableLimit}
 )`;
   }
+  if (table === "session_events") {
+    // ob_session_events has no stored `search_vector` generated column, so
+    // there is no tsvector to match against and no GIN index to ride. The
+    // lexical arm matches `content` with ILIKE, exactly as the entities arm
+    // above does for its own unindexed text. This is substring matching, not
+    // stemming: it is the honest capability of a column that does not exist,
+    // and it is stated here so a reader does not assume FTS parity. The
+    // `ftsConfig` argument is deliberately unused for this table -- a text
+    // search configuration has nothing to configure without a tsvector.
+    const tierFilter = tier ? ` AND se.importance = '${tier}'` : "";
+    const nsFilter = namespaceParamIndex
+      ? namespaceIsArray
+        ? ` AND sl.namespace = ANY(${paramRef(namespaceParamIndex)}::text[])`
+        : ` AND sl.namespace = ${paramRef(namespaceParamIndex)}`
+      : "";
+    return `session_events_fts AS (
+  SELECT
+    '${SESSION_EVENTS_SOURCE_LABEL}' AS source_type,
+    se.id,
+    sl.namespace,
+    se.content AS content_preview,
+    NULL::text[] AS tags,
+    se.created_by,
+    se.created_at,
+    se.created_at AS updated_at,
+    se.importance AS tier,
+    1.0 AS fts_rank,
+    0.5 AS usefulness,
+    0 AS access_count,
+    se.metadata AS extracted_metadata
+  FROM ob_session_events se
+  JOIN ob_session_lanes sl ON sl.id = se.lane_id
+  WHERE se.content ILIKE '%' || (SELECT q FROM fts_query) || '%'${tierFilter}${nsFilter}
+  ORDER BY se.created_at DESC
+  LIMIT ${perTableLimit}
+)`;
+  }
   const alias = TABLE_ALIAS[table];
   const label = SOURCE_LABELS[table];
   const preview = CONTENT_PREVIEW[table];
@@ -867,8 +1007,12 @@ async function relationalGraphSearch(
 ): Promise<SearchRow[]> {
   const parsed = parseRelationalQuery(query);
   if (!parsed) return [];
+  // Relational hydration walks `ob_links` from a seed entity into the physical
+  // content tables. `entities` is the seed side, and `session_events` has no
+  // rows in the link graph, so neither is a hydration target.
   const targetTables = accessibleTables.filter(
-    (table): table is Table => table !== "entities",
+    (table): table is Table =>
+      table !== "entities" && table !== "session_events",
   );
   if (targetTables.length === 0) return [];
 
@@ -1292,7 +1436,12 @@ async function executeSearchInternal(
   const enableGraph = options.enableGraph === true;
   const ftsConfig = options.ftsConfig ?? DEFAULT_FTS_CONFIG;
   if (sourceScope) {
-    accessibleTables = accessibleTables.filter((table) => table !== "entities");
+    // Neither corpus carries `source_refs`, so a source-scope predicate cannot
+    // be evaluated against them. Dropping them is the safe reading: keeping
+    // them would return rows the scope never authorized.
+    accessibleTables = accessibleTables.filter(
+      (table) => table !== "entities" && table !== "session_events",
+    );
     if (accessibleTables.length === 0) return [];
   }
   let rows: SearchRow[];
@@ -1673,9 +1822,10 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
             "projects",
             "sessions",
             "entities",
+            "session_events",
           ])
           .optional()
-          .describe("Optional: limit search to a specific table"),
+          .describe("Optional: restrict search to a single named source"),
         namespace: z
           .string()
           .trim()
@@ -1769,6 +1919,23 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
             };
           }
           accessibleTables = ["entities"];
+        } else if (tableFilter === "session_events") {
+          // Session events are session-scoped content, so they ride the
+          // `sessions` read permission -- the same indirection `entities` uses
+          // above. There is no `session_events` row in PERMISSIONS because the
+          // corpus is read-only through this surface and never written here.
+          if (!canRead(auth.role, "sessions")) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: "Permission denied: cannot read session_events",
+                },
+              ],
+              isError: true,
+            };
+          }
+          accessibleTables = ["session_events"];
         } else if (!canRead(auth.role, tableFilter)) {
           return {
             content: [
@@ -1783,10 +1950,9 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
           accessibleTables = [tableFilter];
         }
       } else {
-        accessibleTables = ALL_TABLES.filter((t) => canRead(auth.role, t));
-        if (canRead(auth.role, "sessions")) {
-          accessibleTables.push("entities");
-        }
+        accessibleTables = readableSearchTables(auth.role, {
+          includeEntities: true,
+        });
       }
 
       if (accessibleTables.length === 0) {
@@ -1844,8 +2010,11 @@ export function registerSearchBrain(server: McpServer, deps: ToolDeps): void {
         };
       }
       if (sourceScope) {
+        // Same reason as executeSearchInternal: no source_refs column means a
+        // source scope cannot be honored, so the corpus is excluded rather
+        // than silently ignoring the scope.
         accessibleTables = accessibleTables.filter(
-          (table) => table !== "entities",
+          (table) => table !== "entities" && table !== "session_events",
         );
       }
       if (accessibleTables.length === 0) {


### PR DESCRIPTION
Closes nothing. **#433 stays open** — this is defect 1 only.

## Summary

`brain_answer` could not reach `ob_session_events` **at all**. It selected its sources by filtering `ALL_TABLES` — the PHYSICAL-table list that drives `PERMISSIONS`, the REST enum, and every write path — so a corpus of **11,136 rows** (80 of them from the last 24h, measured on the dogfood DB 2026-08-07) was structurally absent from every question the tool answered. Asking *"what happened in the last day"* returned months-old thoughts while the day's own events sat unread.

### The shape of it is a duplicated list

`search_brain` had already grown a second, divergent copy of the same selection — it appends `entities`, `brain_answer` did not — and nothing appended the session-event corpus to either. Each new recall surface was one more place to forget.

The selection now lives in **one exported function per serving tree** (`readableSearchTables`, `readableSearchSources`), and every caller uses it. A source added there appears everywhere at once.

### Approach

Session events follow the existing `entities` precedent: a **read-only retrieval source** with its own CTE branch, **not** a widening of `Table`/`ResourceTable`. Those unions carry write contracts and permission rows this corpus has neither of. It rides the `sessions` read permission, so a role that cannot read sessions cannot reach it.

**Namespace isolation is the risk, and it is load-bearing.** `ob_session_events` has **no `namespace` column**. Scope lives on `ob_session_lanes`, reachable only through `lane_id`. Both new CTEs `JOIN` the lane table and apply the auth-derived namespace predicate to `sl.namespace`. Omitting that join would not merely widen results — it would expose every agent's session history to every other namespace.

**Both serving trees are fixed**, because both are live: `server/main.ts` is the local-clone serving entrypoint, and `src/index.ts` still serves core01 via `deploy/open-brain.service` and `scripts/run-two-worker.ts` (the repo states this at `src/index.ts:52-60` and `src/tools/agent-context-pack.ts:215`). Fixing one would have left a live path still blind to the corpus.

### Deliberate limitations, stated rather than hidden

- No stored `search_vector` → the lexical arm matches `content` with ILIKE. **Substring matching, not stemming.** That is the honest capability of a column that does not exist, and it is why `ftsConfig` has nothing to configure for this source.
- No `source_refs` → excluded when a source scope is requested, rather than silently ignoring the scope and returning rows it never authorized.
- No `tier` → `importance` fills the slot; same hot/warm/cold vocabulary, same CHECK constraint.
- `entities` stays **opt-in**, so `brain_answer`'s citation behavior is unchanged by this fix.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

### done-means: red, then green

`scripts/done-means/433-recall-sees-session-events.sh` is the acceptance gate. It seeds a markered event in a throwaway lane, drives the real `executeSearch` of **both** trees, and tears down always.

**RED (before the fix):**

```
probe result    : own=0 other=0
CLAUSE 1 visibility         : FAIL
  INVISIBLE: the row exists (seeded=1, confirmed in ob_session_events) but the
  real recall path returned 0 rows carrying the marker. Searched tables were
  [thoughts,decisions,relationships,projects,sessions] — the session-event
  corpus is not among them.
CLAUSE 2 namespace isolation: FAIL
  not assessed: with the corpus invisible to recall, a zero cross-namespace
  count proves only that nothing is searched.
RESULT: FAIL
```

**GREEN (after the fix):**

```
probe result    : own=1 other=0 (worst across trees)
per serving tree: src=1/0 server=1/0
CLAUSE 1 visibility         : PASS
CLAUSE 2 namespace isolation: PASS
  no leak: the same marker query under an unrelated namespace returned 0
  marker-bearing rows while the owning namespace returned 1
RESULT: PASS
```

The gate calls the real `readableSearchTables`/`readableSearchSources` rather than re-deriving the list — a third copy of a list is precisely the defect being fixed.

### The leak clause is proven, not asserted

Deleting the namespace predicate from the session-event CTE makes the gate report:

```
CLAUSE 2 namespace isolation: FAIL
  NAMESPACE LEAK: 1 marker-bearing row(s) visible from namespace
  done-means-433-other-…, which owns none of them. The lane join is not
  carrying the auth-derived namespace predicate.
```

and makes **3 of the 8 new tests fail**. Restored → all pass.

### Tests and gates

`src/tools/__tests__/session-events-recall.pg.test.ts` — 8 tests on live Postgres: visibility per tree, cross-namespace non-leakage per tree, the both-namespaces-match-the-same-query case (which separates "the predicate works" from "the search is broken"), role gating, and the entities-stays-opt-in guard.

- `bunx tsc --noEmit` — clean (exit 0).
- `bun test` — **3709 pass / 0 fail**, with `OPENBRAIN_TEST_DATABASE_URL` **SET** against a real UTF8 database. Flagging this explicitly: Postgres tests skip silently without it, so a green run with it unset would have proven nothing here.
- One earlier full local run showed `1 fail`; three subsequent full runs were clean, and the failure did not reproduce or name a test in captured output. Reporting it rather than omitting it — it is unexplained, not dismissed. It was **not** the CI failure on this PR, which was a PR-body gate (see below).

## Critical Self-Review

- Highest-risk behavior: cross-namespace leakage of session events. `ob_session_events` has no namespace column, so isolation depends entirely on the `ob_session_lanes` join predicate. Covered by 3 tests plus a gate clause, all mutation-verified to fail when the predicate is removed.
- Assumptions that could be wrong: that the `sessions` read permission is the right gate for session events. It matches the `entities` precedent, but it is a judgment call — a reviewer may prefer an explicit PERMISSIONS row. Also assumed both serving trees are live based on in-repo comments rather than a running-process check.
- Missing/weak tests: no test drives `brain_answer` end-to-end through MCP for the session-event path; coverage is at `executeSearch`. Vector-arm retrieval of session events is untested (tests force keyword mode deliberately, so a vector hit cannot mask a missing lexical path). No test for the source_scope exclusion path.
- Security/permission risk: the namespace predicate is the whole control and it is tested by deletion, not just asserted. The source-scope exclusion takes the conservative direction (drop the corpus rather than ignore the scope). Role gating tested for `discord`.
- Migration/deploy risk: none — no schema change, no migration, read-path only.
- Downstream client/runtime risk: `search_brain`'s `table` enum gains `session_events` and results gain a new `source_type` of `session_event`. A client that exhaustively switches on `source_type` would meet an unhandled value. Per `docs/downstream-rollout.md` this is a client-facing schema change; the rollout lane subsequently classified every client step N/A with evidence (see Downstream Rollout section) — no downstream client enumerates `search_brain` sources or handles its `source_type` exhaustively.
- Rollback/cleanup concern: revert is clean (read path only). The done-means script writes its probe to the temp scratch bucket rather than the checkout, so it leaves `git status` clean.
- Fixes made before PR: the shared helper initially added `entities` to `brain_answer` — a behavior change #433 never asked for — so it was made opt-in and pinned with a test. Also removed a now-unused `canRead` import.
- Known residual risk: ILIKE substring matching on `content` has no index behind it, so the lexical arm scans the corpus. Documented in the code rather than papered over. Real retrieval-quality behavior of session events mixed into RRF ranking has not been evaluated against a human judgment set.
- SME review-memory update: [x] `docs/sme/` updated

`docs/sme/correctness.md` gains the duplicated-selection-list pattern (commit 42fc3bb): one selection rule open-coded per caller diverges silently, and the three checks that follow — extract one selection function, check every serving tree, and do not let the acceptance gate re-derive the list a fourth time.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below

Live checks ran against the dogfood service (`127.0.0.1:3100`, healthy, `revision b2bd77d`) and the dogfood database `open_brain_local_20260724`. The done-means gate seeds into and reads from that live database on every run; the RED and GREEN transcripts above are its real output. Post-run verification confirmed zero residual rows (`session_key like 'done-means-433%'` → 0, marker content → 0), so teardown is proven rather than assumed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- The lane originally left these unchecked because the verification had not been run — see the history for that honest state. A dedicated downstream-rollout lane then ran the classification (2026-08-07); full per-step evidence with file:line citations is in the PR comment: https://github.com/rodaddy/open-brain/pull/610#issuecomment-5224186274
- Summary: rtech-mcps N/A (registry entry is a bare URL pointer, no schemas); mcp2cli N/A (zero hardcoded OB table lists; generated skill carries no param table); rtech-hermes N/A (`READ_TOOL_ALLOWLIST` excludes `search_brain`/`brain_answer`; `search_all` is unaffected by this diff); live canaries N/A pre-merge, with a RUNNING read-only canary proving the deployed build rejects `session_events` today (server-enforced enum).
- Remaining post-merge, tracked on #433: deploy core01, re-run the canary expecting success, one `brain_answer` returning `source_type: "session_event"`.
- Pre-existing drift found (not caused here): rtech-hermes `openbrain/contract.py:50` pins schema v20 / hash `4df9c742…` while live serves v23 / `4b69e9b4…` — exists on `main` today, flagged for its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

