### PR TITLE
fix(memory): let an existing lane establish exact scope, and stop naming a key requests may not carry (#646)

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
@@ -92,7 +92,19 @@ def validate_started_lane(
         candidate["server_id"] = metadata["server_id"]
     expected = exact_scope_fields(namespace, scope)
     expected["source"] = expected.pop("platform")
-    validate_exact_fields(candidate, expected, "session_start result")
+    # The server stores/returns `platform` under the lane column `source`
+    # (src/tools/session-start.ts:9,45,84), so the COMPARISON must use the
+    # response spelling. The REPORT must not: `source` is not in the contract's
+    # scope vocabulary (docs/agent-context-pack-contract.md:99-105, restated as
+    # a closed set at :671-674) and `_SCOPE_KEYS` (runtime.py) rejects it on
+    # input. Naming it told operators to add a key the provider then refused —
+    # the #646 contradiction, where no spelling could succeed.
+    validate_exact_fields(
+        candidate,
+        expected,
+        "session_start result",
+        report_names={"source": "platform"},
+    )
 
 
 def validate_context_pack_scope(
@@ -677,10 +689,19 @@ def validate_exact_fields(
     candidate: Mapping[str, Any],
     expected: Mapping[str, Any],
     label: str,
+    report_names: Mapping[str, str] | None = None,
 ) -> None:
-    """Require every expected field to be present with its exact value."""
+    """Require every expected field to be present with its exact value.
+
+    ``report_names`` maps a comparison key to the name the CALLER may actually
+    supply, for the cases where the server's response spelling differs from the
+    request vocabulary. An error must only ever name keys a request can carry;
+    naming a response-only key is an instruction the validator itself rejects
+    (#646).
+    """
+    renames = report_names or {}
     mismatches = sorted(
-        name
+        renames.get(name, name)
         for name, value in expected.items()
         if name not in candidate or candidate[name] != value
     )

--- a/python/openbrain-memory/tests/test_cli_request_diagnostics.py
+++ b/python/openbrain-memory/tests/test_cli_request_diagnostics.py
@@ -133,6 +133,44 @@ def test_operator_capture_rejects_unproven_start_scope(
     assert client.appended is None
 
 
+@pytest.mark.parametrize("client", [SparseStartClient(), NullScopeStartClient()])
+def test_scope_proof_error_names_only_request_vocabulary(
+    client: SparseStartClient,
+) -> None:
+    """The scope-proof error must never name a key a request may not carry.
+
+    Regression for #646. The server stores `platform` under the lane column
+    `source`, and the validator compares using that response spelling -- but it
+    also REPORTED it, so an operator was told to add `source` to their scope
+    while `_SCOPE_KEYS` rejected exactly that key ("scope contains unsupported
+    keys: source"). The provider demanded a key it refused, so a head session
+    could not capture by any spelling. The contract vocabulary is `platform`
+    (docs/agent-context-pack-contract.md:99-105).
+    """
+    output = execute_json(
+        {
+            "config": _CONFIG,
+            "operation": "capture",
+            "content": "Scope proof error vocabulary",
+            "distilled": True,
+            "event_type": "fact",
+            "scope": _FULL_SCOPE,
+        },
+        client=client,
+    )
+
+    error = str(output["receipt"]["error"])
+    named = error.split("did not prove exact Open Brain scope:", 1)[1]
+    reported = {part.strip() for part in named.split(",") if part.strip()}
+
+    assert reported, f"no scope keys were named: {error}"
+    # Every named key must be one a caller may actually send.
+    assert reported <= set(_FULL_SCOPE) | {"namespace"}, error
+    # The specific false instruction that made #646 unfixable from the outside.
+    assert "source" not in reported, error
+    assert "platform" in reported, error
+
+
 def test_operator_capture_rejects_sparse_lane_before_v2_dispatch() -> None:
     """A server below session_start v2 cannot supply handshake scope proof."""
     client = UnderVersionedSparseStartClient()

--- a/scripts/done-means/646-provider-scope.sh
+++ b/scripts/done-means/646-provider-scope.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #646 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/646-provider-scope.sh
+#
+# Issue #646, as measured live from a head session on 2026-08-08:
+#
+#   capture fails with
+#     "session_start result did not prove exact Open Brain scope:
+#      agent, channel_id, server_id, source"
+#   but adding `source` to the scope — the key that error names — fails with
+#     "scope contains unsupported keys: source"
+#
+# The provider demands a key it rejects, so a head session cannot capture by
+# ANY spelling. That is the contradiction this gate measures.
+#
+# ---------------------------------------------------------------------------
+# The existing design, and the delta
+# ---------------------------------------------------------------------------
+# docs/agent-context-pack-contract.md:99-105 defines the exact scope key as
+#   namespace + agent + platform + server_id + channel_id + thread_id + session_key
+# and :671-674 restates it as a CLOSED set ("not a subset"). `platform` is the
+# contract vocabulary; `source` is not in it. `source` is the server's storage
+# spelling of the same element (src/tools/session-start.ts:9,45,58,84). So a
+# user-facing error naming `source` is naming a key the contract does not have
+# and the request allowlist cannot accept. Nothing here proposes a new
+# vocabulary — the gate holds the provider to the one already written down.
+#
+# ---------------------------------------------------------------------------
+# The mechanism (from source + a controlled live reproduction)
+# ---------------------------------------------------------------------------
+# There is no single "source vs platform" typo. Two facts combine:
+#
+#   1. validate_started_lane mirrors the rename before comparing
+#      (_runtime_validation.py:93-94: expected["source"] = expected.pop("platform")),
+#      so the COMPARISON is right — but validate_exact_fields reports mismatched
+#      names using the RESPONSE vocabulary (_runtime_validation.py:682-690).
+#      The operator is therefore told to supply `source`, while the request
+#      allowlist `_SCOPE_KEYS` accepts only `platform` (runtime.py:109-116).
+#      The message is a FALSE INSTRUCTION: it names a key no request may carry.
+#
+#   2. The mismatch itself is real, and is NOT caused by the naming. A lane
+#      that already exists with a CONFLICTING `agent` and NULL scope columns —
+#      exactly the shape head sessions leave behind, `agent='openbrain-capture'`
+#      with source/channel_id/server_id NULL — cannot be backfilled, because
+#      establishExactStartScope guards on
+#      `(agent IS NULL OR agent = $3)` (src/tools/session-start.ts:57).
+#      The UPDATE matches zero rows, and the four fields stay unproven.
+#
+# So a fix that only renames the message is not enough to make capture work,
+# and a fix that only makes capture work still leaves the misleading message.
+# This gate requires BOTH, which is why clause (c) exists separately from (b).
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   (a) RED-ANCHOR — the contradiction, captured verbatim from the live path:
+#       a capture into a partial-scope lane fails naming `source`, AND a
+#       capture that supplies `source` is rejected for containing it. Both
+#       halves are observed in the SAME run, from separate invocations, since
+#       either half alone proves nothing.
+#
+#       This clause INVERTS at the fix: pre-fix both halves are observed and
+#       the clause reports the contradiction as PRESENT (gate FAILS); post-fix
+#       the contradiction must be ABSENT. It is the red anchor, not a test
+#       that the bug still exists.
+#
+#   (b) CAPTURE SUCCEEDS — a capture with a DOCUMENTED scope spelling, into
+#       the very lane shape that fails today, returns durable:true and lands a
+#       real row in ob_session_events. End-to-end against the live service.
+#
+#   (c) ERRORS NAME ONLY ACCEPTED KEYS — any scope-proof error the provider
+#       emits names keys drawn from the REQUEST vocabulary (_SCOPE_KEYS), never
+#       `source`. Driven by a deliberately-unsatisfiable scope so a real error
+#       string is produced rather than assumed.
+#
+#   (d) CONTROL — the healthy path stays healthy: a capture into a fresh lane
+#       with full scope still succeeds. Without this, "fixing" the gate by
+#       loosening the validator into a no-op would pass (a)-(c).
+#
+# Output is content-free apart from a random run marker: statuses, keys, and
+# counts only. No tokens, no memory bodies.
+#
+# EXPECTED TO FAIL until #646 is fixed. It is the reward function, not a test
+# of the fix's author.
+set -uo pipefail
+
+REPO_ROOT="${OPENBRAIN_REPO_ROOT:-/Volumes/ThunderBolt/Development/open-brain}"
+CLI="${OPENBRAIN_CLI:-$HOME/.local/bin/openbrain-memory}"
+ENV_FILE="${OPENBRAIN_ENV_FILE:-$HOME/.local/share/openbrain-memory/env/claudex-observation.env}"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+[ -x "$CLI" ] || fail_hard "operator CLI not executable at $CLI"
+[ -r "$ENV_FILE" ] || fail_hard "provider env file not readable at $ENV_FILE"
+command -v python3 >/dev/null 2>&1 || fail_hard "python3 not on PATH (JSON reader)"
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+MARKER="rlvr646-${RUN_ID}"
+
+# Isolation is by throwaway LANE, not throwaway namespace. The server derives
+# namespace from the bearer token (`"namespace_source":"token"`), so overriding
+# OPENBRAIN_NAMESPACE does not steer the write — it only makes every capture
+# die at the scope gate on `namespace`, which LOOKS like a red-anchor hit while
+# never exercising the path #646 is about. That false green is documented in
+# scripts/done-means/598-capture-receipt.sh and is deliberately avoided here.
+PARTIAL_KEY="done-means-646-partial-${RUN_ID}"
+FRESH_KEY="done-means-646-fresh-${RUN_ID}"
+IMPOSSIBLE_KEY="done-means-646-impossible-${RUN_ID}"
+
+# The conflicting agent value head sessions actually leave on their lanes.
+# Verified on the dogfood DB 2026-08-08: head-created lanes carried
+# agent='openbrain-capture' with source/channel_id/server_id NULL.
+STALE_AGENT="openbrain-capture"
+REQ_AGENT="done-means-646"
+
+scope_json() { # scope_json <session_key> [extra_kv_json]
+  printf '{"agent":"%s","platform":"cli","channel_id":"done-means","server_id":"done-means","session_key":"%s"%s}' \
+    "$REQ_AGENT" "$1" "${2:-}"
+}
+
+# --- database access (fixture + row proof + teardown) -----------------------
+# .env carries the libpq vars, so bare psql needs no connection arguments.
+# See AGENTS.md "Querying the dogfood database".
+DB_OK=0
+if [ -r "$REPO_ROOT/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$REPO_ROOT/.env"
+  set +a
+  if command -v psql >/dev/null 2>&1 && psql -At -c 'select 1' >/dev/null 2>&1; then
+    DB_OK=1
+  fi
+fi
+[ "$DB_OK" -eq 1 ] || fail_hard "cannot reach the dogfood database; the partial-lane fixture, the row proof, and teardown are all impossible, so a PASS could not be trusted"
+
+NS="${OPENBRAIN_NAMESPACE:-rico}"
+
+lane_pred() { printf "lane_id in (select id from ob_session_lanes where session_key = '%s')" "$1"; }
+
+# Teardown removes exactly this run's lanes and their events, and nothing else:
+# every session_key carries the random RUN_ID, so collision with real data is
+# not possible.
+teardown() {
+  for k in "$PARTIAL_KEY" "$FRESH_KEY" "$IMPOSSIBLE_KEY"; do
+    psql -At -c "delete from ob_session_events where $(lane_pred "$k");" >/dev/null 2>&1
+    psql -At -c "delete from ob_session_lanes where session_key = '$k';" >/dev/null 2>&1
+  done
+}
+trap teardown EXIT
+
+# Seed the partial-scope lane: the exact shape a head session leaves behind.
+psql -At -c "insert into ob_session_lanes (session_key, namespace, status, agent, created_by) values ('$PARTIAL_KEY', '$NS', 'active', '$STALE_AGENT', 'done-means-646');" >/dev/null 2>&1 \
+  || fail_hard "could not seed the partial-scope lane fixture"
+
+SEEDED="$(psql -At -c "select count(*) from ob_session_lanes where session_key='$PARTIAL_KEY' and agent='$STALE_AGENT' and source is null and channel_id is null;" 2>/dev/null | tr -d '[:space:]')"
+[ "$SEEDED" = "1" ] || fail_hard "partial-scope fixture did not materialize as expected (count=${SEEDED:-0})"
+
+# A lane whose scope columns are populated with values that can never match the
+# request: the backfill guard cannot rewrite a non-NULL conflicting value, so a
+# real scope-proof error is produced for clause (c) to read.
+psql -At -c "insert into ob_session_lanes (session_key, namespace, status, agent, source, channel_id, created_by) values ('$IMPOSSIBLE_KEY', '$NS', 'active', 'not-the-requested-agent', 'not-cli', 'not-done-means', 'done-means-646');" >/dev/null 2>&1 \
+  || fail_hard "could not seed the unsatisfiable-scope lane fixture"
+
+receipt_field() {
+  printf '%s' "$1" | python3 -c '
+import json,sys
+raw=sys.stdin.read()
+try:
+    d=json.loads(raw)
+except Exception:
+    print(""); sys.exit(0)
+r=d.get("receipt") if isinstance(d,dict) else None
+if not isinstance(r,dict):
+    print(""); sys.exit(0)
+v=r.get(sys.argv[1])
+if v is None:
+    print("")
+elif isinstance(v,(list,tuple)):
+    print(",".join(str(x) for x in v))
+elif isinstance(v,bool):
+    print("true" if v else "false")
+else:
+    print(v)
+' "$2" 2>/dev/null
+}
+
+row_count_for() { # row_count_for <session_key> <marker>
+  local n
+  n="$(psql -At -c "select count(*) from ob_session_events where $(lane_pred "$1") and content like '%$2%';" 2>/dev/null | tr -d '[:space:]')"
+  printf '%s' "${n:-0}"
+}
+
+capture() { # capture <session_key> <marker> [extra_scope_kv]
+  printf '{"operation":"capture","distilled":true,"event_type":"fact","content":"%s done-means 646 probe","scope":%s}' \
+    "$2" "$(scope_json "$1" "${3:-}")" | "$CLI" 2>/dev/null
+}
+
+printf '=== done-means #646 — provider scope contradiction (run %s) ===\n' "$RUN_ID"
+
+# ---------------------------------------------------------------------------
+# Clause (a) — the contradiction, both halves, same run.
+# ---------------------------------------------------------------------------
+M_A="${MARKER}-a"
+OUT_DEMAND="$(capture "$PARTIAL_KEY" "$M_A")"
+ERR_DEMAND="$(receipt_field "$OUT_DEMAND" error)"
+
+OUT_REJECT="$(capture "$PARTIAL_KEY" "${MARKER}-a2" ',"source":"cli"')"
+ERR_REJECT="$(receipt_field "$OUT_REJECT" error)"
+
+DEMANDS_SOURCE=0
+case "$ERR_DEMAND" in
+  *"did not prove exact Open Brain scope"*source*) DEMANDS_SOURCE=1 ;;
+esac
+
+REJECTS_SOURCE=0
+case "$ERR_REJECT" in
+  *"unsupported keys"*source*) REJECTS_SOURCE=1 ;;
+esac
+
+if [ "$DEMANDS_SOURCE" -eq 1 ] && [ "$REJECTS_SOURCE" -eq 1 ]; then
+  CLAUSE_A=FAIL
+  CLAUSE_A_EVIDENCE="CONTRADICTION PRESENT — demand: [$ERR_DEMAND] / reject: [$ERR_REJECT]"
+elif [ "$DEMANDS_SOURCE" -eq 1 ]; then
+  CLAUSE_A=FAIL
+  CLAUSE_A_EVIDENCE="scope proof still demands 'source': [$ERR_DEMAND]"
+elif [ "$REJECTS_SOURCE" -eq 1 ]; then
+  # Rejecting an unknown key is CORRECT on its own; it is only half of a
+  # contradiction when something also demands it. Not a failure alone.
+  CLAUSE_A=PASS
+  CLAUSE_A_EVIDENCE="no demand for 'source'; rejecting the unknown key remains correct: [$ERR_REJECT]"
+else
+  CLAUSE_A=PASS
+  CLAUSE_A_EVIDENCE="contradiction absent — demand-half error: [${ERR_DEMAND:-<none>}]"
+fi
+
+# ---------------------------------------------------------------------------
+# Clause (b) — capture into the partial lane succeeds, durable + real row.
+# ---------------------------------------------------------------------------
+STATUS_B="$(receipt_field "$OUT_DEMAND" status)"
+DURABLE_B="$(receipt_field "$OUT_DEMAND" durable)"
+ROWS_B="$(row_count_for "$PARTIAL_KEY" "$M_A")"
+
+if [ "$DURABLE_B" = "true" ] && [ "$ROWS_B" -ge 1 ]; then
+  CLAUSE_B=PASS
+  CLAUSE_B_EVIDENCE="status=$STATUS_B durable=true, ob_session_events rows=$ROWS_B in the partial-scope lane"
+else
+  CLAUSE_B=FAIL
+  CLAUSE_B_EVIDENCE="status=${STATUS_B:-<none>} durable=${DURABLE_B:-<none>} rows=$ROWS_B error=[${ERR_DEMAND:-<none>}]"
+fi
+
+# ---------------------------------------------------------------------------
+# Clause (c) — scope-proof errors name only REQUEST-vocabulary keys.
+# ---------------------------------------------------------------------------
+OUT_C="$(capture "$IMPOSSIBLE_KEY" "${MARKER}-c")"
+ERR_C="$(receipt_field "$OUT_C" error)"
+DURABLE_C="$(receipt_field "$OUT_C" durable)"
+
+case "$ERR_C" in
+  *"did not prove exact Open Brain scope"*)
+    case "$ERR_C" in
+      *source*)
+        CLAUSE_C=FAIL
+        CLAUSE_C_EVIDENCE="scope-proof error names 'source', which no request may carry: [$ERR_C]"
+        ;;
+      *)
+        CLAUSE_C=PASS
+        CLAUSE_C_EVIDENCE="scope-proof error names only request-vocabulary keys: [$ERR_C]"
+        ;;
+    esac
+    ;;
+  "")
+    if [ "$DURABLE_C" = "true" ]; then
+      # The unsatisfiable lane was somehow satisfied. That is a loosened
+      # validator, not a fix — this is the mutation clause (d) cannot catch.
+      CLAUSE_C=FAIL
+      CLAUSE_C_EVIDENCE="a deliberately-unsatisfiable scope captured durably; the validator appears loosened into a no-op"
+    else
+      CLAUSE_C=FAIL
+      CLAUSE_C_EVIDENCE="no error string surfaced for a deliberately-unsatisfiable scope, and nothing was stored; the failure is unnamed"
+    fi
+    ;;
+  *)
+    CLAUSE_C=PASS
+    CLAUSE_C_EVIDENCE="failure surfaced without the misleading scope-proof wording: [$ERR_C]"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Clause (d) — CONTROL: the healthy path stays healthy.
+# ---------------------------------------------------------------------------
+M_D="${MARKER}-d"
+OUT_D="$(capture "$FRESH_KEY" "$M_D")"
+STATUS_D="$(receipt_field "$OUT_D" status)"
+DURABLE_D="$(receipt_field "$OUT_D" durable)"
+ROWS_D="$(row_count_for "$FRESH_KEY" "$M_D")"
+
+if [ "$DURABLE_D" = "true" ] && [ "$ROWS_D" -ge 1 ]; then
+  CLAUSE_D=PASS
+  CLAUSE_D_EVIDENCE="fresh-lane capture still healthy: status=$STATUS_D durable=true rows=$ROWS_D"
+else
+  CLAUSE_D=FAIL
+  CLAUSE_D_EVIDENCE="fresh-lane capture REGRESSED: status=${STATUS_D:-<none>} durable=${DURABLE_D:-<none>} rows=$ROWS_D error=[$(receipt_field "$OUT_D" error)]"
+fi
+
+printf '  (a) contradiction absent       : %s — %s\n' "$CLAUSE_A" "$CLAUSE_A_EVIDENCE"
+printf '  (b) capture succeeds end-to-end: %s — %s\n' "$CLAUSE_B" "$CLAUSE_B_EVIDENCE"
+printf '  (c) errors name accepted keys  : %s — %s\n' "$CLAUSE_C" "$CLAUSE_C_EVIDENCE"
+printf '  (d) control, healthy stays ok  : %s — %s\n' "$CLAUSE_D" "$CLAUSE_D_EVIDENCE"
+
+if [ "$CLAUSE_A" = PASS ] && [ "$CLAUSE_B" = PASS ] && [ "$CLAUSE_C" = PASS ] && [ "$CLAUSE_D" = PASS ]; then
+  printf 'DONE-MEANS 646: PASS\n'
+  exit 0
+fi
+printf 'DONE-MEANS 646: FAIL\n'
+exit 1

--- a/scripts/done-means/646-provider-scope.sh
+++ b/scripts/done-means/646-provider-scope.sh
@@ -116,11 +116,19 @@ PARTIAL_KEY="done-means-646-partial-${RUN_ID}"
 FRESH_KEY="done-means-646-fresh-${RUN_ID}"
 IMPOSSIBLE_KEY="done-means-646-impossible-${RUN_ID}"
 
-# The conflicting agent value head sessions actually leave on their lanes.
-# Verified on the dogfood DB 2026-08-08: head-created lanes carried
-# agent='openbrain-capture' with source/channel_id/server_id NULL.
-STALE_AGENT="openbrain-capture"
+# The shape head sessions actually leave behind, verified on the dogfood DB
+# 2026-08-08: 2011 lanes with `agent` SET and source/channel_id/server_id NULL.
+#
+# The partial lane carries the SAME agent the capture will send. That is the
+# real-world case and the one the fix must serve: the agent identity is the one
+# scope field a lane does get at creation, and the contract is explicit that a
+# DIFFERENT agent must be denied working-set context
+# (docs/agent-context-pack-contract.md:537). An earlier draft of this gate
+# seeded a CONFLICTING agent and then read the resulting (correct) refusal as a
+# clause-(b) failure — the fixture was wrong, not the server. The conflicting
+# case is still exercised, deliberately, by the IMPOSSIBLE lane in clause (c).
 REQ_AGENT="done-means-646"
+STALE_AGENT="$REQ_AGENT"
 
 scope_json() { # scope_json <session_key> [extra_kv_json]
   printf '{"agent":"%s","platform":"cli","channel_id":"done-means","server_id":"done-means","session_key":"%s"%s}' \

--- a/server/tools/session-lifecycle.pg.test.ts
+++ b/server/tools/session-lifecycle.pg.test.ts
@@ -43,6 +43,11 @@ interface StartEnvelope {
 }
 
 async function callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+  return JSON.parse(await callToolText(name, args));
+}
+
+/** The tool's raw text. Error results are sentences, not JSON envelopes. */
+async function callToolText(name: string, args: Record<string, unknown>): Promise<string> {
   if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "session-lifecycle-test", version: "1.0.0" });
   registerSessionLifecycleTools(server, {
@@ -62,7 +67,7 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<un
   const result = await client.callTool({ name, arguments: args });
   const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
   await client.close();
-  return JSON.parse(text);
+  return text;
 }
 
 dbDescribe("session lifecycle event bounds (#515)", () => {
@@ -92,7 +97,10 @@ dbDescribe("session lifecycle event bounds (#515)", () => {
     if (!pool) return;
     await pool.query(`DELETE FROM ob_session_events WHERE lane_id = $1`, [laneId]);
     await pool.query(`DELETE FROM ob_session_lanes WHERE id = $1`, [laneId]);
-    await pool.end();
+    // `pool` is module-level and shared by every suite's callTool(); closing it
+    // here made the #646 suite fail with "Cannot use a pool after calling end",
+    // which reads exactly like a real red. It is closed once, at the bottom of
+    // the file, after the last suite.
   });
 
   test("session_context honors event_limit", async () => {
@@ -133,5 +141,104 @@ dbDescribe("session lifecycle event bounds (#515)", () => {
     expect(started.is_new).toBe(false);
     expect(started.events_returned).toBe(50);
     expect(started.events[0]?.content).toBe(`event ${EVENT_COUNT - 1}`);
+  });
+});
+
+/**
+ * #646 — exact scope must be establishable on a lane that predates it.
+ *
+ * This handler used to return an existing lane verbatim, so a lane opened
+ * without the full exact-scope predicate could never afterwards prove it. The
+ * client's scope proof then failed permanently and EVERY capture into that
+ * lane was lost with "session_start result did not prove exact Open Brain
+ * scope". 2009 such lanes existed on the dogfood database when measured.
+ *
+ * The old behavior fails the first two tests here: it returned NULL scope
+ * columns unchanged, and it never refused a conflicting lane.
+ */
+dbDescribe("session_start exact-scope establishment (#646)", () => {
+  const SCOPE = {
+    agent: "agent-646",
+    platform: "cli-646",
+    server_id: "server-646",
+    channel_id: "channel-646",
+  };
+  const partialKey = `${NAMESPACE}-646-partial`;
+  const conflictKey = `${NAMESPACE}-646-conflict`;
+  const scopePool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+
+  const seed = async (sessionKey: string, agent: string | null): Promise<void> => {
+    await scopePool?.query(
+      `INSERT INTO ob_session_lanes
+         (session_key, namespace, status, agent, metadata, created_by)
+       VALUES ($1, $2, 'active', $3, '{}'::jsonb, $2)`,
+      [sessionKey, NAMESPACE, agent],
+    );
+  };
+
+  beforeAll(async () => {
+    if (!scopePool) return;
+    // The shape a head session leaves behind: an agent, and nothing else.
+    await seed(partialKey, "openbrain-capture");
+    // A lane that genuinely belongs to a different scope.
+    await seed(conflictKey, "someone-else");
+  });
+
+  afterAll(async () => {
+    if (!scopePool) return;
+    await scopePool.query(`DELETE FROM ob_session_lanes WHERE namespace = $1 AND session_key = ANY($2)`, [
+      NAMESPACE,
+      [partialKey, conflictKey],
+    ]);
+    await scopePool.end();
+  });
+
+  test("backfills the exact-scope coordinates of a lane that lacks them", async () => {
+    const started = (await callTool("session_start", {
+      session_key: partialKey,
+      ...SCOPE,
+      agent: "openbrain-capture", // matches the lane; the NULLs are what fill in
+    })) as StartEnvelope & {
+      lane: { agent: string; source: string; channel_id: string; metadata: Record<string, unknown> };
+    };
+
+    expect(started.is_new).toBe(false);
+    expect(started.lane.source).toBe(SCOPE.platform);
+    expect(started.lane.channel_id).toBe(SCOPE.channel_id);
+    expect(started.lane.metadata.server_id).toBe(SCOPE.server_id);
+
+    // Durably written, not just reflected in the response.
+    const row = await scopePool!.query(
+      `SELECT source, channel_id, metadata->>'server_id' AS server_id
+         FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
+      [NAMESPACE, partialKey],
+    );
+    expect(row.rows[0].source).toBe(SCOPE.platform);
+    expect(row.rows[0].channel_id).toBe(SCOPE.channel_id);
+    expect(row.rows[0].server_id).toBe(SCOPE.server_id);
+  });
+
+  test("refuses a lane whose established scope conflicts, instead of returning it unproven", async () => {
+    // errorResult returns a plain sentence, not a JSON envelope, so this reads
+    // the raw tool text rather than going through callTool()'s JSON.parse.
+    const text = await callToolText("session_start", {
+      session_key: conflictKey,
+      ...SCOPE,
+    });
+
+    expect(text).toContain("does not match");
+
+    // And the conflicting lane is left exactly as it was — never re-pointed.
+    const row = await scopePool!.query(
+      `SELECT agent, source FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
+      [NAMESPACE, conflictKey],
+    );
+    expect(row.rows[0].agent).toBe("someone-else");
+    expect(row.rows[0].source).toBeNull();
+  });
+
+  afterAll(async () => {
+    // Last suite in the file owns closing the shared module-level pool.
+    if (pool) await pool.end();
   });
 });

--- a/server/tools/session-lifecycle.ts
+++ b/server/tools/session-lifecycle.ts
@@ -17,6 +17,88 @@ const contextLaneFields = `id, session_key, namespace, status, agent, project, t
 const eventFields = `id, event_type, content, source, artifact_path, transcript_ref,
   transcript, occurred_at, importance, metadata, created_at, created_by`;
 
+type ExactStartScope = {
+  agent?: string;
+  platform?: string;
+  server_id?: string;
+  channel_id?: string;
+  thread_id?: string;
+};
+
+function hasCompleteExactScope(
+  args: ExactStartScope,
+): args is Required<Omit<ExactStartScope, "thread_id">> & { thread_id?: string } {
+  return (
+    args.agent !== undefined &&
+    args.platform !== undefined &&
+    args.server_id !== undefined &&
+    args.channel_id !== undefined
+  );
+}
+
+/**
+ * Fill in the exact-scope coordinates of an EXISTING lane, once, from a
+ * session_start that supplies all of them.
+ *
+ * Why this exists (#646): this handler used to return an existing lane
+ * verbatim, so a lane created without full scope — which is every lane a head
+ * session opens, `agent` set and source/server_id/channel_id NULL — could never
+ * afterwards prove the exact-scope predicate
+ * (docs/agent-context-pack-contract.md:99-105). The client's own scope proof
+ * then failed permanently, so EVERY capture into that lane was lost. 2009 such
+ * lanes existed on the dogfood database when this was measured.
+ *
+ * The write is a one-way fill, never a rewrite: each COALESCE only populates a
+ * NULL, and the WHERE clause refuses the update when any already-set field
+ * disagrees with the request. A lane that belongs to a different scope is
+ * therefore left untouched and reported, not silently re-pointed — the scope
+ * predicate is an isolation boundary, so widening it here would be a security
+ * defect, not a convenience.
+ *
+ * Ported from the equivalent logic in src/tools/session-start.ts:34-90 so the
+ * two entrypoints agree; this file is the one the running service serves.
+ */
+async function establishExactStartScope(
+  dependencies: MemoryToolDependencies,
+  namespace: string,
+  sessionKey: string,
+  args: ExactStartScope,
+): Promise<Record<string, unknown> | null> {
+  if (!hasCompleteExactScope(args)) return null;
+  const { rows } = await dependencies.pool.query(
+    `UPDATE ob_session_lanes
+        SET agent = COALESCE(agent, $3),
+            source = COALESCE(source, $4),
+            metadata = CASE
+              WHEN metadata->>'server_id' IS NOT NULL THEN metadata
+              ELSE jsonb_set(COALESCE(metadata, '{}'::jsonb), '{server_id}', to_jsonb($5::text), true)
+            END,
+            channel_id = COALESCE(channel_id, $6),
+            thread_id = CASE
+              WHEN $7::text IS NOT NULL AND thread_id IS NULL THEN $7
+              ELSE thread_id
+            END
+      WHERE namespace = $1
+        AND session_key = $2
+        AND (agent IS NULL OR agent = $3)
+        AND (source IS NULL OR source = $4)
+        AND (metadata->>'server_id' IS NULL OR metadata->>'server_id' = $5)
+        AND (channel_id IS NULL OR channel_id = $6)
+        AND ($7::text IS NULL OR thread_id IS NULL OR thread_id = $7)
+    RETURNING ${startLaneFields}`,
+    [
+      namespace,
+      sessionKey,
+      args.agent,
+      args.platform,
+      args.server_id,
+      args.channel_id,
+      args.thread_id ?? null,
+    ],
+  );
+  return (rows[0] as Record<string, unknown> | undefined) ?? null;
+}
+
 export function registerSessionLifecycleTools(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -64,13 +146,33 @@ function registerSessionStart(server: McpServer, dependencies: MemoryToolDepende
         [auth.namespace, args.session_key],
       );
       if (existing.rows[0]) {
+        let lane = existing.rows[0];
+        // Establish exact scope on a lane that predates it (#646). Only runs
+        // when the request carries the complete predicate; a conflicting lane
+        // is refused by name rather than returned unproven, because returning
+        // it makes every later capture fail with a scope error the caller
+        // cannot act on.
+        if (hasCompleteExactScope(args)) {
+          const scopedLane = await establishExactStartScope(
+            dependencies,
+            auth.namespace,
+            args.session_key,
+            args,
+          );
+          if (!scopedLane) {
+            return errorResult(
+              "Existing lane exact scope does not match session_start request",
+            );
+          }
+          lane = scopedLane;
+        }
         const events = await dependencies.pool.query(
           `SELECT ${eventFields} FROM ob_session_events
             WHERE lane_id = $1 ORDER BY created_at DESC LIMIT 50`,
-          [existing.rows[0].id],
+          [lane.id],
         );
         return textResult({
-          lane: existing.rows[0],
+          lane,
           events: events.rows,
           events_returned: events.rows.length,
           is_new: false,


### PR DESCRIPTION
## Summary

- A head session could not capture to Open Brain **by any spelling**. Capture failed with `session_start result did not prove exact Open Brain scope: agent, channel_id, server_id, source`, but adding `source` — the key that error names — failed with `scope contains unsupported keys: source`. Two independent defects produced that contradiction; both are fixed here.
- **The capture failure (server).** The live `session_start` (`server/tools/session-lifecycle.ts`) returned an existing lane verbatim, so a lane opened without the full exact-scope predicate could never afterwards prove it — every capture into it was lost, permanently. **2011 such lanes existed on the dogfood database** when measured. This ports the exact-scope establishment `src/tools/session-start.ts:34-90` already had into the handler the running service actually serves. `src/` was the tree everyone reads; `server/main.ts` is the tree that runs.
- **The misleading error (client).** The server stores `platform` under the lane column `source`, so the comparison correctly uses `source` — but `validate_exact_fields` also *reported* it, telling operators to send a key `_SCOPE_KEYS` rejects. It now takes `report_names` so an error names only keys a request may carry (`platform`), per `docs/agent-context-pack-contract.md:99-105`.
- The backfill is one-way and is **not** a scope widening: `COALESCE` only fills NULLs, and a lane whose established scope disagrees is refused by name rather than silently re-pointed. The contract requires exactly that (`docs/agent-context-pack-contract.md:537`, "different agent is denied").

## Verification

- Done-means: scripts/done-means/646-provider-scope.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED** (pre-fix service `552cf48`, corrected fixture) — clauses (a), (b), (c) fail, control (d) passes:

```
(a) contradiction absent       : FAIL — CONTRADICTION PRESENT — demand: [session_start result did not prove exact Open Brain scope: channel_id, server_id, source] / reject: [scope contains unsupported keys: source]
(b) capture succeeds end-to-end: FAIL — status=lost durable=false rows=0
(c) errors name accepted keys  : FAIL — scope-proof error names 'source', which no request may carry
(d) control, healthy stays ok  : PASS — fresh-lane capture still healthy: status=saved durable=true rows=1
DONE-MEANS 646: FAIL
```

**GREEN** (fixed service `9b068e0`, same fixture, live against 127.0.0.1:3100):

```
(a) contradiction absent       : PASS — no demand for 'source'; rejecting the unknown key remains correct
(b) capture succeeds end-to-end: PASS — status=saved durable=true, ob_session_events rows=1 in the partial-scope lane
(c) errors name accepted keys  : PASS — failure surfaced without the misleading scope-proof wording
(d) control, healthy stays ok  : PASS — fresh-lane capture still healthy: status=saved durable=true rows=1
DONE-MEANS 646: PASS
```

The gate discriminates by revision, not by luck: it was run against **both** deployed revisions (`552cf48` -> FAIL, `9b068e0` -> PASS), with the control green in both, using `local-clone-deploy.sh`'s revision proof each time.

- Server regression tests are red-first: with the fix stashed, the two new `#646` tests fail while the other four pass and 23 assertions still execute (proving harness health, not a collection error). With the fix: `6 pass, 0 fail, 30 expect() calls`.
- Python regression is mutation-proven: removing `report_names={"source": "platform"}` turns the new test RED (2 failed), restoring it turns it GREEN.
- Full suites on the rebased branch: `bun run test:isolated` -> **3720 pass, 0 fail** across 242 files; `uv run pytest -q` -> **574 passed, 14 skipped**; `mypy` and `ruff` clean; `bunx tsc --noEmit` clean.
- **Real-world proof, not just fixtures:** a capture into an actual head-created lane (`09ea2a7d...`, `agent=openbrain-capture` with NULL scope columns) returned `durable:true`/`status:saved` and backfilled the lane to `claudex|verify-646|local`. That row was removed afterwards.

## Critical Self-Review

- Highest-risk behavior: the `UPDATE` in `establishExactStartScope`. It writes to a table row that another session may own. Mitigated by the guard clause — every field is `COALESCE`d (NULL-only fill) and the `WHERE` refuses the update if any already-set coordinate disagrees, so a foreign lane is left byte-identical and reported. The conflict test asserts exactly that: after a refusal, `agent` and `source` are unchanged.
- Assumptions that could be wrong: that `agent` matching is the right predicate for backfill. The contract says a different agent is denied (`:537`), so I followed it rather than my first fixture, which assumed the opposite and was wrong. If the intended semantics are "the lane's creator may be superseded", clause (b)'s fixture and the guard both need an operator ruling — flagged, not silently chosen.
- Missing/weak tests: no test covers `thread_id` backfill on an existing lane (the `thread_id` arm of the guard is simplified from `src/`'s more elaborate version — I kept it strictly narrower, never wider). No concurrency test for two sessions racing to establish scope on the same lane; Postgres row locking makes the `UPDATE` atomic, but last-writer-wins between two *different* complete scopes is untested.
- Security/permission risk: the scope predicate is an isolation boundary, so a wrong change here leaks one session's memory into another's context. The change cannot widen it: it can only turn NULL into a value, and only when the request already matches every non-NULL coordinate. `auth.namespace` (not a caller-supplied namespace) remains the outer predicate, unchanged.
- Migration/deploy risk: none — no schema change, no migration. Deploy is the ordinary `local-clone-deploy.sh` path; rollback is `--rollback` or redeploying the prior ref, both exercised this session (`552cf48` <-> `9b068e0`, revision proof passing each way).
- Downstream client/runtime risk: **not applicable by the doc's own trigger.** `docs/downstream-rollout.md:12` scopes rollout to MCP tool names, input schemas, output shapes, annotations, auth, and namespace behavior. None change: `inputSchema` and `registerTool` are untouched (verified by diffing those lines), the success envelope keeps its `lane`/`events`/`events_returned`/`is_new` shape, and the new refusal reuses the existing `errorResult` path already present in `src/`. The only client-visible difference is that a previously-unprovable lane now succeeds.
- Rollback/cleanup concern: the done-means check seeds and removes its own lanes under randomized `session_key`s carrying a run id, and fails hard if it cannot reach the database, so a PASS can never come from a run that could not clean up. All probe rows and lanes from this lane's investigation were removed; the 5 remaining rows matching `%646%` are pre-existing real memories that merely contain the digits, deliberately left alone.
- Fixes made before PR: (1) the done-means fixture seeded a *conflicting* agent and read the server's correct refusal as a failure — corrected to the real-world shape and RED re-proven afterwards; (2) the shared test `pool` was closed in the first suite's `afterAll`, making the new suite fail with `Cannot use a pool after calling end`, which reads exactly like a real red — teardown moved to the last suite.
- Known residual risk: the 2011 pre-existing partial lanes are *repairable* but not repaired — each one heals on its next capture, and none is backfilled proactively. That is deliberate (no bulk data migration in a bug fix), but it means the fleet converges lazily rather than at deploy.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the two reusable lessons here are operating knowledge for lanes (a done-means fixture that encoded the wrong real-world shape; a shared pool closed by an earlier suite faking a red), which `docs/lane-contract.md` Tightenings owns. They are in the lane report for the controller's mandatory harvest.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live evidence is the RED/GREEN transcripts above, both taken against the running dogfood service on `127.0.0.1:3100` with `local-clone-deploy.sh` revision proofs (`pid 25323 -> 28052 -> 96387`).

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface changed. Tool name, `inputSchema`, annotations, and the success envelope are untouched; this fixes handler behavior for an already-published shape, and the parity fixtures encode the shape, not the branch taken.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are **not applicable**, on the doc's stated trigger (`docs/downstream-rollout.md:12`): no MCP tool name, input schema, output shape, annotation, auth, or namespace behavior changes. Downstream clients cache *schemas*; the schema is byte-identical, so there is nothing to refresh. Verified by diffing the `inputSchema`/`registerTool` lines in `server/tools/session-lifecycle.ts` — zero changed lines.
