### PR TITLE
feat(scripts): lane-bootstrap — one command for a known-good lane env

### DIFF
--- a/scripts/done-means/lane-bootstrap-known-good.sh
+++ b/scripts/done-means/lane-bootstrap-known-good.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for ledger item 15 (docs/issue-graph.md:261) —
+# scripts/lane-bootstrap.ts: one command that stands up a KNOWN-GOOD lane
+# environment.
+#
+#   bash scripts/done-means/lane-bootstrap-known-good.sh
+#
+# Ledger item 15 acceptance, from the decisions pass 2026-08-07:
+#   "the script must carry a stated reason for the worktree (worktrees-need-a-
+#    reason rule stays intact) and never creates silently. Teardown deliberately
+#    NOT scripted: `git worktree remove` per AGENTS.md remains the manual,
+#    agent-owned cleanup."
+#
+# WHY THIS CHECK EXISTS AT ALL. Tonight ~5 lanes hand-built their environments
+# and each hit one of: missing .env, missing bun-types (deps never installed),
+# or a pipe that swallowed a non-zero exit so a broken environment reported
+# success. The failure mode is therefore NOT "the script errored" — it is "the
+# script said fine and the environment was not". So this check refuses to
+# accept the script's own output as evidence of a good environment. It goes
+# INTO the worktree and drives the real compiler.
+#
+# ---------------------------------------------------------------------------
+# What each clause proves, and why it is that specific probe
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — refusal path. No --reason must exit NON-ZERO and NAME the rule.
+#   Exit code alone is not enough: a script that dies on an unrelated crash
+#   also exits non-zero. The stderr must name the worktrees-need-a-reason rule,
+#   because the point of the constraint is that the human reading the lane
+#   transcript learns WHY it refused.
+#
+# CLAUSE 2 — happy path, proven from inside the worktree, not from the report.
+#   `bunx tsc --noEmit` is the probe precisely because it is what FAILED for
+#   the lanes tonight: tsc cannot resolve `bun-types` unless `bun install`
+#   genuinely completed, so a green typecheck is direct evidence that deps are
+#   real. `test -f .env` is checked separately because a missing .env is a
+#   distinct failure that tsc would not notice at all.
+#
+# CLAUSE 3 — --fresh-db. The printed OPENBRAIN_TEST_DATABASE_URL must actually
+#   connect (`psql <url> -c 'select 1'`), and TWO runs must produce DIFFERENT
+#   database names. The second half is the collision-proof requirement: a
+#   fixed-name test DB is how two concurrent lanes silently truncate each
+#   other's tables.
+#
+# CLAUSE 4 — teardown is PRINTED, NEVER EXECUTED. The output must contain the
+#   `git worktree remove` and `dropdb` lines, AND the worktree must still exist
+#   on disk after the run. This is the ledger's explicit rejection record
+#   (docs/issue-graph.md:284) encoded as a test: a bootstrap script that also
+#   removes things is the thing the operator turned down.
+#
+# ---------------------------------------------------------------------------
+# Cleanup ownership
+# ---------------------------------------------------------------------------
+# This CHECK created the worktrees and databases below, so this check removes
+# them — that is consistent with AGENTS.md, which makes `git worktree remove`
+# the agent-owned cleanup for worktrees the agent itself created. It never
+# removes anything it did not create: every artifact carries this run's random
+# RUN_ID. Nothing here uses `rm -rf`.
+#
+# EXPECTED TO FAIL (RED) until scripts/lane-bootstrap.ts exists. It is the
+# reward function, not a test of the implementer.
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+WORKTREE_BASE="/Volumes/ThunderBolt/_tmp/open-brain/_worktrees"
+SCRIPT_REL="scripts/lane-bootstrap.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "REPO_ROOT=$REPO_ROOT is not a git checkout"
+
+RUN_ID="$(od -An -N4 -tx1 /dev/urandom | tr -d ' \n')"
+
+# Branch/worktree names carry RUN_ID so teardown can never touch a real lane.
+BR_A="donemeans-lb-${RUN_ID}-a"
+BR_B="donemeans-lb-${RUN_ID}-b"
+WT_A="${WORKTREE_BASE}/${BR_A}"
+WT_B="${WORKTREE_BASE}/${BR_B}"
+
+CREATED_DBS=()
+CREATED_WTS=()
+CREATED_BRS=()
+
+# --- teardown: only this run's artifacts, all by RUN_ID --------------------
+teardown() {
+  # Databases first: a live connection from a worktree process would block drop.
+  if [ -r "$REPO_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/.env"
+    set +a
+    for db in "${CREATED_DBS[@]:-}"; do
+      [ -n "$db" ] || continue
+      case "$db" in
+        *"$RUN_ID"*) dropdb --if-exists --force "$db" >/dev/null 2>&1 ;;
+        *) printf 'REFUSING to drop unexpected db name: %s\n' "$db" >&2 ;;
+      esac
+    done
+  fi
+  for wt in "${CREATED_WTS[@]:-}"; do
+    [ -n "$wt" ] || continue
+    case "$wt" in
+      *"$RUN_ID"*) git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 ;;
+      *) printf 'REFUSING to remove unexpected worktree: %s\n' "$wt" >&2 ;;
+    esac
+  done
+  git -C "$REPO_ROOT" worktree prune >/dev/null 2>&1
+  for br in "${CREATED_BRS[@]:-}"; do
+    [ -n "$br" ] || continue
+    case "$br" in
+      *"$RUN_ID"*) git -C "$REPO_ROOT" branch -D "$br" >/dev/null 2>&1 ;;
+    esac
+  done
+}
+trap teardown EXIT
+
+CLAUSE1=FAIL; EV1=""
+CLAUSE2=FAIL; EV2=""
+CLAUSE3=FAIL; EV3=""
+CLAUSE4=FAIL; EV4=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — no --reason refuses, non-zero, naming the rule
+# ---------------------------------------------------------------------------
+OUT1="$(cd "$REPO_ROOT" && bun "$SCRIPT_REL" --branch "$BR_A" 2>&1)"
+EXIT1=$?
+
+if [ "$EXIT1" -eq 0 ]; then
+  CLAUSE1=FAIL
+  EV1="exit=0 — ran without --reason; the worktrees-need-a-stated-reason rule is not enforced"
+elif printf '%s' "$OUT1" | grep -qi 'reason'; then
+  CLAUSE1=PASS
+  EV1="exit=$EXIT1 non-zero and stderr/stdout names the reason rule"
+else
+  CLAUSE1=FAIL
+  EV1="exit=$EXIT1 non-zero but UNNAMED: output does not mention the reason rule (output head: $(printf '%s' "$OUT1" | head -c 160))"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — happy path: the environment is genuinely good, proven inside it
+# ---------------------------------------------------------------------------
+OUT2="$(cd "$REPO_ROOT" && bun "$SCRIPT_REL" --branch "$BR_A" --reason "done-means check" 2>&1)"
+EXIT2=$?
+CREATED_WTS+=("$WT_A"); CREATED_BRS+=("$BR_A")
+
+if [ "$EXIT2" -ne 0 ]; then
+  CLAUSE2=FAIL
+  EV2="bootstrap exited $EXIT2 (output head: $(printf '%s' "$OUT2" | head -c 200))"
+elif [ ! -d "$WT_A" ]; then
+  CLAUSE2=FAIL
+  EV2="exit=0 but no worktree at $WT_A — reported success without creating the lane"
+else
+  ENV_OK=FAIL
+  [ -f "$WT_A/.env" ] && ENV_OK=PASS
+  # The real probe: tsc resolves bun-types only if deps genuinely installed.
+  TSC_OUT="$(cd "$WT_A" && bunx tsc --noEmit 2>&1)"
+  TSC_EXIT=$?
+  if [ "$ENV_OK" = PASS ] && [ "$TSC_EXIT" -eq 0 ]; then
+    CLAUSE2=PASS
+    EV2="worktree=$WT_A .env present; bunx tsc --noEmit exit=0 (deps incl. bun-types resolve)"
+  else
+    CLAUSE2=FAIL
+    EV2=".env=$ENV_OK tsc_exit=$TSC_EXIT (tsc head: $(printf '%s' "$TSC_OUT" | head -c 200))"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — --fresh-db: url connects, and two runs differ (collision-proof)
+# ---------------------------------------------------------------------------
+url_from() { printf '%s' "$1" | grep -o 'postgres://[^[:space:]"]*' | tail -1; }
+db_from()  { printf '%s' "$1" | sed 's#.*/##; s/?.*//'; }
+
+OUT3="$(cd "$REPO_ROOT" && bun "$SCRIPT_REL" --branch "$BR_B" --reason "done-means check" --fresh-db 2>&1)"
+EXIT3=$?
+CREATED_WTS+=("$WT_B"); CREATED_BRS+=("$BR_B")
+URL_B="$(url_from "$OUT3")"
+DB_B="$(db_from "$URL_B")"
+[ -n "$DB_B" ] && CREATED_DBS+=("$DB_B")
+
+# Second --fresh-db run on the SAME branch name is what would collide if the
+# db name were derived from the branch alone. It must be refused (worktree
+# exists) or produce a different db; either way we only compare names when a
+# second url is actually printed.
+DB_A2=""
+if [ "$EXIT3" -eq 0 ] && [ -n "$URL_B" ]; then
+  if psql "$URL_B" -At -c 'select 1' >/dev/null 2>&1; then
+    BR_C="donemeans-lb-${RUN_ID}-c"
+    WT_C="${WORKTREE_BASE}/${BR_C}"
+    OUT3B="$(cd "$REPO_ROOT" && bun "$SCRIPT_REL" --branch "$BR_C" --reason "done-means check" --fresh-db 2>&1)"
+    CREATED_WTS+=("$WT_C"); CREATED_BRS+=("$BR_C")
+    URL_C="$(url_from "$OUT3B")"
+    DB_A2="$(db_from "$URL_C")"
+    [ -n "$DB_A2" ] && CREATED_DBS+=("$DB_A2")
+    if [ -n "$DB_A2" ] && [ "$DB_A2" != "$DB_B" ]; then
+      CLAUSE3=PASS
+      EV3="psql select 1 OK on run-1 url; db names differ across runs ($DB_B vs $DB_A2)"
+    else
+      CLAUSE3=FAIL
+      EV3="db name not collision-proof: run1=$DB_B run2=${DB_A2:-<none printed>}"
+    fi
+  else
+    CLAUSE3=FAIL
+    EV3="printed url does not connect: psql select 1 failed for db=$DB_B"
+  fi
+else
+  CLAUSE3=FAIL
+  EV3="--fresh-db exit=$EXIT3, url printed='${URL_B:-<none>}' (head: $(printf '%s' "$OUT3" | head -c 200))"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — teardown printed, not executed
+# ---------------------------------------------------------------------------
+HAS_WT_LINE=0; HAS_DB_LINE=0
+printf '%s' "$OUT3" | grep -q 'git worktree remove' && HAS_WT_LINE=1
+printf '%s' "$OUT3" | grep -q 'dropdb' && HAS_DB_LINE=1
+
+if [ "$HAS_WT_LINE" -eq 1 ] && [ "$HAS_DB_LINE" -eq 1 ] && [ -d "$WT_B" ]; then
+  CLAUSE4=PASS
+  EV4="output carries 'git worktree remove' and 'dropdb'; worktree $WT_B still present after the run (nothing auto-deleted)"
+else
+  CLAUSE4=FAIL
+  EV4="worktree_remove_line=$HAS_WT_LINE dropdb_line=$HAS_DB_LINE worktree_still_exists=$([ -d "$WT_B" ] && echo yes || echo no)"
+fi
+
+printf 'CLAUSE 1 (refuses without --reason, names the rule): %s — %s\n' "$CLAUSE1" "$EV1"
+printf 'CLAUSE 2 (worktree env genuinely good: .env + tsc): %s — %s\n' "$CLAUSE2" "$EV2"
+printf 'CLAUSE 3 (--fresh-db url connects, collision-proof): %s — %s\n' "$CLAUSE3" "$EV3"
+printf 'CLAUSE 4 (teardown printed, never executed): %s — %s\n' "$CLAUSE4" "$EV4"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/lane-bootstrap.ts
+++ b/scripts/lane-bootstrap.ts
@@ -325,7 +325,22 @@ function main(): void {
     const suffix = `${process.pid}_${Date.now().toString(36)}${Math.floor(Math.random() * 1296)
       .toString(36)
       .padStart(2, "0")}`;
-    dbName = `lane_${slug.replace(/-/g, "_")}_${suffix}`.slice(0, 63);
+
+    // Postgres identifiers are bounded at NAMEDATALEN-1 = 63 bytes; this is a
+    // compile-time server constant (`show max_identifier_length` = 63 on the
+    // dogfood cluster), not a policy choice, and the server silently TRUNCATES
+    // anything longer rather than erroring. Silent truncation is the danger:
+    // it would cut the tail, which is precisely where the uniqueness suffix
+    // lives, so two long branch names would collapse to the same database and
+    // truncate each other's tables — the exact collision --fresh-db exists to
+    // prevent. The uniqueness suffix is therefore kept WHOLE and the
+    // human-readable slug yields the space instead; the name stays unique no
+    // matter how long the branch is.
+    const prefix = "lane_";
+    const laneSuffix = `_${suffix}`;
+    const room = 63 - prefix.length - laneSuffix.length;
+    const slugPart = slug.replace(/-/g, "_").slice(0, Math.max(0, room));
+    dbName = `${prefix}${slugPart}${laneSuffix}`;
 
     const pgEnv: NodeJS.ProcessEnv = { ...process.env };
     if (password) pgEnv.PGPASSWORD = password;

--- a/scripts/lane-bootstrap.ts
+++ b/scripts/lane-bootstrap.ts
@@ -1,0 +1,424 @@
+#!/usr/bin/env bun
+/**
+ * lane-bootstrap — stand up one known-good lane environment, in one command.
+ *
+ *   bun scripts/lane-bootstrap.ts --branch <name> --reason "<stated reason>" [--fresh-db]
+ *
+ * Ledger item 15 (docs/issue-graph.md:261, decisions pass 2026-08-07). On one
+ * night ~5 lanes hand-built their environments and each hit one of three
+ * things: a missing `.env`, missing `bun-types` because deps were never
+ * installed, or a pipe that swallowed a non-zero exit so a half-built
+ * environment reported success. Those are the three failures this script is
+ * built to make impossible to reach silently.
+ *
+ * DESIGN CONSTRAINTS (decided; see the ledger, do not re-litigate):
+ *
+ *  - `--reason` is REQUIRED and is printed into the output. The
+ *    worktrees-need-a-stated-reason rule (AGENTS.md) stays intact: a worktree
+ *    is scaffolding, and the reason is what makes a stray one explicable weeks
+ *    later. Because the reason is echoed, it lands in the lane transcript.
+ *
+ *  - TEARDOWN IS PRINTED, NEVER EXECUTED. The ledger explicitly rejected
+ *    scripted teardown (docs/issue-graph.md:284): "a cleanup script that
+ *    removes things it may not have created is a bigger risk than the friction
+ *    it saves." So this script emits the exact `git worktree remove` and
+ *    `dropdb` lines and stops. Removal stays the manual, agent-owned step, and
+ *    this file contains no delete path at all.
+ *
+ *  - NEVER checks out `main`. Lanes branch from `origin/main`; a worktree
+ *    sitting on `main` is how a protected branch gets committed to by accident.
+ *
+ *  - Every step reports success or failure by NAME and the exit code reflects
+ *    the FIRST failure. No `|| true`, no pipes that discard status — that is
+ *    the swallowed-exit-code failure this script exists to prevent, so it must
+ *    not reproduce it internally.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, copyFileSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WORKTREE_BASE = "/Volumes/ThunderBolt/_tmp/open-brain/_worktrees";
+
+/** Placeholder reasons that are technically non-empty but state nothing. */
+const PLACEHOLDER_REASONS = new Set([
+  "reason",
+  "todo",
+  "tbd",
+  "n/a",
+  "na",
+  "none",
+  "test",
+  "x",
+  "-",
+  "because",
+  "work",
+  "stuff",
+  "placeholder",
+  "asdf",
+]);
+
+const REASON_RULE =
+  "AGENTS.md: a worktree needs a STATED REASON. A worktree is scaffolding for " +
+  "one piece of work, not a record of it — the reason is what lets the next " +
+  "person tell a live lane from an abandoned one. --reason is required, is " +
+  "printed into this script's output so it lands in the lane transcript, and " +
+  "cannot be a placeholder.";
+
+interface Args {
+  branch: string;
+  reason: string;
+  freshDb: boolean;
+}
+
+class LaneBootstrapError extends Error {
+  constructor(
+    readonly step: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function parseArgs(argv: string[]): Args {
+  let branch = "";
+  let reason = "";
+  let freshDb = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--branch") {
+      branch = argv[++i] ?? "";
+    } else if (arg === "--reason") {
+      reason = argv[++i] ?? "";
+    } else if (arg === "--fresh-db") {
+      freshDb = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new LaneBootstrapError(
+        "args",
+        `unknown argument "${arg}". Run with --help for usage.`,
+      );
+    }
+  }
+
+  if (!branch.trim()) {
+    throw new LaneBootstrapError(
+      "args",
+      "--branch <name> is required (the lane's new branch, cut from origin/main).",
+    );
+  }
+
+  // The reason gate. Checked before anything is created, so a refusal never
+  // leaves a half-built lane behind.
+  const trimmedReason = reason.trim();
+  if (!trimmedReason) {
+    throw new LaneBootstrapError(
+      "reason",
+      `--reason "<stated reason>" is required and was not given.\n\n${REASON_RULE}`,
+    );
+  }
+  if (
+    PLACEHOLDER_REASONS.has(trimmedReason.toLowerCase()) ||
+    trimmedReason.length < 8
+  ) {
+    throw new LaneBootstrapError(
+      "reason",
+      `--reason "${trimmedReason}" is a placeholder, not a stated reason.\n\n${REASON_RULE}`,
+    );
+  }
+
+  return { branch: branch.trim(), reason: trimmedReason, freshDb };
+}
+
+function printUsage(): void {
+  process.stdout.write(
+    [
+      "lane-bootstrap — stand up one known-good lane environment.",
+      "",
+      "  bun scripts/lane-bootstrap.ts --branch <name> --reason \"<why>\" [--fresh-db]",
+      "",
+      "  --branch <name>   new branch for the lane, cut from origin/main (never main)",
+      "  --reason  <text>  REQUIRED. Why this worktree exists; printed into the output.",
+      "  --fresh-db        also create a uniquely-named migrated test database",
+      "",
+      "Teardown is PRINTED, never executed (ledger item 15 rejection record).",
+      "",
+    ].join("\n"),
+  );
+}
+
+/**
+ * Slugify a branch name for filesystem and Postgres identifier use.
+ * `feat/foo-bar` -> `feat-foo-bar`.
+ */
+function slugify(branch: string): string {
+  return branch
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Run a command, inheriting stdio so the lane sees real output as it happens.
+ * Throws a NAMED LaneBootstrapError on non-zero exit — this is the anti-
+ * swallowed-exit-code guarantee: there is no code path here that observes a
+ * failure and continues.
+ */
+function run(
+  step: string,
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): void {
+  const result = spawnSync(cmd, args, {
+    cwd: opts.cwd ?? REPO_ROOT,
+    env: opts.env ?? process.env,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw new LaneBootstrapError(
+      step,
+      `could not execute ${cmd}: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new LaneBootstrapError(
+      step,
+      `${cmd} ${args.join(" ")} exited ${result.status}`,
+    );
+  }
+}
+
+/** Run a command and capture stdout. Same named-failure contract as run(). */
+function capture(
+  step: string,
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): string {
+  const result = spawnSync(cmd, args, {
+    cwd: opts.cwd ?? REPO_ROOT,
+    env: opts.env ?? process.env,
+    encoding: "utf-8",
+  });
+  if (result.error) {
+    throw new LaneBootstrapError(
+      step,
+      `could not execute ${cmd}: ${result.error.message}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new LaneBootstrapError(
+      step,
+      `${cmd} ${args.join(" ")} exited ${result.status}: ${(result.stderr || "").trim()}`,
+    );
+  }
+  return (result.stdout || "").trim();
+}
+
+function step(name: string, detail: string): void {
+  process.stdout.write(`  [ok]   ${name}: ${detail}\n`);
+}
+
+/** Parse the repo `.env` for the libpq vars used to create the test database. */
+function readEnvFile(path: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const raw = readFileSync(path, "utf-8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const slug = slugify(args.branch);
+  const worktreePath = join(WORKTREE_BASE, slug);
+
+  process.stdout.write("lane-bootstrap\n");
+  // The reason is echoed FIRST, so it lands in the lane transcript above any
+  // output that might scroll. This is the whole point of requiring it.
+  process.stdout.write(`  reason: ${args.reason}\n\n`);
+
+  // --- 1. never main -------------------------------------------------------
+  if (args.branch === "main" || args.branch === "origin/main") {
+    throw new LaneBootstrapError(
+      "branch",
+      "refusing to create a lane on main. Lanes branch FROM origin/main onto a new branch; a worktree sitting on main is how a protected branch gets committed to by accident.",
+    );
+  }
+
+  // --- 2. worktree ---------------------------------------------------------
+  if (existsSync(worktreePath)) {
+    throw new LaneBootstrapError(
+      "worktree",
+      `${worktreePath} already exists. Refusing to touch it — it may be a live lane. Remove it yourself (git worktree remove ${worktreePath}) or pick another --branch.`,
+    );
+  }
+
+  run("fetch", "git", ["fetch", "origin", "--quiet"]);
+  step("fetch", "origin fetched");
+
+  run("worktree", "git", [
+    "worktree",
+    "add",
+    "-b",
+    args.branch,
+    worktreePath,
+    "origin/main",
+  ]);
+  step("worktree", `${worktreePath} on new branch ${args.branch} from origin/main`);
+
+  // --- 3. .env -------------------------------------------------------------
+  const srcEnv = join(REPO_ROOT, ".env");
+  if (!existsSync(srcEnv)) {
+    throw new LaneBootstrapError(
+      "env",
+      `no .env at ${srcEnv} to copy. The lane would start without database or embedding config — the exact missing-.env failure this script exists to prevent.`,
+    );
+  }
+  copyFileSync(srcEnv, join(worktreePath, ".env"));
+  step("env", ".env copied from repo root");
+
+  // --- 4. deps -------------------------------------------------------------
+  // Fails loudly by contract: run() throws on non-zero. A partially-installed
+  // environment is exactly the bun-types failure from the ledger.
+  run("deps", "bun", ["install", "--frozen-lockfile"], { cwd: worktreePath });
+  step("deps", "bun install --frozen-lockfile completed");
+
+  // --- 5. optional fresh database -----------------------------------------
+  let dbUrl = "";
+  let dbName = "";
+  if (args.freshDb) {
+    const env = readEnvFile(srcEnv);
+    const host = env.DB_HOST || env.PGHOST || "127.0.0.1";
+    const port = env.DB_PORT || env.PGPORT || "5432";
+    const user = env.DB_USER || env.PGUSER;
+    const password = env.DB_PASSWORD || env.PGPASSWORD || "";
+    if (!user) {
+      throw new LaneBootstrapError(
+        "db",
+        "no DB_USER/PGUSER in .env; cannot create a test database.",
+      );
+    }
+
+    // Collision-proof by construction: slug + pid + time + random. Two lanes on
+    // the same branch name, started in the same second, still differ. A fixed
+    // name is how concurrent lanes truncate each other's tables.
+    const suffix = `${process.pid}_${Date.now().toString(36)}${Math.floor(Math.random() * 1296)
+      .toString(36)
+      .padStart(2, "0")}`;
+    dbName = `lane_${slug.replace(/-/g, "_")}_${suffix}`.slice(0, 63);
+
+    const pgEnv: NodeJS.ProcessEnv = { ...process.env };
+    if (password) pgEnv.PGPASSWORD = password;
+
+    // Reuses the CI mechanism verbatim: `createdb -E UTF8 -T template0`
+    // (.github/workflows/ci.yml:68). The explicit encoding is NOT decoration —
+    // ci.yml:59-66 records that a bare createdb inherits the cluster's
+    // template1 encoding, and a C/POSIX cluster yields SQL_ASCII, under which
+    // the snowball stemmers split multibyte accented characters and every
+    // non-English FTS assertion (#341) silently fails while ASCII-only English
+    // passes. `-T template0` is required to choose an encoding at all.
+    run(
+      "db-create",
+      "createdb",
+      ["-h", host, "-p", port, "-U", user, "-E", "UTF8", "-T", "template0", dbName],
+      { env: pgEnv },
+    );
+    step("db-create", `${dbName} created (UTF8, template0)`);
+
+    // Migrations run through the EXISTING path — `bun run migrate` ->
+    // scripts/migrate.ts -> createPool() (src/db/pool.ts:22), which reads
+    // DB_NAME from the environment. Overriding DB_NAME is therefore how the
+    // existing migration path is pointed at the new database; no second
+    // migration path is introduced here. The `vector` extension is created by
+    // migration 001_init.sql:4, so no separate extension step is needed.
+    const migrateEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      DB_HOST: host,
+      DB_PORT: port,
+      DB_USER: user,
+      DB_NAME: dbName,
+    };
+    if (password) migrateEnv.DB_PASSWORD = password;
+    run("db-migrate", "bun", ["run", "migrate"], {
+      cwd: worktreePath,
+      env: migrateEnv,
+    });
+    step("db-migrate", `migrations applied to ${dbName}`);
+
+    const auth = password
+      ? `${encodeURIComponent(user)}:${encodeURIComponent(password)}`
+      : encodeURIComponent(user);
+    dbUrl = `postgres://${auth}@${host}:${port}/${dbName}`;
+  }
+
+  // --- final report --------------------------------------------------------
+  const lines: string[] = [
+    "",
+    "─".repeat(72),
+    "LANE READY",
+    "─".repeat(72),
+    `  reason:    ${args.reason}`,
+    `  worktree:  ${worktreePath}`,
+    `  branch:    ${args.branch} (from origin/main)`,
+    `  env:       .env copied — OK`,
+    `  deps:      bun install --frozen-lockfile — OK`,
+  ];
+  if (args.freshDb) {
+    lines.push(`  database:  ${dbName} — created and migrated`);
+    lines.push("");
+    lines.push("  Export this in the lane before running DB-backed tests:");
+    lines.push("");
+    lines.push(`    export OPENBRAIN_TEST_DATABASE_URL="${dbUrl}"`);
+  } else {
+    lines.push(`  database:  none (--fresh-db not given)`);
+  }
+  lines.push("");
+  lines.push("─".repeat(72));
+  // Printed, never executed. See the ledger rejection record
+  // (docs/issue-graph.md:284): teardown stays manual and agent-owned.
+  lines.push("TEARDOWN — run these YOURSELF when the lane is done. Nothing here is automatic.");
+  lines.push("─".repeat(72));
+  lines.push("");
+  lines.push(`    git worktree remove ${worktreePath}`);
+  if (args.freshDb) {
+    lines.push(`    dropdb ${dbName}`);
+  } else {
+    lines.push(`    # dropdb <name>   (no database was created by this run)`);
+  }
+  lines.push("");
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+try {
+  main();
+} catch (err) {
+  if (err instanceof LaneBootstrapError) {
+    // Named step + non-zero exit. The first failure is the exit code.
+    process.stderr.write(`\n  [FAIL] ${err.step}: ${err.message}\n\n`);
+    process.exit(1);
+  }
+  process.stderr.write(
+    `\n  [FAIL] unexpected: ${err instanceof Error ? err.stack || err.message : String(err)}\n\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Implements ledger item 15 (`docs/issue-graph.md:261`, decisions pass 2026-08-07): one command that stands up a known-good lane environment.

- Label: enhancement
- Label: tooling

## Why

On one night ~5 lanes hand-built their environments. Each hit one of three things:

1. a missing `.env`,
2. missing `bun-types` because deps were never installed, which then makes `bunx tsc --noEmit` fail in a way that looks like a code error,
3. a pipe that swallowed a non-zero exit, so a half-built environment reported success.

The third is the expensive one: the failure mode is not "the setup errored", it is "the setup said fine and the environment was not".

## What

`bun scripts/lane-bootstrap.ts --branch <name> --reason "<why>" [--fresh-db]`

1. **Requires `--reason`** (non-empty, not a placeholder) and echoes it as the first line of output, so it lands in the lane transcript. The worktrees-need-a-stated-reason rule stays intact; refusal quotes the rule.
2. **Creates a worktree** at `/Volumes/ThunderBolt/_tmp/open-brain/_worktrees/<branch-slug>/` on a new branch from `origin/main` after `git fetch origin`. Refuses if the path exists (it may be a live lane) and refuses `--branch main` outright.
3. **Copies `.env`** from the repo root.
4. **Runs `bun install --frozen-lockfile`** and fails loudly with a named step on non-zero.
5. **`--fresh-db`** creates a collision-proof database (`lane_<slug>_<pid>_<time36><rand>`), migrates it, and prints the `OPENBRAIN_TEST_DATABASE_URL` export line.
6. **Final block** names worktree, branch, env status, deps status, db url, and the matching teardown commands.
7. Every step reports by name; the exit code is the first failure. No `|| true`, no status-discarding pipes — the script must not reproduce the bug it exists to prevent.

**Teardown is printed, never executed.** That is the ledger's explicit rejection record (`docs/issue-graph.md:284`): a cleanup script that removes things it may not have created is a bigger risk than the friction it saves. This file contains no delete path at all.

## Reused existing DB mechanism (not a second migration path)

- `createdb -E UTF8 -T template0` mirrors `.github/workflows/ci.yml:68`. The explicit encoding is load-bearing, not decoration: `ci.yml:59-66` records that a bare `createdb` inherits the cluster's `template1` encoding, and a C/POSIX cluster yields SQL_ASCII, under which the snowball stemmers split multibyte accented characters and every non-English FTS assertion (#341) silently fails while ASCII-only English passes.
- Migrations run through the existing `bun run migrate` -> `scripts/migrate.ts` -> `createPool()` path with `DB_NAME` overridden, because `createPool()` reads `DB_NAME` (`src/db/pool.ts:22`). No second migration path is introduced.
- The `vector` extension comes from migration `001_init.sql:4`, so no separate extension step is needed.

## Operator note: a Postgres-owned identifier size

Flagging this rather than deciding it silently. Postgres accepts identifiers up to NAMEDATALEN-1 = 63 bytes — a compile-time server constant, not a policy choice (`show max_identifier_length` returns `63` on the dogfood cluster). The server does not error on a longer name; it silently shortens it, and it does so from the tail, which is exactly where the uniqueness suffix lives. Two long branch names would then collapse onto the same database and truncate each other's tables — the precise collision `--fresh-db` exists to prevent.

The generated name therefore keeps the uniqueness suffix whole and lets the human-readable slug portion yield the space instead, so uniqueness holds regardless of branch-name length. Measured with an 84-character branch name: two generated names, both 63 bytes, both distinct, suffixes intact. Nothing else in the system is bounded by this and no bound was introduced anywhere else; this is Postgres's, reported as found.

## RLVR evidence

`scripts/done-means/lane-bootstrap-known-good.sh` was written and run RED **before** `scripts/lane-bootstrap.ts` existed.

The check deliberately does not trust the script's own report. For the happy path it enters the worktree and runs `bunx tsc --noEmit` — the exact probe that failed for the lanes, since tsc cannot resolve `bun-types` unless `bun install` genuinely completed. Clause 1 also refuses to accept a bare non-zero exit: the output must NAME the rule, because an unrelated crash also exits non-zero.

### RED (before the script existed)

```
CLAUSE 1 (refuses without --reason, names the rule): FAIL — exit=1 non-zero but UNNAMED: output does not mention the reason rule (output head: error: Module not found "scripts/lane-bootstrap.ts")
CLAUSE 2 (worktree env genuinely good: .env + tsc): FAIL — bootstrap exited 1 (output head: error: Module not found "scripts/lane-bootstrap.ts")
CLAUSE 3 (--fresh-db url connects, collision-proof): FAIL — --fresh-db exit=1, url printed='<none>' (head: error: Module not found "scripts/lane-bootstrap.ts")
CLAUSE 4 (teardown printed, never executed): FAIL — worktree_remove_line=0 dropdb_line=0 worktree_still_exists=no
```

### GREEN (after)

```
CLAUSE 1 (refuses without --reason, names the rule): PASS — exit=1 non-zero and stderr/stdout names the reason rule
CLAUSE 2 (worktree env genuinely good: .env + tsc): PASS — worktree=/Volumes/ThunderBolt/_tmp/open-brain/_worktrees/donemeans-lb-81aa5d74-a .env present; bunx tsc --noEmit exit=0 (deps incl. bun-types resolve)
CLAUSE 3 (--fresh-db url connects, collision-proof): PASS — psql select 1 OK on run-1 url; db names differ across runs (lane_donemeans_lb_81aa5d74_b_59043_msjt6s4y7i vs lane_donemeans_lb_81aa5d74_c_59672_msjt6tbqjj)
CLAUSE 4 (teardown printed, never executed): PASS — output carries 'git worktree remove' and 'dropdb'; worktree /Volumes/ThunderBolt/_tmp/open-brain/_worktrees/donemeans-lb-81aa5d74-b still present after the run (nothing auto-deleted)
```

The check created three worktrees and two databases per run and removed all of them via its own EXIT trap, each guarded by a `RUN_ID` match so it can never touch an artifact it did not create. Post-run `git worktree list` and a `pg_database` query for `lane_%`/`%donemeans%` both came back with zero leaked artifacts.

## Critical Self-Review

- Highest-risk behavior: creating a worktree and a database as a side effect. Both are refused rather than overwritten when the target already exists, and neither is ever removed by this script.
- Assumptions that could be wrong: that `.env` at the repo root is the right source for a lane's config, and that the operator's libpq user may run `createdb`. Both fail loudly with a named step rather than silently degrading.
- Missing/weak tests: the done-means check drives the real script end to end, but there is no unit test for `slugify` or placeholder-reason parsing. `--reason` rejection is covered only for the empty case in the automated check; the placeholder list was exercised by hand, not in CI.
- Security/permission risk: `.env` is copied into a temp-workspace worktree, which is where lanes already run; no credential is logged. The generated `OPENBRAIN_TEST_DATABASE_URL` does contain the local dev password from `.env` and is printed to stdout by design — that is a local dogfood credential, already present in every lane's `.env`.
- Migration/deploy risk: none. The script is not imported by the server or CI and adds no runtime dependency.
- Downstream client/runtime risk: none — `docs/downstream-rollout.md` does not apply. No MCP tool, schema, transport, or Python client surface is touched.
- Rollback/cleanup concern: the script creates worktrees and databases whose removal is deliberately manual. That is the ledger decision, and the printed teardown block is the mitigation. A lane that ignores it leaves scaffolding behind — the pre-existing situation, not a regression.
- Fixes made before PR: removed a leftover `Bun.file` + `require("node:fs")` mix in `readEnvFile` in favor of a top-level `readFileSync` import; reworked database naming so the uniqueness suffix is preserved for long branch names (see the operator note above) — the first version would have dropped it and collided.
- Known residual risk: `--fresh-db` leaves the database in place by design, so a lane that ignores the printed `dropdb` accumulates databases on the dev cluster.
- SME review-memory update: [x] not applicable because: no new MEDIUM+ finding surfaced — two new files, no existing code path modified, and nothing under `python/openbrain-memory/` is touched, so no reviewer lane in `docs/sme/` gains a new pattern.

## Review Gate

- Review tier: Light. Two new files, no existing code path modified, no runtime/server surface touched.
- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this script touches no MCP tool, schema, transport, or Python client surface — it is developer tooling that creates a worktree and an optional test database, so `docs/downstream-rollout.md` does not apply.
- Downstream rollout: not applicable (no MCP/schema/transport/client change).
