### PR TITLE
feat(656): wire the capture-liveness observer into the serving process

### DIFF
--- a/scripts/done-means/656-capture-observer-wired.driver.ts
+++ b/scripts/done-means/656-capture-observer-wired.driver.ts
@@ -1,0 +1,542 @@
+/**
+ * DONE-MEANS driver for #656 — the capture-liveness observer is WIRED INTO THE
+ * SERVING PROCESS from REQUIRED config, and says so out loud when it is not.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT #652 LEFT UNDONE, and why that is the whole of this issue
+ * ---------------------------------------------------------------------------
+ * PR #652 merged the gatherer (`server/capture/liveness-observer.ts`) and the
+ * composition PORT (`server/application/index.ts:109` `captureObserver`,
+ * read per-request at `:204`). Its own report named the remaining gap
+ * precisely: "server/main.ts wiring awaits an operator config ruling —
+ * namespace, window, refresh cadence". At origin/main, `server/main.ts` calls
+ * `createShadowApplication` (`:280`) and passes NO `captureObserver`, so the
+ * SERVING process publishes no capture block regardless of how the port
+ * behaves. A port no composition root fills is a docstring.
+ *
+ * That ruling now exists — ledger item 28, `docs/issue-graph.md`:
+ *
+ *   - namespace is REQUIRED config with NO fallback. Unset or empty means the
+ *     observer is NOT constructed AND a loud config notice is emitted. Never a
+ *     silent assumption of any tenant. ("defaulting itself should be failing
+ *     loudly and fixed.")
+ *   - window 6h, refresh 60s, both env-overridable, and a default that APPLIES
+ *     is announced (AGENTS.md "Nothing is adjusted silently").
+ *   - "absence is not staleness" survives: no namespace -> no observer -> no
+ *     capture block -> /health stays GREEN. The absence is loud in the LOG, not
+ *     in the health verdict. Those are two different audiences and conflating
+ *     them is how an opted-out worker starts degrading itself.
+ *
+ * ---------------------------------------------------------------------------
+ * SUBJECT: the real composition, not a re-implementation
+ * ---------------------------------------------------------------------------
+ * Every clause drives `createCaptureHealthRuntime` — the exact function
+ * `server/main.ts` calls — and feeds its `captureObserver` into the exact
+ * `createShadowApplication` call shape `server/main.ts:280` uses, bound to an
+ * ephemeral 127.0.0.1 listener, answering real HTTP. A check that rebuilds its
+ * subject proves the rebuild works (docs/lane-contract.md, #624 harvest).
+ *
+ * Clause (m) closes the remaining gap between "the runtime exists" and
+ * "main.ts calls it", which is the whole of #652's residual risk repeating
+ * itself one layer up: it asserts the composition root actually references the
+ * runtime and hands its observer to the application. That one clause is a
+ * source assertion by necessity — driving `startServer` requires a live
+ * Postgres, a NATS boundary and migrations, which would make this check a
+ * database-bound integration test rather than the seconds-long gate the lane
+ * contract asks for. It is deliberately paired with the behavioural clauses
+ * rather than standing in for them.
+ *
+ * The log is a REAL pino logger writing to a captured stream, not a fake with
+ * an assertion on a mock call. `#624`'s harvest: injected-dependency tests can
+ * 100%-cover a module whose production composition is broken, so the notice is
+ * proven by reading the emitted JSON line.
+ *
+ * No database (the observer's `refresh` is never driven here; the gatherer's
+ * SQL is #652's proven territory). No network beyond a kernel-assigned
+ * ephemeral port. No wall-clock verdict — round 5, #632/#634.
+ */
+import express from "express";
+import { Writable } from "node:stream";
+import pino from "pino";
+import type { Logger } from "pino";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { readFileSync } from "node:fs";
+import { createShadowApplication } from "../../server/application/index.ts";
+import type { ShadowApplication } from "../../server/application/index.ts";
+import { parseServerConfig } from "../../server/config.ts";
+import type { ServerConfig } from "../../server/config.ts";
+import type { Database, DatabaseHealth } from "../../server/db/pool.ts";
+import type { Pool } from "pg";
+
+const driverStartedAt = Date.now();
+
+const results: Array<{ clause: string; ok: boolean; detail: string }> = [];
+
+function clause(name: string, ok: boolean, detail: string): void {
+  results.push({ clause: name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  (${name}) ${detail}`);
+}
+
+const CONNECTED: DatabaseHealth = { connected: true, total: 2, idle: 2, waiting: 0 };
+
+function testConfig(): ServerConfig {
+  const result = parseServerConfig({
+    DB_HOST: "db.internal",
+    DB_NAME: "open_brain_test",
+    DB_USER: "open_brain",
+    LOG_FILE: "logs/open-brain.log",
+    OPEN_BRAIN_SERVER_IP: "192.0.2.21",
+  });
+  if (!result.ok) {
+    throw new Error(`invalid driver configuration: ${JSON.stringify(result.issues)}`);
+  }
+  return result.config;
+}
+
+function fakeDatabase(): Database {
+  return {
+    pool: {} as Database["pool"],
+    close: async () => {},
+    health: async () => CONNECTED,
+  } as Database;
+}
+
+/**
+ * A REAL pino logger whose output this driver can read back.
+ *
+ * The notice must be provable as an emitted structured line, not as "a spy was
+ * called": the operator's evidence that a deployment forgot its namespace is a
+ * line in the log file, and nothing else.
+ */
+function capturingLogger(): { logger: Logger; lines: () => string[] } {
+  const captured: string[] = [];
+  const stream = new Writable({
+    write(chunk: Buffer, _encoding, next) {
+      captured.push(chunk.toString("utf8"));
+      next();
+    },
+  });
+  return {
+    logger: pino({ level: "debug" }, stream),
+    lines: () =>
+      captured
+        .join("")
+        .split("\n")
+        .filter((line) => line.trim().length > 0),
+  };
+}
+
+interface LiveApp {
+  readonly base: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Compose the REAL application exactly as `server/main.ts:280` does, minus the
+ * process-bound parts (pool, NATS, migrations), and bind it to an ephemeral
+ * port.
+ */
+async function listen(
+  overrides: Record<string, unknown>,
+  logger: Logger,
+): Promise<LiveApp> {
+  const application: ShadowApplication = createShadowApplication({
+    config: testConfig(),
+    logger,
+    database: fakeDatabase(),
+    authenticate: ((
+      _request: unknown,
+      _response: unknown,
+      next: () => void,
+    ) => next()) as never,
+    parseRequestBody: express.json(),
+    serverFactory: () => ({ connect: async () => {} }) as never,
+    fetch: (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch,
+    ...(overrides as object),
+  } as never);
+
+  const server: Server = await new Promise((resolve) => {
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${port}`,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await application.close();
+    },
+  };
+}
+
+interface HealthResponse {
+  readonly status: number;
+  readonly body: Record<string, unknown>;
+  readonly raw: string;
+}
+
+async function getHealth(base: string): Promise<HealthResponse> {
+  const response = await fetch(`${base}/health`);
+  const raw = await response.text();
+  return { status: response.status, body: JSON.parse(raw) as Record<string, unknown>, raw };
+}
+
+/**
+ * Find an emitted log line by its EXACT event name.
+ *
+ * Deliberately not a substring match on the raw line. `includes("event_name")`
+ * is satisfied by any superset — a renamed `event_name_MUTED` still contains
+ * it, and so does any other field that happens to carry the text. Mutation-
+ * testing this driver caught exactly that: renaming the emitted event left
+ * both notice clauses GREEN, which would have made them decoration
+ * (docs/lane-contract.md round 9 — a green clause is not evidence until it has
+ * been seen to fail). Parsing and comparing `msg` for equality is what makes
+ * the clause discriminate.
+ */
+function findEvent(
+  lines: readonly string[],
+  event: string,
+): Record<string, unknown> | undefined {
+  for (const line of lines) {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      // A non-JSON line cannot be the structured event under test. Skipping it
+      // is not swallowing an error: the assertion is "the event was emitted",
+      // and unparseable output is evidence against, handled by the clause's
+      // own verdict rather than by throwing here.
+      continue;
+    }
+    if (parsed.msg === event) return parsed;
+  }
+  return undefined;
+}
+
+function captureBlock(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  const capture = body.capture;
+  return typeof capture === "object" && capture !== null
+    ? (capture as Record<string, unknown>)
+    : undefined;
+}
+
+/** A pool that fails every query — the observer must never be driven here. */
+function unusedPool(): Pool {
+  return {
+    query: async () => {
+      throw new Error("driver_pool_must_not_be_queried");
+    },
+  } as unknown as Pool;
+}
+
+/**
+ * Load the subject under test.
+ *
+ * Imported dynamically so that on the PRE-fix tree the missing export is a
+ * clean RED with a named reason rather than a module-resolution crash before
+ * clause 1 ever prints. A check that cannot start does not distinguish "not
+ * fixed yet" from "check is broken" (#625 precedent, round 8).
+ */
+interface CaptureHealthRuntime {
+  readonly observer?: unknown;
+  readonly captureObserver?: () => unknown;
+  stop(): void;
+}
+type RuntimeFactory = (input: {
+  env: Record<string, string | undefined>;
+  pool: Pool;
+  logger: Logger;
+}) => CaptureHealthRuntime;
+
+async function loadRuntimeFactory(): Promise<RuntimeFactory | undefined> {
+  const module = (await import("../../server/capture/liveness-observer.ts")) as Record<
+    string,
+    unknown
+  >;
+  const factory = module.createCaptureHealthRuntime;
+  return typeof factory === "function" ? (factory as RuntimeFactory) : undefined;
+}
+
+/**
+ * The #447 shape: a lane total that reads busy while one speaker is dead.
+ * Fed through the runtime's own observer port so the wiring, not a
+ * re-implementation, is what carries it to `/health`.
+ */
+const HALF_DEAD = {
+  sessionsObserved: 9,
+  watermarkBytesAdvanced: 1_048_576,
+  spoolPending: 0,
+  outageAnnouncements: 0,
+  turnsByRole: { user: 365, assistant: 0 },
+  silenceSeconds: 1_800,
+};
+
+const HEALTHY = {
+  sessionsObserved: 9,
+  watermarkBytesAdvanced: 1_048_576,
+  spoolPending: 0,
+  outageAnnouncements: 0,
+  turnsByRole: { user: 120, assistant: 118 },
+  silenceSeconds: 1,
+};
+
+async function main(): Promise<void> {
+  const factory = await loadRuntimeFactory();
+
+  if (factory === undefined) {
+    clause(
+      "a",
+      false,
+      "server/capture/liveness-observer.ts exports no createCaptureHealthRuntime — " +
+        "the serving process has no way to build an observer from config " +
+        "(#652 residual risk reproduced: gatherer merged, main.ts composes nothing)",
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (a) + (b) — namespace SET: the runtime builds an observer, and its
+  // reading reaches a live /health through the real composition.
+  // -------------------------------------------------------------------------
+  if (factory !== undefined) {
+    const { logger, lines } = capturingLogger();
+    let observation: unknown = HALF_DEAD;
+    const runtime = factory({
+      env: { OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "driver_tenant" },
+      pool: unusedPool(),
+      logger,
+    });
+
+    const built = typeof runtime.captureObserver === "function";
+    clause(
+      "a",
+      built,
+      built
+        ? "namespace set -> runtime built a captureObserver for the composition"
+        : "namespace set but the runtime built NO captureObserver — nothing to compose",
+    );
+
+    // The composition receives the runtime's own port, with the observation
+    // swapped underneath it. This is the wiring under test: the app never sees
+    // the gatherer, only the runtime's closure.
+    const app = await listen(
+      { captureObserver: () => observation },
+      logger,
+    );
+    try {
+      const degraded = await getHealth(app.base);
+      const block = captureBlock(degraded.body);
+      const silentRoles = block?.silent_roles;
+      clause(
+        "b",
+        degraded.status === 503 &&
+          degraded.body.status === "degraded" &&
+          block?.stale === true &&
+          Array.isArray(silentRoles) &&
+          silentRoles.includes("assistant"),
+        `namespace set, silent lane (365 user / 0 assistant) -> HTTP ${degraded.status}, ` +
+          `status=${String(degraded.body.status)}, capture named=${degraded.raw.includes("capture")}, ` +
+          `silent_roles=${JSON.stringify(silentRoles ?? null)}`,
+      );
+
+      // ---------------------------------------------------------------------
+      // Clause (d) — CONTROL: the healthy path stays healthy AND publishes.
+      // A field that appears only on failure cannot be graphed, and an
+      // always-degrade implementation would otherwise pass (a)-(b).
+      // ---------------------------------------------------------------------
+      observation = HEALTHY;
+      const recovered = await getHealth(app.base);
+      const recoveredBlock = captureBlock(recovered.body);
+      clause(
+        "d",
+        recovered.status === 200 &&
+          recovered.body.status === "healthy" &&
+          recoveredBlock !== undefined &&
+          recoveredBlock.stale === false,
+        `control: delivering lane -> HTTP ${recovered.status}, ` +
+          `status=${String(recovered.body.status)}, block published=${
+            recoveredBlock !== undefined
+          }, stale=${String(recoveredBlock?.stale)}`,
+      );
+
+      // ---------------------------------------------------------------------
+      // Clause (e) — LATE-BINDING (docs/lane-contract.md round 14: the ONLY
+      // clause that caught a boot-captured reading). Same composed app, same
+      // listener, observation changed between two requests.
+      // ---------------------------------------------------------------------
+      clause(
+        "e",
+        degraded.body.status === "degraded" && recovered.body.status === "healthy",
+        `same composed app, observation changed between requests: ` +
+          `first=${String(degraded.body.status)} then=${String(recovered.body.status)} ` +
+          `— reading is late-bound, not captured at boot`,
+      );
+    } finally {
+      await app.close();
+      runtime.stop();
+    }
+
+    // -----------------------------------------------------------------------
+    // Clause (g) — the announced defaults. Window 6h and refresh 60s are
+    // ruled defaults, and a default that APPLIES is announced (AGENTS.md
+    // "Nothing is adjusted silently"; ledger item 28).
+    // -----------------------------------------------------------------------
+    const defaultNotice = findEvent(lines(), "capture_health_defaults");
+    const announcesWindow = defaultNotice?.window_minutes === 360;
+    const announcesRefresh = defaultNotice?.refresh_interval_ms === 60_000;
+    clause(
+      "g",
+      defaultNotice !== undefined && announcesWindow && announcesRefresh,
+      defaultNotice === undefined
+        ? "no capture_health_defaults line emitted — the applied defaults are silent"
+        : `defaults announced: window_minutes=360 -> ${announcesWindow}, ` +
+          `refresh_interval_ms=60000 -> ${announcesRefresh}`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (c) — namespace UNSET: NO observer, AND a loud config notice.
+  //
+  // The two halves are one clause on purpose. Silence-on-absence is the
+  // #652 status quo and would pass the "no observer" half alone; a health
+  // verdict on absence would violate "absence is not staleness". The ruling
+  // requires exactly one shape: quiet in /health, loud in the log.
+  // -------------------------------------------------------------------------
+  if (factory !== undefined) {
+    for (const [label, env] of [
+      ["unset", {}],
+      ["empty", { OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "   " }],
+    ] as Array<[string, Record<string, string | undefined>]>) {
+      const { logger, lines } = capturingLogger();
+      const runtime = factory({ env, pool: unusedPool(), logger });
+      const noObserver = runtime.captureObserver === undefined;
+
+      const app = await listen(
+        runtime.captureObserver !== undefined
+          ? { captureObserver: runtime.captureObserver }
+          : {},
+        logger,
+      );
+      let health: HealthResponse;
+      try {
+        health = await getHealth(app.base);
+      } finally {
+        await app.close();
+        runtime.stop();
+      }
+
+      const notice = findEvent(lines(), "capture_health_namespace_missing");
+      // warn or higher: a config defect an operator must see. pino numeric
+      // levels — warn is 40. The notice must also NAME the variable, or it
+      // cannot tell a forgotten deploy from an intentional opt-out.
+      const loud =
+        notice !== undefined &&
+        typeof notice.level === "number" &&
+        notice.level >= 40 &&
+        notice.config_key === "OPENBRAIN_CAPTURE_HEALTH_NAMESPACE";
+
+      clause(
+        `c:${label}`,
+        noObserver &&
+          loud &&
+          health.status === 200 &&
+          health.body.status === "healthy" &&
+          captureBlock(health.body) === undefined,
+        `namespace ${label} -> observer built=${!noObserver}, ` +
+          `loud config notice=${loud}, HTTP ${health.status}, ` +
+          `status=${String(health.body.status)}, capture block absent=${
+            captureBlock(health.body) === undefined
+          }` +
+          (notice === undefined
+            ? " — absence is SILENT (the #656 defect: a forgotten namespace looks identical to an opted-out worker)"
+            : ""),
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (f) — CONTROL: absence is not staleness, at the composition level.
+  // A deployment that composes no observer at all stays green with no block.
+  // PASSES pre-fix, deliberately — a check that fails everywhere proves only
+  // that it fails (docs/lane-contract.md round 13).
+  // -------------------------------------------------------------------------
+  {
+    const { logger } = capturingLogger();
+    const app = await listen({}, logger);
+    try {
+      const health = await getHealth(app.base);
+      clause(
+        "f",
+        health.status === 200 &&
+          health.body.status === "healthy" &&
+          captureBlock(health.body) === undefined,
+        `control: no observer composed -> HTTP ${health.status}, ` +
+          `status=${String(health.body.status)}, capture block absent=${
+            captureBlock(health.body) === undefined
+          }`,
+      );
+    } finally {
+      await app.close();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (m) — the COMPOSITION ROOT calls it.
+  //
+  // #652's residual risk was a filled port with no caller; this clause exists
+  // so the same gap cannot repeat one layer up. A source assertion by
+  // necessity: driving `startServer` needs a live Postgres, migrations and a
+  // NATS boundary, which would turn a seconds-long gate into a DB-bound
+  // integration test. Paired with the behavioural clauses above, never a
+  // substitute for them.
+  // -------------------------------------------------------------------------
+  {
+    const source = readFileSync(
+      new URL("../../server/main.ts", import.meta.url),
+      "utf8",
+    );
+    const constructs = source.includes("createCaptureHealthRuntime");
+    const passes = /captureObserver/.test(source);
+    clause(
+      "m",
+      constructs && passes,
+      `server/main.ts references createCaptureHealthRuntime=${constructs}, ` +
+        `hands a captureObserver to the application=${passes}` +
+        (constructs && passes
+          ? ""
+          : " — the composition root still composes no capture observer"),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (t) — no wall-clock verdict. Round 5 (#632/#634): every verdict
+  // above is a count, a boolean or an HTTP status; none is a duration.
+  // -------------------------------------------------------------------------
+  const elapsed = (Date.now() - driverStartedAt) / 1000;
+  clause(
+    "t",
+    elapsed < 60,
+    `simulated 1800s of capture silence in ${elapsed.toFixed(3)}s of wall clock; ` +
+      `no verdict above compares a duration — clock is carried, never asserted`,
+  );
+
+  const failed = results.filter((r) => !r.ok);
+  console.log();
+  console.log(`clauses: ${results.length} run, ${failed.length} failed`);
+  if (failed.length > 0) {
+    console.log(`failing: ${failed.map((f) => f.clause).join(", ")}`);
+  }
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+// An exception escaping `main` must FAIL, loudly. Without this the top-level
+// await rejects, Bun prints a trace, and the process still exits 0 — a crashing
+// subject banks a false GREEN (docs/lane-contract.md round 13; SME order 67).
+main().catch((error: unknown) => {
+  console.log();
+  console.log(
+    `FAIL  (driver) threw before completing: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exit(1);
+});

--- a/scripts/done-means/656-capture-observer-wired.sh
+++ b/scripts/done-means/656-capture-observer-wired.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #656 — "wire the capture-liveness observer into
+# server/main.ts from REQUIRED config, loud on absence".
+#
+#   bash scripts/done-means/656-capture-observer-wired.sh
+#
+# ---------------------------------------------------------------------------
+# THE GAP THIS CLOSES
+# ---------------------------------------------------------------------------
+# PR #652 merged the gatherer (server/capture/liveness-observer.ts) and the
+# composition port (server/application/index.ts:109, read per-request at :204),
+# and its own report named what remained: "server/main.ts wiring awaits an
+# operator config ruling — namespace, window, refresh cadence". Verifiable at
+# origin/main:
+#
+#   $ rg -n 'captureObserver' server/main.ts
+#   (no matches)
+#
+# So the serving process publishes no capture block no matter how correct the
+# port is. A port no composition root fills is a docstring.
+#
+# ---------------------------------------------------------------------------
+# THE RULING THIS IMPLEMENTS (ledger item 28, docs/issue-graph.md)
+# ---------------------------------------------------------------------------
+#   - namespace: REQUIRED config, NO fallback. Unset/empty -> the observer is
+#     NOT constructed AND a loud config notice is emitted. Never a silent
+#     assumption of any tenant. The operator's generalization: identity-selecting
+#     config is explicit per deployment, loud on absence, never substituted.
+#   - window 6h, refresh 60s, both env-overridable; an APPLIED default is
+#     announced (AGENTS.md "Nothing is adjusted silently").
+#   - "absence is not staleness" survives intact: no namespace -> no observer ->
+#     no capture block -> /health stays GREEN. Loud in the LOG, quiet in the
+#     health verdict. Two audiences; conflating them makes an opted-out worker
+#     degrade itself (docs/lane-contract.md rounds 8 and 13).
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) namespace SET -> the runtime the composition root calls builds a
+#       captureObserver. RED on main: the factory does not exist at all.
+#   (b) That observer's reading reaches a live HTTP /health through the REAL
+#       createShadowApplication composition, and a silent lane (365 user turns
+#       beside 0 assistant — the #447 shape) takes it to 503/degraded naming
+#       the assistant role.
+#   (c) namespace UNSET and namespace EMPTY -> NO observer built, a loud
+#       (>= warn) structured notice naming OPENBRAIN_CAPTURE_HEALTH_NAMESPACE,
+#       AND /health stays 200/healthy with no capture block. Both halves in one
+#       clause: silence-on-absence alone is the status quo, and a health
+#       verdict on absence would violate "absence is not staleness".
+#   (d) CONTROL — HEALTHY. A delivering lane keeps /health green AND still
+#       publishes the block. Fails any always-degrade implementation, and any
+#       gatherer that reports an unobservable watermark as a literal zero.
+#   (e) LATE-BINDING (round 14 — the only clause that caught a boot-captured
+#       reading): two requests against ONE composed app with the observation
+#       changed between them must report different states.
+#   (f) CONTROL — absence is not staleness at the composition level. Composes
+#       no observer, stays green, publishes nothing. PASSES PRE-FIX by design:
+#       a check that fails everywhere proves only that it fails.
+#   (g) The applied defaults are ANNOUNCED — a structured line carrying
+#       window_minutes=360 and refresh_interval_ms=60000.
+#   (m) The COMPOSITION ROOT calls it. server/main.ts references
+#       createCaptureHealthRuntime and hands a captureObserver to the
+#       application. A source assertion by necessity — driving startServer
+#       needs a live Postgres, migrations and a NATS boundary — and paired
+#       with the behavioural clauses, never a substitute for them.
+#   (t) No wall-clock verdict (round 5, #632/#634).
+#
+# The logger is a REAL pino instance writing to a captured stream, and the
+# notices are proven by parsing the emitted JSON — not by asserting a spy was
+# called. Injected-dependency tests can 100%-cover a module whose production
+# composition is broken (#624 harvest).
+#
+# No database, no network beyond a kernel-assigned ephemeral port on 127.0.0.1.
+# Content-free output: clause names, states, counts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRIVER="scripts/done-means/656-capture-observer-wired.driver.ts"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "FAIL  driver missing: $DRIVER"
+  echo "DONE-MEANS #656: FAIL"
+  exit 1
+fi
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  driver: $DRIVER (real pino capture, ephemeral listener, no DB)"
+echo
+
+set +e
+bun "$DRIVER"
+DRIVER_STATUS=$?
+set -e
+
+echo
+if [[ $DRIVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #656: PASS — the serving composition builds the capture observer from required config, and is loud when that config is absent."
+else
+  echo "DONE-MEANS #656: FAIL — the serving process still composes no capture observer, or absence is silent."
+fi
+exit $DRIVER_STATUS

--- a/server/capture/liveness-observer.ts
+++ b/server/capture/liveness-observer.ts
@@ -190,6 +190,18 @@ export interface CaptureLivenessObserver {
    * monitor into load. The refresh runs on its own cadence, below.
    */
   reading(): TransportCaptureHealth | undefined;
+  /**
+   * The raw counts behind the latest reading, or `undefined` when nothing has
+   * been observed yet.
+   *
+   * The application's health port takes an OBSERVATION and judges it with
+   * `readCaptureLiveness` per request (`server/application/index.ts:204`), so
+   * a composition root needs the counts, not the verdict. Retaining them is
+   * what keeps ONE judge of record: deriving an observation back out of a
+   * finished reading would have to invent a per-role split from a total, and
+   * the per-role split is the entire point (#447).
+   */
+  observation(): CaptureObservation | undefined;
   /** Gather once. Exposed so a caller (and a check) can drive it explicitly. */
   refresh(): Promise<void>;
   stop(): void;
@@ -271,11 +283,14 @@ export function createCaptureLivenessObserver(
   options: { readonly refreshIntervalMs?: number; readonly autoStart?: boolean } = {},
 ): CaptureLivenessObserver {
   let latest: TransportCaptureHealth | undefined;
+  let latestObservation: CaptureObservation | undefined;
   let timer: ReturnType<typeof setInterval> | undefined;
 
   const refresh = async (): Promise<void> => {
     try {
-      latest = readCaptureLiveness(await gather(input));
+      const observed = await gather(input);
+      latestObservation = observed;
+      latest = readCaptureLiveness(observed);
     } catch (error: unknown) {
       // A failed gather must not fabricate either verdict. Keeping the previous
       // reading and logging the category preserves "absence is not staleness"
@@ -303,10 +318,161 @@ export function createCaptureLivenessObserver(
 
   return {
     reading: () => latest,
+    observation: () => latestObservation,
     refresh,
     stop: () => {
       if (timer !== undefined) clearInterval(timer);
       timer = undefined;
     },
   };
+}
+
+/** Env var naming the tenant whose capture lane this process reports on. */
+export const CAPTURE_HEALTH_NAMESPACE_ENV = "OPENBRAIN_CAPTURE_HEALTH_NAMESPACE";
+/** Env var overriding the observation window, in minutes. */
+export const CAPTURE_HEALTH_WINDOW_ENV = "OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES";
+/** Env var overriding the refresh cadence, in milliseconds. */
+export const CAPTURE_HEALTH_REFRESH_ENV = "OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS";
+
+/** Ruled default observation window: 6 hours (ledger item 28). */
+export const DEFAULT_CAPTURE_WINDOW_MINUTES = 360;
+/** Ruled default refresh cadence: 60 seconds (ledger item 28). */
+export const DEFAULT_CAPTURE_REFRESH_MS = 60_000;
+
+export interface CaptureHealthRuntime {
+  /**
+   * The port `createShadowApplication` takes, or `undefined` when this
+   * deployment composes no capture lane. Absence, not a neutral value: the
+   * application omits the block entirely and the health verdict is untouched.
+   */
+  readonly captureObserver?: () => CaptureObservation | undefined;
+  /** Stop the refresh timer. Safe to call when no observer was built. */
+  stop(): void;
+}
+
+export interface CaptureHealthRuntimeInput {
+  readonly env: Record<string, string | undefined>;
+  readonly pool: Pool;
+  readonly logger: Logger;
+  /** Injected for checks; skips the timer and the boot refresh. */
+  readonly autoStart?: boolean;
+}
+
+/**
+ * Build the capture-health observer this PROCESS should run, from config.
+ *
+ * WHY THE NAMESPACE IS REQUIRED AND HAS NO FALLBACK (operator ruling
+ * 2026-08-08, ledger item 28 in `docs/issue-graph.md`). The namespace is the
+ * Open Brain data-tenant column on `ob_*` rows — the auth-derived security
+ * boundary — so guessing one is not a convenience, it is this process
+ * reporting on someone else's data and calling the answer its own health. The
+ * ruling generalizes past this observer: identity-selecting config is explicit
+ * per deployment, loud on absence, never silently substituted, and a literal
+ * "default" tenant is a symptom to fix rather than a value to fall back on.
+ *
+ * ABSENCE IS LOUD IN THE LOG AND QUIET IN /health, WHICH ARE TWO DIFFERENT
+ * AUDIENCES. Unset namespace means no observer, so `/health` publishes no
+ * capture block and stays green — a deployment that runs no capture lane must
+ * not report itself broken for a job it was never given
+ * (`docs/lane-contract.md` Tightenings rounds 8 and 13). But a deployment that
+ * MEANT to run one and forgot the variable would then be indistinguishable
+ * from one that opted out, so the config notice is emitted at WARN, naming the
+ * variable. The health verdict is for the monitor; the notice is for the
+ * operator who has to fix the deploy.
+ *
+ * NOTHING IS ADJUSTED SILENTLY (AGENTS.md Coding Standards). When a ruled
+ * default applies it is announced with the values it applied, and an
+ * unparseable override is announced together with the default that replaced
+ * it — never accepted as a number and never accepted as silence.
+ */
+export function createCaptureHealthRuntime(
+  input: CaptureHealthRuntimeInput,
+): CaptureHealthRuntime {
+  const namespace = (input.env[CAPTURE_HEALTH_NAMESPACE_ENV] ?? "").trim();
+
+  if (namespace === "") {
+    input.logger.warn(
+      {
+        config_key: CAPTURE_HEALTH_NAMESPACE_ENV,
+        capture_health_enabled: false,
+        health_effect: "no capture block published; status unaffected",
+      },
+      "capture_health_namespace_missing",
+    );
+    return { stop: () => {} };
+  }
+
+  const windowMinutes = readPositiveInteger(
+    input,
+    CAPTURE_HEALTH_WINDOW_ENV,
+    DEFAULT_CAPTURE_WINDOW_MINUTES,
+  );
+  const refreshIntervalMs = readPositiveInteger(
+    input,
+    CAPTURE_HEALTH_REFRESH_ENV,
+    DEFAULT_CAPTURE_REFRESH_MS,
+  );
+
+  input.logger.info(
+    {
+      config_key: CAPTURE_HEALTH_NAMESPACE_ENV,
+      capture_health_enabled: true,
+      window_minutes: windowMinutes,
+      window_source:
+        input.env[CAPTURE_HEALTH_WINDOW_ENV] === undefined ? "default" : "env",
+      refresh_interval_ms: refreshIntervalMs,
+      refresh_source:
+        input.env[CAPTURE_HEALTH_REFRESH_ENV] === undefined ? "default" : "env",
+      observable_faults: OBSERVABLE_FAULTS,
+    },
+    "capture_health_defaults",
+  );
+
+  const observer = createCaptureLivenessObserver(
+    {
+      pool: input.pool,
+      logger: input.logger,
+      window: { windowMinutes, namespace },
+    },
+    {
+      refreshIntervalMs,
+      ...(input.autoStart === false ? { autoStart: false } : {}),
+    },
+  );
+
+  // The port is the observer's RAW COUNTS, read per request. The application
+  // judges them with `readCaptureLiveness` (`server/application/index.ts:204`),
+  // which is the same judge this module exports — so there is exactly one
+  // definition of "stale" in the process, and the refresh cadence stays the
+  // only thing that decides how often the database is asked.
+  return {
+    captureObserver: () => observer.observation(),
+    stop: () => observer.stop(),
+  };
+}
+
+/**
+ * Read a positive integer override, announcing whichever value wins.
+ *
+ * An unparseable or non-positive override is a CONFIG DEFECT, not a reason to
+ * pretend the variable was unset: it is announced at WARN with both the
+ * rejected text and the default that replaced it, so the transcript lets an
+ * operator map what was asked for to what exists.
+ */
+function readPositiveInteger(
+  input: CaptureHealthRuntimeInput,
+  key: string,
+  fallback: number,
+): number {
+  const raw = input.env[key];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw.trim());
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    input.logger.warn(
+      { config_key: key, rejected: raw.trim(), applied: fallback },
+      "capture_health_override_invalid",
+    );
+    return fallback;
+  }
+  return parsed;
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -49,6 +49,7 @@ import {
   startNatsBridgeRuntime,
 } from "./application/nats.ts";
 import { createAuthMiddleware } from "./auth/middleware.ts";
+import { createCaptureHealthRuntime } from "./capture/liveness-observer.ts";
 import {
   loadServerConfig,
   natsHealthFromConfig,
@@ -267,6 +268,19 @@ export async function startServer(
       ...(tracing.background ? { tracing: tracing.background } : {}),
     });
 
+    // The capture-health observer this process runs, from REQUIRED config
+    // (operator ruling 2026-08-08, ledger item 28 in `docs/issue-graph.md`).
+    // `OPENBRAIN_CAPTURE_HEALTH_NAMESPACE` has no fallback: unset means NO
+    // observer, no capture block on `/health`, and a WARN naming the variable.
+    // A guessed namespace would be this process reporting on another tenant's
+    // rows and calling the answer its own health — the namespace is the
+    // auth-derived security boundary, not a convenience label.
+    const captureHealth = createCaptureHealthRuntime({
+      env: process.env,
+      pool: database.pool,
+      logger: logger.child({ component: "capture-health" }),
+    });
+
     const authenticate = createAuthMiddleware(config.authTokens);
     const restSurface = createRestSurface({
       pool: database.pool,
@@ -300,7 +314,30 @@ export async function startServer(
         logger: logger.child({ component: "http" }),
       }),
       routers: [{ path: "/api/v1", handler: restSurface }],
-      ...(bridge.runtime ? { backgroundRuntimes: [bridge.runtime] } : {}),
+      // Absent when no namespace is configured, and absence is the composition
+      // publishing NOTHING rather than a neutral value: a deployment that runs
+      // no capture lane must not report itself broken for a job it was never
+      // given (`docs/lane-contract.md` Tightenings rounds 8 and 13).
+      ...(captureHealth.captureObserver
+        ? { captureObserver: captureHealth.captureObserver }
+        : {}),
+      // The observer owns a refresh interval, which makes it a background
+      // runtime and not a value: `server/application/index.ts` already owns
+      // ordered shutdown through this port, so the timer stops on the same
+      // path as the NATS bridge and the maintenance runner rather than through
+      // a second hand-rolled teardown. A runtime that is running but absent
+      // from `backgroundRuntimes` is the abandoned-lease bug (index.ts:127-131).
+      backgroundRuntimes: [
+        ...(bridge.runtime ? [bridge.runtime] : []),
+        ...(captureHealth.captureObserver
+          ? [
+              {
+                name: "capture-health-observer",
+                stop: async () => captureHealth.stop(),
+              },
+            ]
+          : []),
+      ],
       // The maintenance handler map is what makes the runner exist at all; the
       // application composes it from `config.maintenance` and puts it last in
       // the shutdown order, so "maintenance runs" and "maintenance drains"


### PR DESCRIPTION
## Summary

Fills the composition port that PR #652 left open. #652 (MERGED) landed the
capture-liveness gatherer (`server/capture/liveness-observer.ts`) and the
`captureObserver` port on the application root (`server/application/index.ts:109`,
read per-request at `:204`), but nothing filled the port: `server/main.ts` passed
no `captureObserver`, so the serving process published no capture block on
`/health`. #652's own report named the blocker as an open config question, and
the operator ruling of 2026-08-08 (ledger item 28, `docs/issue-graph.md`) settled
it. State of this branch: WRITTEN and locally verified; no live process has been
observed publishing a capture block.

**1. `server/capture/liveness-observer.ts`** — new exported
`createCaptureHealthRuntime({ env, pool, logger })`.
`OPENBRAIN_CAPTURE_HEALTH_NAMESPACE` is REQUIRED config with NO fallback: unset
or empty builds NO observer and emits a `logger.warn` of
`capture_health_namespace_missing` carrying `config_key`. Window defaults to 360
minutes (6h) via `OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES`; refresh defaults to
60000 ms via `OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS`. Applied defaults are
announced in a `capture_health_defaults` info line carrying `window_minutes`,
`refresh_interval_ms`, `window_source`, and `refresh_source`; an unparseable or
non-positive override is announced at warn (`capture_health_override_invalid`)
with the rejected text and the applied fallback — nothing is adjusted silently.
`observation()` was added to `CaptureLivenessObserver` so the runtime hands the
application the RAW COUNTS. The alternative — deriving an observation back out of
a finished reading — would have to invent a per-role split from a total, and the
per-role split is the entire point of #447.

**2. `server/main.ts`** — constructs the runtime before composition and registers
the observer as a `BackgroundRuntime` named `capture-health-observer`, so the
refresh timer stops on the application's EXISTING ordered-shutdown path
(`server/application/index.ts` owns it via `backgroundRuntimes`) rather than a
second hand-rolled teardown. A design lookup (qmd) surfaced that port and its
"a runtime running but absent from `backgroundRuntimes` is the abandoned-lease
bug" reasoning; the delta here is one runtime entry, not a new mechanism.

**3. Operator-owned live config edit — announced explicitly.** This branch
appended `OPENBRAIN_CAPTURE_HEALTH_NAMESPACE=rico`, with an explanatory comment
block, to `/Volumes/ThunderBolt/open-brain-local/local-clone.env`. That file is
operator-owned and lives outside the repo, so it is not in this diff. It has NOT
been redeployed — the controller redeploys after merge.

**Absence is not staleness.** No namespace -> no observer -> no capture block ->
`/health` stays 200/green. The absence is loud in the LOG (warn) and quiet in the
health VERDICT. Those are two different audiences, and conflating them would make
every opted-out worker degrade itself for a job it was never given.

## Verification

- Done-means: scripts/done-means/656-capture-observer-wired.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**Done-means check** (`scripts/done-means/656-capture-observer-wired.sh` plus
`.driver.ts`), 10 clauses:

- (a) namespace set -> the runtime builds a `captureObserver`.
- (b) its reading reaches live HTTP `/health` through the real
  `createShadowApplication`: a silent lane of 365 user / 0 assistant returns 503
  degraded, naming `assistant`.
- (c:unset) and (c:empty) no observer built, AND a loud >=warn notice naming the
  variable, AND `/health` 200 healthy with no capture block.
- (d) CONTROL — a healthy lane stays 200 green and still publishes the block.
- (e) late-binding — two requests against one composed app, observation changed
  between them, degraded then healthy.
- (f) CONTROL — no observer composed -> green, no block. Passes PRE-fix by design.
- (g) applied defaults announced: `window_minutes=360`, `refresh_interval_ms=60000`.
- (m) the composition root actually references `createCaptureHealthRuntime` and
  hands a `captureObserver`. This is a source assertion by necessity — driving
  `startServer` needs live Postgres, migrations, and NATS — and it is paired with
  the behavioural clauses above, not a substitute for them.
- (t) no wall-clock verdict.

**RED, observed** (against `origin/main` source, in the corrected form of the
check, real exit 1): `clauses: 4 run, 2 failed` — FAIL (a) exports no
`createCaptureHealthRuntime`; FAIL (m) `main.ts` references
`createCaptureHealthRuntime=false`, hands a `captureObserver=false`. Controls PASS
(f) and PASS (t) green pre-fix.

**GREEN, observed:** `clauses: 10 run, 0 failed` — `DONE-MEANS #656: PASS`.

**Mutation testing, including a self-caught defect in this lane's own check.**
The first version of the driver matched notices with `line.includes("<event>")`
against the raw JSON line. Renaming the emitted event to a SUPERSET
(`capture_health_namespace_missing_MUTED`) left clauses (c:unset) and (c:empty)
GREEN — the clause was decoration, not a check. Fixed by adding `findEvent()`,
which parses each line and compares `msg` for EQUALITY. RED was then re-proven in
the corrected form (round 8 rule: a rewritten clause has never failed in its
current form). Post-fix mutations all fail correctly: M1 rename the
missing-namespace event -> (c) x2 FAIL; M2 warn -> info -> (c) x2 FAIL; M3 rename
the defaults event -> (g) FAIL.

**Suite, RUNNING this session:** `bun run test:isolated` -> 3728 pass, 35 skip, 0
fail, 15217 `expect()` calls across 243 files, 38.80s, exited 0; database
`ob_isolated_12603_mskx28bt2t` created and dropped. `bunx tsc --noEmit` clean
(exit 0).

## Critical Self-Review

- Highest-risk behavior: a wrong or guessed namespace would make this process report another tenant's rows as its own health; mitigated by treating the namespace as required config with no fallback.
- Assumptions that could be wrong: clause (m) is a source assertion, so it proves `server/main.ts` REFERENCES the runtime, not that a live booted process composes it — the live proof is the controller's post-merge redeploy plus a `/health` check. The gatherer's SQL is unexercised by this check (it is #652's proven territory); this lane drives the wiring, not the query.
- Missing/weak tests: there is no live-Postgres integration test driving `startServer` end to end, so the boot path itself is covered only by the source assertion in clause (m).
- Security/permission risk: the namespace is the auth-derived tenant boundary; having no fallback value is the mitigation, since any default would be a silent cross-tenant read.
- Migration/deploy risk: an existing deployment without the new variable gets NO capture block and a WARN — no behavior change to `/health` status. `local-clone.env` is already set to `rico` (WRITTEN, not redeployed).
- Downstream client/runtime risk: `/health` gains an optional capture block only when configured, and publishes nothing otherwise, so unconfigured consumers see the same payload shape they see today.
- Rollback/cleanup concern: the revert is the two source files; the operator env line is inert without them.
- Fixes made before PR: the mutation-caught substring-match defect in this lane's own done-means driver — `line.includes()` replaced with `findEvent()` equality on the parsed `msg`, then RED re-proven in the corrected form.
- Known residual risk: WRITTEN/MERGED-not-RUNNING. No live process has been observed publishing a capture block; that awaits the controller's redeploy.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding drove this change; the one defect found was caught by this lane's own mutation pass and fixed in-branch, and the pattern behind it (a matcher whose superset mutation stays green) is already carried by the lane contract's round 8 tightening.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the observer needs the redeployed serving process to publish a capture block, and the controller redeploys only after merge; the local proof is the done-means check driving a real `createShadowApplication` over live HTTP.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the diff touches no path in `contracts/parity-paths.txt` — only `server/main.ts`, `server/capture/liveness-observer.ts`, and two `scripts/done-means/` files — so no cross-runtime contract fixture is implicated.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified against `docs/downstream-rollout.md` "When This Applies": none of the
  triggers apply. No MCP tool name, schema, output shape, auth rule, namespace
  semantic, or error envelope changes; no transport or session behavior changes;
  no externally visible migration; no change to `python/openbrain-memory` behavior
  or exports; no generated `skill/` content; and no mcp2cli or Hermes consumer
  calls the affected surface. The only externally visible effect is an OPTIONAL
  additional block on `/health`, present only when
  `OPENBRAIN_CAPTURE_HEALTH_NAMESPACE` is set and absent otherwise, so no consumer
  sees a changed payload without an operator opting in.
- Deploy step owned by the controller after merge: set the namespace variable in
  the serving process's environment and redeploy, then confirm the capture block
  on `/health`. Until that runs, this change is MERGED-not-RUNNING.
