### PR TITLE
fix(contracts): tear down every namespace the parity fixtures seed

### DIFF
--- a/contracts/server-tool-parity.test.ts
+++ b/contracts/server-tool-parity.test.ts
@@ -214,13 +214,76 @@ function restoreEnv(key: string, value: string | undefined): void {
   else process.env[key] = value;
 }
 
+// Every namespace this suite writes into, recorded as each test builds one.
+// Teardown deletes exactly these — not a `parity-%` wildcard sweep, which would
+// also delete a concurrently running lane's rows out from under it, and not a
+// hardcoded list, which silently stops covering a fixture the moment one is
+// added.
+const seededNamespaces = new Set<string>();
+
+// Tables the fixtures actually write, in FOREIGN-KEY-SAFE order.
+//
+// Measured, not guessed: a full parity run against a freshly migrated database
+// left rows in exactly these, and only these, under `parity-%` namespaces
+// (#613). Children precede their parents — `ob_raw_turns` references
+// `ob_session_lanes`, and `ob_source_files` references `ob_sources` — so a
+// delete in list order never trips a constraint.
+//
+// This list is deliberately explicit rather than derived from
+// `information_schema` at runtime. A schema-walking teardown would silently
+// widen its own blast radius every time a namespaced table is added, which is
+// the opposite of what a test fixture should do; when a new fixture starts
+// writing somewhere new, the done-means check (#613) fails and this list is
+// updated on purpose.
+const SEEDED_TABLES = [
+  "ob_raw_turns",
+  "ob_session_lanes",
+  "ob_source_files",
+  "ob_sources",
+  "ob_links",
+  "ob_entities",
+  "content_occurrences",
+  "decisions",
+  "relationships",
+  "sessions",
+  "thoughts",
+] as const;
+
+/**
+ * Delete every row this suite seeded, in every namespace it used.
+ *
+ * WHY THIS EXISTS (#613): these fixtures were leaving approved/active
+ * `ob_sources` rows behind. On `main` that was invisible because nothing
+ * produced from them. The maintenance sweep is a CROSS-NAMESPACE producer by
+ * design (`selectSourcesNeedingDerivation` receives `undefined` writable
+ * namespaces, because a server-owned sweep must serve every namespace), so the
+ * moment a producer runs anywhere in the suite, these leftovers become real
+ * queued `graph.derive` jobs and break an unrelated test — observed in PR #609
+ * as `026 maintenance queue` losing its concurrent-claim race (Expected 1,
+ * Received 2). A suite that leaks rows is not a self-contained suite; it is a
+ * time bomb for whoever next turns on a producer.
+ */
+async function deleteSeededRows(): Promise<void> {
+  if (!pool || seededNamespaces.size === 0) return;
+  const namespaces = [...seededNamespaces];
+  for (const table of SEEDED_TABLES) {
+    await pool.query(`DELETE FROM ${table} WHERE namespace = ANY($1)`, [namespaces]);
+  }
+}
+
 dbDescribe("server parity fixtures by implemented provider capability (live Postgres)", () => {
   beforeAll(() => {
     process.env.SHARED_NAMESPACE_CANONICAL = SHARED_NAMESPACE_ISOLATION;
     process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_NAMESPACE_ISOLATION;
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    // Delete BEFORE restoring the shared-namespace override. The deletes are
+    // plain namespace-predicated SQL and do not read that config, so the order
+    // is not load-bearing today — but keeping cleanup inside the isolated
+    // window means it stays correct if a future teardown ever routes through
+    // application code that resolves the shared namespace.
+    await deleteSeededRows();
     restoreEnv("SHARED_NAMESPACE_CANONICAL", priorSharedNamespaceEnv.canonical);
     restoreEnv("SHARED_NAMESPACE_PHYSICAL", priorSharedNamespaceEnv.physical);
   });
@@ -231,11 +294,18 @@ dbDescribe("server parity fixtures by implemented provider capability (live Post
       test(`${provider}: ${fixture.id}`, async () => {
         const providerSlug = provider.replaceAll("-", "_");
         const namespace = `${fixture.auth.client_id}-${providerSlug}-${process.pid}`;
+        const otherNamespace = `${namespace}-other`;
+        // Recorded BEFORE the steps run, not after. A fixture that throws
+        // partway has still written rows, and those are exactly the ones most
+        // worth cleaning up; registering on the way in makes teardown cover the
+        // failure path too.
+        seededNamespaces.add(namespace);
+        seededNamespaces.add(otherNamespace);
         // Captured ids are added to this same map as steps run, so a fixture
         // substitutes namespace tokens and prior-step ids through one mechanism.
         const replacements: Record<string, string> = {
           "{{namespace}}": namespace,
-          "{{other_namespace}}": `${namespace}-other`,
+          "{{other_namespace}}": otherNamespace,
         };
         const auth: AuthInfo = {
           role: fixture.auth.role,

--- a/scripts/done-means/613-fixtures-torn-down.sh
+++ b/scripts/done-means/613-fixtures-torn-down.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #613 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/613-fixtures-torn-down.sh
+#
+# Issue #613, verbatim ask:
+#   "Fix cleanup in the suites that create `parity-source-registry-*` fixtures
+#    so they tear down what they seed. The next global producer added to the
+#    codebase will hit the same rows."
+#
+# ---------------------------------------------------------------------------
+# What is measured, and why it is measured THIS way
+# ---------------------------------------------------------------------------
+# The defect is not "a query returns the wrong answer" — it is RESIDUE. A row
+# that outlives the suite that created it. Residue cannot be observed from
+# inside the suite, and it cannot be observed in a database other work has
+# touched, because a pre-existing `parity-source-registry-%` row would be
+# indistinguishable from one this run leaked.
+#
+# So this check requires a FRESH DATABASE and owns the whole lifecycle:
+#   1. createdb + migrate a throwaway database (the same mechanism as
+#      scripts/lane-bootstrap.ts --fresh-db: createdb, then `bun run migrate`).
+#   2. Assert it starts with ZERO `parity-source-registry-%` rows. Without this
+#      the final count proves nothing.
+#   3. Run the OWNING suite (contracts/server-tool-parity.test.ts) against it.
+#   4. Assert the suite actually exercised the fixture. A suite that silently
+#      skips (no OPENBRAIN_TEST_DATABASE_URL → `describe.skip`,
+#      contracts/server-tool-parity.test.ts:51) leaves zero rows too, and that
+#      zero is a FALSE PASS. Per docs/sme/correctness.md, a gate that can pass
+#      without the real path running is not a gate.
+#   5. Count `ob_sources` rows matching `parity-source-registry-%`. Must be 0.
+#
+# The gate calls the REAL suite rather than re-deriving cleanup itself. A check
+# that hand-rolls its own copy of the teardown can pass while the product stays
+# broken (docs/sme/correctness.md:1921).
+#
+# EXPECTED TO FAIL on origin/main (leftover rows > 0). It is the reward
+# function, not a test of the fix author's diligence.
+#
+# TEARDOWN: this script drops ONLY the database it created itself, by a name it
+# generated, via `dropdb`. It contains no `rm` of any kind and touches no
+# worktree, no repo file, and no database it did not create.
+#
+# The dogfood database and core01 are NOT touched. This check never reads
+# OPENBRAIN_TEST_DATABASE_URL from the environment; it sets its own.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}" || exit 1
+
+PG_HOST="${DONE_MEANS_613_PGHOST:-127.0.0.1}"
+PG_PORT="${DONE_MEANS_613_PGPORT:-5432}"
+PG_USER="${DONE_MEANS_613_PGUSER:-${USER}}"
+DB_NAME="done_means_613_$$_$(date +%s)"
+DB_URL="postgres://${PG_USER}@${PG_HOST}:${PG_PORT}/${DB_NAME}"
+
+FAILURES=0
+DB_CREATED=0
+fail() { printf 'FAIL  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'PASS  %s\n' "$*"; }
+info() { printf 'INFO  %s\n' "$*"; }
+
+cleanup() {
+  if [[ ${DB_CREATED} -eq 1 ]]; then
+    if dropdb "${DB_NAME}" >/dev/null 2>&1; then
+      info "teardown: dropped ${DB_NAME}"
+    else
+      printf 'WARN  teardown: dropdb %s failed; drop it by hand\n' "${DB_NAME}"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+q() { psql -At "${DB_URL}" -c "$1"; }
+
+printf '=== done-means #613: do parity suites tear down what they seed? ===\n'
+printf 'throwaway database: %s\n\n' "${DB_NAME}"
+
+# ---------------------------------------------------------------------------
+# (1) Fresh database.
+# ---------------------------------------------------------------------------
+if ! createdb -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" "${DB_NAME}" 2>&1; then
+  fail "(1) createdb ${DB_NAME} failed; cannot run the check"
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+DB_CREATED=1
+pass "(1) created ${DB_NAME}"
+
+if MIGRATE_LOG="$(DB_HOST="${PG_HOST}" DB_PORT="${PG_PORT}" DB_NAME="${DB_NAME}" \
+  DB_USER="${PG_USER}" bun run migrate 2>&1)"; then
+  pass "(1) migrations applied"
+else
+  fail "(1) migrations failed:"
+  printf '%s\n' "${MIGRATE_LOG}" | tail -20
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# (2) Precondition: the fresh database holds no parity source rows.
+# ---------------------------------------------------------------------------
+BEFORE="$(q "SELECT count(*) FROM ob_sources WHERE namespace LIKE 'parity-source-registry-%';")"
+if [[ "${BEFORE}" == "0" ]]; then
+  pass "(2) precondition: 0 parity-source-registry-% rows before the run"
+else
+  fail "(2) precondition broken: ${BEFORE} parity-source-registry-% row(s) already present in a fresh database"
+fi
+
+# ---------------------------------------------------------------------------
+# (3) Run the owning suite.
+# ---------------------------------------------------------------------------
+info "(3) running contracts/server-tool-parity.test.ts ..."
+SUITE_LOG="$(OPENBRAIN_TEST_DATABASE_URL="${DB_URL}" \
+  bun test contracts/server-tool-parity.test.ts 2>&1)"
+SUITE_EXIT=$?
+printf '%s\n' "${SUITE_LOG}" | tail -12
+if [[ ${SUITE_EXIT} -eq 0 ]]; then
+  pass "(3) suite exited 0"
+else
+  fail "(3) suite exited ${SUITE_EXIT} — a failing suite makes the row count unreadable"
+fi
+
+# ---------------------------------------------------------------------------
+# (4) The suite actually ran the source-registry fixture.
+# ---------------------------------------------------------------------------
+# Bun's default reporter names a test only when it FAILS, so grepping the log
+# for the fixture id cannot confirm a passing run. The count line is the signal
+# that survives both outcomes: `describe.skip` reports `0 pass`, a real run
+# reports the full fixture matrix.
+PASS_COUNT="$(printf '%s' "${SUITE_LOG}" | rg -o '^\s*(\d+) pass' -r '$1' | head -1)"
+if [[ "${PASS_COUNT:-0}" -gt 0 ]]; then
+  pass "(4) suite really executed (${PASS_COUNT} passing tests, not a silent skip)"
+else
+  fail "(4) suite reported 0 passing tests — skipped, so the count in step (5) would be meaningless"
+fi
+
+# ---------------------------------------------------------------------------
+# (5) THE GATE: nothing is left behind.
+# ---------------------------------------------------------------------------
+AFTER="$(q "SELECT count(*) FROM ob_sources WHERE namespace LIKE 'parity-source-registry-%';")"
+if [[ "${AFTER}" == "0" ]]; then
+  pass "(5) 0 parity-source-registry-% rows remain in ob_sources"
+else
+  fail "(5) ${AFTER} parity-source-registry-% row(s) left behind in ob_sources"
+  printf '\n--- leftover rows ---\n'
+  psql "${DB_URL}" -c "SELECT namespace, source_kind, external_id, approval_state, lifecycle_state
+                         FROM ob_sources WHERE namespace LIKE 'parity-source-registry-%';" 2>&1 || true
+fi
+
+printf '\n'
+if [[ ${FAILURES} -eq 0 ]]; then
+  printf '=== RESULT: PASS — parity suites tear down what they seed ===\n'
+  exit 0
+fi
+printf '=== RESULT: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+exit 1


### PR DESCRIPTION
## Summary

- The server parity suite (`contracts/server-tool-parity.test.ts`) built a per-fixture namespace and never deleted what it wrote. It left approved/active `ob_sources` rows behind, plus rows in 8 other namespaced tables. This makes each suite teardown exactly what it seeds, at the owning boundary.
- The rows were inert only because nothing produced from them. The maintenance sweep is a cross-namespace producer by design — `selectSourcesNeedingDerivation` receives `undefined` writable namespaces, because a server-owned sweep must serve every namespace — so in PR #609 the leftovers became real queued `graph.derive` jobs mid-suite and broke an unrelated test: `026 maintenance queue` expects exactly one due job to exist ANYWHERE, and `claimDueJobs` filters on `state`/`run_after` only, so both racers claimed one (Expected 1, Received 2).
- Fixed in the shared harness, not in one fixture. The namespace is constructed in exactly one place (`contracts/server-tool-parity.test.ts:233`), which is why every one of the 39 parity fixtures leaked and why a per-fixture patch would have been the wrong boundary. Each test now records the namespaces it is about to use, and the suite's `afterAll` deletes those exact namespaces from the tables the fixtures actually write.
- Namespaces are recorded on the way IN, before the steps run, so a fixture that throws partway still gets cleaned up. Those are the rows most worth removing.
- Acceptance gate added: `scripts/done-means/613-fixtures-torn-down.sh`.

Two deliberate non-choices, both narrower than the obvious fix:

- Not a `parity-%` wildcard sweep. That would delete a concurrently running lane's rows out from under it.
- Not a schema-walking table list. Deriving tables from `information_schema` would silently widen the blast radius every time a namespaced table is added. The list is explicit, measured against a real run, and ordered foreign-key-safe (`ob_raw_turns` before `ob_session_lanes`, `ob_source_files` before `ob_sources`). When a fixture starts writing somewhere new, the done-means check fails and the list gets updated on purpose.

Scope held: no global cleanup sweep was added, and no unrelated suite was touched. `server/maintenance/maintenance.pg.test.ts` keeps its own `job_kind` cleanup from #609 — that guards a different dimension (the producer's), and removing it would re-open #609's failure.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` — clean.

Python: not applicable, nothing under `python/openbrain-memory/` is touched.

Live smoke: not applicable. This changes test-suite teardown only; no server, schema, or client-facing code path is modified. The dogfood service and core01 were not touched by any run below — every run created and dropped its own throwaway database.

**RED — before the fix, on clean origin/main**

```
=== done-means #613: do parity suites tear down what they seed? ===
throwaway database: done_means_613_57141_1786162479

PASS  (1) created done_means_613_57141_1786162479
PASS  (1) migrations applied
PASS  (2) precondition: 0 parity-source-registry-% rows before the run
INFO  (3) running contracts/server-tool-parity.test.ts ...
 75 pass
 0 fail
Ran 75 tests across 1 file. [1.82s]
PASS  (3) suite exited 0
FAIL  (5) 2 parity-source-registry-% row(s) left behind in ob_sources

--- leftover rows ---
                      namespace                       | source_kind |               external_id               | approval_state | lifecycle_state
------------------------------------------------------+-------------+-----------------------------------------+----------------+-----------------
 parity-source-registry-current_src-57607             | git         | https://example.invalid/parity-repo.git | pending        | active
 parity-source-registry-server_rewrite_scaffold-57607 | git         | https://example.invalid/parity-repo.git | pending        | active
(2 rows)

=== RESULT: FAIL (2 failing clause(s)) ===
INFO  teardown: dropped done_means_613_57141_1786162479
```

Note the suite exits 0 while leaking. That is the whole defect: a green suite and residue are not mutually exclusive, which is why the gate observes the database rather than the exit code.

**GREEN — after the fix**

```
=== done-means #613: do parity suites tear down what they seed? ===
throwaway database: done_means_613_97198_1786162586

PASS  (1) created done_means_613_97198_1786162586
PASS  (1) migrations applied
PASS  (2) precondition: 0 parity-source-registry-% rows before the run
INFO  (3) running contracts/server-tool-parity.test.ts ...
 75 pass
 0 fail
Ran 75 tests across 1 file. [1069.00ms]
PASS  (3) suite exited 0
PASS  (4) suite really executed (75 passing tests, not a silent skip)
PASS  (5) 0 parity-source-registry-% rows remain in ob_sources

=== RESULT: PASS — parity suites tear down what they seed ===
INFO  teardown: dropped done_means_613_97198_1786162586
```

**Residue across every affected table**

The issue names `ob_sources`, but a full parity run against a freshly migrated database leaked into 9 tables. Measured before and after, same fresh-database method:

| table | before | after |
|---|---|---|
| `ob_sources` | 4 | 0 |
| `ob_entities` | 10 | 0 |
| `thoughts` | 6 | 0 |
| `ob_raw_turns` | 4 | 0 |
| `ob_session_lanes` | 4 | 0 |
| `sessions` | 4 | 0 |
| `decisions` | 2 | 0 |
| `ob_links` | 2 | 0 |
| `relationships` | 2 | 0 |
| `content_occurrences` | 0 | 0 |
| `ob_source_files` | 0 | 0 |

The `ob_raw_turns` row confirms the second half of the maintenance comment: leftover `parity-raw-turn-*` fixtures were feeding the distill arm the same way.

**Full-suite differential**

The #609 lesson is that a single-file run cannot distinguish a pre-existing failure from ordering-dependent leakage. Both runs used a separate worktree and a separate freshly-created, freshly-migrated database:

| run | result |
|---|---|
| clean `origin/main` (worktree `baseline-613-origin-main-differential`) | **3710 pass / 0 fail**, 3745 tests across 242 files |
| this branch | **3710 pass / 0 fail**, 3745 tests across 242 files |

Identical. No regression, and no test depended on the leaked rows.

## Critical Self-Review

- Highest-risk behavior: the `afterAll` deletes by namespace across 11 tables. If a namespace string collided with something real, this would delete production-shaped rows. It cannot: the namespaces are recorded from the values this suite itself constructs, which embed `process.pid`, and only namespaces this process actually built are ever in the set. It never deletes by pattern.
- Assumptions that could be wrong: (1) that the 11-table list is complete. It is measured against a full run today, not proven complete for all future fixtures — mitigated by the done-means check failing loudly when a new fixture leaks somewhere unlisted. (2) That the inner `describe`'s `afterAll` runs before the file-level `afterAll` that calls `pool.end()`. If that ordering inverted, teardown would throw on a closed pool. Verified empirically: the GREEN run leaves zero rows, which is only possible if the deletes ran against a live pool.
- Missing/weak tests: the done-means gate covers the `ob_sources` count named by the issue; the other 10 tables are verified by the measured table above rather than by an automated assertion. A regression that re-leaked only `thoughts` would be caught by the manual method, not by CI.
- Security/permission risk: none. No auth, namespace-isolation, or read-policy code path is touched. The deletes are parameterized on namespace; table names come from a hardcoded `as const` allowlist, never from input, per the repo's SQL rule.
- Migration/deploy risk: none. No migration, no schema change, no runtime code. Test-file and script changes only.
- Downstream client/runtime risk: none — checked `docs/downstream-rollout.md`. No MCP tool, schema, protocol, or client-facing surface changes, so rtech-mcps, mcp2cli, and rtech-hermes are unaffected.
- Rollback/cleanup concern: reverting restores the leak, nothing worse. The done-means script drops only the database it created itself, by a name it generated, and contains no `rm` of any kind.
- Fixes made before PR: the gate's step (4) originally grepped the suite log for the fixture id to prove the suite had not silently skipped. That was a false negative — Bun's default reporter names a test only when it FAILS, so the clause failed on a fully passing run. Rewritten to assert a non-zero pass count, which distinguishes a real run from `describe.skip` in both outcomes. Caught because the RED run failed clause (4) for the wrong reason.
- Known residual risk: the explicit table list is a maintenance obligation. It is the intended trade — an implicit schema-walking list would never go stale but would quietly grow its blast radius, which is worse in a teardown path.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern is already captured as `review.producer_activation_promotes_inert_fixtures` in `docs/sme/correctness.md` (2026-08-07), added by #609. This PR is that entry being acted on, not a new finding.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change with no server, schema, or client-facing code path modified.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no fixture content changed. The `.fixture.json` files and the recorded expectations are untouched; this changes only the harness that runs them, and both providers (`current-src`, `server-rewrite-scaffold`) are cleaned identically. All 75 parity tests pass unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: the change is confined to `contracts/server-tool-parity.test.ts` and a new `scripts/done-means/` script. No MCP tool, schema, transport, or Python client surface is altered, so no downstream consumer can observe this change.

Closes #613
