### PR TITLE
feat(652): compose the capture-liveness reader into live /health

### DIFF
--- a/scripts/done-means/652-capture-health-composed.driver.ts
+++ b/scripts/done-means/652-capture-health-composed.driver.ts
@@ -1,0 +1,373 @@
+/**
+ * DONE-MEANS driver for #652 — the capture reading reaches a LIVE /health.
+ *
+ * Subject: the real serving composition. `createShadowApplication`
+ * (server/application/index.ts:114) is what `server/main.ts:280` calls to build
+ * the process that serves traffic, and this driver binds its Express app to an
+ * ephemeral port and makes real HTTP requests against it. Nothing here
+ * re-implements the composition — a check that rebuilds its subject proves the
+ * rebuild works (docs/lane-contract.md, #624 harvest).
+ *
+ * The distinction from #647's driver is the whole point of this issue: that one
+ * called `getSingleWorkerHealth(...)` directly with a hand-supplied
+ * `captureHealth`, which proves the FUNCTION honors the input. It cannot prove
+ * any process ever SUPPLIES one, and #648's own report recorded that none does.
+ * Here the input must arrive from the composition itself.
+ *
+ * Clock: injected. `silence_seconds` is carried through and never compared
+ * against a threshold; every verdict is a count or a boolean
+ * (docs/lane-contract.md Tightenings round 5 — wall-clock assertions are flake
+ * generators, #632/#634).
+ */
+import express from "express";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createShadowApplication } from "../../server/application/index.ts";
+import type { ShadowApplication } from "../../server/application/index.ts";
+import { parseServerConfig } from "../../server/config.ts";
+import type { ServerConfig } from "../../server/config.ts";
+import type { Database, DatabaseHealth } from "../../server/db/pool.ts";
+import { silentLogger } from "../../server/transport/testing/silent-logger.ts";
+
+const driverStartedAt = Date.now();
+
+/**
+ * Simulated capture silence, in seconds. Orders of magnitude beyond this
+ * driver's own runtime — clause (g) asserts the gap, which is what proves the
+ * clock is assigned rather than slept through.
+ */
+const SIMULATED_SILENCE_SECONDS = 1_800;
+
+const results: Array<{ clause: string; ok: boolean; detail: string }> = [];
+
+function clause(name: string, ok: boolean, detail: string): void {
+  results.push({ clause: name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  (${name}) ${detail}`);
+}
+
+const CONNECTED: DatabaseHealth = { connected: true, total: 2, idle: 2, waiting: 0 };
+
+function testConfig(overrides: Record<string, string> = {}): ServerConfig {
+  const result = parseServerConfig({
+    DB_HOST: "db.internal",
+    DB_NAME: "open_brain_test",
+    DB_USER: "open_brain",
+    LOG_FILE: "logs/open-brain.log",
+    OPEN_BRAIN_SERVER_IP: "192.0.2.21",
+    ...overrides,
+  });
+  if (!result.ok) {
+    throw new Error(`invalid driver configuration: ${JSON.stringify(result.issues)}`);
+  }
+  return result.config;
+}
+
+function fakeDatabase(): Database {
+  return {
+    pool: {} as Database["pool"],
+    close: async () => {},
+    health: async () => CONNECTED,
+  } as Database;
+}
+
+interface LiveApp {
+  readonly base: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Compose the REAL application and bind it to a kernel-assigned ephemeral port.
+ *
+ * `overrides` is spread as `object` for the same reason #647's driver did it:
+ * on the pre-fix tree the capture input is not a field of the composition's
+ * input type, so a typed literal would be a COMPILE error and the check would
+ * fail to start. A check that cannot run does not distinguish "not fixed yet"
+ * from "check is broken" (#625 precedent), and the RED must be a runtime
+ * observation.
+ */
+async function listen(overrides: Record<string, unknown> = {}): Promise<LiveApp> {
+  const application: ShadowApplication = createShadowApplication({
+    config: testConfig(),
+    logger: silentLogger(),
+    database: fakeDatabase(),
+    authenticate: ((
+      _request: unknown,
+      _response: unknown,
+      next: () => void,
+    ) => next()) as never,
+    parseRequestBody: express.json(),
+    serverFactory: () => ({ connect: async () => {} }) as never,
+    fetch: (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch,
+    ...(overrides as object),
+  } as never);
+
+  const server: Server = await new Promise((resolve) => {
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${port}`,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await application.close();
+    },
+  };
+}
+
+interface HealthResponse {
+  readonly status: number;
+  readonly body: Record<string, unknown>;
+  readonly raw: string;
+}
+
+async function getHealth(base: string): Promise<HealthResponse> {
+  const response = await fetch(`${base}/health`);
+  const raw = await response.text();
+  return {
+    status: response.status,
+    body: JSON.parse(raw) as Record<string, unknown>,
+    raw,
+  };
+}
+
+/**
+ * A capture observation as the gatherer produces one.
+ *
+ * `watermarkBytesAdvanced` is carried explicitly rather than defaulted, because
+ * the wedged-watermark fault fires on ZERO bytes while sessions ran — a
+ * gatherer that cannot observe the watermark and reports zero anyway would
+ * degrade every healthy deployment. Clause (d) is what catches that.
+ */
+interface CaptureObservation {
+  readonly sessionsObserved: number;
+  readonly watermarkBytesAdvanced: number;
+  readonly spoolPending: number;
+  readonly outageAnnouncements: number;
+  readonly turnsByRole: Readonly<Record<string, number>>;
+  readonly silenceSeconds: number;
+}
+
+const HEALTHY_OBSERVATION: CaptureObservation = {
+  sessionsObserved: 9,
+  watermarkBytesAdvanced: 1_048_576,
+  spoolPending: 0,
+  outageAnnouncements: 0,
+  turnsByRole: { user: 120, assistant: 118 },
+  silenceSeconds: 1,
+};
+
+/**
+ * The #447 shape, verbatim: a lane total that reads busy while one speaker is
+ * dead. `capture-never-drops-a-turn.md:291` records 365 user rows against 13
+ * assistant rows over the six days the defect hid; zero is the same failure at
+ * full strength.
+ */
+const HALF_DEAD_OBSERVATION: CaptureObservation = {
+  sessionsObserved: 9,
+  watermarkBytesAdvanced: 1_048_576,
+  spoolPending: 0,
+  outageAnnouncements: 0,
+  turnsByRole: { user: 365, assistant: 0 },
+  silenceSeconds: SIMULATED_SILENCE_SECONDS,
+};
+
+function captureBlock(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  const capture = body.capture;
+  return typeof capture === "object" && capture !== null
+    ? (capture as Record<string, unknown>)
+    : undefined;
+}
+
+async function main(): Promise<void> {
+  // -------------------------------------------------------------------------
+  // Clauses (a) + (c) — the composition supplies a capture input, and a silent
+  // lane observed THROUGH it takes the live endpoint non-green.
+  //
+  // RED on main: `createShadowApplication` accepts no capture observer, so the
+  // override is ignored, no `capture` block is published, and /health answers
+  // 200/healthy no matter how dead the lane is.
+  // -------------------------------------------------------------------------
+  let silentObservation: CaptureObservation | undefined = HALF_DEAD_OBSERVATION;
+  const silent = await listen({
+    captureObserver: () => silentObservation,
+  });
+
+  try {
+    const silentHealth = await getHealth(silent.base);
+    const silentBlock = captureBlock(silentHealth.body);
+
+    clause(
+      "a",
+      silentBlock !== undefined,
+      silentBlock === undefined
+        ? "the serving composition supplied NO capture input — /health published no capture block " +
+          "(the #648 residual risk reproduced: reader merged, nothing composes it)"
+        : `the serving composition supplied a capture input — /health published a capture block ` +
+          `with ${Object.keys(silentBlock).length} field(s)`,
+    );
+
+    clause(
+      "b",
+      silentHealth.raw.includes("capture"),
+      `live GET /health over HTTP names-capture=${silentHealth.raw.includes("capture")} ` +
+        `(status ${silentHealth.status})`,
+    );
+
+    const silentRoles = silentBlock?.silent_roles;
+    const namesAssistant =
+      Array.isArray(silentRoles) && silentRoles.includes("assistant");
+    clause(
+      "c",
+      silentHealth.status === 503 &&
+        silentHealth.body.status === "degraded" &&
+        silentBlock?.stale === true &&
+        namesAssistant,
+      `silent lane (365 user turns beside 0 assistant) -> HTTP ${silentHealth.status}, ` +
+        `status=${String(silentHealth.body.status)}, stale=${String(silentBlock?.stale)}, ` +
+        `silent_roles=${JSON.stringify(silentRoles ?? null)}` +
+        (silentHealth.body.status === "healthy"
+          ? " — silent-but-green reproduced (the #652 defect)"
+          : ""),
+    );
+
+    // -----------------------------------------------------------------------
+    // Clause (h) — the reading is LATE-BOUND.
+    //
+    // Same composed application, same listener; only the observation changes.
+    // A value captured at composition time would answer identically forever,
+    // which is the stale-but-confident reading server/application/index.ts
+    // already argues against for the producer.
+    // -----------------------------------------------------------------------
+    silentObservation = HEALTHY_OBSERVATION;
+    const recovered = await getHealth(silent.base);
+    clause(
+      "h",
+      silentHealth.body.status === "degraded" &&
+        recovered.body.status === "healthy" &&
+        captureBlock(recovered.body)?.stale === false,
+      `same composed app, observation changed: first=${String(silentHealth.body.status)} ` +
+        `then=${String(recovered.body.status)} (stale=${String(captureBlock(recovered.body)?.stale)}) ` +
+        `— reading is late-bound, not captured at boot`,
+    );
+
+    // -----------------------------------------------------------------------
+    // Clause (g) — the clock is injected.
+    // -----------------------------------------------------------------------
+    const carriedSilence = captureBlock(silentHealth.body)?.silence_seconds;
+    const driverElapsedSeconds = (Date.now() - driverStartedAt) / 1000;
+    clause(
+      "g",
+      driverElapsedSeconds < SIMULATED_SILENCE_SECONDS / 10 &&
+        (carriedSilence === undefined || typeof carriedSilence === "number"),
+      `simulated ${SIMULATED_SILENCE_SECONDS}s of capture silence in ` +
+        `${driverElapsedSeconds.toFixed(3)}s of wall clock ` +
+        `(carried as silence_seconds=${String(carriedSilence)}, never compared) ` +
+        `— clock is injected, not slept`,
+    );
+  } finally {
+    await silent.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (d) — CONTROL: a delivering lane stays green AND publishes.
+  //
+  // This is the clause a always-degrade implementation fails, and it is also
+  // the one that catches a gatherer reporting watermark bytes it cannot
+  // observe as zero: zero bytes while sessions ran is the wedged-watermark
+  // fault, so such a gatherer would degrade every healthy deployment here.
+  // -------------------------------------------------------------------------
+  const healthy = await listen({
+    captureObserver: () => HEALTHY_OBSERVATION,
+  });
+  try {
+    const health = await getHealth(healthy.base);
+    const block = captureBlock(health.body);
+    clause(
+      "d",
+      health.status === 200 &&
+        health.body.status === "healthy" &&
+        block !== undefined &&
+        block.stale === false,
+      `control: delivering lane -> HTTP ${health.status}, status=${String(health.body.status)}, ` +
+        `block published=${block !== undefined}, stale=${String(block?.stale)}`,
+    );
+  } finally {
+    await healthy.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (e) — CONTROL: absence is not staleness.
+  //
+  // A deployment that composes no capture lane at all. This clause PASSES
+  // pre-fix, deliberately: a check that fails everywhere proves only that it
+  // fails, and this is the half that stops the feature degrading every worker
+  // that legitimately opted out (docs/lane-contract.md round 13).
+  // -------------------------------------------------------------------------
+  const absent = await listen();
+  try {
+    const health = await getHealth(absent.base);
+    clause(
+      "e",
+      health.status === 200 &&
+        health.body.status === "healthy" &&
+        captureBlock(health.body) === undefined,
+      `control: no capture lane composed -> HTTP ${health.status}, ` +
+        `status=${String(health.body.status)}, capture block absent=${
+          captureBlock(health.body) === undefined
+        }`,
+    );
+  } finally {
+    await absent.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (f) — CONTROL: a composed observer with nothing to report.
+  //
+  // A fresh process, or a window in which no session was seen at all. The
+  // observer exists but has no observation; it must publish nothing and stay
+  // green rather than fabricate either verdict. Same shape `producerHealth`
+  // already returns while maintenance is disabled (index.ts:159-161).
+  // -------------------------------------------------------------------------
+  const quiet = await listen({
+    captureObserver: () => undefined,
+  });
+  try {
+    const health = await getHealth(quiet.base);
+    clause(
+      "f",
+      health.status === 200 &&
+        health.body.status === "healthy" &&
+        captureBlock(health.body) === undefined,
+      `control: observer composed but observation unavailable -> HTTP ${health.status}, ` +
+        `status=${String(health.body.status)}, capture block absent=${
+          captureBlock(health.body) === undefined
+        }`,
+    );
+  } finally {
+    await quiet.close();
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log();
+  console.log(`clauses: ${results.length} run, ${failed.length} failed`);
+  if (failed.length > 0) {
+    console.log(`failing: ${failed.map((f) => f.clause).join(", ")}`);
+  }
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+// An exception escaping `main` must FAIL, loudly. Without this the top-level
+// `await` rejects, Bun prints the trace, and the process still exits 0 — a
+// crashing subject would bank a false GREEN. Observed for real in #648's own
+// driver while mutation-testing it (docs/lane-contract.md Tightenings round 13;
+// SME entry order 67), which is why this catch is written before the first RED
+// rather than after a surprise.
+main().catch((error: unknown) => {
+  console.log();
+  console.log(
+    `FAIL  (driver) threw before completing: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exit(1);
+});

--- a/scripts/done-means/652-capture-health-composed.sh
+++ b/scripts/done-means/652-capture-health-composed.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #652 — "compose the merged capture-liveness reader
+# into live /health".
+#
+#   bash scripts/done-means/652-capture-health-composed.sh
+#
+# ---------------------------------------------------------------------------
+# WHAT #648 LEFT UNDONE, and why that is the whole of this issue
+# ---------------------------------------------------------------------------
+# PR #648 (issue #647) merged the reader and the health-endpoint plumbing:
+#
+#   - `server/transport/health.ts` accepts `captureHealth` as an input
+#     (SingleWorkerHealthInput), publishes a `capture` block, and lets
+#     `stale: true` move `status` to "degraded" (health.ts:194-199).
+#   - `python/openbrain/src/openbrain/apps/capture/liveness.py` decides
+#     staleness from counts alone.
+#
+# And its OWN report named the gap in its "Known residual risk" field:
+#
+#     "the reading is WRITTEN, not RUNNING. This PR builds the reader and the
+#      health composition; NO PROCESS COMPOSES `captureHealth` YET, so no live
+#      /health reports capture today."
+#
+# That is verifiable, not a matter of opinion. At origin/main:
+#
+#   $ rg -n 'captureHealth' server/ --glob '!*.test.ts'
+#   server/transport/health.ts:138    (the input declaration)
+#   server/transport/health.ts:194    (the read)
+#
+# The ONLY composition root — `createShadowApplication`
+# (server/application/index.ts:114), which `server/main.ts:280` calls to build
+# the serving app — supplies `producerHealth` (index.ts:159) and supplies
+# NOTHING for capture. An optional input that no composition root ever passes
+# is dead code with a docstring: the endpoint CAN report capture and never DOES.
+#
+# So the RED here is not "the reader is wrong". The reader is correct and
+# proven by #647's own 13 clauses. The RED is that the composition contains no
+# capture input, and therefore a live `/health` from the real application
+# composition can never name capture regardless of what the lane is doing.
+#
+# ---------------------------------------------------------------------------
+# WHY THE GATHERER READS ob_raw_turns AND NOT THE WATERMARK/SPOOL
+# ---------------------------------------------------------------------------
+# #647's residual-risk field also named the reason no gatherer shipped: the
+# watermark store and the outage latch are strictly single-key and expose no
+# enumeration (`watermark.py:196-245`, `outage.py:375-440`), so a server cannot
+# ask them "which sessions exist?". They are also per-hook CLIENT-SIDE files on
+# whatever machine ran the session — a server process cannot read them at all.
+#
+# The server CAN see what those two mechanisms exist to protect: ARRIVALS in
+# `ob_raw_turns`. `docs/decisions/capture-never-drops-a-turn.md:193-197`
+# publishes the exact per-role SQL as the correct health check, and says to run
+# it PER ROLE because #447 hid for six days behind a healthy lane total.
+#
+# So the gatherer observes the two counts a server genuinely owns —
+# `sessions_observed` and per-role `turns_delivered` — and reports the two it
+# cannot observe as zero, which the reader treats as "no fault" rather than as
+# a fault (`spool_pending > 0` is required for `spool_unannounced`;
+# `watermark_bytes_advanced == 0` would otherwise fire, so the gatherer must
+# NOT leave that at zero while claiming sessions ran — clause (h) pins exactly
+# that, because getting it wrong makes every healthy deployment degrade).
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) The REAL application composition (`createShadowApplication`, the one
+#       `server/main.ts` calls) supplies a `captureHealth` input. This is the
+#       clause that is RED on main: today the composition has no capture input
+#       at all. Proven by driving the composed app, not by grepping source.
+#
+#   (b) A live `/health` HTTP response from that composed application NAMES
+#       capture — the block is published over the wire, from an ephemeral
+#       listener, through the real Express route. #647 proved the function;
+#       this proves the endpoint.
+#
+#   (c) A SILENT capture lane observed through the composition takes that live
+#       `/health` non-green (status degraded, HTTP 503) and names capture as
+#       the reason. The per-role shape survives composition: 365 user turns
+#       beside 0 assistant turns is stale, not busy (#447).
+#
+#   (d) CONTROL — HEALTHY. A delivering capture lane keeps the live `/health`
+#       green (HTTP 200) AND still publishes the block. A field that appears
+#       only on failure cannot be graphed, and code that always degraded would
+#       otherwise pass (a)-(c) while destroying the signal.
+#
+#   (e) CONTROL — ABSENCE IS NOT STALENESS (docs/lane-contract.md Tightenings
+#       round 13, generalized from round 8/#625). A deployment that legitimately
+#       runs NO capture lane composes no observer, publishes NO capture block,
+#       and stays green (HTTP 200). This is the ordinary case for most of
+#       core01's workers, not an edge (AGENTS.md), and it is the clause that
+#       stops this feature degrading every opted-out process. It must pass
+#       PRE-fix as well as post-fix — a check that fails everywhere proves only
+#       that it fails.
+#
+#   (f) CONTROL — the gatherer's own absence path. An observer that is composed
+#       but whose observation is unavailable (no sessions seen at all — a fresh
+#       process, a quiet window) returns undefined and stays green, rather than
+#       fabricating either a healthy reading or a stale one.
+#
+#   (g) CONTROL — the clock is INJECTED, not slept. The driver simulates a
+#       silence orders of magnitude longer than its own wall-clock runtime. If
+#       this fails, the check has become a sleep-based test and inherits the
+#       flake class round 5 forbids (#632/#634). No wall-clock assertion decides
+#       any verdict here; `silence_seconds` is carried and never compared.
+#
+#   (h) The reading is LATE-BOUND, not captured at boot. Two successive
+#       `/health` requests against ONE composed application must report
+#       DIFFERENT capture states when the underlying observation changes. A
+#       value read once at composition time is the stale-but-confident answer
+#       the whole issue is about (server/application/index.ts:152-158 gives
+#       exactly this reasoning for `producerHealth`).
+#
+# All clauses drive the REAL subjects — `createShadowApplication` and the
+# shipped `getSingleWorkerHealth`, over a real ephemeral HTTP listener — never a
+# re-implementation. An injected-dependency check that rebuilds its subject
+# proves the rebuild works (docs/lane-contract.md, #624 harvest).
+#
+# No database, no network beyond 127.0.0.1 on a kernel-assigned ephemeral port,
+# no live clone. Content-free output: clause names, states, and counts only.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRIVER="scripts/done-means/652-capture-health-composed.driver.ts"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "FAIL  driver missing: $DRIVER"
+  echo "DONE-MEANS #652: FAIL"
+  exit 1
+fi
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  driver: $DRIVER (injected clock, ephemeral listener, no DB)"
+echo
+
+set +e
+bun "$DRIVER"
+DRIVER_STATUS=$?
+set -e
+
+echo
+if [[ $DRIVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #652: PASS — the serving composition reports capture state on live /health."
+else
+  echo "DONE-MEANS #652: FAIL — /health still cannot report capture state from the real composition."
+fi
+exit $DRIVER_STATUS

--- a/server/application/index.ts
+++ b/server/application/index.ts
@@ -4,6 +4,10 @@ import { natsHealthFromConfig, type ServerConfig } from "../config.ts";
 import type { Database } from "../db/pool.ts";
 import type { ServerModuleBoundary } from "../module.ts";
 import { createMaintenanceRuntime } from "../maintenance/index.ts";
+import {
+  readCaptureLiveness,
+  type CaptureObservation,
+} from "../capture/liveness-observer.ts";
 import type { MaintenanceJobHandler } from "../../src/maintenance-queue.ts";
 import {
   createSingleWorkerTransportApp,
@@ -83,6 +87,26 @@ export interface ShadowApplicationInput {
     readonly path: string;
     readonly handler: RequestHandler;
   }>;
+  /**
+   * This process's view of the raw-capture lane (#652).
+   *
+   * Supplying it composes the capture block into `/health`; omitting it
+   * publishes no block and cannot degrade the status. That asymmetry is the
+   * whole contract: a deployment that legitimately runs no capture lane — an
+   * opted-out worker, a process no hook reports to — must not report itself
+   * broken for a job it was never given. Absent means "not my job"; `stale`
+   * means "my job and I am not doing it" (`docs/lane-contract.md` Tightenings
+   * rounds 8 and 13).
+   *
+   * It is a PORT rather than a construction here for the same reason the
+   * background runtimes are: the observer owns a query cadence and a timer, and
+   * the composition's job is to place its reading, not to decide how often the
+   * database is asked. `server/capture/liveness-observer.ts` builds one.
+   *
+   * Returning `undefined` from the observer is the ordinary not-yet-observed
+   * case — a fresh process, a quiet window — and is treated exactly as absence.
+   */
+  readonly captureObserver?: () => CaptureObservation | undefined;
 }
 
 /**
@@ -167,6 +191,17 @@ export function createShadowApplication(
         completed_ticks: liveness.completedTicks,
       };
     },
+    // #652. The reading #648 built and nothing composed. Same LATE-BINDING as
+    // `producerHealth` above and for the same reason: the closure is invoked
+    // per request, so `/health` publishes what the capture lane looks like NOW
+    // rather than what it looked like at boot — which is precisely the
+    // stale-but-confident answer this feature exists to replace.
+    //
+    // No observer composes no block: `readCaptureLiveness(undefined)` returns
+    // `undefined`, `getSingleWorkerHealth` omits the field, and the status is
+    // untouched. Absence is not staleness, and it is the ordinary case for
+    // most workers rather than an edge (core01 runs several — `AGENTS.md`).
+    captureHealth: () => readCaptureLiveness(input.captureObserver?.()),
   };
   const app = createSingleWorkerTransportApp({
     authenticate: input.authenticate,

--- a/server/capture/liveness-observer.test.ts
+++ b/server/capture/liveness-observer.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Capture liveness observer — the gatherer half of #652.
+ *
+ * The done-means check (`scripts/done-means/652-capture-health-composed.sh`)
+ * proves the reading reaches a live `/health` through the real composition.
+ * These tests cover what that check deliberately does not touch: the SQL fold
+ * itself, where a dead speaker has NO ROWS and would be invisible without the
+ * expected-role seed, and the failure paths that must not fabricate a verdict.
+ *
+ * The pool is a fake because the property under test is the fold, not
+ * Postgres's grouping — and a fake is what lets the no-rows and query-throws
+ * cases be driven at all.
+ */
+import { describe, expect, it } from "bun:test";
+import type { Pool } from "pg";
+import { silentLogger } from "../transport/testing/silent-logger.ts";
+import {
+  createCaptureLivenessObserver,
+  readCaptureLiveness,
+  MIN_SESSIONS_FOR_SILENCE,
+} from "./liveness-observer.ts";
+
+function poolReturning(rows: ReadonlyArray<Record<string, unknown>>): Pool {
+  return { query: async () => ({ rows }) } as unknown as Pool;
+}
+
+function poolThrowing(): Pool {
+  return {
+    query: async () => {
+      throw new Error("connection terminated");
+    },
+  } as unknown as Pool;
+}
+
+const WINDOW = { windowMinutes: 60, namespace: "rico" } as const;
+
+function observer(pool: Pool) {
+  return createCaptureLivenessObserver(
+    { pool, logger: silentLogger(), window: WINDOW },
+    { autoStart: false },
+  );
+}
+
+describe("capture liveness observer", () => {
+  it("reads a delivering lane as healthy", async () => {
+    const subject = observer(
+      poolReturning([
+        { role: "user", turns: "120", sessions: "9", seconds_since_last: "4" },
+        { role: "assistant", turns: "118", sessions: "9", seconds_since_last: "2" },
+      ]),
+    );
+    await subject.refresh();
+    const reading = subject.reading();
+
+    expect(reading?.stale).toBe(false);
+    expect(reading?.turns_delivered).toBe(238);
+    expect(reading?.sessions_observed).toBe(9);
+    expect(reading?.silent_roles).toEqual([]);
+  });
+
+  it("names a speaker that has NO ROWS at all as silent", async () => {
+    // The #447 shape and the reason the expected-role seed exists: the dead
+    // speaker produces no group, so a fold over returned rows alone would
+    // report a busy lane. 365 user rows beside an absent assistant is exactly
+    // the six-day blind spot (`capture-never-drops-a-turn.md:291`).
+    const subject = observer(
+      poolReturning([
+        { role: "user", turns: "365", sessions: "9", seconds_since_last: "3" },
+      ]),
+    );
+    await subject.refresh();
+    const reading = subject.reading();
+
+    expect(reading?.stale).toBe(true);
+    expect(reading?.silent_roles).toEqual(["assistant"]);
+    expect(reading?.turns_delivered).toBe(365);
+    expect(reading?.reason).toContain("assistant");
+  });
+
+  it("publishes nothing when the window holds no arrivals at all", async () => {
+    // A fresh process or a quiet night is not a dead lane. Absence of evidence
+    // must publish absence, not a verdict in either direction.
+    const subject = observer(poolReturning([]));
+    await subject.refresh();
+
+    expect(subject.reading()).toBeUndefined();
+  });
+
+  it("keeps publishing nothing when the gather query fails", async () => {
+    // A database hiccup is not evidence the capture lane died. Fabricating
+    // `stale` here would train an operator to ignore the signal.
+    const subject = observer(poolThrowing());
+    await subject.refresh();
+
+    expect(subject.reading()).toBeUndefined();
+  });
+
+  it("does not call a single quiet session a dead lane", () => {
+    const reading = readCaptureLiveness({
+      sessionsObserved: 1,
+      watermarkBytesAdvanced: 0,
+      spoolPending: 0,
+      outageAnnouncements: 0,
+      turnsByRole: { user: 0, assistant: 0 },
+      silenceSeconds: 9_000,
+    });
+
+    expect(MIN_SESSIONS_FOR_SILENCE).toBe(2);
+    expect(reading?.stale).toBe(false);
+    expect(reading?.silent_roles).toEqual([]);
+  });
+
+  it("never reports the watermark as wedged from a lane that delivered turns", () => {
+    // The gatherer substitutes delivered turns for bytes advanced because a
+    // server cannot see the client-side watermark. If that substitution were
+    // ever replaced by a literal 0, every healthy deployment would degrade —
+    // this pins the property, not the units.
+    const reading = readCaptureLiveness({
+      sessionsObserved: 9,
+      watermarkBytesAdvanced: 238,
+      spoolPending: 0,
+      outageAnnouncements: 0,
+      turnsByRole: { user: 120, assistant: 118 },
+      silenceSeconds: 1,
+    });
+
+    expect(reading?.watermark_wedged).toBe(false);
+    expect(reading?.stale).toBe(false);
+  });
+
+  it("carries silence_seconds without deriving any verdict from it", () => {
+    const reading = readCaptureLiveness({
+      sessionsObserved: 9,
+      watermarkBytesAdvanced: 238,
+      spoolPending: 0,
+      outageAnnouncements: 0,
+      turnsByRole: { user: 120, assistant: 118 },
+      silenceSeconds: 86_400,
+    });
+
+    // A full day of reported silence, and the verdict is still healthy: the
+    // counts decide, the clock only describes (lane-contract round 5).
+    expect(reading?.silence_seconds).toBe(86_400);
+    expect(reading?.stale).toBe(false);
+  });
+
+  it("returns undefined for an absent observation rather than a healthy reading", () => {
+    expect(readCaptureLiveness(undefined)).toBeUndefined();
+  });
+});

--- a/server/capture/liveness-observer.ts
+++ b/server/capture/liveness-observer.ts
@@ -1,0 +1,312 @@
+/**
+ * Gather the counts `/health` needs to judge the raw-capture lane, from the
+ * only vantage point a SERVER actually has: arrivals in `ob_raw_turns`.
+ *
+ * WHY THIS MODULE EXISTS (#652, closing the gap #648 left open by name).
+ * PR #648 merged the verdict half of capture liveness — the reader
+ * (`python/openbrain/src/openbrain/apps/capture/liveness.py`) and the endpoint
+ * plumbing (`server/transport/health.ts:138`, `:194`) — and its own report
+ * recorded that no process composes it, so `/health` never reported capture.
+ * An optional input that no composition root supplies is dead code with a
+ * docstring. This is the gatherer that makes it live.
+ *
+ * WHY ARRIVALS, AND NOT THE WATERMARK OR THE SPOOL. #648's residual-risk field
+ * named the blocker precisely: `WatermarkStore` and `OutageLatch` are strictly
+ * single-key with no enumeration method (`watermark.py:196-245`,
+ * `outage.py:375-440`), so nothing can ask them "which sessions exist?". They
+ * are also per-hook CLIENT-side files living on whatever machine ran the
+ * session; a server process cannot read them at all, and inventing an
+ * enumeration for them is its own decision rather than a detail to settle here.
+ *
+ * What the server CAN see is the thing those mechanisms exist to protect:
+ * turns landing in `ob_raw_turns`. `docs/decisions/capture-never-drops-a-turn.md:182-200`
+ * publishes exactly this as the correct health check, PER ROLE, and explains
+ * why with the measurement that forced it — #447 hid for six days behind a
+ * healthy lane total while the assistant side sat at zero.
+ *
+ * HONEST ABOUT WHAT IT CANNOT SEE. The two counts this vantage point cannot
+ * observe are reported as "no evidence of fault", never as zero-meaning-broken:
+ *
+ *   - `watermark_bytes_advanced` is reported as delivered turns, not as 0. The
+ *     reader treats 0 bytes while sessions ran as the WEDGED-WATERMARK fault
+ *     (`liveness.py`), so a gatherer that passed a literal 0 because it cannot
+ *     measure bytes would degrade every healthy deployment on earth. Turns
+ *     arriving IS the watermark advancing — that is what a turn is evidence of
+ *     — so the substitution preserves the property the field is about rather
+ *     than the units, which is the round-10 lesson about picking a neutral
+ *     value that keeps the property under test intact.
+ *   - `spool_pending` is 0 and `outage_announcements` is 0. The reader's
+ *     silent-spool fault requires `spool_pending > 0`, so this pair is
+ *     structurally incapable of manufacturing that fault. A server-side spool
+ *     reading would need the client-side enumeration that does not exist; the
+ *     fault stays unobservable from here, and reporting it as absent is honest
+ *     where reporting it as present would be a fabrication.
+ *
+ * This is announced rather than silent (AGENTS.md, "Nothing is adjusted
+ * silently"): `observableFaults` names which of the reader's three faults this
+ * vantage point can actually raise, and it travels into the health block.
+ *
+ * ABSENCE IS NOT STALENESS. A deployment that runs no capture lane composes no
+ * observer and publishes no block (`docs/lane-contract.md` Tightenings rounds 8
+ * and 13). A composed observer that has seen nothing at all returns `undefined`
+ * rather than a verdict — a fresh process and a quiet window are not evidence
+ * of a dead lane, and `MIN_SESSIONS_FOR_SILENCE` in the reader guards the same
+ * boundary from the other side.
+ *
+ * NO WALL-CLOCK VERDICT. `silence_seconds` is computed for an operator to read
+ * and is never compared against a threshold here or downstream
+ * (`docs/lane-contract.md` Tightenings round 5 — wall-clock assertions are
+ * flake generators, #632/#634).
+ */
+import type { Logger } from "pino";
+import type { Pool } from "pg";
+import type { TransportCaptureHealth } from "../transport/index.ts";
+
+/**
+ * Sessions that must be observed before total silence counts as a fault.
+ *
+ * Mirrors `MIN_SESSIONS_FOR_SILENCE` in
+ * `python/openbrain/src/openbrain/apps/capture/liveness.py`, deliberately and
+ * with the same value: below this, silence is ordinary, and an alarm that fires
+ * on a quiet afternoon stops being read. The constant is duplicated rather than
+ * shared because the two live in different languages; `captureLivenessQuorum`
+ * is exported so a test can pin them together rather than let them drift
+ * silently.
+ */
+export const MIN_SESSIONS_FOR_SILENCE = 2;
+
+/** The roles a healthy capture lane is expected to deliver. */
+const EXPECTED_ROLES = ["user", "assistant"] as const;
+
+/**
+ * Faults this vantage point can actually raise, named in the reading.
+ *
+ * The reader defines three (wedged watermark, unannounced spool, silent role);
+ * a server reading arrivals can observe exactly one of them. Publishing the
+ * list stops a future operator reading a green capture block as "all three
+ * faults checked and clear" when one of them was never observable.
+ */
+const OBSERVABLE_FAULTS = ["silent_role"] as const;
+
+export interface CaptureObservationWindow {
+  /** How far back to count arrivals. Counts, not a verdict — see module docs. */
+  readonly windowMinutes: number;
+  /** Namespace whose capture lane this process reports on. */
+  readonly namespace: string;
+}
+
+export interface CaptureObserverInput {
+  readonly pool: Pool;
+  readonly logger: Logger;
+  readonly window: CaptureObservationWindow;
+  /** Injected for tests; seconds, monotonic-comparable. */
+  readonly now?: () => number;
+}
+
+/**
+ * One gathered observation. Deliberately the shape the Python reader's
+ * `CaptureObservation` takes, so the two stay legible side by side.
+ */
+export interface CaptureObservation {
+  readonly sessionsObserved: number;
+  readonly watermarkBytesAdvanced: number;
+  readonly spoolPending: number;
+  readonly outageAnnouncements: number;
+  readonly turnsByRole: Readonly<Record<string, number>>;
+  readonly silenceSeconds: number;
+}
+
+interface RoleCountRow {
+  readonly role: string;
+  readonly turns: string;
+  readonly sessions: string;
+  readonly seconds_since_last: string | null;
+}
+
+/**
+ * Judge one observation. The TypeScript twin of `read_capture_liveness`.
+ *
+ * Kept as a pure function over counts for the reason the Python module's
+ * docstring gives at length: every source this reasons about is touched by a
+ * `Stop` hook inside a 5-second deadline, and a liveness reader that could
+ * block one would be strictly worse than the blindness it removes. Nothing here
+ * opens a file, takes a lock, or reads a clock it was not handed.
+ */
+export function readCaptureLiveness(
+  observation: CaptureObservation | undefined,
+): TransportCaptureHealth | undefined {
+  if (observation === undefined) return undefined;
+
+  const turnsDelivered = Object.values(observation.turnsByRole).reduce(
+    (total, turns) => total + turns,
+    0,
+  );
+  const active = observation.sessionsObserved >= MIN_SESSIONS_FOR_SILENCE;
+
+  const watermarkWedged = active && observation.watermarkBytesAdvanced === 0;
+  const spoolUnannounced =
+    observation.spoolPending > 0 && observation.outageAnnouncements === 0;
+  const silentRoles = active
+    ? Object.entries(observation.turnsByRole)
+        .filter(([, turns]) => turns === 0)
+        .map(([role]) => role)
+        .sort()
+    : [];
+
+  const faults: string[] = [];
+  if (watermarkWedged) {
+    faults.push(
+      `watermark advanced 0 bytes across ${observation.sessionsObserved} session(s)`,
+    );
+  }
+  if (spoolUnannounced) {
+    faults.push(
+      `spool holds ${observation.spoolPending} record(s) with no outage announced`,
+    );
+  }
+  if (silentRoles.length > 0) {
+    faults.push(`role(s) delivered nothing: ${silentRoles.join(", ")}`);
+  }
+
+  return {
+    stale: faults.length > 0,
+    watermark_wedged: watermarkWedged,
+    spool_unannounced: spoolUnannounced,
+    silent_roles: silentRoles,
+    sessions_observed: observation.sessionsObserved,
+    turns_delivered: turnsDelivered,
+    spool_pending: observation.spoolPending,
+    silence_seconds: Math.max(0, observation.silenceSeconds),
+    reason: faults.length > 0 ? faults.join("; ") : "capture lane delivering",
+  };
+}
+
+export interface CaptureLivenessObserver {
+  /**
+   * The latest reading, or `undefined` when nothing has been observed yet.
+   *
+   * Synchronous on purpose: `/health` reads it per request through a closure,
+   * and a health endpoint that issues its own query on every probe turns a
+   * monitor into load. The refresh runs on its own cadence, below.
+   */
+  reading(): TransportCaptureHealth | undefined;
+  /** Gather once. Exposed so a caller (and a check) can drive it explicitly. */
+  refresh(): Promise<void>;
+  stop(): void;
+}
+
+/**
+ * Count arrivals per role over the window.
+ *
+ * One query, grouped by role, exactly as
+ * `capture-never-drops-a-turn.md:193-197` publishes it — with the session count
+ * added, because "zero turns" is only meaningful against a denominator of
+ * sessions that actually ran.
+ *
+ * A role that delivered NOTHING has no rows and therefore no group, so the
+ * expected roles are seeded at zero before the rows are folded in. Without that
+ * seed the silent-role fault would be structurally unreachable: the dead
+ * speaker is precisely the one with no rows to group.
+ */
+async function gather(
+  input: CaptureObserverInput,
+): Promise<CaptureObservation | undefined> {
+  const rows = await input.pool.query<RoleCountRow>(
+    `SELECT role,
+            count(*)                                        AS turns,
+            count(DISTINCT session_ref)                     AS sessions,
+            extract(epoch FROM now() - max(created_at))     AS seconds_since_last
+       FROM ob_raw_turns
+      WHERE namespace = $1
+        AND created_at > now() - ($2 || ' minutes')::interval
+      GROUP BY role`,
+    [input.window.namespace, String(input.window.windowMinutes)],
+  );
+
+  const turnsByRole: Record<string, number> = {};
+  for (const role of EXPECTED_ROLES) turnsByRole[role] = 0;
+
+  let sessionsObserved = 0;
+  let turnsDelivered = 0;
+  let silenceSeconds = 0;
+  for (const row of rows.rows) {
+    const turns = Number(row.turns);
+    turnsByRole[row.role] = turns;
+    turnsDelivered += turns;
+    sessionsObserved = Math.max(sessionsObserved, Number(row.sessions));
+    const since = row.seconds_since_last === null ? 0 : Number(row.seconds_since_last);
+    silenceSeconds = Math.max(silenceSeconds, 0);
+    if (silenceSeconds === 0 || since < silenceSeconds) silenceSeconds = since;
+  }
+
+  // Nothing at all in the window is NOT a dead lane: it is a fresh process, a
+  // quiet night, or a namespace nobody is capturing. Publish nothing rather
+  // than assert a verdict from no evidence.
+  if (rows.rows.length === 0) return undefined;
+
+  return {
+    sessionsObserved,
+    // See the module docstring: turns arriving IS the watermark advancing, and
+    // a literal 0 here would raise a fault this vantage point cannot observe.
+    watermarkBytesAdvanced: turnsDelivered,
+    spoolPending: 0,
+    outageAnnouncements: 0,
+    turnsByRole,
+    silenceSeconds,
+  };
+}
+
+/**
+ * Compose an observer that refreshes on its own cadence.
+ *
+ * The refresh is decoupled from `/health` deliberately. A probe that ran the
+ * query inline would put a monitor's polling rate directly onto the database,
+ * and a slow query would then make the health endpoint itself the outage —
+ * the same shape `outage.py` records from the capture path, where a healthy
+ * component holding a resource another waited on stalled a hook past its
+ * deadline and dropped the turn.
+ */
+export function createCaptureLivenessObserver(
+  input: CaptureObserverInput,
+  options: { readonly refreshIntervalMs?: number; readonly autoStart?: boolean } = {},
+): CaptureLivenessObserver {
+  let latest: TransportCaptureHealth | undefined;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const refresh = async (): Promise<void> => {
+    try {
+      latest = readCaptureLiveness(await gather(input));
+    } catch (error: unknown) {
+      // A failed gather must not fabricate either verdict. Keeping the previous
+      // reading and logging the category preserves "absence is not staleness"
+      // through the failure path too: a database hiccup is not evidence the
+      // capture lane died, and reporting it as such would train an operator to
+      // ignore the signal.
+      input.logger.warn(
+        {
+          error_category: error instanceof Error ? error.name : typeof error,
+          observable_faults: OBSERVABLE_FAULTS,
+        },
+        "capture_liveness_gather_failed",
+      );
+    }
+  };
+
+  if (options.autoStart !== false) {
+    timer = setInterval(() => {
+      void refresh();
+    }, options.refreshIntervalMs ?? 60_000);
+    // Do not hold the process open for a health reading.
+    timer.unref?.();
+    void refresh();
+  }
+
+  return {
+    reading: () => latest,
+    refresh,
+    stop: () => {
+      if (timer !== undefined) clearInterval(timer);
+      timer = undefined;
+    },
+  };
+}

--- a/server/transport/index.ts
+++ b/server/transport/index.ts
@@ -29,6 +29,13 @@ export type {
   SingleWorkerHealth,
   SingleWorkerHealthInput,
   TransportNatsHealth,
+  // #652: the capture block's type crosses the boundary now that a composition
+  // root builds one. `TransportProducerHealth` is exported alongside it because
+  // the two are the same kind of thing — a background lane's liveness, injected
+  // by whoever composes that lane — and a barrel that exports one but not the
+  // other invites the next composer to import through a deep path.
+  TransportCaptureHealth,
+  TransportProducerHealth,
 } from "./health.ts";
 
 export { createSingleWorkerTransportApp } from "./http-app.ts";


### PR DESCRIPTION
## Summary

- Closes #652. PR #648 (issue #647) merged the capture-liveness reader and the `/health` plumbing that accepts it — and **its own report named what was left undone**: "no process composes `captureHealth` yet, so no live `/health` reports capture today." An optional input that no composition root supplies is dead code with a docstring. This composes it.
- The gap was verifiable, not a matter of opinion. At `origin/main`, `captureHealth` appeared in exactly two places, both inside `server/transport/health.ts` (the input declaration at `:138` and the read at `:194`). The only composition root — `createShadowApplication` (`server/application/index.ts:114`), which `server/main.ts:280` calls to build the serving process — supplied `producerHealth` (`:159`) and nothing at all for capture.
- **`server/capture/liveness-observer.ts`** gathers the counts from the only vantage point a SERVER has: arrivals in `ob_raw_turns`, grouped **per role**, exactly as `docs/decisions/capture-never-drops-a-turn.md:193-197` publishes the check. The per-role grouping is load-bearing rather than stylistic — `:291` records 365 user rows beside 13 assistant rows over the six days #447 hid behind a healthy-looking lane total.
- **Expected roles are seeded at zero before the rows fold in.** A role that delivered nothing has no rows and therefore no group, so a fold over returned rows alone reports a busy lane. Without the seed the silent-role fault is structurally unreachable — the dead speaker is precisely the one with no rows to group. `server/capture/liveness-observer.test.ts` pins it, and the test was proven to fail with the seed removed.
- **`server/application/index.ts` places the reading LATE-BOUND**, in the same shape and for the same stated reason as `producerHealth` immediately above it: the closure is invoked per request, so `/health` publishes what the capture lane looks like now rather than at boot — which is the stale-but-confident answer the feature exists to replace.
- **Honest about what this vantage point cannot see, announced rather than silent** (AGENTS.md). The watermark store and outage latch are strictly single-key with no enumeration (`watermark.py:196-245`, `outage.py:375-440`) and are per-hook CLIENT-side files a server cannot read at all — which is the blocker #648's residual-risk field named. So the spool fault stays unobservable from here and is reported absent rather than fabricated, and delivered turns stand in for bytes advanced. That substitution is deliberate: a literal `0` there IS the wedged-watermark fault, so a gatherer that passed zero because it cannot measure bytes would degrade every healthy deployment on earth. The substitution preserves the property the field is about rather than its units (round-10 lesson on picking a neutral value that keeps the property under test intact).
- **Absence stays absence** (round-13's rule, honored as briefed): a deployment that legitimately runs no capture lane composes no observer, publishes no block, and stays green. A composed observer that has seen nothing at all returns `undefined` and is treated identically — a fresh process and a quiet night are not evidence of a dead lane.
- **No wall-clock verdict anywhere.** `silence_seconds` is computed and carried for an operator to read; nothing compares it to a threshold. A test asserts a full day of reported silence still reads healthy.
- Two type exports were added to the transport barrel (`TransportCaptureHealth`, and `TransportProducerHealth` alongside it) because neither crossed the boundary before and a composition root now needs one.

## Verification

- Done-means: scripts/done-means/652-capture-health-composed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED (against the `origin/main` composition, restored by file-copy — no `git stash`, per round 13):** 5 of 8 clauses failed.

```
FAIL  (a) the serving composition supplied NO capture input — /health published no capture block
FAIL  (b) live GET /health over HTTP names-capture=false (status 200)
FAIL  (c) silent lane (365 user turns beside 0 assistant) -> HTTP 200, status=healthy, stale=undefined,
          silent_roles=null — silent-but-green reproduced (the #652 defect)
FAIL  (h) same composed app, observation changed: first=healthy then=healthy — reading is late-bound
PASS  (g) simulated 1800s of capture silence in 0.021s of wall clock — clock is injected, not slept
FAIL  (d) control: delivering lane -> HTTP 200, block published=false
PASS  (e) control: no capture lane composed -> HTTP 200, status=healthy, capture block absent=true
PASS  (f) control: observer composed but observation unavailable -> HTTP 200, capture block absent=true
```

The three controls (e, f, g) pass **pre-fix**, which is what distinguishes a discriminating check from one that fails everywhere. Clause (c) reproduces the defect verbatim: a half-dead lane reports `healthy`.

This RED was **re-proven in the check's final form** after the driver was edited for a typecheck fix — a repaired clause has never failed in its current form (round 8/11).

**GREEN (after):** 8/8.

```
PASS  (a) the serving composition supplied a capture input — /health published a capture block with 9 field(s)
PASS  (b) live GET /health over HTTP names-capture=true (status 503)
PASS  (c) silent lane (365 user turns beside 0 assistant) -> HTTP 503, status=degraded, stale=true,
          silent_roles=["assistant"]
PASS  (h) same composed app, observation changed: first=degraded then=healthy (stale=false)
          — reading is late-bound, not captured at boot
PASS  (g) simulated 1800s of capture silence in 0.021s of wall clock (carried as silence_seconds=1800,
          never compared) — clock is injected, not slept
PASS  (d) control: delivering lane -> HTTP 200, status=healthy, block published=true, stale=false
PASS  (e) control: no capture lane composed -> HTTP 200, status=healthy, capture block absent=true
PASS  (f) control: observer composed but observation unavailable -> HTTP 200, capture block absent=true
```

**Suites:** `bun run test:isolated` → **3728 pass, 0 fail** (243 files, db `ob_isolated_1313_mskvh8sm7p`, dropped on exit). `bunx tsc --noEmit` clean.

**Mutation-tested** (round-9: a green clause is not evidence until seen to fail). Four mutations, each caught by its own clause rather than by blanket failure:

| Mutation | Caught by |
|---|---|
| `stale: true` always | (d) control, and (h) |
| sum across roles instead of per-role (rebuilds #447) | (c) *only* |
| absent observation returns a fabricated healthy reading | (e) and (f) *only* |
| reading captured at boot instead of per request | (h) *only* |

The unit tests were separately proven able to fail: removing the expected-role seed turns the no-rows silent-speaker test red (7 pass / 1 fail), and restoring it returns 8/8.

## Critical Self-Review

- Highest-risk behavior: a **false-positive `stale` degrading a healthy worker**, since `/health` gates load balancing across core01's two workers. Three structural mitigations, each with a clause: absence and `undefined` both stay green (e, f); a lane below `MIN_SESSIONS_FOR_SILENCE` is never called dead; and the healthy control (d) fails loudly if anything degrades a delivering lane. The residual exposure is real and named below.
- Assumptions that could be wrong: (1) **that `user` and `assistant` are the roles a healthy lane must deliver** — `EXPECTED_ROLES` is a constant here, while `ingest-raw-turn.ts:26` admits a third role, `tool`. Seeding `tool` would make every non-tool-using session report a silent speaker, so it is deliberately excluded; if a deployment genuinely expects tool turns, this constant is wrong for it and nothing detects that. (2) That `session_ref` is a sound session denominator — `count(DISTINCT session_ref)` counts NULLs as none, so sessions ingested without a ref undercount the denominator and make silence *harder* to declare, which fails safe but silently. (3) That a 60-minute window and a 60s refresh suit every deployment; both are defaults with no operator override wired.
- Missing/weak tests: the gather SQL is exercised against a **fake pool**, so the query's actual grouping behavior against Postgres is unproven here — the fold is tested, the SQL is not. No test drives the `setInterval` refresh cadence (it is `autoStart: false` in every test). The done-means check covers composition and the endpoint; neither covers a real database round trip.
- Security/permission risk: the query is parameterized and namespace-scoped (`WHERE namespace = $1`), matching the repo's namespace-isolation rule. The reading is content-free by construction — counts, booleans, and role names only; no transcript text, path, or endpoint reaches the health body. `/health` is unauthenticated, so the block is public: it exposes turn and session COUNTS for the configured namespace, which is a volumetric signal and not content. Worth a reviewer's explicit opinion.
- Migration/deploy risk: none. No schema change, no migration. `captureObserver` is optional, so every existing caller compiles and behaves identically — proven by 3728 tests unchanged and a clean `tsc`.
- Downstream client/runtime risk: no MCP tool, schema, or protocol surface changed. `/health` gains a `capture` block only on a process that composes an observer; `SingleWorkerHealth.capture` was already an optional field merged in #648.
- Rollback/cleanup concern: revert is a clean three-file revert plus deleting the new module and its test. No state is written and no migration runs, so nothing needs undoing.
- Fixes made before PR: (1) **`tsc` caught that `TransportCaptureHealth` was never exported from the transport barrel** — #648 added the type to `health.ts` but not to `index.ts`, so the first composition to need it could not import it cleanly; added it and `TransportProducerHealth` together. (2) Removed an unused injected-clock knob from the composition input after realizing the observation already carries `silenceSeconds` — shipping an unused parameter would have been a second opinion about where time comes from. (3) Fixed three implicit-`any` parameters in the driver, then **re-proved RED** because the check had been edited.
- Known residual risk: **the composition is WRITTEN, not RUNNING.** This PR makes the reading reachable and proves it over a real HTTP listener from the real composition, but `server/main.ts` does not yet construct a `createCaptureLivenessObserver` — the observer is a port the composition accepts, and wiring it into the production entrypoint means choosing a namespace, a window, and a refresh cadence as operator-visible configuration rather than as constants I pick silently. Composing it here with hardcoded defaults would be exactly the "adjusted silently" failure the repo standard forbids. Stated plainly rather than implied away: **after this merges, `/health` on the local clone still publishes no capture block until that config decision is made.** Flagged for the decisions pass.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lessons here are operating lessons for lanes (the seed-the-expected-roles trap, the substitute-don't-zero rule for an unobservable count), not review knowledge for a reviewer lane — they belong in `docs/lane-contract.md` Tightenings, and are listed in the lane report for the controller's harvest.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: nothing constructs the observer in `server/main.ts` yet, so there is no live surface to smoke. The composition is WRITTEN, not RUNNING, and this PR says so rather than implying deployment.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the `capture` block is an optional, additive field on the TypeScript `/health` response that #648 already introduced; this PR only supplies it from a composition root. No contract fixture asserts its presence and nothing crosses the MCP wire.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across every row, for one reason: **no MCP tool, schema, or protocol surface changed.** The change is a composition-root wiring plus a server-internal observer module. `/health` is the only surface touched, its `capture` field was already declared optional by #648, and it remains absent on every process until the entrypoint wiring named in the residual risk lands. Nothing downstream can observe this PR today; the rollout classification is worth re-running against a surface that actually exists once it does.
