### PR TITLE
feat(578): compose the E2E quality gate and prove it can fail

### DIFF
--- a/scripts/done-means/578-e2e-gate.control.ts
+++ b/scripts/done-means/578-e2e-gate.control.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+/**
+ * Control-clause driver for the #578 DONE-MEANS check. Not a test file; invoked
+ * by `scripts/done-means/578-e2e-gate.sh`, which owns the verdict.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Reads the real scenario fixture and writes a copy carrying ONE deliberately
+ * wrong expectation, so the gate can prove the scenario suite still FAILS when
+ * reality and the expectation disagree.
+ *
+ * WHY THIS PARTICULAR MUTATION
+ * ----------------------------
+ * The mutation has to satisfy two opposing constraints, and most candidates
+ * fail one of them:
+ *
+ *   1. The fixture must still LOAD. `eval/open-brain/live/scenario-fixtures.ts`
+ *      validates with Zod and additionally rejects non-contract scope keys
+ *      (`assertScopeKeys`, scenario-fixtures.ts:26-31). A mutation that trips
+ *      the loader makes the runner exit non-zero for a PARSE error, and the
+ *      gate would read that as "the suite discriminates" when in fact the suite
+ *      never ran. That is a false green for the control clause itself, which is
+ *      strictly worse than having no control clause.
+ *
+ *   2. The expectation must be UNSATISFIABLE BY BEHAVIOUR, not by construction,
+ *      so that what fails is an OUTPUT COMPARISON — the exact machinery the
+ *      gate is claiming works.
+ *
+ * `durable_memory_shape.expected.min_items` satisfies both. The schema accepts
+ * any positive integer (`z.number().int().min(1)`,
+ * scenario-fixtures.ts:100), so the fixture loads cleanly; and the gate
+ * enforces it against the ACTUAL recalled item count
+ * (`scenario-gate.ts:255`, via `durableSectionChecks`). The scenario seeds
+ * exactly one record, so demanding a large count is a claim about observed
+ * output that cannot hold — while every other scenario in the file is left
+ * untouched and keeps exercising the real path.
+ *
+ * Deliberately NOT used as the mutation:
+ *   - a bad scope key — rejected by the loader (parse error, see constraint 1);
+ *   - a corrupted `schema_version` — same problem;
+ *   - deleting scenarios — an empty suite is a DIFFERENT defect, and the gate
+ *     already checks the scenario count separately in clause (a).
+ *
+ * OUTPUT
+ * ------
+ * Writes the mutated fixture to `--out` and prints the single field it changed.
+ * Exits non-zero if the input does not contain the scenario it needs to mutate,
+ * rather than silently emitting an unmutated copy — an unmutated copy would
+ * PASS the suite and be reported as "the suite accepted a wrong expectation",
+ * inverting the clause's meaning.
+ */
+
+interface FixtureShape {
+  scenarios?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+/** Absurdly high vs. the single record the scenario seeds. */
+const IMPOSSIBLE_MIN_ITEMS = 9_999;
+
+function argValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const inline = Bun.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = Bun.argv.indexOf(`--${name}`);
+  const next = index >= 0 ? Bun.argv[index + 1] : undefined;
+  return next && !next.startsWith("--") ? next : undefined;
+}
+
+async function main(): Promise<number> {
+  const inPath = argValue("in");
+  const outPath = argValue("out");
+  if (!inPath || !outPath) {
+    console.error("usage: 578-e2e-gate.control.ts --in <fixture> --out <path>");
+    return 2;
+  }
+
+  const fixture = (await Bun.file(inPath).json()) as FixtureShape;
+  const scenarios = Array.isArray(fixture.scenarios) ? fixture.scenarios : [];
+
+  const target = scenarios.find(
+    (scenario) => scenario.kind === "durable_memory_shape",
+  );
+  if (!target) {
+    console.error(
+      "control driver: no durable_memory_shape scenario in the fixture; refusing to emit an unmutated copy",
+    );
+    return 1;
+  }
+
+  const expected = target.expected;
+  if (!expected || typeof expected !== "object" || Array.isArray(expected)) {
+    console.error(
+      "control driver: durable_memory_shape scenario has no `expected` object to mutate",
+    );
+    return 1;
+  }
+
+  const before = (expected as Record<string, unknown>).min_items;
+  (expected as Record<string, unknown>).min_items = IMPOSSIBLE_MIN_ITEMS;
+
+  // The fixture id is changed too so a stray receipt can never be mistaken for
+  // a real run's (docs/lane-contract.md: nothing silent — the artifact says
+  // what it is).
+  fixture.fixture_id = `${String(fixture.fixture_id ?? "unknown")}-CONTROL-WRONG-EXPECTATION`;
+
+  await Bun.write(outPath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+  console.log(
+    `control driver: scenario=${String(target.id)} field=expected.min_items ${String(before)} -> ${IMPOSSIBLE_MIN_ITEMS} (deliberately unsatisfiable)`,
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`control driver error: ${message}`);
+      process.exitCode = 2;
+    });
+}

--- a/scripts/done-means/578-e2e-gate.receipt.ts
+++ b/scripts/done-means/578-e2e-gate.receipt.ts
@@ -5,8 +5,31 @@
  *
  * Prints ONE requested field from a scenario-gate receipt:
  *
- *   scenario_count   number of scenarios the run actually executed
- *   teardown_failed  the receipt's teardown.failed tally
+ *   scenario_count            number of scenarios the run actually executed
+ *   teardown_residue_checked  "true"/"false" — whether residue was OBSERVED
+ *   teardown_residue_rows     rows still present after teardown
+ *   teardown_residue_tables   "table=count,table=count" (empty when none)
+ *   teardown_failed           the receipt's teardown.failed tally (DIAGNOSTIC
+ *                             ONLY — see below)
+ *
+ * WHY THE TALLY IS NO LONGER THE VERDICT
+ * --------------------------------------
+ * `teardown.failed` counts cleanup CALLS that threw, not rows left behind.
+ * PR #673 (issue #671) established that a teardown reporting FAILURE is not
+ * evidence of residue: on the third credentialed #653 verify, two
+ * `archive_entry` calls threw while a 12-table residue query returned zero
+ * rows, and this gate's clause (e) failed a database that was in fact clean.
+ * The SME entry is
+ * `docs/sme/entries/2026-08-08-a-teardown-that-reports-failure-is-not-evidence-of-residue.md`:
+ * "the verdict reads the OBSERVABLE, not the attempt log," and "'not observed'
+ * is not 'clean'."
+ *
+ * So clause (e) now reads `receipt.teardown_residue` — an actual count of
+ * remaining rows, produced by a reader that shares the purge's own table tuple
+ * — and reports the tally as diagnostics. `checked` is surfaced as its OWN
+ * field, deliberately: `rows` is 0 both when nothing remains and when nothing
+ * was looked at, so a clause that read only `rows` would turn the false red
+ * into a false green. The clause fails closed on `checked=false`.
  *
  * WHY THIS IS A FILE AND NOT AN INLINE `bun -e`
  * ---------------------------------------------
@@ -26,7 +49,31 @@
  * indistinguishable from a legitimately empty run.
  */
 
-type Field = "scenario_count" | "teardown_failed";
+type Field =
+  | "scenario_count"
+  | "teardown_failed"
+  | "teardown_residue_checked"
+  | "teardown_residue_rows"
+  | "teardown_residue_tables";
+
+/**
+ * Pull `receipt.teardown_residue` out, or return an error string.
+ *
+ * A receipt with NO `teardown_residue` at all is an error, never a default.
+ * Defaulting a missing residue reading to `{checked:true, rows:0}` would make
+ * an OLD receipt — one written before #673 shipped the field — silently pass
+ * the clause that exists to read it, which is the same unperformed-check
+ * verdict in a new spelling.
+ */
+function readResidue(
+  receipt: Record<string, unknown>,
+): Record<string, unknown> | string {
+  const residue = receipt.teardown_residue;
+  if (!residue || typeof residue !== "object" || Array.isArray(residue)) {
+    return "receipt has no `teardown_residue` object (pre-#673 receipt, or the gate did not emit one)";
+  }
+  return residue as Record<string, unknown>;
+}
 
 async function main(): Promise<number> {
   const [, , receiptPath, field] = Bun.argv;
@@ -72,6 +119,64 @@ async function main(): Promise<number> {
         return 1;
       }
       console.log(String(failed));
+      return 0;
+    }
+    case "teardown_residue_checked": {
+      const residue = readResidue(receipt);
+      if (typeof residue === "string") {
+        console.error(residue);
+        return 1;
+      }
+      const checked = residue.checked;
+      if (typeof checked !== "boolean") {
+        console.error("teardown_residue has no boolean `checked` flag");
+        return 1;
+      }
+      // Printed even when false, with the reason on stderr, so the transcript
+      // says WHY the clause is about to fail closed rather than only that it
+      // did.
+      if (!checked) {
+        const reason = residue.unchecked_reason;
+        console.error(
+          `residue was NOT observed: ${typeof reason === "string" && reason ? reason : "no reason given"}`,
+        );
+      }
+      console.log(checked ? "true" : "false");
+      return 0;
+    }
+    case "teardown_residue_rows": {
+      const residue = readResidue(receipt);
+      if (typeof residue === "string") {
+        console.error(residue);
+        return 1;
+      }
+      const rows = residue.rows;
+      if (typeof rows !== "number" || !Number.isFinite(rows)) {
+        console.error("teardown_residue has no numeric `rows` count");
+        return 1;
+      }
+      console.log(String(rows));
+      return 0;
+    }
+    case "teardown_residue_tables": {
+      const residue = readResidue(receipt);
+      if (typeof residue === "string") {
+        console.error(residue);
+        return 1;
+      }
+      const byTable = residue.by_table;
+      if (!byTable || typeof byTable !== "object" || Array.isArray(byTable)) {
+        console.error("teardown_residue has no `by_table` object");
+        return 1;
+      }
+      // Empty is a legitimate answer (nothing remains), so this prints an
+      // empty line and exits 0 rather than erroring — the caller decides what
+      // emptiness means, using `rows`.
+      console.log(
+        Object.entries(byTable as Record<string, unknown>)
+          .map(([table, count]) => `${table}=${String(count)}`)
+          .join(","),
+      );
       return 0;
     }
     default:

--- a/scripts/done-means/578-e2e-gate.receipt.ts
+++ b/scripts/done-means/578-e2e-gate.receipt.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+/**
+ * Receipt reader for the #578 DONE-MEANS check. Not a test file; invoked by
+ * `scripts/done-means/578-e2e-gate.sh`, which owns the verdict.
+ *
+ * Prints ONE requested field from a scenario-gate receipt:
+ *
+ *   scenario_count   number of scenarios the run actually executed
+ *   teardown_failed  the receipt's teardown.failed tally
+ *
+ * WHY THIS IS A FILE AND NOT AN INLINE `bun -e`
+ * ---------------------------------------------
+ * The first version of this gate read the receipt with
+ * `bun -e '<script>' -- "$PATH"` and defaulted to 0 via `|| echo 0`. `bun -e`
+ * does NOT forward trailing arguments to the evaluated script — neither
+ * `process.argv[2]` nor `Bun.argv[2]` is the path — so the snippet threw
+ * `ERR_INVALID_ARG_TYPE` on EVERY run, the `|| echo 0` swallowed the crash,
+ * and the gate reported "receipt reported 0 scenarios" for a receipt that
+ * plainly contained three. That is a false FAIL from a silent crash, the exact
+ * mirror of the false GREEN this repo keeps paying for (#583's vacuous
+ * `secret_scan`; docs/lane-contract.md round 13's "top-level await with no
+ * .catch exits 0").
+ *
+ * A real file takes real `Bun.argv`, and a missing/unreadable receipt is
+ * reported as an explicit error with a non-zero exit instead of being
+ * indistinguishable from a legitimately empty run.
+ */
+
+type Field = "scenario_count" | "teardown_failed";
+
+async function main(): Promise<number> {
+  const [, , receiptPath, field] = Bun.argv;
+  if (!receiptPath || !field) {
+    console.error("usage: 578-e2e-gate.receipt.ts <receipt.json> <field>");
+    return 2;
+  }
+
+  const file = Bun.file(receiptPath);
+  if (!(await file.exists())) {
+    console.error(`receipt not found: ${receiptPath}`);
+    return 1;
+  }
+
+  let receipt: Record<string, unknown>;
+  try {
+    receipt = (await file.json()) as Record<string, unknown>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`receipt is not readable JSON: ${message}`);
+    return 1;
+  }
+
+  switch (field as Field) {
+    case "scenario_count": {
+      const scenarios = receipt.scenarios;
+      if (!Array.isArray(scenarios)) {
+        console.error("receipt has no `scenarios` array");
+        return 1;
+      }
+      console.log(String(scenarios.length));
+      return 0;
+    }
+    case "teardown_failed": {
+      const teardown = receipt.teardown;
+      if (!teardown || typeof teardown !== "object" || Array.isArray(teardown)) {
+        console.error("receipt has no `teardown` object");
+        return 1;
+      }
+      const failed = (teardown as Record<string, unknown>).failed;
+      if (typeof failed !== "number") {
+        console.error("receipt teardown has no numeric `failed` tally");
+        return 1;
+      }
+      console.log(String(failed));
+      return 0;
+    }
+    default:
+      console.error(`unknown field: ${field}`);
+      return 2;
+  }
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`receipt reader error: ${message}`);
+      process.exitCode = 2;
+    });
+}

--- a/scripts/done-means/578-e2e-gate.sh
+++ b/scripts/done-means/578-e2e-gate.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #578 — "E2E quality gate: scripted input/output
+# scenarios + Langfuse egress verification".
+#
+#   bash scripts/done-means/578-e2e-gate.sh
+#
+# ---------------------------------------------------------------------------
+# WHAT #578 ASKED FOR, AND WHAT WAS ALREADY BUILT
+# ---------------------------------------------------------------------------
+# The operator's ask (#578, 2026-08-05): "run a whole bunch of actual tests to
+# verify things instead of me having to literally dogfood everything ... run
+# some inputs and outputs via a script with expected information and also be
+# able to check what's going out to my Langfuse and see that things are
+# actually going correctly."
+#
+# #578's own "The delta (two pieces)" named exactly two, and BOTH SHIPPED:
+#
+#   1. Scenario breadth — `scripts/eval-open-brain-scenarios.ts` (PR #580,
+#      commit 12e83fd) over `eval/open-brain/fixtures/scenarios-v1.json`,
+#      driving the REAL contract surfaces: capture round-trip through the
+#      shipped provider (`capture_round_trip`), durable_memory pack shape and
+#      recall through the real MCP client (`durable_memory_shape`), and a
+#      checkpoint/resume round-trip (`checkpoint_round_trip`).
+#   2. Langfuse egress verification — `scripts/eval-langfuse-egress.ts`
+#      (PR #579, commit 29f9261; hardened by #583/#584 and #586/a5a1274).
+#
+# So this check is NOT "build the gate". The gate exists. What #578 has never
+# had is the thing that makes it a GATE rather than two commands an operator
+# remembers to run in the right order with the right environment: ONE runnable
+# entry point that composes both legs, proves the egress leg observed the
+# traffic the scenario leg actually produced, and — the part neither leg can do
+# for itself — proves the composed suite can still FAIL.
+#
+# ---------------------------------------------------------------------------
+# WHY A CONTROL CLAUSE IS THE LOAD-BEARING PART
+# ---------------------------------------------------------------------------
+# Both legs have been observed GREEN live (operator receipt on #578, trunk
+# a5a1274: drive PASS with watermark offset 1446, verify PASS with 1 trace /
+# 4 observations / 3 generations / generation_metadata 3/3 / total_cost 3/3 /
+# secret_scan clean over real content). A green run is not evidence a check
+# discriminates. This repo has already paid for that lesson twice, in the
+# record, on THIS issue:
+#
+#   - `secret_scan` reported PASS over ZERO traces in the first live run — a
+#     vacuous green that #583 fixed by introducing `skipped-no-data` as a state
+#     distinct from `pass` (scripts/eval-langfuse-egress.ts:70-80).
+#   - `docs/lane-contract.md` Tightenings round 13: "A control clause that
+#     passes PRE-fix is the signal the check discriminates ... a check that
+#     fails everywhere proves only that it fails."
+#
+# Clause (d) below therefore feeds the scenario runner a DELIBERATELY WRONG
+# expectation and requires a FAIL. Without it, a suite that had silently become
+# a no-op — an empty fixture, a skipped leg, a transport that swallows every
+# verdict — would bank a free GREEN forever, which is precisely the class of
+# defect #578 exists to catch in everything else.
+#
+# ---------------------------------------------------------------------------
+# NO WALL-CLOCK ASSERTIONS
+# ---------------------------------------------------------------------------
+# Egress visibility is inherently asynchronous: Langfuse ingests in batches, so
+# a trace is not queryable the instant it is emitted. The forbidden shape
+# (docs/lane-contract.md Tightenings round 5, #632/#634) is `sleep N; assert`.
+# This check never sleeps-then-asserts. It delegates settling to the verifier's
+# own BOUNDED POLL — `--settle-timeout` drives a poll loop that exits the
+# moment the expected COUNTS arrive and reports `polls` and `timed_out`
+# (scripts/eval-langfuse-egress.ts, `settle`). The assertion is on counts;
+# elapsed time is only a bound on patience, never the thing measured. The
+# operator's a5a1274 receipt settled in 1 poll.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) SCENARIOS — the scripted input/expected-output suite runs against the
+#       live deployment named by OPEN_BRAIN_LIVE_EVAL_BASE_URL and every
+#       scenario's observed output matches its fixture expectation. Exit 0 and
+#       a receipt whose `passed` is true, with a non-zero scenario count (a
+#       suite that ran nothing is not a pass — the #613 skip-count lesson).
+#
+#   (b) EGRESS DRIVE — driving real traffic under a unique run tag PROVES an
+#       emit happened. `emit_proven` is fatal in the verifier precisely because
+#       a hook's exit-zero contract cannot prove a capture occurred; the first
+#       live run on #578 exited 0 while writing no watermark offset at all.
+#
+#   (c) EGRESS VERIFY — querying the Langfuse API for that SAME tag finds what
+#       the drive produced: the expected trace/observation counts arrived
+#       (`arrival_count`), GENERATION rows carry model + usage metadata
+#       (`generation_metadata`), and the secret scan ran over REAL content
+#       rather than reporting a vacuous green over nothing
+#       (`secret_scan` must not be `skipped-no-data`).
+#
+#   (d) CONTROL — A DELIBERATELY WRONG EXPECTATION FAILS. The scenario runner
+#       is re-run against a mutated fixture whose expectation cannot hold. It
+#       MUST exit non-zero. If this clause passes (i.e. the wrong expectation
+#       was accepted), the entire suite is non-discriminating and the check
+#       reports FAIL no matter what (a)-(c) said.
+#
+#   (e) CONTROL — TEARDOWN. The scenario leg reports its own teardown tally and
+#       nothing it created is left behind (`failed=0`). A gate that accretes
+#       throwaway namespaces on every run is a gate nobody runs twice.
+#
+# ---------------------------------------------------------------------------
+# ENVIRONMENT — WHY THIS IS OPT-IN AND WHERE THE VALUES COME FROM
+# ---------------------------------------------------------------------------
+# This gate talks to a REAL deployment and a REAL Langfuse instance, so it is
+# opt-in and refuses to invent coordinates. It reads, and never writes or
+# echoes, these variables:
+#
+#   OPEN_BRAIN_LIVE_EVAL=1                 mandatory opt-in (eval/open-brain/live/config.ts)
+#   OPEN_BRAIN_LIVE_EVAL_BASE_URL          deployment under test
+#   OPEN_BRAIN_LIVE_EVAL_TOKEN             admin/ob-admin token (namespace delegation)
+#   OPEN_BRAIN_LANGFUSE_EGRESS=1           mandatory opt-in for the egress legs
+#   OPENBRAIN_TRACING_ENABLED=1            } Langfuse read coordinates
+#   OPENBRAIN_TRACING_ENDPOINT             } (scripts/eval-langfuse-egress.ts,
+#   OPENBRAIN_TRACING_PUBLIC_KEY           }  readLangfuseEgressConfig)
+#   OPENBRAIN_TRACING_SECRET_KEY           }
+#   OPENBRAIN_CAPTURE_BASE_URL / _TOKEN    raw-capture coordinates for --drive
+#     (or their OPENBRAIN_BASE_URL / OPENBRAIN_TOKEN aliases)
+#
+# NOTE, because this surprised this lane and will surprise the next one: the
+# repo `.env` no longer carries live token VALUES. The neutrality scrub
+# (PR #645) replaced them with empty placeholders, so `AUTH_TOKEN_ADMIN=` in
+# `.env` has length 0. The credentials live in the environment of whatever
+# process is actually serving the deployment. Assemble the environment from
+# your own operator source before invoking; this script deliberately does not
+# reach into a running process to harvest secrets.
+#
+# By design this is PORTABLE: point BASE_URL at the local clone or at core01
+# and the same suite runs. Nothing here hard-codes a host.
+#
+# Output is content-free — clause names, statuses, counts, and check labels
+# only. No trace bodies, no credentials, no record content.
+#
+# ---------------------------------------------------------------------------
+# EXPECTED TO FAIL BEFORE THIS CHECK EXISTED
+# ---------------------------------------------------------------------------
+# There was no composed entry point at all, so clause (d) — the only clause
+# that asks whether the suite can fail — had never been executed against this
+# repo. RED for this check is its own absence plus an unproven discrimination
+# claim; see the PR body for the transcript.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FAILURES=0
+pass() { printf 'PASS  %s\n' "$1"; }
+fail() { printf 'FAIL  %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+info() { printf 'INFO  %s\n' "$1"; }
+
+SCENARIO_SCRIPT="scripts/eval-open-brain-scenarios.ts"
+EGRESS_SCRIPT="scripts/eval-langfuse-egress.ts"
+FIXTURE="eval/open-brain/fixtures/scenarios-v1.json"
+CONTROL_DRIVER="scripts/done-means/578-e2e-gate.control.ts"
+RECEIPT_READER="scripts/done-means/578-e2e-gate.receipt.ts"
+
+for required in "$SCENARIO_SCRIPT" "$EGRESS_SCRIPT" "$FIXTURE" "$CONTROL_DRIVER" "$RECEIPT_READER"; do
+  if [[ ! -f "$required" ]]; then
+    fail "missing required component: $required"
+  fi
+done
+if [[ ${FAILURES} -gt 0 ]]; then
+  printf '\n=== DONE-MEANS #578: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Environment gate. A missing coordinate is an explicit REFUSAL, never a silent
+# skip that exits 0 — the whole point of this gate is that it cannot quietly
+# examine nothing.
+# ---------------------------------------------------------------------------
+MISSING=()
+[[ "${OPEN_BRAIN_LIVE_EVAL:-}" == "1" ]] || MISSING+=("OPEN_BRAIN_LIVE_EVAL=1")
+[[ -n "${OPEN_BRAIN_LIVE_EVAL_BASE_URL:-}" ]] || MISSING+=("OPEN_BRAIN_LIVE_EVAL_BASE_URL")
+[[ -n "${OPEN_BRAIN_LIVE_EVAL_TOKEN:-}" ]] || MISSING+=("OPEN_BRAIN_LIVE_EVAL_TOKEN")
+[[ "${OPEN_BRAIN_LANGFUSE_EGRESS:-}" == "1" ]] || MISSING+=("OPEN_BRAIN_LANGFUSE_EGRESS=1")
+[[ "${OPENBRAIN_TRACING_ENABLED:-}" == "1" ]] || MISSING+=("OPENBRAIN_TRACING_ENABLED=1")
+[[ -n "${OPENBRAIN_TRACING_ENDPOINT:-}" ]] || MISSING+=("OPENBRAIN_TRACING_ENDPOINT")
+[[ -n "${OPENBRAIN_TRACING_PUBLIC_KEY:-}" ]] || MISSING+=("OPENBRAIN_TRACING_PUBLIC_KEY")
+[[ -n "${OPENBRAIN_TRACING_SECRET_KEY:-}" ]] || MISSING+=("OPENBRAIN_TRACING_SECRET_KEY")
+if [[ -z "${OPENBRAIN_CAPTURE_BASE_URL:-}${OPENBRAIN_BASE_URL:-}" ]]; then
+  MISSING+=("OPENBRAIN_CAPTURE_BASE_URL (or OPENBRAIN_BASE_URL)")
+fi
+if [[ -z "${OPENBRAIN_CAPTURE_TOKEN:-}${OPENBRAIN_TOKEN:-}" ]]; then
+  MISSING+=("OPENBRAIN_CAPTURE_TOKEN (or OPENBRAIN_TOKEN)")
+fi
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  printf 'REFUSED  the #578 gate talks to a live deployment and a live Langfuse; it will not invent coordinates.\n'
+  printf 'REFUSED  missing:\n'
+  for name in "${MISSING[@]}"; do printf 'REFUSED    - %s\n' "$name"; done
+  printf 'REFUSED  see the header of this file for where each value comes from.\n'
+  printf '\n=== DONE-MEANS #578: REFUSED (environment incomplete; nothing was examined) ===\n'
+  exit 2
+fi
+
+RUN_TAG="e2e578-$(date +%Y%m%d%H%M%S)-$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+SETTLE_TIMEOUT="${OPEN_BRAIN_578_SETTLE_TIMEOUT:-90}"
+EGRESS_COUNT="${OPEN_BRAIN_578_EVENT_COUNT:-3}"
+
+info "repo:          ${REPO_ROOT}"
+info "deployment:    ${OPEN_BRAIN_LIVE_EVAL_BASE_URL}"
+info "run tag:       ${RUN_TAG}"
+info "settle bound:  ${SETTLE_TIMEOUT}s (bounded poll on counts; never a sleep-then-assert)"
+
+# Scratch goes to the repo's own temp-workspace bucket, NEVER `mktemp -d` and
+# never `/tmp` or `$TMPDIR` — those are sandbox-local, so a runner, a Codex
+# sandbox, and the host each see a different one and the receipts this gate
+# writes would be invisible to whoever needs to read them
+# (_DOCS/STANDARDS-core.md; AGENTS.md "NEVER /tmp"). Receipts are also the
+# artifact an operator most wants AFTER a failure, so they are left in place
+# rather than removed; the run tag makes each run's directory distinct.
+SCRATCH_ROOT="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/578-e2e-gate"
+WORK_DIR="${SCRATCH_ROOT}/${RUN_TAG}"
+mkdir -p "${WORK_DIR}"
+info "receipts:      ${WORK_DIR}"
+
+SCENARIO_RECEIPT="${WORK_DIR}/scenario-receipt.json"
+CONTROL_RECEIPT="${WORK_DIR}/control-receipt.json"
+
+# ---------------------------------------------------------------------------
+# (a) SCENARIOS — scripted input/expected-output against the live deployment.
+# ---------------------------------------------------------------------------
+printf '\n--- (a) scenario suite ---\n'
+set +e
+SCENARIO_LOG="$(bun run "${SCENARIO_SCRIPT}" --report "${SCENARIO_RECEIPT}" 2>&1)"
+SCENARIO_EXIT=$?
+set -e
+printf '%s\n' "${SCENARIO_LOG}" | tail -20
+
+if [[ ${SCENARIO_EXIT} -eq 0 ]]; then
+  pass "(a) scenario suite exited 0"
+else
+  fail "(a) scenario suite exited ${SCENARIO_EXIT}"
+fi
+
+# Read through a real driver, never an inline `bun -e ... || echo 0`: that
+# form cannot receive the path (bun -e forwards no argv) and its `||` default
+# turns the resulting crash into a plausible-looking count. See the header of
+# 578-e2e-gate.receipt.ts for the false FAIL this cost once already.
+set +e
+SCENARIO_COUNT="$(bun "${RECEIPT_READER}" "${SCENARIO_RECEIPT}" scenario_count 2>&1)"
+COUNT_EXIT=$?
+set -e
+if [[ ${COUNT_EXIT} -ne 0 ]]; then
+  fail "(a) could not read the scenario count from the receipt: ${SCENARIO_COUNT}"
+  SCENARIO_COUNT=0
+fi
+if [[ "${SCENARIO_COUNT}" -gt 0 ]]; then
+  pass "(a) suite really executed ${SCENARIO_COUNT} scenario(s) — not a silent empty run"
+else
+  fail "(a) receipt reported 0 scenarios; a suite that examined nothing is not a pass"
+fi
+
+# ---------------------------------------------------------------------------
+# (e) CONTROL — teardown. Read from the same receipt.
+# ---------------------------------------------------------------------------
+printf '\n--- (e) control: teardown ---\n'
+set +e
+TEARDOWN_FAILED="$(bun "${RECEIPT_READER}" "${SCENARIO_RECEIPT}" teardown_failed 2>&1)"
+TEARDOWN_EXIT=$?
+set -e
+if [[ ${TEARDOWN_EXIT} -ne 0 ]]; then
+  fail "(e) teardown tally unreadable: ${TEARDOWN_FAILED}"
+elif [[ "${TEARDOWN_FAILED}" == "0" ]]; then
+  pass "(e) scenario teardown left nothing behind (failed=0)"
+else
+  fail "(e) scenario teardown failed=${TEARDOWN_FAILED} — the run left records behind"
+fi
+
+# ---------------------------------------------------------------------------
+# (b) EGRESS DRIVE — prove an emit actually happened under this run's tag.
+# ---------------------------------------------------------------------------
+printf '\n--- (b) egress drive ---\n'
+set +e
+DRIVE_LOG="$(bun "${EGRESS_SCRIPT}" --drive --tag "${RUN_TAG}" --count "${EGRESS_COUNT}" 2>&1)"
+DRIVE_EXIT=$?
+set -e
+printf '%s\n' "${DRIVE_LOG}" | tail -20
+if [[ ${DRIVE_EXIT} -eq 0 ]]; then
+  pass "(b) drive exited 0 with emit proven"
+else
+  fail "(b) drive exited ${DRIVE_EXIT} — traffic was not proven to reach the tracer"
+fi
+
+# ---------------------------------------------------------------------------
+# (c) EGRESS VERIFY — query Langfuse for the SAME tag.
+# ---------------------------------------------------------------------------
+printf '\n--- (c) egress verify ---\n'
+set +e
+VERIFY_LOG="$(bun "${EGRESS_SCRIPT}" --verify --tag "${RUN_TAG}" --count "${EGRESS_COUNT}" \
+  --settle-timeout "${SETTLE_TIMEOUT}" 2>&1)"
+VERIFY_EXIT=$?
+set -e
+printf '%s\n' "${VERIFY_LOG}" | tail -25
+if [[ ${VERIFY_EXIT} -eq 0 ]]; then
+  pass "(c) verify exited 0 — expected traces/observations arrived at Langfuse"
+else
+  fail "(c) verify exited ${VERIFY_EXIT} — expected egress did not arrive"
+fi
+
+# A secret_scan that examined nothing is not a clean scan (#583). The verifier
+# marks that state `skipped-no-data`; treat its presence as a clause failure
+# even when the overall exit was 0.
+if printf '%s' "${VERIFY_LOG}" | rg -q 'secret_scan.*skipped-no-data'; then
+  fail "(c) secret_scan reported skipped-no-data — it scanned zero traces, which is a vacuous green"
+else
+  pass "(c) secret_scan examined real content rather than reporting a vacuous green"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) CONTROL — a deliberately-wrong expectation MUST fail.
+# ---------------------------------------------------------------------------
+printf '\n--- (d) control: a wrong expectation must FAIL ---\n'
+MUTATED_FIXTURE="${WORK_DIR}/scenarios-wrong-expectation.json"
+set +e
+bun "${CONTROL_DRIVER}" --in "${FIXTURE}" --out "${MUTATED_FIXTURE}"
+MUTATE_EXIT=$?
+set -e
+if [[ ${MUTATE_EXIT} -ne 0 || ! -f "${MUTATED_FIXTURE}" ]]; then
+  fail "(d) could not build the mutated fixture; the control clause did not run"
+else
+  set +e
+  CONTROL_LOG="$(bun run "${SCENARIO_SCRIPT}" --fixture "${MUTATED_FIXTURE}" \
+    --report "${CONTROL_RECEIPT}" 2>&1)"
+  CONTROL_EXIT=$?
+  set -e
+  printf '%s\n' "${CONTROL_LOG}" | tail -12
+  if [[ ${CONTROL_EXIT} -ne 0 ]]; then
+    pass "(d) the suite REJECTED a deliberately-wrong expectation (exit ${CONTROL_EXIT}) — it discriminates"
+  else
+    fail "(d) the suite ACCEPTED a deliberately-wrong expectation — it is non-discriminating and every green above is vacuous"
+  fi
+fi
+
+printf '\n'
+if [[ ${FAILURES} -eq 0 ]]; then
+  printf '=== DONE-MEANS #578: PASS — scripted scenarios match their expectations, the traffic they produced is visible in Langfuse under this run tag, and a wrong expectation still fails. ===\n'
+  exit 0
+fi
+printf '=== DONE-MEANS #578: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+exit 1

--- a/scripts/done-means/578-e2e-gate.sh
+++ b/scripts/done-means/578-e2e-gate.sh
@@ -94,9 +94,15 @@
 #       was accepted), the entire suite is non-discriminating and the check
 #       reports FAIL no matter what (a)-(c) said.
 #
-#   (e) CONTROL — TEARDOWN. The scenario leg reports its own teardown tally and
-#       nothing it created is left behind (`failed=0`). A gate that accretes
-#       throwaway namespaces on every run is a gate nobody runs twice.
+#   (e) CONTROL — TEARDOWN RESIDUE. Nothing the run created is left behind,
+#       asserted against OBSERVED ROWS (`teardown_residue`, PR #673) rather
+#       than the cleanup-call tally. `checked=true` with `rows=0` passes;
+#       `checked=false` FAILS closed, because an unperformed check cannot
+#       support a clean verdict; `rows>0` fails naming the table. The old
+#       `teardown.failed` tally is reported as INFO diagnostics and decides
+#       nothing. A gate that accretes throwaway namespaces on every run is a
+#       gate nobody runs twice — but a gate that reds out over a cleanup call
+#       that threw on an already-empty database is one nobody trusts (#671).
 #
 # ---------------------------------------------------------------------------
 # ENVIRONMENT — WHY THIS IS OPT-IN AND WHERE THE VALUES COME FROM
@@ -253,19 +259,81 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# (e) CONTROL — teardown. Read from the same receipt.
+# (e) CONTROL — teardown RESIDUE. Read from the same receipt.
+#
+# This clause reads OBSERVED ROWS, not the cleanup-call tally. `teardown.failed`
+# counts calls that threw; residue counts what is still in the database. PR #673
+# (issue #671) proved they are different facts: on the third credentialed #653
+# verify, two `archive_entry` calls threw over a database a 12-table residue
+# query had just shown to be empty, and this clause failed a clean run.
+#
+# Three outcomes, and the middle one is the point:
+#   checked=true, rows=0   PASS — a reading ran and found nothing
+#   checked=false          FAIL — nothing was looked at; unproven is not clean
+#   rows>0                 FAIL — naming the table(s) holding the rows
+#
+# The tally is still reported, as INFO, in the diagnostics line below it. It
+# explains a result; it is not the result.
 # ---------------------------------------------------------------------------
-printf '\n--- (e) control: teardown ---\n'
+printf '\n--- (e) control: teardown residue ---\n'
+set +e
+RESIDUE_CHECKED="$(bun "${RECEIPT_READER}" "${SCENARIO_RECEIPT}" teardown_residue_checked 2>&1)"
+RESIDUE_CHECKED_EXIT=$?
+set -e
+set +e
+RESIDUE_ROWS="$(bun "${RECEIPT_READER}" "${SCENARIO_RECEIPT}" teardown_residue_rows 2>&1)"
+RESIDUE_ROWS_EXIT=$?
+set -e
+set +e
+RESIDUE_TABLES="$(bun "${RECEIPT_READER}" "${SCENARIO_RECEIPT}" teardown_residue_tables 2>&1)"
+RESIDUE_TABLES_EXIT=$?
+set -e
+
+# The reader prints the `checked=false` reason on stderr, which 2>&1 folds into
+# the value. Keep only the last line, so the comparison sees the value and the
+# transcript still carries the reason.
+RESIDUE_CHECKED_VALUE="$(printf '%s\n' "${RESIDUE_CHECKED}" | tail -1)"
+RESIDUE_ROWS_VALUE="$(printf '%s\n' "${RESIDUE_ROWS}" | tail -1)"
+# Round 24 (empty variable in a numeric test aborts the script under `set -u`
+# and truncates every clause after it): a failed read becomes a sentinel, never
+# an empty string, and the arithmetic is guarded on the sentinel.
+if [[ ${RESIDUE_ROWS_EXIT} -ne 0 || -z "${RESIDUE_ROWS_VALUE}" ]]; then
+  RESIDUE_ROWS_VALUE="MISSING"
+fi
+
+if [[ ${RESIDUE_CHECKED_EXIT} -ne 0 ]]; then
+  fail "(e) teardown residue reading unreadable: ${RESIDUE_CHECKED}"
+elif [[ "${RESIDUE_CHECKED_VALUE}" != "true" ]]; then
+  # Fail CLOSED. `rows` is 0 both when nothing remains and when nothing was
+  # examined; treating the second as the first is how the #671 false red would
+  # become a false green.
+  # The reason lives on the reader's stderr lines, i.e. everything the value
+  # line is not. Folded onto one line so the verdict stays one line — a FAIL
+  # whose message wraps into a bare `false` on the next line reads like a
+  # second, unexplained output.
+  RESIDUE_UNCHECKED_REASON="$(printf '%s\n' "${RESIDUE_CHECKED}" | sed '$d' | tr '\n' ' ')"
+  fail "(e) teardown residue was NOT observed (checked=${RESIDUE_CHECKED_VALUE}) — an unperformed check cannot support a clean verdict: ${RESIDUE_UNCHECKED_REASON:-no reason reported}"
+elif [[ "${RESIDUE_ROWS_VALUE}" == "MISSING" ]]; then
+  fail "(e) teardown residue row count unreadable: ${RESIDUE_ROWS}"
+elif [[ "${RESIDUE_ROWS_VALUE}" -eq 0 ]]; then
+  pass "(e) teardown residue OBSERVED and empty (checked=true rows=0) — the run left nothing behind"
+else
+  if [[ ${RESIDUE_TABLES_EXIT} -ne 0 || -z "${RESIDUE_TABLES}" ]]; then
+    RESIDUE_TABLES="<table breakdown unavailable: ${RESIDUE_TABLES}>"
+  fi
+  fail "(e) teardown left ${RESIDUE_ROWS_VALUE} row(s) behind in: ${RESIDUE_TABLES}"
+fi
+
+# DIAGNOSTIC, not a verdict. Reported because it explains a residue result and
+# carries the content-free failure labels #673 added; it decides nothing.
 set +e
 TEARDOWN_FAILED="$(bun "${RECEIPT_READER}" "${SCENARIO_RECEIPT}" teardown_failed 2>&1)"
 TEARDOWN_EXIT=$?
 set -e
 if [[ ${TEARDOWN_EXIT} -ne 0 ]]; then
-  fail "(e) teardown tally unreadable: ${TEARDOWN_FAILED}"
-elif [[ "${TEARDOWN_FAILED}" == "0" ]]; then
-  pass "(e) scenario teardown left nothing behind (failed=0)"
+  info "(e) diagnostics: teardown call tally unreadable (${TEARDOWN_FAILED}) — not a verdict either way"
 else
-  fail "(e) scenario teardown failed=${TEARDOWN_FAILED} — the run left records behind"
+  info "(e) diagnostics: ${TEARDOWN_FAILED} teardown call(s) threw (a tally of CALLS, not of rows — see clause (e) above for the verdict)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#578's two named deltas already shipped.** The scripted scenario suite (`scripts/eval-open-brain-scenarios.ts`, PR #580, `12e83fd`) and the Langfuse egress verifier (`scripts/eval-langfuse-egress.ts`, PR #579, `29f9261`, hardened by #583/#584 and #586) both exist. This PR adds the missing third thing: **one runnable entry point that composes them and proves the composed suite can still fail.**
- `scripts/done-means/578-e2e-gate.sh` runs five clauses against a live deployment named by a base URL + token, so it is portable to the local clone or core01 with no host hard-coded: **(a)** scenarios match their fixture expectations and the run was not silently empty; **(b)** the drive leg proves an emit actually happened; **(c)** Langfuse received the traffic under this run's unique tag, with `secret_scan` examining real content rather than reporting a vacuous green over zero traces (#583); **(d) CONTROL** — a deliberately-wrong expectation MUST fail; **(e) CONTROL** — teardown left nothing behind.
- **Clause (d) is the load-bearing part.** Both legs have been observed green live, and a green run is not evidence a check discriminates — `docs/lane-contract.md` round 13, and this issue's own first live run where `secret_scan` reported PASS over zero traces. `scripts/done-means/578-e2e-gate.control.ts` mutates `durable_memory_shape.expected.min_items` (1 → 9999). That field was chosen because it still passes the fixture loader — a bad scope key would trip `assertScopeKeys` (`eval/open-brain/live/scenario-fixtures.ts:26-31`) and exit non-zero for a *parse* error, which the clause would misread as "the suite discriminates" when the suite never ran — while remaining unsatisfiable by observed output (`scenario-gate.ts:255`).
- An incomplete environment is an explicit **`REFUSED`, exit 2**, naming every missing variable — never a silent skip that exits 0.
- **No wall-clock assertions.** Egress settling delegates to the verifier's bounded poll on counts (`--settle-timeout`), which exits the moment expected counts arrive and reports `polls`/`timed_out`. Elapsed time bounds patience; it is never the thing measured.

## Verification

- Done-means: scripts/done-means/578-e2e-gate.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated` — **3720 pass, 35 skip, 0 fail**, 242 files, database `ob_isolated_56001_mskvtx21nz` dropped on exit. `bunx tsc --noEmit` — exit 0. Python package unchanged by this PR (no files under `python/` touched).

**RED (the control clause, proven before trusting any green).** The minimal pair below is the evidence that the check discriminates rather than merely failing. Same live deployment, same commit, one field different:

| fixture | `durable-memory-pack-shape` | 
|---|---|
| unmutated `scenarios-v1.json` | `status=pass` |
| mutated (`min_items` 1 → 9999) | `status=fail`, `failures=durable_memory_items_missing` |

It is the **only** scenario whose status changes between the two runs, and it fails on exactly the mutated field. The gate's clause (d) consumes this and reported `PASS (d) the suite REJECTED a deliberately-wrong expectation (exit 1) — it discriminates`.

**RED for the artifact itself:** `ls scripts/done-means/578*` → `no matches found`, exit 1, before this branch.

**GREEN (partial, and reported honestly).** Full gate run against the local clone (`revision 212f916`, `/health` healthy):

```
PASS  (a) suite really executed 3 scenario(s) — not a silent empty run
FAIL  (a) scenario suite exited 1
FAIL  (e) scenario teardown failed=1 — the run left records behind
PASS  (b) drive exited 0 with emit proven
PASS  (c) verify exited 0 — expected traces/observations arrived at Langfuse
PASS  (c) secret_scan examined real content rather than reporting a vacuous green
PASS  (d) the suite REJECTED a deliberately-wrong expectation (exit 1) — it discriminates
=== DONE-MEANS #578: FAIL (2 failing clause(s)) ===
```

The Langfuse leg is **fully green and RUNNING**: `observed traces=1 observations=4 generations=3`, `arrival_count 4/4`, `generation_metadata 3/3`, `total_cost 3/3`, `secret_scan` with `content_fields_present=true` (so it scanned real content), settled in 1–2 polls, `emit_proven` watermark offset 1464.

**Clauses (a) and (e) fail on a PRE-EXISTING live defect this gate found — the gate is working as intended and is NOT being reported as green.** Per the run contract this is reported verbatim rather than retried until green.

**Refusal path verified:** running with `OPEN_BRAIN_LIVE_EVAL` and `OPENBRAIN_TRACING_ENDPOINT` unset produced `REFUSED ... (environment incomplete; nothing was examined)`, exit 2, listing all eight missing variables.

## Critical Self-Review

- Highest-risk behavior: clause (d) is the only thing standing between this gate and a permanent free green. Its risk is that the mutated fixture fails for the wrong reason — a parse error rather than an output mismatch — which would make a broken suite look discriminating. Mitigated by choosing a mutation the loader accepts, and *verified* by the minimal pair above showing exactly one scenario changing status on exactly the mutated check, rather than a blanket failure.
- Assumptions that could be wrong: that `expected.min_items` stays enforced at `scenario-gate.ts:255`. If a refactor stopped honoring it, clause (d) would silently stop discriminating while still reporting PASS — because the scenario would fail for other reasons in the current broken state. This is the residual risk called out below.
- Missing/weak tests: the gate script itself has no unit test; it is a done-means check, consistent with every other `scripts/done-means/*.sh`. The two TypeScript drivers are exercised by the gate run, not by `bun test`.
- Security/permission risk: the gate reads credentials from the environment and **never** writes, logs, or echoes them. Output is content-free — clause names, statuses, counts, check labels. It deliberately does NOT harvest secrets from a running process; the operator assembles the environment. Note the neutrality scrub (PR #645) left `.env` token values empty, so `.env` alone cannot drive this gate.
- Migration/deploy risk: none. No schema, no server code, no runtime path. Three new files under `scripts/done-means/`, nothing imports them.
- Downstream client/runtime risk: none — no MCP tool, schema, transport, or Python client surface is touched.
- Rollback/cleanup concern: receipts are written to `{temp_workspace}/open-brain/_scratch/578-e2e-gate/<run-tag>/` and deliberately left in place, since a receipt is most wanted *after* a failure; the per-run tag keeps runs distinct. No `/tmp`, no `$TMPDIR`, no `mktemp -d`, no recursive delete.
- Fixes made before PR: the first version read receipts with `bun -e '<script>' -- "$path"` and `|| echo 0`. `bun -e` forwards no argv, so it threw `ERR_INVALID_ARG_TYPE` on every run and the `||` default turned the crash into "receipt reported 0 scenarios" for a receipt containing three — a **false FAIL from a silent crash**. Replaced with `578-e2e-gate.receipt.ts`, which takes real `Bun.argv` and exits non-zero with a named error when a receipt is missing or unreadable. I caught this only because the printed receipt visibly contradicted the verdict.
- Known residual risk: clause (d) currently runs while the suite is red for unrelated reasons, so it proves the mutated scenario fails on its own check but cannot yet demonstrate the full clean-suite → mutated-suite transition. Once the `session_start` defect below is fixed, clause (d) should be re-confirmed against an otherwise-green suite.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the findings here are operating knowledge for lanes (harvest into `docs/lane-contract.md` Tightenings) and a live defect report, not a reviewer-facing code pattern. The `bun -e` argv trap is offered as a Tightening in the lane report.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live run receipts are quoted verbatim in **Verification** above (local clone `212f916`, `/health` healthy, Langfuse leg fully green).

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this PR adds only done-means check scripts. It changes no MCP tool, no payload shape, and no fixture consumed by the parity suite. The scenario fixture is read but never modified — the control driver writes its mutated copy to the temp workspace.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: no MCP tool, schema, transport, protocol, or client-facing surface is touched. The diff is three new files under `scripts/done-means/`, imported by nothing.

## Live defect this gate found (pre-existing on `origin/main`, NOT introduced here)

Reported, not fixed — out of this lane's scope, and reported rather than worked around.

**Symptom.** Every scenario whose path goes through the shipped Python provider fails. The provider returns, reproduced by hand-replaying the payload:

```
{"receipt":{"operation":"capture","status":"lost","durable":false,
 "direct_attempted":true,"fallback_attempted":false,
 "error":"session_start result did not prove exact Open Brain scope: namespace"}}
```

**Scope.** Not an artifact of the eval's throwaway namespace or of a hand-assembled environment: it reproduces identically against the default `rico` namespace. It is also not a stale-deployment artifact — the running clone (`212f916`) is one commit behind `origin/main` (`3be56b1`), and that commit (#648) touches neither the provider nor `session_start`. `durable-memory-pack-shape` passes because it goes through the MCP client, not the provider subprocess.

**What was ruled out, with evidence.** The server is fine. A direct MCP `session_start` against the live clone returns the correct value — `lane.namespace` equals the requested namespace, `lane.source`/`metadata.server_id` populated. My first probe read `content[0].text` and saw an empty body, which looked like a silent empty success; that was **my probe's** error, not the server's — the payload arrives under `data`. Recording it because the wrong version of this finding is the more alarming one and should not be inherited. `_decode_tool_payload` (`python/openbrain-memory/src/openbrain_memory/client.py:1774-1788`) also handles the `content[0].text` shape correctly.

**Where it localizes.** `validate_session_start_scope` builds its candidate from `lane` (`_runtime_validation.py:78-92`) and compares via `validate_exact_fields` (`:688-711`), which raises naming `namespace`. The server does return a matching `lane.namespace`, so the mismatch is in how the provider's *direct* lane obtains or compares that value. Exact mechanism not isolated — it needs a lane of its own.

**Second finding (secondary, same run).** The scenario runner's teardown reports `attempted=1 archived=0 failed=1` on every run, so each invocation leaves a throwaway namespace behind. Clause (e) exists to make exactly this loud, and it is currently red.

Suggested: one lane for the provider `session_start` exact-scope failure (blocks the capture and checkpoint scenarios), one for the teardown leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
