### PR TITLE
fix(679): register the Development safety gates so they REFUSE in open-brain

### DIFF
--- a/.claude/hooks/ob-gate
+++ b/.claude/hooks/ob-gate
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# env bash, not /opt/homebrew/bin/bash: this repo is checked out on the Linux
+# cc-* boxes too, where Homebrew's path does not exist. Stays bash-3.2
+# compatible so it also works if env resolves to Apple's bash in a stripped
+# hook shell.
+#
+# ob-gate (open-brain) — reach the Development-wide enforcement gates from a
+# repo that does not contain them.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS FILE EXISTS — issue #679, cutover pre-flight blocker B7
+# ---------------------------------------------------------------------------
+# /Volumes/ThunderBolt/Development/.claude/settings.json registers four safety
+# gates as:
+#
+#   "${CLAUDE_PROJECT_DIR}"/_ob/bin/ob-gate <gate>
+#
+# That is correct for a session opened on the Development root. When open-brain
+# is CLAUDE_PROJECT_DIR it expands to open-brain/_ob/bin/ob-gate — which does
+# not exist, and cannot: open-brain is a SEPARATE git repo, gitignored by
+# Development (`.gitignore:3:*  open-brain`), so Development's `_ob/` tree is
+# not part of this checkout and never will be.
+#
+# The shell then exits 127, and PreToolUse treats ANY non-2 exit as ALLOW. The
+# gates FAIL OPEN. Measured 2026-08-09: the pre-cutover enforcement audit's own
+# subagent ran `rm -rf`, `grep`, and `find` unblocked inside this repo, while
+# AGENTS.md and CLAUDE.md both claimed those were enforced controls.
+#
+# The upstream ob-gate's header says it "FAILS CLOSED, DELIBERATELY / converts
+# every breakage into exit 2". It cannot, because the file that would do that is
+# the missing one. This is the exact failure mode ob-gate exists to prevent,
+# reproduced one level up — and the reason THIS file's whole job is to fail
+# closed rather than to be clever.
+#
+# ---------------------------------------------------------------------------
+# WHAT IT DOES
+# ---------------------------------------------------------------------------
+# Resolve the Development root, then exec the REAL dispatcher at
+# <root>/_ob/bin/ob-gate. This file deliberately contains no gate logic of its
+# own. The gates are Development-owned and shared across every repo; a second
+# copy here would fork the moment either side changed, and the fork would be
+# invisible because both halves would keep exiting 0 on benign input. One
+# implementation, reached from two places.
+#
+# ---------------------------------------------------------------------------
+# ROOT RESOLUTION — ordered, and every order is deliberate
+# ---------------------------------------------------------------------------
+# Resolution order matches scripts/setup-client.sh:74-95, which solved this same
+# problem for the provider install (#555/#636). An instruction beats a guess:
+#
+#   1. OPENBRAIN_DEVELOPMENT_ROOT — this repo's own name for it, written per-box
+#      by setup-client.sh at install time.
+#   2. DEV_ROOT — what the fleet scripts and ~/.env.machine already call it.
+#      That file is THE one place a machine names its roots, and it keys on
+#      hostname rather than on an attached volume, so a travelling drive cannot
+#      swing the root mid-session.
+#   3. Walk up from THIS FILE's own location. open-brain normally sits at
+#      <root>/open-brain, so the root is two directories up from .claude/hooks.
+#      This keeps the checkout self-describing when the environment is bare —
+#      which is the ordinary case in a hook's stripped shell, and is why the
+#      env vars alone are not sufficient.
+#   4. Probe $HOME/Development (the Air/cc-* layout).
+#
+# Each candidate must actually CONTAIN the dispatcher before it is accepted. A
+# root that exists but holds no _ob/bin/ob-gate is not a root — accepting it
+# would turn a wrong-path problem into a silent no-gate problem, which is #679.
+#
+# Strategy 3 is why this is not a solved problem by env vars alone, and also why
+# it is not solved by strategy 3 alone: a LANE WORKTREE lives under the temp
+# workspace (/Volumes/ThunderBolt/_tmp/open-brain/_worktrees/<lane>), NOT under
+# the Development root, so walking up from a worktree finds nothing. Lanes are
+# where this repo does most of its work, so a resolver that only walked up would
+# be dark in exactly the environment that most needs it. Verified 2026-08-09
+# from a live lane worktree.
+#
+# ---------------------------------------------------------------------------
+# FAILS CLOSED, DELIBERATELY
+# ---------------------------------------------------------------------------
+# If the root will not resolve, or the dispatcher is missing, or bun is absent,
+# this exits 2 with the reason on stderr. Exit 2 BLOCKS the tool call and puts
+# the reason in front of the agent. Exiting anything else — including the 127 a
+# missing file naturally produces — is read as ALLOW and silently disables every
+# gate, which is the whole defect being fixed. Re-creating that failure mode in
+# the fix would be absurd.
+#
+# The cost of failing closed is real and is accepted: on a box with no
+# Development tree, every Bash call in this repo is refused with an explanation
+# naming OPENBRAIN_DEVELOPMENT_ROOT. That is loud, recoverable, and correct.
+# Failing open is quiet, unrecoverable, and is how ~50 GB of user data was
+# deleted on 2026-07-30.
+#
+# ---------------------------------------------------------------------------
+# Usage (from .claude/settings.json):
+#   "${CLAUDE_PROJECT_DIR}"/.claude/hooks/ob-gate fast-tools
+#   "${CLAUDE_PROJECT_DIR}"/.claude/hooks/ob-gate destructive-delete
+#   "${CLAUDE_PROJECT_DIR}"/.claude/hooks/ob-gate irreversible-command
+#   "${CLAUDE_PROJECT_DIR}"/.claude/hooks/ob-gate worktree-hygiene
+set -euo pipefail
+
+readonly SELF="ob-gate (open-brain)"
+
+die() {
+  printf '%s: %s\n' "$SELF" "$1" >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || die "usage: ob-gate <gate-name> [args...]
+
+known gates: fast-tools, destructive-delete, irreversible-command, worktree-hygiene"
+
+# Resolve symlinks first, so an invocation through a link still locates the
+# real file (BASH_SOURCE reports the LINK, whose directory strips to nothing
+# useful). Same handling as the upstream dispatcher.
+src="${BASH_SOURCE[0]}"
+while [ -L "$src" ]; do
+  target="$(readlink -- "$src")"
+  case "$target" in
+    /*) src="$target" ;;
+    *)  src="$(dirname -- "$src")/$target" ;;
+  esac
+done
+here="$(cd -- "$(dirname -- "$src")" && pwd -P)"
+
+# <root>/open-brain/.claude/hooks -> <root>
+repo_root="${here%/.claude/hooks}"
+walk_up_root="$(dirname -- "$repo_root")"
+
+# A candidate is only a root if it actually carries the dispatcher.
+upstream_for() { printf '%s/_ob/bin/ob-gate' "$1"; }
+
+root=""
+root_source=""
+try_root() {
+  local candidate="$1" source="$2"
+  [ -n "$candidate" ] || return 1
+  [ -x "$(upstream_for "$candidate")" ] || return 1
+  root="$candidate"
+  root_source="$source"
+  return 0
+}
+
+try_root "${OPENBRAIN_DEVELOPMENT_ROOT:-}" "OPENBRAIN_DEVELOPMENT_ROOT" \
+  || try_root "${DEV_ROOT:-}" "DEV_ROOT" \
+  || try_root "$walk_up_root" "walked up from this checkout" \
+  || try_root "$HOME/Development" "probed \$HOME/Development" \
+  || true
+
+if [ -z "$root" ]; then
+  die "cannot reach the Development enforcement gates.
+
+    Looked for _ob/bin/ob-gate under, in order:
+      OPENBRAIN_DEVELOPMENT_ROOT  ${OPENBRAIN_DEVELOPMENT_ROOT:-(unset)}
+      DEV_ROOT                    ${DEV_ROOT:-(unset)}
+      walked up from this repo    $walk_up_root
+      \$HOME/Development           $HOME/Development
+
+    BLOCKING rather than allowing, on purpose. These are the fast-tools,
+    destructive-delete, irreversible-command and worktree-hygiene gates; a
+    session that cannot reach them is a session where \`rm -rf\` is unguarded,
+    and letting the command through quietly is issue #679 itself.
+
+    Fix: export OPENBRAIN_DEVELOPMENT_ROOT (or DEV_ROOT) to this machine's
+    Development tree, or mount the volume that holds it."
+fi
+
+gate="$1"
+shift
+
+exec "$(upstream_for "$root")" "$gate" "$@"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,67 @@
   "env": {
     "TMPDIR": "/mnt/ThunderBolt/_tmp/open-brain/_scratch"
   },
+  "permissions": {
+    "deny": [
+      "Bash(grep:*)",
+      "Bash(egrep:*)",
+      "Bash(fgrep:*)",
+      "Bash(find:*)",
+      "Bash(mktemp:*)",
+      "Bash(/usr/bin/python:*)",
+      "Bash(/usr/bin/python3:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(/bin/bash:*)",
+      "Bash(/bin/zsh:*)",
+      "Edit(/tmp/**)",
+      "Read(/tmp/**)",
+      "Write(/tmp/**)",
+      "Bash(rm:*)",
+      "Bash(/bin/rm:*)",
+      "Bash(shred:*)",
+      "Bash(sudo rm:*)",
+      "Bash(mkfs:*)",
+      "Bash(mkfs.ext4:*)",
+      "Bash(mkfs.xfs:*)",
+      "Bash(mkfs.vfat:*)",
+      "Bash(newfs:*)",
+      "Bash(newfs_hfs:*)",
+      "Bash(newfs_apfs:*)",
+      "Bash(diskutil:*)",
+      "Bash(sudo diskutil:*)",
+      "Bash(sudo mkfs:*)",
+      "Bash(gh repo delete:*)",
+      "Bash(gh release delete:*)",
+      "Bash(gh secret delete:*)",
+      "Bash(gh ssh-key delete:*)",
+      "Bash(gh gpg-key delete:*)",
+      "Bash(gh auth token:*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/ob-gate fast-tools"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/ob-gate destructive-delete"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/ob-gate irreversible-command"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}\"/.claude/hooks/ob-gate worktree-hygiene"
+          }
+        ]
+      },
       {
         "matcher": "Write|Edit|NotebookEdit|Bash|Grep|Glob|AskUserQuestion",
         "hooks": [

--- a/scripts/done-means/679-dev-safety-gates-registered.sh
+++ b/scripts/done-means/679-dev-safety-gates-registered.sh
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #679 / cutover pre-flight blocker B7 —
+# "Development-wide safety gates fail OPEN in open-brain".
+#
+#   bash scripts/done-means/679-dev-safety-gates-registered.sh
+#
+# Pre-flight ordered item 7 states the acceptance in one line:
+#   "register the Development-wide safety gates so they resolve for open-brain;
+#    done-means: a destructive-delete and a fast-tool call are REFUSED in this
+#    repo."
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT
+# ---------------------------------------------------------------------------
+# /Volumes/ThunderBolt/Development/.claude/settings.json registers four gates as
+#
+#   "${CLAUDE_PROJECT_DIR}"/_ob/bin/ob-gate <gate>
+#
+# When open-brain is CLAUDE_PROJECT_DIR that expands to open-brain/_ob/bin/ob-gate,
+# which does not exist (open-brain is a SEPARATE git repo, gitignored by
+# Development — `git check-ignore -v open-brain` -> `.gitignore:3:* open-brain` —
+# so Development's own _ob/ tree is not part of this checkout and never will be).
+# The shell exits 127, and PreToolUse treats any non-2 exit as ALLOW. The gate
+# FAILS OPEN.
+#
+# ob-gate's own header says it "FAILS CLOSED, DELIBERATELY / converts every
+# breakage into exit 2". It cannot, because the file that would do that is the
+# missing one. The exact failure mode ob-gate exists to prevent, one level up.
+#
+# The gate LOGIC is fine and is not what this check tests. Running
+# Development/_ob/bin/ob-gate by absolute path from this repo already refuses
+# correctly. What is broken is REACHABILITY FROM THIS REPO, and that is a
+# registration-boundary question, so this check reads the registration.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS CHECK READS settings.json INSTEAD OF CALLING A GATE DIRECTLY
+# ---------------------------------------------------------------------------
+# This is the load-bearing design decision, and it is round 25's rule
+# ("when a gate has no clause-level seam, EXTRACT the clause from the real file
+# — never retype it"). A check that invokes a dispatcher at a path it spells
+# itself proves that the dispatcher works. It proves NOTHING about whether the
+# harness will ever call it, which IS the defect: on 2026-08-09 the gate binary
+# worked perfectly and agents in this repo ran `rm -rf` unblocked anyway.
+#
+# So every clause below extracts the ACTUAL hook commands out of the committed
+# .claude/settings.json, substitutes CLAUDE_PROJECT_DIR exactly as Claude Code
+# does, and executes the result. If the registration is missing, mis-pathed, or
+# points at something absent, these clauses fail. If somebody deletes the
+# registration and leaves the dispatcher on disk, they still fail.
+#
+# ---------------------------------------------------------------------------
+# WHICH TREE RUNS (round 12 / round 23)
+# ---------------------------------------------------------------------------
+# REPO_ROOT is derived from THIS FILE's own location, and every path below hangs
+# off it, so the check structurally cannot reach across trees: run from a lane
+# worktree it tests that worktree's settings.json; run from the primary checkout
+# it tests the primary checkout's. CLAUDE_PROJECT_DIR is set to REPO_ROOT for
+# the same reason — that is what the harness sets it to when a session is open
+# on this repo, and it is the value under which the defect occurs.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   1  DESTRUCTIVE-DELETE IS REFUSED. The registered destructive-delete hook,
+#      driven with a crafted `rm -rf` payload, exits 2. This is half of the
+#      pre-flight's literal done-means sentence.
+#
+#   2  FAST-TOOL IS REFUSED. The registered fast-tools hook, driven with a
+#      crafted `grep -r` payload, exits 2, AND the refusal names `rg` — a
+#      refusal that does not name the replacement is the dead-end-error class
+#      (round 15/19), and AGENTS.md promises "the replacement is in the refusal
+#      text". `find` is asserted too: the issue records the audit subagent
+#      running BOTH grep and find unblocked, and settings.local.json explicitly
+#      allowed `Bash(find:*)`.
+#
+#   3  ALL FOUR GATES ARE REGISTERED AND REACHABLE. fast-tools,
+#      destructive-delete, irreversible-command, worktree-hygiene — the set
+#      Development registers. Asserted in BOTH directions (round 11: "a hook-set
+#      assertion needs both directions"): none missing, and none extra. A fifth
+#      unexplained safety hook is config drift and should be seen.
+#
+#   4  NEGATIVE CONTROL — BENIGN COMMANDS STILL PASS. Every registered gate
+#      exits 0 on `echo hello` and on `rg -n foo src/`. Without this, a
+#      dispatcher that exited 2 unconditionally — i.e. one that had failed
+#      closed and wedged the repo — would satisfy clauses 1-3 and look like
+#      success. This is the clause that distinguishes "enforced" from "broken".
+#
+#   5  FAIL-CLOSED. Point the dispatcher at a root where no gate can be found
+#      and it must exit 2, never 0. This is the property whose ABSENCE is the
+#      entire issue: the pre-fix world exits 127 and the harness reads that as
+#      ALLOW. A fix that merely made the happy path work, while still exiting
+#      non-2 when the Development tree is absent (a laptop without the volume
+#      mounted, a fresh clone), would reintroduce #679 on the next machine.
+#      Asserted by invoking the real dispatcher with a bogus resolved root.
+#
+#   6  permissions.deny CARRIES THE HARD FLOOR. Hooks are the actionable layer;
+#      `permissions.deny` is the layer that holds when bun is missing or a file
+#      is deleted (destructive-delete-gate.ts:26-33 — "deny is the floor; this
+#      is the explanation layered on top"). open-brain had NO permissions block
+#      at all. Assert the rm and fast-tool spellings are denied here.
+#
+#   7  NOTHING RE-ALLOWS WHAT THE FLOOR DENIES. settings.local.json must not
+#      carry a `Bash(find:*)` allow. The issue names this explicitly: an allow
+#      entry for a denied binary is a standing invitation to the exact call the
+#      gate exists to refuse, and it is how this repo got here. Deny wins over
+#      allow in the harness, so this is belt-and-braces — but a stale allow is
+#      a misleading signal to every future reader of the file.
+#
+# Exit 0 only when every clause passes. Exit 3 is a HARNESS error (missing tool,
+# unreadable repo) which is NOT a fail of the thing under test — a harness error
+# must never be readable as a green.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+LOCAL_SETTINGS="$REPO_ROOT/.claude/settings.local.json"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -r "$SETTINGS" ] || fail_hard "settings.json not readable at $SETTINGS"
+
+# The four gates Development registers. Named here so clause 3 can assert the
+# set in both directions.
+EXPECTED_GATES="destructive-delete fast-tools irreversible-command worktree-hygiene"
+
+# ---------------------------------------------------------------------------
+# Extract the REGISTERED hook commands from the real settings.json.
+#
+# Round 25: extract from the real file, never retype. This emits one line per
+# PreToolUse Bash hook command that mentions ob-gate, with ${CLAUDE_PROJECT_DIR}
+# and $CLAUDE_PROJECT_DIR substituted the way Claude Code substitutes them.
+#
+# A retyped copy of the command would prove the copy. Reading the file is the
+# only thing that proves the REGISTRATION, which is the defect.
+# ---------------------------------------------------------------------------
+extract_registered_commands() {
+  SETTINGS_PATH="$SETTINGS" PROJECT_DIR="$REPO_ROOT" bun -e '
+    const fs = require("node:fs");
+    const settings = JSON.parse(fs.readFileSync(process.env.SETTINGS_PATH, "utf8"));
+    const projectDir = process.env.PROJECT_DIR;
+    const out = [];
+    for (const entry of settings?.hooks?.PreToolUse ?? []) {
+      // The matcher must actually cover Bash, or the hook never runs on the
+      // tool that runs rm and grep. A gate registered under a matcher that
+      // excludes Bash is registered and useless.
+      if (!/(^|\|)Bash(\||$)/.test(entry?.matcher ?? "")) continue;
+      for (const hook of entry?.hooks ?? []) {
+        const raw = hook?.command ?? "";
+        if (!raw.includes("ob-gate")) continue;
+        out.push(raw
+          .replaceAll("${CLAUDE_PROJECT_DIR}", projectDir)
+          .replaceAll("$CLAUDE_PROJECT_DIR", projectDir));
+      }
+    }
+    process.stdout.write(out.join("\n"));
+  ' 2>/dev/null
+}
+
+REGISTERED_COMMANDS="$(extract_registered_commands)"
+
+# Round 25: "0 lines extracted, all cases as expected" is a vacuous green. If
+# nothing was extracted that is a legitimate RED (the pre-fix world), not a
+# harness error — so it is recorded as failing clauses, never as exit 3.
+REGISTERED_COUNT=0
+if [ -n "$REGISTERED_COMMANDS" ]; then
+  REGISTERED_COUNT="$(printf '%s\n' "$REGISTERED_COMMANDS" | wc -l | tr -d ' ')"
+fi
+
+# Which gate name does a registered command carry? (last whitespace token)
+gate_name_of() { printf '%s' "${1##* }"; }
+
+# ---------------------------------------------------------------------------
+# Drive one registered hook command the way Claude Code does: a PreToolUse JSON
+# payload on stdin. Sets HOOK_EXIT and HOOK_STDERR.
+#
+# Round 21: never read an exit status through a pipeline whose PIPESTATUS is
+# evaluated in another shell. The command substitution below captures stderr and
+# $? is read immediately, in this shell.
+# ---------------------------------------------------------------------------
+HOOK_EXIT=0
+HOOK_STDERR=""
+run_registered() {
+  local hook_command="$1"
+  local command_text="$2"
+  local payload
+  payload="$(
+    COMMAND_TEXT="$command_text" bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: "679-dev-safety-gates-done-means",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: process.env.COMMAND_TEXT ?? "" },
+      }));
+    '
+  )" || fail_hard "could not build hook payload"
+
+  HOOK_STDERR="$(printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    /usr/bin/env bash -c "$hook_command" 2>&1 >/dev/null)"
+  HOOK_EXIT=$?
+}
+
+# Find the registered command for one gate. Empty when it is not registered.
+command_for_gate() {
+  local want="$1" line
+  [ -n "$REGISTERED_COMMANDS" ] || return 0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    if [ "$(gate_name_of "$line")" = "$want" ]; then
+      printf '%s' "$line"
+      return 0
+    fi
+  done <<< "$REGISTERED_COMMANDS"
+}
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — a destructive delete is REFUSED
+# ---------------------------------------------------------------------------
+DD_CMD="$(command_for_gate destructive-delete)"
+if [ -z "$DD_CMD" ]; then
+  record 1 FAIL "no destructive-delete hook is registered for Bash in $SETTINGS — rm runs unguarded"
+else
+  # A path under the temp workspace, deliberately: the rule has NO carve-out,
+  # and a crafted violation that a carve-out would excuse proves less.
+  run_registered "$DD_CMD" "rm -rf /Volumes/ThunderBolt/_tmp/open-brain/_scratch/679-crafted-violation"
+  if [ "$HOOK_EXIT" -ne 2 ]; then
+    record 1 FAIL "crafted \`rm -rf\` was NOT refused (exit=$HOOK_EXIT; PreToolUse reads any non-2 as ALLOW)"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qiF 'BLOCKED'; then
+    record 1 FAIL "exit=2 but the refusal text never says it blocked anything"
+  else
+    record 1 PASS "crafted \`rm -rf\` refused by the registered hook (exit=2)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — a fast-tool call is REFUSED, and the refusal names the replacement
+# ---------------------------------------------------------------------------
+FT_CMD="$(command_for_gate fast-tools)"
+if [ -z "$FT_CMD" ]; then
+  record 2 FAIL "no fast-tools hook is registered for Bash in $SETTINGS — grep/find run unguarded"
+else
+  run_registered "$FT_CMD" "grep -r needle ."
+  GREP_EXIT="$HOOK_EXIT"
+  GREP_STDERR="$HOOK_STDERR"
+  run_registered "$FT_CMD" "find . -name '*.ts'"
+  FIND_EXIT="$HOOK_EXIT"
+
+  if [ "$GREP_EXIT" -ne 2 ]; then
+    record 2 FAIL "crafted \`grep -r\` was NOT refused (exit=$GREP_EXIT)"
+  elif [ "$FIND_EXIT" -ne 2 ]; then
+    record 2 FAIL "\`grep\` refused but crafted \`find\` was NOT (exit=$FIND_EXIT) — the issue records both running unblocked"
+  elif ! printf '%s' "$GREP_STDERR" | rg -qF 'rg '; then
+    record 2 FAIL "grep refused but the refusal never names \`rg\` — a dead-end refusal (round 15/19)"
+  else
+    record 2 PASS "crafted \`grep -r\` and \`find\` both refused (exit=2), and the grep refusal names rg"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — all four gates registered and reachable, none missing, none extra
+# ---------------------------------------------------------------------------
+MISSING=""
+UNREACHABLE=""
+for gate in $EXPECTED_GATES; do
+  cmd="$(command_for_gate "$gate")"
+  if [ -z "$cmd" ]; then
+    MISSING="$MISSING $gate"
+    continue
+  fi
+  # Reachable means: driven with a benign payload it returns a VERDICT (0 or 2),
+  # not a shell "command not found" (127) or an interpreter error. 127 is the
+  # pre-fix world and is precisely what fails open.
+  run_registered "$cmd" "echo reachability probe"
+  if [ "$HOOK_EXIT" -ne 0 ] && [ "$HOOK_EXIT" -ne 2 ]; then
+    UNREACHABLE="$UNREACHABLE $gate(exit=$HOOK_EXIT)"
+  fi
+done
+
+EXTRA=""
+if [ -n "$REGISTERED_COMMANDS" ]; then
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    name="$(gate_name_of "$line")"
+    case " $EXPECTED_GATES " in
+      *" $name "*) ;;
+      *) EXTRA="$EXTRA $name" ;;
+    esac
+  done <<< "$REGISTERED_COMMANDS"
+fi
+
+if [ -n "$MISSING" ]; then
+  record 3 FAIL "gates not registered:$MISSING (registered command count: $REGISTERED_COUNT)"
+elif [ -n "$UNREACHABLE" ]; then
+  record 3 FAIL "registered but UNREACHABLE (non-verdict exit — this is failing OPEN):$UNREACHABLE"
+elif [ -n "$EXTRA" ]; then
+  record 3 FAIL "unexpected extra safety gate registered:$EXTRA — config drift, name it or remove it"
+else
+  record 3 PASS "all 4 gates registered for Bash and returning verdicts:$(printf ' %s' $EXPECTED_GATES)"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — NEGATIVE CONTROL: benign commands still pass every gate
+# ---------------------------------------------------------------------------
+OVERFIRE=""
+if [ -z "$REGISTERED_COMMANDS" ]; then
+  record 4 FAIL "no gates registered, so the control cannot discriminate (see clause 3)"
+else
+  # Distinguish the two non-zero worlds by name. exit 2 is a real over-fire (the
+  # gate blocked something benign — a wedged repo). Any OTHER non-zero is a
+  # non-verdict: the hook crashed or was never found, which the harness reads as
+  # ALLOW. Reporting the second as "BLOCKED" would send the next reader to fix
+  # over-firing when the actual defect is that nothing ran at all (round 6: a
+  # wrong cause is the dangerous half of a wrong clause).
+  NONVERDICT=""
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    name="$(gate_name_of "$line")"
+    for benign in "echo hello" "rg -n needle src/"; do
+      run_registered "$line" "$benign"
+      if [ "$HOOK_EXIT" -eq 2 ]; then
+        OVERFIRE="$OVERFIRE $name:[$benign]"
+      elif [ "$HOOK_EXIT" -ne 0 ]; then
+        NONVERDICT="$NONVERDICT $name:[$benign]=exit$HOOK_EXIT"
+      fi
+    done
+  done <<< "$REGISTERED_COMMANDS"
+
+  if [ -n "$NONVERDICT" ]; then
+    record 4 FAIL "gates returned NO VERDICT on benign commands (crashed/not found, read as ALLOW):$NONVERDICT"
+  elif [ -n "$OVERFIRE" ]; then
+    record 4 FAIL "benign commands were BLOCKED (exit=2) —$OVERFIRE — a wedged repo is not an enforced one"
+  else
+    record 4 PASS "\`echo hello\` and \`rg -n needle src/\` allowed by every registered gate (exit=0)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 5 — FAIL-CLOSED when the gate cannot be found
+#
+# Drives the REAL registered dispatcher, with its root resolution pointed at a
+# directory that exists but holds no gates. Exit 2 (block + explain) is the only
+# acceptable answer. Exit 0 is #679 itself; 127 is the pre-fix world.
+# ---------------------------------------------------------------------------
+if [ -z "$DD_CMD" ]; then
+  record 5 FAIL "no dispatcher registered to test the fail-closed property against (see clause 1)"
+else
+  BOGUS_ROOT="$REPO_ROOT/.679-nonexistent-development-root"
+  payload="$(
+    bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: "679-fail-closed",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "echo hello" },
+      }));
+    '
+  )" || fail_hard "could not build fail-closed payload"
+
+  FC_STDERR="$(printf '%s' "$payload" | \
+    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    DEV_ROOT="$BOGUS_ROOT" \
+    OPENBRAIN_DEVELOPMENT_ROOT="$BOGUS_ROOT" \
+    /usr/bin/env bash -c "$DD_CMD" 2>&1 >/dev/null)"
+  FC_EXIT=$?
+
+  if [ "$FC_EXIT" -eq 0 ]; then
+    record 5 FAIL "an unresolvable gate root exited 0 — FAILS OPEN, which is #679 reintroduced"
+  elif [ "$FC_EXIT" -ne 2 ]; then
+    record 5 FAIL "an unresolvable gate root exited $FC_EXIT; PreToolUse reads any non-2 as ALLOW, so this fails open"
+  elif [ -z "$FC_STDERR" ]; then
+    record 5 FAIL "blocked at exit=2 but said nothing — a silent block wedges the lane with no reason"
+  else
+    record 5 PASS "unresolvable gate root exits 2 with a stated reason — fails CLOSED"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 6 — permissions.deny carries the hard floor
+# ---------------------------------------------------------------------------
+DENY_MISSING="$(
+  SETTINGS_PATH="$SETTINGS" bun -e '
+    const fs = require("node:fs");
+    const s = JSON.parse(fs.readFileSync(process.env.SETTINGS_PATH, "utf8"));
+    const deny = s?.permissions?.deny ?? [];
+    const required = ["Bash(rm:*)", "Bash(grep:*)", "Bash(find:*)"];
+    process.stdout.write(required.filter((r) => !deny.includes(r)).join(" "));
+  ' 2>/dev/null
+)"
+if [ -n "$DENY_MISSING" ]; then
+  record 6 FAIL "permissions.deny is missing the hard floor: $DENY_MISSING"
+else
+  record 6 PASS "permissions.deny carries Bash(rm:*), Bash(grep:*), Bash(find:*)"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 7 — nothing re-allows what the floor denies
+#
+# settings.local.json is untracked machine-local state, so its ABSENCE is a
+# pass, not a harness error.
+# ---------------------------------------------------------------------------
+if [ ! -r "$LOCAL_SETTINGS" ]; then
+  record 7 PASS "no settings.local.json present — nothing re-allows a denied binary"
+else
+  BAD_ALLOWS="$(
+    LOCAL_PATH="$LOCAL_SETTINGS" bun -e '
+      const fs = require("node:fs");
+      let s = {};
+      try { s = JSON.parse(fs.readFileSync(process.env.LOCAL_PATH, "utf8")); } catch { }
+      const allow = s?.permissions?.allow ?? [];
+      const banned = ["grep", "egrep", "fgrep", "find", "rm", "mktemp", "shred"];
+      process.stdout.write(
+        allow.filter((a) => banned.some((b) => a.startsWith(`Bash(${b}:`) || a === `Bash(${b})`)).join(" "));
+    ' 2>/dev/null
+  )"
+  if [ -n "$BAD_ALLOWS" ]; then
+    record 7 FAIL "settings.local.json re-allows denied binaries: $BAD_ALLOWS"
+  else
+    record 7 PASS "settings.local.json carries no allow entry for a denied binary"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    1) printf 'a crafted destructive delete is REFUSED in this repo' ;;
+    2) printf 'a crafted fast-tool call is REFUSED, naming the replacement' ;;
+    3) printf 'all 4 Development safety gates registered + reachable (none missing, none extra)' ;;
+    4) printf 'CONTROL — benign commands still pass every gate' ;;
+    5) printf 'an unresolvable gate root FAILS CLOSED (exit 2), never open' ;;
+    6) printf 'permissions.deny carries the hard floor' ;;
+    7) printf 'settings.local.json re-allows nothing the floor denies' ;;
+  esac
+}
+
+printf 'registered ob-gate hook commands extracted from %s: %s\n\n' \
+  "${SETTINGS#"$REPO_ROOT"/}" "$REGISTERED_COUNT"
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1

--- a/scripts/done-means/679-dev-safety-gates-registered.sh
+++ b/scripts/done-means/679-dev-safety-gates-registered.sh
@@ -85,13 +85,32 @@
 #      closed and wedged the repo — would satisfy clauses 1-3 and look like
 #      success. This is the clause that distinguishes "enforced" from "broken".
 #
-#   5  FAIL-CLOSED. Point the dispatcher at a root where no gate can be found
-#      and it must exit 2, never 0. This is the property whose ABSENCE is the
+#   5  FAIL-CLOSED. With NO Development tree reachable by ANY of the resolver's
+#      strategies, the dispatcher must exit 2 with a stated reason — never 0,
+#      and never a non-verdict 127. This is the property whose ABSENCE is the
 #      entire issue: the pre-fix world exits 127 and the harness reads that as
 #      ALLOW. A fix that merely made the happy path work, while still exiting
 #      non-2 when the Development tree is absent (a laptop without the volume
 #      mounted, a fresh clone), would reintroduce #679 on the next machine.
-#      Asserted by invoking the real dispatcher with a bogus resolved root.
+#
+#      HOW THIS CLAUSE IS DRIVEN, AND WHY IT IS NOT THE OBVIOUS WAY. The first
+#      version set DEV_ROOT/OPENBRAIN_DEVELOPMENT_ROOT to a bogus path and
+#      asserted exit 2. It PASSED — for the wrong reason, and the refusal text
+#      gave it away: it was the UPSTREAM dispatcher's "Development root does not
+#      exist" message, not this repo's. The resolver had correctly rejected the
+#      bogus env roots and fallen through to $HOME/Development, which on this
+#      machine is a symlink to the real tree. So the env vars alone can never
+#      starve the resolver here, and the fail-closed branch was never reached:
+#      a green clause proving nothing (round 9 — a clause whose PASS comes from
+#      a negative match must be mutation-checked).
+#
+#      Driven instead by COPYING the dispatcher to a scratch location whose
+#      walk-up parent holds no _ob/bin/ob-gate, with HOME and both env vars
+#      pointed at that same barren directory. That starves all four strategies
+#      at once, which is the only state in which the fail-closed branch runs.
+#      The clause additionally asserts the refusal is THIS file's — it must name
+#      OPENBRAIN_DEVELOPMENT_ROOT — so it can never again be satisfied by the
+#      upstream dispatcher answering on the real tree's behalf.
 #
 #   6  permissions.deny CARRIES THE HARD FLOOR. Hooks are the actionable layer;
 #      `permissions.deny` is the layer that holds when bun is missing or a file
@@ -347,10 +366,21 @@ fi
 # directory that exists but holds no gates. Exit 2 (block + explain) is the only
 # acceptable answer. Exit 0 is #679 itself; 127 is the pre-fix world.
 # ---------------------------------------------------------------------------
-if [ -z "$DD_CMD" ]; then
-  record 5 FAIL "no dispatcher registered to test the fail-closed property against (see clause 1)"
+DISPATCHER="$REPO_ROOT/.claude/hooks/ob-gate"
+if [ ! -x "$DISPATCHER" ]; then
+  record 5 FAIL "no repo-local dispatcher at .claude/hooks/ob-gate to test the fail-closed property against"
 else
-  BOGUS_ROOT="$REPO_ROOT/.679-nonexistent-development-root"
+  # Starve EVERY resolution strategy at once. A barren directory serves as the
+  # walk-up parent, as $HOME, and as both env roots; none of them contains
+  # _ob/bin/ob-gate, so the resolver has nowhere left to fall through to. This
+  # is the only state in which the fail-closed branch executes.
+  FC_SCRATCH="$REPO_ROOT/.679-fail-closed-probe.$$"
+  FC_BARREN="$FC_SCRATCH/barren"
+  mkdir -p "$FC_BARREN/open-brain/.claude/hooks" || fail_hard "cannot create fail-closed probe dir"
+  cp "$DISPATCHER" "$FC_BARREN/open-brain/.claude/hooks/ob-gate" \
+    || fail_hard "cannot stage dispatcher for the fail-closed probe"
+  chmod +x "$FC_BARREN/open-brain/.claude/hooks/ob-gate" 2>/dev/null
+
   payload="$(
     bun -e '
       process.stdout.write(JSON.stringify({
@@ -363,10 +393,10 @@ else
   )" || fail_hard "could not build fail-closed payload"
 
   FC_STDERR="$(printf '%s' "$payload" | \
-    CLAUDE_PROJECT_DIR="$REPO_ROOT" \
-    DEV_ROOT="$BOGUS_ROOT" \
-    OPENBRAIN_DEVELOPMENT_ROOT="$BOGUS_ROOT" \
-    /usr/bin/env bash -c "$DD_CMD" 2>&1 >/dev/null)"
+    HOME="$FC_BARREN" \
+    DEV_ROOT="$FC_BARREN/nonexistent" \
+    OPENBRAIN_DEVELOPMENT_ROOT="$FC_BARREN/nonexistent" \
+    "$FC_BARREN/open-brain/.claude/hooks/ob-gate" destructive-delete 2>&1 >/dev/null)"
   FC_EXIT=$?
 
   if [ "$FC_EXIT" -eq 0 ]; then
@@ -375,8 +405,18 @@ else
     record 5 FAIL "an unresolvable gate root exited $FC_EXIT; PreToolUse reads any non-2 as ALLOW, so this fails open"
   elif [ -z "$FC_STDERR" ]; then
     record 5 FAIL "blocked at exit=2 but said nothing — a silent block wedges the lane with no reason"
+  elif ! printf '%s' "$FC_STDERR" | rg -qF 'OPENBRAIN_DEVELOPMENT_ROOT'; then
+    # Guards against the false green this clause was rewritten to kill: an exit
+    # 2 produced by the UPSTREAM dispatcher on a real tree, rather than by this
+    # repo's resolver running out of strategies.
+    record 5 FAIL "exit=2 but the refusal is not this repo's fail-closed message (never names OPENBRAIN_DEVELOPMENT_ROOT) — the probe did not starve the resolver: $(printf '%s' "$FC_STDERR" | tr '\n' ' ' | cut -c1-200)"
   else
-    record 5 PASS "unresolvable gate root exits 2 with a stated reason — fails CLOSED"
+    record 5 PASS "with no Development tree reachable by any strategy, exits 2 naming the remedy — fails CLOSED"
+  fi
+
+  ARCHIVE_DIR="/Volumes/ThunderBolt/_tmp/open-brain/_archive"
+  if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+    mv "$FC_SCRATCH" "$ARCHIVE_DIR/679-fail-closed-probe.$(date +%s).$$" 2>/dev/null
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Cutover pre-flight blocker **B7 / #679**: the four Development-wide safety gates (fast-tools, destructive-delete, irreversible-command, worktree-hygiene) were failing **OPEN** in this repo. Agents here ran `rm -rf`, `grep`, and `find` unblocked while AGENTS.md and CLAUDE.md both claimed those controls were enforced.
- **Root cause is the registration boundary, not the gate logic.** Development registers the gates as `"${CLAUDE_PROJECT_DIR}"/_ob/bin/ob-gate <gate>`. When open-brain is `CLAUDE_PROJECT_DIR` that expands to `open-brain/_ob/bin/ob-gate`, which does not exist and cannot: open-brain is a separate git repo, gitignored by Development (`.gitignore:3:*  open-brain`). The shell exits 127 and PreToolUse reads any non-2 exit as ALLOW. Invoking `Development/_ob/bin/ob-gate` by absolute path from here already refused correctly — only reachability was broken.
- **The fix lands in this repo**, which owns its own `.claude/settings.json`. Development's settings cannot travel into a directory its own `.gitignore` excludes, and `Development/.claude/settings.json` is the only settings file under the Development root registering ob-gate. No Development-repo change is required.
- `.claude/hooks/ob-gate` (new): a repo-local dispatcher that resolves the Development root and execs the real `<root>/_ob/bin/ob-gate`. It carries **no gate logic of its own** — a second copy would fork the moment either side changed, invisibly, since both halves keep exiting 0 on benign input.
- `.claude/settings.json`: registers the four gates on the Bash matcher and adds the `permissions.deny` hard floor mirroring Development's 34 entries. This repo had **no** permissions block at all.

## Verification

- Done-means: scripts/done-means/679-dev-safety-gates-registered.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**RED (two worlds, both proven before the fix existed).** The check reads the REGISTRATION rather than a dispatcher path it spells itself — a check calling the gate directly would have been green through the entire defect, because the gate binary always worked.

RED-A, pre-fix tree as committed (nothing registered) — clauses 1-6 FAIL, clause 7 PASS, exit 1:

```
CLAUSE 1: FAIL — no destructive-delete hook is registered for Bash — rm runs unguarded
CLAUSE 6: FAIL — permissions.deny is missing the hard floor: Bash(rm:*) Bash(grep:*) Bash(find:*)
```

RED-B, the literal #679 world (registration present, `${CLAUDE_PROJECT_DIR}/_ob/bin/ob-gate` unresolved; applied as a deliberate mutant, then reverted) — clauses 1-6 FAIL, exit 1:

```
CLAUSE 1: FAIL — crafted `rm -rf` was NOT refused (exit=127; PreToolUse reads any non-2 as ALLOW)
CLAUSE 3: FAIL — registered but UNREACHABLE (non-verdict exit — this is failing OPEN): all four at exit=127
```

RED-B is the load-bearing one: without it clauses 1-5 had only ever failed through the single "nothing registered" path, and would not have been shown to catch a registered-but-broken gate, which is the shape this issue actually has.

**GREEN — 7/7, exit 0**, and re-run green from a fresh `git clone` of the branch:

```
CLAUSE 1 (a crafted destructive delete is REFUSED in this repo): PASS — exit=2
CLAUSE 2 (a crafted fast-tool call is REFUSED, naming the replacement): PASS — grep and find both exit=2, refusal names rg
CLAUSE 3 (all 4 gates registered + reachable, none missing, none extra): PASS
CLAUSE 4 (CONTROL — benign commands still pass every gate): PASS — exit=0
CLAUSE 5 (an unresolvable gate root FAILS CLOSED, never open): PASS
CLAUSE 6 (permissions.deny carries the hard floor): PASS
CLAUSE 7 (settings.local.json re-allows nothing the floor denies): PASS
```

**The pre-flight's literal done-means**, driven through the registered hook:

```
crafted `rm -rf ...` -> exit 2
  BLOCKED: `rm -r / rm -f` is never run by an agent.
  GIVE THIS TO RICO TO RUN -- do not run it, do not rephrase it:
      rm -rf /Volumes/ThunderBolt/_tmp/open-brain/_scratch/679-crafted

crafted `grep -r needle .` -> exit 2
  BLOCKED: `grep` is not used in Development.
  Use this instead:
    rg needle .

crafted `find . -name *.ts` -> exit 2
  BLOCKED: `find` is not used in Development.
  Use this instead:
    fd *.ts                  # gitignore-aware by default
```

`bunx tsc --noEmit` clean. No TypeScript, Python, migration, or runtime code is touched — the diff is one bash dispatcher, one settings file, and one done-means check.

## Critical Self-Review

- Highest-risk behavior: the dispatcher sits in front of **every Bash call in this repo**. A defect here does not degrade a feature, it either wedges the repo (fails closed on a good machine) or silently disables all four safety gates (fails open). Clause 4 is the negative control for the first — benign `echo hello` and `rg -n needle src/` must still exit 0 through every registered gate — and clause 5 covers the second.
- Assumptions that could be wrong: that `${CLAUDE_PROJECT_DIR}` is substituted in hook `command` strings (documented, and relied on by Development's own settings and this repo's five existing hooks); that PreToolUse treats exit 2 as block and everything else as allow (matches design-lookup-gate.ts / pr-body-gate.ts convention and is what produced the observed fail-open at 127); that the four gate names are the complete set — clause 3 asserts none-missing AND none-extra so a fifth appearing is surfaced rather than absorbed.
- Missing/weak tests: the check drives the hook commands as a shell would, but it does not prove Claude Code's own hook runner invokes them identically — no test can, from inside the repo. Real enforcement is observable only in a live session on this branch. The `irreversible-command` and `worktree-hygiene` gates are proven **reachable and verdict-returning**, not behaviorally exercised; their own logic is Development-owned and tested there.
- Security/permission risk: this PR only ADDS refusals — a deny list and four blocking hooks. It grants nothing. The residual risk is availability, not authorization: a machine that cannot resolve a Development root now has every Bash call refused, deliberately, with the remedy named in the refusal.
- Migration/deploy risk: none. No schema, no server code, no client contract, nothing that runs on core01. This is dev-environment agent safety, which is exactly why the pre-flight separated B7 from the cutover blockers.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched.
- Rollback/cleanup concern: revert the commit and the repo returns to its prior (unguarded) state; nothing persists outside the two `.claude/` files. Lane worktree teardown is reported below.
- Fixes made before PR: **clause 5 was a false green on its first pass and I caught it.** It set the env roots to a bogus path and asserted exit 2, and it passed — but the refusal text was the *upstream* dispatcher's, not this repo's. The resolver had correctly rejected the bogus env roots and fallen through to `$HOME/Development`, which on this machine is a symlink to the real tree, so the env vars alone can never starve the resolver here and the fail-closed branch was never reached. Rewritten to starve all four strategies at once and to require the refusal name `OPENBRAIN_DEVELOPMENT_ROOT`, then RED re-proven by mutating the dispatcher's fail-closed branch to `exit 0` (`CLAUSE 5: FAIL — an unresolvable gate root exited 0 — FAILS OPEN, which is #679 reintroduced`). Separately, clause 4 first reported a 127 as "benign commands were BLOCKED"; a non-verdict is the opposite of blocked, and that wording would have sent the next reader to fix over-firing while nothing was running at all — it now separates exit 2 from any other non-zero.
- Known residual risk: (1) `.claude/settings.local.json` is gitignored (`.gitignore:53:.claude/*`), so its `Bash(find:*)` allow is per-machine operator state **no commit can reach** — removed by hand on this machine and clause 7 now passes against the real file, but on any other box it is a manual step. Clause 7 treats an absent file as a pass so it cannot false-fail a fresh clone. (2) The `$HOME/Development` symlink on this machine means strategy 4 masks strategies 1-3 failing; correct here, but it makes this machine a weak place to observe resolution-order regressions. (3) The merge-gate-bypass claim in #679 is explicitly NOT addressed — the issue records it as unconfirmed and filed separately; I did not investigate it and make no claim about it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lessons here are lane-operating knowledge (false-green through a fallback path, non-verdict vs blocked), which belong in `docs/lane-contract.md` Tightenings via the controller's harvest — they are reported in the lane report for that purpose rather than pre-empting it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no server, schema, transport, or client surface is touched; the change is repo-local agent-safety enforcement with no runtime component.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or fixture surface is touched — the diff is a bash hook dispatcher, a settings registration, and a done-means check.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every downstream axis: no MCP tool, schema, protocol, transport, or Python client behavior changes. `docs/downstream-rollout.md` scopes rollout to client-facing contract changes; this PR's entire surface is `.claude/` enforcement config plus one `scripts/done-means/` check, none of which any downstream client reads.
- **core01 was not contacted and nothing here runs on it.** B7 is dev-environment agent safety, which is why the pre-flight classified it separately from the cutover blockers. There is no core01 application step to write into the runbook for this item.
