### PR TITLE
feat(451): tiered memory-call coverage — capture hard gate, hydration stamp, recall measure

### DIFF
--- a/.claude/hooks/capture-gate.ts
+++ b/.claude/hooks/capture-gate.ts
@@ -1,0 +1,488 @@
+#!/usr/bin/env bun
+/**
+ * capture-gate — repo-local hard gate on `gh pr merge` requiring a SERVER-SIDE
+ * capture receipt for the current session.
+ *
+ * ---------------------------------------------------------------------------
+ * THE RULING THIS IMPLEMENTS
+ * ---------------------------------------------------------------------------
+ * Issue #451 asked where the hard edges of "unskippable memory calls" belong.
+ * Operator ruling 2026-08-08 (ledger item 24, docs/issue-graph.md): TIERED
+ * ALL-THREE. This file is the CAPTURE tier — the only one of the three that is
+ * a hard gate:
+ *
+ *   CAPTURE   HARD GATE at merge. A server-side receipt must exist. (this file)
+ *   HYDRATION VERIFY + STAMP, never a block.  (.claude/hooks/hydration-stamp.ts)
+ *   RECALL    MEASURE into existing telemetry. (apps/hooks/post_tool_use.py)
+ *
+ * It is deliberately the same SHAPE as `.claude/hooks/merge-gate.ts` and shares
+ * its parser: the enforce layer holds no judgment, it compares values a service
+ * returned. A gate that reasons can be reasoned with, and the session that
+ * wants to merge is the one least suited to judging whether it may.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE RECEIPT MUST COME FROM THE SERVER
+ * ---------------------------------------------------------------------------
+ * Operator ruling, verbatim: "server receipt is the proof; local state only a
+ * cache — a local file is forgeable." A gate satisfied by writing a local file
+ * is a gate the gated party can satisfy by writing a file, which is not a gate.
+ * So the receipt is read with a `session_context` query against the live
+ * service (server/tools/session-lifecycle.ts:109-183), scoped by the bearer
+ * token, and nothing on local disk can substitute for it.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY IT DRAINS FIRST, AND WHY AN OUTAGE PASSES
+ * ---------------------------------------------------------------------------
+ * This is the operator's own refinement, and it is what makes the gate safe to
+ * turn on. Capture ALREADY spools durably: during an outage the turn is
+ * captured to disk and replayed when the service returns
+ * (openbrain_memory/_runtime_spool.py, runtime.py:1018 `_drain_spool`,
+ * apps/capture/outage.py). A session in an outage did nothing wrong, and its
+ * memory is not lost — it is merely undelivered.
+ *
+ * So a missing receipt is not yet a verdict. The gate:
+ *
+ *   1. asks the server for a receipt        -> found?  PASS clean
+ *   2. not found: attempts a spool DRAIN    -> delivered? re-ask; PASS clean
+ *   3. service unreachable                  -> PASS **with a loud stamp**
+ *   4. service up, drain produced nothing   -> REFUSE, naming the reason
+ *
+ * Only (4) is a skip, and only (4) blocks. (3) is what keeps (4) honest: a gate
+ * that could not tell an outage from a skip would have to choose between
+ * bricking every outage and never firing at all — and a gate that fires on
+ * innocence teaches agents to route around it, which is this repo's standing
+ * scar (#618, the guard that matched heredoc text and taxed every lane).
+ *
+ * The stamp is not a consolation prize. It is the record that keeps SKIP and
+ * OUTAGE distinguishable permanently, so the operator reading the PR later can
+ * see which one happened rather than inferring it from silence.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IT DOES NOT DO
+ * ---------------------------------------------------------------------------
+ * It does not touch the global ~/.claude lifecycle hooks, and it changes no
+ * fail-open contract. The lifecycle hooks (session_start.py:41-43,
+ * stop.py:16-19, session_end.py:23-27, post_tool_use.py:38-41) all promise
+ * "ALWAYS EXIT 0 ... a hook that observes a session must never block or break
+ * one", and that promise is untouched here: this gate governs a MERGE, an
+ * action the agent chose, not a session boundary. A session that cannot start
+ * is bricked; a merge that refuses until a receipt exists is recoverable. That
+ * distinction is the whole reason the ruling put the hard edge here.
+ *
+ * MECHANISM
+ *
+ *   PreToolUse on Bash — parse the command; if it is `gh pr merge <n>`, resolve
+ *   the receipt as above. Exit 2 blocks and hands stderr back to the model as
+ *   the reason. Exit 0 allows.
+ */
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  parseSimpleCommands,
+  matchGhCommand,
+  firstPositional,
+} from "./lib/shell-command-parse.ts";
+
+type HookInput = {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+};
+
+const HOOK_NAME = "capture-gate";
+
+/** Flags of `gh pr merge` that take a SEPARATE value, so their value is never
+ *  mistaken for the PR number. Mirrors merge-gate.ts. */
+const MERGE_FLAGS_WITH_VALUES = new Set([
+  "--body",
+  "-b",
+  "--body-file",
+  "-F",
+  "--subject",
+  "-t",
+  "--match-head-commit",
+  "--author-email",
+  "-A",
+  "--repo",
+  "-R",
+]);
+
+/**
+ * Read the hook payload with a NON-BLOCKING read.
+ *
+ * `readFileSync(0)` returns whatever is buffered rather than waiting for the
+ * writer to close, which is what `await Bun.stdin.text()` does. That await
+ * wedged a session in this repo on 2026-07-28; see design-lookup-gate.ts
+ * readInput() for the full account. Do not "modernise" this into an await.
+ */
+function readInput(): HookInput {
+  try {
+    const text = readFileSync(0, "utf8");
+    return text.trim() ? (JSON.parse(text) as HookInput) : {};
+  } catch {
+    return {};
+  }
+}
+
+function refuse(lines: string[]): never {
+  console.error(lines.join("\n"));
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const input = readInput();
+
+if ((input.tool_name ?? "") !== "Bash") process.exit(0);
+
+const rawCommand =
+  typeof input.tool_input?.command === "string" ? input.tool_input.command : "";
+if (!rawCommand.trim()) process.exit(0);
+
+let prNumber: string | null = null;
+for (const command of parseSimpleCommands(rawCommand)) {
+  const matched = matchGhCommand(command, "pr", ["merge"]);
+  if (!matched) continue;
+  const positional = firstPositional(matched.rest, MERGE_FLAGS_WITH_VALUES);
+  // The bare form is merge-gate.ts's business to refuse; refusing it twice
+  // would give the model two different reasons for one problem. This gate only
+  // evaluates a merge it can name a PR for.
+  if (!positional) continue;
+  if (!/^\d+$/.test(positional)) continue;
+  prNumber = positional;
+  break;
+}
+
+// Not a `gh pr merge <n>`: allow untouched. This includes every string literal
+// and heredoc body that merely CONTAINS the phrase (#618) — the parser, not a
+// substring match, is what makes that true.
+if (!prNumber) process.exit(0);
+
+const sessionId = (input.session_id ?? "").trim();
+if (!sessionId) {
+  refuse([
+    `BLOCKED by ${HOOK_NAME}: the hook payload carries no session_id.`,
+    "",
+    "A capture receipt is per-session, so without a session id there is nothing",
+    "to look up. Refusing rather than guessing, and rather than silently",
+    "allowing (AGENTS.md, no silent adjustments) — an unreadable payload must",
+    "not be the way enforcement turns itself off.",
+  ]);
+}
+
+const baseUrl = (process.env.OPENBRAIN_BASE_URL ?? "").trim().replace(/\/+$/, "");
+const token = (process.env.OPENBRAIN_TOKEN ?? "").trim();
+
+if (!baseUrl || !token) {
+  const missing = [
+    !baseUrl ? "OPENBRAIN_BASE_URL" : null,
+    !token ? "OPENBRAIN_TOKEN" : null,
+  ].filter(Boolean).join(", ");
+  refuse([
+    `BLOCKED by ${HOOK_NAME}: no Open Brain coordinates (${missing} unset).`,
+    "",
+    "This is UNCONFIGURED, which is not the same as an outage and is not",
+    "treated like one: an outage is a service that should answer and does not,",
+    "while this is a gate that was never pointed at a service. Passing here",
+    "would mean the gate silently does nothing on any machine that forgot to",
+    "set the variables — enforcement that evaporates exactly where it is",
+    "needed.",
+    "",
+    "Satisfy it by sourcing the provider env, e.g.:",
+    "",
+    "    set -a; . ~/.local/share/openbrain-memory/env/claudex-observation.env; set +a",
+  ]);
+}
+
+/**
+ * Outcome of one attempt to read a receipt from the SERVER.
+ *
+ * `reachable` is the field the whole tier turns on: it separates "the service
+ * said there is no receipt" (a skip) from "the service did not say anything"
+ * (an outage). Collapsing those two into a single boolean is precisely the
+ * mistake the drain-first design exists to prevent.
+ */
+type ReceiptLookup = {
+  reachable: boolean;
+  receiptCount: number;
+  detail: string;
+};
+
+/**
+ * Ask the live service whether this session has any captured events.
+ *
+ * Uses `session_context` (server/tools/session-lifecycle.ts:109) because it is
+ * the read-only, namespace-scoped view of a session's events; the namespace is
+ * derived from the bearer token server-side, so this gate cannot widen its own
+ * scope by asking nicely.
+ */
+function lookupReceipt(): ReceiptLookup {
+  const response = spawnSync(
+    "curl",
+    [
+      "-sS",
+      "--max-time",
+      "10",
+      "-H",
+      `Authorization: Bearer ${token}`,
+      "-H",
+      "Content-Type: application/json",
+      "-X",
+      "POST",
+      "--data-binary",
+      JSON.stringify({
+        tool: "session_context",
+        arguments: { session_key: sessionId, include_events: true, event_limit: 1 },
+      }),
+      `${baseUrl}/tools/session_context`,
+    ],
+    { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  );
+
+  if (response.error || response.status !== 0) {
+    return {
+      reachable: false,
+      receiptCount: 0,
+      detail: response.error
+        ? response.error.message
+        : `curl exited ${response.status}: ${String(response.stderr ?? "").trim()}`,
+    };
+  }
+
+  const raw = String(response.stdout ?? "");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Reachable but unintelligible. This is NOT an outage — something answered
+    // — so it must not take the outage path and earn a free pass.
+    return {
+      reachable: true,
+      receiptCount: 0,
+      detail: `service answered with non-JSON (${raw.slice(0, 120)})`,
+    };
+  }
+
+  const count = countEvents(parsed);
+  return {
+    reachable: true,
+    receiptCount: count,
+    detail: count > 0 ? `${count} captured event(s) for this session` : "0 captured events",
+  };
+}
+
+/**
+ * Count the session's events out of a `session_context` reply.
+ *
+ * The reply may arrive either as the tool's own JSON or wrapped in an MCP
+ * text-content envelope, so both are read. Anything unrecognised counts ZERO
+ * rather than throwing: a shape this cannot read is a missing receipt, never an
+ * accidental pass.
+ */
+function countEvents(payload: unknown): number {
+  const direct = readEventCount(payload);
+  if (direct !== null) return direct;
+
+  // MCP envelope: { content: [{ type: "text", text: "<json>" }] }
+  if (payload && typeof payload === "object" && "content" in payload) {
+    const content = (payload as { content?: unknown }).content;
+    if (Array.isArray(content)) {
+      for (const item of content) {
+        if (!item || typeof item !== "object") continue;
+        const text = (item as { text?: unknown }).text;
+        if (typeof text !== "string") continue;
+        try {
+          const inner = readEventCount(JSON.parse(text));
+          if (inner !== null) return inner;
+        } catch {
+          continue;
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+function readEventCount(value: unknown): number | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as { events?: unknown; event_count?: unknown };
+  if (Array.isArray(record.events)) return record.events.length;
+  if (typeof record.event_count === "number") return record.event_count;
+  return null;
+}
+
+/**
+ * Attempt a spool drain, reusing the runtime's own replay path.
+ *
+ * NEVER a reimplementation. `drain_spool_now` (runtime.py:573) is documented as
+ * reusing `_drain_spool` unchanged so that exact-scope replay, quarantine
+ * semantics, and namespace provenance stay identical to the automatic path — a
+ * second drain implementation here would be a second set of those invariants to
+ * keep in sync, and they would diverge.
+ *
+ * Returns true only when the drain reports having delivered something. A drain
+ * that cannot run at all is not an error here: the receipt re-check is what
+ * decides, and a failed drain simply leaves the receipt absent.
+ */
+function attemptDrain(): { ran: boolean; detail: string } {
+  const result = spawnSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import json,sys",
+        "try:",
+        "    from openbrain_memory.runtime import FirstClassMemoryRuntime",
+        "except Exception as exc:",
+        "    print(json.dumps({'ran': False, 'detail': f'runtime unavailable: {exc}'}))",
+        "    sys.exit(0)",
+        "try:",
+        "    runtime = FirstClassMemoryRuntime()",
+        "    report = runtime.drain_spool_now()",
+        "except Exception as exc:",
+        "    print(json.dumps({'ran': False, 'detail': f'drain failed: {exc}'}))",
+        "    sys.exit(0)",
+        "if report is None:",
+        "    print(json.dumps({'ran': True, 'detail': 'nothing pending in the spool'}))",
+        "else:",
+        "    print(json.dumps({'ran': True, 'detail': f'drain report: {report!r}'[:300]}))",
+      ].join("\n"),
+    ],
+    { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 },
+  );
+
+  if (result.error || result.status !== 0) {
+    return {
+      ran: false,
+      detail: result.error ? result.error.message : `python3 exited ${result.status}`,
+    };
+  }
+  try {
+    const parsed = JSON.parse(String(result.stdout ?? "").trim()) as {
+      ran?: boolean;
+      detail?: string;
+    };
+    return { ran: Boolean(parsed.ran), detail: String(parsed.detail ?? "") };
+  } catch {
+    return { ran: false, detail: "drain produced unreadable output" };
+  }
+}
+
+/**
+ * Post the outage stamp so the degradation is visible AFTER the fact.
+ *
+ * Best-effort by design: if the stamp cannot be posted the merge still
+ * proceeds, because the outage path's contract is "never block". The stamp is
+ * also written to stdout, so the transcript carries it even when `gh` fails —
+ * a stamp that exists only on GitHub would vanish exactly when GitHub is the
+ * thing that is unreachable.
+ */
+function stampOutage(pr: string, session: string, detail: string): void {
+  const message = [
+    `⚠️ CAPTURE OUTAGE — merged without a server-side capture receipt.`,
+    "",
+    `  session: ${session}`,
+    `  reason:  Open Brain was unreachable when this merge was gated`,
+    `  detail:  ${detail}`,
+    "",
+    "This is a PASS, recorded loudly rather than absorbed silently. Capture",
+    "spools durably (openbrain_memory/_runtime_spool.py), so this session's",
+    "memory is written to disk and replays when the service returns — it is",
+    "undelivered, not lost.",
+    "",
+    "It is stamped so an outage stays distinguishable from a SKIP forever.",
+    `Gate: ${HOOK_NAME} (issue #451, ledger item 24).`,
+  ].join("\n");
+
+  console.log(message);
+
+  const posted = spawnSync("gh", ["pr", "comment", pr, "--body", message], {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  if (posted.error || posted.status !== 0) {
+    console.log(
+      `${HOOK_NAME}: could not post the outage stamp to PR #${pr} ` +
+        `(${posted.error ? posted.error.message : `gh exited ${posted.status}`}); ` +
+        `the stamp above is still in the transcript.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolve: receipt -> drain -> receipt -> (outage | skip)
+// ---------------------------------------------------------------------------
+const first = lookupReceipt();
+
+if (first.reachable && first.receiptCount > 0) {
+  console.log(
+    [
+      `${HOOK_NAME}: PR #${prNumber} may merge.`,
+      `  capture receipt: ${first.detail} (session ${sessionId})`,
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+if (!first.reachable) {
+  // OUTAGE PATH — pass, loudly. Never a block.
+  stampOutage(prNumber, sessionId, first.detail);
+  process.exit(0);
+}
+
+// Service is UP and says there is no receipt. Before calling that a skip, drain
+// the spool: an undelivered capture is not an absent one.
+const drain = attemptDrain();
+const second = lookupReceipt();
+
+if (second.reachable && second.receiptCount > 0) {
+  console.log(
+    [
+      `${HOOK_NAME}: PR #${prNumber} may merge.`,
+      `  capture receipt appeared after a spool drain: ${second.detail}`,
+      `  drain: ${drain.detail}`,
+      `  (session ${sessionId})`,
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+if (!second.reachable) {
+  // The service went away between the two reads. Treat as an outage, which is
+  // what it is — the drain-first design's job is to never call an outage a skip.
+  stampOutage(prNumber, sessionId, second.detail);
+  process.exit(0);
+}
+
+// SKIP — the only blocking path. The service answered, twice, and a drain
+// produced nothing to deliver.
+refuse([
+  `BLOCKED by ${HOOK_NAME}: no capture receipt for this session.`,
+  "",
+  `  session:      ${sessionId}`,
+  `  service:      ${baseUrl} — REACHABLE (this is not an outage)`,
+  `  receipt:      ${second.detail}`,
+  `  spool drain:  ${drain.detail}`,
+  "",
+  "The capture tier of issue #451 is a HARD GATE (operator ruling 2026-08-08,",
+  "ledger item 24): a merge requires a SERVER-SIDE capture receipt for the",
+  "session doing the merging. The server receipt is the proof; local state is",
+  "only a cache, because a local file is forgeable.",
+  "",
+  "This is a SKIP, not an outage, and the difference is why this refuses. The",
+  "service answered — twice — and a spool drain found nothing undelivered. An",
+  "outage would have passed here with a visible stamp; nothing was captured at",
+  "all.",
+  "",
+  "Satisfy it by capturing this session's durable learning before merging —",
+  "the distilled in-flight event the work actually produced:",
+  "",
+  "    openbrain-memory --event capture",
+  "",
+  "then re-run the merge. A capture that reaches the spool but not the service",
+  "also satisfies this gate once the drain delivers it.",
+]);

--- a/.claude/hooks/hydration-stamp.ts
+++ b/.claude/hooks/hydration-stamp.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+/**
+ * hydration-stamp — repo-local SessionStart check that the canon pack ARRIVED.
+ *
+ * ---------------------------------------------------------------------------
+ * THE RULING THIS IMPLEMENTS, AND WHY IT IS NOT A GATE
+ * ---------------------------------------------------------------------------
+ * Issue #451, operator ruling 2026-08-08 (ledger item 24): the HYDRATION tier
+ * is **VERIFY + STAMP**, never a block. Verbatim: "session start checks the
+ * canon pack arrived with sections > 0; absence lands a loud visible marker on
+ * the session and its PRs, never a block (a hydration block can only fire on
+ * outages)."
+ *
+ * That parenthesis is the entire argument, and it is worth keeping in front of
+ * whoever next wants to "strengthen" this file. A session cannot skip its own
+ * hydration: it does not choose to hydrate, the SessionStart hook does it
+ * automatically. So the ONLY state in which a hydration gate could ever fire is
+ * one where the service failed to answer — an outage, i.e. the one case where
+ * the session is blameless. A block here would therefore be a pure false-block
+ * generator, and false blocks are how agents learn to route around guards
+ * (#618, the guard that fired on heredoc text and taxed every lane until it was
+ * fixed).
+ *
+ * Contrast with `.claude/hooks/capture-gate.ts`, which IS a hard gate: capture
+ * is an action the agent takes or omits, so a missing capture receipt can mean
+ * a skip. Hydration has no skip state. Same issue, different enforcement
+ * strength, and the difference is not an inconsistency — it is the ruling.
+ *
+ * ---------------------------------------------------------------------------
+ * ALWAYS EXIT 0
+ * ---------------------------------------------------------------------------
+ * This preserves, rather than changes, the fail-open contract every lifecycle
+ * hook in this repo carries — session_start.py:41-43 ("FAIL OPEN. A hook that
+ * opens a session must never block or break one"), and the same clause in
+ * stop.py, session_end.py, and post_tool_use.py. Nothing here may exit non-zero
+ * for any reason, including its own internal failure. A hook that breaks
+ * sessions while reporting on session health is worse than no hook.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE MARKER MUST NOT ALWAYS FIRE
+ * ---------------------------------------------------------------------------
+ * A marker printed on every session is decoration: it carries no information,
+ * so it is filtered out by eye within a day and the absence it was meant to
+ * surface becomes invisible again. The healthy path here is therefore SILENT,
+ * and `scripts/done-means/451-tiered-coverage.sh` clause D2 is the standing
+ * control that keeps it silent — it fails if a healthy pack produces a marker.
+ *
+ * MECHANISM
+ *
+ *   SessionStart — read the canon pack the session-start hydration produced and
+ *   count its non-empty sections. Zero sections (or no pack at all) prints a
+ *   loud marker naming the session. Always exits 0.
+ */
+
+import { readFileSync } from "node:fs";
+
+type HookInput = {
+  session_id?: string;
+  hook_event_name?: string;
+  source?: string;
+};
+
+const HOOK_NAME = "hydration-stamp";
+
+/**
+ * Read the hook payload with a NON-BLOCKING read. Same rationale as every other
+ * hook here: `await Bun.stdin.text()` wedged a session on 2026-07-28.
+ */
+function readInput(): HookInput {
+  try {
+    const text = readFileSync(0, "utf8");
+    return text.trim() ? (JSON.parse(text) as HookInput) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * The canon pack this session start produced, or null when none is observable.
+ *
+ * The pack is handed in through `DM451_CANON_PACK` — an explicit input rather
+ * than a reach into the global hydration hook's internals. That is deliberate:
+ * the non-goals of #451 forbid touching the global ~/.claude lifecycle hooks,
+ * and reading their private state would couple this repo-local check to them
+ * just as tightly as editing them.
+ */
+function readPack(): unknown | null {
+  const raw = (process.env.DM451_CANON_PACK ?? "").trim();
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count the non-empty sections of a canon pack.
+ *
+ * The pack's schema is `openbrain.agent_context_pack.v1`: `scope`, `sections`,
+ * `warnings` (apps/hooks/session.py:918-936). "Arrived" means sections > 0 —
+ * a pack whose sections object exists but is empty is exactly the measured
+ * failure `_plans/canon-always-known.md:23-27` recorded (three lanes at 0
+ * items), and it must count as ABSENT rather than present-but-empty. An empty
+ * pack that reported healthy is the specific silence this tier exists to end.
+ */
+function countSections(pack: unknown): number {
+  if (!pack || typeof pack !== "object") return 0;
+  const sections = (pack as { sections?: unknown }).sections;
+  if (!sections || typeof sections !== "object") return 0;
+  let populated = 0;
+  for (const value of Object.values(sections as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) populated += 1;
+    } else if (value !== null && value !== undefined && value !== "") {
+      populated += 1;
+    }
+  }
+  return populated;
+}
+
+// ---------------------------------------------------------------------------
+// Main. Every path exits 0.
+// ---------------------------------------------------------------------------
+const input = readInput();
+const sessionId = (input.session_id ?? "").trim() || "(unknown session)";
+const pack = readPack();
+const sections = countSections(pack);
+
+if (sections > 0) {
+  // HEALTHY — say nothing. See "why the marker must not always fire".
+  process.exit(0);
+}
+
+const reason =
+  pack === null
+    ? "no canon pack was observable for this session"
+    : "the canon pack arrived with ZERO populated sections";
+
+console.error(
+  [
+    "⚠️ HYDRATION MARKER — this session started WITHOUT canon.",
+    "",
+    `  session: ${sessionId}`,
+    `  reason:  ${reason}`,
+    "",
+    "Canon is who Rico is, the rules, and this repo's facts — the context that",
+    "is meant to load automatically. A session missing it will confidently",
+    "re-derive things it was supposed to already know, and the expensive part",
+    "is that it looks exactly like a session that did know them.",
+    "",
+    "This is a MARKER, not a block: the session continues normally (operator",
+    "ruling 2026-08-08, ledger item 24 — a hydration block could only ever fire",
+    "during an outage, punishing a session that skipped nothing).",
+    "",
+    "Recover the context explicitly before relying on canon:",
+    "",
+    "    python3 _ob/skills/brain/scripts/resume.py",
+    "",
+    `Marker: ${HOOK_NAME} (issue #451).`,
+  ].join("\n"),
+);
+
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,23 @@
             "type": "command",
             "command": "bun run \"$CLAUDE_PROJECT_DIR/.claude/hooks/merge-gate.ts\" --event pre-tool-use",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "bun run \"$CLAUDE_PROJECT_DIR/.claude/hooks/capture-gate.ts\" --event pre-tool-use",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run \"$CLAUDE_PROJECT_DIR/.claude/hooks/hydration-stamp.ts\" --event session-start",
+            "timeout": 10
           }
         ]
       }

--- a/python/openbrain/src/openbrain/apps/hooks/post_tool_use.py
+++ b/python/openbrain/src/openbrain/apps/hooks/post_tool_use.py
@@ -1,17 +1,28 @@
-"""The ``PostToolUse`` hook entrypoint: count skill invocations.
+"""The ``PostToolUse`` hook entrypoint: count skill and recall invocations.
 
 Purpose:
     Fires after a tool runs, carrying ``tool_name``, ``tool_input``,
     ``tool_response``, ``tool_use_id``, and ``duration_ms``. It reads that
-    payload and, for ``Skill`` calls only, records ONE usage metric -- which
-    skill, which agent, which repo, which session -- through the server's
-    ``record_skill_usage`` tool (issue #469).
+    payload and, for ``Skill`` calls and Open Brain RECALL reads only, records
+    ONE usage metric -- which slug, which agent, which repo, which session --
+    through the server's ``record_skill_usage`` tool (issues #469 and #451).
 
     METRICS ONLY, and the operator's ruling is why: "no automatic retirement.
     What I need is something that gives me metrics so that decisions can be made
     on facts and not on feel." This counts invocations. It does not categorize,
     recommend, rotate, shelve, or retire anything, and the server tool it calls
     cannot either.
+
+    RECALL IS THE SAME RULE, DELIBERATELY. #451's operator ruling (2026-08-08,
+    ledger item 24) made recall the MEASURE tier of a three-tier design whose
+    other two tiers DO enforce: capture is a hard gate at merge
+    (``.claude/hooks/capture-gate.ts``) and hydration stamps
+    (``.claude/hooks/hydration-stamp.ts``). Recall was ruled measure-only
+    because "recall before re-deriving" is unfalsifiable -- no gate can tell
+    that canon already answered a question the agent chose to ask again -- so a
+    recall ENFORCEMENT would fire on guesses. Counting is what an unfalsifiable
+    property supports: the operator reads the trend and rules on it. Anything
+    here that grows a recommendation has changed tiers without a ruling.
 
 Non-goals:
     THE OPEN QUESTION STAYS OPEN. Tool input and output are the ~96% of

--- a/python/openbrain/src/openbrain/apps/hooks/session.py
+++ b/python/openbrain/src/openbrain/apps/hooks/session.py
@@ -91,6 +91,29 @@ from openbrain.models.turn import RawTurn, TurnRole
 #: (``tests/fixtures/captured_hooks/README.md``).
 COMPACT_SESSION_SOURCE = "compact"
 
+#: The Open Brain reads that count as a RECALL for the #451 measure tier.
+#:
+#: A fixed allowlist of tool NAMES, not a pattern. The tier's product is a trend
+#: the operator reads, and a heuristic denominator that silently widens or
+#: narrows as unrelated tools are renamed would move that trend without saying
+#: so -- a number that changes for reasons outside the thing it measures is
+#: worse than no number.
+#:
+#: These are the four ways a session asks Open Brain what it already knows:
+#: ``brain_answer`` (the question interface), ``agent_context_pack`` (canon
+#: hydration), ``session_context`` (lane history), and ``search_all`` (the
+#: cross-corpus search). Writes are deliberately absent -- capture is the
+#: separate tier with its own enforcement, and counting a write as a recall
+#: would make the trend unreadable.
+RECALL_TOOL_NAMES = frozenset(
+    {
+        "brain_answer",
+        "agent_context_pack",
+        "session_context",
+        "search_all",
+    }
+)
+
 #: The Stop harness deadline, in seconds. NOT a content bound -- this is a TIME
 #: budget tied to an EXTERNAL limit: Claude Code kills a Stop hook that has not
 #: exited within 5 seconds, and a killed process cannot honour the exit-0
@@ -380,6 +403,43 @@ class PostToolUseHook(BaseModel):
             return None
         slug = raw.strip()
         return slug or None
+
+    def recall_slug(self) -> str | None:
+        """Return the recall tool's name, or ``None`` when this is not a recall call.
+
+        Returns:
+            The canonical recall tool name (e.g. ``brain_answer``) when this
+            payload is one of the Open Brain reads in :data:`RECALL_TOOL_NAMES`;
+            ``None`` for every other tool.
+
+        The RECALL tier of #451 (operator ruling 2026-08-08, ledger item 24) is
+        **MEASURE ONLY**: "counts into existing telemetry, facts only; the
+        operator reads the trend." This is the filter that decides what counts
+        as a recall, and it is deliberately a fixed allowlist of tool NAMES
+        rather than a pattern: a heuristic would silently start or stop counting
+        as unrelated tools are renamed, and a trend line whose denominator moves
+        without saying so is worse than no trend line.
+
+        ``tool_input`` IS NOT READ. The tool's name is the whole metric; the
+        arguments are a recall QUERY, which is content, and content is the open
+        memory-versus-observability question
+        (``docs/decisions/capture-never-drops-a-turn.md``) that counting must
+        not resolve by accident. Recall queries are also the most sensitive
+        thing an agent sends -- the questions it asks about the operator -- so
+        the name-only rule is a privacy boundary here, not only a scope one.
+
+        MCP tool names arrive namespaced (``mcp__open-brain__brain_answer``), so
+        the trailing segment is compared rather than the whole string.
+        """
+        if self.tool_name is None:
+            return None
+        name = self.tool_name.strip()
+        if not name:
+            return None
+        # MCP namespacing: `mcp__<server>__<tool>`. The bare name is also
+        # accepted so a non-MCP runtime calling the same tool still counts.
+        leaf = name.rsplit("__", 1)[-1]
+        return leaf if leaf in RECALL_TOOL_NAMES else None
 
     def repo(self) -> str | None:
         """Return the repository name derived from ``cwd``.
@@ -715,7 +775,7 @@ async def run_post_tool_use(
     *,
     recorder: Callable[[CaptureSettings, str, dict[str, Any]], None] | None = None,
 ) -> bool:
-    """Record one skill invocation from a ``PostToolUse`` payload as a usage metric.
+    """Record one skill or recall invocation from a ``PostToolUse`` payload.
 
     Args:
         payload: The parsed ``PostToolUse`` hook fields.
@@ -725,21 +785,36 @@ async def run_post_tool_use(
             ``openbrain_memory`` client calling ``record_skill_usage``.
 
     Returns:
-        ``True`` when a metric was sent, ``False`` when the payload was not a
-        Skill invocation or carried no session -- there is nothing to count then.
+        ``True`` when a metric was sent, ``False`` when the payload was neither a
+        Skill nor a recall invocation, or carried no session -- there is nothing
+        to count then.
 
-    METRICS ONLY (#469). What goes over the wire is the skill slug, the agent,
-    the repo, the session, and the runtime -- who invoked what, where, and how
-    often. NOT ``tool_input`` beyond the skill name, and NOT ``tool_response`` at
-    all: that content stream is the open memory-versus-observability question in
+    METRICS ONLY (#469, and the same rule governs the #451 recall tier). What
+    goes over the wire is the slug, the agent, the repo, the session, and the
+    runtime -- who invoked what, where, and how often. NOT ``tool_input`` beyond
+    the skill name, and NOT ``tool_response`` at all: that content stream is the
+    open memory-versus-observability question in
     ``docs/decisions/capture-never-drops-a-turn.md``, and counting invocations
     does not require answering it. :class:`PostToolUseHook` drops those fields at
     the parse boundary so they cannot reach this function to be sent by mistake.
 
+    TWO KINDS, ONE PATH. A ``Skill`` call counts as ``usage_kind="skill"``
+    (#469); an Open Brain read in :data:`RECALL_TOOL_NAMES` counts as
+    ``usage_kind="canon"`` -- the RECALL tier of #451 (operator ruling
+    2026-08-08, ledger item 24: "counts into existing telemetry, facts only").
+    Recall reuses the EXISTING ``canon`` kind rather than adding a third: the
+    value is pinned by a Zod enum (``server/tools/skill-usage.ts:119-122``) AND
+    a database CHECK constraint (``src/db/migrations/046_skill_usage_log.sql``),
+    so a new kind would be a schema change -- an explicit non-goal of #451.
+    ``canon`` is also honest rather than merely convenient: every tool in the
+    allowlist is a read of assembled canon, which is what that kind already
+    names. The recall trend is therefore read as ``usage_kind='canon'`` filtered
+    to those slugs.
+
     ``PostToolUse`` fires on EVERY tool call, so the filter matters more here
-    than in the other capabilities: everything that is not a ``Skill`` call
-    returns ``False`` before any client is built, which means the common case
-    costs one dict lookup and no network at all.
+    than in the other capabilities: everything that is neither a ``Skill`` call
+    nor a recall returns ``False`` before any client is built, which means the
+    common case costs two dict lookups and no network at all.
 
     Namespace stays token-derived server-side; nothing here sets one.
 
@@ -748,12 +823,17 @@ async def run_post_tool_use(
         metric must never break the session it observes.
     """
     slug = payload.skill_slug()
+    usage_kind = "skill"
+    if slug is None:
+        # Not a Skill call. It may still be a recall, which is the #451 tier.
+        slug = payload.recall_slug()
+        usage_kind = "canon"
     if slug is None or payload.session_id is None:
         return False
 
     arguments: dict[str, Any] = {
         "skill_slug": slug,
-        "usage_kind": "skill",
+        "usage_kind": usage_kind,
         "session_id": payload.session_id,
         "runtime": "claude-code",
         # `agent_id` is a required non-empty field on CaptureSettings, so this

--- a/python/openbrain/tests/test_capture_hooks.py
+++ b/python/openbrain/tests/test_capture_hooks.py
@@ -782,6 +782,121 @@ class TestPostToolUseRecordsOneUsageMetric:
         assert "repo" not in sent[0]
 
 
+class TestPostToolUseCountsRecallInvocations:
+    """The #451 RECALL tier: counts into the existing telemetry lane, facts only.
+
+    Operator ruling 2026-08-08 (ledger item 24): recall is MEASURE, not enforce.
+    These tests pin the count, the kind, and -- most importantly -- that the
+    recall QUERY never travels with it.
+    """
+
+    async def test_a_recall_call_is_counted_as_canon_usage(
+        self, tmp_path: Path
+    ) -> None:
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        sent: list[dict[str, object]] = []
+        payload = PostToolUseHook(
+            tool_name="mcp__open-brain__brain_answer",
+            tool_input={"question": "what did we decide about storage"},
+            session_id="sess-1",
+            cwd="/Volumes/ThunderBolt/Development/open-brain",
+        )
+
+        recorded = await run_post_tool_use(
+            payload, settings, recorder=lambda _s, _k, a: sent.append(a)
+        )
+
+        assert recorded is True
+        assert len(sent) == 1
+        assert sent[0]["skill_slug"] == "brain_answer"
+        # `canon`, not a new kind: the value is pinned by a Zod enum AND a DB
+        # CHECK constraint, and widening either would be a schema change (an
+        # explicit non-goal of #451).
+        assert sent[0]["usage_kind"] == "canon"
+        assert sent[0]["session_id"] == "sess-1"
+        assert sent[0]["repo"] == "open-brain"
+
+    async def test_a_bare_unnamespaced_recall_tool_still_counts(
+        self, tmp_path: Path
+    ) -> None:
+        """A non-MCP runtime calling the same tool must not fall out of the trend."""
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        sent: list[dict[str, object]] = []
+        payload = PostToolUseHook(
+            tool_name="search_all", tool_input={"query": "x"}, session_id="sess-1"
+        )
+
+        recorded = await run_post_tool_use(
+            payload, settings, recorder=lambda _s, _k, a: sent.append(a)
+        )
+
+        assert recorded is True
+        assert sent[0]["skill_slug"] == "search_all"
+
+    async def test_the_recall_query_is_never_sent(self, tmp_path: Path) -> None:
+        """The tool NAME is the metric; the question is content and stays home.
+
+        A recall query is the most sensitive thing a session sends -- the
+        questions it asks about the operator -- so this is a privacy boundary,
+        not only a scope one. An edit that widened the payload fails here.
+        """
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        sent: list[dict[str, object]] = []
+        payload = PostToolUseHook(
+            tool_name="mcp__open-brain__brain_answer",
+            tool_input={"question": "SECRET-RECALL-QUESTION"},
+            session_id="sess-1",
+        )
+
+        await run_post_tool_use(
+            payload, settings, recorder=lambda _s, _k, a: sent.append(a)
+        )
+
+        assert "SECRET-RECALL-QUESTION" not in json.dumps(sent[0])
+        assert set(sent[0]) <= {
+            "skill_slug",
+            "usage_kind",
+            "session_id",
+            "runtime",
+            "agent",
+            "repo",
+        }
+
+    async def test_a_write_tool_is_not_counted_as_a_recall(
+        self, tmp_path: Path
+    ) -> None:
+        """Capture is a separate tier; counting a write would make the trend unreadable."""
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        sent: list[dict[str, object]] = []
+        payload = PostToolUseHook(
+            tool_name="mcp__open-brain__append_session_event",
+            tool_input={"content": "x"},
+            session_id="sess-1",
+        )
+
+        recorded = await run_post_tool_use(
+            payload, settings, recorder=lambda _s, _k, a: sent.append(a)
+        )
+
+        assert recorded is False
+        assert sent == []
+
+    async def test_an_unrelated_tool_is_still_a_no_op(self, tmp_path: Path) -> None:
+        """The common case stays free: neither a Skill nor a recall sends nothing."""
+        settings = capture_settings(tmp_path / "wm.sqlite")
+        sent: list[dict[str, object]] = []
+        payload = PostToolUseHook(
+            tool_name="Bash", tool_input={"command": "echo hello"}, session_id="s"
+        )
+
+        recorded = await run_post_tool_use(
+            payload, settings, recorder=lambda _s, _k, a: sent.append(a)
+        )
+
+        assert recorded is False
+        assert sent == []
+
+
 class TestPostToolUseEntrypointNeverDisruptsTheSession:
     """record_skill_usage swallows everything and exits 0 with empty stdout."""
 

--- a/scripts/done-means/451-tiered-coverage.sh
+++ b/scripts/done-means/451-tiered-coverage.sh
@@ -1,0 +1,484 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #451 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/451-tiered-coverage.sh
+#
+# ---------------------------------------------------------------------------
+# What this gates: the operator's TIERED ruling (2026-08-08, ledger item 24)
+# ---------------------------------------------------------------------------
+# #451 asks where the hard edges of "unskippable memory calls" go. The lane
+# before this one STOPPED at a design delta rather than guess, because every
+# candidate gate contradicted a live fail-open contract. The operator ruled
+# THREE TIERS, each with a DIFFERENT enforcement strength, and the whole point
+# of this check is that the three strengths stay distinguishable:
+#
+#   CAPTURE   HARD GATE at merge. A server-side receipt for the session must
+#             exist. Server receipt is the proof; a local file is forgeable, so
+#             local state is only ever a cache.
+#   HYDRATION VERIFY + STAMP. Session start checks the canon pack arrived with
+#             sections > 0; absence lands a loud visible marker. NEVER a block —
+#             a hydration block can only fire during an outage, which makes it a
+#             pure false-block generator.
+#   RECALL    MEASURE ONLY into the existing telemetry lane. Facts, no
+#             recommendations (the #469 operator ruling this repo already
+#             carries: "metrics so that decisions can be made on facts and not
+#             on feel").
+#
+# ---------------------------------------------------------------------------
+# The clause that matters most: SKIP and OUTAGE must never look alike
+# ---------------------------------------------------------------------------
+# The naive capture gate — "no receipt, refuse" — is WRONG here, and the
+# operator's own refinement is why. Capture already spools durably
+# (openbrain_memory/_runtime_spool.py, capture/outage.py): during an outage the
+# turn IS captured, it just has not been delivered. Refusing that merge punishes
+# a session that did everything right, and agents route around gates that fire
+# on innocence — this repo's standing scar (#618) is exactly a guard that fired
+# on the wrong thing and taxed every lane until fixed.
+#
+# So the gate is DRAIN-FIRST, three outcomes, and clauses A/B/C pin all three:
+#
+#   receipt present            -> PASS clean            (clause B)
+#   no receipt, drain delivers -> PASS clean            (drain produced it)
+#   no receipt, service DOWN   -> PASS *with a stamp*   (clause C)
+#   no receipt, service UP,
+#     drain produced nothing   -> REFUSE, named reason  (clause A)
+#
+# Only the last one is a skip, and it is the only one that blocks. Clause C is
+# therefore not a leniency clause — it is the clause that keeps the refusal in
+# clause A HONEST, because a gate that cannot tell an outage from a skip would
+# have to choose between bricking outages and never firing at all.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   A   service UP, no receipt, empty spool  -> REFUSED (exit 2), naming the
+#                                               reason, the session, and the
+#                                               drain that produced nothing
+#   B   receipt present for the session      -> ALLOWED (exit 0)
+#   C   service DOWN, no receipt             -> ALLOWED **and** the stamp text
+#                                               is emitted naming outage+session
+#   D   canon pack absent / sections == 0    -> hydration marker emitted,
+#                                               exit 0 (STAMP, NEVER A BLOCK)
+#   D2  canon pack present, sections > 0     -> NO marker (the control: a
+#                                               marker that always fires is
+#                                               decoration, not a signal)
+#   E   recall counts reach the EXISTING telemetry lane as facts only
+#   F   the capture gate is REGISTERED in .claude/settings.json
+#
+# CONTROL CLAUSE 0 (harvest of #624, lane-contract.md): a check needs proof its
+# observation window is live, or a dead harness hands every clause a false
+# result. Clause 0 proves bun runs and the hook file is readable BEFORE any
+# clause banks a verdict.
+#
+# ---------------------------------------------------------------------------
+# Why everything here is stubbed, and why there are no wall-clock assertions
+# ---------------------------------------------------------------------------
+# The service is stubbed via a fixture HTTP responder, and `gh` via the
+# stub-on-PATH transcript pattern proven in
+# scripts/done-means/merge-gate-and-verify-lane.sh:132-160. Both are required,
+# not stylistic: clause C's whole subject is "the service is unreachable", which
+# cannot be arranged against a live service without taking it down, and clause A
+# must prove a refusal fires when it IS reachable. An unstubbed call exits 97 so
+# a clause can never silently pass by reaching the real network.
+#
+# No clause asserts on elapsed time. Wall-clock assertions are CI flake
+# generators — three runs, three unrelated timing failures (lane-contract.md
+# Tightenings, 2026-08-08). "Service down" is expressed by pointing the gate at
+# a closed port, not by waiting for a timeout.
+#
+# Exit 0 only when every clause passes. Exit 3 is a HARNESS error (missing tool,
+# unwritable scratch), which is NOT a failure of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$REPO_ROOT/.claude/hooks/capture-gate.ts"
+HYDRATION="$REPO_ROOT/.claude/hooks/hydration-stamp.ts"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+
+# Repo-relative scratch. NEVER an absolute machine path: a hardcoded
+# /Volumes/... default died with EACCES on the Linux CI runner
+# (lane-contract.md Tightenings, 2026-08-08).
+RUN_ID="dm451_$$_$(date +%s)"
+SCRATCH="$REPO_ROOT/_scratch/$RUN_ID"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# ===========================================================================
+# CLAUSE 0 — CONTROL. Prove the observation window is live.
+# ===========================================================================
+if bun -e 'process.stdout.write("ok")' >/dev/null 2>&1; then
+  record 0 PASS "CONTROL: bun executes — harness observation window is live"
+else
+  record 0 FAIL "CONTROL: bun cannot execute — no clause below can be trusted"
+fi
+
+SESSION_ID="dm451-session-${RUN_ID}"
+
+# ===========================================================================
+# The stubs.
+#
+# (1) A fixture Open Brain responder. Clauses control it by FIXTURE FILE, so
+#     "service up with no receipt" and "service up with a receipt" differ only
+#     in data, and "service down" is a port nothing listens on — a real
+#     connection refusal, not a simulated one.
+# (2) A stub `gh` so the gate's PR-comment stamp is observable without posting.
+# ===========================================================================
+STUB_DIR="$SCRATCH/stub-bin"
+mkdir -p "$STUB_DIR" || fail_hard "cannot create stub dir"
+
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Fixture `gh`. Records what would have been posted so a clause can assert on
+# the stamp TEXT, and fails loudly on any un-stubbed shape.
+set -uo pipefail
+args="$*"
+case "$args" in
+  *"pr comment"*)
+    printf '%s\n' "$args" >> "${DM451_GH_LOG:?DM451_GH_LOG unset}"
+    exit 0
+    ;;
+  *"pr view"*)
+    cat "${DM451_PR_VIEW:?DM451_PR_VIEW unset}"
+    exit 0
+    ;;
+esac
+printf 'gh STUB: unstubbed invocation: %s\n' "$args" >&2
+exit 97
+STUB
+chmod +x "$STUB_DIR/gh" || fail_hard "cannot chmod stub gh"
+
+GH_LOG="$SCRATCH/gh-comments.log"
+: > "$GH_LOG"
+
+PR_VIEW="$SCRATCH/pr-view.json"
+cat > "$PR_VIEW" <<'PRVIEW'
+{"number": 999, "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+PRVIEW
+
+# --- the fixture service ----------------------------------------------------
+# A tiny responder that answers the ONE read the gate is allowed to make
+# (session_context for this session) from a fixture file. Started per-clause so
+# a clause can also run with it stopped.
+SERVER_SCRIPT="$SCRATCH/fixture-service.ts"
+cat > "$SERVER_SCRIPT" <<'SERVER'
+// Fixture Open Brain. Serves the session_context read from a fixture file.
+// Content-free: it echoes only what the fixture says, and records nothing.
+const fixture = process.env.DM451_FIXTURE!;
+const port = Number(process.env.DM451_PORT!);
+Bun.serve({
+  port,
+  async fetch(request) {
+    const body = await Bun.file(fixture).text();
+    // Every route answers the same fixture: this stands in for the service
+    // being REACHABLE, and the fixture decides whether a receipt exists.
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  },
+});
+console.log("ready");
+SERVER
+
+# A receipt-bearing fixture and an empty one. The shape mirrors what
+# session_context returns (server/tools/session-lifecycle.ts:180): a lane plus
+# its events.
+cat > "$SCRATCH/fixture-with-receipt.json" <<RECEIPT
+{"lane": {"id": "lane-dm451", "session_key": "$SESSION_ID"},
+ "events": [{"id": "ev-1", "event_type": "fact", "created_at": "2026-08-08T12:00:00.000Z"}],
+ "event_count": 1}
+RECEIPT
+
+cat > "$SCRATCH/fixture-no-receipt.json" <<'NORECEIPT'
+{"lane": {"id": "lane-dm451", "session_key": "dm451"}, "events": [], "event_count": 0}
+NORECEIPT
+
+# An EMPTY spool directory: the drain has nothing to deliver, which is what
+# makes clause A a genuine skip rather than an undelivered capture.
+EMPTY_SPOOL="$SCRATCH/empty-spool"
+mkdir -p "$EMPTY_SPOOL" || fail_hard "cannot create spool dir"
+
+# Pick a port in the task-specific range (Development AGENTS.md: 7100-7199).
+FIXTURE_PORT="${DM451_PORT_OVERRIDE:-7151}"
+# A port nothing listens on == the service is DOWN, for clause C.
+DEAD_PORT="${DM451_DEAD_PORT_OVERRIDE:-7152}"
+
+SERVICE_PID=""
+start_service() {
+  local fixture="$1"
+  DM451_FIXTURE="$fixture" DM451_PORT="$FIXTURE_PORT" \
+    bun "$SERVER_SCRIPT" > "$SCRATCH/service.log" 2>&1 &
+  SERVICE_PID=$!
+  # Poll for readiness rather than sleeping a fixed interval: no wall-clock
+  # assertion, and a slow start cannot make a clause measure the wrong thing.
+  local waited=0
+  while [ "$waited" -lt 100 ]; do
+    if curl -fsS "http://127.0.0.1:$FIXTURE_PORT/" >/dev/null 2>&1; then return 0; fi
+    waited=$((waited + 1))
+    sleep 0.1
+  done
+  return 1
+}
+
+stop_service() {
+  if [ -n "$SERVICE_PID" ]; then
+    kill "$SERVICE_PID" >/dev/null 2>&1
+    wait "$SERVICE_PID" 2>/dev/null
+    SERVICE_PID=""
+  fi
+}
+
+# Teardown: this process's own fixture service and nothing else. Narrow
+# auto-removal exception (ledger item 20): self-created this run, and the PID is
+# one this script started. Scratch FILES are printed, never deleted.
+trap 'stop_service' EXIT
+
+# ---------------------------------------------------------------------------
+# Drive the capture gate the way Claude Code does: a PreToolUse JSON payload on
+# stdin. Sets GATE_EXIT / GATE_STDERR / GATE_STDOUT.
+# ---------------------------------------------------------------------------
+GATE_EXIT=0
+GATE_STDERR=""
+GATE_STDOUT=""
+run_gate() {
+  local command_text="$1" base_url="$2"
+  local payload out_file err_file
+  out_file="$SCRATCH/gate-stdout.$$"
+  err_file="$SCRATCH/gate-stderr.$$"
+  payload="$(
+    COMMAND_TEXT="$command_text" SESSION="$SESSION_ID" bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: process.env.SESSION ?? "",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: process.env.COMMAND_TEXT ?? "" },
+      }));
+    '
+  )" || fail_hard "could not build hook payload"
+
+  printf '%s' "$payload" | \
+    PATH="$STUB_DIR:$PATH" \
+    OPENBRAIN_BASE_URL="$base_url" \
+    OPENBRAIN_TOKEN="dm451-fixture-token" \
+    OPENBRAIN_SPOOL_PATH="$EMPTY_SPOOL" \
+    DM451_GH_LOG="$GH_LOG" \
+    DM451_PR_VIEW="$PR_VIEW" \
+    bun "$GATE" --event pre-tool-use > "$out_file" 2> "$err_file"
+  GATE_EXIT=$?
+  GATE_STDOUT="$(cat "$out_file" 2>/dev/null)"
+  GATE_STDERR="$(cat "$err_file" 2>/dev/null)"
+}
+
+MERGE_CMD="gh pr merge 999 --squash --delete-branch"
+
+if [ ! -r "$GATE" ]; then
+  # RED state: nothing enforces capture at merge. Each clause fails for one
+  # honest reason rather than erroring out, so the RED transcript stays legible.
+  for c in A B C; do
+    record "$c" FAIL "no capture gate at $GATE — nothing requires a capture receipt at merge"
+  done
+  record F FAIL "no capture gate to register"
+else
+  # =========================================================================
+  # CLAUSE A — service UP, no receipt, empty spool -> REFUSED with the reason.
+  # This is the SKIP case, and the only one that blocks.
+  # =========================================================================
+  if start_service "$SCRATCH/fixture-no-receipt.json"; then
+    run_gate "$MERGE_CMD" "http://127.0.0.1:$FIXTURE_PORT"
+    stop_service
+    if [ "$GATE_EXIT" -ne 2 ]; then
+      record A FAIL "merge with NO capture receipt was allowed (exit=$GATE_EXIT) — the hard gate is off"
+    elif ! printf '%s' "$GATE_STDERR" | rg -qF 'capture-gate'; then
+      record A FAIL "refused but the refusal never names the gate"
+    elif ! printf '%s' "$GATE_STDERR" | rg -qiF 'no capture receipt'; then
+      record A FAIL "refused but never names the reason (no capture receipt)"
+    elif ! printf '%s' "$GATE_STDERR" | rg -qF "$SESSION_ID"; then
+      record A FAIL "refused but never names WHICH session has no receipt"
+    else
+      record A PASS "skip refused (exit=2), names the gate, the reason, and the session"
+    fi
+  else
+    record A FAIL "HARNESS: fixture service did not become ready on port $FIXTURE_PORT"
+  fi
+
+  # =========================================================================
+  # CLAUSE B — receipt present -> ALLOWED, clean (no outage stamp).
+  # =========================================================================
+  : > "$GH_LOG"
+  if start_service "$SCRATCH/fixture-with-receipt.json"; then
+    run_gate "$MERGE_CMD" "http://127.0.0.1:$FIXTURE_PORT"
+    stop_service
+    if [ "$GATE_EXIT" -ne 0 ]; then
+      record B FAIL "merge WITH a capture receipt was refused (exit=$GATE_EXIT) — false block: ${GATE_STDERR:0:200}"
+    elif [ -s "$GH_LOG" ]; then
+      record B FAIL "passed but posted an outage stamp on a clean pass — skip and outage must stay distinguishable"
+    else
+      record B PASS "receipt present -> allowed clean (exit=0), no outage stamp posted"
+    fi
+  else
+    record B FAIL "HARNESS: fixture service did not become ready on port $FIXTURE_PORT"
+  fi
+
+  # =========================================================================
+  # CLAUSE C — service DOWN -> ALLOWED **and** the stamp is emitted.
+  # The clause that keeps clause A's refusal honest.
+  # =========================================================================
+  : > "$GH_LOG"
+  # No service started: $DEAD_PORT refuses the connection for real.
+  run_gate "$MERGE_CMD" "http://127.0.0.1:$DEAD_PORT"
+  STAMP_SEEN=0
+  if printf '%s' "$GATE_STDOUT" | rg -qiF 'outage'; then STAMP_SEEN=1; fi
+  if [ -s "$GH_LOG" ] && rg -qiF 'outage' "$GH_LOG"; then STAMP_SEEN=1; fi
+  if [ "$GATE_EXIT" -ne 0 ]; then
+    record C FAIL "service DOWN was BLOCKED (exit=$GATE_EXIT) — an outage must never brick a merge: ${GATE_STDERR:0:200}"
+  elif [ "$STAMP_SEEN" -ne 1 ]; then
+    record C FAIL "service DOWN passed SILENTLY — no outage stamp anywhere; skip and outage are now indistinguishable"
+  elif [ -s "$GH_LOG" ] && ! rg -qF "$SESSION_ID" "$GH_LOG"; then
+    record C FAIL "outage stamp posted but does not name the session"
+  else
+    record C PASS "service down -> allowed (exit=0) WITH a loud outage stamp naming the session"
+  fi
+
+  # =========================================================================
+  # CLAUSE F — the gate is REGISTERED. An unregistered hook enforces nothing.
+  # =========================================================================
+  if [ ! -r "$SETTINGS" ]; then
+    record F FAIL "no $SETTINGS to register the gate in"
+  elif rg -qF 'capture-gate.ts' "$SETTINGS"; then
+    record F PASS "capture-gate.ts is registered in .claude/settings.json"
+  else
+    record F FAIL "capture-gate.ts exists but is NOT registered — it would never fire"
+  fi
+fi
+
+# ===========================================================================
+# CLAUSE D / D2 — HYDRATION: verify + stamp, NEVER a block.
+#
+# D  asserts the marker appears when the canon pack is absent or empty.
+# D2 is the CONTROL: with a healthy pack, NO marker. Without D2, a hook that
+#    unconditionally printed the marker would pass D while carrying no signal
+#    at all — a marker that always fires is decoration.
+# ===========================================================================
+run_hydration() {
+  local pack_json="$1"
+  local out_file err_file payload
+  out_file="$SCRATCH/hyd-stdout.$$"
+  err_file="$SCRATCH/hyd-stderr.$$"
+  payload="$(
+    SESSION="$SESSION_ID" bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: process.env.SESSION ?? "",
+        hook_event_name: "SessionStart",
+        source: "startup",
+      }));
+    '
+  )" || fail_hard "could not build hydration payload"
+  printf '%s' "$payload" | \
+    DM451_CANON_PACK="$pack_json" \
+    bun "$HYDRATION" --event session-start > "$out_file" 2> "$err_file"
+  HYD_EXIT=$?
+  HYD_OUT="$(cat "$out_file" 2>/dev/null)$(cat "$err_file" 2>/dev/null)"
+}
+
+if [ ! -r "$HYDRATION" ]; then
+  record D FAIL "no hydration check at $HYDRATION — canon-pack absence is invisible"
+  record D2 FAIL "no hydration check at $HYDRATION"
+else
+  # D: an empty pack (sections present but zero) must raise the marker.
+  run_hydration '{"sections": {}, "warnings": []}'
+  if [ "$HYD_EXIT" -ne 0 ]; then
+    record D FAIL "hydration check BLOCKED the session (exit=$HYD_EXIT) — the ruling is stamp, never block"
+  elif ! printf '%s' "$HYD_OUT" | rg -qiF 'hydration'; then
+    record D FAIL "canon pack empty but no hydration marker emitted — the absence is silent"
+  else
+    record D PASS "canon pack empty -> loud marker emitted, session NOT blocked (exit=0)"
+  fi
+
+  # D2 (control): a healthy pack must produce NO marker.
+  run_hydration '{"sections": {"profile_guidance": [1,2], "process_guidance": [1]}, "warnings": []}'
+  if [ "$HYD_EXIT" -ne 0 ]; then
+    record D2 FAIL "healthy canon pack still blocked the session (exit=$HYD_EXIT)"
+  elif printf '%s' "$HYD_OUT" | rg -qiF 'hydration marker'; then
+    record D2 FAIL "marker fired on a HEALTHY pack — a marker that always fires is decoration, not a signal"
+  else
+    record D2 PASS "healthy pack -> no marker (control: the marker carries signal)"
+  fi
+fi
+
+# ===========================================================================
+# CLAUSE E — RECALL MEASURE lands in the EXISTING telemetry lane, facts only.
+#
+# The ruling says MEASURE into existing telemetry, and this repo already has
+# exactly one such lane: the PostToolUse -> record_skill_usage counter
+# (python/openbrain/src/openbrain/apps/hooks/post_tool_use.py), built under the
+# #469 ruling "metrics so that decisions can be made on facts and not on feel".
+# So this clause asserts TWO things, and the second is the important one:
+#   (i)  recall invocations are counted, and
+#   (ii) the counting path recommends NOTHING — no retire/rotate/shelve/suggest.
+# A "measure" tier that grew opinions would be a different tier.
+# ===========================================================================
+# The lane's capability lives in session.py (post_tool_use.py is a parse-and-exit
+# shell), and this repo's python tests are FLAT — python/openbrain/tests/ — not
+# mirrored under apps/hooks/. Both paths are named from the tree as it is, after
+# an earlier draft of this clause pointed at a tests/apps/hooks/ path that does
+# not exist; a clause that asserts against a missing file fails for the wrong
+# reason and sends the next reader to build the wrong thing.
+RECALL_SRC="$REPO_ROOT/python/openbrain/src/openbrain/apps/hooks/session.py"
+RECALL_ENTRY="$REPO_ROOT/python/openbrain/src/openbrain/apps/hooks/post_tool_use.py"
+RECALL_TEST="$REPO_ROOT/python/openbrain/tests/test_capture_hooks.py"
+
+# The measure tier must not grow opinions. Matching a bare verb would false-fire
+# on the prose that EXPLAINS the tier ("it does not recommend..."), so this looks
+# for a called function or a def — an implementation, not a mention.
+#
+# Passed with `rg -e`, NEVER `rg -E`: ripgrep's `-E` is `--encoding`, and the
+# first draft of this clause used it, which made rg exit with a flag-parse error
+# that the `elif` chain read as "pattern not found" — i.e. the clause PASSED by
+# skipping to the next branch. Caught by mutation-checking a green run
+# (lane-contract.md Tightenings, 2026-08-08, #621 lane: same trap, second time).
+OPINION_PATTERN='(def |self\.)(retire|rotate|shelve|deprecate|recommend|suggest)'
+
+if [ ! -r "$RECALL_SRC" ]; then
+  record E FAIL "telemetry lane missing at $RECALL_SRC"
+elif ! rg -qF 'RECALL_TOOL_NAMES' "$RECALL_SRC"; then
+  record E FAIL "recall invocations are not counted in the existing telemetry lane ($RECALL_SRC)"
+elif ! rg -qF 'recall_slug' "$RECALL_SRC"; then
+  record E FAIL "no recall filter — RECALL_TOOL_NAMES is declared but nothing counts against it"
+elif rg -q -e "$OPINION_PATTERN" "$RECALL_SRC" "$RECALL_ENTRY"; then
+  record E FAIL "the measure tier grew RECOMMENDATIONS — facts only, per the #469 ruling"
+elif [ ! -r "$RECALL_TEST" ]; then
+  record E FAIL "recall counting present but no test file at $RECALL_TEST"
+elif ! rg -qF 'TestPostToolUseCountsRecallInvocations' "$RECALL_TEST"; then
+  record E FAIL "recall counting present but no test proves it ($RECALL_TEST)"
+else
+  record E PASS "recall counted in the existing telemetry lane, facts only, with tests asserting it"
+fi
+
+# ===========================================================================
+# Verdict
+# ===========================================================================
+printf '\n'
+FAILED=0
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"; rest="${entry#*|}"
+  status="${rest%%|*}"; evidence="${rest#*|}"
+  printf 'CLAUSE %-3s %-4s — %s\n' "$id" "$status" "$evidence"
+  [ "$status" = PASS ] || FAILED=1
+done
+printf '\nscratch (printed, never auto-deleted): %s\n' "$SCRATCH"
+
+if [ "$FAILED" -eq 0 ]; then
+  printf 'RESULT: PASS — all clauses hold\n'
+  exit 0
+fi
+printf 'RESULT: FAIL — at least one clause did not hold\n'
+exit 1


### PR DESCRIPTION
## Summary

- Implements the operator's **TIERED ALL-THREE** ruling for #451 (2026-08-08, ledger item 24, `docs/issue-graph.md`). Each of the three tiers gets a **different enforcement strength**, and keeping them distinguishable is the design rather than an inconsistency.
- **CAPTURE — HARD GATE** (`.claude/hooks/capture-gate.ts`). `PreToolUse` on a parsed `gh pr merge <n>`, requiring a **server-side** capture receipt for the session, read via `session_context` (`server/tools/session-lifecycle.ts:109`). Server receipt is the proof; local state is only a cache, because a local file is forgeable. Shares `lib/shell-command-parse.ts` with `merge-gate.ts` so the #618 heredoc-matching class cannot return through a copy.
- **DRAIN-FIRST, and this is the load-bearing part.** A missing receipt is not yet a verdict: capture already spools durably (`_runtime_spool.py`, `runtime.py:1018`), so an outage means *undelivered*, not *absent*. Receipt found → pass clean. Drain delivers one → pass clean. Service unreachable → **PASS with a loud stamp** naming the outage and session. Service up and the drain produced nothing → **REFUSE** with the named reason. Only the last blocks.
- The outage path is what keeps that refusal **honest**. A gate that cannot tell an outage from a skip must either brick every outage or never fire at all — and a gate that fires on innocence is how agents learn to route around guards (this repo's #618 scar). Skip and outage stay distinguishable in the record permanently.
- **HYDRATION — VERIFY + STAMP** (`.claude/hooks/hydration-stamp.ts`). `SessionStart` checks the canon pack arrived with sections > 0; absence prints a loud marker. **Always exits 0.** A session cannot skip its own hydration, so the only state a hydration gate could ever fire in is an outage — i.e. the one case where the session is blameless. The healthy path is deliberately silent: a marker that always fires is decoration, and clause D2 is the standing control that keeps it silent.
- **RECALL — MEASURE ONLY** (`apps/hooks/session.py`, `post_tool_use.py`). Counts the four Open Brain reads into the **existing** #469 telemetry lane. Recall was ruled measure-only because "recall before re-deriving" is unfalsifiable — no gate can tell that canon already answered a question — so enforcement there would fire on guesses.
- **Reuses `usage_kind="canon"` rather than adding a kind.** The value is pinned by both a Zod enum (`server/tools/skill-usage.ts:119-122`) and a DB CHECK constraint (`src/db/migrations/046_skill_usage_log.sql`), so a third kind would be a schema change — an explicit non-goal. `canon` is honest rather than merely convenient: every allowlisted tool reads assembled canon.
- The tool **name** is the metric; the recall query never travels. That is a privacy boundary as much as a scope one — recall queries are the questions a session asks about the operator.
- **Non-goals honored:** no global `~/.claude` lifecycle hook touched, no fail-open contract changed, no new storage, no schema change.

## Verification

- Done-means: scripts/done-means/451-tiered-coverage.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED** (before any implementation existed, commit-clean tree): all 7 substantive clauses failed, control passed, exit 1.

```
CLAUSE 0   PASS — CONTROL: bun executes — harness observation window is live
CLAUSE A   FAIL — no capture gate at .claude/hooks/capture-gate.ts — nothing requires a capture receipt at merge
CLAUSE B   FAIL — no capture gate ...
CLAUSE C   FAIL — no capture gate ...
CLAUSE F   FAIL — no capture gate to register
CLAUSE D   FAIL — no hydration check at .claude/hooks/hydration-stamp.ts — canon-pack absence is invisible
CLAUSE D2  FAIL — no hydration check ...
CLAUSE E   FAIL — recall invocations are not counted in the existing telemetry lane
RESULT: FAIL — at least one clause did not hold      (real exit code: 1)
```

**GREEN** (after):

```
CLAUSE 0   PASS — CONTROL: bun executes — harness observation window is live
CLAUSE A   PASS — skip refused (exit=2), names the gate, the reason, and the session
CLAUSE B   PASS — receipt present -> allowed clean (exit=0), no outage stamp posted
CLAUSE C   PASS — service down -> allowed (exit=0) WITH a loud outage stamp naming the session
CLAUSE F   PASS — capture-gate.ts is registered in .claude/settings.json
CLAUSE D   PASS — canon pack empty -> loud marker emitted, session NOT blocked (exit=0)
CLAUSE D2  PASS — healthy pack -> no marker (control: the marker carries signal)
CLAUSE E   PASS — recall counted in the existing telemetry lane, facts only, with tests asserting it
RESULT: PASS — all clauses hold
```

Suite and gates, all run in the lane worktree:

- `bun run test:isolated` — **3711 pass, 35 skip, 0 fail**, 242 files, database `ob_isolated_72571_mskm0vq49d` created and dropped.
- `bunx tsc --noEmit` — clean.
- `uv run pytest tests/test_capture_hooks.py -q` — **122 passed** (includes 5 new recall tests).
- `uv run mypy src/openbrain` — Success, 49 source files.
- `uv run ruff check src tests` — All checks passed.

**Mutation-proofs** (a gate observed only green is decoration):

- Injected a `def recommend_a_skill()` into `session.py` → clause E flipped to `FAIL — the measure tier grew RECOMMENDATIONS`. Restored, back to PASS.
- Confirmed `origin/main` carries no `RECALL_TOOL_NAMES`, so clause E fails RED on main for the real reason.

## Critical Self-Review

- Highest-risk behavior: the capture gate blocking a legitimate merge. Mitigated by making the ONLY blocking path the one where the service answered twice and a drain found nothing; both outage paths and both receipt paths pass, and clauses B/C pin that.
- Assumptions that could be wrong: (1) `session_context` returning ≥1 event is the right proxy for "this session captured something" — it counts any event on the lane, not specifically a distilled capture, so a session that only started a lane could satisfy it; (2) the `session_id` the hook payload carries matches the `session_key` the server lanes are keyed by, which is true for the observed hook/provider pairing but is not enforced anywhere; (3) the four names in `RECALL_TOOL_NAMES` are the complete recall surface today.
- Missing/weak tests: the capture gate is proven against a **fixture** service and a stub `gh`, never against live Open Brain — clause C's "service down" is a closed port, which is a real connection refusal but not every outage shape (a hung TCP connection would hit the `--max-time 10` path instead, untested). The drain path is exercised only in the "produced nothing" direction; no test proves a drain that DELIVERS flips a refusal into a pass, because that needs a seeded spool.
- Security/permission risk: the gate sends `OPENBRAIN_TOKEN` to whatever `OPENBRAIN_BASE_URL` names, so a misconfigured base URL leaks the token to that host. Namespace stays token-derived server-side; the gate cannot widen its own scope. The outage stamp is content-free — session id and reason only, no captured content.
- Migration/deploy risk: none. No schema change, no migration, no new storage. `usage_kind="canon"` was chosen specifically to avoid touching the Zod enum and the DB CHECK constraint.
- Downstream client/runtime risk: `run_post_tool_use` gained a second call shape (recall), so a downstream caller asserting "only Skill calls send metrics" would now see `canon` rows. `docs/downstream-rollout.md` classification: this changes no MCP tool schema, no transport, and no Python client contract — the recall counter is a new *caller* of the existing `record_skill_usage` tool, not a change to it.
- Rollback/cleanup concern: both hooks are repo-local and removable by deleting the two files and their `.claude/settings.json` registrations; nothing persists. The lane worktree and its scratch are named under teardown.
- Fixes made before PR: **a false green I caught by mutation-checking.** Clause E's opinion-guard first used `rg -qE`, but ripgrep's `-E` is `--encoding` — rg exited with a flag-parse error that the `elif` chain read as "pattern not found", so the clause PASSED by falling through to the next branch. Fixed to `rg -q -e` and then mutation-proven. Also corrected clause E's test path: an earlier draft pointed at `python/openbrain/tests/apps/hooks/test_post_tool_use.py`, which does not exist (this repo's Python tests are flat).
- Known residual risk: the capture gate is registered alongside `merge-gate.ts` on the same `Bash` matcher, so a merge now consults two gates. They refuse for different reasons and each names itself, but a session hitting both in sequence sees only the first refusal and may fix one thing at a time. The bare `gh pr merge` form is deliberately left to `merge-gate.ts` so the model gets one reason, not two, for that one problem.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the findings here are operating lessons for lanes (the `rg -E` false green, the fixture-service pattern), which the harvest routes to `docs/lane-contract.md` Tightenings rather than the reviewer-facing SME lanes. No new review-time defect class surfaced.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the gate is proven against a fixture service by construction — clause C's subject is "the service is unreachable", which cannot be arranged against live Open Brain without taking it down. A live smoke would exercise only the receipt-present path that clause B already pins.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the two hooks are repo-local Claude Code `PreToolUse`/`SessionStart` gates with no cross-runtime contract, and the recall counter is a new caller of the existing `record_skill_usage` tool rather than a change to any tool schema, transport shape, or client surface.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing surface changed. `record_skill_usage`'s input schema, the `usage_kind` enum, and the `skill_usage_log` table are all untouched — the recall tier deliberately reuses the existing `canon` value precisely so that stays true.
- The only agent-facing behavior change is repo-local and Claude-only: two hooks registered in this repo's own `.claude/settings.json`.
- **Harvest:** this lane DID produce new operating lessons (the `rg -E` false green; the fixture-service pattern for proving an outage path; the closed-enum discovery that redirected the recall tier away from a schema change). They are in the lane report's `lessons` field for the controller's Tightenings harvest. Deliberately NOT claiming `No new lessons:` here — that line would satisfy the ratchet on a false claim.
