### PR TITLE
feat(recall): deliver durable_memory in bursts with a walkable continuation (#563)

### DIFF
--- a/contracts/server/server-context-pack-sections.fixture.json
+++ b/contracts/server/server-context-pack-sections.fixture.json
@@ -187,7 +187,9 @@
             "durable_memory": {
               "content_char_limit": 9007199254740991,
               "content_chars_used": 0,
-              "max_items": 9007199254740991,
+              "burst_items": 10,
+              "burst_offset": 0,
+              "recalled_net_new": 0,
               "max_item_chars": 9007199254740991
             }
           },

--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -387,9 +387,30 @@ inbox, which is the accurate reading of that case.
 The handler still builds the full pack first, and nothing about what it builds
 changed; this changed only how an undeliverable reply is answered.
 
-**Still open:** the 58.5 MB reply does not fit an 8 MB broker, so a
-`durable_memory` request on this namespace gets a clear error rather than a
+**Resolved (#563, operator ruling 2026-08-08, ledger item 23 in
+`docs/issue-graph.md`).** The 58.5 MB reply — re-measured at 60.4 MiB on
+2026-08-05, because the corpus grows daily — did not fit an 8 MB broker, so a
+`durable_memory` request on this namespace got a clear error rather than a
 pack. The 8 MB figure is the NATS server's own `max_payload`, not an Open Brain
-choice — it is reported here as a measurement, and how to resolve it is the
-operator's call, not something this runbook prescribes.
+choice.
+
+The resolution was not to make the reply fit. It was that a whole-corpus reply
+is not a shape the server should ever produce: "I don't see any reason why this
+whole thing would ship in a single shot to anywhere. It defeats the whole
+purpose of this." A `durable_memory` reply now carries a BURST of records
+(`DURABLE_MEMORY_BURST_ITEMS`, 10 — the top of the 5–10 range the ruling names)
+plus the `pointers` pool the pack already builds, and a `next` handle. A caller
+that legitimately wants the whole corpus replays the request with that handle
+and receives the rest as further bursts, server→client, "not ever as the whole
+file."
+
+**This changed delivery, not data.** Records are still stored whole and
+returned whole; every record the query matches is still retrievable, in bursts,
+by walking the handle to completion. Nothing is truncated for being late in the
+ranking, and the storage side is untouched (#604/#606). A pack whose largest
+single reply is now the size of ten records rather than the size of the
+namespace fits any broker by construction, so the `max_payload` measurement
+above is no longer the binding constraint on this path.
+
+Executable acceptance: `scripts/done-means/563-bounded-recall.sh`.
 

--- a/scripts/done-means/563-bounded-recall.driver.ts
+++ b/scripts/done-means/563-bounded-recall.driver.ts
@@ -1,0 +1,284 @@
+/**
+ * Driver for the #563 DONE-MEANS check. Not a test file; invoked by
+ * scripts/done-means/563-bounded-recall.sh, which owns the verdict.
+ *
+ * WHAT IT DRIVES
+ * --------------
+ * The real `agent_context_pack` MCP tool (src/tools/agent-context-pack.ts,
+ * registered on a real McpServer over an in-memory transport) against real
+ * Postgres, in a throwaway namespace this driver seeds and the shell script
+ * tears down. Nothing about the retrieval, section assembly, or pointer
+ * derivation is stubbed — only the embedding PROVIDER, with a deterministic
+ * vector, so the check does not depend on a live MLX endpoint.
+ *
+ * WHAT IT MEASURES (operator ruling 2026-08-08, ledger item 23)
+ * -------------------------------------------------------------
+ * A budgetless, broad `durable_memory` request must not be answerable as one
+ * whole-corpus payload — "I don't see any reason why this whole thing would
+ * ship in a single shot to anywhere." Recall answers with a bounded burst plus
+ * the pointer pool the pack already builds (docs/agent-context-pack-contract.md
+ * "Response Shape": `pointers` is the designated follow-up-fetch surface), and
+ * a caller that legitimately wants all of it walks those pointers in further
+ * bursts. This is response SHAPE. No record is dropped, nothing is stored
+ * smaller, and the walk must reconstruct the complete recalled set.
+ *
+ * The driver performs the walk and reports what it observed. It renders NO
+ * verdict — every threshold lives in the shell script.
+ *
+ * OUTPUT
+ * ------
+ * One JSON object written to the path in DONE_MEANS_563_OUT: seeded row count,
+ * per-burst item counts and identities, per-burst serialized byte sizes, the
+ * union of identities the walk retrieved, and how many requests the walk took.
+ * No record bodies, no credentials.
+ *
+ * It goes to a FILE, not stdout, because this code path legitimately writes
+ * application log lines to stdout; parsing stdout would let a log line be read
+ * as the result (the #605 driver's recorded false-FAIL).
+ */
+import { Pool } from "pg";
+import { randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerAgentContextPack } from "../../src/tools/agent-context-pack.ts";
+import type { ToolDeps } from "../../src/tools/index.ts";
+import type { AuthInfo } from "../../src/types.ts";
+import { WorkingSetStore } from "../../src/realtime/working-set.ts";
+import { RecoveryWalStore } from "../../src/realtime/recovery-wal.ts";
+import { EMBEDDING_DIMENSIONS } from "../../src/embedding.ts";
+
+if (
+  !process.env.DONE_MEANS_563_NS ||
+  !process.env.DONE_MEANS_563_MARKER ||
+  !process.env.DONE_MEANS_563_OUT
+) {
+  console.error(
+    "DONE_MEANS_563_NS, DONE_MEANS_563_MARKER and DONE_MEANS_563_OUT are required",
+  );
+  process.exit(3);
+}
+const NS: string = process.env.DONE_MEANS_563_NS;
+const MARKER: string = process.env.DONE_MEANS_563_MARKER;
+const OUT_PATH: string = process.env.DONE_MEANS_563_OUT;
+
+/**
+ * How many records the throwaway probe corpus holds. Deliberately several times
+ * any plausible burst size, so "one burst" and "the whole corpus" are far apart
+ * and a walk has real work to do. A property of the PROBE CORPUS only; it
+ * constrains nothing the server stores or returns.
+ */
+const SEEDED_RECORDS = 60;
+
+/** A body large enough that a whole-corpus reply is unmistakably large. */
+const BODY_CHARS = 1200;
+
+/** Stops a runaway walk if a continuation handle never terminates. */
+const WALK_REQUEST_CEILING = 200;
+
+const pool = new Pool();
+
+const stubEmbed = async (): Promise<number[]> =>
+  Array(EMBEDDING_DIMENSIONS).fill(0.01);
+
+const SCOPE = {
+  namespace: NS,
+  agent: "done-means-563",
+  platform: "cli",
+  server_id: "done-means-563",
+  channel_id: "done-means-563",
+  session_key: `cli:done-means-563:${MARKER}`,
+};
+
+/**
+ * The broad query. Every seeded record carries the marker, so this matches the
+ * entire seeded corpus — the "broad request" half of the ruling.
+ */
+const BROAD_QUERY = `${MARKER} durable recall probe record`;
+
+function body(index: number): string {
+  const sentence =
+    `${MARKER} durable recall probe record ${index}: this body exists so a ` +
+    `whole-corpus reply would be unmistakably large and a bounded burst is ` +
+    `distinguishable from it by inspection. `;
+  let text = "";
+  while (text.length < BODY_CHARS) text += sentence;
+  return text;
+}
+
+async function seedCorpus(): Promise<number> {
+  const embedding = `[${Array(EMBEDDING_DIMENSIONS).fill(0.01).join(",")}]`;
+  let seeded = 0;
+  for (let index = 0; index < SEEDED_RECORDS; index += 1) {
+    await pool.query(
+      `INSERT INTO decisions
+         (id, namespace, title, rationale, created_by, embedding, tier)
+       VALUES ($1, $2, $3, $4, $5, $6::halfvec, 'warm')`,
+      [
+        randomUUID(),
+        NS,
+        `${MARKER} probe decision ${index}`,
+        body(index),
+        "done-means-563",
+        embedding,
+      ],
+    );
+    seeded += 1;
+  }
+  return seeded;
+}
+
+type Burst = {
+  request: number;
+  item_count: number;
+  identities: string[];
+  pointer_identities: string[];
+  serialized_bytes: number;
+  has_continuation: boolean;
+};
+
+function identitiesOf(items: unknown): string[] {
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item) => {
+      const record = item as Record<string, unknown>;
+      return typeof record.citation_id === "string" ? record.citation_id : null;
+    })
+    .filter((value): value is string => value !== null);
+}
+
+/**
+ * Read a continuation handle from a reply, if the server offers one.
+ *
+ * Deliberately tolerant about WHERE the handle lives: the check must not
+ * dictate the implementation's field naming, only that the remainder stays
+ * reachable through a follow-up request. A reply with no handle ends the walk;
+ * whether that is correct is the shell script's judgement, not the driver's.
+ */
+function continuationOf(section: Record<string, unknown>): unknown {
+  const direct = section.next;
+  if (direct !== undefined && direct !== null) return direct;
+  const cursor = section.continuation;
+  if (cursor !== undefined && cursor !== null) return cursor;
+  return null;
+}
+
+async function main(): Promise<void> {
+  const seeded = await seedCorpus();
+
+  const server = new McpServer({ name: "done-means-563", version: "0" });
+  const deps: ToolDeps = {
+    pool: pool as never,
+    embedFn: stubEmbed,
+    workingSetStore: new WorkingSetStore(),
+    recoveryWalStore: new RecoveryWalStore(),
+  };
+  registerAgentContextPack(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const auth: AuthInfo = { role: "admin", clientId: "done-means-563" };
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: never, options?: never) =>
+    originalSend(message, { ...(options ?? {}), authInfo: auth } as never);
+
+  const client = new Client({ name: "done-means-563", version: "0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  const bursts: Burst[] = [];
+  const union = new Set<string>();
+  let continuation: unknown = null;
+  let request = 0;
+
+  // The FIRST request is the budgetless, broad one the ruling is about: a query
+  // matching the whole seeded corpus, and no budget argument at all. Later
+  // requests replay it carrying whatever continuation handle the server
+  // returned — the paged walk.
+  do {
+    request += 1;
+    const args: Record<string, unknown> = {
+      ...SCOPE,
+      query: BROAD_QUERY,
+      requested_sections: ["durable_memory", "pointers"],
+    };
+    if (continuation !== null) args.continue_from = continuation;
+
+    const reply = await client.callTool({
+      name: "agent_context_pack",
+      arguments: args,
+    });
+
+    const text = (reply as { content?: Array<{ text?: string }> }).content?.[0]
+      ?.text;
+    const serializedBytes = Buffer.byteLength(text ?? "", "utf8");
+    const payload = JSON.parse(text ?? "{}") as Record<string, unknown>;
+    const sections = (payload.sections ?? payload) as Record<string, unknown>;
+    const durable = (sections.durable_memory ?? {}) as Record<string, unknown>;
+    const pointers = (sections.pointers ?? {}) as Record<string, unknown>;
+
+    const identities = identitiesOf(durable.items);
+    const pointerIdentities = identitiesOf(pointers.items);
+    const before = union.size;
+    for (const identity of identities) union.add(identity);
+    const progressed = union.size > before;
+
+    continuation = continuationOf(durable);
+
+    bursts.push({
+      request,
+      item_count:
+        typeof durable.item_count === "number"
+          ? durable.item_count
+          : identities.length,
+      identities,
+      pointer_identities: pointerIdentities,
+      serialized_bytes: serializedBytes,
+      has_continuation: continuation !== null,
+    });
+
+    // A continuation that yields nothing new would loop forever. Stop and let
+    // the shell judge a no-progress walk rather than spinning to the ceiling.
+    if (!progressed) break;
+  } while (continuation !== null && request < WALK_REQUEST_CEILING);
+
+  await client.close();
+  await server.close();
+
+  writeFileSync(
+    OUT_PATH,
+    JSON.stringify(
+      {
+        seeded,
+        namespace: NS,
+        marker: MARKER,
+        requests: request,
+        bursts,
+        union_size: union.size,
+        walk_ceiling_hit: request >= WALK_REQUEST_CEILING,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main()
+  .then(async () => {
+    await pool.end();
+    process.exit(0);
+  })
+  .catch(async (error) => {
+    console.error(error);
+    try {
+      writeFileSync(
+        OUT_PATH,
+        JSON.stringify({ driver_error: String(error) }, null, 2),
+      );
+    } catch {
+      // The shell reports a missing/unreadable result file as a harness error.
+    }
+    await pool.end();
+    process.exit(3);
+  });

--- a/scripts/done-means/563-bounded-recall.sh
+++ b/scripts/done-means/563-bounded-recall.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #563 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/563-bounded-recall.sh
+#
+# THE RULING THIS ENFORCES (operator, 2026-08-08; ledger item 23 in
+# docs/issue-graph.md; the two newest comments on #563):
+#
+#   "I don't see any reason why this whole thing would ship in a single shot to
+#    anywhere. It defeats the whole purpose of this"
+#
+#   "it still should come through as single input outputs or maybe bursts of
+#    5 to 10 input outputs that are sent from the server to the client, but not
+#    ever as the whole file."
+#
+# So a budgetless, broad `durable_memory` request must not be answerable as one
+# whole-corpus payload. It answers with a BOUNDED BURST plus the pointer pool
+# the pack already builds, and a caller that legitimately wants all of it walks
+# those pointers in further bursts until it holds everything.
+#
+# THIS IS RESPONSE SHAPE, NOT DATA REDUCTION. Every seeded record must still be
+# retrievable; clause 4 fails the whole check if the walk ends holding fewer
+# records than were seeded. Storage is untouched (#604/#606 settled that side).
+#
+# ACCEPTANCE, as this script enforces it — five clauses:
+#
+#   1. CONTROL: the probe corpus is real and broadly matchable — the first
+#      budgetless request recalls something. A dead corpus or a failed seed
+#      would hand every later clause a free pass, exactly the failure mode the
+#      #624 lane's control clause was added for.
+#   2. BOUNDED: the first (budgetless, broad) reply's durable_memory item count
+#      is a burst, not the corpus — at most BURST_MAX of the seeded records, and
+#      strictly fewer than were seeded.
+#   3. REACHABLE: that same reply carries the remainder's identities as
+#      pointers and/or a continuation handle. Bounded WITHOUT a way onward would
+#      be data loss, which the ruling explicitly forbids.
+#   4. COMPLETE WALK: following the continuation retrieves the rest in further
+#      bursts, and the union of every burst covers the full seeded corpus. Each
+#      individual burst is also checked to be a burst.
+#   5. NO WHOLE-FILE SHAPE: no single reply in the walk serializes the whole
+#      corpus (its byte size stays well under a full-corpus serialization).
+#
+# EXPECTED TO FAIL before the change: today the budgetless path emits every
+# recalled record in one durable_memory section
+# (DURABLE_MEMORY_MAX_ITEMS = Number.MAX_SAFE_INTEGER,
+# src/tools/agent-context-pack-durable-memory.ts), so clause 2 fails on the
+# first reply. It is the reward function, not a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# One random throwaway NAMESPACE per run, seeded by the driver and deleted here
+# on exit whatever the verdict. The random RUN_ID makes collision with real data
+# impossible, so the teardown DELETE structurally cannot reach anything this run
+# did not create (ledger item 20's prefix-guarded, self-created, session-scoped
+# auto-removal exception — all three hold).
+#
+# The embedding provider is stubbed in the driver with a deterministic vector,
+# so this needs Postgres but no live MLX endpoint.
+#
+# Output is content-free: counts, byte sizes, and verdicts only. No record
+# bodies are printed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DRIVER="$SCRIPT_DIR/563-bounded-recall.driver.ts"
+
+# The ruling's own words: "bursts of 5 to 10 input outputs". A burst at or under
+# 10 satisfies it; the corpus is 60, so a reply carrying the corpus cannot pass.
+BURST_MAX=10
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+[ -r "$DRIVER" ] || fail_hard "driver missing: $DRIVER"
+
+# .env carries the libpq vars, so bare psql needs no connection arguments (see
+# AGENTS.md "Querying the dogfood database"). A bare worktree may lack .env;
+# fall back to the canonical checkout's copy so this runs from either.
+ENV_FILE="$REPO_ROOT/.env"
+[ -r "$ENV_FILE" ] || ENV_FILE="/Volumes/ThunderBolt/Development/open-brain/.env"
+[ -r "$ENV_FILE" ] || fail_hard "no readable .env for Postgres credentials"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+# An isolated lane database, when one is exported, is what the lane's own suite
+# runs against; honour it so this check measures the same tree/database pair.
+if [ -n "${OPENBRAIN_TEST_DATABASE_URL:-}" ]; then
+  export PGDATABASE="${OPENBRAIN_TEST_DATABASE_URL##*/}"
+fi
+
+psql -At -c 'select 1' >/dev/null 2>&1 ||
+  fail_hard "cannot reach Postgres (${PGDATABASE:-unset}); a PASS could not be trusted"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+NS="dm563_${RUN_ID}"
+MARKER="dm563probe${RUN_ID}"
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT_JSON="$SCRATCH/done-means-563-${RUN_ID}.json"
+OUT_LOG="$SCRATCH/done-means-563-${RUN_ID}.log"
+
+teardown() {
+  # Self-created, prefix-guarded, session-scoped: the namespace name contains
+  # this run's random id, so this statement cannot name anything else.
+  psql -At -c "DELETE FROM decisions WHERE namespace = '${NS}';" >/dev/null 2>&1
+  mv -f "$OUT_JSON" "$OUT_JSON.done" 2>/dev/null
+  mv -f "$OUT_LOG" "$OUT_LOG.done" 2>/dev/null
+}
+trap teardown EXIT
+
+DONE_MEANS_563_NS="$NS" \
+  DONE_MEANS_563_MARKER="$MARKER" \
+  DONE_MEANS_563_OUT="$OUT_JSON" \
+  bun "$DRIVER" >"$OUT_LOG" 2>&1
+DRIVER_EXIT=$?
+
+[ -r "$OUT_JSON" ] ||
+  fail_hard "driver wrote no result file (exit ${DRIVER_EXIT}); see $OUT_LOG"
+
+if rg -q '"driver_error"' "$OUT_JSON" 2>/dev/null; then
+  fail_hard "driver errored (exit ${DRIVER_EXIT}); see $OUT_LOG and $OUT_JSON"
+fi
+
+read_json() {
+  bun -e '
+    const fs = require("node:fs");
+    const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const bursts = data.bursts ?? [];
+    const first = bursts[0] ?? {};
+    const counts = bursts.map((b) => b.item_count);
+    const maxBurst = counts.length ? Math.max(...counts) : 0;
+    const maxBytes = bursts.length
+      ? Math.max(...bursts.map((b) => b.serialized_bytes))
+      : 0;
+    const firstReach =
+      (first.pointer_identities ?? []).length + (first.has_continuation ? 1 : 0);
+    process.stdout.write(
+      [
+        data.seeded ?? 0,
+        data.requests ?? 0,
+        data.union_size ?? 0,
+        first.item_count ?? 0,
+        maxBurst,
+        maxBytes,
+        firstReach,
+        data.walk_ceiling_hit ? 1 : 0,
+      ].join(" "),
+    );
+  ' "$OUT_JSON"
+}
+
+read -r SEEDED REQUESTS UNION FIRST_COUNT MAX_BURST MAX_BYTES FIRST_REACH CEILING_HIT <<<"$(read_json)"
+[ -n "${SEEDED:-}" ] || fail_hard "could not parse $OUT_JSON"
+
+OVERALL=PASS
+RESULTS=""
+record_fail() {
+  OVERALL=FAIL
+  RESULTS="${RESULTS}$1"$'\n'
+}
+record_pass() { RESULTS="${RESULTS}$1"$'\n'; }
+
+# ---------------------------------------------------------------------------
+# Clause 1 — CONTROL: the corpus is real and the broad query reaches it.
+# ---------------------------------------------------------------------------
+if [ "$SEEDED" -lt 1 ]; then
+  record_fail "1 control: FAIL — the driver seeded ${SEEDED} records; every later clause would pass vacuously"
+elif [ "$FIRST_COUNT" -lt 1 ]; then
+  record_fail "1 control: FAIL — the budgetless broad request recalled 0 items from a ${SEEDED}-record corpus; boundedness cannot be distinguished from a dead query"
+else
+  record_pass "1 control: PASS — ${SEEDED} records seeded, the budgetless broad request recalled ${FIRST_COUNT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 2 — BOUNDED: the budgetless broad reply is a burst, not the corpus.
+# ---------------------------------------------------------------------------
+if [ "$FIRST_COUNT" -ge "$SEEDED" ]; then
+  record_fail "2 bounded: FAIL — the budgetless broad reply carried ${FIRST_COUNT} of ${SEEDED} records: the whole corpus shipped in a single shot"
+elif [ "$FIRST_COUNT" -gt "$BURST_MAX" ]; then
+  record_fail "2 bounded: FAIL — the budgetless broad reply carried ${FIRST_COUNT} records, past the ${BURST_MAX}-per-burst shape the ruling names"
+else
+  record_pass "2 bounded: PASS — the budgetless broad reply carried ${FIRST_COUNT} records (a burst), not the ${SEEDED}-record corpus"
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 3 — REACHABLE: the first reply says how to get the rest.
+# ---------------------------------------------------------------------------
+if [ "$FIRST_REACH" -lt 1 ]; then
+  record_fail "3 reachable: FAIL — the first reply offered neither pointers nor a continuation handle; a bounded reply with no way onward is data loss, which the ruling forbids"
+else
+  record_pass "3 reachable: PASS — the first reply carried the remainder's reach (pointers and/or a continuation handle)"
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 4 — COMPLETE WALK: bursts reconstruct the whole corpus, nothing lost.
+# ---------------------------------------------------------------------------
+if [ "$CEILING_HIT" = "1" ]; then
+  record_fail "4 complete-walk: FAIL — the walk hit its request ceiling; a continuation that never terminates is not a walk"
+elif [ "$UNION" -lt "$SEEDED" ]; then
+  record_fail "4 complete-walk: FAIL — the walk retrieved ${UNION} of ${SEEDED} records across ${REQUESTS} requests: bounding dropped data instead of re-shaping delivery"
+elif [ "$MAX_BURST" -gt "$BURST_MAX" ]; then
+  record_fail "4 complete-walk: FAIL — the walk retrieved all ${UNION} records, but its largest burst carried ${MAX_BURST}, past the ${BURST_MAX}-per-burst shape"
+elif [ "$REQUESTS" -lt 2 ]; then
+  record_fail "4 complete-walk: FAIL — the whole corpus arrived in ${REQUESTS} request; bursts sent server-to-client are the ruled shape"
+else
+  record_pass "4 complete-walk: PASS — ${REQUESTS} bursts retrieved all ${UNION}/${SEEDED} records, largest burst ${MAX_BURST}"
+fi
+
+# ---------------------------------------------------------------------------
+# Clause 5 — NO WHOLE-FILE SHAPE: a reply's size is set by the burst, not by
+#            how much the query matched.
+# ---------------------------------------------------------------------------
+# The property that actually distinguishes the two shapes is SCALING. A
+# whole-corpus reply grows with the corpus — that is why the live namespace
+# reached 60.4 MiB (measured 2026-08-05) and why no broker will carry it. A
+# burst reply is the size of BURST_MAX whole records plus a fixed envelope, and
+# stays there whether the query matched sixty records or sixty thousand.
+#
+# So the ceiling is expressed per-DELIVERED-RECORD, never as a fraction of the
+# corpus: the largest reply must fit within the bytes a burst legitimately
+# needs. Records are delivered WHOLE (the standing no-reduction rule), so this
+# clause must leave generous room for full bodies, their source_refs, and their
+# citations — measured at ~4.4 KB per delivered record for this corpus's
+# ~1200-char bodies. The allowance below is well above that and still an order
+# of magnitude below a whole-corpus serialization, so it separates the two
+# shapes without ever pressuring the implementation to trim a body.
+BYTES_PER_DELIVERED_RECORD=8000
+BURST_ALLOWANCE=$((BURST_MAX * BYTES_PER_DELIVERED_RECORD))
+WHOLE_CORPUS_BYTES=$((SEEDED * 4400))
+if [ "$MAX_BYTES" -ge "$BURST_ALLOWANCE" ]; then
+  record_fail "5 no-whole-file: FAIL — the largest single reply was ${MAX_BYTES} bytes, past the ${BURST_ALLOWANCE} a ${BURST_MAX}-record burst needs: reply size is tracking the corpus (~${WHOLE_CORPUS_BYTES} bytes), not the burst"
+else
+  record_pass "5 no-whole-file: PASS — the largest single reply was ${MAX_BYTES} bytes, within the ${BURST_ALLOWANCE} a ${BURST_MAX}-record burst needs and far below a ~${WHOLE_CORPUS_BYTES}-byte whole corpus"
+fi
+
+printf '\n=== DONE-MEANS #563: budgetless broad recall is bounded-plus-pointers, walked in bursts ===\n\n'
+printf '%s' "$RESULTS"
+printf '\nnamespace: %s (deleted on exit)   database: %s\n' "$NS" "${PGDATABASE:-default}"
+printf 'transcripts: %s.done  %s.done\n' "$OUT_JSON" "$OUT_LOG"
+printf '\nVERDICT: %s\n\n' "$OVERALL"
+
+[ "$OVERALL" = PASS ] || exit 1
+exit 0

--- a/server/tools/context-pack-args.ts
+++ b/server/tools/context-pack-args.ts
@@ -99,6 +99,27 @@ export const contextPackBudgetInputSchema = z
   })
   .optional();
 
+/**
+ * The continuation handle a caller replays to receive the NEXT burst of a
+ * durable_memory walk (#563, ledger item 23).
+ *
+ * A reply that still has undelivered records carries `durable_memory.next`;
+ * passing it back verbatim resumes the same ranked recall where the previous
+ * burst stopped. It is a delivery position, never a filter — nothing about it
+ * narrows what the query matches, and a walk run to completion has received
+ * every record the query found.
+ */
+export const contextPackContinuationInputSchema = z
+  .object({
+    offset: z.number().int().min(0),
+  })
+  .optional()
+  .describe(
+    "Resume a durable_memory walk: pass back the `next` object from the " +
+      "previous reply to receive the following burst of the same ranked " +
+      "recall. Absent, delivery starts at the top of the ranking.",
+  );
+
 export const agentContextPackInputSchema = {
   ...scopeInputSchema,
   query: z.string().max(4000).optional(),
@@ -134,6 +155,7 @@ export const agentContextPackInputSchema = {
     .boolean()
     .optional()
     .describe("Explicitly include exact-scope quarantined recovery summary"),
+  continue_from: contextPackContinuationInputSchema,
   budget: contextPackBudgetInputSchema,
 };
 

--- a/server/tools/context-pack-durable-memory.ts
+++ b/server/tools/context-pack-durable-memory.ts
@@ -35,14 +35,36 @@ import {
 } from "./prior-context-suppression.ts";
 
 /**
- * Unbounded by default. These were once 8,000 content chars / 8 items / 1,000
+ * Unbounded content by default. These were once 8,000 content chars / 1,000
  * chars per item — numbers an agent wrote, never numbers anyone asked for. A
- * caller that explicitly passes `budget.max_tokens` still gets a bounded pack;
- * absent that, recall means total recall.
+ * caller that explicitly passes `budget.max_tokens` still gets a pack sized to
+ * that request; absent that, a record that IS delivered is delivered whole.
  */
 const DURABLE_MEMORY_MAX_CONTENT_CHARS = Number.MAX_SAFE_INTEGER;
-const DURABLE_MEMORY_MAX_ITEMS = Number.MAX_SAFE_INTEGER;
 const DURABLE_MEMORY_MAX_ITEM_CHARS = Number.MAX_SAFE_INTEGER;
+
+/**
+ * How many recalled records one reply carries — the BURST SIZE (#563, operator
+ * ruling 2026-08-08, ledger item 23).
+ *
+ * This is a DELIVERY SHAPE, not a bound on recall, storage, or what a caller
+ * can obtain. Every record the query matched stays retrievable: rows beyond
+ * this burst are emitted as `pointers` (the resolvable-reference surface
+ * docs/agent-context-pack-contract.md already designates for follow-up fetch)
+ * and the section carries a `next` handle that walks the SAME ranked recall in
+ * further bursts until the caller holds all of it. Nothing is dropped, nothing
+ * is stored smaller, and no record comes back trimmed for being late in the
+ * ranking.
+ *
+ * The operator's words: "it still should come through as single input outputs
+ * or maybe bursts of 5 to 10 input outputs that are sent from the server to the
+ * client, but not ever as the whole file." Ten is the top of the range he
+ * named. Serializing the whole corpus into one reply — 60.4 MiB measured
+ * 2026-08-05, which no broker will carry — is the shape this makes
+ * unproducible: "I don't see any reason why this whole thing would ship in a
+ * single shot to anywhere. It defeats the whole purpose of this."
+ */
+export const DURABLE_MEMORY_BURST_ITEMS = 10;
 
 /**
  * Extra rows fetched beyond the item cap so `pointers` has a net-new pool
@@ -198,10 +220,15 @@ export async function loadDurableMemoryContext(
   );
   const query = args.query?.trim() ?? "";
 
+  // Where in the ranked recall this reply's burst starts. A caller walking the
+  // corpus replays the same request carrying the handle the previous reply
+  // returned; absent one, the walk starts at the top of the ranking.
+  const burstOffset = Math.max(0, Math.trunc(args.continue_from?.offset ?? 0));
+
   const emptyBudget = () => ({
     content_char_limit: maxContentChars,
     content_chars_used: 0,
-    max_items: DURABLE_MEMORY_MAX_ITEMS,
+    burst_items: DURABLE_MEMORY_BURST_ITEMS,
     max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
   });
 
@@ -268,14 +295,16 @@ export async function loadDurableMemoryContext(
       dependencies,
       accessibleTables,
       query,
-      // Everything the query matches, plus the pointer over-fetch. Guard the
+      // Everything the query matches, plus the pointer over-fetch. Retrieval is
+      // UNCHANGED by #563: the burst shape governs how many records one REPLY
+      // carries, never how many the query is allowed to find. Guard the
       // addition: MAX_SAFE_INTEGER + 20 is no longer an exact integer and
       // Postgres rejects it, so an unbounded ask is passed through as-is.
       Number.isSafeInteger(
-        DURABLE_MEMORY_MAX_ITEMS + DURABLE_MEMORY_POINTER_OVERFETCH,
+        Number.MAX_SAFE_INTEGER + DURABLE_MEMORY_POINTER_OVERFETCH,
       )
-        ? DURABLE_MEMORY_MAX_ITEMS + DURABLE_MEMORY_POINTER_OVERFETCH
-        : DURABLE_MEMORY_MAX_ITEMS,
+        ? Number.MAX_SAFE_INTEGER + DURABLE_MEMORY_POINTER_OVERFETCH
+        : Number.MAX_SAFE_INTEGER,
       "hybrid",
       undefined,
       0,
@@ -340,11 +369,19 @@ export async function loadDurableMemoryContext(
   let itemsTruncated = false;
   const pointerCandidatePool: SearchRow[] = [...netNewRows];
 
-  for (const row of netNewRows) {
-    // Hard item cap. Rows beyond it are surfaced as POINTERS, not counted as a
-    // durable truncation, and they remain in the pool above.
-    if (items.length >= DURABLE_MEMORY_MAX_ITEMS) continue;
+  // The burst window: the slice of the ranked net-new recall THIS reply
+  // delivers (#563). Rows before it were delivered by an earlier burst in the
+  // walk; rows after it are delivered by a later one and stay pointer-eligible
+  // meanwhile. Every row is in exactly one burst, so a full walk reconstructs
+  // the complete recalled set — this re-shapes delivery, it does not discard.
+  const burstRows = netNewRows.slice(
+    burstOffset,
+    burstOffset + DURABLE_MEMORY_BURST_ITEMS,
+  );
+  const burstEnd = burstOffset + burstRows.length;
+  const moreAfterBurst = netNewRows.length > burstEnd;
 
+  for (const row of burstRows) {
     const bounded = boundedText(
       row.content_preview,
       Math.min(DURABLE_MEMORY_MAX_ITEM_CHARS, remainingChars),
@@ -385,7 +422,14 @@ export async function loadDurableMemoryContext(
   // body, durable_memory reports zero items with a truncated empty state: the
   // diverted rows still resurface as pointers, but the durable section says
   // truthfully that it emitted no content for a net-new match.
-  if (items.length === 0 && suppression.suppression.net_new > 0) {
+  // Scoped to the burst window: a later burst that is legitimately empty
+  // because the walk has run past the end of the recall must not be reported as
+  // unemittable content.
+  if (
+    items.length === 0 &&
+    burstRows.length > 0 &&
+    suppression.suppression.net_new > 0
+  ) {
     itemsTruncated = true;
   }
 
@@ -393,7 +437,7 @@ export async function loadDurableMemoryContext(
   if (itemsTruncated) {
     truncation.push({
       source: "durable_memory.items",
-      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      burst_items: DURABLE_MEMORY_BURST_ITEMS,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
       content_char_limit: maxContentChars,
     });
@@ -406,13 +450,21 @@ export async function loadDurableMemoryContext(
   //     body (null/empty preview, or the budget admitted none).
   //   - all_suppressed: recall returned rows and suppression removed every one.
   //   - no_matches: recall genuinely found nothing.
+  // `walk_complete` is the fourth genuine zero-item cause, introduced with the
+  // burst shape (#563): the caller walked past the end of the recall, so this
+  // reply is empty for the one benign reason — everything was already
+  // delivered. Checked FIRST because it is a property of the WALK, not of the
+  // records; reporting it as no_matches would tell a caller who now holds the
+  // whole corpus that nothing matched.
   const emptyReason =
     items.length === 0
-      ? suppression.suppression.net_new > 0
-        ? "content_unavailable"
-        : rows.length > 0 && suppression.suppression.suppressed === rows.length
-          ? "all_suppressed"
-          : "no_matches"
+      ? burstRows.length === 0 && burstOffset > 0
+        ? "walk_complete"
+        : suppression.suppression.net_new > 0
+          ? "content_unavailable"
+          : rows.length > 0 && suppression.suppression.suppressed === rows.length
+            ? "all_suppressed"
+            : "no_matches"
       : undefined;
 
   return {
@@ -424,6 +476,18 @@ export async function loadDurableMemoryContext(
       items,
       item_count: items.length,
       truncated: truncation.length > 0,
+      // How to ask for the next burst of this walk (#563). Present ONLY while
+      // records remain undelivered, so a caller walks until it disappears and a
+      // client that ignores it is never left believing a burst was the whole
+      // answer. Its absence IS the completeness signal, which is why no
+      // separate `complete` flag is emitted: one fact, one field, and no way
+      // for the two to disagree. The burst size and the delivery position live
+      // in `budget` (below) rather than being restated here — a tight
+      // whole-pack budget must spend its bytes on records, not on an envelope
+      // describing itself.
+      ...(moreAfterBurst
+        ? { next: { offset: burstEnd, delivered_through: burstEnd } }
+        : {}),
       // Content-free suppression counters (#333): counts only, never an id, a
       // reference, or a body.
       prior_context_suppression: {
@@ -439,7 +503,9 @@ export async function loadDurableMemoryContext(
     budget: {
       content_char_limit: maxContentChars,
       content_chars_used: maxContentChars - remainingChars,
-      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      burst_items: DURABLE_MEMORY_BURST_ITEMS,
+      burst_offset: burstOffset,
+      recalled_net_new: netNewRows.length,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
     },
     citations,

--- a/src/tools/agent-context-pack-durable-memory.ts
+++ b/src/tools/agent-context-pack-durable-memory.ts
@@ -16,30 +16,51 @@ import {
   type PriorContextReference,
 } from "../prior-context-suppression.ts";
 
-// Unbounded by default. These were 8,000 content chars / 8 items / 1,000 chars
+// Unbounded content by default. These were 8,000 content chars / 1,000 chars
 // per item -- numbers an agent wrote, never asked for. A caller that explicitly
-// passes budget.max_tokens still gets a bounded pack; absent that, recall means
-// total recall.
+// passes budget.max_tokens still gets a pack sized to that request; absent
+// that, a record that IS delivered is delivered whole.
 const DURABLE_MEMORY_MAX_CONTENT_CHARS = Number.MAX_SAFE_INTEGER;
-const DURABLE_MEMORY_MAX_ITEMS = Number.MAX_SAFE_INTEGER;
 const DURABLE_MEMORY_MAX_ITEM_CHARS = Number.MAX_SAFE_INTEGER;
 
 /**
- * Extra recall rows fetched beyond {@link DURABLE_MEMORY_MAX_ITEMS} so the
- * `pointers` section (#329) has a net-new, already-authorized pool to draw from
- * WITHOUT a second retrieval stack. The single `executeSearch` call below
- * over-fetches by this much; the first rows become durable_memory items (with
- * bodies) and the surplus net-new rows are handed to the pointer builder as
- * lightweight references only (no body copied, no second query issued). Bounded
- * so recall stays cheap; the pointer builder applies its own hard item ceiling.
+ * How many recalled records one reply carries -- the BURST SIZE (#563, operator
+ * ruling 2026-08-08, ledger item 23).
  *
- * The emitted durable_memory count is unchanged by this over-fetch: it stays
- * capped at {@link DURABLE_MEMORY_MAX_ITEMS} regardless of how large the pool is.
- * What CAN legitimately shift is the fused top-N itself — hybrid RRF ranks over
- * the whole fetched/candidate pool, so a larger pool can reorder or swap which
- * rows land in that top {@link DURABLE_MEMORY_MAX_ITEMS}. That identity/order
- * shift is a property of fetching a deeper pool, not a change to the count; tests
- * assert the count and the pointer/dedupe contract, not a frozen top-N identity.
+ * This is a DELIVERY SHAPE, not a bound on recall, storage, or what a caller
+ * can obtain. Every record the query matched stays retrievable: rows beyond
+ * this burst are emitted as `pointers` (the resolvable-reference surface
+ * docs/agent-context-pack-contract.md already designates for follow-up fetch)
+ * and the section carries a `next` handle that walks the SAME ranked recall in
+ * further bursts until the caller holds all of it. Nothing is dropped, nothing
+ * is stored smaller, and no record comes back trimmed for being late in the
+ * ranking.
+ *
+ * The operator's words: "it still should come through as single input outputs
+ * or maybe bursts of 5 to 10 input outputs that are sent from the server to the
+ * client, but not ever as the whole file." Ten is the top of the range he
+ * named. Serializing the whole corpus into one reply -- 60.4 MiB measured
+ * 2026-08-05, which no broker will carry -- is the shape this makes
+ * unproducible: "I don't see any reason why this whole thing would ship in a
+ * single shot to anywhere. It defeats the whole purpose of this."
+ */
+export const DURABLE_MEMORY_BURST_ITEMS = 10;
+
+/**
+ * Extra recall rows fetched beyond the burst window so the `pointers` section
+ * (#329) has a net-new, already-authorized pool to draw from WITHOUT a second
+ * retrieval stack. The single `executeSearch` call below over-fetches by this
+ * much; the burst window's rows become durable_memory items (with bodies) and
+ * the rest are handed to the pointer builder as lightweight references only (no
+ * body copied, no second query issued).
+ *
+ * The emitted durable_memory count is unchanged by this over-fetch: one reply
+ * carries {@link DURABLE_MEMORY_BURST_ITEMS} regardless of how large the pool
+ * is. What CAN legitimately shift is the fused ranking itself — hybrid RRF ranks
+ * over the whole fetched pool, so a larger pool can reorder which rows land in
+ * a given burst. That identity/order shift is a property of fetching a deeper
+ * pool, not a change to the count; tests assert the count and the
+ * pointer/dedupe contract, not a frozen burst identity.
  */
 const DURABLE_MEMORY_POINTER_OVERFETCH = 20;
 
@@ -204,10 +225,15 @@ export async function loadDurableMemoryContext(
   );
   const query = args.query?.trim() ?? "";
 
+  // Where in the ranked recall this reply's burst starts. A caller walking the
+  // corpus replays the same request carrying the handle the previous reply
+  // returned; absent one, the walk starts at the top of the ranking.
+  const burstOffset = Math.max(0, Math.trunc(args.continue_from?.offset ?? 0));
+
   const emptyBudget = () => ({
     content_char_limit: maxContentChars,
     content_chars_used: 0,
-    max_items: DURABLE_MEMORY_MAX_ITEMS,
+    burst_items: DURABLE_MEMORY_BURST_ITEMS,
     max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
   });
 
@@ -271,16 +297,18 @@ export async function loadDurableMemoryContext(
       deps,
       accessibleTables,
       query,
-      // Everything the query matches. The pointers section (#329) draws its
+      // Everything the query matches. Retrieval is UNCHANGED by #563: the
+      // burst shape governs how many records one REPLY carries, never how many
+      // the query is allowed to find. The pointers section (#329) draws its
       // net-new references from this SAME already-authorized pool, so no second
       // retrieval stack is needed and no over-fetch arithmetic is required.
       // Guard the addition: MAX_SAFE_INTEGER + 20 is no longer an exact integer
       // and Postgres rejects it, so an unbounded ask is passed through as-is.
       Number.isSafeInteger(
-        DURABLE_MEMORY_MAX_ITEMS + DURABLE_MEMORY_POINTER_OVERFETCH,
+        Number.MAX_SAFE_INTEGER + DURABLE_MEMORY_POINTER_OVERFETCH,
       )
-        ? DURABLE_MEMORY_MAX_ITEMS + DURABLE_MEMORY_POINTER_OVERFETCH
-        : DURABLE_MEMORY_MAX_ITEMS,
+        ? Number.MAX_SAFE_INTEGER + DURABLE_MEMORY_POINTER_OVERFETCH
+        : Number.MAX_SAFE_INTEGER,
       "hybrid",
       undefined,
       0,
@@ -331,7 +359,8 @@ export async function loadDurableMemoryContext(
       accessible_table_count: accessibleTables.length,
       namespace_filter: namespaceFilter,
       requested_max_tokens: args.budget?.max_tokens ?? null,
-      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      burst_items: DURABLE_MEMORY_BURST_ITEMS,
+      burst_offset: burstOffset,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
       pointer_overfetch: DURABLE_MEMORY_POINTER_OVERFETCH,
       ...describeError(error),
@@ -386,13 +415,19 @@ export async function loadDurableMemoryContext(
   // whole-pack-trimmed durable row stays pointer-eligible instead of being lost.
   const pointerCandidatePool: SearchRow[] = [...netNewRows];
 
-  for (const row of netNewRows) {
-    // Hard item cap: durable_memory keeps its historical top-N selection even
-    // though recall now over-fetches. Rows beyond the cap are surfaced only as
-    // pointers, not a durable truncation, and remain in the pool above.
-    if (items.length >= DURABLE_MEMORY_MAX_ITEMS) {
-      continue;
-    }
+  // The burst window: the slice of the ranked net-new recall THIS reply
+  // delivers (#563). Rows before it were delivered by an earlier burst in the
+  // walk; rows after it are delivered by a later one and stay pointer-eligible
+  // meanwhile. Every row is in exactly one burst, so a full walk reconstructs
+  // the complete recalled set — this re-shapes delivery, it does not discard.
+  const burstRows = netNewRows.slice(
+    burstOffset,
+    burstOffset + DURABLE_MEMORY_BURST_ITEMS,
+  );
+  const burstEnd = burstOffset + burstRows.length;
+  const moreAfterBurst = netNewRows.length > burstEnd;
+
+  for (const row of burstRows) {
     const bounded = boundedText(
       row.content_preview,
       Math.min(DURABLE_MEMORY_MAX_ITEM_CHARS, remainingChars),
@@ -436,18 +471,25 @@ export async function loadDurableMemoryContext(
     remainingChars -= bounded.text.length;
     if (bounded.truncated) itemsTruncated = true;
   }
-  // A net-new record diverted to the pointer pool because the item cap was hit
-  // is NOT a durable truncation (it is fully surfaced as a pointer). Only a body
-  // the char budget could not admit flips itemsTruncated, which the loop already
-  // does above; do not additionally flip it here for cap-diverted rows.
+  // A net-new record delivered by a DIFFERENT burst of the walk is NOT a
+  // durable truncation: it is fully delivered, just not in this reply, and it
+  // is surfaced as a pointer meanwhile. Only a body the char budget could not
+  // admit flips itemsTruncated, which the loop already does above; do not
+  // additionally flip it here for rows outside this burst window.
   //
   // content_unavailable preservation: when net-new records survived suppression
   // but NONE produced an emittable durable body (all previews null/empty, or the
   // char budget admitted none), durable_memory reports zero items with a
-  // truncated empty state, exactly as before the over-fetch change. The diverted
-  // rows still resurface as pointers, but the durable section truthfully states
-  // it emitted no content for a net-new match.
-  if (items.length === 0 && suppression.suppression.net_new > 0) {
+  // truncated empty state, exactly as before. The rows still resurface as
+  // pointers, but the durable section truthfully states it emitted no content
+  // for a net-new match. Scoped to the burst window: a later burst that is
+  // legitimately empty because the walk has run past the end of the recall must
+  // not be reported as unemittable content.
+  if (
+    items.length === 0 &&
+    burstRows.length > 0 &&
+    suppression.suppression.net_new > 0
+  ) {
     itemsTruncated = true;
   }
 
@@ -455,7 +497,7 @@ export async function loadDurableMemoryContext(
   if (itemsTruncated) {
     truncation.push({
       source: "durable_memory.items",
-      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      burst_items: DURABLE_MEMORY_BURST_ITEMS,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
       content_char_limit: maxContentChars,
     });
@@ -475,13 +517,21 @@ export async function loadDurableMemoryContext(
   // net_new is checked first so a net-new-but-unemittable section can never be
   // mislabeled no_matches; all_suppressed keeps its exact prior meaning (rows
   // recalled, none net-new because all were suppressed).
+  // `walk_complete` is the fourth genuine zero-item cause, introduced with the
+  // burst shape (#563): the caller walked past the end of the recall, so this
+  // reply is empty for the one benign reason — everything was already
+  // delivered. It is checked FIRST because it is a property of the WALK, not of
+  // the records, and reporting it as no_matches would tell a caller who now
+  // holds the whole corpus that nothing matched.
   const emptyReason =
     items.length === 0
-      ? suppression.suppression.net_new > 0
-        ? "content_unavailable"
-        : rows.length > 0 && suppression.suppression.suppressed === rows.length
-          ? "all_suppressed"
-          : "no_matches"
+      ? burstRows.length === 0 && burstOffset > 0
+        ? "walk_complete"
+        : suppression.suppression.net_new > 0
+          ? "content_unavailable"
+          : rows.length > 0 && suppression.suppression.suppressed === rows.length
+            ? "all_suppressed"
+            : "no_matches"
       : undefined;
 
   return {
@@ -493,6 +543,18 @@ export async function loadDurableMemoryContext(
       items,
       item_count: items.length,
       truncated: truncation.length > 0,
+      // How to ask for the next burst of this walk (#563). Present ONLY while
+      // records remain undelivered, so a caller walks until it disappears and a
+      // client that ignores it is never left believing a burst was the whole
+      // answer. Its absence IS the completeness signal, which is why no
+      // separate `complete` flag is emitted: one fact, one field, and no way
+      // for the two to disagree. The burst size and the delivery position live
+      // in `budget` (below) rather than being restated here — a tight
+      // whole-pack budget must spend its bytes on records, not on an envelope
+      // describing itself.
+      ...(moreAfterBurst
+        ? { next: { offset: burstEnd, delivered_through: burstEnd } }
+        : {}),
       // Content-free suppression counters (#333): counts only, never an id, a
       // reference, or a body. `net_new` is pre-budget net-new records; `emitted`
       // is how many survived the char budget.
@@ -509,7 +571,9 @@ export async function loadDurableMemoryContext(
     budget: {
       content_char_limit: maxContentChars,
       content_chars_used: maxContentChars - remainingChars,
-      max_items: DURABLE_MEMORY_MAX_ITEMS,
+      burst_items: DURABLE_MEMORY_BURST_ITEMS,
+      burst_offset: burstOffset,
+      recalled_net_new: netNewRows.length,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
     },
     citations,

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -129,6 +129,27 @@ export const contextPackBudgetInputSchema = z
   })
   .optional();
 
+/**
+ * The continuation handle a caller replays to receive the NEXT burst of a
+ * durable_memory walk (#563, ledger item 23).
+ *
+ * A reply that still has undelivered records carries `durable_memory.next`;
+ * passing it back verbatim resumes the same ranked recall where the previous
+ * burst stopped. It is a delivery position, never a filter — nothing about it
+ * narrows what the query matches, and a walk run to completion has received
+ * every record the query found.
+ */
+export const contextPackContinuationInputSchema = z
+  .object({
+    offset: z.number().int().min(0),
+  })
+  .optional()
+  .describe(
+    "Resume a durable_memory walk: pass back the `next` object from the " +
+      "previous reply to receive the following burst of the same ranked " +
+      "recall. Absent, delivery starts at the top of the ranking.",
+  );
+
 export const agentContextPackInputSchema = {
   ...scopeInputSchema,
   query: z.string().max(4000).optional(),
@@ -164,6 +185,7 @@ export const agentContextPackInputSchema = {
     .boolean()
     .optional()
     .describe("Explicitly include exact-scope quarantined recovery summary"),
+  continue_from: contextPackContinuationInputSchema,
   budget: contextPackBudgetInputSchema,
 };
 


### PR DESCRIPTION
## Summary

- A budgetless, broad `durable_memory` request serialized the whole namespace corpus into one reply — **60.4 MiB** measured 2026-08-05, which no broker will carry. Operator ruling 2026-08-08 (ledger item 23, `docs/issue-graph.md`): *"I don't see any reason why this whole thing would ship in a single shot to anywhere. It defeats the whole purpose of this"*, and delivery *"should come through as single input outputs or maybe bursts of 5 to 10 input outputs that are sent from the server to the client, but not ever as the whole file."*
- One reply now carries `DURABLE_MEMORY_BURST_ITEMS` (10 — the top of the range the ruling names) plus the pointer pool the pack already built, and a `next` handle resumes the same ranked recall where the burst stopped. A caller replays `continue_from` until `next` disappears; **its absence is the completeness signal**, so one fact has one field and no two fields can disagree.
- **This is response SHAPE, not data reduction.** Retrieval is untouched, records are stored and returned whole, and a full walk reconstructs the complete recalled set — the done-means check FAILS if the walk ends holding fewer records than were seeded. Storage was already settled by #604/#606; the no-size-reduction standing rule is not touched.
- Applied to **both** trees: `src/tools/` (reachable via `bun start`, `deploy/open-brain.service`, `run-two-worker.ts`) and `server/tools/` (the serving entrypoint per `scripts/local-clone.ts`). Fixing only one would have left the live surface defective.
- Runbook "Still open" paragraph (`docs/core01-nats-worker-runbook.md`) rewritten: the 8 MB `max_payload` measurement is no longer the binding constraint on this path, because a reply is now sized by the burst rather than by the corpus.

## Verification

- Done-means: scripts/done-means/563-bounded-recall.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

**RED** (pre-change, `git stash` of both source files, same database, same script):

```
1 control: PASS — 60 records seeded, the budgetless broad request recalled 60
2 bounded: FAIL — the budgetless broad reply carried 60 of 60 records: the whole corpus shipped in a single shot
3 reachable: FAIL — the first reply offered neither pointers nor a continuation handle
4 complete-walk: FAIL — the walk retrieved all 60 records, but its largest burst carried 60
5 no-whole-file: FAIL — the largest single reply was 186604 bytes, past the 80000 a 10-record burst needs
VERDICT: FAIL
```

Clause 1 PASSING in the RED run is the control: the corpus was real and the query reached it, so the four failures are measurements rather than a dead probe.

**GREEN** (post-change):

```
1 control: PASS — 60 records seeded, the budgetless broad request recalled 10
2 bounded: PASS — the budgetless broad reply carried 10 records (a burst), not the 60-record corpus
3 reachable: PASS — the first reply carried the remainder's reach
4 complete-walk: PASS — 6 bursts retrieved all 60/60 records, largest burst 10
5 no-whole-file: PASS — the largest single reply was 44437 bytes, far below a ~264000-byte whole corpus
VERDICT: PASS
```

Suite: `bun run test:isolated` → **3711 pass, 35 skip, 0 fail**, 3746 tests across 242 files, on `ob_isolated_1079_msklu49h27`. `bunx tsc --noEmit` clean.

## Critical Self-Review

- Highest-risk behavior: a client that ignores `next` and treats one burst as the whole answer. Mitigated by making `next` present only while records remain undelivered, and by `budget.recalled_net_new` stating how many net-new records the recall actually found, so a truncated read is detectable rather than silent.
- Assumptions that could be wrong: that hybrid-RRF rank order is stable enough across the requests of one walk for offset paging to be coherent. Ranking is recomputed per request, so a corpus mutating mid-walk can shift rows across burst boundaries — see residual risk. The existing pack contract already declines to freeze top-N identity for the same reason.
- Missing/weak tests: no test drives a walk while the corpus is being written concurrently; the done-means check walks a static corpus. No test asserts `walk_complete` specifically.
- Security/permission risk: none identified. `continue_from` carries an integer offset only — no identity, no namespace, no predicate. The auth-derived namespace filter still binds every request in the walk, so a continuation cannot widen scope or resume another caller's walk.
- Migration/deploy risk: no schema change, no migration. Additive input key (`continue_from`) on a `.strict()` schema whose accepted vocabulary is derived from the shape, so it self-lists.
- Downstream client/runtime risk: **real and outstanding** — this changes an MCP output shape and input schema, which `docs/downstream-rollout.md` explicitly covers. Not completed by this lane; see Downstream Rollout below.
- Rollback/cleanup concern: revert is one commit and needs no data repair, since nothing was written, deleted, or migrated.
- Fixes made before PR: (1) the first `durable_memory.delivery` envelope was heavy enough to starve the section under the calibrated `max_tokens: 700` budget test, breaking two real #329 assertions — trimmed to `next` plus fields moved into `budget`, and both tests pass without being edited; (2) clause 5 originally measured a fraction of the corpus, which is the wrong instrument — rewritten to measure per-delivered-record scaling and **re-proven RED** before being trusted; (3) the server parity fixture pinned the removed unbounded item field and was re-recorded.
- Known residual risk: offset paging over a re-ranked recall can skip or repeat a row if the underlying corpus changes mid-walk. No test enforces this and no cursor-token design is proposed here — flagged for a ruling rather than solved silently, since the fix (an identity-anchored cursor) is a larger contract change than #563 authorizes.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no review finding surfaced; the two lane lessons are operating knowledge and are reported for the `docs/lane-contract.md` Tightenings harvest instead.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the lane is forbidden to merge or deploy, and hosted verification per `docs/downstream-rollout.md` runs against `origin/main` after merge.

## Contract Parity

- Contract parity: [x] fixtures updated
- Contract parity: [ ] runtime-specific because:

`contracts/server/server-context-pack-sections.fixture.json` re-recorded: its `durable_memory` budget block pinned the removed unbounded item field. Fixtures compare over RECORDED keys only (`contracts/fixture-shape.ts:84`), so the added fields needed no fixture change — the removed one did.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- This change touches an MCP output shape and input schema, so the gate **applies** — the four boxes above are deliberately UNCHECKED rather than waved through. The rollout order in `docs/downstream-rollout.md` starts after the candidate is on `origin/main`, and this lane is instructed not to merge, so the work is genuinely outstanding and owned by whoever merges.
- Consumer impact to carry into that rollout: a client reading `durable_memory.items` and assuming it holds every matching record will now see the first 10 and must follow `next`. No consumer breaks on parse — the added keys are additive and `next` is optional — but a consumer that never walks will under-read a broad query.
