### PR TITLE
fix(eval): scenario transport requests namespace delegation (#666)

### DIFF
--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -114,6 +114,18 @@ export class LiveScenarioTransport implements ScenarioTransport {
         OPENBRAIN_TOKEN: this.config.primaryToken,
         OPENBRAIN_NAMESPACE: this.config.primaryNamespace,
         OPENBRAIN_PROJECT: this.config.project,
+        // This transport ALWAYS derives a per-run `eval-live-recall-*`
+        // namespace (config.ts runNamespaces) that no token grants by default,
+        // so it always needs the X-Namespace header. Since #657 the provider's
+        // delegation is opt-in and default OFF, and without this flag
+        // session_start binds the token's own namespace and refuses the
+        // configured one (#666, #662's error text). A component that derives
+        // foreign namespaces owns the delegation request — ledger item 30.1
+        // puts the intent here, in code with its reason, rather than in
+        // live-eval.env where every future credential assembly must remember
+        // it. The token must still be admin/ob-admin; the server role-gates
+        // the header regardless of this flag.
+        OPENBRAIN_DELEGATE_NAMESPACE: "1",
       },
       stdin: "pipe",
       stdout: "pipe",

--- a/scripts/done-means/666-transport-delegates-namespace.driver.ts
+++ b/scripts/done-means/666-transport-delegates-namespace.driver.ts
@@ -1,0 +1,254 @@
+/**
+ * DONE-MEANS driver for #666 — the E2E scenario transport requests namespace
+ * delegation when it spawns the provider.
+ *
+ * Not a test file; invoked by
+ * scripts/done-means/666-transport-delegates-namespace.sh, which owns the
+ * verdict.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT IS UNDER TEST, AND FROM WHICH SEAM
+ * ---------------------------------------------------------------------------
+ * `LiveScenarioTransport.executeProvider` spawns `uv run openbrain-memory`
+ * with an env it builds inline. Since #657 the provider's namespace delegation
+ * is opt-in and default OFF, and the transport ALWAYS derives a per-run
+ * `eval-live-recall-*` namespace that no token grants by default — so without
+ * OPENBRAIN_DELEGATE_NAMESPACE=1 the provider binds the token's own namespace
+ * and refuses the configured one (the #662 error text). Ledger item 30.1 rules
+ * that the TRANSPORT owns the delegation request, not `live-eval.env`.
+ *
+ * The subject is therefore the env dictionary that `Bun.spawn` actually
+ * receives from the REAL `executeProvider` — not a helper extracted for
+ * observability. `Bun.spawn` is stubbed for the duration of the call using the
+ * repo's existing convention (`src/tools/__tests__/search-all.test.ts:85`,
+ * `src/tools/__tests__/graph-evidence-consumers.test.ts:268`): the shipped
+ * method runs unmodified and the stub records its second argument. Stubbing
+ * the process boundary is what keeps the clause bound to the real call site
+ * while needing no `uv`, no provider install, no network, and no credentials.
+ *
+ * ---------------------------------------------------------------------------
+ * STUB-VS-LIVE COVERAGE SPLIT — READ THIS BEFORE CITING A GREEN
+ * ---------------------------------------------------------------------------
+ * This check proves the transport ASKS for delegation. It does NOT prove the
+ * end-to-end capture works, and it cannot:
+ *
+ *   - `scripts/done-means/655-eval-teardown.driver.ts:116` supplies its own
+ *     `ScenarioTransport` whose `executeProvider` writes direct SQL. The real
+ *     spawn is never reached there, so #655's green never covered — and could
+ *     never have caught — this defect. That is the coverage trap the verifier
+ *     named (SME `injected_destination_bypasses_broken_composition`).
+ *   - Here the spawn itself is stubbed, so the provider process, the
+ *     X-Namespace header it sends, the server's role gate, and the durable row
+ *     are all OUTSIDE this vantage point.
+ *
+ * The COMPOSED live proof stays exactly where it was: the #578 gate's
+ * credentialed run, re-verified by the controller after this merges and PR
+ * #653 syncs main again. This lane holds no credentials and harvests none.
+ *
+ * ---------------------------------------------------------------------------
+ * CLAUSES
+ * ---------------------------------------------------------------------------
+ *   (a) The env passed to the real spawn contains OPENBRAIN_DELEGATE_NAMESPACE
+ *       set to exactly "1". RED on origin/main: the key is absent entirely.
+ *   (b) CONTROL — the four env keys the transport already set are unchanged:
+ *       OPENBRAIN_BASE_URL / _TOKEN / _NAMESPACE / _PROJECT still carry their
+ *       configured values, and the ambient process env still passes through.
+ *       Passes PRE-fix by design (round 13: a check that fails everywhere
+ *       proves only that it fails). This is the clause that fails if the fix
+ *       replaces the env instead of adding one key to it.
+ *   (c) MUTATION — clause (a) is re-run against the observed env with the
+ *       delegation key stripped, and must FAIL there. Clause (a) is a
+ *       single-key presence assertion, which is exactly the shape that passes
+ *       for the wrong reason when the reader is looking at the wrong object.
+ *
+ * The mutant is applied to the OBSERVED env, not to the source file: deleting
+ * the fix to prove RED is the round-16 "false RED by breaking the import"
+ * hazard in another spelling, and an env-level mutant keeps RED regenerable
+ * forever with the fix in place. It is honest about what it proves — that
+ * clause (a) reads the delegation key specifically and fails on its absence —
+ * and it is announced as such rather than presented as a source-level mutation.
+ *
+ * Output: clause names, states, and env KEY names. No OPENBRAIN_TOKEN value is
+ * printed; the token fixture is a literal string invented here, and it is
+ * still not echoed, because a driver that prints token values teaches the
+ * wrong habit for the day one is real.
+ */
+import type { LiveEvalConfig } from "../../eval/open-brain/live/config.ts";
+import { LiveScenarioTransport } from "../../eval/open-brain/live/scenario-transport.ts";
+
+const MUTATE = process.env.DONE_MEANS_666_MUTATE === "1";
+
+/**
+ * Fixture config. `primaryNamespace` deliberately carries the real
+ * `eval-live-recall-` prefix the gate derives per run: it is the foreign
+ * namespace whose binding is the whole reason the delegation header is needed.
+ */
+const CONFIG: LiveEvalConfig = {
+  baseUrl: "http://127.0.0.1:3100",
+  primaryToken: "fixture-token-not-a-credential",
+  negativeToken: "fixture-token-not-a-credential",
+  negativeTokenIsDistinct: false,
+  primaryNamespace: "eval-live-recall-donemeans666",
+  negativeNamespace: "eval-live-recall-donemeans666-negative",
+  project: "open-brain",
+  searchMode: "hybrid",
+  timeoutMs: 1000,
+};
+
+/** An ambient key planted in process.env to prove passthrough survives (b). */
+const AMBIENT_KEY = "DONE_MEANS_666_AMBIENT";
+const AMBIENT_VALUE = "ambient-passthrough-probe";
+
+const DELEGATE_KEY = "OPENBRAIN_DELEGATE_NAMESPACE";
+
+interface Clause {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+const clauses: Clause[] = [];
+function record(name: string, ok: boolean, detail: string): void {
+  clauses.push({ name, ok, detail });
+}
+
+/**
+ * Drive the REAL `executeProvider` with `Bun.spawn` stubbed, and return the env
+ * record the shipped method handed to the process boundary.
+ *
+ * The stub returns the minimal shape `executeProvider` consumes — a writable
+ * stdin, two readable streams, and an `exited` promise — so the method runs to
+ * completion through its real `parseProviderOutput` path instead of throwing
+ * somewhere that would hide which env it built. Exit 0 with empty stdout is
+ * that function's documented empty-result path, so no receipt is fabricated.
+ */
+async function captureSpawnEnv(): Promise<Record<string, string>> {
+  const originalSpawn = Bun.spawn;
+  let captured: Record<string, string> | null = null;
+  const encoder = new TextEncoder();
+
+  (Bun as unknown as { spawn: unknown }).spawn = (
+    _cmd: string[],
+    options: { env?: Record<string, string> },
+  ) => {
+    captured = { ...(options.env ?? {}) };
+    return {
+      stdin: { write() {}, end() {} },
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(""));
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      exited: Promise.resolve(0),
+    };
+  };
+
+  try {
+    // Neither the tool caller nor the pool is reached by executeProvider; both
+    // are supplied through the constructor's own injection points as stubs so
+    // that a future coupling fails loudly here instead of opening a socket.
+    const transport = new LiveScenarioTransport(
+      (() => {
+        throw new Error("tool caller must not be reached by executeProvider");
+      }) as never,
+      CONFIG,
+      { query: async () => ({ rows: [] }) } as never,
+    );
+    await transport.executeProvider({ operation: "capture" });
+  } finally {
+    (Bun as unknown as { spawn: unknown }).spawn = originalSpawn;
+  }
+
+  if (captured === null) {
+    throw new Error("executeProvider did not reach Bun.spawn");
+  }
+  return captured;
+}
+
+/** Clause (a), factored so the mutation clause can re-run it verbatim. */
+function delegationRequested(env: Record<string, string>): boolean {
+  return env[DELEGATE_KEY] === "1";
+}
+
+async function main(): Promise<number> {
+  process.env[AMBIENT_KEY] = AMBIENT_VALUE;
+  const env = await captureSpawnEnv();
+
+  // ---- (a) the delegation flag reaches the spawned provider ---------------
+  const requested = delegationRequested(env);
+  record(
+    `(a) spawn env sets ${DELEGATE_KEY}=1`,
+    requested,
+    requested
+      ? `${DELEGATE_KEY} present with value "1"`
+      : DELEGATE_KEY in env
+        ? `${DELEGATE_KEY} present but not "1"`
+        : `${DELEGATE_KEY} absent from the spawn env`,
+  );
+
+  // ---- (b) CONTROL: the four existing keys and passthrough are unchanged --
+  const expected: Array<[string, string]> = [
+    ["OPENBRAIN_BASE_URL", CONFIG.baseUrl],
+    ["OPENBRAIN_TOKEN", CONFIG.primaryToken],
+    ["OPENBRAIN_NAMESPACE", CONFIG.primaryNamespace],
+    ["OPENBRAIN_PROJECT", CONFIG.project],
+  ];
+  const wrong = expected
+    .filter(([key, value]) => env[key] !== value)
+    .map(([key]) => key);
+  const passthroughOk = env[AMBIENT_KEY] === AMBIENT_VALUE;
+  record(
+    "(b) CONTROL: four existing keys unchanged + ambient passthrough intact",
+    wrong.length === 0 && passthroughOk,
+    wrong.length === 0 && passthroughOk
+      ? "OPENBRAIN_BASE_URL/_TOKEN/_NAMESPACE/_PROJECT carry configured values; ambient key passed through"
+      : `wrong-or-missing keys: ${wrong.join(", ") || "none"}; ambient passthrough: ${passthroughOk}`,
+  );
+
+  // ---- (c) MUTATION: strip the key, clause (a) must fail ------------------
+  const mutant = { ...env };
+  delete mutant[DELEGATE_KEY];
+  const mutantSurvives = delegationRequested(mutant);
+  record(
+    "(c) MUTATION: clause (a) fails when the delegation key is stripped",
+    !mutantSurvives,
+    mutantSurvives
+      ? "clause (a) still passed without the key — it is not reading the key"
+      : "clause (a) correctly failed on the stripped env",
+  );
+
+  if (MUTATE) {
+    // Escape hatch for a human re-proving the mutation by hand: report clause
+    // (a) AS the mutant and nothing else, so the transcript shows the intended
+    // failure rather than a green run that merely claims one happened.
+    console.log(
+      `INFO  DONE_MEANS_666_MUTATE=1 — reporting clause (a) against the env with ${DELEGATE_KEY} stripped`,
+    );
+    const ok = delegationRequested(mutant);
+    console.log(`MUTANT clause (a) => ${ok ? "PASS (BAD)" : "FAIL (expected)"}`);
+    return ok ? 1 : 0;
+  }
+
+  for (const clause of clauses) {
+    console.log(
+      `${clause.ok ? "PASS" : "FAIL"}  ${clause.name} — ${clause.detail}`,
+    );
+  }
+  const failed = clauses.filter((clause) => !clause.ok).length;
+  console.log(`\nclauses: ${clauses.length}  failed: ${failed}`);
+  return failed === 0 ? 0 : 1;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (error) => {
+    console.error(`FAIL  driver error: ${(error as Error).message}`);
+    process.exit(2);
+  },
+);

--- a/scripts/done-means/666-transport-delegates-namespace.sh
+++ b/scripts/done-means/666-transport-delegates-namespace.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #666 — "the E2E scenario transport spawns the
+# provider WITH OPENBRAIN_DELEGATE_NAMESPACE=1, so the per-run eval namespace it
+# always derives can actually be bound".
+#
+#   bash scripts/done-means/666-transport-delegates-namespace.sh
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT
+# ---------------------------------------------------------------------------
+# eval/open-brain/live/scenario-transport.ts:109-119 spawns
+# `uv run openbrain-memory` with four env keys — OPENBRAIN_BASE_URL, _TOKEN,
+# _NAMESPACE, _PROJECT — and no delegation flag, while ALWAYS deriving a
+# per-run `eval-live-recall-*` namespace (config.ts `runNamespaces`) that the
+# token does not already grant.
+#
+# Since PR #657 the provider's namespace delegation is opt-in and default OFF,
+# so `session_start` binds the token's own namespace instead and refuses the
+# configured one. #662 then made that refusal name its own remedy. Both are
+# working as designed; the transport is the thing that never asked.
+#
+# Verifiable at origin/main:
+#
+#   $ rg -n 'DELEGATE' eval/open-brain/live/scenario-transport.ts
+#   (no matches)
+#
+# Operator ruling, ledger item 30.1 (docs/issue-graph.md): the TRANSPORT owns
+# the delegation request, because the component that derives foreign namespaces
+# is the one that always needs the header, and intent belongs in code with its
+# reason. REJECTED: putting the flag in live-eval.env (buries intent in
+# machine-local operator config, and every future credential assembly has to
+# remember it); rejected: both places (redundant).
+#
+# ---------------------------------------------------------------------------
+# COVERAGE SPLIT — STUB VS LIVE. READ BEFORE CITING THIS GREEN AS PROOF.
+# ---------------------------------------------------------------------------
+# This check is a UNIT-LEVEL proof that the transport ASKS for delegation. It
+# proves nothing about the composed end-to-end capture, by construction:
+#
+#   * WHAT IT COVERS — the real `LiveScenarioTransport.executeProvider` runs
+#     unmodified and the env it hands to the process boundary is read at the
+#     actual `Bun.spawn` call site (the boundary is stubbed with the repo's
+#     existing convention from src/tools/__tests__/search-all.test.ts:85).
+#
+#   * WHAT IT DOES NOT COVER — the provider process, the X-Namespace header it
+#     derives from the flag, the server's role gate on that header, and the
+#     durable row that should land in the derived namespace. All are past the
+#     stubbed boundary.
+#
+#   * WHY #655's GREEN NEVER COVERED THIS — that driver
+#     (scripts/done-means/655-eval-teardown.driver.ts:116) supplies its own
+#     ScenarioTransport whose executeProvider writes direct SQL, so the real
+#     spawn is never reached in it. Its passing state was never evidence about
+#     this env and could not have caught this defect. That is the trap named in
+#     the SME KB as injected_destination_bypasses_broken_composition.
+#
+#   * WHERE THE COMPOSED PROOF LIVES — the #578 gate's CREDENTIALED run, which
+#     the controller re-verifies after this merges and PR #653 syncs main
+#     again. This lane holds no credentials and harvests none, so it cannot and
+#     does not attempt that leg.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) The spawn env carries OPENBRAIN_DELEGATE_NAMESPACE="1". RED on
+#       origin/main: the key is absent entirely.
+#   (b) CONTROL — the four keys the transport already passed still carry their
+#       configured values, and an ambient process-env key still passes through.
+#       Passes PRE-fix by design (round 13: a check failing everywhere proves
+#       only that it fails). Fails any "fix" that rebuilds the env instead of
+#       adding one key to it.
+#   (c) MUTATION — clause (a) re-run against the observed env with the
+#       delegation key stripped must FAIL. A single-key presence assertion is
+#       exactly the shape that passes for the wrong reason, so it gets a mutant.
+#
+# No database, no network, no credentials, no child process. Content-free
+# output: clause names, states, and env KEY names.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRIVER="scripts/done-means/666-transport-delegates-namespace.driver.ts"
+
+if [[ ! -f "$DRIVER" ]]; then
+  echo "FAIL  driver missing: $DRIVER"
+  echo "DONE-MEANS #666: FAIL"
+  exit 1
+fi
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  driver: $DRIVER (real executeProvider, stubbed Bun.spawn; no DB, no network, no credentials)"
+echo "INFO  scope:  unit-level delegation REQUEST only — the composed live proof is the #578 gate's credentialed run"
+echo
+
+set +e
+bun "$DRIVER"
+DRIVER_STATUS=$?
+set -e
+
+echo
+if [[ $DRIVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #666: PASS — the scenario transport spawns the provider with OPENBRAIN_DELEGATE_NAMESPACE=1 and its other env keys unchanged."
+else
+  echo "DONE-MEANS #666: FAIL — the scenario transport still spawns the provider without requesting namespace delegation, or it disturbed the existing env keys."
+fi
+exit $DRIVER_STATUS


### PR DESCRIPTION
## Summary

- Fixes #666. The E2E scenario transport spawned the provider without OPENBRAIN_DELEGATE_NAMESPACE, so every per-run eval namespace it derives was refused.
- eval/open-brain/live/scenario-transport.ts now sets OPENBRAIN_DELEGATE_NAMESPACE=1 in the env it passes to the spawned provider, with a comment carrying the reason. One key added; the other four are untouched.
- Root cause: the transport ALWAYS derives a per-run eval-live-recall-* namespace (config.ts runNamespaces) that no token grants by default, but since #657 the provider's delegation is opt-in and default OFF. session_start therefore bound the token's own namespace and refused the configured one with #662's actionable text. Both #657 and #662 were working as designed; the transport is the component that never asked.
- Per operator ruling, ledger item 30.1: the TRANSPORT owns the delegation request, because the component deriving foreign namespaces is the one that always needs the header, and intent belongs in code with its reason. Rejected there: the flag in live-eval.env (buries intent in machine-local operator config), and both places (redundant).
- Adds the executable done-means check, written red-first.

### Coverage split, stated explicitly

This is a UNIT-LEVEL proof that the transport ASKS for delegation. It is not, and cannot be, the composed proof:

- Covered: the real executeProvider runs unmodified and the env is read at the actual Bun.spawn call site. The boundary is stubbed with the repo's existing convention (src/tools/__tests__/search-all.test.ts:85).
- Not covered: the provider process, the X-Namespace header, the server role gate, and the durable row. All sit past the stubbed boundary.
- Why #655's green never covered this: scripts/done-means/655-eval-teardown.driver.ts:116 supplies its own ScenarioTransport whose executeProvider writes direct SQL, so the real spawn is never reached there. Its passing state was never evidence about this env. That is the SME trap injected_destination_bypasses_broken_composition.
- The composed live proof remains the #578 gate's CREDENTIALED run, which the controller re-verifies after this merges and PR #653 syncs main again. This lane held no credentials and harvested none.

## Verification

- Done-means: scripts/done-means/666-transport-delegates-namespace.sh

RED, before the change (exit read directly from a file redirect, no tee and no PIPESTATUS):

```
EXIT=1
FAIL  (a) spawn env sets OPENBRAIN_DELEGATE_NAMESPACE=1 — OPENBRAIN_DELEGATE_NAMESPACE absent from the spawn env
PASS  (b) CONTROL: four existing keys unchanged + ambient passthrough intact
PASS  (c) MUTATION: clause (a) fails when the delegation key is stripped
clauses: 3  failed: 1
DONE-MEANS #666: FAIL
```

Clause (a) failed for the defect's own reason (key absent from the real spawn env), not at import and not by short-circuit; control (b) passed pre-fix by design.

GREEN, after the change:

```
EXIT=0
PASS  (a) spawn env sets OPENBRAIN_DELEGATE_NAMESPACE=1 — present with value "1"
PASS  (b) CONTROL: four existing keys unchanged + ambient passthrough intact
PASS  (c) MUTATION: clause (a) fails when the delegation key is stripped
clauses: 3  failed: 0
DONE-MEANS #666: PASS
```

Standalone mutation re-proof with the fix in place, DONE_MEANS_666_MUTATE=1: MUTANT clause (a) => FAIL (expected), exit 0.

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

bun run test:isolated exited 0: 3752 pass, 35 skip, 0 fail, 3787 tests across 244 files, on database ob_isolated_65735_msl2d2yzda which self-dropped. bunx tsc --noEmit exited 0. Python package untouched. Live smoke is the credentialed #578 leg and is not this lane's to run.

## Critical Self-Review

- Highest-risk behavior: the eval transport now always requests namespace delegation, so the provider sends X-Namespace on every scenario spawn. With a non-delegating token the server role gate refuses by name rather than silently landing in the token's namespace, which is the #654 behavior and the better failure.
- Assumptions that could be wrong: that a hardcoded 1 is right for every caller of this transport. It is scoped to the live scenario eval, which derives a foreign namespace unconditionally, so there is no caller for which the flag is wrong. If a future caller passes a namespace the token already grants, the flag is redundant rather than harmful.
- Missing/weak tests: the composed path is not covered here by construction. The provider, the header, the role gate, and the durable row need the credentialed #578 run. Stated in the check header and in the coverage split above rather than left implicit.
- Security/permission risk: no credential is read, written, or logged. The driver's token is an invented literal and is never echoed. Requesting the header does not grant it; the server role-gates X-Namespace independently of this flag.
- Migration/deploy risk: none. Eval-only path, no schema, no serving code, no config file.
- Downstream client/runtime risk: none. eval/open-brain/live is not shipped to mcp2cli, rtech-mcps, or Hermes, and no MCP tool, schema, or protocol surface changed.
- Rollback/cleanup concern: revert is the one env line. The lane created one worktree and one isolated test database; the database self-dropped and the worktree is removed.
- Fixes made before PR: none beyond the change itself. The check was written and proven RED before the fix existed.
- Known residual risk: the #578 gate's capture leg stays unproven until the controller's credentialed re-verify. This was named as the fourth and currently only known remaining blocker, so a further one may surface in that run.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the coverage trap this lane navigated is already in the KB as injected_destination_bypasses_broken_composition, and it was applied here rather than newly discovered.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the credentialed leg is the #578 gate run and belongs to the controller; this lane has no credentials and must not harvest any.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is one env key in the TypeScript eval harness that spawns the Python provider. No contract, schema, or fixture surface is involved, and the provider already reads this documented variable.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: the diff touches eval/open-brain/live and scripts/done-means only. No MCP tool, schema, transport, or client-facing surface changed, so no downstream client can observe this. The variable consumed is the provider's existing OPENBRAIN_DELEGATE_NAMESPACE from #657, unchanged here.
