### PR TITLE
fix(662): name the absent-namespace session_start refusal instead of dead-ending

### DIFF
--- a/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
@@ -104,8 +104,37 @@ def validate_started_lane(
     # opaque refusal into an actionable one, and it must stay a REFUSAL: writing
     # into whatever namespace came back is the silent mis-scope this issue is
     # about (server/auth/middleware.ts:9-13).
+    #
+    # The ABSENT case needs its own branch (#662). #654's guard reads
+    # `"namespace" in lane`, so a lane carrying no `namespace` key at all walks
+    # past it into the generic comparison and produces the exact dead-end
+    # message the paragraph above says must never be produced for this key. It
+    # is the same defect #654 fixed, on the other side of its own `if`.
+    #
+    # Absent and mismatched are genuinely different faults and must not share a
+    # message. A mismatch means the server bound the lane somewhere and said
+    # so, and the remedy is delegation. An absence means the response never
+    # stated a namespace at all, so there is nothing the caller can set to
+    # change it: the actionable information is that the SERVER's response shape
+    # is wrong, and the operator's move is to check what is answering. Telling
+    # them to set OPENBRAIN_DELEGATE_NAMESPACE here would be a false remedy —
+    # a dead end with more words.
+    #
+    # It stays a REFUSAL. An unproven namespace is not a proven one, and
+    # writing into a lane whose scope was never established is the silent
+    # mis-scope #654 exists to prevent (server/auth/middleware.ts:9-13).
     served = lane.get("namespace")
-    if "namespace" in lane and served != namespace:
+    if "namespace" not in lane:
+        raise ValueError(
+            "session_start did not return a namespace for the lane, so it "
+            f"cannot prove the configured '{namespace}'. The namespace is "
+            "carried by OPENBRAIN_NAMESPACE and is never a request key, so "
+            "there is nothing to add to the request: the response shape is "
+            "wrong. Check that OPENBRAIN_BASE_URL points at an Open Brain "
+            "whose session_start returns the lane's namespace. Nothing was "
+            f"written to '{namespace}'."
+        )
+    if served != namespace:
         raise ValueError(
             "session_start bound the lane to namespace "
             f"'{served}', not the configured '{namespace}'. The namespace is "

--- a/python/openbrain-memory/tests/test_runtime_direct_scope.py
+++ b/python/openbrain-memory/tests/test_runtime_direct_scope.py
@@ -327,3 +327,65 @@ def test_namespace_mismatch_names_the_cause_and_the_remedy() -> None:
     assert "token-namespace" in error
     assert "bilby" in error
     assert "OPENBRAIN_DELEGATE_NAMESPACE" in error
+
+
+# --- #662: an ABSENT namespace key is a different fault and needs its own name
+
+
+class AbsentNamespaceLaneClient(ScopeResponseClient):
+    """A server whose session_start lane omits `namespace` entirely."""
+
+    def session_start(self, **arguments: Any) -> dict[str, Any]:
+        result = super().session_start(**arguments)
+        result["lane"].pop("namespace", None)
+        return result
+
+
+def test_absent_namespace_names_the_response_shape_not_a_false_remedy() -> None:
+    """#662: #654's guard reads `"namespace" in lane`, so absence walked past it.
+
+    A lane with no `namespace` key fell through to the generic
+    "did not prove exact Open Brain scope: namespace" — the exact dead end
+    #654's own comment says must never be produced for this key, because
+    `namespace` is env-carried and has no request spelling to correct.
+
+    Absence is not mismatch. A mismatch has a remedy (delegate the namespace);
+    an absence does not, because the server never stated one — so the refusal
+    points at the response shape and at the endpoint, and must NOT repeat the
+    delegation remedy, which would be a dead end with more words.
+    """
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        client=AbsentNamespaceLaneClient(),
+    )
+
+    output = runtime.capture_distilled("Absent namespace must be named")
+
+    assert output.receipt.status is not ReceiptStatus.SAVED
+    assert output.receipt.durable is False
+    error = output.receipt.error or ""
+    assert "did not prove exact Open Brain scope: namespace" not in error
+    assert "did not return a namespace" in error
+    assert "bilby" in error
+    assert "OPENBRAIN_BASE_URL" in error
+    assert "OPENBRAIN_DELEGATE_NAMESPACE" not in error
+
+
+def test_absent_namespace_is_still_refused_never_accepted() -> None:
+    """An unproven namespace is not a proven one.
+
+    Separate from the message test on purpose: a fix that improved the wording
+    while letting the write proceed would satisfy the text assertions and
+    reintroduce the silent mis-scope #654 exists to prevent.
+    """
+    runtime = FirstClassMemoryRuntime(
+        runtime_config(),
+        runtime_scope(),
+        client=AbsentNamespaceLaneClient(),
+    )
+
+    output = runtime.capture_distilled("Absent namespace must not be written")
+
+    assert output.receipt.durable is False
+    assert output.receipt.error

--- a/scripts/done-means/662-absent-namespace-scope-proof.sh
+++ b/scripts/done-means/662-absent-namespace-scope-proof.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #662 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/662-absent-namespace-scope-proof.sh
+#
+# ---------------------------------------------------------------------------
+# The issue
+# ---------------------------------------------------------------------------
+# #654 (PR #657) made a namespace MISMATCH actionable: when the session_start
+# lane comes back bound to a different namespace than the configured one, the
+# provider now names the cause (the token's namespace won) and the remedy
+# (OPENBRAIN_DELEGATE_NAMESPACE=1 with an admin/ob-admin token). That fix is
+# guarded by `if "namespace" in lane and served != namespace`
+# (_runtime_validation.py:107-116).
+#
+# The ABSENT case walks straight past it. A lane object carrying NO `namespace`
+# key at all falls through to the generic comparison in `validate_exact_fields`,
+# which reports:
+#
+#     session_start result did not prove exact Open Brain scope: namespace
+#
+# That is the dead-end-error class (Tightenings round 15). `namespace` is
+# env-carried and is NEVER a request key — the fix's own comment at lines 93-99
+# says so, and `_SCOPE_KEYS` in runtime.py rejects it on input. So the error
+# names the one key the caller provably cannot supply, and the operator has
+# nothing to act on. Same disease as #646 (`source`), one key over, and the
+# same disease #654 cured for the sibling branch of the same `if`.
+#
+# ---------------------------------------------------------------------------
+# Which boundary owns the fix (decided, with the evidence)
+# ---------------------------------------------------------------------------
+# The dispatch offered a server-side fix — "if the server omits the effective
+# namespace, make it always return it." Checked, and the server does NOT omit
+# it, on either implementation:
+#
+#   - server/tools/session-lifecycle.ts:13 (`startLaneFields`) and :144,:186
+#     select/RETURN `namespace` on both the existing-lane and insert paths.
+#     This is the SERVING tree (`bun run server/main.ts`, confirmed via
+#     `lsof -nP -iTCP:3100`).
+#   - src/tools/session-start.ts:9 (`LANE_COLUMNS`) does the same on the
+#     non-serving tree.
+#   - server/tools/lanes.ts:93 — the mcp2cli fallback's `lane_upsert` returns
+#     `namespace: auth.namespace` explicitly.
+#   - Observed live 2026-08-08 against 127.0.0.1:3100: a raw `tools/call` of
+#     `session_start` returned `"namespace":"admin"` in the lane object.
+#
+# So there is no server-side omission to fix, and adding a redundant "always
+# return it" would be a change to code that already does it. The defect is
+# entirely in the validator: it has a hostile-input branch it handles badly.
+# The lane object is UNTRUSTED input — it is the thing being validated — so
+# "our server always sends it" is not a reason to leave the absent branch
+# dead-ended. A future server version, a proxy, a mocked client, or the
+# mcp2cli fallback shape drifting all reach it, and #662 was filed because a
+# real run DID reach it.
+#
+# The fix is therefore CLIENT-SIDE and narrow: the absent case gets its own
+# refusal, naming what an operator can actually check, and it stays a
+# REFUSAL — accepting a lane that never proved its namespace is the silent
+# mis-scope #654 exists to prevent.
+#
+# ---------------------------------------------------------------------------
+# #529 — checked, and NOT covered by this fix
+# ---------------------------------------------------------------------------
+# #529 (CLOSED) reported `... exact Open Brain scope: agent, channel_id,
+# source` from the same `validate_exact_fields` call. Those three keys differ
+# from `namespace` in the way that matters here: they ARE request keys. The
+# caller sends `agent`, `platform` (reported as `platform`, compared as
+# `source`), and `channel_id` in the scope object, so naming them is already
+# actionable — the operator has a field to correct. `namespace` is the sole
+# scope key with no request spelling, which is exactly why it needed #654 and
+# needs this. Clause (d) below pins that distinction so a future "improvement"
+# cannot quietly reroute the request-key shapes into a namespace-flavoured
+# message. #529 needs no further work from this issue; if its shapes are ever
+# judged insufficiently actionable, that is its own lane.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   (a) RED ANCHOR — a lane with NO `namespace` key produces the generic
+#       dead-end error today. INVERTS at the fix: pre-fix the dead end is
+#       PRESENT (gate FAILS), post-fix it must be ABSENT.
+#
+#   (b) THE ABSENT REFUSAL IS ACTIONABLE — the new error names the configured
+#       namespace, says the response never proved it, and points at something
+#       checkable. Asserted on the ERROR TEXT, not the status, because a
+#       refusal that refuses for an unsayable reason is the defect.
+#
+#   (c) STILL A REFUSAL — the absent case must NOT become a pass. A lane that
+#       never proved its namespace is not permission to write; this clause
+#       exists so the gate cannot be satisfied by deleting the check. Reads
+#       the receipt: durable false, status not SAVED.
+#
+#   (d) CONTROL, #657 MISMATCH UNCHANGED — the mismatch branch still names the
+#       served namespace, the configured one, and OPENBRAIN_DELEGATE_NAMESPACE.
+#       Must pass BOTH pre-fix and post-fix; if it ever goes red, the absent
+#       fix ate its sibling.
+#
+#   (e) CONTROL, #529's REQUEST-KEY SHAPES UNCHANGED — a lane wrong on `agent`
+#       still reports `agent` by name, and does NOT get rerouted into the
+#       namespace message. Proves the fix is scoped to the one key with no
+#       request spelling.
+#
+#   (f) CONTROL, HEALTHY PATH — a fully-correct lane still validates clean.
+#       Without it, breaking everything would score as progress.
+#
+# Clauses (a)-(f) are HERMETIC: they drive the SHIPPED validator in-process
+# with constructed lane objects. No service, no database, no credentials. Per
+# ledger 26.2 (hermetic-default) this is deliberate — the absent-namespace lane
+# is not a shape the current server can emit (see the boundary section), so a
+# live clause could only ever confirm what is already known and would go stale
+# on the next redeploy. There is no post-deploy clause because there is no
+# server-side change to deploy: the fix ships with the Python package.
+#
+# Output is statuses and key names only. No tokens, no memory bodies.
+#
+# EXPECTED TO FAIL until #662 is fixed. It is the reward function, not a test
+# of the fix's author.
+set -uo pipefail
+
+REPO_ROOT="${OPENBRAIN_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+PKG_DIR="$REPO_ROOT/python/openbrain-memory"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+[ -d "$PKG_DIR" ] || fail_hard "python package not found at $PKG_DIR"
+command -v uv >/dev/null 2>&1 || fail_hard "uv not on PATH (provider runner)"
+
+printf 'subject    : %s\n' "$PKG_DIR/src/openbrain_memory/_runtime_validation.py"
+printf 'mode       : hermetic (in-process validator; no service, no database)\n\n'
+
+DRIVER="$REPO_ROOT/scripts/done-means/662_absent_namespace_driver.py"
+[ -r "$DRIVER" ] || fail_hard "driver not readable at $DRIVER"
+
+( cd "$PKG_DIR" && uv run python "$DRIVER" )
+STATUS=$?
+
+# The driver owns the verdict line and the exit code. A non-zero status that is
+# not 1 means the driver itself broke (import error, uv failure) rather than a
+# clause failing — that is a harness error, not a RED, and conflating the two
+# is how a false RED banks confidence in a check that measured nothing
+# (Tightenings round 16/18).
+if [ "$STATUS" -ne 0 ] && [ "$STATUS" -ne 1 ]; then
+  fail_hard "driver exited $STATUS — this is a harness failure, not a clause failure"
+fi
+exit "$STATUS"

--- a/scripts/done-means/662_absent_namespace_driver.py
+++ b/scripts/done-means/662_absent_namespace_driver.py
@@ -1,0 +1,200 @@
+"""Driver for the #662 done-means check. Run it via the shell wrapper.
+
+Drives the SHIPPED validator in-process against constructed session_start
+results. The lane object is the untrusted input under test, so constructing it
+by hand IS the realistic shape: the validator's job is to be correct about
+whatever a server sends, and #662 is a lane shape a server sent.
+
+The import is DYNAMIC (importlib) rather than a module-level `from ... import`.
+A static import of a symbol that does not exist at the pre-fix tree kills the
+driver at module resolution before a single clause prints — a false RED
+indistinguishable at the shell from a real one (Tightenings round 18). Nothing
+imported here is new, but the pattern is the default path, not an edge case.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Scope:
+    """The exact-scope coordinates a lane must prove."""
+
+    session_key: str = "repo/session-4"
+    agent: str = "bilby"
+    platform: str = "discord"
+    server_id: str = "guild-1"
+    channel_id: str = "channel-2"
+    thread_id: str | None = "thread-3"
+
+
+CONFIGURED_NAMESPACE = "bilby"
+DEAD_END = "did not prove exact Open Brain scope: namespace"
+
+
+def correct_lane() -> dict[str, Any]:
+    """A lane that proves every coordinate, including the namespace."""
+    scope = Scope()
+    return {
+        "namespace": CONFIGURED_NAMESPACE,
+        "session_key": scope.session_key,
+        "agent": scope.agent,
+        "source": scope.platform,
+        "channel_id": scope.channel_id,
+        "thread_id": scope.thread_id,
+        "metadata": {"server_id": scope.server_id},
+    }
+
+
+def validate(lane: dict[str, Any]) -> str | None:
+    """Return the refusal text, or None when the lane validated clean."""
+    module = importlib.import_module("openbrain_memory._runtime_validation")
+    validate_started_lane = module.validate_started_lane
+    try:
+        validate_started_lane({"lane": lane}, CONFIGURED_NAMESPACE, Scope())
+    except ValueError as error:
+        return str(error)
+    return None
+
+
+FAILURES = 0
+
+
+def report(clause: str, ok: bool, detail: str) -> None:
+    global FAILURES
+    if ok:
+        print(f"{clause:<40}: PASS - {detail}")
+    else:
+        print(f"{clause:<40}: FAIL - {detail}")
+        FAILURES += 1
+
+
+def main() -> int:
+    # -- (a) RED ANCHOR: the absent case must not produce the dead-end error.
+    absent = correct_lane()
+    del absent["namespace"]
+    absent_error = validate(absent)
+    if absent_error is None:
+        report(
+            "(a) absent namespace not dead-ended",
+            False,
+            "the absent lane VALIDATED CLEAN - a lane that never proved its "
+            "namespace was accepted, which is the silent mis-scope #654 exists "
+            "to prevent",
+        )
+    elif DEAD_END in absent_error:
+        report(
+            "(a) absent namespace not dead-ended",
+            False,
+            f"RED ANCHOR PRESENT - generic dead-end error returned: [{absent_error}]",
+        )
+    else:
+        report(
+            "(a) absent namespace not dead-ended",
+            True,
+            "the generic scope-proof dead end is gone",
+        )
+
+    # -- (b) The absent refusal must be actionable.
+    #
+    # Actionable here means: it says the response OMITTED the key (so the
+    # reader knows this is a server-shape problem, not something to retype),
+    # and it names the configured namespace so the reader can see what was
+    # asked for. Asserting on text is the point - a refusal that refuses for
+    # an unsayable reason IS the defect (#646/#654 dead-end class).
+    text = absent_error or ""
+    lowered = text.lower()
+    says_omitted = any(
+        word in lowered for word in ("did not return", "omitted", "no namespace")
+    )
+    names_configured = CONFIGURED_NAMESPACE in text
+    report(
+        "(b) absent refusal is actionable",
+        says_omitted and names_configured and DEAD_END not in text,
+        (
+            f"says-omitted={says_omitted} names-configured={names_configured} "
+            f"error=[{text or '<none>'}]"
+        ),
+    )
+
+    # -- (c) The absent case must STAY a refusal.
+    #
+    # Separate from (b) on purpose. (b) could be satisfied by a warning that
+    # then returned normally; this clause is the one that says the write does
+    # not happen. Splitting them is the round-17 lesson: a claim with two
+    # halves asserted in one clause passes for the wrong reason.
+    report(
+        "(c) absent namespace still refused",
+        absent_error is not None,
+        (
+            "refused"
+            if absent_error is not None
+            else "ACCEPTED - the check was satisfied by removing the guard"
+        ),
+    )
+
+    # -- (d) CONTROL: #657's mismatch branch is untouched. Passes pre- and post-fix.
+    mismatch = correct_lane()
+    mismatch["namespace"] = "token-namespace"
+    mismatch_error = validate(mismatch) or ""
+    mismatch_ok = (
+        "token-namespace" in mismatch_error
+        and CONFIGURED_NAMESPACE in mismatch_error
+        and "OPENBRAIN_DELEGATE_NAMESPACE" in mismatch_error
+    )
+    report(
+        "(d) control, #657 mismatch intact",
+        mismatch_ok,
+        f"error=[{mismatch_error or '<none>'}]",
+    )
+
+    # -- (e) CONTROL: #529's request-key shapes are unchanged.
+    #
+    # `agent` IS a request key, so naming it is already actionable. This clause
+    # pins that the namespace work did not reroute request-key mismatches into
+    # a namespace-flavoured message, and that they are still reported by their
+    # own names.
+    wrong_agent = correct_lane()
+    wrong_agent["agent"] = "someone-else"
+    agent_error = validate(wrong_agent) or ""
+    agent_ok = (
+        "did not prove exact Open Brain scope" in agent_error
+        and "agent" in agent_error
+        and "namespace" not in agent_error
+    )
+    report(
+        "(e) control, #529 request keys intact",
+        agent_ok,
+        f"error=[{agent_error or '<none>'}]",
+    )
+
+    # -- (f) CONTROL: the healthy path still validates clean.
+    healthy_error = validate(correct_lane())
+    report(
+        "(f) control, correct lane validates",
+        healthy_error is None,
+        (
+            "clean"
+            if healthy_error is None
+            else f"a fully-correct lane was REFUSED: [{healthy_error}]"
+        ),
+    )
+
+    print()
+    if FAILURES == 0:
+        print(
+            "=== DONE-MEANS 662: PASS - an absent namespace key is refused with an "
+            "error naming what the caller can check, the #657 mismatch remedy is "
+            "intact, and #529's request-key shapes are unchanged. ==="
+        )
+        return 0
+    print(f"=== DONE-MEANS 662: FAIL ({FAILURES} failing clause(s)) ===")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Fixes #662. A session_start lane object carrying NO namespace key fell through to the generic "session_start result did not prove exact Open Brain scope: namespace" — the exact dead-end message #654's own comment says must never be produced for this key, because namespace is env-carried and has no request spelling for the operator to correct.
- Root cause: #654 (PR #657) diagnosed the MISMATCH case behind the guard `if "namespace" in lane and served != namespace` at _runtime_validation.py:107-116. Absence walks past that guard into validate_exact_fields, where a missing key counts as a mismatch and gets reported by name. Same defect #654 fixed, on the other side of its own if.
- Decided at the owning boundary, and the boundary is the VALIDATOR, not the server. The dispatch proposed a possible server-side fix; checked and rejected on evidence. Both session_start implementations already return namespace unconditionally — server/tools/session-lifecycle.ts:13 (startLaneFields, used by all three sub-paths at :144, :167, :186) and src/tools/session-start.ts:9 (LANE_COLUMNS) — and the mcp2cli fallback calls the same session_start tool (_runtime_router.py:145-149), so it inherits the same shape. Confirmed live: a raw tools/call against the serving process on 127.0.0.1:3100 returned the namespace in the lane object. There is no server-side omission to correct, so a "always return it" change would edit code that already does it.
- The lane object is untrusted input to this validator — it is the thing being validated — so "our server always sends it" is not a reason to leave a hostile-input branch dead-ended. The codebase already contains namespace-less lane SELECTs on a neighbouring path (server/tools/context-pack-durable-lane.ts:292-293, src/tools/agent-context-pack-durable-lane.ts:265), and #662 was filed because a real run reached this branch.
- Absence and mismatch now carry different messages because they are different faults. A mismatch has a remedy: delegate the namespace. An absence does not, because the server never stated one, so repeating the delegation advice would be a false remedy — a dead end with more words. The absent refusal names the configured namespace, says the response omitted it, and points at OPENBRAIN_BASE_URL as the thing to check.
- It stays a REFUSAL. An unproven namespace is not a proven one; accepting the lane would be the silent mis-scope #654 exists to prevent.

**On #529, checked and stated either way as asked:** this fix does NOT cover it, and #529 needs no further work from this issue. #529 (CLOSED) reported the same validator's generic message naming agent, channel_id, source. Those keys differ in the way that matters: they ARE request keys, carried in the caller's scope object, so naming them is already actionable — the operator has a field to correct. namespace is the sole scope key with no request spelling, which is why it needed #654 and needs this. Scope was deliberately not expanded. Clause (e) of the done-means pins the distinction so a future change cannot quietly reroute the request-key shapes into a namespace-flavoured message; if those shapes are ever judged insufficiently actionable, that is its own lane.

## Verification

- Done-means: scripts/done-means/662-absent-namespace-scope-proof.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED (pre-fix, at the committed check against origin/main's validator) — real exit 1:**

```
(a) absent namespace not dead-ended     : FAIL - RED ANCHOR PRESENT - generic dead-end error returned: [session_start result did not prove exact Open Brain scope: namespace]
(b) absent refusal is actionable        : FAIL - says-omitted=False names-configured=False error=[session_start result did not prove exact Open Brain scope: namespace]
(c) absent namespace still refused      : PASS - refused
(d) control, #657 mismatch intact       : PASS
(e) control, #529 request keys intact   : PASS - error=[session_start result did not prove exact Open Brain scope: agent]
(f) control, correct lane validates     : PASS - clean

=== DONE-MEANS 662: FAIL (2 failing clause(s)) ===
EXIT=1
```

Two clauses red with four controls green is the discriminating shape — a check that failed everywhere would only prove it fails. Each RED was read for WHY, not tallied: (a) fails because the dead-end string is present, (b) because the message names neither the omission nor the configured namespace.

**GREEN (post-fix, clean committed worktree) — exit 0:**

```
(a) absent namespace not dead-ended     : PASS - the generic scope-proof dead end is gone
(b) absent refusal is actionable        : PASS - says-omitted=True names-configured=True error=[session_start did not return a namespace for the lane, so it cannot prove the configured 'bilby'. ... Check that OPENBRAIN_BASE_URL points at an Open Brain whose session_start returns the lane's namespace. Nothing was written to 'bilby'.]
(c) absent namespace still refused      : PASS - refused
(d) control, #657 mismatch intact       : PASS - error names token-namespace, bilby, and OPENBRAIN_DELEGATE_NAMESPACE
(e) control, #529 request keys intact   : PASS
(f) control, correct lane validates     : PASS - clean

=== DONE-MEANS 662: PASS ===
EXIT=0
```

**Pytest regression, proven red-first by file-copy (no stash — round-13 rule):** with origin/main's validator restored under the new tests, test_absent_namespace_names_the_response_shape_not_a_false_remedy FAILED on the dead-end assertion (1 failed, 21 passed). Its sibling test_absent_namespace_is_still_refused_never_accepted passes both pre- and post-fix by design: it is a control proving the fix does not loosen the refusal, not a red anchor. Fix restored, 22 passed.

**Gates:**

- bun run test:isolated — 3747 pass, 35 skip, 0 fail across 244 files, database ob_isolated_11875_msl19achic created and dropped
- bunx tsc --noEmit — clean, exit 0
- uv run mypy src/openbrain_memory — Success, no issues in 17 source files
- uv run ruff check src tests — All checks passed
- uv run pytest -q — 579 passed, 14 skipped (skip count checked, not just the pass count — round-10 lesson)

**Hermetic by design, per ledger 26.2.** All six clauses drive the shipped validator in-process with constructed lane objects: no service, no database, no credentials. This is deliberate rather than a gap. The absent-namespace lane is not a shape the current server can emit (see the boundary evidence above), so a live clause could only confirm what is already known and would go stale on the next redeploy — the round-12 non-portable-receipt problem. There is no post-deploy clause because there is no server-side change to deploy: the fix ships inside the Python package.

## Critical Self-Review

- Highest-risk behavior: the branch that decides whether a capture is allowed to proceed. Getting it wrong in the permissive direction means writing into a lane whose namespace was never proven, which is a cross-tenant landing, not a cosmetic error. The fix adds a raise on a path that previously also raised, so the permissive direction is not reachable by this diff; clause (c) and a dedicated pytest case both assert the refusal survives.
- Assumptions that could be wrong: that no live server omits namespace from a session_start lane. Verified for both in-repo implementations by source and confirmed live against the local dogfood service, but NOT verified against hosted core01 at 10.71.1.21:3100 — I did not query it. If core01 runs an older build that omits the key, this change is what makes that situation legible rather than opaque, so the assumption failing makes the fix more valuable, not less. Second assumption: that an operator reading "check what OPENBRAIN_BASE_URL points at" can act on it; that is a judgement about usefulness and is not machine-checkable.
- Missing/weak tests: no test asserts a real server response can never omit the key — that would be a server-side contract test, and it is not what this issue is about. The message assertions are substring-based, so a reworded-but-still-actionable message would fail them; that is intentional (the text IS the deliverable) but it makes them brittle to unrelated copy edits.
- Security/permission risk: the change tightens rather than loosens. Namespace isolation is a security boundary in this repo, and the absent case now refuses by name instead of refusing opaquely. No auth, role, or predicate logic is touched. No new input is trusted.
- Migration/deploy risk: none. No schema change, no migration, no server change, no config key.
- Downstream client/runtime risk: this IS a Python client change, so downstream-rollout classification applies and is filled in below. The change is to error TEXT on an already-failing path plus one new raise on a path that already raised — no tool schema, no protocol, no wire shape, no public signature changes. A downstream consumer that string-matches the old generic error for the absent case would see the new message, which is the point of the issue.
- Rollback/cleanup concern: revert of a single commit touching four files; no state to unwind. Lane worktree and lane database are torn down by the lane.
- Fixes made before PR: the driver's import was switched to importlib after reading the round-18 lesson — a static import of a symbol absent at the pre-fix tree kills the driver before any clause prints, producing a false RED shaped exactly like a real one. Nothing imported here is new, but the pattern is now the default. Also split the actionable-message assertion from the still-refused assertion into separate clauses and separate tests, after the round-17 lesson that a two-halved claim in one clause passes for the wrong reason.
- Known residual risk: hosted core01's session_start lane shape is unverified from this lane (stated above, not implied away). Separately, the absent-case message tells the operator to check the endpoint, which is the honest advice available at the client, but it cannot name WHICH server build is answering — a version field in the response would make it sharper and does not exist today. PROPOSED, not filed.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the dead-end-error class is already captured for reviewers by the #654/#646 material and the lane-contract round-15 Tightening, and this lane's reusable lesson is an operating one for lanes (a guard written as "key present AND wrong" leaves the absent branch unguarded) which belongs in the lane contract's Tightenings via the controller's harvest, not in a reviewer lane file.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the fix is client-side and ships in the Python package with nothing to deploy, and the defect's input shape cannot be produced by the running server, so a live clause would exercise the healthy path only. The live probes that WERE run are recorded above as boundary evidence, not as acceptance.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this changes only the Python provider's refusal text for a response shape it rejects either way. No tool contract, schema version, or wire field changes, so there is no cross-runtime fixture to update.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified per docs/downstream-rollout.md as a Python-client change with NO contract surface. No MCP tool, schema, protocol, or client-facing signature is modified: the diff adds one raise on an already-raising path and rewords one error string. rtech-mcps and mcp2cli mediate tool contracts, which are untouched, so no handoff or cache refresh applies.
- rtech-hermes consumes this package. The behavioral delta a Hermes runtime could observe is the error TEXT on a session_start response that was already being rejected — captures that failed before still fail, with a message that names the fault. No Hermes code change is required and no canary is gated on this; a Hermes agent picks up the new text on its next package bump.
- Truth labels: the fix is MERGED-to-branch only, i.e. WRITTEN and pushed, not merged and not deployed. Every clause result above is RUNNING as of this lane's execution against the committed branch tree. The claim that the serving process returns namespace is RUNNING, observed live on 127.0.0.1:3100. The claim about hosted core01 is explicitly unverified.
