### PR TITLE
chore(451): retire the capture merge-gate tier on main (ledger item 25)

### DIFF
--- a/.claude/hooks/_retired/capture-gate.ts
+++ b/.claude/hooks/_retired/capture-gate.ts
@@ -1,5 +1,45 @@
 #!/usr/bin/env bun
 /**
+ * ===========================================================================
+ * RETIRED 2026-08-08 — NOT REGISTERED, NOT RUNNING. DO NOT RE-REGISTER.
+ * ===========================================================================
+ * Ruling: operator, 2026-08-08, ledger item 25 (`docs/issue-graph.md`), which
+ * AMENDS item 24. This gate fired live exactly once and wedged the pipeline:
+ * it blocked the controller's merge of PR #645, and structurally blocked the
+ * merge of any fix for itself.
+ *
+ * Two reasons it is retired rather than repaired:
+ *
+ *   1. Its live defects were the same gaps PR #642 had disclosed as PROPOSED —
+ *      the receipt probe hit a nonexistent endpoint (HTML 404), the provider
+ *      scope-proof demanded a key it simultaneously rejected, and the drain
+ *      step could not import openbrain_memory in the hook interpreter (#646).
+ *      #646 is fixed regardless: a tool demanding a key it rejects is a defect
+ *      with or without a consumer.
+ *   2. The reason that actually decided it — raw capture is AUTOMATIC (Stop
+ *      hooks -> watermark -> durable spool, running regardless of any gate),
+ *      and distilling raw sessions into durable memory is the DREAM pipeline's
+ *      designed job (`docs/dream-design.md`). So this gate was hard-blocking
+ *      merges to force HAND distillation of something the architecture intends
+ *      to automate. Enforcing a manual duplicate of a designed automatic step
+ *      is backwards.
+ *
+ * WHAT REPLACES IT: an automatic-capture LIVENESS check (#647), built on the
+ * #625 pattern — prove the raw capture lane DELIVERED for recent sessions and
+ * be loud on silence. The real risk is the automatic lane dying quietly, not
+ * an agent skipping a hand-written receipt.
+ *
+ * WHY THE FILE IS KEPT: the server-side receipt probe, the drain step, and the
+ * outage-vs-skip discrimination below are prior art for #647, which has to
+ * answer the same question ("did capture deliver for this session?") without
+ * the block. Deleting it would make that lane rediscover it. Retirement is
+ * enforced by `scripts/done-means/648-capture-gate-retired.sh`.
+ *
+ * Everything below this header describes the gate AS IT WAS and is retained
+ * verbatim as the record of the design; the KEPT tiers of item 24 are
+ * hydration (`.claude/hooks/hydration-stamp.ts`) and recall telemetry.
+ * ===========================================================================
+ *
  * capture-gate — repo-local hard gate on `gh pr merge` requiring a SERVER-SIDE
  * capture receipt for the current session.
  *

--- a/.claude/hooks/hydration-stamp.ts
+++ b/.claude/hooks/hydration-stamp.ts
@@ -21,10 +21,15 @@
  * (#618, the guard that fired on heredoc text and taxed every lane until it was
  * fixed).
  *
- * Contrast with `.claude/hooks/capture-gate.ts`, which IS a hard gate: capture
- * is an action the agent takes or omits, so a missing capture receipt can mean
- * a skip. Hydration has no skip state. Same issue, different enforcement
- * strength, and the difference is not an inconsistency — it is the ruling.
+ * The capture tier used to be the contrast case: a hard gate at merge, on the
+ * argument that capture is an action the agent takes or omits, so a missing
+ * receipt can mean a skip. Ledger item 25 (2026-08-08) RETIRED that tier —
+ * raw capture turned out to be automatic and distillation is DREAM's job, so
+ * the gate was blocking merges to force a hand-made duplicate of an automated
+ * step, and its first live firing wedged the pipeline. The retired source is
+ * kept at `.claude/hooks/_retired/capture-gate.ts` as prior art for the #647
+ * liveness check. This file — verify and stamp, never block — is the tier that
+ * survived, and the paragraph above is why it never had that failure mode.
  *
  * ---------------------------------------------------------------------------
  * ALWAYS EXIT 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,11 +26,6 @@
             "type": "command",
             "command": "bun run \"$CLAUDE_PROJECT_DIR/.claude/hooks/merge-gate.ts\" --event pre-tool-use",
             "timeout": 30
-          },
-          {
-            "type": "command",
-            "command": "bun run \"$CLAUDE_PROJECT_DIR/.claude/hooks/capture-gate.ts\" --event pre-tool-use",
-            "timeout": 30
           }
         ]
       }

--- a/python/openbrain/src/openbrain/apps/hooks/post_tool_use.py
+++ b/python/openbrain/src/openbrain/apps/hooks/post_tool_use.py
@@ -14,9 +14,10 @@ Purpose:
     cannot either.
 
     RECALL IS THE SAME RULE, DELIBERATELY. #451's operator ruling (2026-08-08,
-    ledger item 24) made recall the MEASURE tier of a three-tier design whose
-    other two tiers DO enforce: capture is a hard gate at merge
-    (``.claude/hooks/capture-gate.ts``) and hydration stamps
+    ledger item 24) made recall the MEASURE tier of a three-tier design. The
+    capture tier was a hard merge gate until ledger item 25 (2026-08-08)
+    retired it (source kept at ``.claude/hooks/_retired/capture-gate.ts``);
+    hydration stamps and does not block
     (``.claude/hooks/hydration-stamp.ts``). Recall was ruled measure-only
     because "recall before re-deriving" is unfalsifiable -- no gate can tell
     that canon already answered a question the agent chose to ask again -- so a

--- a/scripts/done-means/451-tiered-coverage.sh
+++ b/scripts/done-means/451-tiered-coverage.sh
@@ -12,9 +12,16 @@
 # THREE TIERS, each with a DIFFERENT enforcement strength, and the whole point
 # of this check is that the three strengths stay distinguishable:
 #
-#   CAPTURE   HARD GATE at merge. A server-side receipt for the session must
-#             exist. Server receipt is the proof; a local file is forgeable, so
-#             local state is only ever a cache.
+#   CAPTURE   RETIRED 2026-08-08 by ledger item 25, which AMENDS item 24. It
+#             was a HARD GATE at merge requiring a server-side receipt; its
+#             first live firing wedged the pipeline, and the decisive reason
+#             was that raw capture is already AUTOMATIC (spool) while
+#             distillation is the DREAM pipeline's job — the gate was forcing a
+#             hand-made duplicate of a designed automatic step. Clauses A/B/C/F
+#             below are INVERTED to assert the retirement instead of the
+#             refusal; the source is kept at .claude/hooks/_retired/ as prior
+#             art for the #647 liveness check. Retirement is gated in full by
+#             scripts/done-means/648-capture-gate-retired.sh.
 #   HYDRATION VERIFY + STAMP. Session start checks the canon pack arrived with
 #             sections > 0; absence lands a loud visible marker. NEVER a block —
 #             a hydration block can only fire during an outage, which makes it a
@@ -25,7 +32,14 @@
 #             on feel").
 #
 # ---------------------------------------------------------------------------
-# The clause that matters most: SKIP and OUTAGE must never look alike
+# HISTORICAL (item 24) — the capture gate's design, retained because #647 has
+# to solve the same discrimination without the block
+# ---------------------------------------------------------------------------
+# The section below describes the gate AS IT WAS. It is not live: clauses
+# A/B/C/F assert retirement now. It is kept because the outage-vs-skip problem
+# it solved is real and the liveness check inherits it.
+#
+# The clause that mattered most: SKIP and OUTAGE must never look alike
 # ---------------------------------------------------------------------------
 # The naive capture gate — "no receipt, refuse" — is WRONG here, and the
 # operator's own refinement is why. Capture already spools durably
@@ -51,19 +65,25 @@
 # ---------------------------------------------------------------------------
 # Clauses
 # ---------------------------------------------------------------------------
-#   A   service UP, no receipt, empty spool  -> REFUSED (exit 2), naming the
-#                                               reason, the session, and the
-#                                               drain that produced nothing
-#   B   receipt present for the session      -> ALLOWED (exit 0)
-#   C   service DOWN, no receipt             -> ALLOWED **and** the stamp text
-#                                               is emitted naming outage+session
+#   A   capture tier is RETIRED: no gate on the live hook path  (was: service
+#       UP, no receipt, empty spool -> REFUSED naming reason/session/drain)
+#   B   capture tier is RETIRED                                 (was: receipt
+#       present -> ALLOWED clean)
+#   C   capture tier is RETIRED                                 (was: service
+#       DOWN -> ALLOWED with an outage stamp naming the session)
+#   F   the retired source is KEPT at .claude/hooks/_retired/ and registered
+#       nowhere                                                 (was: the gate
+#       is REGISTERED in .claude/settings.json)
+#
+#   A/B/C/F FAIL if the source is absent from BOTH paths — deleting it loses
+#   the prior art #647 needs, and item 25 says retire.
+#
 #   D   canon pack absent / sections == 0    -> hydration marker emitted,
 #                                               exit 0 (STAMP, NEVER A BLOCK)
 #   D2  canon pack present, sections > 0     -> NO marker (the control: a
 #                                               marker that always fires is
 #                                               decoration, not a signal)
 #   E   recall counts reach the EXISTING telemetry lane as facts only
-#   F   the capture gate is REGISTERED in .claude/settings.json
 #
 # CONTROL CLAUSE 0 (harvest of #624, lane-contract.md): a check needs proof its
 # observation window is live, or a dead harness hands every clause a false
@@ -92,6 +112,7 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 GATE="$REPO_ROOT/.claude/hooks/capture-gate.ts"
+RETIRED_GATE="$REPO_ROOT/.claude/hooks/_retired/capture-gate.ts"
 HYDRATION="$REPO_ROOT/.claude/hooks/hydration-stamp.ts"
 SETTINGS="$REPO_ROOT/.claude/settings.json"
 
@@ -280,13 +301,25 @@ run_gate() {
 
 MERGE_CMD="gh pr merge 999 --squash --delete-branch"
 
-if [ ! -r "$GATE" ]; then
-  # RED state: nothing enforces capture at merge. Each clause fails for one
-  # honest reason rather than erroring out, so the RED transcript stays legible.
+if [ ! -e "$GATE" ] && [ -r "$RETIRED_GATE" ]; then
+  # RETIRED state (ledger item 25) — the EXPECTED state since 2026-08-08.
+  # Clauses A/B/C/F are inverted: the tier's correctness is now that it does
+  # NOT fire, and the assertion is on the retirement being complete rather
+  # than on the refusal behaviour. The strong form of that assertion lives in
+  # scripts/done-means/648-capture-gate-retired.sh, which also re-runs THIS
+  # check; duplicating it here would make the two checks mutually recursive.
+  record A PASS "RETIRED (item 25): no capture gate on the hook path — nothing can wedge a merge on a receipt"
+  record B PASS "RETIRED (item 25): capture is automatic (spool) and distillation is DREAM's job — no merge-time receipt requirement"
+  record C PASS "RETIRED (item 25): with no gate there is no outage-vs-skip verdict to keep honest"
+  record F PASS "RETIRED (item 25): source kept at $RETIRED_GATE as #647 prior art, and registered nowhere"
+elif [ ! -r "$GATE" ]; then
+  # NEITHER present: the source was DELETED rather than retired, which loses
+  # the receipt-probe prior art #647 depends on. That is a real failure, and
+  # keeping it a failure is why the retired branch above tests for the file.
   for c in A B C; do
-    record "$c" FAIL "no capture gate at $GATE — nothing requires a capture receipt at merge"
+    record "$c" FAIL "capture gate is absent from BOTH $GATE and $RETIRED_GATE — deleted, not retired (ledger item 25 says retire)"
   done
-  record F FAIL "no capture gate to register"
+  record F FAIL "no capture gate at either path"
 else
   # =========================================================================
   # CLAUSE A — service UP, no receipt, empty spool -> REFUSED with the reason.

--- a/scripts/done-means/648-capture-gate-retired.sh
+++ b/scripts/done-means/648-capture-gate-retired.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for #648 — the capture merge-gate is RETIRED, not deleted.
+#
+#   bash scripts/done-means/648-capture-gate-retired.sh
+#
+# ---------------------------------------------------------------------------
+# What this gates: operator ruling 2026-08-08, ledger item 25 (docs/issue-graph.md)
+# ---------------------------------------------------------------------------
+# Ledger item 24 made CAPTURE a hard merge gate. Item 25 AMENDS it: on the
+# gate's first live firing it wedged the pipeline — it blocked the controller's
+# merge of PR #645, including structurally blocking any fix's own merge. The
+# ruling retires the tier permanently, for a reason bigger than the defects
+# (#646): raw capture is AUTOMATIC (Stop hooks -> watermark -> durable spool),
+# and DISTILLATION of raw sessions is the DREAM pipeline's designed job
+# (docs/dream-design.md). The gate was hard-blocking merges to force HAND
+# distillation of something the architecture already automates.
+#
+# KEPT from item 24, and asserted here so retirement cannot quietly take them
+# with it: hydration verify+stamp, and recall telemetry. Neither can wedge.
+# WHAT REPLACES the gate: an automatic-capture LIVENESS check (#647, the #625
+# pattern) — out of scope for this check, which gates the retirement only.
+#
+# ---------------------------------------------------------------------------
+# Why RETIRE and not DELETE
+# ---------------------------------------------------------------------------
+# capture-gate.ts contains a working server-side receipt probe, a drain step,
+# and an outage-vs-skip discrimination. That is prior art for the #647 liveness
+# lane, which has to answer the same question ("did the raw capture lane
+# deliver for this session?") without the block. Deleting it would make #647
+# rediscover it. So the file MOVES to .claude/hooks/_retired/ — off every hook
+# path, still readable — and carries a header pointing at the ruling.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   0   CONTROL — the observation window is live (bun runs, settings readable).
+#       Harvest of #624: a dead harness hands every clause a false result.
+#   A   .claude/settings.json contains ZERO capture-gate references anywhere.
+#   B   .claude/hooks/capture-gate.ts no longer exists at the live hook path.
+#   C   .claude/hooks/_retired/capture-gate.ts EXISTS and names the ruling
+#       (ledger item 25) and the issues (#646/#647) — retire, not delete, and
+#       the next reader is told why.
+#   D   The registered hook set is EXACTLY the five survivors:
+#       pr-body-gate, merge-gate, design-lookup-gate, design-contract,
+#       hydration-stamp. Both directions: none missing, none extra. Without the
+#       "none extra" half this clause would pass while a sixth hook crept in;
+#       without "none missing" the retirement could take a survivor with it.
+#   E   scripts/done-means/451-tiered-coverage.sh PASSES against the new state.
+#       This is the clause that proves the retirement is COHERENT rather than
+#       merely applied: 451 still owns the hydration and recall tiers, and it
+#       must not be left asserting a gate that no longer exists.
+#
+# Exit 0 only when every clause passes. Exit 3 is a HARNESS error, which is NOT
+# a failure of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+LIVE_GATE="$REPO_ROOT/.claude/hooks/capture-gate.ts"
+RETIRED_GATE="$REPO_ROOT/.claude/hooks/_retired/capture-gate.ts"
+CHECK_451="$REPO_ROOT/scripts/done-means/451-tiered-coverage.sh"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v rg  >/dev/null 2>&1 || fail_hard "rg not on PATH"
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# ===========================================================================
+# CLAUSE 0 — CONTROL. Prove the observation window is live before any verdict.
+# ===========================================================================
+if ! bun -e 'process.stdout.write("ok")' >/dev/null 2>&1; then
+  record 0 FAIL "CONTROL: bun cannot execute — no clause below can be trusted"
+elif [ ! -r "$SETTINGS" ]; then
+  record 0 FAIL "CONTROL: $SETTINGS is not readable — clause A would pass vacuously"
+else
+  record 0 PASS "CONTROL: bun executes and settings.json is readable"
+fi
+
+# ===========================================================================
+# CLAUSE A — zero capture-gate references in settings.json.
+# Substring match on the bare name, not the .ts path: a reference in a comment
+# key, a different matcher block, or a renamed command would still be a live
+# registration path, and this clause is about the file being UNREACHABLE from
+# the hook config at all.
+# ===========================================================================
+if [ ! -r "$SETTINGS" ]; then
+  record A FAIL "no $SETTINGS to inspect"
+elif rg -qF 'capture-gate' "$SETTINGS"; then
+  record A FAIL "settings.json still references capture-gate — the wedge can still fire: $(rg -nF 'capture-gate' "$SETTINGS" | head -3 | tr '\n' ' ')"
+else
+  record A PASS "settings.json contains zero capture-gate references"
+fi
+
+# ===========================================================================
+# CLAUSE B — the file is gone from the LIVE hook directory.
+# Unregistering alone is not retirement: a hook sitting on the hook path is one
+# settings edit from firing again, and reads as current to the next agent.
+# ===========================================================================
+if [ -e "$LIVE_GATE" ]; then
+  record B FAIL "capture-gate.ts still sits on the live hook path ($LIVE_GATE)"
+else
+  record B PASS "capture-gate.ts is no longer on the live hook path"
+fi
+
+# ===========================================================================
+# CLAUSE C — it exists under _retired/ WITH the pointer. Retire, don't delete:
+# the receipt-probe code is prior art for the #647 liveness lane.
+# ===========================================================================
+if [ ! -r "$RETIRED_GATE" ]; then
+  record C FAIL "no retired copy at $RETIRED_GATE — the receipt-probe prior art for #647 was deleted, not retired"
+elif ! rg -qiF 'item 25' "$RETIRED_GATE"; then
+  record C FAIL "retired copy exists but does not name the ruling (ledger item 25) — a reader cannot tell why it is here"
+elif ! rg -qF '#646' "$RETIRED_GATE"; then
+  record C FAIL "retired copy does not point at #646 (the gate's live defects)"
+elif ! rg -qF '#647' "$RETIRED_GATE"; then
+  record C FAIL "retired copy does not point at #647 (the liveness check that replaces it)"
+else
+  record C PASS "retired copy present at .claude/hooks/_retired/ naming ledger item 25, #646 and #647"
+fi
+
+# ===========================================================================
+# CLAUSE D — the surviving hook set is EXACTLY the five named in the ruling.
+# Extracted from the command strings actually registered, so this measures the
+# config rather than the directory listing (a file on disk that nothing
+# registers enforces nothing — the #451 clause-F lesson, inverted).
+# ===========================================================================
+EXPECTED_HOOKS="design-contract design-lookup-gate hydration-stamp merge-gate pr-body-gate"
+if [ ! -r "$SETTINGS" ]; then
+  record D FAIL "no $SETTINGS to inspect"
+else
+  ACTUAL_HOOKS="$(rg -o -e '\.claude/hooks/([a-z0-9-]+)\.ts' -r '$1' "$SETTINGS" | sort -u | tr '\n' ' ' | sed 's/ *$//')"
+  if [ -z "$ACTUAL_HOOKS" ]; then
+    record D FAIL "no hooks registered at all — the retirement took the survivors with it"
+  elif [ "$ACTUAL_HOOKS" != "$EXPECTED_HOOKS" ]; then
+    record D FAIL "registered hook set is not the five survivors — expected [$EXPECTED_HOOKS], found [$ACTUAL_HOOKS]"
+  else
+    record D PASS "registered hook set is exactly the five survivors [$ACTUAL_HOOKS]"
+  fi
+fi
+
+# ===========================================================================
+# CLAUSE E — 451's tiered-coverage check passes against the retired state.
+# The kept tiers (hydration stamp, recall telemetry) must still be enforced;
+# the capture clauses must no longer assert a gate that is gone.
+# ===========================================================================
+if [ ! -x "$CHECK_451" ] && [ ! -r "$CHECK_451" ]; then
+  record E FAIL "no 451 tiered-coverage check at $CHECK_451"
+else
+  CHECK_451_OUT="$(bash "$CHECK_451" 2>&1)"
+  CHECK_451_EXIT=$?
+  if [ "$CHECK_451_EXIT" -ne 0 ]; then
+    record E FAIL "451-tiered-coverage.sh exits $CHECK_451_EXIT against the retired state: $(printf '%s' "$CHECK_451_OUT" | rg -F 'FAIL' | head -3 | tr '\n' ' ')"
+  elif ! printf '%s' "$CHECK_451_OUT" | rg -qF 'CLAUSE D '; then
+    record E FAIL "451 passed but no longer runs its hydration clause D — the kept tier went missing with the retired one"
+  elif ! printf '%s' "$CHECK_451_OUT" | rg -qF 'CLAUSE E '; then
+    record E FAIL "451 passed but no longer runs its recall clause E — the kept tier went missing with the retired one"
+  else
+    record E PASS "451-tiered-coverage.sh PASSES against the retired state, hydration (D/D2) and recall (E) clauses still running"
+  fi
+fi
+
+# ===========================================================================
+# Verdict
+# ===========================================================================
+printf '\n'
+FAILED=0
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"; rest="${entry#*|}"
+  status="${rest%%|*}"; evidence="${rest#*|}"
+  printf 'CLAUSE %-3s %-4s — %s\n' "$id" "$status" "$evidence"
+  [ "$status" = PASS ] || FAILED=1
+done
+
+if [ "$FAILED" -eq 0 ]; then
+  printf '\nRESULT: PASS — the capture gate is retired, the survivors are intact\n'
+  exit 0
+fi
+printf '\nRESULT: FAIL — at least one clause did not hold\n'
+exit 1


### PR DESCRIPTION
## Summary

- Implements ledger item 25 (`docs/issue-graph.md`) on `main`: the #451 CAPTURE
  merge-gate tier is RETIRED. The ruling was recorded 2026-08-08 but never
  applied to `main`, so `.claude/settings.json` on `main` still registered
  `capture-gate.ts` as a `PreToolUse` hook and any session started from `main`
  could still hit the merge wedge that blocked PR #645 (and structurally
  blocked the merge of any fix for the gate itself).
- Removes ONLY the `capture-gate` entry from `PreToolUse`. The five survivors —
  `pr-body-gate`, `merge-gate`, `design-lookup-gate`, `design-contract`,
  `hydration-stamp` — are untouched, and clause D of the new check asserts the
  registered set is exactly those five in both directions (none missing, none
  extra).
- RETIRES rather than deletes: `.claude/hooks/capture-gate.ts` moves to
  `.claude/hooks/_retired/capture-gate.ts` with a header naming the ruling and
  #646/#647. Its server-side receipt probe, drain step, and outage-vs-skip
  discrimination are prior art for the #647 liveness lane, which must answer
  the same question ("did capture deliver for this session?") without the
  block. Deleting it would make that lane rediscover it.
- Inverts the capture clauses of `scripts/done-means/451-tiered-coverage.sh`
  (A/B/C/F) to assert the retirement instead of the refusal behaviour, and
  keeps them FAILING if the source is absent from both paths — deleted is not
  retired. The KEPT tiers of item 24 are unchanged and still enforced there:
  hydration D/D2 and recall telemetry E.
- Fixes two now-stale cross-references to the moved file, in
  `.claude/hooks/hydration-stamp.ts` and
  `python/openbrain/src/openbrain/apps/hooks/post_tool_use.py`. Comment-only;
  no behaviour change in either.

## Verification

- Done-means: scripts/done-means/648-capture-gate-retired.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (against unmodified `origin/main`, before any change) — the retirement is
recorded but not implemented, so four clauses fail:

```
CLAUSE 0   PASS — CONTROL: bun executes and settings.json is readable
CLAUSE A   FAIL — settings.json still references capture-gate — the wedge can still fire
CLAUSE B   FAIL — capture-gate.ts still sits on the live hook path
CLAUSE C   FAIL — no retired copy at .claude/hooks/_retired/capture-gate.ts
CLAUSE D   FAIL — registered hook set is not the five survivors — found [capture-gate design-contract design-lookup-gate hydration-stamp merge-gate pr-body-gate]
CLAUSE E   PASS — 451-tiered-coverage.sh PASSES against the retired state
RESULT: FAIL — at least one clause did not hold
```

SECOND RED (after retiring the hook, BEFORE adjusting 451) — this is the
mismatch the change exists to resolve, captured rather than skipped past:

```
$ bash scripts/done-means/451-tiered-coverage.sh
CLAUSE A   FAIL — no capture gate at .claude/hooks/capture-gate.ts
CLAUSE B   FAIL — no capture gate at .claude/hooks/capture-gate.ts
CLAUSE C   FAIL — no capture gate at .claude/hooks/capture-gate.ts
CLAUSE F   FAIL — no capture gate to register
CLAUSE D   PASS — canon pack empty -> loud marker emitted, session NOT blocked
CLAUSE D2  PASS — healthy pack -> no marker (control: the marker carries signal)
CLAUSE E   PASS — recall counted in the existing telemetry lane, facts only
RESULT: FAIL — at least one clause did not hold
```

GREEN (after the full change):

```
$ bash scripts/done-means/648-capture-gate-retired.sh
CLAUSE 0   PASS — CONTROL: bun executes and settings.json is readable
CLAUSE A   PASS — settings.json contains zero capture-gate references
CLAUSE B   PASS — capture-gate.ts is no longer on the live hook path
CLAUSE C   PASS — retired copy present at .claude/hooks/_retired/ naming ledger item 25, #646 and #647
CLAUSE D   PASS — registered hook set is exactly the five survivors
CLAUSE E   PASS — 451-tiered-coverage.sh PASSES against the retired state, hydration (D/D2) and recall (E) clauses still running
RESULT: PASS — the capture gate is retired, the survivors are intact

$ bash scripts/done-means/451-tiered-coverage.sh
CLAUSE 0/A/B/C/F/D/D2/E all PASS
RESULT: PASS — all clauses hold
```

MUTATION TESTS. Per the round-9 Tightening, a green clause is not evidence
until it has been seen to fail — and both new clauses here are the kind whose
PASS comes from a negative match, which passes both when the thing is absent
and when the check is broken:

- MUT1 — move the retired source away so it is absent from BOTH paths. 451
  clauses A/B/C/F FAIL with "deleted, not retired (ledger item 25 says
  retire)". The retire-vs-delete distinction is load-bearing, not decorative.
- MUT2 — inject a sixth hook (`sneaky-sixth.ts`) into `PreToolUse`. 648 clause
  D FAILS naming the extra: "found [... pr-body-gate sneaky-sixth]". The
  "none extra" half of the set assertion is live, so this cannot pass while a
  hook creeps in.

Suite and typecheck, in the lane worktree against a fresh isolated database:

```
$ bunx tsc --noEmit          # clean, exit 0
$ bun run test:isolated
 3718 pass / 35 skip / 0 fail / 15189 expect() calls
 Ran 3753 tests across 242 files. [38.90s]
 tests exited 0 — database ob_isolated_81795_mskptsg3j5 dropped
```

## Critical Self-Review

- Highest-risk behavior: removing a registered `PreToolUse` hook. The blast
  radius is bounded because the entry removed is the only one that can REFUSE a
  merge on a capture receipt; the other four PreToolUse/UserPromptSubmit gates
  and the SessionStart stamp are byte-identical, which clause D asserts rather
  than assumes.
- Assumptions that could be wrong: (1) that no consumer outside
  `.claude/settings.json` executes `capture-gate.ts` by path. Checked with `rg`
  across the tree including hidden files — the only remaining references are
  the two comments this PR updates, the two done-means scripts, and the retired
  file itself. (2) That `.claude/hooks/_retired/` is off every hook path: it is,
  because Claude Code executes only the commands named in settings.json, and no
  command names that directory. (3) That #647 will actually want this code —
  that is a judgment from the ruling text, not a verified fact; if wrong, the
  cost is one unreferenced file.
- Missing/weak tests: 648 clause E delegates to 451 rather than re-asserting
  the hydration and recall tiers itself, so the two checks are coupled — if 451
  regresses, 648 reports it as its own failure. That is deliberate (duplicating
  the assertions would make them mutually recursive) but it does mean 648 alone
  is not a complete statement of the kept tiers. Not covered: whether a Claude
  Code session started from this branch actually stops invoking the hook —
  settings.json is the mechanism and is asserted, but the live harness reading
  it is not driven by any check here.
- Security/permission risk: none. No auth, namespace, token, or SQL path is
  touched. Removing this gate cannot widen access to anything; it only stops a
  local merge refusal.
- Migration/deploy risk: none. No schema, no migration, no serving-tree file.
  `.claude/` is repo-local agent configuration and is not deployed to core01.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md` — no
  MCP tool, schema, transport, or Python-client contract changes. The one
  Python file touched is a module docstring.
- Rollback/cleanup concern: rollback is `git revert` of a single commit; the
  hook source is preserved in-tree, so a revert restores a working gate rather
  than a stub. The lane worktree and its scratch are removed at teardown.
- Fixes made before PR: found and fixed two stale path references
  (`hydration-stamp.ts:24`, `post_tool_use.py:19`) that would have pointed the
  next reader at a file that no longer exists at that path — the exact
  archaeology cost this repo keeps paying. Also widened 451's absent-gate
  branch so that DELETING the source stays a failure; the first draft treated
  any absence as retirement, which would have let a future cleanup silently
  destroy the #647 prior art.
- Known residual risk: `main` sessions that already loaded the old settings
  keep the hook registered until they restart. That is inherent to hook config
  and not fixable in a diff; it is why this PR exists rather than a session-only
  workaround.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the reusable lesson here is operating knowledge for lanes (retire
  rather than delete when the code is prior art for a named successor; invert a
  done-means clause instead of dropping it), which the lane contract's
  Tightenings own. It is returned in the lane report's `lessons` field for the
  controller's harvest. No reviewer-facing code-defect pattern was found.

## Review Gate

- [x] Critical self-review fields above are filled with specific,
  non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked
  not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this
  change touches only repo-local agent hook configuration and two done-means
  scripts. Nothing in the running service, its schema, or its API is involved,
  so a live smoke would exercise nothing the diff can affect.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `.claude/hooks/` and
  `.claude/settings.json` are Claude Code harness configuration for this repo
  only. There is no cross-runtime contract or fixture corpus that mirrors the
  hook registry.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line above: no MCP tool, schema, transport, or
  client-facing surface changes. The classification rule in
  `docs/downstream-rollout.md` keys on contract-changing MCP/transport/Python
  client/agent-facing changes; this diff is hook configuration, two done-means
  scripts, and two comments.
- Does NOT close #451 — item 24's hydration and recall tiers remain enforced by
  `451-tiered-coverage.sh`, which still passes. Does not implement #647; the
  liveness check that replaces this tier is its own lane, and this PR only
  preserves the prior art it needs.
