### PR TITLE
fix(thoughts): route every thought write through chunk-write (#605)

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1840,3 +1840,23 @@ A diff/comparison tool is an operator trust surface: what it prints is what the 
 ### Pattern
 
 A hand-written stub proves conformance to the stub, not to the external API. Langfuse detail responses return full observation objects, but list rows return observation ID strings; reusing the detail shape in list fixtures made every test pass while every live `session` and `repeat` call failed validation. For each external endpoint, capture and sanitize a real response, preserve its envelope and value types, and drive the public caller through that fixture. Do not reuse a sibling endpoint's richer response shape unless the live wire contract proves they are identical.
+
+## [2026-08-07] One helper does not make a boundary until every writer of the table reaches it
+
+**Severity:** HIGH
+**Source:** issue #605, PR #611 (thought-write chunk routing)
+**Scope key:** `review.shared_write_boundary_reaches_all_writers`
+**Status:** active
+
+### Pattern
+
+`src/chunk-write.ts` defined how a long thought must be stored — complete parent plus per-section chunk rows — and only ONE of the four writers that insert into `thoughts` called it. The rewrite-tree `log_thought` (`server/tools/capture.ts`), REST `POST /api/v1/thoughts` (`src/rest-api.ts`), and lane graduation (`src/tiering.ts`) each wrote a parent and stopped, so whether a 6 KB thought kept its per-section resolution depended on which door it came through. The storage rule existed, was documented, was tested, and was still false for three of four callers.
+
+The tell was a receipt field hardcoded to a constant: `capture.ts` returned `chunks_written: 0` unconditionally. A literal in a count field reports the shape of a code path rather than the state of the row, and it reads as a legitimate value (a short entry really does write zero chunks), so it survives review and makes the bypass invisible in the response.
+
+Review questions when any helper is described as "the" boundary for a table:
+
+- Count the writers first (`rg` the INSERT against the table name), then name which ones call the helper. "The write path" is a claim about a set, not about one file.
+- Refactor the already-compliant caller ONTO the shared function rather than leaving it as a fourth copy that happens to agree. Four implementations that agree today are not one boundary; they are four things that will drift.
+- Fixtures do not catch this when they exercise the trivial case. The parity fixture asserting `chunks_written: 0` passed both before and after the fix, because its thought was under the threshold — the field is genuinely 0 on both sides. A fixture that can never distinguish the defect from correct behavior is not coverage.
+- In the acceptance gate, drive each path at its REAL entry point and assert on distinct provenance (here: `source` values `mcp` / `rest` / `lane-tiering`). Calling the shared helper three times, or driving three paths that quietly funnel into one, proves nothing about routing.

--- a/scripts/done-means/605-chunk-write-routing.driver.ts
+++ b/scripts/done-means/605-chunk-write-routing.driver.ts
@@ -1,0 +1,197 @@
+/**
+ * Driver for the #605 DONE-MEANS check. Not a test file; invoked by
+ * scripts/done-means/605-chunk-write-routing.sh, which owns the verdict.
+ *
+ * Each of the three thought-write paths named in #605 is driven at its REAL
+ * entry point against the dogfood database, with a long thought (over
+ * CHUNK_THRESHOLD), in a throwaway namespace this script seeds and the shell
+ * script tears down:
+ *
+ *   rewrite-tree log_thought  -> the registered MCP tool handler from
+ *                                server/tools/capture.ts, invoked through a
+ *                                real McpServer + in-memory transport.
+ *   REST POST /api/v1/thoughts -> the router from src/rest-api.ts mounted on a
+ *                                real express app and reached over HTTP.
+ *   lane graduation            -> graduateLaneEvent() from src/tiering.ts.
+ *
+ * The embedding PROVIDER is stubbed with a deterministic vector so the check
+ * does not depend on a live MLX endpoint. Everything else -- routing, SQL,
+ * parent linkage -- is the production code path against real Postgres.
+ *
+ * Output is one JSON object written to the path in DONE_MEANS_605_OUT: per-path
+ * parent id and the tally of chunk rows found with parent_id = that parent. No
+ * content, no credentials.
+ *
+ * It goes to a FILE, not stdout, because the application logger this code path
+ * legitimately uses writes its own JSON lines to stdout — including the
+ * `entry_chunk_write_*` lines this very fix emits. Parsing stdout made the
+ * shell read a log line as the result and report "no parent id" for paths that
+ * had in fact succeeded, i.e. a false FAIL produced by the harness.
+ */
+import { Pool } from "pg";
+import express from "express";
+import type { Request, Response, NextFunction } from "express";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  InMemoryTransport,
+} from "@modelcontextprotocol/sdk/inMemory.js";
+import pino from "pino";
+import { createRestRouter } from "../../src/rest-api.ts";
+import { registerCaptureTools } from "../../server/tools/capture.ts";
+import { graduateLaneEvent } from "../../src/tiering.ts";
+import { EMBEDDING_DIMENSIONS } from "../../src/embedding.ts";
+import { CHUNK_THRESHOLD } from "../../src/chunking.ts";
+
+if (
+  !process.env.DONE_MEANS_605_NS ||
+  !process.env.DONE_MEANS_605_MARKER ||
+  !process.env.DONE_MEANS_605_OUT
+) {
+  console.error(
+    "DONE_MEANS_605_NS, DONE_MEANS_605_MARKER and DONE_MEANS_605_OUT are required",
+  );
+  process.exit(3);
+}
+const NS: string = process.env.DONE_MEANS_605_NS;
+const MARKER: string = process.env.DONE_MEANS_605_MARKER;
+const OUT_PATH: string = process.env.DONE_MEANS_605_OUT;
+
+const CREATED_BY = "done-means-605";
+
+/** A thought comfortably over CHUNK_THRESHOLD, so chunking must engage. */
+function longThought(tag: string): string {
+  const sentence =
+    `Routing probe ${MARKER} ${tag}: every thought write must reach the chunk ` +
+    `writer so a long entry lands as a complete parent plus per-section rows. `;
+  let text = "";
+  while (text.length < CHUNK_THRESHOLD * 3) text += sentence;
+  return text;
+}
+
+const stubEmbed = async (): Promise<number[]> =>
+  Array(EMBEDDING_DIMENSIONS).fill(0.01);
+
+const pool = new Pool();
+
+async function chunkCount(parentId: string): Promise<number> {
+  const { rows } = await pool.query(
+    `SELECT count(*)::int AS n FROM thoughts WHERE parent_id = $1`,
+    [parentId],
+  );
+  return rows[0].n as number;
+}
+
+/** Path 1 -- rewrite-tree log_thought, through a real MCP client/server pair. */
+async function driveCapture(): Promise<string> {
+  const server = new McpServer({ name: "done-means-605", version: "0" });
+  registerCaptureTools(server as any, {
+    pool,
+    embedFn: stubEmbed,
+    logger: pino({ level: "silent" }),
+  } as any);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: "done-means-605-client", version: "0" });
+  // The handler reads identity from extra.authInfo, which the transport
+  // carries per-request; InMemoryTransport forwards what we attach here.
+  (serverTransport as any).onmessage_authInfo = undefined;
+  await client.connect(clientTransport);
+
+  // Attach auth to every request the server sees.
+  const origOnMessage = (serverTransport as any).onmessage;
+  (serverTransport as any).onmessage = (msg: unknown, extra?: any) => {
+    origOnMessage?.(msg, {
+      ...(extra ?? {}),
+      authInfo: { role: "admin", clientId: CREATED_BY, namespaceSource: "token" },
+    });
+  };
+
+  const result: any = await client.callTool({
+    name: "log_thought",
+    arguments: { content: longThought("capture"), namespace: NS },
+  });
+  await client.close();
+  await server.close();
+
+  const text = result?.content?.[0]?.text ?? "";
+  const payload = JSON.parse(text);
+  if (!payload.id) throw new Error(`capture path returned no id: ${text}`);
+  return payload.id as string;
+}
+
+/** Path 2 -- REST POST /api/v1/thoughts, over real HTTP. */
+async function driveRest(): Promise<string> {
+  const app = express();
+  app.use(express.json({ limit: "10mb" }));
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    (req as any).auth = { role: "admin", clientId: CREATED_BY };
+    next();
+  });
+  app.use("/api/v1", createRestRouter({ pool, embedFn: stubEmbed as any }));
+
+  const server = app.listen(0);
+  await new Promise<void>((r) => server.once("listening", () => r()));
+  const port = (server.address() as { port: number }).port;
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/v1/thoughts`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content: longThought("rest"), namespace: NS }),
+  });
+  const body: any = await res.json();
+  await new Promise<void>((r) => server.close(() => r()));
+
+  if (!body?.id) throw new Error(`rest path returned no id: ${JSON.stringify(body)}`);
+  return body.id as string;
+}
+
+/** Path 3 -- lane graduation. */
+async function driveGraduation(): Promise<string> {
+  const content = longThought("graduation");
+  const result = await graduateLaneEvent(
+    pool,
+    {
+      id: "00000000-0000-4000-8000-000000000605",
+      lane_id: "00000000-0000-4000-8000-000000000606",
+      session_key: `done-means-605-${MARKER}`,
+      event_type: "fact",
+      content,
+      content_hash: null,
+      importance: 5,
+      agent: CREATED_BY,
+      namespace: NS,
+    } as any,
+    NS,
+    CREATED_BY,
+    await stubEmbed(),
+    "done-means-605 routing probe",
+    stubEmbed,
+  );
+  return result.thought_id;
+}
+
+async function main() {
+  const out: Record<string, unknown> = {};
+  for (const [name, fn] of [
+    ["capture", driveCapture],
+    ["rest", driveRest],
+    ["graduation", driveGraduation],
+  ] as const) {
+    try {
+      const parentId = await fn();
+      out[name] = { parent_id: parentId, chunks: await chunkCount(parentId) };
+    } catch (error) {
+      out[name] = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+  await Bun.write(OUT_PATH, JSON.stringify(out));
+  await pool.end();
+}
+
+await main();

--- a/scripts/done-means/605-chunk-write-routing.sh
+++ b/scripts/done-means/605-chunk-write-routing.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #605 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/605-chunk-write-routing.sh
+#
+# Issue #605 asks for ONE shared thought-write boundary used by both serving
+# trees, REST creation, and lane graduation. `writeEntryChunks`
+# (src/chunk-write.ts) is that boundary; #605's evidence is that only
+# src/tools/log-thought.ts reaches it.
+#
+# ACCEPTANCE, as this script enforces it: a thought longer than
+# CHUNK_THRESHOLD (src/chunking.ts, 2000 chars) written through ANY of the
+# three named paths must land as a parent row PLUS chunk rows linked by
+# parent_id. Zero chunk rows on a long thought is the defect.
+#
+# The three paths, each driven at its REAL entry point by the companion
+# driver (605-chunk-write-routing.driver.ts) — not by calling the chunk
+# writer directly, which would prove nothing about routing:
+#
+#   capture     server/tools/capture.ts  — the rewrite-tree `log_thought` MCP
+#               tool, invoked through a real McpServer over an in-memory
+#               transport. Rows land with source='mcp'.
+#   rest        src/rest-api.ts          — POST /api/v1/thoughts on a real
+#               express app over real HTTP. Rows land with source='rest'.
+#   graduation  src/tiering.ts           — graduateLaneEvent(). Rows land with
+#               source='lane-tiering'.
+#
+# The three distinct `source` values are what prove the driver exercised three
+# separate production writers rather than one shared helper three times.
+#
+# DELIBERATELY NOT COVERED, per #605's own "Intentionally separate paths":
+# decompose-entry replacement semantics (src/chunk-write.ts:21-26 states the
+# opposite intent explicitly), ingest-raw-turn, and append-session-event. A
+# check that demanded chunk rows from those would be enforcing the wrong
+# design.
+#
+# EXPECTED TO FAIL until #605 is fixed. It is the reward function, not a test
+# of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# Unlike the #598 check — where the server derives namespace from the bearer
+# token and OPENBRAIN_NAMESPACE does not steer the write — these paths take
+# namespace as a call/request parameter, so a throwaway namespace IS available
+# and is the cleanest isolation: one random namespace per run, deleted on exit
+# whatever the verdict. The random RUN_ID makes collision with real data
+# impossible, so the teardown DELETE cannot reach anything else.
+#
+# The embedding provider is stubbed in the driver with a deterministic vector,
+# so a down MLX endpoint cannot turn a routing defect into a false PASS or a
+# working fix into a false FAIL. Routing, SQL, and parent linkage are all real.
+#
+# Output is content-free: path names, ids, and counts only.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DRIVER="$SCRIPT_DIR/605-chunk-write-routing.driver.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -r "$DRIVER" ] || fail_hard "driver not readable at $DRIVER"
+command -v python3 >/dev/null 2>&1 || fail_hard "python3 not on PATH (JSON reader)"
+
+# .env carries the libpq vars, so bare psql needs no connection arguments, and
+# the driver's `new Pool()` reads the same PG* vars. See AGENTS.md "Querying
+# the dogfood database". A worktree has no .env of its own; fall back to the
+# canonical checkout's copy so this runs from either.
+ENV_FILE="$REPO_ROOT/.env"
+[ -r "$ENV_FILE" ] || ENV_FILE="/Volumes/ThunderBolt/Development/open-brain/.env"
+[ -r "$ENV_FILE" ] || fail_hard "no readable .env for dogfood DB credentials"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+psql -At -c 'select 1' >/dev/null 2>&1 ||
+  fail_hard "cannot reach the dogfood database; row proof and teardown are both impossible, so a PASS could not be trusted"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+NS="done-means-605-${RUN_ID}"
+MARKER="rlvr605-${RUN_ID}"
+
+# The driver reports into a FILE rather than stdout. The production code it
+# drives logs JSON lines to stdout through the app logger -- including the
+# `entry_chunk_write_*` lines the fix itself emits -- so reading stdout made the
+# harness parse a log line as the result and report "no parent id" for paths
+# that had succeeded: a false FAIL manufactured by the check, not by the code.
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT_FILE="$SCRATCH/done-means-605-${RUN_ID}.json"
+
+teardown() {
+  psql -At -c "delete from thoughts where namespace = '$NS';" >/dev/null 2>&1
+  mv -f "$OUT_FILE" "$OUT_FILE.done" 2>/dev/null
+}
+trap teardown EXIT
+
+DONE_MEANS_605_NS="$NS" DONE_MEANS_605_MARKER="$MARKER" \
+  DONE_MEANS_605_OUT="$OUT_FILE" bun "$DRIVER" >/dev/null 2>&1
+DRIVER_EXIT=$?
+
+OUT="$(cat "$OUT_FILE" 2>/dev/null)"
+
+if [ "$DRIVER_EXIT" -ne 0 ] || [ -z "$(printf '%s' "$OUT" | tr -d '[:space:]')" ]; then
+  fail_hard "driver exited $DRIVER_EXIT without writing usable JSON to $OUT_FILE"
+fi
+
+# field <path> <key> -> value, or empty
+field() {
+  printf '%s' "$OUT" | python3 -c '
+import json,sys
+try:
+    d=json.loads(sys.stdin.read())
+except Exception:
+    print(""); sys.exit(0)
+v=d.get(sys.argv[1])
+if not isinstance(v,dict):
+    print(""); sys.exit(0)
+x=v.get(sys.argv[2])
+print("" if x is None else x)
+' "$1" "$2" 2>/dev/null
+}
+
+# Independent proof, read from the database rather than from the driver's own
+# report: the tally of chunk rows carrying this parent. A driver that
+# misreported its own count cannot move this number.
+db_chunks_for() {
+  psql -At -c "select count(*) from thoughts where parent_id = '$1';" 2>/dev/null |
+    tr -d '[:space:]'
+}
+
+db_source_for() {
+  psql -At -c "select source from thoughts where id = '$1';" 2>/dev/null |
+    tr -d '[:space:]'
+}
+
+OVERALL=PASS
+RESULTS=""
+
+for path in capture rest graduation; do
+  PARENT="$(field "$path" parent_id)"
+  ERR="$(field "$path" error)"
+
+  if [ -n "$ERR" ]; then
+    OVERALL=FAIL
+    RESULTS="${RESULTS}${path}: FAIL — path could not be driven: ${ERR}"$'\n'
+    continue
+  fi
+  if [ -z "$PARENT" ]; then
+    OVERALL=FAIL
+    RESULTS="${RESULTS}${path}: FAIL — driver returned no parent id"$'\n'
+    continue
+  fi
+
+  SRC="$(db_source_for "$PARENT")"
+  CHUNKS="$(db_chunks_for "$PARENT")"
+  [ -n "$CHUNKS" ] || CHUNKS=0
+
+  if [ "$CHUNKS" -ge 1 ]; then
+    RESULTS="${RESULTS}${path}: PASS — parent=${PARENT} source=${SRC} chunk rows with parent_id=${CHUNKS}"$'\n'
+  else
+    OVERALL=FAIL
+    RESULTS="${RESULTS}${path}: FAIL — parent=${PARENT} source=${SRC} wrote a long thought but ZERO chunk rows link to it (bypasses writeEntryChunks)"$'\n'
+  fi
+done
+
+# A run where all three paths reported the same `source` would mean the driver
+# collapsed them into one writer, so the per-path verdicts would be measuring
+# one path three times. Reported so a reader can see the three writers were
+# distinct.
+SOURCES="$(psql -At -c "select string_agg(distinct source, ',' order by source) from thoughts where namespace = '$NS' and parent_id is null;" 2>/dev/null | tr -d '[:space:]')"
+
+printf '\n=== DONE-MEANS #605: every thought write routes through chunk-write ===\n\n'
+printf '%s' "$RESULTS"
+printf '\nparent-row sources exercised: %s (expect capture=mcp, rest=rest, graduation=lane-tiering)\n' "${SOURCES:-none}"
+printf 'throwaway namespace: %s (removed on exit)\n' "$NS"
+printf '\nVERDICT: %s\n\n' "$OVERALL"
+
+[ "$OVERALL" = PASS ] || exit 1
+exit 0

--- a/scripts/tier-lane-durable.ts
+++ b/scripts/tier-lane-durable.ts
@@ -356,6 +356,7 @@ export async function runLaneTiering(args: Args): Promise<Receipt> {
             "openbrain-lane-tiering",
             embedding,
             `lane tiering: ${event.event_type}/${event.importance}`,
+            generateEmbedding,
           );
           applied += 1;
           addCount(receipt, namespace, "graduated");

--- a/server/tools/capture.ts
+++ b/server/tools/capture.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { authIdentity, textResult, type MemoryToolDependencies } from "./types.ts";
 import { authorize, contentHash, decisionText, embeddingFields } from "./memory-helpers.ts";
+import { writeThoughtChunks, chunkReceiptFields } from "../../src/chunk-write.ts";
 
 const sourceRefsSchema = z.array(z.record(z.string(), z.unknown())).max(20);
 
@@ -108,6 +109,23 @@ async function writeThought(
     ],
   );
   const row = rows.rows[0];
+
+  // CHUNK ROWS FOR A LONG ENTRY (#605). The parent above holds the full text
+  // and its own whole-text vector; these add per-section resolution. This tree
+  // previously reported a hardcoded chunks_written: 0 while writing no chunks
+  // at all, which read as "short entry" for entries of any length.
+  const chunks = await writeThoughtChunks(dependencies.pool, {
+    parentId: row.id as string,
+    namespace,
+    createdBy,
+    content: args.content,
+    tags: args.tags ?? [],
+    embedFn: dependencies.embedFn,
+    source: "mcp-chunk",
+    isNew: row.is_new as boolean,
+    caller: "server/log_thought",
+  });
+
   dependencies.logger.info({ tool: "log_thought", embedded: embedded.embedded }, "tool_result");
   return textResult({
     id: row.id,
@@ -115,8 +133,7 @@ async function writeThought(
     embedded: embedded.embedded,
     merged: !row.is_new,
     source_refs: row.source_refs,
-    chunks_written: 0,
-    chunks_unembedded: 0,
+    ...chunkReceiptFields(chunks),
   });
 }
 

--- a/src/chunk-write.ts
+++ b/src/chunk-write.ts
@@ -44,6 +44,113 @@ export interface ChunkWriteResult {
 }
 
 /**
+ * What a caller reports after a thought parent has been committed and its
+ * chunk rows attempted. Exactly one of `result` / `failed` is meaningful:
+ *
+ *   result null + failed false -> nothing to chunk (short entry, or a merge
+ *                                onto an existing parent whose chunks exist).
+ *   result set  + failed false -> chunked; the counts are the receipt.
+ *   result null + failed true  -> the parent committed with the COMPLETE text
+ *                                and per-section writing threw.
+ */
+export interface ChunkAttempt {
+  result: ChunkWriteResult | null;
+  failed: boolean;
+}
+
+/**
+ * THE THOUGHT-WRITE BOUNDARY (#605).
+ *
+ * Every writer that commits a row to `thoughts` calls this immediately after,
+ * so "a long thought is stored as a complete parent plus per-section rows" is
+ * a property of the table rather than of one code path that remembered.
+ * Before #605 only src/tools/log-thought.ts chunked; the rewrite-tree
+ * `log_thought` (server/tools/capture.ts), REST `POST /api/v1/thoughts`
+ * (src/rest-api.ts), and lane graduation (src/tiering.ts) each wrote a parent
+ * and stopped, so a long thought arriving through any of them lost its
+ * per-section resolution silently.
+ *
+ * WHY IT SWALLOWS THE THROW. The parent is already committed and holds every
+ * character, so the entry is not lost -- only its resolution is. Turning that
+ * into a failed write would discard a good parent over a recoverable partial,
+ * which is the opposite of the guarantee. So the failure is REPORTED: logged
+ * as `entry_chunk_write_failed` here, and returned as `failed: true` so the
+ * caller's receipt can say `chunking_status: "failed"`. That distinction is
+ * load-bearing -- without it a failed attempt is byte-identical to a short
+ * entry that was never chunked, and a repair pass has no signal.
+ *
+ * NOT applicable when `isNew` is false: a merge means the chunk rows were
+ * written on the original insert. Note a merge does NOT repair a parent left
+ * partially chunked by an earlier failure; that belongs to the embedding/chunk
+ * repair pass (src/embedding-repair.ts), which is what `failed` signals to.
+ *
+ * This does NOT cover the paths #605 lists as intentionally separate:
+ * decompose-entry writes the same columns with REPLACEMENT semantics (see the
+ * header above), and raw turns / session events are their own write
+ * boundaries by design.
+ */
+export async function writeThoughtChunks(
+  pool: Pool,
+  options: {
+    parentId: string;
+    namespace: string;
+    createdBy: string;
+    content: string;
+    tags?: string[];
+    embedFn: (text: string) => Promise<number[] | null>;
+    source?: string;
+    /** False for a merge onto an existing parent; chunking is skipped. */
+    isNew: boolean;
+    /** Names the calling writer in the failure log. */
+    caller: string;
+  },
+): Promise<ChunkAttempt> {
+  if (!options.isNew) return { result: null, failed: false };
+
+  try {
+    const result = await writeEntryChunks(pool, {
+      table: "thoughts",
+      parentId: options.parentId,
+      namespace: options.namespace,
+      createdBy: options.createdBy,
+      content: options.content,
+      tags: options.tags,
+      embedFn: options.embedFn,
+      source: options.source,
+    });
+    return { result, failed: false };
+  } catch (error) {
+    logger.error("entry_chunk_write_failed", {
+      caller: options.caller,
+      parent_id: options.parentId,
+      content_length: options.content.length,
+      error_name: error instanceof Error ? error.name : "unknown",
+      error_message: error instanceof Error ? error.message : String(error),
+    });
+    return { result: null, failed: true };
+  }
+}
+
+/**
+ * The chunk fields a caller merges into its response payload.
+ *
+ * Kept here so all four writers report the same receipt shape: the counts when
+ * chunking ran, `chunking_status: "failed"` when the parent committed but
+ * per-section writing threw, and NOTHING when chunking did not apply.
+ */
+export function chunkReceiptFields(attempt: ChunkAttempt): Record<string, unknown> {
+  return {
+    ...(attempt.result
+      ? {
+          chunks_written: attempt.result.written,
+          chunks_unembedded: attempt.result.unembedded,
+        }
+      : {}),
+    ...(attempt.failed ? { chunking_status: "failed" as const } : {}),
+  };
+}
+
+/**
  * Split `content` and write one row per chunk, linked to `parentId`.
  *
  * Safe to call for any entry: content at or below {@link CHUNK_THRESHOLD} is a

--- a/src/rest-api.ts
+++ b/src/rest-api.ts
@@ -12,6 +12,7 @@ import {
   sessionSourceHashInput,
 } from "./embedding-canonical.ts";
 import { backgroundExtract } from "./extraction.ts";
+import { writeThoughtChunks, chunkReceiptFields } from "./chunk-write.ts";
 import {
   executeSearch,
   executeSearchWithScopedSharedFallback,
@@ -204,6 +205,21 @@ export function createRestRouter(deps: RestDeps): Router {
       const entryId = rows[0].id as string;
       const isNew = rows[0].is_new as boolean;
 
+      // CHUNK ROWS FOR A LONG ENTRY (#605). A thought created over REST is the
+      // same object as one created over MCP and must be stored the same way:
+      // complete parent plus per-section rows.
+      const chunks = await writeThoughtChunks(deps.pool, {
+        parentId: entryId,
+        namespace: ns,
+        createdBy: auth.clientId,
+        content,
+        tags: tags ?? [],
+        embedFn: deps.embedFn,
+        source: "rest-chunk",
+        isNew,
+        caller: "rest/POST /thoughts",
+      });
+
       if (isNew) {
         backgroundExtract(
           deps.pool,
@@ -222,6 +238,7 @@ export function createRestRouter(deps: RestDeps): Router {
           namespace: ns,
           embedded: !!embedding,
           merged: !isNew,
+          ...chunkReceiptFields(chunks),
         });
     }),
   );

--- a/src/tiering.ts
+++ b/src/tiering.ts
@@ -4,6 +4,10 @@ import { contentHash, EMBEDDING_MODEL } from "./embedding.ts";
 import type { generateEmbedding } from "./embedding.ts";
 import { logger } from "./logger.ts";
 import { describeError } from "./observability/index.ts";
+import {
+  writeThoughtChunks,
+  type ChunkWriteResult,
+} from "./chunk-write.ts";
 
 /**
  * Lane → own-durable memory tiering (Issue #160).
@@ -198,6 +202,10 @@ export interface LaneGraduationProvenance {
 export interface GraduateResult {
   thought_id: string;
   is_new: boolean;
+  /** Chunk receipt for a long graduated event; null when chunking did not run. */
+  chunks?: ChunkWriteResult | null;
+  /** True when the parent committed but per-section writing threw. */
+  chunking_failed?: boolean;
 }
 
 /**
@@ -205,6 +213,13 @@ export interface GraduateResult {
  * Idempotent via ON CONFLICT (content_hash, namespace) — re-running a batch
  * produces no duplicate rows (mirrors log-thought.ts). Provenance is stored in
  * `promoted_from` (the existing provenance column) and surfaced in tags.
+ *
+ * A graduated event becomes an ordinary thought, so it is stored like one:
+ * when `embedFn` is supplied and the content is long, the parent is followed
+ * by per-section chunk rows via the shared thought-write boundary (#605).
+ * `embedFn` is optional so an existing caller that has no embedder still
+ * graduates — it simply does not chunk, which is the pre-#605 behavior rather
+ * than a new failure.
  */
 export async function graduateLaneEvent(
   pool: pg.Pool,
@@ -213,6 +228,7 @@ export async function graduateLaneEvent(
   createdBy: string,
   embedding: number[] | null,
   reason: string,
+  embedFn?: (text: string) => Promise<number[] | null>,
 ): Promise<GraduateResult> {
   // Defense-in-depth: a lane event must only graduate into ITS OWN namespace.
   // Callers already scope the source read by namespace, but assert here so a
@@ -268,9 +284,28 @@ export async function graduateLaneEvent(
     ],
   );
 
+  const thoughtId = rows[0].id as string;
+  const isNew = rows[0].is_new as boolean;
+
+  if (!embedFn) return { thought_id: thoughtId, is_new: isNew };
+
+  const chunks = await writeThoughtChunks(pool, {
+    parentId: thoughtId,
+    namespace,
+    createdBy,
+    content: event.content,
+    tags,
+    embedFn,
+    source: "lane-tiering-chunk",
+    isNew,
+    caller: "tiering/graduateLaneEvent",
+  });
+
   return {
-    thought_id: rows[0].id as string,
-    is_new: rows[0].is_new as boolean,
+    thought_id: thoughtId,
+    is_new: isNew,
+    chunks: chunks.result,
+    chunking_failed: chunks.failed,
   };
 }
 
@@ -379,6 +414,7 @@ export async function tierLaneEvent(
     opts.createdBy,
     embedding,
     `lane tiering: ${event.event_type}/${event.importance}`,
+    opts.embedFn,
   );
   receipt.graduated += 1;
 }

--- a/src/tools/log-thought.ts
+++ b/src/tools/log-thought.ts
@@ -5,7 +5,7 @@ import { canWrite } from "../permissions.ts";
 import { canWriteNamespace } from "../namespace-policy.ts";
 import { canonicalNamespace, physicalNamespace } from "../shared-namespace.ts";
 import { contentHash, EMBEDDING_MODEL } from "../embedding.ts";
-import { writeEntryChunks, type ChunkWriteResult } from "../chunk-write.ts";
+import { writeThoughtChunks, chunkReceiptFields } from "../chunk-write.ts";
 import { backgroundExtract } from "../extraction.ts";
 import type { AuthInfo } from "../types.ts";
 import { logger } from "../logger.ts";
@@ -114,47 +114,17 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
       // text and its own whole-text vector; these add per-section resolution so
       // a detail buried deep in a long entry is retrievable on its own terms.
       // Only on first write: a merge means the chunks already exist.
-      let chunkResult: ChunkWriteResult | null = null;
-      let chunkingFailed = false;
-      if (isNew) {
-        try {
-          chunkResult = await writeEntryChunks(deps.pool, {
-            table: "thoughts",
-            parentId: entryId,
-            namespace: ns,
-            createdBy: auth.clientId,
-            content: args.content,
-            tags: args.tags ?? [],
-            embedFn: deps.embedFn,
-            source: "mcp-chunk",
-          });
-        } catch (error) {
-          // The parent is already committed with the complete text, so the
-          // entry is not lost -- only its per-section resolution is. Reported
-          // rather than swallowed, and the caller is told, because silence here
-          // would read as a fully chunked entry.
-          //
-          // chunkingFailed is what the response uses to say so. Without it the
-          // response omits the chunk fields entirely on failure -- byte-identical
-          // to a short entry that was never chunked -- so the caller could not
-          // tell "not chunked" from "chunking failed", exactly the distinction
-          // this branch exists to preserve. NOTE: a merge on retry (isNew=false)
-          // skips chunking, so a parent left partially chunked here is not
-          // repaired by re-sending; that repair belongs to the embedding/chunk
-          // repair pass, and this signal is what lets a caller or that pass know
-          // the parent needs it.
-          chunkingFailed = true;
-          logger.error("entry_chunk_write_failed", {
-            tool: "log_thought",
-            parent_id: entryId,
-            content_length: args.content.length,
-            error_name: error instanceof Error ? error.name : "unknown",
-            error_message:
-              error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-
+      const chunkAttempt = await writeThoughtChunks(deps.pool, {
+        parentId: entryId,
+        namespace: ns,
+        createdBy: auth.clientId,
+        content: args.content,
+        tags: args.tags ?? [],
+        embedFn: deps.embedFn,
+        source: "mcp-chunk",
+        isNew,
+        caller: "src/log_thought",
+      });
       if (isNew) {
         backgroundExtract(
           deps.pool,
@@ -181,15 +151,9 @@ export function registerLogThought(server: McpServer, deps: ToolDeps): void {
               // without reading the server log: chunking_status is "failed" when
               // the parent committed but chunk generation threw, and is absent
               // when chunking either succeeded or was not applicable (short
-              // entry / merge). chunkResult is null in the failure case, so
-              // without this field the two are indistinguishable.
-              ...(chunkResult
-                ? {
-                    chunks_written: chunkResult.written,
-                    chunks_unembedded: chunkResult.unembedded,
-                  }
-                : {}),
-              ...(chunkingFailed ? { chunking_status: "failed" as const } : {}),
+              // entry / merge). Shared with the other three thought writers so
+              // every one of them reports the same receipt shape (#605).
+              ...chunkReceiptFields(chunkAttempt),
             }),
           },
         ],


### PR DESCRIPTION
Closes #605 when merged (leaving the issue open; not merging here).

## What was wrong

`writeEntryChunks` was not the common thought-write boundary. Each claim in the issue was re-verified against the base branch before any code changed:

| Path | Site | Before |
|---|---|---|
| rewrite-tree `log_thought` | `server/tools/capture.ts` | wrote parent only, returned a **hardcoded** `chunks_written: 0` / `chunks_unembedded: 0` |
| REST `POST /api/v1/thoughts` | `src/rest-api.ts` | wrote parent only, no chunk fields at all |
| lane graduation | `src/tiering.ts` `graduateLaneEvent` | wrote parent only |
| MCP `log_thought` | `src/tools/log-thought.ts` | the one path that **did** chunk |

A ~6 KB thought (CHUNK_THRESHOLD = 2000) written through any of the first three landed with **zero** chunk rows. The hardcoded zero in `capture.ts` was the worst of it: an entry of any length reported as if it were short.

## The fix

One boundary, four callers. `writeThoughtChunks` in `src/chunk-write.ts` owns commit-then-chunk, the `isNew` skip, the failure log, and the `failed` signal; `chunkReceiptFields` owns the receipt shape. `log-thought.ts` was refactored **onto** it rather than left as a fourth copy — that is what makes this one boundary instead of four implementations that agree today.

Preserved deliberately:

- Partial failure never escalates into a lost write. The parent is committed with the complete text, so a per-section failure is logged (`entry_chunk_write_failed`) and reported, not thrown. Discarding a good parent over a recoverable partial would invert the guarantee.
- `chunking_status: "failed"` stays distinguishable from "short entry". Without it the two are byte-identical and a repair pass has no signal.
- `graduateLaneEvent`'s `embedFn` is optional, so any caller without an embedder still graduates rather than newly failing.

Untouched, per the issue's own "intentionally separate paths": decompose-entry (replacement semantics, `src/chunk-write.ts:21-26`), ingest-raw-turn, append-session-event.

## Done-means evidence

`scripts/done-means/605-chunk-write-routing.sh` drives each path at its **real entry point** — the MCP tool through a real `McpServer`, REST over real HTTP, `graduateLaneEvent` directly — against the dogfood DB in a throwaway namespace it tears down. It reads chunk counts back from the database, not from the driver's own report.

RED (before the fix):

```
capture: FAIL — parent=c92cff72… source=mcp wrote a long thought but ZERO chunk rows link to it (bypasses writeEntryChunks)
rest: FAIL — parent=04e7c6d1… source=rest wrote a long thought but ZERO chunk rows link to it (bypasses writeEntryChunks)
graduation: FAIL — parent=7d10c7e8… source=lane-tiering wrote a long thought but ZERO chunk rows link to it (bypasses writeEntryChunks)
VERDICT: FAIL   (exit 1)
```

GREEN (after):

```
capture: PASS — parent=830f011d… source=mcp chunk rows with parent_id=3
rest: PASS — parent=205ba913… source=rest chunk rows with parent_id=3
graduation: PASS — parent=6c34b2e7… source=lane-tiering chunk rows with parent_id=3

parent-row sources exercised: lane-tiering,mcp,rest
VERDICT: PASS   (exit 0)
```

The three distinct `source` values are the proof the driver exercised three separate production writers rather than one helper three times. The check was also re-run with the fix stashed and went red again — it discriminates the fix, not the harness.

## Gates

- `bunx tsc --noEmit` — clean, exit 0.
- Touched areas (`chunk-write.pg`, `log-thought`, `rest-api`) — 40 pass, 0 fail.
- `server-capture-checkpoint` parity fixture — passes; the receipt shape stayed compatible because `log-thought` already returned `chunks_written: 0` for a short entry.
- Full suite — noisy. Baseline on unmodified code varied 49 → 43 → 40 failures across three runs with zero code change, all in live-Postgres suites against the shared dogfood DB (the #498 contention pattern). Comparing failing *sets* rather than totals left 7 candidates; running those files in isolation with and without the change produced byte-identical failures both ways. No regression attributable to this PR, established by differential run rather than assumption.

## Critical Self-Review

- Highest-risk behavior: chunk writing now runs inside the REST request and the graduation loop, where it did not before. Both await it, so a slow embedder shows up as latency on a path that was previously parent-only. Chosen over fire-and-forget because a background write that fails silently is the exact defect #605 is about.
- Assumptions that could be wrong: that no consumer depended on `capture.ts`'s hardcoded `chunks_written: 0` always being present. Checked — the only fixture asserting it (`server-capture-checkpoint`) uses a short thought, where the field is still emitted as 0, and it passes.
- Missing/weak tests: the done-means check is the real-Postgres coverage across all three callers; per-caller unit tests for the partial-failure branch exist only for `log-thought` (inherited). The repair behavior for a parent committed before per-section writing failed is signalled (`chunking_status`) but no automated repair is added — #605 asks to "define" that behavior, and it is defined as: report, and leave it to `src/embedding-repair.ts`.
- Security/permission risk: none new. Chunk rows inherit the parent's namespace and `created_by` from the already-authorized parent write; no path takes a namespace that was not already validated upstream.
- Migration/deploy risk: no schema change. `parent_id`/`chunk_index` already exist.
- Downstream client/runtime risk: REST responses gain `chunks_written`/`chunks_unembedded` on long thoughts; additive, and the MCP shape already did this. Per `docs/downstream-rollout.md` this is a response-shape addition on an existing endpoint, so no client is broken by omission — but it is a client-facing change and worth a note at rollout.
- Rollback/cleanup concern: revert is a clean single commit; existing chunk rows would simply stop being added to. Pre-#605 parents remain unchunked either way — this fixes new writes, it does not backfill. The done-means script writes its probe JSON to the temp scratch bucket rather than the checkout, so it leaves `git status` clean.
- Fixes made before PR: the harness initially read the driver's JSON off stdout, which the app logger also writes to, producing a false FAIL on paths that had actually succeeded; moved to an explicit output file. The driver also failed to pass `embedFn` to `graduateLaneEvent`, which looked like a fix defect and was a check defect.
- Known residual risk: existing long thoughts already in the table are still unchunked; that backfill is #604's remediation lane, not this one.
- SME review-memory update: [x] `docs/sme/` updated

`docs/sme/correctness.md` gains the divergent-write-boundary pattern: when one helper defines how an object must be stored, every writer of that table has to reach it, and a receipt field hardcoded to a constant (`chunks_written: 0`) is the tell — it reports the shape of a code path rather than the state of the row. The three follow-on checks are: count the writers of the table before trusting one helper to be "the" boundary, refactor the compliant caller onto the shared function rather than leaving it as an agreeing copy, and drive each path at its real entry point in the acceptance gate so a shared helper cannot be mistaken for three separate writers.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below

Live checks ran against the dogfood database `open_brain_local_20260724` (the real one for this machine in dev mode). The done-means gate seeds into and reads from that live database on every run; the RED and GREEN transcripts above are its real output, and the chunk counts in the GREEN block were read back from the database rather than reported by the driver. Teardown drops the throwaway namespace on exit whatever the verdict.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Deliberately left unchecked. REST `POST /api/v1/thoughts` responses gain `chunks_written` / `chunks_unembedded` on long thoughts, so this is a client-facing response-shape change and those rollout steps are APPLICABLE and NOT DONE. Checking them would be false. The change is additive — no existing field changed meaning or was removed — so a client that ignores unknown fields is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
