### PR TITLE
feat(pr): hold the PR template against its own validator, add pr-scribe

### DIFF
--- a/.claude/agents/pr-scribe.md
+++ b/.claude/agents/pr-scribe.md
@@ -1,0 +1,101 @@
+---
+name: pr-scribe
+description: Composes an open-brain PR body from a lane's actual evidence and proves it passes scripts/validate-pr-body.ts before returning it. Use when a lane is about to run gh pr create, when a PR body was rejected by the PR Body check, or when asked to write or fix a PR description in this repo.
+model: opus
+effort: medium
+tools: Bash, Read, Write, Edit
+---
+
+You write the PR body for a lane that has finished its work, and you do not
+return one that fails the repo's own validator.
+
+You are a scribe, not a reviewer. You do not judge whether the work is good,
+and you do not fix code. You take what the lane actually did and render it in
+the shape `scripts/validate-pr-body.ts` accepts.
+
+## The one rule
+
+**Never return a body you have not just seen pass.** The last thing you do,
+every time, is:
+
+```bash
+PR_BODY="$(cat <body-file>)" PR_TITLE="<title>" bun scripts/validate-pr-body.ts
+```
+
+If it exits non-zero, fix the body and run it again. Only a body that has
+produced exit 0 in THIS session may be returned, and you paste that passing
+output with it. The agent wraps the script; the script never trusts the agent.
+
+Set `CONTRACT_PARITY_REQUIRED=true` as well when the diff touches any path in
+`contracts/parity-paths.txt` — CI computes that flag from the diff
+(`.github/workflows/pr-body.yml`), so a body that only passes without the flag
+will still fail on GitHub.
+
+## Start from the template, never from memory
+
+Read `.github/pull_request_template.md` and fill it in. It is checked against
+the validator by `scripts/done-means/pr-template-passes-validator.sh`, so a
+body that starts there cannot fail on shape. Reconstructing the sections from
+memory is how the three known failures happened:
+
+- **A bolded label breaks the anchor.** `requireSpecificLine` builds
+  `/^-\s*<label>:/` (`scripts/validate-pr-body.ts:32-47`). `- Highest-risk
+  behavior:` matches; `- **Highest-risk behavior:**` does not, and the field
+  reads as empty however much text follows it. No bold, no italics, no
+  backticks on a required label.
+- **A missing section is a hard error.** `## Review Gate` and
+  `## Critical Self-Review` are looked up by exact heading text
+  (`scripts/validate-pr-body.ts:15-30`). Do not rename, renumber, or nest them.
+- **Do not fence the body.** Wrapping the whole PR body in a ``` fence is the
+  symptom of composing it in chat instead of in a file. Write the body to a
+  file and `cat` it into `PR_BODY`. Fenced code blocks are fine INSIDE a
+  section for transcripts and evidence.
+
+Each either/or line takes exactly one side. `[x] linked below` **or**
+`[x] not applicable because: <real reason>` — never both, never neither, and
+the reason may not be one of `-`, `n/a`, `na`, `none`, `todo`, `tbd`
+(`scripts/validate-pr-body.ts:9`).
+
+## Fill it from evidence, not from adjectives
+
+The validator only checks that a field is non-empty and non-placeholder. It
+cannot tell whether the content is real, and that is precisely the part you are
+responsible for. Every field is a claim about this specific diff.
+
+- **Critical Self-Review** — nine fields, each naming a concrete thing about
+  THIS change. "Highest-risk behavior" is a named function, endpoint, or
+  migration and what it could do wrong, not "low risk overall". "Missing/weak
+  tests" names what is not covered; if the answer is genuinely nothing, say
+  which tests do cover it and why that is sufficient. Ask the lane for what it
+  ran and what it observed; do not invent a receipt.
+- **SME review-memory update** — if the change came from a review finding at
+  MEDIUM or above, `docs/sme/` gets the pattern and you check `updated`.
+  Otherwise check `not applicable because:` with the actual reason.
+- **Downstream Rollout** — classify against `docs/downstream-rollout.md`
+  "When This Applies": MCP tool names/schemas/output shapes/auth/namespace
+  semantics/error envelopes, transport and session behavior, externally visible
+  migrations, `python/openbrain-memory` behavior or exports, generated `skill/`
+  content, or anything an mcp2cli/Hermes consumer calls. If none apply, the doc
+  requires you to say so explicitly rather than leave it blank.
+- **Contract Parity** — required when the diff touches
+  `contracts/parity-paths.txt` paths. `fixtures updated` or
+  `runtime-specific because: <reason>`, exactly one.
+
+State each claim at its real strength — RUNNING / MERGED / WRITTEN / PROPOSED.
+A test you watched pass is RUNNING; a file you wrote is WRITTEN. Do not write
+"verified" over something nobody ran.
+
+## Procedure
+
+1. Read the diff: `git diff origin/main...HEAD --stat`, then the substantive
+   hunks. Read `git log origin/main..HEAD` for what the lane said it was doing.
+2. Ask the lane (or read its report) for: commands run and their output, tests
+   added, known gaps. If evidence for a field is missing, ask for it — do not
+   fill the field with something plausible.
+3. Copy the template to a scratch file under
+   `/Volumes/ThunderBolt/_tmp/open-brain/_scratch/` and fill it. Never `/tmp`.
+4. Run the validator. Fix and re-run until exit 0.
+5. Return the body path and the passing validator output.
+
+You never run `gh pr create` or `gh pr edit` unless explicitly told to. Your
+deliverable is a body that passes.

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,14 @@ reports/
 !.claude/hooks/
 !.claude/settings.json
 
+# AND the repo-local agent definitions, for the same reason. `pr-scribe` exists
+# so a lane composes a PR body that passes scripts/validate-pr-body.ts on the
+# first try; an untracked copy helps only the machine that wrote it, while every
+# worktree and worker -- where the body is actually written -- gets nothing.
+# scripts/done-means/pr-template-passes-validator.sh asserts the file exists, so
+# leaving it ignored would pass locally and fail on a fresh clone.
+!.claude/agents/
+
 # Session report buffers are local-only, never committed (public repo)
 _reports/
 

--- a/docs/issue-graph.md
+++ b/docs/issue-graph.md
@@ -128,6 +128,21 @@ dependencies and sub-issues are enabled here. The wayfinder reference requires
 this be checked once per repo and recorded so later sessions do not re-probe —
 this is that record.
 
+### Lane briefing: PR bodies
+
+Validate the PR body locally BEFORE `gh pr create`, never after CI rejects it:
+`PR_BODY="$(cat body.md)" PR_TITLE="..." bun scripts/validate-pr-body.ts`
+(add `CONTRACT_PARITY_REQUIRED=true` when the diff touches
+`contracts/parity-paths.txt`). Start from `.github/pull_request_template.md`
+rather than reconstructing the sections — it is held against the validator by
+`scripts/done-means/pr-template-passes-validator.sh`, so a filled template
+cannot fail on shape. Three lanes failed the check three different ways in one
+night, all format rather than substance: a bolded `- **Label:**` breaks the
+`/^-\s*Label:/` anchor, a renamed or missing `## Review Gate` is a hard error,
+and a body composed in chat arrives wrapped in a code fence. The `pr-scribe`
+agent (`.claude/agents/pr-scribe.md`) composes a body from a lane's real
+evidence and returns one only after it has seen the validator exit 0.
+
 ## Relationship to existing skills
 
 **Existing patterns, deliberately reused — and a new paradigm built on them.**

--- a/scripts/done-means/pr-template-passes-validator.sh
+++ b/scripts/done-means/pr-template-passes-validator.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for ledger item 14 (docs/issue-graph.md, decisions pass
+# 2026-08-07) — "make PR bodies right the first time".
+#
+#   bash scripts/done-means/pr-template-passes-validator.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# In one night, three lanes failed scripts/validate-pr-body.ts three DIFFERENT
+# ways, and every one of them was a formatting failure rather than a thinking
+# failure:
+#
+#   1. the whole body pasted inside a ``` code fence — section() matches
+#      `## Name` on a trimmed line (validate-pr-body.ts:15-30), and a fenced
+#      heading is still a line, but a fence around the WHOLE body means the
+#      lane hand-typed it from a chat transcript rather than from the template;
+#   2. `- **Highest-risk behavior:** ...` — requireSpecificLine builds
+#      /^-\s*<label>:/ (validate-pr-body.ts:32-47), so the `**` between the
+#      dash and the label breaks the anchor and the field reads as empty;
+#   3. `## Review Gate` omitted entirely.
+#
+# All three are prevented by ONE thing: a checked-in template that already
+# passes the validator when filled, so a lane that starts from it cannot fail
+# on shape. This check is the reward function for that claim. It does not test
+# whether a lane wrote GOOD content — the validator's placeholder rules do that
+# — it tests that FORMAT is no longer a way to fail.
+#
+# ---------------------------------------------------------------------------
+# Three clauses
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — FILLED TEMPLATE PASSES.
+#   Take the committed template verbatim, mechanically fill it the way a lane
+#   would (append a dummy non-placeholder value to every empty `- Label:` line,
+#   tick every `[ ]` checkbox, pick the first disposition of each either/or
+#   pair), and feed it to the validator. Expect exit 0.
+#
+#   Filling is done with sed on the template's own text — no second copy of the
+#   field list is maintained here for clause 1, because a hand-maintained copy
+#   would itself be the drift this check exists to prevent.
+#
+#   Note the dummy value must not be one of PLACEHOLDER_REASONS
+#   (validate-pr-body.ts:9) — "-", "n/a", "na", "none", "todo", "tbd" — or the
+#   check would fail for a reason that has nothing to do with the template.
+#
+# CLAUSE 2 — DRIFT DETECTION.
+#   The validator is the source of truth for WHICH sections and labels exist.
+#   Clause 1 alone cannot catch a validator that grew a new required section,
+#   because a template missing that section would fail clause 1 with a message
+#   nobody reads as "drift". So the required headings and labels are enumerated
+#   HERE, deliberately duplicated, and cross-checked in BOTH directions:
+#
+#     (a) every heading/label this check knows about is present in the
+#         template — the template has not fallen behind, and
+#     (b) every heading/label the VALIDATOR SOURCE names is in this check's
+#         list — this check has not fallen behind the validator.
+#
+#   (b) is what makes the duplication safe. The list below is extracted from
+#   scripts/validate-pr-body.ts by reading its literal strings, so adding a
+#   required field to the validator without updating both this check and the
+#   template turns the build red rather than silently passing.
+#
+# CLAUSE 3 — THE SCRIBE CANNOT SKIP THE VALIDATOR.
+#   .claude/agents/pr-scribe.md must exist and must contain the literal string
+#   `validate-pr-body.ts`. The agent composes a body from a lane's evidence and
+#   then runs the script; the script never trusts the agent. An agent definition
+#   that no longer names the script has quietly become advice.
+#
+# Exit 0 only when all three clauses pass. Exit 3 is a harness error (missing
+# tool / unreadable repo), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+VALIDATOR="$REPO_ROOT/scripts/validate-pr-body.ts"
+SCRIBE="$REPO_ROOT/.claude/agents/pr-scribe.md"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -r "$VALIDATOR" ] || fail_hard "validator not readable at $VALIDATOR"
+
+CLAUSE1=FAIL
+CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL
+CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL
+CLAUSE3_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# The validator's own requirements, enumerated. Kept in sync by clause 2(b).
+# ---------------------------------------------------------------------------
+# Section headings the validator looks up via section().
+REQUIRED_SECTIONS="Critical Self-Review
+Review Gate"
+
+# Labels the validator anchors with /^-\s*<label>:/ via requireSpecificLine().
+REQUIRED_LABELS="Highest-risk behavior
+Assumptions that could be wrong
+Missing/weak tests
+Security/permission risk
+Migration/deploy risk
+Downstream client/runtime risk
+Rollback/cleanup concern
+Fixes made before PR
+Known residual risk"
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — the committed template, mechanically filled, passes the validator.
+# ---------------------------------------------------------------------------
+DUMMY="dummy specific content for the acceptance gate"
+
+if [ ! -r "$TEMPLATE" ]; then
+  CLAUSE1=FAIL
+  CLAUSE1_EVIDENCE="no template at $TEMPLATE — a lane has nothing to start from"
+else
+  # A lane filling the template does exactly this, by hand:
+  #   1. every `- Some Label:` with nothing after the colon gets content;
+  #   2. every `- [ ]` checkbox gets ticked;
+  #   3. every `[ ] first or [ ] second: ` either/or picks ONE side.
+  # Order matters: the disposition rewrite (3) runs BEFORE the generic
+  # empty-label fill (1), because a disposition line ends in `because:` with
+  # nothing after it and would otherwise be filled as if it were a plain field,
+  # leaving BOTH sides of the either/or checked — which the validator correctly
+  # rejects with "must check exactly one disposition".
+  FILLED="$(
+    sed \
+      -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
+      -e 's/^- \[ \]/- [x]/' \
+      -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
+      "$TEMPLATE"
+  )"
+
+  VOUT="$(PR_BODY="$FILLED" PR_TITLE="done-means pr-template gate" bun "$VALIDATOR" 2>&1)"
+  VEXIT=$?
+
+  if [ "$VEXIT" -eq 0 ]; then
+    CLAUSE1=PASS
+    CLAUSE1_EVIDENCE="filled template validated: exit=0 — $(printf '%s' "$VOUT" | tr '\n' ' ')"
+  else
+    CLAUSE1=FAIL
+    CLAUSE1_EVIDENCE="filled template REJECTED (exit=$VEXIT): $(printf '%s' "$VOUT" | tr '\n' ' ')"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — drift, both directions.
+# ---------------------------------------------------------------------------
+DRIFT=""
+
+if [ ! -r "$TEMPLATE" ]; then
+  DRIFT="template absent"
+else
+  # (a) template has everything this check requires.
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    if ! grep -qixF "## $s" "$TEMPLATE"; then
+      DRIFT="${DRIFT}template missing section '## $s'; "
+    fi
+  done <<EOF
+$REQUIRED_SECTIONS
+EOF
+
+  while IFS= read -r l; do
+    [ -n "$l" ] || continue
+    # Same anchor shape the validator uses: dash, optional space, bare label,
+    # colon. A bolded `- **Label:**` deliberately does NOT match — that was
+    # failure mode 2 and the template must not reintroduce it.
+    if ! grep -qE "^-[[:space:]]*$(printf '%s' "$l" | sed 's/[][\\.*^$/]/\\&/g'):" "$TEMPLATE"; then
+      DRIFT="${DRIFT}template missing label line '- $l:'; "
+    fi
+  done <<EOF
+$REQUIRED_LABELS
+EOF
+
+  # (b) this check has everything the VALIDATOR names. Extracted from the
+  # validator source, not from memory.
+  V_SECTIONS="$(grep -oE 'section\(body, "[^"]+"\)' "$VALIDATOR" | sed 's/.*"\(.*\)".*/\1/' | sort -u)"
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    # Contract Parity is conditional (options.contractParityRequired) so it is
+    # not in the unconditional required set; it is still checked for presence in
+    # the template below, but its absence from REQUIRED_SECTIONS is correct.
+    [ "$s" = "Contract Parity" ] && continue
+    if ! printf '%s\n' "$REQUIRED_SECTIONS" | grep -qxF "$s"; then
+      DRIFT="${DRIFT}check is behind validator: unknown required section '$s'; "
+    fi
+  done <<EOF
+$V_SECTIONS
+EOF
+
+  # requireSpecificLine labels live in the single array literal that feeds it.
+  V_LABELS="$(
+    awk '/requireSpecificLine\(criticalSelfReview/{exit} /for \(const label of \[/{f=1;next} f&&/^\s*\]/{f=0} f' "$VALIDATOR" \
+      | grep -oE '"[^"]+"' | tr -d '"'
+  )"
+  [ -n "$V_LABELS" ] || fail_hard "could not extract requireSpecificLine labels from $VALIDATOR — the extraction, not the template, is broken"
+  while IFS= read -r l; do
+    [ -n "$l" ] || continue
+    if ! printf '%s\n' "$REQUIRED_LABELS" | grep -qxF "$l"; then
+      DRIFT="${DRIFT}check is behind validator: unknown required label '$l'; "
+    fi
+  done <<EOF
+$V_LABELS
+EOF
+
+  # The conditional section still has to exist in the template, because a
+  # contract-touching PR is validated with CONTRACT_PARITY_REQUIRED=true and a
+  # lane that started from a template without it would fail on shape again.
+  if ! grep -qixF "## Contract Parity" "$TEMPLATE"; then
+    DRIFT="${DRIFT}template missing conditional section '## Contract Parity'; "
+  fi
+fi
+
+if [ -z "$DRIFT" ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="template and check both current with validator: $(printf '%s\n' "$REQUIRED_SECTIONS" | grep -c .) sections + Contract Parity, $(printf '%s\n' "$REQUIRED_LABELS" | grep -c .) labels cross-checked in both directions"
+else
+  CLAUSE2=FAIL
+  CLAUSE2_EVIDENCE="drift: $DRIFT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the scribe agent names the validator.
+# ---------------------------------------------------------------------------
+if [ ! -r "$SCRIBE" ]; then
+  CLAUSE3=FAIL
+  CLAUSE3_EVIDENCE="no agent definition at $SCRIBE"
+elif grep -qF 'validate-pr-body.ts' "$SCRIBE"; then
+  CLAUSE3=PASS
+  CLAUSE3_EVIDENCE="$SCRIBE names validate-pr-body.ts $(grep -cF 'validate-pr-body.ts' "$SCRIBE") time(s) — the unskippable final step is still written down"
+else
+  CLAUSE3=FAIL
+  CLAUSE3_EVIDENCE="$SCRIBE exists but never names validate-pr-body.ts — the agent has become advice"
+fi
+
+printf 'CLAUSE 1 (filled template passes the validator): %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (template and check track the validator): %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf 'CLAUSE 3 (pr-scribe agent runs the validator): %s — %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Three lanes failed `scripts/validate-pr-body.ts` three different ways in one
night. Every one was a formatting failure, not a thinking failure:

1. the body pasted inside a ``` code fence;
2. `- **Highest-risk behavior:**` — the `**` between the dash and the label
   breaks the `/^-\s*<label>:/` anchor (`scripts/validate-pr-body.ts:32-47`), so
   the field reads as empty however much text follows it;
3. `## Review Gate` missing entirely.

**A finding that changed the shape of this change:** the committed
`.github/pull_request_template.md` was ALREADY structurally correct — the first
run of the new gate passed clauses 1 and 2 against the pre-existing file,
before any template edit. The template was never the defect. The real gaps were
that nothing *proved* it stayed correct as the validator evolved, and nothing
put it in a lane's hands at the moment the body gets written. So this PR does
not rewrite the template. It pins it and routes lanes to it.

No generator script was added. The design allowed one "if the validator's
requirements are cleanly extractable" — they are, but a generator would emit a
file that already exists byte-for-byte, so the smaller owning-boundary change is
the drift check that clause 2 performs directly against the validator source.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` exits 0. No Python, MCP, transport, or migration surface is
touched, so the package checks and the live smoke are not applicable.

### RED — before `.claude/agents/pr-scribe.md` existed

```
CLAUSE 1 (filled template passes the validator): PASS — filled template validated: exit=0 — PR body validation passed for done-means pr-template gate.
CLAUSE 2 (template and check track the validator): PASS — template and check both current with validator: 2 sections + Contract Parity, 9 labels cross-checked in both directions
CLAUSE 3 (pr-scribe agent runs the validator): FAIL — no agent definition at .../.claude/agents/pr-scribe.md
EXIT=1
```

Clause 3 is the only one that was red, because clauses 1 and 2 were already
satisfied by the existing template. That is reported rather than engineered
away — manufacturing a red by first breaking the template would have tested the
mutation, not the repo.

### Mutation proof — clauses 1 and 2 CAN fail

A gate that has only ever been green is not evidence. Each real-world failure
mode was reintroduced into the template and the gate re-run:

```
### MUTANT A: bold the label (real failure mode 2)
CLAUSE 1: FAIL — filled template REJECTED (exit=1): - Critical Self-Review field 'Highest-risk behavior' needs specific content.
CLAUSE 2: FAIL — drift: template missing label line '- Highest-risk behavior:';

### MUTANT B: rename ## Review Gate (real failure mode 3)
CLAUSE 1: FAIL — filled template REJECTED (exit=1): - Missing '## Review Gate' section.
CLAUSE 2: FAIL — drift: template missing section '## Review Gate';

### MUTANT C: whole body in a code fence (failure mode 1)
CLAUSE 1: PASS
CLAUSE 2: PASS
```

Mutant C passing is a real result, kept here rather than hidden. `section()`
matches on a trimmed line, so a fence genuinely does not affect the validator —
failure mode 1 was a lane hand-composing a body in chat, never a template
defect. A check asserting "no fences in the template" would encode a wrong
theory of that failure. It is addressed where it actually lives: the pr-scribe
agent writes the body to a file and `cat`s it, and says so explicitly.

### GREEN — full gate, and from a clean clone

```
CLAUSE 1 (filled template passes the validator): PASS — filled template validated: exit=0 — PR body validation passed for done-means pr-template gate.
CLAUSE 2 (template and check track the validator): PASS — template and check both current with validator: 2 sections + Contract Parity, 9 labels cross-checked in both directions
CLAUSE 3 (pr-scribe agent runs the validator): PASS — .../.claude/agents/pr-scribe.md names validate-pr-body.ts 6 time(s) — the unskippable final step is still written down
CLONE_EXIT=0
```

The clean-clone run is the one that matters: it caught that `.gitignore:53`
excludes `.claude/*`, which would have left `pr-scribe.md` untracked. Clause 3
would have passed on this machine and failed for every worktree, worker, and
fresh clone — the exact places a PR body actually gets written. Fixed with a
`!.claude/agents/` re-include following the existing `!.claude/hooks/` pattern.

## Critical Self-Review

- Highest-risk behavior: the `sed` fill in clause 1 of the gate. It emulates how a lane fills the template, and if it silently stops matching (a template line reshaped so the `^\(- [^][]*:\)[[:space:]]*$` anchor misses) the clause could pass while proving nothing about a real filled body. Mutants A and B demonstrate it still discriminates today; the ordering hazard is called out in the script comments because the disposition rewrite MUST precede the generic fill or both sides of an either/or get checked.
- Assumptions that could be wrong: that clause 2's extraction of validator labels via `awk`/`grep` over the source keeps working. It is brittle to refactoring — if the `for (const label of [...])` literal becomes a computed list, extraction returns empty. That case is handled: empty extraction calls `fail_hard` (exit 3, harness error) rather than passing vacuously, so it fails loudly instead of silently.
- Missing/weak tests: there is no automated test that the pr-scribe AGENT behaves as written — clause 3 only asserts the file names the validator, which is a proxy for the behavior, not the behavior. Agent prose is not executable, so the enforceable half is the script it must call; that boundary is deliberate and stated in the agent file.
- Security/permission risk: none. No auth, namespace, SQL, token, or network path is touched. The gate reads two repo files and shells out to `bun` on a local script.
- Migration/deploy risk: none — no schema, no migration, no service. Nothing is deployed by this change.
- Downstream client/runtime risk: none applicable per `docs/downstream-rollout.md` "When This Applies" — no MCP tool name, input schema, output shape, annotation, auth, or error envelope; no transport/session behavior; no externally visible migration; no `python/openbrain-memory` behavior or exports; no generated `skill/` content; nothing an mcp2cli or Hermes consumer calls. This is repo-local authoring tooling.
- Rollback/cleanup concern: `git revert` is sufficient and complete — four additive files, no state, no data. The worktree at `/Volumes/ThunderBolt/_tmp/open-brain/_worktrees/pr-scribe/` is removed by this lane in the same session that created it.
- Fixes made before PR: found and fixed the `.gitignore` trap via the clean-clone run (agent file would never have been committed); corrected an initial mutation test that used BSD `sed -i ''` syntax against GNU sed 4.10 — it errored out and I nearly recorded the resulting unchanged-file "PASS" as evidence the mutants were caught, which would have been a false green in the one place this PR claims rigor.
- Known residual risk: clause 2 duplicates the validator's field list inside the check by design, so the two must be edited together. That duplication is the mechanism, not an oversight — direction (b) cross-checks the list against the validator source precisely so the duplicate cannot rot silently. A validator refactor that defeats the `awk` extraction degrades to exit 3, which is visible.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this change originates from a ledger item about authoring ergonomics, not from a MEDIUM+ review finding about repo code behavior.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no Open Brain server, database, MCP, or client surface is exercised by this change

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched, verified with `git diff --quiet origin/main...HEAD -- $(cat contracts/parity-paths.txt)`, so CI computes `CONTRACT_PARITY_REQUIRED=false` and this section is informational

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable, stated explicitly as the doc requires. The diff is four files: a bash acceptance gate, a repo-local agent definition, a `.gitignore` re-include, and a docs paragraph. No consumer-facing surface.

## How drift is prevented

The template and the validator cannot drift apart without turning the gate red,
and the check is cross-verified in BOTH directions:

- **(a) template → check.** Every heading and label the check enumerates must be
  present in the template, matched with the same `^-\s*Label:` anchor shape the
  validator uses — so a bolded label fails here exactly as it fails there.
- **(b) check → validator.** Every section name the validator passes to
  `section()` and every label in its `requireSpecificLine` array is extracted
  from `scripts/validate-pr-body.ts` at run time and must appear in the check's
  own list. Adding a required field to the validator alone turns the gate red
  instead of passing silently.

`## Contract Parity` is deliberately excluded from the unconditional required
set — it is gated by `options.contractParityRequired` — but its presence in the
template is still asserted, because a contract-touching PR is validated with the
flag on and a lane starting from a template without that section would fail on
shape all over again.

## Claim states

- WRITTEN: all four files, committed on `feat/pr-template-and-scribe`.
- RUNNING: the acceptance gate — exit 0 in the worktree AND from a clean
  `git clone` of the committed tree; the three mutation runs; `bunx tsc --noEmit`
  exit 0; this PR body itself passing `scripts/validate-pr-body.ts` locally
  before `gh pr create`.
- PROPOSED: that lanes will actually reach for `pr-scribe`. Nothing forces an
  agent to invoke it — the enforceable part is that CI still rejects a bad body
  regardless, which is unchanged by this PR.
- Not merged, not deployed.
