### PR TITLE
fix(local-clone): honor five ruled env keys, stop announcing suppressions

### DIFF
--- a/scripts/done-means/661-launcher-honors-six-keys.driver.ts
+++ b/scripts/done-means/661-launcher-honors-six-keys.driver.ts
@@ -1,0 +1,606 @@
+/**
+ * DONE-MEANS driver for #661 — the launcher HONORS the configured keys that
+ * #660 taught it to announce as dropped, and stops announcing the one that was
+ * never a configuration at all.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS A SEPARATE ISSUE FROM #659
+ * ---------------------------------------------------------------------------
+ * #659 made the drop VISIBLE: `describeDroppedChildEnvironment` names every
+ * configured-looking key the allowlist discards, and the start path announces
+ * it before spawning. The moment drops became visible, the deployed clone's
+ * boot line named six more keys that had been silently dropped for their whole
+ * life. Observed RUNNING 2026-08-08 22:45Z.
+ *
+ * ---------------------------------------------------------------------------
+ * THE AMENDED RULING (29.2a) AND WHY IT IS FIVE, NOT SIX
+ * ---------------------------------------------------------------------------
+ * Ledger item 29.2 read "all six are honored". Writing this check RED-first
+ * proved one of the six could not be: the launcher THREW on it, at a guard,
+ * before reaching the allowlist at all.
+ *
+ *   FAIL (b) Local clone mode prohibits EMBEDDING_WATCHDOG_RESTART_SCRIPT
+ *
+ * `src/local-clone-mode.ts:15` lists that key in `PROHIBITED_PATH_KEYS` and
+ * lines 190-194 refuse any non-empty value, pinned by a passing test at
+ * `src/local-clone-mode.test.ts:138-145`. In the deployed env file it is set
+ * EMPTY (`local-clone.env:17`) — the documented clone-mode suppression form,
+ * shown as exactly `EMBEDDING_WATCHDOG_RESTART_SCRIPT=` in
+ * `docs/local-clone-dogfood.md:147`, the same shape as `QMD_PATH=`. It appeared
+ * in the boot line only because the reporter skipped on `undefined` and not on
+ * the empty string, so an explicitly-DISABLED key read as a dropped
+ * CONFIGURATION.
+ *
+ * Operator ruling 2026-08-08 (29.2a) on that finding: honor the FIVE keys that
+ * carry real values, leave the watchdog key out because the clone-mode
+ * prohibition guard wins, and teach the reporter to tell unset / set-empty /
+ * set-valued apart.
+ *
+ *   HONORED (five):  LOG_LEVEL, LOG_MAX_BYTES, LOG_MAX_FILES,
+ *                    OPENBRAIN_MCP_AUDIT_ENABLED, SERVICE_NAME
+ *   NOT honored:     EMBEDDING_WATCHDOG_RESTART_SCRIPT (prohibited in clone
+ *                    mode; empty in the env file means deliberately off)
+ *
+ * Announcing a deliberate configuration and then ignoring it is
+ * accept-and-ignore with a receipt — the #464 class one step further along, and
+ * the same deploy coupling as #530 (tracing) and #659 (capture-health). The
+ * announcement is the correct mechanism; it is not the resolution. But
+ * announcing a deliberate SUPPRESSION is the mirror defect: a false positive
+ * that teaches an operator the line is noise.
+ *
+ * ---------------------------------------------------------------------------
+ * CLAUSES
+ * ---------------------------------------------------------------------------
+ *   (a) Each of the five honored keys, set in the input env, appears in
+ *       `buildChildEnvironment` output with its configured value. RED on the
+ *       pre-fix tree: all five are absent.
+ *   (b) With the five honored and the watchdog key empty-suppressed, the
+ *       launcher's boot announcement for THIS env file goes SILENT. Both halves
+ *       in ONE clause (round 18): no announce line at all AND the five keys
+ *       present in the spawned child's env. Split apart, "no announce line"
+ *       passes on a launcher that announces nothing and delivers nothing —
+ *       which is the pre-#659 world. Driven through the REAL
+ *       `runLocalCloneLauncher` start path via its injected boundaries, because
+ *       the launcher spawn chain is exactly the seam #659 lived in.
+ *   (c) CONTROL, mutation-proofed — the allowlist stays an allowlist AND the
+ *       announce mechanism stays alive. A junk unlisted key carrying a HONORED
+ *       key's own prefix must still NOT reach the child, and MUST still be
+ *       announced. Both halves in one clause: a fix that waves the LOG_ or
+ *       SERVICE_ family through fails the first half; a fix that honors the
+ *       five by deleting the drop report fails the second.
+ *   (d) CONTROL — the families that already worked still work: DB_*,
+ *       AUTH_TOKEN_*, AUTH_TOKEN_USER_*, OPENBRAIN_TRACING_*, and the #659
+ *       OPENBRAIN_CAPTURE_HEALTH_* keys. Passes PRE-fix by design (round 13: a
+ *       check that fails everywhere proves only that it fails).
+ *   (e) The three-state rule, with its own mutation proof. An explicitly-EMPTY
+ *       key is NOT announced (it is a suppression, not a dropped config), while
+ *       a set-VALUED unlisted key with the IDENTICAL NAME IS. Both halves in one
+ *       clause over the same key, differing only in value: that is the mutation.
+ *       Neither half alone constrains anything — "empty not announced" passes on
+ *       a reporter that announces nothing, and "valued announced" passes on
+ *       today's over-reporting one. Asserted for the real watchdog key and for a
+ *       synthetic one, so the rule is the VALUE STATE and not a name allowlist.
+ *
+ * No database, no network, no real child process: the subjects are a pure
+ * function over a record plus the launcher's already-injectable boundaries.
+ * Content-free output — clause names, states, key names, never values.
+ */
+import {
+  buildChildEnvironment,
+  runLocalCloneLauncher,
+  type LocalCloneLauncherDependencies,
+} from "../local-clone.ts";
+import { EventEmitter } from "node:events";
+import { mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { ChildProcess } from "node:child_process";
+
+/**
+ * A real directory for the clone-root fixture.
+ *
+ * `src/local-clone-mode.ts` requires OPENBRAIN_LOCAL_CLONE_ROOT to EXIST, and
+ * clause (b) drives that validation for real. Repo-relative and gitignored
+ * rather than an absolute machine path — a hardcoded `/Volumes/...` default
+ * died with EACCES on the Linux CI runner once already (docs/lane-contract.md,
+ * #612 harvest).
+ */
+const CLONE_ROOT = fileURLToPath(
+  new URL("../../_scratch/done-means-661-clone-root", import.meta.url),
+);
+
+/**
+ * The FIVE keys honored under amended ruling 29.2a, with the values the
+ * deployed env file actually carries (`local-clone.env:36,40-43`). Real values
+ * rather than invented ones: round 12 — query the real distribution before
+ * inventing a fixture shape.
+ */
+const HONORED_KEYS: ReadonlyArray<readonly [string, string]> = [
+  ["LOG_LEVEL", "debug"],
+  ["LOG_MAX_BYTES", "67108864"],
+  ["LOG_MAX_FILES", "12"],
+  ["OPENBRAIN_MCP_AUDIT_ENABLED", "1"],
+  ["SERVICE_NAME", "open-brain"],
+] as const;
+
+/**
+ * The sixth key from the original ruling, held OUT by amendment 29.2a.
+ *
+ * `src/local-clone-mode.ts:15` prohibits it in clone mode and the launcher
+ * throws on any non-empty value. The deployed env file sets it EMPTY
+ * (`local-clone.env:17`), which `docs/local-clone-dogfood.md:147` documents as
+ * the suppression form. It must reach neither the child nor the drop report.
+ */
+const SUPPRESSED_KEY = "EMBEDDING_WATCHDOG_RESTART_SCRIPT";
+
+const results: Array<{ clause: string; ok: boolean; detail: string }> = [];
+
+function clause(name: string, ok: boolean, detail: string): void {
+  results.push({ clause: name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  (${name}) ${detail}`);
+}
+
+/**
+ * The env the deployed clone actually runs with, INCLUDING the six keys whose
+ * silent drop #660's announcement exposed.
+ *
+ * The key set is the deployed one, not an invented shape (round 12: query the
+ * real distribution before inventing a fixture). Ambient launchd vars are
+ * present because `scripts/local-clone-autostart.sh` sources the env file with
+ * `set -a`, so the launcher's environment is the file UNIONED with launchd's.
+ */
+function deployedEnv(): Record<string, string | undefined> {
+  return {
+    // --- allowlisted before this change, must keep passing (clause d) ---
+    ALLOWED_ORIGINS: "http://127.0.0.1:7100",
+    AUTH_TOKEN_ADMIN: "placeholder-admin",
+    AUTH_TOKEN_AGENT: "placeholder-agent",
+    AUTH_TOKEN_DISCORD: "placeholder-discord",
+    AUTH_TOKEN_OB_ADMIN: "placeholder-ob-admin",
+    AUTH_TOKEN_PROMOTER: "placeholder-promoter",
+    AUTH_TOKEN_READONLY: "placeholder-readonly",
+    AUTH_TOKEN_USER_RICO: "rico:placeholder-user-token",
+    DB_HOST: "127.0.0.1",
+    DB_NAME: "open_brain_local_clone",
+    DB_PASSWORD: "placeholder-db-password",
+    DB_POOL_MAX: "10",
+    DB_PORT: "55432",
+    DB_USER: "open_brain_local_clone",
+    EMBEDDING_API_KEY: "placeholder-embedding-key",
+    EMBEDDING_BASE_URL: "http://127.0.0.1:8791/v1",
+    EMBEDDING_DIMENSIONS: "768",
+    EMBEDDING_MODEL: "embeddinggemma-300m-8bit",
+    // Both runtime paths must sit beneath OPENBRAIN_LOCAL_CLONE_ROOT —
+    // `src/local-clone-mode.ts` enforces it, and clause (b) drives the real
+    // launcher through that validation.
+    LOG_FILE: `${CLONE_ROOT}/logs/open-brain.log`,
+    OPEN_BRAIN_BIND_HOST: "127.0.0.1",
+    OPEN_BRAIN_MAINTENANCE_ENABLED: "1",
+    OPEN_BRAIN_RUN_MIGRATIONS: "0",
+    OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "rico",
+    OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: "60000",
+    OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: "360",
+    OPENBRAIN_LOCAL_CLONE: "1",
+    OPENBRAIN_LOCAL_CLONE_ROOT: CLONE_ROOT,
+    OPENBRAIN_RECOVERY_WAL_PATH: `${CLONE_ROOT}/recovery.wal`,
+    OPENBRAIN_TRACING_ENABLED: "1",
+    OPENBRAIN_TRACING_ENDPOINT: "http://tracing.invalid:3000",
+    OPENBRAIN_TRACING_PUBLIC_KEY: "placeholder-public",
+    OPENBRAIN_TRACING_SECRET_KEY: "placeholder-secret",
+    OPENBRAIN_TRANSPORT: "http",
+    PORT: "3100",
+    // Clone mode requires QMD_PATH to be explicitly EMPTY, not merely unset.
+    QMD_PATH: "",
+
+    // --- the #661 subject: configured deliberately, announced, still dropped ---
+    ...Object.fromEntries(HONORED_KEYS),
+    // Explicitly EMPTY, exactly as the deployed env file sets it. Prohibited in
+    // clone mode with a value; a deliberate suppression when empty. Must reach
+    // neither the child nor the drop report.
+    [SUPPRESSED_KEY]: "",
+
+    // --- ambient, must NEVER reach the child and must NOT be announced ---
+    PATH: "/usr/bin:/bin",
+    HOME: "/placeholder/home",
+    SSH_AUTH_SOCK: "/placeholder/ssh-agent.sock",
+  };
+}
+
+/**
+ * A key that is not in the allowlist and never will be — the negative control.
+ *
+ * It carries `LOG_`, one of the prefixes this change touches, on purpose: the
+ * lazy way to honor LOG_LEVEL/LOG_MAX_BYTES/LOG_MAX_FILES is a whole-family
+ * passthrough, and that "fix" must fail clause (c). `SERVICE_` gets the same
+ * treatment via a second junk key.
+ */
+const JUNK_KEYS = [
+  "LOG_DEFINITELY_NOT_A_REAL_SERVER_KEY",
+  "SERVICE_DEFINITELY_NOT_A_REAL_SERVER_KEY",
+] as const;
+
+/** One dropped key, as the launcher reports it: named, never valued. */
+interface DroppedChildEnvEntry {
+  readonly key: string;
+}
+type DropReporter = (
+  env: Record<string, string | undefined>,
+) => readonly DroppedChildEnvEntry[];
+
+/**
+ * Load the drop reporter DYNAMICALLY.
+ *
+ * Round 18: a done-means check for an export that may not exist at the tree
+ * being measured must import it at RUNTIME. A static import against a tree
+ * lacking the export dies at module resolution before any clause prints — a
+ * false RED indistinguishable in shape from a real one. `describeDropped-
+ * ChildEnvironment` exists on `main` today (it shipped in #660), but resolving
+ * it dynamically keeps this driver's RED regenerable against any tree, which is
+ * the property that makes the check reusable rather than a one-shot.
+ */
+async function loadDropReporter(): Promise<DropReporter | undefined> {
+  const module = (await import("../local-clone.ts")) as Record<string, unknown>;
+  const reporter = module.describeDroppedChildEnvironment;
+  return typeof reporter === "function"
+    ? (reporter as DropReporter)
+    : undefined;
+}
+
+const MISSING_REPORTER =
+  "scripts/local-clone.ts exports no describeDroppedChildEnvironment — " +
+  "the #659/#660 announce mechanism is gone, so the drop is silent again";
+
+/** A launcher child stub that exits 0 as soon as it is spawned. */
+function stubChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, { exitCode: null, signalCode: null, kill: () => true });
+  return child;
+}
+
+function launcherDependencies(
+  announced: string[],
+  capture: { env?: Record<string, string> },
+): LocalCloneLauncherDependencies {
+  const child = stubChild();
+  return {
+    database: {
+      prove: async () => ({
+        database: "open_brain_local_clone",
+        user: "open_brain_local_clone",
+        serverAddress: "127.0.0.1",
+        serverPort: 55432,
+        postgresMajor: 18,
+        transactionReadOnly: true,
+        pgvectorAvailable: true,
+        pgvectorInstalled: true,
+      }),
+    },
+    embedding: {
+      prove: async () => ({
+        model: "embeddinggemma-300m-8bit",
+        dimensions: 768,
+      }),
+    },
+    child: {
+      spawn: (childEnv) => {
+        capture.env = childEnv;
+        queueMicrotask(() => child.emit("exit", 0, null));
+        return child;
+      },
+    },
+    writeReceipt: () => {},
+    onSignal: () => () => {},
+    announce: (line: string) => announced.push(line),
+  };
+}
+
+async function main(): Promise<void> {
+  mkdirSync(CLONE_ROOT, { recursive: true });
+  const describeDropped = await loadDropReporter();
+
+  // -------------------------------------------------------------------------
+  // Clause (a) — each of the five honored keys reaches the child with its value,
+  // and the empty-suppressed watchdog key does NOT.
+  //
+  // Asserted per key, not as a tally: a partial fix that adds four of five is a
+  // deploy that still silently ignores an operator decision, and a count would
+  // report that as "mostly done". The suppressed key is asserted here too so
+  // that "honor the five" cannot quietly become "honor everything announced".
+  // -------------------------------------------------------------------------
+  {
+    const child = buildChildEnvironment(deployedEnv());
+    const missing = HONORED_KEYS.filter(([key]) => child[key] === undefined).map(
+      ([key]) => key,
+    );
+    const wrongValue = HONORED_KEYS.filter(
+      ([key, value]) => child[key] !== undefined && child[key] !== value,
+    ).map(([key]) => key);
+    const suppressedLeaked = child[SUPPRESSED_KEY] !== undefined;
+    const ok =
+      missing.length === 0 && wrongValue.length === 0 && !suppressedLeaked;
+    clause(
+      "a",
+      ok,
+      ok
+        ? `all ${HONORED_KEYS.length} operator-ruled keys reach the server child with their configured values ` +
+            `(${HONORED_KEYS.map(([key]) => key).join(", ")}), and the clone-mode-prohibited ` +
+            `${SUPPRESSED_KEY} correctly does not`
+        : [
+            missing.length > 0
+              ? `ruled keys DROPPED by the launcher: ${missing.join(", ")} — the operator configured them deliberately and the child never sees them`
+              : "",
+            wrongValue.length > 0
+              ? `delivered with a MUTATED value: ${wrongValue.join(", ")}`
+              : "",
+            suppressedLeaked
+              ? `${SUPPRESSED_KEY} reached the child — clone mode prohibits it (src/local-clone-mode.ts:15)`
+              : "",
+          ]
+            .filter(Boolean)
+            .join("; "),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (b) — with all six honored, the boot announcement goes SILENT.
+  //
+  // BOTH halves in one clause (round 18). "No announce line" alone passes on a
+  // launcher that announces nothing — the pre-#659 world, which is the bug this
+  // whole thread exists to kill. "Keys present" alone passes on a launcher that
+  // delivers them and still shouts about dropping them. The claim is a QUIET
+  // BOOT FOR A FULLY-HONORED ENV FILE, and only the conjunction states it.
+  //
+  // Driven through the real `runLocalCloneLauncher` start path: #659 survived a
+  // passing unit check because the launcher spawn chain was outside its
+  // vantage. The seam is the subject.
+  // -------------------------------------------------------------------------
+  {
+    const announced: string[] = [];
+    const capture: { env?: Record<string, string> } = {};
+    try {
+      const code = await runLocalCloneLauncher(
+        "start",
+        deployedEnv(),
+        launcherDependencies(announced, capture),
+      );
+      const missing = HONORED_KEYS.filter(
+        ([key, value]) => capture.env?.[key] !== value,
+      ).map(([key]) => key);
+      const silent = announced.length === 0;
+      clause(
+        "b",
+        code === 0 && silent && missing.length === 0,
+        `boot on the deployed env file: exit=${code}, announce lines=${
+          announced.length
+        }, ruled keys missing from the spawned child=${
+          missing.length === 0 ? "none" : missing.join(", ")
+        }` +
+          (silent && missing.length === 0
+            ? " — a fully-honored env file boots quiet"
+            : silent
+              ? " — quiet boot, but the child did not get the keys: silence without delivery is the pre-#659 world"
+              : ` — the launcher still reports dropping configured keys: ${announced.join(" | ")}`),
+      );
+    } catch (error: unknown) {
+      clause(
+        "b",
+        false,
+        `the launcher start path threw before completing: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (c) — CONTROL, mutation-proofed on both halves.
+  //
+  // Round 9/18: a clause whose PASS comes from a negative match passes both
+  // when the thing is absent and when the check is broken. So the negative
+  // ("junk key does NOT reach the child") is paired in ONE clause with the
+  // positive that keeps it honest ("junk key IS still announced").
+  //
+  // A fix that honors LOG_LEVEL by passing the whole `LOG_` family fails the
+  // first half. A fix that silences the boot line by deleting the drop report
+  // — which would also make clause (b) pass for the wrong reason — fails the
+  // second. The junk keys carry `LOG_` and `SERVICE_` precisely so the lazy
+  // family-passthrough route is the one that trips.
+  // -------------------------------------------------------------------------
+  {
+    const env = {
+      ...deployedEnv(),
+      ...Object.fromEntries(
+        JUNK_KEYS.map((key) => [key, "configured-but-unlisted"]),
+      ),
+    };
+    const child = buildChildEnvironment(env);
+    const leaked = [...JUNK_KEYS, "PATH", "HOME", "SSH_AUTH_SOCK"].filter(
+      (key) => child[key] !== undefined,
+    );
+
+    if (describeDropped === undefined) {
+      clause("c", false, MISSING_REPORTER);
+    } else {
+      const names = describeDropped(env).map((entry) => entry.key);
+      const unannounced = JUNK_KEYS.filter((key) => !names.includes(key));
+      const noisy = ["PATH", "HOME", "SSH_AUTH_SOCK"].filter((key) =>
+        names.includes(key),
+      );
+      const serialized = JSON.stringify(describeDropped(env));
+      const leaksValue = serialized.includes("configured-but-unlisted");
+      const ok =
+        leaked.length === 0 &&
+        unannounced.length === 0 &&
+        noisy.length === 0 &&
+        !leaksValue;
+      clause(
+        "c",
+        ok,
+        ok
+          ? `control: the allowlist still holds (${JUNK_KEYS.join(", ")} and the ambient host vars excluded) ` +
+              "AND the announce mechanism still names them, without echoing values"
+          : [
+              leaked.length > 0
+                ? `the allowlist was ABOLISHED, not extended: ${leaked.join(", ")} reached the child`
+                : "",
+              unannounced.length > 0
+                ? `the announce mechanism went silent for: ${unannounced.join(", ")} — honoring six keys must not delete the drop report`
+                : "",
+              noisy.length > 0
+                ? `the report named ambient host vars: ${noisy.join(", ")}`
+                : "",
+              leaksValue ? "the report ECHOED a dropped VALUE" : "",
+            ]
+              .filter(Boolean)
+              .join("; "),
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (d) — CONTROL: the previously-working families still work.
+  //
+  // Passes PRE-fix by design. This is what distinguishes "the allowlist gained
+  // six entries" from "the allowlist was rewritten and broke the deploy", and
+  // it explicitly covers the #659 capture-health keys so this change cannot
+  // regress the fix directly upstream of it.
+  // -------------------------------------------------------------------------
+  {
+    const child = buildChildEnvironment(deployedEnv());
+    const expected: ReadonlyArray<readonly [string, string]> = [
+      ["DB_HOST", "127.0.0.1"],
+      ["DB_PASSWORD", "placeholder-db-password"],
+      ["AUTH_TOKEN_ADMIN", "placeholder-admin"],
+      ["AUTH_TOKEN_USER_RICO", "rico:placeholder-user-token"],
+      ["OPENBRAIN_TRACING_ENABLED", "1"],
+      ["OPENBRAIN_TRACING_SECRET_KEY", "placeholder-secret"],
+      ["OPENBRAIN_CAPTURE_HEALTH_NAMESPACE", "rico"],
+      ["OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS", "60000"],
+      ["OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES", "360"],
+    ];
+    const broken = expected
+      .filter(([key, value]) => child[key] !== value)
+      .map(([key]) => key);
+    clause(
+      "d",
+      broken.length === 0,
+      broken.length === 0
+        ? "control: DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_*, OPENBRAIN_TRACING_* and the #659 OPENBRAIN_CAPTURE_HEALTH_* keys all still reach the child"
+        : `REGRESSION: previously-delivered keys no longer reach the server child: ${broken.join(", ")}`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Clause (e) — the three-state rule: unset / set-empty / set-valued.
+  //
+  // This is the clause amendment 29.2a added, and it is where the original
+  // "all six" ruling came from: the reporter skipped only on `undefined`, so an
+  // explicitly-EMPTY key — the documented clone-mode suppression form
+  // (`docs/local-clone-dogfood.md:147`) — was announced as dropped
+  // CONFIGURATION. A human read that boot line and filed an issue asking for a
+  // prohibited key to be honored.
+  //
+  // The empty-means-suppressed semantic is NOT invented here: clone mode
+  // already requires `QMD_PATH` to be explicitly empty to suppress the
+  // production default (`src/local-clone-mode.ts:203-209`). This clause extends
+  // that established three-state reading to the drop reporter.
+  //
+  // MUTATION PROOF, per round 9/18: the PASS half here comes from a negative
+  // match ("empty is NOT announced"), which passes just as well on a reporter
+  // that announces nothing at all. So both halves are asserted over the SAME
+  // KEY NAME, differing only in VALUE STATE. That is the mutation — flip the
+  // value from "" to a real string and the expected answer inverts. Run for the
+  // real watchdog key AND a synthetic one, so what is proven is the value-state
+  // rule rather than a name allowlist.
+  // -------------------------------------------------------------------------
+  {
+    if (describeDropped === undefined) {
+      clause("e", false, MISSING_REPORTER);
+    } else {
+      const probes = [SUPPRESSED_KEY, "OPENBRAIN_SOME_SUPPRESSIBLE_KEY"];
+      const failures: string[] = [];
+      for (const key of probes) {
+        const emptyNames = describeDropped({
+          ...deployedEnv(),
+          [key]: "",
+        }).map((entry) => entry.key);
+        // The mutation: same key, same env, value flipped empty -> real.
+        const valuedNames = describeDropped({
+          ...deployedEnv(),
+          [key]: "a-real-configured-value",
+        }).map((entry) => entry.key);
+
+        if (emptyNames.includes(key)) {
+          failures.push(
+            `${key}: explicitly-empty was ANNOUNCED as dropped configuration — ` +
+              "a deliberate suppression reported as a mistake is the false positive that produced this issue",
+          );
+        }
+        if (!valuedNames.includes(key)) {
+          failures.push(
+            `${key}: set-VALUED and unlisted was NOT announced — the reporter ` +
+              "is skipping on falsiness or has gone silent; a real dropped configuration is invisible again",
+          );
+        }
+
+        // "0" and "false" are values an operator CHOSE. Swallowing them would
+        // be the silent drop this reporter exists to prevent, wearing the
+        // suppression rule as a disguise.
+        //
+        // Honest note on what this does and does not prove. Mutating the fix to
+        // `!configured` does NOT fail these probes, because `configured` is
+        // `string | undefined`, `undefined` is skipped one line earlier, and
+        // every non-empty STRING is truthy — `!"0"` is false. So `=== ""` and
+        // `!configured` are equivalent mutants at this type, and no fixture can
+        // separate them. These probes guard the reachable regression instead:
+        // a future refactor that widens the value type, coerces, trims, or
+        // reaches for a truthiness helper. Recorded rather than dressed up as a
+        // mutation kill the check did not make.
+        for (const falsy of ["0", "false"]) {
+          const falsyNames = describeDropped({
+            ...deployedEnv(),
+            [key]: falsy,
+          }).map((entry) => entry.key);
+          if (!falsyNames.includes(key)) {
+            failures.push(
+              `${key}="${falsy}": a falsy-LOOKING but real configured value was ` +
+                "treated as a suppression — the reporter is testing falsiness, not emptiness",
+            );
+          }
+        }
+      }
+      clause(
+        "e",
+        failures.length === 0,
+        failures.length === 0
+          ? `three-state rule holds under mutation for ${probes.join(" and ")}: ` +
+              "set-empty is a suppression (not announced), set-valued-and-unlisted is a drop (announced), unset is neither"
+          : failures.join("; "),
+      );
+    }
+  }
+
+  finish();
+}
+
+function finish(): void {
+  const failed = results.filter((r) => !r.ok);
+  console.log();
+  console.log(`clauses: ${results.length} run, ${failed.length} failed`);
+  if (failed.length > 0) {
+    console.log(`failing: ${failed.map((f) => f.clause).join(", ")}`);
+  }
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+// An exception escaping `main` must FAIL, loudly. Without this a top-level
+// throw lets Bun print a trace and still exit 0 — a crashing subject banks a
+// false GREEN (docs/lane-contract.md round 13; SME order 67).
+main().catch((error: unknown) => {
+  console.log();
+  console.log(
+    `FAIL  (driver) threw before completing: ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+  process.exit(1);
+});

--- a/scripts/done-means/661-launcher-honors-six-keys.sh
+++ b/scripts/done-means/661-launcher-honors-six-keys.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #661 — "the local-clone launcher HONORS the five
+# ruled configuration keys it announces as dropped, and stops announcing the
+# sixth, which was never a configuration at all".
+#
+#   bash scripts/done-means/661-launcher-honors-six-keys.sh
+#
+# ---------------------------------------------------------------------------
+# THE GAP THIS CLOSES
+# ---------------------------------------------------------------------------
+# #659 (PR #660) made the launcher's env drops VISIBLE. The first boot after
+# that change named six more configured keys the allowlist had been discarding
+# in silence for their whole life — observed RUNNING on the deployed clone
+# 2026-08-08 22:45Z. Ledger item 29.2 ruled that all six be honored.
+#
+# Writing this check RED-first proved one of the six could not be. The launcher
+# THREW on it, at a guard, before the allowlist was ever consulted:
+#
+#   FAIL (b) Local clone mode prohibits EMBEDDING_WATCHDOG_RESTART_SCRIPT
+#
+# src/local-clone-mode.ts:15 lists that key in PROHIBITED_PATH_KEYS; lines
+# 190-194 refuse any non-empty value; src/local-clone-mode.test.ts:138-145 pins
+# it. The deployed env file sets it EMPTY (local-clone.env:17), which
+# docs/local-clone-dogfood.md:147 documents as the suppression form — the same
+# shape as QMD_PATH=. It reached the boot line only because the drop reporter
+# skipped on `undefined` and not on the empty string, so an explicitly-DISABLED
+# key was reported as a dropped CONFIGURATION, and a human filed an issue asking
+# for a prohibited key to be honored.
+#
+# Amended operator ruling 2026-08-08 (29.2a): honor the FIVE keys carrying real
+# values, keep the watchdog key out because the clone-mode prohibition guard
+# wins, and teach the reporter to tell unset / set-empty / set-valued apart.
+#
+#   HONORED:      LOG_LEVEL, LOG_MAX_BYTES, LOG_MAX_FILES,
+#                 OPENBRAIN_MCP_AUDIT_ENABLED, SERVICE_NAME
+#   NOT honored:  EMBEDDING_WATCHDOG_RESTART_SCRIPT
+#
+# Verifiable at the pre-fix tree:
+#
+#   $ rg -n 'LOG_LEVEL|SERVICE_NAME|MCP_AUDIT' scripts/local-clone.ts
+#   (no matches)
+#
+# Announcing a drop is the correct mechanism and is NOT the resolution: an
+# announced-and-ignored deliberate setting is accept-and-ignore with a receipt.
+# Announcing a deliberate SUPPRESSION is the mirror defect — a false positive
+# that teaches an operator the line is noise.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) Each of the five honored keys, set in the input env, appears in
+#       buildChildEnvironment output with its configured value, and the
+#       empty-suppressed watchdog key does NOT. Asserted per key, never as a
+#       tally — a partial fix is an ignored operator decision. RED pre-fix.
+#   (b) With the five honored and the watchdog key empty-suppressed, the
+#       launcher's boot announcement for this env file goes SILENT. Both halves
+#       in ONE clause: zero announce lines AND the five keys present in the
+#       SPAWNED CHILD's env. Split apart, "quiet" passes on the pre-#659
+#       launcher that announced nothing and delivered nothing. Driven through
+#       the real runLocalCloneLauncher start path via its injected boundaries —
+#       the launcher spawn chain is the seam #659 lived in, and a unit-level
+#       check had it outside its vantage. RED pre-fix.
+#   (c) CONTROL, mutation-proofed both ways — a junk unlisted key must still NOT
+#       reach the child AND must still be announced, with no value echoed and no
+#       ambient host var named. The junk keys carry the LOG_ and SERVICE_
+#       prefixes on purpose: the lazy way to honor LOG_LEVEL is a whole-family
+#       passthrough, and that fails the first half. Deleting the drop report to
+#       silence the boot line — which would make (b) pass for the wrong reason —
+#       fails the second. Passes PRE-fix by design.
+#   (d) CONTROL — DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_*, OPENBRAIN_TRACING_* and
+#       the #659 OPENBRAIN_CAPTURE_HEALTH_* keys still reach the child. Passes
+#       PRE-fix by design (round 13: a check that fails everywhere proves only
+#       that it fails).
+#   (e) The three-state rule, with its own mutation proof: an explicitly-EMPTY
+#       key is NOT announced (a suppression), while the SAME KEY carrying a real
+#       value IS (a drop). Both halves over one key name differing only in value
+#       state — flip "" to a string and the expected answer inverts. Neither
+#       half alone constrains anything. RED pre-fix.
+#
+# No database, no network, no real child process — the subjects are a pure
+# function over a record plus the launcher's already-injectable boundaries.
+# Content-free output: clause names, states, key names.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRIVER="scripts/done-means/661-launcher-honors-six-keys.driver.ts"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "FAIL  driver missing: $DRIVER"
+  echo "DONE-MEANS #661: FAIL"
+  exit 1
+fi
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  driver: $DRIVER (pure env projection + injected launcher boundaries; no DB, no network)"
+echo
+
+set +e
+bun "$DRIVER"
+DRIVER_STATUS=$?
+set -e
+
+echo
+if [[ $DRIVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #661: PASS — the five operator-ruled keys reach the server child, the empty-suppressed watchdog key is neither delivered nor announced, the fully-honored env file boots quiet, and the allowlist plus its drop report both still hold."
+else
+  echo "DONE-MEANS #661: FAIL — the launcher still drops operator-ruled configuration keys, or the fix abolished the allowlist or its drop report."
+fi
+exit $DRIVER_STATUS

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -271,6 +271,74 @@ describe("local clone launcher", () => {
     expect(child.OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS).toBe("60000");
   });
 
+  // #661 (operator ruling 29.2a): five keys the operator set with real values
+  // in the clone env file were dropped in silence for their whole life, and
+  // only became visible when #659 taught the launcher to announce its drops.
+  it("passes the operator-ruled logging, audit and service keys to the server child", () => {
+    const child = buildChildEnvironment({
+      ...cloneEnv(),
+      LOG_LEVEL: "debug",
+      LOG_MAX_BYTES: "67108864",
+      LOG_MAX_FILES: "12",
+      OPENBRAIN_MCP_AUDIT_ENABLED: "1",
+      SERVICE_NAME: "open-brain",
+    });
+    expect(child.LOG_LEVEL).toBe("debug");
+    expect(child.LOG_MAX_BYTES).toBe("67108864");
+    expect(child.LOG_MAX_FILES).toBe("12");
+    expect(child.OPENBRAIN_MCP_AUDIT_ENABLED).toBe("1");
+    expect(child.SERVICE_NAME).toBe("open-brain");
+  });
+
+  // The sixth key from the original ruling. Clone mode PROHIBITS it with a
+  // value (`src/local-clone-mode.ts`), so honoring it would hand the clone a
+  // capability its own guard refuses.
+  it("does not pass the clone-mode-prohibited embedding watchdog script to the child", () => {
+    const child = buildChildEnvironment({
+      ...cloneEnv(),
+      EMBEDDING_WATCHDOG_RESTART_SCRIPT: "",
+    });
+    expect(child).not.toHaveProperty("EMBEDDING_WATCHDOG_RESTART_SCRIPT");
+  });
+
+  // The three-state rule. An explicitly-empty value is a deliberate off switch
+  // — the same reading clone mode already gives `QMD_PATH=` — so reporting it
+  // as dropped configuration is a false positive. That false positive is what
+  // put a prohibited key into #661's original "honor all six" text.
+  it("does not report an explicitly-empty key as dropped configuration", () => {
+    const dropped = describeDroppedChildEnvironment({
+      ...cloneEnv(),
+      EMBEDDING_WATCHDOG_RESTART_SCRIPT: "",
+      OPENBRAIN_SOME_SUPPRESSED_KEY: "",
+    }).map((entry) => entry.key);
+    expect(dropped).not.toContain("EMBEDDING_WATCHDOG_RESTART_SCRIPT");
+    expect(dropped).not.toContain("OPENBRAIN_SOME_SUPPRESSED_KEY");
+  });
+
+  // The mutation half: same key, value flipped from empty to real, expected
+  // answer inverts. Without this, "empty is not announced" also passes on a
+  // reporter that announces nothing at all.
+  it("still reports the same key when it carries a real value", () => {
+    const dropped = describeDroppedChildEnvironment({
+      ...cloneEnv(),
+      OPENBRAIN_SOME_SUPPRESSED_KEY: "a-real-configured-value",
+    }).map((entry) => entry.key);
+    expect(dropped).toContain("OPENBRAIN_SOME_SUPPRESSED_KEY");
+  });
+
+  // Falsy is not empty. "0" and "false" are configured values an operator
+  // chose, and dropping them in silence is the exact bug this reporter exists
+  // to prevent — a `!configured` test instead of `=== ""` would swallow both.
+  it("reports a key whose configured value is falsy-looking but real", () => {
+    const dropped = describeDroppedChildEnvironment({
+      ...cloneEnv(),
+      OPENBRAIN_SOME_ZERO_KEY: "0",
+      OPENBRAIN_SOME_FALSE_KEY: "false",
+    }).map((entry) => entry.key);
+    expect(dropped).toContain("OPENBRAIN_SOME_ZERO_KEY");
+    expect(dropped).toContain("OPENBRAIN_SOME_FALSE_KEY");
+  });
+
   it("names a configured server-config key it drops, without echoing its value", () => {
     const dropped = describeDroppedChildEnvironment({
       ...cloneEnv(),

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -50,7 +50,21 @@ const CHILD_ENV_KEYS = [
   "EMBEDDING_MODEL",
   "EMBEDDING_TIMEOUT_MS",
   "LOG_FILE",
+  // #661 operator ruling 29.2a: these five were configured with real values in
+  // the operator-owned env file and dropped in silence for their whole life --
+  // surfaced the moment #659's announce-on-drop made the drops visible. Fourth
+  // instance of the deploy-coupling class documented at the #530 comment below.
+  //
+  // The sixth key that boot line named, EMBEDDING_WATCHDOG_RESTART_SCRIPT, is
+  // deliberately NOT here: `src/local-clone-mode.ts` prohibits it in clone mode
+  // and the launcher throws on any non-empty value. It is set EMPTY in the env
+  // file, which is the documented suppression form -- see the empty-value rule
+  // in `describeDroppedChildEnvironment` below.
+  "LOG_LEVEL",
+  "LOG_MAX_BYTES",
+  "LOG_MAX_FILES",
   "NODE_ENV",
+  "OPENBRAIN_MCP_AUDIT_ENABLED",
   "OPENBRAIN_LOCAL_CLONE",
   "OPENBRAIN_LOCAL_CLONE_ROOT",
   // #659 capture-health observer (PR #656, ledger item 28): these three must
@@ -69,6 +83,7 @@ const CHILD_ENV_KEYS = [
   "OPENBRAIN_TRANSPORT",
   "PORT",
   "QMD_PATH",
+  "SERVICE_NAME",
   "TZ",
 ] as const;
 
@@ -202,6 +217,27 @@ export interface DroppedChildEnvEntry {
  * Reporting is not honoring: the allowlist stays an allowlist. A key named here
  * is one a human must either add to `CHILD_ENV_KEYS` or delete from the env
  * file.
+ *
+ * A CONFIGURED value has three states here, not two (#661, operator ruling
+ * 29.2a). Reading only `undefined` as "not configured" made this function
+ * report deliberate SUPPRESSIONS as mistakes:
+ *
+ *   unset        -- absent from the env file. Not configured, not reported.
+ *   set-empty    -- `KEY=` in the env file. A deliberate OFF SWITCH, not a
+ *                   dropped configuration, so it is not reported either.
+ *   set-valued   -- `KEY=something`. Configured; reported if the child will not
+ *                   receive it.
+ *
+ * Clone mode already reads an explicit empty this way: `QMD_PATH` MUST be empty
+ * to suppress the production `/opt/qmd` default
+ * (`src/local-clone-mode.ts`), and `EMBEDDING_WATCHDOG_RESTART_SCRIPT=` is the
+ * documented way to disable the embedding watchdog in a clone
+ * (`docs/local-clone-dogfood.md`) -- a key clone mode PROHIBITS from carrying a
+ * value at all. Announcing those as dropped configuration is the mirror of the
+ * #659 defect: a false positive that teaches an operator the boot line is
+ * noise, which costs exactly what silence costs. It also has a live receipt --
+ * the first boot after #659 named the empty watchdog key, and #661 was filed
+ * asking that a prohibited key be honored.
  */
 export function describeDroppedChildEnvironment(
   env: Record<string, string | undefined>,
@@ -210,6 +246,11 @@ export function describeDroppedChildEnvironment(
   const dropped: DroppedChildEnvEntry[] = [];
   for (const [key, configured] of Object.entries(env)) {
     if (configured === undefined) continue;
+    // An explicitly-empty value is a suppression, not a dropped setting. Note
+    // this tests the RAW value for `""` rather than falsiness: a key whose
+    // configured value is the string "0" or "false" IS configured, and dropping
+    // it silently is the bug this whole function exists to prevent.
+    if (configured === "") continue;
     if (delivered[key] !== undefined) continue;
     if (!SERVER_CONFIG_PREFIXES.some((prefix) => key.startsWith(prefix))) {
       continue;


### PR DESCRIPTION
## Summary

- Fixes #661. Adds five operator-configured keys to CHILD_ENV_KEYS in scripts/local-clone.ts so they reach the server child: LOG_LEVEL, LOG_MAX_BYTES, LOG_MAX_FILES, OPENBRAIN_MCP_AUDIT_ENABLED, SERVICE_NAME. Each was set with a real value in the operator-owned clone env file and dropped in silence for its whole life. Fourth instance of the deploy-coupling class already documented at the #530 tracing comment, after #530 and #659.
- **Scope amended mid-lane, by operator ruling 29.2a.** Ledger item 29.2 said all six announced keys be honored. Writing the done-means red-first proved the sixth could not be: EMBEDDING_WATCHDOG_RESTART_SCRIPT is in PROHIBITED_PATH_KEYS at src/local-clone-mode.ts:15, refused with any non-empty value at lines 190-194, pinned by a passing test at src/local-clone-mode.test.ts:138-145. The launcher threw on it before the allowlist was ever consulted. Honoring it would have handed the clone a capability its own isolation guard exists to refuse.
- **Why it was in that boot line at all.** The deployed env file sets it EMPTY (local-clone.env:17), which docs/local-clone-dogfood.md:147 documents as the suppression form, the same shape as an explicit empty QMD_PATH. The #659 drop reporter skipped only on undefined, so a deliberately-DISABLED key was reported as dropped CONFIGURATION. A human read that false positive and filed an issue asking that a prohibited key be honored.
- So describeDroppedChildEnvironment now reads three states rather than two: unset (absent, not reported), set-empty (a deliberate off switch, not reported), set-valued (configured, reported if the child will not receive it). This is not a new semantic. Clone mode already requires an explicit empty QMD_PATH to suppress the production default, at src/local-clone-mode.ts:203-209; the reporter now reads an empty value the same way the validator already does.
- Announcing a drop remains the correct mechanism and is still not the resolution. Announcing a deliberate suppression is the mirror defect: a false positive that teaches an operator the boot line is noise, which costs exactly what silence costs. This PR has a live receipt for that cost.

## Verification

- Done-means: scripts/done-means/661-launcher-honors-six-keys.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, before the fix, real nonzero exit. Clause (b) reproduced the live 2026-08-08 boot line verbatim, all six keys named:

```
FAIL  (a) ruled keys DROPPED by the launcher: LOG_LEVEL, LOG_MAX_BYTES, LOG_MAX_FILES, OPENBRAIN_MCP_AUDIT_ENABLED, SERVICE_NAME
FAIL  (b) boot on the deployed env file: exit=0, announce lines=1 ... local-clone launcher ADJUSTED the server child's environment: 6 configured key(s) are NOT in the child allowlist and were dropped -- EMBEDDING_WATCHDOG_RESTART_SCRIPT, LOG_LEVEL, LOG_MAX_BYTES, LOG_MAX_FILES, OPENBRAIN_MCP_AUDIT_ENABLED, SERVICE_NAME
PASS  (c) control: the allowlist still holds ... AND the announce mechanism still names them, without echoing values
PASS  (d) control: DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_* and OPENBRAIN_TRACING_* and the #659 capture-health keys all still reach the child
FAIL  (e) EMBEDDING_WATCHDOG_RESTART_SCRIPT: explicitly-empty was ANNOUNCED as dropped configuration
clauses: 5 run, 3 failed
DONE-MEANS #661: FAIL
EXIT=1
```

The first RED run failed clause (b) with "Local clone mode prohibits EMBEDDING_WATCHDOG_RESTART_SCRIPT" rather than an announcement mismatch. Reading WHY the clause failed instead of banking the tally is what surfaced the prohibition and produced the amended ruling. Controls (c) and (d) passed pre-fix throughout, so the check discriminates rather than merely failing.

GREEN, after the fix:

```
PASS  (a) all 5 operator-ruled keys reach the server child with their configured values, and the clone-mode-prohibited EMBEDDING_WATCHDOG_RESTART_SCRIPT correctly does not
PASS  (b) boot on the deployed env file: exit=0, announce lines=0, ruled keys missing from the spawned child=none -- a fully-honored env file boots quiet
PASS  (c) control: the allowlist still holds AND the announce mechanism still names them, without echoing values
PASS  (d) control: DB_*, AUTH_TOKEN_*, AUTH_TOKEN_USER_*, OPENBRAIN_TRACING_* and the #659 capture-health keys all still reach the child
PASS  (e) three-state rule holds under mutation: set-empty is a suppression (not announced), set-valued-and-unlisted is a drop (announced), unset is neither
clauses: 5 run, 0 failed
EXIT=0
```

Suite and typecheck, from the lane worktree:

- bun run test:isolated -- 3752 pass, 35 skip, 0 fail, 244 files, database ob_isolated_2835_msl18cscj2 created and dropped on exit.
- bunx tsc --noEmit -- exit 0.
- scripts/local-clone.test.ts alone went 14 to 19 tests, 51 assertions, proving the five new tests execute rather than trusting a green run (Bun names tests only on failure).

Mutation results, three mutants:

- Removing the empty-skip line: clause (e) FAILS on both probe keys. Killed.
- Removing LOG_LEVEL, LOG_MAX_BYTES, LOG_MAX_FILES from the allowlist: clause (a) FAILS naming exactly those three. Killed.
- Swapping the empty test for a truthiness test: SURVIVES, and this is reported rather than hidden. It is an equivalent mutant at this type. The value is string-or-undefined, undefined is skipped one line earlier, and every non-empty string is truthy, so no fixture can separate the two spellings. Clause (e) still probes "0" and "false" to guard the reachable regression, which is a future refactor that widens the type, coerces, or trims. The driver comment records this honestly instead of claiming a kill the check did not make.

Live smoke is not applicable from the lane: this changes what the launcher hands its child, and the proof is a redeploy plus a boot-log read, which is the controller's step and explicitly a non-goal here.

## Critical Self-Review

- Highest-risk behavior: the empty-skip in describeDroppedChildEnvironment. It is a deliberate narrowing of a safety announcement, so a key genuinely meant to carry a value but accidentally left empty in the env file is now silent where it used to be loud. Judged correct because an empty value is the documented suppression form in this repo and the launcher cannot distinguish "empty on purpose" from "empty by mistake"; the alternative keeps a permanent false positive on every boot.
- Assumptions that could be wrong: that empty-means-suppressed generalizes beyond QMD_PATH and the watchdog script to every server-config key. It is the established repo reading and matches both documented cases, but it is now applied uniformly rather than per key.
- Missing/weak tests: no test asserts LOG_LEVEL actually changes server behavior once delivered. server/config.ts reading it is the coupling this PR restores, and proving it needs a running server, which is the post-merge redeploy step. The done-means proves delivery to the child, not consumption by it, and names that seam rather than implying more.
- Security/permission risk: low, and one boundary was actively defended. The prohibition on EMBEDDING_WATCHDOG_RESTART_SCRIPT in clone mode is preserved; the original ruling would have removed it. Clause (c) proves the allowlist still excludes unlisted keys, including junk keys carrying the LOG_ and SERVICE_ prefixes this PR touches, so no prefix family was waved through. The drop report still names keys and never values, so an unlisted AUTH_TOKEN_ spelling cannot be logged.
- Migration/deploy risk: no migration. Deploy risk is that the clone must be redeployed for any of this to be RUNNING; until then the merged change is MERGED and dark, which is precisely the #659 conflation this thread exists to stop.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changes; scripts/local-clone.ts is the local dogfood launcher only.
- Rollback/cleanup concern: revert the commit. The five allowlist entries and the empty-skip are independent, so either half can be reverted alone. No state is written and nothing persists.
- Fixes made before PR: corrected the stale PASS banner in the shell wrapper that still said "six" after the amendment, since an inaccurate receipt is the silent-adjustment class this repo bans. Corrected a driver comment that claimed the falsiness mutation was a kill when it is an equivalent mutant.
- Known residual risk: LOG_LEVEL taking effect in the server, and the boot line going silent on the real clone, are both unproven here and belong to the post-merge redeploy. Stated as MERGED-not-RUNNING rather than implied complete.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the reusable lesson is a lane-operating one, not a reviewer-facing code pattern, and it is being harvested into the Tightenings in docs/lane-contract.md by the merge pass. The underlying accept-and-ignore pattern is already SME gotcha-agent #464.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the behavior changed is what the launcher hands its child process, which no live API call can observe. Its proof is the post-merge redeploy boot log, the controller's step.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is the local-clone launcher's process-env projection, which has no cross-runtime contract surface and no Python client equivalent.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board. No MCP tool, schema, protocol, or client-facing surface is touched; the change is confined to the local dogfood launcher's child-environment projection and its drop reporter.
- Post-merge, the controller redeploys the clone and reads the boot log for two things: the ADJUSTED line absent (all configured keys now honored or correctly suppressed), and LOG_LEVEL taking effect so server/config.ts stops defaulting. Both are RUNNING claims this PR does not make.
