### PR TITLE
fix(local-clone): pass capture-health config to the server child and announce dropped keys

### DIFF
--- a/scripts/done-means/659-launcher-env-passthrough.driver.ts
+++ b/scripts/done-means/659-launcher-env-passthrough.driver.ts
@@ -1,0 +1,465 @@
+/**
+ * DONE-MEANS driver for #659 — the local-clone launcher's child-environment
+ * allowlist carries the capture-health keys, and ANNOUNCES every configured key
+ * it drops instead of discarding it in silence.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT, AS OBSERVED
+ * ---------------------------------------------------------------------------
+ * PR #656 merged the capture-health observer wiring into `server/main.ts` and
+ * ledger item 28 supplied the config ruling. `OPENBRAIN_CAPTURE_HEALTH_NAMESPACE`
+ * was then set in the deployed clone's env file, the clone was redeployed with a
+ * passing revision proof — and live `/health` still published no capture block,
+ * because `buildChildEnvironment()` never handed the key to the server child.
+ * The launcher process HAD the variable; the child it spawned did not.
+ *
+ * That is two defects, and this check asserts both:
+ *
+ *   1. The three `OPENBRAIN_CAPTURE_HEALTH_*` keys do not reach the child.
+ *   2. The allowlist drops CONFIGURED keys with no signal at all, so every
+ *      future server config key re-buys this same bug. That violates the repo
+ *      coding standard "Nothing is adjusted silently" (operator ruling
+ *      2026-08-08): a tool that transforms its input to satisfy a constraint
+ *      announces the adjustment in its normal output.
+ *
+ * The SME KB already carries this exact class — `docs/sme/gotcha-agent.md`,
+ * "An allowlist that drops unrecognized keys is accept-and-ignore, not
+ * tolerance" (#464). Its first review question is the one this check enforces:
+ * *does the drop path name what it dropped?* A count is unactionable at the
+ * moment it matters; names cost one list. Its second is why clause (a) is a bug
+ * in both directions: a dropped key that appears in the project's own constant
+ * set is not an unknown future field, it is a supported concept the reader
+ * forgot.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE ALLOWLIST STAYS AN ALLOWLIST
+ * ---------------------------------------------------------------------------
+ * The launcher exists to hand the server child a tightly scoped environment —
+ * `scripts/local-clone.test.ts` asserts `PATH`, `SSH_AUTH_SOCK` and a host
+ * identity var never reach it. Passing the whole environment would fix #659 by
+ * deleting the property the launcher was built for. Clause (d) is the control
+ * that fails any such "fix": an unlisted junk key must still be dropped.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE ANNOUNCEMENT IS SCOPED, AND WHY THAT SCOPE IS ITSELF ASSERTED
+ * ---------------------------------------------------------------------------
+ * `scripts/local-clone-autostart.sh:56-59` does `set -a; source local-clone.env`,
+ * so the launcher's own environment is the env file UNIONED with launchd's
+ * ambient environment. Announcing every dropped variable would name `PATH`,
+ * `HOME`, `SSH_AUTH_SOCK` and dozens of others on every boot — noise that
+ * teaches an operator to ignore the line, which is silence with extra steps.
+ *
+ * So the announcement is scoped to keys that look like Open Brain SERVER
+ * configuration, and clause (e) asserts that scope from BOTH sides: an ambient
+ * host variable is NOT announced, and a configured-looking one IS. A scope
+ * rule with only its positive half tested passes just as well when the filter
+ * is "announce nothing".
+ *
+ * No database, no network, no child process: `buildChildEnvironment` and
+ * `describeDroppedChildEnvironment` are pure functions over a record. Clause
+ * (f) drives the REAL `runLocalCloneLauncher` start path through its injected
+ * boundaries so the announcement is proven to reach the launcher's actual
+ * output, not merely to be computable in isolation.
+ */
+import {
+  buildChildEnvironment,
+  runLocalCloneLauncher,
+  type LocalCloneLauncherDependencies,
+} from "../local-clone.ts";
+import {
+  CAPTURE_HEALTH_NAMESPACE_ENV,
+  CAPTURE_HEALTH_REFRESH_ENV,
+  CAPTURE_HEALTH_WINDOW_ENV,
+} from "../../server/capture/liveness-observer.ts";
+import { EventEmitter } from "node:events";
+import { mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { ChildProcess } from "node:child_process";
+
+/**
+ * A real directory for the clone-root fixture.
+ *
+ * `src/local-clone-mode.ts` requires OPENBRAIN_LOCAL_CLONE_ROOT to EXIST, and
+ * clause (f) drives that validation for real. Repo-relative and gitignored
+ * (`.gitignore:119`) rather than an absolute machine path — a hardcoded
+ * `/Volumes/...` default died with EACCES on the Linux CI runner once already
+ * (docs/lane-contract.md, #612 harvest).
+ */
+const CLONE_ROOT = fileURLToPath(
+  new URL("../../_scratch/done-means-659-clone-root", import.meta.url),
+);
+
+const results: Array<{ clause: string; ok: boolean; detail: string }> = [];
+
+function clause(name: string, ok: boolean, detail: string): void {
+  results.push({ clause: name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  (${name}) ${detail}`);
+}
+
+/**
+ * The env the deployed clone actually runs with: the env file's keys unioned
+ * with a handful of ambient launchd/shell variables. Values are placeholders —
+ * this driver never connects to anything — but the KEY SET is the real one,
+ * read from `/Volumes/ThunderBolt/open-brain-local/local-clone.env` on
+ * 2026-08-08. A fixture whose key set is invented would prove nothing about the
+ * deployment this issue is about (round 12: query the real distribution before
+ * inventing a fixture shape).
+ */
+function deployedEnv(): Record<string, string | undefined> {
+  return {
+    // --- allowlisted today, must keep passing (clause c) ---
+    ALLOWED_ORIGINS: "http://127.0.0.1:7100",
+    AUTH_TOKEN_ADMIN: "placeholder-admin",
+    AUTH_TOKEN_AGENT: "placeholder-agent",
+    AUTH_TOKEN_DISCORD: "placeholder-discord",
+    AUTH_TOKEN_OB_ADMIN: "placeholder-ob-admin",
+    AUTH_TOKEN_PROMOTER: "placeholder-promoter",
+    AUTH_TOKEN_READONLY: "placeholder-readonly",
+    AUTH_TOKEN_USER_RICO: "rico:placeholder-user-token",
+    DB_HOST: "127.0.0.1",
+    DB_NAME: "open_brain_local_clone",
+    DB_PASSWORD: "placeholder-db-password",
+    DB_POOL_MAX: "10",
+    DB_PORT: "55432",
+    DB_USER: "open_brain_local_clone",
+    EMBEDDING_API_KEY: "placeholder-embedding-key",
+    EMBEDDING_BASE_URL: "http://127.0.0.1:8791/v1",
+    EMBEDDING_DIMENSIONS: "768",
+    EMBEDDING_MODEL: "embeddinggemma-300m-8bit",
+    // Both runtime paths must sit beneath OPENBRAIN_LOCAL_CLONE_ROOT —
+    // `src/local-clone-mode.ts:17-20` enforces it, and clause (f) drives the
+    // real launcher through that validation.
+    LOG_FILE: `${CLONE_ROOT}/logs/open-brain.log`,
+    OPEN_BRAIN_BIND_HOST: "127.0.0.1",
+    OPEN_BRAIN_MAINTENANCE_ENABLED: "1",
+    OPEN_BRAIN_RUN_MIGRATIONS: "0",
+    OPENBRAIN_LOCAL_CLONE: "1",
+    OPENBRAIN_LOCAL_CLONE_ROOT: CLONE_ROOT,
+    OPENBRAIN_RECOVERY_WAL_PATH: `${CLONE_ROOT}/recovery.wal`,
+    OPENBRAIN_TRACING_ENABLED: "1",
+    OPENBRAIN_TRACING_ENDPOINT: "http://tracing.invalid:3000",
+    OPENBRAIN_TRACING_PUBLIC_KEY: "placeholder-public",
+    OPENBRAIN_TRACING_SECRET_KEY: "placeholder-secret",
+    OPENBRAIN_TRANSPORT: "http",
+    PORT: "3100",
+    // Clone mode requires QMD_PATH to be explicitly EMPTY, not merely unset
+    // (`src/local-clone-mode.ts`). The deployed env file sets it the same way.
+    QMD_PATH: "",
+
+    // --- the #659 subject: configured, read by the serving tree, dropped ---
+    [CAPTURE_HEALTH_NAMESPACE_ENV]: "rico",
+
+    // --- ambient, must NEVER reach the child and must NOT be announced ---
+    PATH: "/usr/bin:/bin",
+    HOME: "/placeholder/home",
+    SSH_AUTH_SOCK: "/placeholder/ssh-agent.sock",
+  };
+}
+
+/**
+ * A key that is not in the allowlist and never will be — the negative control.
+ * Deliberately carries the `OPENBRAIN_` prefix so it also proves the fix did not
+ * take the lazy route of passing an entire prefix family through.
+ */
+const JUNK_KEY = "OPENBRAIN_DEFINITELY_NOT_A_REAL_SERVER_KEY";
+
+/** One dropped key, as the launcher reports it: named, never valued. */
+interface DroppedChildEnvEntry {
+  readonly key: string;
+}
+type DropReporter = (
+  env: Record<string, string | undefined>,
+) => readonly DroppedChildEnvEntry[];
+
+/**
+ * Load the drop reporter DYNAMICALLY.
+ *
+ * A static `import { describeDroppedChildEnvironment }` against the pre-fix
+ * tree is a module-resolution SyntaxError: the driver dies before clause (a)
+ * ever prints, and every clause "fails" without having measured anything. That
+ * is a false RED — round 16's lesson, hit for real on this lane's first RED
+ * run. Resolving the export at runtime means the pre-fix tree produces a clean,
+ * per-clause, named RED and the surviving clauses still run.
+ */
+async function loadDropReporter(): Promise<DropReporter | undefined> {
+  const module = (await import("../local-clone.ts")) as Record<string, unknown>;
+  const reporter = module.describeDroppedChildEnvironment;
+  return typeof reporter === "function"
+    ? (reporter as DropReporter)
+    : undefined;
+}
+
+/** Absent on the pre-fix tree; each dependent clause says so by name. */
+const MISSING_REPORTER =
+  "scripts/local-clone.ts exports no describeDroppedChildEnvironment — " +
+  "the launcher has no way to report what it dropped (the #659 silent half)";
+
+async function main(): Promise<void> {
+  mkdirSync(CLONE_ROOT, { recursive: true });
+  const describeDropped = await loadDropReporter();
+  // -------------------------------------------------------------------------
+  // Clause (a) — the three capture-health keys reach the child.
+  //
+  // The key NAMES come from the observer's own exported constants rather than
+  // being retyped here. A driver that hardcodes the strings keeps passing when
+  // the observer renames one, which is the same substring-superset trap round
+  // 17 harvested: the clause must break when the subject moves.
+  // -------------------------------------------------------------------------
+  {
+    const env = {
+      ...deployedEnv(),
+      [CAPTURE_HEALTH_WINDOW_ENV]: "360",
+      [CAPTURE_HEALTH_REFRESH_ENV]: "60000",
+    };
+    const child = buildChildEnvironment(env);
+    const missing = [
+      CAPTURE_HEALTH_NAMESPACE_ENV,
+      CAPTURE_HEALTH_WINDOW_ENV,
+      CAPTURE_HEALTH_REFRESH_ENV,
+    ].filter((key) => child[key] === undefined);
+    clause(
+      "a",
+      missing.length === 0 &&
+        child[CAPTURE_HEALTH_NAMESPACE_ENV] === "rico" &&
+        child[CAPTURE_HEALTH_WINDOW_ENV] === "360" &&
+        child[CAPTURE_HEALTH_REFRESH_ENV] === "60000",
+      missing.length === 0
+        ? `all three capture-health keys reach the server child with their configured values ` +
+            `(namespace=${String(child[CAPTURE_HEALTH_NAMESPACE_ENV])})`
+        : `capture-health keys DROPPED by the launcher: ${missing.join(", ")} — ` +
+            `the merged #656 observer cannot go RUNNING on the deployed clone`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (b) — a configured-but-unlisted key is ANNOUNCED as dropped.
+  //
+  // Today this is silent, which is the half of #659 that keeps the bug
+  // renewable. The announcement must NAME the key: a count tells the operator
+  // something was ignored without saying what, which is unactionable at exactly
+  // the moment it matters (SME #464).
+  // -------------------------------------------------------------------------
+  {
+    const env = { ...deployedEnv(), [JUNK_KEY]: "configured-but-unlisted" };
+    if (describeDropped === undefined) {
+      clause("b", false, MISSING_REPORTER);
+      clause("b:no-values", false, MISSING_REPORTER);
+    } else {
+      const dropped = describeDropped(env);
+      const names = dropped.map((entry) => entry.key);
+      clause(
+        "b",
+        names.includes(JUNK_KEY),
+        names.includes(JUNK_KEY)
+          ? `a configured-but-unlisted key is named in the launcher's drop report: ${JUNK_KEY}`
+          : `configured key ${JUNK_KEY} was dropped SILENTLY — reported keys: ` +
+              `${names.length === 0 ? "(none)" : names.join(", ")}`,
+      );
+
+      // The announcement must not leak the VALUE. The dropped set includes
+      // secrets in the general case (an unlisted AUTH_TOKEN_* spelling would
+      // land here), and this line goes to a log file the deploy runbook tells
+      // an operator to read. Names are diagnostic; values are a credential leak.
+      const serialized = JSON.stringify(dropped);
+      clause(
+        "b:no-values",
+        !serialized.includes("configured-but-unlisted"),
+        !serialized.includes("configured-but-unlisted")
+          ? "the drop report names keys without echoing their values"
+          : "the drop report ECHOES the dropped VALUE — a secret in an unlisted key would be logged",
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (c) — CONTROL: the families that already work still work.
+  //
+  // Passes PRE-fix by design. A check that fails everywhere proves only that it
+  // fails (round 13); this is what distinguishes "the allowlist gained three
+  // keys" from "the allowlist was rewritten and broke the deploy".
+  // -------------------------------------------------------------------------
+  {
+    const child = buildChildEnvironment(deployedEnv());
+    const ok =
+      child.DB_PASSWORD === "placeholder-db-password" &&
+      child.DB_HOST === "127.0.0.1" &&
+      child.AUTH_TOKEN_ADMIN === "placeholder-admin" &&
+      child.AUTH_TOKEN_USER_RICO === "rico:placeholder-user-token" &&
+      child.OPENBRAIN_TRACING_ENABLED === "1" &&
+      child.OPENBRAIN_TRACING_SECRET_KEY === "placeholder-secret";
+    clause(
+      "c",
+      ok,
+      ok
+        ? "control: DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_* and OPENBRAIN_TRACING_* all still reach the child"
+        : "REGRESSION: a previously-passing env family no longer reaches the server child",
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (d) — CONTROL: the allowlist is still an allowlist.
+  //
+  // The ruling is "announced, not abolished". This fails any fix that passes
+  // the whole environment through, and — because JUNK_KEY carries the
+  // OPENBRAIN_ prefix — any fix that waves a whole prefix family through.
+  // Also asserts the ambient host variables the launcher was built to strip.
+  // -------------------------------------------------------------------------
+  {
+    const env = { ...deployedEnv(), [JUNK_KEY]: "configured-but-unlisted" };
+    const child = buildChildEnvironment(env);
+    const leaked = [JUNK_KEY, "PATH", "HOME", "SSH_AUTH_SOCK"].filter(
+      (key) => child[key] !== undefined,
+    );
+    clause(
+      "d",
+      leaked.length === 0,
+      leaked.length === 0
+        ? `control: the allowlist holds — ${JUNK_KEY} and the ambient host vars are still excluded`
+        : `the allowlist was ABOLISHED, not announced: ${leaked.join(", ")} reached the child`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (e) — MUTATION PROOF for the negative-match scope rule.
+  //
+  // Clause (b) passes on a filter that announces EVERYTHING, and clause (d)
+  // does not constrain the report at all. Round 9: mutation-check any clause
+  // whose PASS comes from a negative match — those pass both when the thing is
+  // absent and when the check is broken. So the scope is asserted from both
+  // sides in one clause: the ambient vars must NOT be announced (or the line
+  // becomes boot noise an operator learns to skip) while the configured one
+  // MUST be. A filter that announces nothing fails the first half; a filter
+  // that announces everything fails the second.
+  // -------------------------------------------------------------------------
+  {
+    const env = { ...deployedEnv(), [JUNK_KEY]: "configured-but-unlisted" };
+    if (describeDropped === undefined) {
+      clause("e", false, MISSING_REPORTER);
+    } else {
+      const names = describeDropped(env).map((e) => e.key);
+      const noisy = ["PATH", "HOME", "SSH_AUTH_SOCK"].filter((key) =>
+        names.includes(key),
+      );
+      const announcesSubject = names.includes(JUNK_KEY);
+      clause(
+        "e",
+        noisy.length === 0 && announcesSubject,
+        `scope, both directions: ambient host vars announced=${
+          noisy.length === 0 ? "no" : noisy.join(",")
+        }, configured unlisted key announced=${announcesSubject}` +
+          (noisy.length === 0 && announcesSubject
+            ? ""
+            : " — an unscoped report is boot noise; an empty one is silence with extra steps"),
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (f) — CHAIN: the announcement reaches the LAUNCHER'S OWN OUTPUT.
+  //
+  // Clauses (a)-(e) prove the functions compute the right thing. This one
+  // proves the start path actually SAYS it, by driving the real
+  // `runLocalCloneLauncher` through its injected boundaries and capturing what
+  // it reports. #656's done-means drove `createShadowApplication` directly and
+  // so had this entire launcher seam outside its vantage — which is precisely
+  // why #659 survived a passing check and a passing revision proof. A function
+  // whose output nothing prints is the silent drop wearing a different hat.
+  // -------------------------------------------------------------------------
+  {
+    const env = { ...deployedEnv(), [JUNK_KEY]: "configured-but-unlisted" };
+    const announced: string[] = [];
+    let spawnedEnv: Record<string, string> | undefined;
+
+    const child = new EventEmitter() as ChildProcess;
+    (child as { exitCode: number | null }).exitCode = null;
+    (child as { signalCode: NodeJS.Signals | null }).signalCode = null;
+
+    const deps: LocalCloneLauncherDependencies = {
+      database: {
+        prove: async () => ({
+          database: "open_brain_local_clone",
+          user: "open_brain_local_clone",
+          serverAddress: "127.0.0.1",
+          serverPort: 55432,
+          postgresMajor: 18,
+          transactionReadOnly: true,
+          pgvectorAvailable: true,
+          pgvectorInstalled: true,
+        }),
+      },
+      embedding: {
+        prove: async () => ({
+          model: "embeddinggemma-300m-8bit",
+          dimensions: 768,
+        }),
+      },
+      child: {
+        spawn: (childEnv) => {
+          spawnedEnv = childEnv;
+          queueMicrotask(() => child.emit("exit", 0, null));
+          return child;
+        },
+      },
+      writeReceipt: () => {},
+      onSignal: () => () => {},
+      // The announcement sink. Cast because the pre-fix
+      // `LocalCloneLauncherDependencies` has no such member — driving the real
+      // launcher is the point of this clause, and on the pre-fix tree the
+      // absent sink is exactly what makes it RED rather than a type error that
+      // stops the whole driver.
+      announce: (line: string) => announced.push(line),
+    } as LocalCloneLauncherDependencies;
+
+    try {
+      const code = await runLocalCloneLauncher("start", env, deps);
+      const line = announced.join("\n");
+      const namesSubject = line.includes(JUNK_KEY);
+      const quietOnAmbient = !/\bPATH\b|\bSSH_AUTH_SOCK\b/.test(line);
+      const reachedChild =
+        spawnedEnv?.[CAPTURE_HEALTH_NAMESPACE_ENV] === "rico";
+      clause(
+        "f",
+        code === 0 && namesSubject && quietOnAmbient && reachedChild,
+        `chain: launcher exit=${code}, announced ${announced.length} line(s), ` +
+          `names the dropped key=${namesSubject}, quiet on ambient=${quietOnAmbient}, ` +
+          `capture namespace reached the spawned child=${reachedChild}` +
+          (namesSubject
+            ? ""
+            : " — the drop is computable but the launcher never prints it"),
+      );
+    } catch (error: unknown) {
+      clause(
+        "f",
+        false,
+        `chain: the launcher start path threw before announcing: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  finish();
+}
+
+function finish(): void {
+  const failed = results.filter((r) => !r.ok);
+  console.log();
+  console.log(`clauses: ${results.length} run, ${failed.length} failed`);
+  if (failed.length > 0) {
+    console.log(`failing: ${failed.map((f) => f.clause).join(", ")}`);
+  }
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+// An exception escaping `main` must FAIL, loudly. Without this a top-level
+// throw lets Bun print a trace and still exit 0 — a crashing subject banks a
+// false GREEN (docs/lane-contract.md round 13; SME order 67).
+main().catch((error: unknown) => {
+  console.log();
+  console.log(
+    `FAIL  (driver) threw before completing: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exit(1);
+});

--- a/scripts/done-means/659-launcher-env-passthrough.sh
+++ b/scripts/done-means/659-launcher-env-passthrough.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #659 — "the local-clone launcher's child-env
+# allowlist carries the capture-health keys, and announces every configured key
+# it drops".
+#
+#   bash scripts/done-means/659-launcher-env-passthrough.sh
+#
+# ---------------------------------------------------------------------------
+# THE GAP THIS CLOSES
+# ---------------------------------------------------------------------------
+# PR #656 merged the capture-health observer wiring, ledger item 28 supplied the
+# config ruling, and OPENBRAIN_CAPTURE_HEALTH_NAMESPACE was set in the deployed
+# clone's env file. The clone was redeployed with a PASSING revision proof — and
+# live /health published no capture block. The launcher process had the
+# variable; the server child it spawned did not.
+#
+# Verifiable at origin/main:
+#
+#   $ rg -n 'CAPTURE_HEALTH' scripts/local-clone.ts
+#   (no matches)
+#
+# `buildChildEnvironment()` passes an allowlist (CHILD_ENV_KEYS) plus two prefix
+# families (AUTH_TOKEN_USER_*, OPENBRAIN_TRACING_*). OPENBRAIN_CAPTURE_HEALTH_*
+# is in neither, so the launcher drops it. This is the THIRD instance of the
+# deploy-coupling class the code documents at its own #530 tracing comment
+# ("must reach the server child or createTracingRuntime silently stays off").
+#
+# ---------------------------------------------------------------------------
+# TWO DEFECTS, NOT ONE
+# ---------------------------------------------------------------------------
+#   1. The three OPENBRAIN_CAPTURE_HEALTH_* keys do not reach the server child.
+#   2. The allowlist drops CONFIGURED keys with no signal, so every future
+#      server config key re-buys this bug. That violates "Nothing is adjusted
+#      silently" (AGENTS.md coding standard, operator ruling 2026-08-08) and is
+#      the class already in the SME KB as #464, "An allowlist that drops
+#      unrecognized keys is accept-and-ignore, not tolerance" — whose first
+#      review question is exactly "does the drop path name what it dropped?"
+#
+# Fixing only (1) closes this issue and leaves the mechanism that produced it.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) The three capture-health keys reach the child with their configured
+#       values. Key names come from the observer's exported constants, so a
+#       rename breaks the clause instead of silently passing. RED on main.
+#   (b) A configured-but-unlisted key is NAMED in the launcher's drop report.
+#       RED on main: the drop is entirely silent. Paired with (b:no-values),
+#       which proves the report names keys WITHOUT echoing values — an unlisted
+#       AUTH_TOKEN_* spelling would otherwise put a credential in the log.
+#   (c) CONTROL — DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_*, OPENBRAIN_TRACING_*
+#       still pass. Passes PRE-fix by design (round 13: a check that fails
+#       everywhere proves only that it fails).
+#   (d) CONTROL — the allowlist stays an allowlist. A deliberately-unlisted junk
+#       key (carrying the OPENBRAIN_ prefix, so a lazy whole-family passthrough
+#       fails too) and the ambient PATH/HOME/SSH_AUTH_SOCK must NOT reach the
+#       child. Fails any "fix" that passes the whole environment.
+#   (e) MUTATION PROOF for the negative-match scope rule. (b) passes on a filter
+#       that announces everything; (d) does not constrain the report at all. So
+#       (e) asserts scope from BOTH sides in one clause: ambient host vars are
+#       NOT announced AND the configured key IS. A filter announcing nothing
+#       fails one half, one announcing everything fails the other.
+#   (f) CHAIN — the announcement reaches the launcher's OWN OUTPUT, proven by
+#       driving the real runLocalCloneLauncher start path through its injected
+#       boundaries. #656's done-means drove createShadowApplication directly and
+#       had this whole launcher seam outside its vantage, which is why #659
+#       survived a passing check AND a passing revision proof.
+#
+# No database, no network, no real child process — the subjects are pure
+# functions over a record plus the launcher's already-injectable boundaries.
+# Content-free output: clause names, states, key names.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRIVER="scripts/done-means/659-launcher-env-passthrough.driver.ts"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "FAIL  driver missing: $DRIVER"
+  echo "DONE-MEANS #659: FAIL"
+  exit 1
+fi
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  driver: $DRIVER (pure env projection + injected launcher boundaries; no DB, no network)"
+echo
+
+set +e
+bun "$DRIVER"
+DRIVER_STATUS=$?
+set -e
+
+echo
+if [[ $DRIVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #659: PASS — the capture-health keys reach the server child, and configured keys the allowlist drops are announced by name."
+else
+  echo "DONE-MEANS #659: FAIL — the launcher still drops configured server config keys, or drops them silently."
+fi
+exit $DRIVER_STATUS

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   buildChildEnvironment,
+  describeDroppedChildEnvironment,
   LOCAL_CLONE_VERIFY_RECEIPT_SCHEMA,
   productionDependencies,
   runLocalCloneLauncher,
@@ -68,6 +69,7 @@ function fakeDependencies(
     child: { spawn: () => childProcess() },
     writeReceipt: () => undefined,
     onSignal: () => () => undefined,
+    announce: () => undefined,
     ...overrides,
   };
 }
@@ -251,6 +253,91 @@ describe("local clone launcher", () => {
     expect(spawnedEnv).not.toHaveProperty("SSH_AUTH_SOCK");
     expect(spawnedEnv).not.toHaveProperty("CORE01_HOST");
     expect(handlers.size).toBe(0);
+  });
+
+  // #659: the capture-health observer merged in #656 builds nothing unless
+  // these reach the server child. The clone was redeployed with a PASSING
+  // revision proof and live /health still published no capture block, because
+  // the launcher dropped the configured namespace in silence.
+  it("passes the capture-health observer configuration to the server child", () => {
+    const child = buildChildEnvironment({
+      ...cloneEnv(),
+      OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "rico",
+      OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: "360",
+      OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: "60000",
+    });
+    expect(child.OPENBRAIN_CAPTURE_HEALTH_NAMESPACE).toBe("rico");
+    expect(child.OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES).toBe("360");
+    expect(child.OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS).toBe("60000");
+  });
+
+  it("names a configured server-config key it drops, without echoing its value", () => {
+    const dropped = describeDroppedChildEnvironment({
+      ...cloneEnv(),
+      OPENBRAIN_SOME_FUTURE_SERVER_KEY: "super-secret-value",
+    });
+    expect(dropped.map((entry) => entry.key)).toContain(
+      "OPENBRAIN_SOME_FUTURE_SERVER_KEY",
+    );
+    expect(JSON.stringify(dropped)).not.toContain("super-secret-value");
+  });
+
+  it("does not report ambient host variables as dropped configuration", () => {
+    // The autostart wrapper sources the env file with `set -a`, so the
+    // launcher's environment is the env file UNIONED with launchd's. A report
+    // naming PATH and HOME on every boot is noise an operator learns to skip,
+    // which is silence with extra steps.
+    const dropped = describeDroppedChildEnvironment({
+      ...cloneEnv(),
+      PATH: "/usr/bin:/bin",
+      HOME: "/Users/placeholder",
+      SSH_AUTH_SOCK: "/placeholder/agent.sock",
+    }).map((entry) => entry.key);
+    expect(dropped).not.toContain("PATH");
+    expect(dropped).not.toContain("HOME");
+    expect(dropped).not.toContain("SSH_AUTH_SOCK");
+  });
+
+  it("reporting a dropped key does not deliver it — the allowlist stays an allowlist", () => {
+    const env = {
+      ...cloneEnv(),
+      OPENBRAIN_SOME_FUTURE_SERVER_KEY: "configured-but-unlisted",
+    };
+    expect(
+      describeDroppedChildEnvironment(env).map((entry) => entry.key),
+    ).toContain("OPENBRAIN_SOME_FUTURE_SERVER_KEY");
+    expect(buildChildEnvironment(env)).not.toHaveProperty(
+      "OPENBRAIN_SOME_FUTURE_SERVER_KEY",
+    );
+  });
+
+  it("announces the dropped keys on the start path before spawning", async () => {
+    const child = childProcess();
+    const announced: string[] = [];
+    const deps = fakeDependencies({
+      child: {
+        spawn: () => {
+          queueMicrotask(() => child.emit("exit", 0, null));
+          return child;
+        },
+      },
+      announce: (line) => announced.push(line),
+    });
+
+    const code = await runLocalCloneLauncher(
+      "start",
+      { ...cloneEnv(), OPENBRAIN_SOME_FUTURE_SERVER_KEY: "unlisted" },
+      deps,
+    );
+
+    expect(code).toBe(0);
+    expect(announced.join("\n")).toContain("OPENBRAIN_SOME_FUTURE_SERVER_KEY");
+  });
+
+  it("stays quiet when every configured server-config key is delivered", () => {
+    // The healthy path must not emit the notice, or the line is decoration an
+    // operator cannot use to tell a broken deploy from a normal one.
+    expect(describeDroppedChildEnvironment(cloneEnv())).toEqual([]);
   });
 
   it("rejects an environment that is not explicitly local-clone mode", async () => {

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -53,6 +53,15 @@ const CHILD_ENV_KEYS = [
   "NODE_ENV",
   "OPENBRAIN_LOCAL_CLONE",
   "OPENBRAIN_LOCAL_CLONE_ROOT",
+  // #659 capture-health observer (PR #656, ledger item 28): these three must
+  // reach the server child or `createCaptureHealthRuntime` builds no observer
+  // and /health publishes no capture block -- the same deploy coupling the
+  // #530 tracing comment below documents, third instance. Listed by NAME
+  // rather than by an `OPENBRAIN_CAPTURE_HEALTH_` prefix sweep so that adding
+  // a fourth key stays a deliberate act with a reviewer attached.
+  "OPENBRAIN_CAPTURE_HEALTH_NAMESPACE",
+  "OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS",
+  "OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES",
   "OPENBRAIN_RECOVERY_WAL_PATH",
   "OPEN_BRAIN_BIND_HOST",
   "OPEN_BRAIN_MAINTENANCE_ENABLED",
@@ -99,6 +108,12 @@ export interface LocalCloneLauncherDependencies {
   child: ChildBoundary;
   writeReceipt(receipt: unknown): void;
   onSignal(signal: NodeJS.Signals, handler: () => void): () => void;
+  /**
+   * The launcher's normal operational output -- diagnostics an operator reads,
+   * kept separate from `writeReceipt` because the verify receipt is a
+   * content-free machine-parsed JSON document and must stay one line.
+   */
+  announce(line: string): void;
 }
 
 interface DatabaseProbeRow {
@@ -137,6 +152,71 @@ export function parseLocalCloneArgs(argv: string[]): LauncherMode {
   if (argv.length === 1 && argv[0] === "--verify") return "verify";
   if (argv.length === 1 && argv[0] === "--start") return "start";
   throw new Error("Usage: bun run scripts/local-clone.ts --verify | --start");
+}
+
+/**
+ * Prefixes that mark a variable as OPEN BRAIN SERVER CONFIGURATION.
+ *
+ * The launcher's environment is the clone env file UNIONED with launchd's
+ * ambient environment (`scripts/local-clone-autostart.sh:56-59` does
+ * `set -a; source local-clone.env`), so "everything not allowlisted" includes
+ * `PATH`, `HOME`, `SSH_AUTH_SOCK` and dozens more. Announcing all of them on
+ * every boot is noise that teaches an operator to skip the line -- silence with
+ * extra steps. Announcing none of them is #659. So the drop report is scoped to
+ * the namespaces this project actually configures itself with.
+ */
+const SERVER_CONFIG_PREFIXES = [
+  "ALLOWED_",
+  "AUTH_TOKEN_",
+  "DB_",
+  "EMBEDDING_",
+  "LOG_",
+  "OPENBRAIN_",
+  "OPEN_BRAIN_",
+  "SERVICE_",
+] as const;
+
+/** One configured key the child environment does not carry. */
+export interface DroppedChildEnvEntry {
+  readonly key: string;
+}
+
+/**
+ * The keys that LOOK like Open Brain server configuration and are nevertheless
+ * dropped from the child environment.
+ *
+ * This exists because an allowlist that discards a configured key without
+ * saying so is accept-and-ignore, not tolerance -- the class already recorded
+ * in `docs/sme/gotcha-agent.md` from #464, whose first review question is
+ * "does the drop path name what it dropped?". #659 is that question answered
+ * the wrong way for a third time: `OPENBRAIN_CAPTURE_HEALTH_NAMESPACE` was set
+ * in the deployed env file, the redeploy's revision proof PASSED, and live
+ * /health still published no capture block, because the launcher dropped the
+ * key in silence.
+ *
+ * Returned as NAMES ONLY, never values. The dropped set can contain secrets in
+ * the general case -- an unlisted `AUTH_TOKEN_*` spelling lands here -- and
+ * this report is written to a log file the deploy runbook tells an operator to
+ * read.
+ *
+ * Reporting is not honoring: the allowlist stays an allowlist. A key named here
+ * is one a human must either add to `CHILD_ENV_KEYS` or delete from the env
+ * file.
+ */
+export function describeDroppedChildEnvironment(
+  env: Record<string, string | undefined>,
+): readonly DroppedChildEnvEntry[] {
+  const delivered = buildChildEnvironment(env);
+  const dropped: DroppedChildEnvEntry[] = [];
+  for (const [key, configured] of Object.entries(env)) {
+    if (configured === undefined) continue;
+    if (delivered[key] !== undefined) continue;
+    if (!SERVER_CONFIG_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+      continue;
+    }
+    dropped.push({ key });
+  }
+  return dropped.sort((left, right) => left.key.localeCompare(right.key));
 }
 
 export function buildChildEnvironment(
@@ -279,6 +359,22 @@ export async function runLocalCloneLauncher(
       },
     });
     return 0;
+  }
+
+  // Announce BEFORE spawning. A server that starts without the config key it
+  // was given is the #659 failure, and the operator's chance to notice is the
+  // boot log -- which is only useful if the line precedes the child's own
+  // output rather than being buried under it.
+  const dropped = describeDroppedChildEnvironment(env);
+  if (dropped.length > 0) {
+    deps.announce(
+      `local-clone launcher ADJUSTED the server child's environment: ` +
+        `${dropped.length} configured key(s) are NOT in the child allowlist and ` +
+        `were dropped -- ${dropped.map((entry) => entry.key).join(", ")}. ` +
+        `The server child will not see them. Add each to CHILD_ENV_KEYS in ` +
+        `scripts/local-clone.ts if it is meant to reach the server, or remove ` +
+        `it from the clone env file if it is not.`,
+    );
   }
 
   let child: ChildProcess;
@@ -429,6 +525,13 @@ export const productionDependencies: LocalCloneLauncherDependencies = {
   onSignal(signal, handler): () => void {
     process.on(signal, handler);
     return () => process.off(signal, handler);
+  },
+  announce(line): void {
+    // stderr, not stdout: `writeReceipt` puts a machine-parsed JSON document on
+    // stdout, and an operator diagnostic sharing that stream would corrupt it.
+    // The autostart wrapper captures both into the same log file, so the
+    // operator still reads this line where they look for boot problems.
+    process.stderr.write(`${line}\n`);
   },
 };
 


### PR DESCRIPTION
## Summary

- Closes #659. `scripts/local-clone.ts` `buildChildEnvironment()` passes the server child an allowlist (`CHILD_ENV_KEYS`) plus two prefix families. The three `OPENBRAIN_CAPTURE_HEALTH_*` keys were in neither, so the launcher dropped them — and dropped them **silently**. `OPENBRAIN_CAPTURE_HEALTH_NAMESPACE=rico` sat in the deployed clone's env file, the redeploy's revision proof PASSED, and live `/health` still published no capture block. The launcher process had the variable; the child it spawned did not. The merged #656 observer could not go RUNNING.
- **Defect 1 — the keys.** The three capture-health keys are now in `CHILD_ENV_KEYS`, listed **by name** rather than swept in by an `OPENBRAIN_CAPTURE_HEALTH_` prefix, so adding a fourth stays a deliberate act with a reviewer attached. This is the third instance of the deploy-coupling class the file already documents at its own #530 tracing comment ("must reach the server child or `createTracingRuntime` silently stays off").
- **Defect 2 — the silence.** New `describeDroppedChildEnvironment()` reports every configured key the child allowlist drops, and the start path announces it **before** spawning. Fixing only defect 1 closes the issue and leaves the mechanism that produced it: every future server config key would re-buy this same bug. This is the class already recorded in `docs/sme/gotcha-agent.md` from #464 — "An allowlist that drops unrecognized keys is accept-and-ignore, not tolerance" — whose first review question is exactly *does the drop path name what it dropped?*
- **The allowlist stays an allowlist.** Reporting is not honoring; the ruling is announced, not abolished. A key named in the report is one a human must either add to `CHILD_ENV_KEYS` or delete from the env file. Clause (d) fails any "fix" that passes the whole environment through, and the junk key it uses carries the `OPENBRAIN_` prefix so a lazy whole-family passthrough fails too.
- **Two scoping decisions, both asserted rather than assumed.** The report is scoped to Open Brain server-config prefixes because `scripts/local-clone-autostart.sh:56-59` does `set -a; source local-clone.env`, making the launcher's environment the env file unioned with launchd's — an unscoped report would name `PATH` and `HOME` on every boot, noise an operator learns to skip, which is silence with extra steps. And it returns **names only, never values**: the dropped set contains secrets in the general case (an unlisted `AUTH_TOKEN_*` spelling lands there) and this line goes to a log file the deploy runbook tells an operator to read.

**Found while fixing, wider than the issue as filed (PROPOSED, not addressed here):** the deployed env file configures **seven** keys this allowlist drops, not three. Besides the capture-health key: `EMBEDDING_WATCHDOG_RESTART_SCRIPT`, `LOG_LEVEL`, `LOG_MAX_BYTES`, `LOG_MAX_FILES`, `OPENBRAIN_MCP_AUDIT_ENABLED`, `SERVICE_NAME` — every one read by the serving tree, and `LOG_LEVEL`/`SERVICE_NAME` read by `server/config.ts` itself, where they silently default (`:124`, `:126`). So the operator sets `LOG_LEVEL` and the server runs at `info` regardless. Those are left for an operator ruling rather than swept into the allowlist here: honoring a key changes deployed behavior and is not this issue's scope. **The announcement now makes all six visible on the next boot instead of leaving them invisible.**

## Verification

- Done-means: scripts/done-means/659-launcher-env-passthrough.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED** (at `origin/main`, before the fix — real nonzero exit):

```
FAIL  (a) capture-health keys DROPPED by the launcher: OPENBRAIN_CAPTURE_HEALTH_NAMESPACE, OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES, OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS
FAIL  (b) scripts/local-clone.ts exports no describeDroppedChildEnvironment — the launcher has no way to report what it dropped
FAIL  (b:no-values) (same cause)
PASS  (c) control: DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_* and OPENBRAIN_TRACING_* all still reach the child
PASS  (d) control: the allowlist holds — junk key and ambient host vars still excluded
FAIL  (e) (same cause)
FAIL  (f) chain: launcher exit=0, announced 0 line(s), names the dropped key=false, capture namespace reached the spawned child=false
clauses: 7 run, 5 failed          EXIT=1
```

Controls (c) and (d) **pass pre-fix by design** — a check that fails everywhere proves only that it fails. Clause (f) is the live symptom exactly: the launcher ran to completion, announced nothing, and the namespace never reached the child.

**GREEN** (after the fix): `clauses: 7 run, 0 failed`, exit 0. Also re-run from a **clean clone** of the pushed branch (7/7) — the only thing that catches a lane file silently dropped by `.gitignore`.

- `bun run test:isolated` — **3747 pass, 35 skip, 0 fail**, 15298 expect() calls, 244 files; isolated DB dropped cleanly.
- `bunx tsc --noEmit` — clean. It caught the real boundary: adding `announce` to `LocalCloneLauncherDependencies` broke the test fixture, which is the type system doing its job.

**Mutation proofs** (every negative-match clause seen to fail):

1. *Allowlist abolished* (pass whole env) → (d) FAILS naming `PATH, HOME, SSH_AUTH_SOCK` as leaked; (b)(e)(f) also catch it.
2. *Scope filter removed* (announce everything) → (e) FAILS with `ambient host vars announced=PATH,HOME,SSH_AUTH_SOCK`. **Only (e) catches this** — every other clause accepts an announce-everything filter, which is why the scope is asserted from both sides in one clause.
3. *One capture key renamed* → (a) FAILS naming just that key, proving it is not a substring superset (round 17).
4. *Key removed from allowlist* → the new unit test `passes the capture-health observer configuration to the server child` FAILS. New tests proven able to fail before being trusted.

## Critical Self-Review

- Highest-risk behavior: the `SERVER_CONFIG_PREFIXES` scope. Too narrow and a genuinely-dropped key stays invisible (the #659 defect, quieter); too wide and the boot log becomes noise an operator skips. Asserted from both directions by clause (e) and mutation 2, but it is a heuristic over key *names* and a future key outside these eight prefixes would not be reported.
- Assumptions that could be wrong: that announcing on **stderr** reaches the operator. Verified the autostart wrapper does not redirect the streams separately, so both land in the same log file — but I did not observe the deployed log after a real restart, because redeploy is the controller's post-merge step. If some launchd plist splits the streams, the line lands in a file nobody reads.
- Missing/weak tests: no test asserts the announcement's exact wording or that it precedes the spawn — clause (f) proves ordering only implicitly (the announce happens before `deps.child.spawn`, but nothing fails if that order is swapped). The `announce`-before-spawn intent is enforced by code position and a comment, not by a check.
- Security/permission risk: the report could log a secret. Actively defended: `b:no-values` asserts values never appear, and mutation-checked by construction (the junk key's value is a distinctive string the clause greps for). Names of secret-bearing keys can still appear, which is intended and is not itself a leak.
- Migration/deploy risk: none in-repo. Deploy-side, this changes what the server child receives — that is the point. The capture-health observer will construct on the next redeploy where the namespace is set, so `/health` gains a `capture` block. Per #656's design absence stays green, so a clone without the namespace is unaffected.
- Downstream client/runtime risk: none. `scripts/local-clone.ts` is the local dogfood launcher only; it is explicitly not the core01 deploy path (`com.rico.open-brain`) and no client, MCP tool, schema, or Python surface is touched.
- Rollback/cleanup concern: revert the commit. The `announce` dependency is a new **required** member of `LocalCloneLauncherDependencies`, so any out-of-tree construction of that object would need updating — there are none in this repo beyond `productionDependencies` and the test fixture.
- Fixes made before PR: (1) my first RED was a **false RED** — a static import of the not-yet-existing export killed the driver at module resolution, so clauses (a)/(c)/(d) measured nothing; switched to a dynamic import so the pre-fix tree gives a clean per-clause RED, and re-proved RED afterward. (2) Clause (f) initially failed on three successive *fixture* defects (WAL path, clone-root existence, `QMD_PATH`), not the defect under test; corrected so (f) fails for the right reason. (3) The clone-root fixture was moved to a repo-relative gitignored `_scratch/` path rather than an absolute machine path, which died with EACCES on the Linux CI runner once before (#612).
- Known residual risk: **the live half is unproven from here.** Every claim in this PR is at the code/check level. That the deployed clone actually publishes a capture block requires a redeploy plus a live `/health` read, which is the controller's post-merge step — and #659 exists precisely because a passing revision proof was mistaken for that. Also: the six other silently-dropped keys are named above but not honored; `LOG_LEVEL` and `SERVICE_NAME` still silently default in `server/config.ts` regardless of the env file.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the class is already the active entry "An allowlist that drops unrecognized keys is accept-and-ignore, not tolerance" (`docs/sme/gotcha-agent.md`, from #464). This PR is a third instance of that recorded pattern, not a new one — its review questions are what shaped the fix. A new entry would duplicate it; the lane report proposes adding #659 as provenance to the existing entry instead.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the launcher is proven through its injected boundaries with no DB and no network; the live proof is the post-merge redeploy plus a `/health` read, which belongs to the controller and is named as residual risk above.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is the local dogfood launcher's process-spawn boundary. No MCP tool, schema, transport, or client contract is touched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: the change is confined to `scripts/local-clone.ts` and its test, plus a new done-means check. No MCP tool, schema, protocol, or client-facing surface changes, so no downstream runtime consumes anything different. The one deploy-side consequence — the server child receiving three more env keys — lands on the local dogfood clone only, not core01.
