### PR TITLE
feat(hooks): force PR-body validation with a parsed-args PreToolUse gate

### DIFF
--- a/.claude/hooks/pr-body-gate.ts
+++ b/.claude/hooks/pr-body-gate.ts
@@ -1,0 +1,511 @@
+#!/usr/bin/env bun
+/**
+ * pr-body-gate -- repo-local hard gate on PR bodies for open-brain.
+ *
+ * WHY THIS EXISTS -- AND WHY IT IS FORCED RATHER THAN ADVISORY
+ *
+ * Ledger item 14 (docs/issue-graph.md, 2026-08-07) built the deterministic
+ * floor after three lanes failed `scripts/validate-pr-body.ts` three different
+ * ways in one night, all format rather than substance: a PR template generated
+ * from the validator's own field list, a local validation command in every lane
+ * briefing, and a `pr-scribe` agent that only returns a body the validator has
+ * already accepted. Every piece of it was ADVISORY -- a lane that did not run
+ * the validator paid nothing until CI rejected the PR, which is the round trip
+ * the whole thing existed to remove.
+ *
+ * Ledger item 17, operator ruling 2026-08-08:
+ *
+ *   "if it's not enforced, it's pretty much useless. Everything that's not
+ *    enforced eventually gets unused... If I don't hammer it into you and force
+ *    you to use it, eventually you'll decide that it's not useful and you
+ *    won't."
+ *
+ * So the validator stops being something a lane is asked to remember. This hook
+ * runs it on the way out. CI stays the backstop; it is no longer the first
+ * detector. Global promotion is deliberately deferred -- this is repo-local.
+ *
+ * WHY PARSED ARGUMENTS, NOT TEXT MATCHING
+ *
+ * A guard that over-fires is a worse tax than the failure it prevents, and this
+ * repo has the receipt: issue #618, a git guard that matched protected-branch
+ * names inside heredoc TEXT rather than in the command being run, and taxed
+ * every lane until it was fixed. `rg -q 'gh pr create'` on the raw command
+ * string would reintroduce exactly that -- it cannot tell a lane RUNNING
+ * `gh pr create` from a lane WRITING a doc about running it, and lanes in this
+ * repo write about it constantly (this very file contains the phrase).
+ *
+ * The mechanism is therefore: tokenize the command with real shell quoting
+ * rules and STRIP heredoc bodies first, split on command separators, and for
+ * each resulting simple command check that the executable word is `gh`, the
+ * subcommand is `pr`, and the verb is `create` or `edit`. Only then are
+ * `--body`/`-b`/`--body-file`/`-F` read as OPTIONS OF THAT COMMAND. A quoted
+ * string is a single token and is never inspected for command structure, so
+ * `echo 'gh pr create --body bad'` is one `echo` with one argument, and a
+ * heredoc is content rather than syntax. `scripts/done-means/pr-body-gate-fires.sh`
+ * clauses 4a-4c are the standing proof, and they fail loudly if anyone
+ * "simplifies" this into a substring match.
+ *
+ * WHY IT NEVER FAILS QUIETLY
+ *
+ * Per the no-silent-adjustments rule (AGENTS.md Coding Standards, 2026-08-08):
+ * when this hook cannot do its job -- an unreadable `--body-file`, a validator
+ * that will not run -- it REFUSES AND SAYS WHY. It does not silently allow
+ * (that turns the gate off exactly when a lane is doing something unusual, and
+ * nothing reports the gate stopped working) and it does not silently block (a
+ * lane wedged with no reason burns a session guessing).
+ *
+ * The one deliberate fail-open is an unparseable or absent hook PAYLOAD: that
+ * yields no command, which is not a `gh pr create`, so the call proceeds. A bad
+ * read must degrade to "no enforcement", never "no session" -- the same
+ * decision design-lookup-gate.ts documents at its own readInput().
+ *
+ * MECHANISM
+ *
+ *   PreToolUse on Bash -- parse the command; if it is a gh pr create/edit
+ *   carrying a body, run that body through scripts/validate-pr-body.ts with
+ *   PR_BODY/PR_TITLE set. Exit 2 blocks the call and hands stderr back to the
+ *   model as the reason. Exit 0 allows.
+ *
+ * The validator is SPAWNED, never reimplemented. Its rules are the contract
+ * (`scripts/done-means/pr-template-passes-validator.sh` holds the template
+ * against them); a second copy of those rules here would be the drift that
+ * check exists to prevent.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { isAbsolute, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+type HookInput = {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+};
+
+const HOOK_NAME = "pr-body-gate";
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const VALIDATOR = join(REPO_ROOT, "scripts", "validate-pr-body.ts");
+
+/**
+ * Read the hook payload with a NON-BLOCKING read.
+ *
+ * `readFileSync(0)` returns whatever is buffered rather than waiting for the
+ * writer to close, which is what `await Bun.stdin.text()` does. That await
+ * wedged a session in this repo on 2026-07-28 and needed a Claude restart to
+ * recover; see design-lookup-gate.ts readInput() for the full account. Do not
+ * "modernise" this back into an await.
+ */
+function readInput(): HookInput {
+  try {
+    const text = readFileSync(0, "utf8");
+    return text.trim() ? (JSON.parse(text) as HookInput) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Remove heredoc BODIES from a command string, leaving the redirection operator.
+ *
+ * A heredoc body is data the shell feeds to a process; it is not command syntax
+ * and must never be scanned for one. This is the #618 failure mode in its purest
+ * form -- a lane writing a doc that quotes an invalid PR body inside
+ * `git commit -F - <<'EOF' ... EOF` is not creating a PR.
+ *
+ * Handles `<<WORD`, `<<'WORD'`, `<<"WORD"`, and the `<<-` indented form (whose
+ * terminator may be preceded by tabs).
+ */
+function stripHeredocBodies(command: string): string {
+  const lines = command.split("\n");
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    out.push(line);
+    i += 1;
+
+    // Collect every heredoc opened on this line, in order.
+    const opens = [...line.matchAll(/<<(-?)\s*(["']?)([A-Za-z_][A-Za-z0-9_]*)\2/g)];
+    for (const open of opens) {
+      const dashed = open[1] === "-";
+      const terminator = open[3]!;
+      while (i < lines.length) {
+        const candidate = dashed ? lines[i]!.replace(/^\t+/, "") : lines[i]!;
+        i += 1;
+        if (candidate.trim() === terminator) break;
+      }
+    }
+  }
+
+  return out.join("\n");
+}
+
+type Token = { value: string; quoted: boolean };
+
+/**
+ * Tokenize with shell quoting rules.
+ *
+ * `quoted` records whether any part of the token came from inside quotes. That
+ * flag is what keeps `echo 'gh pr create'` from ever being read as a command:
+ * the whole phrase is ONE token, and a quoted token is never treated as an
+ * executable name or a separator.
+ */
+function tokenize(command: string): Token[] {
+  const tokens: Token[] = [];
+  let current = "";
+  let quoted = false;
+  let started = false;
+  let mode: "none" | "single" | "double" = "none";
+
+  const push = () => {
+    if (started) tokens.push({ value: current, quoted });
+    current = "";
+    quoted = false;
+    started = false;
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i]!;
+
+    if (mode === "single") {
+      if (ch === "'") mode = "none";
+      else current += ch;
+      continue;
+    }
+
+    if (mode === "double") {
+      if (ch === '"') mode = "none";
+      else if (ch === "\\" && i + 1 < command.length) {
+        i += 1;
+        current += command[i]!;
+      } else current += ch;
+      continue;
+    }
+
+    if (ch === "'") {
+      mode = "single";
+      quoted = true;
+      started = true;
+      continue;
+    }
+    if (ch === '"') {
+      mode = "double";
+      quoted = true;
+      started = true;
+      continue;
+    }
+    if (ch === "\\" && i + 1 < command.length) {
+      i += 1;
+      current += command[i]!;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      push();
+      continue;
+    }
+
+    current += ch;
+    started = true;
+  }
+
+  push();
+  return tokens;
+}
+
+/**
+ * Split a token stream into simple commands on UNQUOTED separators.
+ *
+ * `a && gh pr create ...` must still be inspected; `echo '&& gh pr create'`
+ * must not be split at all, because that separator is inside a quoted token.
+ */
+const SEPARATORS = new Set(["&&", "||", ";", "|", "&", "\n"]);
+
+function splitCommands(tokens: Token[]): Token[][] {
+  const commands: Token[][] = [];
+  let current: Token[] = [];
+
+  for (const token of tokens) {
+    if (!token.quoted && SEPARATORS.has(token.value)) {
+      if (current.length > 0) commands.push(current);
+      current = [];
+      continue;
+    }
+    current.push(token);
+  }
+  if (current.length > 0) commands.push(current);
+  return commands;
+}
+
+/**
+ * Drop leading env assignments and common wrappers so `FOO=1 command gh pr ...`
+ * and `env X=y gh pr ...` still resolve to `gh`. Deliberately small: this is
+ * about not being trivially evaded by a habitual prefix, not about emulating a
+ * shell.
+ */
+function executableWords(command: Token[]): Token[] {
+  let index = 0;
+  while (index < command.length) {
+    const token = command[index]!;
+    if (!token.quoted && /^[A-Za-z_][A-Za-z0-9_]*=/.test(token.value)) {
+      index += 1;
+      continue;
+    }
+    if (!token.quoted && (token.value === "env" || token.value === "command")) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return command.slice(index);
+}
+
+function isGhBinary(word: string): boolean {
+  if (word === "gh") return true;
+  // An absolute or relative path to the gh binary is still gh.
+  return /(^|\/)gh$/.test(word) && word.includes("/");
+}
+
+type BodySource =
+  | { kind: "inline"; flag: string; value: string }
+  | { kind: "file"; flag: string; path: string };
+
+type PrCommand = {
+  verb: "create" | "edit";
+  title: string | null;
+  body: BodySource | null;
+};
+
+/**
+ * Identify a `gh pr create|edit` and read its body/title OPTIONS.
+ *
+ * Everything here is positional and flag-shaped: the executable must be gh, the
+ * next word must be `pr`, the next must be create/edit. A command that does not
+ * have that shape returns null and is allowed untouched, which is why
+ * `gh pr view 610`, `gh issue create --body ...`, and any non-gh command never
+ * reach the validator.
+ */
+function parsePrCommand(command: Token[]): PrCommand | null {
+  const words = executableWords(command);
+  const first = words[0];
+  if (!first || first.quoted || !isGhBinary(first.value)) return null;
+
+  // Skip gh's own global flags between `gh` and `pr` (e.g. --repo owner/name).
+  let index = 1;
+  const globalWithValue = new Set(["--repo", "-R"]);
+  while (index < words.length) {
+    const word = words[index]!;
+    if (word.quoted || !word.value.startsWith("-")) break;
+    if (word.value.includes("=")) index += 1;
+    else if (globalWithValue.has(word.value)) index += 2;
+    else index += 1;
+  }
+
+  const subcommand = words[index];
+  if (!subcommand || subcommand.value !== "pr") return null;
+  const verbToken = words[index + 1];
+  if (!verbToken) return null;
+  const verb = verbToken.value;
+  if (verb !== "create" && verb !== "edit") return null;
+
+  let title: string | null = null;
+  let body: BodySource | null = null;
+
+  const valueOf = (i: number, inlineValue: string | null): [string | null, number] => {
+    if (inlineValue !== null) return [inlineValue, i + 1];
+    const next = words[i + 1];
+    if (!next) return [null, i + 1];
+    return [next.value, i + 2];
+  };
+
+  let i = index + 2;
+  while (i < words.length) {
+    const word = words[i]!;
+    // A quoted token is a VALUE, never a flag. `--body '--body-file x'` is a
+    // body whose text happens to look like a flag.
+    if (word.quoted || !word.value.startsWith("-")) {
+      i += 1;
+      continue;
+    }
+
+    const eq = word.value.indexOf("=");
+    const flag = eq === -1 ? word.value : word.value.slice(0, eq);
+    const inlineValue = eq === -1 ? null : word.value.slice(eq + 1);
+
+    if (flag === "--body" || flag === "-b") {
+      const [value, next] = valueOf(i, inlineValue);
+      if (value !== null) body = { kind: "inline", flag, value };
+      i = next;
+      continue;
+    }
+    if (flag === "--body-file" || flag === "-F") {
+      const [value, next] = valueOf(i, inlineValue);
+      if (value !== null) body = { kind: "file", flag, path: value };
+      i = next;
+      continue;
+    }
+    if (flag === "--title" || flag === "-t") {
+      const [value, next] = valueOf(i, inlineValue);
+      title = value;
+      i = next;
+      continue;
+    }
+
+    i += 1;
+  }
+
+  return { verb, title, body };
+}
+
+function refuse(lines: string[]): never {
+  console.error(lines.join("\n"));
+  process.exit(2);
+}
+
+const REMEDY = [
+  "",
+  "Fix it before the call, not after CI:",
+  "",
+  "  1. Start from .github/pull_request_template.md — it is held against the",
+  "     validator by scripts/done-means/pr-template-passes-validator.sh, so a",
+  "     filled template cannot fail on SHAPE. Do not reconstruct the sections.",
+  "  2. Or delegate composition to the pr-scribe agent",
+  "     (.claude/agents/pr-scribe.md), which returns a body only after it has",
+  "     seen the validator exit 0.",
+  "  3. Validate locally, then re-run this command:",
+  "",
+  '       PR_BODY="$(cat body.md)" PR_TITLE="..." bun scripts/validate-pr-body.ts',
+  "",
+  "     Add CONTRACT_PARITY_REQUIRED=true when the diff touches paths in",
+  "     contracts/parity-paths.txt.",
+  "",
+  "Ledger item 17 (docs/issue-graph.md), operator 2026-08-08: this is FORCED,",
+  "not advisory — \"if it's not enforced, it's pretty much useless\". CI is the",
+  "backstop, not the first detector.",
+];
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const input = readInput();
+
+if ((input.tool_name ?? "") !== "Bash") process.exit(0);
+
+const rawCommand =
+  typeof input.tool_input?.command === "string" ? input.tool_input.command : "";
+if (!rawCommand.trim()) process.exit(0);
+
+const commands = splitCommands(tokenize(stripHeredocBodies(rawCommand)));
+
+let target: PrCommand | null = null;
+for (const command of commands) {
+  const parsed = parsePrCommand(command);
+  if (parsed?.body) {
+    target = parsed;
+    break;
+  }
+}
+
+// Not a gh pr create/edit carrying a body: allow untouched. This includes
+// `gh pr view`, `gh pr create` with no body (gh opens an editor, and there is
+// no text to validate yet), and every non-gh command in the repo.
+if (!target || !target.body) process.exit(0);
+
+const source = target.body;
+let body: string;
+
+if (source.kind === "inline") {
+  body = source.value;
+} else {
+  const path = isAbsolute(source.path)
+    ? source.path
+    : join(input.cwd ?? process.cwd(), source.path);
+  if (!existsSync(path)) {
+    refuse([
+      `BLOCKED by ${HOOK_NAME}: could not read the PR body file.`,
+      "",
+      `  ${source.flag} ${source.path}`,
+      `  resolved to: ${path}`,
+      "  reason: no such file",
+      "",
+      "This is a refusal, not a pass. The gate cannot validate a body it cannot",
+      "read, and silently allowing would turn enforcement off at exactly the",
+      "moment something unusual is happening (AGENTS.md, no silent adjustments).",
+      "",
+      "Check the path — a body file written to /tmp is invisible across sandbox",
+      "boundaries and is a repo rule violation in its own right. Use",
+      "{temp_workspace}/open-brain/_scratch/.",
+    ]);
+  }
+  try {
+    body = readFileSync(path, "utf8");
+  } catch (error) {
+    refuse([
+      `BLOCKED by ${HOOK_NAME}: could not read the PR body file.`,
+      "",
+      `  ${source.flag} ${source.path}`,
+      `  resolved to: ${path}`,
+      `  reason: ${error instanceof Error ? error.message : String(error)}`,
+      "",
+      "This is a refusal, not a pass. The gate cannot validate a body it cannot",
+      "read (AGENTS.md, no silent adjustments).",
+    ]);
+  }
+}
+
+if (!existsSync(VALIDATOR)) {
+  refuse([
+    `BLOCKED by ${HOOK_NAME}: the PR body validator is missing.`,
+    "",
+    `  expected at: ${VALIDATOR}`,
+    "",
+    "The gate refuses rather than waving the call through, because a missing",
+    "validator means enforcement is not happening and nobody would be told",
+    "(AGENTS.md, no silent adjustments). Restore the script, or say explicitly",
+    "that this PR is going out unvalidated and why.",
+  ]);
+}
+
+const result = spawnSync("bun", [VALIDATOR], {
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    PR_BODY: body,
+    PR_TITLE: target.title ?? "",
+  },
+});
+
+if (result.error || result.status === null) {
+  refuse([
+    `BLOCKED by ${HOOK_NAME}: could not run the PR body validator.`,
+    "",
+    `  command: bun ${VALIDATOR}`,
+    `  reason: ${result.error ? result.error.message : "process produced no exit status"}`,
+    "",
+    "The gate refuses rather than allowing an unvalidated body through",
+    "(AGENTS.md, no silent adjustments).",
+  ]);
+}
+
+if (result.status !== 0) {
+  const validatorOutput = `${result.stdout ?? ""}${result.stderr ?? ""}`.trimEnd();
+  refuse([
+    `BLOCKED by ${HOOK_NAME}: this PR body fails scripts/validate-pr-body.ts.`,
+    "",
+    `  gh pr ${target.verb}, body from ${source.kind === "inline" ? source.flag : `${source.flag} ${source.path}`}`,
+    "",
+    "The validator said:",
+    "",
+    validatorOutput
+      .split("\n")
+      .map((line) => `  ${line}`)
+      .join("\n"),
+    ...REMEDY,
+  ]);
+}
+
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-body-gate.ts\" --event pre-tool-use",
+            "timeout": 20
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/docs/issue-graph.md
+++ b/docs/issue-graph.md
@@ -143,6 +143,26 @@ and a body composed in chat arrives wrapped in a code fence. The `pr-scribe`
 agent (`.claude/agents/pr-scribe.md`) composes a body from a lane's real
 evidence and returns one only after it has seen the validator exit 0.
 
+**This is FORCED, not advisory** (ledger item 17, operator 2026-08-08 — "if
+it's not enforced, it's pretty much useless"). `.claude/hooks/pr-body-gate.ts`
+is registered as a repo-local `PreToolUse` hook on `Bash`: a `gh pr create` or
+`gh pr edit` carrying `--body`/`-b`/`--body-file`/`-F` has that body run
+through `scripts/validate-pr-body.ts` before the command executes, and a
+failing body is refused with the validator's own errors. CI stays the backstop
+rather than the first detector. Nothing about the local step changes — running
+the validator yourself is still how you avoid meeting the hook at all.
+
+The gate judges by **parsed arguments**, never substring matching: it strips
+heredoc bodies, tokenizes with shell quoting rules, and only inspects
+`--body`-family flags once the executable word is `gh`, the subcommand `pr`,
+and the verb `create`/`edit`. So `gh pr view`, an `echo` of a string containing
+"gh pr create", and a commit heredoc quoting an invalid PR body all pass
+untouched — #618 is the standing example of a text-matching guard misfiring on
+heredoc TEXT and taxing every lane. Those non-firing cases are asserted by
+`scripts/done-means/pr-body-gate-fires.sh`, alongside the firing ones and an
+unreadable `--body-file`, which is refused out loud rather than silently
+allowed or silently blocked (AGENTS.md, no silent adjustments).
+
 ## Relationship to existing skills
 
 **Existing patterns, deliberately reused — and a new paradigm built on them.**

--- a/scripts/done-means/pr-body-gate-fires.sh
+++ b/scripts/done-means/pr-body-gate-fires.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for ledger item 17 (docs/issue-graph.md, decisions pass
+# 2026-08-08) — "pr-scribe/PR-body enforcement: advisory or forced?" → FORCED.
+#
+#   bash scripts/done-means/pr-body-gate-fires.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# Ledger item 14 (2026-08-07) built the deterministic floor: a template held
+# against the validator, a local validation command, and a pr-scribe agent that
+# only returns bodies the validator has accepted. All of it was ADVISORY. The
+# operator's ruling on 2026-08-08 is that advisory tooling decays:
+#
+#   "if it's not enforced, it's pretty much useless. Everything that's not
+#    enforced eventually gets unused... If I don't hammer it into you and force
+#    you to use it, eventually you'll decide that it's not useful and you won't."
+#
+# So `.claude/hooks/pr-body-gate.ts` runs as a repo-local PreToolUse hook on
+# Bash and makes the CI round-trip impossible: a `gh pr create`/`gh pr edit`
+# carrying an invalid body never leaves the machine. CI stays the backstop, not
+# the first detector.
+#
+# ---------------------------------------------------------------------------
+# Why the NON-FIRING clauses are half this file
+# ---------------------------------------------------------------------------
+# A guard that blocks too much is a worse tax than the failure it prevents.
+# Issue #618 is this repo's standing example: a text-matching guard fired on
+# heredoc TEXT — the words appeared inside a string literal a lane was writing,
+# not in a command it was running — and every lane paid for it. This hook must
+# therefore judge by PARSED ARGUMENTS: tokenize the command with shell quoting
+# rules, walk to the `gh` word, confirm the `pr` subcommand and the
+# `create`/`edit` verb, and read `--body`/`-b`/`--body-file`/`-F` as OPTIONS of
+# that command. Text that merely contains "gh pr create" is not a gh invocation
+# and clauses 4a-4c prove the hook agrees.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   1  invalid --body            -> BLOCKED, names the hook, echoes validator errors
+#   2  valid   --body            -> ALLOWED
+#   3a invalid --body-file       -> BLOCKED
+#   3b valid   --body-file       -> ALLOWED
+#   4a gh pr view 610            -> ALLOWED (no body, not create/edit)
+#   4b echo "...gh pr create..." -> ALLOWED (string literal, not an invocation)
+#   4c git commit heredoc w/ invalid PR body -> ALLOWED (heredoc TEXT, #618)
+#   5  unreadable --body-file    -> BLOCKED with an explicit named reason
+#
+# Clause 5 is the no-silent-adjustments rule (AGENTS.md Coding Standards,
+# 2026-08-08): a hook that cannot read the body must SAY it cannot, not pick a
+# side quietly. Silently allowing turns the gate off exactly when a lane is
+# doing something unusual; silently blocking wedges the lane with no reason.
+#
+# Verdict convention matches design-lookup-gate.ts: exit 2 = blocked with the
+# reason on stderr, exit 0 = allowed.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error (missing tool,
+# unreadable repo), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/.claude/hooks/pr-body-gate.ts"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+VALIDATOR="$REPO_ROOT/scripts/validate-pr-body.ts"
+SCRATCH="$REPO_ROOT/.pr-body-gate-check.$$"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -r "$VALIDATOR" ] || fail_hard "validator not readable at $VALIDATOR"
+[ -r "$TEMPLATE" ] || fail_hard "template not readable at $TEMPLATE"
+
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+# ---------------------------------------------------------------------------
+# Bodies. The VALID body is the committed template, mechanically filled exactly
+# the way scripts/done-means/pr-template-passes-validator.sh fills it, so this
+# check inherits that gate's guarantee instead of maintaining a second copy of
+# the field list. The INVALID body is the template UNFILLED — empty labels and
+# both dispositions unchecked — which is precisely what a lane submits when it
+# skips the validator.
+# ---------------------------------------------------------------------------
+DUMMY="dummy specific content for the acceptance gate"
+VALID_BODY_FILE="$SCRATCH/valid-body.md"
+INVALID_BODY_FILE="$SCRATCH/invalid-body.md"
+
+sed \
+  -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
+  -e 's/^- \[ \]/- [x]/' \
+  -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
+  "$TEMPLATE" > "$VALID_BODY_FILE" || fail_hard "could not build valid body"
+cp "$TEMPLATE" "$INVALID_BODY_FILE" || fail_hard "could not build invalid body"
+
+# Sanity: the validator itself must agree with our labelling, or every clause
+# below is measuring the wrong thing.
+PR_BODY="$(cat "$VALID_BODY_FILE")" PR_TITLE="gate sanity" bun "$VALIDATOR" >/dev/null 2>&1 \
+  || fail_hard "the 'valid' body does not pass the validator — fixture is wrong, not the hook"
+if PR_BODY="$(cat "$INVALID_BODY_FILE")" PR_TITLE="gate sanity" bun "$VALIDATOR" >/dev/null 2>&1; then
+  fail_hard "the 'invalid' body PASSES the validator — fixture is wrong, not the hook"
+fi
+
+VALID_BODY="$(cat "$VALID_BODY_FILE")"
+INVALID_BODY="$(cat "$INVALID_BODY_FILE")"
+
+# ---------------------------------------------------------------------------
+# Drive the hook the way Claude Code does: a PreToolUse JSON payload on stdin.
+# Sets HOOK_EXIT and HOOK_STDERR.
+# ---------------------------------------------------------------------------
+HOOK_EXIT=0
+HOOK_STDERR=""
+run_hook() {
+  local command_text="$1"
+  local payload
+  payload="$(
+    COMMAND_TEXT="$command_text" bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: "pr-body-gate-done-means",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: process.env.COMMAND_TEXT ?? "" },
+      }));
+    '
+  )" || fail_hard "could not build hook payload"
+
+  HOOK_STDERR="$(printf '%s' "$payload" | bun "$HOOK" --event pre-tool-use 2>&1 >/dev/null)"
+  HOOK_EXIT=$?
+}
+
+# Shell-quote a value for embedding in a synthetic command line.
+q() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+if [ ! -r "$HOOK" ]; then
+  # RED state: the hook does not exist yet. Every clause fails for one honest
+  # reason rather than erroring out, so the RED transcript is legible.
+  for c in 1 2 3a 3b 4a 4b 4c 5; do
+    record "$c" FAIL "no hook at $HOOK — nothing is enforcing PR bodies"
+  done
+else
+  # -- CLAUSE 1: invalid inline body is BLOCKED, by name, with validator text --
+  run_hook "gh pr create --title 'feat: thing' --body $(q "$INVALID_BODY")"
+  if [ "$HOOK_EXIT" -ne 2 ]; then
+    record 1 FAIL "invalid --body was NOT blocked (exit=$HOOK_EXIT)"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF 'pr-body-gate'; then
+    record 1 FAIL "blocked but the refusal never names pr-body-gate"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF "Critical Self-Review field"; then
+    record 1 FAIL "blocked but the validator's own error text is missing"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF 'pr-scribe'; then
+    record 1 FAIL "blocked but never points at .claude/agents/pr-scribe.md"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF 'validate-pr-body.ts'; then
+    record 1 FAIL "blocked but never gives the local validation command"
+  else
+    record 1 PASS "exit=2, names the hook, echoes validator errors, routes to pr-scribe + local command"
+  fi
+
+  # -- CLAUSE 2: valid inline body is ALLOWED --
+  run_hook "gh pr create --title 'feat: thing' --body $(q "$VALID_BODY")"
+  if [ "$HOOK_EXIT" -eq 0 ]; then
+    record 2 PASS "valid --body allowed (exit=0)"
+  else
+    record 2 FAIL "valid --body was blocked (exit=$HOOK_EXIT): $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-300)"
+  fi
+
+  # -- CLAUSE 3a: invalid --body-file is BLOCKED --
+  run_hook "gh pr create --title 'feat: thing' --body-file $(q "$INVALID_BODY_FILE")"
+  if [ "$HOOK_EXIT" -eq 2 ] && printf '%s' "$HOOK_STDERR" | rg -qF 'Critical Self-Review field'; then
+    record 3a PASS "invalid --body-file blocked with validator errors (exit=2)"
+  else
+    record 3a FAIL "invalid --body-file not properly blocked (exit=$HOOK_EXIT)"
+  fi
+
+  # -- CLAUSE 3b: valid --body-file is ALLOWED, including the -F spelling --
+  run_hook "gh pr edit 610 -F $(q "$VALID_BODY_FILE")"
+  if [ "$HOOK_EXIT" -eq 0 ]; then
+    record 3b PASS "valid -F body-file on 'gh pr edit' allowed (exit=0)"
+  else
+    record 3b FAIL "valid -F body-file blocked (exit=$HOOK_EXIT): $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-300)"
+  fi
+
+  # -- CLAUSE 4a: a gh pr command with no body at all is ALLOWED --
+  run_hook "gh pr view 610"
+  if [ "$HOOK_EXIT" -eq 0 ]; then
+    record 4a PASS "gh pr view 610 allowed (exit=0)"
+  else
+    record 4a FAIL "gh pr view was blocked (exit=$HOOK_EXIT) — the gate is over-firing"
+  fi
+
+  # -- CLAUSE 4b: the phrase inside a string literal is NOT an invocation --
+  run_hook "echo 'run gh pr create --body bad next time'"
+  if [ "$HOOK_EXIT" -eq 0 ]; then
+    record 4b PASS "echo of a string literal containing 'gh pr create' allowed (exit=0)"
+  else
+    record 4b FAIL "echo'd string literal was blocked (exit=$HOOK_EXIT) — substring matching, the #618 defect"
+  fi
+
+  # -- CLAUSE 4c: #618 proper. An invalid PR body inside heredoc TEXT. --
+  HEREDOC_CMD="git commit -F - <<'EOF'
+docs: record the PR body format
+
+A lane once submitted this and CI rejected it:
+
+$INVALID_BODY
+
+Do not do that; run gh pr create only after the validator passes.
+EOF"
+  run_hook "$HEREDOC_CMD"
+  if [ "$HOOK_EXIT" -eq 0 ]; then
+    record 4c PASS "git commit heredoc carrying an invalid PR body allowed (exit=0) — #618 not reintroduced"
+  else
+    record 4c FAIL "heredoc TEXT triggered the gate (exit=$HOOK_EXIT) — this is exactly the #618 defect"
+  fi
+
+  # -- CLAUSE 5: unreadable body file refuses OUT LOUD --
+  MISSING_FILE="$SCRATCH/definitely-not-here.md"
+  run_hook "gh pr create --title 'feat: thing' --body-file $(q "$MISSING_FILE")"
+  if [ "$HOOK_EXIT" -ne 2 ]; then
+    record 5 FAIL "unreadable --body-file silently ALLOWED (exit=$HOOK_EXIT) — the gate turns itself off"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF 'pr-body-gate'; then
+    record 5 FAIL "refused but does not name the hook"
+  # NOTE: ripgrep's -E is --encoding, NOT grep's extended-regex. Use -e for the
+  # pattern; rg is regex by default. Getting this wrong makes the assertion
+  # error out and read as a hook failure, which it did on the first GREEN run.
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qi -e 'could not read|unreadable|cannot read'; then
+    record 5 FAIL "refused but never says the body file was unreadable — a silent block"
+  else
+    record 5 PASS "unreadable --body-file refused with an explicit named reason (exit=2)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    1)  printf 'invalid inline --body is BLOCKED by name with validator errors' ;;
+    2)  printf 'valid inline --body is ALLOWED' ;;
+    3a) printf 'invalid --body-file is BLOCKED' ;;
+    3b) printf 'valid --body-file/-F is ALLOWED' ;;
+    4a) printf 'gh pr view (no body) is ALLOWED' ;;
+    4b) printf "echo of a 'gh pr create' string literal is ALLOWED" ;;
+    4c) printf 'git commit heredoc containing an invalid PR body is ALLOWED (#618)' ;;
+    5)  printf 'unreadable --body-file is REFUSED with a named reason, never silent' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+# Scratch fixtures are this script's own; retire them into the temp workspace
+# archive rather than deleting (AGENTS.md: the agent's cleanup verb is mv).
+ARCHIVE_DIR="/Volumes/ThunderBolt/_tmp/open-brain/_archive"
+if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+  mv "$SCRATCH" "$ARCHIVE_DIR/$(basename "$SCRATCH").$(date +%s)" 2>/dev/null
+fi
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1


### PR DESCRIPTION
## Summary

- Ledger item 17 (`docs/issue-graph.md`, operator 2026-08-08): PR-body enforcement is **FORCED**, not advisory — *"if it's not enforced, it's pretty much useless. Everything that's not enforced eventually gets unused... If I don't hammer it into you and force you to use it, eventually you'll decide that it's not useful and you won't."*
- Item 14 built the deterministic floor (template generated from the validator's field list, a local validation command, a `pr-scribe` agent that only returns validated bodies) but every piece of it was advisory. A lane that skipped the validator paid nothing until CI rejected the PR — the exact round trip the floor existed to remove.
- `.claude/hooks/pr-body-gate.ts` is registered as a repo-local `PreToolUse` hook on `Bash`. A `gh pr create`/`gh pr edit` carrying `--body`/`-b`/`--body-file`/`-F` has that body spawned through `scripts/validate-pr-body.ts` before the command runs; a failing body is refused with the validator's own errors and routed to the template, the `pr-scribe` agent, and the local command. CI stays the backstop rather than the first detector.
- The validator is **reused, never reimplemented**. A second copy of its rules inside the hook would be precisely the drift `scripts/done-means/pr-template-passes-validator.sh` exists to prevent.
- Docs: the lane-briefing "PR bodies" note in `docs/issue-graph.md` now records that the step is forced, and the hook's header comment carries the operator quote and the parsed-args rationale.

**Parsed arguments, not substring matching.** The hook strips heredoc bodies, tokenizes the command with shell quoting rules, splits on *unquoted* separators, and only reads `--body`-family flags once the executable word is `gh`, the subcommand is `pr`, and the verb is `create`/`edit`. A quoted token is a value and is never read as command structure. #618 is this repo's standing example of a text-matching guard misfiring on heredoc TEXT and taxing every lane; clauses 4a–4c fail loudly if anyone reintroduces it.

**Never fails quietly.** An unreadable `--body-file`, a missing validator, and a validator that will not run are each refused *out loud* with the named reason — never silently allowed (which turns the gate off unobserved) and never silently blocked (which wedges a lane with no reason). AGENTS.md no-silent-adjustments, 2026-08-08. The one deliberate fail-open is an unparseable hook payload: it yields no command, so the call proceeds, matching `design-lookup-gate.ts`'s documented decision that a bad read degrades to "no enforcement", never "no session".

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` exits 0. `scripts/done-means/pr-template-passes-validator.sh` still passes 3/3 (no regression in the sibling gate). No Python surface is touched and no service behavior changes, so the package checks and the live smoke are not applicable — this is repo-local agent tooling.

RLVR contract, `scripts/done-means/pr-body-gate-fires.sh` — RED **before** the hook existed:

```
CLAUSE 1 (invalid inline --body is BLOCKED by name with validator errors): FAIL — no hook at .../.claude/hooks/pr-body-gate.ts — nothing is enforcing PR bodies
CLAUSE 2 (valid inline --body is ALLOWED): FAIL — no hook ...
CLAUSE 3a (invalid --body-file is BLOCKED): FAIL — no hook ...
CLAUSE 3b (valid --body-file/-F is ALLOWED): FAIL — no hook ...
CLAUSE 4a (gh pr view (no body) is ALLOWED): FAIL — no hook ...
CLAUSE 4b (echo of a 'gh pr create' string literal is ALLOWED): FAIL — no hook ...
CLAUSE 4c (git commit heredoc containing an invalid PR body is ALLOWED (#618)): FAIL — no hook ...
CLAUSE 5 (unreadable --body-file is REFUSED with a named reason, never silent): FAIL — no hook ...
EXIT=1
```

GREEN after:

```
CLAUSE 1 (invalid inline --body is BLOCKED by name with validator errors): PASS — exit=2, names the hook, echoes validator errors, routes to pr-scribe + local command
CLAUSE 2 (valid inline --body is ALLOWED): PASS — valid --body allowed (exit=0)
CLAUSE 3a (invalid --body-file is BLOCKED): PASS — invalid --body-file blocked with validator errors (exit=2)
CLAUSE 3b (valid --body-file/-F is ALLOWED): PASS — valid -F body-file on 'gh pr edit' allowed (exit=0)
CLAUSE 4a (gh pr view (no body) is ALLOWED): PASS — gh pr view 610 allowed (exit=0)
CLAUSE 4b (echo of a 'gh pr create' string literal is ALLOWED): PASS — echo of a string literal containing 'gh pr create' allowed (exit=0)
CLAUSE 4c (git commit heredoc containing an invalid PR body is ALLOWED (#618)): PASS — git commit heredoc carrying an invalid PR body allowed (exit=0) — #618 not reintroduced
CLAUSE 5 (unreadable --body-file is REFUSED with a named reason, never silent): PASS — unreadable --body-file refused with an explicit named reason (exit=2)
EXIT=0
```

A live refusal, captured by piping a real `PreToolUse` payload into the hook (exit 2):

```
BLOCKED by pr-body-gate: this PR body fails scripts/validate-pr-body.ts.

  gh pr create, body from --body

The validator said:

  PR body validation failed:
  - Missing '## Critical Self-Review' section.
  - Missing '## Review Gate' section.

Fix it before the call, not after CI:
  1. Start from .github/pull_request_template.md ...
  2. Or delegate composition to the pr-scribe agent (.claude/agents/pr-scribe.md) ...
  3. Validate locally, then re-run this command: PR_BODY="$(cat body.md)" ... bun scripts/validate-pr-body.ts
```

## Critical Self-Review

- Highest-risk behavior: false-positive blocking. This hook sits on every `Bash` call in the repo, so an over-firing parse taxes every lane exactly the way #618 did. Mitigated by parsing rather than matching, and by three dedicated non-firing clauses (4a-4c) that fail if the mechanism regresses to substring matching. The complementary risk, a false negative letting a bad body through, is bounded because CI still validates.
- Assumptions that could be wrong: the tokenizer covers the shell constructs lanes actually use, and it deliberately does not emulate a full shell, so exotic forms (command substitution producing the `gh` word, `eval`, a shell function wrapping `gh`) parse as non-matching and are ALLOWED. That is a fail-open on evasion I judged correct, since CI catches it and an over-eager parser is the costlier failure. Also: `gh` global-flag skipping between `gh` and `pr` handles only `--repo`/`-R` and `--flag=value`, so a novel global flag taking a separate value could shift the subcommand index and cause a miss, again fail-open; and `spawnSync("bun", ...)` assumes `bun` is on the hook PATH, which if false produces a loud refusal rather than a pass.
- Missing/weak tests: no test drives the hook through the real Claude Code hook chain. The clauses feed synthetic payloads directly, so registration in `.claude/settings.json` is verified only as valid JSON with two `PreToolUse` blocks, not as observed live firing. There is also no clause for the `--body=text` inline-equals spelling or for `gh pr create` with no body at all, both of which the code handles but only reasoning attests to. Adding them is cheap and I would take that as review feedback.
- Security/permission risk: low, and worth naming precisely. The hook reads a caller-supplied path from `--body-file` and passes body text into a subprocess environment variable, not a shell string, via `spawnSync` with an argv array, so there is no interpolation into a shell. It reads only a file the lane already named and writes nothing. It does not touch the database, auth, or namespaces.
- Migration/deploy risk: none. No schema, no service, no migration. It is agent tooling that takes effect in this repo's checkouts when `.claude/settings.json` is loaded; existing sessions pick it up on restart.
- Downstream client/runtime risk: not applicable per `docs/downstream-rollout.md`. No MCP tool, schema, protocol, transport, or client-facing surface changes, so rtech-mcps, mcp2cli, and rtech-hermes are unaffected. Global promotion beyond this repo is deliberately deferred by ledger item 17.
- Rollback/cleanup concern: rollback is deleting the `Bash` block from `.claude/settings.json`, since the hook file itself is inert unless registered. The done-means script writes fixtures under a scratch dir inside the repo and `mv`s it into `/Volumes/ThunderBolt/_tmp/open-brain/_archive` at the end, never `rm`; if the script dies mid-run a `.pr-body-gate-check.<pid>` dir can survive in the worktree, which is untidy but harmless and untracked.
- Fixes made before PR: the first GREEN run failed clause 5 for a defect in my own check rather than the hook. `rg -qiE` is invalid, because ripgrep's `-E` is `--encoding` and not grep's extended-regex, so the assertion errored and read as a hook failure. Corrected to `rg -qi -e` with a comment recording the trap. The hook refusal text was correct the whole time; only the assertion was broken.
- Known residual risk: the evasion fail-opens named above (`eval`, command substitution, a shell alias) mean a determined lane can still route around the gate. That is accepted: the gate's purpose is to make the accidental skip impossible, and CI remains the backstop for the deliberate one. A gate that tried to close those paths would need to emulate a shell and would over-fire, which is the failure mode that costs more.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this adds repo-local agent tooling and introduces no code-review finding pattern; the reusable lesson (parse arguments, never match text) is recorded in the hook header, the done-means rationale, and `docs/issue-graph.md` where lanes actually read it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no Open Brain service surface, schema, or query path is touched, since this is repo-local Claude Code hook tooling plus a shell acceptance check.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is a Claude Code repo-local hook with no TS/Python client pair and no shared runtime-neutral contract; nothing in `contracts/parity-paths.txt` is touched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are **not applicable**. The rollout doc scopes downstream work to MCP tool/schema/protocol/client-facing changes; this PR adds a `.claude/` hook, a `scripts/done-means/` acceptance check, a settings registration, and a docs paragraph. No MCP tool, transport, or Python client surface is modified — confirmed by the changed-file list (4 files, none under `src/` or `python/`).
