### PR TITLE
fix(lane-bootstrap): announce DB-name slug shortening; codify no-silent-adjustments rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,7 @@ uv run pytest -q
 - Python client behavior must be covered by fake transport tests for headers, session lifecycle, error redaction, and wrapper call shapes. Live canaries stay env-gated.
 - Python package source must pass `uv run mypy src/openbrain_memory` and `uv run ruff check src tests` with zero errors, matching the quality bar used by `/Volumes/ThunderBolt/Development/king-capital/king-signals`.
 - Keep fixes scoped to the issue. Avoid broad refactors unless they are required to close the bug safely.
+- **Nothing is adjusted silently** (operator ruling, 2026-08-08). Any script, tool, or lane that transforms its input to satisfy a constraint — shortens a name to fit a bound, substitutes a default, skips a step as N/A, coerces a value — announces the adjustment in its normal output: original → adjusted, and why. Provably-safe and cosmetic adjustments are not exempt; the transcript must let the reader map what was asked for to what exists. SME entry: `docs/sme/entries/2026-08-08-nothing-is-adjusted-silently-tools-announce-every-self-made-decision.md`.
 - When a review or post-merge issue exposes a missed pattern, update `docs/sme/` so the next swarm checks for it.
 - For contract-changing MCP, transport, Python client, or agent-facing changes,
   follow `docs/downstream-rollout.md`; do not treat local tests or hosted

--- a/docs/sme/entries/2026-08-08-nothing-is-adjusted-silently-tools-announce-every-self-made-decision.md
+++ b/docs/sme/entries/2026-08-08-nothing-is-adjusted-silently-tools-announce-every-self-made-decision.md
@@ -1,0 +1,23 @@
+---
+lane: gotcha-agent
+order: 40
+---
+## [2026-08-08] Nothing is adjusted silently: tools announce every self-made decision
+
+**Severity:** HIGH
+**Source:** Operator ruling 2026-08-08 during the PR #616 decisions review; first instance `scripts/lane-bootstrap.ts` DB-name shortening
+**Scope:** any script, tool, or lane that transforms its input to satisfy a constraint
+**Status:** active
+
+### Pattern
+
+Operator ruling, verbatim intent: "anything silently is an unacceptable outcome." When a tool adjusts something on its own — shortens a name to fit a bound, substitutes a default, skips an inapplicable step, coerces a value, retries with a variant — the adjustment must be announced in its output, even when the adjustment is provably safe.
+
+The instance that produced the ruling: `lane-bootstrap.ts` correctly kept DB names under Postgres's 63-byte identifier bound (server truncates silently — the danger it defended against), but performed its own slug-shortening without printing it. The defense against silent behavior was itself silent. Correct handling and unannounced handling are different defects: the first corrupts state, the second corrupts the operator's model of state.
+
+Review checks:
+
+- For every `slice`/`substring`/`replace`/default-fallback on the path from user input to an external system, find the corresponding output line that states original → adjusted and why. Absent line = defect.
+- "It only changes cosmetics" is not an exemption; the transcript must let the reader map what they asked for to what exists.
+- Skipped steps count: a tool that decides a step is N/A says so and why (the downstream-rollout classification format is the model).
+- The announcement belongs in the tool's normal output, not a log level that is off by default.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1393,3 +1393,23 @@ Checks for the next swarm:
 - **Agent creation is not `skill-maintainer`'s job.** That skill owns
   `_ob/skills/<slug>/` canonicals and their runtime adapters (four verbs:
   create/update/audit/sync). An agent definition is a different artifact.
+
+## [2026-08-08] Nothing is adjusted silently: tools announce every self-made decision
+
+**Severity:** HIGH
+**Source:** Operator ruling 2026-08-08 during the PR #616 decisions review; first instance `scripts/lane-bootstrap.ts` DB-name shortening
+**Scope:** any script, tool, or lane that transforms its input to satisfy a constraint
+**Status:** active
+
+### Pattern
+
+Operator ruling, verbatim intent: "anything silently is an unacceptable outcome." When a tool adjusts something on its own — shortens a name to fit a bound, substitutes a default, skips an inapplicable step, coerces a value, retries with a variant — the adjustment must be announced in its output, even when the adjustment is provably safe.
+
+The instance that produced the ruling: `lane-bootstrap.ts` correctly kept DB names under Postgres's 63-byte identifier bound (server truncates silently — the danger it defended against), but performed its own slug-shortening without printing it. The defense against silent behavior was itself silent. Correct handling and unannounced handling are different defects: the first corrupts state, the second corrupts the operator's model of state.
+
+Review checks:
+
+- For every `slice`/`substring`/`replace`/default-fallback on the path from user input to an external system, find the corresponding output line that states original → adjusted and why. Absent line = defect.
+- "It only changes cosmetics" is not an exemption; the transcript must let the reader map what they asked for to what exists.
+- Skipped steps count: a tool that decides a step is N/A says so and why (the downstream-rollout classification format is the model).
+- The announcement belongs in the tool's normal output, not a log level that is off by default.

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -79,7 +79,10 @@ ENTRIES_DIR="$SME_DIR/entries"
 BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 
 # Pinned pre-migration measurement. See the header block for provenance.
-EXPECTED_ENTRY_COUNT=226
+# 226 at migration (PR #617); +1 = the 2026-08-08 no-silent-adjustments entry
+# (operator ruling) — raised in the same commit that adds it, as the gate's
+# own failure text instructs.
+EXPECTED_ENTRY_COUNT=227
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"

--- a/scripts/lane-bootstrap.ts
+++ b/scripts/lane-bootstrap.ts
@@ -339,8 +339,19 @@ function main(): void {
     const prefix = "lane_";
     const laneSuffix = `_${suffix}`;
     const room = 63 - prefix.length - laneSuffix.length;
-    const slugPart = slug.replace(/-/g, "_").slice(0, Math.max(0, room));
+    const fullSlug = slug.replace(/-/g, "_");
+    const slugPart = fullSlug.slice(0, Math.max(0, room));
     dbName = `${prefix}${slugPart}${laneSuffix}`;
+    if (slugPart !== fullSlug) {
+      // Operator ruling 2026-08-07: nothing is adjusted silently. The name is
+      // still collision-proof (suffix whole); only the readable part shrank,
+      // and the lane transcript must say so rather than leave a name that
+      // doesn't match the branch unexplained.
+      step(
+        "db-name",
+        `NOTICE: branch slug shortened to fit Postgres's 63-byte identifier bound: "${fullSlug}" -> "${slugPart}" (uniqueness suffix kept whole; database is ${dbName})`,
+      );
+    }
 
     const pgEnv: NodeJS.ProcessEnv = { ...process.env };
     if (password) pgEnv.PGPASSWORD = password;


### PR DESCRIPTION
## Summary

- Operator ruling 2026-08-08 during the tooling decisions review: "anything silently is an unacceptable outcome." `lane-bootstrap.ts` kept DB names under Postgres's 63-byte identifier bound correctly (uniqueness suffix whole), but performed its slug-shortening without printing it — the defense against silent server truncation was itself silent on our side.
- `scripts/lane-bootstrap.ts`: a `db-name` NOTICE step now prints original slug → shortened slug → final database name whenever shortening occurs.
- The ruling is codified where future work will meet it: an AGENTS.md Coding Standards bullet, and SME entry `docs/sme/entries/2026-08-08-nothing-is-adjusted-silently-tools-announce-every-self-made-decision.md` (gotcha-agent lane, order 40).
- First SME addition under the PR #617 per-entry structure: pinned count raised 226→227 in the same commit, exactly as the gate's failure text instructs.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` exit 0. `scripts/done-means/sme-per-entry-files.sh` GREEN at 227 on the committed tree (it refused the dirty tree first — by design). Live proof of the NOTICE (RUNNING): bootstrapped an 88-char branch name with `--fresh-db`; transcript line: `[ok] db-name: NOTICE: branch slug shortened to fit Postgres's 63-byte identifier bound: "test_this_is_a_deliberately_very_long_branch_name_to_prove_the_shortening_notice_prints" -> "test_this_is_a_deliberately_very_long_bra" (uniqueness suffix kept whole; database is lane_test_this_is_a_deliberately_very_long_bra_64746_msjujeoitq)`. Proof worktree, database, and branch removed afterwards; `pg_database` shows zero `lane_%` rows.

## Critical Self-Review

- Highest-risk behavior: none functional — the DB name algorithm is unchanged; the change adds an output line and documentation. The riskiest piece is raising the SME pinned count, which is exactly the stated procedure for additions.
- Assumptions that could be wrong: that `step()` output reaches lane transcripts in all invocation modes; verified in the live run above for direct invocation.
- Missing/weak tests: the NOTICE line is proven by a live transcript, not an automated test. An automated case would need a full `--fresh-db` bootstrap inside the done-means check; judged not worth doubling the check's runtime for an output-only change. Stated, not hidden.
- Security/permission risk: none — no auth, namespace, or SQL surface touched.
- Migration/deploy risk: none — dev-tooling script and docs only.
- Downstream client/runtime risk: none — no MCP/client-facing surface.
- Rollback/cleanup concern: revert is a single squash-commit revert; the SME count comment documents both values.
- Fixes made before PR: reworded the count comment to drop a guessed PR number (issues and PRs share the counter; the guess could have been wrong the moment it merged).
- Known residual risk: other tools in the repo may still adjust silently; the SME entry gives reviewers the checklist to catch them lane by lane rather than pretending this PR swept the repo.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no Open Brain server surface changed; the live check that applies (lane-bootstrap NOTICE transcript) is quoted under Verification.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: dev-tooling script, repo docs, and SME knowledge base only; no contract surface.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, transport, or client-facing change. The diff is a local dev script's output line, AGENTS.md prose, and SME knowledge files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
