### PR TITLE
feat(pr): require done-means check in every PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ## Verification
 
+- Done-means:
 - [ ] Relevant Open Brain tests/typecheck/migrations passed
 - [ ] Python package checks passed or are not applicable
 - [ ] Live Open Brain smoke passed or is not applicable

--- a/scripts/done-means/done-means-field-required.sh
+++ b/scripts/done-means/done-means-field-required.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for operator-approved improvement #2 (2026-08-08): every
+# PR names the executable check that declares the work done, or gives a real
+# reason why no executable check applies.
+#
+#   bash scripts/done-means/done-means-field-required.sh
+#
+# Exit 0 only when all five caller-visible validator behaviors pass. Exit 3 is
+# a harness error, not a failure of the rule under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+VALIDATOR="$REPO_ROOT/scripts/validate-pr-body.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -r "$TEMPLATE" ] || fail_hard "template not readable at $TEMPLATE"
+[ -r "$VALIDATOR" ] || fail_hard "validator not readable at $VALIDATOR"
+
+DUMMY="dummy specific content for the acceptance gate"
+BASE_BODY="$(
+  sed \
+    -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
+    -e 's/^- \[ \]/- [x]/' \
+    -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
+    -e '/^- Done-means:/d' \
+    "$TEMPLATE"
+)" || fail_hard "could not build base PR body"
+
+with_done_means() {
+  local value="$1"
+  printf '%s\n' "$BASE_BODY" | sed "/^## Verification$/a\\
+- Done-means: $value"
+}
+
+run_validator() {
+  local body="$1"
+  VALIDATOR_OUTPUT="$(PR_BODY="$body" PR_TITLE="done-means field gate" bun "$VALIDATOR" 2>&1)"
+  VALIDATOR_EXIT=$?
+}
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+run_validator "$BASE_BODY"
+if [ "$VALIDATOR_EXIT" -ne 0 ] && printf '%s' "$VALIDATOR_OUTPUT" | rg -qF "Done-means"; then
+  record a PASS "missing line rejected and the error names Done-means"
+else
+  record a FAIL "missing line was not rejected by the Done-means rule (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+run_validator "$(with_done_means 'scripts/validate-pr-body.ts')"
+if [ "$VALIDATOR_EXIT" -eq 0 ]; then
+  record b PASS "existing repo-relative path accepted"
+else
+  record b FAIL "existing path rejected (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+run_validator "$(with_done_means 'scripts/done-means/definitely-not-here.sh')"
+if [ "$VALIDATOR_EXIT" -ne 0 ] && printf '%s' "$VALIDATOR_OUTPUT" | rg -qF "Done-means"; then
+  record c PASS "nonexistent path rejected and the error names Done-means"
+else
+  record c FAIL "nonexistent path was not rejected by the Done-means rule (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+run_validator "$(with_done_means 'not applicable because: documentation-only change has no executable behavior')"
+if [ "$VALIDATOR_EXIT" -eq 0 ]; then
+  record d PASS "not-applicable form with a specific reason accepted"
+else
+  record d FAIL "specific not-applicable reason rejected (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+run_validator "$(with_done_means 'not applicable because: tbd')"
+if [ "$VALIDATOR_EXIT" -ne 0 ] && printf '%s' "$VALIDATOR_OUTPUT" | rg -qF "Done-means"; then
+  record e PASS "placeholder not-applicable reason rejected and the error names Done-means"
+else
+  record e FAIL "placeholder reason was not rejected by the Done-means rule (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+label_for() {
+  case "$1" in
+    a) printf 'body without Done-means fails naming the rule' ;;
+    b) printf 'existing repo-relative path passes' ;;
+    c) printf 'nonexistent path fails naming the rule' ;;
+    d) printf 'not-applicable form with real reason passes' ;;
+    e) printf 'placeholder not-applicable reason fails naming the rule' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1

--- a/scripts/done-means/pr-body-gate-fires.sh
+++ b/scripts/done-means/pr-body-gate-fires.sh
@@ -90,6 +90,7 @@ INVALID_BODY_FILE="$SCRATCH/invalid-body.md"
 sed \
   -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
   -e 's/^- \[ \]/- [x]/' \
+  -e 's|^- Done-means:.*$|- Done-means: scripts/validate-pr-body.ts|' \
   -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
   "$TEMPLATE" > "$VALID_BODY_FILE" || fail_hard "could not build valid body"
 cp "$TEMPLATE" "$INVALID_BODY_FILE" || fail_hard "could not build invalid body"

--- a/scripts/done-means/pr-template-passes-validator.sh
+++ b/scripts/done-means/pr-template-passes-validator.sh
@@ -94,11 +94,13 @@ CLAUSE3_EVIDENCE=""
 # The validator's own requirements, enumerated. Kept in sync by clause 2(b).
 # ---------------------------------------------------------------------------
 # Section headings the validator looks up via section().
-REQUIRED_SECTIONS="Critical Self-Review
+REQUIRED_SECTIONS="Verification
+Critical Self-Review
 Review Gate"
 
 # Labels the validator anchors with /^-\s*<label>:/ via requireSpecificLine().
-REQUIRED_LABELS="Highest-risk behavior
+REQUIRED_LABELS="Done-means
+Highest-risk behavior
 Assumptions that could be wrong
 Missing/weak tests
 Security/permission risk
@@ -130,6 +132,7 @@ else
     sed \
       -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
       -e 's/^- \[ \]/- [x]/' \
+      -e 's|^- Done-means:.*$|- Done-means: scripts/validate-pr-body.ts|' \
       -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
       "$TEMPLATE"
   )"
@@ -192,10 +195,14 @@ EOF
 $V_SECTIONS
 EOF
 
-  # requireSpecificLine labels live in the single array literal that feeds it.
+  # requireSpecificLine labels live in the array literal or direct literal calls.
   V_LABELS="$(
-    awk '/requireSpecificLine\(criticalSelfReview/{exit} /for \(const label of \[/{f=1;next} f&&/^\s*\]/{f=0} f' "$VALIDATOR" \
-      | grep -oE '"[^"]+"' | tr -d '"'
+    {
+      awk '/requireSpecificLine\(criticalSelfReview/{exit} /for \(const label of \[/{f=1;next} f&&/^\s*\]/{f=0} f' "$VALIDATOR" \
+        | grep -oE '"[^"]+"' | tr -d '"'
+      grep -oE 'requireSpecificLine\([^,]+, "[^"]+"' "$VALIDATOR" \
+        | sed 's/.*"\([^"]*\)"/\1/'
+    } | sort -u
   )"
   [ -n "$V_LABELS" ] || fail_hard "could not extract requireSpecificLine labels from $VALIDATOR — the extraction, not the template, is broken"
   while IFS= read -r l; do

--- a/scripts/validate-pr-body.test.ts
+++ b/scripts/validate-pr-body.test.ts
@@ -5,6 +5,10 @@ const validBody = `## Summary
 
 - test
 
+## Verification
+
+- Done-means: scripts/done-means/done-means-field-required.sh
+
 ## Critical Self-Review
 
 - Highest-risk behavior: delegated auth provenance can drift

--- a/scripts/validate-pr-body.ts
+++ b/scripts/validate-pr-body.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve, sep } from "node:path";
+
 interface ValidationResult {
   errors: string[];
 }
@@ -33,6 +36,7 @@ function requireSpecificLine(
   sectionBody: string,
   label: string,
   errors: string[],
+  sectionName = "Critical Self-Review",
 ): void {
   const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = sectionBody.match(
@@ -41,7 +45,35 @@ function requireSpecificLine(
   const value = match?.[1]?.trim() ?? "";
   if (!value || value === "-" || value.toLowerCase() === "n/a") {
     errors.push(
-      `Critical Self-Review field '${label}' needs specific content.`,
+      `${sectionName} field '${label}' needs specific content.`,
+    );
+  }
+}
+
+function requireDoneMeans(sectionBody: string, errors: string[]): void {
+  const match = sectionBody.match(
+    /^-\s*Done-means:[^\S\r\n]*([^\r\n]+)$/im,
+  );
+  const value = match?.[1]?.trim() ?? "";
+  const notApplicable = /^not applicable because:\s*(.*)$/i.exec(value);
+  if (notApplicable) {
+    if (isPlaceholderReason(notApplicable[1]?.trim() ?? "")) {
+      errors.push(
+        "Verification field 'Done-means' not-applicable form needs a specific reason.",
+      );
+    }
+    return;
+  }
+
+  if (!value || value === "-" || value.toLowerCase() === "n/a") return;
+
+  const repoRoot = resolve(import.meta.dir, "..");
+  const candidate = resolve(repoRoot, value);
+  const insideRepo =
+    candidate === repoRoot || candidate.startsWith(`${repoRoot}${sep}`);
+  if (isAbsolute(value) || !insideRepo || !existsSync(candidate)) {
+    errors.push(
+      `Verification field 'Done-means' must name an existing repo-relative path; not found: ${value}`,
     );
   }
 }
@@ -98,6 +130,14 @@ export function validatePrBody(
   options: ValidationOptions = {},
 ): ValidationResult {
   const errors: string[] = [];
+  const verification = section(body, "Verification");
+  if (!verification) {
+    errors.push("Missing '## Verification' section.");
+  } else {
+    requireSpecificLine(verification, "Done-means", errors, "Verification");
+    requireDoneMeans(verification, errors);
+  }
+
   const criticalSelfReview = section(body, "Critical Self-Review");
   if (!criticalSelfReview) {
     errors.push("Missing '## Critical Self-Review' section.");


### PR DESCRIPTION
## Summary

- Require every PR Verification section to name an existing repo-relative done-means check or give a specific not-applicable reason.
- Add the field to the PR template and keep validator-derived template/hook fixtures synchronized.
- Add a red-first five-clause acceptance gate for missing, valid, nonexistent, justified N/A, and placeholder N/A forms.

## Verification

- Done-means: scripts/done-means/done-means-field-required.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

## Critical Self-Review

- Highest-risk behavior: path resolution could reject a real check if the repository root were derived from the caller working directory; the implementation derives it from import.meta.dir instead.
- Assumptions that could be wrong: an existing file or directory is sufficient evidence for the operator-approved path rule; executable-bit enforcement was not requested.
- Missing/weak tests: the done-means gate covers the five required behaviors but does not separately exercise absolute paths or parent-directory traversal, which the validator conservatively rejects.
- Security/permission risk: validation reads filesystem metadata only and rejects absolute or outside-repository paths; it does not execute the named check.
- Migration/deploy risk: no database, migration, runtime service, or deployment behavior changes.
- Downstream client/runtime risk: no MCP schema, transport, Python client, generated skill, or Hermes contract changes.
- Rollback/cleanup concern: reverting this commit restores the prior optional Verification shape; the temporary lane worktree and PR-body scratch file are removed or archived after CI.
- Fixes made before PR: updated the validator unit fixture, runtime-required-label extraction, and hook valid-body fixture after the new field made their prior assumptions stale.
- Known residual risk: existence is checked when the PR body is validated; a later commit could remove the named path and requires the normal revalidation boundary.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding was produced during this bounded validator change

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this change affects repository PR tooling only and has no live service path

## Contract Parity

- Contract parity: [x] fixtures updated
- Contract parity: [ ] runtime-specific because:

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

**RED before validator edit**

```text
CLAUSE a (body without Done-means fails naming the rule): FAIL — missing line was not rejected by the Done-means rule (exit=0): PR body validation passed for done-means field gate.
CLAUSE b (existing repo-relative path passes): PASS — existing repo-relative path accepted
CLAUSE c (nonexistent path fails naming the rule): FAIL — nonexistent path was not rejected by the Done-means rule (exit=0): PR body validation passed for done-means field gate.
CLAUSE d (not-applicable form with real reason passes): PASS — not-applicable form with a specific reason accepted
CLAUSE e (placeholder not-applicable reason fails naming the rule): FAIL — placeholder reason was not rejected by the Done-means rule (exit=0): PR body validation passed for done-means field gate.
```

**GREEN after implementation**

```text
CLAUSE a (body without Done-means fails naming the rule): PASS — missing line rejected and the error names Done-means
CLAUSE b (existing repo-relative path passes): PASS — existing repo-relative path accepted
CLAUSE c (nonexistent path fails naming the rule): PASS — nonexistent path rejected and the error names Done-means
CLAUSE d (not-applicable form with real reason passes): PASS — not-applicable form with a specific reason accepted
CLAUSE e (placeholder not-applicable reason fails naming the rule): PASS — placeholder not-applicable reason rejected and the error names Done-means
```

Additional GREEN evidence:

- `bun test scripts/validate-pr-body.test.ts` — 12 pass, 0 fail.
- `bunx tsc --noEmit` — passed.
- `scripts/done-means/pr-template-passes-validator.sh` — all 3 clauses passed; 3 required sections plus Contract Parity and 10 labels tracked.
- `scripts/done-means/pr-body-gate-fires.sh` — all 8 enforcement/non-overfiring clauses passed.
- Pre-push validation — 3,318 pass, 520 skip, 0 fail; branch pushed only after all checks passed.
