### PR TITLE
fix(memory): request the configured namespace over the wire, or refuse by name (#654)

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
@@ -90,6 +90,31 @@ def validate_started_lane(
     }
     if isinstance(metadata, Mapping) and "server_id" in metadata:
         candidate["server_id"] = metadata["server_id"]
+    # A namespace mismatch is diagnosed separately, BEFORE the generic
+    # comparison, because it is the one scope key an operator cannot fix by
+    # editing the request (#654). `namespace` is env-carried and never a
+    # request key (the provider's own `--help` says so), so the generic
+    # "did not prove exact Open Brain scope: namespace" pointed at a key there
+    # is no way to send — the same shape of dead end as the #646 `source`
+    # contradiction, one key over.
+    #
+    # What it actually means is that the server bound the lane to the TOKEN's
+    # namespace rather than the configured one, because the request carried no
+    # `X-Namespace` delegation header. Naming the cause and the remedy turns an
+    # opaque refusal into an actionable one, and it must stay a REFUSAL: writing
+    # into whatever namespace came back is the silent mis-scope this issue is
+    # about (server/auth/middleware.ts:9-13).
+    served = lane.get("namespace")
+    if "namespace" in lane and served != namespace:
+        raise ValueError(
+            "session_start bound the lane to namespace "
+            f"'{served}', not the configured '{namespace}'. The namespace is "
+            "carried by OPENBRAIN_NAMESPACE and is never a request key; to bind "
+            "a namespace your token does not already grant, set "
+            "OPENBRAIN_DELEGATE_NAMESPACE=1 with an admin/ob-admin token so the "
+            "request sends the X-Namespace header. Nothing was written to "
+            f"'{namespace}'."
+        )
     expected = exact_scope_fields(namespace, scope)
     expected["source"] = expected.pop("platform")
     # The server stores/returns `platform` under the lane column `source`

--- a/python/openbrain-memory/src/openbrain_memory/cli.py
+++ b/python/openbrain-memory/src/openbrain_memory/cli.py
@@ -130,6 +130,13 @@ _HELP_ENVIRONMENT = {
         "OPENBRAIN_NAMESPACE -- namespace for every request; NOT a request key",
         "OPENBRAIN_TOKEN -- the bearer value sent as the Authorization header",
     ],
+    "optional": [
+        "OPENBRAIN_DELEGATE_NAMESPACE -- 1 to send OPENBRAIN_NAMESPACE as the "
+        "X-Namespace header, binding a namespace the token does not already "
+        "grant; requires an admin/ob-admin token and is refused for other "
+        "roles. Off by default: without it the server uses the token's own "
+        "namespace",
+    ],
     "note": (
         "The example is a request body and carries no identity. base_url, "
         "token, and namespace are read from these variables, or from an "

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -98,6 +98,7 @@ MAX_DISTILLED_CONTENT_BYTES = _runtime_validation.MAX_DISTILLED_CONTENT_BYTES
 _CONFIG_KEYS = {
     "allow_insecure_http",
     "base_url",
+    "delegate_namespace",
     "fallback_enabled",
     "namespace",
     "project",
@@ -307,6 +308,22 @@ class RuntimeConfig:
     timeout: float = 30.0
     fallback_enabled: bool = False
     spool_path: Path | None = None
+    # Send the configured namespace as `X-Namespace` so the server binds THIS
+    # namespace instead of the token's own (#654).
+    #
+    # Off by default, and that default is not timidity — the server gates the
+    # header on ROLE, not on the value: an `agent`-role token presenting
+    # `X-Namespace: rico` is a 403 even though `rico` is already its own
+    # namespace (observed live 2026-08-08 against revision 212f916). Sending it
+    # unconditionally would therefore 403 every non-admin caller in the fleet,
+    # all of whom are correctly served by their token's namespace today.
+    #
+    # It must nonetheless be REACHABLE, because without it a caller configured
+    # for a namespace its token does not grant is silently written to the
+    # token's namespace instead. That is the exact failure
+    # `server/auth/middleware.ts:9-13` names as the dangerous variant: "the
+    # caller believes it wrote somewhere it did not."
+    delegate_namespace: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "base_url", _require_text(self.base_url, "base_url"))
@@ -374,6 +391,12 @@ class RuntimeConfig:
                 "fallback_enabled",
                 env,
                 "OPENBRAIN_MCP2CLI_FALLBACK",
+            ),
+            delegate_namespace=_source_bool(
+                values,
+                "delegate_namespace",
+                env,
+                "OPENBRAIN_DELEGATE_NAMESPACE",
             ),
             spool_path=Path(str(spool_value)) if spool_value is not None else None,
         )
@@ -517,7 +540,7 @@ class FirstClassMemoryRuntime:
                     timeout=config.timeout,
                     transport=transport,
                     allow_insecure_http=config.allow_insecure_http,
-                    delegate_namespace=False,
+                    delegate_namespace=config.delegate_namespace,
                 )
             except Exception as error:
                 # Threaded into the router, which surfaces it on the first call

--- a/python/openbrain-memory/tests/test_runtime_direct_scope.py
+++ b/python/openbrain-memory/tests/test_runtime_direct_scope.py
@@ -238,3 +238,92 @@ def test_invalid_direct_context_without_fallback_fails_open() -> None:
 
     assert output.receipt.status is ReceiptStatus.FAILED
     assert output.context == {}
+
+
+# --- #654: the configured namespace must reach the wire, or be refused by name
+
+
+class RecordingClientFactory:
+    """Capture the keyword arguments the runtime builds its direct client with.
+
+    The runtime's `client_factory` seam is the only place `delegate_namespace`
+    is decided, so asserting on what arrives here is what proves the config
+    value is plumbed rather than hardcoded. The produced client is never used
+    for a call — construction is the whole observation.
+    """
+
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    def __call__(self, base_url: str, **kwargs: Any) -> Any:
+        self.kwargs = dict(kwargs)
+        return ScopeResponseClient()
+
+
+def test_delegate_namespace_config_reaches_the_direct_client() -> None:
+    """#654: `delegate_namespace` was hardcoded False, so `X-Namespace` was never sent.
+
+    Without the header the server binds the lane to the TOKEN's namespace
+    (server/tools/memory-helpers.ts:125) while the client validates against the
+    CONFIGURED one — the two disagree and every capture is lost. The client
+    already knew how to send the header; the runtime never asked it to.
+    """
+    factory = RecordingClientFactory()
+
+    FirstClassMemoryRuntime(
+        runtime_config(delegate_namespace=True),
+        runtime_scope(),
+        client_factory=factory,
+    )
+
+    assert factory.kwargs["delegate_namespace"] is True
+    assert factory.kwargs["namespace"] == "bilby"
+
+
+def test_delegate_namespace_defaults_off_so_ordinary_tokens_are_unaffected() -> None:
+    """The server gates `X-Namespace` on ROLE, not on the value.
+
+    An `agent`-role token presenting its OWN namespace is still a 403 (observed
+    live 2026-08-08). So the header must stay opt-in: turning it on by default
+    would break every non-admin caller, all of whom are correctly served by
+    their token's namespace.
+    """
+    factory = RecordingClientFactory()
+
+    FirstClassMemoryRuntime(runtime_config(), runtime_scope(), client_factory=factory)
+
+    assert factory.kwargs["delegate_namespace"] is False
+
+
+class ForeignNamespaceLaneClient(ScopeResponseClient):
+    """A server that binds the lane to a namespace other than the configured one."""
+
+    def session_start(self, **arguments: Any) -> dict[str, Any]:
+        result = super().session_start(**arguments)
+        result["lane"]["namespace"] = "token-namespace"
+        return result
+
+
+def test_namespace_mismatch_names_the_cause_and_the_remedy() -> None:
+    """#654: the bare "did not prove exact scope: namespace" was a dead end.
+
+    `namespace` is env-carried and never a request key, so an operator told
+    that key was unproven had nothing to edit — the same shape as the #646
+    `source` contradiction, one key over. The refusal must name what the server
+    actually did and how to authorize it, and must stay a REFUSAL: accepting
+    the returned namespace is the silent mis-scope the middleware warns about.
+    """
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        client=ForeignNamespaceLaneClient(),
+    )
+
+    output = runtime.capture_distilled("Namespace mismatch must be named")
+
+    assert output.receipt.status is not ReceiptStatus.SAVED
+    assert output.receipt.durable is False
+    error = output.receipt.error or ""
+    assert "token-namespace" in error
+    assert "bilby" in error
+    assert "OPENBRAIN_DELEGATE_NAMESPACE" in error

--- a/scripts/done-means/654-namespace-scope-proof.sh
+++ b/scripts/done-means/654-namespace-scope-proof.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #654 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/654-namespace-scope-proof.sh
+#
+# Issue #654, as measured live against the running dogfood service (revision
+# 212f916) on 2026-08-08:
+#
+#   OPENBRAIN_NAMESPACE=e2e-654-probe  +  a non-delegating token
+#     -> capture fails with
+#        "session_start result did not prove exact Open Brain scope: namespace"
+#        status=lost, durable=false
+#     -> AND the lane it created landed in namespace 'rico' (the TOKEN's
+#        namespace), not in the requested one.
+#
+# This is #646's disease on a different key. #646 (PR #650) fixed the
+# demand/reject contradiction on `source` and taught the SERVING tree to
+# establish exact scope on an existing lane. `namespace` survived that fix
+# because it is not a lane column the server backfills — it is the predicate
+# the server derives from identity, so the client and server can silently
+# disagree about it.
+#
+# ---------------------------------------------------------------------------
+# Root cause (from source + controlled live reproduction, both recorded)
+# ---------------------------------------------------------------------------
+# `namespace` is env-carried and NEVER a request key (ledger item 28; the
+# provider's own `--help` says so verbatim: "OPENBRAIN_NAMESPACE -- namespace
+# for every request; NOT a request key"). The only wire mechanism that binds a
+# request to a namespace other than the token's is the `X-Namespace` header,
+# which the server honors ONLY for admin/ob-admin and 403s for every other role
+# (server/auth/middleware.ts:79-89). Its own comment names the failure mode
+# this issue is an instance of: "Silently ignoring the header is the dangerous
+# variant: the caller believes it wrote somewhere it did not."
+#
+# The client did exactly that. `FirstClassMemoryRuntime` constructs its direct
+# client with a hardcoded `delegate_namespace=False`
+# (runtime.py:520, unchanged since #294), so `X-Namespace` is NEVER sent
+# (client.py:1542-1543). The server therefore falls back to `identity.clientId`
+# (server/tools/memory-helpers.ts:125) and the lane is created under the
+# TOKEN's namespace — while the client validates the response against
+# `config.namespace` (runtime.py:1165), the namespace it was asked for. The two
+# disagree, and `validate_started_lane` correctly refuses to prove the scope.
+#
+# So the scope-proof error is a TRUE report of a real mis-scope, and it is the
+# only thing standing between the operator and a silent write into the wrong
+# namespace. THE VALIDATOR IS NOT THE BUG AND MUST NOT BE WEAKENED. The bug is
+# that the runtime never asks for the namespace it was configured with, and
+# then reports the resulting divergence as an opaque scope-proof failure
+# instead of naming the cause.
+#
+# The fix must therefore do BOTH, which is why (b) and (d) are separate:
+#   - request the configured namespace over the wire when it differs from the
+#     one the token would supply, so a delegation-authorized token lands in the
+#     namespace the operator asked for; and
+#   - when the request is NOT authorized to bind that namespace, fail LOUDLY
+#     and by name rather than writing somewhere else.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   (a) RED ANCHOR — with a delegation-capable token and a throwaway
+#       namespace, capture fails on `namespace` today. This clause INVERTS at
+#       the fix: pre-fix the failure is PRESENT (gate FAILS); post-fix it must
+#       be ABSENT. It is the anchor, not a test that the bug persists.
+#
+#   (b) SCOPE PROVEN + CAPTURE DURABLE — the same request returns
+#       durable:true / status=saved, AND the row lands in the REQUESTED
+#       namespace. The namespace check is the point: a "fix" that made capture
+#       succeed while still writing to the token's namespace is the exact
+#       silent mis-scope the middleware comment warns about, so (b) reads the
+#       database, not just the receipt.
+#
+#   (c) CONTROL, ISOLATION HELD — a token WITHOUT delegation authority asking
+#       for a foreign namespace is still REFUSED, and writes nothing into it.
+#       Namespace isolation is a security boundary (AGENTS.md Coding
+#       Standards); this clause exists so the gate cannot be passed by
+#       loosening the validator or by having the client accept whatever the
+#       server returns. It must pass BOTH pre-fix and post-fix.
+#
+#   (d) CONTROL, FAILURE IS NAMED — when the namespace cannot be bound, the
+#       operator-visible error names `namespace` and the cause, rather than
+#       succeeding silently into the wrong one. Guards the "adjusted silently"
+#       failure (AGENTS.md: nothing is adjusted silently).
+#
+#   (e) CONTROL, HEALTHY PATH UNTOUCHED — an ordinary capture with NO namespace
+#       override still succeeds. Without this, breaking the default path to
+#       satisfy (a)-(d) would score as progress.
+#
+# Output is content-free apart from a random run marker: statuses, keys, and
+# counts only. No tokens, no memory bodies.
+#
+# EXPECTED TO FAIL until #654 is fixed. It is the reward function, not a test
+# of the fix's author.
+set -uo pipefail
+
+REPO_ROOT="${OPENBRAIN_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+ENV_FILE="${OPENBRAIN_ENV_FILE:-$HOME/.local/share/openbrain-memory/env/claudex-observation.env}"
+PKG_DIR="$REPO_ROOT/python/openbrain-memory"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+[ -r "$ENV_FILE" ] || fail_hard "provider env file not readable at $ENV_FILE"
+[ -d "$PKG_DIR" ] || fail_hard "python package not found at $PKG_DIR"
+command -v python3 >/dev/null 2>&1 || fail_hard "python3 not on PATH (JSON reader)"
+command -v uv >/dev/null 2>&1 || fail_hard "uv not on PATH (provider runner)"
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+[ -n "${OPENBRAIN_BASE_URL:-}" ] || fail_hard "OPENBRAIN_BASE_URL unset"
+[ -n "${OPENBRAIN_TOKEN:-}" ] || fail_hard "OPENBRAIN_TOKEN unset"
+
+TOKEN_NS="${OPENBRAIN_NAMESPACE:-rico}"
+
+# --- database access (row proof + teardown) --------------------------------
+# .env carries the libpq vars, so bare psql needs no connection arguments.
+# See AGENTS.md "Querying the dogfood database".
+DB_OK=0
+if [ -r "$REPO_ROOT/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$REPO_ROOT/.env"
+  set +a
+  if command -v psql >/dev/null 2>&1 && psql -At -c 'select 1' >/dev/null 2>&1; then
+    DB_OK=1
+  fi
+fi
+[ "$DB_OK" -eq 1 ] || fail_hard "cannot reach the dogfood database; the namespace row proof and teardown are both impossible, so a PASS could not be trusted"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+PROBE_NS="e2e654-${RUN_ID}"
+
+# A delegation-capable token is REQUIRED, not optional. The whole issue is
+# about binding a namespace other than the token's, and the only authorized way
+# to do that is admin/ob-admin delegation. Without one there is no honest way
+# to distinguish "the fix works" from "the request was refused", so the gate
+# refuses to run rather than emit a green that examined nothing (#583).
+#
+# The token must be the one the RUNNING service accepts, which is not
+# necessarily this checkout's `.env`: the dogfood service is served from a
+# deploy clone and takes its tokens from the launchd environment, so the
+# repo's `AUTH_TOKEN_ADMIN` answers 401 while the live one answers 200
+# (observed 2026-08-08). Preferring the repo value would make the gate refuse
+# on a healthy system, so the live process environment is read first and the
+# repo `.env` is only a fallback for a service started from this checkout.
+ADMIN_TOKEN="${OPENBRAIN_654_ADMIN_TOKEN:-}"
+if [ -z "$ADMIN_TOKEN" ]; then
+  OB_PID="$(pgrep -f 'bun run server/main.ts' 2>/dev/null | head -1)"
+  if [ -n "$OB_PID" ]; then
+    ADMIN_TOKEN="$(ps eww "$OB_PID" 2>/dev/null | tr ' ' '\n' | grep '^AUTH_TOKEN_ADMIN=' | head -1 | cut -d= -f2-)"
+  fi
+fi
+[ -n "$ADMIN_TOKEN" ] || ADMIN_TOKEN="${AUTH_TOKEN_ADMIN:-}"
+[ -n "$ADMIN_TOKEN" ] || fail_hard "no delegation-capable token available (set OPENBRAIN_654_ADMIN_TOKEN); a gate that cannot bind a foreign namespace cannot measure this issue"
+
+# Prove the token really can delegate BEFORE measuring anything. Without this,
+# a 403 on every request would make clause (a) look green — the bug "absent"
+# because nothing was ever attempted. A gate that examined nothing is not a
+# pass (#583).
+DELEG_CODE="$(curl -s -o /dev/null -w '%{http_code}' -X POST "$OPENBRAIN_BASE_URL/mcp" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H "X-Namespace: $PROBE_NS" \
+  -H 'Accept: application/json, text/event-stream' -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"done-means-654","version":"1"}}}' 2>/dev/null)"
+[ "$DELEG_CODE" = "200" ] || fail_hard "the supplied token cannot delegate X-Namespace (HTTP $DELEG_CODE); this gate would measure a refusal instead of the issue"
+
+DELEGATE_KEY="done-means-654-delegate-${RUN_ID}"
+REFUSED_KEY="done-means-654-refused-${RUN_ID}"
+HEALTHY_KEY="done-means-654-healthy-${RUN_ID}"
+REQ_AGENT="done-means-654"
+
+# Teardown removes exactly this run's namespace and lanes, and nothing else:
+# the probe namespace and every session_key carry the random RUN_ID, so
+# collision with real data is not possible.
+teardown() {
+  for k in "$DELEGATE_KEY" "$REFUSED_KEY" "$HEALTHY_KEY"; do
+    psql -At -c "delete from ob_session_events where lane_id in (select id from ob_session_lanes where session_key = '$k');" >/dev/null 2>&1
+    psql -At -c "delete from ob_session_lanes where session_key = '$k';" >/dev/null 2>&1
+  done
+  psql -At -c "delete from ob_session_events where lane_id in (select id from ob_session_lanes where namespace = '$PROBE_NS');" >/dev/null 2>&1
+  psql -At -c "delete from ob_session_lanes where namespace = '$PROBE_NS';" >/dev/null 2>&1
+}
+trap teardown EXIT
+
+# --- provider invocation ----------------------------------------------------
+# Runs the SHIPPED provider entry point exactly as a real caller does: one JSON
+# object on stdin, identity from the environment. Nothing is imported or
+# monkey-patched, so what passes here is what an operator gets.
+#
+# The 4th argument is the OPENBRAIN_DELEGATE_NAMESPACE value. It is passed
+# EXPLICITLY per call rather than exported once, so each clause states the
+# posture it is measuring: (a)/(b) ask for delegation, (c) deliberately does
+# not, and (e) is the untouched default path. An inherited value would let one
+# clause silently change another's meaning.
+run_capture() { # run_capture <namespace> <token> <session_key> <delegate 0|1>
+  ( cd "$PKG_DIR" \
+    && OPENBRAIN_BASE_URL="$OPENBRAIN_BASE_URL" \
+       OPENBRAIN_TOKEN="$2" \
+       OPENBRAIN_NAMESPACE="$1" \
+       OPENBRAIN_DELEGATE_NAMESPACE="${4:-0}" \
+       uv run python -m openbrain_memory ) <<JSON 2>/dev/null
+{"operation":"capture",
+ "content":"done-means 654 probe ${RUN_ID}",
+ "event_type":"fact",
+ "distilled":true,
+ "scope":{"agent":"${REQ_AGENT}","platform":"cli","channel_id":"done-means","server_id":"done-means","session_key":"$3"}}
+JSON
+}
+
+receipt_field() { # receipt_field <json> <field>
+  printf '%s' "$1" | python3 -c '
+import json,sys
+raw=sys.stdin.read()
+try:
+    d=json.loads(raw)
+except Exception:
+    print(""); sys.exit(0)
+r=d.get("receipt") if isinstance(d,dict) else None
+if not isinstance(r,dict):
+    print(""); sys.exit(0)
+v=r.get(sys.argv[1])
+if v is None:
+    print("")
+elif isinstance(v,bool):
+    print("true" if v else "false")
+else:
+    print(v)
+' "$2"
+}
+
+lane_ns() { # lane_ns <session_key> -> the namespace the lane actually landed in
+  psql -At -c "select namespace from ob_session_lanes where session_key='$1' order by created_at desc limit 1;" 2>/dev/null | tr -d '[:space:]'
+}
+
+event_count_in_ns() { # event_count_in_ns <namespace>
+  psql -At -c "select count(*) from ob_session_events where lane_id in (select id from ob_session_lanes where namespace='$1');" 2>/dev/null | tr -d '[:space:]'
+}
+
+FAILURES=0
+pass() { printf '%-34s: PASS — %s\n' "$1" "$2"; }
+fail() { printf '%-34s: FAIL — %s\n' "$1" "$2"; FAILURES=$((FAILURES+1)); }
+
+printf 'run marker : %s\n' "$RUN_ID"
+printf 'probe ns   : %s (throwaway, removed at exit)\n' "$PROBE_NS"
+printf 'token ns   : %s\n' "$TOKEN_NS"
+printf 'service    : %s\n\n' "$OPENBRAIN_BASE_URL"
+
+# ---------------------------------------------------------------------------
+# (a) RED ANCHOR + (b) SCOPE PROVEN — one delegated capture, read two ways.
+# ---------------------------------------------------------------------------
+DELEGATE_OUT="$(run_capture "$PROBE_NS" "$ADMIN_TOKEN" "$DELEGATE_KEY" 1)"
+D_STATUS="$(receipt_field "$DELEGATE_OUT" status)"
+D_DURABLE="$(receipt_field "$DELEGATE_OUT" durable)"
+D_ERROR="$(receipt_field "$DELEGATE_OUT" error)"
+D_LANE_NS="$(lane_ns "$DELEGATE_KEY")"
+
+if printf '%s' "$D_ERROR" | grep -q 'did not prove exact Open Brain scope: namespace'; then
+  fail "(a) namespace scope proof" "RED ANCHOR PRESENT — [$D_ERROR] status=$D_STATUS durable=$D_DURABLE lane_namespace=${D_LANE_NS:-<none>}"
+else
+  pass "(a) namespace scope proof" "no namespace scope-proof failure (status=$D_STATUS durable=$D_DURABLE)"
+fi
+
+if [ "$D_STATUS" = "saved" ] && [ "$D_DURABLE" = "true" ] && [ "$D_LANE_NS" = "$PROBE_NS" ]; then
+  pass "(b) capture durable in requested ns" "status=saved durable=true lane_namespace=$PROBE_NS"
+else
+  fail "(b) capture durable in requested ns" "status=${D_STATUS:-<none>} durable=${D_DURABLE:-<none>} lane_namespace=${D_LANE_NS:-<none>} expected_namespace=$PROBE_NS"
+fi
+
+# ---------------------------------------------------------------------------
+# (c)+(d) CONTROL — a non-delegating token must still be REFUSED a foreign
+# namespace, by name, and must not write into it. Must hold pre- AND post-fix.
+# ---------------------------------------------------------------------------
+BEFORE_REFUSED="$(event_count_in_ns "$PROBE_NS")"
+# Delegation is REQUESTED here, with a token that has no authority to it. That
+# is the adversarial shape: post-fix the header is actually sent, so this is a
+# live test of the server's role gate rather than of the client declining to
+# ask. A token that could bind a foreign namespace merely by asking would be
+# the isolation breach.
+REFUSED_OUT="$(run_capture "$PROBE_NS" "$OPENBRAIN_TOKEN" "$REFUSED_KEY" 1)"
+R_STATUS="$(receipt_field "$REFUSED_OUT" status)"
+R_DURABLE="$(receipt_field "$REFUSED_OUT" durable)"
+R_ERROR="$(receipt_field "$REFUSED_OUT" error)"
+R_LANE_NS="$(lane_ns "$REFUSED_KEY")"
+
+# The security property: the unauthorized request did not land in the foreign
+# namespace. It may fail; it may not succeed there, and it may not silently
+# succeed in the token's own namespace either — that is the mis-scope itself.
+if [ "$R_DURABLE" != "true" ] && [ "$R_LANE_NS" != "$PROBE_NS" ]; then
+  pass "(c) isolation held for weak token" "refused (durable=${R_DURABLE:-false}); nothing written to $PROBE_NS (lane_namespace=${R_LANE_NS:-<none>})"
+else
+  fail "(c) isolation held for weak token" "ISOLATION BREACH — durable=${R_DURABLE:-<none>} lane_namespace=${R_LANE_NS:-<none>} reached $PROBE_NS without delegation authority"
+fi
+
+if printf '%s' "$R_ERROR" | grep -qi 'namespace'; then
+  pass "(d) refusal names the cause" "error names namespace: [$R_ERROR]"
+else
+  fail "(d) refusal names the cause" "refusal did not name 'namespace' — status=${R_STATUS:-<none>} error=[${R_ERROR:-<none>}]; an operator cannot tell why the write went elsewhere"
+fi
+
+# ---------------------------------------------------------------------------
+# (e) CONTROL — the ordinary path, no namespace override, must stay healthy.
+# ---------------------------------------------------------------------------
+HEALTHY_OUT="$(run_capture "$TOKEN_NS" "$OPENBRAIN_TOKEN" "$HEALTHY_KEY" 0)"
+H_STATUS="$(receipt_field "$HEALTHY_OUT" status)"
+H_DURABLE="$(receipt_field "$HEALTHY_OUT" durable)"
+H_LANE_NS="$(lane_ns "$HEALTHY_KEY")"
+
+if [ "$H_STATUS" = "saved" ] && [ "$H_DURABLE" = "true" ] && [ "$H_LANE_NS" = "$TOKEN_NS" ]; then
+  pass "(e) control, default path healthy" "status=saved durable=true lane_namespace=$TOKEN_NS"
+else
+  fail "(e) control, default path healthy" "status=${H_STATUS:-<none>} durable=${H_DURABLE:-<none>} lane_namespace=${H_LANE_NS:-<none>}"
+fi
+
+printf '\n'
+if [ "$FAILURES" -eq 0 ]; then
+  printf '=== DONE-MEANS 654: PASS — the configured namespace is requested over the wire and proven in the response, an unauthorized namespace bind is still refused by name, and the default path is unchanged. ===\n'
+  exit 0
+fi
+printf '=== DONE-MEANS 654: FAIL (%d failing clause(s)) ===\n' "$FAILURES"
+exit 1


### PR DESCRIPTION
## Summary

- **The defect.** `FirstClassMemoryRuntime` constructed its direct client with a hardcoded `delegate_namespace=False` (`python/openbrain-memory/src/openbrain_memory/runtime.py:520`, unchanged since #294), so the `X-Namespace` header was **never sent**. The server then fell back to the token's own namespace (`server/tools/memory-helpers.ts:125`) while the client validated the response against the **configured** namespace (`runtime.py:1165`). The two disagreed, `validate_started_lane` correctly refused to prove the scope, and every capture was lost with `session_start result did not prove exact Open Brain scope: namespace`.
- **Why #650 did not cover it.** This is #646's disease one key over. PR #650 fixed the demand/reject contradiction on `source` and taught the serving tree to establish exact scope on an existing lane. `namespace` survived that fix because it is not a lane column the server backfills — it is the predicate the server derives from *identity*, so client and server can silently disagree about it.
- **RUNNING evidence of real harm, not just a failed check.** Against the live dogfood service (revision `212f916`) with `OPENBRAIN_NAMESPACE=e2e654-<run>` and a delegation-capable token, the lane landed in namespace **`admin`** — the operator asked for one namespace and the write went to another. That is precisely the failure `server/auth/middleware.ts:9-13` names as the dangerous variant: *"Silently ignoring the header is the dangerous variant: the caller believes it wrote somewhere it did not."*
- **The fix, at the owning boundary — two parts.**
  1. `delegate_namespace` becomes a real config key (`OPENBRAIN_DELEGATE_NAMESPACE`), plumbed through to the client that **already** knew how to send the header (`client.py:1542-1543`). No new mechanism was invented.
  2. A namespace mismatch is diagnosed **by name** before the generic comparison. It names what the server bound, what was configured, and how to authorize the difference.
- **Default stays OFF, deliberately.** The server gates `X-Namespace` on **role, not on value**: an `agent`-role token presenting `X-Namespace: rico` is a 403 even though `rico` is already its own namespace (observed live, 403 vs 200 for admin/ob-admin). Sending it unconditionally would 403 every non-admin caller in the fleet, all of whom are correctly served today.
- **The validator was NOT weakened.** Accepting whatever namespace came back is the silent mis-scope itself. Namespace isolation is a security boundary, so clause (c) exists to prove the boundary still holds.

## Verification

- Done-means: scripts/done-means/654-namespace-scope-proof.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED** (pre-fix, unmodified `origin/main`, live against `127.0.0.1:3100` revision `212f916`):

```
(a) namespace scope proof         : FAIL — RED ANCHOR PRESENT — [session_start result did not prove exact Open Brain scope: namespace] status=lost durable=false lane_namespace=admin
(b) capture durable in requested ns: FAIL — status=lost durable=false lane_namespace=admin expected_namespace=e2e654-ed7589d7a264
(c) isolation held for weak token : PASS — refused (durable=false); nothing written to e2e654-ed7589d7a264 (lane_namespace=rico)
(d) refusal names the cause       : PASS — error names namespace: [session_start result did not prove exact Open Brain scope: namespace]
(e) control, default path healthy : PASS — status=saved durable=true lane_namespace=rico

=== DONE-MEANS 654: FAIL (2 failing clause(s)) ===
```

Note `lane_namespace=admin` on the RED run: the clause failed *and* demonstrated the mis-scope, which is stronger than the issue's original report.

**GREEN** (this branch, same service, no redeploy — the change is entirely client-side):

```
(a) namespace scope proof         : PASS — no namespace scope-proof failure (status=saved durable=true)
(b) capture durable in requested ns: PASS — status=saved durable=true lane_namespace=e2e654-b9036450de3e
(c) isolation held for weak token : PASS — refused (durable=false); nothing written to e2e654-b9036450de3e (lane_namespace=<none>)
(d) refusal names the cause       : PASS — error names namespace: [Open Brain HTTP error status=403 context=initialize body={"error": "Role not permitted to delegate namespace"}]
(e) control, default path healthy : PASS — status=saved durable=true lane_namespace=rico

=== DONE-MEANS 654: PASS ===
```

The gate refuses to run at all unless its token can actually delegate (a `200` pre-check against `/mcp` with `X-Namespace`). Without that, a blanket 403 would make clause (a) look green because nothing was ever attempted — a gate that examined nothing is not a pass (#583).

**Regression tests are red-first, proven by mutation, not asserted:**

- Reverting the plumbing to `delegate_namespace=False` → `test_delegate_namespace_config_reaches_the_direct_client` fails with `assert False is True`; restoring it passes.
- Removing the named-diagnostic block → `test_namespace_mismatch_names_the_cause_and_the_remedy` fails with `assert 'token-namespace' in 'session_start result did not prove exact Open Brain scope: namespace'` — the old message, verbatim; restoring it passes.

**Python bars on the branch:** `uv run pytest -q` → **577 passed, 14 skipped**; `uv run mypy src/openbrain_memory` → clean (17 files); `uv run ruff check src tests` → clean.

**`bun run test:isolated` not run, and here is the honest reason:** this diff touches **zero** TypeScript files (`git diff --name-only | rg '\.ts$'` → 0). The change is confined to the Python client and one shell check. Running the TS suite would prove nothing about this diff.

## Critical Self-Review

- Highest-risk behavior: the new `X-Namespace` header being sent at all. If it were sent by default it would 403 the entire non-admin fleet, converting a lost-capture bug into a total outage. Mitigated by defaulting to off and by clause (e), which drives the ordinary no-override path and asserts it still lands in the token's namespace.
- Assumptions that could be wrong: that opt-in is the right ergonomic. A caller who *should* delegate but does not set the flag now gets a clear refusal rather than a silent mis-scope — better, but still a manual step. I considered auto-detecting by comparing the configured namespace to the token's, and rejected it: there is no identity-introspection endpoint (`/whoami` and `/auth/whoami` both 404), so the client cannot know the token's namespace without first making a write and reading where it landed. Inferring it from a failed write would mean writing to the wrong namespace to discover that it was wrong.
- Missing/weak tests: no test covers a *delegated* namespace flowing through the fallback/spool path — the spool already stamps a parked namespace and refuses cross-namespace drain (`runtime.py:1055-1067`), but that interaction with delegation is untested here. No test covers `X-Namespace` for `checkpoint`/`wrap` specifically; they share the same client construction, so the coverage is structural rather than per-operation.
- Security/permission risk: this is a namespace-isolation change, so the risk is real and it is why clause (c) is adversarial rather than cosmetic: the weak token **requests** delegation (`run_capture ... 1`) and must still be refused. Post-fix the header genuinely goes out, so (c) tests the server's role gate rather than the client politely declining. Verified independently at the wire: admin/ob-admin → `200`, observation token → `403`, including when the requested namespace equals its own. Nothing in this diff can widen a predicate; the only new capability requires a token that already had delegation authority.
- Migration/deploy risk: none. No schema change, no migration, no server change, and therefore no redeploy — the GREEN run above is against the already-running `212f916`. Rollback is reverting the commit; the default-off flag means an un-upgraded client behaves exactly as before.
- Downstream client/runtime risk: the gate **applies** — `docs/downstream-rollout.md:14` names `python/openbrain-memory` client behavior explicitly. See the Downstream Rollout section; the honest summary is that behavior is additive and default-off, but I did not run the downstream canaries and am not claiming them.
- Rollback/cleanup concern: the check tears down its own throwaway namespace and all three lanes by exact `RUN_ID`, verified `0` rows remaining after the final run. Three lanes from my manual reproduction (`654-repro-*`, `654-ns-*`) were also removed; confirmed `0`.
- Fixes made before PR: (1) the first draft of the gate read `AUTH_TOKEN_ADMIN` from the repo `.env`, which returns `401` — the live service is served from `/Volumes/ThunderBolt/open-brain-local/app` and takes tokens from the launchd environment, so the gate would have hard-failed on a healthy system; it now reads the running process's environment first. (2) The gate initially referenced `PROBE_NS` in its delegation pre-check before `RUN_ID` was defined; caught and reordered. (3) The delegation pre-check itself was added after I realised a blanket 403 would produce a false green on clause (a).
- Known residual risk: the 403 for a non-delegating token surfaces as an `initialize`-stage transport error (`Open Brain HTTP error status=403 ... Role not permitted to delegate namespace`) rather than a purpose-built message. It is accurate, names the cause, and satisfies clause (d), but it is a raw HTTP error where a shaped one would read better. Left alone deliberately: shaping it means adding an error-translation path this issue did not ask for.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the reusable lesson here is operating knowledge for lanes (a live-service gate must read the *serving* process's credentials, and must prove its own precondition or risk a vacuous green), which `docs/lane-contract.md` Tightenings owns. It is in the lane report for the controller's mandatory harvest.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] linked below or [ ] not applicable because:

Live evidence is the RED/GREEN transcripts above, both taken against the running dogfood service on `127.0.0.1:3100` at revision `212f916` (unchanged across both — the fix is client-side, so the same server produced both results).

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface changed. No MCP tool name, `inputSchema`, annotation, or response shape is touched — zero TypeScript files are in this diff. `X-Namespace` is a pre-existing, already-specified header (`server/auth/middleware.ts:9-13`) that this client simply never sent; the parity fixtures encode the wire shape, which is unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- The gate **applies**: `docs/downstream-rollout.md:14` names `python/openbrain-memory` client behavior, and this changes it. I am not marking it away.
- **rtech-mcps / mcp2cli: not applicable.** Both consume the MCP tool surface, which is byte-identical here — no tool name, schema, annotation, or response shape changed, and no `.ts` file is in the diff. They cache schemas; there is no schema delta to refresh.
- **rtech-hermes and the live canaries are left UNCHECKED deliberately, because I did not run them.** Checking them would be a claim I cannot support. What I can say precisely: the change is additive and default-off, so a Hermes runtime that does not set `OPENBRAIN_DELEGATE_NAMESPACE` constructs its client exactly as before (`delegate_namespace=False`) and its behavior is unchanged — the 577-test suite passing with the default off is the evidence for that. Any Hermes agent that today *intends* to write to a namespace its token does not grant is already silently mis-scoping and would need the new flag; identifying whether such an agent exists is a downstream survey this lane did not perform. Flagging for the controller rather than closing it out.
