### PR TITLE
fix(eval): teardown verdict reads residue, not the cleanup tally (#671)

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -1938,3 +1938,59 @@ is a namespace-isolation risk the moment it becomes searchable.
 predicate across that JOIN. Prove it by deleting the predicate and watching a
 cross-namespace test fail; an isolation test that has never been seen to fail
 is decoration.
+
+## [2026-08-08] A teardown that reports FAILURE is not evidence of residue
+
+**Severity:** HIGH
+**Source:** issue #671 (found by the third credentialed #653 verify, head d9d3712)
+**Scope:** `eval/open-brain/live/gate.ts`, `eval/open-brain/live/scenario-gate.ts`, `eval/open-brain/live/scenario-transport.ts`
+**Status:** active
+
+### Pattern
+
+Round 16's SME rule — "a teardown that reports success is not evidence of
+removal" — has a mirror that cost a full credentialed verify run. The scenario
+gate's teardown verdict read `teardown.failed`, a tally of cleanup CALLS, and
+treated it as a claim about ROWS. Those are different facts.
+
+The receipt read `attempted=6 archived=4 already_absent=0 failed=2`. All three
+scenarios passed live, delegation was confirmed in the service logs, and a
+12-purge-table residue query for the run's namespaces returned ZERO rows. The
+gate exited 1 anyway: two `archive_entry` calls had thrown, the composed
+namespace purge then removed every row, and nothing corrected the count.
+
+Two things to check in any teardown, cleanup, or reconcile verdict:
+
+1. **The verdict reads the OBSERVABLE, not the attempt log.** If the claim is
+   "nothing was left behind," the assertion is a row count queried after the
+   fact, not a counter incremented by the code doing the removing. A tally is a
+   diagnostic; it explains a result, it is not the result. Note the arithmetic
+   tell in the receipt above: `4+0+2=6` proves the two failures were record-loop
+   throws, because a purge failure increments `failed` WITHOUT touching
+   `attempted` — a tally that mixes two populations cannot be read as one.
+
+2. **"Not observed" is not "clean."** A residue reading that could not run must
+   fail the verdict, not pass it. Otherwise the fix trades a false red for a
+   false green, which is strictly worse. Same for a PARTIAL reading: a residue
+   counter that could not read some tables reports `checked: false`, because the
+   rows it failed to count are exactly where residue would hide.
+
+Companion defect in the same code, worth checking separately: the cleanup error
+was discarded into a bare `catch {}`, so when `failed=2` appeared the label of
+the throw was unrecoverable from the receipt, the log, or anywhere else — the
+dead-end-error class inside our own eval tooling. Keep the catch (one bad record
+must not strand the rest) and capture a CONTENT-FREE label per failure: a
+transport error's already-redacted label, or otherwise the error's class name
+only. Never an arbitrary `Error.message`, which can echo row content, a
+namespace, or a token fragment into an artifact that gets pasted into issues.
+
+### Reviewer check
+
+- Does any pass/fail decision rest on a counter maintained by the code being
+  judged? Ask what independent observation would confirm it.
+- If a residue/leak/orphan check exists, can it distinguish "zero" from "did not
+  look"? Trace the unchecked branch to a verdict.
+- Does the residue reader share its table/resource list with the remover, or
+  maintain a parallel one? A parallel list drifts silently and GREEN — the table
+  the remover stopped clearing also stops being counted.
+- Does every swallowed error contribute a label somewhere an operator can read?

--- a/docs/sme/entries/2026-08-08-a-teardown-that-reports-failure-is-not-evidence-of-residue.md
+++ b/docs/sme/entries/2026-08-08-a-teardown-that-reports-failure-is-not-evidence-of-residue.md
@@ -1,0 +1,59 @@
+---
+lane: correctness
+order: 66
+---
+## [2026-08-08] A teardown that reports FAILURE is not evidence of residue
+
+**Severity:** HIGH
+**Source:** issue #671 (found by the third credentialed #653 verify, head d9d3712)
+**Scope:** `eval/open-brain/live/gate.ts`, `eval/open-brain/live/scenario-gate.ts`, `eval/open-brain/live/scenario-transport.ts`
+**Status:** active
+
+### Pattern
+
+Round 16's SME rule — "a teardown that reports success is not evidence of
+removal" — has a mirror that cost a full credentialed verify run. The scenario
+gate's teardown verdict read `teardown.failed`, a tally of cleanup CALLS, and
+treated it as a claim about ROWS. Those are different facts.
+
+The receipt read `attempted=6 archived=4 already_absent=0 failed=2`. All three
+scenarios passed live, delegation was confirmed in the service logs, and a
+12-purge-table residue query for the run's namespaces returned ZERO rows. The
+gate exited 1 anyway: two `archive_entry` calls had thrown, the composed
+namespace purge then removed every row, and nothing corrected the count.
+
+Two things to check in any teardown, cleanup, or reconcile verdict:
+
+1. **The verdict reads the OBSERVABLE, not the attempt log.** If the claim is
+   "nothing was left behind," the assertion is a row count queried after the
+   fact, not a counter incremented by the code doing the removing. A tally is a
+   diagnostic; it explains a result, it is not the result. Note the arithmetic
+   tell in the receipt above: `4+0+2=6` proves the two failures were record-loop
+   throws, because a purge failure increments `failed` WITHOUT touching
+   `attempted` — a tally that mixes two populations cannot be read as one.
+
+2. **"Not observed" is not "clean."** A residue reading that could not run must
+   fail the verdict, not pass it. Otherwise the fix trades a false red for a
+   false green, which is strictly worse. Same for a PARTIAL reading: a residue
+   counter that could not read some tables reports `checked: false`, because the
+   rows it failed to count are exactly where residue would hide.
+
+Companion defect in the same code, worth checking separately: the cleanup error
+was discarded into a bare `catch {}`, so when `failed=2` appeared the label of
+the throw was unrecoverable from the receipt, the log, or anywhere else — the
+dead-end-error class inside our own eval tooling. Keep the catch (one bad record
+must not strand the rest) and capture a CONTENT-FREE label per failure: a
+transport error's already-redacted label, or otherwise the error's class name
+only. Never an arbitrary `Error.message`, which can echo row content, a
+namespace, or a token fragment into an artifact that gets pasted into issues.
+
+### Reviewer check
+
+- Does any pass/fail decision rest on a counter maintained by the code being
+  judged? Ask what independent observation would confirm it.
+- If a residue/leak/orphan check exists, can it distinguish "zero" from "did not
+  look"? Trace the unchecked branch to a verdict.
+- Does the residue reader share its table/resource list with the remover, or
+  maintain a parallel one? A parallel list drifts silently and GREEN — the table
+  the remover stopped clearing also stops being counted.
+- Does every swallowed error contribute a label somewhere an operator can read?

--- a/eval/open-brain/live/__tests__/gate.test.ts
+++ b/eval/open-brain/live/__tests__/gate.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { runLiveGate, type GateClients } from "../gate.ts";
+import {
+  labelTeardownError,
+  runLiveGate,
+  teardownRecords,
+  type GateClients,
+} from "../gate.ts";
 import type { LiveEvalConfig } from "../config.ts";
 import {
   LiveTransportError,
@@ -311,6 +316,9 @@ describe("runLiveGate happy path", () => {
       archived: 3,
       already_absent: 0,
       failed: 0,
+      // #671: empty on a clean run, and asserted EXACTLY so a label leaking in
+      // where nothing failed would fail this test rather than pass unnoticed.
+      failure_labels: [],
     });
     expect(state.archived.sort()).toEqual(
       ["srv-neg-secret", "srv-prim-a", "srv-prim-b"].sort(),
@@ -666,5 +674,58 @@ describe("runLiveGate through the REAL transport parseHits boundary", () => {
     // not the transport boundary -- classified it as foreign-namespace.
     expect(err.label).toBe("search_brain:foreign-namespace");
     expect(err.label).not.toContain("srv-no-ns");
+  });
+});
+
+// Issue #671: the bare `catch {}` in `teardownRecords` discarded the cleanup
+// error, so when the third credentialed #653 verify reported failed=2 the
+// throw's label was unrecoverable from the receipt, the log, or anywhere else.
+describe("teardownRecords failure labels (#671)", () => {
+  it("captures a LiveTransportError's redacted label, one per failure, in order", async () => {
+    const tally = await teardownRecords(
+      ["ok", "bad-a", "bad-b"],
+      async (record) => {
+        if (record === "ok") return "archived";
+        throw new LiveTransportError(`archive_entry:${record}`, false);
+      },
+    );
+    expect(tally.attempted).toBe(3);
+    expect(tally.archived).toBe(1);
+    expect(tally.failed).toBe(2);
+    expect(tally.failure_labels).toEqual([
+      "archive_entry:bad-a",
+      "archive_entry:bad-b",
+    ]);
+  });
+
+  it("keeps going after a failure — one bad record never strands the rest", async () => {
+    const cleaned: string[] = [];
+    const tally = await teardownRecords(["a", "b", "c"], async (record) => {
+      if (record === "a") throw new Error("boom");
+      cleaned.push(record);
+      return "archived";
+    });
+    expect(cleaned).toEqual(["b", "c"]);
+    expect(tally.archived).toBe(2);
+    expect(tally.failed).toBe(1);
+  });
+
+  it("never lets an arbitrary error's MESSAGE into the label — class name only", async () => {
+    // A receipt gets pasted into issues and PRs, and an arbitrary Error.message
+    // can carry row content, a namespace value, or a token fragment.
+    const secret = "namespace=rico row=super-secret-content";
+    const tally = await teardownRecords(["x"], async () => {
+      throw new Error(secret);
+    });
+    expect(tally.failure_labels).toEqual(["Error"]);
+    expect(tally.failure_labels.join(" ")).not.toContain("rico");
+    expect(tally.failure_labels.join(" ")).not.toContain("super-secret-content");
+  });
+
+  it("labels a non-Error throw without inventing detail", () => {
+    expect(labelTeardownError("just a string")).toBe("unknown");
+    expect(labelTeardownError(new LiveTransportError("tool:label", true))).toBe(
+      "tool:label",
+    );
   });
 });

--- a/eval/open-brain/live/__tests__/namespace-purge.test.ts
+++ b/eval/open-brain/live/__tests__/namespace-purge.test.ts
@@ -3,6 +3,7 @@ import {
   EVAL_NAMESPACE_PREFIX,
   NamespacePurgeRefused,
   assertPurgeableNamespace,
+  countNamespaceResidue,
   purgeNamespace,
 } from "../namespace-purge.ts";
 import { makeRunId, runNamespaces } from "../config.ts";
@@ -155,5 +156,85 @@ describe("purgeNamespace", () => {
     expect(result.deleted_by_table).toEqual({});
     expect(result.failed_tables).toEqual({});
     expect(result.namespace).toBe(namespace);
+  });
+});
+
+/**
+ * Issue #671: the teardown VERDICT now rests on this counter rather than on a
+ * tally of cleanup calls, so what it reads and what it does when it cannot read
+ * are both load-bearing.
+ */
+describe("countNamespaceResidue", () => {
+  test("counts every table the purge deletes from — one list, two readers", async () => {
+    // Drift between a purge list and a residue list fails silently and GREEN: a
+    // table the purge stopped clearing would also stop being counted.
+    const purgeTables: string[] = [];
+    const recordingPurge = {
+      query: (sql: string) => {
+        purgeTables.push(sql.replace(/^DELETE FROM (\w+).*$/s, "$1"));
+        return Promise.resolve({ rowCount: 0 });
+      },
+    } as never;
+    const residueTables: string[] = [];
+    const recordingResidue = {
+      query: (sql: string) => {
+        residueTables.push(sql.replace(/^SELECT count\(\*\)::int AS n FROM (\w+).*$/s, "$1"));
+        return Promise.resolve({ rows: [{ n: 0 }] });
+      },
+    } as never;
+
+    const namespace = runNamespaces(
+      makeRunId({ prefix: "scenario-unit", randomHex: "0123456789ab", env: {} }),
+    ).primary;
+    await purgeNamespace(recordingPurge, namespace);
+    await countNamespaceResidue(recordingResidue, namespace);
+
+    expect(residueTables).toEqual(purgeTables);
+    expect(residueTables.length).toBeGreaterThan(0);
+  });
+
+  test("binds the namespace and never mutates", async () => {
+    const seen: Array<{ sql: string; params: unknown[] }> = [];
+    const recording = {
+      query: (sql: string, params: unknown[]) => {
+        seen.push({ sql, params });
+        return Promise.resolve({ rows: [{ n: 3 }] });
+      },
+    } as never;
+
+    const namespace = runNamespaces(
+      makeRunId({ prefix: "scenario-unit", randomHex: "0123456789ab", env: {} }),
+    ).primary;
+    const result = await countNamespaceResidue(recording, namespace);
+
+    for (const call of seen) {
+      expect(call.sql).toContain("SELECT count(*)");
+      expect(call.sql).not.toContain("DELETE");
+      expect(call.sql).toContain("WHERE namespace = $1");
+      expect(call.params).toEqual([namespace]);
+    }
+    expect(result.rows).toBe(3 * seen.length);
+  });
+
+  test("records an unreadable table by class instead of reporting it as zero", async () => {
+    // Counting an unreadable table as zero is how a residue reading would go
+    // clean over exactly the rows it exists to find.
+    let calls = 0;
+    const flaky = {
+      query: () => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new TypeError("boom"));
+        return Promise.resolve({ rows: [{ n: 0 }] });
+      },
+    } as never;
+
+    const namespace = runNamespaces(
+      makeRunId({ prefix: "scenario-unit", randomHex: "0123456789ab", env: {} }),
+    ).primary;
+    const result = await countNamespaceResidue(flaky, namespace);
+
+    expect(Object.keys(result.unreadable_tables)).toHaveLength(1);
+    expect(Object.values(result.unreadable_tables)).toEqual(["TypeError"]);
+    expect(result.rows).toBe(0);
   });
 });

--- a/eval/open-brain/live/__tests__/scenario-gate.test.ts
+++ b/eval/open-brain/live/__tests__/scenario-gate.test.ts
@@ -13,6 +13,7 @@ import type {
   ScenarioFixture,
   ScenarioRecord,
   ScenarioTransport,
+  TeardownResidue,
   TeardownTally,
 } from "../scenario-types.ts";
 
@@ -41,6 +42,14 @@ interface FakeOptions {
   packItemCount?: number;
   packThrows?: boolean;
   cleanupFails?: number;
+  /**
+   * Rows the fake transport reports as REMAINING after cleanup (#671). Distinct
+   * from `cleanupFails`, which is calls that threw -- keeping them separate is
+   * the whole point of the issue: a thrown call is not a stranded row.
+   */
+  residueRows?: number;
+  /** Report the residue observation as never having run (#671). */
+  residueUnchecked?: boolean;
 }
 
 interface LaneState {
@@ -148,13 +157,34 @@ function fakeTransport(opts: FakeOptions = {}): ScenarioTransport {
         ? { lane, events: lane.events, event_count: lane.events.length }
         : { lane: null, events: [], event_count: 0 };
     },
-    async cleanup(records: ScenarioRecord[]): Promise<TeardownTally> {
+    async cleanup(
+      records: ScenarioRecord[],
+    ): Promise<{ tally: TeardownTally; residue: TeardownResidue }> {
       const failed = Math.min(opts.cleanupFails ?? 0, records.length);
+      const rows = opts.residueRows ?? 0;
       return {
-        attempted: records.length,
-        archived: records.length - failed,
-        already_absent: 0,
-        failed,
+        tally: {
+          attempted: records.length,
+          archived: records.length - failed,
+          already_absent: 0,
+          failed,
+          failure_labels: Array.from(
+            { length: failed },
+            (_unused, index) => `fake_cleanup:threw-${index}`,
+          ),
+        },
+        residue: opts.residueUnchecked
+          ? {
+              checked: false,
+              rows: 0,
+              by_table: {},
+              unchecked_reason: "fake transport reported no observation",
+            }
+          : {
+              checked: true,
+              rows,
+              by_table: rows > 0 ? { thoughts: rows } : {},
+            },
       };
     },
     async close() {},
@@ -224,7 +254,13 @@ describe("runScenarioGate", () => {
       archived: 6,
       already_absent: 0,
       failed: 0,
+      failure_labels: [],
     });
+    // #671: a clean run observes residue and finds none — distinct from never
+    // having looked, which the gate refuses to pass on.
+    expect(outcome.receipt.teardown_residue.checked).toBe(true);
+    expect(outcome.receipt.teardown_residue.rows).toBe(0);
+    expect(outcome.receipt.diagnostics).toEqual([]);
     expectContentFree(outcome.receipt);
   });
 
@@ -359,10 +395,34 @@ describe("runScenarioGate", () => {
     expect(outcome.receipt.teardown.failed).toBe(0);
   });
 
-  it("fails an otherwise-green batch when teardown strands a record", async () => {
-    const outcome = await run(fakeTransport({ cleanupFails: 1 }));
+  it("fails an otherwise-green batch when teardown leaves RESIDUE, naming the table and count", async () => {
+    const outcome = await run(fakeTransport({ residueRows: 2 }));
     expect(outcome.passed).toBe(false);
-    expect(outcome.receipt.teardown.failed).toBe(1);
-    expect(outcome.receipt.failures).toContain("teardown_failed:1");
+    expect(outcome.receipt.teardown_residue.rows).toBe(2);
+    expect(outcome.receipt.failures).toContain("teardown_residue:rows=2;thoughts=2");
+  });
+
+  it("PASSES when cleanup calls threw but no rows remain, reporting the labels as diagnostics (#671)", async () => {
+    // The third credentialed #653 verify in miniature: calls threw, the database
+    // came back clean, and the old gate exited 1 anyway.
+    const outcome = await run(fakeTransport({ cleanupFails: 2 }));
+    expect(outcome.passed).toBe(true);
+    expect(outcome.receipt.teardown.failed).toBe(2);
+    // The tally is REPORTED, so the operator still learns the calls failed...
+    expect(outcome.receipt.diagnostics.join(" ")).toContain("teardown_call_failures:2");
+    // ...by label, which the bare `catch {}` used to discard...
+    expect(outcome.receipt.teardown.failure_labels).toEqual([
+      "fake_cleanup:threw-0",
+      "fake_cleanup:threw-1",
+    ]);
+    expect(outcome.receipt.diagnostics.join(" ")).toContain("fake_cleanup:threw-0");
+    // ...and it is NOT in the verdict channel.
+    expect(outcome.receipt.failures.join(" ")).not.toContain("teardown");
+  });
+
+  it("refuses to pass when residue was never observed — unchecked is unproven, not clean (#671)", async () => {
+    const outcome = await run(fakeTransport({ residueUnchecked: true }));
+    expect(outcome.passed).toBe(false);
+    expect(outcome.receipt.failures.join(" ")).toContain("teardown_residue_unchecked");
   });
 });

--- a/eval/open-brain/live/gate.ts
+++ b/eval/open-brain/live/gate.ts
@@ -65,13 +65,78 @@ export interface TeardownTally {
   archived: number;
   already_absent: number;
   failed: number;
+  /**
+   * One content-free label per cleanup failure, in failure order (issue #671).
+   *
+   * Before this existed, `teardownRecords` caught the cleanup error into a bare
+   * `catch {}` and only the integer `failed` survived. When the third
+   * credentialed #653 verify hit `failed=2`, the label of the throw was
+   * unrecoverable from the receipt, the log, or anywhere else -- the
+   * dead-end-error class (docs/lane-contract.md Tightenings rounds 15/19)
+   * inside our own eval tooling. The catch STAYS, because a teardown that
+   * aborts on the first bad record strands every later one; what changes is
+   * that the error stops being discarded.
+   *
+   * Content-free by construction: `labelTeardownError` emits a
+   * `LiveTransportError`'s already-redacted `label`, or otherwise the error's
+   * CLASS NAME only -- never `error.message` from an arbitrary throw, which can
+   * echo row content or a namespace value into a receipt.
+   */
+  failure_labels: string[];
+}
+
+/**
+ * Residue -- the DB-queryable truth about what a teardown actually left behind.
+ *
+ * This exists because the tally cannot answer the question the tally was being
+ * asked (issue #671). A tally counts CALLS: `failed` means "a cleanup call
+ * threw", which is not the same claim as "rows remain". The third credentialed
+ * #653 verify reported `attempted=6 archived=4 already_absent=0 failed=2` on a
+ * database that a 12-table residue query proved was clean -- two archive calls
+ * threw, the composed purge then removed everything, and nothing corrected the
+ * count. The gate exited 1 on a clean database.
+ *
+ * Round 16's Tightening says "a teardown that reports success is not evidence
+ * of removal"; this is its mirror -- a teardown that reports FAILURE is not
+ * evidence of residue. So the verdict channel now reads rows, and the tally is
+ * demoted to diagnostics.
+ *
+ * `checked: false` means no residue observation was possible (no database
+ * handle). That is NOT a pass: a verdict may not be derived from an
+ * unperformed check, so callers treat unchecked as unproven and say so.
+ */
+export interface TeardownResidue {
+  /** Whether a residue observation actually ran. False is unproven, not clean. */
+  checked: boolean;
+  /** Total rows still carrying this run's namespace, across every table checked. */
+  rows: number;
+  /** Per-table counts, only for tables that had any rows left. */
+  by_table: Record<string, number>;
+  /** Content-free reason the observation could not run, when `checked` is false. */
+  unchecked_reason?: string;
+}
+
+/**
+ * Reduce an arbitrary thrown value to a content-free label safe for a receipt.
+ *
+ * A `LiveTransportError` already carries a redacted label by contract, so that
+ * label passes through -- it is the one that names WHICH tool call failed and
+ * why, which is the whole point of capturing it. Anything else contributes its
+ * constructor name only: an arbitrary `Error.message` may contain row content,
+ * a namespace, or a token fragment, and a receipt is an artifact that gets
+ * pasted into issues and PRs.
+ */
+export function labelTeardownError(error: unknown): string {
+  if (error instanceof LiveTransportError) return error.label;
+  if (error instanceof Error) return `${error.constructor.name}`;
+  return "unknown";
 }
 
 /**
  * Shared EVAL-3 teardown accounting. Callers provide the exact records this run
  * created and one record-specific cleanup operation; every record is attempted,
- * individual failures never prevent later cleanup, and the receipt carries only
- * counts.
+ * individual failures never prevent later cleanup, and the receipt carries
+ * counts plus one content-free label per failure (#671).
  */
 export async function teardownRecords<T>(
   records: readonly T[],
@@ -82,6 +147,7 @@ export async function teardownRecords<T>(
     archived: 0,
     already_absent: 0,
     failed: 0,
+    failure_labels: [],
   };
   for (const record of records) {
     tally.attempted += 1;
@@ -89,8 +155,11 @@ export async function teardownRecords<T>(
       const outcome = await cleanup(record);
       if (outcome === "archived") tally.archived += 1;
       else tally.already_absent += 1;
-    } catch {
+    } catch (error: unknown) {
+      // The catch is deliberate and stays: one bad record must not strand the
+      // rest. What #671 changes is that the error is no longer DISCARDED.
       tally.failed += 1;
+      tally.failure_labels.push(labelTeardownError(error));
     }
   }
   return tally;

--- a/eval/open-brain/live/namespace-purge.ts
+++ b/eval/open-brain/live/namespace-purge.ts
@@ -167,3 +167,70 @@ export async function purgeNamespace(
 
   return { namespace, deleted_by_table: deletedByTable, deleted, failed_tables: failedTables };
 }
+
+/**
+ * Count rows still carrying `namespace`, per table -- the DB-queryable truth a
+ * teardown verdict is allowed to rest on (issue #671).
+ *
+ * WHY THIS LIVES HERE AND NOT IN THE TRANSPORT
+ * --------------------------------------------
+ * It reads the SAME `PURGE_TABLES` tuple the purge writes. A separately
+ * maintained residue table list would drift the moment either side gained a
+ * table, and the drift's failure mode is silent and green: a table the purge
+ * stopped clearing would also stop being counted, so the residue verdict would
+ * report clean over exactly the rows it exists to find. One list, two readers.
+ *
+ * NOT prefix-guarded, deliberately: this only ever runs `SELECT count(*)`, so
+ * there is nothing for a guard to protect. Guarding it would also make it
+ * useless for the one job it has -- proving, from outside, that a name was
+ * cleaned.
+ *
+ * A table that cannot be read is recorded in `unreadable_tables` and is NOT
+ * silently treated as zero: a residue reading is only load-bearing if it can
+ * say which tables it actually managed to read.
+ */
+export interface NamespaceResidueResult {
+  namespace: string;
+  /** Rows remaining, per table, only for tables that had any. */
+  rows_by_table: Record<string, number>;
+  /** Total rows remaining across every table that could be read. */
+  rows: number;
+  /** Tables whose count could not be read, by name, with a content-free reason. */
+  unreadable_tables: Record<string, string>;
+}
+
+export async function countNamespaceResidue(
+  pool: Pool,
+  namespace: string,
+): Promise<NamespaceResidueResult> {
+  const rowsByTable: Record<string, number> = {};
+  const unreadableTables: Record<string, string> = {};
+  let rows = 0;
+
+  for (const table of PURGE_TABLES) {
+    try {
+      // Same interpolation argument as `purgeNamespace`: the table name comes
+      // from the module-local const tuple, never from a caller. The namespace
+      // is parameterized.
+      const result = await pool.query(
+        `SELECT count(*)::int AS n FROM ${table} WHERE namespace = $1`,
+        [namespace],
+      );
+      const count = Number(result.rows[0]?.n ?? 0);
+      if (count > 0) {
+        rowsByTable[table] = count;
+        rows += count;
+      }
+    } catch (error: unknown) {
+      unreadableTables[table] =
+        error instanceof Error ? error.constructor.name : "unknown";
+    }
+  }
+
+  return {
+    namespace,
+    rows_by_table: rowsByTable,
+    rows,
+    unreadable_tables: unreadableTables,
+  };
+}

--- a/eval/open-brain/live/scenario-gate.ts
+++ b/eval/open-brain/live/scenario-gate.ts
@@ -8,6 +8,7 @@ import type {
   ScenarioScope,
   ScenarioTransport,
   ScenarioVerdict,
+  TeardownResidue,
   TeardownTally,
 } from "./scenario-types.ts";
 import { LiveTransportError, type ContextPackScope } from "./transport.ts";
@@ -31,6 +32,22 @@ const EMPTY_TEARDOWN: TeardownTally = {
   archived: 0,
   already_absent: 0,
   failed: 0,
+  failure_labels: [],
+};
+
+/**
+ * The residue reading used when the transport reported none (issue #671).
+ *
+ * NOT a pass. `checked: false` says the run could not observe rows, and the
+ * verdict below treats that as unproven rather than clean -- a verdict derived
+ * from an unperformed check is exactly the defect this issue exists to remove,
+ * in the other direction.
+ */
+const UNCHECKED_RESIDUE: TeardownResidue = {
+  checked: false,
+  rows: 0,
+  by_table: {},
+  unchecked_reason: "transport reported no residue observation",
 };
 
 function materialize<T>(value: T, runId: string, namespace: string): T {
@@ -359,6 +376,7 @@ export async function runScenarioGate(
   const records: ScenarioRecord[] = [];
   const verdicts: ScenarioVerdict[] = [];
   let teardown = EMPTY_TEARDOWN;
+  let residue: TeardownResidue = UNCHECKED_RESIDUE;
 
   try {
     for (const scenario of fixture.scenarios) {
@@ -395,15 +413,59 @@ export async function runScenarioGate(
     const uniqueRecords = Array.from(
       new Map(records.map((record) => [`${record.kind}:${record.id}`, record])).values(),
     );
-    teardown = await opts.transport.cleanup(uniqueRecords, opts.namespace);
+    const cleanup = await opts.transport.cleanup(uniqueRecords, opts.namespace);
+    teardown = cleanup.tally;
+    residue = cleanup.residue;
   }
 
   const failures = verdicts.flatMap((verdict) =>
     verdict.failures.map((failure) => `${verdict.scenario_id}:${failure}`),
   );
-  if (teardown.failed > 0) {
-    failures.push(`teardown_failed:${teardown.failed}`);
+
+  // THE TEARDOWN VERDICT CHANNEL (issue #671).
+  //
+  // What fails the run is RESIDUE -- rows this run's namespace still owns,
+  // read back out of the database. What does NOT fail the run is `teardown.failed`,
+  // which counts cleanup CALLS THAT THREW. Those are different facts, and
+  // conflating them is what made the third credentialed #653 verify exit 1 on a
+  // database a 12-table residue query had just proven clean: two `archive_entry`
+  // calls threw, the composed namespace purge then removed every row, and no
+  // one corrected the count.
+  //
+  // The thrown calls are not swept under the rug -- they are REPORTED, by label,
+  // as a diagnostic below. An operator reading the receipt still learns exactly
+  // which call failed and why; they just no longer learn a wrong verdict from it.
+  if (!residue.checked) {
+    // Unchecked is unproven, not clean. Refusing to pass here is the same
+    // discipline in the opposite direction: a verdict may not rest on an
+    // observation that never ran.
+    failures.push(
+      `teardown_residue_unchecked:${residue.unchecked_reason ?? "no reason given"}`,
+    );
+  } else if (residue.rows > 0) {
+    const tables = Object.entries(residue.by_table)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([table, count]) => `${table}=${count}`)
+      .join(",");
+    // Names the table and the count, because "residue exists" without saying
+    // WHERE is the dead-end-error class this issue's sibling defect is about.
+    failures.push(
+      `teardown_residue:rows=${residue.rows}${tables ? `;${tables}` : ""}`,
+    );
   }
+  // DIAGNOSTIC, never a verdict input: the labels of any cleanup calls that
+  // threw. Emitted whenever there were any, INCLUDING on an otherwise-passing
+  // run -- a silent throw is how the #671 label went unrecoverable in the first
+  // place.
+  const teardownDiagnostics =
+    teardown.failed > 0
+      ? [
+          `teardown_call_failures:${teardown.failed}` +
+            (teardown.failure_labels.length > 0
+              ? `;labels=${teardown.failure_labels.join("|")}`
+              : ""),
+        ]
+      : [];
   const passed = failures.length === 0;
   return {
     passed,
@@ -416,7 +478,9 @@ export async function runScenarioGate(
       scenarios: verdicts,
       passed,
       failures,
+      diagnostics: teardownDiagnostics,
       teardown,
+      teardown_residue: residue,
     },
   };
 }

--- a/eval/open-brain/live/scenario-transport.ts
+++ b/eval/open-brain/live/scenario-transport.ts
@@ -2,13 +2,14 @@ import { resolve } from "node:path";
 import { Pool } from "pg";
 import { summarizeChildStderr } from "../../../src/child-stderr.ts";
 import type { LiveEvalConfig } from "./config.ts";
-import { teardownRecords } from "./gate.ts";
-import { purgeNamespace } from "./namespace-purge.ts";
+import { labelTeardownError, teardownRecords } from "./gate.ts";
+import { countNamespaceResidue, purgeNamespace } from "./namespace-purge.ts";
 import type {
   ProviderExecution,
   ProviderReceipt,
   ScenarioRecord,
   ScenarioTransport,
+  TeardownResidue,
   TeardownTally,
 } from "./scenario-types.ts";
 import {
@@ -204,15 +205,24 @@ export class LiveScenarioTransport implements ScenarioTransport {
    * eval prefix. That narrow shape is what `docs/issue-graph.md` ledger item 20
    * permits, and nothing wider.
    *
-   * A purge failure is reported as a teardown failure rather than thrown: the
-   * receipt is the artifact an operator reads after a bad run, and a throw here
-   * would discard the record tally that explains what did get cleaned. Silently
+   * A purge failure is reported in the tally rather than thrown: the receipt is
+   * the artifact an operator reads after a bad run, and a throw here would
+   * discard the record tally that explains what did get cleaned. Silently
    * swallowing it would rebuild the exact defect #655 is about.
+   *
+   * THEN THE RESIDUE READING (issue #671). The tally above counts CALLS, and a
+   * call that threw is not the same fact as a row that remains. On the third
+   * credentialed #653 verify the two `archive_entry` throws pushed `failed=2`
+   * while the purge that followed removed every row; the gate read the tally and
+   * exited 1 on a clean database. So after everything has run, this asks the
+   * database what is actually left, and THAT is what the gate's verdict reads.
+   * The tally stays -- demoted to diagnostics, with the throw labels now
+   * captured (`teardownRecords`) instead of discarded into a bare catch.
    */
   async cleanup(
     records: ScenarioRecord[],
     namespace: string,
-  ): Promise<TeardownTally> {
+  ): Promise<{ tally: TeardownTally; residue: TeardownResidue }> {
     const unique = Array.from(
       new Map(records.map((record) => [`${record.kind}:${record.id}`, record])).values(),
     );
@@ -231,14 +241,48 @@ export class LiveScenarioTransport implements ScenarioTransport {
       const failedTables = Object.keys(purge.failed_tables);
       if (failedTables.length > 0) {
         tally.failed += failedTables.length;
+        // The purge's per-table failures are content-free class names already;
+        // labelling them by table keeps the diagnostic actionable rather than a
+        // bare increment (#671).
+        for (const [table, reason] of Object.entries(purge.failed_tables)) {
+          tally.failure_labels.push(`purge:${table}:${reason}`);
+        }
       }
-    } catch {
-      // A refusal or a connection failure. Counted, never hidden: a nonzero
-      // `failed` is what the #578 gate's clause (e) reads.
+    } catch (error: unknown) {
+      // A refusal or a connection failure. Counted AND labelled, never hidden.
       tally.failed += 1;
+      tally.failure_labels.push(`purge:${labelTeardownError(error)}`);
     }
 
-    return tally;
+    let residue: TeardownResidue;
+    try {
+      const observed = await countNamespaceResidue(this.pool, namespace);
+      const unreadable = Object.keys(observed.unreadable_tables);
+      residue =
+        unreadable.length > 0
+          ? {
+              // A partial reading cannot support a clean verdict: the rows we
+              // failed to count are exactly where residue would hide.
+              checked: false,
+              rows: observed.rows,
+              by_table: observed.rows_by_table,
+              unchecked_reason: `unreadable_tables=${unreadable.sort().join(",")}`,
+            }
+          : {
+              checked: true,
+              rows: observed.rows,
+              by_table: observed.rows_by_table,
+            };
+    } catch (error: unknown) {
+      residue = {
+        checked: false,
+        rows: 0,
+        by_table: {},
+        unchecked_reason: `residue_query_failed:${labelTeardownError(error)}`,
+      };
+    }
+
+    return { tally, residue };
   }
 
   /**

--- a/eval/open-brain/live/scenario-types.ts
+++ b/eval/open-brain/live/scenario-types.ts
@@ -1,4 +1,4 @@
-import type { TeardownTally } from "./gate.ts";
+import type { TeardownResidue, TeardownTally } from "./gate.ts";
 import type { ContextPackScope } from "./transport.ts";
 
 export type ScenarioKind =
@@ -130,11 +130,22 @@ export interface ScenarioTransport {
     sessionKey: string;
     namespace: string;
   }): Promise<Record<string, unknown>>;
-  cleanup(records: ScenarioRecord[], namespace: string): Promise<TeardownTally>;
+  /**
+   * Remove this run's records and namespace, and REPORT WHAT IS LEFT (#671).
+   *
+   * The residue half is the load-bearing return value: the tally counts cleanup
+   * CALLS, and a call that threw is not the same fact as a row that remains.
+   * A transport that cannot observe rows returns `checked: false` -- which the
+   * gate treats as unproven, never as clean.
+   */
+  cleanup(
+    records: ScenarioRecord[],
+    namespace: string,
+  ): Promise<{ tally: TeardownTally; residue: TeardownResidue }>;
   close(): Promise<void>;
 }
 
-export type { TeardownTally };
+export type { TeardownResidue, TeardownTally };
 
 export interface ScenarioVerdict {
   scenario_id: string;
@@ -160,5 +171,23 @@ export interface ScenarioGateReceipt {
   scenarios: ScenarioVerdict[];
   passed: boolean;
   failures: string[];
+  /**
+   * Content-free NON-VERDICT observations (#671). Anything an operator needs in
+   * order to explain a run but which must never by itself decide pass/fail --
+   * today, the labels of cleanup calls that threw. Kept out of `failures` on
+   * purpose: `failures` is the verdict channel, and mixing a diagnostic into it
+   * is the exact defect #671 removes.
+   */
+  diagnostics: string[];
+  /**
+   * DIAGNOSTICS ONLY since #671. Counts of cleanup calls plus one content-free
+   * label per failure. The gate verdict does NOT read `failed` -- see
+   * `teardown_residue`, which reads rows.
+   */
   teardown: TeardownTally;
+  /**
+   * The load-bearing teardown signal (#671): rows still carrying this run's
+   * namespace, queried from the database after cleanup ran.
+   */
+  teardown_residue: TeardownResidue;
 }

--- a/scripts/done-means/655-eval-teardown.driver.ts
+++ b/scripts/done-means/655-eval-teardown.driver.ts
@@ -41,12 +41,14 @@ import { runScenarioGate } from "../../eval/open-brain/live/scenario-gate.ts";
 import { teardownRecords } from "../../eval/open-brain/live/gate.ts";
 import {
   assertPurgeableNamespace,
+  countNamespaceResidue,
   purgeNamespace,
 } from "../../eval/open-brain/live/namespace-purge.ts";
 import type {
   ProviderExecution,
   ScenarioRecord,
   ScenarioTransport,
+  TeardownResidue,
   TeardownTally,
 } from "../../eval/open-brain/live/scenario-types.ts";
 import { runNamespaces, makeRunId } from "../../eval/open-brain/live/config.ts";
@@ -280,11 +282,27 @@ class DriverTransport implements ScenarioTransport {
   async cleanup(
     records: ScenarioRecord[],
     namespace: string,
-  ): Promise<TeardownTally> {
+  ): Promise<{ tally: TeardownTally; residue: TeardownResidue }> {
     this.cleanupEntered = true;
     const tally = await teardownRecords(records, (record) =>
       this.cleanupRecord(record, namespace),
     );
+    // #671 added the residue half of the transport contract. This driver reads
+    // it with the SHIPPED counter for the same reason it purges with the
+    // shipped purge: a hand-rolled copy can agree with itself while the product
+    // is wrong.
+    const observe = async (): Promise<TeardownResidue> => {
+      const seen = await countNamespaceResidue(pool, namespace);
+      const unreadable = Object.keys(seen.unreadable_tables);
+      return unreadable.length > 0
+        ? {
+            checked: false,
+            rows: seen.rows,
+            by_table: seen.rows_by_table,
+            unchecked_reason: `unreadable_tables=${unreadable.sort().join(",")}`,
+          }
+        : { checked: true, rows: seen.rows, by_table: seen.rows_by_table };
+    };
     // DONE_MEANS_655_SKIP_PURGE reproduces the pre-fix world exactly: record
     // teardown runs, the namespace purge does not. It exists so the RED
     // transcript can be regenerated at any time WITHOUT deleting the fix, and
@@ -296,11 +314,11 @@ class DriverTransport implements ScenarioTransport {
       console.log(
         "INFO  DONE_MEANS_655_SKIP_PURGE=1 — namespace purge deliberately SKIPPED (pre-fix reproduction)",
       );
-      return tally;
+      return { tally, residue: await observe() };
     }
     const purge = await purgeNamespace(pool, namespace);
     this.purgedRows = purge.deleted;
-    return tally;
+    return { tally, residue: await observe() };
   }
 
   private async cleanupRecord(

--- a/scripts/done-means/671-teardown-verdict-residue.driver.ts
+++ b/scripts/done-means/671-teardown-verdict-residue.driver.ts
@@ -1,0 +1,529 @@
+/**
+ * Driver for the #671 DONE-MEANS check. Not a test file; invoked by
+ * scripts/done-means/671-teardown-verdict-residue.sh, which owns the verdict.
+ *
+ * WHAT IS BEING PROVEN, AND WHERE THIS CHECK STANDS TO SEE IT
+ * -----------------------------------------------------------
+ * The defect (#671) is that the scenario gate's TEARDOWN VERDICT read a tally
+ * of cleanup CALLS instead of the rows those calls were supposed to remove. The
+ * third credentialed #653 verify reported `attempted=6 archived=4
+ * already_absent=0 failed=2` and exited 1 on a database that a 12-table residue
+ * query had just proven clean: two `archive_entry` calls threw, the composed
+ * namespace purge then removed every row, and nothing corrected the count.
+ *
+ * So this check's vantage has to be: a REAL database (residue is a database
+ * fact and cannot be faked), driven through the SHIPPED `runScenarioGate`,
+ * `teardownRecords`, `purgeNamespace` and `countNamespaceResidue`, with ONE
+ * thing stubbed -- the `archive_entry` call, made to throw a labelled error.
+ *
+ * WHY THE STUB IS THE ARCHIVE CALL AND NOTHING ELSE
+ * -------------------------------------------------
+ * The whole issue is the interaction between "a cleanup call threw" and "no
+ * rows remain". Reproducing it needs a throwing archive AND a working purge in
+ * the same run. On a live deployment that combination happens by accident and
+ * only sometimes; here it is deterministic. Everything downstream of the throw
+ * -- the tally arithmetic, the purge, the residue reading, the verdict -- is
+ * the shipped code path, unmodified.
+ *
+ * ITS LIMITATION, STATED RATHER THAN IMPLIED (round 22 Tightening). The #655
+ * driver's known gap was that a stubbed seam hides defects living in the real
+ * seam -- exactly how #666 slipped past #655's green. The same gap applies
+ * here: this driver's `archive_entry` is a local throw, NOT the live
+ * MCP `archive_entry` tool, so this check CANNOT tell you WHY the live tool
+ * throws on memory-kind records. It proves only what it claims -- that a
+ * throwing archive plus a successful purge yields a GREEN verdict with the
+ * throw's label reported. Establishing the live throw's cause is a separate,
+ * credentialed job (#671 says so explicitly: do not absorb it here).
+ *
+ * Output is one JSON object written to DONE_MEANS_671_OUT. Counts, booleans and
+ * this driver's own error labels only -- no row content, no credentials.
+ */
+import { randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { runScenarioGate } from "../../eval/open-brain/live/scenario-gate.ts";
+import { teardownRecords } from "../../eval/open-brain/live/gate.ts";
+import { purgeNamespace } from "../../eval/open-brain/live/namespace-purge.ts";
+import type {
+  ProviderExecution,
+  ScenarioRecord,
+  ScenarioTransport,
+  TeardownTally,
+} from "../../eval/open-brain/live/scenario-types.ts";
+import { LiveTransportError } from "../../eval/open-brain/live/transport.ts";
+import { runNamespaces, makeRunId } from "../../eval/open-brain/live/config.ts";
+import { loadScenarioFixture } from "../../eval/open-brain/live/scenario-fixtures.ts";
+
+const DB_URL = process.env.DONE_MEANS_671_DB_URL;
+const OUT_PATH = process.env.DONE_MEANS_671_OUT;
+if (!DB_URL || !OUT_PATH) {
+  console.error("DONE_MEANS_671_DB_URL and DONE_MEANS_671_OUT are required");
+  process.exit(3);
+}
+
+const pool = new Pool({ connectionString: DB_URL });
+
+const CREATED_BY = "done-means-671";
+
+/**
+ * The residue shape, declared LOCALLY on purpose.
+ *
+ * `TeardownResidue` is one of the things the fix adds, so importing its type
+ * from the product would make this driver unloadable on the pre-fix tree. A
+ * static import of a not-yet-existing export dies at module resolution before a
+ * single clause prints — a false RED shaped exactly like a real one, reached by
+ * the ordinary act of writing a check for something that does not exist yet
+ * (docs/lane-contract.md Tightenings round 18). The local declaration keeps the
+ * driver loadable on BOTH trees so the RED it produces is the defect and not
+ * the import.
+ */
+interface TeardownResidue {
+  checked: boolean;
+  rows: number;
+  by_table: Record<string, number>;
+  unchecked_reason?: string;
+}
+
+/**
+ * `countNamespaceResidue` is likewise added by the fix, so it is resolved
+ * DYNAMICALLY at call time. On the fixed tree this is the shipped counter — the
+ * same function the product uses, not a copy that could agree with itself while
+ * the product is wrong. On the pre-fix tree the export is absent, and rather
+ * than crashing the driver (false RED) this falls back to counting the same
+ * tables directly, so the clauses can still report a real verdict.
+ *
+ * The fallback list is deliberately SHORT and is only ever reached on a tree
+ * that has no shipped counter to be authoritative about; it announces itself in
+ * the log so a reader never mistakes it for the product's reading.
+ */
+const FALLBACK_TABLES = [
+  "ob_session_lanes",
+  "thoughts",
+  "decisions",
+  "sessions",
+] as const;
+
+async function observeResidue(namespace: string): Promise<TeardownResidue> {
+  const module = (await import(
+    "../../eval/open-brain/live/namespace-purge.ts"
+  )) as Record<string, unknown>;
+  const shipped = module.countNamespaceResidue as
+    | ((pool: Pool, ns: string) => Promise<{
+        rows: number;
+        rows_by_table: Record<string, number>;
+        unreadable_tables: Record<string, string>;
+      }>)
+    | undefined;
+
+  if (typeof shipped === "function") {
+    const seen = await shipped(pool, namespace);
+    const unreadable = Object.keys(seen.unreadable_tables);
+    return unreadable.length > 0
+      ? {
+          checked: false,
+          rows: seen.rows,
+          by_table: seen.rows_by_table,
+          unchecked_reason: `unreadable_tables=${unreadable.sort().join(",")}`,
+        }
+      : { checked: true, rows: seen.rows, by_table: seen.rows_by_table };
+  }
+
+  console.log(
+    "INFO  countNamespaceResidue is ABSENT from this tree (pre-fix) — falling back to a direct row count so the clauses still get a real reading",
+  );
+  const byTable: Record<string, number> = {};
+  let rows = 0;
+  for (const table of FALLBACK_TABLES) {
+    const result = await pool.query(
+      `SELECT count(*)::int AS n FROM ${table} WHERE namespace = $1`,
+      [namespace],
+    );
+    const count = Number(result.rows[0]?.n ?? 0);
+    if (count > 0) {
+      byTable[table] = count;
+      rows += count;
+    }
+  }
+  return { checked: true, rows, by_table: byTable };
+}
+
+/**
+ * The label the stubbed archive throws with.
+ *
+ * Clause (c) is a MUTATION clause: rename this constant and the receipt text
+ * must follow. If the receipt still reads the old label, the "label reaches the
+ * receipt" claim was being satisfied by something other than the label -- the
+ * round-9/17 negative-match family. It deliberately does not appear anywhere in
+ * the shell script as a hardcoded literal; the shell reads it from this
+ * driver's own JSON output, so the two cannot drift apart into a false green.
+ */
+const STUB_ARCHIVE_LABEL = "archive_entry:done-means-671-stub-throw";
+
+interface DriverOut {
+  /** Which mode this run was in: "throwing_archive" or "residue_control". */
+  mode: string;
+  /** The label this driver's stub threw with, so the shell need not hardcode it. */
+  expected_label: string;
+  scenario_count: number;
+  /** The gate's own composite verdict. */
+  gate_passed: boolean;
+  /** The gate's verdict-bearing failure strings. */
+  gate_failures: string[];
+  /** The gate's NON-verdict diagnostics (#671). */
+  gate_diagnostics: string[];
+  /** Tally: cleanup calls that threw. Diagnostics only since #671. */
+  teardown_failed: number;
+  /** Tally: the captured labels of those throws. */
+  teardown_failure_labels: string[];
+  /** Residue: whether an observation actually ran. */
+  residue_checked: boolean;
+  /** Residue: rows remaining under this run's namespace. */
+  residue_rows: number;
+  /** Residue: which tables still hold rows. */
+  residue_tables: string[];
+  /** Independent confirmation, taken by this driver AFTER the gate returned. */
+  independent_residue_rows: number;
+}
+
+/**
+ * A ScenarioTransport whose database side is entirely real, whose provider side
+ * is a local shape, and whose `archive_entry` DELIBERATELY THROWS.
+ */
+class ThrowingArchiveTransport implements ScenarioTransport {
+  purgedRows = 0;
+  archiveThrows = 0;
+
+  constructor(
+    private readonly namespace: string,
+    /**
+     * `false` disables the namespace purge, which is clause (b)'s control: with
+     * the purge off, the seeded rows genuinely REMAIN, and the gate must FAIL
+     * naming the table and count. Announced in the run log, never silent.
+     */
+    private readonly purgeEnabled: boolean,
+  ) {}
+
+  async executeProvider(
+    request: Record<string, unknown>,
+  ): Promise<ProviderExecution> {
+    const scope = request.scope as Record<string, unknown> | undefined;
+    const sessionKey = String(scope?.session_key ?? "");
+    const operation = String(request.operation ?? "capture");
+
+    const laneId = await this.upsertLane(sessionKey, request);
+    const result: Record<string, unknown> = { lane_id: laneId };
+
+    if (operation === "checkpoint") {
+      const sessionId = randomUUID();
+      await pool.query(
+        `INSERT INTO sessions (id, namespace, summary, created_by) VALUES ($1, $2, $3, $4)`,
+        [sessionId, this.namespace, String(request.summary ?? ""), CREATED_BY],
+      );
+      await pool.query(
+        `UPDATE ob_session_lanes SET current_context_md = $1 WHERE id = $2`,
+        [String(request.summary ?? ""), laneId],
+      );
+      result.session_id = sessionId;
+    } else {
+      const eventId = randomUUID();
+      await pool.query(
+        `INSERT INTO ob_session_events (id, lane_id, event_type, content, created_by)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          eventId,
+          laneId,
+          String(request.event_type ?? "decision"),
+          String(request.content ?? ""),
+          CREATED_BY,
+        ],
+      );
+      result.event_id = eventId;
+    }
+
+    return {
+      exitCode: 0,
+      receipt: {
+        operation,
+        status: "saved",
+        durable: true,
+        direct_attempted: true,
+        fallback_attempted: false,
+      },
+      result,
+    };
+  }
+
+  private async upsertLane(
+    sessionKey: string,
+    request: Record<string, unknown>,
+  ): Promise<string> {
+    const existing = await pool.query(
+      `SELECT id FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
+      [this.namespace, sessionKey],
+    );
+    if (existing.rows.length > 0) return existing.rows[0].id as string;
+    const scope = request.scope as Record<string, unknown> | undefined;
+    const laneId = randomUUID();
+    // Same column mapping the #655 driver announces: `ob_session_lanes` has no
+    // platform/server_id columns, so the fixture's platform lands in `source`
+    // and its server_id in `project`. Announced, not silently dropped.
+    await pool.query(
+      `INSERT INTO ob_session_lanes (id, namespace, session_key, agent, source, project, channel_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        laneId,
+        this.namespace,
+        sessionKey,
+        String(scope?.agent ?? "scenario-eval"),
+        String(scope?.platform ?? "eval"),
+        String(scope?.server_id ?? "open-brain-scenarios"),
+        String(scope?.channel_id ?? "driver"),
+        CREATED_BY,
+      ],
+    );
+    return laneId;
+  }
+
+  async logMemory(opts: {
+    table: "thoughts" | "decisions";
+    content: string;
+    tags: string[];
+    namespace: string;
+  }): Promise<{ id: string }> {
+    const id = randomUUID();
+    if (opts.table === "thoughts") {
+      await pool.query(
+        `INSERT INTO thoughts (id, namespace, content, tags, created_by) VALUES ($1, $2, $3, $4, $5)`,
+        [id, opts.namespace, opts.content, opts.tags, CREATED_BY],
+      );
+    } else {
+      await pool.query(
+        `INSERT INTO decisions (id, namespace, title, rationale, tags, created_by)
+         VALUES ($1, $2, $3, $3, $4, $5)`,
+        [id, opts.namespace, opts.content, opts.tags, CREATED_BY],
+      );
+    }
+    return { id };
+  }
+
+  async contextPack(opts: {
+    scope: { namespace: string };
+    query: string;
+    budgetMaxTokens: number;
+  }): Promise<{
+    status: string;
+    sections: Record<string, unknown>;
+    budget: Record<string, unknown>;
+  }> {
+    const { rows } = await pool.query(
+      `SELECT id, content FROM thoughts WHERE namespace = $1 AND archived_at IS NULL`,
+      [opts.scope.namespace],
+    );
+    return {
+      status: "ok",
+      sections: {
+        durable_memory: {
+          item_count: rows.length,
+          items: rows.map((row) => ({ id: row.id, content: row.content })),
+        },
+      },
+      budget: { whole_pack: { content_char_limit: 100_000 } },
+    };
+  }
+
+  async sessionContext(opts: {
+    sessionKey: string;
+    namespace: string;
+  }): Promise<Record<string, unknown>> {
+    const laneRows = await pool.query(
+      `SELECT id, current_context_md FROM ob_session_lanes
+       WHERE namespace = $1 AND session_key = $2`,
+      [opts.namespace, opts.sessionKey],
+    );
+    if (laneRows.rows.length === 0) return { lane: null, events: [] };
+    const lane = laneRows.rows[0];
+    const events = await pool.query(
+      `SELECT id, content FROM ob_session_events WHERE lane_id = $1 ORDER BY created_at`,
+      [lane.id],
+    );
+    return {
+      lane: { id: lane.id, current_context_md: lane.current_context_md },
+      events: events.rows.map((row) => ({ id: row.id, content: row.content })),
+    };
+  }
+
+  /**
+   * The shipped composition, reproduced with exactly one substitution: the
+   * archive call throws. `teardownRecords`, `purgeNamespace` and
+   * `countNamespaceResidue` are the real functions.
+   */
+  async cleanup(
+    records: ScenarioRecord[],
+    namespace: string,
+  ): Promise<{ tally: TeardownTally; residue: TeardownResidue }> {
+    const tally = await teardownRecords(records, (record) =>
+      this.cleanupRecord(record, namespace),
+    );
+
+    if (this.purgeEnabled) {
+      const purge = await purgeNamespace(pool, namespace);
+      this.purgedRows = purge.deleted;
+    } else {
+      console.log(
+        "INFO  purge DISABLED for this run (clause (b) residue control) — rows are expected to REMAIN",
+      );
+    }
+
+    // Returned in BOTH shapes on purpose, and this is load-bearing for the RED
+    // run rather than defensive habit.
+    //
+    // The fix changes `cleanup`'s contract from `TeardownTally` to
+    // `{ tally, residue }`. A driver returning only the NEW shape hands the
+    // PRE-FIX gate an object with no `failed` property; `teardown.failed > 0`
+    // reads `undefined > 0`, which is false, and the pre-fix gate then reports
+    // PASS — the driver would have accidentally repaired the very defect it
+    // exists to expose. Observed on the first RED attempt: `gate passed=true`
+    // on unmodified origin/main.
+    //
+    // Spreading the tally's own fields alongside means the pre-fix gate reads
+    // the real `failed` and fails exactly as it does in production, while the
+    // fixed gate reads `.tally`/`.residue` and ignores the extras. One driver,
+    // an honest reading on both trees.
+    const residue = await observeResidue(namespace);
+    return { ...tally, tally, residue } as unknown as {
+      tally: TeardownTally;
+      residue: TeardownResidue;
+    };
+  }
+
+  private async cleanupRecord(
+    record: ScenarioRecord,
+    namespace: string,
+  ): Promise<"archived" | "already_absent"> {
+    if (record.kind === "memory") {
+      // THE STUB. On a live deployment this is the MCP `archive_entry` tool,
+      // and on the third credentialed #653 verify it threw on exactly these
+      // memory-kind records. Throwing a LiveTransportError reproduces the shape
+      // the live client raises, so the label capture under test is exercised
+      // through its real branch rather than the generic fallback.
+      this.archiveThrows += 1;
+      throw new LiveTransportError(STUB_ARCHIVE_LABEL, false);
+    }
+    const result =
+      record.kind === "event"
+        ? await pool.query(
+            `DELETE FROM ob_session_events AS event USING ob_session_lanes AS lane
+             WHERE event.id = $1 AND event.lane_id = $2
+               AND lane.id = event.lane_id AND lane.namespace = $3 RETURNING event.id`,
+            [record.id, record.lane_id, namespace],
+          )
+        : await pool.query(
+            `DELETE FROM ob_session_lanes
+             WHERE id = $1 AND namespace = $2 AND session_key = $3 RETURNING id`,
+            [record.id, namespace, record.session_key],
+          );
+    return (result.rowCount ?? 0) > 0 ? "archived" : "already_absent";
+  }
+
+  async close(): Promise<void> {}
+}
+
+async function main(): Promise<void> {
+  // "residue_control" is clause (b): the purge is disabled so rows genuinely
+  // remain and the gate MUST fail naming them. Announced in the output.
+  const mode = process.env.DONE_MEANS_671_MODE === "residue_control"
+    ? "residue_control"
+    : "throwing_archive";
+  const purgeEnabled = mode !== "residue_control";
+  console.log(`INFO  mode=${mode} purge_enabled=${purgeEnabled}`);
+
+  const runId = makeRunId({
+    prefix: `scenario-donemeans671`,
+    randomHex: randomUUID().replaceAll("-", "").slice(0, 12),
+    // An operator label in the ambient environment would otherwise change the
+    // namespace this check asserts on. Announced, per nothing-is-adjusted-silently.
+    env: {},
+  });
+  const { primary } = runNamespaces(runId);
+  console.log(`INFO  driver namespace: ${primary}`);
+
+  const fixture = await loadScenarioFixture(
+    "eval/open-brain/fixtures/scenarios-v1.json",
+  );
+  const transport = new ThrowingArchiveTransport(primary, purgeEnabled);
+
+  const outcome = await runScenarioGate({
+    fixture,
+    namespace: primary,
+    transport,
+    commit: "done-means-671",
+    generatedAt: new Date().toISOString(),
+    runId,
+  });
+
+  const receipt = outcome.receipt;
+  console.log(
+    `INFO  gate passed=${receipt.passed} scenarios=${receipt.scenarios.length} ` +
+      `archive_throws=${transport.archiveThrows} purged_rows=${transport.purgedRows}`,
+  );
+  console.log(`INFO  gate failures: ${JSON.stringify(receipt.failures)}`);
+  console.log(
+    `INFO  gate diagnostics: ${JSON.stringify((receipt as unknown as Record<string, unknown>).diagnostics ?? null)}`,
+  );
+  console.log(`INFO  teardown tally: ${JSON.stringify(receipt.teardown)}`);
+  console.log(
+    `INFO  teardown residue: ${JSON.stringify((receipt as unknown as Record<string, unknown>).teardown_residue ?? null)}`,
+  );
+
+  // An INDEPENDENT reading, taken after the gate returned and not through the
+  // gate's own report. Round 16/19's rule: the run's self-report is never the
+  // proof; a count from outside it is.
+  const independent = await observeResidue(primary);
+
+  // Every field the FIX adds to the receipt is read defensively. On the pre-fix
+  // tree `diagnostics`, `failure_labels` and `teardown_residue` do not exist, and
+  // a hard property access would crash the driver into a false RED rather than
+  // letting the clauses report the absence as the real result it is.
+  const loose = receipt as unknown as Record<string, unknown>;
+  const diagnostics = Array.isArray(loose.diagnostics)
+    ? (loose.diagnostics as string[])
+    : [];
+  const tallyLoose = receipt.teardown as unknown as Record<string, unknown>;
+  const failureLabels = Array.isArray(tallyLoose.failure_labels)
+    ? (tallyLoose.failure_labels as string[])
+    : [];
+  const reportedResidue = loose.teardown_residue as TeardownResidue | undefined;
+
+  const out: DriverOut = {
+    mode,
+    expected_label: STUB_ARCHIVE_LABEL,
+    scenario_count: receipt.scenarios.length,
+    gate_passed: receipt.passed,
+    gate_failures: receipt.failures,
+    gate_diagnostics: diagnostics,
+    teardown_failed: receipt.teardown.failed,
+    teardown_failure_labels: failureLabels,
+    // A tree whose gate reports no residue at all is exactly the #671 defect:
+    // `checked: false` records that the GATE never observed rows, which is a
+    // different fact from "there were none".
+    residue_checked: reportedResidue?.checked ?? false,
+    residue_rows: reportedResidue?.rows ?? 0,
+    residue_tables: Object.keys(reportedResidue?.by_table ?? {}).sort(),
+    independent_residue_rows: independent.rows,
+  };
+  await Bun.write(OUT_PATH!, JSON.stringify(out, null, 2));
+  console.log(`INFO  wrote ${OUT_PATH}`);
+}
+
+try {
+  await main();
+} catch (error: unknown) {
+  // A top-level await with no catch exits 0 when it throws (Tightening round
+  // 13), which would bank a false GREEN for the shell wrapper. Fail loudly.
+  console.error(
+    `FATAL driver threw: ${error instanceof Error ? error.constructor.name : "unknown"}`,
+  );
+  console.error(error);
+  await pool.end();
+  process.exit(4);
+}
+await pool.end();

--- a/scripts/done-means/671-teardown-verdict-residue.sh
+++ b/scripts/done-means/671-teardown-verdict-residue.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #671 — "E2E gate verdict channel: clause (e)
+# asserts a tally instead of residue, and teardownRecords swallows the archive
+# error — red on a clean database".
+#
+#   bash scripts/done-means/671-teardown-verdict-residue.sh
+#
+# ---------------------------------------------------------------------------
+# WHAT THE EXISTING DESIGN SAYS, AND WHAT THE DELTA IS
+# ---------------------------------------------------------------------------
+# The teardown design added by #655 is not being replaced. `teardownRecords`
+# (eval/open-brain/live/gate.ts) still removes seeded records one at a time by
+# exact id and tallies attempted/archived/already_absent/failed;
+# `LiveScenarioTransport.cleanup` (eval/open-brain/live/scenario-transport.ts)
+# still runs that record pass first and the prefix-guarded `purgeNamespace`
+# after it. Both stay exactly as they were.
+#
+# UNVERIFIED, stated rather than implied: `qmd search "teardown residue
+# namespace purge"` and `aqmd search "teardown"` both returned "No results
+# found" fast (not a hang — round 22's distinction), so the design above was
+# read from the source files directly rather than recovered from the index.
+#
+# The delta is the VERDICT CHANNEL, and it is a correctness delta, not a
+# cosmetic one. Two defects, observed on the third credentialed #653 verify
+# (2026-08-08, head d9d3712) where all three scenarios PASSED live and a
+# 12-purge-table residue query returned ZERO rows, and the gate still exited 1:
+#
+#   1. THE TALLY CONFLATES "A CLEANUP CALL THREW" WITH "ROWS REMAIN". The
+#      receipt read `attempted=6 archived=4 already_absent=0 failed=2`. The
+#      arithmetic (4+0+2=6) proves both failures were record-loop `archive_entry`
+#      throws, because the purge's own failures increment `failed` WITHOUT
+#      touching `attempted`. The purge that followed then removed everything and
+#      nothing corrected the count. Round 16's Tightening — "a teardown that
+#      reports success is not evidence of removal" — has a mirror, and this is
+#      it: a teardown that reports FAILURE is not evidence of residue.
+#
+#   2. THE ARCHIVE ERROR WAS DISCARDED. `teardownRecords` caught into a bare
+#      `catch {}`, so only the integer survived; the throw's label was
+#      unrecoverable from the receipt, the log, or anywhere else. That is the
+#      dead-end-error class (Tightenings rounds 15/19) inside our own tooling.
+#
+# So: residue (a database query) becomes the load-bearing signal, the tally is
+# demoted to diagnostics but is still REPORTED, and each swallowed error now
+# contributes a content-free label to the receipt. The catch stays — a teardown
+# that aborts on the first bad record strands every later one.
+#
+# NOT IN SCOPE, DELIBERATELY. The underlying `archive_entry` throw on memory-kind
+# records is REAL and its cause is NOT ESTABLISHED. #671 says to surface the
+# label and file separately, never to absorb a fix for it. This check therefore
+# STUBS the archive to throw; it proves the verdict channel handles a throwing
+# archive correctly and makes no claim about why the live tool throws.
+#
+# ---------------------------------------------------------------------------
+# WHERE THIS CHECK STANDS TO SEE THE DEFECT, AND WHAT IT CANNOT SEE
+# ---------------------------------------------------------------------------
+# Residue is a database fact, so the database is REAL: a throwaway database this
+# script creates, migrates and drops. The gate, the teardown, the purge, the
+# residue counter and the verdict logic are all the SHIPPED functions. Exactly
+# one thing is substituted — the `archive_entry` call, made to throw a labelled
+# `LiveTransportError`, because a throwing archive AND a working purge in the
+# same run is the combination that produced the false red, and on a live
+# deployment that combination is intermittent.
+#
+# ITS LIMITATION, STATED (round 22 Tightening). The #655 driver's known gap was
+# that a stubbed seam hides defects living in the real seam — which is how #666
+# slipped past #655's green. The same gap applies here: the stub is a local
+# throw, not the live MCP `archive_entry`. This check CANNOT establish why the
+# live tool throws. It proves only its own claim.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) A throwing archive over a CLEAN database is GREEN. The archive throws,
+#       the purge cleans, zero rows remain — and the gate PASSES. RED before the
+#       fix: the gate reads `teardown.failed` and fails on a clean database.
+#
+#   (b) CONTROL — genuine residue still FAILS, naming the table and the count.
+#       The purge is disabled so the rows really do remain. A check that only
+#       ever goes green proves nothing; this is the clause that proves the new
+#       verdict channel still discriminates.
+#
+#   (c) THE LABEL REACHES THE RECEIPT. The thrown error's label appears in the
+#       gate's diagnostics and in the tally's `failure_labels`. MUTATION-PROVEN:
+#       the expected label is read from the driver's own JSON output rather than
+#       hardcoded here, and the check additionally asserts the label is NOT the
+#       empty string and NOT a generic placeholder — so renaming the thrown error
+#       moves both sides together and cannot leave a stale literal passing.
+#
+#   (d) THE TALLY IS STILL REPORTED, as diagnostics, and is NOT in the verdict
+#       channel. Both halves in ONE clause (round 18): `failed` is nonzero AND
+#       the gate's `failures` array contains no teardown-tally entry. Split into
+#       two, each half passes for the wrong reason.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS SCRIPT TOUCHES, AND WHAT IT REFUSES TO
+# ---------------------------------------------------------------------------
+# It creates ONE throwaway database by a name it generates itself, and drops
+# that same database via `dropdb` on the way out. It contains no `rm` of any
+# kind. It never reads OPENBRAIN_TEST_DATABASE_URL from the environment. It
+# needs no credentials, talks to no deployment, and touches neither the dogfood
+# database nor core01. Output is content-free: clause names, counts, statuses,
+# and this driver's own error labels.
+#
+# The check resolves the driver from its OWN tree (BASH_SOURCE-derived root), so
+# it structurally cannot measure a different checkout than the one it ships in
+# (round 23 Tightening).
+#
+# ---------------------------------------------------------------------------
+# EXPECTED TO FAIL BEFORE THE FIX
+# ---------------------------------------------------------------------------
+# On `origin/main` the transport's `cleanup` returns a bare tally with no
+# residue, `teardownRecords` discards the error, and `runScenarioGate` pushes
+# `teardown_failed:<n>` into `failures`. Clause (a) fails (green run reported
+# red), clause (c) fails (no label anywhere), clause (d) fails (the tally IS the
+# verdict). RED transcript is in the PR body.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}" || exit 1
+
+PG_HOST="${DONE_MEANS_671_PGHOST:-127.0.0.1}"
+PG_PORT="${DONE_MEANS_671_PGPORT:-5432}"
+PG_USER="${DONE_MEANS_671_PGUSER:-${USER}}"
+DB_NAME="done_means_671_$$_$(date +%s)"
+DB_URL="postgres://${PG_USER}@${PG_HOST}:${PG_PORT}/${DB_NAME}"
+
+DRIVER="${REPO_ROOT}/scripts/done-means/671-teardown-verdict-residue.driver.ts"
+
+FAILURES=0
+DB_CREATED=0
+fail() { printf 'FAIL  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+pass() { printf 'PASS  %s\n' "$*"; }
+info() { printf 'INFO  %s\n' "$*"; }
+
+cleanup() {
+  if [[ ${DB_CREATED} -eq 1 ]]; then
+    if dropdb -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" "${DB_NAME}" >/dev/null 2>&1; then
+      info "teardown: dropped ${DB_NAME}"
+    else
+      printf 'WARN  teardown: dropdb %s failed; drop it by hand:\n' "${DB_NAME}"
+      printf 'WARN    dropdb -h %s -p %s -U %s %s\n' "${PG_HOST}" "${PG_PORT}" "${PG_USER}" "${DB_NAME}"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+q() { psql -At "${DB_URL}" -c "$1"; }
+
+printf '=== done-means #671: does the teardown verdict read residue, and does the swallowed archive label reach the receipt? ===\n'
+printf 'throwaway database: %s\n\n' "${DB_NAME}"
+
+if [[ ! -f "${DRIVER}" ]]; then
+  fail "missing required component: ${DRIVER}"
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+
+if ! createdb -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" "${DB_NAME}" 2>&1; then
+  fail "createdb ${DB_NAME} failed; cannot run the check"
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+DB_CREATED=1
+pass "created ${DB_NAME}"
+
+if MIGRATE_LOG="$(DB_HOST="${PG_HOST}" DB_PORT="${PG_PORT}" DB_NAME="${DB_NAME}" \
+  DB_USER="${PG_USER}" bun run migrate 2>&1)"; then
+  pass "migrations applied"
+else
+  fail "migrations failed:"
+  printf '%s\n' "${MIGRATE_LOG}" | tail -20
+  printf '\n=== RESULT: FAIL (%d) ===\n' "${FAILURES}"
+  exit 1
+fi
+
+# Precondition: a fresh database holds no eval-prefixed rows. Without it, every
+# residue count below proves nothing (the #613 standard).
+BEFORE="$(q "SELECT (SELECT count(*) FROM thoughts WHERE namespace LIKE 'eval-live-recall-%')
+              + (SELECT count(*) FROM decisions WHERE namespace LIKE 'eval-live-recall-%')
+              + (SELECT count(*) FROM ob_session_lanes WHERE namespace LIKE 'eval-live-recall-%');")"
+if [[ "${BEFORE}" == "0" ]]; then
+  pass "precondition: 0 eval-live-recall-% rows before the run"
+else
+  fail "precondition broken: ${BEFORE} eval-live-recall-% row(s) already present in a FRESH database"
+fi
+
+SCRATCH_DIR="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/671-teardown-verdict"
+mkdir -p "${SCRATCH_DIR}"
+
+read_json() {
+  # $1 = file, $2 = key. Prints the value; a JSON array prints as compact JSON.
+  #
+  # Prints the sentinel MISSING when the file or key is absent, rather than the
+  # empty string. On the first RED run an empty result flowed into `[[ "${X}" -gt
+  # 0 ]]`, which bash evaluated as the unset variable `undefined` and aborted the
+  # script mid-clause under `set -u` — the remaining clauses never printed and the
+  # transcript looked like a crash rather than a verdict. A sentinel keeps every
+  # clause reachable and makes the absence visible in the output.
+  local value
+  value="$(bun -e 'const f=Bun.file(process.argv[2]);if(!(await f.exists())){console.log("MISSING");process.exit(0)}let r;try{r=await f.json()}catch{console.log("MISSING");process.exit(0)}const v=r[process.argv[3]];console.log(v===undefined||v===null?"MISSING":(Array.isArray(v)?JSON.stringify(v):String(v)))' \
+    x "$1" "$2" 2>/dev/null)"
+  printf '%s' "${value:-MISSING}"
+}
+
+# Numeric comparison that survives a MISSING sentinel: `[[ MISSING -gt 0 ]]`
+# is a bash arithmetic evaluation of a bare word, which under `set -u` aborts.
+is_positive_int() { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 > 0 )); }
+is_zero_int() { [[ "$1" == "0" ]]; }
+
+run_driver() {
+  # $1 = mode, $2 = out path. Echoes the driver log; returns the driver's exit.
+  local mode="$1" out="$2"
+  DONE_MEANS_671_DB_URL="${DB_URL}" DONE_MEANS_671_OUT="${out}" \
+    DONE_MEANS_671_MODE="${mode}" bun "${DRIVER}" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# (a)+(c)+(d) — one run with a THROWING archive and a WORKING purge.
+# ---------------------------------------------------------------------------
+printf '\n--- run 1: throwing archive, purge enabled (clauses a, c, d) ---\n'
+OUT_A="${SCRATCH_DIR}/throwing-archive-${DB_NAME}.json"
+info "receipt: ${OUT_A}"
+set +e
+LOG_A="$(run_driver throwing_archive "${OUT_A}")"
+EXIT_A=$?
+set -e
+printf '%s\n' "${LOG_A}" | tail -25
+if [[ ${EXIT_A} -ne 0 ]]; then
+  fail "run 1 driver exited ${EXIT_A} — clause results below may be unreadable"
+fi
+
+printf '\n--- (a) a throwing archive over a clean database is GREEN ---\n'
+A_SCENARIOS="$(read_json "${OUT_A}" scenario_count)"
+if is_positive_int "${A_SCENARIOS}"; then
+  pass "(a) the run really executed ${A_SCENARIOS} scenario(s) — not a silent empty run"
+else
+  fail "(a) the run reported ${A_SCENARIOS} scenario(s); every count below would be meaningless"
+fi
+
+A_FAILED="$(read_json "${OUT_A}" teardown_failed)"
+if is_positive_int "${A_FAILED}"; then
+  pass "(a) the archive really threw (${A_FAILED} cleanup call(s) failed) — the defect's precondition is present"
+else
+  fail "(a) no cleanup call failed (failed=${A_FAILED}); this run did NOT reproduce the throwing-archive condition, so a green verdict below would prove nothing"
+fi
+
+A_RESIDUE_CHECKED="$(read_json "${OUT_A}" residue_checked)"
+A_RESIDUE_ROWS="$(read_json "${OUT_A}" residue_rows)"
+A_INDEPENDENT="$(read_json "${OUT_A}" independent_residue_rows)"
+if [[ "${A_RESIDUE_CHECKED}" == "true" ]]; then
+  pass "(a) residue was actually OBSERVED (checked=true) — the verdict rests on a reading that ran"
+else
+  fail "(a) residue was not observed (checked=${A_RESIDUE_CHECKED}); an unperformed check may not support a verdict"
+fi
+if is_zero_int "${A_RESIDUE_ROWS}" && is_zero_int "${A_INDEPENDENT}"; then
+  pass "(a) 0 rows remain, confirmed twice — by the gate and by an independent count taken after it returned"
+else
+  fail "(a) rows remain (gate=${A_RESIDUE_ROWS}, independent=${A_INDEPENDENT}); this run is not the clean-database case clause (a) needs"
+fi
+
+A_PASSED="$(read_json "${OUT_A}" gate_passed)"
+A_GATE_FAILURES="$(read_json "${OUT_A}" gate_failures)"
+if [[ "${A_PASSED}" == "true" ]]; then
+  pass "(a) the gate PASSED on a clean database despite the archive throw — the false red is gone"
+else
+  fail "(a) the gate FAILED on a database with zero residue: ${A_GATE_FAILURES}"
+fi
+
+printf '\n--- (c) the swallowed archive error reaches the receipt, by label ---\n'
+# The expected label comes from the DRIVER'S OWN OUTPUT, never a literal here.
+# Renaming the thrown error moves both sides together, so a stale hardcoded
+# string cannot keep this clause green (the mutation requirement).
+EXPECTED_LABEL="$(read_json "${OUT_A}" expected_label)"
+A_LABELS="$(read_json "${OUT_A}" teardown_failure_labels)"
+A_DIAGNOSTICS="$(read_json "${OUT_A}" gate_diagnostics)"
+
+if [[ -n "${EXPECTED_LABEL}" && "${EXPECTED_LABEL}" != "undefined" && "${EXPECTED_LABEL}" != "null" \
+      && "${EXPECTED_LABEL}" != "unknown" && "${EXPECTED_LABEL}" != "Error" ]]; then
+  pass "(c) the driver declared a specific expected label — not empty, not a generic placeholder"
+else
+  fail "(c) the expected label is empty or generic ('${EXPECTED_LABEL}'); a label that names nothing is the dead end this clause exists to remove"
+fi
+
+if [[ "${A_LABELS}" == *"${EXPECTED_LABEL}"* ]]; then
+  pass "(c) the tally carries the thrown label in failure_labels"
+else
+  fail "(c) the thrown label '${EXPECTED_LABEL}' is NOT in failure_labels: ${A_LABELS}"
+fi
+
+if [[ "${A_DIAGNOSTICS}" == *"${EXPECTED_LABEL}"* ]]; then
+  pass "(c) the gate receipt's diagnostics carry the thrown label — an operator can recover WHY the call failed"
+else
+  fail "(c) the thrown label '${EXPECTED_LABEL}' is NOT in the receipt diagnostics: ${A_DIAGNOSTICS}"
+fi
+
+printf '\n--- (d) the tally is reported as diagnostics and is NOT the verdict ---\n'
+# Both halves in one clause (round 18): reported AND non-verdict. Split apart,
+# each half passes for the wrong reason — a gate that drops the tally entirely
+# would satisfy "not in failures", and the old broken gate satisfied "reported".
+if is_positive_int "${A_FAILED}" && [[ "${A_DIAGNOSTICS}" == *"teardown_call_failures"* \
+      && "${A_GATE_FAILURES}" != *"teardown"* ]]; then
+  pass "(d) failed=${A_FAILED} is REPORTED in diagnostics AND absent from the verdict channel"
+else
+  fail "(d) tally reporting/verdict separation not proven — failed=${A_FAILED} diagnostics=${A_DIAGNOSTICS} failures=${A_GATE_FAILURES}"
+fi
+
+# ---------------------------------------------------------------------------
+# (b) CONTROL — genuine residue must still FAIL, naming the table and count.
+# ---------------------------------------------------------------------------
+printf '\n--- run 2: purge disabled, rows genuinely remain (clause b) ---\n'
+OUT_B="${SCRATCH_DIR}/residue-control-${DB_NAME}.json"
+info "receipt: ${OUT_B}"
+set +e
+LOG_B="$(run_driver residue_control "${OUT_B}")"
+EXIT_B=$?
+set -e
+printf '%s\n' "${LOG_B}" | tail -20
+if [[ ${EXIT_B} -ne 0 ]]; then
+  fail "run 2 driver exited ${EXIT_B} — clause (b) results below may be unreadable"
+fi
+
+B_ROWS="$(read_json "${OUT_B}" residue_rows)"
+B_INDEPENDENT="$(read_json "${OUT_B}" independent_residue_rows)"
+B_PASSED="$(read_json "${OUT_B}" gate_passed)"
+B_GATE_FAILURES="$(read_json "${OUT_B}" gate_failures)"
+B_TABLES="$(read_json "${OUT_B}" residue_tables)"
+
+# The PRECONDITION reads the INDEPENDENT count, deliberately, not the gate's own
+# reading: whether the control actually produced residue is a fact about the
+# database, and asking the gate would make this clause unable to distinguish
+# "no rows were left" from "the gate cannot see rows" — which is #671 itself.
+if is_positive_int "${B_INDEPENDENT}"; then
+  pass "(b) the control really produced residue (${B_INDEPENDENT} row(s), counted independently of the gate) — it is testing the failing case"
+else
+  fail "(b) the control produced no residue (independent=${B_INDEPENDENT}); it is not exercising the failure branch"
+fi
+
+# "The gate failed" alone is NOT this clause. Observed in the RED run: the
+# pre-fix gate also failed here, but it failed on `teardown_failed:2` — the very
+# tally #671 removes from the verdict channel — while its residue reading did not
+# exist. A clause satisfied by the OLD verdict on the pre-fix tree is the
+# round-9/17 negative-match family: it would report "still discriminates" about a
+# mechanism that is not present. So the clause requires the failure to be a
+# RESIDUE failure specifically, and requires the gate to have observed residue at
+# all.
+B_RESIDUE_CHECKED="$(read_json "${OUT_B}" residue_checked)"
+if [[ "${B_PASSED}" == "false" && "${B_RESIDUE_CHECKED}" == "true" \
+      && "${B_GATE_FAILURES}" == *"teardown_residue"* ]]; then
+  pass "(b) the gate FAILED specifically on OBSERVED residue — the new verdict channel discriminates on the right signal"
+else
+  fail "(b) the gate's failure is not a residue verdict — passed=${B_PASSED} residue_checked=${B_RESIDUE_CHECKED} failures=${B_GATE_FAILURES}"
+fi
+
+if [[ "${B_GATE_FAILURES}" == *"teardown_residue:rows="* ]]; then
+  pass "(b) the failure names the residue and its count"
+else
+  fail "(b) the failure does not name residue: ${B_GATE_FAILURES}"
+fi
+
+# Naming the COUNT is not naming WHERE. A residue failure that cannot say which
+# table is the dead-end-error class (rounds 15/19) in a new spelling.
+NAMED_A_TABLE=0
+for table in ob_session_lanes thoughts decisions sessions; do
+  if [[ "${B_GATE_FAILURES}" == *"${table}="* ]]; then NAMED_A_TABLE=1; break; fi
+done
+if [[ ${NAMED_A_TABLE} -eq 1 ]]; then
+  pass "(b) the failure names the TABLE holding the residue (observed tables: ${B_TABLES})"
+else
+  fail "(b) the failure names a count but no table: ${B_GATE_FAILURES}"
+fi
+
+printf '\n'
+if [[ ${FAILURES} -eq 0 ]]; then
+  printf '=== RESULT: PASS — the teardown verdict reads residue, a throwing archive over a clean database is green with its label reported, and genuine residue still fails naming the table ===\n'
+  exit 0
+fi
+printf '=== RESULT: FAIL (%d failing clause(s)) ===\n' "${FAILURES}"
+exit 1


### PR DESCRIPTION
## Summary

- Fixes #671. The scenario gate's teardown verdict read `teardown.failed` — a tally of cleanup CALLS — and treated it as a claim about ROWS. On the third credentialed #653 verify (2026-08-08, head d9d3712) all three scenarios passed live and a 12-table residue query returned zero rows, yet the gate exited 1 because two `archive_entry` calls had thrown before the composed purge cleaned everything. Round 16's Tightening has a mirror: a teardown that reports FAILURE is not evidence of residue.
- `countNamespaceResidue` (eval/open-brain/live/namespace-purge.ts) counts remaining rows per table, reading the SAME `PURGE_TABLES` tuple the purge writes. One list, two readers — a parallel list drifts silently and green, because the table the purge stopped clearing would also stop being counted.
- The transport's `cleanup` now returns tally plus residue; `runScenarioGate` fails on `residue.rows > 0` naming the table and count, and REFUSES to pass when residue was never observed. Unchecked is unproven, not clean — otherwise the fix trades a false red for a false green.
- `teardownRecords` keeps its catch (one bad record must not strand the rest) and captures a content-free label per failure. `labelTeardownError` passes through a `LiveTransportError`'s already-redacted label and otherwise emits the error CLASS only, never an arbitrary message that could echo row content into a receipt.
- The tally is still REPORTED, in a new non-verdict `diagnostics` field on the receipt.
- NOT ABSORBED, deliberately: the underlying `archive_entry` throw on memory-kind records is real and its cause is NOT ESTABLISHED. This PR makes its label visible so the next credentialed run prints it; filed separately as #672, per #671's instruction.

## Verification

- Done-means: scripts/done-means/671-teardown-verdict-residue.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (clean upstream default branch, separate worktree, this check copied in):

```
PASS  precondition: 0 eval-live-recall-% rows before the run
INFO  gate passed=false scenarios=3 archive_throws=2 purged_rows=2
INFO  gate failures: ["teardown_failed:2"]
PASS  (a) the run really executed 3 scenario(s) — not a silent empty run
PASS  (a) the archive really threw (2 cleanup call(s) failed) — the defect's precondition is present
FAIL  (a) residue was not observed (checked=false); an unperformed check may not support a verdict
PASS  (a) 0 rows remain, confirmed twice — by the gate and by an independent count taken after it returned
FAIL  (a) the gate FAILED on a database with zero residue: ["teardown_failed:2"]
FAIL  (c) the thrown label is NOT in failure_labels: []
FAIL  (c) the thrown label is NOT in the receipt diagnostics: []
FAIL  (d) tally reporting/verdict separation not proven — failed=2 diagnostics=[] failures=["teardown_failed:2"]
PASS  (b) the control really produced residue (2 row(s), counted independently of the gate)
FAIL  (b) the gate's failure is not a residue verdict — passed=false residue_checked=false failures=["teardown_failed:2"]
FAIL  (b) the failure does not name residue: ["teardown_failed:2"]
FAIL  (b) the failure names a count but no table: ["teardown_failed:2"]
=== RESULT: FAIL (8 failing clause(s)) ===
```

Exit code read directly from a file redirect, never through a pipe: RED_EXIT=1.

GREEN (this branch):

```
INFO  gate passed=true scenarios=3 archive_throws=2 purged_rows=2
INFO  gate diagnostics: ["teardown_call_failures:2;labels=archive_entry:done-means-671-stub-throw|archive_entry:done-means-671-stub-throw"]
INFO  teardown residue: {"checked":true,"rows":0,"by_table":{}}
PASS  (a) residue was actually OBSERVED (checked=true) — the verdict rests on a reading that ran
PASS  (a) 0 rows remain, confirmed twice — by the gate and by an independent count taken after it returned
PASS  (a) the gate PASSED on a clean database despite the archive throw — the false red is gone
PASS  (c) the tally carries the thrown label in failure_labels
PASS  (c) the gate receipt's diagnostics carry the thrown label
PASS  (d) failed=2 is REPORTED in diagnostics AND absent from the verdict channel
INFO  gate failures: ["teardown_residue:rows=2;sessions=1,thoughts=1"]
PASS  (b) the gate FAILED specifically on OBSERVED residue
PASS  (b) the failure names the residue and its count
PASS  (b) the failure names the TABLE holding the residue
=== RESULT: PASS ===
```

GREEN_EXIT=0.

Mutation proofs — three, each run against the fixed tree:

1. Renamed the thrown label to `archive_entry:MUTATED-LABEL-XYZ`. The receipt text FOLLOWED (`labels=archive_entry:MUTATED-LABEL-XYZ|...`), proving clause (c) tracks the real label rather than a stale literal. The shell reads the expected label out of the driver's own JSON, so the two cannot drift.
2. Replaced the label capture in the product with a discard. Clause (c) went RED, 2 failing clauses, exit 1 — diagnostics degraded to `teardown_call_failures:2` with no labels.
3. Disabled the residue branch of the verdict. Clause (b) went RED, 3 failing clauses, exit 1 — the gate passed with 2 rows left behind.

Other gates:

- `bunx tsc --noEmit` — exit 0.
- `bun run test:isolated` — 3761 pass, 35 skip, 0 fail, 244 files.
- `bash scripts/done-means/655-eval-teardown.sh` — still PASS (this PR touches its driver for the new transport contract).
- New tests PROVEN to execute by count, not by a green suite: namespace-purge 13 to 16, gate 17 to 21, scenario-gate 15 to 17, measured on both trees with the same command.

## Critical Self-Review

- Highest-risk behavior: the verdict now depends on a database query that the gate itself issues. If that query silently returned zero on a dirty database, the gate would go green over real residue — strictly worse than the false red being fixed. Mitigations: the residue counter shares the purge's table tuple (unit-tested for exact equality against the purge's own statements), an unreadable table forces `checked: false`, and `checked: false` FAILS the verdict rather than passing it. The done-means also takes an independent count outside the gate and compares.
- Assumptions that could be wrong: that `PURGE_TABLES` is the complete set of tables carrying an eval namespace. If a table with a `namespace` column is added and not registered there, both the purge and the residue count miss it together. That coupling is deliberate — one list is better than two that disagree — but it does mean the list is now load-bearing for a verdict, not just for cleanup.
- Missing/weak tests: the done-means stubs `archive_entry` rather than driving the live MCP tool, so it cannot prove anything about the real archive path. Stated in the check header and in the driver's own docblock rather than implied. No test covers the residue reader against a table that exists but lacks a `namespace` column; that would surface as an unreadable table and correctly force `checked: false`, but it is reasoned, not executed.
- Security/permission risk: no auth or namespace-scoping change. The residue counter issues only `SELECT count(*)` with a bound namespace parameter, is not prefix-guarded (nothing to protect on a read), and is unit-tested to contain no `DELETE`. Labels are content-free by construction: a transport error's redacted label or an error class name, never `error.message`. A unit test plants a secret-bearing `Error.message` and asserts it does not reach the label.
- Migration/deploy risk: none. No schema change, no migration, eval-tree only.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classification is not-applicable — no MCP tool, schema, protocol, or client-facing surface changes. `ScenarioTransport.cleanup`'s return type changed, but that interface has exactly two implementors, both in this repo (the live transport and the #655 done-means driver), and both are updated here.
- Rollback/cleanup concern: revert is a single-commit revert. The throwaway databases this check creates are dropped by its own EXIT trap, which prints the exact `dropdb` line if the drop fails.
- Fixes made before PR: (1) the first RED attempt reported `gate passed=true` on the unmodified upstream tree — my driver returned only the NEW cleanup shape, so the pre-fix gate read `undefined > 0` as false and accidentally repaired the defect it was meant to expose. The driver now returns both shapes. (2) An empty `read_json` result flowed into a bash arithmetic test and aborted the script mid-clause under `set -u`; it now returns a `MISSING` sentinel and numeric comparisons go through a guard. (3) Clause (b) originally passed PRE-fix off the old `teardown_failed` verdict — it now requires the failure to be a residue verdict specifically, and re-proved RED after the edit.
- Known residual risk: the real `archive_entry` throw remains undiagnosed (#672). This PR does not reduce its likelihood; it makes it visible and stops it from failing an otherwise-clean run. If it turns out to leave rows behind in some case, the residue check is what will now catch it — which is the intended ordering.
- SME review-memory update: [x] `docs/sme/` updated — `entries/2026-08-08-a-teardown-that-reports-failure-is-not-evidence-of-residue.md`, lane correctness, order 66, indexes rebuilt.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this lane is uncredentialed by dispatch constraint — no credentialed runs and no live-service mutations. The done-means uses a throwaway local database and stubs the one call that would need a deployment. The credentialed leg belongs to the controller-dispatched verifier.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is confined to the eval harness under `eval/open-brain/live/`. No server contract, MCP tool schema, or client-facing shape is touched, so there is no fixture to update.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: eval-harness-only change with no MCP tool, transport, schema, or Python client surface touched. `ScenarioTransport` is an internal eval interface with two in-repo implementors, both updated in this PR.
- Branch-side work this lane could NOT do, reported for the next sync lane: clause (e) of `scripts/done-means/578-e2e-gate.sh` on the `lane/578-e2e-gate` branch still asserts the tally. It is NOT trivially separable — it needs two coordinated edits on that branch: `578-e2e-gate.receipt.ts` must gain `teardown_residue_rows` and `teardown_residue_checked` fields (its `Field` union and switch are closed over two names today), and the clause body must assert residue with the tally moved to an INFO line. This PR ships the receipt fields those reads require.
