### PR TITLE
fix(logging): route the server logger through in-process multistream (#612)

### DIFF
--- a/docs/sme/entries/2026-08-08-injecting-a-test-destination-can-bypass-the-composition-that-is-broken.md
+++ b/docs/sme/entries/2026-08-08-injecting-a-test-destination-can-bypass-the-composition-that-is-broken.md
@@ -1,0 +1,60 @@
+---
+lane: gotcha-agent
+order: 41
+---
+## [2026-08-08] Injecting a test destination can bypass the very composition that is broken
+
+**Severity:** HIGH
+**Source:** issue #612, PR #609 self-review (residual risk that became this issue)
+**Scope key:** `sme.injected_destination_bypasses_broken_composition`
+**Status:** active
+
+### Pattern
+
+A seam that exists so tests can inject a fake — `createLogger(config, destination)`,
+`createClient(config, transport)`, any `fn(config, dep = realDefault())` — splits
+the code into a tested path and a shipped path. When the defect lives in
+`realDefault()`, every test passes and production is broken, and the test suite
+reports confidence it never earned.
+
+Measured instance: `server/logging/logger.ts` composed its destination with a
+MULTI-TARGET `pino.transport` (stdout + `pino-roll`). `loggerOptions` set
+`formatters.level` to emit the level as the string `"info"` rather than pino's
+numeric `30`, as the shared envelope requires. Multi-target transports route on
+that serialized value — `pino-abstract-transport` sets
+`stream.lastLevel = value.level` unmapped, and `pino/lib/multistream.js` selects
+with `dest.level <= level` — so every line evaluated `30 <= "info"`, false for
+every destination, and was written nowhere. No error, no warning, no
+dropped-line counter.
+
+Every test in `server/logging/logging.test.ts` passed, because all five called
+`createLogger(CONFIG, stream)` with an in-memory `Writable`. A SINGLE
+destination returns its stream directly with no level routing
+(`pino/lib/worker.js:126`), so the injected path never executed the broken
+composition. The service logged into a void for the entire life of the server
+path while its logging tests were green.
+
+It surfaced only as an incidental observation — "no `component` line reaches the
+clone logs" in a PR self-review — and read as a child-logger quirk, because the
+3,465 lines that DID land came from the unrelated legacy `src/logger.ts` module
+logger writing `LOG_FILE` itself. The surviving lines disguised total loss as
+partial loss.
+
+Checks for the next swarm:
+
+- For any `fn(config, dep = buildRealDep())` signature, ask which tests exercise
+  the DEFAULT. If every caller in the test file passes an explicit `dep`, the
+  default is untested code shipping to production — flag it regardless of the
+  suite's pass count or coverage number.
+- Coverage does not catch this: `logger.ts` reported 100% line and function
+  coverage while emitting nothing, because `createLogTransport` was *called* and
+  its return value merely discarded everything downstream.
+- At least one test per output boundary must use the production composition and
+  observe the real destination — read the file back off disk, not a spy.
+- Treat "logs are missing" as a routing question before a formatting one, and
+  confirm which logger emits a surviving line before concluding a subset is
+  dropped. Two logging systems in one process (`src/logger.ts` and
+  `server/logging/`) make partial-looking evidence normal.
+- A library option that is legal in one composition and fatal in another
+  (`formatters.level` here) deserves a comment at the composition site saying
+  so. It was reintroduced-safe only because the constraint is now written down.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1413,3 +1413,60 @@ Review checks:
 - "It only changes cosmetics" is not an exemption; the transcript must let the reader map what they asked for to what exists.
 - Skipped steps count: a tool that decides a step is N/A says so and why (the downstream-rollout classification format is the model).
 - The announcement belongs in the tool's normal output, not a log level that is off by default.
+
+## [2026-08-08] Injecting a test destination can bypass the very composition that is broken
+
+**Severity:** HIGH
+**Source:** issue #612, PR #609 self-review (residual risk that became this issue)
+**Scope key:** `sme.injected_destination_bypasses_broken_composition`
+**Status:** active
+
+### Pattern
+
+A seam that exists so tests can inject a fake — `createLogger(config, destination)`,
+`createClient(config, transport)`, any `fn(config, dep = realDefault())` — splits
+the code into a tested path and a shipped path. When the defect lives in
+`realDefault()`, every test passes and production is broken, and the test suite
+reports confidence it never earned.
+
+Measured instance: `server/logging/logger.ts` composed its destination with a
+MULTI-TARGET `pino.transport` (stdout + `pino-roll`). `loggerOptions` set
+`formatters.level` to emit the level as the string `"info"` rather than pino's
+numeric `30`, as the shared envelope requires. Multi-target transports route on
+that serialized value — `pino-abstract-transport` sets
+`stream.lastLevel = value.level` unmapped, and `pino/lib/multistream.js` selects
+with `dest.level <= level` — so every line evaluated `30 <= "info"`, false for
+every destination, and was written nowhere. No error, no warning, no
+dropped-line counter.
+
+Every test in `server/logging/logging.test.ts` passed, because all five called
+`createLogger(CONFIG, stream)` with an in-memory `Writable`. A SINGLE
+destination returns its stream directly with no level routing
+(`pino/lib/worker.js:126`), so the injected path never executed the broken
+composition. The service logged into a void for the entire life of the server
+path while its logging tests were green.
+
+It surfaced only as an incidental observation — "no `component` line reaches the
+clone logs" in a PR self-review — and read as a child-logger quirk, because the
+3,465 lines that DID land came from the unrelated legacy `src/logger.ts` module
+logger writing `LOG_FILE` itself. The surviving lines disguised total loss as
+partial loss.
+
+Checks for the next swarm:
+
+- For any `fn(config, dep = buildRealDep())` signature, ask which tests exercise
+  the DEFAULT. If every caller in the test file passes an explicit `dep`, the
+  default is untested code shipping to production — flag it regardless of the
+  suite's pass count or coverage number.
+- Coverage does not catch this: `logger.ts` reported 100% line and function
+  coverage while emitting nothing, because `createLogTransport` was *called* and
+  its return value merely discarded everything downstream.
+- At least one test per output boundary must use the production composition and
+  observe the real destination — read the file back off disk, not a spy.
+- Treat "logs are missing" as a routing question before a formatting one, and
+  confirm which logger emits a surviving line before concluding a subset is
+  dropped. Two logging systems in one process (`src/logger.ts` and
+  `server/logging/`) make partial-looking evidence normal.
+- A library option that is legal in one composition and fatal in another
+  (`formatters.level` here) deserves a comment at the composition site saying
+  so. It was reintroduced-safe only because the constraint is now written down.

--- a/scripts/done-means/612-component-lines-reach-logs.sh
+++ b/scripts/done-means/612-component-lines-reach-logs.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #612 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/612-component-lines-reach-logs.sh
+#
+# Issue #612 acceptance, verbatim:
+#   An executable check that greps the clone log file for a child-logger line
+#   with a `component` field emitted during the run, red on current behavior.
+#
+# This drives the LIVE local dogfood service. core01/hosted is NOT touched
+# (two-host rule); this lane is the local half.
+#
+# ---------------------------------------------------------------------------
+# What is actually broken, measured 2026-08-08 before any fix
+# ---------------------------------------------------------------------------
+# The issue frames this as child-logger lines being dropped. Measured against
+# the live clone, the defect is BROADER: not one pino line of any kind reaches
+# the clone's log file. In /Volumes/ThunderBolt/open-brain-local/log/open-brain.log:
+#
+#   - `"component"` lines:                            0
+#   - pino server lines (mcp_tracing_configured,
+#     migrations_complete, server_shutdown_*):        0
+#   - `graph_derivation_enqueue_sweep` lines:     3,465
+#
+# The 3,465 surviving lines are the reason this looked like a child-logger
+# problem. They do not come from pino at all: `graph_derivation_enqueue_sweep`
+# is emitted by the LEGACY module logger `src/logger.ts`
+# (src/graph-derivation-handler.ts:297), which writes LOG_FILE itself through
+# its own rotating sink. Every pino line — module and child alike — is lost.
+#
+# Mechanism, isolated by bisecting loggerOptions field by field:
+#
+#   `formatters.level` (server/logging/logger.ts:49) rewrites the serialized
+#   `level` field from pino's numeric 30 to the string "info". That is required
+#   by the shared envelope (_DOCS/STANDARDS-observability.md:58). It is also
+#   fatal in combination with a MULTI-TARGET pino.transport:
+#
+#     - pino/lib/worker.js:126 — a SINGLE target returns its stream directly,
+#       with no level routing. Multiple targets go through build(..., metadata)
+#       and pino.multistream instead.
+#     - pino-abstract-transport/index.js:49 — `stream.lastLevel = value.level`,
+#       taken raw off the parsed JSON. Unmapped.
+#     - pino/lib/multistream.js:61 — routes on `dest.level <= level`.
+#
+#   So the comparison performed for every line is `30 <= "info"`, which is
+#   false for every destination, and multistream silently writes the line
+#   nowhere. No error, no warning, no dropped-line counter.
+#
+# The unit tests could never have caught it: server/logging/logging.test.ts:31
+# injects an in-memory Writable via createLogger(CONFIG, stream), which is the
+# single-destination path where formatters.level works correctly. Only the
+# production default — createLogTransport()'s two targets — takes the broken
+# path. The test and production disagreed about which pino code ran.
+#
+# ---------------------------------------------------------------------------
+# Why this check observes the sweep rather than emitting its own line
+# ---------------------------------------------------------------------------
+# The observation point has to be a line the SERVER emits on its own, through
+# the real composed logger, in the serving process. A check that constructs a
+# logger and asserts it wrote proves the library works; it cannot distinguish
+# that from a server whose composed transport drops everything — which is
+# exactly the bug.
+#
+# So this seeds one real derivable ob_sources row, enqueues NOTHING, and waits
+# for the server's own maintenance sweep to run and emit
+# `maintenance_sweep_complete` through logger.child({component:"maintenance"})
+# (server/main.ts:310 -> src/maintenance-sweep.ts:257). The sweep is the
+# documented instance named in the issue.
+#
+# Every row this check creates is tagged with a run marker and removed in the
+# trap on every exit path.
+#
+# NOT-RUNNING IS LOUD, NOT VACUOUS. If the clone is not serving, this exits 3
+# with an explicit message rather than reporting a pass over an empty file.
+# A grep over a log nobody is writing to succeeds at examining nothing, and
+# that silent-success shape is the class this check exists to avoid
+# (AGENTS.md Coding Standards, 2026-08-08).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+MARKER="done-means-612-$(date +%s)-$$"
+NS="done-means-612"
+HEALTH_URL="${OPEN_BRAIN_HEALTH_URL:-http://127.0.0.1:3100/health}"
+CLONE_LOG_DIR="${OPENBRAIN_CLONE_LOG_DIR:-/Volumes/ThunderBolt/open-brain-local/log}"
+# The sweep ticks on OPEN_BRAIN_MAINTENANCE_POLL_MS (default 5000). Allow
+# several ticks plus handler and file-flush time.
+WAIT_SECONDS="${DONE_MEANS_612_WAIT_SECONDS:-90}"
+
+EXIT_NOT_RUNNING=3
+
+FAILURES=0
+fail() { printf 'FAIL  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'PASS  %s\n' "$*"; }
+info() { printf 'INFO  %s\n' "$*"; }
+
+# Loud, distinct exit for "there was nothing to examine". Never a pass.
+abort_not_running() {
+  printf '\n'
+  printf 'ABORT (exit %d) — PRECONDITION NOT MET, NOTHING WAS EXAMINED\n' "${EXIT_NOT_RUNNING}"
+  printf '  %s\n' "$*"
+  printf '  This is NOT a pass and NOT a fail: the check could not observe the\n'
+  printf '  serving process at all. Start the local clone and re-run.\n'
+  exit "${EXIT_NOT_RUNNING}"
+}
+
+# `.env` is untracked, so it is absent from a fresh worktree. Fall back to the
+# canonical checkout's copy: the dogfood database is a property of the machine,
+# not of which worktree you happen to be standing in.
+ENV_FILE=".env"
+if [[ ! -f "${ENV_FILE}" ]]; then
+  ENV_FILE="${DONE_MEANS_612_ENV_FILE:-/Volumes/ThunderBolt/Development/open-brain/.env}"
+fi
+if [[ ! -f "${ENV_FILE}" ]]; then
+  abort_not_running "no .env found (looked in ${REPO_ROOT} and ${ENV_FILE}); cannot reach the dogfood database"
+fi
+set -a
+# shellcheck disable=SC1091
+. "${ENV_FILE}"
+set +a
+
+SIZES_FILE=""
+
+cleanup() {
+  [[ -n "${SIZES_FILE}" && -f "${SIZES_FILE}" ]] && mv -f "${SIZES_FILE}" "${SIZES_FILE}.done" 2>/dev/null
+  psql -q -c "DELETE FROM maintenance_jobs WHERE namespace = '${NS}' OR idempotency_key LIKE '%${MARKER}%';" >/dev/null 2>&1
+  psql -q -c "DELETE FROM ob_entities WHERE namespace = '${NS}';" >/dev/null 2>&1
+  psql -q -c "DELETE FROM ob_sources WHERE namespace = '${NS}';" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+printf '=== done-means #612: do component child-logger lines reach the clone log? ===\n'
+printf 'run marker: %s\n\n' "${MARKER}"
+
+# ---------------------------------------------------------------------------
+# Preconditions. Each one, unmet, means nothing can be observed.
+# ---------------------------------------------------------------------------
+HEALTH="$(curl -s -m 5 "${HEALTH_URL}" 2>/dev/null)"
+if [[ -z "${HEALTH}" ]]; then
+  abort_not_running "no response from ${HEALTH_URL}; the local clone is not serving"
+fi
+HEALTH_STATUS="$(printf '%s' "${HEALTH}" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')"
+if [[ "${HEALTH_STATUS}" != "healthy" ]]; then
+  abort_not_running "local clone status=${HEALTH_STATUS:-unparseable}; refusing to grep logs of an unhealthy service"
+fi
+pass "(pre1) local clone serving, status=healthy"
+
+SERVER_PID="$(lsof -nP -iTCP:3100 -sTCP:LISTEN -t 2>/dev/null | head -1)"
+if [[ -z "${SERVER_PID}" ]]; then
+  abort_not_running "nothing is listening on 3100"
+fi
+pass "(pre2) serving pid ${SERVER_PID}"
+
+if [[ ! -d "${CLONE_LOG_DIR}" ]]; then
+  abort_not_running "clone log dir ${CLONE_LOG_DIR} does not exist"
+fi
+
+# The pino file destination is derived per worker (workerLogPath), so the exact
+# filename is not knowable from here. Consider every log file in the clone log
+# dir; the assertion is that SOME clone log file carries the line.
+LOG_FILE_COUNT="$(fd -t f -e log . "${CLONE_LOG_DIR}" 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "${LOG_FILE_COUNT}" -eq 0 ]]; then
+  abort_not_running "no *.log files at all under ${CLONE_LOG_DIR}; nothing to examine"
+fi
+info "watching ${LOG_FILE_COUNT} log file(s) under ${CLONE_LOG_DIR}"
+
+# Only lines written from THIS run count. Record each file's current size so a
+# historical line can never satisfy the assertion. A file created after this
+# point has no recorded size and is therefore scanned from byte 0, which is
+# correct: all of its content is new.
+# Deliberately NOT mktemp/$TMPDIR: those are sandbox-local, so a runner, a
+# sandbox, and the host each see a different one (Development AGENTS.md, hard
+# rule). The scratch bucket is a real shared path.
+SCRATCH_DIR="${DONE_MEANS_612_SCRATCH_DIR:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}"
+mkdir -p "${SCRATCH_DIR}" 2>/dev/null
+SIZES_FILE="${SCRATCH_DIR}/done-means-612-sizes.$$"
+: > "${SIZES_FILE}"
+while IFS= read -r f; do
+  printf '%s\t%s\n' "$(wc -c < "$f" 2>/dev/null || echo 0)" "$f" >> "${SIZES_FILE}"
+done < <(fd -t f -e log . "${CLONE_LOG_DIR}" 2>/dev/null)
+
+start_size_of() {
+  local target="$1"
+  awk -F'\t' -v t="${target}" '$2 == t { print $1; found = 1; exit } END { if (!found) print 0 }' \
+    "${SIZES_FILE}"
+}
+
+# Scan only the bytes appended since the run started, across all clone log
+# files, plus any log file created after the run started.
+scan_new_lines() {
+  local pattern="$1" f start now hits
+  local total=0
+  while IFS= read -r f; do
+    start="$(start_size_of "$f")"
+    now="$(wc -c < "$f" 2>/dev/null || echo 0)"
+    [[ "${now}" -le "${start}" ]] && continue
+    hits="$(tail -c "+$((start + 1))" "$f" 2>/dev/null | rg -c -- "${pattern}" 2>/dev/null || echo 0)"
+    total=$((total + hits))
+  done < <(fd -t f -e log . "${CLONE_LOG_DIR}" 2>/dev/null)
+  printf '%s' "${total}"
+}
+
+# ---------------------------------------------------------------------------
+# Seed one real derivable source. Enqueue nothing. Let the server's own sweep
+# run and emit its child-logger line.
+# ---------------------------------------------------------------------------
+SEED_HASH="$(printf '%s' "${MARKER}" | shasum -a 256 | cut -d' ' -f1)"
+if ! psql -q -c "INSERT INTO ob_sources
+     (namespace, source_kind, external_id, title, approval_state, approved_by,
+      approved_at, lifecycle_state, content_hash, created_by)
+   VALUES
+     ('${NS}', 'drop', '${MARKER}', 'done-means 612 probe', 'approved',
+      'done-means-612', now(), 'active', '${SEED_HASH}', 'done-means-612');" 2>&1
+then
+  fail "could not seed probe source; cannot drive the sweep (error above)"
+  printf '\n=== RESULT: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+  exit 1
+fi
+info "seeded 1 approved/active source in namespace ${NS}; enqueued nothing"
+
+info "waiting up to ${WAIT_SECONDS}s for the server's own sweep to log..."
+
+COMPONENT_HITS=0
+SWEEP_HITS=0
+DEADLINE=$((SECONDS + WAIT_SECONDS))
+while [[ "${SECONDS}" -lt "${DEADLINE}" ]]; do
+  COMPONENT_HITS="$(scan_new_lines '"component":"maintenance"')"
+  SWEEP_HITS="$(scan_new_lines 'maintenance_sweep_complete')"
+  if [[ "${COMPONENT_HITS}" -gt 0 && "${SWEEP_HITS}" -gt 0 ]]; then
+    break
+  fi
+  sleep 5
+done
+LEGACY_HITS="$(scan_new_lines 'graph_derivation_enqueue_sweep')"
+
+# ---------------------------------------------------------------------------
+# (z) Control clause: prove the observation window itself was live.
+# ---------------------------------------------------------------------------
+# Without this, "no component line appeared" is ambiguous between the defect
+# and a run in which the server happened to log nothing at all. The legacy
+# module-logger sweep line is known to land today, so its ABSENCE means the
+# window was dead and the other clauses are not interpretable.
+if [[ "${LEGACY_HITS}" -gt 0 ]]; then
+  pass "(z) observation window live: ${LEGACY_HITS} legacy module-logger line(s) appeared during the run"
+else
+  abort_not_running "no module-logger lines appeared during the ${WAIT_SECONDS}s window either; the window was dead, so the component result is not interpretable"
+fi
+
+# ---------------------------------------------------------------------------
+# (a) The child-logger line reaches the clone log file. THE ACCEPTANCE CLAUSE.
+# ---------------------------------------------------------------------------
+if [[ "${COMPONENT_HITS}" -gt 0 ]]; then
+  pass "(a) ${COMPONENT_HITS} line(s) carrying \"component\":\"maintenance\" reached the clone log"
+else
+  fail "(a) no \"component\":\"...\" line reached any clone log file during the run"
+fi
+
+# ---------------------------------------------------------------------------
+# (b) That line is specifically the documented child-logger instance.
+# ---------------------------------------------------------------------------
+if [[ "${SWEEP_HITS}" -gt 0 ]]; then
+  pass "(b) ${SWEEP_HITS} maintenance_sweep_complete line(s) reached the clone log"
+else
+  fail "(b) maintenance_sweep_complete never reached any clone log file"
+fi
+
+if [[ "${FAILURES}" -eq 0 ]]; then
+  printf '\n=== RESULT: PASS — component child-logger lines reach the clone logs ===\n'
+  exit 0
+fi
+printf '\n=== RESULT: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+exit 1

--- a/server/logging/logger.ts
+++ b/server/logging/logger.ts
@@ -56,22 +56,61 @@ export function loggerOptions(config: ServerConfig["logging"]): LoggerOptions {
   };
 }
 
-/** Create JSON stdout plus the required rotating per-worker file transport. */
+/**
+ * Create JSON stdout plus the required rotating per-worker file transport.
+ *
+ * Fan-out is in-process `pino.multistream`, NOT a multi-target
+ * `pino.transport`. The difference is not stylistic — the multi-target form
+ * silently discarded every line this logger ever emitted (#612).
+ *
+ * Why: `loggerOptions` sets `formatters.level` to render the level as the
+ * string `"info"` rather than pino's numeric `30`, which the shared envelope
+ * requires (`_DOCS/STANDARDS-observability.md`, "Structured output and
+ * required fields"). Multi-target transports route on that serialized value:
+ *
+ *   - `pino/lib/worker.js:126` — a SINGLE target returns its stream directly
+ *     with no level routing, which is why every unit test passed. Two or more
+ *     targets go through `pino.multistream` in the transport worker instead.
+ *   - `pino-abstract-transport/index.js:49` — `stream.lastLevel = value.level`,
+ *     read straight off the parsed JSON with no label-to-number mapping.
+ *   - `pino/lib/multistream.js:61` — selects destinations with
+ *     `dest.level <= level`.
+ *
+ * So the comparison performed for every line was `30 <= "info"` — false for
+ * every destination — and multistream wrote the line nowhere. No error, no
+ * warning, no dropped-line counter: the service logged into a void for as long
+ * as the server path has existed. Measured on the live clone before the fix:
+ * zero pino lines of any kind in the clone log against 3,465 lines from the
+ * legacy `src/logger.ts` module logger, which is why the symptom looked
+ * specific to child loggers rather than total.
+ *
+ * In-process multistream is immune because it takes its routing level from
+ * pino's own numeric level via the metadata symbol, BEFORE `formatters.level`
+ * rewrites the serialized field. The envelope is therefore unchanged — string
+ * level, `timestamp`, `service`, `worker`, `correlation_id`, `message` all
+ * emit exactly as before — and both required destinations receive every line.
+ *
+ * `pino.transport` is still used for the file half, with a SINGLE target,
+ * which keeps `pino-roll`'s rotation off the main thread and stays on the
+ * safe single-target path above.
+ *
+ * Passing `levels` explicitly rather than relying on the default keeps the
+ * label-to-number map owned here, next to the formatter that makes it matter.
+ */
 export function createLogTransport(config: ServerConfig["logging"]): DestinationStream {
-  return pino.transport({
-    targets: [
-      { target: "pino/file", options: { destination: 1 } },
-      {
-        target: "pino-roll",
-        options: {
-          file: workerLogPath(config.file, config.workerName),
-          size: "1m",
-          limit: { count: 3 },
-          mkdir: true,
-        },
-      },
-    ],
+  const rotatingFile = pino.transport({
+    target: "pino-roll",
+    options: {
+      file: workerLogPath(config.file, config.workerName),
+      size: "1m",
+      limit: { count: 3 },
+      mkdir: true,
+    },
   });
+  return pino.multistream(
+    [{ stream: process.stdout }, { stream: rotatingFile }],
+    { levels: pino.levels.values },
+  );
 }
 
 /** Create the service logger; tests may inject an in-memory destination. */

--- a/server/logging/logging.test.ts
+++ b/server/logging/logging.test.ts
@@ -4,11 +4,20 @@
  */
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { Writable } from "node:stream";
 import type { DestinationStream } from "pino";
 import { withCorrelation } from "./context.ts";
 import { createLogger, withOperation, workerLogPath } from "./logger.ts";
 import { sanitizeValue } from "./sanitize.ts";
+
+// The shared temp workspace, never `/tmp` or `$TMPDIR`: those are sandbox-local,
+// so a runner, a sandbox, and the host each see a different one and anything
+// written there is invisible to the others (Development AGENTS.md, hard rule).
+const SCRATCH_ROOT =
+  process.env.OPENBRAIN_TEST_SCRATCH_DIR ?? "/Volumes/ThunderBolt/_tmp/open-brain/_scratch";
+await mkdir(SCRATCH_ROOT, { recursive: true });
 
 const CONFIG = {
   level: "debug" as const,
@@ -81,5 +90,51 @@ describe("structured logging boundary", () => {
 
   it("derives a separate file path for every worker", () => {
     expect(workerLogPath("logs/open-brain.log", "worker/2")).toBe("logs/open-brain.worker_2.log");
+  });
+
+  // Regression for #612. Every other test in this file injects an in-memory
+  // stream, which is the SINGLE-destination pino path — and that is precisely
+  // why they all passed while the running server logged nothing at all. This
+  // one takes the production default (`createLogger(config)` with no injected
+  // destination) and reads the file back off disk, because the defect lived
+  // entirely in the composition the tests were substituting away.
+  //
+  // Asserts a CHILD-logger line specifically: `component` arrives as a child
+  // binding, which is the shape #612 was reported against.
+  it("delivers module and child lines to the real rotating file destination", async () => {
+    const dir = await mkdtemp(join(SCRATCH_ROOT, "logging-612-"));
+    const configured = join(dir, "open-brain.log");
+    const logger = createLogger({ ...CONFIG, file: configured });
+
+    logger.info({ probe: "module" }, "routing_probe_module");
+    logger.child({ component: "maintenance" }).info({ probe: "child" }, "routing_probe_child");
+
+    // pino-roll appends an index to the configured name and writes through a
+    // worker thread, so poll for the content rather than assuming it is
+    // flushed synchronously.
+    const expectedFile = workerLogPath(configured, CONFIG.workerName)
+      .replace(/\.log$/, ".1.log");
+    let contents = "";
+    for (let attempt = 0; attempt < 100 && !contents.includes("routing_probe_child"); attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      contents = await readFile(expectedFile, "utf8").catch(() => "");
+    }
+
+    const lines = contents.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    const moduleLine = lines.find((line) => line.message === "routing_probe_module");
+    const childLine = lines.find((line) => line.message === "routing_probe_child");
+
+    // The module line proves the destination receives anything at all; without
+    // it a missing child line is ambiguous between "child bindings are lost"
+    // and "nothing is written", and the real defect was the latter.
+    expect(moduleLine).toBeDefined();
+    expect(childLine).toBeDefined();
+    expect(childLine?.component).toBe("maintenance");
+    // The envelope must survive the routing fix unchanged — a string level is
+    // what the shared envelope requires, and is also what broke multi-target
+    // routing in the first place.
+    expect(childLine?.level).toBe("info");
+    expect(childLine?.service).toBe(CONFIG.service);
+    expect(typeof childLine?.timestamp).toBe("string");
   });
 });

--- a/server/logging/logging.test.ts
+++ b/server/logging/logging.test.ts
@@ -12,11 +12,18 @@ import { withCorrelation } from "./context.ts";
 import { createLogger, withOperation, workerLogPath } from "./logger.ts";
 import { sanitizeValue } from "./sanitize.ts";
 
-// The shared temp workspace, never `/tmp` or `$TMPDIR`: those are sandbox-local,
-// so a runner, a sandbox, and the host each see a different one and anything
-// written there is invisible to the others (Development AGENTS.md, hard rule).
+// A repo-relative scratch dir, never `/tmp` or `$TMPDIR`: those are
+// sandbox-local, so a runner, a sandbox, and the host each see a different one
+// and anything written there is invisible to the others (Development
+// AGENTS.md, hard rule).
+//
+// Repo-relative rather than the shared `{temp_workspace}` path, because this
+// runs in CI too. An absolute `/Volumes/...` default is unwritable on the Linux
+// runner and fails with `EACCES: permission denied, mkdir '/Volumes'` — which
+// is exactly how the first push of this test failed. `_scratch/` is already
+// gitignored and already used by `src/operator-doctor.test.ts`.
 const SCRATCH_ROOT =
-  process.env.OPENBRAIN_TEST_SCRATCH_DIR ?? "/Volumes/ThunderBolt/_tmp/open-brain/_scratch";
+  process.env.OPENBRAIN_TEST_SCRATCH_DIR ?? join(import.meta.dir, "../../_scratch/logging");
 await mkdir(SCRATCH_ROOT, { recursive: true });
 
 const CONFIG = {


### PR DESCRIPTION
## Summary

Closes #612.

`server/logging/logger.ts` composed its destination with a multi-target `pino.transport` (stdout + `pino-roll`). That composition silently discarded **every line the server logger ever emitted** — not just child-logger lines.

`loggerOptions` (`server/logging/logger.ts:51`) sets `formatters.level` to render the level as the string `"info"` rather than pino's numeric `30`, which the shared envelope requires (`_DOCS/STANDARDS-observability.md`, "Structured output and required fields"). Multi-target transports route on that serialized value:

- `pino/lib/worker.js:126` — a **single** target returns its stream directly with no level routing. Two or more targets go through `pino.multistream` in the transport worker instead.
- `pino-abstract-transport/index.js:49` — `stream.lastLevel = value.level`, read straight off the parsed JSON with no label-to-number mapping.
- `pino/lib/multistream.js:61` — selects destinations with `dest.level <= level`.

So the comparison performed for every line was `30 <= "info"` — false for every destination — and multistream wrote the line nowhere. No error, no warning, no dropped-line counter.

**The fix** (`server/logging/logger.ts:59-101`) replaces the multi-target fan-out with in-process `pino.multistream`, which takes its routing level from pino's own numeric level via the metadata symbol, *before* `formatters.level` rewrites the serialized field. The envelope is unchanged — string `level`, `timestamp`, `service`, `worker`, `correlation_id`, `message` all emit exactly as before — and both required destinations receive every line. The file half keeps a **single-target** `pino.transport` so `pino-roll`'s rotation stays off the main thread and stays on the safe path above.

This is a routing change only. No logger interface, envelope field, call site, or level semantics changed.

### Why it looked like a child-logger defect

The issue reports `component` lines missing while module lines land. Measured on the live clone before the fix:

| Line class | Count in `open-brain.log` |
|---|---|
| `"component":"..."` (any) | **0** |
| pino server lines (`mcp_tracing_configured`, `migrations_complete`, `server_shutdown_*`) | **0** |
| `graph_derivation_enqueue_sweep` | **3,465** |

The 3,465 surviving lines do not come from pino at all. `graph_derivation_enqueue_sweep` is emitted by the **legacy** `src/logger.ts` module logger (`src/graph-derivation-handler.ts:297`), which writes `LOG_FILE` itself through its own rotating sink. Two logging systems in one process made total loss look like partial loss.

### Both serving trees, checked

Only one tree has the defect.

| Tree | Logger | State |
|---|---|---|
| `server/main.ts` (**serving** since the Phase 6 cutover, `scripts/local-clone.ts:31` `SERVING_ENTRYPOINT`) | pino via `server/logging/logger.ts:60` | **was broken**, fixed here |
| `src/index.ts` (legacy) | custom `src/logger.ts` | unaffected — writes `LOG_FILE` directly, never used `pino.transport` |

`createLogger`/`createLogTransport` have exactly one non-test caller (`server/main.ts:210`); the other `rg` hits are `docs/standards/typescript-exemplar/`, which is documentation and has its own unrelated logging module.

## Verification

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — **not applicable**: no file under `python/openbrain-memory/` is touched.
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` — exit 0, no output.

`bun test` — **3711 pass, 35 skip, 0 fail** across 242 files. `OPENBRAIN_TEST_DATABASE_URL` **was set** to a freshly created and migrated `ob_test_612_*` database (47 migrations, 25 tables verified present), so the Postgres suites genuinely ran rather than skipping silently. Database dropped afterward.

### RLVR check — RED then GREEN on the live clone

`scripts/done-means/612-component-lines-reach-logs.sh` drives the **live local dogfood clone**. It seeds one real derivable `ob_sources` row, **enqueues nothing**, and waits for the server's own maintenance sweep to emit `maintenance_sweep_complete` through `logger.child({component:"maintenance"})` (`server/main.ts:310` → `src/maintenance-sweep.ts:257`) — the documented child-logger instance from the issue. It observes production rather than simulating it: a check that constructs a logger and asserts it wrote proves the library works, which is exactly what could not distinguish this bug.

**RED (revision `e6562d5` deployed — check present, fix absent):**

```
PASS  (pre1) local clone serving, status=healthy
PASS  (pre2) serving pid 95620
INFO  watching 13 log file(s) under /Volumes/ThunderBolt/open-brain-local/log
INFO  seeded 1 approved/active source in namespace done-means-612; enqueued nothing
INFO  waiting up to 90s for the server's own sweep to log...
PASS  (z) observation window live: 19 legacy module-logger line(s) appeared during the run
FAIL  (a) no "component":"..." line reached any clone log file during the run
FAIL  (b) maintenance_sweep_complete never reached any clone log file

=== RESULT: FAIL (2 failing clause(s)) ===
```

**GREEN (revision `552cf48` deployed):**

```
PASS  (pre1) local clone serving, status=healthy
PASS  (pre2) serving pid 55955
INFO  watching 13 log file(s) under /Volumes/ThunderBolt/open-brain-local/log
INFO  seeded 1 approved/active source in namespace done-means-612; enqueued nothing
INFO  waiting up to 90s for the server's own sweep to log...
PASS  (z) observation window live: 1 legacy module-logger line(s) appeared during the run
PASS  (a) 1 line(s) carrying "component":"maintenance" reached the clone log
PASS  (b) 1 maintenance_sweep_complete line(s) reached the clone log

=== RESULT: PASS — component child-logger lines reach the clone logs ===
```

The line now on disk, from the pino file that had been 0 bytes since Aug 2:

```json
{"level":"info","timestamp":"2026-08-08T04:31:55.441Z","service":"open-brain-server",
 "worker":"worker","component":"maintenance","correlation_id":"system",
 "distill_batches_selected":0,"distill_jobs_enqueued":0,"distill_batches_deferred":0,
 "distill_turns_deferred":0,"graph_jobs_enqueued":1,"graph_limit_reached":0,
 "message":"maintenance_sweep_complete"}
```

**The check fails loudly rather than vacuously.** Per the no-silent rule (`AGENTS.md` Coding Standards, 2026-08-08), a grep over a log nobody is writing to succeeds at examining nothing. Preconditions exit **3** with an explicit `ABORT — PRECONDITION NOT MET, NOTHING WAS EXAMINED` banner, never a pass, when the clone is not serving, is unhealthy, has no log files, or has no `.env`. Verified live:

```
$ OPEN_BRAIN_HEALTH_URL=http://127.0.0.1:7199/health bash scripts/done-means/612-...sh
ABORT (exit 3) — PRECONDITION NOT MET, NOTHING WAS EXAMINED
  no response from http://127.0.0.1:7199/health; the local clone is not serving
not-running exit code = 3
green exit code = 0
```

There is also a **control clause (z)**: it asserts that *legacy* module-logger lines appeared during the window. Without it, "no component line appeared" is ambiguous between the defect and a run where the server logged nothing at all. This fired for real on the first RED attempt — the clone had stopped sweeping — and the check refused to report a result rather than banking a free red.

### Unit regression

`server/logging/logging.test.ts` gains a test that takes the **production default** (`createLogger(config)` with no injected destination) and reads the file back off disk. Verified to fail against the pre-fix wiring:

```
(fail) structured logging boundary > delivers module and child lines to the real rotating file destination [5000.23ms]
  ^ this test timed out after 5000ms.
 4 pass, 1 fail
```

and to pass after: `5 pass, 0 fail, 18 expect() calls`.

### Live clone state after this PR

Deployed to the **local dogfood clone only** via `scripts/local-clone-deploy.sh`. No core01/hosted config touched (two-host rule).

- Revision proof: `pid 95620 -> 55955, cwd /Volumes/ThunderBolt/open-brain-local/app, revision 552cf48`
- Post-deploy health check passed on port 3100
- Left **healthy and serving**; `/health` reports `"status":"healthy"`, `"revision":"552cf48"`, database connected, embedding connected.

## Critical Self-Review

- Highest-risk behavior: stdout now receives lines from the main thread via `process.stdout` rather than through a transport worker. A slow or blocked stdout consumer therefore applies backpressure in-process instead of in a worker thread. Accepted: this is how pino's own documented `multistream` usage works, the file half (the volume-heavy destination with rotation) stays on a worker, and the alternative shipped a logger that wrote nothing at all. `pino.multistream` is pino's own API for exactly this composition, not a hand-rolled fan-out.
- Assumptions that could be wrong: that `formatters.level` was the sole cause. Not assumed — bisected field by field across all nine `loggerOptions` settings (`bare`, `level_only`, `base`, `messageKey`, `timestamp`, `formatters.level`, `formatters.log`, `mixin`, `redact`) against a live two-target transport; only `formatters.level` produced `stdout_lines=0 file_bytes=0` and every other variant wrote both destinations. Confirmed positively as well: keeping the level numeric while adding the label under a different key restored output through the identical two targets. Also assumed `server/main.ts` is the only serving entrypoint — verified from `scripts/local-clone.ts:31` `SERVING_ENTRYPOINT` and `scripts/local-clone-autostart.sh:66-70`, not from memory.
- Missing/weak tests: the done-means check needs the live service and is not CI-runnable, so CI proves the composition and the live loop is proven by hand. The new unit test covers the `pino-roll` file destination; it does not assert the stdout half of the multistream, because capturing `process.stdout` inside a Bun test process is exactly the global-state swap the existing suite deliberately avoids — stdout delivery is instead evidenced by the transcript above. No test pins the *reason* `formatters.level` is dangerous; that is carried by a comment at the composition site and the SME entry.
- Security/permission risk: none added. Redaction is unchanged — `redact` paths and `formatters.log`/`sanitizeValue` are untouched, and both run before the destination. The fix changes only which stream object receives an already-serialized, already-redacted line. Worth noting the fix *increases* what reaches disk: lines that were silently discarded now land, so redaction correctness matters more in practice than it did yesterday. It was verified unchanged, and the existing redaction tests still pass.
- Migration/deploy risk: no schema change, no config change, no new env var. `LOG_FILE` semantics and `workerLogPath` per-worker derivation are unchanged. Restart-only deploy; rollback is `scripts/local-clone-deploy.sh --rollback`.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as not applicable — no MCP tool, schema, transport, or Python-client contract is touched. One caveat stated plainly: any host log tooling tailing the clone's pino file will begin seeing lines where it previously saw an empty file. That is the fix working, but it is a real change in log volume for anything downstream of that file.
- Rollback/cleanup concern: all probe rows removed by the check's own trap (namespace `done-means-612` verified 0 rows in `ob_sources`); the temp test database `ob_test_612_41956` was dropped; scratch probe files live under the shared temp scratch bucket and the lane worktree is removed at teardown.
- Fixes made before PR: removed a `mktemp`/`$TMPDIR` call from the first draft of the done-means check and replaced it with the shared `_scratch` bucket (sandbox-local temp is a hard rule); added the control clause (z) after the first RED attempt aborted on a dead observation window, which showed a red could otherwise be banked without proving anything was live.
- Known residual risk: the local clone stopped emitting sweep lines for ~18 minutes before the first RED attempt (last line 04:07:06 while `/health` still reported healthy). It resumed on restart and is unrelated to this change — it reproduced on the pre-fix revision — but it is unexplained and is **not** investigated here. If a sweep can go quiet while health stays green, that is its own defect and deserves its own issue; flagging rather than folding it into this PR.
- SME review-memory update: [x] `docs/sme/` updated — new `gotcha-agent` entry: injecting a test destination can bypass the very composition that is broken (all five logging tests passed against an in-memory stream while the production default discarded every line, at 100% reported coverage for `logger.ts`).

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/`
- Live Open Brain checks: [x] linked below

Live checks are the RED/GREEN done-means runs above, executed against the local dogfood clone (revision `552cf48`, pid 55955) and its database, plus the on-disk log line and the exit-code verification.

## Contract Parity

- Contract parity: [x] runtime-specific because: this changes only how the TypeScript server fans log lines out to its own destinations. No wire contract, tool schema, or cross-runtime fixture is involved, and no contract fixture references logging composition.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable, no MCP tool or schema change
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable, no tool surface change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable, no client-facing change
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable, server-internal logging only

Notes/evidence:

- **#384 remains open and gains its unblock from this.** The native blocked-by edge already exists (#612 blocking #384). #384's final acceptance criterion requires the maintenance sweep's warn-level bound-reached lines to be logged, and those ride this exact stream — the `graph_limit_reached` field is visible in the `maintenance_sweep_complete` line quoted above, now that the stream reaches disk. This PR does not close #384; it removes the routing defect that made that criterion unverifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
