### PR TITLE
feat(test): isolated-database test run as the trustworthy default (#614)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,8 +150,36 @@ Repo-specific rules below this line override the copies when stricter.
 bun install --frozen-lockfile   # install deps
 bunx tsc --noEmit               # typecheck
 bun run migrate                 # run migrations
-bun test                        # run tests
+bun run test:isolated           # run tests — the trustworthy default (#614)
+bun test                        # quick single-file iteration only; see below
 ```
+
+### `bun run test:isolated` — the default way to run the suite
+
+`bun run test:isolated` (`scripts/test-isolated.ts`) creates a uniquely-named
+database, migrates it, points `OPENBRAIN_TEST_DATABASE_URL` at it, runs
+`bun test` with whatever arguments you pass, prints the database name, and drops
+the database on the way out — including on SIGINT/SIGTERM. If the drop itself
+fails it prints the orphan's name and the exact `dropdb` line rather than
+leaking quietly.
+
+```bash
+bun run test:isolated                              # whole suite
+bun run test:isolated src/maintenance-queue.pg.test.ts   # one file
+```
+
+It invents no new mechanism: creation is CI's `createdb -E UTF8 -T template0`
+(`.github/workflows/ci.yml:68`, by way of `scripts/lane-bootstrap.ts
+--fresh-db`), migrations run through the existing `bun run migrate` path, and
+`bun test` itself is unchanged.
+
+**A full `bun test` run against the dogfood database is NOT evidence.** It
+returns a different failure count each time on unmodified code — 49 → 43 → 40
+across consecutive runs (#614, 2026-08-06; same class as #498) — while the same
+tree against a fresh database is clean. Shared mutable state is the contaminant,
+not the tests (#613 documents one concrete leakage mechanism). Bare `bun test`
+remains fine for quick single-file iteration; do not cite its full-suite counts
+in a PR, an issue, or a review verdict.
 
 ### Querying the dogfood database
 
@@ -171,7 +199,8 @@ repeatedly, until the libpq vars were added on 2026-07-29.
 The dogfood database is `open_brain_local_20260724` on `127.0.0.1` — the real one
 for this machine while in dev/dogfood mode. Note that `bun test` Postgres tests
 SKIP SILENTLY without `OPENBRAIN_TEST_DATABASE_URL`, so a green run may have
-tested nothing.
+tested nothing. `bun run test:isolated` sets that variable for you, which is the
+other reason to prefer it.
 
 ## Codex Durable Memory
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db": "bun run --env-file=.env scripts/db.ts",
     "sync-issues": "bun run scripts/sync-issues.ts",
     "test": "bun test",
+    "test:isolated": "bun run scripts/test-isolated.ts",
     "typecheck": "bunx tsc --noEmit",
     "backfill": "bun run scripts/backfill.ts",
     "codex-memory-smoke": "bun run scripts/codex-memory-smoke.ts",

--- a/scripts/done-means/614-isolated-test-run.sh
+++ b/scripts/done-means/614-isolated-test-run.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #614 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/614-isolated-test-run.sh
+#
+# #614: a full `bun test` run against the shared dogfood database produces
+# unstable failure counts on UNMODIFIED code (49 -> 43 -> 40, 2026-08-06), so a
+# red run is not evidence a change is broken and a green one is not proof it is
+# safe. Fresh-database runs of the same tree were clean (3701/0). The ask is to
+# make the trustworthy path the DEFAULT: a single entry point that runs the
+# suite against an isolated database.
+#
+# ACCEPTANCE, as this script enforces it — four checks:
+#
+#   1. The entry point exists, and a scoped run executes against a database
+#      whose name it PRINTED, and that name is NOT the dogfood database
+#      (open_brain_local_20260724). "Executed" is proven by the bun test output
+#      showing the pg test actually RAN — >0 tests passed in a file that
+#      `describe.skip`s itself when OPENBRAIN_TEST_DATABASE_URL is unset. This
+#      check exists because the silent-skip trap (AGENTS.md, Commands) makes
+#      "0 fail" indistinguishable from "nothing ran".
+#   2. After the run exits, that database no longer exists. It created it, so it
+#      removes it.
+#   3. After a simulated interrupt (SIGINT to the runner mid-run), the database
+#      is ALSO gone, OR the tool printed the orphan's name together with a drop
+#      command. A silent leak fails; a loud orphan is acceptable because the
+#      operator can act on it.
+#   4. AGENTS.md names the entry point, so the trustworthy path is discoverable
+#      without reading source.
+#
+# EXPECTED TO FAIL until #614 is fixed (check 1 fails on a missing entry point).
+# It is the reward function, not a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# This script creates NOTHING in the database itself — the entry point under
+# test owns every database created here. What this script owns is its transcript
+# files under {temp_workspace}/open-brain/_scratch, retired on exit.
+#
+# If check 2 or 3 finds a database still standing, the script REPORTS the name
+# and the drop command rather than dropping it: cleanup belongs to the tool that
+# created it, and a checker that silently repairs the thing it is measuring
+# cannot measure it. Any such name is printed in the verdict block.
+#
+# Output is content-free: database names, counts, and verdicts only.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DOGFOOD_DB="open_brain_local_20260724"
+# One fast, genuinely DB-backed file. It skips itself without
+# OPENBRAIN_TEST_DATABASE_URL, which is exactly the property check 1 needs.
+SCOPE_TEST="src/maintenance-queue.pg.test.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+
+# .env carries the libpq vars, so bare psql needs no connection arguments (see
+# AGENTS.md "Querying the dogfood database"). A worktree may lack .env; fall
+# back to the canonical checkout's copy so this runs from either.
+ENV_FILE="$REPO_ROOT/.env"
+[ -r "$ENV_FILE" ] || ENV_FILE="/Volumes/ThunderBolt/Development/open-brain/.env"
+[ -r "$ENV_FILE" ] || fail_hard "no readable .env for Postgres credentials"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+psql -At -d postgres -c 'select 1' >/dev/null 2>&1 ||
+  fail_hard "cannot reach the Postgres cluster; existence proofs are impossible, so a PASS could not be trusted"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT_CLEAN="$SCRATCH/done-means-614-clean-${RUN_ID}.log"
+OUT_INT="$SCRATCH/done-means-614-interrupt-${RUN_ID}.log"
+
+teardown() {
+  mv -f "$OUT_CLEAN" "$OUT_CLEAN.done" 2>/dev/null
+  mv -f "$OUT_INT" "$OUT_INT.done" 2>/dev/null
+}
+trap teardown EXIT
+
+# db_exists <name> -> prints "1" when the database is present
+db_exists() {
+  psql -At -d postgres -c \
+    "select 1 from pg_database where datname = '$1';" 2>/dev/null |
+    tr -d '[:space:]'
+}
+
+OVERALL=PASS
+RESULTS=""
+ORPHANS=""
+
+record_fail() {
+  OVERALL=FAIL
+  RESULTS="${RESULTS}$1"$'\n'
+}
+record_pass() {
+  RESULTS="${RESULTS}$1"$'\n'
+}
+
+# ---------------------------------------------------------------------------
+# Check 1 — entry point exists, runs the scoped pg test against a printed,
+#           non-dogfood database, and that test actually EXECUTED.
+# ---------------------------------------------------------------------------
+ENTRY_PRESENT=no
+if bun run --silent 2>&1 | rg -q '^\s*test:isolated\b' ||
+  rg -q '"test:isolated"' "$REPO_ROOT/package.json" 2>/dev/null; then
+  ENTRY_PRESENT=yes
+fi
+
+CLEAN_DB=""
+if [ "$ENTRY_PRESENT" != yes ]; then
+  record_fail "1 entry-point: FAIL — no \`test:isolated\` entry point in package.json; there is no single command that runs the suite against an isolated database"
+else
+  (cd "$REPO_ROOT" && bun run test:isolated "$SCOPE_TEST") >"$OUT_CLEAN" 2>&1
+  CLEAN_EXIT=$?
+
+  # The database name must come from the tool's own output — a name this script
+  # guessed would prove nothing about what the run actually used.
+  CLEAN_DB="$(rg -o -N '\bob_isolated_[a-z0-9_]+' "$OUT_CLEAN" 2>/dev/null | head -1)"
+
+  # Did the pg test really run? bun prints a per-file pass tally; a silently
+  # skipped file yields 0 pass and would otherwise read as a clean run.
+  PASS_COUNT="$(rg -o -N '^\s*(\d+) pass' -r '$1' "$OUT_CLEAN" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+  [ -n "$PASS_COUNT" ] || PASS_COUNT=0
+
+  if [ -z "$CLEAN_DB" ]; then
+    record_fail "1 entry-point: FAIL — the run printed no isolated database name (exit ${CLEAN_EXIT}); a run whose database is unnamed cannot be shown to have avoided the dogfood DB"
+  elif [ "$CLEAN_DB" = "$DOGFOOD_DB" ]; then
+    record_fail "1 entry-point: FAIL — the run used the dogfood database ${DOGFOOD_DB}"
+  elif [ "$PASS_COUNT" -lt 1 ]; then
+    record_fail "1 entry-point: FAIL — db=${CLEAN_DB} but the pg test reported ${PASS_COUNT} passing tests: it was silently SKIPPED, so OPENBRAIN_TEST_DATABASE_URL never reached it"
+  elif [ "$CLEAN_EXIT" -ne 0 ]; then
+    record_fail "1 entry-point: FAIL — db=${CLEAN_DB}, ${PASS_COUNT} tests ran, but the runner exited ${CLEAN_EXIT}"
+  else
+    record_pass "1 entry-point: PASS — ${SCOPE_TEST} ran ${PASS_COUNT} tests against ${CLEAN_DB} (not ${DOGFOOD_DB}), exit 0"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 2 — the database it created is gone after a clean exit.
+# ---------------------------------------------------------------------------
+if [ -z "$CLEAN_DB" ]; then
+  record_fail "2 clean-teardown: FAIL — no database name from check 1 to verify"
+elif [ "$(db_exists "$CLEAN_DB")" = "1" ]; then
+  record_fail "2 clean-teardown: FAIL — ${CLEAN_DB} still exists after a clean exit (leaked)"
+  ORPHANS="${ORPHANS}    dropdb --if-exists ${CLEAN_DB}"$'\n'
+else
+  record_pass "2 clean-teardown: PASS — ${CLEAN_DB} no longer exists"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3 — an interrupt mid-run does not leak silently.
+# ---------------------------------------------------------------------------
+if [ "$ENTRY_PRESENT" != yes ]; then
+  record_fail "3 interrupt: FAIL — no entry point to interrupt"
+else
+  (cd "$REPO_ROOT" && exec bun run test:isolated "$SCOPE_TEST") >"$OUT_INT" 2>&1 &
+  RUN_PID=$!
+
+  # Wait for the tool to name its database, then interrupt — interrupting
+  # before the name is printed would test process startup, not teardown.
+  INT_DB=""
+  for _ in $(seq 1 240); do
+    INT_DB="$(rg -o -N '\bob_isolated_[a-z0-9_]+' "$OUT_INT" 2>/dev/null | head -1)"
+    [ -n "$INT_DB" ] && break
+    kill -0 "$RUN_PID" 2>/dev/null || break
+    sleep 0.5
+  done
+
+  if [ -z "$INT_DB" ]; then
+    kill -0 "$RUN_PID" 2>/dev/null && kill -INT "$RUN_PID" 2>/dev/null
+    wait "$RUN_PID" 2>/dev/null
+    record_fail "3 interrupt: FAIL — the run never printed a database name, so an interrupt leak cannot be distinguished from no database at all"
+  else
+    # Signal the whole process group: the runner spawns bun test as a child, and
+    # signalling only the parent would leave the child holding connections.
+    sleep 1
+    kill -INT -"$RUN_PID" 2>/dev/null || kill -INT "$RUN_PID" 2>/dev/null
+    wait "$RUN_PID" 2>/dev/null
+    sleep 2
+
+    STILL_THERE="$(db_exists "$INT_DB")"
+    # A loud orphan is acceptable: the operator can act on a printed name plus
+    # a drop command. A silent one is the failure.
+    if rg -q "$INT_DB" "$OUT_INT" 2>/dev/null && rg -qi 'dropdb' "$OUT_INT" 2>/dev/null; then
+      LOUD=yes
+    else
+      LOUD=no
+    fi
+
+    if [ "$STILL_THERE" != "1" ]; then
+      record_pass "3 interrupt: PASS — ${INT_DB} was dropped despite the interrupt"
+    elif [ "$LOUD" = yes ]; then
+      record_pass "3 interrupt: PASS (loud orphan) — ${INT_DB} survives, but the tool printed its name and a dropdb command"
+      ORPHANS="${ORPHANS}    dropdb --if-exists ${INT_DB}"$'\n'
+    else
+      record_fail "3 interrupt: FAIL — ${INT_DB} survives the interrupt and the tool said nothing: a silent leak"
+      ORPHANS="${ORPHANS}    dropdb --if-exists ${INT_DB}"$'\n'
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4 — AGENTS.md names the entry point.
+# ---------------------------------------------------------------------------
+if rg -q 'test:isolated' "$REPO_ROOT/AGENTS.md" 2>/dev/null; then
+  record_pass "4 documented: PASS — AGENTS.md names \`test:isolated\`"
+else
+  record_fail "4 documented: FAIL — AGENTS.md does not name the entry point, so the trustworthy path is not discoverable"
+fi
+
+printf '\n=== DONE-MEANS #614: isolated database is the default test path ===\n\n'
+printf '%s' "$RESULTS"
+if [ -n "$ORPHANS" ]; then
+  printf '\nDATABASES STILL STANDING — this checker does not drop what it did not create:\n\n%s' "$ORPHANS"
+fi
+printf '\ntranscripts: %s.done  %s.done\n' "$OUT_CLEAN" "$OUT_INT"
+printf '\nVERDICT: %s\n\n' "$OVERALL"
+
+[ "$OVERALL" = PASS ] || exit 1
+exit 0

--- a/scripts/test-isolated.ts
+++ b/scripts/test-isolated.ts
@@ -1,0 +1,348 @@
+#!/usr/bin/env bun
+/**
+ * test-isolated — run the test suite against a database nobody else is using.
+ *
+ *   bun run test:isolated                    # whole suite
+ *   bun run test:isolated src/foo.pg.test.ts # one file (any `bun test` args)
+ *
+ * WHY THIS EXISTS (#614). A full `bun test` run against the shared dogfood
+ * database returns a DIFFERENT failure count each time on unmodified code —
+ * 49 -> 43 -> 40 observed across consecutive runs on 2026-08-06, the same class
+ * as #498. The tests are not the problem: the same tree against a freshly
+ * created database was 3701 pass / 0 fail. The shared mutable state is the
+ * contaminant, and #613 documents one concrete leakage mechanism. A run whose
+ * red does not mean broken and whose green does not mean safe is not a gate, so
+ * this script exists to make the trustworthy path the DEFAULT rather than
+ * something each lane hand-builds.
+ *
+ * WHAT IT DOES: creates a uniquely-named database, migrates it, points
+ * OPENBRAIN_TEST_DATABASE_URL at it, runs `bun test` with whatever arguments
+ * were passed, prints the database name, and drops the database on the way out.
+ *
+ * DESIGN CONSTRAINTS:
+ *
+ *  - NOTHING NEW IS INVENTED. The creation mechanism is the one CI already
+ *    uses (`createdb -E UTF8 -T template0`, .github/workflows/ci.yml:68) by way
+ *    of `scripts/lane-bootstrap.ts --fresh-db`, which borrowed it first;
+ *    migrations run through the existing `bun run migrate` path with DB_NAME
+ *    overridden. `bun test` itself is unchanged, and the tests' existing
+ *    OPENBRAIN_TEST_DATABASE_URL convention is what is being fed.
+ *
+ *  - IT DROPS ONLY WHAT IT CREATED. This is the narrow exception to the
+ *    printed-teardown rule that lane-bootstrap follows (docs/issue-graph.md:284
+ *    rejected scripted teardown for a *lane*, on the grounds that "a cleanup
+ *    script that removes things it may not have created is a bigger risk than
+ *    the friction it saves"). That reasoning turns the other way here: this
+ *    process creates the database itself, seconds earlier, with a name only it
+ *    knows, and a per-run database that outlives its run is pure garbage. The
+ *    name is captured in one variable and the drop is by that exact name with
+ *    --if-exists; there is no path by which it can name anything else, and no
+ *    recursive or forced filesystem delete anywhere in this file.
+ *
+ *  - A CRASH CANNOT LEAK SILENTLY. Teardown is installed on normal exit and on
+ *    SIGINT/SIGTERM/SIGHUP/uncaught exception. If teardown itself fails, the
+ *    orphan's name and the exact `dropdb` line are printed LOUDLY (operator
+ *    ruling 2026-08-08: nothing is adjusted silently). A leak the operator can
+ *    see is recoverable; a silent one is what produced #614's ambiguity.
+ *
+ *  - THE DOGFOOD DATABASE IS NEVER TOUCHED. Names are generated with a fixed
+ *    `ob_isolated_` prefix and a random suffix, and the drop is guarded to
+ *    refuse any name lacking that prefix.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Every database this script creates carries this prefix, and the drop refuses
+ * any name without it. That is what makes it structurally impossible for this
+ * file to drop the dogfood database or anything else it did not create.
+ */
+const DB_PREFIX = "ob_isolated_";
+
+interface DbConfig {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+}
+
+/** Parse the repo `.env` for the libpq vars. Mirrors lane-bootstrap's reader. */
+function readEnvFile(path: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of readFileSync(path, "utf-8").split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function fail(step: string, message: string): never {
+  process.stderr.write(`\n  [FAIL] ${step}: ${message}\n\n`);
+  process.exit(2);
+}
+
+function note(step: string, detail: string): void {
+  process.stdout.write(`  [ok]   ${step}: ${detail}\n`);
+}
+
+function resolveDbConfig(): DbConfig {
+  const envPath = join(REPO_ROOT, ".env");
+  // The environment wins over the file, so a caller that has already exported
+  // PG*/DB_* (CI does exactly this) is honoured without a .env present at all.
+  const fileEnv = existsSync(envPath) ? readEnvFile(envPath) : {};
+  const pick = (...keys: string[]): string => {
+    for (const key of keys) {
+      const fromProcess = process.env[key];
+      if (fromProcess) return fromProcess;
+    }
+    for (const key of keys) {
+      if (fileEnv[key]) return fileEnv[key];
+    }
+    return "";
+  };
+
+  const user = pick("DB_USER", "PGUSER");
+  if (!user) {
+    fail(
+      "config",
+      "no DB_USER/PGUSER in the environment or .env; cannot create an isolated test database.",
+    );
+  }
+  return {
+    host: pick("DB_HOST", "PGHOST") || "127.0.0.1",
+    port: pick("DB_PORT", "PGPORT") || "5432",
+    user,
+    password: pick("DB_PASSWORD", "PGPASSWORD"),
+  };
+}
+
+/**
+ * Collision-proof by construction: pid + time + random, same shape as
+ * lane-bootstrap's. Two concurrent runs never share a database, which is the
+ * whole point — a fixed name would reintroduce the shared-state contamination
+ * this script exists to remove. Comfortably inside Postgres's 63-byte
+ * identifier bound, so there is no silent truncation to explain.
+ */
+function makeDbName(): string {
+  const suffix = `${process.pid}_${Date.now().toString(36)}${Math.floor(Math.random() * 1296)
+    .toString(36)
+    .padStart(2, "0")}`;
+  return `${DB_PREFIX}${suffix}`;
+}
+
+function pgEnv(cfg: DbConfig): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (cfg.password) env.PGPASSWORD = cfg.password;
+  return env;
+}
+
+function dbUrlFor(cfg: DbConfig, dbName: string): string {
+  const auth = cfg.password
+    ? `${encodeURIComponent(cfg.user)}:${encodeURIComponent(cfg.password)}`
+    : encodeURIComponent(cfg.user);
+  return `postgres://${auth}@${cfg.host}:${cfg.port}/${dbName}`;
+}
+
+function dropCommand(cfg: DbConfig, dbName: string): string {
+  return `dropdb --if-exists --force -h ${cfg.host} -p ${cfg.port} -U ${cfg.user} ${dbName}`;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+const testArgs = process.argv.slice(2);
+const cfg = resolveDbConfig();
+const dbName = makeDbName();
+
+// Printed BEFORE creation, so an interrupt at any point after this line leaves
+// the operator holding the name. A tool that names its database only on success
+// is exactly how an orphan becomes silent.
+process.stdout.write(
+  [
+    "",
+    "─".repeat(72),
+    "ISOLATED TEST RUN (#614)",
+    "─".repeat(72),
+    `  database:  ${dbName}  (created for this run, dropped on exit)`,
+    `  host:      ${cfg.host}:${cfg.port}`,
+    `  scope:     ${testArgs.length ? testArgs.join(" ") : "full suite"}`,
+    `  if this run is killed, drop it with:`,
+    `    ${dropCommand(cfg, dbName)}`,
+    "─".repeat(72),
+    "",
+  ].join("\n"),
+);
+
+let created = false;
+let torndown = false;
+
+/**
+ * Drop the database this process created. Guarded by the prefix so it can only
+ * ever name a database from makeDbName(). Synchronous on purpose: it has to
+ * complete inside a signal handler and inside process.on("exit").
+ */
+function teardown(reason: string): void {
+  if (torndown || !created) return;
+  torndown = true;
+  if (!dbName.startsWith(DB_PREFIX)) {
+    // Unreachable by construction; kept because the cost of being wrong here is
+    // dropping a database that matters.
+    process.stderr.write(
+      `\n  [REFUSED] teardown: "${dbName}" lacks the ${DB_PREFIX} prefix; not dropping.\n`,
+    );
+    return;
+  }
+  const result = spawnSync(
+    "dropdb",
+    [
+      "--if-exists",
+      "--force",
+      "-h",
+      cfg.host,
+      "-p",
+      cfg.port,
+      "-U",
+      cfg.user,
+      dbName,
+    ],
+    { env: pgEnv(cfg), encoding: "utf-8" },
+  );
+  if (result.error || result.status !== 0) {
+    // LOUD, per the no-silent rule. The operator gets the name and the command.
+    process.stderr.write(
+      [
+        "",
+        "!".repeat(72),
+        `ORPHANED DATABASE — teardown (${reason}) could not drop it.`,
+        `  name: ${dbName}`,
+        `  err:  ${result.error?.message ?? ((result.stderr || "").trim() || `dropdb exited ${result.status}`)}`,
+        "  drop it yourself with:",
+        `    ${dropCommand(cfg, dbName)}`,
+        "!".repeat(72),
+        "",
+      ].join("\n"),
+    );
+    return;
+  }
+  process.stdout.write(`\n  [ok]   teardown (${reason}): ${dbName} dropped\n`);
+}
+
+process.on("exit", () => teardown("exit"));
+for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+  process.on(sig, () => {
+    process.stdout.write(`\n  [!]    ${sig} received — dropping ${dbName}\n`);
+    teardown(sig);
+    process.exit(130);
+  });
+}
+process.on("uncaughtException", (err) => {
+  process.stderr.write(`\n  [FAIL] uncaught: ${err instanceof Error ? err.message : String(err)}\n`);
+  teardown("uncaughtException");
+  process.exit(2);
+});
+
+// --- create ----------------------------------------------------------------
+// The CI mechanism verbatim (.github/workflows/ci.yml:68): the explicit
+// `-E UTF8 -T template0` is not decoration — ci.yml:59-66 records that a bare
+// createdb inherits the cluster's template1 encoding, and a C/POSIX cluster
+// yields SQL_ASCII, under which the snowball stemmers split multibyte accented
+// characters and every non-English FTS assertion (#341) silently fails while
+// ASCII-only English passes.
+{
+  const result = spawnSync(
+    "createdb",
+    ["-h", cfg.host, "-p", cfg.port, "-U", cfg.user, "-E", "UTF8", "-T", "template0", dbName],
+    { env: pgEnv(cfg), encoding: "utf-8" },
+  );
+  if (result.error) fail("db-create", `could not execute createdb: ${result.error.message}`);
+  if (result.status !== 0) {
+    fail("db-create", `createdb exited ${result.status}: ${(result.stderr || "").trim()}`);
+  }
+  created = true;
+  note("db-create", `${dbName} created (UTF8, template0)`);
+}
+
+// --- migrate ---------------------------------------------------------------
+// Through the EXISTING path: `bun run migrate` -> scripts/migrate.ts ->
+// createPool() (src/db/pool.ts), which reads DB_NAME from the environment.
+// Overriding DB_NAME is how that path is pointed at the new database; no second
+// migration path is introduced. The `vector` extension comes from migration
+// 001_init.sql, so there is no separate extension step.
+{
+  const result = spawnSync("bun", ["run", "migrate"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      DB_HOST: cfg.host,
+      DB_PORT: cfg.port,
+      DB_USER: cfg.user,
+      DB_NAME: dbName,
+      ...(cfg.password ? { DB_PASSWORD: cfg.password } : {}),
+    },
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  if (result.error) fail("db-migrate", `could not execute bun run migrate: ${result.error.message}`);
+  if (result.status !== 0) fail("db-migrate", `migrations exited ${result.status}`);
+  note("db-migrate", `migrations applied to ${dbName}`);
+}
+
+// --- run tests -------------------------------------------------------------
+// `bun test` itself is unchanged; it is handed the isolated URL through the
+// env var the tests already honour. Anything after `--`/the script name is
+// passed straight through, so `bun run test:isolated src/x.pg.test.ts` and any
+// other bun test flag work exactly as they do bare.
+const testEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  OPENBRAIN_TEST_DATABASE_URL: dbUrlFor(cfg, dbName),
+  DB_HOST: cfg.host,
+  DB_PORT: cfg.port,
+  DB_USER: cfg.user,
+  DB_NAME: dbName,
+};
+if (cfg.password) testEnv.DB_PASSWORD = cfg.password;
+
+note("test", `OPENBRAIN_TEST_DATABASE_URL -> ${dbName}; running bun test ${testArgs.join(" ")}`);
+
+const child = spawn("bun", ["test", ...testArgs], {
+  cwd: REPO_ROOT,
+  env: testEnv,
+  stdio: "inherit",
+});
+
+child.on("error", (err) => {
+  process.stderr.write(`\n  [FAIL] test: could not execute bun test: ${err.message}\n`);
+  teardown("spawn-error");
+  process.exit(2);
+});
+
+child.on("exit", (code, signal) => {
+  const exitCode = signal ? 130 : (code ?? 1);
+  process.stdout.write(
+    [
+      "",
+      "─".repeat(72),
+      `  tests exited ${signal ? `on ${signal}` : exitCode}`,
+      `  database:  ${dbName}`,
+      "─".repeat(72),
+    ].join("\n") + "\n",
+  );
+  teardown("test-complete");
+  process.exit(exitCode);
+});


### PR DESCRIPTION
## Summary

- Adds `bun run test:isolated` (`scripts/test-isolated.ts`): creates a uniquely-named database, migrates it, points `OPENBRAIN_TEST_DATABASE_URL` at it, runs `bun test` with the caller's arguments, prints the database name, and drops the database on exit — including on SIGINT/SIGTERM/uncaught exception.
- Reuses the existing mechanism rather than inventing one: creation is CI's `createdb -E UTF8 -T template0` (`.github/workflows/ci.yml:68`, by way of `scripts/lane-bootstrap.ts:368` `--fresh-db`), migrations run through the existing `bun run migrate` path with `DB_NAME` overridden (`scripts/lane-bootstrap.ts:385`), and the tests' existing `OPENBRAIN_TEST_DATABASE_URL` convention is what is fed. **`bun test` itself is unchanged and the dogfood database is never touched.**
- `AGENTS.md` names it as the trustworthy default and records that full-suite counts from the dogfood database are not evidence (#614). Bare `bun test` stays documented for quick single-file iteration.
- Adds the acceptance gate `scripts/done-means/614-isolated-test-run.sh`.
- Closes #614.

### Headline evidence — the same tree, both ways

Run on this branch, unmodified code, back to back:

| path | run 1 | run 2 | run 3 | wall clock |
|---|---|---|---|---|
| `bun test` → dogfood `open_brain_local_20260724` | 3676 pass / **37 fail** | 3673 pass / **41 fail** | 3676 pass / **37 fail** | ~133–141s |
| `bun run test:isolated` → fresh DB | 3710 pass / **0 fail** | 3710 pass / **0 fail** | — | ~38s |

The dogfood failure count moves on code that did not change, which is exactly #614's claim (49 → 43 → 40 observed 2026-08-06; 37 → 41 → 37 here). The isolated path is identical across runs and 3.5× faster. This does not fix the leakage — #613 is one concrete mechanism and is a separate lane — it makes the contaminated path stop being the default.

### RLVR transcripts

RED, before `scripts/test-isolated.ts` existed (script exit 1):

```
=== DONE-MEANS #614: isolated database is the default test path ===

1 entry-point: FAIL — no `test:isolated` entry point in package.json; there is no single command that runs the suite against an isolated database
2 clean-teardown: FAIL — no database name from check 1 to verify
3 interrupt: FAIL — no entry point to interrupt
4 documented: FAIL — AGENTS.md does not name the entry point, so the trustworthy path is not discoverable

VERDICT: FAIL
```

GREEN, after (script exit 0):

```
=== DONE-MEANS #614: isolated database is the default test path ===

1 entry-point: PASS — src/maintenance-queue.pg.test.ts ran 4 tests against ob_isolated_21914_msjv40z3yw (not open_brain_local_20260724), exit 0
2 clean-teardown: PASS — ob_isolated_21914_msjv40z3yw no longer exists
3 interrupt: PASS — ob_isolated_22312_msjv42ru94 was dropped despite the interrupt
4 documented: PASS — AGENTS.md names `test:isolated`

VERDICT: PASS
```

Check 1 asserts the pg test **actually ran** (>0 passing tests in a file that `describe.skip`s itself without the env var), not merely that the run was green — the silent-skip trap makes "0 fail" otherwise indistinguishable from "nothing ran". Check 3 sends SIGINT to the running process group after the tool has printed its database name, then asserts the database is gone, accepting a *loud* orphan (name plus `dropdb` line printed) as an alternative pass but failing a silent one.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bunx tsc --noEmit` clean; full suite 3710 pass / 35 skip / 0 fail through the new entry point (twice); `scripts/done-means/614-isolated-test-run.sh` PASS.
- [x] Python package checks passed or are not applicable — not applicable: no file under `python/openbrain-memory/` is touched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable: no server, tool, schema, or transport code changes; this is a test-invocation script plus docs.

Post-run check `select datname from pg_database where datname like 'ob_isolated_%'` returned zero rows — nothing leaked across every run in this lane.

## Critical Self-Review

- Highest-risk behavior: the `dropdb` call. It is the only destructive operation, so it is constrained three ways — the name comes from one variable set by `makeDbName()` seconds earlier in the same process, every generated name carries a fixed `ob_isolated_` prefix, and `teardown()` refuses outright to drop a name lacking that prefix. There is no code path by which it can name the dogfood database or any database this process did not create, and no recursive or forced filesystem delete anywhere in the file.
- Assumptions that could be wrong: (a) that the `.env`/environment Postgres role can `createdb` — if it cannot, the run fails loudly at `db-create` and creates nothing; (b) that migrations are the complete schema setup — verified by the pg tests actually passing, which they would not against an unmigrated database; (c) that no test hard-codes the dogfood database name and thereby escapes the isolation — not exhaustively audited, but the 0-fail result argues against any material case.
- Missing/weak tests: no unit test of `scripts/test-isolated.ts` itself; the done-means script is the behavioural test and covers creation, execution, clean teardown, and interrupt teardown end to end against real Postgres. Not covered: SIGKILL (uncatchable by construction — such a run leaves an orphan whose name was printed *before* creation, which is why the name is printed first), and a teardown failure while the cluster is unreachable (the loud-orphan branch is reasoned, not exercised).
- Security/permission risk: none new. No auth, namespace, or SQL predicate is touched; no credential is printed — the database URL is built in-process and only the bare database *name* reaches stdout.
- Migration/deploy risk: none. No migration is added or altered; nothing in `src/` changes; nothing ships to core01.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` applies to MCP tool/schema/protocol/client-facing changes; this is a developer test-invocation script, a `package.json` script entry, and documentation. No consumer of Open Brain can observe it.
- Rollback/cleanup concern: revert is a single commit with no state to unwind. Each run drops its own database; a killed run leaves one whose name and drop command were printed. All databases created during this lane were verified gone.
- Fixes made before PR: `bunx tsc --noEmit` caught TS5076 (`??` mixed with `||` without parentheses) in the orphan-message construction; fixed before commit. The RED transcript above was captured before the entry point existed, so the gate is proven to discriminate rather than to pass vacuously.
- Known residual risk: this changes the *default path*, not the underlying leakage — the suites that leave `parity-source-registry-*` fixtures behind (#613) are untouched and remain that lane's scope, as instructed. A SIGKILLed run still orphans a database (loudly). The dogfood failures are now routed around rather than diagnosed; the ~37–41 failing tests on that database are not individually explained here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new review finding — this implements an already-filed, already-diagnosed issue (#614) whose pattern is recorded in that issue and in #613's `docs/sme/correctness.md` entry.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no server, MCP tool, transport, or schema surface is touched; the change is a test-invocation script and documentation.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or client-facing surface changes — `scripts/test-isolated.ts` is a local developer entry point with no runtime counterpart to keep in parity.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable, no MCP surface change
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable, no tool list or schema change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable, no Python or protocol change
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable, nothing deploys

Notes/evidence:

- Existing mechanism reused, with file:line: `.github/workflows/ci.yml:68` (`createdb -E UTF8 -T template0`), `scripts/lane-bootstrap.ts:368` (same call, already borrowed for `--fresh-db`), `scripts/lane-bootstrap.ts:385` (`bun run migrate` with `DB_NAME` overridden).
- Claim states: the entry point, the done-means gate, and the AGENTS.md text are **WRITTEN** and, in this lane, **RUNNING** — every transcript above is from an execution in this worktree this session. Merge state is **PROPOSED** until this PR lands.
