### PR TITLE
fix(655): tear down the eval namespace the scenario runner creates

### DIFF
--- a/eval/open-brain/live/__tests__/namespace-purge.test.ts
+++ b/eval/open-brain/live/__tests__/namespace-purge.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import {
+  EVAL_NAMESPACE_PREFIX,
+  NamespacePurgeRefused,
+  assertPurgeableNamespace,
+  purgeNamespace,
+} from "../namespace-purge.ts";
+import { makeRunId, runNamespaces } from "../config.ts";
+
+/**
+ * The prefix guard is the whole authority for auto-removal here
+ * (`docs/issue-graph.md` ledger item 20, condition 2: "prefix-guarded so it
+ * structurally cannot name anything it did not create"). These tests exist so
+ * that claim is EXERCISED rather than asserted, and so they run with no
+ * database at all — a guard reachable only behind a live connection is a guard
+ * nobody fires, and an unfired guard is the one that turns out to be wrong.
+ *
+ * Following `server/tools/search-read-scope.test.ts`, the purge tests assert on
+ * the SQL and bound parameters the code actually sends, not merely on its
+ * return value: a namespace predicate is only a boundary if it is in the
+ * statement.
+ */
+describe("assertPurgeableNamespace", () => {
+  test("accepts the namespaces the eval config actually generates", () => {
+    for (const label of ["scenario-abc123", "live578", "epic336kw"]) {
+      const { primary, negative } = runNamespaces(
+        makeRunId({ prefix: label, randomHex: "0123456789ab", env: {} }),
+      );
+      expect(() => assertPurgeableNamespace(primary)).not.toThrow();
+      expect(() => assertPurgeableNamespace(negative)).not.toThrow();
+    }
+  });
+
+  test.each([
+    ["an operator namespace", "rico"],
+    ["the shared knowledge base", "shared-kb"],
+    ["a bare empty string", ""],
+    ["one character off the prefix", "eval-live-recal-abc123"],
+    ["a different eval family", "eval-kwdiag-1889c167"],
+  ])("refuses %s", (_label, namespace) => {
+    expect(() => assertPurgeableNamespace(namespace)).toThrow(
+      NamespacePurgeRefused,
+    );
+  });
+
+  test("refuses the bare prefix, which no run ever produces", () => {
+    // `runNamespaces` always appends a nonce, so the bare prefix names nothing
+    // this process created. Accepting it would mean accepting a name that could
+    // only have come from somewhere else.
+    expect(() => assertPurgeableNamespace(EVAL_NAMESPACE_PREFIX)).toThrow(
+      NamespacePurgeRefused,
+    );
+  });
+
+  test("refuses a name that merely CONTAINS the prefix", () => {
+    // The specific defect a `.includes()` guard ships with.
+    expect(() =>
+      assertPurgeableNamespace(`not-${EVAL_NAMESPACE_PREFIX}abc123`),
+    ).toThrow(NamespacePurgeRefused);
+    expect(() =>
+      assertPurgeableNamespace(`rico-${EVAL_NAMESPACE_PREFIX}abc123`),
+    ).toThrow(NamespacePurgeRefused);
+  });
+
+  test("the refusal message carries no namespace content", () => {
+    // A refusal can be pointed at an operator's real namespace, so the message
+    // must not echo it into a log or a receipt.
+    const secret = "rico-private-namespace";
+    let message = "";
+    try {
+      assertPurgeableNamespace(secret);
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).not.toContain(secret);
+    expect(message).toContain("REFUSED");
+  });
+});
+
+describe("purgeNamespace", () => {
+  test("refuses BEFORE issuing any statement", async () => {
+    // The mutation proof, in unit form: a pool that throws on ANY query. If the
+    // guard ran after the first DELETE, this would surface as the pool's error
+    // rather than the refusal.
+    const exploding = {
+      query: () => {
+        throw new Error("purgeNamespace issued a statement on a refused name");
+      },
+    } as never;
+
+    await expect(purgeNamespace(exploding, "rico")).rejects.toThrow(
+      NamespacePurgeRefused,
+    );
+  });
+
+  test("every statement is a namespace-parameterized DELETE", async () => {
+    const seen: Array<{ sql: string; params: unknown[] }> = [];
+    const recording = {
+      query: (sql: string, params: unknown[]) => {
+        seen.push({ sql, params });
+        return Promise.resolve({ rowCount: 1 });
+      },
+    } as never;
+
+    const namespace = runNamespaces(
+      makeRunId({ prefix: "scenario-unit", randomHex: "0123456789ab", env: {} }),
+    ).primary;
+    const result = await purgeNamespace(recording, namespace);
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(result.deleted).toBe(seen.length);
+    for (const call of seen) {
+      // No statement may reach a row by any predicate other than this exact
+      // namespace, and the namespace is bound, never interpolated.
+      expect(call.sql).toContain("DELETE FROM");
+      expect(call.sql).toContain("WHERE namespace = $1");
+      expect(call.params).toEqual([namespace]);
+    }
+  });
+
+  test("records a failing table instead of aborting the rest", async () => {
+    // A partially-purged namespace still needs its tally reported; swallowing
+    // the remainder is the defect #655 is about.
+    let calls = 0;
+    const flaky = {
+      query: () => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new TypeError("boom"));
+        return Promise.resolve({ rowCount: 0 });
+      },
+    } as never;
+
+    const namespace = runNamespaces(
+      makeRunId({ prefix: "scenario-unit", randomHex: "0123456789ab", env: {} }),
+    ).primary;
+    const result = await purgeNamespace(flaky, namespace);
+
+    expect(Object.keys(result.failed_tables)).toHaveLength(1);
+    // The error CLASS, never the driver's message, which can echo row content.
+    expect(Object.values(result.failed_tables)).toEqual(["TypeError"]);
+    expect(calls).toBeGreaterThan(1);
+  });
+
+  test("reports zero deletions without inventing a table entry", async () => {
+    const empty = {
+      query: () => Promise.resolve({ rowCount: 0 }),
+    } as never;
+
+    const namespace = runNamespaces(
+      makeRunId({ prefix: "scenario-unit", randomHex: "0123456789ab", env: {} }),
+    ).primary;
+    const result = await purgeNamespace(empty, namespace);
+
+    expect(result.deleted).toBe(0);
+    expect(result.deleted_by_table).toEqual({});
+    expect(result.failed_tables).toEqual({});
+    expect(result.namespace).toBe(namespace);
+  });
+});

--- a/eval/open-brain/live/namespace-purge.ts
+++ b/eval/open-brain/live/namespace-purge.ts
@@ -1,0 +1,169 @@
+import type { Pool } from "pg";
+
+/**
+ * Prefix-guarded purge of a per-run throwaway eval namespace.
+ *
+ * WHY THIS EXISTS (issue #655)
+ * ----------------------------
+ * The scenario runner already tore down its RECORDS by exact id, but a record
+ * teardown cannot remove a NAMESPACE, for two independent reasons observed live
+ * in the dogfood database on 2026-08-08:
+ *
+ *   1. `archive_entry` is a SOFT delete -- it sets `archived_at` and leaves the
+ *      row (src/tools/archive-entry.ts:54). Twenty-one `eval-live-recall-*`
+ *      namespaces in the dogfood database hold nothing but archived rows: the
+ *      teardown "succeeded" and the namespace is still there, permanently.
+ *   2. When the archive call THROWS, the tally records `failed` and the row is
+ *      left fully LIVE. Six `eval-live-recall-scenario-*` namespaces are in
+ *      exactly that state (`archived_at IS NULL`), from receipts showing
+ *      `attempted=1 archived=0 already_absent=0 failed=1`.
+ *
+ * A namespace in this schema is not a registry row -- there is no namespaces
+ * table. It exists precisely as long as some row carries it. So removing the
+ * namespace means removing its rows, which is a DELETE, not an archive.
+ *
+ * THE AUTHORITY THIS OPERATES UNDER, AND ITS EXACT BOUNDS
+ * ------------------------------------------------------
+ * `docs/issue-graph.md` ledger item 20 (operator ruling, 2026-08-08) permits a
+ * process to auto-remove a resource on exit ONLY when all three hold. This
+ * function is written so that each one is a structural property, not a promise:
+ *
+ *   (1) SELF-CREATED THIS RUN -- the namespace is derived from a per-invocation
+ *       crypto nonce (`makeRunId`, eval/open-brain/live/config.ts), so no other
+ *       run and no human namespace can collide with it.
+ *   (2) PREFIX-GUARDED -- `assertPurgeableNamespace` REFUSES any name outside
+ *       the eval prefix, before a single statement runs. The guard is the first
+ *       thing this module does and it throws rather than returning a tally, so
+ *       a caller cannot mistake a refusal for a clean purge.
+ *   (3) SESSION-SCOPED THROWAWAY -- the content is fixture text seeded by the
+ *       scenario suite seconds earlier.
+ *
+ * Everywhere outside those bounds, the repo's printed-never-executed teardown
+ * rule stands unchanged. Nothing here reads an operator-supplied namespace, and
+ * nothing here can widen its own scope: the prefix is a module constant, not a
+ * parameter.
+ */
+
+/**
+ * The one prefix this module may ever touch. A constant, deliberately NOT a
+ * parameter: a caller-supplied prefix would make the guard a formality the
+ * caller could dial open, which is the failure mode ledger item 20 was ratified
+ * to prevent. `runNamespaces` (config.ts) builds every eval namespace from this
+ * same literal, so widening one without the other breaks the tests in
+ * `__tests__/namespace-purge.test.ts` rather than silently unguarding a purge.
+ */
+export const EVAL_NAMESPACE_PREFIX = "eval-live-recall-";
+
+/**
+ * Tables whose rows carry a `namespace` column and are seeded by the live eval
+ * suites. Ordered children-before-parents so a delete never trips a foreign key.
+ * Enumerated explicitly rather than discovered from `information_schema`: a
+ * discovered list would silently grow to cover tables this module was never
+ * reviewed against, which is the same class of quiet scope-widening the prefix
+ * guard exists to stop.
+ */
+const PURGE_TABLES = [
+  "ob_session_lanes",
+  "thoughts",
+  "decisions",
+  "sessions",
+  "relationships",
+  "projects",
+  "candidate_memory",
+  "candidate_grade",
+  "candidate_reinforcement",
+  "content_occurrences",
+  "discarded_entries",
+  "ob_entities",
+  "ob_links",
+  "ob_raw_turns",
+] as const;
+
+export interface NamespacePurgeResult {
+  namespace: string;
+  /** Rows removed, per table, for tables that actually had any. */
+  deleted_by_table: Record<string, number>;
+  /** Total rows removed across every table. */
+  deleted: number;
+  /** Tables that could not be purged, by name, with a content-free reason. */
+  failed_tables: Record<string, string>;
+}
+
+export class NamespacePurgeRefused extends Error {
+  constructor(readonly namespace: string) {
+    // Content-free: names the rule and the length of the offending value, never
+    // the value itself, which may be an operator's real namespace.
+    super(
+      `namespace purge REFUSED: a name of length ${namespace.length} does not start with the required "${EVAL_NAMESPACE_PREFIX}" prefix; this purge may only remove namespaces it created`,
+    );
+    this.name = "NamespacePurgeRefused";
+  }
+}
+
+/**
+ * The guard. Throws `NamespacePurgeRefused` for anything outside the eval
+ * prefix. Exported so the mutation proof can call it directly: a guard that is
+ * only reachable behind a live database connection cannot be tested cheaply,
+ * and an untested guard is the one that is wrong.
+ *
+ * Rejects the bare prefix itself (`eval-live-recall-`) as well: that is not a
+ * name any run produces (`runNamespaces` always appends a nonce), so accepting
+ * it would mean accepting a name this process did not create.
+ */
+export function assertPurgeableNamespace(namespace: string): void {
+  if (
+    typeof namespace !== "string" ||
+    !namespace.startsWith(EVAL_NAMESPACE_PREFIX) ||
+    namespace.length <= EVAL_NAMESPACE_PREFIX.length
+  ) {
+    throw new NamespacePurgeRefused(String(namespace));
+  }
+}
+
+/**
+ * Remove every row carrying `namespace`, after the prefix guard passes.
+ *
+ * The guard runs BEFORE any statement, so a refused call is provably a no-op
+ * against the database. Each table is attempted independently and a failure is
+ * recorded rather than thrown, because a partially-purged namespace still needs
+ * its tally reported -- silently swallowing the rest would rebuild the exact
+ * defect #655 is about.
+ *
+ * Session events are removed via their lane: `ob_session_events` has no
+ * `namespace` column, and `ob_session_lanes` cascades. The lane delete is
+ * therefore listed first and does that work.
+ */
+export async function purgeNamespace(
+  pool: Pool,
+  namespace: string,
+): Promise<NamespacePurgeResult> {
+  assertPurgeableNamespace(namespace);
+
+  const deletedByTable: Record<string, number> = {};
+  const failedTables: Record<string, string> = {};
+  let deleted = 0;
+
+  for (const table of PURGE_TABLES) {
+    try {
+      // Table name comes from the module-local const tuple above -- never from
+      // a caller, a request, or the database -- so interpolating it introduces
+      // no injection surface. The namespace is parameterized.
+      const result = await pool.query(
+        `DELETE FROM ${table} WHERE namespace = $1`,
+        [namespace],
+      );
+      const count = result.rowCount ?? 0;
+      if (count > 0) {
+        deletedByTable[table] = count;
+        deleted += count;
+      }
+    } catch (error: unknown) {
+      // Content-free: the error class, never the driver's message, which can
+      // echo row content back into a receipt.
+      failedTables[table] =
+        error instanceof Error ? error.constructor.name : "unknown";
+    }
+  }
+
+  return { namespace, deleted_by_table: deletedByTable, deleted, failed_tables: failedTables };
+}

--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -3,6 +3,7 @@ import { Pool } from "pg";
 import { summarizeChildStderr } from "../../../src/child-stderr.ts";
 import type { LiveEvalConfig } from "./config.ts";
 import { teardownRecords } from "./gate.ts";
+import { purgeNamespace } from "./namespace-purge.ts";
 import type {
   ProviderExecution,
   ProviderReceipt,
@@ -163,6 +164,39 @@ export class LiveScenarioTransport implements ScenarioTransport {
     });
   }
 
+  /**
+   * Record teardown, then the namespace purge.
+   *
+   * The record pass is unchanged and stays first: it removes each seeded row by
+   * exact id, which is the precise, reviewable operation and the one that
+   * produces the tally the receipt reports.
+   *
+   * The purge that follows exists because record teardown, run perfectly,
+   * still cannot remove a NAMESPACE (issue #655). Two independent reasons, both
+   * measured in the dogfood database on 2026-08-08 rather than inferred:
+   *
+   *   - `archive_entry` is a SOFT delete (src/tools/archive-entry.ts:54). It
+   *     sets `archived_at` and the row stays. Since a namespace in this schema
+   *     is not a registry row — it exists exactly as long as some row carries
+   *     it — an archived row keeps its namespace alive permanently. 21
+   *     `eval-live-recall-*` namespaces held nothing but archived rows.
+   *   - When the archive call THROWS, the tally counts `failed` and the row is
+   *     left fully LIVE. Six `eval-live-recall-scenario-*` namespaces were in
+   *     that state, from a receipt reading `attempted=1 archived=0
+   *     already_absent=0 failed=1`.
+   *
+   * So this is an ADDITION, not a replacement, and it is not the "broad
+   * namespace sweep" `cleanupRecord` below rules out: it targets one namespace
+   * this process generated from a per-invocation crypto nonce, and
+   * `purgeNamespace` refuses — before executing anything — any name outside the
+   * eval prefix. That narrow shape is what `docs/issue-graph.md` ledger item 20
+   * permits, and nothing wider.
+   *
+   * A purge failure is reported as a teardown failure rather than thrown: the
+   * receipt is the artifact an operator reads after a bad run, and a throw here
+   * would discard the record tally that explains what did get cleaned. Silently
+   * swallowing it would rebuild the exact defect #655 is about.
+   */
   async cleanup(
     records: ScenarioRecord[],
     namespace: string,
@@ -176,9 +210,23 @@ export class LiveScenarioTransport implements ScenarioTransport {
       lane: 2,
     };
     unique.sort((a, b) => order[a.kind] - order[b.kind]);
-    return teardownRecords(unique, (record) =>
+    const tally = await teardownRecords(unique, (record) =>
       this.cleanupRecord(record, namespace),
     );
+
+    try {
+      const purge = await purgeNamespace(this.pool, namespace);
+      const failedTables = Object.keys(purge.failed_tables);
+      if (failedTables.length > 0) {
+        tally.failed += failedTables.length;
+      }
+    } catch {
+      // A refusal or a connection failure. Counted, never hidden: a nonzero
+      // `failed` is what the #578 gate's clause (e) reads.
+      tally.failed += 1;
+    }
+
+    return tally;
   }
 
   /**

--- a/scripts/done-means/655-eval-teardown.driver.ts
+++ b/scripts/done-means/655-eval-teardown.driver.ts
@@ -1,0 +1,465 @@
+/**
+ * Driver for the #655 DONE-MEANS check. Not a test file; invoked by
+ * scripts/done-means/655-eval-teardown.sh, which owns the verdict.
+ *
+ * WHY THE TRANSPORT IS LOCAL AND THE DATABASE IS REAL
+ * ---------------------------------------------------
+ * The defect is RESIDUE in Postgres, so the database half must be real: rows
+ * are seeded through actual SQL into a fresh migrated database, and the leak is
+ * measured by querying that database afterwards.
+ *
+ * The MCP/provider half is driven through a local `ScenarioTransport`
+ * implementation rather than a live deployment, for a reason that is about
+ * correctness and not convenience. `LiveScenarioTransport` needs an admin or
+ * ob-admin bearer token with X-Namespace delegation authority. Since the
+ * neutrality scrub (PR #645) the repo `.env` carries empty placeholders, so
+ * those values live only in the environment of whatever process is serving a
+ * deployment — and a done-means check that reached into a running process to
+ * harvest them would be doing exactly what the #578 gate header forbids. Making
+ * the check depend on operator credentials would also mean it could not run in
+ * CI or on a fresh clone, i.e. it would be a check nobody runs.
+ *
+ * What matters is that NOTHING under test is faked. `runScenarioGate`,
+ * `teardownRecords`, the record-ordering, the namespace purge and its prefix
+ * guard are all the shipped code. The transport supplies the two things a
+ * deployment would otherwise supply — a seeded row and a session context —
+ * writing both to the real database with real SQL, so the residue this check
+ * measures is residue the shipped teardown either removed or did not.
+ *
+ * The transport records WHEN cleanup was invoked relative to when the scenario
+ * read its record back. That ordering is what clause (c) needs and is not
+ * observable from the receipt: a purge that ran too early would make the
+ * scenario's own seed unfindable and could turn a broken run green.
+ *
+ * Output is one JSON object written to DONE_MEANS_655_OUT. Counts and booleans
+ * only — no row content, no namespaces beyond the ones this run generated, no
+ * credentials.
+ */
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { runScenarioGate } from "../../eval/open-brain/live/scenario-gate.ts";
+import { teardownRecords } from "../../eval/open-brain/live/gate.ts";
+import {
+  assertPurgeableNamespace,
+  purgeNamespace,
+} from "../../eval/open-brain/live/namespace-purge.ts";
+import type {
+  ProviderExecution,
+  ScenarioRecord,
+  ScenarioTransport,
+  TeardownTally,
+} from "../../eval/open-brain/live/scenario-types.ts";
+import { runNamespaces, makeRunId } from "../../eval/open-brain/live/config.ts";
+import { loadScenarioFixture } from "../../eval/open-brain/live/scenario-fixtures.ts";
+
+const DB_URL = process.env.DONE_MEANS_655_DB_URL;
+const OUT_PATH = process.env.DONE_MEANS_655_OUT;
+if (!DB_URL || !OUT_PATH) {
+  console.error("DONE_MEANS_655_DB_URL and DONE_MEANS_655_OUT are required");
+  process.exit(3);
+}
+
+const pool = new Pool({ connectionString: DB_URL });
+
+/**
+ * `created_by` is NOT NULL with no default on every table this driver writes,
+ * so it must be supplied explicitly. A constant naming this check makes any row
+ * that somehow outlives the throwaway database immediately attributable.
+ */
+const CREATED_BY = "done-means-655";
+
+/**
+ * Names the guard MUST refuse. The first two are the cases a naive
+ * `namespace.includes("eval-live-recall-")` check waves through, which is why
+ * they are here and not just an obviously-unrelated name.
+ */
+const MUST_REFUSE = [
+  "rico", // an operator's real namespace
+  "shared-kb", // the shared knowledge base
+  "eval-live-recall-", // the bare prefix — no run ever produces it
+  "not-eval-live-recall-abc123", // merely CONTAINS the prefix
+  "eval-live-recal-abc123", // one character off
+  "", // empty
+];
+
+interface DriverOut {
+  scenario_count: number;
+  scenario_assertions_passed: boolean;
+  evidence_readable_before_teardown: boolean;
+  teardown_failed: number;
+  namespace_purged_rows: number;
+  guard_cases: number;
+  guard_refusals: number;
+  guard_rows_touched_on_refusal: number;
+  guard_allows_own_namespace: boolean;
+}
+
+/**
+ * A ScenarioTransport backed by the real database for everything that leaves
+ * residue, and by local shapes for the provider subprocess a deployment would
+ * run. Cleanup delegates to the SHIPPED `teardownRecords` plus the SHIPPED
+ * `purgeNamespace` — the code under test — rather than re-deriving either.
+ */
+class DriverTransport implements ScenarioTransport {
+  /** Set when a scenario reads its own seeded row back successfully. */
+  evidenceReadBack = false;
+  /** Set the moment cleanup is first entered, so ordering is observable. */
+  cleanupEntered = false;
+  purgedRows = 0;
+
+  constructor(private readonly namespace: string) {}
+
+  /**
+   * The provider subprocess a deployment would spawn. A capture writes a lane
+   * and an event with real SQL so both become residue this check can measure.
+   */
+  async executeProvider(
+    request: Record<string, unknown>,
+  ): Promise<ProviderExecution> {
+    const scope = request.scope as Record<string, unknown> | undefined;
+    const sessionKey = String(scope?.session_key ?? "");
+    const operation = String(request.operation ?? "capture");
+
+    const laneId = await this.upsertLane(sessionKey, request);
+    const result: Record<string, unknown> = { lane_id: laneId };
+
+    if (operation === "checkpoint") {
+      const sessionId = randomUUID();
+      await pool.query(
+        `INSERT INTO sessions (id, namespace, summary, created_by) VALUES ($1, $2, $3, $4)`,
+        [sessionId, this.namespace, String(request.summary ?? ""), CREATED_BY],
+      );
+      await pool.query(
+        `UPDATE ob_session_lanes SET current_context_md = $1 WHERE id = $2`,
+        [String(request.summary ?? ""), laneId],
+      );
+      result.session_id = sessionId;
+    } else {
+      const eventId = randomUUID();
+      await pool.query(
+        `INSERT INTO ob_session_events (id, lane_id, event_type, content, created_by)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          eventId,
+          laneId,
+          String(request.event_type ?? "decision"),
+          String(request.content ?? ""),
+          CREATED_BY,
+        ],
+      );
+      result.event_id = eventId;
+    }
+
+    return {
+      exitCode: 0,
+      receipt: {
+        operation,
+        status: "saved",
+        durable: true,
+        direct_attempted: true,
+        fallback_attempted: false,
+      },
+      result,
+    };
+  }
+
+  private async upsertLane(
+    sessionKey: string,
+    request: Record<string, unknown>,
+  ): Promise<string> {
+    const existing = await pool.query(
+      `SELECT id FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
+      [this.namespace, sessionKey],
+    );
+    if (existing.rows.length > 0) return existing.rows[0].id as string;
+    const scope = request.scope as Record<string, unknown> | undefined;
+    const laneId = randomUUID();
+    // `ob_session_lanes` has no `platform`/`server_id` columns — the fixture's
+    // scope carries them for the provider, and the lane table records `source`
+    // instead. Announced rather than silently dropped: the fixture's
+    // platform/server_id are folded into `source`, and `project` carries the
+    // fixture's server_id, so nothing the fixture supplies is discarded.
+    await pool.query(
+      `INSERT INTO ob_session_lanes (id, namespace, session_key, agent, source, project, channel_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        laneId,
+        this.namespace,
+        sessionKey,
+        String(scope?.agent ?? "scenario-eval"),
+        String(scope?.platform ?? "eval"),
+        String(scope?.server_id ?? "open-brain-scenarios"),
+        String(scope?.channel_id ?? "driver"),
+        CREATED_BY,
+      ],
+    );
+    return laneId;
+  }
+
+  /** Seeds a real durable-memory row — the one that leaked in production. */
+  async logMemory(opts: {
+    table: "thoughts" | "decisions";
+    content: string;
+    tags: string[];
+    namespace: string;
+  }): Promise<{ id: string }> {
+    const id = randomUUID();
+    if (opts.table === "thoughts") {
+      await pool.query(
+        `INSERT INTO thoughts (id, namespace, content, tags, created_by) VALUES ($1, $2, $3, $4, $5)`,
+        [id, opts.namespace, opts.content, opts.tags, CREATED_BY],
+      );
+    } else {
+      await pool.query(
+        `INSERT INTO decisions (id, namespace, title, rationale, tags, created_by)
+         VALUES ($1, $2, $3, $3, $4, $5)`,
+        [id, opts.namespace, opts.content, opts.tags, CREATED_BY],
+      );
+    }
+    return { id };
+  }
+
+  /**
+   * Reads the seeded row back out of the real database. This is the evidence
+   * read: if teardown ran first, the row would be gone and `found` would be
+   * false, which is precisely what clause (c) is watching for.
+   */
+  async contextPack(opts: {
+    scope: { namespace: string };
+    query: string;
+    budgetMaxTokens: number;
+  }): Promise<{
+    status: string;
+    sections: Record<string, unknown>;
+    budget: Record<string, unknown>;
+  }> {
+    const { rows } = await pool.query(
+      `SELECT id, content FROM thoughts WHERE namespace = $1 AND archived_at IS NULL`,
+      [opts.scope.namespace],
+    );
+    if (rows.length > 0) this.evidenceReadBack = true;
+    const sections = {
+      durable_memory: {
+        item_count: rows.length,
+        items: rows.map((row) => ({ id: row.id, content: row.content })),
+      },
+    };
+    return {
+      status: "ok",
+      sections,
+      budget: { whole_pack: { content_char_limit: 100_000 } },
+    };
+  }
+
+  async sessionContext(opts: {
+    sessionKey: string;
+    namespace: string;
+  }): Promise<Record<string, unknown>> {
+    const laneRows = await pool.query(
+      `SELECT id, current_context_md FROM ob_session_lanes
+       WHERE namespace = $1 AND session_key = $2`,
+      [opts.namespace, opts.sessionKey],
+    );
+    if (laneRows.rows.length === 0) return { lane: null, events: [] };
+    const lane = laneRows.rows[0];
+    const events = await pool.query(
+      `SELECT id, content FROM ob_session_events WHERE lane_id = $1 ORDER BY created_at`,
+      [lane.id],
+    );
+    if (events.rows.length > 0) this.evidenceReadBack = true;
+    return {
+      lane: { id: lane.id, current_context_md: lane.current_context_md },
+      events: events.rows.map((row) => ({ id: row.id, content: row.content })),
+    };
+  }
+
+  /**
+   * The code under test. Record teardown first (the existing design), then the
+   * namespace purge (the #655 delta). Both are the shipped functions.
+   */
+  async cleanup(
+    records: ScenarioRecord[],
+    namespace: string,
+  ): Promise<TeardownTally> {
+    this.cleanupEntered = true;
+    const tally = await teardownRecords(records, (record) =>
+      this.cleanupRecord(record, namespace),
+    );
+    // DONE_MEANS_655_SKIP_PURGE reproduces the pre-fix world exactly: record
+    // teardown runs, the namespace purge does not. It exists so the RED
+    // transcript can be regenerated at any time WITHOUT deleting the fix, and
+    // so anyone can confirm this check still discriminates rather than taking
+    // a green run on faith (docs/lane-contract.md Tightenings round 13: "a
+    // control clause that passes PRE-fix is the signal the check
+    // discriminates"). It is read only by this driver, never by shipped code.
+    if (process.env.DONE_MEANS_655_SKIP_PURGE === "1") {
+      console.log(
+        "INFO  DONE_MEANS_655_SKIP_PURGE=1 — namespace purge deliberately SKIPPED (pre-fix reproduction)",
+      );
+      return tally;
+    }
+    const purge = await purgeNamespace(pool, namespace);
+    this.purgedRows = purge.deleted;
+    return tally;
+  }
+
+  private async cleanupRecord(
+    record: ScenarioRecord,
+    namespace: string,
+  ): Promise<"archived" | "already_absent"> {
+    if (record.kind === "memory") {
+      // Mirrors archive_entry's SOFT delete exactly (src/tools/archive-entry.ts:54).
+      // Reproducing the soft-delete faithfully is the whole point: if this
+      // driver hard-deleted here, the check could pass without the purge
+      // existing and would prove nothing.
+      const result = await pool.query(
+        `UPDATE ${record.table} SET archived_at = NOW()
+         WHERE id = $1 AND archived_at IS NULL AND namespace = $2 RETURNING id`,
+        [record.id, namespace],
+      );
+      return (result.rowCount ?? 0) > 0 ? "archived" : "already_absent";
+    }
+    const result =
+      record.kind === "event"
+        ? await pool.query(
+            `DELETE FROM ob_session_events AS event USING ob_session_lanes AS lane
+             WHERE event.id = $1 AND event.lane_id = $2
+               AND lane.id = event.lane_id AND lane.namespace = $3 RETURNING event.id`,
+            [record.id, record.lane_id, namespace],
+          )
+        : await pool.query(
+            `DELETE FROM ob_session_lanes
+             WHERE id = $1 AND namespace = $2 AND session_key = $3 RETURNING id`,
+            [record.id, namespace, record.session_key],
+          );
+    return (result.rowCount ?? 0) > 0 ? "archived" : "already_absent";
+  }
+
+  async close(): Promise<void> {}
+}
+
+/**
+ * Clause (b): fire the guard at names it must refuse, and PROVE the refusal was
+ * not merely an exception raised after the deletes had already run. Each
+ * refused name gets a canary row planted under it first; if the row survives,
+ * the refusal happened before any mutation.
+ */
+async function proveGuard(): Promise<{
+  cases: number;
+  refusals: number;
+  rowsTouched: number;
+  allowsOwn: boolean;
+}> {
+  let refusals = 0;
+  let rowsTouched = 0;
+
+  for (const name of MUST_REFUSE) {
+    const canaryId = randomUUID();
+    let planted = false;
+    if (name.length > 0) {
+      await pool.query(
+        `INSERT INTO thoughts (id, namespace, content, tags, created_by) VALUES ($1, $2, $3, $4, $5)`,
+        [canaryId, name, "done-means-655 guard canary", ["done-means-655"], CREATED_BY],
+      );
+      planted = true;
+    }
+
+    try {
+      await purgeNamespace(pool, name);
+    } catch {
+      refusals += 1;
+    }
+
+    if (planted) {
+      const survived = await pool.query(
+        `SELECT 1 FROM thoughts WHERE id = $1`,
+        [canaryId],
+      );
+      if ((survived.rowCount ?? 0) === 0) rowsTouched += 1;
+      // The canary is this driver's own row, planted seconds ago in a throwaway
+      // database this check created and drops. Removing it here keeps the
+      // clause (a) count honest.
+      await pool.query(`DELETE FROM thoughts WHERE id = $1`, [canaryId]);
+    }
+  }
+
+  // The positive case: a real per-run namespace must still be accepted, or the
+  // guard is just a refusal machine and its refusals mean nothing.
+  let allowsOwn = false;
+  try {
+    assertPurgeableNamespace(
+      runNamespaces(makeRunId({ prefix: "guard-positive", randomHex: "abc123" })).primary,
+    );
+    allowsOwn = true;
+  } catch {
+    allowsOwn = false;
+  }
+
+  return { cases: MUST_REFUSE.length, refusals, rowsTouched, allowsOwn };
+}
+
+async function main(): Promise<void> {
+  const runId = makeRunId({
+    prefix: "scenario-donemeans655",
+    randomHex: randomUUID().replaceAll("-", "").slice(0, 12),
+    // An operator label in the ambient environment would otherwise be picked up
+    // and change the namespace this check asserts on. Announced, per the
+    // nothing-is-adjusted-silently rule.
+    env: {},
+  });
+  const { primary } = runNamespaces(runId);
+  console.log(`INFO  driver namespace: ${primary}`);
+
+  const fixture = await loadScenarioFixture(
+    "eval/open-brain/fixtures/scenarios-v1.json",
+  );
+  const transport = new DriverTransport(primary);
+
+  const outcome = await runScenarioGate({
+    fixture,
+    namespace: primary,
+    transport,
+    commit: "done-means-655",
+    generatedAt: new Date().toISOString(),
+    runId,
+  });
+
+  console.log(
+    `INFO  gate passed=${outcome.passed} scenarios=${outcome.receipt.scenarios.length} ` +
+      `teardown=${JSON.stringify(outcome.receipt.teardown)} purged_rows=${transport.purgedRows}`,
+  );
+  for (const verdict of outcome.receipt.scenarios) {
+    console.log(
+      `INFO  scenario ${verdict.scenario_id}: passed=${verdict.passed}` +
+        (verdict.failures.length > 0 ? ` failures=${verdict.failures.join(",")}` : ""),
+    );
+  }
+
+  const guard = await proveGuard();
+  console.log(
+    `INFO  guard: ${guard.refusals}/${guard.cases} refused, ` +
+      `rows_touched_on_refusal=${guard.rowsTouched}, allows_own=${guard.allowsOwn}`,
+  );
+
+  const out: DriverOut = {
+    scenario_count: outcome.receipt.scenarios.length,
+    scenario_assertions_passed: outcome.passed,
+    evidence_readable_before_teardown: transport.evidenceReadBack,
+    teardown_failed: outcome.receipt.teardown.failed,
+    namespace_purged_rows: transport.purgedRows,
+    guard_cases: guard.cases,
+    guard_refusals: guard.refusals,
+    guard_rows_touched_on_refusal: guard.rowsTouched,
+    guard_allows_own_namespace: guard.allowsOwn,
+  };
+  await Bun.write(OUT_PATH as string, `${JSON.stringify(out, null, 2)}\n`);
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(
+      `driver error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 4;
+  })
+  .finally(() => pool.end());

--- a/scripts/done-means/655-eval-teardown.sh
+++ b/scripts/done-means/655-eval-teardown.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #655 — "E2E scenario runner leaks one namespace per
+# run (eval-live-recall-scenario-*) — teardown missing".
+#
+#   bash scripts/done-means/655-eval-teardown.sh
+#
+# ---------------------------------------------------------------------------
+# WHAT THE EXISTING DESIGN SAYS, AND WHAT THE DELTA IS
+# ---------------------------------------------------------------------------
+# The repo already has a teardown design and it is a good one:
+# `teardownRecords` (eval/open-brain/live/gate.ts:76) removes seeded records ONE
+# AT A TIME by exact id, tallying attempted/archived/already_absent/failed, and
+# `LiveScenarioTransport.cleanupRecord` (eval/open-brain/live/scenario-transport.ts:184)
+# states the rule in its own words: rows are removed "by exact id plus namespace
+# ... never by a broad namespace/query sweep." That rule is not being replaced.
+#
+# The delta is that record teardown, executed perfectly, still cannot remove a
+# NAMESPACE — and both of the reasons were measured, not reasoned:
+#
+#   1. SOFT-DELETE IS NOT REMOVAL. `archive_entry` sets `archived_at` and leaves
+#      the row (src/tools/archive-entry.ts:54). A namespace in this schema has no
+#      registry row — there is no namespaces table, so a namespace exists exactly
+#      as long as some row carries it. 21 `eval-live-recall-*` namespaces in the
+#      dogfood database hold nothing but archived rows: teardown reported
+#      success and the namespace is still there, permanently.
+#
+#   2. A THROWN ARCHIVE LEAVES THE ROW FULLY LIVE. Receipt
+#      `_scratch/578-e2e-gate/e2e578-20260808172426-.../scenario-receipt.json`
+#      reads `attempted=1 archived=0 already_absent=0 failed=1`, and the matching
+#      dogfood row has `archived_at IS NULL`. Six `eval-live-recall-scenario-*`
+#      namespaces are in exactly that state.
+#
+# So the fix ADDS a namespace purge AFTER `teardownRecords`, rather than
+# replacing it. The narrow authority for a purge is `docs/issue-graph.md` ledger
+# item 20; the prefix guard is what earns it, which is why clause (b) is the
+# load-bearing clause below rather than an afterthought.
+#
+# ---------------------------------------------------------------------------
+# WHY THE CLAUSES ARE SHAPED THIS WAY
+# ---------------------------------------------------------------------------
+# Residue cannot be observed from inside the run that produced it, and it cannot
+# be observed in a database other work has touched — a pre-existing
+# `eval-live-recall-%` row is indistinguishable from one this run leaked. So
+# clause (a) owns a FRESH DATABASE end to end and asserts the zero-row
+# precondition BEFORE it asserts anything else (the #613 standard).
+#
+# Clause (b) is load-bearing. Ledger item 20's second condition is that the
+# process be prefix-guarded so it "structurally cannot name anything it did not
+# create". A guard that has never been fired against a name it must refuse is an
+# unproven claim, and this repo has already paid for treating an unexercised
+# control as a control (docs/lane-contract.md Tightenings round 13). Clause (b)
+# therefore points the purge at names it MUST refuse — including the bare prefix
+# and a name that merely CONTAINS it, the two cases a naive `includes()` guard
+# waves through — and requires both a refusal AND proof the refused call touched
+# zero rows. A guard that throws after deleting is not a guard. It also requires
+# the guard to still ALLOW a genuine per-run namespace: a guard that refuses
+# everything proves only that it refuses.
+#
+# Clause (c) is the control that stops the fix from becoming a worse bug. The
+# obvious wrong implementation purges at the START of teardown, before the
+# scenario assertions have read their records back — which eats the evidence and
+# would make a broken run look clean by rendering its own seed unfindable.
+# Clause (c) requires the run to report that verification read its seeded record
+# while it still existed, and that real scenario verdicts were produced.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) LEAK — a scenario run leaves ZERO rows in any eval-prefixed namespace it
+#       created. RED before the fix: the seeded row survives.
+#   (b) GUARD, MUTATION-PROVEN — the purge REFUSES every non-eval-prefixed name,
+#       deletes nothing when it refuses, and still allows a real eval namespace.
+#   (c) CONTROL — teardown does not eat the evidence.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS SCRIPT TOUCHES, AND WHAT IT REFUSES TO
+# ---------------------------------------------------------------------------
+# It creates ONE throwaway database, by a name it generates itself, and drops
+# that same database on the way out via `dropdb` — ledger item 20's own worked
+# example. It contains no `rm` of any kind. It never reads
+# OPENBRAIN_TEST_DATABASE_URL from the environment; it sets its own. The dogfood
+# database and core01 are NOT touched, and this check will not purge anything in
+# them: the pre-existing leaked rows there are operator-gated (#655 says so
+# explicitly) and their cleanup SQL is printed in the PR body for the operator to
+# run, never executed here.
+#
+# Output is content-free — clause names, counts, and statuses only.
+#
+# ---------------------------------------------------------------------------
+# EXPECTED TO FAIL BEFORE THE FIX
+# ---------------------------------------------------------------------------
+# On `origin/main` there is no purge at all: clause (a) finds the seeded row
+# still present and clause (b) cannot even load the guard module. RED transcript
+# is in the PR body.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}" || exit 1
+
+PG_HOST="${DONE_MEANS_655_PGHOST:-127.0.0.1}"
+PG_PORT="${DONE_MEANS_655_PGPORT:-5432}"
+PG_USER="${DONE_MEANS_655_PGUSER:-${USER}}"
+DB_NAME="done_means_655_$$_$(date +%s)"
+DB_URL="postgres://${PG_USER}@${PG_HOST}:${PG_PORT}/${DB_NAME}"
+
+DRIVER="scripts/done-means/655-eval-teardown.driver.ts"
+
+FAILURES=0
+DB_CREATED=0
+fail() { printf 'FAIL  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'PASS  %s\n' "$*"; }
+info() { printf 'INFO  %s\n' "$*"; }
+
+cleanup() {
+  if [[ ${DB_CREATED} -eq 1 ]]; then
+    if dropdb -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" "${DB_NAME}" >/dev/null 2>&1; then
+      info "teardown: dropped ${DB_NAME}"
+    else
+      printf 'WARN  teardown: dropdb %s failed; drop it by hand:\n' "${DB_NAME}"
+      printf 'WARN    dropdb -h %s -p %s -U %s %s\n' "${PG_HOST}" "${PG_PORT}" "${PG_USER}" "${DB_NAME}"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+q() { psql -At "${DB_URL}" -c "$1"; }
+
+printf '=== done-means #655: does the scenario runner remove the namespace it created? ===\n'
+printf 'throwaway database: %s\n\n' "${DB_NAME}"
+
+if [[ ! -f "${DRIVER}" ]]; then
+  fail "missing required component: ${DRIVER}"
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Fresh database. Same mechanism as scripts/lane-bootstrap.ts --fresh-db.
+# ---------------------------------------------------------------------------
+if ! createdb -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" "${DB_NAME}" 2>&1; then
+  fail "createdb ${DB_NAME} failed; cannot run the check"
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+DB_CREATED=1
+pass "created ${DB_NAME}"
+
+if MIGRATE_LOG="$(DB_HOST="${PG_HOST}" DB_PORT="${PG_PORT}" DB_NAME="${DB_NAME}" \
+  DB_USER="${PG_USER}" bun run migrate 2>&1)"; then
+  pass "migrations applied"
+else
+  fail "migrations failed:"
+  printf '%s\n' "${MIGRATE_LOG}" | tail -20
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Precondition: the fresh database holds no eval-prefixed rows. Without this the
+# count in clause (a) proves nothing.
+# ---------------------------------------------------------------------------
+BEFORE="$(q "SELECT (SELECT count(*) FROM thoughts WHERE namespace LIKE 'eval-live-recall-%')
+              + (SELECT count(*) FROM decisions WHERE namespace LIKE 'eval-live-recall-%')
+              + (SELECT count(*) FROM ob_session_lanes WHERE namespace LIKE 'eval-live-recall-%');")"
+if [[ "${BEFORE}" == "0" ]]; then
+  pass "precondition: 0 eval-live-recall-% rows before the run"
+else
+  fail "precondition broken: ${BEFORE} eval-live-recall-% row(s) already present in a FRESH database"
+fi
+
+# ---------------------------------------------------------------------------
+# (a)+(b)+(c) One driver run. It calls runScenarioGate itself rather than
+# re-deriving teardown: a check that hand-rolls its own copy of the cleanup can
+# pass while the product stays broken (docs/sme/correctness.md).
+# ---------------------------------------------------------------------------
+printf '\n--- driving the real gate against the fresh database ---\n'
+# Scratch goes to the repo's temp-workspace bucket, never the repo root (which
+# would leave an untracked file behind — the same class of residue this check
+# exists to catch) and never `/tmp`/`$TMPDIR`/`mktemp -d`, which are
+# sandbox-local so a runner, a Codex sandbox, and the host each see a different
+# one (_DOCS/STANDARDS-core.md). The receipt is what an operator most wants
+# AFTER a failure, so it is left in place; the run tag keeps runs distinct.
+SCRATCH_DIR="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/655-eval-teardown"
+mkdir -p "${SCRATCH_DIR}"
+DRIVER_OUT="${SCRATCH_DIR}/driver-${DB_NAME}.json"
+info "receipt: ${DRIVER_OUT}"
+set +e
+DRIVER_LOG="$(DONE_MEANS_655_DB_URL="${DB_URL}" DONE_MEANS_655_OUT="${DRIVER_OUT}" \
+  bun "${DRIVER}" 2>&1)"
+DRIVER_EXIT=$?
+set -e
+printf '%s\n' "${DRIVER_LOG}" | tail -30
+
+if [[ ${DRIVER_EXIT} -ne 0 ]]; then
+  fail "driver exited ${DRIVER_EXIT} — clause results below may be unreadable"
+fi
+
+read_driver() {
+  if [[ ! -f "${DRIVER_OUT}" ]]; then printf 'missing'; return 1; fi
+  bun -e "const r=await Bun.file(process.argv[2]).json();console.log(String(r[process.argv[3]]))" \
+    x "${DRIVER_OUT}" "$1" 2>/dev/null
+}
+
+printf '\n--- (c) control: the run examined something, and teardown did not eat it ---\n'
+SCENARIO_COUNT="$(read_driver scenario_count)"
+if [[ "${SCENARIO_COUNT:-0}" -gt 0 ]]; then
+  pass "(c) the run really executed ${SCENARIO_COUNT} scenario(s) — not a silent empty run"
+else
+  fail "(c) the run reported 0 scenarios; a suite that examined nothing makes every count below meaningless"
+fi
+
+EVIDENCE_OK="$(read_driver evidence_readable_before_teardown)"
+if [[ "${EVIDENCE_OK}" == "true" ]]; then
+  pass "(c) scenario verification read its own seeded record BEFORE teardown ran"
+else
+  fail "(c) teardown ate the evidence: verification could not read the seeded record (got '${EVIDENCE_OK}')"
+fi
+
+VERDICTS_REAL="$(read_driver scenario_assertions_passed)"
+if [[ "${VERDICTS_REAL}" == "true" ]]; then
+  pass "(c) the run's own assertions still pass with teardown in place"
+else
+  fail "(c) the run's assertions did not pass with teardown in place (got '${VERDICTS_REAL}')"
+fi
+
+printf '\n--- (a) the leak: nothing eval-prefixed is left behind ---\n'
+TEARDOWN_FAILED="$(read_driver teardown_failed)"
+if [[ "${TEARDOWN_FAILED}" == "0" ]]; then
+  pass "(a) record teardown reported failed=0"
+else
+  fail "(a) record teardown reported failed=${TEARDOWN_FAILED}"
+fi
+
+AFTER="$(q "SELECT (SELECT count(*) FROM thoughts WHERE namespace LIKE 'eval-live-recall-%')
+             + (SELECT count(*) FROM decisions WHERE namespace LIKE 'eval-live-recall-%')
+             + (SELECT count(*) FROM ob_session_lanes WHERE namespace LIKE 'eval-live-recall-%')
+             + (SELECT count(*) FROM sessions WHERE namespace LIKE 'eval-live-recall-%');")"
+if [[ "${AFTER}" == "0" ]]; then
+  pass "(a) 0 eval-live-recall-% rows remain — the run removed the namespace it created"
+else
+  fail "(a) ${AFTER} eval-live-recall-% row(s) left behind — the run leaked its namespace"
+  printf '\n--- leftover namespaces (names and counts only, no content) ---\n'
+  psql -At "${DB_URL}" -c "SELECT 'thoughts', namespace, count(*) FROM thoughts WHERE namespace LIKE 'eval-live-recall-%' GROUP BY 2
+                           UNION ALL SELECT 'decisions', namespace, count(*) FROM decisions WHERE namespace LIKE 'eval-live-recall-%' GROUP BY 2
+                           UNION ALL SELECT 'ob_session_lanes', namespace, count(*) FROM ob_session_lanes WHERE namespace LIKE 'eval-live-recall-%' GROUP BY 2;" 2>&1 || true
+fi
+
+# ---------------------------------------------------------------------------
+# (b) GUARD — mutation-proven refusal.
+# ---------------------------------------------------------------------------
+printf '\n--- (b) control: the prefix guard REFUSES a non-eval name, without mutating ---\n'
+GUARD_REFUSED="$(read_driver guard_refusals)"
+GUARD_EXPECTED="$(read_driver guard_cases)"
+GUARD_ROWS_TOUCHED="$(read_driver guard_rows_touched_on_refusal)"
+GUARD_ALLOWED_OK="$(read_driver guard_allows_own_namespace)"
+
+if [[ -n "${GUARD_EXPECTED:-}" && "${GUARD_EXPECTED}" != "missing" \
+      && "${GUARD_REFUSED}" == "${GUARD_EXPECTED}" && "${GUARD_EXPECTED}" -gt 0 ]]; then
+  pass "(b) the guard refused all ${GUARD_EXPECTED} non-eval name(s) it was pointed at"
+else
+  fail "(b) the guard refused ${GUARD_REFUSED:-?} of ${GUARD_EXPECTED:-?} non-eval name(s) — it does not structurally refuse"
+fi
+
+if [[ "${GUARD_ROWS_TOUCHED}" == "0" ]]; then
+  pass "(b) a refused purge deleted ZERO rows — it refuses BEFORE it mutates"
+else
+  fail "(b) a refused purge deleted ${GUARD_ROWS_TOUCHED:-?} row(s) — it throws AFTER mutating, which is not a guard"
+fi
+
+if [[ "${GUARD_ALLOWED_OK}" == "true" ]]; then
+  pass "(b) the guard still ALLOWS a genuine per-run eval namespace — it discriminates"
+else
+  fail "(b) the guard refused a real eval namespace too; a check that refuses everything proves nothing"
+fi
+
+printf '\n'
+if [[ ${FAILURES} -eq 0 ]]; then
+  printf '=== RESULT: PASS — the scenario run removes the namespace it created, the guard refuses everything else without mutating, and the evidence survives long enough to be verified ===\n'
+  exit 0
+fi
+printf '=== RESULT: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+exit 1


### PR DESCRIPTION
## Summary

- Closes #655. The E2E scenario runner tore down its RECORDS but never its NAMESPACE, leaving one `eval-live-recall-scenario-*` namespace behind per run. This adds a prefix-guarded namespace purge that runs AFTER the existing record teardown.
- **The record teardown was not broken — it cannot do this job.** Two mechanisms, both measured in the dogfood database on 2026-08-08 rather than reasoned about:
  - `archive_entry` is a SOFT delete (`src/tools/archive-entry.ts:54`): it sets `archived_at` and the row stays. A namespace in this schema has no registry row (there is no namespaces table) — it exists exactly as long as some row carries it — so an archived row keeps its namespace alive permanently. **24** `eval-live-recall-*` namespaces hold nothing but archived rows: teardown reported success and the namespace is still there.
  - When the archive call THROWS, the tally counts `failed` and the row is left fully LIVE. **6** `eval-live-recall-scenario-*` namespaces are in exactly that state (`archived_at IS NULL`), from a receipt reading `attempted=1 archived=0 already_absent=0 failed=1`.
- `eval/open-brain/live/namespace-purge.ts` (new) hard-deletes rows for ONE namespace after `teardownRecords`, under `docs/issue-graph.md` ledger item 20's narrow auto-drop exception. All three conditions are structural, not promised: **self-created** (the namespace derives from a per-invocation crypto nonce in `makeRunId`), **prefix-guarded** (`assertPurgeableNamespace` refuses anything outside `eval-live-recall-` before issuing a single statement, and the prefix is a module constant, not a parameter a caller could dial open), **session-scoped throwaway** (fixture text seeded seconds earlier).
- `LiveScenarioTransport.cleanup` composes the purge after the record pass. A purge failure increments the teardown `failed` tally rather than throwing, so the #578 gate's clause (e) still reads it and the record tally that explains what DID get cleaned is not discarded.
- **Scope note:** this fixes the leak going forward. The rows already in the dogfood database are pre-existing data and are NOT touched — see "Pre-existing leaked rows" below for the count and the exact operator-gated cleanup SQL.

## Verification

- Done-means: scripts/done-means/655-eval-teardown.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED** (pre-fix reproduction via `DONE_MEANS_655_SKIP_PURGE=1`, which skips only the new purge and leaves everything else intact):

```
INFO  gate passed=true scenarios=3 teardown={"attempted":6,"archived":4,"already_absent":2,"failed":0} purged_rows=0
PASS  (c) the run really executed 3 scenario(s) — not a silent empty run
PASS  (c) scenario verification read its own seeded record BEFORE teardown ran
PASS  (c) the run's own assertions still pass with teardown in place
PASS  (a) record teardown reported failed=0
FAIL  (a) 2 eval-live-recall-% row(s) left behind — the run leaked its namespace
thoughts|eval-live-recall-scenario-donemeans655-c2bf5739ccbe|1
PASS  (b) the guard refused all 6 non-eval name(s) it was pointed at
PASS  (b) a refused purge deleted ZERO rows — it refuses BEFORE it mutates
PASS  (b) the guard still ALLOWS a genuine per-run eval namespace — it discriminates
=== RESULT: FAIL (1 failing clause(s)) ===
```

That RED is the production defect exactly: 3/3 scenarios pass, teardown self-reports `failed=0`, and the namespace leaks anyway. A teardown that reports success while leaving residue is why this needed a row-count gate rather than a tally assertion.

**GREEN**:

```
INFO  gate passed=true scenarios=3 teardown={"attempted":6,"archived":4,"already_absent":2,"failed":0} purged_rows=2
PASS  (c) the run really executed 3 scenario(s) — not a silent empty run
PASS  (c) scenario verification read its own seeded record BEFORE teardown ran
PASS  (c) the run's own assertions still pass with teardown in place
PASS  (a) record teardown reported failed=0
PASS  (a) 0 eval-live-recall-% rows remain — the run removed the namespace it created
PASS  (b) the guard refused all 6 non-eval name(s) it was pointed at
PASS  (b) a refused purge deleted ZERO rows — it refuses BEFORE it mutates
PASS  (b) the guard still ALLOWS a genuine per-run eval namespace — it discriminates
=== RESULT: PASS ===
```

`purged_rows=2` is exactly the 2 rows that leaked in RED.

Other checks, all RUNNING this session:

- `bun run test:isolated` — **3741 pass, 35 skip, 0 fail** across 244 files, fresh database `ob_isolated_46330_mskx6quux8`, dropped on exit.
- `bunx tsc --noEmit` — clean, no output.
- `bun test eval/open-brain/live/__tests__/` — 204 pass, 0 fail.
- **Guard mutation proof.** Swapping `startsWith` for `includes` in `assertPurgeableNamespace` turns the unit suite from 13 pass / 0 fail into 12 pass / **1 fail**; restoring returns it to 13 pass. The guard test is proven able to fail, so its green is worth something.
- `scripts/done-means/636-neutrality.sh` — FAILs with exactly 2 violations, both in `server/application/index.ts:203` and `server/transport/health.ts:136`, both present on `origin/main` (`git show origin/main:server/transport/health.ts` line 136), neither in a file this PR touches. Pre-existing, reported not fixed. **Labelled from a same-tree comparison, not a single-file run.**

## Critical Self-Review

- Highest-risk behavior: a hard `DELETE` running automatically. The mitigation is that the prefix is a module constant rather than a parameter, so no caller can widen it, and clause (b) plants a canary row under each refused name and verifies it SURVIVES — proving the guard refuses before mutating rather than throwing after the deletes have run.
- Assumptions that could be wrong: `PURGE_TABLES` is hand-enumerated. If a future migration adds a namespaced table the eval suites seed, the purge will silently miss it and the leak returns for that table. I chose the explicit list over discovering from `information_schema` deliberately — a discovered list would quietly grow to cover tables this module was never reviewed against — but the tradeoff is real and is the most likely way this regresses.
- Missing/weak tests: the done-means driver uses a local `ScenarioTransport` against a real fresh database rather than `LiveScenarioTransport` against a live deployment. `runScenarioGate`, `teardownRecords`, `purgeNamespace` and the guard are all the shipped code and the residue measured is real, but the composition inside `LiveScenarioTransport.cleanup` itself is **WRITTEN, not RUNNING** — see residual risk.
- Security/permission risk: the purge bypasses the MCP auth layer and talks to Postgres directly, so no namespace predicate is derived from a token. That is why the prefix guard is the boundary, and why it is tested against `rico` and `shared-kb` specifically. The refusal message deliberately carries no namespace content (a refusal can be pointed at an operator's real namespace) and there is a test asserting the offending value does not appear in it.
- Migration/deploy risk: none. No schema change, no migration; eval-only code path.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as not applicable — no MCP tool, schema, transport, or Python-client surface changes. `eval/` is not imported by the server or the Python package.
- Rollback/cleanup concern: revert is a clean `git revert`; nothing persists.
- Fixes made before PR: (1) the check originally wrote its receipt to the repo root and claimed it was git-ignored — it was not, and the check would have left an untracked file behind, the same class of residue it exists to catch. Moved to the temp-workspace scratch bucket and the false claim removed. (2) First RED attempt died on a module-not-found import and never measured the leak at all; replaced with `DONE_MEANS_655_SKIP_PURGE=1`, which reproduces the pre-fix world with everything else intact and keeps RED regenerable without deleting the fix. (3) Two schema mismatches in the driver (`created_by` NOT NULL; `ob_session_lanes` has no `platform`/`server_id` columns) surfaced as `scenario_transport_error` — announced in the code comment rather than silently dropped, with the fixture's `platform`/`server_id` folded into `source`/`project`.
- Known residual risk: `LiveScenarioTransport.cleanup` is **WRITTEN, not RUNNING** — it has not been executed against a live deployment. Running it needs an admin/ob-admin token with X-Namespace delegation authority, and since the neutrality scrub (PR #645) the repo `.env` carries empty placeholders (`AUTH_TOKEN_ADMIN` has length 0); the values live only in the serving process's environment, and harvesting them from a running process is what the #578 gate header forbids. The next `bash scripts/done-means/578-e2e-gate.sh` run with real coordinates is the RUNNING proof, and its clause (e) reads the tally this PR feeds.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the operating lesson here (a teardown can report success and still leave residue, because soft-delete is not removal) is a LANE lesson, harvested into `docs/lane-contract.md` Tightenings by the controller's merge pass per ledger item 19, not a reviewer-facing code-review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no admin/ob-admin token with X-Namespace delegation is available in this lane (see residual risk); the #578 gate is the live proof and is the controller's to run.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: eval-harness teardown only. No MCP tool, schema, or wire contract changes, so there is no parity fixture to update.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every downstream line: the change is confined to `eval/` and `scripts/done-means/`. No tool schema, transport, or client-facing surface is touched, so no downstream consumer can observe it.

### Pre-existing leaked rows — REPORTED, NOT DELETED

Counted in the dogfood database (`open_brain_local_20260724`) this session. **Nothing here was deleted**: pre-existing data is operator-gated, so this is the count plus the exact SQL for the operator to run by hand.

The six namespaces this issue names, all with `archived_at IS NULL` (the thrown-archive case), 1 `thoughts` row each:

```
eval-live-recall-scenario-3be56b18bc82-0be200df59a1
eval-live-recall-scenario-3be56b18bc82-3de7dae8061c
eval-live-recall-scenario-3be56b18bc82-76708f80140a
eval-live-recall-scenario-3be56b18bc82-a422aa9f8559
eval-live-recall-scenario-3be56b18bc82-ba69018f3ed7
eval-live-recall-scenario-3be56b18bc82-f16d2f1a7932
```

The wider `eval-live-recall-*` family is **24 further namespaces holding 94 rows**, every one of them already archived — the soft-delete case, where teardown genuinely succeeded and the namespace survived anyway.

Counted this session against `open_brain_local_20260724`: **100 rows across 30 `eval-live-recall-*` namespaces** — 69 `thoughts`, 30 `decisions`, 1 `ob_session_lanes`, 0 `sessions`. (An earlier draft of this body said 105 rows / 28 namespaces; that was wrong and is corrected here against the query output.)

Operator cleanup SQL, scoped by the same prefix the code guard uses. Run the SELECT first and read the counts:

```sql
-- 1. Review before removing anything.
SELECT 'thoughts' AS tbl, namespace, count(*) FROM thoughts
  WHERE namespace LIKE 'eval-live-recall-%' GROUP BY 1, 2
UNION ALL SELECT 'decisions', namespace, count(*) FROM decisions
  WHERE namespace LIKE 'eval-live-recall-%' GROUP BY 1, 2
UNION ALL SELECT 'ob_session_lanes', namespace, count(*) FROM ob_session_lanes
  WHERE namespace LIKE 'eval-live-recall-%' GROUP BY 1, 2
ORDER BY 2, 1;

-- 2. Remove, children before parents. Wrap in a transaction and check the
--    row counts before COMMIT.
BEGIN;
DELETE FROM ob_session_events e USING ob_session_lanes l
  WHERE e.lane_id = l.id AND l.namespace LIKE 'eval-live-recall-%';
DELETE FROM ob_session_lanes WHERE namespace LIKE 'eval-live-recall-%';
DELETE FROM thoughts        WHERE namespace LIKE 'eval-live-recall-%';
DELETE FROM decisions       WHERE namespace LIKE 'eval-live-recall-%';
DELETE FROM sessions        WHERE namespace LIKE 'eval-live-recall-%';
-- COMMIT;   -- uncomment after reading the counts above
```

One namespace outside the prefix, `eval-kwdiag-1889c167` (1 row), is from a different eval family and is deliberately excluded from both the guard and this SQL — it is not this issue's residue and removing it is a separate operator decision.
