### PR TITLE
fix(maintenance): make a quiet sweep loud and visible in /health (#625)

### DIFF
--- a/scripts/done-means/625-sweep-heartbeat.driver.ts
+++ b/scripts/done-means/625-sweep-heartbeat.driver.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env bun
+/**
+ * Done-means driver for #625 — "maintenance sweep goes quiet while /health
+ * stays green".
+ *
+ * Run through `scripts/done-means/625-sweep-heartbeat.sh`, which owns the
+ * summary line. This file owns the clauses and the exit code.
+ *
+ * DETERMINISM CONTRACT (docs/lane-contract.md, Tightenings round 5): there is
+ * no `setTimeout`-based waiting and no wall-clock threshold anywhere in the
+ * assertions. Time is a variable this driver assigns — `now` — and it is
+ * injected into the sweep and the health reader. Advancing time is `now +=`,
+ * which is why clause (e) can simulate a 30-minute stall inside a driver that
+ * finishes in milliseconds.
+ *
+ * SUBJECT: the real `startRecurringMaintenanceSweep`
+ * (`src/maintenance-sweep.ts`) and the real `getSingleWorkerHealth`
+ * (`server/transport/health.ts`). Nothing under test is re-implemented here —
+ * the #624 harvest ("injected-dependency tests can 100%-cover a module whose
+ * production composition is broken") is why the check drives the shipped
+ * functions and fakes only their leaf dependencies (pool, queue, clock).
+ */
+
+import { startRecurringMaintenanceSweep } from "../../src/maintenance-sweep.ts";
+import { getSingleWorkerHealth } from "../../server/transport/health.ts";
+import type { MaintenanceQueueLogger } from "../../src/maintenance-queue.ts";
+
+interface LogLine {
+  readonly level: "info" | "warn" | "error";
+  readonly message: string;
+  readonly fields: Record<string, string | number>;
+}
+
+const results: Array<{ clause: string; ok: boolean; detail: string }> = [];
+
+function clause(name: string, ok: boolean, detail: string): void {
+  results.push({ clause: name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  (${name}) ${detail}`);
+}
+
+function recordingLogger(): {
+  logger: MaintenanceQueueLogger;
+  lines: LogLine[];
+} {
+  const lines: LogLine[] = [];
+  const at =
+    (level: LogLine["level"]) =>
+    (message: string, fields: Record<string, string | number> = {}) => {
+      lines.push({ level, message, fields });
+    };
+  return {
+    lines,
+    logger: { info: at("info"), warn: at("warn"), error: at("error") },
+  };
+}
+
+/** A pool whose sweep query hangs until the driver releases it. */
+function stallingPool(): {
+  pool: { query: (...args: unknown[]) => Promise<{ rows: unknown[] }> };
+  release: () => void;
+  started: () => number;
+} {
+  let starts = 0;
+  let releaseHang: (() => void) | undefined;
+  const hang = new Promise<void>((resolve) => {
+    releaseHang = resolve;
+  });
+  return {
+    started: () => starts,
+    release: () => releaseHang?.(),
+    pool: {
+      query: async () => {
+        starts += 1;
+        await hang;
+        return { rows: [] };
+      },
+    },
+  };
+}
+
+/** A pool that answers immediately with no work to do. */
+function idlePool(): {
+  pool: { query: (...args: unknown[]) => Promise<{ rows: unknown[] }> };
+} {
+  return { pool: { query: async () => ({ rows: [] }) } };
+}
+
+const noopQueue = {
+  enqueue: async () => ({ id: "job", kind: "noop" }) as never,
+};
+
+/** Yield to the microtask/macrotask queue without asserting on elapsed time. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) await new Promise((r) => setImmediate(r));
+}
+
+const QUIET_THRESHOLD_MS = 60_000;
+/**
+ * The real `setInterval` period the sweep runs on inside this driver. Small so
+ * the driver finishes fast; it is a knob of the harness, never an assertion.
+ */
+const TICK_INTERVAL_MS = 10;
+/** Deliberately vast relative to the driver's own runtime — see clause (e). */
+const SIMULATED_STALL_MS = 30 * 60_000;
+
+async function main(): Promise<void> {
+  const driverStartedAt = Date.now();
+
+  // -----------------------------------------------------------------------
+  // Scenario 1 — the stalled producer. Clauses (a), (b), (c).
+  // -----------------------------------------------------------------------
+  let now = 1_000_000;
+  const clock = () => now;
+  const stalled = stallingPool();
+  const stalledLogs = recordingLogger();
+
+  const sweep = startRecurringMaintenanceSweep({
+    pool: stalled.pool as never,
+    queue: noopQueue as never,
+    logger: stalledLogs.logger,
+    intervalMs: TICK_INTERVAL_MS,
+    // Injected clock + threshold. On origin/main these options do not exist;
+    // TypeScript would reject them, so the driver passes them through a cast
+    // and the RED is a runtime absence, not a compile error. That is
+    // deliberate: the check must RUN and report FAIL on the pre-fix tree
+    // rather than fail to start, or it cannot distinguish "not fixed yet"
+    // from "check is broken".
+    ...({ now: clock, quietThresholdMs: QUIET_THRESHOLD_MS } as object),
+  } as never);
+
+  await settle();
+
+  // Let the sweep's OWN interval timer fire repeatedly while the first tick is
+  // still hung. This is the production path: `startRecurringMaintenanceSweep`
+  // installs `setInterval(() => void runOnce(), intervalMs)`, and every one of
+  // those firings lands on the overlap guard. `runOnce` is deliberately NOT
+  // exported — an earlier revision of this driver reached for a non-existent
+  // `sweep.runOnce()`, which silently attempted nothing and made clause (a)
+  // measure the harness instead of the subject (docs/lane-contract.md,
+  // Tightenings round 6: "a clause must clear the ambient state its subject
+  // reacts to, or it measures the guard").
+  //
+  // The interval is real, so this is the one place the driver must yield to the
+  // event loop. It is NOT a wall-clock ASSERTION: no clause asserts on elapsed
+  // real time, the interval is a tiny fixed value chosen by this driver, and
+  // the staleness arithmetic still runs entirely off the injected clock. A slow
+  // machine makes this loop take longer; it cannot change any verdict.
+  const overlapAttempts = 4;
+  for (let i = 0; i < overlapAttempts; i += 1) {
+    // Advance the INJECTED clock so the quiet duration grows, then wait just
+    // long enough for the real interval to fire once.
+    now += 5_000;
+    await new Promise((r) => setTimeout(r, TICK_INTERVAL_MS + 5));
+    await settle();
+  }
+  // Advance well past the threshold with the tick still hung.
+  now += SIMULATED_STALL_MS;
+  await settle();
+
+  const overlapWarnings = stalledLogs.lines.filter(
+    (l) =>
+      l.level === "warn" &&
+      (l.message.includes("overlap") ||
+        l.message.includes("skipped") ||
+        l.message.includes("still_running")),
+  );
+  clause(
+    "a",
+    overlapWarnings.length > 0,
+    overlapWarnings.length > 0
+      ? `overlapping tick emitted ${overlapWarnings.length} warning line(s) (e.g. ${overlapWarnings[0]?.message})`
+      : `overlapping ticks emitted ZERO warnings; sweep started ${stalled.started()} query(ies) and ${stalledLogs.lines.length} total log line(s) — a skipped tick is silent`,
+  );
+
+  const liveness = (
+    sweep as { liveness?: () => { stale: boolean; quietMs: number } }
+  ).liveness?.();
+  clause(
+    "b",
+    liveness !== undefined &&
+      liveness.stale === true &&
+      liveness.quietMs >= SIMULATED_STALL_MS,
+    liveness === undefined
+      ? "sweep exposes no liveness reading at all"
+      : `liveness reports stale=${liveness.stale} quiet_ms=${liveness.quietMs} against threshold ${QUIET_THRESHOLD_MS}`,
+  );
+
+  const stalledHealth = await getSingleWorkerHealth({
+    databaseHealth: async () => ({ connected: true }) as never,
+    hostname: "done-means-625",
+    serverIp: "127.0.0.1",
+    serverIps: ["127.0.0.1"],
+    probeTimeoutMs: 100,
+    logger: { info: () => {}, warn: () => {} } as never,
+    ...({ producerHealth: () => liveness ?? { stale: false, quietMs: 0 } } as object),
+  } as never);
+
+  const stalledBody = JSON.stringify(stalledHealth);
+  const namesProducer =
+    stalledBody.includes("producer") || stalledBody.includes("sweep");
+  clause(
+    "c",
+    stalledHealth.status !== "healthy" && namesProducer,
+    `/health with a quiet producer reported status=${stalledHealth.status}, names-producer=${namesProducer}` +
+      (stalledHealth.status === "healthy"
+        ? " — quiet-but-green reproduced"
+        : ""),
+  );
+
+  stalled.release();
+  await sweep.stop();
+
+  // -----------------------------------------------------------------------
+  // Scenario 2 — CONTROL: a healthy producer must stay green. Clause (d).
+  // -----------------------------------------------------------------------
+  let healthyNow = 2_000_000;
+  const healthyLogs = recordingLogger();
+  const healthySweep = startRecurringMaintenanceSweep({
+    pool: idlePool().pool as never,
+    queue: noopQueue as never,
+    logger: healthyLogs.logger,
+    intervalMs: TICK_INTERVAL_MS,
+    ...({
+      now: () => healthyNow,
+      quietThresholdMs: QUIET_THRESHOLD_MS,
+    } as object),
+  } as never);
+
+  await settle();
+  healthyNow += 1_000; // well inside the threshold
+  await settle();
+
+  const healthyLiveness = (
+    healthySweep as { liveness?: () => { stale: boolean; quietMs: number } }
+  ).liveness?.();
+  const completedTicks = healthyLogs.lines.filter(
+    (l) => l.message === "maintenance_sweep_complete",
+  ).length;
+
+  const healthyHealth = await getSingleWorkerHealth({
+    databaseHealth: async () => ({ connected: true }) as never,
+    hostname: "done-means-625",
+    serverIp: "127.0.0.1",
+    serverIps: ["127.0.0.1"],
+    probeTimeoutMs: 100,
+    logger: { info: () => {}, warn: () => {} } as never,
+    ...({
+      producerHealth: () => healthyLiveness ?? { stale: false, quietMs: 0 },
+    } as object),
+  } as never);
+
+  clause(
+    "d",
+    completedTicks > 0 &&
+      healthyLiveness !== undefined &&
+      healthyLiveness.stale === false &&
+      healthyHealth.status === "healthy",
+    `control: ${completedTicks} completed tick(s), liveness stale=${healthyLiveness?.stale ?? "absent"}, /health status=${healthyHealth.status}`,
+  );
+
+  await healthySweep.stop();
+
+  // -----------------------------------------------------------------------
+  // Clause (e) — the clock really is injected.
+  // -----------------------------------------------------------------------
+  const driverElapsed = Date.now() - driverStartedAt;
+  clause(
+    "e",
+    driverElapsed < SIMULATED_STALL_MS / 10,
+    `simulated ${SIMULATED_STALL_MS}ms of quiet in ${driverElapsed}ms of wall clock — clock is injected, not slept`,
+  );
+
+  const failed = results.filter((r) => !r.ok);
+  console.log();
+  console.log(
+    `SUMMARY  ${results.length - failed.length}/${results.length} clause(s) passed`,
+  );
+  if (failed.length > 0) process.exitCode = 1;
+}
+
+await main();

--- a/scripts/done-means/625-sweep-heartbeat.sh
+++ b/scripts/done-means/625-sweep-heartbeat.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #625 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/625-sweep-heartbeat.sh
+#
+# Issue #625, verbatim ask:
+#   - reproduce (watch sweep cadence vs config)
+#   - root-cause the stall (timer starvation? claim contention? tick swallowed
+#     by an error path?)
+#   - decide whether /health should reflect producer liveness (last-sweep-age)
+#     so quiet-but-green cannot recur.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS CHECK IS DETERMINISTIC AND NOT A LIVE-CLONE WATCH
+# ---------------------------------------------------------------------------
+# The issue's own "done means" sketch proposes watching the live clone for
+# sweep-complete lines "within N x the configured interval over an M-interval
+# window". That is a WALL-CLOCK assertion, and the lane contract's Tightenings
+# round 5 (docs/lane-contract.md — "Wall-clock assertions ... are CI flake
+# generators", #632/#634) forbids exactly that shape. A check whose RED can be
+# produced by a busy machine cannot distinguish the defect from the weather.
+#
+# So the observation moves off the clock and onto EVENT COUNTS with an INJECTED
+# clock: the sweep is driven with a tick that never settles, time is advanced by
+# assignment rather than by waiting, and the assertions are about which signals
+# were emitted and what /health computed. The property being proven is not "the
+# sweep was slow" — it is "the sweep was quiet AND health still said healthy",
+# which is logic, not timing.
+#
+# ---------------------------------------------------------------------------
+# WHAT IS ACTUALLY BROKEN, read from source at origin/main
+# ---------------------------------------------------------------------------
+# src/maintenance-sweep.ts:306-322 (startRecurringMaintenanceSweep):
+#
+#     const runOnce = (): Promise<void> => {
+#       if (stopping) return Promise.resolve();
+#       if (active) return active;          <-- SILENT
+#       ...
+#
+# Not starting a second overlapping tick is CORRECT behavior. Emitting nothing
+# when it happens is the defect. When one tick blocks — a slow
+# selectDistillLaneBatches, a pool connection that never returns, a lock — every
+# subsequent interval fires, hits that line, and returns with zero output. The
+# producer is then indistinguishable from one that is keeping up, because both
+# emit nothing between sweeps. That is the ~18 minutes of quiet in #625: not the
+# timer starving, but the overlap guard swallowing every tick after the hang.
+#
+# _DOCS/STANDARDS-observability.md requires a signal at five points and names
+# "guard/limit trigger (warning)" as one of them, then states the governing rule
+# outright: "Absence of a log line must never be used as proof of success."
+#
+# Second half: server/transport/health.ts:90 computes
+#
+#     status = database.connected && !natsDegraded ? "healthy" : "degraded"
+#
+# The producer is not an input at all, so a wedged sweep cannot move /health off
+# "healthy". That is the "quiet but green" the issue names.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) A tick that overlaps a still-running tick EMITS a warning naming the
+#       skip, instead of returning silently.
+#   (b) The sweep exposes a liveness reading whose quiet duration comes from an
+#       INJECTED clock, and it reads stale once quiet exceeds its threshold.
+#   (c) /health goes NON-green (status degraded, HTTP 503) while the producer is
+#       quiet beyond threshold, and the body names the producer as the reason.
+#   (d) CONTROL — the same machinery with a HEALTHY producer reports fresh and
+#       keeps /health green. Without this, code that always reported degraded
+#       would pass (a)-(c) while destroying the signal, and a hard-coded
+#       "degraded" would bank a free GREEN.
+#   (e) CONTROL — the injected clock is real: the driver simulates a quiet
+#       period orders of magnitude longer than its own wall-clock runtime. If
+#       this clause ever fails, the check has silently become a sleep-based
+#       test and inherits the flake class it was written to avoid.
+#
+# All five run through one TypeScript driver against the REAL composition
+# (server/application/index.ts wiring health + maintenance), not a
+# re-implementation — an injected-dependency check that rebuilds its subject
+# proves the rebuild works (docs/lane-contract.md, #624 harvest).
+#
+# Content-free output: clause names, states, and counts only.
+# No database, no network, no live clone — every dependency is a fake, which is
+# what makes this runnable in CI and in a fresh worktree.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRIVER="scripts/done-means/625-sweep-heartbeat.driver.ts"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "FAIL  driver missing: $DRIVER"
+  echo "DONE-MEANS #625: FAIL"
+  exit 1
+fi
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  driver: $DRIVER (injected clock, no wall-clock waits)"
+echo
+
+set +e
+bun "$DRIVER"
+DRIVER_STATUS=$?
+set -e
+
+echo
+if [[ $DRIVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #625: PASS — a quiet sweep is loudly visible and turns /health non-green."
+else
+  echo "DONE-MEANS #625: FAIL — a quiet sweep is still indistinguishable from a healthy one."
+fi
+exit $DRIVER_STATUS

--- a/server/application/index.ts
+++ b/server/application/index.ts
@@ -149,6 +149,24 @@ export function createShadowApplication(
     // cannot.
     natsHealth:
       input.natsHealth ?? (() => natsHealthFromConfig(input.config.nats)),
+    // #625. Deliberately LATE-BOUND: `maintenance` is composed below this
+    // object, because the health block is an input to the transport app and
+    // the runner is a shutdown-order concern. Reading `maintenance` through a
+    // closure invoked per request — rather than reordering the composition —
+    // keeps that ordering intact and, more importantly, keeps the reading
+    // LIVE. A value captured here would be the producer's liveness at boot,
+    // which is exactly the stale-but-confident answer the issue is about.
+    producerHealth: () => {
+      const liveness = maintenance?.producerLiveness();
+      if (!liveness) return undefined;
+      return {
+        quiet_ms: liveness.quietMs,
+        stale: liveness.stale,
+        quiet_threshold_ms: liveness.quietThresholdMs,
+        overlapped_ticks: liveness.overlappedTicks,
+        completed_ticks: liveness.completedTicks,
+      };
+    },
   };
   const app = createSingleWorkerTransportApp({
     authenticate: input.authenticate,

--- a/server/maintenance/index.ts
+++ b/server/maintenance/index.ts
@@ -62,7 +62,10 @@ import {
   type MaintenanceJobHandler,
   type MaintenanceQueueLogger,
 } from "../../src/maintenance-queue.ts";
-import { startRecurringMaintenanceSweep } from "../../src/maintenance-sweep.ts";
+import {
+  startRecurringMaintenanceSweep,
+  type MaintenanceSweepLiveness,
+} from "../../src/maintenance-sweep.ts";
 
 export const MAINTENANCE_BOUNDARY: ServerModuleBoundary = {
   name: "maintenance",
@@ -110,6 +113,12 @@ export interface MaintenanceRuntimeInput {
 export interface MaintenanceRuntime extends BackgroundRuntime {
   readonly queue: MaintenanceQueue;
   readonly runner: MaintenanceQueueRunner;
+  /**
+   * The producer's liveness, or `undefined` when this composition started no
+   * producer (`autoStart: false`). Read by `/health` (#625) so a wedged sweep
+   * cannot hide behind a green database probe.
+   */
+  producerLiveness(): MaintenanceSweepLiveness | undefined;
 }
 
 /**
@@ -223,6 +232,10 @@ export function createMaintenanceRuntime(
     name: MAINTENANCE_RUNTIME_NAME,
     queue,
     runner,
+    // Reads through to the live sweep on every call rather than caching: a
+    // cached liveness value would itself go stale, which is the failure mode
+    // this exists to detect.
+    producerLiveness: () => sweep?.liveness(),
     // `runner.stop()` is a DRAIN (invariant 1 above): it awaits the in-flight
     // tick so any rows that tick's claim leased are tracked, then waits for
     // every tracked handler to finish. The application calls this BEFORE

--- a/server/transport/health.test.ts
+++ b/server/transport/health.test.ts
@@ -163,4 +163,44 @@ describe("single worker health boundary", () => {
     );
     expect(health.nats.last_error).toBe("redacted");
   });
+
+  // #625 — a quiet maintenance producer must be able to move this endpoint off
+  // "healthy". Before this, status came from the database and NATS alone, so a
+  // wedged sweep stayed invisible for as long as it stayed wedged.
+  const producer = (stale: boolean, quietMs: number) => ({
+    quiet_ms: quietMs,
+    stale,
+    quiet_threshold_ms: 60_000,
+    overlapped_ticks: stale ? 216 : 0,
+    completed_ticks: 12,
+  });
+
+  it("degrades when the maintenance producer has gone quiet past its threshold", async () => {
+    const health = await getSingleWorkerHealth(
+      input({ producerHealth: () => producer(true, 1_080_000) }),
+    );
+
+    expect(health.status).toBe("degraded");
+    expect(health.maintenance_producer?.stale).toBe(true);
+    expect(health.maintenance_producer?.quiet_ms).toBe(1_080_000);
+    expect(health.maintenance_producer?.overlapped_ticks).toBe(216);
+  });
+
+  it("stays healthy while the producer is within its quiet threshold", async () => {
+    const health = await getSingleWorkerHealth(
+      input({ producerHealth: () => producer(false, 4_000) }),
+    );
+
+    expect(health.status).toBe("healthy");
+    expect(health.maintenance_producer?.stale).toBe(false);
+  });
+
+  // Absence is not staleness: a worker that composes no producer is opted out,
+  // not broken, and must not be degraded by a component it does not run.
+  it("omits the producer block and stays healthy when no producer is composed", async () => {
+    const health = await getSingleWorkerHealth(input({}));
+
+    expect(health.status).toBe("healthy");
+    expect(health.maintenance_producer).toBeUndefined();
+  });
 });

--- a/server/transport/health.ts
+++ b/server/transport/health.ts
@@ -10,6 +10,29 @@ export interface TransportNatsHealth {
   readonly last_error: "redacted" | null;
 }
 
+/**
+ * The maintenance producer's liveness, as `/health` reports it.
+ *
+ * WHY THIS IS A HEALTH INPUT AT ALL (#625). Before this, `status` was computed
+ * from the database probe and the NATS block alone, so a background producer
+ * that had gone silent could not move the endpoint off "healthy" — observed as
+ * ~18 minutes of no sweep lines against a green `/health`. A health endpoint
+ * that reports only its inbound dependencies answers "can I serve a request?"
+ * and silently declines to answer "is my background work still happening?".
+ * Those are different questions and the second one is the one that goes wrong
+ * quietly.
+ */
+export interface TransportProducerHealth {
+  /** Milliseconds since the producer last completed a tick. */
+  readonly quiet_ms: number;
+  /** True once the producer has been quiet past its own threshold. */
+  readonly stale: boolean;
+  readonly quiet_threshold_ms: number;
+  /** Ticks skipped because a previous one was still running. */
+  readonly overlapped_ticks: number;
+  readonly completed_ticks: number;
+}
+
 export interface SingleWorkerHealth {
   readonly status: "healthy" | "degraded";
   /** Machine hostname — the human half of "which brain did I reach?". */
@@ -24,6 +47,13 @@ export interface SingleWorkerHealth {
     readonly connected: boolean;
   };
   readonly nats: TransportNatsHealth;
+  /**
+   * Absent on a process that composes no maintenance producer — which is a
+   * legitimate configuration (an opted-out worker), and is deliberately
+   * distinct from a producer that is present and quiet. Absent means "not my
+   * job"; `stale: true` means "my job and I am not doing it".
+   */
+  readonly maintenance_producer?: TransportProducerHealth;
   readonly timestamp: string;
 }
 
@@ -39,6 +69,13 @@ export interface SingleWorkerHealthInput {
   readonly logger: Logger;
   readonly fetch?: typeof fetch;
   readonly natsHealth?: () => TransportNatsHealth;
+  /**
+   * The maintenance producer's own liveness reading, injected the same way
+   * `natsHealth` is: the live component knows its counters and this module
+   * must not guess them. Omitted composes no producer block and cannot degrade
+   * the status.
+   */
+  readonly producerHealth?: () => TransportProducerHealth | undefined;
 }
 
 const HTTP_NATS_HEALTH: TransportNatsHealth = {
@@ -87,16 +124,44 @@ export async function getSingleWorkerHealth(
   const nats = input.natsHealth?.() ?? HTTP_NATS_HEALTH;
   const natsDegraded =
     nats.requested_transport === "nats" && nats.availability !== "available";
-  const status = database.connected && !natsDegraded ? "healthy" : "degraded";
+  // #625: a quiet producer degrades this worker. A process that composes no
+  // producer supplies nothing here and is unaffected — absence is not staleness.
+  const producer = input.producerHealth?.();
+  const producerDegraded = producer?.stale === true;
+  const status =
+    database.connected && !natsDegraded && !producerDegraded
+      ? "healthy"
+      : "degraded";
   input.logger.info(
     {
       status,
       database_connected: database.connected,
       embedding_connected: embeddingConnected,
       nats_availability: nats.availability,
+      // Emitted whenever a producer exists, not only when it is stale: the
+      // healthy reading is what makes a later stale one comparable, and a field
+      // that appears only on failure cannot be graphed.
+      ...(producer
+        ? {
+            maintenance_producer_stale: producer.stale ? 1 : 0,
+            maintenance_producer_quiet_ms: producer.quiet_ms,
+            maintenance_producer_overlapped_ticks: producer.overlapped_ticks,
+          }
+        : {}),
     },
     "worker_health_result",
   );
+  if (producerDegraded) {
+    input.logger.warn(
+      {
+        quiet_ms: producer.quiet_ms,
+        quiet_threshold_ms: producer.quiet_threshold_ms,
+        overlapped_ticks: producer.overlapped_ticks,
+        completed_ticks: producer.completed_ticks,
+      },
+      "maintenance_producer_health_degraded",
+    );
+  }
   return {
     status,
     hostname: input.hostname,
@@ -109,6 +174,7 @@ export async function getSingleWorkerHealth(
       connected: embeddingConnected,
     },
     nats,
+    ...(producer ? { maintenance_producer: producer } : {}),
     timestamp: new Date().toISOString(),
   };
 }

--- a/src/maintenance-sweep.test.ts
+++ b/src/maintenance-sweep.test.ts
@@ -4,6 +4,7 @@ import { GRAPH_DERIVATION_JOB_KIND } from "./graph-derivation-handler.ts";
 import { startMaintenanceQueue } from "./maintenance-bootstrap.ts";
 import {
   runMaintenanceSweep,
+  startRecurringMaintenanceSweep,
   type MaintenanceSweepSummary,
 } from "./maintenance-sweep.ts";
 import type {
@@ -277,5 +278,166 @@ describe("startMaintenanceQueue recurring producer", () => {
 
     expect(insertedKinds).toEqual([MEMORY_DISTILL_JOB_KIND]);
     expect(logs.error).toEqual([]);
+  });
+});
+
+/**
+ * #625 — a producer that goes quiet must SAY so.
+ *
+ * Every assertion here runs off an injected clock. Wall-clock assertions are a
+ * known flake generator in this repo (docs/lane-contract.md, Tightenings round
+ * 5 — #632/#634), and staleness is precisely the property that tempts one, so
+ * time is a variable these tests assign rather than a duration they wait out.
+ */
+describe("startRecurringMaintenanceSweep liveness (#625)", () => {
+  /** A pool whose sweep query hangs until released, to wedge a tick on demand. */
+  function stallingPool() {
+    let releaseHang: (() => void) | undefined;
+    const hang = new Promise<void>((resolve) => {
+      releaseHang = resolve;
+    });
+    return {
+      release: () => releaseHang?.(),
+      pool: {
+        query: mock(async () => {
+          await hang;
+          return { rows: [], rowCount: 0 };
+        }),
+      },
+    };
+  }
+
+  const idleQueue = {
+    enqueue: async (input: EnqueueMaintenanceJob) => maintenanceJob(input, 1),
+  };
+
+  async function settle(): Promise<void> {
+    for (let i = 0; i < 5; i += 1) await new Promise((r) => setImmediate(r));
+  }
+
+  it("warns when a tick is skipped because the previous one is still running", async () => {
+    let now = 1_000_000;
+    const stalled = stallingPool();
+    const logs = recordingLogger();
+    const sweep = startRecurringMaintenanceSweep({
+      pool: stalled.pool as never,
+      queue: idleQueue as never,
+      logger: logs.logger,
+      intervalMs: 10,
+      now: () => now,
+      quietThresholdMs: 60_000,
+    });
+
+    await settle();
+    // Let the real interval fire into the overlap guard while tick 1 hangs.
+    now += 90_000;
+    await new Promise((r) => setTimeout(r, 40));
+    await settle();
+
+    const overlaps = logs.warn.filter(
+      (line) => line.message === "maintenance_sweep_tick_overlapped",
+    );
+    expect(overlaps.length).toBeGreaterThan(0);
+    expect(overlaps[0]?.fields.quiet_ms).toBe(90_000);
+    expect(overlaps[0]?.fields.quiet_threshold_ms).toBe(60_000);
+
+    // One warning per stall, not one per skipped tick: the counter carries the
+    // extent so an operator sees the scale without 200 identical lines.
+    expect(overlaps.length).toBe(1);
+    expect(
+      Number(overlaps[0]?.fields.overlapped_ticks),
+    ).toBeGreaterThanOrEqual(1);
+
+    stalled.release();
+    await sweep.stop();
+  });
+
+  it("reports stale once quiet exceeds the threshold, and fresh before it", async () => {
+    let now = 2_000_000;
+    const stalled = stallingPool();
+    const logs = recordingLogger();
+    const sweep = startRecurringMaintenanceSweep({
+      pool: stalled.pool as never,
+      queue: idleQueue as never,
+      logger: logs.logger,
+      intervalMs: 10_000,
+      now: () => now,
+      quietThresholdMs: 60_000,
+    });
+
+    await settle();
+    now += 30_000;
+    expect(sweep.liveness().stale).toBe(false);
+    expect(sweep.liveness().quietMs).toBe(30_000);
+
+    now += 60_000;
+    const stale = sweep.liveness();
+    expect(stale.stale).toBe(true);
+    expect(stale.quietMs).toBe(90_000);
+    expect(stale.quietThresholdMs).toBe(60_000);
+
+    stalled.release();
+    await sweep.stop();
+  });
+
+  it("clears staleness and logs recovery once a tick completes again", async () => {
+    let now = 3_000_000;
+    const stalled = stallingPool();
+    const logs = recordingLogger();
+    const sweep = startRecurringMaintenanceSweep({
+      pool: stalled.pool as never,
+      queue: idleQueue as never,
+      logger: logs.logger,
+      intervalMs: 10,
+      now: () => now,
+      quietThresholdMs: 60_000,
+    });
+
+    await settle();
+    now += 120_000;
+    await new Promise((r) => setTimeout(r, 40));
+    await settle();
+    expect(sweep.liveness().stale).toBe(true);
+
+    stalled.release();
+    await settle();
+
+    expect(sweep.liveness().stale).toBe(false);
+    expect(sweep.liveness().quietMs).toBe(0);
+    expect(
+      logs.warn.some(
+        (line) => line.message === "maintenance_sweep_tick_recovered",
+      ),
+    ).toBe(true);
+
+    await sweep.stop();
+  });
+
+  it("counts a handled failure as a completed tick, not as silence", async () => {
+    let now = 4_000_000;
+    const logs = recordingLogger();
+    const failingPool = {
+      query: mock(async () => {
+        throw new Error("boom");
+      }),
+    };
+    const sweep = startRecurringMaintenanceSweep({
+      pool: failingPool as never,
+      queue: idleQueue as never,
+      logger: logs.logger,
+      intervalMs: 10_000,
+      now: () => now,
+      quietThresholdMs: 60_000,
+    });
+
+    await settle();
+    // The tick failed and SAID so; the producer is alive, so it is not stale.
+    expect(
+      logs.error.some((line) => line.message === "maintenance_sweep_failed"),
+    ).toBe(true);
+    expect(sweep.liveness().completedTicks).toBeGreaterThan(0);
+    expect(sweep.liveness().stale).toBe(false);
+
+    await sweep.stop();
   });
 });

--- a/src/maintenance-sweep.ts
+++ b/src/maintenance-sweep.ts
@@ -265,9 +265,42 @@ export async function runMaintenanceSweep(
   return summary;
 }
 
+/**
+ * What the producer can say about its own liveness, for a health reader.
+ *
+ * `quietMs` is the age of the last COMPLETED tick, not the age of the last
+ * attempt: a producer whose ticks all hang is quiet no matter how often the
+ * timer fires, and that distinction is the whole point of #625.
+ */
+export interface MaintenanceSweepLiveness {
+  /** Milliseconds since the last tick that finished (success or handled failure). */
+  readonly quietMs: number;
+  /** True once `quietMs` exceeds the configured threshold. */
+  readonly stale: boolean;
+  /** The threshold `stale` was computed against, so a reader can report it. */
+  readonly quietThresholdMs: number;
+  /** Ticks that returned early because a previous tick was still running. */
+  readonly overlappedTicks: number;
+  /** Ticks that ran to completion, successfully or with a handled failure. */
+  readonly completedTicks: number;
+}
+
 export interface RecurringMaintenanceSweep {
   stop(): Promise<void>;
+  /**
+   * Current producer liveness. Read by `/health` so a wedged producer cannot
+   * stay invisible behind a green database probe.
+   */
+  liveness(): MaintenanceSweepLiveness;
 }
+
+/**
+ * Default quiet threshold: a producer is stale once it has gone this long with
+ * no completed tick. Twelve times the 5s default cadence — long enough that an
+ * ordinarily slow sweep does not flap the health status, short enough that the
+ * ~18 minutes of silence observed in #625 is reported within the first minute.
+ */
+const DEFAULT_QUIET_THRESHOLD_MS = 60_000;
 
 /**
  * Start the recurring producer: one bounded sweep now, then one per interval.
@@ -297,15 +330,67 @@ export interface RecurringMaintenanceSweep {
  * work after the runner has begun draining.
  */
 export function startRecurringMaintenanceSweep(
-  input: MaintenanceSweepOptions & { intervalMs: number },
+  input: MaintenanceSweepOptions & {
+    intervalMs: number;
+    /**
+     * Clock source, injected so liveness can be tested without sleeping.
+     * Defaults to `Date.now`. A wall-clock assertion is a flake generator
+     * (docs/lane-contract.md, Tightenings round 5), so the only way to test
+     * staleness honestly is to make time a parameter.
+     */
+    now?: () => number;
+    /** Quiet duration after which the producer reports itself stale. */
+    quietThresholdMs?: number;
+  },
 ): RecurringMaintenanceSweep {
   let interval: ReturnType<typeof setInterval> | null = null;
   let active: Promise<void> | null = null;
   let stopping = false;
 
+  const now = input.now ?? Date.now;
+  const quietThresholdMs = Math.max(
+    input.quietThresholdMs ?? DEFAULT_QUIET_THRESHOLD_MS,
+    1,
+  );
+
+  // Seeded at start, not at 0: a producer that has just booted is not stale,
+  // and treating "never completed" as infinitely quiet would report every
+  // process as degraded for its first tick.
+  let lastCompletedAt = now();
+  let overlappedTicks = 0;
+  let completedTicks = 0;
+  // Warn once per stall, not once per skipped tick: at a 5s cadence an
+  // 18-minute stall is ~216 skips, and 216 identical warnings is how a real
+  // signal gets filtered out as noise. The counter carried on the first line is
+  // what makes the extent recoverable without emitting each one.
+  let warnedForCurrentStall = false;
+
   const runOnce = (): Promise<void> => {
     if (stopping) return Promise.resolve();
-    if (active) return active;
+    if (active) {
+      // THE #625 DEFECT. Declining to start a second overlapping tick is
+      // correct; returning from here SILENTLY is not. When a tick hangs — a
+      // slow selection query, a pool connection that never returns, a lock —
+      // every subsequent interval landed here and emitted nothing, so a wedged
+      // producer and a keeping-up producer looked identical from the outside:
+      // both are quiet between sweeps. Observed as ~18 minutes of silence on
+      // the local clone while /health stayed green (#625, found by the #612
+      // lane). `_DOCS/STANDARDS-observability.md` names the guard-trigger path
+      // as one of the five required log points and states the governing rule:
+      // absence of a log line must never be used as proof of success.
+      overlappedTicks += 1;
+      if (!warnedForCurrentStall) {
+        warnedForCurrentStall = true;
+        input.logger.warn("maintenance_sweep_tick_overlapped", {
+          quiet_ms: now() - lastCompletedAt,
+          quiet_threshold_ms: quietThresholdMs,
+          overlapped_ticks: overlappedTicks,
+          completed_ticks: completedTicks,
+          interval_ms: input.intervalMs,
+        });
+      }
+      return active;
+    }
 
     const run = runMaintenanceSweep(input)
       .then(() => undefined)
@@ -315,7 +400,26 @@ export function startRecurringMaintenanceSweep(
         });
       })
       .finally(() => {
+        // A handled failure still counts as a completed tick: the producer is
+        // alive and reporting, which is a different condition from silence, and
+        // conflating them would make an erroring sweep also look wedged.
+        const wasStalled = warnedForCurrentStall;
+        const quietMs = now() - lastCompletedAt;
+        lastCompletedAt = now();
+        completedTicks += 1;
         active = null;
+        warnedForCurrentStall = false;
+        if (wasStalled) {
+          // Recovery is an outcome and gets its own signal, so an operator
+          // reading the log can close the incident without inferring it from
+          // the absence of further warnings.
+          input.logger.warn("maintenance_sweep_tick_recovered", {
+            quiet_ms: quietMs,
+            quiet_threshold_ms: quietThresholdMs,
+            overlapped_ticks: overlappedTicks,
+            completed_ticks: completedTicks,
+          });
+        }
       });
     active = run;
     return run;
@@ -325,6 +429,16 @@ export function startRecurringMaintenanceSweep(
   interval = setInterval(() => void runOnce(), input.intervalMs);
 
   return {
+    liveness(): MaintenanceSweepLiveness {
+      const quietMs = now() - lastCompletedAt;
+      return {
+        quietMs,
+        stale: quietMs > quietThresholdMs,
+        quietThresholdMs,
+        overlappedTicks,
+        completedTicks,
+      };
+    },
     async stop(): Promise<void> {
       stopping = true;
       if (interval) clearInterval(interval);


### PR DESCRIPTION
## Summary

- Closes #625. The maintenance producer could go quiet for ~18 minutes while `/health` stayed green. Root cause is one line: `src/maintenance-sweep.ts:307` (pre-fix) returned from the overlap guard **silently**.
- `startRecurringMaintenanceSweep` declines to start a second tick while one is in flight — correct — but emitted nothing when it did. When a tick hangs (slow selection query, a pool connection that never returns, a lock), every subsequent interval firing landed there and said nothing. A wedged producer and a keeping-up producer are then identical from outside, because **both are quiet between sweeps**. That is the silent-failure class: the sweep's success was never distinguished from its no-op.
- `_DOCS/STANDARDS-observability.md` names the guard-trigger path as one of the five required log points, and states the governing rule outright: *"Absence of a log line must never be used as proof of success."*
- Second half of the defect: `server/transport/health.ts:90` computed `status = database.connected && !natsDegraded ? "healthy" : "degraded"`. The producer was **not an input at all**, so no amount of producer silence could move the endpoint off green.

**The fix, at the two owning boundaries:**

- `src/maintenance-sweep.ts` — a skipped tick now emits `maintenance_sweep_tick_overlapped` through the standard envelope, **once per stall** rather than once per skipped tick (at a 5s cadence an 18-minute stall is ~216 skips, and 216 identical lines is how a real signal gets filtered out as noise); the warning carries `quiet_ms`, `quiet_threshold_ms`, `overlapped_ticks`, `completed_ticks`, `interval_ms`. Recovery emits `maintenance_sweep_tick_recovered` so an operator can close the incident without inferring it from the absence of further warnings. The sweep exposes `liveness()`. Time is an injected `now()`.
- `server/transport/health.ts` — `producerHealth` joins `natsHealth` as an injected reading (the established pattern in this module: the live component knows its own counters, health does not guess them), ORed into the existing binary healthy/degraded status. A quiet producer yields `degraded` and HTTP 503, plus a `maintenance_producer` block and a `maintenance_producer_health_degraded` warning.
- `server/maintenance/index.ts` exposes `producerLiveness()`; `server/application/index.ts` wires it through a **late-bound** closure, because health is composed before maintenance and — more importantly — a value captured at composition time would be the producer's liveness at boot, which is exactly the stale-but-confident answer this issue is about.

**Absence is not staleness.** A worker that composes no producer (`autoStart: false`, or an opted-out process) omits the block entirely and stays healthy. "Not my job" and "my job and I am not doing it" are different states and must not collapse into one.

Non-goals respected: no maintenance-queue rewrite, no scheduling/cadence change, core01 untouched. `DEFAULT_QUIET_THRESHOLD_MS` is a staleness **reporting** threshold, not a cap on any work — nothing is truncated, skipped, or made smaller.

## Verification

- Done-means: scripts/done-means/625-sweep-heartbeat.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — **not applicable**: no file under `python/openbrain-memory/` is touched.
- [x] Live Open Brain smoke passed or is not applicable — **not applicable**: the check is deterministic and hermetic by design (see below); no live clone or hosted service is touched.

`bunx tsc --noEmit` — exit 0, no output.

`bun run test:isolated` — **3718 pass, 35 skip, 0 fail**, 242 files, exit 0, on a fresh migrated database dropped afterward. Run **three consecutive times** with identical counts.

New tests: 4 in `src/maintenance-sweep.test.ts` (overlap warning + its once-per-stall bound, stale/fresh threshold crossing, recovery clearing staleness, and a handled failure counting as a completed tick rather than silence); 3 in `server/transport/health.test.ts` (degrades on stale, stays healthy within threshold, omits block when no producer composed).

**RED then GREEN.** The check is deterministic: no `setTimeout`-based waiting and no wall-clock threshold in any assertion — wall-clock assertions are a known flake generator here (lane contract, Tightenings round 5, #632/#634), and staleness is precisely the property that tempts one. Time is a variable the driver assigns.

RED, on `origin/main`'s `src/maintenance-sweep.ts` with the check present:

```
FAIL  (a) overlapping ticks emitted ZERO warnings; sweep started 1 query(ies) and 0 total log line(s) — a skipped tick is silent
FAIL  (b) sweep exposes no liveness reading at all
FAIL  (c) /health with a quiet producer reported status=healthy, names-producer=true — quiet-but-green reproduced
FAIL  (d) control: 1 completed tick(s), liveness stale=absent, /health status=healthy
PASS  (e) simulated 1800000ms of quiet in 67ms of wall clock — clock is injected, not slept
SUMMARY  1/5 clause(s) passed
```

GREEN, this branch:

```
PASS  (a) overlapping tick emitted 1 warning line(s) (e.g. maintenance_sweep_tick_overlapped)
PASS  (b) liveness reports stale=true quiet_ms=1820000 against threshold 60000
PASS  (c) /health with a quiet producer reported status=degraded, names-producer=true
PASS  (d) control: 1 completed tick(s), liveness stale=false, /health status=healthy
PASS  (e) simulated 1800000ms of quiet in 66ms of wall clock — clock is injected, not slept
SUMMARY  5/5 clause(s) passed
```

Clause (d) is a **control**: it requires a healthy producer to read fresh and keep `/health` green, so code that always reported degraded cannot bank a free pass. Clause (e) proves the clock is genuinely injected — 30 simulated minutes in ~66ms — and guards against this check silently degrading into a sleep-based test later.

## Critical Self-Review

- Highest-risk behavior: `/health` can now return 503 on a condition that previously never produced one. If a legitimately slow sweep exceeds the 60s quiet threshold, a load balancer or monitor could pull a serving worker that is fine for request-serving. Mitigated by measuring the last **completed** tick (a slow-but-finishing sweep resets it every tick) and by a threshold ~12x the 5s default cadence, but this is the change most worth a second opinion.
- Assumptions that could be wrong: (1) that 60s is the right default threshold — chosen from the 5s cadence, not from measured production sweep durations, and a heavily-loaded core01 worker with a genuinely long sweep could flap; (2) that degrading the whole worker is the right response, rather than reporting the producer as unhealthy while leaving `status` green; (3) that `Date.now` as default clock is safe against wall-clock jumps (NTP step) — a monotonic source would be stricter.
- Missing/weak tests: no test drives the composed `server/application/index.ts` late-bound closure end-to-end through a real HTTP `/health` request — the wiring is proven by the done-means driver calling `getSingleWorkerHealth` with the same shape, plus typecheck, not by an HTTP round trip. No test covers two workers disagreeing about producer liveness behind the core01 front.
- Security/permission risk: none identified. No new endpoint, no auth path, no namespace predicate, no SQL. The new health fields are counters and durations — no identifiers, payloads, or error strings, consistent with the module's existing content-free logging.
- Migration/deploy risk: no migration. `/health` gains an optional field; a consumer parsing it strictly would see a new key, and a monitor treating any non-200 as an outage will now react to producer staleness where it previously could not.
- Downstream client/runtime risk: `docs/downstream-rollout.md` checked. No MCP tool, schema, protocol, or Python client surface changes — `/health` is an operational endpoint, not an MCP contract. `SingleWorkerHealth` gains an optional field; `MaintenanceRuntime` gains a method (additive, internal to the server tree). Worker-proxy aggregation across core01's two workers is unchanged and untested here.
- Rollback/cleanup concern: revert is a clean single-commit revert; no state is written anywhere, so nothing needs undoing. Lane worktree and database torn down.
- Fixes made before PR: the check's clause (a) initially called a non-existent `sweep.runOnce()`, which attempted nothing and made the clause measure the harness instead of the subject — it would have passed on the fix while proving nothing. Caught because it stayed FAIL after the fix landed, rewritten to drive the sweep's own `setInterval`, and **RED was re-proven from scratch** against `origin/main` with the corrected driver. This is the lane contract's round-6 pattern ("a clause must clear the ambient state its subject reacts to, or it measures the guard").
- Known residual risk: the 60s default is unvalidated against real core01 sweep durations — the flap risk above is real and unmeasured. The once-per-stall warning means a stall's *duration* must be read from `quiet_ms` on the recovery line or from `/health`, not by counting warnings.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lesson here is operating knowledge for lanes (a done-means clause that measures its own harness), which belongs in `docs/lane-contract.md` Tightenings via the controller's harvest, not in the reviewer-facing SME lanes. Reported in `lessons` for that harvest.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the done-means check is hermetic and deterministic by design — every dependency (pool, queue, clock) is a fake, which is what lets it run in CI and in a fresh worktree and what keeps its verdicts independent of machine speed. #625's own sketch proposed a live-clone watch; that shape is a wall-clock assertion and is forbidden by the lane contract, so the observation was moved to event counts under an injected clock. No core01 involvement (non-goal).

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no MCP tool, schema, or contract surface is touched. `/health` is an operational HTTP endpoint outside the tool-parity contract, and the other changed symbols are internal to the server/src trees.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable, no MCP surface change
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable, no tool schema change
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable, no client-facing contract change
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- Root cause: `src/maintenance-sweep.ts:307` (pre-fix) `if (active) return active;` — the overlap guard with no emitted signal.
- Health gap: `server/transport/health.ts:90` (pre-fix) — status derived from database + NATS only, producer not an input.
- Provenance: found by the #612 lane during PR #624 RED-proof runs, deliberately scoped out there and filed as #625.
- MERGED-state dependencies: #384 (producer exists) and #624 (server logger actually reaches the log files) are both merged; without #624 these new warn lines would be emitted into the same void that made the quiet hard to see.
